### PR TITLE
NO-ISSUE: Separate target for grpc code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ publish: build-containers
 generate:
 	go generate -v $(shell go list ./...)
 	hack/mockgen.sh
+
+generate-grpc:
 	hack/grpcgen.sh
 
 tidy:


### PR DESCRIPTION
This is done rarely, and until we have a containerized grpc build or buf based it causes issues with the CI checks when protoc version in CI does not match the protoc version in the local environment.