### PR TITLE
NO-ISSUE: Validate the device template settings of a fleet

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -91,6 +91,23 @@ func (r Fleet) Validate() []error {
 	allErrs = append(allErrs, validation.ValidateResourceName(r.Metadata.Name)...)
 	allErrs = append(allErrs, validation.ValidateLabels(r.Metadata.Labels)...)
 	allErrs = append(allErrs, validation.ValidateAnnotations(r.Metadata.Annotations)...)
+
+	// Validate the Device spec settings
+	if r.Spec.Template.Spec.Os != nil {
+		allErrs = append(allErrs, validation.ValidateOciImageReference(&r.Spec.Template.Spec.Os.Image, "spec.template.spec.os.image")...)
+	}
+
+	if r.Spec.Template.Spec.Config != nil {
+		for _, config := range *r.Spec.Template.Spec.Config {
+			value, err := config.ValueByDiscriminator()
+			if err != nil {
+				allErrs = append(allErrs, fmt.Errorf("invalid configType: %s", err))
+			} else {
+				allErrs = append(allErrs, value.(Validator).Validate()...)
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/internal/service/fleet.go
+++ b/internal/service/fleet.go
@@ -41,9 +41,6 @@ func (h *ServiceHandler) CreateFleet(ctx context.Context, request server.CreateF
 	if errs := request.Body.Validate(); len(errs) > 0 {
 		return server.CreateFleet400JSONResponse{Message: errors.Join(errs...).Error()}, nil
 	}
-	if err := validateDiscriminators(request.Body); err != nil {
-		return server.CreateFleet400JSONResponse{Message: err.Error()}, nil
-	}
 
 	result, err := h.store.Fleet().Create(ctx, orgId, request.Body, h.callbackManager.FleetUpdatedCallback)
 	switch err {

--- a/internal/service/fleet.go
+++ b/internal/service/fleet.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"strings"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
@@ -138,9 +137,6 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, request server.Replac
 	if request.Name != *request.Body.Metadata.Name {
 		return server.ReplaceFleet400JSONResponse{Message: "resource name specified in metadata does not match name in path"}, nil
 	}
-	if err := validateDiscriminators(request.Body); err != nil {
-		return server.ReplaceFleet400JSONResponse{Message: err.Error()}, nil
-	}
 
 	result, created, err := h.store.Fleet().CreateOrUpdate(ctx, orgId, request.Body, h.callbackManager.FleetUpdatedCallback)
 	switch err {
@@ -215,32 +211,6 @@ func (h *ServiceHandler) ReplaceFleetStatus(ctx context.Context, request server.
 	default:
 		return nil, err
 	}
-}
-
-func validateDiscriminators(fleet *v1alpha1.Fleet) error {
-	if fleet.Spec.Template.Spec.Config == nil {
-		return nil
-	}
-	for _, config := range *fleet.Spec.Template.Spec.Config {
-		discriminator, err := config.Discriminator()
-		if err != nil {
-			return err
-		}
-		found := false
-		discriminators := []string{
-			string(v1alpha1.TemplateDiscriminatorGitConfig),
-			string(v1alpha1.TemplateDiscriminatorKubernetesSec),
-			string(v1alpha1.TemplateDiscriminatorInlineConfig)}
-		for _, d := range discriminators {
-			if discriminator == d {
-				found = true
-			}
-		}
-		if !found {
-			return fmt.Errorf("configType must be one of %s", strings.Join(discriminators, ", "))
-		}
-	}
-	return nil
 }
 
 // (PATCH /api/v1/fleets/{name})


### PR DESCRIPTION
Currently, a fleet's device template configuration items are only partially validated.

I completed the validations by adding the OS image and config template validations.
Alternatively, would it be better to validate the entire spec, by invoking the same validation method for a device spec?

Note: The UI does not validate the OS image using the regexp yet, it's tracked separately.
