### PR TITLE
OCTOET-476: Split agent facing API endpoint to its own port

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-server-agent-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-agent-service.yaml
@@ -4,18 +4,18 @@ kind: Service
 metadata:
   labels:
     flightctl.service: flightctl-server
-  name: flightctl-server
+  name: flightctl-server-agent
   namespace: {{ .Values.flightctl.server.namespace }}
 spec:
-  {{ if .Values.flightctl.server.nodePort }}
+  {{ if .Values.flightctl.server.agentNodePort }}
   type: NodePort
   {{ end }}
   ports:
-    - name: "flightctl-api"
-      port: 3333
-      targetPort: 3333
-      {{ if .Values.flightctl.server.nodePort }}
-      nodePort: {{ .Values.flightctl.server.nodePort }}
+    - name: "flightctl-agent-api"
+      port: 7443
+      targetPort: 7443
+      {{ if .Values.flightctl.server.agentNodePort }}
+      nodePort: {{ .Values.flightctl.server.agentNodePort }}
       {{ end }}
   selector:
     flightctl.service: flightctl-server

--- a/deploy/helm/flightctl/templates/flightctl-server-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-config.yaml
@@ -15,9 +15,18 @@ data:
         password: {{ .Values.flightctl.db.masterPassword }}   # we should funnel this via secrets instead
     service:
         address: :3333
+        agentEndpointAddress: :7443
         baseUrl: https://{{ .Values.flightctl.server.hostName }}:3333/
+        {{ if .Values.flightctl.server.agentAPIHostName }}
+        baseAgentEndpointUrl:  https://{{ .Values.flightctl.server.agentAPIHostName }}:7443/
+        {{ else }}
+        baseAgentEndpointUrl:  https://{{ .Values.flightctl.server.hostName }}:7443/
+        {{ end }}
         altNames:
           - {{ .Values.flightctl.server.hostName }}
+          {{ if .Values.flightctl.server.agentAPIHostName }}
+          - {{ .Values.flightctl.server.agentAPIHostName }}
+          {{ end }}
           - flightctl-server
           - flightctl-server.{{ .Values.flightctl.server.namespace }}
           - flightctl-server.{{ .Values.flightctl.server.namespace }}.svc.cluster.local

--- a/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
@@ -27,6 +27,10 @@ spec:
               value: "/root"
           ports:
             - containerPort: 3333
+              name: service-api
+              protocol: TCP
+            - containerPort: 7443
+              name: agent-api
               protocol: TCP
           volumeMounts:
             - mountPath: /root/.flightctl/

--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -7,6 +7,7 @@ flightctl:
     imagePullPolicy: IfNotPresent
     hostName: localhost
     nodePort: 3333 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
+    agentNodePort: 7443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
 
 storageClassName: standard
 storageClassNameRWM: standard

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -14,6 +14,7 @@ flightctl:
     image: quay.io/flightctl/flightctl-server:latest
     imagePullPolicy: Always
     hostName: api.flightctl.example.com
+    # agentAPIHostName: agent-api.flightctl.example.com # optional, will use hostName otherwise
 
 storageClassName: aws-ebs
 storageClassNameRWM: aws-efs-tier-c4

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -12,12 +12,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device"
 	"github.com/flightctl/flightctl/internal/agent/device/config"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/spec"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
-	"github.com/flightctl/flightctl/internal/client"
 	fcrypto "github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/executer"

--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	client "github.com/flightctl/flightctl/internal/api/client/agent"
+	baseclient "github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/pkg/reqid"
+	"github.com/go-chi/chi/middleware"
+)
+
+// NewFromConfig returns a new FlightCtl API client from the given config.
+func NewFromConfig(config *baseclient.Config) (*client.ClientWithResponses, error) {
+
+	httpClient, err := baseclient.NewHTTPClientFromConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("NewFromConfig: creating HTTP client %w", err)
+	}
+	ref := client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		req.Header.Set(middleware.RequestIDHeader, reqid.GetReqID())
+		return nil
+	})
+	return client.NewClientWithResponses(config.Service.Server, client.WithHTTPClient(httpClient), ref)
+}
+
+type Config = baseclient.Config
+type AuthInfo = baseclient.AuthInfo
+type Service = baseclient.Service
+
+func NewDefault() *Config {
+	return baseclient.NewDefault()
+}

