### PR TITLE
EDM-276: Add workflow to publish cli binary releases

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -1,0 +1,53 @@
+name: "Publish GitHub CLI Binaries"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    strategy: 
+      matrix:
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+    env:
+      NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Build"
+        env:
+          GOARCH: ${{ matrix.arch }}
+          GOOS: ${{ matrix.os }}
+        run: |       
+          make build
+          mv bin/flightctl bin/${{ env.NAME }}
+      - name: "Save binary"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}
+          path: ${{ github.workspace }}/bin/${{ env.NAME }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Load binaries"
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: "Publish"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=flightctl-cli-$(date +%Y%m%d)-$(git describe --always)
+          gh release create $TAG flightctl-*
+

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -31,9 +31,39 @@ jobs:
           name: ${{ env.NAME }}
           path: ${{ github.workspace }}/bin/${{ env.NAME }}
 
-  publish:
+  verify-darwin:
+    runs-on: macos-latest
+    needs: [build]
+    
+    steps: 
+      - name: "Load binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: flightctl-darwin-arm64
+
+      - name: "Verify"
+        run: |
+          ./flightctl version
+          exit $?
+
+  verify-linux:
     runs-on: ubuntu-latest
     needs: [build]
+    
+    steps:
+      - name: "Load binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: flightctl-linux-amd64
+
+      - name: "Verify"
+        run: |
+          ./flightctl version
+          exit $?
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [verify-darwin, verify-linux]
 
     steps:
       - name: "Checkout"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERBOSE ?= false
 SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
-BIN_TIMESTAMP ?=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
 MAJOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$1}')
 MINOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$2}')
 PATCH := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$3}')

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ var (
 	minorFromGit string
 	// patch version
 	patchFromGit string
-	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	// build date, output of $(date +'%Y%m%d')
 	buildDate string
 	// state of git tree, either "clean" or "dirty"
 	gitTreeState string
@@ -38,7 +38,7 @@ type Info struct {
 }
 
 func (info Info) String() string {
-	return info.GitVersion
+	return fmt.Sprintf("%s-%s", info.BuildDate, info.GitVersion)
 }
 
 func Get() Info {


### PR DESCRIPTION
On push to main, create a GitHub release of the flightctl CLI for {Linux, Darwin} on {amd64, arm64}. Since we do not currently have versioning, the releases are named "flightctl-cli-[year][month][day]-[commit hash]"