### PR TITLE
EDM-327: agent: ensure stale configs are removed on sync

### DIFF
--- a/internal/agent/device/config/common.go
+++ b/internal/agent/device/config/common.go
@@ -37,5 +37,5 @@ func IgnParseWrapper(rawIgn []byte) (interface{}, error) {
 		return ignCfgV3, nil
 	}
 
-	return ignv3types.Config{}, fmt.Errorf("parsing Ignition config spec v3 failed with error: %v\nReport: %v", errV3, rptV3)
+	return ignv3types.Config{}, fmt.Errorf("parsing Ignition config spec v3 failed with error: %w\nReport: %v", errV3, rptV3)
 }

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -12,6 +12,7 @@ import (
 // against the device spec.
 type Controller struct {
 	deviceWriter *fileio.Writer
+	trackedFiles map[string]struct{}
 	log          *log.PrefixLogger
 }
 
@@ -22,11 +23,12 @@ func NewController(
 ) *Controller {
 	return &Controller{
 		deviceWriter: deviceWriter,
+		trackedFiles: make(map[string]struct{}),
 		log:          log,
 	}
 }
 
-func (c *Controller) Sync(desired *v1alpha1.RenderedDeviceSpec) error {
+func (c *Controller) Sync(current *v1alpha1.RenderedDeviceSpec, desired *v1alpha1.RenderedDeviceSpec) error {
 	c.log.Debug("Syncing device configuration")
 	defer c.log.Debug("Finished syncing device configuration")
 
@@ -38,7 +40,33 @@ func (c *Controller) Sync(desired *v1alpha1.RenderedDeviceSpec) error {
 	desiredConfigRaw := []byte(*desired.Config)
 	ignitionConfig, err := ParseAndConvertConfig(desiredConfigRaw)
 	if err != nil {
-		return fmt.Errorf("parsing and converting config failed: %w", err)
+		return err
+	}
+
+	// warm cache if empty
+	if len(c.trackedFiles) == 0 && current.Config != nil {
+		// initialize tracked files
+		currentConfigRaw := []byte(*current.Config)
+		currentIgnitionConfig, err := ParseAndConvertConfig(currentConfigRaw)
+		if err != nil {
+			return err
+		}
+		for _, file := range currentIgnitionConfig.Storage.Files {
+			c.trackedFiles[file.Path] = struct{}{}
+		}
+	}
+
+	// calculate diff between existing and desired files
+	desiredIgnFiles := make(map[string]struct{})
+	for _, file := range ignitionConfig.Storage.Files {
+		desiredIgnFiles[file.Path] = struct{}{}
+	}
+
+	for _, file := range c.computeRemoval(desiredIgnFiles) {
+		c.log.Infof("Deleting stale file no longer part of config: %s", file)
+		if err := c.deviceWriter.RemoveFile(file); err != nil {
+			return fmt.Errorf("deleting files failed: %w", err)
+		}
 	}
 
 	err = c.deviceWriter.WriteIgnitionFiles(ignitionConfig.Storage.Files...)
@@ -46,5 +74,18 @@ func (c *Controller) Sync(desired *v1alpha1.RenderedDeviceSpec) error {
 		return fmt.Errorf("writing ignition files failed: %w", err)
 	}
 
+	c.trackedFiles = desiredIgnFiles
+
 	return nil
+}
+
+func (c *Controller) computeRemoval(desiredIgnFiles map[string]struct{}) []string {
+	var removeFilePaths []string
+	for path := range c.trackedFiles {
+		if _, exists := desiredIgnFiles[path]; !exists {
+			removeFilePaths = append(removeFilePaths, path)
+		}
+	}
+
+	return removeFilePaths
 }

--- a/internal/agent/device/config/controller_test.go
+++ b/internal/agent/device/config/controller_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSync(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name                  string
+		current               *v1alpha1.RenderedDeviceSpec
+		desired               *v1alpha1.RenderedDeviceSpec
+		desiredTrackFileCount int
+		wantErr               error
+	}{
+		{
+			name:    "no desired config",
+			current: &v1alpha1.RenderedDeviceSpec{},
+			desired: &v1alpha1.RenderedDeviceSpec{},
+		},
+		{
+			name: "desired config is invalid",
+			current: &v1alpha1.RenderedDeviceSpec{
+				Config: util.StrToPtr(`{"ignition":{"version":"3.4.0"}}`),
+			},
+			desired: &v1alpha1.RenderedDeviceSpec{
+				Config: util.StrToPtr("invalid"),
+			},
+			wantErr: errors.ErrInvalid,
+		},
+		{
+			name: "desired config is valid current is nil",
+			current: &v1alpha1.RenderedDeviceSpec{
+				Config: nil,
+			},
+			desired: &v1alpha1.RenderedDeviceSpec{
+				Config: util.StrToPtr(`{"ignition":{"version":"3.4.0"}}`),
+			},
+		},
+		{
+			name: "validate removal of files",
+			current: &v1alpha1.RenderedDeviceSpec{
+				Config: util.StrToPtr(ignitionConfigCurrent),
+			},
+			desired: &v1alpha1.RenderedDeviceSpec{
+				Config: util.StrToPtr(ignitionConfigDesired),
+			},
+			desiredTrackFileCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			deviceWriter := fileio.NewWriter()
+			deviceWriter.SetRootdir(testDir)
+			controller := NewController(
+				deviceWriter,
+				log.NewPrefixLogger("test"),
+			)
+
+			// Write the current config to the disk
+			if tt.current.Config != nil {
+				currentConfigRaw := []byte(*tt.current.Config)
+				currentIgnitionConfig, err := ParseAndConvertConfig(currentConfigRaw)
+				require.NoError(err)
+				err = controller.deviceWriter.WriteIgnitionFiles(currentIgnitionConfig.Storage.Files...)
+				require.NoError(err)
+			}
+
+			err := controller.Sync(tt.current, tt.desired)
+			if tt.wantErr != nil {
+				require.ErrorIs(err, tt.wantErr)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tt.desiredTrackFileCount, len(controller.trackedFiles))
+			require.Equal(tt.desiredTrackFileCount, countFilesInDir(testDir+"/etc/example"))
+		})
+	}
+}
+
+func countFilesInDir(dir string) int {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	fileCount := 0
+	for _, file := range files {
+		if !file.IsDir() {
+			fileCount++
+		}
+	}
+
+	return fileCount
+}
+
+var ignitionConfigCurrent = `{
+  "ignition": {
+    "version": "3.1.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/example/file1.txt",
+        "contents": {
+          "source": "data:,File%201%20contents"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/example/file2.txt",
+        "contents": {
+          "source": "data:,File%202%20contents"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/example/file3.txt",
+        "contents": {
+          "source": "data:,File%203%20contents"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}`
+
+var ignitionConfigDesired = `{
+  "ignition": {
+    "version": "3.1.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/example/file1.txt",
+        "contents": {
+          "source": "data:,File%201%20contents"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/example/file2.txt",
+        "contents": {
+          "source": "data:,File%202%20contents"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}`

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -143,7 +143,7 @@ func (a *Agent) syncDevice(ctx context.Context) (bool, error) {
 		}
 	}
 
-	if err := a.configController.Sync(&desired); err != nil {
+	if err := a.configController.Sync(&current, &desired); err != nil {
 		return false, err
 	}
 

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -116,6 +116,11 @@ func writeFileAtomically(fpath string, b []byte, dirMode, fileMode os.FileMode, 
 	return t.CloseAtomicallyReplace()
 }
 
+// RemoveFile removes the file at the provided path
+func (w *Writer) RemoveFile(path string) error {
+	return os.Remove(filepath.Join(w.rootDir, path))
+}
+
 // This is essentially ResolveNodeUidAndGid() from Ignition; XXX should dedupe
 // In testMode the permissions will be defined user
 func getFileOwnership(file ign3types.File, testMode bool) (int, int, error) {


### PR DESCRIPTION
This is really a bug today we only add new configs we don't purge

TODO:

- [x] add tests