### PR TITLE
MGMT-16972 Deploy via kind+helm

### DIFF
--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -9,9 +9,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
+
 jobs:
   # This line defines a job with the ID `check-links` that is stored within the `jobs` key.
-  podman-smoke-test:
+  kind-cluster:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -27,24 +28,18 @@ jobs:
           go install gotest.tools/gotestsum@latest
           go get -u github.com/proglottis/gpgme
 
-      - name: Install podman-compose
-        run: pip3 install podman-compose
-
-      - name: Install podman 4
-        run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-              https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
-
+      - name: Create cluster
+        run: make cluster
+      
       - name: Deploy
-        run: make build deploy
+        run: make deploy
+
+      - name: Check
+        run: |
+          kubectl get pods --all-namespaces
+
+      - name: Make the cmdline tool
+        run: make build
 
       - name: Apply device
         run: bin/flightctl apply -f examples/device.yaml

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -26,22 +26,8 @@ jobs:
           go install gotest.tools/gotestsum@latest
           go get -u github.com/proglottis/gpgme
 
-      # used to deploy the database container during unit testing
-      - name: Install podman 4
-        run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-              https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
-
-      - name: Install podman-compose
-        run: pip3 install podman-compose
+      - name: Deploy DB with helm and kind
+        run: make deploy-db-helm
 
       - name: Running Unit tests
-        run: make unit-test
+        run: make run-unit-test

--- a/README.md
+++ b/README.md
@@ -36,20 +36,13 @@ export PGSQL_IMAGE=registry.redhat.io/rhel8/postgresql-12
 podman login registry.redhat.io
 ```
 
-
-Start the Flight Control database:
-
+The service can be deployed locally in kind with the following command:
 ```
-podman-compose -f deploy/podman/compose.yaml up
+make deploy
 ```
 
-Start the Flight Control API server:
-
-```
-bin/flightctl-server
-```
-
-Note it stores its generated CA cert, server cert, and client-bootstrap cert in `$HOME/.flightctl/certs`.
+Note it stores its generated CA cert, server cert, and client-bootstrap cert in `$HOME/.flightctl/certs`
+and the client configuration in `$HOME/.flightctl/config.yaml`.
 
 Use the `flightctl` CLI to apply, get, or delete resources:
 
@@ -62,6 +55,21 @@ Use the `devicesimulator` to simulate load from devices:
 
 ```
 bin/devicesimulator --count=100