--- a/internal/agent/client/enrollment.go
+++ b/internal/agent/client/enrollment.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/api/client"
+	client "github.com/flightctl/flightctl/internal/api/client/agent"
 )
 
 func NewEnrollment(

--- a/internal/agent/client/management.go
+++ b/internal/agent/client/management.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/api/client"
+	client "github.com/flightctl/flightctl/internal/api/client/agent"
 )
 
 var (
@@ -26,55 +26,6 @@ func NewManagement(
 type Management struct {
 	client                 *client.ClientWithResponses
 	rpcMetricsCallbackFunc func(operation string, durationSeconds float64, err error)
-}
-
-func (m *Management) GetDevice(ctx context.Context, name string, rcb ...client.RequestEditorFn) (*v1alpha1.Device, error) {
-	start := time.Now()
-	resp, err := m.client.ReadDeviceWithResponse(ctx, name, rcb...)
-	if err != nil {
-		return nil, err
-	}
-	if resp.HTTPResponse != nil {
-		defer resp.HTTPResponse.Body.Close()
-	}
-
-	if m.rpcMetricsCallbackFunc != nil {
-		m.rpcMetricsCallbackFunc("get_device_duration", time.Since(start).Seconds(), err)
-	}
-
-	if resp.JSON200 == nil {
-		return nil, ErrEmptyResponse
-	}
-
-	return resp.JSON200, nil
-}
-
-func (m *Management) UpdateDevice(ctx context.Context, name string, req v1alpha1.Device, rcb ...client.RequestEditorFn) (*v1alpha1.Device, error) {
-	device := v1alpha1.Device{
-		Metadata: v1alpha1.ObjectMeta{
-			Name: &name,
-		},
-		Spec: req.Spec,
-	}
-
-	start := time.Now()
-	resp, err := m.client.ReplaceDeviceStatusWithResponse(ctx, name, device, rcb...)
-	if err != nil {
-		return nil, err
-	}
-	if resp.HTTPResponse != nil {
-		defer resp.HTTPResponse.Body.Close()
-	}
-
-	if m.rpcMetricsCallbackFunc != nil {
-		m.rpcMetricsCallbackFunc("update_device_duration", time.Since(start).Seconds(), err)
-	}
-
-	if resp.JSON200 == nil {
-		return nil, ErrEmptyResponse
-	}
-
-	return resp.JSON200, nil
 }
 
 // UpdateDeviceStatus updates the status of the device with the given name.

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"

--- a/internal/agent/device/boostrap_test.go
+++ b/internal/agent/device/boostrap_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/spec"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/container"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/executer"
@@ -68,7 +68,7 @@ func TestEnsureEnrollment(t *testing.T) {
 			mockEnrollmentServer := createMockEnrollmentServer(t, tt.enrollmentApproved)
 			defer mockEnrollmentServer.Close()
 			enrollmentEndpoint := mockEnrollmentServer.URL
-			httpClient, err := testutil.NewClient(enrollmentEndpoint, nil, nil)
+			httpClient, err := testutil.NewAgentClient(enrollmentEndpoint, nil, nil)
 			require.NoError(err)
 			enrollmentClient := client.NewEnrollment(httpClient)
 

--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -9,10 +9,10 @@ import (
 	"os"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/spec"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/container"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/pkg/log"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -58,7 +58,7 @@ func TestManager(t *testing.T) {
 			defer server.Close()
 
 			serverUrl := server.URL
-			httpClient, err := testutil.NewClient(serverUrl, nil, nil)
+			httpClient, err := testutil.NewAgentClient(serverUrl, nil, nil)
 			require.NoError(err)
 			managementClient := client.NewManagement(httpClient)
 

--- a/internal/agent/device/status/containers_test.go
+++ b/internal/agent/device/status/containers_test.go
@@ -101,8 +101,8 @@ const podmanListResult = `
     "Ports": [
       {
         "host_ip": "127.0.0.1",
-        "container_port": 4444,
-        "host_port": 4444,
+        "container_port": 7443,
+        "host_port": 7443,
         "range": 1,
         "protocol": "tcp"
       }

--- a/internal/agent/device/status/mock_status.go
+++ b/internal/agent/device/status/mock_status.go
@@ -14,7 +14,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/flightctl/flightctl/api/v1alpha1"
-	client "github.com/flightctl/flightctl/internal/client"
+	client "github.com/flightctl/flightctl/internal/agent/client"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/agent/device/status/status.go
+++ b/internal/agent/device/status/status.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,15 +29,17 @@ type dbConfig struct {
 }
 
 type svcConfig struct {
-	Address     string   `json:"address,omitempty"`
-	CertStore   string   `json:"cert,omitempty"`
-	BaseUrl     string   `json:"baseUrl,omitempty"`
-	CaCertFile  string   `json:"caCertFile,omitempty"`
-	CaKeyFile   string   `json:"caKeyFile,omitempty"`
-	SrvCertFile string   `json:"srvCertFile,omitempty"`
-	SrvKeyFile  string   `json:"srvKeyFile,omitempty"`
-	AltNames    []string `json:"altNames,omitempty"`
-	LogLevel    string   `json:"logLevel,omitempty"`
+	Address              string   `json:"address,omitempty"`
+	AgentEndpointAddress string   `json:"agentEndpointAddress,omitempty"`
+	CertStore            string   `json:"cert,omitempty"`
+	BaseUrl              string   `json:"baseUrl,omitempty"`
+	BaseAgentEndpointUrl string   `json:"baseAgentEndpointUrl,omitempty"`
+	CaCertFile           string   `json:"caCertFile,omitempty"`
+	CaKeyFile            string   `json:"caKeyFile,omitempty"`
+	SrvCertFile          string   `json:"srvCertFile,omitempty"`
+	SrvKeyFile           string   `json:"srvKeyFile,omitempty"`
+	AltNames             []string `json:"altNames,omitempty"`
+	LogLevel             string   `json:"logLevel,omitempty"`
 }
 
 func ConfigDir() string {
@@ -67,10 +69,12 @@ func NewDefault() *Config {
 			Password: "adminpass",
 		},
 		Service: &svcConfig{
-			Address:   ":3333",
-			CertStore: CertificateDir(),
-			BaseUrl:   "https://localhost:3333",
-			LogLevel:  "info",
+			Address:              ":3333",
+			AgentEndpointAddress: ":7443",
+			CertStore:            CertificateDir(),
+			BaseUrl:              "https://localhost:3333",
+			BaseAgentEndpointUrl: "https://localhost:7443",
+			LogLevel:             "info",
 		},
 	}
 	return c

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -19,6 +19,14 @@ import (
 // Wraps openshift/library-go/pkg/crypto to use ECDSA and simplify the interface
 const ClientBootstrapCommonName = "client-enrollment"
 const AdminCommonName = "flightctl-admin"
+const DeviceCommonNamePrefix = "device:"
+
+func CNFromDeviceFingerprint(fingerprint string) (string, error) {
+	if len(fingerprint) < 16 {
+		return "", errors.New("device fingerprint must have 16 characters at least")
+	}
+	return DeviceCommonNamePrefix + fingerprint, nil
+}
 
 type TLSCertificateConfig oscrypto.TLSCertificateConfig
 

--- a/internal/server/middleware/server_test.go
+++ b/internal/server/middleware/server_test.go
@@ -1,4 +1,4 @@
-package server_test
+package middleware_test
 
 import (
 	"errors"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
-	"github.com/flightctl/flightctl/internal/server"
+	"github.com/flightctl/flightctl/internal/server/middleware"
 	"github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,10 +50,10 @@ var _ = Describe("Low level server behavior", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// create a listener using the next available port
-		listener, err = server.NewTLSListener("", tlsConfig)
+		listener, err = middleware.NewTLSListener("", tlsConfig)
 		Expect(err).ToNot(HaveOccurred())
 
-		srv := server.NewHTTPServerWithTLSContext(testTLSCNServer{}, serverLog, listener.Addr().String())
+		srv := middleware.NewHTTPServerWithTLSContext(testTLSCNServer{}, serverLog, listener.Addr().String())
 
 		go func() {
 			defer GinkgoRecover()
@@ -97,7 +97,7 @@ type testTLSCNServer struct {
 }
 
 func (s testTLSCNServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	tlsCN := request.Context().Value(server.TLSCommonNameContextKey)
+	tlsCN := request.Context().Value(middleware.TLSCommonNameContextKey)
 	if tlsCN == nil {
 		// this should not really happen, this will make the tests fail
 		response.WriteHeader(http.StatusInternalServerError)

--- a/internal/service/agent/handler.go
+++ b/internal/service/agent/handler.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flightctl/flightctl/internal/api/server"
+	agentServer "github.com/flightctl/flightctl/internal/api/server/agent"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/server/middleware"
+	"github.com/flightctl/flightctl/internal/service/common"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/sirupsen/logrus"
+)
+
+type AgentServiceHandler struct {
+	store store.Store
+	ca    *crypto.CA
+	log   logrus.FieldLogger
+}
+
+// Make sure we conform to servers Service interface
+var _ agentServer.Service = (*AgentServiceHandler)(nil)
+
+func ValidateDeviceAccessFromContext(ctx context.Context, name string, log logrus.FieldLogger) error {
+	cn, ok := ctx.Value(middleware.TLSCommonNameContextKey).(string)
+	if !ok {
+		log.Warningf("an attempt to access device %q without a CN in tls certificate has been detected", name)
+		return errors.New("no common name in certificate")
+	}
+	if expectedCn, err := crypto.CNFromDeviceFingerprint(name); err != nil {
+		return err
+	} else if cn != expectedCn {
+		log.Warningf("an attempt to access device %q with a certificate with CN %q has been detected", name, cn)
+		return errors.New("invalid tls CN for device")
+	}
+	// all good, you shall pass
+	return nil
+}
+
+func ValidateEnrollmentAccessFromContext(ctx context.Context, log logrus.FieldLogger) error {
+	cn, ok := ctx.Value(middleware.TLSCommonNameContextKey).(string)
+	if !ok {
+		return errors.New("no common name in certificate")
+	}
+	if cn != crypto.ClientBootstrapCommonName {
+		log.Warningf("an attempt to perform enrollment with a certificate with CN %q has been detected", cn)
+		return errors.New("invalid tls CN for enrollment request")
+	}
+	// all good, you shall pass
+	return nil
+}
+
+func NewAgentServiceHandler(store store.Store, ca *crypto.CA, log logrus.FieldLogger) *AgentServiceHandler {
+	return &AgentServiceHandler{
+		store: store,
+		ca:    ca,
+		log:   log,
+	}
+}
+
+// (GET /api/v1/devices/{name}/rendered)
+func (s *AgentServiceHandler) GetRenderedDeviceSpec(ctx context.Context, request agentServer.GetRenderedDeviceSpecRequestObject) (agentServer.GetRenderedDeviceSpecResponseObject, error) {
+
+	if err := ValidateDeviceAccessFromContext(ctx, request.Name, s.log); err != nil {
+		return agentServer.GetRenderedDeviceSpec401JSONResponse{
+			Message: err.Error(),
+		}, err
+	}
+
+	serverRequest := server.GetRenderedDeviceSpecRequestObject{
+		Name:   request.Name,
+		Params: request.Params,
+	}
+	return common.GetRenderedDeviceSpec(ctx, s.store, serverRequest)
+}
+
+// (PUT /api/v1/devices/{name}/status)
+func (s *AgentServiceHandler) ReplaceDeviceStatus(ctx context.Context, request agentServer.ReplaceDeviceStatusRequestObject) (agentServer.ReplaceDeviceStatusResponseObject, error) {
+
+	if err := ValidateDeviceAccessFromContext(ctx, request.Name, s.log); err != nil {
+		return agentServer.ReplaceDeviceStatus401JSONResponse{
+			Message: err.Error(),
+		}, err
+	}
+
+	serverRequest := server.ReplaceDeviceStatusRequestObject{
+		Name: request.Name,
+		Body: request.Body,
+	}
+	return common.ReplaceDeviceStatus(ctx, s.store, serverRequest)
+}
+
+// (POST /api/v1/enrollmentrequests)
+func (s *AgentServiceHandler) CreateEnrollmentRequest(ctx context.Context, request agentServer.CreateEnrollmentRequestRequestObject) (agentServer.CreateEnrollmentRequestResponseObject, error) {
+
+	if err := ValidateEnrollmentAccessFromContext(ctx, s.log); err != nil {
+		return agentServer.CreateEnrollmentRequest401JSONResponse{
+			Message: err.Error(),
+		}, err
+	}
+
+	serverRequest := server.CreateEnrollmentRequestRequestObject{
+		Body: request.Body,
+	}
+	return common.CreateEnrollmentRequest(ctx, s.store, serverRequest)
+}
+
+// (GET /api/v1/enrollmentrequests/{name})
+func (s *AgentServiceHandler) ReadEnrollmentRequest(ctx context.Context, request agentServer.ReadEnrollmentRequestRequestObject) (agentServer.ReadEnrollmentRequestResponseObject, error) {
+
+	if err := ValidateEnrollmentAccessFromContext(ctx, s.log); err != nil {
+		return agentServer.ReadEnrollmentRequest401JSONResponse{
+			Message: err.Error(),
+		}, err
+	}
+	serverRequest := server.ReadEnrollmentRequestRequestObject{
+		Name: request.Name,
+	}
+	return common.ReadEnrollmentRequest(ctx, s.store, serverRequest)
+}

--- a/internal/service/common.go
+++ b/internal/service/common.go
@@ -14,14 +14,6 @@ import (
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 )
 
-func NilOutManagedObjectMetaProperties(om *v1alpha1.ObjectMeta) {
-	om.Generation = nil
-	om.Owner = nil
-	om.Annotations = nil
-	om.CreationTimestamp = nil
-	om.DeletionTimestamp = nil
-}
-
 func validateAgainstSchema(ctx context.Context, obj []byte, objPath string) error {
 	swagger, err := v1alpha1.GetSwagger()
 	if err != nil {

--- a/internal/service/common/common.go
+++ b/internal/service/common/common.go
@@ -1,0 +1,11 @@
+package common
+
+import "github.com/flightctl/flightctl/api/v1alpha1"
+
+func NilOutManagedObjectMetaProperties(om *v1alpha1.ObjectMeta) {
+	om.Generation = nil
+	om.Owner = nil
+	om.Annotations = nil
+	om.CreationTimestamp = nil
+	om.DeletionTimestamp = nil
+}

--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/api/server"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+)
+
+func ReplaceDeviceStatus(ctx context.Context, st store.Store, request server.ReplaceDeviceStatusRequestObject) (server.ReplaceDeviceStatusResponseObject, error) {
+	orgId := store.NullOrgId
+
+	device := request.Body
+	device.Status.UpdatedAt = time.Now()
+
+	result, err := st.Device().UpdateStatus(ctx, orgId, device)
+	switch err {
+	case nil:
+		return server.ReplaceDeviceStatus200JSONResponse(*result), nil
+	case flterrors.ErrResourceIsNil:
+		return server.ReplaceDeviceStatus400JSONResponse{Message: err.Error()}, nil
+	case flterrors.ErrResourceNameIsNil:
+		return server.ReplaceDeviceStatus400JSONResponse{Message: err.Error()}, nil
+	case flterrors.ErrResourceNotFound:
+		return server.ReplaceDeviceStatus404JSONResponse{}, nil
+	default:
+		return nil, err
+	}
+}
+
+func GetRenderedDeviceSpec(ctx context.Context, st store.Store, request server.GetRenderedDeviceSpecRequestObject) (server.GetRenderedDeviceSpecResponseObject, error) {
+	orgId := store.NullOrgId
+
+	result, err := st.Device().GetRendered(ctx, orgId, request.Name, request.Params.KnownRenderedVersion)
+	switch err {
+	case nil:
+		if result == nil {
+			return server.GetRenderedDeviceSpec204Response{}, nil
+		}
+		return server.GetRenderedDeviceSpec200JSONResponse(*result), nil
+	case flterrors.ErrResourceNotFound:
+		return server.GetRenderedDeviceSpec404JSONResponse{}, nil
+	case flterrors.ErrResourceOwnerIsNil:
+		return server.GetRenderedDeviceSpec409JSONResponse{Message: err.Error()}, nil
+	case flterrors.ErrTemplateVersionIsNil:
+		return server.GetRenderedDeviceSpec409JSONResponse{Message: err.Error()}, nil
+	case flterrors.ErrInvalidTemplateVersion:
+		return server.GetRenderedDeviceSpec409JSONResponse{Message: err.Error()}, nil
+	default:
+		return nil, err
+	}
+}

--- a/internal/service/common/enrollmentrequest.go
+++ b/internal/service/common/enrollmentrequest.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/api/server"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+)
+
+func ValidateAndCompleteEnrollmentRequest(enrollmentRequest *v1alpha1.EnrollmentRequest) error {
+	if enrollmentRequest.Status == nil {
+		enrollmentRequest.Status = &v1alpha1.EnrollmentRequestStatus{
+			Certificate: nil,
+			Conditions:  []v1alpha1.Condition{},
+		}
+	}
+	return nil
+}
+
+func CreateEnrollmentRequest(ctx context.Context, st store.Store, request server.CreateEnrollmentRequestRequestObject) (server.CreateEnrollmentRequestResponseObject, error) {
+	orgId := store.NullOrgId
+
+	// don't set fields that are managed by the service
+	request.Body.Status = nil
+	NilOutManagedObjectMetaProperties(&request.Body.Metadata)
+
+	if errs := request.Body.Validate(); len(errs) > 0 {
+		return server.CreateEnrollmentRequest400JSONResponse{Message: errors.Join(errs...).Error()}, nil
+	}
+
+	// verify if the enrollment request already exists, and return it with a 208 status code if it does
+	if enrollmentReq, err := st.EnrollmentRequest().Get(ctx, orgId, *request.Body.Metadata.Name); err == nil {
+		return server.CreateEnrollmentRequest208JSONResponse(*enrollmentReq), nil
+	}
+
+	// if the enrollment request does not exist, create it
+	if err := ValidateAndCompleteEnrollmentRequest(request.Body); err != nil {
+		return nil, err
+	}
+
+	result, err := st.EnrollmentRequest().Create(ctx, orgId, request.Body)
+	switch err {
+	case nil:
+		return server.CreateEnrollmentRequest201JSONResponse(*result), nil
+	case flterrors.ErrResourceIsNil:
+		return server.CreateEnrollmentRequest400JSONResponse{Message: err.Error()}, nil
+	default:
+		return nil, err
+	}
+}
+
+func ReadEnrollmentRequest(ctx context.Context, st store.Store, request server.ReadEnrollmentRequestRequestObject) (server.ReadEnrollmentRequestResponseObject, error) {
+	orgId := store.NullOrgId
+
+	result, err := st.EnrollmentRequest().Get(ctx, orgId, request.Name)
+	switch err {
+	case nil:
+		return server.ReadEnrollmentRequest200JSONResponse(*result), nil
+	case flterrors.ErrResourceNotFound:
+		return server.ReadEnrollmentRequest404JSONResponse{}, nil
+	default:
+		return nil, err
+	}
+}

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -12,7 +12,7 @@ type ServiceHandler struct {
 	store       store.Store
 	ca          *crypto.CA
 	log         logrus.FieldLogger
-	taskManager tasks.TaskManager
+	taskManager *tasks.TaskManager
 }
 
 // Make sure we conform to servers Service interface
@@ -23,6 +23,6 @@ func NewServiceHandler(store store.Store, taskManager tasks.TaskManager, ca *cry
 		store:       store,
 		ca:          ca,
 		log:         log,
-		taskManager: taskManager,
+		taskManager: &taskManager,
 	}
 }

--- a/internal/service/resourcesync.go
+++ b/internal/service/resourcesync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/go-openapi/swag"
 	"k8s.io/apimachinery/pkg/labels"
@@ -20,7 +21,7 @@ func (h *ServiceHandler) CreateResourceSync(ctx context.Context, request server.
 
 	// don't set fields that are managed by the service
 	request.Body.Status = nil
-	NilOutManagedObjectMetaProperties(&request.Body.Metadata)
+	common.NilOutManagedObjectMetaProperties(&request.Body.Metadata)
 
 	if errs := request.Body.Validate(); len(errs) > 0 {
 		return server.CreateResourceSync400JSONResponse{Message: errors.Join(errs...).Error()}, nil
@@ -112,7 +113,7 @@ func (h *ServiceHandler) ReplaceResourceSync(ctx context.Context, request server
 
 	// don't overwrite fields that are managed by the service
 	request.Body.Status = nil
-	NilOutManagedObjectMetaProperties(&request.Body.Metadata)
+	common.NilOutManagedObjectMetaProperties(&request.Body.Metadata)
 	if errs := request.Body.Validate(); len(errs) > 0 {
 		return server.ReplaceResourceSync400JSONResponse{Message: errors.Join(errs...).Error()}, nil
 	}
@@ -189,7 +190,7 @@ func (h *ServiceHandler) PatchResourceSync(ctx context.Context, request server.P
 		return server.PatchResourceSync400JSONResponse{Message: "status is immutable"}, nil
 	}
 
-	NilOutManagedObjectMetaProperties(&newObj.Metadata)
+	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	result, _, err := h.store.ResourceSync().CreateOrUpdate(ctx, orgId, newObj)
 
 	switch err {

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -12,6 +12,9 @@ nodes:
   - containerPort: 3333 # flightctl API
     hostPort: 3333
     protocol: TCP
+  - containerPort: 7443 # flightctl agent endpoint API
+    hostPort: 7443
+    protocol: TCP
   - containerPort: 5432 # postgresql DB
     hostPort: 5432
     protocol: TCP

--- a/test/scripts/prepare_agent_config.sh
+++ b/test/scripts/prepare_agent_config.sh
@@ -15,7 +15,7 @@ enrollment-service:
     client-key: certs/client-enrollment.key
   service:
     certificate-authority: certs/ca.crt
-    server: https://${IP}:3333
+    server: https://${IP}:7443
   enrollment-ui-endpoint: https://${IP}:8080
 spec-fetch-interval: 0m10s
 status-update-interval: 0m10s


### PR DESCRIPTION

Also ensures that only admin can access to the main endpoint, and
that devices can only update their own status, and pull their own
specification.