### PR TITLE
EDM-295: Reorganize helm charts top down

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-certs-persistentvolumeclaim.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-certs-persistentvolumeclaim.yaml
@@ -7,13 +7,9 @@ metadata:
   labels:
     paas.redhat.com/appcode: {{ .Values.appCode }}
   name: flightctl-api-certs
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  #this is how we would do RWM for multiple pods...
-  #storageClassName: {{ .Values.storageClassNameRWM }}
-  #accessModes:
-  #  - ReadWriteMany
-  storageClassName: {{ .Values.storageClassName }}
+  storageClassName: {{ .Values.global.flightctl.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/deploy/helm/flightctl/templates/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-config.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flightctl-api-config
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |-
     database:
-        hostname: flightctl-db.{{ .Values.flightctl.db.namespace }}.svc.cluster.local
+        hostname: flightctl-db.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local
         type: pgsql
         port: 5432
         name: flightctl
@@ -17,28 +17,45 @@ data:
         address: :3443
         agentEndpointAddress: :7443
         agentGrpcAddress: :7444
-        baseUrl: https://{{ .Values.flightctl.api.hostName }}:3443/
-        {{ if .Values.flightctl.api.agentAPIHostName }}
-        baseAgentEndpointUrl:  https://{{ .Values.flightctl.api.agentAPIHostName }}:7443/
+        {{ if .Values.flightctl.api.hostName }}
+        baseUrl: https://{{ .Values.flightctl.api.hostName }}{{ if .Values.flightctl.api.nodePort }}:{{ .Values.flightctl.api.nodePort }}{{ end }}/
         {{ else }}
-        baseAgentEndpointUrl:  https://{{ .Values.flightctl.api.hostName }}:7443/
+        baseUrl: https://api.{{ .Values.global.flightctl.baseDomain }}{{ if .Values.flightctl.api.nodePort }}:{{ .Values.flightctl.api.nodePort }}{{ end }}/
         {{ end }}
+
+        {{ if .Values.flightctl.api.agentAPIHostName }}
+        baseAgentEndpointUrl:  https://{{ .Values.flightctl.api.agentAPIHostName }}{{ if .Values.flightctl.api.agentAPINodePort }}:{{ .Values.flightctl.api.agentAPINodePort }}{{ end }}/
+        {{ else }}
+        baseAgentEndpointUrl:  https://agent-api.{{ .Values.global.flightctl.baseDomain }}{{ if .Values.flightctl.api.agentAPINodePort }}:{{ .Values.flightctl.api.agentAPINodePort }}{{ end }}/
+        {{ end }}
+
         {{ if .Values.flightctl.api.agentGrpcBaseURL }}
         baseAgentGrpcUrl:  {{ .Values.flightctl.api.agentGrpcBaseURL }}
+        {{ else }}
+        baseAgentGrpcUrl:  grpcs://agent-grpc.{{ .Values.global.flightctl.baseDomain }}{{ if .Values.flightctl.api.agentGrpcNodePort }}:{{ .Values.flightctl.api.agentGrpcNodePort }}{{ end }}
         {{ end }}
+
         altNames:
+          {{ if .Values.flightctl.api.hostName }}
           - {{ .Values.flightctl.api.hostName }}
+          {{ else }}
+          - api.{{ .Values.global.flightctl.baseDomain }}
+          {{ end }}
           {{ if .Values.flightctl.api.agentAPIHostName }}
           - {{ .Values.flightctl.api.agentAPIHostName }}
+          {{ else }}
+          - agent-api.{{ .Values.global.flightctl.baseDomain }}
           {{ end }}
           {{ if .Values.flightctl.api.agentGrpcHostName }}
           - {{ .Values.flightctl.api.agentGrpcHostName }}
+          {{ else }}
+          - agent-grpc.{{ .Values.global.flightctl.baseDomain }}
           {{ end }} 
           - flightctl-api
-          - flightctl-api.{{ .Values.flightctl.api.namespace }}
-          - flightctl-api.{{ .Values.flightctl.api.namespace }}.svc.cluster.local
+          - flightctl-api.{{ .Release.Namespace }}
+          - flightctl-api.{{ .Release.Namespace }}.svc.cluster.local
     queue:
-        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@{{ .Values.flightctl.rabbitmq.name }}.{{ .Values.flightctl.rabbitmq.namespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
+        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@flightctl-rabbitmq.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
     {{ if .Values.flightctl.api.auth.enabled }}
     auth:
         {{ if .Values.flightctl.api.auth.oidcAuthority }}

--- a/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-api
   name: flightctl-api
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
         - name: flightctl-api
-          image: {{ .Values.flightctl.api.image }}:{{ default .Chart.AppVersion .Values.flightctl.api.imageTag }}
-          imagePullPolicy: {{ .Values.flightctl.api.imagePullPolicy }}
+          image: {{ .Values.flightctl.api.image.image }}:{{ default .Chart.AppVersion .Values.flightctl.api.image.tag }}
+          imagePullPolicy: {{ .Values.flightctl.api.image.pullPolicy }}
           env:
             - name: HOME
               value: "/root"

--- a/deploy/helm/flightctl/templates/flightctl-api-route-agent-grpc.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-route-agent-grpc.yaml
@@ -8,9 +8,13 @@ metadata:
     paas.redhat.com/appcode: {{ .Values.appCode }}
     shard: external
   name: flightctl-api-route-agent-grpc
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
+  {{ if .Values.flightctl.api.agentGrpcHostName }}
   host: {{ .Values.flightctl.api.agentGrpcHostName }}
+  {{ else }}
+  host: agent-grpc.{{ .Values.global.flightctl.baseDomain }}
+  {{ end }}
   port:
     targetPort: 7444
   tls:

--- a/deploy/helm/flightctl/templates/flightctl-api-route-agent.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-route-agent.yaml
@@ -8,9 +8,13 @@ metadata:
     paas.redhat.com/appcode: {{ .Values.appCode }}
     shard: external
   name: flightctl-api-route-agent
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
+  {{ if .Values.flightctl.api.agentAPIHostName }}
   host: {{ .Values.flightctl.api.agentAPIHostName }}
+  {{ else }}
+  host: agent-api.{{ .Values.global.flightctl.baseDomain }}
+  {{ end }}
   port:
     targetPort: 7443
   tls:

--- a/deploy/helm/flightctl/templates/flightctl-api-route.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-route.yaml
@@ -1,5 +1,4 @@
 {{ if and (.Values.flightctl.api.enabled) (not .Values.flightctl.api.nodePort) }}
-
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -8,9 +7,13 @@ metadata:
     paas.redhat.com/appcode: {{ .Values.appCode }}
     shard: external
   name: flightctl-api-route
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
+  {{ if .Values.flightctl.api.hostName }}
   host: {{ .Values.flightctl.api.hostName }}
+  {{ else }}
+  host: api.{{ .Values.global.flightctl.baseDomain }}
+  {{ end }}
   port:
     targetPort: 3443
   tls:

--- a/deploy/helm/flightctl/templates/flightctl-api-service-agent-grpc.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-service-agent-grpc.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-api
   name: flightctl-api-agent-grpc
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.flightctl.api.agentGrpcNodePort }}
   type: NodePort

--- a/deploy/helm/flightctl/templates/flightctl-api-service-agent.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-service-agent.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-api
   name: flightctl-api-agent
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.flightctl.api.agentNodePort }}
   type: NodePort

