### PR TITLE
NO-ISSUE: Gather client cert CN and create separate certs

### DIFF
--- a/cmd/flightctl-server/main.go
+++ b/cmd/flightctl-server/main.go
@@ -15,9 +15,11 @@ const (
 	caCertValidityDays          = 365 * 10
 	serverCertValidityDays      = 365 * 1
 	clientBootStrapValidityDays = 365 * 1
+	adminCertValidityDays       = 365 * 1
 	signerCertName              = "ca"
 	serverCertName              = "server"
 	clientBootstrapCertName     = "client-enrollment"
+	flightctlAdminCertificate   = "flightctl-admin"
 )
 
 func main() {
@@ -45,13 +47,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("ensuring server cert: %v", err)
 	}
-	clientCert, _, err := ca.EnsureClientCertificate(certFile(clientBootstrapCertName), keyFile(clientBootstrapCertName), clientBootstrapCertName, clientBootStrapValidityDays)
+
+	_, _, err = ca.EnsureClientCertificate(certFile(clientBootstrapCertName), keyFile(clientBootstrapCertName), crypto.ClientBootstrapCommonName, clientBootStrapValidityDays)
 	if err != nil {
 		log.Fatalf("ensuring bootstrap client cert: %v", err)
 	}
 
+	adminCert, _, err := ca.EnsureClientCertificate(certFile(flightctlAdminCertificate), keyFile(flightctlAdminCertificate), crypto.AdminCommonName, adminCertValidityDays)
+	if err != nil {
+		log.Fatalf("ensuring flightctl-admin client cert: %v", err)
+	}
 	// also write out a client config file
-	err = client.WriteConfig(config.ClientConfigFile(), cfg.Service.BaseUrl, "", ca.Config, clientCert)
+	err = client.WriteConfig(config.ClientConfigFile(), cfg.Service.BaseUrl, "", ca.Config, adminCert)
 	if err != nil {
 		log.Fatalf("writing client config: %v", err)
 	}

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -17,6 +17,8 @@ import (
 )
 
 // Wraps openshift/library-go/pkg/crypto to use ECDSA and simplify the interface
