### PR TITLE
MGMT-18283: agent: harden resource monitoring

### DIFF
--- a/internal/agent/device/console.go
+++ b/internal/agent/device/console.go
@@ -35,8 +35,8 @@ func NewConsoleController(grpcClient grpc_v1.RouterServiceClient, deviceName str
 }
 
 func (c *ConsoleController) Sync(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error {
-	c.log.Info("Syncing console status")
-	defer c.log.Info("Finished syncing console status")
+	c.log.Debug("Syncing console status")
+	defer c.log.Debug("Finished syncing console status")
 
 	// do we have an open console stream, and we are supposed to close it?
 	if desired.Console == nil {
@@ -212,10 +212,6 @@ func (c *ConsoleController) bashProcess() (io.WriteCloser, io.ReadCloser, error)
 	}
 
 	cmd.Stderr = cmd.Stdout
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting stderr pipe: %w", err)
-	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("error starting bash process: %w", err)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -182,13 +182,13 @@ func (a *Agent) syncDevice(ctx context.Context) (bool, error) {
 
 	updateFns := []status.UpdateStatusFn{
 		status.SetConfig(v1alpha1.DeviceConfigStatus{
-			RenderedVersion: current.RenderedVersion,
+			RenderedVersion: desired.RenderedVersion,
 		}),
 	}
 
-	if current.Os != nil {
+	if desired.Os != nil {
 		updateFns = append(updateFns, status.SetOSImage(v1alpha1.DeviceOSStatus{
-			Image: current.Os.Image,
+			Image: desired.Os.Image,
 		}))
 	}
 

--- a/internal/agent/device/resource/common.go
+++ b/internal/agent/device/resource/common.go
@@ -1,0 +1,134 @@
+package resource
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+func updateMonitor(
+	log *log.PrefixLogger,
+	monitor *v1alpha1.ResourceMonitor,
+	currentSampleInterval *time.Duration,
+	alerts map[v1alpha1.ResourceAlertSeverityType]*Alert,
+	updateIntervalCh chan time.Duration,
+) (bool, error) {
+	spec, err := getMonitorSpec(monitor)
+	if err != nil {
+		return false, err
+	}
+
+	newSamplingInterval, err := time.ParseDuration(spec.ResourceMonitorSpec.SamplingInterval)
+	if err != nil {
+		return false, err
+	}
+
+	updated, err := updateAlerts(spec.AlertRules, alerts)
+	if err != nil {
+		return updated, err
+	}
+
+	if *currentSampleInterval != newSamplingInterval {
+		log.Infof("Updating sampling interval from %s to %s", *currentSampleInterval, newSamplingInterval)
+		updateIntervalCh <- newSamplingInterval
+		*currentSampleInterval = newSamplingInterval
+		updated = true
+	}
+
+	return updated, nil
+}
+
+func updateAlerts(newRules []v1alpha1.ResourceAlertRule, existingAlerts map[v1alpha1.ResourceAlertSeverityType]*Alert) (bool, error) {
+	updated := false
+
+	// if we had alerts but the rules have been removed clear existing alerts
+	if len(newRules) == 0 && len(existingAlerts) > 0 {
+		for key := range existingAlerts {
+			delete(existingAlerts, key)
+		}
+		return true, nil
+	}
+
+	seen := make(map[v1alpha1.ResourceAlertSeverityType]struct{})
+	for _, rule := range newRules {
+		seen[rule.Severity] = struct{}{}
+	}
+
+	for severity := range existingAlerts {
+		if _, ok := seen[severity]; !ok {
+			delete(existingAlerts, severity)
+			updated = true
+		}
+	}
+
+	var err error
+	for _, rule := range newRules {
+		alert, ok := existingAlerts[rule.Severity]
+		if !ok {
+			alert, err = NewAlert(rule)
+			if err != nil {
+				return false, err
+			}
+			existingAlerts[rule.Severity] = alert
+			updated = true
+		}
+
+		if !reflect.DeepEqual(alert.ResourceAlertRule, rule) {
+			if err := alert.UpdateRule(rule); err != nil {
+				return false, err
+			}
+			updated = true
+		}
+	}
+
+	return updated, nil
+}
+
+func getMonitorSpec(monitor *v1alpha1.ResourceMonitor) (*MonitorSpec, error) {
+	monitorType, err := monitor.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+
+	switch monitorType {
+	case CPUMonitorType:
+		spec, err := monitor.AsCPUResourceMonitorSpec()
+		if err != nil {
+			return nil, err
+		}
+		return &MonitorSpec{
+			ResourceMonitorSpec: v1alpha1.ResourceMonitorSpec{
+				SamplingInterval: spec.SamplingInterval,
+				AlertRules:       spec.AlertRules,
+			},
+		}, nil
+	case DiskMonitorType:
+		spec, err := monitor.AsDiskResourceMonitorSpec()
+		if err != nil {
+			return nil, err
+		}
+		return &MonitorSpec{
+			ResourceMonitorSpec: v1alpha1.ResourceMonitorSpec{
+				SamplingInterval: spec.SamplingInterval,
+				AlertRules:       spec.AlertRules,
+			},
+			Path: spec.Path,
+		}, nil
+	case MemoryMonitorType:
+		spec, err := monitor.AsMemoryResourceMonitorSpec()
+		if err != nil {
+			return nil, err
+		}
+		return &MonitorSpec{
+			ResourceMonitorSpec: v1alpha1.ResourceMonitorSpec{
+				SamplingInterval: spec.SamplingInterval,
+				AlertRules:       spec.AlertRules,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown monitor type: %s", monitorType)
+	}
+}

--- a/internal/agent/device/resource/common_test.go
+++ b/internal/agent/device/resource/common_test.go
@@ -1,0 +1,305 @@
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	retryInterval = 100 * time.Millisecond
+	retryTimeout  = 5 * time.Second
+)
+
+func TestUpdateMonitor(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name                  string
+		monitor               v1alpha1.ResourceMonitor
+		alerts                map[v1alpha1.ResourceAlertSeverityType]*Alert
+		currentSampleInterval time.Duration
+		expectedUpdated       bool
+		alertRuleCount        int
+	}{
+		{
+			name:                  "update monitor new alerts",
+			monitor:               newMockCPUResourceMonitor(require, 1*time.Second),
+			currentSampleInterval: 1 * time.Second,
+			expectedUpdated:       true,
+			alertRuleCount:        3,
+		},
+		{
+			name:                  "update monitor no change",
+			monitor:               newEmptyMonitor(require, 1*time.Second),
+			currentSampleInterval: 1 * time.Second,
+			expectedUpdated:       false,
+			alertRuleCount:        0,
+		},
+		{
+			name:                  "update interval",
+			monitor:               newEmptyMonitor(require, 2*time.Second),
+			currentSampleInterval: 1 * time.Second,
+			expectedUpdated:       true,
+			alertRuleCount:        0,
+		},
+		{
+			name:                  "update monitor remove alerts",
+			monitor:               newEmptyMonitor(require, 1*time.Second),
+			currentSampleInterval: 1 * time.Second,
+			alerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeCritical: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Severity: v1alpha1.ResourceAlertSeverityTypeCritical,
+					},
+				},
+			},
+			expectedUpdated: true,
+			alertRuleCount:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := log.NewPrefixLogger("test")
+			updateIntervalCh := make(chan time.Duration, 1)
+
+			var alerts map[v1alpha1.ResourceAlertSeverityType]*Alert
+			if tt.alerts == nil {
+				alerts = make(map[v1alpha1.ResourceAlertSeverityType]*Alert)
+			} else {
+				alerts = tt.alerts
+			}
+			updated, err := updateMonitor(log, &tt.monitor, &tt.currentSampleInterval, alerts, updateIntervalCh)
+			require.NoError(err)
+			require.Equal(tt.expectedUpdated, updated)
+			require.Equal(tt.alertRuleCount, len(alerts))
+		})
+
+	}
+}
+
+func TestIsAlertFiring(t *testing.T) {
+	tests := []struct {
+		name            string
+		alert           *Alert
+		usagePercentage int64
+		firingSince     time.Time
+		expectedFiring  bool
+	}{
+		{
+			name: "usage percentage is below alert percentage",
+			alert: &Alert{
+				ResourceAlertRule: v1alpha1.ResourceAlertRule{
+					Percentage: 2,
+					Duration:   "1s",
+				},
+				duration: 1 * time.Second,
+			},
+			usagePercentage: 1,
+			expectedFiring:  false,
+		},
+		{
+			name: "alert firing over duration",
+			alert: &Alert{
+				ResourceAlertRule: v1alpha1.ResourceAlertRule{
+					Percentage: 1,
+					Duration:   "1h",
+				},
+				firingSince: time.Now().Add(-61 * time.Minute), // inject duration + 1 minute
+				duration:    1 * time.Hour,
+			},
+			usagePercentage: 2,
+			expectedFiring:  true,
+		},
+		{
+			name: "alert observed but below duration threshold",
+			alert: &Alert{
+				ResourceAlertRule: v1alpha1.ResourceAlertRule{
+					Percentage: 80,
+					Duration:   "30m",
+				},
+				firingSince: time.Now().Add(-29 * time.Minute), // inject duration - 1 minute
+				duration:    30 * time.Minute,
+			},
+			usagePercentage: 90,
+			expectedFiring:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.alert.Sync(tt.usagePercentage)
+			require.Equal(t, tt.expectedFiring, tt.alert.IsFiring())
+		})
+	}
+
+}
+
+func TestUpdateAlerts(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name            string
+		existingAlerts  map[v1alpha1.ResourceAlertSeverityType]*Alert
+		expectedAlerts  map[v1alpha1.ResourceAlertSeverityType]*Alert
+		expectedUpdated bool
+		newRules        []v1alpha1.ResourceAlertRule
+	}{
+		{
+			name: "new rules empty clear existing alerts",
+			existingAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeCritical: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Percentage: 80,
+						Duration:   "1s",
+					},
+					duration: 1 * time.Second,
+				},
+			},
+			expectedAlerts:  map[v1alpha1.ResourceAlertSeverityType]*Alert{},
+			newRules:        []v1alpha1.ResourceAlertRule{},
+			expectedUpdated: true,
+		},
+		{
+			name: "new rules remove an existing alerts",
+			existingAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeCritical: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Percentage: 80,
+						Duration:   "1s",
+					},
+				},
+				v1alpha1.ResourceAlertSeverityTypeWarning: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Percentage: 40,
+						Duration:   "1h",
+					},
+				},
+			},
+			expectedAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeWarning: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+						Percentage: 40,
+						Duration:   "1h",
+					},
+					duration: 1 * time.Hour,
+				},
+			},
+			newRules: []v1alpha1.ResourceAlertRule{
+				{
+					Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+					Percentage: 40,
+					Duration:   "1h",
+				},
+			},
+			expectedUpdated: true,
+		},
+		{
+			name:           "new rules add an alert",
+			existingAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{},
+			expectedAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeWarning: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+						Percentage: 40,
+						Duration:   "1h",
+					},
+					duration: 1 * time.Hour,
+				},
+			},
+			newRules: []v1alpha1.ResourceAlertRule{
+				{
+					Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+					Percentage: 40,
+					Duration:   "1h",
+				},
+			},
+			expectedUpdated: true,
+		},
+		{
+			name: "new rules no change",
+			existingAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeWarning: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+						Percentage: 40,
+						Duration:   "1h",
+					},
+				},
+			},
+			expectedAlerts: map[v1alpha1.ResourceAlertSeverityType]*Alert{
+				v1alpha1.ResourceAlertSeverityTypeWarning: {
+					ResourceAlertRule: v1alpha1.ResourceAlertRule{
+						Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+						Percentage: 40,
+						Duration:   "1h",
+					},
+				},
+			},
+			newRules: []v1alpha1.ResourceAlertRule{
+				{
+					Severity:   v1alpha1.ResourceAlertSeverityTypeWarning,
+					Percentage: 40,
+					Duration:   "1h",
+				},
+			},
+			expectedUpdated: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated, err := updateAlerts(tt.newRules, tt.existingAlerts)
+			require.NoError(err)
+			if tt.expectedUpdated {
+				require.True(updated)
+			} else {
+				require.False(updated)
+			}
+			require.Equal(tt.expectedAlerts, tt.existingAlerts)
+		})
+	}
+}
+
+func newEmptyMonitor(require *require.Assertions, samplingInterval time.Duration) v1alpha1.ResourceMonitor {
+	monitorSpec := v1alpha1.CPUResourceMonitorSpec{
+		SamplingInterval: samplingInterval.String(),
+		MonitorType:      CPUMonitorType,
+		AlertRules:       []v1alpha1.ResourceAlertRule{},
+	}
+	rm := v1alpha1.ResourceMonitor{}
+	err := rm.FromCPUResourceMonitorSpec(monitorSpec)
+	require.NoError(err)
+	return rm
+}
+
+func newMockCPUResourceMonitor(require *require.Assertions, samplingInterval time.Duration) v1alpha1.ResourceMonitor {
+	monitorSpec := v1alpha1.CPUResourceMonitorSpec{
+		SamplingInterval: samplingInterval.String(),
+		MonitorType:      CPUMonitorType,
+		AlertRules: []v1alpha1.ResourceAlertRule{
+			{
+				Severity:    v1alpha1.ResourceAlertSeverityTypeCritical,
+				Percentage:  80,
+				Duration:    "20m",
+				Description: "Critical: CPU usage is above 80% for 20m",
+			},
+			{
+				Severity:    v1alpha1.ResourceAlertSeverityTypeWarning,
+				Percentage:  70,
+				Duration:    "10m",
+				Description: "Warning: CPU usage is above 70% for 10m",
+			},
+			{
+				Severity:    v1alpha1.ResourceAlertSeverityTypeInfo,
+				Percentage:  50,
+				Duration:    "1h",
+				Description: "Warning: CPU usage is above 50% for 1h",
+			},
+		},
+	}
+	rm := v1alpha1.ResourceMonitor{}
+	err := rm.FromCPUResourceMonitorSpec(monitorSpec)
+	require.NoError(err)
+	return rm
+}

