### PR TITLE
NO-ISSUE: Increase DB container resource request

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
@@ -40,6 +40,10 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/pgsql/data
               name: flightctl-db
+          resources:
+            requests:
+              cpu: "1000m"
+              memory: "2Gi"
       restartPolicy: Always
       volumes:
         - name: flightctl-db


### PR DESCRIPTION
Otherwise the DB runs out of memory and eventually gets killed because our demo cloud will apply default resource constraints of 512Mb and very little CPU.