### PR TITLE
NO-ISSUE: agent: remove cadvisor as a dep and add non linux build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_L
 GO_FILES := $(shell find ./ -name ".go" -not -path "./bin" -not -path "./packaging/*")
 GO_CACHE := -v $${HOME}/go/flightctl-go-cache:/opt/app-root/src/go:Z -v $${HOME}/go/flightctl-go-cache/.cache:/opt/app-root/src/.cache:Z
 TIMEOUT ?= 30m
+GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
@@ -65,16 +67,16 @@ lint: tools
 	$(GOBIN)/golangci-lint run -v
 
 build: bin
-	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
 build-api: bin
-	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-api
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-api
 
 build-worker: bin
-	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-worker
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-worker
 
 build-periodic: bin
-	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-periodic
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-periodic
 
 
 # rebuild container only on source changes

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-openapi/swag v0.23.0
-	github.com/google/cadvisor v0.49.0
 	github.com/google/go-tpm v0.9.0
 	github.com/google/go-tpm-tools v0.4.4
 	github.com/google/renameio v1.0.1
@@ -101,8 +100,6 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-sqlite3 v1.14.18 // indirect
-	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
-	github.com/moby/sys/mountinfo v0.7.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cadvisor v0.49.0 h1:1PYeiORXmcFYi609M4Qvq5IzcvcVaWgYxDt78uH8jYA=
-github.com/google/cadvisor v0.49.0/go.mod h1:s6Fqwb2KiWG6leCegVhw4KW40tf9f7m+SF1aXiE8Wsk=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -184,10 +182,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-sqlite3 v1.14.18 h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI=
 github.com/mattn/go-sqlite3 v1.14.18/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
-github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible h1:aKW/4cBs+yK6gpqU3K/oIwk9Q/XICqd3zOX/UFuvqmk=
-github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
-github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
-github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/agent/device/status/exporters_linux.go
+++ b/internal/agent/device/status/exporters_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+// +build linux
+
+package status
+
+import (
+	"os"
+
+	"github.com/flightctl/flightctl/internal/agent/device/resource"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	// BootIDPath is the path to the boot ID file.
+	DefaultBootIDPath = "/proc/sys/kernel/random/boot_id"
+)
+
+func newExporters(
+	resourceManager resource.Manager,
+	executer executer.Executer,
+	log *log.PrefixLogger,
+) []Exporter {
+	return []Exporter{
+		newSystemD(executer),
+		newContainer(executer),
+		newSystemInfo(executer),
+		newResources(log, resourceManager),
+	}
+}
+
+func getBootID(bootIDPath string) (string, error) {
+	bootID, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return "", err
+	}
+	return string(bootID), nil
+}

--- a/internal/agent/device/status/exporters_linux.go
+++ b/internal/agent/device/status/exporters_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package status
 
@@ -9,11 +8,6 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/resource"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
-)
-
-const (
-	// BootIDPath is the path to the boot ID file.
-	DefaultBootIDPath = "/proc/sys/kernel/random/boot_id"
 )
 
 func newExporters(

--- a/internal/agent/device/status/exporters_non_linux.go
+++ b/internal/agent/device/status/exporters_non_linux.go
@@ -1,0 +1,45 @@
+//go:build !linux
+// +build !linux
+
+package status
+
+import (
+	"context"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/device/resource"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+func newExporters(
+	resourceManager resource.Manager,
+	executer executer.Executer,
+	log *log.PrefixLogger,
+) []Exporter {
+	return []Exporter{
+		newSystemD(executer),
+		newContainer(executer),
+		newSystemInfo(executer),
+		newUnsupportedExporter(log, "resources"),
+	}
+}
+
+func getBootID(_ string) (string, error) {
+	return "", nil
+}
+
+func newUnsupportedExporter(log *log.PrefixLogger, name string) Exporter {
+	log.Warnf("Status exporter %q is not supported on this platform", name)
+	return &unsupportedExporter{}
+}
+
+type unsupportedExporter struct {
+}
+
+func (u *unsupportedExporter) Export(context.Context, *v1alpha1.DeviceStatus) error {
+	return nil
+}
+
+func (u *unsupportedExporter) SetProperties(*v1alpha1.RenderedDeviceSpec) {
+}

--- a/internal/agent/device/status/exporters_other.go
+++ b/internal/agent/device/status/exporters_other.go
@@ -1,5 +1,4 @@
-//go:build !linux
-// +build !linux
+//go:build darwin || !linux
 
 package status
 

--- a/internal/agent/device/status/status.go
+++ b/internal/agent/device/status/status.go
@@ -21,12 +21,7 @@ func NewManager(
 	executer executer.Executer,
 	log *log.PrefixLogger,
 ) *StatusManager {
-	exporters := []Exporter{
-		newSystemD(executer),
-		newContainer(executer),
-		newSystemInfo(executer),
-		newResources(log, resourceManager),
-	}
+	exporters := newExporters(resourceManager, executer, log)
 	status := v1alpha1.NewDeviceStatus()
 	return &StatusManager{
 		deviceName: deviceName,

--- a/internal/agent/device/status/systeminfo.go
+++ b/internal/agent/device/status/systeminfo.go
@@ -8,22 +8,17 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/container"
 	"github.com/flightctl/flightctl/pkg/executer"
-	"github.com/google/cadvisor/fs"
-	"github.com/google/cadvisor/machine"
-	"github.com/google/cadvisor/utils/sysfs"
 )
 
 var _ Exporter = (*SystemInfo)(nil)
 
 // SystemInfo collects system information.
 type SystemInfo struct {
-	sysFs       sysfs.SysFs
 	bootcClient *container.BootcCmd
 }
 
 func newSystemInfo(exec executer.Executer) *SystemInfo {
 	return &SystemInfo{
-		sysFs:       sysfs.NewRealSysFs(),
 		bootcClient: container.NewBootcCmd(exec),
 	}
 }
@@ -33,20 +28,15 @@ func (s *SystemInfo) Export(ctx context.Context, status *v1alpha1.DeviceStatus) 
 		return nil
 	}
 
-	fsInfo, err := fs.NewFsInfo(fs.Context{})
+	bootID, err := getBootID(DefaultBootIDPath)
 	if err != nil {
-		return fmt.Errorf("getting file system info: %w", err)
-	}
-	inHostNamespace := true
-	info, err := machine.Info(s.sysFs, fsInfo, inHostNamespace)
-	if err != nil {
-		return fmt.Errorf("getting machine info: %w", err)
+		return fmt.Errorf("getting boot ID: %w", err)
 	}
 
 	status.SystemInfo = v1alpha1.DeviceSystemInfo{
 		Architecture:    runtime.GOARCH,
 		OperatingSystem: runtime.GOOS,
-		BootID:          info.BootID,
+		BootID:          bootID,
 	}
 
 	bootcInfo, err := s.bootcClient.Status(ctx)

--- a/internal/agent/device/status/systeminfo.go
+++ b/internal/agent/device/status/systeminfo.go
@@ -10,6 +10,11 @@ import (
 	"github.com/flightctl/flightctl/pkg/executer"
 )
 
+const (
+	// BootIDPath is the path to the boot ID file.
+	DefaultBootIDPath = "/proc/sys/kernel/random/boot_id"
+)
+
 var _ Exporter = (*SystemInfo)(nil)
 
 // SystemInfo collects system information.


### PR DESCRIPTION
This PR removes cadvisor as a dep and gates linux specific agent logic with build targets. Resource collectors are linux opinionated and disabled for all non-linux builds.
