### PR TITLE
NO-ISSUE: Fix client config validation

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -377,9 +377,10 @@ func validateService(service Service, baseDir string, testRootDir string) []erro
 		u, err := url.Parse(service.Server)
 		if err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("invalid server format %q: %w", service.Server, err))
-		}
-		if len(u.Hostname()) == 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("invalid server format %q: no hostname", service.Server))
+		} else {
+			if len(u.Hostname()) == 0 {
+				validationErrors = append(validationErrors, fmt.Errorf("invalid server format %q: no hostname", service.Server))
+			}
 		}
 	}
 	// Make sure CA data and CA file aren't both specified


### PR DESCRIPTION
Don't check the hostname length if we failed to parse the URL. This leads to the agent crashing.