### PR TITLE
NO-ISSUE: Create doc about async service tasks

### DIFF
--- a/docs/architecture/tasks.md
+++ b/docs/architecture/tasks.md
@@ -1,0 +1,14 @@
+|          **Trigger**         |                   **Task**                  |
+|------------------------------|---------------------------------------------|
+| Fleet template updated       | Create new TemplateVersion                  |
+| Fleet created                | Create new TemplateVersion                  |
+| TemplateVersion created      | Populate the TemplateVersion's Status       |
+| TemplateVersion set as valid | Roll out TemplateVersion to Fleet's devices |
+| Device created               | Roll out latest TemplateVersion to device   |
+| Device owner updated         | Roll out latest TemplateVersion to device   |
+| Fleet created                | Update device ownership as necessary        |
+| Fleet selector updated       | Update device ownership as necessary        |
+| Fleet deleted                | Update device ownership as necessary        |
+| Device created               | Update device ownership as necessary        |
+| Device labels updated        | Update device ownership as necessary        |
+| Device deleted               | Update device ownership as necessary        |

--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -300,6 +300,9 @@ func (f FleetSelectorMatchingLogic) CompareFleetsAndSetDeviceOwner(ctx context.C
 
 	device, err := f.devStore.Get(ctx, f.resourceRef.OrgID, f.resourceRef.Name)
 	if err != nil {
+		if errors.Is(err, flterrors.ErrResourceNotFound) {
+			return nil
+		}
 		return fmt.Errorf("failed to get device: %w", err)
 	}
 

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -181,8 +181,8 @@ func (t TaskManager) DeviceUpdatedCallback(before *model.Device, after *model.De
 	} else if after == nil {
 		// Deleted device
 		device = before
-		labelsUpdated = false // Nothing to roll out
-		ownerUpdated = true
+		labelsUpdated = true
+		ownerUpdated = false // Nothing to roll out
 	} else {
 		device = after
 		labelsUpdated = !reflect.DeepEqual(before.Labels, after.Labels)


### PR DESCRIPTION
Also fixed a bug that deleting a device should trigger the task that updates device ownership (important in case there are overlapping selectors, so the Fleet's Conditions can be updated if fixed).