### PR TITLE
MGMT-18196: Replace parameters upon fleet rollout

### DIFF
--- a/internal/tasks/config_helpers.go
+++ b/internal/tasks/config_helpers.go
@@ -1,0 +1,65 @@
+package tasks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	paramsRegex *regexp.Regexp = regexp.MustCompile(`(?P<full>{{\w*(?P<param>.*?)\w*}})`)
+	labelRegex  *regexp.Regexp = regexp.MustCompile(`device.metadata.labels\[(?P<key>.*)\]`)
+)
+
+func ContainsParameter(b []byte) bool {
+	return paramsRegex.Match(b)
+}
+
+func ReplaceParameters(b []byte, labels *map[string]string) ([]byte, error) {
+	replacements := map[string]string{}
+	paramsToMatches := map[string]string{}
+
+	if labels == nil {
+		return b, nil
+	}
+
+	matches := paramsRegex.FindAllStringSubmatch(string(b), -1)
+	for _, match := range matches {
+		paramsToMatches[match[0]] = match[1]
+	}
+
+	for param, match := range paramsToMatches {
+		if !labelRegex.MatchString(param) {
+			return []byte(""), fmt.Errorf("found unknown parameter: %s", param)
+		}
+
+		key, err := findKeyinLabelParam(param)
+		if err != nil {
+			return []byte(""), err
+		}
+
+		val, ok := (*labels)[key]
+		if !ok {
+			return []byte(""), fmt.Errorf("no label found with key %s", key)
+		}
+
+		replacements[match] = val
+	}
+
+	outputStr := string(b)
+	for old, new := range replacements {
+		outputStr = strings.ReplaceAll(outputStr, old, new)
+	}
+
+	return []byte(outputStr), nil
+}
+
+func findKeyinLabelParam(param string) (string, error) {
+	matches := labelRegex.FindStringSubmatch(param)
+	for i, name := range labelRegex.SubexpNames() {
+		if name == "key" {
+			return matches[i], nil
+		}
+	}
+	return "", fmt.Errorf("could not find label key in param %s", param)
+}

