### PR TITLE
MGMT-16972 Avoid rebuilding the server container every time we deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,12 @@ lint: tools
 build: bin
 	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
-flightctl-server-container:
+# rebuild container only on source changes
+bin/.flightctl-server-container: bin Containerfile go.mod go.sum $(shell find ./ -name "*.go" -not -path "./packaging/*")
 	podman build -f Containerfile -t flightctl-server:latest
+	touch bin/.flightctl-server-container
+
+flightctl-server-container: bin/.flightctl-server-container
 
 deploy-db:
 	cd deploy/podman && podman-compose up -d flightctl-db


### PR DESCRIPTION
We introduce an intermediate empty target that depends on go.mod,
go.sum and the go files of the project.

The rebuild has become more evident during the work to deploy with kind+helm.