### PR TITLE
MGMT-18283: agent: add default resource alerts

### DIFF
--- a/internal/agent/device/resource/controller.go
+++ b/internal/agent/device/resource/controller.go
@@ -28,8 +28,8 @@ func (c *Controller) Sync(ctx context.Context, desired *v1alpha1.RenderedDeviceS
 
 	if desired.Resources == nil {
 		c.log.Debug("Device resources are nil")
-		// Clear all alerts if no resources are defined
-		return c.manager.ClearAll()
+		// Reset all resource alerts to default
+		return c.manager.ResetAlertDefaults()
 	}
 
 	if err := c.ensureMonitors(desired.Resources); err != nil {

--- a/internal/agent/device/resource/mock_resource.go
+++ b/internal/agent/device/resource/mock_resource.go
@@ -54,18 +54,18 @@ func (mr *MockManagerMockRecorder) Alerts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Alerts", reflect.TypeOf((*MockManager)(nil).Alerts))
 }
 
-// ClearAll mocks base method.
-func (m *MockManager) ClearAll() error {
+// ResetAlertDefaults mocks base method.
+func (m *MockManager) ResetAlertDefaults() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClearAll")
+	ret := m.ctrl.Call(m, "ResetAlertDefaults")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ClearAll indicates an expected call of ClearAll.
-func (mr *MockManagerMockRecorder) ClearAll() *gomock.Call {
+// ResetAlertDefaults indicates an expected call of ResetAlertDefaults.
+func (mr *MockManagerMockRecorder) ResetAlertDefaults() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAll", reflect.TypeOf((*MockManager)(nil).ClearAll))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAlertDefaults", reflect.TypeOf((*MockManager)(nil).ResetAlertDefaults))
 }
 
 // Run mocks base method.


### PR DESCRIPTION
This PR adds a first pass to define default alert thresholds for CPU disk and memory. This is functional and improves the current UI UX which shows `Unknown` by default to now reports `Healthy` assuming the alerts are not firing.

status

```json
"resources": {
  "cpu": "Healthy",
  "disk": "Healthy",
  "memory": "Healthy"
}
```

disk
```go
AlertRules: []v1alpha1.ResourceAlertRule{
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeCritical,
    Percentage:  90,
    Duration:    "10m",
    Description: "", // use generated description
  },
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeWarning,
    Percentage:  80,
    Duration:    "30m",
    Description: "", // use generated description
  }
},
Path: "/sysroot"
```

reference for sysroot: https://github.com/containers/bootc/blob/bc28c591c1f265f654821721047aa530e6d9617c/docs/src/filesystem-sysroot.md?plain=1#L18

CPU
```go
AlertRules: []v1alpha1.ResourceAlertRule{
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeCritical,
    Percentage:  90,
    Duration:    "30m",
    Description: "", // use generated description
  },
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeWarning,
    Percentage:  80,
    Duration:    "1h",
    Description: "", // use generated description
  },
},
```
Memory
```go
AlertRules: []v1alpha1.ResourceAlertRule{
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeCritical,
    Percentage:  90,
    Duration:    "30m",
    Description: "", // use generated description
  },
  {
    Severity:    v1alpha1.ResourceAlertSeverityTypeWarning,
    Percentage:  80,
    Duration:    "1h",
    Description: "", // use generated description
  },
}
```