### PR TITLE
Enabling packit for PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,52 @@
+packages:
+  flightctl-agent:
+    specfile_path: packaging/rpm/flightctl-agent.spec
+
+    # add or remove files that should be synced
+    files_to_sync:
+        - packaging/rpm/flightctl-agent.spec
+        - .packit.yaml
+
+    upstream_package_name: flightctl-agent
+    downstream_package_name: flightctl-agent
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    enable_net: True # this is necessary for go modules to download the sources
+    targets:
+      - fedora-eln-aarch64
+      - centos-stream-9-x86_64
+
+  - job: copr_build
+    trigger: commit
+    owner: "@redhat-et"
+    project: flightctl-dev
+    preserve_project: True
+    enable_net: True # this is necessary for go modules to download the sources
+    targets:
+      - fedora-39-aarch64
+      - fedora-39-x86_64
+      - fedora-eln-aarch64
+      - fedora-eln-x86_64
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
+
+
+  - job: copr_build
+    trigger: release
+    owner: "@redhat-et"
+    project: flightctl
+    preserve_project: True
+    enable_net: True # this is necessary for go modules to download the sources
+    targets:
+      - fedora-39-aarch64
+      - fedora-39-x86_64
+      - fedora-eln-aarch64
+      - fedora-eln-x86_64
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - rhel-9-aarch64
+      - rhel-9-x86_64

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,12 @@ deploy: build flightctl-server-container
 bin:
 	mkdir -p bin
 
