### PR TITLE
internal/agent/controller: remove agent dependency

### DIFF
--- a/internal/agent/controller.go
+++ b/internal/agent/controller.go
@@ -5,8 +5,6 @@ import (
 )
 
 type DeviceAgentController interface {
-	SetDeviceAgent(a *DeviceAgent)
-
 	NeedsUpdate(r *api.Device) bool
 	StageUpdate(r *api.Device) (bool, error)
 	ApplyUpdate(r *api.Device) (bool, error)
@@ -16,7 +14,6 @@ type DeviceAgentController interface {
 }
 
 func (a *DeviceAgent) AddController(c DeviceAgentController) *DeviceAgent {
-	c.SetDeviceAgent(a)
 	a.controllers = append(a.controllers, c)
 	return a
 }

--- a/internal/agent/controller/containers.go
+++ b/internal/agent/controller/containers.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
 type ContainerController struct {
-	agent *agent.DeviceAgent
-	exec  executer.Executer
+	exec executer.Executer
 }
 
 func NewContainerController() *ContainerController {
@@ -28,10 +26,6 @@ func NewContainerControllerWithExecuter(exec executer.Executer) *ContainerContro
 	return &ContainerController{
 		exec: exec,
 	}
-}
-
-func (c *ContainerController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *ContainerController) NeedsUpdate(r *api.Device) bool {

--- a/internal/agent/controller/systemd.go
+++ b/internal/agent/controller/systemd.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
 type SystemDController struct {
-	agent *agent.DeviceAgent
-	exec  executer.Executer
+	exec executer.Executer
 }
 
 func NewSystemDController() *SystemDController {
@@ -28,10 +26,6 @@ func NewSystemDControllerWithExecuter(exec executer.Executer) *SystemDController
 	return &SystemDController{
 		exec: exec,
 	}
-}
-
-func (c *SystemDController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *SystemDController) NeedsUpdate(r *api.Device) bool {

--- a/internal/agent/controller/systeminfo.go
+++ b/internal/agent/controller/systeminfo.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/google/cadvisor/fs"
 	"github.com/google/cadvisor/machine"
@@ -13,7 +12,6 @@ import (
 )
 
 type SystemInfoController struct {
-	agent      *agent.DeviceAgent
 	tpmChannel *tpm.TPM
 
 	systemInfo *api.DeviceSystemInfo
@@ -21,10 +19,6 @@ type SystemInfoController struct {
 
 func NewSystemInfoController(tpmChannel *tpm.TPM) *SystemInfoController {
 	return &SystemInfoController{tpmChannel: tpmChannel}
-}
-
-func (c *SystemInfoController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *SystemInfoController) NeedsUpdate(r *api.Device) bool {


### PR DESCRIPTION
This appears to be unused code and creates a circular dep on the agent which blocks test creation.