### PR TITLE
NO-ISSUE: Update SSHCommand function in e2e

### DIFF
--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -84,6 +84,7 @@ func (v *TestVM) SSHCommand(inputArgs []string) *exec.Cmd {
 	args := []string{"-p", v.SSHPassword, "ssh", "-p", port, sshDestination,
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "PubkeyAuthentication=no", // avoid any local SSH keys to be used
 		"-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(inputArgs) > 0 {
 		args = append(args, inputArgs...)


### PR DESCRIPTION
Updated SSHCommand function with "PubkeyAuthentication=no" to avoid that any local SSH key is used for the authentication.

This will avoid a possible "Too many authentication failures" error when the test runs in local env

