### PR TITLE
EDM-206: Allow fetching devices with value-less labelSelector

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -101,17 +101,6 @@ func (o *GetOptions) Complete(cmd *cobra.Command, args []string) error {
 	if o.Rendered && len(o.Output) == 0 {
 		o.Output = jsonFormat
 	}
-	// If a label selector is provided, ensure keys without value still have '=' appended
-	if len(o.LabelSelector) > 0 {
-		labels := strings.Split(o.LabelSelector, ",")
-		for i, label := range labels {
-			l := strings.Split(label, "=")
-			if len(l) == 1 {
-				labels[i] = l[0] + "="
-			}
-		}
-		o.LabelSelector = strings.Join(labels, ",")
-	}
 	return nil
 }
 

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
@@ -55,7 +56,15 @@ func (h *ServiceHandler) ListDevices(ctx context.Context, request server.ListDev
 
 	labelSelector := ""
 	if request.Params.LabelSelector != nil {
-		labelSelector = *request.Params.LabelSelector
+		// If a label selector is provided, ensure keys without value still have '=' appended
+		labels := strings.Split(*request.Params.LabelSelector, ",")
+		for i, label := range labels {
+			l := strings.Split(label, "=")
+			if len(l) == 1 {
+				labels[i] = l[0] + "="
+			}
+		}
+		labelSelector = strings.Join(labels, ",")
 	}
 	statusFilter := []string{}
 	if request.Params.StatusFilter != nil {


### PR DESCRIPTION
Previously we modified the CLI to add empty values to the labelSelector, but this doesn't help the UI which uses the API directly. This commit moves the logic from the CLI to the service so that the behavior is consistent for the CLI and API.