+```
+
+## Running the server locally
+For development purposes it can be useful to run the database in a container in kind, and
+the server locally. To do this, first start the database:
+
+```
+make deploy-db
+```
+
+Then start the server:
+
+```
+rm $HOME/.flightctl/client.yaml
+bin/flightctl-server
 ```
 
 ## Metrics

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -1,0 +1,30 @@
+cluster:
+	./hack/install_kind.sh
+	kind get clusters | grep kind || ./hack/create_cluster.sh
+
+clean-cluster:
+	kind delete cluster
+
+deploy: flightctl-server-container cluster deploy-helm
+
+deploy-helm:
+	kubectl config set-context kind-kind
+	hack/install_helm.sh
+	hack/deploy_with_helm.sh
+
+deploy-db-helm: cluster
+	hack/deploy_with_helm.sh --only-db
+
+deploy-db:
+	podman rm -f flightctl-db || true
+	podman volume rm podman_flightctl-db || true
+	podman volume create --opt device=tmpfs --opt type=tmpfs --opt o=nodev,noexec podman_flightctl-db
+	cd deploy/podman && podman-compose up -d flightctl-db
+	hack/wait_for_postgres.sh podman
+	podman exec -it flightctl-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
+	podman exec -it flightctl-db createdb admin || true
+
+kill-db:
+	cd deploy/podman && podman-compose down flightctl-db
+
+.PHONY: deploy-db deploy cluster run-db-container kill-db-container

--- a/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
@@ -32,6 +32,7 @@ spec:
             - name: POSTGRESQL_USER
               value: {{ .Values.flightctl.db.user }}
           image: {{ .Values.flightctl.db.image }}
+          imagePullPolicy: {{ .Values.flightctl.db.imagePullPolicy }}
           name: flightctl-db
           ports:
             - containerPort: 5432

--- a/deploy/helm/flightctl/templates/flightctl-db-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-service.yaml
@@ -6,9 +6,15 @@ metadata:
   name: flightctl-db
   namespace: {{ .Values.flightctl.db.namespace }}
 spec:
+  {{ if .Values.flightctl.db.nodePort }}
+  type: NodePort
+  {{ end }}
   ports:
     - name: "5432"
       port: 5432
       targetPort: 5432
+      {{ if .Values.flightctl.db.nodePort }}
+      nodePort: {{ .Values.flightctl.db.nodePort }}
+      {{ end }}
   selector:
     flightctl.service: flightctl-db

--- a/deploy/helm/flightctl/templates/flightctl-server-certs-persistentvolumeclaim.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-certs-persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.server.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,4 +19,4 @@ spec:
   resources:
     requests:
       storage: 128Mi
-
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-server-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-config.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.server.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,9 +15,10 @@ data:
         password: {{ .Values.flightctl.db.masterPassword }}   # we should funnel this via secrets instead
     service:
         address: :3333
-        baseUrl: https://{{ .Values.flightctl.server.hostName }}:3333/api
+        baseUrl: https://{{ .Values.flightctl.server.hostName }}:3333/
         altNames:
           - {{ .Values.flightctl.server.hostName }}
           - flightctl-server
           - flightctl-server.{{ .Values.flightctl.server.namespace }}
           - flightctl-server.{{ .Values.flightctl.server.namespace }}.svc.cluster.local
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.server.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,7 +29,7 @@ spec:
             - containerPort: 3333
               protocol: TCP
           volumeMounts:
-            - mountPath: /root/.flightctl/certs
+            - mountPath: /root/.flightctl/
               name: flightctl-server-certs
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-server-config
@@ -43,3 +44,4 @@ spec:
         - name: flightctl-server-config
           configMap:
             name: flightctl-server-config
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-server-route.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-route.yaml
@@ -1,3 +1,5 @@
+{{ if and (.Values.flightctl.server.enabled) (not .Values.flightctl.server.nodePort) }}
+
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -19,3 +21,5 @@ spec:
     name: flightctl-server
     weight: 100
   wildcardPolicy: None
+
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-server-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.server.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,10 +7,16 @@ metadata:
   name: flightctl-server
   namespace: {{ .Values.flightctl.server.namespace }}
 spec:
+  {{ if .Values.flightctl.db.nodePort }}
+  type: NodePort
+  {{ end }}
   ports:
-    - name: "3333"
+    - name: "flightctl-api"
       port: 3333
       targetPort: 3333
+      {{ if .Values.flightctl.server.nodePort }}
+      nodePort: {{ .Values.flightctl.server.nodePort }}
+      {{ end }}
   selector:
     flightctl.service: flightctl-server
-
+{{ end }}

--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -1,0 +1,12 @@
+flightctl:
+  db:
+    nodePort: 5432 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
+    imagePullPolicy: IfNotPresent
+  server:
+    image: localhost/flightctl-server:latest
+    imagePullPolicy: IfNotPresent
+    hostName: localhost
+    nodePort: 3333 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
+
+storageClassName: standard
+storageClassNameRWM: standard

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -2,17 +2,18 @@ flightctl:
   db:
     namespace: flightctl-internal
     image: quay.io/cloudservices/postgresql-rds:12-9ee2984
+    imagePullPolicy: Always
     password: adminpass
     masterPassword: adminpass
     masterUser: admin
     user: demouser
     userPassword: demopass
   server:
+    enabled: true
     namespace: flightctl-external
     image: quay.io/flightctl/flightctl-server:latest
     imagePullPolicy: Always
     hostName: api.flightctl.example.com
-
 
 storageClassName: aws-ebs
 storageClassNameRWM: aws-efs-tier-c4

--- a/deploy/podman/compose.yaml
+++ b/deploy/podman/compose.yaml
@@ -51,18 +51,6 @@ services:
       - flightctl-network
     restart: unless-stopped
 
-  flightctl-server:
-    container_name: flightctl-server
-    image: localhost/flightctl-server:latest
-    ports:
-      - "3333:3333"
-    restart: unless-stopped
-    volumes:
-      - flightctl-server-certs:/root/.flightctl/certs/
-      - ./config.yaml:/root/.flightctl/config.yaml
-    networks:
-      - flightctl-network
-
   flightctl-auth:
     container_name: flightctl-auth
     image: quay.io/keycloak/keycloak
@@ -90,7 +78,6 @@ services:
 
 volumes:
   flightctl-db:
-  flightctl-server-certs:
   flightctl-auth-db:
   flightctl-auth:
   config:

--- a/examples/repository.yaml
+++ b/examples/repository.yaml
@@ -3,6 +3,4 @@ kind: Repository
 metadata:
   name: defaultRepo
 spec:
-  repo: https://github.com/flightctl/flightctl.git
-  username: myuser
-  password: mypassword
+  repo: https://github.com/flightctl/flightctl-demos.git

--- a/hack/create_cluster.sh
+++ b/hack/create_cluster.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+kind create cluster --config hack/kind_cluster.yaml
+
+echo ""

--- a/hack/deploy_with_helm.sh
+++ b/hack/deploy_with_helm.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -x
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+METHOD=install
+ONLY_DB=
+NO_AUTH=
+
+# Use external getopt for long options
+options=$(getopt -o adh --long only-db,no-auth,help -n "$0" -- "$@")
+eval set -- "$options"
+
+while true; do
+  case "$1" in
+    -a|--only-db) ONLY_DB="--set flightctl.server.enabled=false" ; shift ;;
+    -d|--no-auth) NO_AUTH="--set flightctl.keycloak.enabled=false"; shift ;;
+    -h|--help) echo "Usage: $0 [--only-db] [--no-auth]"; exit 0 ;;
+    --) shift; break ;;
+    *) echo "Invalid option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# if we have an existing deployment, try to upgrade it instead
+if helm list --kube-context kind-kind -A | grep flightctl > /dev/null; then
+  METHOD=upgrade
+fi
+
+# helm expects the namespaces to exist, and creating namespaces
+# inside the helm charts is not recommended.
+kubectl create namespace flightctl-external --context kind-kind 2>/dev/null || true
+kubectl create namespace flightctl-internal --context kind-kind 2>/dev/null || true
+
+# if we are only deploying the database, we don't need inject the server container
+if [ -z "$ONLY_DB" ]; then
+  # In github CI, kind gets confused and tries to pull the image from docker instead
+  # of podman, so if regular docker-image fails we need to:
+  #   * save it to OCI image format
+  #   * then load it into kind
+  if ! kind load docker-image localhost/flightctl-server:latest; then
+    podman save localhost/flightctl-server:latest -o flightctl-server.tar && \
+    kind load image-archive flightctl-server.tar
+  fi
+fi
+
+# if we need another database image we can set it with PGSQL_IMAGE (i.e. arm64 images)
+if [ ! -z "$PGSQL_IMAGE" ]; then
+  DB_IMG="localhost/flightctl-db:latest"
+  # we send the image directly to kind, so we don't need to inject the credentials in the kind cluster
+  podman pull "${PGSQL_IMAGE}"
+  podman tag "${PGSQL_IMAGE}" "${DB_IMG}"
+  kind load docker-image "${DB_IMG}"
+  DB_IMG="--set flightctl.db.image=${DB_IMG}"
+fi
+
+helm ${METHOD} --values ./deploy/helm/flightctl/values.kind.yaml ${ONLY_DB} ${NO_AUTH} ${DB_IMG} flightctl \
+              ./deploy/helm/flightctl/ --kube-context kind-kind 
+
+"${SCRIPT_DIR}"/wait_for_postgres.sh
+
+# Make sure the database is usable from the unit tests
+DB_POD=$(kubectl get pod -n flightctl-internal -L flightctl.service=flightctl-db --no-headers -o custom-columns=":metadata.name" --context kind-kind )
+kubectl exec -n flightctl-internal --context kind-kind "${DB_POD}" -- psql -c 'ALTER ROLE admin WITH SUPERUSER'
+kubectl exec -n flightctl-internal --context kind-kind "${DB_POD}" -- createdb admin 2>/dev/null|| true
+
+
+if [ -z "$ONLY_DB" ]; then
+  mkdir -p  ~/.flightctl/certs
+
+  # Extract .fligthctl files from the server pod, but we must wait for the server to be ready
+
+  kubectl rollout status deployment flightctl-server -n flightctl-external -w --timeout=300s --context kind-kind
+
+  # we actually don't need to download the ca.key or server.key but apparently the flightctl
+  # client expects them to be present TODO: fix this in flightctl
+  SRV_POD=$(kubectl get pod -n flightctl-external -L flightctl.service=flightctl-server --no-headers -o custom-columns=":metadata.name" --context kind-kind )
+
+  # wait for the server to write the client.yaml file
+  until kubectl exec -n flightctl-external "${SRV_POD}" --context kind-kind  -- cat /root/.flightctl/client.yaml > /dev/null 2>&1;
+  do
+    sleep 1;
+  done
+
+  # pull agent-usable details as well as client configuration file
+  for f in certs/{ca.crt,client-enrollment.crt,client-enrollment.key} client.yaml; do
+    # a kubectl cp would be more efficient, but tar is not available on the image, and we don't want
+    # to switch from ubi9-micro just for tar
+    kubectl exec -n flightctl-external "${SRV_POD}" --context kind-kind  -- cat /root/.flightctl/$f > ~/.flightctl/$f
+  done
+
+  chmod og-rwx ~/.flightctl/certs/*.key
+fi

--- a/hack/install_helm.sh
+++ b/hack/install_helm.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+which helm 2>/dev/null 1>/dev/null
+if [ $? -eq 0 ]; then
+    echo "Helm already installed"
+    exit 0
+fi
+
+# Get the remote shell script and make sure it's the one we expect, inside the script there is also
+# verification of the downloaded binaries
+curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/0d0f91d1ce277b2c8766cdc4c7aa04dbafbf2503/scripts/get-helm-3
+echo "6701e269a95eec0a5f67067f504f43ad94e9b4a52ec1205d26b3973d6f5cb3dc  /tmp/get_helm.sh" | sha256sum --check || exit 1
+chmod a+x /tmp/get_helm.sh
+/tmp/get_helm.sh
+
+rm /tmp/get_helm.sh

--- a/hack/install_kind.sh
+++ b/hack/install_kind.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+KIND_VERSION=0.22.0
+
+EXISTING_VERSION=$(kind version 2>&1 | awk '{print $2}' | sed 's/v//')
+
+if [ "$EXISTING_VERSION" == "$KIND_VERSION" ]; then
+     echo "Kind v${KIND_VERSION} already installed"
+else
+    echo "Installing kind v${KIND_VERSION}"
+    # Install kind
+    go install sigs.k8s.io/kind@v${KIND_VERSION}
+    sudo cp $(go env GOPATH)/bin/kind /usr/local/bin
+fi
+
+if which systemctl; then
+
+    if [ -f /etc/systemd/system/user@.service.d/delegate.conf ]; then
+        echo "Kind systemd rootless already configured" && exit 0
+    else
+        echo "Configuring Kind for rootless operation in Linux"
+        # Enable rootless Kind, see https://kind.sigs.k8s.io/docs/user/rootless/
+        sudo mkdir -p /etc/systemd/system/user@.service.d
+        cat << EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf > /dev/null
+[Service]
+Delegate=yes
+EOF
+
+        sudo systemctl daemon-reload
+    fi
+fi
+

--- a/hack/kind_cluster.yaml
+++ b/hack/kind_cluster.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  apiServer:
+    extraArgs:
+      "service-node-port-range": "3000-32767"
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 3333
+    hostPort: 3333
+    protocol: TCP
+  - containerPort: 5432
+    hostPort: 5432
+    protocol: TCP

--- a/hack/wait_for_postgres.sh
+++ b/hack/wait_for_postgres.sh
@@ -2,16 +2,26 @@
 
 set -euo pipefail
 
+DB_NAMESPACE=flightctl-internal
 PG_USER=admin
 PG_DATABASE=flightctl
 PG_HOST=127.0.0.1
 PG_PORT=5432
 export PGPASSWORD=adminpass
 
-set -x
+METHOD=${1:-"kubectl"}
 
-if [ -x "$(command -v pg_isready)" ]; then
+if [ "$METHOD" == "podman" ];
+then
     until podman exec flightctl-db pg_isready -U ${PG_USER} --dbname ${PG_DATABASE} --host ${PG_HOST} --port ${PG_PORT}; do sleep 1; done
 else
-    until podman exec flightctl-db psql -h ${PG_HOST} -U ${PG_USER} -d ${PG_DATABASE} -c "select 1" > /dev/null 2>&1; do sleep 1; done
+    echo "Waiting for postgress deployment to be ready"
+    kubectl rollout status deployment flightctl-db -n ${DB_NAMESPACE} -w --timeout=300s
+
+    DB_POD=$(kubectl get pod -n ${DB_NAMESPACE} -L flightctl.service=flightctl-db --no-headers -o custom-columns=":metadata.name" --context kind-kind )
+    set -x
+    until kubectl exec --context kind-kind -n ${DB_NAMESPACE} ${DB_POD} -- psql -h ${PG_HOST} -U ${PG_USER} -d ${PG_DATABASE} -c "select 1" > /dev/null 2>&1;
+    do
+        sleep 1;
+    done
 fi


### PR DESCRIPTION
This pull request moves the deployment of flightctl-server and db to use the existing
helm charts which have been tuned to allow conditional deployment in kind, and conditional deployment of the server.

This also adds the capability for the flightctl cmdline to use other servers based on the ~/.fligthctl/client.yaml config

Other services like keycloak, or metrics also need to be deployed with helm, but that will be addressed in a follow up patch as this one is already lengthy enough.