### PR TITLE
NO-ISSUE: Add simple validation for different Repo types

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -97,12 +97,31 @@ func (r Repository) Validate() []error {
 	allErrs = append(allErrs, validation.ValidateResourceName(r.Metadata.Name)...)
 	allErrs = append(allErrs, validation.ValidateLabels(r.Metadata.Labels)...)
 	allErrs = append(allErrs, validation.ValidateAnnotations(r.Metadata.Annotations)...)
-	repoSpec, err := r.Spec.GetGitGenericRepoSpec()
-	if err != nil {
-		allErrs = append(allErrs, fmt.Errorf("invalid repository type: %s", err))
-	} else {
-		allErrs = append(allErrs, validation.ValidateString(&repoSpec.Repo, "spec.repo", 1, 2048, nil, "")...)
+
+	// Validate GitGenericRepoSpec
+	gitGenericRepoSpec, genericErr := r.Spec.GetGitGenericRepoSpec()
+	if genericErr == nil {
+		allErrs = append(allErrs, validation.ValidateString(&gitGenericRepoSpec.Repo, "spec.repo", 1, 2048, nil, "")...)
 	}
+
+	// Validate GitHttpRepoSpec
+	gitHttpRepoSpec, httpErr := r.Spec.GetGitHttpRepoSpec()
+	if httpErr == nil {
+		allErrs = append(allErrs, validation.ValidateString(&gitHttpRepoSpec.Repo, "spec.repo", 1, 2048, nil, "")...)
+		// TODO: Validate httpRepoSpec
+	}
+
+	// Validate GitSshRepoSpec
+	gitSshRepoSpec, sshErr := r.Spec.GetGitSshRepoSpec()
+	if sshErr == nil {
+		allErrs = append(allErrs, validation.ValidateString(&gitSshRepoSpec.Repo, "spec.repo", 1, 2048, nil, "")...)
+		// TODO: Validate sshRepoSpec
+	}
+
+	if genericErr != nil && httpErr != nil && sshErr != nil {
+		allErrs = append(allErrs, fmt.Errorf("invalid repository type: no valid spec found"))
+	}
+
 	return allErrs
 }
 

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -71,9 +71,18 @@ func ValidateString(s *string, path string, minLen int, maxLen int, patternRegex
 	return asErrors(errs)
 }
 
-func IsBase64(s string) bool {
+func ValidateBase64Field(s string, path string, maxLen int) []error {
+	errs := field.ErrorList{}
+
+	if len(s) > maxLen {
+		errs = append(errs, field.TooLong(fieldPathFor(path), s, maxLen))
+	}
 	_, err := base64.StdEncoding.DecodeString(s)
-	return err == nil
+	if err != nil {
+		errs = append(errs, field.Invalid(fieldPathFor(path), s, "must be a valid base64 encoded string"))
+	}
+
+	return asErrors(errs)
 }
 
 func fieldPathFor(path string) *field.Path {

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -68,6 +69,11 @@ func ValidateString(s *string, path string, minLen int, maxLen int, patternRegex
 		errs = append(errs, field.Invalid(fieldPathFor(path), *s, k8sutilvalidation.RegexError("Invalidpattern", patternFmt, patternExample...)))
 	}
 	return asErrors(errs)
+}
+
+func IsBase64(s string) bool {
+	_, err := base64.StdEncoding.DecodeString(s)
+	return err == nil
 }
 
 func fieldPathFor(path string) *field.Path {


### PR DESCRIPTION
We are getting an error where the generic repo is being validated, but it does not allow either the sshConfig or httpConfig object. 