### PR TITLE
NO-ISSUE: Better debug details on E2E failure

### DIFF
--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -38,6 +38,21 @@ var _ = Describe("VM Agent behavior", func() {
 	})
 
 	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			fmt.Printf("oops... %s failed, collecting agent output\n", CurrentSpecReport().FullText())
+
+			stdout, _ := harness.VM.RunSSH([]string{"sudo", "systemctl", "status", "flightctl-agent"}, nil)
+			fmt.Print("\n\n\n")
+			fmt.Println("============ systemctl status flightctl-agent ============")
+			fmt.Println(stdout.String())
+			fmt.Println("=============== journalctl -u flightctl-agent ============")
+			stdout, _ = harness.VM.RunSSH([]string{"sudo", "journalctl", "-u", "flightctl-agent"}, nil)
+			fmt.Println(stdout.String())
+			fmt.Println("======================= VM Console =======================")
+			fmt.Println(harness.VM.GetConsoleOutput())
+			fmt.Println("==========================================================")
+			fmt.Print("\n\n\n")
+		}
 		harness.Cleanup()
 	})
 


### PR DESCRIPTION
Sometimes a test can fail, and we know something is wrong with the flightctl-agent, gathering logs from the flightctl-agent would be helpful in that situation.

This pach retrieves and prints the flightctl-agent status and logs in case of test failure.