### PR TITLE
MGMT-17053: Fix device labels on EnrollmentRequest approval

### DIFF
--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -44,6 +44,7 @@ func approveAndSignEnrollmentRequest(ca *crypto.CA, enrollmentRequest *api.Enrol
 	enrollmentRequest.Status = &api.EnrollmentRequestStatus{
 		Certificate: util.StrToPtr(string(certData)),
 		Conditions:  &[]api.Condition{},
+		Approval:    approval,
 	}
 	condition := api.Condition{
 		Type:    api.EnrollmentRequestApproved,


### PR DESCRIPTION
This fix ensures that device has the requested labels and adds E2E regression tests.