--- a/internal/agent/device/resource/controller.go
+++ b/internal/agent/device/resource/controller.go
@@ -28,7 +28,8 @@ func (c *Controller) Sync(ctx context.Context, desired *v1alpha1.RenderedDeviceS
 
 	if desired.Resources == nil {
 		c.log.Debug("Device resources are nil")
-		return nil
+		// Clear all alerts if no resources are defined
+		return c.manager.ClearAll()
 	}
 
 	if err := c.ensureMonitors(desired.Resources); err != nil {
@@ -44,7 +45,7 @@ func (c *Controller) ensureMonitors(monitors *[]v1alpha1.ResourceMonitor) error 
 		if err != nil {
 			return err
 		}
-		updated, err := c.manager.Update(monitor)
+		updated, err := c.manager.Update(&monitor)
 		if err != nil {
 			return err
 		}

--- a/internal/agent/device/resource/controller.go
+++ b/internal/agent/device/resource/controller.go
@@ -40,7 +40,8 @@ func (c *Controller) Sync(ctx context.Context, desired *v1alpha1.RenderedDeviceS
 }
 
 func (c *Controller) ensureMonitors(monitors *[]v1alpha1.ResourceMonitor) error {
-	for _, monitor := range *monitors {
+	for i := range *monitors {
+		monitor := (*monitors)[i]
 		monitorType, err := monitor.Discriminator()
 		if err != nil {
 			return err

--- a/internal/agent/device/resource/disk_test.go
+++ b/internal/agent/device/resource/disk_test.go
@@ -66,7 +66,7 @@ func TestDiskMonitor(t *testing.T) {
 	// ensure only 2 alerts are firing
 	var alerts []v1alpha1.ResourceAlertRule
 	require.Eventually(func() bool {
-		alerts := diskMonitor.Alerts()
+		alerts = diskMonitor.Alerts()
 		return len(alerts) == 2
 	}, retryTimeout, retryInterval, "alert add")
 

--- a/internal/agent/device/resource/memory_test.go
+++ b/internal/agent/device/resource/memory_test.go
@@ -147,6 +147,6 @@ func TestMemoryMonitor(t *testing.T) {
 	// ensure no alerts after clearing
 	require.Eventually(func() bool {
 		alerts := memoryMonitor.Alerts()
-		return len(alerts) == 1
-	}, retryTimeout, retryInterval, "alert add")
+		return len(alerts) == 0
+	}, retryTimeout, retryInterval, "alerts remove")
 }

--- a/internal/agent/device/resource/mock_resource.go
+++ b/internal/agent/device/resource/mock_resource.go
@@ -54,6 +54,20 @@ func (mr *MockManagerMockRecorder) Alerts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Alerts", reflect.TypeOf((*MockManager)(nil).Alerts))
 }
 
+// ClearAll mocks base method.
+func (m *MockManager) ClearAll() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearAll")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearAll indicates an expected call of ClearAll.
+func (mr *MockManagerMockRecorder) ClearAll() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAll", reflect.TypeOf((*MockManager)(nil).ClearAll))
+}
+
 // Run mocks base method.
 func (m *MockManager) Run(ctx context.Context) {
 	m.ctrl.T.Helper()
@@ -67,7 +81,7 @@ func (mr *MockManagerMockRecorder) Run(ctx any) *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockManager) Update(monitor v1alpha1.ResourceMonitor) (bool, error) {
+func (m *MockManager) Update(monitor *v1alpha1.ResourceMonitor) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", monitor)
 	ret0, _ := ret[0].(bool)
@@ -145,7 +159,7 @@ func (mr *MockMonitorMockRecorder[T]) Run(ctx any) *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockMonitor[T]) Update(monitor v1alpha1.ResourceMonitor) (bool, error) {
+func (m *MockMonitor[T]) Update(monitor *v1alpha1.ResourceMonitor) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", monitor)
 	ret0, _ := ret[0].(bool)
@@ -157,18 +171,4 @@ func (m *MockMonitor[T]) Update(monitor v1alpha1.ResourceMonitor) (bool, error) 
 func (mr *MockMonitorMockRecorder[T]) Update(monitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockMonitor[T])(nil).Update), monitor)
-}
-
-// Usage mocks base method.
-func (m *MockMonitor[T]) Usage() *T {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Usage")
-	ret0, _ := ret[0].(*T)
-	return ret0
-}
-
-// Usage indicates an expected call of Usage.
-func (mr *MockMonitorMockRecorder[T]) Usage() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Usage", reflect.TypeOf((*MockMonitor[T])(nil).Usage))
 }

