### PR TITLE
EDM-297: Publish helm charts under quay.io/flightctl/charts

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -8,10 +8,12 @@ on:
 
 env:
   QUAY_ORG: quay.io/flightctl
+  QUAY_CHARTS: quay.io/flightctl/charts
 
 jobs:
   publish-helm-charts-containers:
     runs-on: ubuntu-latest
+    needs: publish-flightctl-containers
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,7 +43,7 @@ jobs:
 
       - name: Push helm charts
         run: |
-          helm push flightctl-helm-*.tgz oci://${{ env.QUAY_ORG }}/
+          helm push "flightctl-${VERSION}.tgz" oci://${{ env.QUAY_CHARTS }}/
 
   publish-flightctl-containers:
     strategy:

--- a/deploy/helm/flightctl/Chart.yaml
+++ b/deploy/helm/flightctl/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: flightctl-helm
+name: flightctl
 description: A helm chart for flightctl
 home: https://github.com/flightctl/flightctl
 type: application

--- a/hack/publish_charts.sh
+++ b/hack/publish_charts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+QUAY_CHARTS=${QUAY_CHARTS:-quay.io/flightctl/charts}
+FLIGHTCTL_VERSION=$(git describe --long --tags)
+FLIGHTCTL_VERSION=${FLIGHTCTL_VERSION#v} # remove the leading v prefix for version
+
+VERSION=${VERSION:-$FLIGHTCTL_VERSION}
+
+echo packaging "${VERSION}"
+helm package deploy/helm/flightctl --version "${VERSION}" --app-version "${VERSION}"
+
+#login with helm registry login quay.io -u ${USER} -p ${PASSWORD}
+helm push "flightctl-${VERSION}.tgz" oci://${QUAY_CHARTS}/


### PR DESCRIPTION
This makes the charts compatible with ArgoCD usage, since ArgoCD expects a base OCI repo like this.

Also makes the helm charts publishing depending on the publishing of the containers. (Otherwise we would render helm charts that point to a container version that has not been published)