### PR TITLE
NO-ISSUE: Name CLI release

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -101,5 +101,9 @@ jobs:
             git push --delete origin $OLD_TAG
           fi
           
-          gh release create -p -n "Flightctl CLI pre-release" latest release/*
+          gh release create -p \
+            -n "Flightctl CLI pre-release" \
+            -t "latest: $(git describe --always)" \
+            latest \
+            release/*
 


### PR DESCRIPTION
GitHub will include the merge commit message in the title of our releases, so explicitly provide a title of the form "latest: <hash>".