-rpm: build
-	mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-	mkdir -p bin/flightctl-agent-0.0.1
-	cp bin/flightctl-agent bin/flightctl-agent-0.0.1
-	cp packaging/systemd/flightctl-agent.service bin/flightctl-agent-0.0.1
-	tar cvf rpmbuild/SOURCES/flightctl-agent-0.0.1.tar -C bin/ flightctl-agent-0.0.1
-	rpmbuild --define "_topdir $(GOBASE)/rpmbuild" -ba $(GOBASE)/packaging/rpm/flightctl-agent.spec
+rpm:
+	rm $(shell uname -m)/flightctl-*.rpm || true
+	rm bin/rpm/* || true
+	mkdir -p bin/rpm
+	packit build locally
+	mv $(shell uname -m)/flightctl-*.rpm bin/rpm
 
 clean:
 	- podman-compose -f deploy/podman/compose.yaml down

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Let's take a look at the provided Containerfile located in packaging/Containerfi
 ```
 FROM quay.io/centos-bootc/fedora-bootc:eln
 
-COPY rpmbuild/RPMS/x86_64/flightctl-agent-0.0.1-1.el9.x86_64.rpm /tmp/
+COPY bin/rpm/flightctl-agent-*.rpm /tmp/
 
 COPY packaging/flightctl-custom-assets/flightctl_rsa.pub /usr/etc-system/root.keys
 RUN touch /etc/ssh/sshd_config.d/30-auth-system.conf; \
@@ -97,7 +97,7 @@ ADD packaging/flightctl-custom-assets/config.yaml /etc/flightctl/
 ADD packaging/flightctl-custom-assets/ca.crt /etc/flightctl
 ADD packaging/flightctl-custom-assets/client-enrollment.* /etc/flightctl/
 
-RUN rpm-ostree install -y /tmp/flightctl-agent-0.0.1-1.el9.x86_64.rpm
+RUN rpm-ostree install -y /tmp/flightctl-*.rpm
 RUN ln -s /usr/lib/systemd/system/podman.socket /usr/lib/systemd/system/multi-user.target.wants/
 RUN ln -s /usr/lib/systemd/system/flightctl-agent.service /usr/lib/systemd/system/multi-user.target.wants/
 RUN ostree container commit 
@@ -106,7 +106,7 @@ RUN ostree container commit
 
 In order to make this work for your own service, first you need to have deployed the service (by following the section above where the podman-compose manifests is applied).
 
-Install the rpm build tools with `sudo dnf install -y rpmdevtool` and execute `make rpm` to build the agent RPM package. It will be picked up and injected into the image.
+Install the rpm build tools with `sudo dnf install -y rpmdevtool packit` and execute `make rpm` to build the agent RPM package. It will be picked up and injected into the image.
 Now, add the following assets to the directory `packaging/flightctl-custom-assets/`:
 
 - The public SSH key you want to inject as `packaging/flightctl-custom-assets/flightctl_rsa.pub`

--- a/packaging/Containerfile.fedora
+++ b/packaging/Containerfile.fedora
@@ -1,6 +1,6 @@
 FROM quay.io/centos-bootc/fedora-bootc:eln
 
-COPY rpmbuild/RPMS/x86_64/flightctl-agent-0.0.1-1.el9.x86_64.rpm /tmp/
+COPY bin/rpm/flightctl-agent-*rpm /tmp/
 
 COPY packaging/flightctl-custom-assets/flightctl_rsa.pub /usr/etc-system/root.keys
 RUN touch /etc/ssh/sshd_config.d/30-auth-system.conf; \
@@ -13,7 +13,7 @@ ADD packaging/flightctl-custom-assets/config.yaml /etc/flightctl/
 ADD packaging/flightctl-custom-assets/ca.crt /etc/flightctl
 ADD packaging/flightctl-custom-assets/client-enrollment.* /etc/flightctl/
 
-RUN rpm-ostree install -y /tmp/flightctl-agent-0.0.1-1.el9.x86_64.rpm
+RUN rpm-ostree install -y /tmp/flightctl-agent-*.rpm
 RUN ln -s /usr/lib/systemd/system/podman.socket /usr/lib/systemd/system/multi-user.target.wants/
 RUN ln -s /usr/lib/systemd/system/flightctl-agent.service /usr/lib/systemd/system/multi-user.target.wants/
 COPY packaging/flightctl-custom-assets/00-fedora.toml /usr/lib/bootc/install/

--- a/packaging/rpm/flightctl-agent.spec
+++ b/packaging/rpm/flightctl-agent.spec
@@ -2,27 +2,42 @@
 
 Name: flightctl-agent
 Version: 0.0.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Flightctl Agent
 
 License: XXX
 URL: https://github.com/flightctl/flightctl
-Source0: flightctl-agent-0.0.1.tar
+Source0: flightctl-agent-0.0.1.tar.gz
+
+BuildRequires: golang
+BuildRequires: make
+BuildRequires: git
+BuildRequires: openssl-devel
+Requires: openssl
 
 %description
 Flightctl Agent is a component of the flightctl tool.
 
 %prep
-%setup -q
+%setup -q -n flightctl-agent-0.0.1
 
 %build
 
+# if this is a buggy version of go we need to set GOPROXY as workaround
+# see https://github.com/golang/go/issues/61928
+GOENVFILE=$(go env GOROOT)/go.env
+if [[ ! -f "{$GOENVFILE}" ]]; then
+    export GOPROXY='https://proxy.golang.org,direct'
+fi
+
+make build
+
 %install
+
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
-cp flightctl-agent %{buildroot}/usr/bin
-cp flightctl-agent.service %{buildroot}/usr/lib/systemd/system
-
+cp bin/flightctl-agent %{buildroot}/usr/bin
+cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 
 
 %files
@@ -30,5 +45,8 @@ cp flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 /usr/lib/systemd/system/flightctl-agent.service
 
 %changelog
+
+* Wed Feb 7 2024 Miguel Angel Ajo Pelayo <majopela@redhat.com> - 0.0.1-2
+- Initial RPM building via packit for the flightctl agent
 * Mon Dec 11 2023 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-1
 - Initial RPM package for flightctl agent


### PR DESCRIPTION
Enable packit for PRs, merges and releases:

   commit merges to the main branch will be released in: https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl-dev/ and can be enabled by using:

`dnf copr enable @redhat-et/flightctl-dev`


or importing the right repo: i.e.: https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl-dev/repo/fedora-eln/group_redhat-et-flightctl-dev-fedora-eln.repo

New releases in github should be released in: https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/ and can be enabled by using:

`dnf copr enable @redhat-et/flightctl`

or importing the right repo: i.e.: https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/repo/fedora-eln/group_redhat-et-flightctl-fedora-eln.repo


Packit takes care of creating transient repositories for the PRs


 
 
