### PR TITLE
EDM-118: ensure max boot attempts for greenboot

### DIFF
--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -19,6 +19,7 @@ RUN dnf install -y /tmp/flightctl-agent-*.rpm && \
 
 RUN dnf install -y epel-release epel-next-release
 RUN dnf install -y greenboot greenboot-default-health-checks podman-compose
+COPY test/scripts/agent-images/greenboot.conf /etc/greenboot.conf
 
 RUN useradd -ms /bin/bash user && \
     echo "user:user" | chpasswd && \

--- a/test/scripts/agent-images/greenboot.conf
+++ b/test/scripts/agent-images/greenboot.conf
@@ -1,0 +1,27 @@
+# Greenboot configuration file
+
+## Generic
+GREENBOOT_MAX_BOOT_ATTEMPTS=3
+
+## Watchdog
+### This variable controls 
+### This value can be "true, TRUE, True..." as it will be lowercased.
+### Set it to anything else to disable this check.
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+
+### This variable is the number of hours after an upgrade that we consider
+### the new deployment as culprit of reboot.
+### It has to be a positive integer. Defaults to 24 (hours).
+# GREENBOOT_WATCHDOG_GRACE_PERIOD=24
+
+### This variable allows you to specify healthchecks to be skipped. 
+### The healthcheck must be specified by script name, as in the 
+### example below. Multiple healthchecks may be skipped by separating
+### the script names with spaces.
+### NOTE: Script names must be spelled EXACTLY. Typos will result in
+### unwanted behaviour.
+### DISABLED_HEALTHCHECKS=(
+### 	"01_repository_dns_check.sh" 
+### 	"02_watchdog.sh"
+### )
+DISABLED_HEALTHCHECKS=()


### PR DESCRIPTION
By default greenboot does not set a max reboot before rollback. This sets it to GREENBOOT_MAX_BOOT_ATTEMPTS to 3 for e2e testing.

