### PR TITLE
Test harness

### DIFF
--- a/cmd/flightctl-server/main.go
+++ b/cmd/flightctl-server/main.go
@@ -67,7 +67,12 @@ func main() {
 		log.Fatalf("failed creating TLS config: %v", err)
 	}
 
-	server := server.New(log, cfg, store, tlsConfig, ca)
+	listener, err := server.NewTLSLister(cfg.Service.Address, tlsConfig)
+	if err != nil {
+		log.Fatalf("creating listener: %s", err)
+	}
+
+	server := server.New(log, cfg, store, ca, listener)
 	if err := server.Run(); err != nil {
 		log.Fatalf("Error running server: %s", err)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -104,6 +104,8 @@ type DeviceAgent struct {
 
 	rpcMetricsCallbackFunc func(operation string, duractionSeconds float64, err error)
 
+	issueDir string
+
 	log logrus.FieldLogger
 }
 
@@ -163,6 +165,12 @@ func (a *DeviceAgent) SetStatusUpdateInterval(interval time.Duration, jitter tim
 
 func (a *DeviceAgent) SetRpcMetricsCallbackFunction(callback func(operation string, duractionSeconds float64, err error)) *DeviceAgent {
 	a.rpcMetricsCallbackFunc = callback
+	return a
+}
+
+// SetIssueDir defines the directory where the agent will write the issue file. Useful for testing.
+func (a *DeviceAgent) SetIssueDir(path string) *DeviceAgent {
+	a.issueDir = path
 	return a
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/controller"
 	"github.com/flightctl/flightctl/internal/config"
@@ -15,6 +12,8 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
 	testutils "github.com/flightctl/flightctl/test/utils"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestDeviceAgent(t *testing.T) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/controller"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/tpm"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/log"
+	testutils "github.com/flightctl/flightctl/test/utils"
+)
+
+func TestDeviceAgent(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "TestDeviceAgent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			testDirPath := t.TempDir()
+			cfg := *config.NewDefault()
+			log := log.InitLogs()
+
+			// create store
+			store, dbName := testutils.NewTestStore(t, cfg, log)
+			cfg.Database.Name = dbName
+
+			// create certs
+			cfg.Service.CertStore = testDirPath
+			ca, serverCerts, clientCerts := testutils.NewTestCerts(t, &cfg)
+
+			// create server
+			server, listener := testutils.NewTestServer(t, log, &cfg, store, ca, serverCerts)
+			cfg.Service.Address = listener.Addr().String()
+			defer listener.Close()
+
+			// start server
+			go func() {
+				err := server.Run()
+				require.NoError(err)
+			}()
+
+			tpmChannel, err := tpm.OpenTPMSimulator()
+			require.NoError(err)
+
+			fetchSpecInterval := 1 * time.Second
+			statusUpdateInterval := 1 * time.Second
+
+			agentInstance := NewDeviceAgent("https://"+cfg.Service.Address, "https://"+cfg.Service.Address, cfg.Service.Address, testDirPath, log).
+				AddController(controller.NewSystemInfoController(tpmChannel)).
+				AddController(controller.NewContainerController()).
+				AddController(controller.NewSystemDController()).
+				SetFetchSpecInterval(fetchSpecInterval, 0).
+				SetStatusUpdateInterval(statusUpdateInterval, 0).
+				SetIssueDir(testDirPath)
+
+			// start agent
+			go func() {
+				err = agentInstance.Run(ctx)
+				require.NoError(err)
+			}()
+
+			// create client
+			client, err := testutils.NewClient("https://"+listener.Addr().String(), ca.Config, clientCerts)
+			require.NoError(err)
+
+			var deviceName string
+			// wait for the enrollment request to be created
+			err = wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+				listResp, err := client.ListEnrollmentRequestsWithResponse(ctx, &api.ListEnrollmentRequestsParams{})
+				if err != nil {
+					return false, err
+				}
+				if len(listResp.JSON200.Items) == 0 {
+					return false, nil
+				}
+				deviceName = *listResp.JSON200.Items[0].Metadata.Name
+				return true, nil
+			})
+
+			// approve the enrollment request
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"label": "value"},
+				Region:   util.StrToPtr("region"),
+			}
+			_, err = client.CreateEnrollmentRequestApprovalWithResponse(ctx, deviceName, approval)
+			require.NoError(err)
+		})
+	}
+}

