### PR TITLE
MGMT-17157: Fixed an issue where owner was not set via RS task

### DIFF
--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -163,13 +163,12 @@ func (s *FleetStore) createOrUpdateTx(tx *gorm.DB, orgId uuid.UUID, resource *ap
 	}
 	fleet.OrgID = orgId
 
-	// don't overwrite status, generation, or owner
+	// don't overwrite status and generation
 	fleet.Status = nil
 	fleet.Generation = nil
 	if fleet.Spec != nil && fleet.Spec.Data.Template.Metadata != nil {
 		fleet.Spec.Data.Template.Metadata.Generation = nil
 	}
-	fleet.Owner = nil
 
 	var existingRecord *model.Fleet
 

--- a/internal/tasks/resourcesync_test.go
+++ b/internal/tasks/resourcesync_test.go
@@ -82,6 +82,7 @@ var _ = Describe("ResourceSync", Ordered, func() {
 			rs := model.ResourceSync{
 				Resource: model.Resource{
 					Generation: util.Int64ToPtr(1),
+					Name:       *util.StrToPtr("rs"),
 				},
 				Spec: &model.JSONField[api.ResourceSyncSpec]{
 					Data: api.ResourceSyncSpec{
@@ -120,7 +121,7 @@ var _ = Describe("ResourceSync", Ordered, func() {
 			Expect(err).To(HaveOccurred())
 		})
 		It("parse fleet", func() {
-			owner := util.StrToPtr("ResourceSync/foo")
+			owner := util.SetResourceOwner(model.ResourceSyncKind, "foo")
 
 			genericResources, err := resourceSync.extractResourcesFromFile(memfs, "/examples/fleet.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -149,18 +150,18 @@ var _ = Describe("ResourceSync", Ordered, func() {
 		})
 
 		It("delta calc", func() {
-			owner := "ResourceSync/foo"
+			owner := util.SetResourceOwner(model.ResourceSyncKind, "foo")
 			ownedFleets := []api.Fleet{
 				{
 					Metadata: api.ObjectMeta{
 						Name:  util.StrToPtr("fleet-1"),
-						Owner: util.StrToPtr(owner),
+						Owner: owner,
 					},
 				},
 				{
 					Metadata: api.ObjectMeta{
 						Name:  util.StrToPtr("fleet-2"),
-						Owner: util.StrToPtr(owner),
+						Owner: owner,
 					},
 				},
 			}


### PR DESCRIPTION
We can safely remove the `owner=nil` line in the store, since we do the same thing at the API layer to prevent users from overwriting the owner.