### PR TITLE
NO-ISSUE: Dependabot commit prefix and docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,20 @@ updates:
         patterns:
           - "github.com/onsi/ginkgo"
           - "github.com/onsi/gomega"
+    commit-message:
+      prefix: "NO-ISSUE"
 
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "NO-ISSUE"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "NO-ISSUE"


### PR DESCRIPTION
This PR adds a prefix of `NO-ISSUE` to dependabot commits.
In addition, added docker ecosystem to scan containerfiles.