### PR TITLE
NO-ISSUE: Improve CLI publish workflow

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
@@ -23,11 +24,12 @@ jobs:
           GOARCH: ${{ matrix.arch }}
           GOOS: ${{ matrix.os }}
         run: |       
-          make build
-          SHA=$(sha256sum bin/flightctl | awk '{ print $1 }')
+          make build-cli
+          SHA=$(sha256sum bin | awk '{ print $1 }')
           echo $SHA > ${{ env.NAME }}-sha256.txt
-          tar cvf ${{ env.NAME }}.tar.gz  bin/flightctl
-          mv bin/flightctl ${{ env.NAME }} 
+          tar cvf ${{ env.NAME }}.tar.gz  bin
+          mv bin ${{ env.NAME }}
+
       - name: "Save tar binary"
         uses: actions/upload-artifact@v4
         with:
@@ -70,6 +72,7 @@ jobs:
           exit $?
 
   publish:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [verify]
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ lint: tools
 build: bin
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
+build-cli:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl
+
 build-api: bin
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-api
 


### PR DESCRIPTION
Add build-cli Makefile target that only builds flightctlc cli.

Check that PRs can build flightctl by running the cli build workflow without publishing anything.