### PR TITLE
OCTOET-412: E2E registry bootc images

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Make rpm, and agent images
         run: |
-          make agent-image
+          make e2e-agent-images
 
       - name: Make sure the images are owned by the runner user
         run: |

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ deb: bin/arm64 bin/amd64 bin/riscv64
 	ln -f -s packaging/debian debian
 	debuild -us -uc -b
 
-clean: clean-agent-vm
+clean: clean-agent-vm clean-e2e-agent-images
 	- kind delete cluster
 	- podman-compose -f deploy/podman/compose.yaml down
 	- rm -r ~/.flightctl
@@ -104,3 +104,4 @@ $(GOBIN)/golangci-lint:
 include deploy/deploy.mk
 include deploy/agent-vm.mk
 include test/test.mk
+include test/scripts/agent-images/agent-images.mk

--- a/deploy/agent-vm.mk
+++ b/deploy/agent-vm.mk
@@ -4,25 +4,6 @@ VMCPUS ?= 1
 VMDISK = /var/lib/libvirt/images/$(VMNAME).qcow2
 VMWAIT ?= 0
 
-bin/output/qcow2/disk.qcow2: hack/Containerfile.local bin/.rpm
-	sudo podman build -f hack/Containerfile.local -t localhost/local-flightctl-agent:latest .
-	mkdir -p bin/output
-	sudo podman run --rm \
-					-it \
-					--privileged \
-					--pull=newer \
-					--security-opt label=type:unconfined_t \
-	                -v $(shell pwd)/bin/output:/output \
-					-v /var/lib/containers/storage:/var/lib/containers/storage \
-					quay.io/centos-bootc/bootc-image-builder:latest \
-					--type qcow2 \
-					--local localhost/local-flightctl-agent:latest
-
-agent-image: bin/output/qcow2/disk.qcow2
-	@echo "Agent image built at bin/output/qcow2/disk.qcow2"
-	sudo chmod a+rw $(VMDISK) 2>/dev/null || true
-
-.PHONY: agent-image
 
 agent-vm: bin/output/qcow2/disk.qcow2
 	@echo "Booting Agent VM from $(VMDISK)"

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -1,4 +1,5 @@
-cluster:
+
+cluster: bin/e2e-certs/ca.pem
 	test/scripts/install_kind.sh
 	kind get clusters | grep kind || test/scripts/create_cluster.sh
 

--- a/deploy/helm/e2e-extras/templates/registry-deployment.yaml
+++ b/deploy/helm/e2e-extras/templates/registry-deployment.yaml
@@ -23,4 +23,17 @@ spec:
           ports:
             - containerPort: 5000
               protocol: TCP
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+          env:
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /certs/registry.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /certs/registry.key
+      volumes:
+        - name: certs
+          hostPath:
+            path: {{ .Values.registry.certsPath }}
+            type: Directory
       restartPolicy: Always

--- a/deploy/helm/e2e-extras/values.kind.yaml
+++ b/deploy/helm/e2e-extras/values.kind.yaml
@@ -2,3 +2,4 @@ registry:
   image: docker.io/library/registry:2
   nodePort: 5000
   namespace: flightctl-e2e
+  certsPath: /tmp/e2e-certs/

--- a/test/README.md
+++ b/test/README.md
@@ -131,6 +131,10 @@ with agents on VMs, or connect the server to the local kind k8s cluster.
 We use ginkgo/gomega for these tests, as they are more complex and require
 more setup and teardown than unit tests.
 
+For E2E testing we build several agent images that we exercise and update through
+in the tests, more details can be found here  [Agent Images](./scripts/agent-image/README.md)
+
+### Running E2E tests
 ```bash
 make e2e-test
 ```

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -1,4 +1,16 @@
+# localhost:5000/flightctl-device:base
+#     ${IP}:5000/flightctl-device:base
+#
+# Base bootc image used for E2E testing and agent-vm with the following features:
+#
+# * User/pw: redhat/redhat
+# * Trust on our E2E CA Certificate
+# * flightctl-agent configured to talk to our e2e kind flightctl-server
+
 FROM quay.io/centos-bootc/centos-bootc:stream9
+
+COPY bin/e2e-certs/ca.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
 
 COPY bin/rpm/flightctl-agent-*.rpm /tmp/
 RUN dnf install -y /tmp/flightctl-agent-*.rpm && \

--- a/test/scripts/agent-images/Containerfile-e2e-v2.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v2.local
@@ -1,0 +1,15 @@
+# localhost:5000/flightctl-device:v2
+#     $(IP):5000/flightctl-device:v2
+#
+# Image built on top of our E2E base image which also includes two dummy systemd services:
+#
+# * test-e2e-dummy which just runs a sleep 3600 for 1h
+# * test-e2e-crashing which runs /bin/false and attempts restart every few minutes
+
+FROM localhost:5000/flightctl-device:base
+
+COPY test/scripts/agent-images/test-e2e-dummy.service /etc/systemd/system/
+COPY test/scripts/agent-images/test-e2e-crashing.service /etc/systemd/system/
+
+RUN systemctl enable test-e2e-dummy.service
+RUN systemctl enable test-e2e-crashing.service