--- a/deploy/helm/flightctl/templates/flightctl-api-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-api
   name: flightctl-api
-  namespace: {{ .Values.flightctl.api.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.flightctl.db.nodePort }}
   type: NodePort

--- a/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     flightctl.service: flightctl-db
   name: flightctl-db
-  namespace: {{ .Values.flightctl.db.namespace }}
+  namespace:  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
   replicas: 1
   selector:
@@ -31,8 +31,8 @@ spec:
               value: {{ .Values.flightctl.db.userPassword }}
             - name: POSTGRESQL_USER
               value: {{ .Values.flightctl.db.user }}
-          image: {{ .Values.flightctl.db.image }}
-          imagePullPolicy: {{ .Values.flightctl.db.imagePullPolicy }}
+          image: {{ .Values.flightctl.db.image.image }}:{{ .Values.flightctl.db.image.tag }}
+          imagePullPolicy: {{ .Values.flightctl.db.image.pullPolicy }}
           name: flightctl-db
           ports:
             - containerPort: 5432

--- a/deploy/helm/flightctl/templates/flightctl-db-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-from-flightctl
-  namespace: {{ .Values.flightctl.db.namespace }}
+  namespace:  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
   ingress:
   - from:
@@ -11,8 +11,8 @@ spec:
         - key: kubernetes.io/metadata.name
           operator: In
           values:
