### PR TITLE
Add logrus usage to agent

### DIFF
--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -49,7 +49,7 @@ func (s *DeviceStore) InitialMigration() error {
 }
 
 func (s *DeviceStore) CreateDevice(ctx context.Context, orgId uuid.UUID, resource *api.Device) (*api.Device, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	if resource == nil {
 		return nil, fmt.Errorf("resource is nil")
 	}
@@ -65,7 +65,7 @@ func (s *DeviceStore) ListDevices(ctx context.Context, orgId uuid.UUID, listPara
 	var devices model.DeviceList
 	var nextContinue *string
 	var numRemaining *int64
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 
 	query := BuildBaseListQuery(s.db.Model(&devices), orgId, listParams.Labels)
 	// Request 1 more than the user asked for to see if we need to return "continue"
@@ -111,7 +111,7 @@ func (s *DeviceStore) DeleteDevices(ctx context.Context, orgId uuid.UUID) error 
 }
 
 func (s *DeviceStore) GetDevice(ctx context.Context, orgId uuid.UUID, name string) (*api.Device, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	device := model.Device{
 		Resource: model.Resource{OrgID: orgId, Name: name},
 	}

--- a/internal/store/enrollmentrequest.go
+++ b/internal/store/enrollmentrequest.go
@@ -32,7 +32,7 @@ func (s *EnrollmentRequestStore) InitialMigration() error {
 }
 
 func (s *EnrollmentRequestStore) CreateEnrollmentRequest(ctx context.Context, orgId uuid.UUID, resource *api.EnrollmentRequest) (*api.EnrollmentRequest, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	if resource == nil {
 		return nil, fmt.Errorf("resource is nil")
 	}
@@ -47,7 +47,7 @@ func (s *EnrollmentRequestStore) ListEnrollmentRequests(ctx context.Context, org
 	var enrollmentRequests model.EnrollmentRequestList
 	var nextContinue *string
 	var numRemaining *int64
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 
 	query := BuildBaseListQuery(s.db.Model(&enrollmentRequests), orgId, listParams.Labels)
 	// Request 1 more than the user asked for to see if we need to return "continue"
@@ -93,7 +93,7 @@ func (s *EnrollmentRequestStore) DeleteEnrollmentRequests(ctx context.Context, o
 }
 
 func (s *EnrollmentRequestStore) GetEnrollmentRequest(ctx context.Context, orgId uuid.UUID, name string) (*api.EnrollmentRequest, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	enrollmentRequest := model.EnrollmentRequest{
 		Resource: model.Resource{OrgID: orgId, Name: name},
 	}

--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -32,7 +32,7 @@ func (s *FleetStore) InitialMigration() error {
 }
 
 func (s *FleetStore) CreateFleet(ctx context.Context, orgId uuid.UUID, resource *api.Fleet) (*api.Fleet, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	if resource == nil {
 		return nil, fmt.Errorf("resource is nil")
 	}
@@ -48,7 +48,7 @@ func (s *FleetStore) ListFleets(ctx context.Context, orgId uuid.UUID, listParams
 	var nextContinue *string
 	var numRemaining *int64
 
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	query := BuildBaseListQuery(s.db.Model(&fleets), orgId, listParams.Labels)
 	// Request 1 more than the user asked for to see if we need to return "continue"
 	query = AddPaginationToQuery(query, listParams.Limit+1, listParams.Continue)
@@ -93,7 +93,7 @@ func (s *FleetStore) DeleteFleets(ctx context.Context, orgId uuid.UUID) error {
 }
 
 func (s *FleetStore) GetFleet(ctx context.Context, orgId uuid.UUID, name string) (*api.Fleet, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	fleet := model.Fleet{
 		Resource: model.Resource{OrgID: orgId, Name: name},
 	}

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -32,7 +32,7 @@ func (s *RepositoryStore) InitialMigration() error {
 }
 
 func (s *RepositoryStore) CreateRepository(ctx context.Context, orgId uuid.UUID, resource *api.Repository) (*api.RepositoryRead, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	if resource == nil {
 		return nil, fmt.Errorf("resource is nil")
 	}
@@ -50,7 +50,7 @@ func (s *RepositoryStore) ListRepositories(ctx context.Context, orgId uuid.UUID,
 	var nextContinue *string
 	var numRemaining *int64
 
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	query := BuildBaseListQuery(s.db.Model(&repositories), orgId, listParams.Labels)
 	// Request 1 more than the user asked for to see if we need to return "continue"
 	query = AddPaginationToQuery(query, listParams.Limit+1, listParams.Continue)
@@ -95,7 +95,7 @@ func (s *RepositoryStore) DeleteRepositories(ctx context.Context, orgId uuid.UUI
 }
 
 func (s *RepositoryStore) GetRepository(ctx context.Context, orgId uuid.UUID, name string) (*api.RepositoryRead, error) {
-	log := log.WithReqID(ctx, s.log)
+	log := log.WithReqIDFromCtx(ctx, s.log)
 	repository := model.Repository{
 		Resource: model.Resource{OrgID: orgId, Name: name},
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,11 @@ func InitLogs() *logrus.Logger {
 	return log
 }
 
-// WithReqID create logger with request id from the context, request id is set by middleware.RequestID
-func WithReqID(ctx context.Context, inner logrus.FieldLogger) logrus.FieldLogger {
+// WithReqIDFromCtx create logger with request id from the context, request id is set by middleware.RequestID
+func WithReqIDFromCtx(ctx context.Context, inner logrus.FieldLogger) logrus.FieldLogger {
 	return inner.WithField("request_id", middleware.GetReqID(ctx))
+}
+
+func WithReqID(reqID string, inner logrus.FieldLogger) logrus.FieldLogger {
+	return inner.WithField("request_id", reqID)
 }

--- a/pkg/reqid/reqid.go
+++ b/pkg/reqid/reqid.go
@@ -1,0 +1,28 @@
+package reqid
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+)
+
+var prefix string
+var reqid uint64
+
+func init() {
+	hostname, err := os.Hostname()
+	if hostname == "" || err != nil {
+		hostname = "localhost"
+	}
+
+	prefix = hostname
+}
+
+// NextRequestID generates the next request ID in the sequence.
+func NextRequestID() string {
+	return fmt.Sprintf("%s-%09d", prefix, atomic.AddUint64(&reqid, 1))
+}
+
+func GetReqID() string {
+	return fmt.Sprintf("%s-%09d", prefix, reqid)
+}


### PR DESCRIPTION
To monitor operations between agent and the service it require to keep using the same request-id on each interaction.
Added a reqid package to have a standard request id format and a way to get a new request id when needed.
Sequential request id will better to understand the flow of the interaction
Instead of passing the logger to each function device logger is updated on each interaction with the request id field.

In the future if there will be async operations on the agent it will require to pass the logger with the relevant request id to the async part in order to trace the operations

I decided not to use the context to keep the request id because the way `WithValue` function is implemented, it will add additional context each time with value is called in the long run it will create a long chane of value context objects

To set the context from the agent i added a request editor function (WithRequestEditorFn) that update the header and setting the request id, this way each interaction is tracked with the same request id between the client and the server

agent logs example 
```sh
INFO[0069]/root/test/flightctl/internal/agent/agent.go:320 github.com/flightctl/flightctl/internal/agent.(*DeviceAgent).FetchSpec() device-0005 fetching spec                request_id=rdu-infra-edge-03.infra-edge.lab.eng.rdu2.redhat.com-000000012
INFO[0069]/root/test/flightctl/internal/agent/agent.go:278 github.com/flightctl/flightctl/internal/agent.(*DeviceAgent).Reconcile() device-0005 running reconciler                request_id=rdu-infra-edge-03.infra-edge.lab.eng.rdu2.redhat.com-000000012
```

server logs example
```sh
INFO[0097]/root/test/flightctl/internal/store/device.go:119 github.com/flightctl/flightctl/internal/store.(*DeviceStore).GetDevice() db.Find({"OrgID":"00000000-0000-0000-0000-...
"}}}): 1 rows affected, error is <nil>  pkg=store request_id=rdu-infra-edge-03.infra-edge.lab.eng.rdu2.redhat.com-000000012
2024/01/11 06:24:28 [rdu-infra-edge-03.infra-edge.lab.eng.rdu2.redhat.com-000000012] "GET https://localhost:3333/api/v1/devices/77d21624adddb011902accbc48122
8ca6ddc577867aa1374fe7f8854e1e667cb HTTP/1.1" from [::1]:42126 - 200 2316B in 1.170376ms
```