### PR TITLE
GITHUB-354: Make ClusterRole and binding optional

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-config.yaml
@@ -23,10 +23,8 @@ data:
         {{ else }}
         baseAgentEndpointUrl:  https://{{ .Values.flightctl.api.hostName }}:7443/
         {{ end }}
-        {{ if .Values.flightctl.api.agentGrpcHostName }}
-        baseAgentGrpcUrl:  grpcs://{{ .Values.flightctl.api.agentGrpcHostName }}:7444/
-        {{ else }}
-        baseAgentGrpcUrl:  grpcs://{{ .Values.flightctl.api.hostName }}:7444/
+        {{ if .Values.flightctl.api.agentGrpcBaseURL }}
+        baseAgentGrpcUrl:  {{ .Values.flightctl.api.agentGrpcBaseURL }}
         {{ end }}
         altNames:
           - {{ .Values.flightctl.api.hostName }}

--- a/deploy/helm/flightctl/templates/flightctl-worker-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.worker.enableSecretsClusterRoleBinding }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,3 +10,4 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-worker-clusterrolebinding.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.flightctl.worker.enableSecretsClusterRoleBinding }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ roleRef:
   kind: ClusterRole
   name: flightctl-worker
   apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -16,11 +16,13 @@ flightctl:
     hostName: api.flightctl.example.com
     agentAPIHostName: agent-api.flightctl.example.com
     agentGrpcHostName: agent-grpc.flightctl.example.com
+    agentGrpcBaseURL: grpcs://agent-grpc.flightctl.example.com
   worker:
     enabled: true
     namespace: flightctl-internal
     image: quay.io/flightctl/flightctl-worker:latest
     imagePullPolicy: Always
+    enableSecretsClusterRoleBinding: true
   periodic:
     enabled: true
     namespace: flightctl-internal

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -68,6 +68,7 @@ helm ${METHOD} --values ./deploy/helm/flightctl/values.kind.yaml \
                   --set flightctl.api.hostName=${IP} \
                   --set flightctl.api.agentAPIHostName=${IP} \
                   --set flightctl.api.agentGrpcHostName=${IP} \
+                  --set flightctl.api.agentGrpcBaseURL=grpcs://${IP}:7444 \
                    ${ONLY_DB} ${NO_AUTH} ${DB_IMG} ${RABBITMQ_ARG} flightctl \
               ./deploy/helm/flightctl/ --kube-context kind-kind
 


### PR DESCRIPTION
Makes the deployment of ClusterRole and CLusterRoleBinding for secret access optional, it's too wide for a cluster and many PAAS offerings won't accept this.

Related-Issue: #354