### PR TITLE
NO-ISSUE: Allow agent-vm and image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ deb: bin/arm64 bin/amd64 bin/riscv64
 	ln -f -s packaging/debian debian
 	debuild -us -uc -b
 
-clean:
+clean: clean-agent-vm
 	- kind delete cluster
 	- podman-compose -f deploy/podman/compose.yaml down
 	- rm -r ~/.flightctl
@@ -126,3 +126,4 @@ $(GOBIN)/golangci-lint:
 
 # include the deployment targets
 include deploy/deploy.mk
+include deploy/agent-vm.mk

--- a/README.md
+++ b/README.md
@@ -51,6 +51,53 @@ bin/flightctl apply -f examples/fleet.yaml
 bin/flightctl get fleets
 ```
 
+Use an agent VM to test a device interaction, an image is automatically created from
+hack/Containerfile.local and a qcow2 image is derived in output/qcow2/disk.qcow2, currently
+this only works on a Linux host.
+
+```
+make agent-vm agent-vm-console # user/password is redhat/redhat
+```
+
+The agent-vm target accepts multiple parameters:
+- VMNAME: the name of the VM to create (default: flightctl-device-default)
+- VMCPUS: the number of CPUs to allocate to the VM (default: 1)
+- VMMEM: the amount of memory to allocate to the VM (default: 512)
+- VMWAIT: the amount of minutes to wait on the console during first boot (default: 0)
+
+It is possible to create multiple VMs with different names:
+
+```
+make agent-vm VMNAME=flightctl-device-1
+make agent-vm VMNAME=flightctl-device-2
+make agent-vm VMNAME=flightctl-device-3
+```
+
+Those should appear on the root virsh list:
+```
+$ sudo virsh list
+ Id   Name                        State
+-------------------------------------------
+ 13   flightctl-device-1          running
+ 14   flightctl-device-2          running
+ 15   flightctl-device-3          running
+````
+
+And you can log in the consoles with agent-vm-console:
+```
+make agent-vm-console VMNAME=flightctl-device-1
+```
+
+NOTE: You can exit the console with Ctrl + ] , and `stty rows 80` and `stty columns 140` (for example) are useful to resize your console otherwise very small.
+
+
+If you created individual devices you need to clean them one by one:
+```
+make agent-vm-clean VMNAME=flightctl-device-1
+make agent-vm-clean VMNAME=flightctl-device-2
+make agent-vm-clean VMNAME=flightctl-device-3
+```
+
 Use the `devicesimulator` to simulate load from devices:
 
 ```

--- a/deploy/agent-vm.mk
+++ b/deploy/agent-vm.mk
@@ -1,0 +1,48 @@
+VMNAME ?= flightctl-device-default
+VMRAM ?= 512
+VMCPUS ?= 1
+VMDISK = /var/lib/libvirt/images/$(VMNAME).qcow2
+VMWAIT ?= 0
+
+bin/output/disk.qcow2: hack/Containerfile.local rpm
+	sudo podman build -f hack/Containerfile.local -t localhost/local-flightctl-agent:latest .
+	mkdir -p bin/output
+	sudo podman run --rm \
+					-it \
+					--privileged \
+					--pull=newer \
+					--security-opt label=type:unconfined_t \
+	                -v $(shell pwd)/bin/output:/output \
+					-v /var/lib/containers/storage:/var/lib/containers/storage \
+					quay.io/centos-bootc/bootc-image-builder:latest \
+					--type qcow2 \
+					--local localhost/local-flightctl-agent:latest
+
+agent-image: bin/output/disk.qcow2
+	@echo "Agent image built at bin/output/disk.qcow2"
+
+.PHONY: agent-image
+
+agent-vm: bin/output/qcow2/disk.qcow2
+	@echo "Booting Agent VM from $(VMDISK)"
+	sudo cp bin/output/qcow2/disk.qcow2 $(VMDISK)
+	sudo chown qemu:qemu $(VMDISK)
+	sudo virt-install --name $(VMNAME) \
+					  --vcpus $(VMCPUS) \
+					  --memory $(VMRAM) \
+					  --import --disk $(VMDISK),format=qcow2 \
+					  --os-variant fedora-eln  \
+					  --console pty,target_type=serial  \
+					  --wait $(VMWAIT) \
+					  --transient
+
+agent-vm-console:
+	sudo virsh console $(VMNAME)
+
+.PHONY: agent-vm
+
+clean-agent-vm:
+	sudo virsh destroy $(VMNAME) || true
+	sudo rm -f $(VMDISK)
+
+.PHONY: clean-agent-vm


### PR DESCRIPTION
This commit enables the agent-vm and image building, it requires sudo root privileges, and libvirtd/virt-install tools.