### PR TITLE
NO-ISSUE: Move service port to a port that indicates TLS

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-server-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-config.yaml
@@ -14,9 +14,9 @@ data:
         user: {{ .Values.flightctl.db.masterUser }}
         password: {{ .Values.flightctl.db.masterPassword }}   # we should funnel this via secrets instead
     service:
-        address: :3333
+        address: :3443
         agentEndpointAddress: :7443
-        baseUrl: https://{{ .Values.flightctl.server.hostName }}:3333/
+        baseUrl: https://{{ .Values.flightctl.server.hostName }}:3443/
         {{ if .Values.flightctl.server.agentAPIHostName }}
         baseAgentEndpointUrl:  https://{{ .Values.flightctl.server.agentAPIHostName }}:7443/
         {{ else }}

--- a/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - name: HOME
               value: "/root"
           ports:
-            - containerPort: 3333
+            - containerPort: 3443
               name: service-api
               protocol: TCP
             - containerPort: 7443

--- a/deploy/helm/flightctl/templates/flightctl-server-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-server-service.yaml
@@ -12,8 +12,8 @@ spec:
   {{ end }}
   ports:
     - name: "flightctl-api"
-      port: 3333
-      targetPort: 3333
+      port: 3443
+      targetPort: 3443
       {{ if .Values.flightctl.server.nodePort }}
       nodePort: {{ .Values.flightctl.server.nodePort }}
       {{ end }}

--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -6,7 +6,7 @@ flightctl:
     image: localhost/flightctl-server:latest
     imagePullPolicy: IfNotPresent
     hostName: localhost
-    nodePort: 3333 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
+    nodePort: 3443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     agentNodePort: 7443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
 
 storageClassName: standard

--- a/deploy/podman/config.yaml
+++ b/deploy/podman/config.yaml
@@ -6,8 +6,8 @@ database:
   user: admin
   password: adminpass
 service:
-  address: :3333
-  baseUrl: https://localhost:3333
+  address: :3443
+  baseUrl: https://localhost:3443
   altNames:
     - my-host.abc.com
     - localhost

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -30,7 +30,7 @@ const (
 	// DefaultCertsDir is the default directory where the device's certificates are stored
 	DefaultCertsDirName = "certs"
 	// DefaultManagementEndpoint is the default address of the device management server
-	DefaultManagementEndpoint = "https://localhost:3333"
+	DefaultManagementEndpoint = "https://localhost:3443"
 	// name of the CA bundle file
 	CacertFile = "ca.crt"
 	// GeneratedCertFile is the name of the cert file which is generated as the result of enrollment

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -37,10 +37,10 @@ func TestValidConfig(t *testing.T) {
 		name   string
 		config Config
 	}{
-		{name: "only server", config: Config{Service: Service{Server: "https://localhost:3333"}}},
-		{name: "server with CA cert data", config: Config{Service: Service{Server: "https://localhost:3333", CertificateAuthorityData: []byte(certData)}, testRootDir: testRootDir}},
-		{name: "server with absolute path to CA file", config: Config{Service: Service{Server: "https://localhost:3333", CertificateAuthority: filepath.Join(configDir, certsDir, certFile)}, testRootDir: testRootDir}},
-		{name: "server with relative path to CA file", config: Config{Service: Service{Server: "https://localhost:3333", CertificateAuthority: filepath.Join(certsDir, certFile)}, baseDir: configDir, testRootDir: testRootDir}},
+		{name: "only server", config: Config{Service: Service{Server: "https://localhost:3443"}}},
+		{name: "server with CA cert data", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthorityData: []byte(certData)}, testRootDir: testRootDir}},
+		{name: "server with absolute path to CA file", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthority: filepath.Join(configDir, certsDir, certFile)}, testRootDir: testRootDir}},
+		{name: "server with relative path to CA file", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthority: filepath.Join(certsDir, certFile)}, baseDir: configDir, testRootDir: testRootDir}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -100,9 +100,9 @@ func TestClientConfig(t *testing.T) {
 	}{
 		{
 			name:           "local service",
-			server:         "https://localhost:3333",
+			server:         "https://localhost:3443",
 			serverName:     "",
-			serverWant:     "https://localhost:3333/",
+			serverWant:     "https://localhost:3443/",
 			serverNameWant: "localhost",
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,10 +69,10 @@ func NewDefault() *Config {
 			Password: "adminpass",
 		},
 		Service: &svcConfig{
-			Address:              ":3333",
+			Address:              ":3443",
 			AgentEndpointAddress: ":7443",
 			CertStore:            CertificateDir(),
-			BaseUrl:              "https://localhost:3333",
+			BaseUrl:              "https://localhost:3443",
 			BaseAgentEndpointUrl: "https://localhost:7443",
 			LogLevel:             "info",
 		},

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -9,8 +9,8 @@ kubeadmConfigPatches:
 nodes:
 - role: control-plane
   extraPortMappings:
-  - containerPort: 3333 # flightctl API
-    hostPort: 3333
+  - containerPort: 3443 # flightctl API
+    hostPort: 3443
     protocol: TCP
   - containerPort: 7443 # flightctl agent endpoint API
     hostPort: 7443


### PR DESCRIPTION
Since #303 is changing configuration and being slightly disruptive for existing images and configurations, we are using the opportunity to change the server API port to a port that indicates we are using TLS (3443 in this case).