### PR TITLE
EDM-276: Fix token permissions for release publication

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -57,6 +57,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [verify]
+    permissions:
+      contents: write
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
The Flightctl repo disables all GitHub Actions write permissions by default. Enable them so our workflow can publish the binary releases.