### PR TITLE
MGMT-17847: internal/experimental: add support for experimental features

### DIFF
--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -1,0 +1,39 @@
+package experimental
+
+import (
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// ExperimentalFeatureEnvKey is the environment variable key used to enable experimental features.
+	ExperimentalFeatureEnvKey = "FLIGHTCTL_EXPERIMENTAL_FEATURES_ENABLED"
+)
+
+// NewFeatures creates a new experimental Features. The experimental features
+// are enabled if the FLIGHTCTL_EXPERIMENTAL_FEATURES_ENABLED environment
+// variable is set.
+func NewFeatures() *Features {
+	var enabled bool
+	value, exists := os.LookupEnv(ExperimentalFeatureEnvKey)
+	if exists && value != "" {
+		klog.Warning("Experimental features enabled")
+		enabled = true
+	}
+
+	return &Features{
+		enabled: enabled,
+	}
+}
+
+// Features represents the experimental features.
+type Features struct {
+	// Enabled is true if the experimental features are enabled.
+	enabled bool
+}
+
+// IsEnabled returns true if the experimental features are enabled.
+func (f *Features) IsEnabled() bool {
+	return f.enabled
+}

--- a/internal/experimental/experimental_test.go
+++ b/internal/experimental/experimental_test.go
@@ -1,0 +1,52 @@
+package experimental
+
+import (
+	"os"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/util"
+)
+
+func TestNewFeatures(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		value string
+		want  bool
+	}{
+		{
+			name:  "environment variable not set",
+			env:   "",
+			value: "",
+			want:  false,
+		},
+		{
+			name:  "environment variable set to empty string",
+			env:   ExperimentalFeatureEnvKey,
+			value: "",
+			want:  false,
+		},
+		{
+			name:  "environment variable set to non-empty string",
+			env:   ExperimentalFeatureEnvKey,
+			value: "true-ish",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetEnv := util.TestTempEnv(tt.env, tt.value)
+			defer resetEnv()
+
+			if tt.env == "" {
+				os.Unsetenv(ExperimentalFeatureEnvKey)
+			}
+
+			experimentalFeatures := NewFeatures()
+			if got := experimentalFeatures.IsEnabled(); got != tt.want {
+				t.Errorf("NewFeatures().IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -140,5 +141,18 @@ func TestEnrollmentApproval() *v1alpha1.EnrollmentRequestApproval {
 		Approved: true,
 		Labels:   &map[string]string{"label": "value"},
 		Region:   util.StrToPtr("region"),
+	}
+}
+
+// TestTempEnv sets the environment variable key to value and returns a function that will reset the environment variable to its original value.
+func TestTempEnv(key, value string) func() {
+	originalValue, hadOriginalValue := os.LookupEnv(key)
+	os.Setenv(key, value)
+	return func() {
+		if hadOriginalValue {
+			os.Setenv(key, originalValue)
+		} else {
+			os.Unsetenv(key)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a simple mechanism for the agent and service to enable experimental features based on the existence of `FLIGHTCTL_EXPERIMENTAL_FEATURES_ENABLED` with a non-empty value.. 

usage
```
experimentalFeatures := experimental.NewFeatures()
if experimentalFeatures.IsEnabled() {
  // do potentially unstable things 
}
```

OCP ref. https://github.com/openshift/installer/blob/294318e39b4ba31a16f87fed688134fee51dd6c2/cmd/openshift-install/create.go#L204C15-L204C67