### PR TITLE
EDM-276: Release workflow improvements

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -1,4 +1,4 @@
-name: "Publish GitHub CLI Binaries"
+name: "Release CLI Binaries on GH"
 on:
   workflow_dispatch:
   push:
@@ -24,12 +24,27 @@ jobs:
           GOOS: ${{ matrix.os }}
         run: |       
           make build
-          mv bin/flightctl bin/${{ env.NAME }}
+          SHA=$(sha256sum bin/flightctl | awk '{ print $1 }')
+          echo $SHA > ${{ env.NAME }}-sha256.txt
+          tar cvf ${{ env.NAME }}.tar.gz  bin/flightctl
+          mv bin/flightctl ${{ env.NAME }} 
+      - name: "Save tar binary"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}.tar.gz
+          path: ${{ env.NAME }}.tar.gz
+      
       - name: "Save binary"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NAME }}
-          path: ${{ github.workspace }}/bin/${{ env.NAME }}
+          path: ${{ env.NAME }}
+    
+      - name: "Save checksum"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.NAME }}-sha256.txt
+          path: ${{ env.NAME }}-sha256.txt
 
   verify:
     strategy:
@@ -64,15 +79,24 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Load binaries"
+      - name: "Load binary archives"
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: release
 
       - name: "Publish"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=flightctl-cli-$(date +%Y%m%d)-$(git describe --always)
-          gh release create $TAG flightctl-*
+          OLD_RELEASE=$(gh release list | awk '/^latest\s/ { print $1 }')
+          if [ $OLD_RELEASE ]; then
+            gh release delete $OLD_RELEASE
+          fi
+          OLD_TAG=$(git tag | awk '/^latest\s/ { print $1 }')
+          if [ $OLD_TAG ]; then
+            git push --delete origin $OLD_TAG
+          fi
+          
+          gh release create -p -n "Flightctl CLI pre-release" latest release/*
 

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get version
         run: |
-          VERSION=$(git describe --long --tags)
+          VERSION=$(git describe --long --tags --exclude latest)
           VERSION=${VERSION#v} # remove the leading v prefix for version
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "VERSION=${VERSION}"
@@ -57,7 +57,7 @@ jobs:
       - name: Generate tags
         id: generate-tags
         run: |
-          VERSION=$(git describe --long --tags)
+          VERSION=$(git describe --long --tags --exclude latest)
           VERSION=${VERSION#v} # remove the leading v prefix for version
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "VERSION=${VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
+SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --exclude latest --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')


### PR DESCRIPTION
Make the following changes to the "Release CLI Binaries on GH" workflow
- Release checksums
- Mark release as pre-release
- Delete all previous releases
- Change release name format from "flightctl-cli-DATE-HASH" to "latest"