### PR TITLE
Revert "Fix conmon issue with 2.1.9 on CI"

### DIFF
--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -34,7 +34,7 @@ jobs:
               https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
             | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update -qq
-          sudo apt-get -qq -y install conmon=2:2.1.8-0ubuntu22.04+obs16.39 podman
+          sudo apt-get -qq -y install podman
 
       - name: Deploy
         run: make build deploy


### PR DESCRIPTION
Reverts flightctl/flightctl#29
This didn't really help as the package doesn't seem to be available in their repository versions anymore.

We can only wait to get an updated conmon or go back to podman3