### PR TITLE
MGMT-17158: Fixed a crash in fleet store

### DIFF
--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -214,10 +214,10 @@ func (s *FleetStore) createOrUpdateTx(tx *gorm.DB, orgId uuid.UUID, resource *ap
 				fleet.Generation = existingRecord.Generation
 			}
 
+			if fleet.Spec.Data.Template.Metadata == nil {
+				fleet.Spec.Data.Template.Metadata = &api.ObjectMeta{}
+			}
 			if !sameTemplateSpec {
-				if fleet.Spec.Data.Template.Metadata == nil {
-					fleet.Spec.Data.Template.Metadata = &api.ObjectMeta{}
-				}
 				if existingRecord.Spec.Data.Template.Metadata.Generation == nil {
 					fleet.Spec.Data.Template.Metadata.Generation = util.Int64ToPtr(1)
 				} else {

--- a/internal/tasks/resourcesync.go
+++ b/internal/tasks/resourcesync.go
@@ -177,6 +177,7 @@ func (r *ResourceSync) parseAndValidateResources(rs *model.ResourceSync, repo *m
 		r.log.Infof("resourcesync/%s: No new commits or path. skipping", rs.Name)
 		return nil, nil
 	}
+	addSyncedCondition(rs, fmt.Errorf("out of sync"))
 
 	rs.Status.Data.ObservedCommit = util.StrToPtr(hash)
 


### PR DESCRIPTION
Fixed `panic: runtime error: invalid memory address or nil pointer dereference` that was causing fleets and RS to get out of sync. (@ [line](https://github.com/flightctl/flightctl/compare/main...sagidayan:MGMT-17158?expand=1#diff-39dfd11e5d1a6f08d9547a94f24514780b031511e6465df7b64531bc59f06f89R227) )

Also, if sync needs to happen, we now set an "out of sync" condition to prevent false positive sync status when crashes or bugs like this happen in the future.

This "out of sync" status will ensure that the process continues in the next task iteration.