### PR TITLE
EDN-221: Secret data should not be decoded

### DIFF
--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -247,11 +246,7 @@ func renderK8sConfig(configItem *api.DeviceSpec_Config_Item, args *renderConfigA
 		return k8sSpec.Name, fmt.Errorf("failed to create ignition wrapper: %w", err)
 	}
 	splits := filepath.SplitList(k8sSpec.SecretRef.MountPath)
-	for name, encodedContents := range secret.Data {
-		contents, err := base64.StdEncoding.DecodeString(string(encodedContents))
-		if err != nil {
-			return k8sSpec.Name, fmt.Errorf("failed to base64 decode secret %s: %w", name, err)
-		}
+	for name, contents := range secret.Data {
 		ignitionWrapper.SetFile(filepath.Join(append(splits, name)...), contents, 0o644)
 	}
 	if !args.validateOnly {

--- a/internal/tasks/templateversion_populate.go
+++ b/internal/tasks/templateversion_populate.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -179,11 +178,7 @@ func (t *TemplateVersionPopulateLogic) handleK8sConfig(configItem *api.DeviceSpe
 		return fmt.Errorf("failed to create ignition wrapper: %w", err)
 	}
 	splits := filepath.SplitList(k8sSpec.SecretRef.MountPath)
-	for name, encodedContents := range secret.Data {
-		contents, err := base64.StdEncoding.DecodeString(string(encodedContents))
-		if err != nil {
-			return fmt.Errorf("failed to base64 decode secret %s: %w", name, err)
-		}
+	for name, contents := range secret.Data {
 		ignitionWrapper.SetFile(filepath.Join(append(splits, name)...), contents, 0o644)
 	}
 	m, err := ignitionWrapper.AsMap()

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -254,7 +253,7 @@ func mockSecret(mockK8sClient *k8sclient.MockK8SClient, secrets map[string]strin
 				Namespace: "secret-namespace",
 			},
 			Data: lo.MapValues(secrets, func(v, _ string) []byte {
-				return []byte(base64.StdEncoding.EncodeToString([]byte(v)))
+				return []byte(v)
 			}),
 		}, nil).AnyTimes()
 }


### PR DESCRIPTION
When handling kubernetes secrets, they are currently expected to be base64 encoded. But the data itself as received in kubernetes API is not encoded since JSON decodes it before the data can be handled by the caller. So the current base64 decoding should be removed.