### PR TITLE
EDM-362: Keycloak storageClassName global fix

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-certs-persistentvolumeclaim.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-certs-persistentvolumeclaim.yaml
@@ -9,7 +9,7 @@ metadata:
   name: flightctl-api-certs
   namespace: {{ .Release.Namespace }}
 spec:
-  storageClassName: {{ .Values.global.flightctl.storageClassName }}
+  storageClassName: {{ .Values.global.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/deploy/helm/flightctl/templates/flightctl-db-persistentvolumeclaim.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-persistentvolumeclaim.yaml
@@ -8,7 +8,7 @@ metadata:
   name: flightctl-db
   namespace:  {{ default .Release.Namespace .Values.global.flightctl.internalNamespace }}
 spec:
-  storageClassName: {{ .Values.global.flightctl.storageClassName }}
+  storageClassName: {{ .Values.global.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-rabbitmq-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         labels:
           paas.redhat.com/appcode: {{ .Values.appCode }}
       spec:
-        storageClassName: {{ .Values.global.flightctl.storageClassName }}
+        storageClassName: {{ .Values.global.storageClassName }}
         accessModes:
           - {{ .Values.flightctl.rabbitmq.persistence.accessMode }}
         resources:

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -13,11 +13,11 @@
 global:
   flightctl:
     baseDomain: "" # flightctl.example.com
-    storageClassName: "standard"
     metrics:
       enabled: true
     internalNamespace: ""
     clusterLevelSecretAccess: false
+  storageClassName: "standard"
 
 
 ## @section Compoment specific parameters


### PR DESCRIPTION
This commit leaves storageClassName at base global level for all subcharts to pick up.