### PR TITLE
EDM-177: ResourceSync overwrites fleet status on sync

### DIFF
--- a/internal/store/enrollmentrequest.go
+++ b/internal/store/enrollmentrequest.go
@@ -133,6 +133,7 @@ func (s *EnrollmentRequestStore) CreateOrUpdate(ctx context.Context, orgId uuid.
 		}
 	}
 
+	enrollmentrequest.Status = nil
 	var updatedEnrollmentRequest model.EnrollmentRequest
 	where := model.EnrollmentRequest{Resource: model.Resource{OrgID: enrollmentrequest.OrgID, Name: enrollmentrequest.Name}}
 	result = s.db.Where(where).Assign(enrollmentrequest).FirstOrCreate(&updatedEnrollmentRequest)

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -164,13 +164,14 @@ func (s *RepositoryStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, r
 		}
 	}
 
+	repository.Status = nil
 	var updatedRepository model.Repository
 	where := model.Repository{Resource: model.Resource{OrgID: repository.OrgID, Name: repository.Name}}
 	result = s.db.Where(where).Assign(repository).FirstOrCreate(&updatedRepository)
 
 	updatedResource, toApiErr := updatedRepository.ToApiResource()
 	if result.Error == nil {
-		callback(repository)
+		callback(&updatedRepository)
 	}
 	err := flterrors.ErrorFromGormError(result.Error)
 	if err == nil {

--- a/internal/store/resourcesync.go
+++ b/internal/store/resourcesync.go
@@ -171,6 +171,7 @@ func (s *ResourceSyncStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID,
 		}
 	}
 
+	resourcesync.Status = nil
 	var updatedResourceSync model.ResourceSync
 	where := model.ResourceSync{Resource: model.Resource{OrgID: resourcesync.OrgID, Name: resourcesync.Name}}
 	result = s.db.Where(where).Assign(resourcesync).FirstOrCreate(&updatedResourceSync)

--- a/internal/tasks/resourcesync.go
+++ b/internal/tasks/resourcesync.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
@@ -298,6 +299,12 @@ func (r ResourceSync) parseFleets(resources []genericResourceMap, owner *string)
 				return nil, fmt.Errorf("found multiple fleet definitions with name '%s'", name)
 			}
 			names[name] = name
+			// don't overwrite fields that are managed by the service
+			fleet.Status = nil
+			common.NilOutManagedObjectMetaProperties(&fleet.Metadata)
+			if fleet.Spec.Template.Metadata != nil {
+				common.NilOutManagedObjectMetaProperties(fleet.Spec.Template.Metadata)
+			}
 
 			fleet.Metadata.Owner = owner
 

--- a/test/integration/store/enrollmentrequest_test.go
+++ b/test/integration/store/enrollmentrequest_test.go
@@ -29,6 +29,9 @@ func createEnrollmentRequests(numEnrollmentRequests int, ctx context.Context, st
 			Spec: api.EnrollmentRequestSpec{
 				Csr: "csr string",
 			},
+			Status: &api.EnrollmentRequestStatus{
+				Certificate: util.StrToPtr("cert"),
+			},
 		}
 
 		_, err := store.EnrollmentRequest().Create(ctx, orgId, &resource)
@@ -173,14 +176,14 @@ var _ = Describe("enrollmentRequestStore create", func() {
 				},
 				Status: nil,
 			}
-			dev, created, err := storeInst.EnrollmentRequest().CreateOrUpdate(ctx, orgId, &enrollmentrequest)
+			er, created, err := storeInst.EnrollmentRequest().CreateOrUpdate(ctx, orgId, &enrollmentrequest)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(Equal(true))
-			Expect(dev.ApiVersion).To(Equal(model.EnrollmentRequestAPI))
-			Expect(dev.Kind).To(Equal(model.EnrollmentRequestKind))
-			Expect(dev.Spec.Csr).To(Equal("csr string"))
-			Expect(dev.Status.Conditions).ToNot(BeNil())
-			Expect(dev.Status.Conditions).To(BeEmpty())
+			Expect(er.ApiVersion).To(Equal(model.EnrollmentRequestAPI))
+			Expect(er.Kind).To(Equal(model.EnrollmentRequestKind))
+			Expect(er.Spec.Csr).To(Equal("csr string"))
+			Expect(er.Status.Conditions).ToNot(BeNil())
+			Expect(er.Status.Conditions).To(BeEmpty())
 		})
 
 		It("CreateOrUpdateEnrollmentRequest update mode", func() {
@@ -189,18 +192,25 @@ var _ = Describe("enrollmentRequestStore create", func() {
 					Name: util.StrToPtr("myenrollmentrequest-1"),
 				},
 				Spec: api.EnrollmentRequestSpec{
-					Csr: "csr string",
+					Csr: "new csr string",
 				},
-				Status: nil,
+				Status: &api.EnrollmentRequestStatus{
+					Certificate: util.StrToPtr("bogus-cert"),
+				},
 			}
-			dev, created, err := storeInst.EnrollmentRequest().CreateOrUpdate(ctx, orgId, &enrollmentrequest)
+			er, created, err := storeInst.EnrollmentRequest().CreateOrUpdate(ctx, orgId, &enrollmentrequest)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(Equal(false))
-			Expect(dev.ApiVersion).To(Equal(model.EnrollmentRequestAPI))
-			Expect(dev.Kind).To(Equal(model.EnrollmentRequestKind))
-			Expect(dev.Spec.Csr).To(Equal("csr string"))
-			Expect(dev.Status.Conditions).ToNot(BeNil())
-			Expect(dev.Status.Conditions).To(BeEmpty())
+			Expect(er.ApiVersion).To(Equal(model.EnrollmentRequestAPI))
+			Expect(er.Kind).To(Equal(model.EnrollmentRequestKind))
+			Expect(er.Spec.Csr).To(Equal("new csr string"))
+
+			er, err = storeInst.EnrollmentRequest().Get(ctx, orgId, "myenrollmentrequest-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(er.ApiVersion).To(Equal(model.EnrollmentRequestAPI))
+			Expect(er.Kind).To(Equal(model.EnrollmentRequestKind))
+			Expect(er.Spec.Csr).To(Equal("new csr string"))
+			Expect(*er.Status.Certificate).To(Equal("cert"))
 		})
 
 		It("UpdateEnrollmentRequestStatus", func() {


### PR DESCRIPTION
1. When the ResourceSync task updates the fleet spec, it should nil out some fields, just like the code in internal/service/fleet.go does
2. For CreateOrUpdate, we should always nil out the status.  This applies to other resources as well.