### PR TITLE
NO-ISSUE: client: make sure to close response body

### DIFF
--- a/internal/agent/device/status/status_test.go
+++ b/internal/agent/device/status/status_test.go
@@ -1,0 +1,52 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/tpm"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// go test -benchmem -run=^$ -bench ^BenchmarkManager$ -memprofile memprofile.prof github.com/flightctl/flightctl/internal/agent/device/status
+func BenchmarkAggregateDeviceStatus(b *testing.B) {
+	require := require.New(b)
+	log := log.NewPrefixLogger("test")
+	tpmChannel, err := tpm.OpenTPMSimulator()
+	require.NoError(err)
+	defer tpmChannel.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(b)
+	execMock := executer.NewMockExecuter(ctrl)
+	execMock.EXPECT().LookPath("crictl").Return("/usr/bin/crictl", nil).AnyTimes()
+	execMock.EXPECT().LookPath("podman").Return("/usr/bin/podman", nil).AnyTimes()
+	execMock.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/crictl", "ps", "-a", "--output", "json").Return(crioListResult, "", 0).AnyTimes()
+	execMock.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/podman", "ps", "-a", "--format", "json").Return(podmanListResult, "", 0).AnyTimes()
+	execMock.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "list-units", "--all", "--output", "json", "crio.service").Return(systemdUnitListResult, "", 0).AnyTimes()
+
+	manager := NewManager("test", tpmChannel, execMock, log)
+	systemdPatterns := []string{"crio.service"}
+
+	spec := &v1alpha1.RenderedDeviceSpec{
+		Systemd: &struct {
+			MatchPatterns *[]string `json:"matchPatterns,omitempty"`
+		}{
+			MatchPatterns: &systemdPatterns,
+		},
+	}
+
+	manager.SetProperties(spec)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		status, err := manager.aggregateDeviceStatus(ctx)
+		require.NoError(err)
+		require.NotNil(status)
+	}
+}

--- a/internal/client/enrollment.go
+++ b/internal/client/enrollment.go
@@ -33,6 +33,10 @@ func (e *Enrollment) CreateEnrollmentRequest(ctx context.Context, req v1alpha1.E
 	if err != nil {
 		return nil, err
 	}
+	if resp.HTTPResponse != nil {
+		defer resp.HTTPResponse.Body.Close()
+	}
+
 	if e.rpcMetricsCallbackFunc != nil {
 		e.rpcMetricsCallbackFunc("create_enrollmentrequest_duration", time.Since(start).Seconds(), err)
 	}
@@ -57,6 +61,10 @@ func (e *Enrollment) GetEnrollmentRequest(ctx context.Context, id string, cb ...
 	if err != nil {
 		return nil, err
 	}
+	if resp.HTTPResponse != nil {
+		defer resp.HTTPResponse.Body.Close()
+	}
+
 	if e.rpcMetricsCallbackFunc != nil {
 		e.rpcMetricsCallbackFunc("get_enrollmentrequest_duration", time.Since(start).Seconds(), err)
 	}


### PR DESCRIPTION
This PR ensures response bodies are closed for HTTP client requests. Failure to do so can result in resource leaks and I believe this is a possible root cause of the observed memory leak.

The benchmark was added to validate that the leak was not from status collection. This benchmark can be used in the future to ensure memory allocations and time complexity are kept in check.