### PR TITLE
NO-ISSUE: Include public ca-certificates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,12 @@ COPY ./ .
 USER 0
 RUN make build
 
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+RUN microdnf update --nodocs -y  && microdnf install ca-certificates --nodocs -y
+
 FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 COPY --from=build /app/bin/flightctl-server .
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+
 CMD ./flightctl-server


### PR DESCRIPTION
The ubi-micro is really small but does not contain the ca-certificates package.

This is necessary to authenticate public git servers contacted from the flightctl-server, otherwise it is impossible for our server to validate the TLS cert from github.com i.e.

Co-Authored-by: Mario Parra de Miguel <mparrade@redhat.com>