### PR TITLE
NO-ISSUE: Add local Containerfile for e2e testing purposes

### DIFF
--- a/hack/Containerfile.local
+++ b/hack/Containerfile.local
@@ -1,0 +1,13 @@
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
+COPY bin/rpm/flightctl-agent-*.rpm /tmp/
+RUN dnf install -y /tmp/flightctl-agent-*.rpm && \
+    systemctl enable flightctl-agent.service
+
+RUN useradd -ms /bin/bash redhat && \
+    echo "redhat:redhat" | chpasswd && \
+    echo "redhat ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+## Add your flightctl configuration and certificates
+ADD bin/agent/etc/flightctl/config.yaml /etc/flightctl/
+ADD bin/agent/etc/flightctl/certs/* /etc/flightctl/certs/


### PR DESCRIPTION
We have a problem because BIB still does not support local registries. We'll figure out a way. 