### PR TITLE
MGMT-17100 Convert agent tests into Ginkgo

### DIFF
--- a/internal/agent/testdata/device.yaml
+++ b/internal/agent/testdata/device.yaml
@@ -18,7 +18,7 @@ spec:
             - contents:
                 source: >-
                   data:,This%20system%20is%20managed%20by%20flightctl.%0A
-              mode: 600
+              mode: 0600
               overwrite: true
               path: "/etc/motd"
   systemd:


### PR DESCRIPTION
Refactor the tests into ginkgo before adding more tests.

This makes use of the test harness, and segments the features being tested, although it adds some level of repetition to what we execute on the tests, this helps isolate better why an specific test could be failing.