### PR TITLE
NO-ISSUE: E2E Full harness (with API) + test for checking TPM status reporting

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -40,6 +40,7 @@ runs:
           go install gotest.tools/gotestsum@latest
           go get -u github.com/proglottis/gpgme
           go install go.uber.org/mock/mockgen@v0.4.0
+          go install github.com/onsi/ginkgo/v2/ginkgo
           echo "::endgroup::"
 
       - name: Install podman 4

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -48,5 +48,4 @@ jobs:
           sudo chown -R runner:runner bin/output|| true
 
       - name: Run E2E Tests
-        run: make run-e2e-test VERBOSE=true
-          
+        run:  make run-e2e-test VERBOSE=true # use DEBUG_VM_CONSOLE=1 to see the VM console output

--- a/hack/prepare_agent_config.sh
+++ b/hack/prepare_agent_config.sh
@@ -14,4 +14,5 @@ enrollment-endpoint: https://${IP}:3333
 enrollment-ui-endpoint: https://${IP}:8080
 spec-fetch-interval: 0m10s
 status-update-interval: 0m10s
+tpm-path: /dev/tpmrm0
 EOF

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -2,10 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	"k8s.io/client-go/util/homedir"
+	"github.com/flightctl/flightctl/internal/client"
 )
 
 const (
@@ -30,7 +29,7 @@ var (
 )
 
 func init() {
-	defaultClientConfigFile = filepath.Join(homedir.HomeDir(), ".flightctl", "client.yaml")
+	defaultClientConfigFile = client.DefaultFlightctlClientConfigPath()
 }
 
 func parseAndValidateKindName(arg string) (string, string, error) {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/yaml"
 )
 
@@ -91,6 +92,11 @@ func NewFromConfig(config *Config) (*client.ClientWithResponses, error) {
 		return nil
 	})
 	return client.NewClientWithResponses(config.Service.Server, client.WithHTTPClient(httpClient), ref)
