### PR TITLE
NO-ISSUE: Create an agent config we can use

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -5,12 +5,15 @@ cluster:
 clean-cluster:
 	kind delete cluster
 
-deploy: flightctl-server-container cluster deploy-helm
+deploy: flightctl-server-container cluster deploy-helm prepare-agent-config
 
 deploy-helm:
 	kubectl config set-context kind-kind
 	hack/install_helm.sh
 	hack/deploy_with_helm.sh
+
+prepare-agent-config:
+	hack/prepare_agent_config.sh
 
 deploy-db-helm: cluster
 	hack/deploy_with_helm.sh --only-db

--- a/hack/deploy_with_helm.sh
+++ b/hack/deploy_with_helm.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 METHOD=install
 ONLY_DB=
 NO_AUTH=
+IP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
 
 # Use external getopt for long options
 options=$(getopt -o adh --long only-db,no-auth,help -n "$0" -- "$@")
@@ -53,7 +54,7 @@ if [ ! -z "$PGSQL_IMAGE" ]; then
   DB_IMG="--set flightctl.db.image=${DB_IMG}"
 fi
 
-helm ${METHOD} --values ./deploy/helm/flightctl/values.kind.yaml ${ONLY_DB} ${NO_AUTH} ${DB_IMG} flightctl \
+helm ${METHOD} --values ./deploy/helm/flightctl/values.kind.yaml --set flightctl.server.hostName=${IP} ${ONLY_DB} ${NO_AUTH} ${DB_IMG} flightctl \
               ./deploy/helm/flightctl/ --kube-context kind-kind 
 
 "${SCRIPT_DIR}"/wait_for_postgres.sh

--- a/hack/prepare_agent_config.sh
+++ b/hack/prepare_agent_config.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+mkdir -p bin/agent/etc/flightctl/certs
+cp ~/.flightctl/certs/ca.crt bin/agent/etc/flightctl/certs/ca.crt
+cp ~/.flightctl/certs/client-enrollment.{crt,key} bin/agent/etc/flightctl/certs/
+
+IP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
+echo "Found ethernet interface IP: ${IP}"
+
+echo "Creating agent config"
+cat <<EOF > bin/agent/etc/flightctl/config.yaml
+management-endpoint: https://${IP}:3333
+enrollment-endpoint: https://${IP}:3333
+enrollment-ui-endpoint: https://${IP}:8080
+spec-fetch-interval: 0m10s
+status-update-interval: 0m10s
+EOF


### PR DESCRIPTION
This exposes the service over the local address of our ethernet/wifi interface, by finding the exit route IP.

Then it prepares this configuration along with the certificates into the bin/agent/ directory for later image embedding.