--- a/test/scripts/agent-images/Containerfile-e2e-v3.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v3.local
@@ -1,0 +1,12 @@
+# localhost:5000/flightctl-device:v3
+#     $(IP):5000/flightctl-device:v3
+#
+# Image built on top of our E2E base image which also includes on dummy servive
+#
+# * test-e2e-another-dummy which just runs a sleep 3600 for 1h
+
+FROM localhost:5000/flightctl-device:base
+
+COPY test/scripts/agent-images/test-e2e-another-dummy.service /etc/systemd/system/
+RUN systemctl enable test-e2e-another-dummy.service
+

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -1,0 +1,38 @@
+# E2E Agent images
+
+We generate multiple agent images for testing purposes, each with a different
+services running, but all connected to our flightctl service for management.
+
+This work is performed by the `create_agent_images.sh` script in this
+directory.
+
+And can be triggered from the top-level makefile with: `make e2e-agent-images`
+
+The images are built using the `Containerfile-*` files in this directory, functionality
+or service deployment changes should be implemented on those container files, or if
+additional transition images are required we should create and document new Containerfiles.
+
+| Name   | Image                         | Bootc Containers                 |
+|------  |-------------------------------|----------------------------------|
+| base   | `bin/output/qcow2/disk.qcow2` | ${IP}:5000/flightctl-device:base |
+| v2     | N/A                           | $(IP):5000/flightctl-device:v2   |
+| v3     | N/A                           | $(IP):5000/flightctl-device:v3   |
+
+## Image descriptions
+### base
+This image is the base image for all other images. It contains the following services:
+- `flightctl-agent` - The agent service that connects to the flightctl service configured
+   with the `test/script/prepare_agent_config.sh` script to be connected to our local
+   flightctl service.
+
+It is configured to trust our locally generated CA created in `test/scripts/create_e2e_certs.sh`
+
+### v2
+This image builds on top of the base image, and adds the following services, useful
+to test agent reporting of systemd services:
+ * test-e2e-dummy which just runs a sleep 3600 for 1h
+ * test-e2e-crashing which runs /bin/false and attempts restart every few minutes
+
+### v3
+This image builds on top of the base image, and adds the following services, useful
+ * test-e2e-another-dummy which just runs a sleep 3600 for 1h

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -1,0 +1,12 @@
+
+bin/output/qcow2/disk.qcow2: e2e-agent-images
+
+e2e-agent-images: bin rpm bin/e2e-certs
+	./test/scripts/agent-images/create_agent_images.sh
+
+.PHONY: e2e-agent-images
+
+clean-e2e-agent-images:
+	sudo rm bin/output/qcow2/disk.qcow2
+	rm -f out/.e2e-agent-images
+

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+IP=$("${SCRIPT_DIR}"/../get_ext_ip.sh)
+
+
+IMAGE_LIST="base v2 v3"
+
+for img in $IMAGE_LIST; do
+   echo -e "\033[32mCreating image "${IP}:5000/flightctl-device:${img}" \033[m"
+   podman build -f "${SCRIPT_DIR}"/Containerfile-e2e-"${img}".local -t localhost:5000/flightctl-device:${img} .
+   podman tag "localhost:5000/flightctl-device:${img}" "${IP}:5000/flightctl-device:${img}"
+   podman push "${IP}:5000/flightctl-device:${img}"
+done
+
+CONTAINER_CREATE_DATE=$(podman inspect -f '{{.Created}}' ${IP}:5000/flightctl-device:base)
+if [[ -f bin/output/qcow2/disk.qcow2 ]]; then
+	QCOW_CREATE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2  "+%Y-%m-%d %H:%M:%S")
+fi 
+
+if [[ "${CONTAINER_CREATE_DATE}" < "${QCOW_CREATE_DATE}" ]]; then
+    echo -e "\033[32mqcow2 is already up to date with the contaner \033[m"
+    exit 0
+fi
+
+echo -e "\033[32mProducing qcow2 image for ${IP}:5000/flightctl-device:base \033[m"
+mkdir -p bin/output
+# pull the image to the root user system storage in /var/lib/containers/storage
+echo -e "\033[32mPulling ${IP}:5000/flightctl-device:base to /var/lib/containers/storage\033[m"
+sudo podman pull "${IP}:5000/flightctl-device:base"
+echo -e "\033[32m Producing qcow image for ${IP}:5000/flightctl-device:base \033[m"
+sudo podman run --rm \
+                -it \
+                --privileged \
+                --pull=newer \
+                --security-opt label=type:unconfined_t \
+                -v $(pwd)/bin/output:/output \
+                -v /var/lib/containers/storage:/var/lib/containers/storage \
+                quay.io/centos-bootc/bootc-image-builder:latest \
+                --type qcow2 \
+                --local "${IP}:5000/flightctl-device:base"

