### PR TITLE
MGMT-18185: Fix deletion errors

### DIFF
--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -34,7 +34,7 @@ type Device struct {
 	RenderedConfig *string
 
 	// Join table with the relationship of devices to repositories (only maintained for standalone devices)
-	Repositories []Repository `gorm:"many2many:device_repos;"`
+	Repositories []Repository `gorm:"many2many:device_repos;constraint:OnDelete:CASCADE;"`
 }
 
 type ServiceConditions struct {

--- a/internal/store/model/fleet.go
+++ b/internal/store/model/fleet.go
@@ -26,7 +26,7 @@ type Fleet struct {
 	Status *JSONField[api.FleetStatus]
 
 	// Join table with the relationship of fleets to repositories
-	Repositories []Repository `gorm:"many2many:fleet_repos;"`
+	Repositories []Repository `gorm:"many2many:fleet_repos;constraint:OnDelete:CASCADE;"`
 }
 
 type FleetList []Fleet

--- a/internal/store/model/repository.go
+++ b/internal/store/model/repository.go
@@ -24,10 +24,10 @@ type Repository struct {
 	Status *JSONField[api.RepositoryStatus]
 
 	// Join table with the relationship of repository to fleets
-	Fleets []Fleet `gorm:"many2many:fleet_repos;"`
+	Fleets []Fleet `gorm:"many2many:fleet_repos;constraint:OnDelete:CASCADE;"`
 
 	// Join table with the relationship of repository to devices (only maintained for standalone devices)
-	Devices []Device `gorm:"many2many:device_repos;"`
+	Devices []Device `gorm:"many2many:device_repos;constraint:OnDelete:CASCADE;"`
 }
 
 type RepositoryList []Repository

--- a/internal/tasks/git_helpers.go
+++ b/internal/tasks/git_helpers.go
@@ -37,6 +37,9 @@ type cloneGitRepoFunc func(repo *model.Repository, revision *string, depth *int)
 func CloneGitRepo(repo *model.Repository, revision *string, depth *int) (billy.Filesystem, string, error) {
 	storage := gitmemory.NewStorage()
 	mfs := memfs.New()
+	if repo.Spec == nil {
+		return nil, "", fmt.Errorf("repository has no spec")
+	}
 	repoURL, err := repo.Spec.Data.GetRepoURL()
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Deleting devices, fleets, and repos was failing due to foreign key constraints introduced by the many-to-many relationships. This fixes the issue by adding cascading deletes so that when a resource is deleted, the associated entry in the join table is also deleted.