### PR TITLE
NO-ISSUE: Client config improvements

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"time"
@@ -38,6 +39,8 @@ const (
 	EnrollmentCertFile = "client-enrollment.crt"
 	// name of the enrollment key file
 	EnrollmentKeyFile = "client-enrollment.key"
+	// TestRootDirEnvKey is the environment variable key used to set the file system root when testing.
+	TestRootDirEnvKey = "FLIGHTCTL_TEST_ROOT_DIR"
 )
 
 type Config struct {
@@ -83,7 +86,7 @@ type Config struct {
 }
 
 func NewDefault() *Config {
-	return &Config{
+	c := &Config{
 		ManagementEndpoint:   DefaultManagementEndpoint,
 		EnrollmentEndpoint:   DefaultManagementEndpoint,
 		EnrollmentUIEndpoint: DefaultManagementEndpoint,
@@ -99,14 +102,14 @@ func NewDefault() *Config {
 		reader:               fileio.NewReader(),
 		LogLevel:             logrus.InfoLevel.String(),
 	}
-}
 
-func (cfg *Config) SetTestRootDir(rootDir string) {
-	klog.Warning("Setting testRootDir is intended for testing only. Do not use in production.")
-	if cfg.reader != nil {
-		cfg.reader.SetRootdir(rootDir)
+	if value := os.Getenv(TestRootDirEnvKey); value != "" {
+		klog.Warning("Setting testRootDir is intended for testing only. Do not use in production.")
+		c.testRootDir = filepath.Clean(value)
+		c.reader.SetRootdir(c.testRootDir)
 	}
-	cfg.testRootDir = rootDir
+
+	return c
 }
 
 func (cfg *Config) GetTestRootDir() string {

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -91,6 +91,7 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 	fetchSpecInterval := 1 * time.Second
 	statusUpdateInterval := 2 * time.Second
 
+	os.Setenv(agent.TestRootDirEnvKey, testDirPath)
 	cfg := agent.NewDefault()
 	// TODO: remove the cert/key modifications from default, and start storing
 	// the test harness files for those in the testDir/etc/flightctl/certs path
@@ -102,7 +103,6 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 	cfg.ManagementEndpoint = "https://" + serverCfg.Service.Address
 	cfg.SpecFetchInterval = fetchSpecInterval
 	cfg.StatusUpdateInterval = statusUpdateInterval
-	cfg.SetTestRootDir(testDirPath)
 
 	// create client to talk to the server
 	client, err := testutil.NewClient("https://"+listener.Addr().String(), ca.Config, clientCerts)
@@ -134,6 +134,8 @@ func (h *TestHarness) Cleanup() {
 	h.cancelCtx()
 	// stop the server
 	h.serverListener.Close()
+	// unset env var for the test dir path
+	os.Unsetenv(agent.TestRootDirEnvKey)
 }
 
 func (h *TestHarness) AgentDownloadedCertificate() bool {


### PR DESCRIPTION
- Introduces FLIGHTCTL_TEST_ROOT_DIR env var to make the test root dir configurable.
- Allows client config file to contain relative paths to certs.
- Adds Equal() and DeepCopy() methods to client config.