### PR TITLE
EDM-344: Fleet valid status is not set to 'false' if a repository present in its template config is deleted

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -103,6 +103,20 @@ func (s *DataStore) InitialMigration() error {
 	if err := s.ResourceSync().InitialMigration(); err != nil {
 		return err
 	}
+	return s.customizeMigration()
+}
+
+func (s *DataStore) customizeMigration() error {
+	if s.db.Migrator().HasConstraint("fleet_repos", "fk_fleet_repos_repository") {
+		if err := s.db.Migrator().DropConstraint("fleet_repos", "fk_fleet_repos_repository"); err != nil {
+			return err
+		}
+	}
+	if s.db.Migrator().HasConstraint("device_repos", "fk_device_repos_repository") {
+		if err := s.db.Migrator().DropConstraint("device_repos", "fk_device_repos_repository"); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION


Currently there is a cascade delete foreign key constraint on table "fleet_repos" which is used for the many to many relationship between table repositories and fleets.  This causes the association record to be deleted when repository is deleted (which is not desirable). This change removes the constraint during migration.  It means that the association will only be deleted when the fleet is deleted. Same change was done for table "device_repos".