### PR TITLE
MGMT-18170: PreEnrollment Request Endpoint draft

### DIFF
--- a/api/v1alpha1/openapi.yaml
+++ b/api/v1alpha1/openapi.yaml
@@ -1307,6 +1307,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/preenrollmentrequests:
+  # Leaving this blank until we know whether this differs from the enrollmentrequests endpoint
+    get: TODO
+    post: TODO
+    delete: TODO
   /api/v1/fleets:
     get:
       tags:
@@ -3009,3 +3014,152 @@ components:
       - 'TemplateDiscriminatorKubernetesSec'
       - 'TemplateDiscriminatorInlineConfig'
       - 'TemplateDiscriminatorHttpConfig'
+    PreEnrollmentRequestApproval:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          description: 'labels is a set of labels to apply to the device.'
+        approved:
+          type: boolean
+          description: 'approved indicates whether the request has been approved.'
+        approvedBy:
+          type: string
+          description: 'approvedBy is the name of the approver.'
+        approvedAt:
+          type: string
+          format: date-time
+          description: 'approvedAt is the time at which the request was approved.'
+      required:
+        - approved
+    PreEnrollmentRequestCondition:
+    # this could be replaced with Condition, but it is not a 1:1 match to the k8s schema
+      description: 'Information about a CSR'
+      properties:
+        lastTransitionTime:
+          description: 'Time of the last status transition'
+          type: string
+          format: date-time
+        lastUpdateTime:
+          description: 'Time of the last update to current condition'
+          type: string
+          format: date-time
+        message:
+          description: 'Human readable message with details about the request state'
+          type: string
+        reason:
+          description: 'Brief reason for the request state'
+          type: string
+        status:
+          description: 'True, False, or Unknown'
+          $ref: '#/components/schemas/ConditionStatus'
+        type:
+          description: 'Approved, Denied, and/or Failed'
+          type: string
+          enum:
+            - 'Approved'
+            - 'Denied'
+            - 'Failed'
+      required:
+        - type
+        - status
+      type: object
+    PreEnrollmentRequest:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        kind:
+          type: string
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        metadata:
+          $ref: '#/components/schemas/ObjectMeta'
+        spec:
+          $ref: '#/components/schemas/PreEnrollmentRequestSpec'
+        status:
+          $ref: '#/components/schemas/PreEnrollmentRequestStatus'
+      required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+      description: 'PreEnrollmentRequest represents a request for approval to enroll a device'
+
+    PreEnrollmentRequestList:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        kind:
+          type: string
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        metadata:
+          $ref: '#/components/schemas/ListMeta'
+        items:
+          type: array
+          description: 'List of EnrollmentRequest.'
+          items:
+            $ref: '#/components/schemas/PreEnrollmentRequest'
+      required:
+        - apiVersion
+        - kind
+        - metadata
+        - items
+      description: 'PreEnrollmentRequestList is a list of PreEnrollmentRequest'
+    PreEnrollmentRequestSpec:
+      description: 'Wrapper around a user-created CSR, modeled on kubernetes io.k8s.api.certificates.v1.CertificateSigningRequestSpec'
+      properties:
+        expirationSeconds:
+          description: 'Requested duration of validity for the certificate'
+        extra:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          description: 'Extra attributes of the user that created the CSR, populated by the API server on creation and immutable'
+          type: object
+        groups:
+          description: 'Group membership of the user that created the CSR, populated by the API server on creation and immutable'
+          items:
+            type: string
+          type: array
+        request:
+          description: 'The base64-encoded CSR. Matches the spec.request field in a kubernetes CertificateSigningRequest resource'
+          format: byte
+          type: string
+        signerName:
+          description: 'Indicates the requested signer, and is a qualified name'
+          type: string
+        uid:
+          description: 'UID of the user that created the CSR, populated by the API server on creation and immutable'
+          type: string
+        usages:
+          description: 'Usages requested in the issued certificate'
+          items:
+            type: string
+          type: array
+        username:
+          description: 'Name of the user that created the CSR, populated by the API server on creation and immutable'
+          type: string
+      required:
+        - request
+        - signerName
+      type: object
+    PreEnrollmentRequestStatus:
+      description: 'Indicates approval/denial/failure status of the CSR, and containes the issued certifiate if any exists'
+      properties:
+        certificate:
+          description: 'The issued signed certificate, immutable once populated'
+          format: byte
+          type: string
+        conditions:
+          description: 'Information about the certificate and CSR'
+          items:
+            $ref: '#/components/schemas/CertificateSigningRequestCondition'
+          type: array
+      required:
+      type: object


### PR DESCRIPTION
Drafted some schemas based on https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json but saw it is highly similar to the schemas used by the enrollmentrequests endpoint. Will discuss what if anything needs to be different before making updates. See also the update comment in the referenced issue.