--- a/internal/agent/device/resource/resource.go
+++ b/internal/agent/device/resource/resource.go
@@ -2,35 +2,36 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/pkg/log"
 )
 
+type MonitorType string
+
 const (
 	CPUMonitorType    = "CPU"
 	DiskMonitorType   = "Disk"
 	MemoryMonitorType = "Memory"
 
-	DefaultSamplingInterval = 1 * time.Hour
-)
-
-var (
-	ErrAlertFiring = fmt.Errorf("alert is firing")
+	DefaultSamplingInterval = 5 * time.Minute
 )
 
 type Manager interface {
 	Run(ctx context.Context)
-	Update(monitor v1alpha1.ResourceMonitor) (bool, error)
+	Update(monitor *v1alpha1.ResourceMonitor) (bool, error)
+	// ClearAll clears all alerts rules for each registered resource monitor
+	ClearAll() error
 	Alerts() *Alerts
 }
 
 type Monitor[T any] interface {
 	Run(ctx context.Context)
-	Update(monitor v1alpha1.ResourceMonitor) (bool, error)
-	Usage() *T
+	Update(monitor *v1alpha1.ResourceMonitor) (bool, error)
 	CollectUsage(ctx context.Context, usage *T) error
 	Alerts() []v1alpha1.ResourceAlertRule
 }
