### PR TITLE
Pass down the enrollmentUIEndpoint to agent controller

### DIFF
--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -58,6 +58,7 @@ func NewController(
 		enrollmentClient:         enrollmentClient,
 		enrollmentVerifyBackoff:  enrollmentVerifyBackoff,
 		enrollmentServerEndpoint: enrollmentServerEndpoint,
+		enrollmentUIEndpoint:     enrollmentUIEndpoint,
 		caFilePath:               caFilePath,
 		managementServerEndpoint: managementServerEndpoint,
 		managementCertFilePath:   managementCertFilePath,


### PR DESCRIPTION
Without this the code responsible for writing the enrollment banner to /etc/issue.d/flightctl-banner.issue will not work, assuming that we are using the device simulator.