--- a/test/scripts/agent-images/test-e2e-another-dummy.service
+++ b/test/scripts/agent-images/test-e2e-another-dummy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Test E2E Dummy V3
+
+[Service]
+Type=simple
+WorkingDirectory=/tmp
+ExecStart=/usr/bin/sleep 3600
+KillMode=process
+Restart=never
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/test/scripts/agent-images/test-e2e-crashing.service
+++ b/test/scripts/agent-images/test-e2e-crashing.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Test E2E Crash Dummy
+
+[Service]
+Type=simple
+WorkingDirectory=/tmp
+ExecStart=/usr/bin/false
+KillMode=process
+Restart=alwas
+RestartSec=30
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/test/scripts/agent-images/test-e2e-dummy.service
+++ b/test/scripts/agent-images/test-e2e-dummy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Test E2E Dummy
+
+[Service]
+Type=simple
+WorkingDirectory=/tmp
+ExecStart=/usr/bin/sleep 3600
+KillMode=process
+Restart=never
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/test/scripts/create_e2e_certs.sh
+++ b/test/scripts/create_e2e_certs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script is used to generate a CA and the necessary certificates for a
+# private Docker registry targetting the local IP
+
+set -x -e
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+IP=$("${SCRIPT_DIR}"/get_ext_ip.sh)
+
+CERT_DIR="bin/e2e-certs"
+mkdir -p "${CERT_DIR}"
+if [[ -f "${CERT_DIR}/ca.key" ]]; then
+    echo "CA key already exists, skipping generation"
+    exit 0
+fi
+
+openssl genrsa -out "${CERT_DIR}/ca.key" 2048
+openssl req -new -x509 -days 365 -key "${CERT_DIR}/ca.key" -out "${CERT_DIR}/ca.crt" -subj "/CN=e2e-ca"
+
+openssl x509 -in "${CERT_DIR}/ca.crt" -out "${CERT_DIR}/ca.pem" -outform PEM
+
+openssl genrsa -out "${CERT_DIR}/registry.key" 2048
+openssl req -new -key "${CERT_DIR}/registry.key" -out "${CERT_DIR}/registry.csr" -subj "/CN=${IP}"  -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:localhost,IP:${IP}"))
+openssl x509 -req -days 365 -in "${CERT_DIR}/registry.csr" -CA "${CERT_DIR}/ca.crt" -CAkey "${CERT_DIR}/ca.key" -CAcreateserial -out "${CERT_DIR}/registry.crt" -extfile <(printf "subjectAltName=DNS:localhost,IP:${IP}")
+

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -96,10 +96,13 @@ fi
 
 # deploy E2E local services for testing: local registry, eventually a git server, ostree repos, etc...
 helm ${METHOD} --values ./deploy/helm/e2e-extras/values.kind.yaml flightctl-e2e-extras \
-                        ./deploy/helm/e2e-extras/ --kube-context kind-kind 
+                        ./deploy/helm/e2e-extras/ --kube-context kind-kind
 
 sudo tee /etc/containers/registries.conf.d/flightctl-e2e.conf <<EOF
 [[registry]]
 location = "${IP}:5000"
+insecure = true
+[[registry]]
+location = "localhost:5000"
 insecure = true
 EOF

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -18,4 +18,6 @@ nodes:
   - containerPort: 5000 # local registry for E2E testing
     hostPort: 5000
     protocol: TCP
-  
+  extraMounts:
+  - hostPath: ./bin/e2e-certs
+    containerPath: /tmp/e2e-certs

--- a/test/scripts/prepare_agent_config.sh
+++ b/test/scripts/prepare_agent_config.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+IP=$("${SCRIPT_DIR}"/get_ext_ip.sh)
+OUTFILE=bin/agent/etc/flightctl/config.yaml
 mkdir -p bin/agent/etc/flightctl/certs
 cp ~/.flightctl/certs/ca.crt bin/agent/etc/flightctl/certs/ca.crt
 cp ~/.flightctl/certs/client-enrollment.{crt,key} bin/agent/etc/flightctl/certs/
 
-IP=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
-echo "Found ethernet interface IP: ${IP}"
-
-echo "Creating agent config"
-cat <<EOF > bin/agent/etc/flightctl/config.yaml
+echo "Creating agent config in ${OUTFILE}"
+tee ${OUTFILE} <<EOF
 management-endpoint: https://${IP}:3333
 enrollment-endpoint: https://${IP}:3333
 enrollment-ui-endpoint: https://${IP}:8080

--- a/test/test.mk
+++ b/test/test.mk
@@ -59,6 +59,9 @@ test: unit-test integration-test e2e-test
 
 run-test: unit-test run-intesgration-test
 
+bin/e2e-certs/ca.pem:
+	test/scripts/create_e2e_certs.sh
+
 .PHONY: test run-test
 
 $(REPORTS):


### PR DESCRIPTION
* Setups an E2E CA and registry service certificates that the agents will trust
* Creates several agent image variants and pushes them all to the registry
