### PR TITLE
EDM-178: Fix approve error checking

### DIFF
--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -84,7 +84,7 @@ func (o *ApproveOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating enrollmentrequestapproval: %w, http response: %+v", err, resp)
 	}
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("creating enrollmentrequestapproval: %+v", resp)
 	}
 	return nil


### PR DESCRIPTION
Currently, `flightctl approve` expects the server to return an HTTP 201 when the API specifies that it returns a HTTP 200. Correct this so that we don't get an error on successful enrollment request approval.