### PR TITLE
NO-ISSUE: fix rabbitmq pv path

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
               value: "{{ .Values.rabbitmq.auth.password }}"
           volumeMounts:
             - name: rabbitmq-data
-              mountPath: /var/lib/rabbitmq
+              mountPath: /var/lib/rabbitmq/mnesia
   volumeClaimTemplates:
     - metadata:
         name: rabbitmq-data


### PR DESCRIPTION
Exclude .erlang.cookie file from PV to fix the startup error:
```
Exception during startup:

error:{badmatch,{error,{{shutdown,{failed_to_start_child,auth,{"Cookie file /var/lib/rabbitmq/.erlang.cookie must be accessible by owner only",
```