### PR TITLE
Refresh devices/fleets upon repo update

### DIFF
--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -6,18 +6,18 @@ import (
 	"gorm.io/gorm"
 )
 
-func BuildBaseListQuery(db *gorm.DB, orgId uuid.UUID, listParams ListParams) *gorm.DB {
-	query := db.Where("org_id = ?", orgId).Order("name")
+func BuildBaseListQuery(query *gorm.DB, orgId uuid.UUID, listParams ListParams) *gorm.DB {
+	query = query.Where("org_id = ?", orgId).Order("name")
 	invertLabels := false
 	if listParams.InvertLabels != nil && *listParams.InvertLabels {
 		invertLabels = true
 	}
 	query = LabelSelectionQuery(query, listParams.Labels, invertLabels)
 	if listParams.Owner != nil {
-		query = db.Where("owner = ?", *listParams.Owner)
+		query = query.Where("owner = ?", *listParams.Owner)
 	}
 	if listParams.FleetName != nil {
-		query = db.Where("fleet_name = ?", *listParams.FleetName)
+		query = query.Where("fleet_name = ?", *listParams.FleetName)
 	}
 	return query
 }

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -32,6 +32,9 @@ type Device struct {
 
 	// The rendered ignition config, exposed in a separate endpoint.
 	RenderedConfig *string
+
+	// Join table with the relationship of devices to repositories (only maintained for standalone devices)
+	Repositories []Repository `gorm:"many2many:device_repos;"`
 }
 
 type ServiceConditions struct {

--- a/internal/store/model/fleet.go
+++ b/internal/store/model/fleet.go
@@ -24,6 +24,9 @@ type Fleet struct {
 
 	// The last reported state, stored as opaque JSON object.
 	Status *JSONField[api.FleetStatus]
+
+	// Join table with the relationship of fleets to repositories
+	Repositories []Repository `gorm:"many2many:fleet_repos;"`
 }
 
 type FleetList []Fleet

--- a/internal/store/model/repository.go
+++ b/internal/store/model/repository.go
@@ -22,6 +22,12 @@ type Repository struct {
 
 	// The last reported state, stored as opaque JSON object.
 	Status *JSONField[api.RepositoryStatus]
+
+	// Join table with the relationship of repository to fleets
+	Fleets []Fleet `gorm:"many2many:fleet_repos;"`
+
+	// Join table with the relationship of repository to devices (only maintained for standalone devices)
+	Devices []Device `gorm:"many2many:device_repos;"`
 }
 
 type RepositoryList []Repository

--- a/internal/tasks/common.go
+++ b/internal/tasks/common.go
@@ -1,7 +1,7 @@
 package tasks
 
 import (
-	"fmt"
+	"errors"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/store/model"
@@ -10,21 +10,7 @@ import (
 
 const ItemsPerPage = 1000
 
-type ErrUnknownConfigName struct {
-	Err error
-}
-
-func (e ErrUnknownConfigName) Error() string {
-	return fmt.Sprintf("failed to find configuration item name: %v", e.Err)
-}
-
-func (e ErrUnknownConfigName) Unwrap() error {
-	return e.Err
-}
-
-func NewUnknownConfigNameError(err error) error {
-	return ErrUnknownConfigName{Err: err}
-}
+var ErrUnknownConfigName = errors.New("failed to find configuration item name")
 
 func getOwnerFleet(device *api.Device) (string, bool, error) {
 	if device.Metadata.Owner == nil {

--- a/internal/tasks/common.go
+++ b/internal/tasks/common.go
@@ -1,12 +1,30 @@
 package tasks
 
 import (
+	"fmt"
+
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
 )
 
 const ItemsPerPage = 1000
+
+type ErrUnknownConfigName struct {
+	Err error
+}
+
+func (e ErrUnknownConfigName) Error() string {
+	return fmt.Sprintf("failed to find configuration item name: %v", e.Err)
+}
+
+func (e ErrUnknownConfigName) Unwrap() error {
+	return e.Err
+}
+
+func NewUnknownConfigNameError(err error) error {
+	return ErrUnknownConfigName{Err: err}
+}
 
 func getOwnerFleet(device *api.Device) (string, bool, error) {
 	if device.Metadata.Owner == nil {

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -3,7 +3,9 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	config_latest "github.com/coreos/ignition/v2/config/v3_4"
 	config_latest_types "github.com/coreos/ignition/v2/config/v3_4/types"
@@ -49,6 +51,7 @@ type DeviceRenderLogic struct {
 	resourceRef    ResourceReference
 	device         *api.Device
 	renderedConfig *config_latest_types.Config
+	repoNames      []string
 }
 
 func NewDeviceRenderLogic(taskManager TaskManager, log logrus.FieldLogger, store store.Store, resourceRef ResourceReference) DeviceRenderLogic {
@@ -66,14 +69,38 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	emptyIgnitionConfig, _, _ := config_latest.ParseCompatibleVersion([]byte("{\"ignition\": {\"version\": \"3.4.0\"}"))
 	t.renderedConfig = &emptyIgnitionConfig
 
+	invalidConfigs := []string{}
 	if device.Spec != nil && device.Spec.Config != nil {
 		for i := range *device.Spec.Config {
 			configItem := (*device.Spec.Config)[i]
-			err := t.handleConfigItem(ctx, &configItem)
+			name, err := t.handleConfigItem(ctx, &configItem)
 			if err != nil {
-				return t.setStatus(ctx, err)
+				var unknownErr ErrUnknownConfigName
+				if errors.As(err, &unknownErr) {
+					name = "<unknown>"
+				}
+				invalidConfigs = append(invalidConfigs, name)
 			}
+			t.log.Errorf("failed rendering config %s for device %s/%s: %v", name, t.resourceRef.OrgID, t.resourceRef.Name, err)
 		}
+	}
+
+	if device.Metadata.Owner == nil || *device.Metadata.Owner == "" {
+		// Set the many-to-may relationship with the repos (we do this even if the validation failed so that we will
+		// validate the fleet again if the repository is updated, and then it might be fixed)
+		err = t.store.Device().OverwriteRepositoryRefs(ctx, t.resourceRef.OrgID, *device.Metadata.Name, t.repoNames...)
+		if err != nil {
+			return t.setStatus(ctx, fmt.Errorf("setting repository references: %w", err))
+		}
+	}
+
+	if len(invalidConfigs) != 0 {
+		configurationStr := "configuration"
+		if len(invalidConfigs) > 1 {
+			configurationStr += "s"
+		}
+		err = fmt.Errorf("device has %d invalid %s: %s", len(invalidConfigs), configurationStr, strings.Join(invalidConfigs, ", "))
+		return t.setStatus(ctx, err)
 	}
 
 	configjson, err := json.Marshal(t.renderedConfig)
@@ -85,10 +112,11 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	return t.setStatus(ctx, err)
 }
 
-func (t *DeviceRenderLogic) handleConfigItem(ctx context.Context, configItem *api.DeviceSpec_Config_Item) error {
+func (t *DeviceRenderLogic) handleConfigItem(ctx context.Context, configItem *api.DeviceSpec_Config_Item) (string, error) {
+
 	disc, err := configItem.Discriminator()
 	if err != nil {
-		return fmt.Errorf("failed getting discriminator: %w", err)
+		return "", NewUnknownConfigNameError(fmt.Errorf("failed getting discriminator: %w", err))
 	}
 
 	switch disc {
@@ -97,77 +125,87 @@ func (t *DeviceRenderLogic) handleConfigItem(ctx context.Context, configItem *ap
 	case string(api.TemplateDiscriminatorKubernetesSec):
 		return t.handleK8sConfig(configItem)
 	case string(api.TemplateDiscriminatorInlineConfig):
-		inlineSpec, err := configItem.AsInlineConfigProviderSpec()
-		if err != nil {
-			return fmt.Errorf("failed getting config item %s as InlineConfigProviderSpec: %w", inlineSpec.Name, err)
-		}
-
-		return t.handleInlineConfig(&inlineSpec)
+		return t.handleInlineConfig(configItem)
 	default:
-		return fmt.Errorf("unsupported discriminator %s", disc)
+		return "", NewUnknownConfigNameError(fmt.Errorf("unsupported discriminator %s", disc))
 	}
 }
 
-func (t *DeviceRenderLogic) handleGitConfig(ctx context.Context, configItem *api.DeviceSpec_Config_Item) error {
+func (t *DeviceRenderLogic) handleGitConfig(ctx context.Context, configItem *api.DeviceSpec_Config_Item) (string, error) {
 	gitSpec, err := configItem.AsGitConfigProviderSpec()
 	if err != nil {
-		return fmt.Errorf("failed getting config item as GitConfigProviderSpec: %w", err)
+		return "", NewUnknownConfigNameError(fmt.Errorf("failed getting config item as GitConfigProviderSpec: %w", err))
 	}
 
+	t.repoNames = append(t.repoNames, gitSpec.GitRef.Repository)
 	repo, err := t.store.Repository().GetInternal(ctx, t.resourceRef.OrgID, gitSpec.GitRef.Repository)
 	if err != nil {
-		return fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+	}
+
+	if repo.Spec == nil {
+		return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
 	}
 
 	// TODO: Use local cache
 	mfs, _, err := CloneGitRepo(repo, &gitSpec.GitRef.TargetRevision, nil)
 	if err != nil {
-		return fmt.Errorf("failed cloning specified git repository %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		return gitSpec.Name, fmt.Errorf("failed cloning specified git repository %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
 	}
 
 	// Create an ignition from the git subtree and merge it into the rendered config
 	ignitionConfig, err := ConvertFileSystemToIgnition(mfs, gitSpec.GitRef.Path)
 	if err != nil {
-		return fmt.Errorf("failed parsing git config item %s: %w", gitSpec.Name, err)
+		return gitSpec.Name, fmt.Errorf("failed parsing git config item %s: %w", gitSpec.Name, err)
 	}
 	renderedConfig := config_latest.Merge(*t.renderedConfig, *ignitionConfig)
 	t.renderedConfig = &renderedConfig
 
-	return nil
+	return gitSpec.Name, nil
 }
 
 // TODO: implement
-func (t *DeviceRenderLogic) handleK8sConfig(configItem *api.DeviceSpec_Config_Item) error {
-	return fmt.Errorf("service does not yet support kubernetes config")
+func (t *DeviceRenderLogic) handleK8sConfig(configItem *api.DeviceSpec_Config_Item) (string, error) {
+	k8sSpec, err := configItem.AsKubernetesSecretProviderSpec()
+	if err != nil {
+		return "", NewUnknownConfigNameError(fmt.Errorf("failed getting config item as KubernetesSecretProviderSpec: %w", err))
+	}
+
+	return k8sSpec.Name, fmt.Errorf("service does not yet support kubernetes config")
 }
 
-func (t *DeviceRenderLogic) handleInlineConfig(inlineSpec *api.InlineConfigProviderSpec) error {
+func (t *DeviceRenderLogic) handleInlineConfig(configItem *api.DeviceSpec_Config_Item) (string, error) {
+	inlineSpec, err := configItem.AsInlineConfigProviderSpec()
+	if err != nil {
+		return "", NewUnknownConfigNameError(fmt.Errorf("failed getting config item as InlineConfigProviderSpec: %w", err))
+	}
+
 	// Add this inline config into the unrendered config
 	newConfig := &api.TemplateVersionStatus_Config_Item{}
-	err := newConfig.FromInlineConfigProviderSpec(*inlineSpec)
+	err = newConfig.FromInlineConfigProviderSpec(inlineSpec)
 	if err != nil {
-		return fmt.Errorf("failed creating inline config from item %s: %w", inlineSpec.Name, err)
+		return inlineSpec.Name, fmt.Errorf("failed creating inline config from item %s: %w", inlineSpec.Name, err)
 	}
 
 	// Convert yaml to json
 	yamlBytes, err := yaml.Marshal(inlineSpec.Inline)
 	if err != nil {
-		return fmt.Errorf("invalid yaml in inline config item %s: %w", inlineSpec.Name, err)
+		return inlineSpec.Name, fmt.Errorf("invalid yaml in inline config item %s: %w", inlineSpec.Name, err)
 	}
 	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
 	if err != nil {
-		return fmt.Errorf("failed converting yaml to json in inline config item %s: %w", inlineSpec.Name, err)
+		return inlineSpec.Name, fmt.Errorf("failed converting yaml to json in inline config item %s: %w", inlineSpec.Name, err)
 	}
 
 	// Convert to ignition and merge into the rendered config
 	ignitionConfig, _, err := config_latest.ParseCompatibleVersion(jsonBytes)
 	if err != nil {
-		return fmt.Errorf("failed parsing inline config item %s: %w", inlineSpec.Name, err)
+		return inlineSpec.Name, fmt.Errorf("failed parsing inline config item %s: %w", inlineSpec.Name, err)
 	}
 
 	renderedConfig := config_latest.Merge(*t.renderedConfig, ignitionConfig)
 	t.renderedConfig = &renderedConfig
-	return nil
+	return inlineSpec.Name, nil
 }
 
 func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {

--- a/internal/tasks/repo_update.go
+++ b/internal/tasks/repo_update.go
@@ -1,0 +1,133 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/reqid"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/sirupsen/logrus"
+)
+
+func RepositoryUpdate(taskManager TaskManager) {
+	for {
+		select {
+		case <-taskManager.ctx.Done():
+			taskManager.log.Info("Received ctx.Done(), stopping")
+			return
+		case resourceRef := <-taskManager.channels[ChannelRepositoryUpdates]:
+			requestID := reqid.NextRequestID()
+			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, requestID)
+			log := log.WithReqIDFromCtx(ctx, taskManager.log)
+			logic := NewRepositoryUpdateLogic(taskManager, log, taskManager.store, resourceRef)
+
+			switch {
+			case resourceRef.Op == RepositoryUpdateOpUpdate && resourceRef.Kind == model.RepositoryKind:
+				err := logic.HandleRepositoryUpdate(ctx)
+				if err != nil {
+					log.Errorf("failed to notify associated resources of update to repository %s/%s: %v", resourceRef.OrgID, resourceRef.Name, err)
+				}
+			case resourceRef.Op == RepositoryUpdateOpDeleteAll && resourceRef.Kind == model.RepositoryKind:
+				err := logic.HandleAllRepositoriesDeleted(ctx, log)
+				if err != nil {
+					log.Errorf("failed to notify associated resources deletion of all repositories in org %s: %v", resourceRef.OrgID, err)
+				}
+			default:
+				log.Errorf("RepositoryUpdate called with unexpected kind %s and op %s", resourceRef.Kind, resourceRef.Op)
+			}
+		}
+	}
+}
+
+type RepositoryUpdateLogic struct {
+	taskManager TaskManager
+	log         logrus.FieldLogger
+	store       store.Store
+	resourceRef ResourceReference
+}
+
+func NewRepositoryUpdateLogic(taskManager TaskManager, log logrus.FieldLogger, store store.Store, resourceRef ResourceReference) RepositoryUpdateLogic {
+	return RepositoryUpdateLogic{taskManager: taskManager, log: log, store: store, resourceRef: resourceRef}
+}
+
+func (t *RepositoryUpdateLogic) HandleRepositoryUpdate(ctx context.Context) error {
+	fleets, err := t.store.Repository().GetFleetRefs(ctx, t.resourceRef.OrgID, t.resourceRef.Name)
+	if err != nil {
+		return fmt.Errorf("fetching fleets: %w", err)
+	}
+
+	for _, fleet := range fleets.Items {
+		t.taskManager.FleetSourceUpdated(t.resourceRef.OrgID, *fleet.Metadata.Name)
+	}
+
+	devices, err := t.store.Repository().GetDeviceRefs(ctx, t.resourceRef.OrgID, t.resourceRef.Name)
+	if err != nil {
+		return fmt.Errorf("fetching devices: %w", err)
+	}
+
+	for _, device := range devices.Items {
+		t.taskManager.DeviceSourceUpdated(t.resourceRef.OrgID, *device.Metadata.Name)
+	}
+
+	return nil
+}
+
+func (t *RepositoryUpdateLogic) HandleAllRepositoriesDeleted(ctx context.Context, log logrus.FieldLogger) error {
+	fleets, err := t.store.Fleet().List(ctx, t.resourceRef.OrgID, store.ListParams{})
+	if err != nil {
+		return fmt.Errorf("fetching fleets: %w", err)
+	}
+
+	for _, fleet := range fleets.Items {
+		hasReference, err := t.doesConfigReferenceAnyRepo(*fleet.Spec.Template.Spec.Config)
+		if err != nil {
+			log.Errorf("failed checking if fleet %s/%s references any repo: %v", t.resourceRef.OrgID, *fleet.Metadata.Name, err)
+			continue
+		}
+
+		if hasReference {
+			t.taskManager.FleetSourceUpdated(t.resourceRef.OrgID, *fleet.Metadata.Name)
+		}
+	}
+
+	devices, err := t.store.Device().List(ctx, t.resourceRef.OrgID, store.ListParams{})
+	if err != nil {
+		return fmt.Errorf("fetching devices: %w", err)
+	}
+
+	for _, device := range devices.Items {
+		hasReference, err := t.doesConfigReferenceAnyRepo(*device.Spec.Config)
+		if err != nil {
+			log.Errorf("failed checking if device %s/%s references any repo: %v", t.resourceRef.OrgID, *device.Metadata.Name, err)
+			continue
+		}
+
+		if hasReference {
+			t.taskManager.DeviceSourceUpdated(t.resourceRef.OrgID, *device.Metadata.Name)
+		}
+	}
+
+	return nil
+}
+
+func (t *RepositoryUpdateLogic) doesConfigReferenceAnyRepo(configItems []v1alpha1.DeviceSpec_Config_Item) (bool, error) {
+	for _, configItem := range configItems {
+		disc, err := configItem.Discriminator()
+		if err != nil {
+			return false, fmt.Errorf("failed getting discriminator: %w", err)
+		}
+
+		if disc != string(api.TemplateDiscriminatorGitConfig) {
+			continue
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/test/integration/store/repository_test.go
+++ b/test/integration/store/repository_test.go
@@ -2,7 +2,6 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/config"
@@ -11,32 +10,12 @@ import (
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
+	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
-
-func createRepositories(numRepositories int, ctx context.Context, storeInst store.Store, orgId uuid.UUID) {
-	for i := 1; i <= numRepositories; i++ {
-		spec := api.RepositorySpec{}
-		err := spec.FromGitGenericRepoSpec(api.GitGenericRepoSpec{
-			Repo: "myrepo",
-		})
-		Expect(err).ToNot(HaveOccurred())
-		resource := api.Repository{
-			Metadata: api.ObjectMeta{
-				Name:   util.StrToPtr(fmt.Sprintf("myrepository-%d", i)),
-				Labels: &map[string]string{"key": fmt.Sprintf("value-%d", i)},
-			},
-			Spec: spec,
-		}
-
-		callback := store.RepositoryStoreCallback(func(*model.Repository) {})
-		_, err = storeInst.Repository().Create(ctx, orgId, &resource, callback)
-		Expect(err).ToNot(HaveOccurred())
-	}
-}
 
 var _ = Describe("RepositoryStore create", func() {
 	var (
@@ -60,7 +39,8 @@ var _ = Describe("RepositoryStore create", func() {
 		callbackCalled = false
 		callback = store.RepositoryStoreCallback(func(*model.Repository) { callbackCalled = true })
 
-		createRepositories(3, ctx, storeInst, orgId)
+		err := testutil.CreateRepositories(ctx, 3, storeInst, orgId)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/test/integration/store/resourcesync_test.go
+++ b/test/integration/store/resourcesync_test.go
@@ -20,7 +20,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func createResourceSyncs(numResourceSyncs int, ctx context.Context, storeInst store.Store, orgId uuid.UUID) {
+func createResourceSyncs(ctx context.Context, numResourceSyncs int, storeInst store.Store, orgId uuid.UUID) {
 	for i := 1; i <= numResourceSyncs; i++ {
 		resource := api.ResourceSync{
 			Metadata: api.ObjectMeta{
@@ -58,7 +58,7 @@ var _ = Describe("ResourceSyncStore create", func() {
 		numResourceSyncs = 3
 		storeInst, cfg, dbName = store.PrepareDBForUnitTests(log)
 
-		createResourceSyncs(3, ctx, storeInst, orgId)
+		createResourceSyncs(ctx, 3, storeInst, orgId)
 	})
 
 	AfterEach(func() {
@@ -146,8 +146,8 @@ var _ = Describe("ResourceSyncStore create", func() {
 		It("Delete all resourcesyncs in org", func() {
 			owner := util.SetResourceOwner(model.ResourceSyncKind, "myresourcesync-1")
 			otherOrgId, _ := uuid.NewUUID()
-			testutil.CreateTestFleets(2, ctx, storeInst.Fleet(), orgId, "myfleet", true, owner)
-			testutil.CreateTestFleets(2, ctx, storeInst.Fleet(), otherOrgId, "myfleet", true, owner)
+			testutil.CreateTestFleets(ctx, 2, storeInst.Fleet(), orgId, "myfleet", true, owner)
+			testutil.CreateTestFleets(ctx, 2, storeInst.Fleet(), otherOrgId, "myfleet", true, owner)
 			callbackCalled := false
 			err := storeInst.ResourceSync().DeleteAll(ctx, otherOrgId, func(ctx context.Context, tx *gorm.DB, orgId uuid.UUID, kind string) error {
 				callbackCalled = true

--- a/test/integration/store/templateversion_test.go
+++ b/test/integration/store/templateversion_test.go
@@ -58,7 +58,7 @@ var _ = Describe("TemplateVersion", func() {
 		It("List with paging", func() {
 			numResources := 5
 			testutil.CreateTestFleet(ctx, storeInst.Fleet(), orgId, "myfleet", nil, nil)
-			err := testutil.CreateTestTemplateVersions(numResources, ctx, tvStore, orgId, "myfleet")
+			err := testutil.CreateTestTemplateVersions(ctx, numResources, tvStore, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
 			listParams := store.ListParams{}
@@ -107,12 +107,12 @@ var _ = Describe("TemplateVersion", func() {
 		It("Delete all templateVersions of fleet", func() {
 			numResources := 5
 			testutil.CreateTestFleet(ctx, storeInst.Fleet(), orgId, "myfleet", nil, nil)
-			err := testutil.CreateTestTemplateVersions(numResources, ctx, tvStore, orgId, "myfleet")
+			err := testutil.CreateTestTemplateVersions(ctx, numResources, tvStore, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
 			otherOrgId, _ := uuid.NewUUID()
 			testutil.CreateTestFleet(ctx, storeInst.Fleet(), otherOrgId, "myfleet", nil, nil)
-			err = testutil.CreateTestTemplateVersions(numResources, ctx, tvStore, otherOrgId, "myfleet")
+			err = testutil.CreateTestTemplateVersions(ctx, numResources, tvStore, otherOrgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
 			err = storeInst.TemplateVersion().DeleteAll(ctx, otherOrgId, util.StrToPtr("myfleet"))
@@ -130,12 +130,12 @@ var _ = Describe("TemplateVersion", func() {
 		It("Delete fleet deletes its templateVersions", func() {
 			numResources := 5
 			testutil.CreateTestFleet(ctx, storeInst.Fleet(), orgId, "myfleet", nil, nil)
-			err := testutil.CreateTestTemplateVersions(numResources, ctx, tvStore, orgId, "myfleet")
+			err := testutil.CreateTestTemplateVersions(ctx, numResources, tvStore, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
 			otherOrgId, _ := uuid.NewUUID()
 			testutil.CreateTestFleet(ctx, storeInst.Fleet(), otherOrgId, "myfleet", nil, nil)
-			err = testutil.CreateTestTemplateVersions(numResources, ctx, tvStore, otherOrgId, "myfleet")
+			err = testutil.CreateTestTemplateVersions(ctx, numResources, tvStore, otherOrgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
 			callback := store.FleetStoreCallback(func(before *model.Fleet, after *model.Fleet) {})

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -62,7 +62,7 @@ var _ = Describe("FleetRollout", func() {
 			testutil.CreateTestFleet(ctx, fleetStore, orgId, "myfleet-1", nil, nil)
 			err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.bad", "my bad OS", false)
 			Expect(err).ToNot(HaveOccurred())
-			testutil.CreateTestDevices(numDevices, ctx, deviceStore, orgId, util.StrToPtr("Fleet/myfleet-1"), true)
+			testutil.CreateTestDevices(ctx, numDevices, deviceStore, orgId, util.StrToPtr("Fleet/myfleet-1"), true)
 			fleet, err := fleetStore.Get(ctx, orgId, "myfleet-1")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*fleet.Metadata.Generation).To(Equal(int64(1)))

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -144,6 +144,11 @@ var _ = Describe("FleetValidate", func() {
 			Expect(*fleet.Status.Conditions).To(HaveLen(1))
 			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
 			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusTrue))
+
+			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repos.Items).To(HaveLen(1))
+			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("repo"))
 		})
 	})
 
@@ -186,6 +191,11 @@ var _ = Describe("FleetValidate", func() {
 			Expect(*fleet.Status.Conditions).To(HaveLen(1))
 			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
 			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusFalse))
+
+			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repos.Items).To(HaveLen(1))
+			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("missingrepo"))
 		})
 	})
 
@@ -228,6 +238,11 @@ var _ = Describe("FleetValidate", func() {
 			Expect(*fleet.Status.Conditions).To(HaveLen(1))
 			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
 			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusFalse))
+
+			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repos.Items).To(HaveLen(1))
+			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("repo"))
 		})
 	})
 

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -3,6 +3,7 @@ package tasks_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/config"
@@ -246,20 +247,21 @@ var _ = Describe("FleetValidate", func() {
 		})
 	})
 
-	When("a Repository definition is valid", func() {
-		It("creates new TemplateVersions for relevant Fleets", func() {
-			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "repo", Kind: model.RepositoryKind}
+	When("a Fleet has an invalid configuration type", func() {
+		It("sets an error Condition", func() {
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "myfleet", Kind: model.FleetKind}
 			logic := tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
 
 			gitItem := api.DeviceSpec_Config_Item{}
 			err := gitItem.FromGitConfigProviderSpec(*goodGitConfig)
 			Expect(err).ToNot(HaveOccurred())
-
-			inlineItem := api.DeviceSpec_Config_Item{}
-			err = inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
+			b, err := gitItem.MarshalJSON()
+			Expect(err).ToNot(HaveOccurred())
+			invalidStr := strings.ReplaceAll(string(b), "GitConfigProviderSpec", "InvalidProviderSpec")
+			err = gitItem.UnmarshalJSON([]byte(invalidStr))
 			Expect(err).ToNot(HaveOccurred())
 
-			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem, inlineItem}
+			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem}
 
 			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
 			Expect(err).ToNot(HaveOccurred())
@@ -271,83 +273,8 @@ var _ = Describe("FleetValidate", func() {
 			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 
-			logic.ValidateFleetsReferencingRepository(ctx)
-
-			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(1))
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(fleet.Status.Conditions).ToNot(BeNil())
-			Expect(*fleet.Status.Conditions).To(HaveLen(1))
-			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
-			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusTrue))
-		})
-
-		It("doesn't create new TemplateVersions for irrelevant Fleets", func() {
-			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "repo", Kind: model.RepositoryKind}
-			logic := tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
-
-			gitItem := api.DeviceSpec_Config_Item{}
-			err := gitItem.FromGitConfigProviderSpec(*badGitConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			inlineItem := api.DeviceSpec_Config_Item{}
-			err = inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem, inlineItem}
-
-			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			logic.ValidateFleetsReferencingRepository(ctx)
-
-			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fleet.Status.Conditions).To(BeNil())
-		})
-	})
-
-	When("a Repository definition is invalid", func() {
-		It("doesn't create new TemplateVersions for relevant Fleets", func() {
-			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "missingrepo", Kind: model.RepositoryKind}
-			logic := tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
-
-			gitItem := api.DeviceSpec_Config_Item{}
-			err := gitItem.FromGitConfigProviderSpec(*badGitConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			inlineItem := api.DeviceSpec_Config_Item{}
-			err = inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem, inlineItem}
-
-			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			logic.ValidateFleetsReferencingRepository(ctx)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
 			Expect(err).ToNot(HaveOccurred())
@@ -360,79 +287,7 @@ var _ = Describe("FleetValidate", func() {
 			Expect(*fleet.Status.Conditions).To(HaveLen(1))
 			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
 			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusFalse))
+			Expect(*((*fleet.Status.Conditions)[0].Message)).To(Equal("fleet has 1 invalid configuration: <unknown>"))
 		})
 	})
-
-	When("all repositories are deleted", func() {
-		It("sets fleets that reference repositories as invalid", func() {
-			resourceRef := tasks.ResourceReference{OrgID: orgId, Kind: model.RepositoryKind}
-			logic := tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
-
-			gitItem := api.DeviceSpec_Config_Item{}
-			err := gitItem.FromGitConfigProviderSpec(*badGitConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			inlineItem := api.DeviceSpec_Config_Item{}
-			err = inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem, inlineItem}
-
-			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			logic.ValidateFleetsReferencingAnyRepository(ctx)
-
-			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(fleet.Status.Conditions).ToNot(BeNil())
-			Expect(*fleet.Status.Conditions).To(HaveLen(1))
-			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
-			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusFalse))
-		})
-
-		It("has no effect on fleets that don't reference any repositories", func() {
-			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "repo", Kind: model.RepositoryKind}
-			logic := tasks.NewFleetValidateLogic(taskManager, log, storeInst, resourceRef)
-
-			inlineItem := api.DeviceSpec_Config_Item{}
-			err := inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{inlineItem}
-
-			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
-			Expect(err).ToNot(HaveOccurred())
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			logic.ValidateFleetsReferencingAnyRepository(ctx)
-
-			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tvList.Items).To(HaveLen(0))
-
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fleet.Status.Conditions).To(BeNil())
-		})
-	})
-
 })

--- a/test/integration/tasks/repo_update_test.go
+++ b/test/integration/tasks/repo_update_test.go
@@ -1,0 +1,166 @@
+package tasks_test
+
+import (
+	"context"
+	"encoding/json"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/util"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("RepoUpdate", func() {
+	var (
+		log         *logrus.Logger
+		ctx         context.Context
+		orgId       uuid.UUID
+		storeInst   store.Store
+		cfg         *config.Config
+		dbName      string
+		taskManager tasks.TaskManager
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		orgId, _ = uuid.NewUUID()
+		log = flightlog.InitLogs()
+		storeInst, cfg, dbName = store.PrepareDBForUnitTests(log)
+		taskManager = tasks.Init(log, storeInst)
+
+		// Create 2 git config items, each to a different repo
+		err := testutil.CreateRepositories(ctx, 2, storeInst, orgId)
+		Expect(err).ToNot(HaveOccurred())
+
+		gitConfig1 := &api.GitConfigProviderSpec{
+			ConfigType: string(api.TemplateDiscriminatorGitConfig),
+			Name:       "gitConfig1",
+		}
+		gitConfig1.GitRef.Path = "path"
+		gitConfig1.GitRef.Repository = "myrepository-1"
+		gitConfig1.GitRef.TargetRevision = "rev"
+		gitItem1 := api.DeviceSpec_Config_Item{}
+		err = gitItem1.FromGitConfigProviderSpec(*gitConfig1)
+		Expect(err).ToNot(HaveOccurred())
+
+		gitConfig2 := &api.GitConfigProviderSpec{
+			ConfigType: string(api.TemplateDiscriminatorGitConfig),
+			Name:       "gitConfig2",
+		}
+		gitConfig1.GitRef.Path = "path"
+		gitConfig1.GitRef.Repository = "myrepository-2"
+		gitConfig1.GitRef.TargetRevision = "rev"
+		gitItem2 := api.DeviceSpec_Config_Item{}
+		err = gitItem2.FromGitConfigProviderSpec(*gitConfig2)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create an inline config item
+		inlineConfig := &api.InlineConfigProviderSpec{
+			ConfigType: string(api.TemplateDiscriminatorInlineConfig),
+			Name:       "inlineConfig",
+		}
+		var goodInline map[string]interface{}
+		err = json.Unmarshal([]byte("{\"ignition\": {\"version\": \"3.4.0\"}}"), &goodInline)
+		Expect(err).ToNot(HaveOccurred())
+		inlineConfig.Inline = goodInline
+		inlineItem := api.DeviceSpec_Config_Item{}
+		err = inlineItem.FromInlineConfigProviderSpec(*inlineConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		config1 := []api.DeviceSpec_Config_Item{gitItem1, inlineItem}
+		config2 := []api.DeviceSpec_Config_Item{gitItem2, inlineItem}
+
+		// Create fleet1 referencing repo1, fleet2 referencing repo2
+		fleet1 := api.Fleet{
+			Metadata: api.ObjectMeta{Name: util.StrToPtr("fleet1")},
+			Spec:     api.FleetSpec{},
+		}
+		fleet1.Spec.Template.Spec = api.DeviceSpec{Config: &config1}
+
+		fleet2 := api.Fleet{
+			Metadata: api.ObjectMeta{Name: util.StrToPtr("fleet2")},
+			Spec:     api.FleetSpec{},
+		}
+		fleet2.Spec.Template.Spec = api.DeviceSpec{Config: &config2}
+
+		fleetCallback := store.FleetStoreCallback(func(before *model.Fleet, after *model.Fleet) {})
+		_, err = storeInst.Fleet().Create(ctx, orgId, &fleet1, fleetCallback)
+		Expect(err).ToNot(HaveOccurred())
+		err = storeInst.Fleet().OverwriteRepositoryRefs(ctx, orgId, "fleet1", "myrepository-1")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = storeInst.Fleet().Create(ctx, orgId, &fleet2, fleetCallback)
+		Expect(err).ToNot(HaveOccurred())
+		err = storeInst.Fleet().OverwriteRepositoryRefs(ctx, orgId, "fleet2", "myrepository-2")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create device1 referencing repo1, device2 referencing repo2
+		device1 := api.Device{
+			Metadata: api.ObjectMeta{Name: util.StrToPtr("device1")},
+			Spec: &api.DeviceSpec{
+				Config: &config1,
+			},
+		}
+
+		device2 := api.Device{
+			Metadata: api.ObjectMeta{Name: util.StrToPtr("device2")},
+			Spec: &api.DeviceSpec{
+				Config: &config2,
+			},
+		}
+
+		devCallback := store.DeviceStoreCallback(func(before *model.Device, after *model.Device) {})
+		_, err = storeInst.Device().Create(ctx, orgId, &device1, devCallback)
+		Expect(err).ToNot(HaveOccurred())
+		err = storeInst.Device().OverwriteRepositoryRefs(ctx, orgId, "device1", "myrepository-1")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = storeInst.Device().Create(ctx, orgId, &device2, devCallback)
+		Expect(err).ToNot(HaveOccurred())
+		err = storeInst.Device().OverwriteRepositoryRefs(ctx, orgId, "device2", "myrepository-2")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		store.DeleteTestDB(cfg, storeInst, dbName)
+	})
+
+	When("a Repository definition is updated", func() {
+		It("refreshes relevant fleets and devices", func() {
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "myrepository-1", Kind: model.RepositoryKind}
+			logic := tasks.NewRepositoryUpdateLogic(taskManager, log, storeInst, resourceRef)
+			err := logic.HandleRepositoryUpdate(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleetRef := taskManager.GetTask(tasks.ChannelFleetValidate)
+			Expect(fleetRef.Name).To(Equal("fleet1"))
+			Expect(taskManager.HasTasks(tasks.ChannelFleetValidate)).To(BeFalse())
+			devRef := taskManager.GetTask(tasks.ChannelDeviceRender)
+			Expect(devRef.Name).To(Equal("device1"))
+			Expect(taskManager.HasTasks(tasks.ChannelDeviceRender)).To(BeFalse())
+		})
+	})
+
+	When("all Repository definitions are deleted", func() {
+		It("refreshes relevant fleets and devices", func() {
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Kind: model.RepositoryKind}
+			logic := tasks.NewRepositoryUpdateLogic(taskManager, log, storeInst, resourceRef)
+			err := logic.HandleAllRepositoriesDeleted(ctx, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// both fleets and both devices
+			_ = taskManager.GetTask(tasks.ChannelFleetValidate)
+			_ = taskManager.GetTask(tasks.ChannelFleetValidate)
+			Expect(taskManager.HasTasks(tasks.ChannelFleetValidate)).To(BeFalse())
+			_ = taskManager.GetTask(tasks.ChannelDeviceRender)
+			_ = taskManager.GetTask(tasks.ChannelDeviceRender)
+			Expect(taskManager.HasTasks(tasks.ChannelDeviceRender)).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Two commits:

- MGMT-18098: Track references of fleets/devices to repositories
    Create a join table in SQL and update references from fleets and
    standalone devices to repositories. Later, when a repository is updated
    we can immediately know which fleets and devices are affected.
- MGMT-17945: Refresh devices/fleets upon repo update
    If a repository resource is updated, make sure to:
    1. Create a new TemplateVersion for each fleet that references it
    2. Render each standalone device that references it