### PR TITLE
MGMT-18250: Set fleet as invalid for bad parameter

### DIFF
--- a/internal/tasks/config_helpers_test.go
+++ b/internal/tasks/config_helpers_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"testing"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
@@ -20,8 +21,8 @@ var _ = Describe("config helpers", func() {
 			configItem := "ignition blah blah {{ device.metadata.labels[key]}} blah blah {{ device.metadata.labels[key2] }} blah {{ device.metadata.name }} ok"
 			labels := map[string]string{"key": "val", "key2": "val2", "otherkey": "otherval"}
 			meta := api.ObjectMeta{Labels: &labels, Name: util.StrToPtr("devname")}
-			new, err := ReplaceParameters([]byte(configItem), meta)
-			Expect(err).ToNot(HaveOccurred())
+			new, warnings := ReplaceParameters([]byte(configItem), meta)
+			Expect(warnings).To(HaveLen(0))
 			Expect(string(new)).To(Equal("ignition blah blah val blah blah val2 blah devname ok"))
 		})
 	})
@@ -31,8 +32,8 @@ var _ = Describe("config helpers", func() {
 			configItem := "ignition blah blah {{ device.metadata.labels[key]}} blah blah {{ device.metadata.labels[key2] }} blah"
 			labels := map[string]string{"key": "val", "otherkey": "otherval"}
 			meta := api.ObjectMeta{Labels: &labels, Name: util.StrToPtr("devname")}
-			_, err := ReplaceParameters([]byte(configItem), meta)
-			Expect(err).To(HaveOccurred())
+			_, warnings := ReplaceParameters([]byte(configItem), meta)
+			Expect(warnings).To(HaveLen(1))
 		})
 	})
 
@@ -41,8 +42,45 @@ var _ = Describe("config helpers", func() {
 			configItem := "ignition blah blah {{ device.metadata.labels[key]}} blah blah {{ device.metadata.name }} blah"
 			labels := map[string]string{"key": "val", "otherkey": "otherval"}
 			meta := api.ObjectMeta{Labels: &labels}
-			_, err := ReplaceParameters([]byte(configItem), meta)
-			Expect(err).To(HaveOccurred())
+			_, warnings := ReplaceParameters([]byte(configItem), meta)
+			Expect(warnings).To(HaveLen(1))
+		})
+	})
+
+	When("the config has an invalid parameter", func() {
+		It("will return a validation error", func() {
+			configItems := []string{
+				"ignition blah blah {{ {{ device.metadata.name }} {{ }} blah",
+				"ignition blah blah {{ {{ device.metadata.name }} }} blah",
+				"ignition blah blah {{ device.metadata.owner }} blah",
+				"ignition blah blah {{ device.metadata.name x }} blah",
+				"ignition blah blah {{ x device.metadata.name }} blah",
+				"ignition blah blah {{ device.metadata.namex }} blah",
+				"ignition blah blah {{ xdevice.metadata.name }} blah",
+				"ignition blah blah {{ device.metadata.labels[x] x }} blah",
+				"ignition blah blah {{ x device.metadata.labels[x] }} blah",
+				"ignition blah blah {{ device.metadata.labels[x]x }} blah",
+				"ignition blah blah {{ xdevice.metadata.labels[x] }} blah",
+				"ignition blah blah {{ hello }} blah",
+			}
+			for _, configItem := range configItems {
+				err := ValidateParameterFormat([]byte(configItem))
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	})
+
+	When("the config has no invalid parameter", func() {
+		It("will not return a validation error", func() {
+			configItems := []string{
+				"ignition blah blah {{ device.metadata.name  }} blah",
+				"ignition blah blah {{  device.metadata.labels[x] }} blah",
+			}
+			for _, configItem := range configItems {
+				fmt.Printf("testing: %s\n", configItem)
+				err := ValidateParameterFormat([]byte(configItem))
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 	})
 })

--- a/internal/tasks/fleet_validate.go
+++ b/internal/tasks/fleet_validate.go
@@ -44,7 +44,7 @@ func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Co
 		return fmt.Errorf("failed getting fleet %s/%s: %w", t.resourceRef.OrgID, t.resourceRef.Name, err)
 	}
 
-	_, repoNames, validationErr := renderConfig(ctx, t.resourceRef.OrgID, t.store, t.k8sClient, fleet.Spec.Template.Spec.Config, true)
+	_, repoNames, validationErr := renderConfig(ctx, t.resourceRef.OrgID, t.store, t.k8sClient, fleet.Spec.Template.Spec.Config, true, true)
 
 	// Set the many-to-many relationship with the repos (we do this even if the validation failed so that we will
 	// validate the fleet again if the repository is updated, and then it might be fixed).

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -47,6 +47,13 @@ func DefaultIfNil(s *string, defaultS string) string {
 	return *s
 }
 
+func IsEmptyString(s *string) bool {
+	if s == nil {
+		return true
+	}
+	return len(*s) == 0
+}
+
 func StrToPtr(s string) *string {
 	return &s
 }

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -3,6 +3,7 @@ package tasks_test
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
@@ -58,7 +59,7 @@ var _ = Describe("FleetValidate", func() {
 		Expect(err).ToNot(HaveOccurred())
 		repository = &api.Repository{
 			Metadata: api.ObjectMeta{
-				Name: util.StrToPtr("repo"),
+				Name: util.StrToPtr("git-repo"),
 			},
 			Spec: spec,
 		}
@@ -92,8 +93,8 @@ var _ = Describe("FleetValidate", func() {
 			ConfigType: string(api.TemplateDiscriminatorGitConfig),
 			Name:       "goodGitConfig",
 		}
-		goodGitConfig.GitRef.Path = "path"
-		goodGitConfig.GitRef.Repository = "repo"
+		goodGitConfig.GitRef.Path = "path-{{ device.metadata.name }}"
+		goodGitConfig.GitRef.Repository = "git-repo"
 		goodGitConfig.GitRef.TargetRevision = "rev"
 
 		badGitConfig = &api.GitConfigProviderSpec{
@@ -127,7 +128,7 @@ var _ = Describe("FleetValidate", func() {
 			Name:       "goodHttpConfig",
 		}
 		goodHttpConfig.HttpRef.Repository = "http-repo"
-		goodHttpConfig.HttpRef.FilePath = "http-path"
+		goodHttpConfig.HttpRef.FilePath = "http-path-{{ device.metadata.labels[key] }}"
 		goodHttpConfig.HttpRef.Suffix = util.StrToPtr("/suffix")
 
 		badHttpConfig = &api.HttpConfigProviderSpec{
@@ -190,8 +191,10 @@ var _ = Describe("FleetValidate", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repos.Items).To(HaveLen(2))
-			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("repo"))
-			Expect(*((repos.Items[1]).Metadata.Name)).To(Equal("http-repo"))
+			repoNames := []string{*((repos.Items[0]).Metadata.Name), *((repos.Items[1]).Metadata.Name)}
+			slices.Sort(repoNames)
+			Expect(repoNames[0]).To(Equal("git-repo"))
+			Expect(repoNames[1]).To(Equal("http-repo"))
 
 		})
 	})
@@ -240,8 +243,10 @@ var _ = Describe("FleetValidate", func() {
 			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repos.Items).To(HaveLen(2))
-			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("http-repo"))
-			Expect(*((repos.Items[1]).Metadata.Name)).To(Equal("missingrepo"))
+			repoNames := []string{*((repos.Items[0]).Metadata.Name), *((repos.Items[1]).Metadata.Name)}
+			slices.Sort(repoNames)
+			Expect(repoNames[0]).To(Equal("http-repo"))
+			Expect(repoNames[1]).To(Equal("missingrepo"))
 		})
 	})
 
