### PR TITLE
EDM-363: Add route support for keycloak and use baseDomain

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-ingress.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.global.flightctl.useIngress -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -7,9 +7,17 @@ metadata:
 spec:
   tls:
     - hosts:
+      {{ if .Values.global.flightctl.baseDomain }}
+        - auth.{{ .Values.global.flightctl.baseDomain }}
+      {{ else }}
         - {{ .Values.ingress.hostname }}
+      {{ end }}
   rules:
+    {{ if .Values.global.flightctl.baseDomain }}
+    - host: auth.{{ .Values.global.flightctl.baseDomain }}
+    {{ else }}
     - host: {{ .Values.ingress.hostname }}
+    {{ end }}
       http:
         paths:
           - path: /

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-route.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-route.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.global.flightctl.useRoutes -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: keycloak
+  name: keycloak
+  namespace: {{ default .Release.Namespace .Values.namespace }}
+spec:
+  {{ if .Values.global.flightctl.baseDomain }}
+  host: auth.{{ .Values.global.flightctl.baseDomain }}
+  {{ else }}
+  host: {{ .Values.route.hostname }}
+  {{ end }}
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+
+    {{ if .Values.route.tls.cert }}
+    certificate: {{ .Values.route.tls.cert | quote }}
+    {{ else }}
+        {{ if .Values.global.flightctl.baseDomainTls.cert }}
+    certificate: {{ .Values.global.flightctl.baseDomainTls.cert | quote }}
+        {{ end }}
+    {{ end }}
+
+    {{ if .Values.route.tls.key }}
+    key: {{ .Values.route.tls.key | quote }}
+    {{ else }}
+        {{ if .Values.global.flightctl.baseDomainTls.key }}
+    key: {{ .Values.global.flightctl.baseDomainTls.key | quote }}
+        {{ end }}
+    {{ end }}
+    insecureEdgeTerminationPolicy: None
+  to:
+    kind: Service
+    name: keycloak
+    weight: 100
+  wildcardPolicy: None
+{{- end -}}

--- a/deploy/helm/flightctl/charts/keycloak/values.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/values.yaml
@@ -55,9 +55,13 @@ service:
     https: ""
 
 ingress:
-  enabled: true
-  hostname: api.flightctl.127.0.0.1.nip.io
+  hostname: ""
 
+route:
+  hostname: ""
+  tls:
+    cert: ""
+    key: ""
 db:
   ## @param db.namespace The namespace into which to deploy the Keycloak database
   namespace: flightctl

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -5,6 +5,11 @@
 ## @descriptionEnd
 ##
 ## @param global.flightctl.baseDomain Base domain to construct the FQDN for the service endpoints.
+## @param.global.flightctl.baseDomainTls.cert Certificate for the base domain wildcard certificate, it should be valid for *.${baseDomain}.
+##                                            this certificate is only used for non mTLS endpoints, mTLS endpoints like agent-api, etc will use different certificates.
+## @param.global.flightctl.baseDomainTls.key Key for the base domain wildcard certificate.
+## @param.global.flightctl.useRoutes Use routes for http/https endpoints
+## @param global.flightctl.useIngress Use ingress for http/https endpoints
 ## @param global.flightctl.storageClassName Storage class name for the PVCs.
 ## @param global.flightctl.metrics.enabled Enable metrics exporting and service
 ## @param global.flightctl.timestamp Timestamp to be used to trigger a new deployment, i.e. if you want pods to be restarted and pickup ":latest"
@@ -13,6 +18,11 @@
 global:
   flightctl:
     baseDomain: "" # flightctl.example.com
+    baseDomainTls:
+      cert: ""
+      key: ""
+    useRoutes: false # Use routes for http/https endpoints
+    useIngress: false # Use ingress for http/https endpoints
     metrics:
       enabled: true
     internalNamespace: ""


### PR DESCRIPTION
This fixes keycloak deployment on OpenShift until we have working ingresses again.