### PR TITLE
MGMT-18371: add device summary status periodic

### DIFF
--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -58,12 +58,12 @@ func (s *Server) Run() error {
 	resourceSyncThread.Start()
 	defer resourceSyncThread.Stop()
 
-	// device liveness
-	deviceLiveness := tasks.NewDeviceLiveness(s.log, s.store)
-	deviceLivenessThread := thread.New(
-		s.log.WithField("pkg", "device-liveness"), "Device liveness", tasks.DeviceLivenessPollingInterval, deviceLiveness.Poll)
-	deviceLivenessThread.Start()
-	defer deviceLivenessThread.Stop()
+	// device disconnected
+	deviceDisconnected := tasks.NewDeviceDisconnected(s.log, s.store)
+	deviceDisconnectedThread := thread.New(
+		s.log.WithField("pkg", "device-disconnected"), "Device disconnected", tasks.DeviceDisconnectedPollingInterval, deviceDisconnected.Poll)
+	deviceDisconnectedThread.Start()
+	defer deviceDisconnectedThread.Stop()
 
 	sigShutdown := make(chan os.Signal, 1)
 

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -33,25 +33,38 @@ func New(
 	}
 }
 
+// TODO: expose metrics
 func (s *Server) Run() error {
 	provider := queues.NewAmqpProvider(s.cfg.Queue.AmqpURL, s.log)
 	defer provider.Stop()
-	repoTester := tasks.NewRepoTester(s.log, s.store)
-	repoTesterThread := thread.New(
-		s.log.WithField("pkg", "repository-tester"), "Repository tester", 2*time.Minute, repoTester.TestRepositories)
-	repoTesterThread.Start()
-	defer repoTesterThread.Stop()
 
 	publisher, err := tasks.TaskQueuePublisher(provider)
 	if err != nil {
 		return err
 	}
 	callbackManager := tasks.NewCallbackManager(publisher, s.log)
+
+	// repository tester
+	repoTester := tasks.NewRepoTester(s.log, s.store)
+	repoTesterThread := thread.New(
+		s.log.WithField("pkg", "repository-tester"), "Repository tester", 2*time.Minute, repoTester.TestRepositories)
+	repoTesterThread.Start()
+	defer repoTesterThread.Stop()
+
+	// resource sync
 	resourceSync := tasks.NewResourceSync(callbackManager, s.store, s.log)
 	resourceSyncThread := thread.New(
 		s.log.WithField("pkg", "resourcesync"), "ResourceSync", 2*time.Minute, resourceSync.Poll)
 	resourceSyncThread.Start()
 	defer resourceSyncThread.Stop()
+
+	// device liveness
+	deviceLiveness := tasks.NewDeviceLiveness(s.log, s.store)
+	deviceLivenessThread := thread.New(
+		s.log.WithField("pkg", "device-liveness"), "Device liveness", tasks.DeviceLivenessPollingInterval, deviceLiveness.Poll)
+	deviceLivenessThread.Start()
+	defer deviceLivenessThread.Stop()
+
 	sigShutdown := make(chan os.Signal, 1)
 
 	signal.Notify(sigShutdown, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)

--- a/internal/tasks/device_liveness.go
+++ b/internal/tasks/device_liveness.go
@@ -1,0 +1,76 @@
+package tasks
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// TODO: make configurable
+	// DeviceLivenessTimeout is the duration after which a device is considered to be not reporting and set to unknown status.
+	DeviceLivenessTimeout = 5 * time.Minute
+	// DeviceLivenessPollingInterval is the interval at which the device liveness task runs.
+	DeviceLivenessPollingInterval = 2 * time.Minute
+)
+
+type DeviceLiveness struct {
+	log         logrus.FieldLogger
+	deviceStore store.Device
+}
+
+func NewDeviceLiveness(log logrus.FieldLogger, store store.Store) *DeviceLiveness {
+	return &DeviceLiveness{
+		log:         log,
+		deviceStore: store.Device(),
+	}
+}
+
+// Poll checks the status of devices and updates the status to unknown if the device has not reported in the last DeviceLivenessTimeout.
+func (t *DeviceLiveness) Poll() {
+	t.log.Info("Running DeviceLiveness Polling")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// TODO: one thread per org?
+	orgID := uuid.UUID{}
+	// batch of 1000 devices
+	listParams := store.ListParams{Limit: ItemsPerPage}
+	for {
+		devices, err := t.deviceStore.List(ctx, orgID, listParams)
+		if err != nil {
+			t.log.WithError(err).Error("failed to list devices")
+			return
+		}
+
+		var batch []string
+		for _, device := range devices.Items {
+			if device.Status != nil && device.Status.Summary.Status != v1alpha1.DeviceSummaryStatusUnknown {
+				if device.Status.UpdatedAt.Add(DeviceLivenessTimeout).Before(time.Now()) {
+					batch = append(batch, *device.Metadata.Name)
+				}
+			}
+		}
+
+		t.log.Infof("Updating %d devices to unknown status", len(batch))
+		if err := t.deviceStore.UpdateSummaryStatusBatch(ctx, orgID, batch, v1alpha1.DeviceSummaryStatusUnknown); err != nil {
+			t.log.WithError(err).Error("failed to update device summary status")
+			return
+		}
+
+		if devices.Metadata.Continue == nil {
+			break
+		} else {
+			cont, err := store.ParseContinueString(devices.Metadata.Continue)
+			if err != nil {
+				t.log.WithError(err).Error("failed to parse continuation for paging")
+				return
+			}
+			listParams.Continue = cont
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a simple MVP periodic task that checks the device `updatedAt` timestamp and sets the status to `Unknown` if it has not reported in more than 5 minutes. 

manually tested

![image](https://github.com/user-attachments/assets/9217226c-53b1-498c-9fac-b7cb6f916be3)

`<shutdown device>`

![image](https://github.com/user-attachments/assets/a90b7a50-bb3e-4fc0-8a8c-78a5d431bcf4)

```
time="2024-07-11T18:52:31Z" level=info msg="Updating 0 devices to unknown status" func="github.com/flightctl/flightctl/internal/tasks.(*DeviceLiveness).Poll" file="/app/internal/tasks/device_liveness.go:59"
time="2024-07-11T18:54:31Z" level=info msg="Running RepoTester" func="github.com/flightctl/flightctl/internal/tasks.(*RepoTester).TestRepositories" file="/app/internal/tasks/repotester.go:43" request_id=repotester-000000000
time="2024-07-11T18:54:31Z" level=info msg="Running ResourceSync Polling" func="github.com/flightctl/flightctl/internal/tasks.(*ResourceSync).Poll" file="/app/internal/tasks/resourcesync.go:49" request_id=resourcesync-000000000
time="2024-07-11T18:54:31Z" level=info msg="Running DeviceLiveness Polling" func="github.com/flightctl/flightctl/internal/tasks.(*DeviceLiveness).Poll" file="/app/internal/tasks/device_liveness.go:35"
time="2024-07-11T18:54:31Z" level=info msg="Updating 1 devices to unknown status" func="github.com/flightctl/flightctl/internal/tasks.(*DeviceLiveness).Poll" file="/app/internal/tasks/device_liveness.go:59"
```

```
        "summary": {
          "info": "Did not check in for 5 minutes",
          "status": "Unknown"
        },
```
