### PR TITLE
 NO-ISSUE:  Add support for builtin hooks

### DIFF
--- a/internal/agent/client/podman_compose.go
+++ b/internal/agent/client/podman_compose.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const podmanCommandDuration = time.Minute
+
+func PodmanComposeUp(ctx context.Context, path string, exec executer.Executer, _ *log.PrefixLogger) error {
+	ctx, cancel := context.WithTimeout(ctx, podmanCommandDuration)
+	defer cancel()
+
+	_, stderr, exitCode := exec.ExecuteWithContext(ctx, "podman-compose", "-f", path, "up", "-d")
+	if exitCode != 0 {
+		return fmt.Errorf("podman-compose up hook for path %s failed with exitCode %d: %s", path, exitCode, stderr)
+	}
+	return nil
+}
+
+func PodmanComposeDown(ctx context.Context, path string, exec executer.Executer, log *log.PrefixLogger) error {
+	ctx, cancel := context.WithTimeout(ctx, podmanCommandDuration)
+	defer cancel()
+
+	_, stderr, exitCode := exec.ExecuteWithContext(ctx, "podman-compose", "-f", path, "down")
+	if exitCode == 0 {
+		return nil
+	}
+	_, err := os.Stat(path)
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("podman-compose down failed for existing path %s with exit code %d: %s", path, exitCode, stderr)
+	}
+	psStdout, psStderr, psExitCode := exec.ExecuteWithContext(ctx, "podman", "ps", "-a", "--format=json")
+	if psExitCode != 0 {
+		log.Errorf("podman ps --all failed: %s", psStderr)
+		return fmt.Errorf("podman-compose down failed for path %s with exit code %d: %s", path, exitCode, stderr)
+	}
+	type psRecord struct {
+		Labels map[string]string `json:"Labels"`
+	}
+	var psRecords []psRecord
+	if err = json.Unmarshal([]byte(psStdout), &psRecords); err != nil {
+		log.WithError(err).Errorf("json unmarshal failed:")
+		return fmt.Errorf("podman-compose down failed for path %s with exit code %d: %s", path, exitCode, stderr)
+	}
+
+	for _, p := range psRecords {
+		if p.Labels != nil && p.Labels["com.docker.compose.project.config_files"] == path {
+			return fmt.Errorf("podman-compose down failed for path %s but container created by compose file exists: %s", path, stderr)
+		}
+	}
+	return nil
+}

