### PR TITLE
NO-ISSUE: tasks: ensure empty ignition has a version

### DIFF
--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -80,6 +80,7 @@ func (a *Agent) Run(ctx context.Context) error {
 					a.log.Errorf("Failed to update device status: %v", updateErr)
 				}
 				a.log.Error(infoMsg)
+				continue
 			}
 
 			_, updateErr := a.statusManager.Update(ctx, status.SetDeviceSummary(v1alpha1.DeviceSummaryStatus{

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -134,7 +134,11 @@ type renderConfigArgs struct {
 
 func renderConfig(ctx context.Context, orgId uuid.UUID, store store.Store, config *[]api.DeviceSpec_Config_Item, validateOnly bool) (renderedConfig []byte, repoNames []string, err error) {
 	args := renderConfigArgs{}
-	emptyIgnitionConfig, _, _ := config_latest.ParseCompatibleVersion([]byte("{\"ignition\": {\"version\": \"3.4.0\"}"))
+	emptyIgnitionConfig := config_latest_types.Config{
+		Ignition: config_latest_types.Ignition{
+			Version: config_latest_types.MaxVersion.String(),
+		},
+	}
 	args.ignitionConfig = &emptyIgnitionConfig
 	args.validateOnly = validateOnly
 	args.orgId = orgId


### PR DESCRIPTION
The agent verifies the version of the ign is valid during deserialization so currently on renderedVersion 1 the agent fails in the steady state until another renderedVersion is sent. This PR 

- ensures a valid version is sent for empty config, ParseCompatibleVersion strips the version.
- continue on error bug found while debugging steady state.