-          - {{ .Values.flightctl.api.namespace }}
-          - {{ .Values.flightctl.worker.namespace }}
+          -  {{ .Release.Namespace }}
+          -  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
       podSelector: {}
   podSelector: {}
   policyTypes:

--- a/deploy/helm/flightctl/templates/flightctl-db-persistentvolumeclaim.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-persistentvolumeclaim.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     paas.redhat.com/appcode: {{ .Values.appCode }}
   name: flightctl-db
-  namespace: {{ .Values.flightctl.db.namespace }}
+  namespace:  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
-  storageClassName: {{ .Values.storageClassName }}
+  storageClassName: {{ .Values.global.flightctl.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/deploy/helm/flightctl/templates/flightctl-db-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     flightctl.service: flightctl-db
   name: flightctl-db
-  namespace: {{ .Values.flightctl.db.namespace }}
+  namespace:  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
   {{ if .Values.flightctl.db.nodePort }}
   type: NodePort

--- a/deploy/helm/flightctl/templates/flightctl-periodic-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-periodic-config.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flightctl-periodic-config
-  namespace: {{.Values.flightctl.periodic.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 data:
   config.yaml: |-
     database:
-        hostname: flightctl-db.{{ .Values.flightctl.db.namespace }}.svc.cluster.local
+        hostname: flightctl-db.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local
         type: pgsql
         port: 5432
         name: flightctl
@@ -15,5 +15,5 @@ data:
         password: {{ .Values.flightctl.db.masterPassword }}   # we should funnel this via secrets instead
     service: {}
     queue:
-        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@{{ .Values.flightctl.rabbitmq.name }}.{{ .Values.flightctl.rabbitmq.namespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
+        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@flightctl-rabbitmq.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-periodic
   name: flightctl-periodic
-  namespace: {{ .Values.flightctl.periodic.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
   replicas: 1
   selector:
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
         - name: periodic
-          image: {{ .Values.flightctl.periodic.image }}:{{ default .Chart.AppVersion .Values.flightctl.periodic.imageTag }}
-          imagePullPolicy: {{ .Values.flightctl.periodic.imagePullPolicy }}
+          image: {{ .Values.flightctl.periodic.image.image }}:{{ default .Chart.AppVersion .Values.flightctl.periodic.image.tag }}
+          imagePullPolicy: {{ .Values.flightctl.periodic.image.pullPolicy }}
           env:
             - name: HOME
               value: "/root"

--- a/deploy/helm/flightctl/templates/flightctl-rabbitmq-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-rabbitmq-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.flightctl.rabbitmq.name }}
-  namespace: {{ .Values.flightctl.rabbitmq.namespace }}
+  name: flightctl-rabbitmq
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
   labels:
-    flightctl.service: {{ .Values.flightctl.rabbitmq.name }}
+    flightctl.service: flightctl-rabbitmq
 spec:
   type: {{ .Values.flightctl.rabbitmq.service.type }}
   ports:
@@ -15,4 +15,4 @@ spec:
       targetPort: 15672
       name: management
   selector:
-    flightctl.service: {{ .Values.flightctl.rabbitmq.name }}
+    flightctl.service: flightctl-rabbitmq

--- a/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
@@ -2,25 +2,25 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.flightctl.rabbitmq.name }}
-  namespace: {{ .Values.flightctl.rabbitmq.namespace }}
+  name: flightctl-rabbitmq
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
   labels:
-    flightctl.service: {{ .Values.flightctl.rabbitmq.name }}
+    flightctl.service: flightctl-rabbitmq
 spec:
-  serviceName: {{ .Values.flightctl.rabbitmq.name }}
+  serviceName: flightctl-rabbitmq
   replicas: {{ .Values.flightctl.rabbitmq.replicaCount }}
   selector:
     matchLabels:
-      flightctl.service: {{ .Values.flightctl.rabbitmq.name }}
+      flightctl.service: flightctl-rabbitmq
   template:
     metadata:
       labels:
-        flightctl.service: {{ .Values.flightctl.rabbitmq.name }}
+        flightctl.service: flightctl-rabbitmq
     spec:
       containers:
         - name: rabbitmq
-          image: {{ .Values.flightctl.rabbitmq.image }}
-          imagePullPolicy: {{ .Values.flightctl.rabbitmq.imagePullPolicy }}
+          image: {{ .Values.flightctl.rabbitmq.image.image }}:{{ .Values.flightctl.rabbitmq.image.tag }}
+          imagePullPolicy: {{ .Values.flightctl.rabbitmq.image.pullPolicy }}
           ports:
             - name: amqp
               containerPort: 5672
@@ -42,7 +42,7 @@ spec:
         labels:
           paas.redhat.com/appcode: {{ .Values.appCode }}
       spec:
-        storageClassName: {{ .Values.storageClassName }}
+        storageClassName: {{ .Values.global.flightctl.storageClassName }}
         accessModes:
           - {{ .Values.flightctl.rabbitmq.persistence.accessMode }}
         resources:

--- a/deploy/helm/flightctl/templates/flightctl-worker-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-clusterrole.yaml
@@ -1,11 +1,11 @@
-{{ if .Values.flightctl.worker.enableSecretsClusterRoleBinding }}
+{{ if .Values.global.flightctl.clusterLevelSecretAccess }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     flightctl.service: flightctl-worker
   name: flightctl-worker
-  namespace: {{ .Values.flightctl.worker.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]

--- a/deploy/helm/flightctl/templates/flightctl-worker-clusterrolebinding.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.flightctl.worker.enableSecretsClusterRoleBinding }}
+{{ if .Values.global.flightctl.clusterLevelSecretAccess }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: flightctl-worker
-    namespace: {{ .Values.flightctl.worker.namespace }}
+    namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 roleRef:
   kind: ClusterRole
   name: flightctl-worker

--- a/deploy/helm/flightctl/templates/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-config.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flightctl-worker-config
-  namespace: {{.Values.flightctl.worker.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 data:
   config.yaml: |-
     database:
-        hostname: flightctl-db.{{ .Values.flightctl.db.namespace }}.svc.cluster.local
+        hostname: flightctl-db.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local
         type: pgsql
         port: 5432
         name: flightctl
@@ -15,5 +15,5 @@ data:
         password: {{ .Values.flightctl.db.masterPassword }}   # we should funnel this via secrets instead
     service: {}
     queue:
-        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@{{ .Values.flightctl.rabbitmq.name }}.{{ .Values.flightctl.rabbitmq.namespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
+        amqpUrl: amqp://{{ .Values.flightctl.rabbitmq.auth.username }}:{{ .Values.flightctl.rabbitmq.auth.password }}@flightctl-rabbitmq.{{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}.svc.cluster.local:{{ .Values.flightctl.rabbitmq.ports.amqp }}/
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     flightctl.service: flightctl-worker
   name: flightctl-worker
-  namespace: {{ .Values.flightctl.worker.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
   replicas: 1
   selector:
@@ -21,8 +21,8 @@ spec:
       serviceAccountName: flightctl-worker
       containers:
         - name: flightctl-worker
-          image: {{ .Values.flightctl.worker.image }}:{{ default .Chart.AppVersion .Values.flightctl.worker.imageTag }}
-          imagePullPolicy: {{ .Values.flightctl.worker.imagePullPolicy }}
+          image: {{ .Values.flightctl.worker.image.image }}:{{ default .Chart.AppVersion .Values.flightctl.worker.image.tag }}
+          imagePullPolicy: {{ .Values.flightctl.worker.image.pullPolicy }}
           env:
             - name: HOME
               value: "/root"

--- a/deploy/helm/flightctl/templates/flightctl-worker-serviceaccount.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   labels:
     flightctl.service: flightctl-worker
   name: flightctl-worker
-  namespace: {{ .Values.flightctl.worker.namespace }}
+  namespace: {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}

--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -1,11 +1,14 @@
+global:
+  flightctl:
+    internalNamespace: flightctl-internal
 flightctl:
   db:
     nodePort: 5432 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     imagePullPolicy: IfNotPresent
   api:
-    image: localhost/flightctl-api
-    imagePullPolicy: IfNotPresent
-    hostName: localhost
+    image:
+      image:  localhost/flightctl-api
+      pullPolicy: IfNotPresent
     nodePort: 3443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     agentNodePort: 7443 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
     agentGrpcNodePort: 7444 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
@@ -13,18 +16,20 @@ flightctl:
       enabled: false
       internalOidcAuthority: http://keycloak.flightctl-external.svc.cluster.local:8080/realms/flightctl
   worker:
-    image: localhost/flightctl-worker
-    imagePullPolicy: IfNotPresent
+    image:
+      image: localhost/flightctl-worker
+      pullPolicy: IfNotPresent
   periodic:
-    image: localhost/flightctl-periodic
-    imagePullPolicy: IfNotPresent
+    image:
+      image: localhost/flightctl-periodic
+      pullPolicy: IfNotPresent
   rabbitmq:
-    image: rabbitmq:3.13-management
-    imagePullPolicy: IfNotPresent
+    image:
+      image: docker.io/rabbitmq
+      tag: 3.13-management
+      pullPolicy: IfNotPresent
     nodePort: 15672 # this is also mapped in /hack/kind_cluster.yaml as an extraPortMapping
 
-storageClassName: standard
-storageClassNameRWM: standard
 
 keycloak:
   namespace: flightctl-external

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -1,22 +1,55 @@
+
+## @section Global parameters
+## @descriptionStart This section contains parameters common to all the
+## components in the deployment, including sub-charts, ui charts, etc.
+## @descriptionEnd
+##
+## @param global.flightctl.baseDomain Base domain to construct the FQDN for the service endpoints.
+## @param global.flightctl.storageClassName Storage class name for the PVCs.
+## @param global.flightctl.metrics.enabled Enable metrics exporting and service
+## @param global.flightctl.timestamp Timestamp to be used to trigger a new deployment, i.e. if you want pods to be restarted and pickup ":latest"
+## @param global.flightctl.internalNamespace Namespace where internal components are deployed
+## @param global.flightctl.clusterLevelSecretAccess Allow flightctl-worker to access secrets at the cluster level for embedding in device configs
+global:
+  flightctl:
+    baseDomain: "" # flightctl.example.com
+    storageClassName: "standard"
+    metrics:
+      enabled: true
+    internalNamespace: ""
+    clusterLevelSecretAccess: false
+
+
+## @section Compoment specific parameters
+## @descriptionStart This section provides individual parameters for each component
+## @descriptionEnd
+
 flightctl:
   db:
-    namespace: flightctl-internal
-    image: quay.io/sclorg/postgresql-12-c8s:latest
-    imagePullPolicy: Always
+    image:
+      image: quay.io/sclorg/postgresql-12-c8s
+      tag: latest
+      pullPolicy: Always
     password: adminpass
     masterPassword: adminpass
     masterUser: admin
     user: demouser
     userPassword: demopass
+    nodePort: ""
   api:
     enabled: true
     namespace: flightctl-external
-    image: quay.io/flightctl/flightctl-api
-    imagePullPolicy: Always
-    hostName: api.flightctl.example.com
-    agentAPIHostName: agent-api.flightctl.example.com
-    agentGrpcHostName: agent-grpc.flightctl.example.com
-    agentGrpcBaseURL: grpcs://agent-grpc.flightctl.example.com
+    image:
+      image: quay.io/flightctl/flightctl-api
+      pullPolicy: Always
+      tag: ""
+    nodePort: "" # used for local development
+    agentNodePort: "" # used for local development
+    agentGrpcNodePort: "" # used for local development
+    hostName: "" # api.flightctl.example.com
+    agentAPIHostName: "" # agent-api.flightctl.example.com
+    agentGrpcHostName: "" # agent-grpc.flightctl.example.com
+    agentGrpcBaseURL: "" # grpcs://agent-grpc.flightctl.example.com
     auth:
       ## @param enabled True if auth should be enabled. One of 'openShiftApiUrl' or 'oidcAuthority' params will be required.
       enabled: false
@@ -28,22 +61,24 @@ flightctl:
       internalOidcAuthority: ""
   worker:
     enabled: true
-    namespace: flightctl-internal
-    image: quay.io/flightctl/flightctl-worker
-    imagePullPolicy: Always
+    image:
+      image: quay.io/flightctl/flightctl-worker
+      pullPolicy: Always
+      tag: ""
     enableSecretsClusterRoleBinding: true
   periodic:
     enabled: true
-    namespace: flightctl-internal
-    image: quay.io/flightctl/flightctl-periodic
-    imagePullPolicy: Always
+    image:
+      image: quay.io/flightctl/flightctl-periodic
+      tag: ""
+      pullPolicy: Always
   rabbitmq:
     enabled: true
-    name: flightctl-rabbitmq
-    namespace: flightctl-internal
     replicaCount: 1
-    image: docker.io/library/rabbitmq:3.13-management
-    imagePullPolicy: IfNotPresent
+    image:
+      image: docker.io/library/rabbitmq
+      tag: 3.13-management
+      pullPolicy: IfNotPresent
     ports:
       amqp: 5672
       management: 15672
@@ -58,10 +93,6 @@ flightctl:
       type: ClusterIP
       amqpPort: 5672
       managementPort: 15672
-
-
-storageClassName: aws-ebs
-storageClassNameRWM: aws-efs-tier-c4
 
 
 # This is only related to deployment in Red Hat's PAAS

--- a/test/scripts/prepare_agent_config.sh
+++ b/test/scripts/prepare_agent_config.sh
@@ -15,9 +15,9 @@ enrollment-service:
     client-key: certs/client-enrollment.key
   service:
     certificate-authority: certs/ca.crt
-    server: https://${IP}:7443
-  enrollment-ui-endpoint: https://${IP}:8080
-grpc-management-endpoint: grpcs://${IP}:7444
+    server: https://agent-api.${IP}.nip.io:7443
+  enrollment-ui-endpoint: https://ui.${IP}.nip.io:8080
+grpc-management-endpoint: grpcs://agent-grpc.${IP}.nip.io:7444
 spec-fetch-interval: 0m10s
 status-update-interval: 0m10s
 tpm-path: /dev/tpmrm0


### PR DESCRIPTION
* If not individually overriden domains are composed from .global.flightctl.baseDomain

* Image references equalized under image.{image,tag,pullPolicy}

* Added internal namespace support, while single namespace is still posible

* Uses .Release.namespace instead of a value-passed namespace