### PR TITLE
Cli improvements

### DIFF
--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Make the cmdline tool
         run: make build
 
+      - name: Copy the client.yaml into the right location
+        run: mkdir -p $HOME/.config/flightctl && cp $HOME/.flightctl/client.yaml $HOME/.config/flightctl/client.yaml
+
       - name: Apply device
         run: bin/flightctl apply -f examples/device.yaml
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/coreos/ignition/v2 v2.19.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/gliderlabs/ssh v0.3.7

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.9.0
 	github.com/thoas/go-funk v0.9.3
 	github.com/vincent-petithory/dataurl v1.0.0
@@ -103,7 +104,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
-	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -16,6 +16,7 @@ import (
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -25,13 +26,24 @@ var (
 )
 
 type ApplyOptions struct {
+	GlobalOptions
+
 	Filenames []string
 	DryRun    bool
 	Recursive bool
 }
 
+func DefaultApplyOptions() *ApplyOptions {
+	return &ApplyOptions{
+		GlobalOptions: DefaultGlobalOptions(),
+		Filenames:     []string{},
+		DryRun:        false,
+		Recursive:     false,
+	}
+}
+
 func NewCmdApply() *cobra.Command {
-	o := &ApplyOptions{Filenames: []string{}, DryRun: false, Recursive: false}
+	o := DefaultApplyOptions()
 	cmd := &cobra.Command{
 		Use:   "apply -f FILENAME",
 		Short: "Apply a configuration to a resource by file name or stdin.",
@@ -46,28 +58,39 @@ func NewCmdApply() *cobra.Command {
 		},
 		SilenceUsage: true,
 	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
 
-	flags := cmd.Flags()
-	flags.StringSliceVarP(&o.Filenames, "filename", "f", o.Filenames, "The files or directory that contain the resources to apply.")
+func (o *ApplyOptions) Bind(fs *pflag.FlagSet) {
+	o.GlobalOptions.Bind(fs)
+
+	fs.StringSliceVarP(&o.Filenames, "filename", "f", o.Filenames, "The files or directory that contain the resources to apply.")
 	annotations := make([]string, 0, len(fileExtensions))
 	for _, ext := range fileExtensions {
 		annotations = append(annotations, strings.TrimLeft(ext, "."))
 	}
-	err := flags.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
+	err := fs.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
 	if err != nil {
 		log.Fatalf("setting filename flag annotation: %v", err)
 	}
-	flags.BoolVarP(&o.DryRun, "dry-run", "", o.DryRun, "Only print the object that would be sent, without sending it.")
-	flags.BoolVarP(&o.Recursive, "recursive", "R", o.Recursive, "Process the directory used in -f, --filename recursively.")
-
-	return cmd
+	fs.BoolVarP(&o.DryRun, "dry-run", "", o.DryRun, "Only print the object that would be sent, without sending it.")
+	fs.BoolVarP(&o.Recursive, "recursive", "R", o.Recursive, "Process the directory used in -f, --filename recursively.")
 }
 
 func (o *ApplyOptions) Complete(cmd *cobra.Command, args []string) error {
+	if err := o.GlobalOptions.Complete(cmd, args); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (o *ApplyOptions) Validate(args []string) error {
+	if err := o.GlobalOptions.Validate(args); err != nil {
+		return err
+	}
+
 	if len(o.Filenames) == 0 {
 		return fmt.Errorf("must specify -f FILENAME")
 	}

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -101,7 +101,7 @@ func (o *ApplyOptions) Validate(args []string) error {
 }
 
 func (o *ApplyOptions) Run(ctx context.Context, args []string) error {
-	client, err := client.NewFromConfigFile(defaultClientConfigFile)
+	c, err := client.NewFromConfigFile(o.ConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
@@ -110,7 +110,7 @@ func (o *ApplyOptions) Run(ctx context.Context, args []string) error {
 	for _, filename := range o.Filenames {
 		switch {
 		case filename == "-":
-			errs = append(errs, applyFromReader(ctx, client, "<stdin>", os.Stdin, o.DryRun)...)
+			errs = append(errs, applyFromReader(ctx, c, "<stdin>", os.Stdin, o.DryRun)...)
 		default:
 			expandedFilenames, err := expandIfFilePattern(filename)
 			if err != nil {
@@ -148,7 +148,7 @@ func (o *ApplyOptions) Run(ctx context.Context, args []string) error {
 						return nil
 					}
 					defer r.Close()
-					errs = append(errs, applyFromReader(ctx, client, path, r, o.DryRun)...)
+					errs = append(errs, applyFromReader(ctx, c, path, r, o.DryRun)...)
 					return nil
 				})
 				if err != nil {

--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -69,7 +69,7 @@ func (o *ApproveOptions) Validate(args []string) error {
 }
 
 func (o *ApproveOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(defaultClientConfigFile)
+	c, err := client.NewFromConfigFile(o.ConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -6,14 +6,24 @@ import (
 
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type DeleteOptions struct {
+	GlobalOptions
+
 	FleetName string
 }
 
+func DefaultDeleteOptions() *DeleteOptions {
+	return &DeleteOptions{
+		GlobalOptions: DefaultGlobalOptions(),
+		FleetName:     "",
+	}
+}
+
 func NewCmdDelete() *cobra.Command {
-	o := &DeleteOptions{}
+	o := DefaultDeleteOptions()
 	cmd := &cobra.Command{
 		Use:   "delete (TYPE | TYPE/NAME)",
 		Short: "Delete resources by resources or owner.",
@@ -29,15 +39,29 @@ func NewCmdDelete() *cobra.Command {
 		},
 		SilenceUsage: true,
 	}
-	cmd.Flags().StringVarP(&o.FleetName, "fleetname", "f", o.FleetName, "Fleet name for accessing templateversions.")
+	o.Bind(cmd.Flags())
 	return cmd
 }
 
+func (o *DeleteOptions) Bind(fs *pflag.FlagSet) {
+	o.GlobalOptions.Bind(fs)
+
+	fs.StringVarP(&o.FleetName, "fleetname", "f", o.FleetName, "Fleet name for accessing templateversions.")
+}
+
 func (o *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
+	if err := o.GlobalOptions.Complete(cmd, args); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (o *DeleteOptions) Validate(args []string) error {
+	if err := o.GlobalOptions.Validate(args); err != nil {
+		return err
+	}
+
 	kind, _, err := parseAndValidateKindName(args[0])
 	if err != nil {
 		return err

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -73,7 +73,7 @@ func (o *DeleteOptions) Validate(args []string) error {
 }
 
 func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(defaultClientConfigFile)
+	c, err := client.NewFromConfigFile(o.ConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -144,7 +144,7 @@ func (o *GetOptions) Validate(args []string) error {
 }
 
 func (o *GetOptions) Run(ctx context.Context, args []string) error { // nolint: gocyclo
-	c, err := client.NewFromConfigFile(defaultClientConfigFile)
+	c, err := client.NewFromConfigFile(o.ConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -17,18 +17,22 @@ const (
 
 type GlobalOptions struct {
 	ConfigFilePath string
+	Context        string
 }
 
 func DefaultGlobalOptions() GlobalOptions {
 	return GlobalOptions{
-		ConfigFilePath: ConfigFilePath(),
+		ConfigFilePath: ConfigFilePath(""),
+		Context:        "",
 	}
 }
 
 func (o *GlobalOptions) Bind(fs *pflag.FlagSet) {
+	fs.StringVarP(&o.Context, "context", "c", o.Context, "Read client config from 'client_<context>.yaml' instead of 'client.yaml'.")
 }
 
 func (o *GlobalOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.ConfigFilePath = ConfigFilePath(o.Context)
 	return nil
 }
 
@@ -36,7 +40,10 @@ func (o *GlobalOptions) Validate(args []string) error {
 	return nil
 }
 
-func ConfigFilePath() string {
+func ConfigFilePath(context string) string {
+	if len(context) > 0 && context != "default" {
+		return filepath.Join(ConfigDir(), defaultConfigFileName+"_"+context+"."+defaultConfigFileExt)
+	}
 	return filepath.Join(ConfigDir(), defaultConfigFileName+"."+defaultConfigFileExt)
 }
 

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -1,15 +1,28 @@
 package cli
 
 import (
+	"log"
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
+const (
+	appName               = "flightctl"
+	defaultConfigFileName = "client"
+	defaultConfigFileExt  = "yaml"
+)
+
 type GlobalOptions struct {
+	ConfigFilePath string
 }
 
 func DefaultGlobalOptions() GlobalOptions {
-	return GlobalOptions{}
+	return GlobalOptions{
+		ConfigFilePath: ConfigFilePath(),
+	}
 }
 
 func (o *GlobalOptions) Bind(fs *pflag.FlagSet) {
@@ -21,4 +34,16 @@ func (o *GlobalOptions) Complete(cmd *cobra.Command, args []string) error {
 
 func (o *GlobalOptions) Validate(args []string) error {
 	return nil
+}
+
+func ConfigFilePath() string {
+	return filepath.Join(ConfigDir(), defaultConfigFileName+"."+defaultConfigFileExt)
+}
+
+func ConfigDir() string {
+	configRoot, err := os.UserConfigDir()
+	if err != nil {
+		log.Fatal("Could not find the user config directory because ", err)
+	}
+	return filepath.Join(configRoot, appName)
 }

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type GlobalOptions struct {
+}
+
+func DefaultGlobalOptions() GlobalOptions {
+	return GlobalOptions{}
+}
+
+func (o *GlobalOptions) Bind(fs *pflag.FlagSet) {
+}
+
+func (o *GlobalOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *GlobalOptions) Validate(args []string) error {
+	return nil
+}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"fmt"
 	"strings"
-
-	"github.com/flightctl/flightctl/internal/client"
 )
 
 const (
@@ -17,8 +15,7 @@ const (
 )
 
 var (
-	defaultClientConfigFile string
-	resourceKinds           = map[string]string{
+	resourceKinds = map[string]string{
 		DeviceKind:            "devices",
 		EnrollmentRequestKind: "enrollmentrequests",
 		FleetKind:             "fleets",
@@ -27,10 +24,6 @@ var (
 		TemplateVersionKind:   "templateversions",
 	}
 )
-
-func init() {
-	defaultClientConfigFile = client.DefaultFlightctlClientConfigPath()
-}
 
 func parseAndValidateKindName(arg string) (string, string, error) {
 	kind, name, _ := strings.Cut(arg, "/")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -98,6 +98,13 @@ func TimeStampStringPtr() *string {
 	return StrToPtr(time.Now().Format(time.RFC3339))
 }
 
+func BoolToStr(b bool, ifTrue string, ifFalse string) string {
+	if b {
+		return ifTrue
+	}
+	return ifFalse
+}
+
 func SingleQuote(input []string) []string {
 	output := make([]string, len(input))
 	for i, val := range input {


### PR DESCRIPTION
This is a start of a series of small improvements to the CLI. This PR contains:

- Add structure for global options.
- Switch reading the client config from the OS's standard config directory (on Linux `$HOME/.config/flightctl/client.yaml`).
- Add a `-c/--context`global option that allows to select between multiple client config files.
- Add new statuses and other fields to the output of `flightctl get`.