### PR TITLE
MGMT-17323: Update fleet condition upon repository update

### DIFF
--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -22,7 +22,7 @@ func (h *ServiceHandler) CreateRepository(ctx context.Context, request server.Cr
 	request.Body.Status = nil
 	NilOutManagedObjectMetaProperties(&request.Body.Metadata)
 
-	result, err := h.store.Repository().Create(ctx, orgId, request.Body)
+	result, err := h.store.Repository().Create(ctx, orgId, request.Body, h.taskManager.RepositoryUpdatedCallback)
 	switch err {
 	case nil:
 		return server.CreateRepository201JSONResponse(*result), nil
@@ -77,7 +77,7 @@ func (h *ServiceHandler) ListRepositories(ctx context.Context, request server.Li
 func (h *ServiceHandler) DeleteRepositories(ctx context.Context, request server.DeleteRepositoriesRequestObject) (server.DeleteRepositoriesResponseObject, error) {
 	orgId := store.NullOrgId
 
-	err := h.store.Repository().DeleteAll(ctx, orgId)
+	err := h.store.Repository().DeleteAll(ctx, orgId, h.taskManager.AllRepositoriesDeletedCallback)
 	switch err {
 	case nil:
 		return server.DeleteRepositories200JSONResponse{}, nil
@@ -115,7 +115,7 @@ func (h *ServiceHandler) ReplaceRepository(ctx context.Context, request server.R
 	request.Body.Status = nil
 	NilOutManagedObjectMetaProperties(&request.Body.Metadata)
 
-	result, created, err := h.store.Repository().CreateOrUpdate(ctx, orgId, request.Body)
+	result, created, err := h.store.Repository().CreateOrUpdate(ctx, orgId, request.Body, h.taskManager.RepositoryUpdatedCallback)
 	switch err {
 	case nil:
 		if created {
@@ -138,7 +138,7 @@ func (h *ServiceHandler) ReplaceRepository(ctx context.Context, request server.R
 func (h *ServiceHandler) DeleteRepository(ctx context.Context, request server.DeleteRepositoryRequestObject) (server.DeleteRepositoryResponseObject, error) {
 	orgId := store.NullOrgId
 
-	err := h.store.Repository().Delete(ctx, orgId, request.Name)
+	err := h.store.Repository().Delete(ctx, orgId, request.Name, h.taskManager.RepositoryUpdatedCallback)
 	switch err {
 	case nil:
 		return server.DeleteRepository200JSONResponse{}, nil

--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -64,7 +64,9 @@ func (s *FleetStore) Create(ctx context.Context, orgId uuid.UUID, resource *api.
 	fleet.Generation = util.Int64ToPtr(1)
 	fleet.Spec.Data.Template.Metadata.Generation = util.Int64ToPtr(1)
 	result := s.db.Create(fleet)
-	callback(nil, fleet)
+	if result.Error == nil {
+		callback(nil, fleet)
+	}
 	return resource, flterrors.ErrorFromGormError(result.Error)
 }
 

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -21,7 +21,7 @@ func FleetRollouts(taskManager TaskManager) {
 		case <-taskManager.ctx.Done():
 			taskManager.log.Info("Received ctx.Done(), stopping")
 			return
-		case resourceRef := <-taskManager.channels[ChannelFleetTemplateRollout]:
+		case resourceRef := <-taskManager.channels[ChannelFleetRollout]:
 			requestID := reqid.NextRequestID()
 			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, requestID)
 			log := log.WithReqIDFromCtx(ctx, taskManager.log)

--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -43,7 +43,7 @@ func FleetSelectorMatching(taskManager TaskManager) {
 		case <-taskManager.ctx.Done():
 			taskManager.log.Info("Received ctx.Done(), stopping")
 			return
-		case resourceRef := <-taskManager.channels[ChannelFleetSelectorMatching]:
+		case resourceRef := <-taskManager.channels[ChannelFleetSelectorMatch]:
 			requestID := reqid.NextRequestID()
 			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, requestID)
 			log := log.WithReqIDFromCtx(ctx, taskManager.log)
@@ -58,17 +58,17 @@ func FleetSelectorMatching(taskManager TaskManager) {
 			var err error
 
 			switch {
-			case resourceRef.Op == FleetSelectorOpUpdate && resourceRef.Kind == model.FleetKind:
+			case resourceRef.Op == FleetSelectorMatchOpUpdate && resourceRef.Kind == model.FleetKind:
 				err = logic.FleetSelectorUpdatedNoOverlapping(ctx)
-			case resourceRef.Op == FleetSelectorOpUpdateOverlap && resourceRef.Kind == model.FleetKind:
+			case resourceRef.Op == FleetSelectorMatchOpUpdateOverlap && resourceRef.Kind == model.FleetKind:
 				err = logic.HandleOrgwideUpdate(ctx)
-			case resourceRef.Op == FleetSelectorOpDeleteAll && resourceRef.Kind == model.FleetKind:
+			case resourceRef.Op == FleetSelectorMatchOpDeleteAll && resourceRef.Kind == model.FleetKind:
 				err = logic.HandleDeleteAllFleets(ctx)
-			case resourceRef.Op == FleetSelectorOpUpdate && resourceRef.Kind == model.DeviceKind:
+			case resourceRef.Op == FleetSelectorMatchOpUpdate && resourceRef.Kind == model.DeviceKind:
 				err = logic.CompareFleetsAndSetDeviceOwner(ctx)
-			case resourceRef.Op == FleetSelectorOpUpdateOverlap && resourceRef.Kind == model.DeviceKind:
+			case resourceRef.Op == FleetSelectorMatchOpUpdateOverlap && resourceRef.Kind == model.DeviceKind:
 				err = logic.HandleOrgwideUpdate(ctx)
-			case resourceRef.Op == FleetSelectorOpDeleteAll && resourceRef.Kind == model.DeviceKind:
+			case resourceRef.Op == FleetSelectorMatchOpDeleteAll && resourceRef.Kind == model.DeviceKind:
 				err = logic.HandleDeleteAllDevices(ctx)
 			default:
 				err = fmt.Errorf("FleetSelectorMatching called with unexpected kind %s and op %s", resourceRef.Kind, resourceRef.Op)

--- a/internal/tasks/fleet_validate.go
+++ b/internal/tasks/fleet_validate.go
@@ -1,0 +1,178 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	config_latest "github.com/coreos/ignition/v2/config/v3_4"
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/reqid"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+func FleetValidate(taskManager TaskManager) {
+	for {
+		select {
+		case <-taskManager.ctx.Done():
+			taskManager.log.Info("Received ctx.Done(), stopping")
+			return
+		case resourceRef := <-taskManager.channels[ChannelFleetValidate]:
+			requestID := reqid.NextRequestID()
+			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, requestID)
+			log := log.WithReqIDFromCtx(ctx, taskManager.log)
+			logic := NewFleetValidateLogic(taskManager, log, taskManager.store, resourceRef)
+
+			if resourceRef.Op == FleetValidateOpUpdate {
+				err := logic.CreateNewTemplateVersionIfFleetValid(ctx)
+				if err != nil {
+					log.Errorf("failed validating fleet %s/%s: %v", resourceRef.OrgID, resourceRef.Name, err)
+				}
+			} else {
+				log.Errorf("TemplateVersionPopulate called with unexpected kind %s and op %s", resourceRef.Kind, resourceRef.Op)
+			}
+		}
+	}
+}
+
+type FleetValidateLogic struct {
+	taskManager TaskManager
+	log         logrus.FieldLogger
+	store       store.Store
+	resourceRef ResourceReference
+}
+
+func NewFleetValidateLogic(taskManager TaskManager, log logrus.FieldLogger, store store.Store, resourceRef ResourceReference) FleetValidateLogic {
+	return FleetValidateLogic{taskManager: taskManager, log: log, store: store, resourceRef: resourceRef}
+}
+
+func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Context) error {
+	fleet, err := t.store.Fleet().Get(ctx, t.resourceRef.OrgID, t.resourceRef.Name)
+	if err != nil {
+		return fmt.Errorf("fetching fleet: %w", err)
+	}
+
+	err = t.validateFleetTemplate(ctx, fleet)
+	if err != nil {
+		return fmt.Errorf("validating fleet: %w", err)
+	}
+
+	templateVersion := api.TemplateVersion{
+		Metadata: api.ObjectMeta{Name: util.TimeStampStringPtr()},
+		Spec:     api.TemplateVersionSpec{Fleet: t.resourceRef.Name},
+	}
+
+	_, err = t.store.TemplateVersion().Create(ctx, t.resourceRef.OrgID, &templateVersion, t.taskManager.TemplateVersionCreatedCallback)
+	return err
+}
+
+func (t *FleetValidateLogic) validateFleetTemplate(ctx context.Context, fleet *api.Fleet) error {
+	if fleet.Spec.Template.Spec.Config == nil {
+		return nil
+	}
+
+	invalidConfigs := []string{}
+	for i := range *fleet.Spec.Template.Spec.Config {
+		configItem := (*fleet.Spec.Template.Spec.Config)[i]
+		name, err := t.validateConfigItem(ctx, &configItem)
+		t.log.Debugf("Validated config %s from fleet %s/%s: %v", name, t.resourceRef.OrgID, t.resourceRef.Name, err)
+		if err != nil {
+			invalidConfigs = append(invalidConfigs, name)
+		}
+	}
+
+	condition := api.Condition{Type: api.FleetValid}
+	var retErr error
+	if len(invalidConfigs) == 0 {
+		condition.Status = api.ConditionStatusTrue
+		condition.Reason = util.StrToPtr("Valid")
+		retErr = nil
+	} else {
+		condition.Status = api.ConditionStatusFalse
+		condition.Reason = util.StrToPtr("Invalid")
+		condition.Message = util.StrToPtr(fmt.Sprintf("Fleet has %d invalid configurations: %s", len(invalidConfigs), strings.Join(invalidConfigs, ", ")))
+		retErr = fmt.Errorf("found %d invalid configurations: %s", len(invalidConfigs), strings.Join(invalidConfigs, ", "))
+	}
+
+	if fleet.Status.Conditions == nil {
+		fleet.Status.Conditions = &[]api.Condition{}
+	}
+	api.SetStatusCondition(fleet.Status.Conditions, condition)
+	err := t.store.Fleet().UpdateConditions(ctx, t.resourceRef.OrgID, t.resourceRef.Name, *fleet.Status.Conditions)
+	if err != nil {
+		t.log.Warnf("failed setting condition on fleet %s/%s: %v", t.resourceRef.OrgID, t.resourceRef.Name, err)
+	}
+
+	return retErr
+}
+
+func (t *FleetValidateLogic) validateConfigItem(ctx context.Context, configItem *api.DeviceSpecification_Config_Item) (string, error) {
+	unknownName := "<unknown>"
+
+	disc, err := configItem.Discriminator()
+	if err != nil {
+		return unknownName, fmt.Errorf("failed getting discriminator: %w", err)
+	}
+
+	switch disc {
+	case string(api.TemplateDiscriminatorGitConfig):
+		gitSpec, err := configItem.AsGitConfigProviderSpec()
+		if err != nil {
+			return unknownName, fmt.Errorf("failed getting config item as GitConfigProviderSpec: %w", err)
+		}
+		_, err = t.store.Repository().GetInternal(ctx, t.resourceRef.OrgID, gitSpec.GitRef.Repository)
+		if err != nil {
+			return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		}
+		return gitSpec.Name, nil
+
+	case string(api.TemplateDiscriminatorKubernetesSec):
+		k8sSpec, err := configItem.AsKubernetesSecretProviderSpec()
+		if err != nil {
+			return unknownName, fmt.Errorf("failed getting config item as AsKubernetesSecretProviderSpec: %w", err)
+		}
+		return k8sSpec.Name, fmt.Errorf("service does not yet support kubernetes config")
+
+	case string(api.TemplateDiscriminatorInlineConfig):
+		inlineSpec, err := configItem.AsInlineConfigProviderSpec()
+		if err != nil {
+			return unknownName, fmt.Errorf("failed getting config item %s as InlineConfigProviderSpec: %w", inlineSpec.Name, err)
+		}
+		return inlineSpec.Name, t.validateInlineConfig(&inlineSpec)
+
+	default:
+		return unknownName, fmt.Errorf("unsupported discriminator %s", disc)
+	}
+}
+
+func (t *FleetValidateLogic) validateInlineConfig(inlineSpec *api.InlineConfigProviderSpec) error {
+	// Add this inline config into the unrendered config
+	newConfig := &api.TemplateVersionStatus_Config_Item{}
+	err := newConfig.FromInlineConfigProviderSpec(*inlineSpec)
+	if err != nil {
+		return fmt.Errorf("failed creating inline config from item %s: %w", inlineSpec.Name, err)
+	}
+
+	// Convert yaml to json
+	yamlBytes, err := yaml.Marshal(inlineSpec.Inline)
+	if err != nil {
+		return fmt.Errorf("invalid yaml in inline config item %s: %w", inlineSpec.Name, err)
+	}
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	if err != nil {
+		return fmt.Errorf("failed converting yaml to json in inline config item %s: %w", inlineSpec.Name, err)
+	}
+
+	// Convert to ignition
+	_, _, err = config_latest.ParseCompatibleVersion(jsonBytes)
+	if err != nil {
+		return fmt.Errorf("failed parsing inline config item %s: %w", inlineSpec.Name, err)
+	}
+
+	return nil
+}

--- a/internal/tasks/fleet_validate_test.go
+++ b/internal/tasks/fleet_validate_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = Describe("FleetSelector", func() {
+var _ = Describe("FleetValidate", func() {
 	var (
 		log              *logrus.Logger
 		ctx              context.Context
@@ -26,7 +26,7 @@ var _ = Describe("FleetSelector", func() {
 		cfg              *config.Config
 		dbName           string
 		taskManager      tasks.TaskManager
-		logic            tasks.TemplateVersionLogic
+		logic            tasks.FleetValidateLogic
 		fleet            *api.Fleet
 		repository       *api.Repository
 		goodGitConfig    *api.GitConfigProviderSpec
@@ -44,7 +44,7 @@ var _ = Describe("FleetSelector", func() {
 		taskManager = tasks.Init(log, storeInst)
 		resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "myfleet"}
 
-		logic = tasks.NewTemplateVersionLogic(taskManager, log, storeInst, resourceRef)
+		logic = tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
 
 		repository = &api.Repository{
 			Metadata: api.ObjectMeta{
@@ -124,7 +124,7 @@ var _ = Describe("FleetSelector", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = logic.CreateNewTemplateVersion(ctx)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -160,7 +160,7 @@ var _ = Describe("FleetSelector", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = logic.CreateNewTemplateVersion(ctx)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -196,7 +196,7 @@ var _ = Describe("FleetSelector", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = logic.CreateNewTemplateVersion(ctx)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -53,6 +53,7 @@ const (
 	FleetSelectorMatchOpDeleteAll     = "delete-all"
 	TemplateVersionPopulateOpCreated  = "create"
 	FleetValidateOpUpdate             = "update"
+	FleetValidateOpDeleteAll          = "delete-all"
 )
 
 func Init(log logrus.FieldLogger, store store.Store) TaskManager {
@@ -156,6 +157,19 @@ func (t TaskManager) FleetUpdatedCallback(before *model.Fleet, after *model.Flee
 		}
 		t.SubmitTask(ChannelFleetSelectorMatch, ref, op)
 	}
+}
+
+func (t TaskManager) RepositoryUpdatedCallback(repository *model.Repository) {
+	resourceRef := ResourceReference{
+		OrgID: repository.OrgID,
+		Kind:  model.RepositoryKind,
+		Name:  repository.Name,
+	}
+	t.SubmitTask(ChannelFleetValidate, resourceRef, FleetValidateOpUpdate)
+}
+
+func (t TaskManager) AllRepositoriesDeletedCallback(orgId uuid.UUID) {
+	t.SubmitTask(ChannelFleetValidate, ResourceReference{OrgID: orgId, Kind: model.RepositoryKind}, FleetValidateOpDeleteAll)
 }
 
 func (t TaskManager) AllFleetsDeletedCallback(orgId uuid.UUID) {

--- a/internal/tasks/repotester/repotester_test.go
+++ b/internal/tasks/repotester/repotester_test.go
@@ -43,7 +43,8 @@ func createRepository(ctx context.Context, repostore store.Repository, orgId uui
 		},
 	}
 
-	_, err := repostore.Create(ctx, orgId, &resource)
+	callback := store.RepositoryStoreCallback(func(*model.Repository) {})
+	_, err := repostore.Create(ctx, orgId, &resource, callback)
 	return err
 }
 


### PR DESCRIPTION
Two commits:
    MGMT-17323: Update fleet condition upon repository update
    
    When a repository is created/updated/deleted, update the Condition of
    any Fleet that references it. If the Fleet is valid, create a new
    TemplateVersion.

    NO-ISSUE: Better organize async tasks
    
    Rename tasks to <resource>-<verb> for consistency.
    Split "templateversion" task into two separate tasks since they were
    essentially unrelated.