### PR TITLE
NO-ISSUE: tasks add device disconnected bench 

### DIFF
--- a/internal/tasks/device_disconnected_test.go
+++ b/internal/tasks/device_disconnected_test.go
@@ -1,0 +1,127 @@
+package tasks
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// Note: Running this benchmark will require a database connection. You can use `make deploy` to deploy a database`
+//
+// go test  -v -benchmem -run=^$ -timeout 30m -bench ^BenchmarkDeviceDisconnectedPoll$ github.com/flightctl/flightctl/internal/tasks
+func BenchmarkDeviceDisconnectedPoll(b *testing.B) {
+	require := require.New(b)
+	log := log.InitLogs()
+	log.Level = logrus.ErrorLevel
+	for _, deviceCount := range []int{1000, 2000, 5000} {
+		dbStore, cfg, dbName, db := store.PrepareDBForUnitTests(log)
+		devices := generateMockDevices(deviceCount)
+		err := batchCreateDevices(db, devices, deviceCount)
+		require.NoError(err)
+
+		deviceNames := make([]string, deviceCount)
+		for i := 0; i < deviceCount; i++ {
+			deviceNames[i] = fmt.Sprintf("device-%d", i)
+		}
+		cleanupFn := func() {
+			dbStore.Close()
+			store.DeleteTestDB(log, cfg, dbStore, dbName)
+		}
+		b.Run(fmt.Sprintf("update_summary_status_%d_devices", deviceCount), func(b *testing.B) {
+			err := benchmarkUpdateSummaryStatusBatch(b, log, db, dbStore, deviceNames)
+			require.NoError(err)
+		})
+		cleanupFn()
+	}
+}
+
+func benchmarkUpdateSummaryStatusBatch(b *testing.B, log *logrus.Logger, db *gorm.DB, dbStore store.Store, deviceNames []string) error {
+	disconnected := NewDeviceDisconnected(log, dbStore)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		disconnected.Poll()
+		b.StopTimer()
+
+		err := resetDeviceStatus(db, deviceNames)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetDeviceStatus(db *gorm.DB, deviceNames []string) error {
+	status := v1alpha1.NewDeviceStatus()
+	status.UpdatedAt = time.Now().Add(-10 * time.Minute)
+	status.Summary.Status = v1alpha1.DeviceSummaryStatusOnline
+	err := db.Transaction(func(innerTx *gorm.DB) (err error) {
+		for _, name := range deviceNames {
+			result := innerTx.Model(&model.Device{}).Where("name = ?", name).Update("status", status)
+			if result.Error != nil {
+				return flterrors.ErrorFromGormError(result.Error)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reset device status: %w", err)
+	}
+	return db.Exec("VACUUM").Error
+}
+
+func generateMockDevices(count int) []v1alpha1.Device {
+	devices := make([]v1alpha1.Device, count)
+	status := v1alpha1.NewDeviceStatus()
+	status.UpdatedAt = time.Now().Add(-10 * time.Minute)
+	status.Summary.Status = v1alpha1.DeviceSummaryStatusOnline
+	for i := 0; i < count; i++ {
+		devices[i] = v1alpha1.Device{
+			Metadata: v1alpha1.ObjectMeta{
+				Name: util.StrToPtr(fmt.Sprintf("device-%d", i)),
+			},
+			Spec: &v1alpha1.DeviceSpec{},
+
+			Status: &status,
+		}
+	}
+	return devices
+}
+
+func batchCreateDevices(db *gorm.DB, devices []v1alpha1.Device, batchSize int) error {
+	for i := 0; i < len(devices); i += batchSize {
+		end := i + batchSize
+		if end > len(devices) {
+			end = len(devices)
+		}
+		if err := batchCreateDeviceTransaction(db, devices[i:end]); err != nil {
+			return fmt.Errorf("failed to insert batch: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func batchCreateDeviceTransaction(db *gorm.DB, devices []v1alpha1.Device) error {
+	return db.Transaction(func(innerTx *gorm.DB) (err error) {
+		for _, device := range devices {
+			deviceCopy := device
+			modelDevice := model.NewDeviceFromApiResource(&deviceCopy)
+			result := innerTx.Create(modelDevice)
+			if result.Error != nil {
+				return flterrors.ErrorFromGormError(result.Error)
+			}
+		}
+		return nil
+	})
+}

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -54,7 +54,7 @@ var _ = Describe("DeviceStore create", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("Device store", func() {

--- a/test/integration/store/enrollmentrequest_test.go
+++ b/test/integration/store/enrollmentrequest_test.go
@@ -63,7 +63,7 @@ var _ = Describe("enrollmentRequestStore create", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("EnrollmentRequest store", func() {

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -41,7 +41,7 @@ var _ = Describe("FleetStore create", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("Fleet store", func() {

--- a/test/integration/store/repository_test.go
+++ b/test/integration/store/repository_test.go
@@ -50,7 +50,7 @@ var _ = Describe("RepositoryStore create", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("Repository store", func() {

--- a/test/integration/store/resourcesync_test.go
+++ b/test/integration/store/resourcesync_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ResourceSyncStore create", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("ResourceSync store", func() {

--- a/test/integration/store/templateversion_test.go
+++ b/test/integration/store/templateversion_test.go
@@ -36,7 +36,7 @@ var _ = Describe("TemplateVersion", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("TemplateVersion store", func() {

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -64,7 +64,7 @@ var _ = Describe("FleetRollout", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 		ctrl.Finish()
 	})
 

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -49,7 +49,7 @@ var _ = Describe("FleetSelector", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	Context("FleetSelector", func() {

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -108,7 +108,7 @@ var _ = Describe("FleetValidate", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	When("a Fleet has a valid configuration", func() {

--- a/test/integration/tasks/repo_update_test.go
+++ b/test/integration/tasks/repo_update_test.go
@@ -166,7 +166,7 @@ var _ = Describe("RepoUpdate", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	When("a Repository definition is updated", func() {

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -70,7 +70,7 @@ var _ = Describe("RepoTester", func() {
 	})
 
 	AfterEach(func() {
-		store.DeleteTestDB(cfg, stores, dbName)
+		store.DeleteTestDB(log, cfg, stores, dbName)
 	})
 
 	Context("Conditions", func() {

--- a/test/integration/tasks/templateversion_populate_test.go
+++ b/test/integration/tasks/templateversion_populate_test.go
@@ -70,7 +70,7 @@ var _ = Describe("TVPopulate", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
-		store.DeleteTestDB(cfg, storeInst, dbName)
+		store.DeleteTestDB(log, cfg, storeInst, dbName)
 	})
 
 	When("a template has a valid inline config with no params", func() {


### PR DESCRIPTION
This PR adds a benchmark for testing performance improvements. The bench assumes worst-case scenario where all devices must have status updated. The majority of the time is spent in writing the update.

```
name                                                          time/op
DeviceDisconnectedPoll/update_summary_status_1000_devices-12  87.5ms ±20%
DeviceDisconnectedPoll/update_summary_status_2000_devices-12   183ms ± 6%
DeviceDisconnectedPoll/update_summary_status_5000_devices-12   486ms ±11%

name                                                          alloc/op
DeviceDisconnectedPoll/update_summary_status_1000_devices-12  4.26MB ± 0%
DeviceDisconnectedPoll/update_summary_status_2000_devices-12  8.53MB ± 0%
DeviceDisconnectedPoll/update_summary_status_5000_devices-12  21.3MB ± 0%

name                                                          allocs/op
DeviceDisconnectedPoll/update_summary_status_1000_devices-12   63.2k ± 0%
DeviceDisconnectedPoll/update_summary_status_2000_devices-12    127k ± 0%
DeviceDisconnectedPoll/update_summary_status_5000_devices-12    316k ± 0%
```