--- a/internal/tasks/config_helpers_test.go
+++ b/internal/tasks/config_helpers_test.go
@@ -1,0 +1,34 @@
+package tasks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ConfigHelpers Suite")
+}
+
+var _ = Describe("config helpers", func() {
+	When("config has appropriate parameters", func() {
+		It("will replace them correctly", func() {
+			configItem := "ignition blah blah {{ device.metadata.labels[key]}} blah blah {{ device.metadata.labels[key2] }} blah"
+			labels := map[string]string{"key": "val", "key2": "val2", "otherkey": "otherval"}
+			new, err := ReplaceParameters([]byte(configItem), &labels)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(new)).To(Equal("ignition blah blah val blah blah val2 blah"))
+		})
+	})
+
+	When("the config references a label that does not exist", func() {
+		It("will return an error", func() {
+			configItem := "ignition blah blah {{ device.metadata.labels[key]}} blah blah {{ device.metadata.labels[key2] }} blah"
+			labels := map[string]string{"key": "val", "otherkey": "otherval"}
+			_, err := ReplaceParameters([]byte(configItem), &labels)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -2,6 +2,7 @@ package tasks_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -36,6 +37,7 @@ var _ = Describe("FleetRollout", func() {
 		cfg         *config.Config
 		dbName      string
 		numDevices  int
+		fleetName   string
 		callback    store.FleetStoreCallback
 		taskManager tasks.TaskManager
 	)
@@ -49,6 +51,7 @@ var _ = Describe("FleetRollout", func() {
 		deviceStore = storeInst.Device()
 		fleetStore = storeInst.Fleet()
 		tvStore = storeInst.TemplateVersion()
+		fleetName = "myfleet"
 		callback = func(before *model.Fleet, after *model.Fleet) {}
 		taskManager = tasks.Init(log, storeInst)
 	})
@@ -57,13 +60,13 @@ var _ = Describe("FleetRollout", func() {
 		store.DeleteTestDB(cfg, storeInst, dbName)
 	})
 
-	Context("FleetRollout", func() {
-		It("Fleet rollout good flow", func() {
-			testutil.CreateTestFleet(ctx, fleetStore, orgId, "myfleet-1", nil, nil)
-			err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.bad", "my bad OS", false)
+	When("the fleet is valid", func() {
+		It("its devices are rolled out successfully", func() {
+			testutil.CreateTestFleet(ctx, fleetStore, orgId, fleetName, nil, nil)
+			err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0.bad", "my bad OS", false)
 			Expect(err).ToNot(HaveOccurred())
-			testutil.CreateTestDevices(ctx, numDevices, deviceStore, orgId, util.StrToPtr("Fleet/myfleet-1"), true)
-			fleet, err := fleetStore.Get(ctx, orgId, "myfleet-1")
+			testutil.CreateTestDevices(ctx, numDevices, deviceStore, orgId, util.StrToPtr("Fleet/myfleet"), true)
+			fleet, err := fleetStore.Get(ctx, orgId, fleetName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*fleet.Metadata.Generation).To(Equal(int64(1)))
 			Expect(*fleet.Spec.Template.Metadata.Generation).To(Equal(int64(1)))
@@ -76,7 +79,7 @@ var _ = Describe("FleetRollout", func() {
 			logic := tasks.NewFleetRolloutsLogic(taskManager, log, storeInst, tasks.ResourceReference{OrgID: orgId, Name: *fleet.Metadata.Name})
 			logic.SetItemsPerPage(2)
 
-			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.0", "my first OS", true)
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0.0", "my first OS", true)
 			Expect(err).ToNot(HaveOccurred())
 			err = logic.RolloutFleet(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -88,7 +91,7 @@ var _ = Describe("FleetRollout", func() {
 			}
 
 			// Second update
-			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.1", "my new OS", true)
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0.1", "my new OS", true)
 			Expect(err).ToNot(HaveOccurred())
 			fleet.Spec.Template.Spec.Os = &api.DeviceOSSpec{Image: "my new OS"}
 			_, _, err = fleetStore.CreateOrUpdate(ctx, orgId, fleet, callback)
@@ -103,12 +106,12 @@ var _ = Describe("FleetRollout", func() {
 			}
 		})
 
-		It("Device rollout good flow", func() {
-			testutil.CreateTestFleet(ctx, fleetStore, orgId, "myfleet-1", nil, nil)
-			err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.bad", "my bad OS", false)
+		It("a new device is rolled out correctly", func() {
+			testutil.CreateTestFleet(ctx, fleetStore, orgId, fleetName, nil, nil)
+			err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0.bad", "my bad OS", false)
 			Expect(err).ToNot(HaveOccurred())
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mydevice-1", util.StrToPtr("Fleet/myfleet-1"), nil, nil)
-			fleet, err := fleetStore.Get(ctx, orgId, "myfleet-1")
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mydevice-1", util.StrToPtr("Fleet/myfleet"), nil, nil)
+			fleet, err := fleetStore.Get(ctx, orgId, fleetName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*fleet.Metadata.Generation).To(Equal(int64(1)))
 			Expect(*fleet.Spec.Template.Metadata.Generation).To(Equal(int64(1)))
@@ -116,7 +119,7 @@ var _ = Describe("FleetRollout", func() {
 			logic := tasks.NewFleetRolloutsLogic(taskManager, log, storeInst, tasks.ResourceReference{OrgID: orgId, Name: "mydevice-1"})
 			logic.SetItemsPerPage(2)
 
-			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "myfleet-1", "1.0.0", "my first OS", true)
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0.0", "my first OS", true)
 			Expect(err).ToNot(HaveOccurred())
 			err = logic.RolloutDevice(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -124,6 +127,161 @@ var _ = Describe("FleetRollout", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dev.Metadata.Annotations).ToNot(BeNil())
 			Expect((*dev.Metadata.Annotations)[model.DeviceAnnotationTemplateVersion]).To(Equal("1.0.0"))
+		})
+
+		When("the fleet is valid and contains parameters", func() {
+			var (
+				gitConfig    *api.GitConfigProviderSpec
+				inlineConfig *api.InlineConfigProviderSpec
+			)
+
+			BeforeEach(func() {
+				gitConfig = &api.GitConfigProviderSpec{
+					ConfigType: string(api.TemplateDiscriminatorGitConfig),
+					Name:       "paramGitConfig",
+				}
+				gitConfig.GitRef.Path = "path-{{ device.metadata.labels[key] }}"
+				gitConfig.GitRef.Repository = "repo"
+				gitConfig.GitRef.TargetRevision = "rev"
+
+				inlineConfig = &api.InlineConfigProviderSpec{
+					ConfigType: string(api.TemplateDiscriminatorInlineConfig),
+					Name:       "paramInlineConfig",
+				}
+				var inline map[string]interface{}
+				err := json.Unmarshal([]byte("{\"ignition\": {\"version\": \"3.4.{{ device.metadata.labels[version] }}\"}}"), &inline)
+				Expect(err).ToNot(HaveOccurred())
+				inlineConfig.Inline = inline
+			})
+
+			It("its devices are rolled out successfully", func() {
+				// Create fleet and TV
+				testutil.CreateTestFleet(ctx, fleetStore, orgId, fleetName, nil, nil)
+				err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0", "myOS", true)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Update the TV with git and inline configs, both with parameters
+				tv, err := storeInst.TemplateVersion().Get(ctx, orgId, fleetName, "1.0")
+				Expect(err).ToNot(HaveOccurred())
+				gitItem := api.TemplateVersionStatus_Config_Item{}
+				err = gitItem.FromGitConfigProviderSpec(*gitConfig)
+				Expect(err).ToNot(HaveOccurred())
+				inlineItem := api.TemplateVersionStatus_Config_Item{}
+				err = inlineItem.FromInlineConfigProviderSpec(*inlineConfig)
+				Expect(err).ToNot(HaveOccurred())
+				tv.Status.Config = &[]api.TemplateVersionStatus_Config_Item{gitItem, inlineItem}
+				tvCallback := store.TemplateVersionStoreCallback(func(tv *model.TemplateVersion) {})
+				err = storeInst.TemplateVersion().UpdateStatus(ctx, orgId, tv, util.BoolToPtr(true), tvCallback)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Add devices to the fleet
+				testutil.CreateTestDevices(ctx, numDevices, deviceStore, orgId, util.StrToPtr("Fleet/myfleet"), false)
+				fleet, err := fleetStore.Get(ctx, orgId, fleetName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*fleet.Metadata.Generation).To(Equal(int64(1)))
+				Expect(*fleet.Spec.Template.Metadata.Generation).To(Equal(int64(1)))
+
+				devices, err := deviceStore.List(ctx, orgId, store.ListParams{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(devices.Items)).To(Equal(numDevices))
+
+				// Roll out the devices and check their configs
+				logic := tasks.NewFleetRolloutsLogic(taskManager, log, storeInst, tasks.ResourceReference{OrgID: orgId, Name: *fleet.Metadata.Name})
+				err = logic.RolloutFleet(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				for i := 1; i <= numDevices; i++ {
+					dev, err := deviceStore.Get(ctx, orgId, fmt.Sprintf("mydevice-%d", i))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dev.Metadata.Annotations).ToNot(BeNil())
+					Expect((*dev.Metadata.Annotations)[model.DeviceAnnotationTemplateVersion]).To(Equal("1.0"))
+					Expect(dev.Spec.Config).ToNot(BeNil())
+					Expect(*dev.Spec.Config).To(HaveLen(2))
+					for _, configItem := range *dev.Spec.Config {
+						disc, err := configItem.Discriminator()
+						Expect(err).ToNot(HaveOccurred())
+						switch disc {
+						case string(api.TemplateDiscriminatorGitConfig):
+							gitSpec, err := configItem.AsGitConfigProviderSpec()
+							Expect(err).ToNot(HaveOccurred())
+							Expect(gitSpec.GitRef.Path).To(Equal(fmt.Sprintf("path-value-%d", i)))
+						case string(api.TemplateDiscriminatorInlineConfig):
+							inlineSpec, err := configItem.AsInlineConfigProviderSpec()
+							Expect(err).ToNot(HaveOccurred())
+							ig := inlineSpec.Inline["ignition"]
+							igMap, ok := ig.(map[string]interface{})
+							Expect(ok).To(BeTrue())
+							ver := igMap["version"]
+							verStr, ok := ver.(string)
+							Expect(ok).To(BeTrue())
+							Expect(verStr).To(Equal(fmt.Sprintf("3.4.%d", i)))
+						default:
+							Expect("").To(Equal("unexpected discriminator"))
+						}
+					}
+				}
+			})
+
+			It("a new device is rolled out correctly", func() {
+				// Create fleet and TV
+				testutil.CreateTestFleet(ctx, fleetStore, orgId, fleetName, nil, nil)
+				err := testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "1.0", "myOS", true)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Update the TV with git and inline configs, both with parameters
+				tv, err := storeInst.TemplateVersion().Get(ctx, orgId, fleetName, "1.0")
+				Expect(err).ToNot(HaveOccurred())
+				gitItem := api.TemplateVersionStatus_Config_Item{}
+				err = gitItem.FromGitConfigProviderSpec(*gitConfig)
+				Expect(err).ToNot(HaveOccurred())
+				inlineItem := api.TemplateVersionStatus_Config_Item{}
+				err = inlineItem.FromInlineConfigProviderSpec(*inlineConfig)
+				Expect(err).ToNot(HaveOccurred())
+				tv.Status.Config = &[]api.TemplateVersionStatus_Config_Item{gitItem, inlineItem}
+				tvCallback := store.TemplateVersionStoreCallback(func(tv *model.TemplateVersion) {})
+				err = storeInst.TemplateVersion().UpdateStatus(ctx, orgId, tv, util.BoolToPtr(true), tvCallback)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Add a device to the fleet
+				labels := map[string]string{"key": "some-value", "otherkey": "other-value", "version": "2"}
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, "mydevice-1", util.StrToPtr("Fleet/myfleet"), nil, &labels)
+				fleet, err := fleetStore.Get(ctx, orgId, fleetName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*fleet.Metadata.Generation).To(Equal(int64(1)))
+				Expect(*fleet.Spec.Template.Metadata.Generation).To(Equal(int64(1)))
+
+				// Roll out to the single device
+				logic := tasks.NewFleetRolloutsLogic(taskManager, log, storeInst, tasks.ResourceReference{OrgID: orgId, Name: "mydevice-1"})
+				err = logic.RolloutDevice(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				dev, err := deviceStore.Get(ctx, orgId, "mydevice-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dev.Metadata.Annotations).ToNot(BeNil())
+				Expect((*dev.Metadata.Annotations)[model.DeviceAnnotationTemplateVersion]).To(Equal("1.0"))
+				Expect(dev.Spec.Config).ToNot(BeNil())
+				Expect(*dev.Spec.Config).To(HaveLen(2))
+				for _, configItem := range *dev.Spec.Config {
+					disc, err := configItem.Discriminator()
+					Expect(err).ToNot(HaveOccurred())
+					switch disc {
+					case string(api.TemplateDiscriminatorGitConfig):
+						gitSpec, err := configItem.AsGitConfigProviderSpec()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(gitSpec.GitRef.Path).To(Equal("path-some-value"))
+					case string(api.TemplateDiscriminatorInlineConfig):
+						inlineSpec, err := configItem.AsInlineConfigProviderSpec()
+						Expect(err).ToNot(HaveOccurred())
+						ig := inlineSpec.Inline["ignition"]
+						igMap, ok := ig.(map[string]interface{})
+						Expect(ok).To(BeTrue())
+						ver := igMap["version"]
+						verStr, ok := ver.(string)
+						Expect(ok).To(BeTrue())
+						Expect(verStr).To(Equal("3.4.2"))
+					default:
+						Expect("").To(Equal("unexpected discriminator"))
+					}
+				}
+			})
 		})
 	})
 })

--- a/test/integration/tasks/templateversion_populate_test.go
+++ b/test/integration/tasks/templateversion_populate_test.go
@@ -1,0 +1,143 @@
+package tasks_test
+
+import (
+	"context"
+	"encoding/json"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/util"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("TVPopulate", func() {
+	var (
+		log           *logrus.Logger
+		ctx           context.Context
+		orgId         uuid.UUID
+		storeInst     store.Store
+		cfg           *config.Config
+		dbName        string
+		taskManager   tasks.TaskManager
+		fleet         *api.Fleet
+		tv            *api.TemplateVersion
+		fleetCallback store.FleetStoreCallback
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		orgId, _ = uuid.NewUUID()
+		log = flightlog.InitLogs()
+		storeInst, cfg, dbName = store.PrepareDBForUnitTests(log)
+		taskManager = tasks.Init(log, storeInst)
+		fleetCallback = store.FleetStoreCallback(func(before *model.Fleet, after *model.Fleet) {})
+
+		fleet = &api.Fleet{
+			Metadata: api.ObjectMeta{Name: util.StrToPtr("fleet")},
+			Spec:     api.FleetSpec{},
+		}
+		_, err := storeInst.Fleet().Create(ctx, orgId, fleet, fleetCallback)
+		Expect(err).ToNot(HaveOccurred())
+
+		testutil.CreateTestDevices(ctx, 2, storeInst.Device(), orgId, util.SetResourceOwner(model.FleetKind, *fleet.Metadata.Name), false)
+
+		tv = &api.TemplateVersion{
+			Metadata: api.ObjectMeta{
+				Name:  util.StrToPtr("tv"),
+				Owner: util.SetResourceOwner(model.FleetKind, *fleet.Metadata.Name),
+			},
+			Spec: api.TemplateVersionSpec{Fleet: *fleet.Metadata.Name},
+		}
+		tvCallback := store.TemplateVersionStoreCallback(func(tv *model.TemplateVersion) {})
+		_, err = storeInst.TemplateVersion().Create(ctx, orgId, tv, tvCallback)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		store.DeleteTestDB(cfg, storeInst, dbName)
+	})
+
+	When("a template has a valid inline config with no params", func() {
+		It("copies the config as is", func() {
+			inlineConfig := &api.InlineConfigProviderSpec{
+				ConfigType: string(api.TemplateDiscriminatorInlineConfig),
+				Name:       "inlineConfig",
+			}
+			var inline map[string]interface{}
+			err := json.Unmarshal([]byte("{\"ignition\": {\"version\": \"3.4.0\"}}"), &inline)
+			Expect(err).ToNot(HaveOccurred())
+			inlineConfig.Inline = inline
+
+			inlineItem := api.DeviceSpec_Config_Item{}
+			err = inlineItem.FromInlineConfigProviderSpec(*inlineConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{inlineItem}
+			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, fleet, fleetCallback)
+			Expect(err).ToNot(HaveOccurred())
+
+			owner := util.SetResourceOwner(model.FleetKind, *fleet.Metadata.Name)
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Op: tasks.TemplateVersionPopulateOpCreated, Name: "tv", Kind: model.TemplateVersionKind, Owner: *owner}
+			logic := tasks.NewTemplateVersionPopulateLogic(taskManager, log, storeInst, resourceRef)
+			err = logic.SyncFleetTemplateToTemplateVersion(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			tv, err = storeInst.TemplateVersion().Get(ctx, orgId, *fleet.Metadata.Name, *tv.Metadata.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(tv.Status.Config).ToNot(BeNil())
+			Expect(*tv.Status.Config).To(HaveLen(1))
+			configItem := (*tv.Status.Config)[0]
+			newInline, err := configItem.AsInlineConfigProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(newInline.Inline).To(Equal(inline))
+		})
+	})
+
+	When("a template has a valid inline config with params", func() {
+		It("copies the config as is", func() {
+			inlineConfig := &api.InlineConfigProviderSpec{
+				ConfigType: string(api.TemplateDiscriminatorInlineConfig),
+				Name:       "inlineConfig",
+			}
+			var inline map[string]interface{}
+			err := json.Unmarshal([]byte("{\"ignition\":{\"version\":\"3.4.0\"},\"storage\":{\"files\":[{\"overwrite\":true,\"path\":\"/etc/motd\",\"contents\":{\"source\":\"data:,{{ device.metadata.labels[key] }}\"},\"mode\":422}]}}"), &inline)
+			Expect(err).ToNot(HaveOccurred())
+			inlineConfig.Inline = inline
+
+			inlineItem := api.DeviceSpec_Config_Item{}
+			err = inlineItem.FromInlineConfigProviderSpec(*inlineConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{inlineItem}
+			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, fleet, fleetCallback)
+			Expect(err).ToNot(HaveOccurred())
+
+			owner := util.SetResourceOwner(model.FleetKind, *fleet.Metadata.Name)
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Op: tasks.TemplateVersionPopulateOpCreated, Name: "tv", Kind: model.TemplateVersionKind, Owner: *owner}
+			logic := tasks.NewTemplateVersionPopulateLogic(taskManager, log, storeInst, resourceRef)
+			err = logic.SyncFleetTemplateToTemplateVersion(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			tv, err = storeInst.TemplateVersion().Get(ctx, orgId, *fleet.Metadata.Name, *tv.Metadata.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(tv.Status.Config).ToNot(BeNil())
+			Expect(*tv.Status.Config).To(HaveLen(1))
+			configItem := (*tv.Status.Config)[0]
+			newInline, err := configItem.AsInlineConfigProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(newInline.Inline).To(Equal(inline))
+		})
+	})
+})

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -42,9 +42,10 @@ func CreateTestDevice(ctx context.Context, deviceStore store.Device, orgId uuid.
 
 func CreateTestDevices(ctx context.Context, numDevices int, deviceStore store.Device, orgId uuid.UUID, owner *string, sameVals bool) {
 	for i := 1; i <= numDevices; i++ {
-		labels := map[string]string{"key": fmt.Sprintf("value-%d", i), "otherkey": "othervalue"}
+		labels := map[string]string{"key": fmt.Sprintf("value-%d", i), "otherkey": "othervalue", "version": fmt.Sprintf("%d", i)}
 		if sameVals {
 			labels["key"] = "value"
+			labels["version"] = "1"
 		}
 
 		CreateTestDevice(ctx, deviceStore, orgId, fmt.Sprintf("mydevice-%d", i), owner, nil, &labels)


### PR DESCRIPTION
At this point, the only parameters recognized are of the form {{ device.metadata.labels[key] }}, and the service will replace that with the label value corresponding to the specified key for each device.

Parameters in gitConfig and inlineConfig are replaced upon rollout. Errors are currently logged but not reported to users - this will be fixed in a followup.

For gitConfig, parameters in TargetRevision require special handling and will be handled in a followup.

Outline of changes:
1. When validating fleets: do not validate ignition format if inline config contains parameters.
2. When populating templateVersion: remove redundant validations of inline configs.
3. When populating templateVersion: propogate the error when setting the status.
4. When rolling out a templateVersion to a fleet: replace parameters before writing to device.spec