### PR TITLE
NO-ISSUE: Makefile: fix override of GO_UNITTEST_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,13 @@ VERBOSE ?= false
 REPORTS ?= $(ROOT_DIR)/reports
 
 GO_TEST_FORMAT = pkgname
+GO_UNITTEST_FLAGS = -count=1 -race -coverprofile=$(REPORTS)/coverage.out $(GO_BUILD_FLAGS) ./...
 ifeq ($(VERBOSE), true)
-        GO_TEST_FORMAT=standard-verbose
+	GO_TEST_FORMAT=standard-verbose
+	GO_UNITTEST_FLAGS += -v
 endif
 
-GINKGO_REPORTFILE := $(or $(GINKGO_REPORTFILE), ./junit_unit_test.xml)
-GO_UNITTEST_FLAGS = --format=$(GO_TEST_FORMAT) $(GOTEST_PUBLISH_FLAGS) -- -count=1 -coverprofile=coverage.out $(GO_BUILD_FLAGS)
-GINKGO_UNITTEST_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo.v -ginkgo.reportFile=$(GINKGO_REPORTFILE)
-GO_UNITTEST_FLAGS=-race
+GO_TEST_FLAGS := --format=$(GO_TEST_FORMAT) --junitfile $(REPORTS)/junit_unit_test.xml $(GOTEST_PUBLISH_FLAGS)
 
 .EXPORT_ALL_VARIABLES:
 
@@ -104,7 +103,7 @@ clean:
 	- rm -f -r debian
 
 _unit_test: $(REPORTS)
-	gotestsum -- $(GO_UNITTEST_FLAGS) -timeout $(TIMEOUT) ./... || ($(MAKE) _post_unit_test && /bin/false)
+	gotestsum $(GO_TEST_FLAGS) -- $(GO_UNITTEST_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _post_unit_test && /bin/false)
 	$(MAKE) _post_unit_test
 
 _post_unit_test: $(REPORTS)


### PR DESCRIPTION
This PR fixes a bug where a test overide to `GO_UNITTEST_FLAGS` with -race flag was committed. It also cleans up the population of the `coverprofile` and  `junitfile` artifacts into the the reports directory. The Ginkgo specific ENV have been removed for now as they are run directly by gotestsum. In the future we can use full ginkgo test invocation for e2e tests.