### PR TITLE
NO-ISSUE: Fix default data-dir does not exist

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,5 +1,9 @@
 flightctl (0.0.1) jammy; urgency=medium
 
+  * Adding default directory for runtime data
+
+ -- Ricardo Noriega <rnoriega@redhat.com> Wed, 13 Mar 2024 12:07:25 +0000
+
   * Initial ppa/deb packaging.
 
  -- Miguel Angel Ajo <majopela@redhat.com>  Tue, 13 Feb 2024 21:49:18 +0000

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -21,6 +21,8 @@ override_dh_auto_install:
 	cp bin/$(shell dpkg --print-architecture)/flightctl-agent debian/flightctl-agent/usr/bin/
 	cp bin/$(shell dpkg --print-architecture)/flightctl debian/flightctl-agent/usr/bin/
 
+	mkdir -p debian/flightctl-agent/var/lib/flightctl
+
 	dh_install
 
 	install -D -m 644 debian/flightctl-agent.service debian/flightctl-agent/lib/systemd/system/flightctl-agent.service

--- a/packaging/rpm/flightctl-agent.spec
+++ b/packaging/rpm/flightctl-agent.spec
@@ -2,7 +2,7 @@
 
 Name: flightctl-agent
 Version: 0.0.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Flightctl Agent
 
 License: XXX
@@ -36,6 +36,7 @@ make build
 
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
+mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
 cp bin/flightctl-agent %{buildroot}/usr/bin
 cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 
@@ -43,9 +44,11 @@ cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 %files
 /usr/bin/flightctl-agent
 /usr/lib/systemd/system/flightctl-agent.service
+%{_sharedstatedir}/flightctl
 
 %changelog
-
+* Wed Mar 13 2024 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-3
+- Adding default directory for runtime data
 * Wed Feb 7 2024 Miguel Angel Ajo Pelayo <majopela@redhat.com> - 0.0.1-2
 - Initial RPM building via packit for the flightctl agent
 * Mon Dec 11 2023 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-1


### PR DESCRIPTION
```
3T10:41:48Z" level=fatal msg="Error validating config: data-dir: path does not exist: /var/lib/flightctl" func=main.NewAgentCommand file="/builddir/b>
Main process exited, code=exited, status=1/FAILURE
```

Agent throws this error when using default data-dir. This should be fixed in packaging step.