### PR TITLE
NO-ISSUE: Align CLI and UI device fingerprint naming

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -300,7 +300,7 @@ func printListResourceResponse(response interface{}, err error, resourceType str
 }
 
 func printDevicesTable(w *tabwriter.Writer, response *apiclient.ListDevicesResponse) {
-	fmt.Fprintln(w, "NAME\tOWNER\tSYSTEM\tUPDATED\tAPPLICATIONS\tLAST SEEN")
+	fmt.Fprintln(w, "FINGERPRINT\tOWNER\tSYSTEM\tUPDATED\tAPPLICATIONS\tLAST SEEN")
 	for _, d := range response.JSON200.Items {
 		lastSeen := "<never>"
 		if !d.Status.UpdatedAt.IsZero() {
@@ -318,7 +318,7 @@ func printDevicesTable(w *tabwriter.Writer, response *apiclient.ListDevicesRespo
 }
 
 func printEnrollmentRequestsTable(w *tabwriter.Writer, response *apiclient.ListEnrollmentRequestsResponse) {
-	fmt.Fprintln(w, "NAME\tAPPROVAL\tAPPROVER\tAPPROVED LABELS")
+	fmt.Fprintln(w, "FINGERPRINT\tAPPROVAL\tAPPROVER\tAPPROVED LABELS")
 	for _, e := range response.JSON200.Items {
 		approval, approver, approvedLabels := "Pending", "<none>", ""
 		if e.Status.Approval != nil {


### PR DESCRIPTION
Currently, the terminology in the CLI and the UI regarding the identifier for a device is different.
The UI refers to this as the "Fingerprint", while the CLI refers to it as the "name".

Since we also define a "display name / name", it seems best that we apply the same terminology everywhere.