@@ -289,9 +294,10 @@ var _ = Describe("FleetValidate", func() {
 			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repos.Items).To(HaveLen(2))
-			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("repo"))
-			Expect(*((repos.Items[1]).Metadata.Name)).To(Equal("http-repo"))
-
+			repoNames := []string{*((repos.Items[0]).Metadata.Name), *((repos.Items[1]).Metadata.Name)}
+			slices.Sort(repoNames)
+			Expect(repoNames[0]).To(Equal("git-repo"))
+			Expect(repoNames[1]).To(Equal("http-repo"))
 		})
 	})
 
@@ -339,8 +345,63 @@ var _ = Describe("FleetValidate", func() {
 			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repos.Items).To(HaveLen(2))
-			Expect(*((repos.Items[0]).Metadata.Name)).To(Equal("repo"))
-			Expect(*((repos.Items[1]).Metadata.Name)).To(Equal("http-missingrepo"))
+			repoNames := []string{*((repos.Items[0]).Metadata.Name), *((repos.Items[1]).Metadata.Name)}
+			slices.Sort(repoNames)
+			Expect(repoNames[0]).To(Equal("git-repo"))
+			Expect(repoNames[1]).To(Equal("http-missingrepo"))
+		})
+	})
+
+	When("a Fleet has a configuration with an invalid parameter", func() {
+		It("sets an error Condition", func() {
+			resourceRef := tasks.ResourceReference{OrgID: orgId, Name: "myfleet", Kind: model.FleetKind}
+			logic := tasks.NewFleetValidateLogic(callbackManager, log, storeInst, nil, resourceRef)
+
+			gitItem := api.DeviceSpec_Config_Item{}
+			// Set a parameter that we don't support
+			goodGitConfig.GitRef.Path = "path-{{ device.metadata.owner }}"
+			err := gitItem.FromGitConfigProviderSpec(*goodGitConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			inlineItem := api.DeviceSpec_Config_Item{}
+			err = inlineItem.FromInlineConfigProviderSpec(*goodInlineConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			httpItem := api.DeviceSpec_Config_Item{}
+			err = httpItem.FromHttpConfigProviderSpec(*goodHttpConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleet.Spec.Template.Spec.Config = &[]api.DeviceSpec_Config_Item{gitItem, inlineItem, httpItem}
+
+			tvList, err := storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tvList.Items).To(HaveLen(0))
+
+			_, err = storeInst.Fleet().Create(ctx, orgId, fleet, callback)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = logic.CreateNewTemplateVersionIfFleetValid(ctx)
+			Expect(err).To(HaveOccurred())
+
+			tvList, err = storeInst.TemplateVersion().List(ctx, orgId, store.ListParams{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tvList.Items).To(HaveLen(0))
+
+			fleet, err = storeInst.Fleet().Get(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fleet.Status.Conditions).ToNot(BeNil())
+			Expect(fleet.Status.Conditions).To(HaveLen(1))
+			Expect(fleet.Status.Conditions[0].Type).To(Equal(api.FleetValid))
+			Expect(fleet.Status.Conditions[0].Status).To(Equal(api.ConditionStatusFalse))
+
+			repos, err := storeInst.Fleet().GetRepositoryRefs(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repos.Items).To(HaveLen(2))
+			repoNames := []string{*((repos.Items[0]).Metadata.Name), *((repos.Items[1]).Metadata.Name)}
+			slices.Sort(repoNames)
+			Expect(repoNames[0]).To(Equal("git-repo"))
+			Expect(repoNames[1]).To(Equal("http-repo"))
 		})
 	})
 


### PR DESCRIPTION
If a fleet template contains a parameter with invalid syntax, set its Valid condition to false.
Also, ensure device specs don't contain parameters.