### PR TITLE
Fix readme prequisite packages on clean RHEL8.6 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Flight Control is a service for declarative, GitOps-driven management of edge de
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.21), `openssl`, `openssl-devel`, and `podman-compose`
+* `git`, `make`, and `go` (>= 1.21), `openssl`, `openssl-devel` and `podman-compose`
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/test/README.md
+++ b/test/README.md
@@ -153,6 +153,7 @@ make run-e2e-test GO_E2E_DIRS=test/e2e/cli
 ### Local testing side services
 For the purpose of providing a local testing environment, we have a set of side services
 that run inside the kind cluster to provide a complete testing environment.
+Therefore, [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) and [kind](https://kind.sigs.k8s.io/) must be installed.
 
 #### Local container registry
 


### PR DESCRIPTION
Adding 'kind' and 'kubectl' . Lacking them caused failures in clean RHEL8.6 openshift installation.

`[kni@titan52 flightctl]$ make e2e-test 
test/scripts/install_kind.sh
Installing kind v0.22.0
cp: cannot stat '/home/kni/go/bin/kind': No such file or directory
/usr/bin/systemctl
Kind systemd rootless already configured
kind get clusters | grep kind || test/scripts/create_cluster.sh
/bin/sh: kind: command not found
`

`Successfully tagged localhost/git-server:latest
bcde4e9d36337d0c40266dc0384ed08aeba63172f4783661435c33f8fc19518e
kubectl config set-context kind-kind
make: kubectl: Command not found
make: *** [deploy/deploy.mk:12: deploy-helm] Error 127
`
