### PR TITLE
EDM-361: agent: add version and debug metadata

### DIFF
--- a/cmd/flightctl-agent/main.go
+++ b/cmd/flightctl-agent/main.go
@@ -8,9 +8,17 @@ import (
 
 	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/version"
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		versionInfo := version.Get()
+		fmt.Printf("Flightctl Agent Version: %s\n", versionInfo.String())
+		fmt.Printf("Git Commit: %s\n", versionInfo.GitCommit)
+		os.Exit(0)
+	}
+
 	command := NewAgentCommand()
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
@@ -33,8 +41,10 @@ func NewAgentCommand() *agentCmd {
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
-		fmt.Println("This program starts an agent with the specified configuration. Below are the available flags:")
+		fmt.Println("flags:")
 		flag.PrintDefaults()
+		fmt.Println("commands:")
+		fmt.Println("  version    Display version information")
 	}
 
 	flag.Parse()

--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/version"
 	"github.com/skip2/go-qrcode"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/cert"
@@ -77,6 +78,13 @@ func NewBootstrap(
 
 func (b *Bootstrap) Initialize(ctx context.Context) error {
 	b.log.Infof("Bootstrapping device: %s", b.deviceName)
+	versionInfo := version.Get()
+	b.log.Infof("System information: version=%s, go-version=%s, platform=%s, git-commit=%s",
+		versionInfo.String(),
+		versionInfo.GoVersion,
+		versionInfo.Platform,
+		versionInfo.GitCommit,
+	)
 
 	if err := b.ensureSpecFiles(); err != nil {
 		return err


### PR DESCRIPTION
```
Usage of bin/flightctl-agent:
flags
  -config string
        Path to the agent's configuration file. (default "/etc/flightctl/config.yaml")
commands:
  version    Display version information
```  

```
level=info msg="System information: version=20240820-v0.1.0-5-g1f0daa1, go-version=go1.21.8, platform=linux/amd64, git-commit=1f0daa1"
```

```
bin/flightctl-agent version
Flightctl Agent Version: 20240820-v0.1.0-4-g6122840
Git Commit: 6122840
```