### PR TITLE
NO-ISSUE: Fix E2E VM boot on fedora hosts

### DIFF
--- a/test/harness/e2e/vm/domain-template.xml
+++ b/test/harness/e2e/vm/domain-template.xml
@@ -24,7 +24,9 @@
     <boot dev='hd'/>
     <firmware>
       <feature enabled='yes' name='secure-boot'/>
-      <feature enabled='yes' name='enrolled-keys'/>
+      <!-- we enable secureboot to make sure that attestation is happening, but don't enroll the keys to avoid
+	   issues booting vms in fedora -->
+      <feature enabled='no' name='enrolled-keys'/>
    </firmware>
   </os>
   <devices>


### PR DESCRIPTION
On some fedora hosts the enrollment keys installed through libvirt into the UEFI firmware are incomplete or incorrect and we cannot boot our images.

So we leave secureboot enabled for the attestation part, but we disable enforcing signature checks by not installing secureboot keys.