@@ -63,7 +64,7 @@ func (m *ResourceManager) Run(ctx context.Context) {
 	m.memoryMonitor.Run(ctx)
 }
 
-func (m *ResourceManager) Update(monitor v1alpha1.ResourceMonitor) (bool, error) {
+func (m *ResourceManager) Update(monitor *v1alpha1.ResourceMonitor) (bool, error) {
 	monitorType, err := monitor.Discriminator()
 	if err != nil {
 		return false, err
@@ -81,6 +82,55 @@ func (m *ResourceManager) Update(monitor v1alpha1.ResourceMonitor) (bool, error)
 	}
 }
 
+func (m *ResourceManager) ClearAll() error {
+	var errs []error
+
+	// cpu
+	cpuMonitor, err := defaultCPUResourceMonitor()
+	if err != nil {
+		errs = append(errs, err)
+	}
+	updated, err := m.cpuMonitor.Update(cpuMonitor)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if updated {
+		m.log.Infof("Cleared CPU monitor alerts")
+	}
+
+	// disk
+	diskMonitor, err := defaultDiskResourceMonitor()
+	if err != nil {
+		errs = append(errs, err)
+	}
+	updated, err = m.diskMonitor.Update(diskMonitor)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if updated {
+		m.log.Infof("Cleared disk monitor alerts")
+	}
+
+	// memory
+	memoryMonitor, err := defaultMemoryResourceMonitor()
+	if err != nil {
+		errs = append(errs, err)
+	}
+	updated, err = m.memoryMonitor.Update(memoryMonitor)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if updated {
+		m.log.Infof("Cleared memory monitor alerts")
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
 func (m *ResourceManager) Alerts() *Alerts {
 	return &Alerts{
 		DiskUsage:   m.diskMonitor.Alerts(),
@@ -96,10 +146,16 @@ type Alerts struct {
 }
 
 type Alert struct {
+	mu sync.Mutex
 	v1alpha1.ResourceAlertRule
-	duration    time.Duration
-	firing      bool
+
+	// duration is the time the alert must be observed before it is considered firing
+	// this is a helper field to avoid parsing the duration string on every sync.
+	// it is set when the alert is using NewAlert or must be set manually.
+	duration time.Duration
+	// firingSince is the time the alert started firing
 	firingSince time.Time
+	firing      bool
 }
 
 func NewAlert(rule v1alpha1.ResourceAlertRule) (*Alert, error) {
@@ -113,8 +169,50 @@ func NewAlert(rule v1alpha1.ResourceAlertRule) (*Alert, error) {
 	}, nil
 }
 
+func (a *Alert) Sync(usagePercentage int64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// if the available usage is below the threshold, reset the firingSince time
+	if usagePercentage > int64(a.Percentage) {
+		if a.firingSince.IsZero() {
+			a.firingSince = time.Now()
+		}
+	} else {
+		// reset
+		a.firingSince = time.Time{}
+	}
+
+	// if the alert has been firing for the duration, set the firing flag
+	if isDurationExceeded(a.firingSince, a.duration) {
+		a.firing = true
+	} else {
+		a.firing = false
+	}
+}
+
+func isDurationExceeded(since time.Time, duration time.Duration) bool {
+	return !since.IsZero() && time.Since(since) > duration
+}
+
 func (a *Alert) IsFiring() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.firing
+}
+
+// UpdateRule updates the alert rule and duration.
+func (a *Alert) UpdateRule(rule v1alpha1.ResourceAlertRule) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	duration, err := time.ParseDuration(rule.Duration)
+	if err != nil {
+		return err
+	}
+	a.ResourceAlertRule = rule
+	a.duration = duration
+	return nil
 }
 
 var AlertLevelMap = map[v1alpha1.ResourceAlertSeverityType]AlertSeverity{
@@ -128,13 +226,22 @@ type AlertSeverity struct {
 	Level  int
 }
 
-// GetHighestSeverityResourceStatusFromAlerts returns the highest severity statusDeviceResourceStatusType from a list of alerts.
-func GetHighestSeverityResourceStatusFromAlerts(alerts []v1alpha1.ResourceAlertRule) (v1alpha1.DeviceResourceStatusType, error) {
+// MonitorSpec is a wrapper around v1alpha1.ResourceMonitorSpec that includes additional fields for all monitors.
+type MonitorSpec struct {
+	v1alpha1.ResourceMonitorSpec
+
+	// Path is the absolute path used for the disk monitor.
+	Path string `json:"path,omitempty"`
+}
+
+// GetHighestSeverityResourceStatusFromAlerts returns the highest severity statusDeviceResourceStatusType from a list of alerts along with the alert message.
+// The alert message is auto generated if the alert description is empty.
+func GetHighestSeverityResourceStatusFromAlerts(resource string, alerts []v1alpha1.ResourceAlertRule) (v1alpha1.DeviceResourceStatusType, string) {
 	if len(alerts) == 0 {
-		return v1alpha1.DeviceResourceStatusUnknown, nil
+		return v1alpha1.DeviceResourceStatusUnknown, ""
 	}
 
-	var err error
+	var info string
 	// initialize with the lowest severity (info)
 	maxSeverity := AlertLevelMap[v1alpha1.ResourceAlertSeverityTypeInfo]
 	var highestSeverity v1alpha1.DeviceResourceStatusType
@@ -143,9 +250,43 @@ func GetHighestSeverityResourceStatusFromAlerts(alerts []v1alpha1.ResourceAlertR
 		if severity.Level > maxSeverity.Level {
 			maxSeverity = AlertLevelMap[alert.Severity]
 			highestSeverity = severity.Status
-			err = fmt.Errorf("%w: %s", ErrAlertFiring, alert.Severity)
+			if alert.Description == "" {
+				info = fmt.Sprintf("%s: %s usage is above %d %% for more than %s", alert.Severity, resource, int64(alert.Percentage), alert.Duration)
+			} else {
+				info = fmt.Sprintf("%s: %s", alert.Severity, alert.Description)
+			}
 		}
 	}
 
-	return highestSeverity, err
+	return highestSeverity, info
+}
+
+func defaultCPUResourceMonitor() (*v1alpha1.ResourceMonitor, error) {
+	spec := v1alpha1.CPUResourceMonitorSpec{
+		SamplingInterval: DefaultSamplingInterval.String(),
+		MonitorType:      CPUMonitorType,
+	}
+	rm := &v1alpha1.ResourceMonitor{}
+	err := rm.FromCPUResourceMonitorSpec(spec)
+	return rm, err
+}
+
+func defaultDiskResourceMonitor() (*v1alpha1.ResourceMonitor, error) {
+	spec := v1alpha1.DiskResourceMonitorSpec{
+		SamplingInterval: DefaultSamplingInterval.String(),
+		MonitorType:      DiskMonitorType,
+	}
+	rm := &v1alpha1.ResourceMonitor{}
+	err := rm.FromDiskResourceMonitorSpec(spec)
+	return rm, err
+}
+
+func defaultMemoryResourceMonitor() (*v1alpha1.ResourceMonitor, error) {
+	spec := v1alpha1.MemoryResourceMonitorSpec{
+		SamplingInterval: DefaultSamplingInterval.String(),
+		MonitorType:      MemoryMonitorType,
+	}
+	rm := &v1alpha1.ResourceMonitor{}
+	err := rm.FromMemoryResourceMonitorSpec(spec)
+	return rm, err
 }


### PR DESCRIPTION
This PR
- simplifies resource monitor logic by breaking out shared code.
- fixes flakey monitor tests
- additional unit tests
- race cleanup
- ensures the status message is taken from the alert description cc @avishayt 
- status improvements/bug fixes

notes:
I validated tests with 500 iterations with `-race` flag and achieved zero percent failure

```
go test -v -race -count=500 ./internal/agent/device/resource/...
PASS
ok      github.com/flightctl/flightctl/internal/agent/device/resource   454.768s
```

During an alert the device summary status will go Degraded and the message will be generated like below or populated by the user if a description is provided.

```json
        "resources": {
          "cpu": "Unknown",
          "disk": "Unknown",
          "memory": "Warning"
        },
        "summary": {
          "info": "Warning: Memory usage is above 80 % for more than 30m",
          "status": "Degraded"
        },
 ```
 
 manually tested and verified