### PR TITLE
EDM-387: Filter resourcesyncs by repository

### DIFF
--- a/api/v1alpha1/openapi.yaml
+++ b/api/v1alpha1/openapi.yaml
@@ -62,6 +62,11 @@ paths:
           schema:
             type: integer
             format: int32
+        - name: repository
+          in: query
+          description: The name of the repository to filter results by.
+          schema:
+            type: string
       responses:
         "200":
           description: OK

--- a/api/v1alpha1/spec.gen.go
+++ b/api/v1alpha1/spec.gen.go
@@ -183,10 +183,10 @@ var swaggerSpec = []string{
 	"zjMlXI85CpJzSRUXdKcnxE787mHbUaPJM/Vwl3jebHFuiy6MvqdSNfA5Bj6OfuXRr3yDaq3uXI4u5U6O",
 	"tSW60GsdDjE88RvchXzhTXDPwYbNmUeF86FtQDXajUg7Q3xjHdTdEHI2Q6T22rCPXQfspvJnKU/3EeoC",
 	"PqwOajohOB1paaSlYR6lDoKyLpfHQ1FPxsHUj4ZHC/NTszA3D2p/J1Mn34cO3+JBvTsJ/X7P6qgRjAzi",
-	"9hlETfmQvBAJkRuW7GZrNf1PNyyJqiFVk2dtbK0wvdXc6jUNm1trWB/NraO5dTS33uBirE7TaHDdwrW2",
-	"mlw7WJczutaY190Idd4U9254bc49CloPb3qtUXFM/hlmfe0g9LbgM0x1qg39+O1m3QT/TC1nfaS9oB22",
-	"g66MJXakqpGq3G08zCLbQVrWSvm4aOsJ2WX7UfNoeHl6hpfmkR1im+28C6x19ts8sncpzN/3uR3Vh5Fd",
-	"3A270J+Micec50Jkk9eT/cn1l+v/HwAA///2h66zr3EBAA==",
+	"9hlETfmQvBAJkRuW7GZrNf1PNyyJqiFVk2dtbK0wvdXc6jUNm1trWB/NraO59bnlmZ8t6xGTFYPTmzan",
+	"mQbLre0iCktNTHkovbM6zKO9dwvT3Grx7eCczuZb4513I1N6U9y73bc59yjnPbzlt0bFMfFrmPG3g9Db",
+	"ctcwza029OM323UT/DM13PURNoNm4A66MobgkapGqnK38TCDcAdpWSPp46KtJ2QW7kfNo93n6dl9mkd2",
+	"iGm48y6wxuFv88jepTB/3+d2VB9GdnE37EJ/MhYmc54LkU1eT/Yn11+u/38AAAD//6uQ4nsucgEA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1alpha1/types.gen.go
+++ b/api/v1alpha1/types.gen.go
@@ -1262,6 +1262,9 @@ type ListResourceSyncParams struct {
 
 	// Limit The maximum number of results returned in the list response. The server will set the 'continue' field in the list response if more results exist. The continue value may then be specified as parameter in a subsequent query.
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Repository The name of the repository to filter results by.
+	Repository *string `form:"repository,omitempty" json:"repository,omitempty"`
 }
 
 // CreateCertificateSigningRequestJSONRequestBody defines body for CreateCertificateSigningRequest for application/json ContentType.

--- a/internal/api/client/client.gen.go
+++ b/internal/api/client/client.gen.go
@@ -3695,6 +3695,22 @@ func NewListResourceSyncRequest(server string, params *ListResourceSyncParams) (
 
 		}
 
+		if params.Repository != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "repository", runtime.ParamLocationQuery, *params.Repository); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 

--- a/internal/api/server/server.gen.go
+++ b/internal/api/server/server.gen.go
@@ -1979,6 +1979,14 @@ func (siw *ServerInterfaceWrapper) ListResourceSync(w http.ResponseWriter, r *ht
 		return
 	}
 
