### PR TITLE
EDM-322: CreateOrDelete can create deleted resources in a race

### DIFF
--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -211,7 +211,7 @@ func (h *ServiceHandler) PatchCertificateSigningRequest(ctx context.Context, req
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	result, _, err := h.store.CertificateSigningRequest().CreateOrUpdate(ctx, orgId, newObj)
+	result, err := h.store.CertificateSigningRequest().Update(ctx, orgId, newObj)
 
 	switch err {
 	case nil:

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -249,7 +249,7 @@ func (h *ServiceHandler) PatchDevice(ctx context.Context, request server.PatchDe
 		updateCallback = h.callbackManager.DeviceUpdatedCallback
 	}
 	// create
-	result, _, err := h.store.Device().CreateOrUpdate(ctx, orgId, newObj, nil, true, updateCallback)
+	result, err := h.store.Device().Update(ctx, orgId, newObj, nil, true, updateCallback)
 
 	switch err {
 	case nil:

--- a/internal/service/device_test.go
+++ b/internal/service/device_test.go
@@ -50,6 +50,10 @@ func (s *DummyDevice) Get(ctx context.Context, orgId uuid.UUID, name string) (*v
 	return nil, flterrors.ErrResourceNotFound
 }
 
+func (s *DummyDevice) Update(ctx context.Context, orgId uuid.UUID, device *v1alpha1.Device, fieldsToUnset []string, fromAPI bool, callback store.DeviceStoreCallback) (*v1alpha1.Device, error) {
+	return device, nil
+}
+
 func (s *DummyDevice) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *v1alpha1.Device, fieldsToUnset []string, fromAPI bool, callback store.DeviceStoreCallback) (*v1alpha1.Device, bool, error) {
 	return device, false, nil
 }

--- a/internal/service/fleet.go
+++ b/internal/service/fleet.go
@@ -258,7 +258,7 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, request server.PatchFle
 	if h.callbackManager != nil {
 		updateCallback = h.callbackManager.FleetUpdatedCallback
 	}
-	result, _, err := h.store.Fleet().CreateOrUpdate(ctx, orgId, newObj, updateCallback)
+	result, err := h.store.Fleet().Update(ctx, orgId, newObj, updateCallback)
 
 	switch err {
 	case nil:

--- a/internal/service/fleet_test.go
+++ b/internal/service/fleet_test.go
@@ -34,6 +34,10 @@ func (s *DummyFleet) Get(ctx context.Context, orgId uuid.UUID, name string, opts
 	return nil, flterrors.ErrResourceNotFound
 }
 
+func (s *DummyFleet) Update(ctx context.Context, orgId uuid.UUID, fleet *v1alpha1.Fleet, callback store.FleetStoreCallback) (*v1alpha1.Fleet, error) {
+	return fleet, nil
+}
+
 func (s *DummyFleet) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *v1alpha1.Fleet, callback store.FleetStoreCallback) (*v1alpha1.Fleet, bool, error) {
 	return fleet, false, nil
 }

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -202,7 +202,7 @@ func (h *ServiceHandler) PatchRepository(ctx context.Context, request server.Pat
 	if h.callbackManager != nil {
 		updateCallback = h.callbackManager.RepositoryUpdatedCallback
 	}
-	result, _, err := h.store.Repository().CreateOrUpdate(ctx, orgId, newObj, updateCallback)
+	result, err := h.store.Repository().Update(ctx, orgId, newObj, updateCallback)
 
 	switch err {
 	case nil:

--- a/internal/service/repository_test.go
+++ b/internal/service/repository_test.go
@@ -34,6 +34,10 @@ func (s *DummyRepository) Get(ctx context.Context, orgId uuid.UUID, name string)
 	return nil, flterrors.ErrResourceNotFound
 }
 
+func (s *DummyRepository) Update(ctx context.Context, orgId uuid.UUID, repository *v1alpha1.Repository, callback store.RepositoryStoreCallback) (*v1alpha1.Repository, error) {
+	return repository, nil
+}
+
 func (s *DummyRepository) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, repository *v1alpha1.Repository, callback store.RepositoryStoreCallback) (*v1alpha1.Repository, bool, error) {
 	return repository, false, nil
 }

--- a/internal/service/resourcesync.go
+++ b/internal/service/resourcesync.go
@@ -194,7 +194,7 @@ func (h *ServiceHandler) PatchResourceSync(ctx context.Context, request server.P
 
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
-	result, _, err := h.store.ResourceSync().CreateOrUpdate(ctx, orgId, newObj)
+	result, err := h.store.ResourceSync().Update(ctx, orgId, newObj)
 
 	switch err {
 	case nil:

--- a/internal/service/resourcesync_test.go
+++ b/internal/service/resourcesync_test.go
@@ -34,6 +34,10 @@ func (s *DummyResourceSync) Get(ctx context.Context, orgId uuid.UUID, name strin
 	return nil, flterrors.ErrResourceNotFound
 }
 
+func (s *DummyResourceSync) Update(ctx context.Context, orgId uuid.UUID, resourceSync *v1alpha1.ResourceSync) (*v1alpha1.ResourceSync, error) {
+	return resourceSync, nil
+}
+
 func (s *DummyResourceSync) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resourceSync *v1alpha1.ResourceSync) (*v1alpha1.ResourceSync, bool, error) {
 	return resourceSync, false, nil
 }

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -14,6 +14,14 @@ import (
 
 const retryIterations = 10
 
+type CreateOrUpdateMode string
+
+const (
+	ModeCreateOnly     CreateOrUpdateMode = "create-only"
+	ModeUpdateOnly     CreateOrUpdateMode = "update-only"
+	ModeCreateOrUpdate CreateOrUpdateMode = "create-or-update"
+)
+
 func BuildBaseListQuery(query *gorm.DB, orgId uuid.UUID, listParams ListParams) *gorm.DB {
 	query = query.Where("org_id = ?", orgId).Order("name")
 	invertLabels := false

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -230,7 +230,7 @@ func (f FleetRolloutsLogic) updateDeviceInStore(ctx context.Context, device *api
 		}
 
 		device.Spec = newDeviceSpec
-		_, _, err = f.devStore.CreateOrUpdate(ctx, f.resourceRef.OrgID, device, nil, false, f.callbackManager.DeviceUpdatedCallback)
+		_, err = f.devStore.Update(ctx, f.resourceRef.OrgID, device, nil, false, f.callbackManager.DeviceUpdatedCallback)
 		if err != nil {
 			if errors.Is(err, flterrors.ErrResourceVersionConflict) {
 				device, err = f.devStore.Get(ctx, f.resourceRef.OrgID, *device.Metadata.Name)

--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -613,7 +613,7 @@ func (f FleetSelectorMatchingLogic) updateDeviceOwner(ctx context.Context, devic
 
 	f.log.Infof("Updating fleet of device %s from %s to %s", *device.Metadata.Name, util.DefaultIfNil(device.Metadata.Owner, "<none>"), util.DefaultIfNil(newOwnerRef, "<none>"))
 	device.Metadata.Owner = newOwnerRef
-	_, _, err := f.devStore.CreateOrUpdate(ctx, f.resourceRef.OrgID, device, fieldsToNil, false, f.callbackManager.DeviceUpdatedCallback)
+	_, err := f.devStore.Update(ctx, f.resourceRef.OrgID, device, fieldsToNil, false, f.callbackManager.DeviceUpdatedCallback)
 	return err
 }
 


### PR DESCRIPTION
There are cases where we should fail when updating a resource that no longer exists, but today we recreate them due to races:
1. PATCH operations get the resource, modify it, and call the store to update it.  If the resource is deleted after getting it, we will recreate it.
2. When rolling out a fleet, a device that was deleted will be similarly recreated.
3. When updating a device owner upon label/selector change, we can similarly recreate a deleted device.