### PR TITLE
MGMT-18037: Fix TemplateVersion issues

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -43,7 +43,7 @@ func (o *DeleteOptions) Validate(args []string) error {
 		return err
 	}
 	if kind == TemplateVersionKind && len(o.FleetName) == 0 {
-		return fmt.Errorf("fleetname must be specified when deleting templatevesions")
+		return fmt.Errorf("fleetname must be specified when deleting templateversions")
 	}
 	return nil
 }

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -88,7 +88,7 @@ func (o *GetOptions) Validate(args []string) error {
 		}
 	}
 	if kind == TemplateVersionKind && len(o.FleetName) == 0 {
-		return fmt.Errorf("fleetname must be specified when fetching templatevesions")
+		return fmt.Errorf("fleetname must be specified when fetching templateversions")
 	}
 	if o.Rendered && (kind != DeviceKind || len(name) == 0) {
 		return fmt.Errorf("rendered must only be specified when fetching a specific device")

--- a/internal/service/templateversion.go
+++ b/internal/service/templateversion.go
@@ -41,9 +41,10 @@ func (h *ServiceHandler) ListTemplateVersions(ctx context.Context, request serve
 	}
 
 	listParams := store.ListParams{
-		Labels:   labelMap,
-		Limit:    int(swag.Int32Value(request.Params.Limit)),
-		Continue: cont,
+		Labels:    labelMap,
+		Limit:     int(swag.Int32Value(request.Params.Limit)),
+		Continue:  cont,
+		FleetName: &request.Fleet,
 	}
 	if listParams.Limit == 0 {
 		listParams.Limit = store.MaxRecordsPerListRequest
@@ -65,7 +66,7 @@ func (h *ServiceHandler) ListTemplateVersions(ctx context.Context, request serve
 func (h *ServiceHandler) DeleteTemplateVersions(ctx context.Context, request server.DeleteTemplateVersionsRequestObject) (server.DeleteTemplateVersionsResponseObject, error) {
 	orgId := store.NullOrgId
 
-	err := h.store.TemplateVersion().DeleteAll(ctx, orgId, request.Fleet)
+	err := h.store.TemplateVersion().DeleteAll(ctx, orgId, &request.Fleet)
 	switch err {
 	case nil:
 		return server.DeleteTemplateVersions200JSONResponse{}, nil

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -16,6 +16,9 @@ func BuildBaseListQuery(db *gorm.DB, orgId uuid.UUID, listParams ListParams) *go
 	if listParams.Owner != nil {
 		query = db.Where("owner = ?", *listParams.Owner)
 	}
+	if listParams.FleetName != nil {
+		query = db.Where("fleet_name = ?", *listParams.FleetName)
+	}
 	return query
 }
 

--- a/internal/store/model/resource.go
+++ b/internal/store/model/resource.go
@@ -39,18 +39,6 @@ type Resource struct {
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
-type ResourceWithPrimaryKeyOwner struct {
-	OrgID       uuid.UUID      `gorm:"type:uuid;primary_key;"`
-	Name        string         `gorm:"primary_key;"`
-	Owner       *string        `gorm:"primary_key;"`
-	Labels      pq.StringArray `gorm:"type:text[]"`
-	Annotations pq.StringArray `gorm:"type:text[]"`
-	Generation  *int64
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   gorm.DeletedAt `gorm:"index"`
-}
-
 func (r *Resource) BeforeCreate(tx *gorm.DB) error {
 	if len(r.Name) == 0 {
 		r.Name = uuid.New().String()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -110,6 +110,7 @@ type ListParams struct {
 	Owner        *string
 	Limit        int
 	Continue     *Continue
+	FleetName    *string
 }
 
 type Continue struct {

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -244,21 +244,16 @@ func (t TaskManager) TemplateVersionCreatedCallback(templateVersion *model.Templ
 		OrgID: templateVersion.OrgID,
 		Kind:  model.TemplateVersionKind,
 		Name:  templateVersion.Name,
-		Owner: *templateVersion.Owner,
+		Owner: *util.SetResourceOwner(model.FleetKind, templateVersion.FleetName),
 	}
 	t.SubmitTask(ChannelTemplateVersionPopulate, resourceRef, TemplateVersionPopulateOpCreated)
 }
 
 func (t TaskManager) TemplateVersionValidatedCallback(templateVersion *model.TemplateVersion) {
-	_, fleetName, err := util.GetResourceOwner(templateVersion.Owner)
-	if err != nil {
-		t.log.Errorf("failed getting templateVersion owner: %v", err)
-		return
-	}
 	resourceRef := ResourceReference{
 		OrgID: templateVersion.OrgID,
 		Kind:  model.FleetKind,
-		Name:  fleetName,
+		Name:  templateVersion.FleetName,
 	}
 	t.SubmitTask(ChannelFleetRollout, resourceRef, FleetRolloutOpUpdate)
 }


### PR DESCRIPTION
4 commits:
1. Fix "templatevesions" typo in CLI
2. TemplateVersions were not being deleted after the associated fleet is.  This is a symptom of the TV schema not having the fleet as a foreign key as it should. This commit adds the foreign key with cascading delete.
3. Listing template versions in the CLI did not apply the filter by fleetname, and returned TVs belonging to other fleets.
4. (unrelated) singular/plural message on invalid fleet