### PR TITLE
MGMT-17137: Add systemd notify to ensure enrollment QR is ready

### DIFF
--- a/packaging/systemd/flightctl-agent.service
+++ b/packaging/systemd/flightctl-agent.service
@@ -7,6 +7,7 @@ Before=getty@tty1.service
 [Service]
 ExecStart=/usr/bin/flightctl-agent
 Restart=always
+Type=notify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Flightctl-agent service notifies readiness way before the enrollment QR code is written in the issue directory. The systemd service is supposed to get active before getty, but it depends on the intervals from the config file.