### PR TITLE
Add API client config file

### DIFF
--- a/cmd/flightctl-server/main.go
+++ b/cmd/flightctl-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"path/filepath"
 
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/server"
@@ -44,9 +45,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("ensuring server cert: %v", err)
 	}
-	_, _, err = ca.EnsureClientCertificate(certFile(clientBootstrapCertName), keyFile(clientBootstrapCertName), clientBootstrapCertName, clientBootStrapValidityDays)
+	clientCert, _, err := ca.EnsureClientCertificate(certFile(clientBootstrapCertName), keyFile(clientBootstrapCertName), clientBootstrapCertName, clientBootStrapValidityDays)
 	if err != nil {
 		log.Fatalf("ensuring bootstrap client cert: %v", err)
+	}
+
+	// also write out a client config file
+	err = client.WriteConfig(config.ClientConfigFile(), cfg.Service.BaseUrl, "", ca.Config, clientCert)
+	if err != nil {
+		log.Fatalf("writing client config: %v", err)
 	}
 
 	log.Println("Initializing data store")

--- a/cmd/flightctl/approve.go
+++ b/cmd/flightctl/approve.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ func NewCmdApprove() *cobra.Command {
 }
 
 func RunApprove(enrollmentRequestName string) error {
-	c, err := getClient()
+	c, err := client.NewFromConfigFile(clientConfigFile)
 	if err != nil {
 		return fmt.Errorf("creating client: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.29.0 // indirect
 	k8s.io/apiextensions-apiserver v0.28.2 // indirect
 	k8s.io/apiserver v0.28.2 // indirect

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/util"
-	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -1,0 +1,130 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/pkg/reqid"
+	"github.com/go-chi/chi/middleware"
+	certutil "k8s.io/client-go/util/cert"
+	"sigs.k8s.io/yaml"
+)
+
+// Config holds the information needed to connect to a FlightCtl API server
+type Config struct {
+	Service  Service  `json:"service"`
+	AuthInfo AuthInfo `json:"authentication"`
+}
+
+// Service contains information how to connect to and authenticate the FlightCtl API server.
+type Service struct {
+	// Server is the URL of the FlightCtl API server (the part before /api/v1/...).
+	Server string `json:"server"`
+	// TLSServerName is passed to the server for SNI and is used in the client to check server certificates against.
+	// If TLSServerName is empty, the hostname used to contact the server is used.
+	// +optional
+	TLSServerName string `json:"tls-server-name,omitempty"`
+	// CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+	// +optional
+	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
+}
+
+// AuthInfo contains information for authenticating FlightCtl API clients.
+type AuthInfo struct {
+	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS.
+	// +optional
+	ClientCertificateData []byte `json:"client-certificate-data,omitempty"`
+	// ClientKeyData contains PEM-encoded data from a client key file for TLS.
+	// +optional
+	ClientKeyData []byte `json:"client-key-data,omitempty" datapolicy:"security-key"`
+}
+
+// NewFromConfig returns a new FlightCtl API client from the given config.
+func NewFromConfig(config *Config) (*client.ClientWithResponses, error) {
+	caPool, err := certutil.NewPoolFromBytes(config.Service.CertificateAuthorityData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA certs: %v", err)
+	}
+
+	tlsServerName := config.Service.TLSServerName
+	if len(tlsServerName) == 0 {
+		u, err := url.Parse(config.Service.Server)
+		if err != nil {
+			return nil, fmt.Errorf("parsing CA certs: %v", err)
+		}
+		tlsServerName = u.Hostname()
+	}
+
+	clientCert, err := tls.X509KeyPair(config.AuthInfo.ClientCertificateData, config.AuthInfo.ClientKeyData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing client cert and key: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      caPool,
+				ServerName:   tlsServerName,
+				Certificates: []tls.Certificate{clientCert},
+				MinVersion:   tls.VersionTLS13,
+			},
+		},
+	}
+	ref := client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		req.Header.Set(middleware.RequestIDHeader, reqid.GetReqID())
+		return nil
+	})
+	return client.NewClientWithResponses(config.Service.Server, client.WithHTTPClient(httpClient), ref)
+}
+
+// NewFromConfigFile returns a new FlightCtl API client using the config read from the given file.
+func NewFromConfigFile(filename string) (*client.ClientWithResponses, error) {
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %v", err)
+	}
+	var config Config
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return nil, fmt.Errorf("decoding config: %v", err)
+	}
+	// TODO: validation
+	return NewFromConfig(&config)
+}
+
+// WriteConfig writes a client config file using the given parameters.
+func WriteConfig(filename string, server string, tlsServerName string, ca *crypto.TLSCertificateConfig, client *crypto.TLSCertificateConfig) error {
+	caCertPEM, _, err := ca.GetPEMBytes()
+	if err != nil {
+		return fmt.Errorf("PEM-encoding CA certs: %v", err)
+	}
+	clientCertPEM, clientKeyPEM, err := client.GetPEMBytes()
+	if err != nil {
+		return fmt.Errorf("PEM-encoding client cert and key: %v", err)
+	}
+
+	config := Config{
+		Service: Service{
+			Server:                   server,
+			TLSServerName:            tlsServerName,
+			CertificateAuthorityData: caCertPEM,
+		},
+		AuthInfo: AuthInfo{
+			ClientCertificateData: clientCertPEM,
+			ClientKeyData:         clientKeyPEM,
+		},
+	}
+	contents, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("encoding config: %v", err)
+	}
+	if err := os.WriteFile(filename, contents, 0600); err != nil {
+		return fmt.Errorf("writing config: %v", err)
+	}
+	return nil
+}

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"crypto/x509"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	caCertValidityDays          = 365 * 10
+	serverCertValidityDays      = 365 * 1
+	clientBootStrapValidityDays = 365 * 1
+	signerCertName              = "ca"
+	clientBootstrapCertName     = "client-enrollment"
+)
+
+func TestClientConfig(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name           string
+		server         string
+		serverWant     string
+		serverName     string
+		serverNameWant string
+	}{
+		{
+			name:           "local service",
+			server:         "https://localhost:3333",
+			serverName:     "",
+			serverWant:     "https://localhost:3333/",
+			serverNameWant: "localhost",
+		},
+		{
+			name:           "remote service",
+			server:         "https://api.flightctl.edge-devices.net/devicemanagement/",
+			serverName:     "flightctl.edge-devices.net",
+			serverWant:     "https://api.flightctl.edge-devices.net/devicemanagement/",
+			serverNameWant: "flightctl.edge-devices.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDirPath := t.TempDir()
+			configFile := filepath.Join(testDirPath, "client.yaml")
+
+			// generate the CA and client certs
+			ca, _, err := crypto.EnsureCA(filepath.Join(testDirPath, "ca.crt"), filepath.Join(testDirPath, "ca.key"), "", signerCertName, caCertValidityDays)
+			require.NoError(err)
+			clientCert, _, err := ca.EnsureClientCertificate(filepath.Join(testDirPath, "client-enrollment.crt"), filepath.Join(testDirPath, "client-enrollment.key"), clientBootstrapCertName, clientBootStrapValidityDays)
+			require.NoError(err)
+
+			// write client config to disk
+			err = WriteConfig(configFile, tt.server, tt.serverName, ca.Config, clientCert)
+			require.NoError(err)
+
+			// read client config from disk and create API client from it
+			client, err := NewFromConfigFile(configFile)
+			require.NoError(err)
+			require.NotNil(client)
+
+			// test results match expected
+			c, ok := client.ClientInterface.(*apiclient.Client)
+			require.True(ok)
+			require.Equal(tt.serverWant, c.Server)
+
+			httpClient, ok := c.Client.(*http.Client)
+			require.True(ok)
+
+			httpTransport, ok := httpClient.Transport.(*http.Transport)
+			require.True(ok)
+			require.Equal(tt.serverNameWant, httpTransport.TLSClientConfig.ServerName)
+			require.NotEmpty(httpTransport.TLSClientConfig.Certificates)
+			require.ElementsMatch(clientCert.Certs[0].Raw, httpTransport.TLSClientConfig.Certificates[0].Certificate[0])
+			require.NotNil(httpTransport.TLSClientConfig.RootCAs)
+			caPool := x509.NewCertPool()
+			for _, caCert := range ca.Config.Certs {
+				caPool.AddCert(caCert)
+			}
+			require.True(caPool.Equal(httpTransport.TLSClientConfig.RootCAs))
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,10 @@ func ConfigFile() string {
 	return filepath.Join(ConfigDir(), "config.yaml")
 }
 
+func ClientConfigFile() string {
+	return filepath.Join(ConfigDir(), "client.yaml")
+}
+
 func CertificateDir() string {
 	return filepath.Join(ConfigDir(), "certs")
 }
@@ -64,7 +68,7 @@ func NewDefault() *Config {
 		Service: &svcConfig{
 			Address:   ":3333",
 			CertStore: CertificateDir(),
-			BaseUrl:   "http://localhost:3333/api",
+			BaseUrl:   "https://localhost:3333/api",
 		},
 	}
 	return c


### PR DESCRIPTION
Adds a config file encapsulates API client information (server URL, CA bundle, user auth), writes that file to `~/.flightctl/client.yaml` when the server starts, updates the `flightctl` CLI client to use that file.