### PR TITLE
EDM-202: Correct helm packaging and make image tags follow appVersion

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -18,21 +18,28 @@ jobs:
       - name: Setup all dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Get version
+        run: |
+          VERSION=$(git describe --long --tags)
+          VERSION=${VERSION#v} # remove the leading v prefix for version
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}"
+
       - name: Build helm charts
         run: |
-          echo packaging $(git describe --long --tags)
-          helm package ./deploy/helm/flightctl --version $(git describe --long --tags) --app-version ${{ github.sha }}
+          echo packaging "${VERSION}"
+          helm package ./deploy/helm/flightctl --version "${VERSION}" --app-version "${VERSION}"
 
       - name: Login helm
         env:
           PASSWORD: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
           USER: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
         run:
-          helm registry login -u ${USER} -p ${PASSWORD}
+          helm registry login quay.io -u ${USER} -p ${PASSWORD}
 
       - name: Push helm charts
         run: |
-          helm registry push flightctl-*.tgz oci://${{ env.QUAY_ORG }}/helm-charts
+          helm push flightctl-helm-*.tgz oci://${{ env.QUAY_ORG }}/
 
   publish-flightctl-containers:
     strategy:
@@ -46,7 +53,12 @@ jobs:
       - name: Generate tags
         id: generate-tags
         run: |
-          tags=( latest-${GITHUB_SHA} latest )
+          VERSION=$(git describe --long --tags)
+          VERSION=${VERSION#v} # remove the leading v prefix for version
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}"
+
+          tags=( latest-${GITHUB_SHA} latest ${VERSION} )
           echo "tags=${tags[@]}" >> $GITHUB_OUTPUT
           echo "tags=${tags[@]}"
 

--- a/deploy/helm/flightctl/Chart.yaml
+++ b/deploy/helm/flightctl/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
-name: flightctl
+name: flightctl-helm
 description: A helm chart for flightctl
+home: https://github.com/flightctl/flightctl
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "latest" # this is replaced at packaging with the hash of the image release
 dependencies:
   - name: keycloak
     condition: keycloak.enabled

--- a/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: flightctl-api
-          image: {{ .Values.flightctl.api.image }}
+          image: {{ .Values.flightctl.api.image }}:{{ default .Chart.AppVersion .Values.flightctl.api.imageTag }}
           imagePullPolicy: {{ .Values.flightctl.api.imagePullPolicy }}
           env:
             - name: HOME

--- a/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: periodic
-          image: {{ .Values.flightctl.periodic.image }}
+          image: {{ .Values.flightctl.periodic.image }}:{{ default .Chart.AppVersion .Values.flightctl.periodic.imageTag }}
           imagePullPolicy: {{ .Values.flightctl.periodic.imagePullPolicy }}
           env:
             - name: HOME

--- a/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: flightctl-worker
       containers:
         - name: flightctl-worker
-          image: {{ .Values.flightctl.worker.image }}
+          image: {{ .Values.flightctl.worker.image }}:{{ default .Chart.AppVersion .Values.flightctl.worker.imageTag }}
           imagePullPolicy: {{ .Values.flightctl.worker.imagePullPolicy }}
           env:
             - name: HOME

--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -3,17 +3,17 @@ flightctl:
     nodePort: 5432 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     imagePullPolicy: IfNotPresent
   api:
-    image: localhost/flightctl-api:latest
+    image: localhost/flightctl-api
     imagePullPolicy: IfNotPresent
     hostName: localhost
     nodePort: 3443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     agentNodePort: 7443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     agentGrpcNodePort: 7444 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
   worker:
-    image: localhost/flightctl-worker:latest
+    image: localhost/flightctl-worker
     imagePullPolicy: IfNotPresent
   periodic:
-    image: localhost/flightctl-periodic:latest
+    image: localhost/flightctl-periodic
     imagePullPolicy: IfNotPresent
   rabbitmq:
     image: rabbitmq:3.13-management

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -11,7 +11,7 @@ flightctl:
   api:
     enabled: true
     namespace: flightctl-external
-    image: quay.io/flightctl/flightctl-api:latest
+    image: quay.io/flightctl/flightctl-api
     imagePullPolicy: Always
     hostName: api.flightctl.example.com
     agentAPIHostName: agent-api.flightctl.example.com
@@ -20,13 +20,13 @@ flightctl:
   worker:
     enabled: true
     namespace: flightctl-internal
-    image: quay.io/flightctl/flightctl-worker:latest
+    image: quay.io/flightctl/flightctl-worker
     imagePullPolicy: Always
     enableSecretsClusterRoleBinding: true
   periodic:
     enabled: true
     namespace: flightctl-internal
-    image: quay.io/flightctl/flightctl-periodic:latest
+    image: quay.io/flightctl/flightctl-periodic
     imagePullPolicy: Always
   rabbitmq:
     enabled: true


### PR DESCRIPTION
By packaging the appVersion latest-${git-sha} we make sure that every release of the charts gets tied to an specific version of our code, and can be deployed with the corelated images.