### PR TITLE
MGMT-17001: add support for greenboot rollback on agent service failure

### DIFF
--- a/packaging/greenboot/flightctl-agent-running-check.sh
+++ b/packaging/greenboot/flightctl-agent-running-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -x -eo pipefail
+
+TIMEOUT=60
+SUCCESS_DURATION=60
+
+# This script is used to check if the flightctl-agent service is running. It is
+# used in the greenboot process to ensure that the flightctl-agent service is
+# running before proceeding. The script will wait for the service to be active,
+# and will fail if the service is not active within the timeout.
+
+verify_flightctl_agent_status() {
+  local -r failed_status=$(systemctl is-failed flightctl-agent.service)
+  local -r active_status=$(systemctl is-active flightctl-agent.service)
+
+  # fail fast
+  if [ "${failed_status}" = "failed" ] ; then
+    echo "Critical: flightctl-agent.service has encountered a failure. Aborting..."
+    kill -TERM ${SCRIPT_PID}
+  fi
+
+  if ! [ "${active_status}" = "active" ] ; then
+    return 1
+  fi
+
+  return 0
+}
+
+wait_for_success() {
+  local timeout=$1
+  local success_duration=$2
+  shift 2
+  local command="$@"
+
+  local -r start=$(date +%s)
+  local now
+
+  while : ; do
+    $command & # run in background
+    local command_pid=$!
+
+    while : ; do
+      # verify command still running
+      if kill -0 $command_pid 2>/dev/null; then
+        now=$(date +%s)
+        if [ $((now - start)) -ge "${timeout}" ]; then
+          # timeout fail fast
+          kill $command_pid
+          return 1
+        fi
+        sleep 1
+      else
+        # check status of command and return it
+        wait $command_pid
+        local status=$?
+        if [ $status -eq 0 ]; then
+          # success, now ensure runtime for success_duration
+          local -r success_start=$(date +%s)
+          local success_now
+          while : ; do
+            # new check command
+            $command &
+            local check_pid=$!
+            while kill -0 $check_pid 2>/dev/null; do
+              success_now=$(date +%s)
+              if [ $((success_now - success_start)) -ge "${success_duration}" ]; then
+                kill $check_pid
+                return 0
+              fi
+              sleep 1
+            done
+            wait $check_pid
+            local check_status=$?
+            if [ $check_status -ne 0 ]; then
+              return 1
+            fi
+          done
+        else
+          # retry until timeout
+          break
+        fi
+      fi
+    done
+
+    now=$(date +%s)
+    if [ $((now - start)) -ge "${timeout}" ]; then
+      return 1
+    fi
+  done
+}
+
+
+# Wait for flightctl-agent service to be active (failed status terminates the script)
+echo "Waiting ${TIMEOUT}s for flightctl-agent service to be active..."
+if ! wait_for_success "${TIMEOUT}" "${SUCCESS_DURATION}" verify_flightctl_agent_status ; then
+  echo "Error: flightctl-agent.service did not become active within ${TIMEOUT}s. Aborting..."
+  exit 1
+fi

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -2,7 +2,7 @@
 
 Name: flightctl
 Version: 0.0.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Flightctl CLI
 
 License: XXX
@@ -42,6 +42,8 @@ mkdir -p %{buildroot}/usr/bin
 cp bin/flightctl %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
+mkdir -p %{buildroot}/usr/lib/greenboot/check/required.d
+install -m 0755 packaging/greenboot/flightctl-agent-running-check.sh %{buildroot}/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
 cp bin/flightctl-agent %{buildroot}/usr/bin
 cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 
@@ -52,7 +54,10 @@ cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
 /usr/bin/flightctl-agent
 /usr/lib/systemd/system/flightctl-agent.service
 %{_sharedstatedir}/flightctl
+/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
 
 %changelog
 * Wed Mar 13 2024 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-3
 - New specfile for both CLI and agent packages
+* Wed Aug 7 2024 Sam Batschelet <sbatsche@redhat.com> - 0.0.1-4
+- Add basic greenboot support for failed flightctl-agent service 


### PR DESCRIPTION
The script checks if the flightctl-agent.service is active and running without failure. It waits for the service to become active within a specified timeout (60s) and ensures it remains running for an additional duration (60s). If the service fails or does not become active in time, the script aborts exiting non 0 with an error message.

- On failure 1,2 greenboot will reboot
- On on failure 3 it will rollback if available.


Testing: manually tested