### PR TITLE
NO-ISSUE: Fix database image for CI/local deployment

### DIFF
--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -1,7 +1,7 @@
 flightctl:
   db:
     namespace: flightctl-internal
-    image: quay.io/cloudservices/postgresql-rds:12-9ee2984
+    image: quay.io/sclorg/postgresql-12-c8s:latest
     imagePullPolicy: Always
     password: adminpass
     masterPassword: adminpass


### PR DESCRIPTION
The image in https://quay.io/cloudservices/postgresql-rds is not available anymore.

We switched to quay.io/sclorg/postgresql-12-c8s:latest from the software collections repository.

 https://github.com/sclorg