--- a/internal/agent/controller.go
+++ b/internal/agent/controller.go
@@ -5,8 +5,6 @@ import (
 )
 
 type DeviceAgentController interface {
-	SetDeviceAgent(a *DeviceAgent)
-
 	NeedsUpdate(r *api.Device) bool
 	StageUpdate(r *api.Device) (bool, error)
 	ApplyUpdate(r *api.Device) (bool, error)
@@ -16,7 +14,6 @@ type DeviceAgentController interface {
 }
 
 func (a *DeviceAgent) AddController(c DeviceAgentController) *DeviceAgent {
-	c.SetDeviceAgent(a)
 	a.controllers = append(a.controllers, c)
 	return a
 }

--- a/internal/agent/controller/containers.go
+++ b/internal/agent/controller/containers.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
 type ContainerController struct {
-	agent *agent.DeviceAgent
-	exec  executer.Executer
+	exec executer.Executer
 }
 
 func NewContainerController() *ContainerController {
@@ -28,10 +26,6 @@ func NewContainerControllerWithExecuter(exec executer.Executer) *ContainerContro
 	return &ContainerController{
 		exec: exec,
 	}
-}
-
-func (c *ContainerController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *ContainerController) NeedsUpdate(r *api.Device) bool {

--- a/internal/agent/controller/systemd.go
+++ b/internal/agent/controller/systemd.go
@@ -7,15 +7,13 @@ import (
 	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
 type SystemDController struct {
-	agent *agent.DeviceAgent
-	exec  executer.Executer
+	exec executer.Executer
 }
 
 func NewSystemDController() *SystemDController {
@@ -28,10 +26,6 @@ func NewSystemDControllerWithExecuter(exec executer.Executer) *SystemDController
 	return &SystemDController{
 		exec: exec,
 	}
-}
-
-func (c *SystemDController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *SystemDController) NeedsUpdate(r *api.Device) bool {

--- a/internal/agent/controller/systeminfo.go
+++ b/internal/agent/controller/systeminfo.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/google/cadvisor/fs"
 	"github.com/google/cadvisor/machine"
@@ -13,7 +12,6 @@ import (
 )
 
 type SystemInfoController struct {
-	agent      *agent.DeviceAgent
 	tpmChannel *tpm.TPM
 
 	systemInfo *api.DeviceSystemInfo
@@ -21,10 +19,6 @@ type SystemInfoController struct {
 
 func NewSystemInfoController(tpmChannel *tpm.TPM) *SystemInfoController {
 	return &SystemInfoController{tpmChannel: tpmChannel}
-}
-
-func (c *SystemInfoController) SetDeviceAgent(a *agent.DeviceAgent) {
-	c.agent = a
 }
 
 func (c *SystemInfoController) NeedsUpdate(r *api.Device) bool {

--- a/internal/agent/enrollment.go
+++ b/internal/agent/enrollment.go
@@ -84,7 +84,7 @@ func (a *DeviceAgent) writeQRBanner(message, url string) error {
 	fmt.Fprintf(buffer, message, url)
 
 	// duplicate file to /etc/issue.d/flightctl-banner.issue
-	if err := os.WriteFile("/etc/issue.d/flightctl-banner.issue", buffer.Bytes(), os.FileMode(0666)); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/flightctl-banner.issue", a.issueDir), buffer.Bytes(), os.FileMode(0666)); err != nil {
 		return fmt.Errorf("writeQRBanner: %w", err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -36,7 +37,7 @@ type Server struct {
 	cfg    *config.Config
 	store  store.Store
 	ca     *crypto.CA
-	lister net.Listener
+	listener net.Listener
 }
 
 // New returns a new instance of a flightctl server.
@@ -52,7 +53,7 @@ func New(
 		cfg:    cfg,
 		store:  store,
 		ca:     ca,
-		lister: listener,
+		listener: listener,
 	}
 }
 
@@ -106,8 +107,8 @@ func (s *Server) Run() error {
 		taskManager.Stop()
 	}()
 
-	s.log.Printf("Listening on %s...", s.lister.Addr().String())
-	if err := srv.Serve(s.lister); err != nil && err != http.ErrServerClosed {
+	s.log.Printf("Listening on %s...", s.listener.Addr().String())
+	if err := srv.Serve(s.listener); err != nil && !errors.Is(err, net.ErrClosed) {
 		return err
 	}
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -8,15 +8,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
-
 	"github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/server"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/server"
+	"github.com/flightctl/flightctl/internal/store"
+)
+
+const (
+	caCertValidityDays          = 365 * 10
+	serverCertValidityDays      = 365 * 1
+	clientBootStrapValidityDays = 365 * 1
+	signerCertName              = "ca"
+	serverCertName              = "server"
+	clientBootstrapCertName     = "client-enrollment"
+)
+
+// NewTestServer creates a new test server and returns the server and the listener listening on localhost's next available port.
+func NewTestServer(t testing.TB, log logrus.FieldLogger, cfg *config.Config, store store.Store, ca *crypto.CA, serverCerts *crypto.TLSCertificateConfig) (*server.Server, net.Listener) {
+	t.Helper()
+	require := require.New(t)
+	// create a listener using the next available port
+	tlsConfig, err := crypto.TLSConfigForServer(ca.Config, serverCerts)
+	require.NoError(err)
+
+	// create a listener using the next available port
+	listener, err := server.NewTLSLister("", tlsConfig)
+	require.NoError(err)
+
+	return server.New(log, cfg, store, ca, listener), listener
+}
+
+// NewTestStore creates a new test store and returns the store and the database name.
+func NewTestStore(t testing.TB, cfg config.Config, log *logrus.Logger) (store.Store, string) {
+	t.Helper()
+
+	require := require.New(t)
+	// cfg.Database.Name = ""
+	dbTemp, err := store.InitDB(&cfg)
+	require.NoError(err)
+	defer store.CloseDB(dbTemp)
+
+	randomDBName := fmt.Sprintf("_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
+	t.Logf("DB name: %s", randomDBName)
+	dbTemp = dbTemp.Exec(fmt.Sprintf("CREATE DATABASE %s;", randomDBName))
+	require.NoError(dbTemp.Error)
+
+	cfg.Database.Name = randomDBName
+	db, err := store.InitDB(&cfg)
+	require.NoError(err)
+
+	store := store.NewStore(db, log.WithField("pkg", "store"))
+	err = store.InitialMigration()
+	require.NoError(err)
+
+	return store, randomDBName
+}
+
+// NewTestCerts creates new test certificates in the service certstore and returns the CA, server certificate, and client certificate.
+func NewTestCerts(t testing.TB, cfg *config.Config) (*crypto.CA, *crypto.TLSCertificateConfig, *crypto.TLSCertificateConfig) {
+	t.Helper()
+
+	require := require.New(t)
+	ca, _, err := crypto.EnsureCA(filepath.Join(cfg.Service.CertStore, "ca.crt"), filepath.Join(cfg.Service.CertStore, "ca.key"), "", "ca", caCertValidityDays)
+	require.NoError(err)
+
+	// default certificate hostnames to localhost if nothing else is configured
+	if len(cfg.Service.AltNames) == 0 {
+		cfg.Service.AltNames = []string{"localhost", "127.0.0.1"}
+	}
+
+	serverCerts, _, err := ca.EnsureServerCertificate(filepath.Join(cfg.Service.CertStore, "server.crt"), filepath.Join(cfg.Service.CertStore, "server.key"), cfg.Service.AltNames, serverCertValidityDays)
+	require.NoError(err)
+
+	clientCerts, _, err := ca.EnsureClientCertificate(filepath.Join(cfg.Service.CertStore, "client-enrollment.crt"), filepath.Join(cfg.Service.CertStore, "client-enrollment.key"), clientBootstrapCertName, clientBootStrapValidityDays)
+	require.NoError(err)
+
+	return ca, serverCerts, clientCerts
+}
+
+// NewClient creates a new client with the given server URL and certificates.
+func NewClient(serverUrl string, caCert, clientCert *crypto.TLSCertificateConfig) (*client.ClientWithResponses, error) {
+	tlsConfig, err := crypto.TLSConfigForClient(caCert, clientCert)
+	if err != nil {
+		return nil, fmt.Errorf("creating TLS config: %v", err)
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+	return client.NewClientWithResponses(serverUrl, client.WithHTTPClient(httpClient))
+}


### PR DESCRIPTION
This PR adds a new utils package in test/utils and implements an example test that exercises the agent enrollment e2e. The idea is that these tests can be run locally requiring only a postgres container. This is extremely valuable as it allows you to debug the client, server and agent with dlv.

Depends on #87 

TODO: move all existing tests to use testutils.

Also need to tweak the action to use `go test ./...` which runs all ginko and other golang tests  