### PR TITLE
Fix wrong resource names in lists

### DIFF
--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -62,7 +62,7 @@ func (d *Device) ToApiResource() api.Device {
 		ApiVersion: DeviceAPI,
 		Kind:       DeviceKind,
 		Metadata: api.ObjectMeta{
-			Name:              &d.Name,
+			Name:              util.StrToPtr(d.Name),
 			CreationTimestamp: util.StrToPtr(d.CreatedAt.UTC().Format(time.RFC3339)),
 		},
 		Spec:   d.Spec.Data,

--- a/internal/store/model/enrollmentrequest.go
+++ b/internal/store/model/enrollmentrequest.go
@@ -62,7 +62,7 @@ func (e *EnrollmentRequest) ToApiResource() api.EnrollmentRequest {
 		ApiVersion: EnrollmentRequestAPI,
 		Kind:       EnrollmentRequestKind,
 		Metadata: api.ObjectMeta{
-			Name:              &e.Name,
+			Name:              util.StrToPtr(e.Name),
 			CreationTimestamp: util.StrToPtr(e.CreatedAt.UTC().Format(time.RFC3339)),
 		},
 		Spec:   e.Spec.Data,
@@ -79,13 +79,13 @@ func (el EnrollmentRequestList) ToApiResource() api.EnrollmentRequestList {
 		}
 	}
 
-	EnrollmentRequestList := make([]api.EnrollmentRequest, len(el))
-	for i, EnrollmentRequest := range el {
-		EnrollmentRequestList[i] = EnrollmentRequest.ToApiResource()
+	enrollmentRequestList := make([]api.EnrollmentRequest, len(el))
+	for i, enrollmentRequest := range el {
+		enrollmentRequestList[i] = enrollmentRequest.ToApiResource()
 	}
 	return api.EnrollmentRequestList{
 		ApiVersion: EnrollmentRequestAPI,
 		Kind:       EnrollmentRequestListKind,
-		Items:      EnrollmentRequestList,
+		Items:      enrollmentRequestList,
 	}
 }

--- a/internal/store/model/fleet.go
+++ b/internal/store/model/fleet.go
@@ -62,7 +62,7 @@ func (f *Fleet) ToApiResource() api.Fleet {
 		ApiVersion: FleetAPI,
 		Kind:       FleetKind,
 		Metadata: api.ObjectMeta{
-			Name:              &f.Name,
+			Name:              util.StrToPtr(f.Name),
 			CreationTimestamp: util.StrToPtr(f.CreatedAt.UTC().Format(time.RFC3339)),
 		},
 		Spec:   f.Spec.Data,


### PR DESCRIPTION
Fixes a bug introduced by the recent refactoring of the data store where resource names were copied by pointer not value, resulting in wrong name being used in lists of resources.