### PR TITLE
MGMT-18170: Accept enrollment certificates from the CSR API

### DIFF
--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -18,15 +18,15 @@ import (
 
 // Wraps openshift/library-go/pkg/crypto to use ECDSA and simplify the interface
 const ClientBootstrapCommonName = "client-enrollment"
-const UuidCommonNamePrefix = "client-enrollment-"
+const ClientBootstrapCommonNamePrefix = "client-enrollment-"
 const AdminCommonName = "flightctl-admin"
 const DeviceCommonNamePrefix = "device:"
 
-func CNFromRequestedName(uuid string) (string, error) {
-	if len(uuid) < 16 {
+func BootrapCNFromName(name string) (string, error) {
+	if len(name) < 16 {
 		return "", errors.New("subject common name (uuid) must have 16 characters at least")
 	}
-	return UuidCommonNamePrefix + uuid, nil
+	return ClientBootstrapCommonNamePrefix + name, nil
 }
 
 func CNFromDeviceFingerprint(fingerprint string) (string, error) {

--- a/internal/service/agent/handler.go
+++ b/internal/service/agent/handler.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/flightctl/flightctl/internal/api/server"
 	agentServer "github.com/flightctl/flightctl/internal/api/server/agent"
@@ -44,8 +45,9 @@ func ValidateEnrollmentAccessFromContext(ctx context.Context, log logrus.FieldLo
 	if !ok {
 		return errors.New("no common name in certificate")
 	}
-	if cn != crypto.ClientBootstrapCommonName {
-		log.Warningf("an attempt to perform enrollment with a certificate with CN %q has been detected", cn)
+	if cn != crypto.ClientBootstrapCommonName &&
+		!strings.HasPrefix(cn, crypto.ClientBootstrapCommonNamePrefix) {
+		log.Errorf("an attempt to perform enrollment with a certificate with CN %q has been detected", cn)
 		return errors.New("invalid tls CN for enrollment request")
 	}
 	// all good, you shall pass

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -47,7 +47,7 @@ func signApprovedCertificateSigningRequest(ca *crypto.CA, request *api.Certifica
 	if u == "" {
 		u = uuid.NewString()
 	}
-	csr.Subject.CommonName, err = crypto.CNFromRequestedName(u)
+	csr.Subject.CommonName, err = crypto.BootrapCNFromName(u)
 	if err != nil {
 		return fmt.Errorf("signApprovedCertificateRequest: error setting CN in CSR: %w", err)
 	}


### PR DESCRIPTION
During enrollment it should be possible to accept certificates created for such purpose through our CSR API.