### PR TITLE
NO-ISSUE: fix bootc-image-builder

### DIFF
--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -37,5 +37,6 @@ sudo podman run --rm \
                 -v $(pwd)/bin/output:/output \
                 -v /var/lib/containers/storage:/var/lib/containers/storage \
                 quay.io/centos-bootc/bootc-image-builder:latest \
+                build \
                 --type qcow2 \
                 --local "${IP}:5000/flightctl-device:base"


### PR DESCRIPTION
since https://github.com/osbuild/bootc-image-builder/commit/1a79b1d6d17f91af6e07fa6db3f4f222ce38f0e6 `build` is the default subcommand which is a breaking change. this unblocks e2e

ref https://github.com/flightctl/flightctl/actions/runs/10459089773/job/28962282904