+	// ------------- Optional query parameter "repository" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "repository", r.URL.Query(), &params.Repository)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repository", Err: err})
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListResourceSync(w, r, params)
 	}))

--- a/internal/service/common.go
+++ b/internal/service/common.go
@@ -89,8 +89,8 @@ func ApplyJSONPatch[T any](ctx context.Context, obj T, newObj T, patchRequest v1
 	return decoder.Decode(&newObj)
 }
 
-// ConvertStatusFilterParamsToMap converts statusFilter query params to to a validated filterMap map.
-func ConvertStatusFilterParamsToMap(params []string) (map[string][]string, error) {
+// ConvertFieldFilterParamsToMap converts filter query params to to a validated filterMap map.
+func ConvertFieldFilterParamsToMap(params []string) (map[string][]string, error) {
 	fieldMap := make(map[string][]string)
 	if len(params) == 0 {
 		return fieldMap, nil
@@ -132,11 +132,11 @@ func validateFieldKey(key string) (string, error) {
 	return key, nil
 }
 
-// validateFieldValue validates a field value. Valid characters are [a-zA-Z0-9,]
+// validateFieldValue validates a field value. Valid characters are [a-zA-Z0-9,-.]
 func validateFieldValue(value string) (string, error) {
 	value = strings.TrimSpace(value)
 	for _, char := range value {
-		if !unicode.IsLetter(char) && !unicode.IsDigit(char) && char != ',' {
+		if !unicode.IsLetter(char) && !unicode.IsDigit(char) && char != ',' && char != '-' && char != '.' {
 			return "", fmt.Errorf("%w: %s", ErrorInvalidFieldValue, value)
 		}
 	}

--- a/internal/service/common_test.go
+++ b/internal/service/common_test.go
@@ -9,40 +9,47 @@ import (
 func TestConvertSelectorToFieldsMap(t *testing.T) {
 	require := require.New(t)
 	tests := []struct {
-		name         string
-		statusFilter []string
-		want         map[string][]string
-		wantErr      error
+		name        string
+		fieldFilter []string
+		want        map[string][]string
+		wantErr     error
 	}{
 		{
-			name:         "valid key and value",
-			statusFilter: []string{"example.key=value"},
+			name:        "valid key and value",
+			fieldFilter: []string{"example.key=value"},
 			want: map[string][]string{
 				"example.key": {"value"},
 			},
 		},
 		{
-			name:         "valid key and value whitespace",
-			statusFilter: []string{" example.key=value "},
+			name:        "valid key and value whitespace",
+			fieldFilter: []string{" example.key=value "},
 			want: map[string][]string{
 				"example.key": {"value"},
 			},
 		},
 		{
-			name:         "invalid key",
-			statusFilter: []string{"example/key=value"},
-			want:         nil,
-			wantErr:      ErrorInvalidFieldKey,
+			name:        "valid value with hyphen and dot",
+			fieldFilter: []string{"example.key=val-u.e"},
+			want: map[string][]string{
+				"example.key": {"val-u.e"},
+			},
 		},
 		{
-			name:         "invalid value",
-			statusFilter: []string{"example.key=value_"},
-			want:         nil,
-			wantErr:      ErrorInvalidFieldValue,
+			name:        "invalid key",
+			fieldFilter: []string{"example/key=value"},
+			want:        nil,
+			wantErr:     ErrorInvalidFieldKey,
+		},
+		{
+			name:        "invalid value",
+			fieldFilter: []string{"example.key=value_"},
+			want:        nil,
+			wantErr:     ErrorInvalidFieldValue,
 		},
 		{
 			name: "valid key with multiple values",
-			statusFilter: []string{
+			fieldFilter: []string{
 				"example.key=value1",
 				"example.key=value2",
 				"example.key=value3",
@@ -53,7 +60,7 @@ func TestConvertSelectorToFieldsMap(t *testing.T) {
 		},
 		{
 			name: "multiple key value pairs",
-			statusFilter: []string{
+			fieldFilter: []string{
 				"example.key=value1",
 				"example.key=value2",
 				"example.key=value3",
@@ -67,7 +74,7 @@ func TestConvertSelectorToFieldsMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConvertStatusFilterParamsToMap(tt.statusFilter)
+			got, err := ConvertFieldFilterParamsToMap(tt.fieldFilter)
 			if tt.wantErr != nil {
 				require.ErrorIs(err, tt.wantErr)
 				return

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -68,7 +68,9 @@ func (h *ServiceHandler) ListDevices(ctx context.Context, request server.ListDev
 	}
 	statusFilter := []string{}
 	if request.Params.StatusFilter != nil {
-		statusFilter = *request.Params.StatusFilter
+		for _, filter := range *request.Params.StatusFilter {
+			statusFilter = append(statusFilter, fmt.Sprintf("status.%s", filter))
+		}
 	}
 
 	labelMap, err := labels.ConvertSelectorToLabelsMap(labelSelector)
@@ -76,7 +78,7 @@ func (h *ServiceHandler) ListDevices(ctx context.Context, request server.ListDev
 		return server.ListDevices400JSONResponse{Message: err.Error()}, nil
 	}
 
-	filterMap, err := ConvertStatusFilterParamsToMap(statusFilter)
+	filterMap, err := ConvertFieldFilterParamsToMap(statusFilter)
 	if err != nil {
 		return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to convert status filter: %v", err)}, nil
 	}

--- a/internal/service/resourcesync.go
+++ b/internal/service/resourcesync.go
@@ -70,6 +70,15 @@ func (h *ServiceHandler) ListResourceSync(ctx context.Context, request server.Li
 		return server.ListResourceSync400JSONResponse{Message: fmt.Sprintf("limit cannot exceed %d", store.MaxRecordsPerListRequest)}, nil
 	}
 
+	if request.Params.Repository != nil {
+		specFilter := []string{fmt.Sprintf("spec.repository=%s", *request.Params.Repository)}
+		filterMap, err := ConvertFieldFilterParamsToMap(specFilter)
+		if err != nil {
+			return server.ListResourceSync400JSONResponse{Message: fmt.Sprintf("failed to convert repository filter: %v", err)}, nil
+		}
+		listParams.Filter = filterMap
+	}
+
 	result, err := h.store.ResourceSync().List(ctx, orgId, listParams)
 	switch err {
 	case nil:

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -29,7 +29,7 @@ func BuildBaseListQuery(query *gorm.DB, orgId uuid.UUID, listParams ListParams) 
 		invertLabels = true
 	}
 	query = LabelSelectionQuery(query, listParams.Labels, invertLabels)
-	query = StatusFilterSelectionQuery(query, listParams.Filter)
+	query = FieldFilterSelectionQuery(query, listParams.Filter)
 
 	queryStr, args := createOrQuery("owner", listParams.Owners)
 	if len(queryStr) > 0 {
@@ -114,11 +114,12 @@ func LabelSelectionQuery(query *gorm.DB, labels map[string]string, inverse bool)
 	return query.Where(queryString, arrayValues...)
 }
 
-// StatusFilterSelectionQuery takes a GORM DB query and a map of search parameters. To search for a key-value pair in the
+// FieldFilterSelectionQuery takes a GORM DB query and a map of search parameters. To search for a key-value pair in the
 // in a JSON object use the key to reflect location in the JSON data and the value to reflect the value to search for.
-// example map[string]string{"config.summary.status": "UpToDate"} will search config.summary.status for for the value "UpToDate".
+// example map[string]string{"status.config.summary.status": "UpToDate"} will search status.config.summary.status for the
+// value "UpToDate".
 // To search for multiple values in the same field, separate the values with a comma.
-func StatusFilterSelectionQuery(query *gorm.DB, fieldMap map[string][]string) *gorm.DB {
+func FieldFilterSelectionQuery(query *gorm.DB, fieldMap map[string][]string) *gorm.DB {
 	queryStr, args := createQueryFromFilterMap(fieldMap)
 	if len(queryStr) > 0 {
 		query = query.Where(queryStr, args...)
@@ -154,9 +155,11 @@ func createQueryFromFilterMap(fieldMap map[string][]string) (string, []interface
 
 func createParamsFromKey(key string) string {
 	parts := strings.Split(key, ".")
-	params := "status"
+	params := ""
 	for i, part := range parts {
-		if i == len(parts)-1 {
+		if i == 0 {
+			params += part
+		} else if i == len(parts)-1 {
 			// prefix last part with the ->> operator for JSONB fetching text
 			params += fmt.Sprintf(" ->> '%s'", part)
 		} else {

--- a/internal/store/common_test.go
+++ b/internal/store/common_test.go
@@ -35,21 +35,21 @@ func TestCreateQueryFromFilterMap(t *testing.T) {
 		},
 		{
 			name:          "single field",
-			fieldMap:      map[string][]string{"status": {"active"}},
+			fieldMap:      map[string][]string{"status.status": {"active"}},
 			expectedQuery: []string{"status ->> 'status' = ?"},
 			expectedArgs:  []interface{}{"active"},
 		},
 		{
 			name:          "nested fields",
-			fieldMap:      map[string][]string{"device.status": {"active"}},
+			fieldMap:      map[string][]string{"status.device.status": {"active"}},
 			expectedQuery: []string{"status -> 'device' ->> 'status' = ?"},
 			expectedArgs:  []interface{}{"active"},
 		},
 		{
 			name: "nested fields multiple values",
 			fieldMap: map[string][]string{
-				"updated.status":              {"UpToDate", "OutOfDate"},
-				"applications.summary.status": {"Degraded"},
+				"status.updated.status":              {"UpToDate", "OutOfDate"},
+				"status.applications.summary.status": {"Degraded"},
 			},
 			expectedQuery: []string{
 				"status -> 'updated' ->> 'status' = ?",

--- a/internal/store/model/certificatesigningrequest.go
+++ b/internal/store/model/certificatesigningrequest.go
@@ -20,10 +20,10 @@ type CertificateSigningRequest struct {
 	Resource
 
 	// The desired state of the enrollment request, stored as opaque JSON object.
-	Spec *JSONField[api.CertificateSigningRequestSpec]
+	Spec *JSONField[api.CertificateSigningRequestSpec] `gorm:"type:jsonb"`
 
 	// The last reported state of the enrollment request, stored as opaque JSON object.
-	Status *JSONField[api.CertificateSigningRequestStatus]
+	Status *JSONField[api.CertificateSigningRequestStatus] `gorm:"type:jsonb"`
 }
 
 type CertificateSigningRequestList []CertificateSigningRequest

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -24,7 +24,7 @@ type Device struct {
 	Resource
 
 	// The desired state, stored as opaque JSON object.
-	Spec *JSONField[api.DeviceSpec]
+	Spec *JSONField[api.DeviceSpec] `gorm:"type:jsonb"`
 
 	// The last reported state, stored as opaque JSON object.
 	Status *JSONField[api.DeviceStatus] `gorm:"type:jsonb"`

--- a/internal/store/model/enrollmentrequest.go
+++ b/internal/store/model/enrollmentrequest.go
@@ -20,10 +20,10 @@ type EnrollmentRequest struct {
 	Resource
 
 	// The desired state of the enrollment request, stored as opaque JSON object.
-	Spec *JSONField[api.EnrollmentRequestSpec]
+	Spec *JSONField[api.EnrollmentRequestSpec] `gorm:"type:jsonb"`
 
 	// The last reported state of the enrollment request, stored as opaque JSON object.
-	Status *JSONField[api.EnrollmentRequestStatus]
+	Status *JSONField[api.EnrollmentRequestStatus] `gorm:"type:jsonb"`
 }
 
 type EnrollmentRequestList []EnrollmentRequest

--- a/internal/store/model/fleet.go
+++ b/internal/store/model/fleet.go
@@ -22,10 +22,10 @@ type Fleet struct {
 	Resource
 
 	// The desired state, stored as opaque JSON object.
-	Spec *JSONField[api.FleetSpec]
+	Spec *JSONField[api.FleetSpec] `gorm:"type:jsonb"`
 
 	// The last reported state, stored as opaque JSON object.
-	Status *JSONField[api.FleetStatus]
+	Status *JSONField[api.FleetStatus] `gorm:"type:jsonb"`
 
 	// Join table with the relationship of fleets to repositories
 	Repositories []Repository `gorm:"many2many:fleet_repos;constraint:OnDelete:CASCADE;"`

--- a/internal/store/model/repository.go
+++ b/internal/store/model/repository.go
@@ -20,10 +20,10 @@ type Repository struct {
 	Resource
 
 	// The desired state, stored as opaque JSON object.
-	Spec *JSONField[api.RepositorySpec]
+	Spec *JSONField[api.RepositorySpec] `gorm:"type:jsonb"`
 
 	// The last reported state, stored as opaque JSON object.
-	Status *JSONField[api.RepositoryStatus]
+	Status *JSONField[api.RepositoryStatus] `gorm:"type:jsonb"`
 
 	// Join table with the relationship of repository to fleets
 	Fleets []Fleet `gorm:"many2many:fleet_repos;constraint:OnDelete:CASCADE;"`

--- a/internal/store/model/resourcesync.go
+++ b/internal/store/model/resourcesync.go
@@ -20,10 +20,10 @@ type ResourceSync struct {
 	Resource
 
 	// The desired state, stored as opaque JSON object.
-	Spec *JSONField[api.ResourceSyncSpec]
+	Spec *JSONField[api.ResourceSyncSpec] `gorm:"type:jsonb"`
 
 	// The last reported state, stored as opaque JSON object.
-	Status *JSONField[api.ResourceSyncStatus]
+	Status *JSONField[api.ResourceSyncStatus] `gorm:"type:jsonb"`
 }
 
 type ResourceSyncList []ResourceSync

--- a/internal/store/model/templateversion.go
+++ b/internal/store/model/templateversion.go
@@ -34,10 +34,10 @@ type TemplateVersion struct {
 	DeletedAt       gorm.DeletedAt `gorm:"index"`
 
 	// The desired state, stored as opaque JSON object.
-	Spec *JSONField[api.TemplateVersionSpec]
+	Spec *JSONField[api.TemplateVersionSpec] `gorm:"type:jsonb"`
 
 	// The last reported state, stored as opaque JSON object.
-	Status *JSONField[api.TemplateVersionStatus]
+	Status *JSONField[api.TemplateVersionStatus] `gorm:"type:jsonb"`
 
 	// An indication if this version is valid. It exposed in a Condition but easier to query here.
 	Valid *bool

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -277,7 +277,7 @@ var _ = Describe("DeviceStore create", func() {
 		It("List with status field filter paging", func() {
 			listParams := store.ListParams{
 				Filter: map[string][]string{
-					"updated.status": {"Unknown", "Updating"},
+					"status.updated.status": {"Unknown", "Updating"},
 				},
 				Limit: 1000,
 			}


### PR DESCRIPTION
This commit adds a filter allowing listing resourcesyncs by repository. This is needed by the UI.

The changes are:
1. Make the current status filter logic generic so that it can also filter specs.
2. Add the repository filter, internally implemented by the above filter logic.
3. Ensure that all specs and statuses are jasonb rather than bytea so that the filters work properly.