--- a/internal/agent/device/hook/default_hooks.go
+++ b/internal/agent/device/hook/default_hooks.go
@@ -2,7 +2,7 @@ package hook
 
 import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/internal/agent/client"
 )
 
 func marshalExecutable(run string, envVars *[]string, workDir string, timeout string) v1alpha1.HookAction {
@@ -19,55 +19,52 @@ func marshalExecutable(run string, envVars *[]string, workDir string, timeout st
 	return ret
 }
 
-func defaultAfterUpdateHooks() []v1alpha1.DeviceUpdateHookSpec {
-	return []v1alpha1.DeviceUpdateHookSpec{
+func executableActionFactory(run string, envVars *[]string, workDir string, timeout string) ActionHookFactory {
+	return newApiHookActionFactory(marshalExecutable(run, envVars, workDir, timeout))
+}
+
+func defaultAfterUpdateHooks() []HookDefinition {
+	return []HookDefinition{
 		{
-			Name:        util.StrToPtr("podman compose up"),
-			Path:        util.StrToPtr("/var/run/flightctl/compose"),
-			Description: util.StrToPtr("Bring up a multi-container system based on the provided YAML podman-compose definition file"),
-			OnFile:      &[]v1alpha1.FileOperation{v1alpha1.FileOperationCreate, v1alpha1.FileOperationUpdate, v1alpha1.FileOperationReboot},
-			Actions: []v1alpha1.HookAction{
-				marshalExecutable("podman-compose -f {{ .FilePath }} up -d", nil,
-					"/var/run/flightctl/compose", "1m"),
+			name:        "podman compose up",
+			path:        "/var/run/flightctl/compose",
+			description: "Bring up a multi-container system based on the provided YAML podman-compose definition file",
+			ops:         []v1alpha1.FileOperation{v1alpha1.FileOperationCreate, v1alpha1.FileOperationUpdate, v1alpha1.FileOperationReboot},
+			actionHooks: []ActionHookFactory{
+				builtinHookFactory(client.PodmanComposeUp),
 			},
 		},
 		{
-			Name:        util.StrToPtr("microshift manifest up"),
-			Path:        util.StrToPtr("/var/usr/klusterlet-manifests"),
-			Description: util.StrToPtr("Apply the provided microshift manifest"),
-			OnFile:      &[]v1alpha1.FileOperation{v1alpha1.FileOperationCreate, v1alpha1.FileOperationUpdate},
-			Actions: []v1alpha1.HookAction{
-				marshalExecutable("kubectl apply -f {{ .FilePath }}", &[]string{"KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig"},
+			name:        "microshift manifest up",
+			path:        "/var/usr/klusterlet-manifests",
+			description: "Apply the provided microshift manifest",
+			ops:         []v1alpha1.FileOperation{v1alpha1.FileOperationCreate, v1alpha1.FileOperationUpdate},
+			actionHooks: []ActionHookFactory{
+				executableActionFactory("kubectl apply -f {{ .FilePath }}", &[]string{"KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig"},
 					"/var/usr/klusterlet-manifests", "1m"),
 			},
 		},
 	}
 }
 
-func defaultBeforeUpdateHooks() []v1alpha1.DeviceUpdateHookSpec {
-	return []v1alpha1.DeviceUpdateHookSpec{
+func defaultBeforeUpdateHooks() []HookDefinition {
+	return []HookDefinition{
 		{
-			Name:        util.StrToPtr("podman compose down"),
-			Path:        util.StrToPtr("/var/run/flightctl/compose"),
-			Description: util.StrToPtr("Bring down a multi-container system based on the provided YAML podman-compose definition file"),
-			OnFile:      &[]v1alpha1.FileOperation{v1alpha1.FileOperationUpdate, v1alpha1.FileOperationRemove},
-			Actions: []v1alpha1.HookAction{
-				marshalExecutable(`output=$(podman-compose -f {{ .FilePath }} down 2>&1); exit_code=$? ; \
-										if [[ $exit_code -eq 0 ]] || ( [[ ! -f {{ .FilePath }} ]] && \
-                                            ! ( podman ps -a --format=json | jq -r '.[] | .Labels."com.docker.compose.project.config_files"' | grep -q  -E '^{{ .FilePath }}$' )) ; then  \ 
-											exit 0; \
-										fi ; \
-										echo "$output" 1>&2 && exit $exit_code`, nil,
-					"/var/run/flightctl/compose", "1m"),
+			name:        "podman compose down",
+			path:        "/var/run/flightctl/compose",
+			description: "Bring down a multi-container system based on the provided YAML podman-compose definition file",
+			ops:         []v1alpha1.FileOperation{v1alpha1.FileOperationUpdate, v1alpha1.FileOperationRemove},
+			actionHooks: []ActionHookFactory{
+				builtinHookFactory(client.PodmanComposeDown),
 			},
 		},
 		{
-			Name:        util.StrToPtr("microshift manifest down"),
-			Path:        util.StrToPtr("/var/usr/klusterlet-manifests"),
-			Description: util.StrToPtr("Delete the provided microshift manifest"),
-			OnFile:      &[]v1alpha1.FileOperation{v1alpha1.FileOperationRemove},
-			Actions: []v1alpha1.HookAction{
-				marshalExecutable("kubectl delete -f {{ .FileName }}", &[]string{"KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig"},
+			name:        "microshift manifest down",
+			path:        "/var/usr/klusterlet-manifests",
+			description: "Delete the provided microshift manifest",
+			ops:         []v1alpha1.FileOperation{v1alpha1.FileOperationRemove},
+			actionHooks: []ActionHookFactory{
+				executableActionFactory("kubectl delete -f {{ .FileName }}", &[]string{"KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig"},
 					"/var/usr/klusterlet-manifests", "1m"),
 			},
 		},

--- a/internal/agent/device/hook/mock_manager.go
+++ b/internal/agent/device/hook/mock_manager.go
@@ -14,6 +14,8 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/flightctl/flightctl/api/v1alpha1"
+	executer "github.com/flightctl/flightctl/pkg/executer"
+	log "github.com/flightctl/flightctl/pkg/log"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -188,6 +190,44 @@ func (m *MockManager) Sync(current, desired *v1alpha1.RenderedDeviceSpec) error 
 func (mr *MockManagerMockRecorder) Sync(current, desired any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), current, desired)
+}
+
+// MockActionHookFactory is a mock of ActionHookFactory interface.
+type MockActionHookFactory struct {
+	ctrl     *gomock.Controller
+	recorder *MockActionHookFactoryMockRecorder
+}
+
+// MockActionHookFactoryMockRecorder is the mock recorder for MockActionHookFactory.
+type MockActionHookFactoryMockRecorder struct {
+	mock *MockActionHookFactory
+}
+
+// NewMockActionHookFactory creates a new mock instance.
+func NewMockActionHookFactory(ctrl *gomock.Controller) *MockActionHookFactory {
+	mock := &MockActionHookFactory{ctrl: ctrl}
+	mock.recorder = &MockActionHookFactoryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockActionHookFactory) EXPECT() *MockActionHookFactoryMockRecorder {
+	return m.recorder
+}
+
+// Create mocks base method.
+func (m *MockActionHookFactory) Create(exec executer.Executer, log *log.PrefixLogger) (ActionHook, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", exec, log)
+	ret0, _ := ret[0].(ActionHook)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockActionHookFactoryMockRecorder) Create(exec, log any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockActionHookFactory)(nil).Create), exec, log)
 }
 
 // MockActionHook is a mock of ActionHook interface.


### PR DESCRIPTION
   
    
    Add support for builtin hooks in addition to the existing support of api
    hooks.
    The builtin hooks are actualy functions that perform specific task.
    This PR changes the implementation of podman-compose up and
    podman-compose down to use builtin hooks

