### PR TITLE
*: remove gorm *db from server and internal

### DIFF
--- a/cmd/flightctl-server/main.go
+++ b/cmd/flightctl-server/main.go
@@ -56,6 +56,8 @@ func main() {
 	}
 
 	store := store.NewStore(db, log.WithField("pkg", "store"))
+	defer store.Close()
+
 	if err := store.InitialMigration(); err != nil {
 		log.Fatalf("running initial migration: %v", err)
 	}
@@ -65,7 +67,7 @@ func main() {
 		log.Fatalf("failed creating TLS config: %v", err)
 	}
 
-	server := server.New(log, cfg, store, db, tlsConfig, ca)
+	server := server.New(log, cfg, store, tlsConfig, ca)
 	if err := server.Run(); err != nil {
 		log.Fatalf("Error running server: %s", err)
 	}

--- a/internal/monitors/device-updater/device_updater.go
+++ b/internal/monitors/device-updater/device_updater.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 )
 
 type API interface {
@@ -18,15 +17,13 @@ type API interface {
 
 type DeviceUpdater struct {
 	log        logrus.FieldLogger
-	db         *gorm.DB
 	fleetStore store.Fleet
 	devStore   store.Device
 }
 
-func NewDeviceUpdater(log logrus.FieldLogger, db *gorm.DB, store store.Store) *DeviceUpdater {
+func NewDeviceUpdater(log logrus.FieldLogger, store store.Store) *DeviceUpdater {
 	return &DeviceUpdater{
 		log:        log,
-		db:         db,
 		fleetStore: store.Fleet(),
 		devStore:   store.Device(),
 	}

--- a/internal/monitors/device-updater/device_updater_test.go
+++ b/internal/monitors/device-updater/device_updater_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 )
 
 func TestController(t *testing.T) {
@@ -63,9 +62,9 @@ var _ = Describe("DeviceUpdater", func() {
 		log           *logrus.Logger
 		ctx           context.Context
 		orgId         uuid.UUID
-		db            *gorm.DB
 		deviceStore   store.Device
 		fleetStore    store.Fleet
+		stores        store.Store
 		cfg           *config.Config
 		dbName        string
 		numDevices    int
@@ -77,15 +76,14 @@ var _ = Describe("DeviceUpdater", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numDevices = 3
-		var stores store.Store
-		db, stores, cfg, dbName = store.PrepareDBForUnitTests(log)
+		stores, cfg, dbName = store.PrepareDBForUnitTests(log)
 		deviceStore = stores.Device()
 		fleetStore = stores.Fleet()
-		deviceUpdater = NewDeviceUpdater(log, db, stores)
+		deviceUpdater = NewDeviceUpdater(log, stores)
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, db, dbName)
+		store.DeleteTestDB(cfg, stores, dbName)
 	})
 
 	Context("DeviceUpdater", func() {

--- a/internal/monitors/repotester/repotester.go
+++ b/internal/monitors/repotester/repotester.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 )
 
 type API interface {
@@ -25,14 +24,12 @@ type API interface {
 
 type RepoTester struct {
 	log       logrus.FieldLogger
-	db        *gorm.DB
 	repoStore store.Repository
 }
 
-func NewRepoTester(log logrus.FieldLogger, db *gorm.DB, store store.Store) *RepoTester {
+func NewRepoTester(log logrus.FieldLogger, store store.Store) *RepoTester {
 	return &RepoTester{
 		log:       log,
-		db:        db,
 		repoStore: store.Repository(),
 	}
 }

--- a/internal/monitors/repotester/repotester_test.go
+++ b/internal/monitors/repotester/repotester_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 )
 
 func TestStore(t *testing.T) {
@@ -42,7 +41,7 @@ var _ = Describe("RepoTester", func() {
 		log        *logrus.Logger
 		ctx        context.Context
 		orgId      uuid.UUID
-		db         *gorm.DB
+		stores     store.Store
 		cfg        *config.Config
 		dbName     string
 		repotester *RepoTester
@@ -52,13 +51,12 @@ var _ = Describe("RepoTester", func() {
 		ctx = context.Background()
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
-		var stores store.Store
-		db, stores, cfg, dbName = store.PrepareDBForUnitTests(log)
-		repotester = NewRepoTester(log, db, stores)
+		stores, cfg, dbName = store.PrepareDBForUnitTests(log)
+		repotester = NewRepoTester(log, stores)
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, db, dbName)
+		store.DeleteTestDB(cfg, stores, dbName)
 	})
 
 	Context("RepoTester", func() {

--- a/internal/monitors/resourcesync/resourcesync.go
+++ b/internal/monitors/resourcesync/resourcesync.go
@@ -41,10 +41,9 @@ type genericResourceMap map[string]interface{}
 var fileExtensions = []string{"json", "yaml", "yml"}
 var supportedResources = []string{model.FleetKind}
 
-func NewResourceSync(log logrus.FieldLogger, db *gorm.DB, store store.Store) *ResourceSync {
+func NewResourceSync(log logrus.FieldLogger, store store.Store) *ResourceSync {
 	return &ResourceSync{
 		log:   log,
-		db:    db,
 		store: store,
 	}
 }

--- a/internal/monitors/resourcesync/resourcesync_test.go
+++ b/internal/monitors/resourcesync/resourcesync_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"gorm.io/gorm"
 )
 
 func TestStore(t *testing.T) {
@@ -37,8 +36,8 @@ var _ = Describe("ResourceSync", Ordered, func() {
 		log          *logrus.Logger
 		ctx          context.Context
 		orgId        uuid.UUID
-		db           *gorm.DB
 		cfg          *config.Config
+		stores       store.Store
 		dbName       string
 		resourceSync *ResourceSync
 		//hash         string
@@ -77,13 +76,12 @@ var _ = Describe("ResourceSync", Ordered, func() {
 		ctx = context.Background()
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
-		var stores store.Store
-		db, stores, cfg, dbName = store.PrepareDBForUnitTests(log)
-		resourceSync = NewResourceSync(log, db, stores)
+		stores, cfg, dbName = store.PrepareDBForUnitTests(log)
+		resourceSync = NewResourceSync(log, stores)
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, db, dbName)
+		store.DeleteTestDB(cfg, stores, dbName)
 	})
 
 	Context("ResourceSync tests", func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,7 +48,6 @@ func New(
 	log logrus.FieldLogger,
 	cfg *config.Config,
 	store store.Store,
-	db *gorm.DB,
 	tlsConfig *tls.Config,
 	ca *crypto.CA,
 ) *Server {
@@ -56,7 +55,6 @@ func New(
 		log:       log,
 		cfg:       cfg,
 		store:     store,
-		db:        db,
 		tlsConfig: tlsConfig,
 		ca:        ca,
 	}
@@ -108,19 +106,19 @@ func (s *Server) Run() error {
 		_ = srv.Shutdown(ctxTimeout)
 	}()
 
-	repoTester := repotester.NewRepoTester(s.log, s.db, s.store)
+	repoTester := repotester.NewRepoTester(s.log, s.store)
 	repoTesterThread := thread.New(
 		s.log.WithField("pkg", "repository-tester"), "Repository tester", threadIntervalMinute(2), repoTester.TestRepo)
 	repoTesterThread.Start()
 	defer repoTesterThread.Stop()
 
-	deviceUpdater := device_updater.NewDeviceUpdater(s.log, s.db, s.store)
+	deviceUpdater := device_updater.NewDeviceUpdater(s.log, s.store)
 	deviceUpdaterThread := thread.New(
 		s.log.WithField("pkg", "device-updater"), "Device updater", threadIntervalMinute(2), deviceUpdater.UpdateDevices)
 	deviceUpdaterThread.Start()
 	defer deviceUpdaterThread.Stop()
 
-	resourceSync := resourcesync.NewResourceSync(s.log, s.db, s.store)
+	resourceSync := resourcesync.NewResourceSync(s.log, s.store)
 	resourceSyncThread := thread.New(
 		s.log.WithField("pkg", "resourcesync"), "ResourceSync", threadIntervalMinute(2), resourceSync.Poll)
 	resourceSyncThread.Start()

--- a/internal/store/common_unittest_db.go
+++ b/internal/store/common_unittest_db.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func PrepareDBForUnitTests(log *logrus.Logger) (*gorm.DB, Store, *config.Config, string) {
+func PrepareDBForUnitTests(log *logrus.Logger) (Store, *config.Config, string) {
 	cfg := config.NewDefault()
 	cfg.Database.Name = ""
 	dbTemp, err := InitDB(cfg)
@@ -37,11 +37,12 @@ func PrepareDBForUnitTests(log *logrus.Logger) (*gorm.DB, Store, *config.Config,
 	err = store.InitialMigration()
 	Expect(err).ShouldNot(HaveOccurred())
 
-	return db, store, cfg, randomDBName
+	return store, cfg, randomDBName
 }
 
-func DeleteTestDB(cfg *config.Config, db *gorm.DB, dbName string) {
-	CloseDB(db)
+func DeleteTestDB(cfg *config.Config, store Store, dbName string) {
+	err := store.Close()
+	Expect(err).ShouldNot(HaveOccurred())
 	cfg.Database.Name = ""
 	db, err := InitDB(cfg)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/internal/store/device_test.go
+++ b/internal/store/device_test.go
@@ -49,7 +49,6 @@ var _ = Describe("DeviceStore create", func() {
 		log        *logrus.Logger
 		ctx        context.Context
 		orgId      uuid.UUID
-		db         *gorm.DB
 		store      Store
 		cfg        *config.Config
 		dbName     string
@@ -61,13 +60,13 @@ var _ = Describe("DeviceStore create", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numDevices = 3
-		db, store, cfg, dbName = PrepareDBForUnitTests(log)
+		store, cfg, dbName = PrepareDBForUnitTests(log)
 
 		createDevices(3, ctx, store, orgId)
 	})
 
 	AfterEach(func() {
-		DeleteTestDB(cfg, db, dbName)
+		DeleteTestDB(cfg, store, dbName)
 	})
 
 	Context("Device store", func() {

--- a/internal/store/enrollmentrequest_test.go
+++ b/internal/store/enrollmentrequest_test.go
@@ -41,7 +41,6 @@ var _ = Describe("enrollmentRequestStore create", func() {
 		log                   *logrus.Logger
 		ctx                   context.Context
 		orgId                 uuid.UUID
-		db                    *gorm.DB
 		store                 Store
 		cfg                   *config.Config
 		dbName                string
@@ -53,13 +52,13 @@ var _ = Describe("enrollmentRequestStore create", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numEnrollmentRequests = 3
-		db, store, cfg, dbName = PrepareDBForUnitTests(log)
+		store, cfg, dbName = PrepareDBForUnitTests(log)
 
 		createEnrollmentRequests(3, ctx, store, orgId)
 	})
 
 	AfterEach(func() {
-		DeleteTestDB(cfg, db, dbName)
+		DeleteTestDB(cfg, store, dbName)
 	})
 
 	Context("EnrollmentRequest store", func() {

--- a/internal/store/fleet_test.go
+++ b/internal/store/fleet_test.go
@@ -43,7 +43,6 @@ var _ = Describe("FleetStore create", func() {
 		log       *logrus.Logger
 		ctx       context.Context
 		orgId     uuid.UUID
-		db        *gorm.DB
 		store     Store
 		cfg       *config.Config
 		dbName    string
@@ -55,13 +54,13 @@ var _ = Describe("FleetStore create", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numFleets = 3
-		db, store, cfg, dbName = PrepareDBForUnitTests(log)
+		store, cfg, dbName = PrepareDBForUnitTests(log)
 
 		createFleets(3, ctx, store, orgId)
 	})
 
 	AfterEach(func() {
-		DeleteTestDB(cfg, db, dbName)
+		DeleteTestDB(cfg, store, dbName)
 	})
 
 	Context("Fleet store", func() {

--- a/internal/store/repository_test.go
+++ b/internal/store/repository_test.go
@@ -41,7 +41,6 @@ var _ = Describe("RepositoryStore create", func() {
 		log             *logrus.Logger
 		ctx             context.Context
 		orgId           uuid.UUID
-		db              *gorm.DB
 		store           Store
 		cfg             *config.Config
 		dbName          string
@@ -53,13 +52,13 @@ var _ = Describe("RepositoryStore create", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numRepositories = 3
-		db, store, cfg, dbName = PrepareDBForUnitTests(log)
+		store, cfg, dbName = PrepareDBForUnitTests(log)
 
 		createRepositories(3, ctx, store, orgId)
 	})
 
 	AfterEach(func() {
-		DeleteTestDB(cfg, db, dbName)
+		DeleteTestDB(cfg, store, dbName)
 	})
 
 	Context("Repository store", func() {

--- a/internal/store/resourcesync_test.go
+++ b/internal/store/resourcesync_test.go
@@ -42,7 +42,6 @@ var _ = Describe("ResourceSyncStore create", func() {
 		log              *logrus.Logger
 		ctx              context.Context
 		orgId            uuid.UUID
-		db               *gorm.DB
 		store            Store
 		cfg              *config.Config
 		dbName           string
@@ -54,13 +53,13 @@ var _ = Describe("ResourceSyncStore create", func() {
 		orgId, _ = uuid.NewUUID()
 		log = flightlog.InitLogs()
 		numResourceSyncs = 3
-		db, store, cfg, dbName = PrepareDBForUnitTests(log)
+		store, cfg, dbName = PrepareDBForUnitTests(log)
 
 		createResourceSyncs(3, ctx, store, orgId)
 	})
 
 	AfterEach(func() {
-		DeleteTestDB(cfg, db, dbName)
+		DeleteTestDB(cfg, store, dbName)
 	})
 
 	Context("ResourceSync store", func() {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,6 +23,7 @@ type Store interface {
 	Repository() Repository
 	ResourceSync() ResourceSync
 	InitialMigration() error
+	Close() error
 }
 
 type DataStore struct {
@@ -31,6 +32,8 @@ type DataStore struct {
 	fleet             Fleet
 	repository        Repository
 	resourceSync      ResourceSync
+
+	db *gorm.DB
 }
 
 func NewStore(db *gorm.DB, log logrus.FieldLogger) Store {
@@ -40,6 +43,7 @@ func NewStore(db *gorm.DB, log logrus.FieldLogger) Store {
 		fleet:             NewFleet(db, log),
 		repository:        NewRepository(db, log),
 		resourceSync:      NewResourceSync(db, log),
+		db:                db,
 	}
 }
 
@@ -80,6 +84,14 @@ func (s *DataStore) InitialMigration() error {
 		return err
 	}
 	return nil
+}
+
+func (s *DataStore) Close() error {
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
 }
 
 type ListParams struct {


### PR DESCRIPTION
Since the store encapsulates the db we should not need to pass it to the server. This PR  removes the form db references in the server and other internal packages.

This PR also ensures the database is closed after the server is shutdown.