### PR TITLE
Allow using a multi-arch image for postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ make build
 
 ## Running
 
+Note: If you are developing with podman on an arm64 system (i.e. M1/M2 Mac) change the postgresql
+image with:
+```
+export PGSQL_IMAGE=registry.redhat.io/rhel8/postgresql-12
+podman login registry.redhat.io
+```
+
+
 Start the Flight Control database:
 
 ```

--- a/deploy/podman/compose.yaml
+++ b/deploy/podman/compose.yaml
@@ -3,7 +3,7 @@ version: '4.4'
 services:
   flightctl-db:
     container_name: flightctl-db
-    image: quay.io/cloudservices/postgresql-rds:12-9ee2984
+    image: ${PGSQL_IMAGE:-quay.io/cloudservices/postgresql-rds:12-9ee2984}
     environment:
       - POSTGRESQL_DATABASE=flightctl
       - POSTGRESQL_USER=demouser


### PR DESCRIPTION
Without this you can't locally deploy on an arm64 mac book. The caveat is that this image is behind login and you will need to run:
```
podman login registry.redhat.io
```