### PR TITLE
Support altnames in flightctl-server config

### DIFF
--- a/cmd/flightctl-server/main.go
+++ b/cmd/flightctl-server/main.go
@@ -48,7 +48,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("ensuring CA cert: %v", err)
 	}
-	serverCerts, _, err := ca.EnsureServerCertificate(certFile(serverCertName), keyFile(serverCertName), []string{"localhost"}, serverCertValidityDays)
+
+	// default certificate hostnames to localhost if nothing else is configured
+	if len(cfg.Service.AltNames) == 0 {
+		cfg.Service.AltNames = []string{"localhost"}
+	}
+
+	serverCerts, _, err := ca.EnsureServerCertificate(certFile(serverCertName), keyFile(serverCertName), cfg.Service.AltNames, serverCertValidityDays)
 	if err != nil {
 		log.Fatalf("ensuring server cert: %v", err)
 	}

--- a/deploy/podman/config.yaml
+++ b/deploy/podman/config.yaml
@@ -8,3 +8,6 @@ database:
 service:
   address: :3333
   baseUrl: http://localhost:3333/api
+  altNames:
+    - my-host.abc.com
+    - localhost

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,13 +31,14 @@ type dbConfig struct {
 }
 
 type svcConfig struct {
-	Address     string `json:"address,omitempty"`
-	CertStore   string `json:"cert,omitempty"`
-	BaseUrl     string `json:"baseUrl,omitempty"`
-	CaCertFile  string `json:"caCertFile,omitempty"`
-	CaKeyFile   string `json:"caKeyFile,omitempty"`
-	SrvCertFile string `json:"srvCertFile,omitempty"`
-	SrvKeyFile  string `json:"srvKeyFile,omitempty"`
+	Address     string   `json:"address,omitempty"`
+	CertStore   string   `json:"cert,omitempty"`
+	BaseUrl     string   `json:"baseUrl,omitempty"`
+	CaCertFile  string   `json:"caCertFile,omitempty"`
+	CaKeyFile   string   `json:"caKeyFile,omitempty"`
+	SrvCertFile string   `json:"srvCertFile,omitempty"`
+	SrvKeyFile  string   `json:"srvKeyFile,omitempty"`
+	AltNames    []string `json:"altNames,omitempty"`
 }
 
 type agentConfig struct {


### PR DESCRIPTION
Support altNames in server cert:
```
            X509v3 Subject Alternative Name:
                DNS:my-host.abc.com, DNS:localhost
```