### PR TITLE
EDM-234: Build RPM for FlightCtl CLI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,14 +1,14 @@
 packages:
-  flightctl-agent:
-    specfile_path: packaging/rpm/flightctl-agent.spec
+  flightctl:
+    specfile_path: packaging/rpm/flightctl.spec
 
     # add or remove files that should be synced
     files_to_sync:
-        - packaging/rpm/flightctl-agent.spec
+        - packaging/rpm/flightctl.spec
         - .packit.yaml
 
-    upstream_package_name: flightctl-agent
-    downstream_package_name: flightctl-agent
+    upstream_package_name: flightctl
+    downstream_package_name: flightctl
 
 jobs:
   - job: copr_build

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ flightctl-worker-container: bin/.flightctl-worker-container
 flightctl-periodic-container: bin/.flightctl-periodic-container
 
 
-build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container 
+build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container
 
 .PHONY: build-containers
 
@@ -108,13 +108,13 @@ build-containers: flightctl-api-container flightctl-worker-container flightctl-p
 update-server-container: bin/.flightctl-server-container
 	kind load docker-image localhost/flightctl-server:latest
 	kubectl delete pod -l flightctl.service=flightctl-server -n flightctl-external
-	kubectl rollout status deployment flightctl-server -n flightctl-external -w --timeout=30s 
+	kubectl rollout status deployment flightctl-server -n flightctl-external -w --timeout=30s
 	kubectl logs -l flightctl.service=flightctl-server -n flightctl-external -f
 bin:
 	mkdir -p bin
 
 # only trigger the rpm build when not built before or changes happened to the codebase
-bin/.rpm: bin $(shell find ./ -name "*.go" -not -path "./packaging/*") packaging/rpm/flightctl-agent.spec packaging/systemd/flightctl-agent.service hack/build_rpms.sh
+bin/.rpm: bin $(shell find ./ -name "*.go" -not -path "./packaging/*") packaging/rpm/flightctl.spec packaging/systemd/flightctl-agent.service hack/build_rpms.sh
 	./hack/build_rpms.sh
 	touch bin/.rpm
 

--- a/hack/build_rpms_packit.sh
+++ b/hack/build_rpms_packit.sh
@@ -6,7 +6,7 @@ rm $(uname -m)/flightctl-*.rpm 2>/dev/null || true
 rm bin/rpm/* 2>/dev/null || true
 mkdir -p bin/rpm
 # save the spec as packit will modify it locally to inject versioning and we don't want that
-cp packaging/rpm/flightctl-agent.spec /tmp
+cp packaging/rpm/flightctl.spec /tmp
 packit build locally
-cp /tmp/flightctl-agent.spec packaging/rpm
+cp /tmp/flightctl.spec packaging/rpm
 mv $(uname -m)/flightctl-*.rpm bin/rpm

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -1,13 +1,13 @@
 %define debug_package %{nil}
 
-Name: flightctl-agent
+Name: flightctl
 Version: 0.0.1
 Release: 3%{?dist}
-Summary: Flightctl Agent
+Summary: Flightctl CLI
 
 License: XXX
 URL: https://github.com/flightctl/flightctl
-Source0: flightctl-agent-0.0.1.tar.gz
+Source0: flightctl-0.0.1.tar.gz
 
 BuildRequires: golang
 BuildRequires: make
@@ -16,10 +16,16 @@ BuildRequires: openssl-devel
 Requires: openssl
 
 %description
+Flightctl is a command line interface for managing edge device fleets.
+
+
+%package agent
+Summary: Flightctl Agent
+%description agent
 Flightctl Agent is a component of the flightctl tool.
 
 %prep
-%setup -q -n flightctl-agent-0.0.1
+%setup -q -n flightctl-0.0.1
 
 %build
 
@@ -29,27 +35,24 @@ GOENVFILE=$(go env GOROOT)/go.env
 if [[ ! -f "{$GOENVFILE}" ]]; then
     export GOPROXY='https://proxy.golang.org,direct'
 fi
-
 make build
 
 %install
-
 mkdir -p %{buildroot}/usr/bin
+cp bin/flightctl %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
 cp bin/flightctl-agent %{buildroot}/usr/bin
 cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 
-
 %files
+/usr/bin/flightctl
+
+%files agent
 /usr/bin/flightctl-agent
 /usr/lib/systemd/system/flightctl-agent.service
 %{_sharedstatedir}/flightctl
 
 %changelog
 * Wed Mar 13 2024 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-3
-- Adding default directory for runtime data
-* Wed Feb 7 2024 Miguel Angel Ajo Pelayo <majopela@redhat.com> - 0.0.1-2
-- Initial RPM building via packit for the flightctl agent
-* Mon Dec 11 2023 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-1
-- Initial RPM package for flightctl agent
+- New specfile for both CLI and agent packages


### PR DESCRIPTION
Build RPMs in COPR recurrently for flightctl command line.

The CLI could be install with:

```
sudo dnf copr enable -y @redhat-et/flightctl-dev
sudo dnf install -y flightctl
```