### PR TITLE
MGMT-17100: Fix enrolled device reboot crash

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -80,7 +80,7 @@ func TestDeviceAgent(t *testing.T) {
 
 	var deviceName string
 	// wait for the enrollment request to be created
-	err = wait.PollInfinite(100*time.Millisecond, func() (bool, error) {
+	err = wait.PollImmediate(100*time.Millisecond, 120*time.Second, func() (bool, error) {
 		listResp, err := client.ListEnrollmentRequestsWithResponse(ctx, &v1alpha1.ListEnrollmentRequestsParams{})
 		if err != nil {
 			return false, err
@@ -106,7 +106,7 @@ func TestDeviceAgent(t *testing.T) {
 	require.NoError(err)
 
 	// wait for the enrollment request to be approved
-	err = wait.PollInfinite(100*time.Millisecond, func() (bool, error) {
+	err = wait.PollImmediate(100*time.Millisecond, 120*time.Second, func() (bool, error) {
 		listResp, err := client.ListEnrollmentRequestsWithResponse(ctx, &v1alpha1.ListEnrollmentRequestsParams{})
 		if err != nil {
 			return false, err
@@ -137,7 +137,7 @@ func TestDeviceAgent(t *testing.T) {
 	require.NoError(err)
 
 	// wait for the device config to be written
-	err = wait.PollInfinite(100*time.Millisecond, func() (bool, error) {
+	err = wait.PollImmediate(100*time.Millisecond, 120*time.Second, func() (bool, error) {
 		_, err := os.Stat(filepath.Join(testDirPath, "/etc/motd"))
 		if err != nil && os.IsNotExist(err) {
 			return false, nil

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -79,6 +79,14 @@ func (c *Controller) Sync(ctx context.Context, device v1alpha1.Device) error {
 		return err
 	}
 
+	// create the management client now that we are properly bootstrapped
+	if managementHTTPClient, err := client.NewWithResponses(c.managementServerEndpoint,
+		c.caFilePath, c.managementCertFilePath, c.agentKeyFilePath); err == nil {
+		c.managementClient = client.NewManagement(managementHTTPClient)
+	} else {
+		return fmt.Errorf("failed to create management client: %w", err)
+	}
+
 	// ensure the device configuration is reconciled
 	if err := c.ensureConfig(ctx, &device); err != nil {
 		updateErr := c.updateStatus(ctx, &device, err.Error())

--- a/internal/agent/device/writer/writer.go
+++ b/internal/agent/device/writer/writer.go
@@ -75,7 +75,7 @@ func (w *Writer) WriteIgnitionFiles(files ...ign3types.File) error {
 
 // WriteFile writes the provided data to the file at the path with the provided permissions
 func (w *Writer) WriteFile(name string, data []byte, perm fs.FileMode) error {
-	return os.WriteFile(w.rootDir+name, []byte{}, 0)
+	return os.WriteFile(filepath.Join(w.rootDir, name), data, perm)
 }
 
 // writeFileAtomically uses the renameio package to provide atomic file writing, we can't use renameio.WriteFile


### PR DESCRIPTION
The manager client is only initialized for the agent controller only on bootstrap. Subsequent boots won't initialize the reference neither will print the management QR. This commit fixes the issue.