+const ClientBootstrapCommonName = "client-enrollment"
+const AdminCommonName = "flightctl-admin"
 
 type TLSCertificateConfig oscrypto.TLSCertificateConfig
 

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -263,7 +263,6 @@ func (ca *CA) MakeClientCertificate(certFile, keyFile string, subject string, ex
 
 	now := time.Now()
 	clientTemplate := &x509.Certificate{
-		Subject: pkix.Name{CommonName: subject},
 
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
 
@@ -277,6 +276,9 @@ func (ca *CA) MakeClientCertificate(certFile, keyFile string, subject string, ex
 
 		AuthorityKeyId: ca.Config.Certs[0].SubjectKeyId,
 		SubjectKeyId:   clientPublicKeyHash,
+	}
+	if subject != "" {
+		clientTemplate.Subject = pkix.Name{CommonName: subject}
 	}
 	clientCrt, err := ca.signCertificate(clientTemplate, clientPublicKey)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,143 @@
+package server_test
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/server"
+	"github.com/flightctl/flightctl/pkg/log"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server Suite")
+}
+
+var _ = Describe("Low level server behavior", func() {
+	var (
+		ca             *crypto.CA
+		enrollmentCert *crypto.TLSCertificateConfig
+		clientCert     *crypto.TLSCertificateConfig
+		noSubjectCert  *crypto.TLSCertificateConfig
+		listener       net.Listener
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir := GinkgoT().TempDir()
+		serverLog := log.InitLogs()
+		config := config.NewDefault()
+		config.Service.CertStore = tempDir
+
+		var serverCerts *crypto.TLSCertificateConfig
+
+		ca, serverCerts, enrollmentCert, clientCert, err = testutil.NewTestCerts(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		noSubjectCert, _, err = ca.EnsureClientCertificate(filepath.Join(tempDir, "no-subject.crt"), filepath.Join(tempDir, "no-subject.key"), "", 365)
+		Expect(err).NotTo(HaveOccurred())
+
+		tlsConfig, err := crypto.TLSConfigForServer(ca.Config, serverCerts)
+		Expect(err).ToNot(HaveOccurred())
+
+		// create a listener using the next available port
+		listener, err = server.NewTLSListener("", tlsConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		srv := server.NewHTTPServerWithTLSContext(testTLSCNServer{}, serverLog, listener.Addr().String())
+
+		go func() {
+			defer GinkgoRecover()
+			if err := srv.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		// close the listener, this will cause the server to stop
+		if listener != nil {
+			listener.Close()
+		}
+	})
+
+	Context("TLS client peer CommonName", func() {
+		It("should be included as context in the request for client bootstrap", func() {
+			dataStr := requestFromTLSCNServer(ca.Config, enrollmentCert, listener)
+			Expect(dataStr).To(Equal(crypto.ClientBootstrapCommonName))
+		})
+
+		It("should be included as context in the request for admin cert", func() {
+			dataStr := requestFromTLSCNServer(ca.Config, clientCert, listener)
+			Expect(dataStr).To(Equal(crypto.AdminCommonName))
+		})
+
+	})
+
+	Context("TLS client peer with no subject/common name", func() {
+		It("should not include a context in the request", func() {
+			requestFromTLSCNServerExpectNotFound(ca.Config, noSubjectCert, listener)
+		})
+	})
+
+})
+
+// testTLSCNServer is a simple http server that returns the TLS CommonName from the request context
+// if it exists, otherwise it returns a NotFound status code.
+type testTLSCNServer struct {
+}
+
+func (s testTLSCNServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	tlsCN := request.Context().Value(server.TLSCommonNameContextKey)
+	if tlsCN == nil {
+		// this should not really happen, this will make the tests fail
+		response.WriteHeader(http.StatusInternalServerError)
+	} else {
+		tlsCN := tlsCN.(string)
+		if tlsCN != "" {
+			response.WriteHeader(http.StatusOK)
+			_, err := response.Write([]byte(tlsCN))
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func requestFromTLSCNServer(caCert, clientCert *crypto.TLSCertificateConfig, listener net.Listener) string {
+	client, err := testutil.NewBareHTTPsClient(caCert, clientCert)
+	Expect(err).NotTo(HaveOccurred())
+
+	resp, err := client.Get("https://" + listener.Addr().String())
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	data := make([]byte, 1024)
+	n, err := resp.Body.Read(data)
+	Expect(err).To(Or(Equal(io.EOF), BeNil()))
+
+	dataStr := string(data[:n])
+	return dataStr
+}
+
+func requestFromTLSCNServerExpectNotFound(caCert, clientCert *crypto.TLSCertificateConfig, listener net.Listener) {
+	client, err := testutil.NewBareHTTPsClient(caCert, clientCert)
+	Expect(err).NotTo(HaveOccurred())
+
+	resp, err := client.Get("https://" + listener.Addr().String())
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+}

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type contextKey string
+
+const TLSCommonNameContextKey contextKey = "tls-cn"
+
+func NewHTTPServerWithTLSContext(router http.Handler, log logrus.FieldLogger, address string) *http.Server {
+	return &http.Server{
+		Addr:         address,
+		Handler:      router,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			tc := c.(*tls.Conn)
+			// We need to ensure TLS handshake is complete before
+			// we try to get anything useful from the ConnectionState
+			// tls delays handshake until the first Read of Write
+			err := tc.Handshake()
+			if err != nil {
+				log.Errorf("TLS handshake error: %v", err)
+				return ctx
+			}
+
+			cs := tc.ConnectionState()
+			if len(cs.PeerCertificates) == 0 {
+				log.Warningf("Warning no TLS Peer Certificates: %v", err)
+				return ctx
+			}
+			peerCertificate := cs.PeerCertificates[0]
+			return context.WithValue(ctx, TLSCommonNameContextKey, peerCertificate.Subject.CommonName)
+		},
+	}
+}
+
+// NewTLSListener returns a new TLS listener. If the address is empty, it will
+// listen on localhost's next available port.
+func NewTLSListener(address string, tlsConfig *tls.Config) (net.Listener, error) {
+	if address == "" {
+		address = "localhost:0"
+	}
+	ln, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	return tls.NewListener(ln, tlsConfig), nil
+}

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -64,7 +64,7 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 
 	// create certs
 	serverCfg.Service.CertStore = testDirPath
-	ca, serverCerts, clientCerts, err := testutil.NewTestCerts(&serverCfg)
+	ca, serverCerts, _, clientCerts, err := testutil.NewTestCerts(&serverCfg)
 	if err != nil {
 		return nil, fmt.Errorf("NewTestHarness: %w", err)
 	}


### PR DESCRIPTION
From the http server, every time a connection is served make sure that we gather the TLS client certificate details and put the CommonName in the context, so it's accessible later down when serving the API request.

Additionally when creating client certificates, define different common names for a client-admin key/cert, and for general agent bootstrapping certificates in a way that we can differentiate the origin of requests.