### PR TITLE
NO-ISSUE: e2e: enable free disk space step

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Setup all dependencies
         uses: ./.github/actions/setup-dependencies
         with:


### PR DESCRIPTION
This is needed because e2e has been failing from no space on device

```
cp: error copying '/store/stage/uuid-ae0e4adf8b0c45fbbed26150f7e4df8b/data/tree/./disk.qcow2' to '/output/qcow2/./disk.qcow2': No space left on device
```

ref. https://github.com/flightctl/flightctl/actions/runs/9910087335/job/27379656537?pr=353