### PR TITLE
MGMT-18179: Remove duplication between config validate and render

### DIFF
--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
@@ -45,13 +46,10 @@ func DeviceRender(taskManager TaskManager) {
 }
 
 type DeviceRenderLogic struct {
-	taskManager    TaskManager
-	log            logrus.FieldLogger
-	store          store.Store
-	resourceRef    ResourceReference
-	device         *api.Device
-	renderedConfig *config_latest_types.Config
-	repoNames      []string
+	taskManager TaskManager
+	log         logrus.FieldLogger
+	store       store.Store
+	resourceRef ResourceReference
 }
 
 func NewDeviceRenderLogic(taskManager TaskManager, log logrus.FieldLogger, store store.Store, resourceRef ResourceReference) DeviceRenderLogic {
@@ -63,56 +61,123 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 
 	device, err := t.store.Device().Get(ctx, t.resourceRef.OrgID, t.resourceRef.Name)
 	if err != nil {
-		return err
-	}
-	t.device = device
-	emptyIgnitionConfig, _, _ := config_latest.ParseCompatibleVersion([]byte("{\"ignition\": {\"version\": \"3.4.0\"}"))
-	t.renderedConfig = &emptyIgnitionConfig
-
-	invalidConfigs := []string{}
-	if device.Spec != nil && device.Spec.Config != nil {
-		for i := range *device.Spec.Config {
-			configItem := (*device.Spec.Config)[i]
-			name, err := t.handleConfigItem(ctx, &configItem)
-			if err != nil {
-				if errors.Is(err, ErrUnknownConfigName) {
-					name = "<unknown>"
-				}
-				invalidConfigs = append(invalidConfigs, name)
-			}
-			t.log.Errorf("failed rendering config %s for device %s/%s: %v", name, t.resourceRef.OrgID, t.resourceRef.Name, err)
-		}
+		return fmt.Errorf("failed getting device %s/%s: %w", t.resourceRef.OrgID, t.resourceRef.Name, err)
 	}
 
+	// If device.Spec or device.Spec.Config are nil, we still want to render an empty ignition config
+	var config *[]api.DeviceSpec_Config_Item
+	if device.Spec != nil {
+		config = device.Spec.Config
+	}
+
+	renderedConfig, repoNames, renderErr := renderConfig(ctx, t.resourceRef.OrgID, t.store, config, false)
+
+	// Set the many-to-many relationship with the repos (we do this even if the render failed so that we will
+	// render the device again if the repository is updated, and then it might be fixed).
+	// This only applies to devices that don't belong to a fleet, because otherwise the fleet will be
+	// notified about changes to the repository.
 	if device.Metadata.Owner == nil || *device.Metadata.Owner == "" {
-		// Set the many-to-may relationship with the repos (we do this even if the validation failed so that we will
-		// validate the fleet again if the repository is updated, and then it might be fixed)
-		err = t.store.Device().OverwriteRepositoryRefs(ctx, t.resourceRef.OrgID, *device.Metadata.Name, t.repoNames...)
+		err = t.store.Device().OverwriteRepositoryRefs(ctx, t.resourceRef.OrgID, *device.Metadata.Name, repoNames...)
 		if err != nil {
 			return t.setStatus(ctx, fmt.Errorf("setting repository references: %w", err))
 		}
 	}
 
-	if len(invalidConfigs) != 0 {
-		configurationStr := "configuration"
-		if len(invalidConfigs) > 1 {
-			configurationStr += "s"
-		}
-		err = fmt.Errorf("device has %d invalid %s: %s", len(invalidConfigs), configurationStr, strings.Join(invalidConfigs, ", "))
-		return t.setStatus(ctx, err)
+	if renderErr != nil {
+		return t.setStatus(ctx, renderErr)
 	}
 
-	configjson, err := json.Marshal(t.renderedConfig)
-	if err != nil {
-		return t.setStatus(ctx, err)
-	}
-
-	err = t.store.Device().UpdateRendered(ctx, t.resourceRef.OrgID, t.resourceRef.Name, string(configjson))
+	err = t.store.Device().UpdateRendered(ctx, t.resourceRef.OrgID, t.resourceRef.Name, string(renderedConfig))
 	return t.setStatus(ctx, err)
 }
 
-func (t *DeviceRenderLogic) handleConfigItem(ctx context.Context, configItem *api.DeviceSpec_Config_Item) (string, error) {
+func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {
+	condition := api.Condition{Type: api.DeviceSpecValid}
 
+	if renderErr == nil {
+		condition.Status = api.ConditionStatusTrue
+		condition.Reason = util.StrToPtr("Valid")
+	} else {
+		condition.Status = api.ConditionStatusFalse
+		condition.Reason = util.StrToPtr("Invalid")
+		condition.Message = util.StrToPtr(renderErr.Error())
+	}
+
+	err := t.store.Device().SetServiceConditions(ctx, t.resourceRef.OrgID, t.resourceRef.Name, []api.Condition{condition})
+	if err != nil {
+		t.log.Errorf("Failed setting condition for device %s/%s: %v", t.resourceRef.OrgID, t.resourceRef.Name, err)
+	}
+	return renderErr
+}
+
+type renderConfigArgs struct {
+	orgId          uuid.UUID
+	store          store.Store
+	ignitionConfig *config_latest_types.Config
+	repoNames      []string
+	validateOnly   bool
+}
+
+func renderConfig(ctx context.Context, orgId uuid.UUID, store store.Store, config *[]api.DeviceSpec_Config_Item, validateOnly bool) (renderedConfig []byte, repoNames []string, err error) {
+	args := renderConfigArgs{}
+	emptyIgnitionConfig, _, _ := config_latest.ParseCompatibleVersion([]byte("{\"ignition\": {\"version\": \"3.4.0\"}"))
+	args.ignitionConfig = &emptyIgnitionConfig
+	args.validateOnly = validateOnly
+	args.orgId = orgId
+	args.store = store
+
+	err = renderConfigItems(ctx, config, &args)
+	if err != nil {
+		return nil, args.repoNames, err
+	}
+
+	if validateOnly {
+		return nil, args.repoNames, nil
+	}
+
+	renderedConfig, err = json.Marshal(args.ignitionConfig)
+	if err != nil {
+		return nil, args.repoNames, fmt.Errorf("failed marshalling configuration: %w", err)
+	}
+
+	return renderedConfig, args.repoNames, nil
+}
+
+func renderConfigItems(ctx context.Context, config *[]api.DeviceSpec_Config_Item, args *renderConfigArgs) error {
+	if config == nil {
+		return nil
+	}
+
+	invalidConfigs := []string{}
+	var firstError error
+	for i := range *config {
+		configItem := (*config)[i]
+		name, err := renderConfigItem(ctx, &configItem, args)
+		if err != nil {
+			if errors.Is(err, ErrUnknownConfigName) {
+				name = "<unknown>"
+			}
+			invalidConfigs = append(invalidConfigs, name)
+			if len(invalidConfigs) == 1 {
+				firstError = err
+			}
+		}
+	}
+
+	if len(invalidConfigs) != 0 {
+		configurationStr := "configuration"
+		errorStr := "Error"
+		if len(invalidConfigs) > 1 {
+			configurationStr += "s"
+			errorStr = "First error"
+		}
+		return fmt.Errorf("%d invalid %s: %s. %s: %v", len(invalidConfigs), configurationStr, strings.Join(invalidConfigs, ", "), errorStr, firstError)
+	}
+
+	return nil
+}
+
+func renderConfigItem(ctx context.Context, configItem *api.DeviceSpec_Config_Item, args *renderConfigArgs) (string, error) {
 	disc, err := configItem.Discriminator()
 	if err != nil {
 		return "", fmt.Errorf("%w: failed getting discriminator: %w", ErrUnknownConfigName, err)
@@ -120,36 +185,40 @@ func (t *DeviceRenderLogic) handleConfigItem(ctx context.Context, configItem *ap
 
 	switch disc {
 	case string(api.TemplateDiscriminatorGitConfig):
-		return t.handleGitConfig(ctx, configItem)
+		return renderGitConfig(ctx, configItem, args)
 	case string(api.TemplateDiscriminatorKubernetesSec):
-		return t.handleK8sConfig(configItem)
+		return renderK8sConfig(configItem)
 	case string(api.TemplateDiscriminatorInlineConfig):
-		return t.handleInlineConfig(configItem)
+		return renderInlineConfig(configItem, args)
 	default:
 		return "", fmt.Errorf("%w: unsupported discriminator: %s", ErrUnknownConfigName, disc)
 	}
 }
 
-func (t *DeviceRenderLogic) handleGitConfig(ctx context.Context, configItem *api.DeviceSpec_Config_Item) (string, error) {
+func renderGitConfig(ctx context.Context, configItem *api.DeviceSpec_Config_Item, args *renderConfigArgs) (string, error) {
 	gitSpec, err := configItem.AsGitConfigProviderSpec()
 	if err != nil {
 		return "", fmt.Errorf("%w: failed getting config item as GitConfigProviderSpec: %w", ErrUnknownConfigName, err)
 	}
 
-	t.repoNames = append(t.repoNames, gitSpec.GitRef.Repository)
-	repo, err := t.store.Repository().GetInternal(ctx, t.resourceRef.OrgID, gitSpec.GitRef.Repository)
+	args.repoNames = append(args.repoNames, gitSpec.GitRef.Repository)
+	repo, err := args.store.Repository().GetInternal(ctx, args.orgId, gitSpec.GitRef.Repository)
 	if err != nil {
-		return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", args.orgId, gitSpec.GitRef.Repository, err)
 	}
 
 	if repo.Spec == nil {
-		return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		return gitSpec.Name, fmt.Errorf("empty Repository definition %s/%s: %w", args.orgId, gitSpec.GitRef.Repository, err)
+	}
+
+	if args.validateOnly {
+		return gitSpec.Name, nil
 	}
 
 	// TODO: Use local cache
 	mfs, _, err := CloneGitRepo(repo, &gitSpec.GitRef.TargetRevision, nil)
 	if err != nil {
-		return gitSpec.Name, fmt.Errorf("failed cloning specified git repository %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
+		return gitSpec.Name, fmt.Errorf("failed cloning specified git repository %s/%s: %w", args.orgId, gitSpec.GitRef.Repository, err)
 	}
 
 	// Create an ignition from the git subtree and merge it into the rendered config
@@ -157,33 +226,26 @@ func (t *DeviceRenderLogic) handleGitConfig(ctx context.Context, configItem *api
 	if err != nil {
 		return gitSpec.Name, fmt.Errorf("failed parsing git config item %s: %w", gitSpec.Name, err)
 	}
-	renderedConfig := config_latest.Merge(*t.renderedConfig, *ignitionConfig)
-	t.renderedConfig = &renderedConfig
+	mergedConfig := config_latest.Merge(*args.ignitionConfig, *ignitionConfig)
+	args.ignitionConfig = &mergedConfig
 
 	return gitSpec.Name, nil
 }
 
 // TODO: implement
-func (t *DeviceRenderLogic) handleK8sConfig(configItem *api.DeviceSpec_Config_Item) (string, error) {
+func renderK8sConfig(configItem *api.DeviceSpec_Config_Item) (string, error) {
 	k8sSpec, err := configItem.AsKubernetesSecretProviderSpec()
 	if err != nil {
 		return "", fmt.Errorf("%w: failed getting config item as KubernetesSecretProviderSpec: %w", ErrUnknownConfigName, err)
 	}
 
-	return k8sSpec.Name, fmt.Errorf("service does not yet support kubernetes config")
+	return k8sSpec.Name, fmt.Errorf("kubernetes config type not yet supported")
 }
 
-func (t *DeviceRenderLogic) handleInlineConfig(configItem *api.DeviceSpec_Config_Item) (string, error) {
+func renderInlineConfig(configItem *api.DeviceSpec_Config_Item, args *renderConfigArgs) (string, error) {
 	inlineSpec, err := configItem.AsInlineConfigProviderSpec()
 	if err != nil {
 		return "", fmt.Errorf("%w: failed getting config item as InlineConfigProviderSpec: %w", ErrUnknownConfigName, err)
-	}
-
-	// Add this inline config into the unrendered config
-	newConfig := &api.TemplateVersionStatus_Config_Item{}
-	err = newConfig.FromInlineConfigProviderSpec(inlineSpec)
-	if err != nil {
-		return inlineSpec.Name, fmt.Errorf("failed creating inline config from item %s: %w", inlineSpec.Name, err)
 	}
 
 	// Convert yaml to json
@@ -202,26 +264,9 @@ func (t *DeviceRenderLogic) handleInlineConfig(configItem *api.DeviceSpec_Config
 		return inlineSpec.Name, fmt.Errorf("failed parsing inline config item %s: %w", inlineSpec.Name, err)
 	}
 
-	renderedConfig := config_latest.Merge(*t.renderedConfig, ignitionConfig)
-	t.renderedConfig = &renderedConfig
+	if !args.validateOnly {
+		mergedConfig := config_latest.Merge(*args.ignitionConfig, ignitionConfig)
+		args.ignitionConfig = &mergedConfig
+	}
 	return inlineSpec.Name, nil
-}
-
-func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {
-	condition := api.Condition{Type: api.DeviceSpecValid}
-
-	if renderErr == nil {
-		condition.Status = api.ConditionStatusTrue
-		condition.Reason = util.StrToPtr("Valid")
-	} else {
-		condition.Status = api.ConditionStatusFalse
-		condition.Reason = util.StrToPtr("Invalid")
-		condition.Message = util.StrToPtr(fmt.Sprintf("Device configuration is invalid: %v", renderErr))
-	}
-
-	err := t.store.Device().SetServiceConditions(ctx, t.resourceRef.OrgID, t.resourceRef.Name, []api.Condition{condition})
-	if err != nil {
-		t.log.Errorf("Failed setting condition for device %s/%s: %v", t.resourceRef.OrgID, t.resourceRef.Name, err)
-	}
-	return renderErr
 }

--- a/internal/tasks/fleet_validate.go
+++ b/internal/tasks/fleet_validate.go
@@ -2,11 +2,8 @@ package tasks
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
-	config_latest "github.com/coreos/ignition/v2/config/v3_4"
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
@@ -15,7 +12,6 @@ import (
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 )
 
 func FleetValidate(taskManager TaskManager) {
@@ -32,12 +28,7 @@ func FleetValidate(taskManager TaskManager) {
 
 			switch {
 			case resourceRef.Op == FleetValidateOpUpdate && resourceRef.Kind == model.FleetKind:
-				fleet, err := taskManager.store.Fleet().Get(ctx, resourceRef.OrgID, resourceRef.Name)
-				if err != nil {
-					log.Errorf("fetching fleet while validating: %v", err)
-					continue
-				}
-				err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+				err := logic.CreateNewTemplateVersionIfFleetValid(ctx)
 				if err != nil {
 					log.Errorf("failed validating fleet %s/%s: %v", resourceRef.OrgID, resourceRef.Name, err)
 				}
@@ -53,25 +44,29 @@ type FleetValidateLogic struct {
 	log         logrus.FieldLogger
 	store       store.Store
 	resourceRef ResourceReference
-	repoNames   []string
 }
 
 func NewFleetValidateLogic(taskManager TaskManager, log logrus.FieldLogger, store store.Store, resourceRef ResourceReference) FleetValidateLogic {
 	return FleetValidateLogic{taskManager: taskManager, log: log, store: store, resourceRef: resourceRef}
 }
 
-func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Context, fleet *api.Fleet) error {
-	validationErr := t.validateFleetTemplate(ctx, fleet)
+func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Context) error {
+	fleet, err := t.store.Fleet().Get(ctx, t.resourceRef.OrgID, t.resourceRef.Name)
+	if err != nil {
+		return fmt.Errorf("failed getting fleet %s/%s: %w", t.resourceRef.OrgID, t.resourceRef.Name, err)
+	}
 
-	// Set the many-to-may relationship with the repos (we do this even if the validation failed so that we will
-	// validate the fleet again if the repository is updated, and then it might be fixed)
-	err := t.store.Fleet().OverwriteRepositoryRefs(ctx, t.resourceRef.OrgID, *fleet.Metadata.Name, t.repoNames...)
+	_, repoNames, validationErr := renderConfig(ctx, t.resourceRef.OrgID, t.store, fleet.Spec.Template.Spec.Config, true)
+
+	// Set the many-to-many relationship with the repos (we do this even if the validation failed so that we will
+	// validate the fleet again if the repository is updated, and then it might be fixed).
+	err = t.store.Fleet().OverwriteRepositoryRefs(ctx, t.resourceRef.OrgID, *fleet.Metadata.Name, repoNames...)
 	if err != nil {
 		return fmt.Errorf("setting repository references: %w", err)
 	}
 
 	if validationErr != nil {
-		return fmt.Errorf("validating fleet: %w", validationErr)
+		return t.setStatus(ctx, validationErr)
 	}
 
 	templateVersion := api.TemplateVersion{
@@ -84,7 +79,7 @@ func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Co
 
 	tv, err := t.store.TemplateVersion().Create(ctx, t.resourceRef.OrgID, &templateVersion, t.taskManager.TemplateVersionCreatedCallback)
 	if err != nil {
-		return fmt.Errorf("creating templateVersion for valid fleet: %w", err)
+		return t.setStatus(ctx, fmt.Errorf("creating templateVersion for valid fleet: %w", err))
 	}
 
 	annotations := map[string]string{
@@ -92,119 +87,27 @@ func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Co
 	}
 	err = t.store.Fleet().UpdateAnnotations(ctx, t.resourceRef.OrgID, *fleet.Metadata.Name, annotations, nil)
 	if err != nil {
-		return fmt.Errorf("setting fleet annotation with newly-created templateVersion: %w", err)
+		return t.setStatus(ctx, fmt.Errorf("setting fleet annotation with newly-created templateVersion: %w", err))
 	}
 
-	return nil
+	return t.setStatus(ctx, nil)
 }
 
-func (t *FleetValidateLogic) validateFleetTemplate(ctx context.Context, fleet *api.Fleet) error {
-	if fleet.Spec.Template.Spec.Config == nil {
-		return nil
-	}
-
-	invalidConfigs := []string{}
-	for i := range *fleet.Spec.Template.Spec.Config {
-		configItem := (*fleet.Spec.Template.Spec.Config)[i]
-		name, err := t.validateConfigItem(ctx, &configItem)
-		if err != nil {
-			if errors.Is(err, ErrUnknownConfigName) {
-				name = "<unknown>"
-			}
-			invalidConfigs = append(invalidConfigs, name)
-			t.log.Errorf("failed rendering config %s for fleet %s/%s: %v", name, t.resourceRef.OrgID, *fleet.Metadata.Name, err)
-		}
-	}
-
+func (t *FleetValidateLogic) setStatus(ctx context.Context, validationErr error) error {
 	condition := api.Condition{Type: api.FleetValid}
-	var retErr error
-	if len(invalidConfigs) == 0 {
+
+	if validationErr == nil {
 		condition.Status = api.ConditionStatusTrue
 		condition.Reason = util.StrToPtr("Valid")
-		retErr = nil
 	} else {
 		condition.Status = api.ConditionStatusFalse
 		condition.Reason = util.StrToPtr("Invalid")
-		configurationStr := "configuration"
-		if len(invalidConfigs) > 1 {
-			configurationStr += "s"
-		}
-		retErr = fmt.Errorf("fleet has %d invalid %s: %s", len(invalidConfigs), configurationStr, strings.Join(invalidConfigs, ", "))
-		condition.Message = util.StrToPtr(retErr.Error())
+		condition.Message = util.StrToPtr(validationErr.Error())
 	}
 
-	if fleet.Status.Conditions == nil {
-		fleet.Status.Conditions = &[]api.Condition{}
-	}
-	err := t.store.Fleet().UpdateConditions(ctx, t.resourceRef.OrgID, *fleet.Metadata.Name, []api.Condition{condition})
+	err := t.store.Fleet().UpdateConditions(ctx, t.resourceRef.OrgID, t.resourceRef.Name, []api.Condition{condition})
 	if err != nil {
-		t.log.Warnf("failed setting condition on fleet %s/%s: %v", t.resourceRef.OrgID, *fleet.Metadata.Name, err)
+		t.log.Errorf("Failed setting condition for fleet %s/%s: %v", t.resourceRef.OrgID, t.resourceRef.Name, err)
 	}
-
-	return retErr
-}
-
-func (t *FleetValidateLogic) validateConfigItem(ctx context.Context, configItem *api.DeviceSpec_Config_Item) (string, error) {
-	disc, err := configItem.Discriminator()
-	if err != nil {
-		return "", fmt.Errorf("%w: failed getting discriminator: %w", ErrUnknownConfigName, err)
-	}
-
-	switch disc {
-	case string(api.TemplateDiscriminatorGitConfig):
-		gitSpec, err := configItem.AsGitConfigProviderSpec()
-		if err != nil {
-			return "", fmt.Errorf("%w: failed getting config item %s as GitConfigProviderSpec: %w", ErrUnknownConfigName, gitSpec.Name, err)
-		}
-		t.repoNames = append(t.repoNames, gitSpec.GitRef.Repository)
-		_, err = t.store.Repository().GetInternal(ctx, t.resourceRef.OrgID, gitSpec.GitRef.Repository)
-		if err != nil {
-			return gitSpec.Name, fmt.Errorf("failed fetching specified Repository definition %s/%s: %w", t.resourceRef.OrgID, gitSpec.GitRef.Repository, err)
-		}
-		return gitSpec.Name, nil
-
-	case string(api.TemplateDiscriminatorKubernetesSec):
-		k8sSpec, err := configItem.AsKubernetesSecretProviderSpec()
-		if err != nil {
-			return "", fmt.Errorf("%w: failed getting config item %s as AsKubernetesSecretProviderSpec: %w", ErrUnknownConfigName, k8sSpec.Name, err)
-		}
-		return k8sSpec.Name, fmt.Errorf("service does not yet support kubernetes config")
-
-	case string(api.TemplateDiscriminatorInlineConfig):
-		inlineSpec, err := configItem.AsInlineConfigProviderSpec()
-		if err != nil {
-			return "", fmt.Errorf("%w: failed getting config item %s as InlineConfigProviderSpec: %w", ErrUnknownConfigName, inlineSpec.Name, err)
-		}
-		return inlineSpec.Name, t.validateInlineConfig(&inlineSpec)
-
-	default:
-		return "", fmt.Errorf("%w: unsupported discriminator %s", ErrUnknownConfigName, disc)
-	}
-}
-
-func (t *FleetValidateLogic) validateInlineConfig(inlineSpec *api.InlineConfigProviderSpec) error {
-	// Add this inline config into the unrendered config
-	newConfig := &api.TemplateVersionStatus_Config_Item{}
-	err := newConfig.FromInlineConfigProviderSpec(*inlineSpec)
-	if err != nil {
-		return fmt.Errorf("failed creating inline config from item %s: %w", inlineSpec.Name, err)
-	}
-
-	// Convert yaml to json
-	yamlBytes, err := yaml.Marshal(inlineSpec.Inline)
-	if err != nil {
-		return fmt.Errorf("invalid yaml in inline config item %s: %w", inlineSpec.Name, err)
-	}
-	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
-	if err != nil {
-		return fmt.Errorf("failed converting yaml to json in inline config item %s: %w", inlineSpec.Name, err)
-	}
-
-	// Convert to ignition
-	_, _, err = config_latest.ParseCompatibleVersion(jsonBytes)
-	if err != nil {
-		return fmt.Errorf("failed parsing inline config item %s: %w", inlineSpec.Name, err)
-	}
-
-	return nil
+	return validationErr
 }

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -128,10 +128,7 @@ var _ = Describe("FleetValidate", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -175,10 +172,7 @@ var _ = Describe("FleetValidate", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -222,10 +216,7 @@ var _ = Describe("FleetValidate", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -270,10 +261,7 @@ var _ = Describe("FleetValidate", func() {
 			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
 			Expect(err).ToNot(HaveOccurred())
 
-			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
-			Expect(err).ToNot(HaveOccurred())
-
-			err = logic.CreateNewTemplateVersionIfFleetValid(ctx, fleet)
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
 			Expect(err).To(HaveOccurred())
 
 			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
@@ -287,7 +275,7 @@ var _ = Describe("FleetValidate", func() {
 			Expect(*fleet.Status.Conditions).To(HaveLen(1))
 			Expect((*fleet.Status.Conditions)[0].Type).To(Equal(api.FleetValid))
 			Expect((*fleet.Status.Conditions)[0].Status).To(Equal(api.ConditionStatusFalse))
-			Expect(*((*fleet.Status.Conditions)[0].Message)).To(Equal("fleet has 1 invalid configuration: <unknown>"))
+			Expect(*((*fleet.Status.Conditions)[0].Message)).To(Equal("1 invalid configuration: <unknown>. Error: failed to find configuration item name: unsupported discriminator: InvalidProviderSpec"))
 		})
 	})
 })


### PR DESCRIPTION
1. Combined the code that validates a fleet template and the code that renders a device since they are very similar.
2. Add an error message to the condition if validation fails.