+}
+
+// DefaultFlightctlClientConfigPath returns the default path to the FlightCtl client config file.
+func DefaultFlightctlClientConfigPath() string {
+	return filepath.Join(homedir.HomeDir(), ".flightctl", "client.yaml")
 }
 
 // NewFromConfigFile returns a new FlightCtl API client using the config read from the given file.

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -2,18 +2,18 @@ package agent_test
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/harness/e2e/vm"
-	"github.com/google/uuid"
+	"github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
-const TIMEOUT = "30s"
+const TIMEOUT = "1m"
 const POLLING = "250ms"
 
 func TestAgent(t *testing.T) {
@@ -23,47 +23,103 @@ func TestAgent(t *testing.T) {
 
 var _ = Describe("VM Agent behavior", func() {
 	var (
-		testVM vm.TestVMInterface
+		harness *e2e.Harness
 	)
 
 	BeforeEach(func() {
-
-		currentWorkDirectory, err := os.Getwd()
-
-		Expect(err).ToNot(HaveOccurred())
-
-		testVM, err = vm.StartAndWaitForSSH(vm.TestVM{
-			TestDir:       GinkgoT().TempDir(),
-			VMName:        "flightctl-e2e-vm-" + uuid.New().String(),
-			DiskImagePath: filepath.Join(currentWorkDirectory, "../../bin/output/qcow2/disk.qcow2"),
-			VMUser:        "redhat",
-			SSHPassword:   "redhat",
-			SSHPort:       2233, // TODO: randomize and retry on erro
-		})
+		harness = e2e.NewTestHarness()
+		err := harness.VM.RunAndWaitForSSH()
+		if err != nil {
+			fmt.Println("============ Console output ============")
+			fmt.Println(harness.VM.GetConsoleOutput())
+			fmt.Println("========================================")
+		}
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		err := testVM.ForceDelete()
-		Expect(err).ToNot(HaveOccurred())
+		harness.Cleanup()
 	})
 
 	Context("vm", func() {
+
 		It("should print QR output to console", func() {
 			// Wait for the top-most part of the QR output to appear
-			Eventually(testVM.GetConsoleOutput, TIMEOUT, POLLING).Should(ContainSubstring("████████████████████████████████"))
-			output := testVM.GetConsoleOutput()
-			// this is only to show output when VERBOSE=true
+			Eventually(harness.VM.GetConsoleOutput, TIMEOUT, POLLING).Should(ContainSubstring("████████████████████████████████"))
+
 			fmt.Println("============ Console output ============")
-			lines := strings.Split(output, "\n")
+			lines := strings.Split(harness.VM.GetConsoleOutput(), "\n")
 			fmt.Println(strings.Join(lines[len(lines)-20:], "\n"))
 			fmt.Println("========================================")
 		})
+
 		It("should have flightctl-agent running", func() {
-			stdout, err := testVM.RunSSH([]string{"sudo", "systemctl", "status", "flightctl-agent"}, nil)
+			stdout, err := harness.VM.RunSSH([]string{"sudo", "systemctl", "status", "flightctl-agent"}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stdout.String()).To(ContainSubstring("Active: active (running)"))
+		})
+
+		It("should be reporting tpm info on enrollment request as well as device status", func() {
+			// Get the enrollment Request ID from the console output
+			enrollmentID := harness.GetEnrollmentIDFromConsole()
+			logrus.Infof("Enrollment ID found in VM console output: %s", enrollmentID)
+
+			// Wait for the device to create the enrollment request, and check the TPM details
+			enrollmentRequest := harness.WaitForEnrollmentRequest(enrollmentID)
+			Expect(enrollmentRequest.Spec).ToNot(BeNil())
+			Expect(enrollmentRequest.Spec.DeviceStatus).ToNot(BeNil())
+			Expect(enrollmentRequest.Spec.DeviceStatus.SystemInfo).ToNot(BeNil())
+			Expect(enrollmentRequest.Spec.DeviceStatus.SystemInfo.Measurements).ToNot(BeNil())
+			verifyPCRRegistersNotEmpty(enrollmentRequest.Spec.DeviceStatus.SystemInfo.Measurements)
+
+			// Approve the enrollment and wait for the device details to be populated by the agent
+			harness.ApproveEnrollment(enrollmentID, testutil.TestEnrollmentApproval())
+			logrus.Infof("Waiting for device %s to report status so we can check TPM PCRs again", enrollmentID)
+
+			// wait for the device to pickup enrollment and report measurements on device status
+			Eventually(getDeviceWithStatusSystemInfo, TIMEOUT, POLLING).WithArguments(
+				harness, enrollmentID).ShouldNot(BeNil())
+
+			device := getDeviceWithStatusSystemInfo(harness, enrollmentID)
+
+			// make sure that the PCR registers aren't empty
+			verifyPCRRegistersNotEmpty(device.JSON200.Status.SystemInfo.Measurements)
+
+			// verify that the measurements are the same as the ones we saw in the enrollment request
+			Expect(device.JSON200.Status.SystemInfo.Measurements).To(Equal(enrollmentRequest.Spec.DeviceStatus.SystemInfo.Measurements))
 		})
 	})
 
 })
+
+// PCR registers are initialized to a string of 00's at boot. Later on as
+// measurements are taken during boot steps, the PCR registers are updated inside the
+// TPM with: update_pcr(n, new_measurement){ pcr[n] = SHAx(pcr[n] || new_measurement) }
+// This means that the PCR registers should not be empty or all 0's after boot.
+// More details about the specific registers can be found here:
+// https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/
+func verifyPCRRegistersNotEmpty(measurements map[string]string) {
+	Expect(measurements).ToNot(BeNil())
+	for i := 1; i < 10; i++ {
+		pcrReg := fmt.Sprintf("pcr%02d", i)
+		pcr := measurements[pcrReg]
+		Expect(pcr).ToNot(BeNil())
+		// the length of the mesaurement will be different depending on the TPM
+		// sha algorithm so we just check that it's not empty or all 0's, we remove all
+		// 0's to make sure that the measurement isn't just a bunch of 0's
+		pcrRemove0x := strings.ReplaceAll(pcr, "0", "")
+		Expect(pcrRemove0x).ToNot(BeEmpty(), "PCR %s is empty or all 0's, is the VM booting in EFI secure boot?", pcrReg)
+	}
+}
+
+// get device from API, and return only devices that have a Status.SystemInfo
+func getDeviceWithStatusSystemInfo(harness *e2e.Harness, enrollmentID string) *client.ReadDeviceResponse {
+	device, err := harness.Client.ReadDeviceWithResponse(harness.Context, enrollmentID)
+	Expect(err).NotTo(HaveOccurred())
+	// we keep waiting for a 200 response, with filled in Status.SystemInfo
+	if device.JSON200 == nil || device.JSON200.Status == nil ||
+		device.JSON200.Status.SystemInfo == nil {
+		return nil
+	}
+	return device
+}

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -1,0 +1,109 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	client "github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/test/harness/e2e/vm"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+const POLLING = "250ms"
+const TIMEOUT = "60s"
+
+type Harness struct {
+	VM        vm.TestVMInterface
+	Client    *apiclient.ClientWithResponses
+	Context   context.Context
+	ctxCancel context.CancelFunc
+}
+
+func findTopLevelDir() string {
+	currentWorkDirectory, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+
+	parts := strings.Split(currentWorkDirectory, "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] == "test" {
+			path := strings.Join(parts[:i], "/")
+			logrus.Debugf("Top-level directory: %s", path)
+			return path
+		}
+	}
+	Fail("Could not find top-level directory")
+	// this return is not reachable but we need to satisfy the compiler
+	return ""
+}
+
+func NewTestHarness() *Harness {
+
+	testVM, err := vm.NewVM(vm.TestVM{
+		TestDir:       GinkgoT().TempDir(),
+		VMName:        "flightctl-e2e-vm-" + uuid.New().String(),
+		DiskImagePath: filepath.Join(findTopLevelDir(), "bin/output/qcow2/disk.qcow2"),
+		VMUser:        "redhat",
+		SSHPassword:   "redhat",
+		SSHPort:       2233, // TODO: randomize and retry on error
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	c, err := client.NewFromConfigFile(client.DefaultFlightctlClientConfigPath())
+	Expect(err).ToNot(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Harness{
+		VM:        testVM,
+		Client:    c,
+		Context:   ctx,
+		ctxCancel: cancel,
+	}
+}
+
+func (h *Harness) Cleanup() {
+	err := h.VM.ForceDelete()
+	Expect(err).ToNot(HaveOccurred())
+	// This will stop any blocking function that is waiting for the context to be canceled
+	h.ctxCancel()
+}
+
+func (h *Harness) GetEnrollmentIDFromConsole() string {
+	// wait for the enrollment ID on the console
+	Eventually(h.VM.GetConsoleOutput, TIMEOUT, POLLING).Should(ContainSubstring("/enroll/"))
+	output := h.VM.GetConsoleOutput()
+
+	enrollmentID := output[strings.Index(output, "/enroll/")+8:]
+	enrollmentID = enrollmentID[:strings.Index(enrollmentID, "\r")]
+	enrollmentID = strings.TrimRight(enrollmentID, "\n")
+	return enrollmentID
+}
+
+func (h *Harness) WaitForEnrollmentRequest(id string) *v1alpha1.EnrollmentRequest {
+	var enrollmentRequest *v1alpha1.EnrollmentRequest
+	Eventually(func() *v1alpha1.EnrollmentRequest {
+		resp, _ := h.Client.ReadEnrollmentRequestWithResponse(h.Context, id)
+		if resp != nil && resp.JSON200 != nil {
+			enrollmentRequest = resp.JSON200
+		}
+		return enrollmentRequest
+	}, TIMEOUT, POLLING).ShouldNot(BeNil())
+	return enrollmentRequest
+}
+
+func (h *Harness) ApproveEnrollment(id string, approval *v1alpha1.EnrollmentRequestApproval) {
+	Expect(approval).NotTo(BeNil())
+
+	logrus.Infof("Approving device enrollment: %s", id)
+	apr, err := h.Client.CreateEnrollmentRequestApprovalWithResponse(h.Context, id, *approval)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(apr.JSON200).NotTo(BeNil())
+	logrus.Infof("Approved device enrollment: %s", id)
+}

--- a/test/harness/e2e/vm/domain-template.xml
+++ b/test/harness/e2e/vm/domain-template.xml
@@ -10,14 +10,22 @@
     <acpi></acpi>
     <apic></apic>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode='custom' check='none'>
+    <!-- this oddly specific CPU model is used because it works well with github CI and locally,
+         it limits the feature set exposure of the CPU, avoiding a kernel crash at boot when
+         secureboot is enabled -->
+    <model>Opteron_G4</model>
+  </cpu>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>
   <on_crash>destroy</on_crash>
-  <os>
+  <os firmware='efi'>
     <type machine='q35'>hvm</type>
     <boot dev='hd'/>
-
+    <firmware>
+      <feature enabled='yes' name='secure-boot'/>
+      <feature enabled='yes' name='enrolled-keys'/>
+   </firmware>
   </os>
   <devices>
     <serial type='pty'>
@@ -26,7 +34,7 @@
       </target>
       <alias name='serial0'/>
     </serial>
-    <console type='pty' tty='/dev/pts/2'>
+    <console type='pty'>
       <target type='serial' port='0'/>
       <alias name='serial0'/>
     </console>

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -38,10 +38,10 @@ type TestVMInterface interface {
 	Delete() error
 	IsRunning() (bool, error)
 	WaitForSSHToBeReady() error
+	RunAndWaitForSSH() error
 	SSHCommand(inputArgs []string) *exec.Cmd
 	RunSSH(inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer, error)
 	Exists() (bool, error)
-	ReadConsole() string
 	GetConsoleOutput() string
 }
 
@@ -121,15 +121,5 @@ func StartAndWaitForSSH(params TestVM) (vm TestVMInterface, err error) {
 		return nil, fmt.Errorf("failed to create new VM: %w", err)
 	}
 
-	err = vm.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run VM: %w", err)
-	}
-
-	err = vm.WaitForSSHToBeReady()
-	if err != nil {
-		return nil, fmt.Errorf("waiting for SSH: %w", err)
-	}
-
-	return vm, nil
+	return vm, vm.RunAndWaitForSSH()
 }

--- a/test/test.mk
+++ b/test/test.mk
@@ -9,7 +9,6 @@ GO_E2E_DIRS 			= ./test/e2e/...
 
 GO_UNITTEST_FLAGS 		 = $(GO_TESTING_FLAGS) $(GO_UNITTEST_DIRS)        -coverprofile=$(REPORTS)/unit-coverage.out
 GO_INTEGRATIONTEST_FLAGS = $(GO_TESTING_FLAGS) $(GO_INTEGRATIONTEST_DIRS) -coverprofile=$(REPORTS)/integration-coverage.out
-GO_E2E_FLAGS 			 = $(GO_TESTING_FLAGS) $(GO_E2E_DIRS) -coverprofile=$(REPORTS)/integration-coverage.out
 
 ifeq ($(VERBOSE), true)
 	GO_TEST_FORMAT=standard-verbose
@@ -19,7 +18,6 @@ endif
 
 GO_TEST_FLAGS := 			 --format=$(GO_TEST_FORMAT) --junitfile $(REPORTS)/junit_unit_test.xml $(GOTEST_PUBLISH_FLAGS)
 GO_TEST_INTEGRATION_FLAGS := --format=$(GO_TEST_FORMAT) --junitfile $(REPORTS)/junit_integration_test.xml $(GOTEST_PUBLISH_FLAGS)
-GO_TEST_E2E_FLAGS := 		 --format=$(GO_TEST_FORMAT) --junitfile $(REPORTS)/junit_e2e_test.xml $(GOTEST_PUBLISH_FLAGS)
 
 _integration_test: $(REPORTS)
 	gotestsum $(GO_TEST_E2E_FLAGS) -- $(GO_INTEGRATIONTEST_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _collect_junit && /bin/false)
@@ -27,8 +25,7 @@ _integration_test: $(REPORTS)
 
 _e2e_test: $(REPORTS)
 	sudo chown $(shell whoami):$(shell whoami) -R bin/output
-	gotestsum $(GO_TEST_E2E_FLAGS) -- $(GO_E2E_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _collect_junit && /bin/false)
-	$(MAKE) _collect_junit
+	ginkgo run --timeout 30m --race -vv --junit-report $(REPORTS)/junit_e2e_test.xml --github-output $(GO_E2E_DIRS)
 
 _unit_test: $(REPORTS)
 	gotestsum $(GO_TEST_FLAGS) -- $(GO_UNITTEST_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _collect_junit && /bin/false)


### PR DESCRIPTION
This PR extends the basic E2E harness including the admin API
client, and moves the two e2e agent tests to the new harness

As an example where the API is required introduces a new test that:

* Verifies the TPM reporting from within the VM

This also switches the runner for E2E to the ginkgo binary which
produces better reporting console output as well as better junit output.