### PR TITLE
Optimize flightctl-server-container build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,15 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as build
 WORKDIR /app
-COPY ./ .
+COPY ./api api
+COPY ./cmd cmd
+COPY ./deploy deploy
+COPY ./hack hack
+COPY ./internal internal
+COPY ./go.* .
+COPY ./pkg pkg
+COPY ./test test
+COPY ./Makefile .
+
 USER 0
 RUN make build
 

--- a/Makefile
+++ b/Makefile
@@ -40,18 +40,15 @@ build: bin
 	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
 # rebuild container only on source changes
-bin/.flightctl-server-container: bin bin/go-cache Containerfile go.mod go.sum $(shell find ./ -name "*.go" -not -path "./bin/*" -not -path "./packaging/*")
-	podman build -f Containerfile -v $(shell pwd)/bin/go-cache:/opt/app-root/src/go:Z -t flightctl-server:latest
+bin/.flightctl-server-container: bin Containerfile go.mod go.sum $(shell find ./ -name "*.go" -not -path "./bin/*" -not -path "./packaging/*")
+	mkdir -p $${HOME}/go/flightctl-go-cache
+	podman build -f Containerfile -v $${HOME}/go/flightctl-go-cache:/opt/app-root/src/go:Z -t flightctl-server:latest
 	touch bin/.flightctl-server-container
 
 flightctl-server-container: bin/.flightctl-server-container
 
 bin:
 	mkdir -p bin
-
-# used for caching go container builds download
-bin/go-cache:
-	mkdir -p bin/go-cache
 
 # only trigger the rpm build when not built before or changes happened to the codebase
 bin/.rpm: bin $(shell find ./ -name "*.go" -not -path "./packaging/*") packaging/rpm/flightctl-agent.spec packaging/systemd/flightctl-agent.service hack/build_rpms.sh


### PR DESCRIPTION
The go-cache in bin/go-cache creates issues with the linter and other processes. And Copying the whole directory is slow when we have artifacts in bin/

We could use dockerignore and be less explicit but then we cannot copy some artifacts that we need from bin/ for other container builds.