### PR TITLE
internal: remove Interface from non generated interface names

### DIFF
--- a/internal/monitors/device-updater/device_updater.go
+++ b/internal/monitors/device-updater/device_updater.go
@@ -20,8 +20,8 @@ type API interface {
 type DeviceUpdater struct {
 	log        logrus.FieldLogger
 	db         *gorm.DB
-	fleetStore service.FleetStoreInterface
-	devStore   service.DeviceStoreInterface
+	fleetStore service.FleetStore
+	devStore   service.DeviceStore
 }
 
 func NewDeviceUpdater(log logrus.FieldLogger, db *gorm.DB, store *store.Store) *DeviceUpdater {

--- a/internal/monitors/device-updater/device_updater_test.go
+++ b/internal/monitors/device-updater/device_updater_test.go
@@ -24,7 +24,7 @@ func TestController(t *testing.T) {
 	RunSpecs(t, "DeviceUpdater Suite")
 }
 
-func createDevices(numDevices int, ctx context.Context, deviceStore service.DeviceStoreInterface, orgId uuid.UUID) {
+func createDevices(numDevices int, ctx context.Context, deviceStore service.DeviceStore, orgId uuid.UUID) {
 	for i := 1; i <= numDevices; i++ {
 		resource := api.Device{
 			Metadata: api.ObjectMeta{
@@ -40,7 +40,7 @@ func createDevices(numDevices int, ctx context.Context, deviceStore service.Devi
 	}
 }
 
-func createFleet(ctx context.Context, fleetStore service.FleetStoreInterface, orgId uuid.UUID) *api.Fleet {
+func createFleet(ctx context.Context, fleetStore service.FleetStore, orgId uuid.UUID) *api.Fleet {
 	resource := api.Fleet{
 		Metadata: api.ObjectMeta{
 			Name: util.StrToPtr("myfleet"),
@@ -65,8 +65,8 @@ var _ = Describe("DeviceUpdater", func() {
 		ctx           context.Context
 		orgId         uuid.UUID
 		db            *gorm.DB
-		deviceStore   service.DeviceStoreInterface
-		fleetStore    service.FleetStoreInterface
+		deviceStore   service.DeviceStore
+		fleetStore    service.FleetStore
 		cfg           *config.Config
 		dbName        string
 		numDevices    int

--- a/internal/monitors/repotester/repotester.go
+++ b/internal/monitors/repotester/repotester.go
@@ -27,7 +27,7 @@ type API interface {
 type RepoTester struct {
 	log       logrus.FieldLogger
 	db        *gorm.DB
-	repoStore service.RepositoryStoreInterface
+	repoStore service.RepositoryStore
 }
 
 func NewRepoTester(log logrus.FieldLogger, db *gorm.DB, store *store.Store) *RepoTester {

--- a/internal/monitors/repotester/repotester_test.go
+++ b/internal/monitors/repotester/repotester_test.go
@@ -24,7 +24,7 @@ func TestStore(t *testing.T) {
 	RunSpecs(t, "RepoTester Suite")
 }
 
-func createRepository(ctx context.Context, repostore service.RepositoryStoreInterface, orgId uuid.UUID) error {
+func createRepository(ctx context.Context, repostore service.RepositoryStore, orgId uuid.UUID) error {
 	resource := api.Repository{
 		Metadata: api.ObjectMeta{
 			Name: util.StrToPtr("myrepo"),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,6 @@
+package server
+
+// Service is a wrapper around the generated server interface.
+type Service interface {
+	StrictServerInterface
+}

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-type DeviceStoreInterface interface {
+type DeviceStore interface {
 	CreateDevice(ctx context.Context, orgId uuid.UUID, device *api.Device) (*api.Device, error)
 	ListDevices(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.DeviceList, error)
 	GetDevice(ctx context.Context, orgId uuid.UUID, name string) (*api.Device, error)

--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -18,7 +18,7 @@ import (
 
 const ClientCertExpiryDays = 365
 
-type EnrollmentRequestStoreInterface interface {
+type EnrollmentRequestStore interface {
 	CreateEnrollmentRequest(ctx context.Context, orgId uuid.UUID, req *api.EnrollmentRequest) (*api.EnrollmentRequest, error)
 	ListEnrollmentRequests(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.EnrollmentRequestList, error)
 	GetEnrollmentRequest(ctx context.Context, orgId uuid.UUID, name string) (*api.EnrollmentRequest, error)
@@ -67,7 +67,7 @@ func approveAndSignEnrollmentRequest(ca *crypto.CA, enrollmentRequest *api.Enrol
 	return nil
 }
 
-func createDeviceFromEnrollmentRequest(ctx context.Context, deviceStore DeviceStoreInterface, orgId uuid.UUID, enrollmentRequest *api.EnrollmentRequest) error {
+func createDeviceFromEnrollmentRequest(ctx context.Context, deviceStore DeviceStore, orgId uuid.UUID, enrollmentRequest *api.EnrollmentRequest) error {
 	apiResource := &api.Device{
 		Metadata: api.ObjectMeta{
 			Name: enrollmentRequest.Metadata.Name,

--- a/internal/service/fleet.go
+++ b/internal/service/fleet.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-type FleetStoreInterface interface {
+type FleetStore interface {
 	CreateFleet(ctx context.Context, orgId uuid.UUID, fleet *api.Fleet) (*api.Fleet, error)
 	ListFleets(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.FleetList, error)
 	GetFleet(ctx context.Context, orgId uuid.UUID, name string) (*api.Fleet, error)

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -50,28 +50,28 @@ func ParseContinueString(contStr *string) (*Continue, error) {
 	return &cont, nil
 }
 
-type DataStoreInterface interface {
-	GetDeviceStore() DeviceStoreInterface
-	GetEnrollmentRequestStore() EnrollmentRequestStoreInterface
-	GetFleetStore() FleetStoreInterface
-	GetRepositoryStore() RepositoryStoreInterface
-	GetResourceSyncStore() ResourceSyncStoreInterface
+type DataStore interface {
+	GetDeviceStore() DeviceStore
+	GetEnrollmentRequestStore() EnrollmentRequestStore
+	GetFleetStore() FleetStore
+	GetRepositoryStore() RepositoryStore
+	GetResourceSyncStore() ResourceSyncStore
 }
 
 type ServiceHandler struct {
-	deviceStore            DeviceStoreInterface
-	enrollmentRequestStore EnrollmentRequestStoreInterface
-	fleetStore             FleetStoreInterface
-	repositoryStore        RepositoryStoreInterface
-	resourceSyncStore      ResourceSyncStoreInterface
+	deviceStore            DeviceStore
+	enrollmentRequestStore EnrollmentRequestStore
+	fleetStore             FleetStore
+	repositoryStore        RepositoryStore
+	resourceSyncStore      ResourceSyncStore
 	ca                     *crypto.CA
 	log                    logrus.FieldLogger
 }
 
-// Make sure we conform to StrictServerInterface
-var _ server.StrictServerInterface = (*ServiceHandler)(nil)
+// Make sure we conform to servers Service interface
+var _ server.Service = (*ServiceHandler)(nil)
 
-func NewServiceHandler(store DataStoreInterface, ca *crypto.CA, log logrus.FieldLogger) *ServiceHandler {
+func NewServiceHandler(store DataStore, ca *crypto.CA, log logrus.FieldLogger) *ServiceHandler {
 	return &ServiceHandler{
 		deviceStore:            store.GetDeviceStore(),
 		enrollmentRequestStore: store.GetEnrollmentRequestStore(),

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-type RepositoryStoreInterface interface {
+type RepositoryStore interface {
 	CreateRepository(ctx context.Context, orgId uuid.UUID, repository *api.Repository) (*api.Repository, error)
 	ListRepositories(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.RepositoryList, error)
 	ListAllRepositoriesInternal() ([]model.Repository, error)

--- a/internal/service/resourcesync.go
+++ b/internal/service/resourcesync.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-type ResourceSyncStoreInterface interface {
+type ResourceSyncStore interface {
 	CreateResourceSync(ctx context.Context, orgId uuid.UUID, repository *api.ResourceSync) (*api.ResourceSync, error)
 	ListResourceSync(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.ResourceSyncList, error)
 	ListAllResourceSyncInternal() ([]model.ResourceSync, error)

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -20,8 +20,8 @@ type DeviceStore struct {
 	log logrus.FieldLogger
 }
 
-// Make sure we conform to DeviceStoreInterface
-var _ service.DeviceStoreInterface = (*DeviceStore)(nil)
+// Make sure we conform to DeviceStore interface
+var _ service.DeviceStore = (*DeviceStore)(nil)
 
 func NewDeviceStore(db *gorm.DB, log logrus.FieldLogger) *DeviceStore {
 	return &DeviceStore{db: db, log: log}

--- a/internal/store/enrollmentrequest.go
+++ b/internal/store/enrollmentrequest.go
@@ -20,8 +20,8 @@ type EnrollmentRequestStore struct {
 	log logrus.FieldLogger
 }
 
-// Make sure we conform to EnrollmentRequestStoreInterface
-var _ service.EnrollmentRequestStoreInterface = (*EnrollmentRequestStore)(nil)
+// Make sure we conform to EnrollmentRequestStore interface
+var _ service.EnrollmentRequestStore = (*EnrollmentRequestStore)(nil)
 
 func NewEnrollmentRequestStoreStore(db *gorm.DB, log logrus.FieldLogger) *EnrollmentRequestStore {
 	return &EnrollmentRequestStore{db: db, log: log}

--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -23,8 +23,8 @@ type FleetStore struct {
 	log logrus.FieldLogger
 }
 
-// Make sure we conform to FleetStoreInterface
-var _ service.FleetStoreInterface = (*FleetStore)(nil)
+// Make sure we conform to FleetStore interface
+var _ service.FleetStore = (*FleetStore)(nil)
 
 func NewFleetStore(db *gorm.DB, log logrus.FieldLogger) *FleetStore {
 	return &FleetStore{db: db, log: log}

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -20,8 +20,8 @@ type RepositoryStore struct {
 	log logrus.FieldLogger
 }
 
-// Make sure we conform to RepositoryStoreInterface
-var _ service.RepositoryStoreInterface = (*RepositoryStore)(nil)
+// Make sure we conform to RepositoryStore interface
+var _ service.RepositoryStore = (*RepositoryStore)(nil)
 
 func NewRepositoryStore(db *gorm.DB, log logrus.FieldLogger) *RepositoryStore {
 	return &RepositoryStore{db: db, log: log}

--- a/internal/store/resourcesync.go
+++ b/internal/store/resourcesync.go
@@ -20,8 +20,8 @@ type ResourceSyncStore struct {
 	log logrus.FieldLogger
 }
 
-// Make sure we conform to ResourceSyncStoreInterface
-var _ service.ResourceSyncStoreInterface = (*ResourceSyncStore)(nil)
+// Make sure we conform to ResourceSyncStore interface
+var _ service.ResourceSyncStore = (*ResourceSyncStore)(nil)
 
 func NewResourceSyncStore(db *gorm.DB, log logrus.FieldLogger) *ResourceSyncStore {
 	return &ResourceSyncStore{db: db, log: log}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,23 +24,23 @@ func NewStore(db *gorm.DB, log logrus.FieldLogger) *Store {
 	}
 }
 
-func (s *Store) GetRepositoryStore() service.RepositoryStoreInterface {
+func (s *Store) GetRepositoryStore() service.RepositoryStore {
 	return s.repositoryStore
 }
 
-func (s *Store) GetDeviceStore() service.DeviceStoreInterface {
+func (s *Store) GetDeviceStore() service.DeviceStore {
 	return s.deviceStore
 }
 
-func (s *Store) GetEnrollmentRequestStore() service.EnrollmentRequestStoreInterface {
+func (s *Store) GetEnrollmentRequestStore() service.EnrollmentRequestStore {
 	return s.enrollmentRequestStore
 }
 
-func (s *Store) GetFleetStore() service.FleetStoreInterface {
+func (s *Store) GetFleetStore() service.FleetStore {
 	return s.fleetStore
 }
 
-func (s *Store) GetResourceSyncStore() service.ResourceSyncStoreInterface {
+func (s *Store) GetResourceSyncStore() service.ResourceSyncStore {
 	return s.resourceSyncStore
 }
 


### PR DESCRIPTION
While `oapi-codegen` generates its interfaces with the `Interface` suffix this pattern isn't followed in idiomatic go. This PR renames all non codegen interfaces removing this `Interface` suffix which can be assumed by its type. 