### PR TITLE
EDM-373: Spec Manager Test Coverage

### DIFF
--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -20,9 +20,9 @@ import (
 
 var (
 	ErrMissingRenderedSpec = fmt.Errorf("missing rendered spec")
+	ErrReadingRenderedSpec = fmt.Errorf("reading rendered spec")
+	ErrWritingRenderedSpec = fmt.Errorf("writing rendered spec")
 	ErrNoContent           = fmt.Errorf("no content")
-	ErrReadingSpec         = fmt.Errorf("reading spec")
-	ErrWritingSpec         = fmt.Errorf("writing spec")
 	ErrCheckingFileExists  = fmt.Errorf("checking if file exists")
 	ErrUnmarshalSpec       = fmt.Errorf("unmarshalling spec")
 )
@@ -229,7 +229,7 @@ func (s *SpecManager) Read(specType Type) (*v1alpha1.RenderedDeviceSpec, error) 
 	}
 	spec, err := readRenderedSpecFromFile(s.deviceReadWriter, filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading %s: %w", specType, err)
 	}
 	return spec, nil
 }
@@ -331,7 +331,7 @@ func (s *SpecManager) write(specType Type, spec *v1alpha1.RenderedDeviceSpec) er
 
 	err = writeRenderedToFile(s.deviceReadWriter, spec, filePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("writing %s: %w", specType, err)
 	}
 	return nil
 }
@@ -419,7 +419,7 @@ func readRenderedSpecFromFile(
 			// if the file does not exist, this means it has been removed/corrupted
 			return nil, fmt.Errorf("%w: reading %q: %w", ErrMissingRenderedSpec, filePath, err)
 		}
-		return nil, fmt.Errorf("%w: reading %q: %w", ErrReadingSpec, filePath, err)
+		return nil, fmt.Errorf("%w: reading %q: %w", ErrReadingRenderedSpec, filePath, err)
 	}
 
 	// read bytes from file
@@ -436,7 +436,7 @@ func writeRenderedToFile(writer fileio.Writer, rendered *v1alpha1.RenderedDevice
 		return err
 	}
 	if err := writer.WriteFile(filePath, renderedBytes, fileio.DefaultFilePermissions); err != nil {
-		return fmt.Errorf("%w: writing to %q: %w", ErrWritingSpec, filePath, err)
+		return fmt.Errorf("%w: writing to %q: %w", ErrWritingRenderedSpec, filePath, err)
 	}
 	return nil
 }

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -331,7 +331,7 @@ func (s *SpecManager) write(specType Type, spec *v1alpha1.RenderedDeviceSpec) er
 
 	err = writeRenderedToFile(s.deviceReadWriter, spec, filePath)
 	if err != nil {
-		return fmt.Errorf("%w: %s: %w", ErrWritingSpec, specType, err)
+		return err
 	}
 	return nil
 }
@@ -417,9 +417,9 @@ func readRenderedSpecFromFile(
 	if err != nil {
 		if os.IsNotExist(err) {
 			// if the file does not exist, this means it has been removed/corrupted
-			return nil, fmt.Errorf("%w: reading %s: %w", ErrMissingRenderedSpec, filePath, err)
+			return nil, fmt.Errorf("%w: reading %q: %w", ErrMissingRenderedSpec, filePath, err)
 		}
-		return nil, fmt.Errorf("%w: reading %s: %w", ErrReadingSpec, filePath, err)
+		return nil, fmt.Errorf("%w: reading %q: %w", ErrReadingSpec, filePath, err)
 	}
 
 	// read bytes from file
@@ -436,7 +436,7 @@ func writeRenderedToFile(writer fileio.Writer, rendered *v1alpha1.RenderedDevice
 		return err
 	}
 	if err := writer.WriteFile(filePath, renderedBytes, fileio.DefaultFilePermissions); err != nil {
-		return fmt.Errorf("write default device spec file %q: %w", filePath, err)
+		return fmt.Errorf("%w: writing to %q: %w", ErrWritingSpec, filePath, err)
 	}
 	return nil
 }

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -25,6 +25,7 @@ var (
 	ErrNoContent           = fmt.Errorf("no content")
 	ErrCheckingFileExists  = fmt.Errorf("checking if file exists")
 	ErrUnmarshalSpec       = fmt.Errorf("unmarshalling spec")
+	ErrGettingBootcStatus  = fmt.Errorf("getting current bootc status")
 )
 
 type Type string
@@ -172,11 +173,11 @@ func (s *SpecManager) IsRollingBack(ctx context.Context) (bool, error) {
 func (s *SpecManager) Upgrade() error {
 	desired, err := s.Read(Desired)
 	if err != nil {
-		return fmt.Errorf("read current rendered spec: %w", err)
+		return err
 	}
 
 	if err := s.write(Current, desired); err != nil {
-		return fmt.Errorf("write current rendered spec: %w", err)
+		return err
 	}
 
 	s.log.Infof("Spec upgrade complete: clearing rollback spec")
@@ -307,7 +308,7 @@ func (s *SpecManager) IsOSUpdate() (bool, error) {
 func (s *SpecManager) CheckOsReconciliation(ctx context.Context) (string, bool, error) {
 	bootc, err := s.bootcClient.Status(ctx)
 	if err != nil {
-		return "", false, fmt.Errorf("getting current bootc status: %w", err)
+		return "", false, fmt.Errorf("%w: %w", ErrGettingBootcStatus, err)
 	}
 	bootedOSImage := bootc.GetBootedImage()
 

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -229,7 +229,7 @@ func TestRead(t *testing.T) {
 		deviceReadWriter: mockReadWriter,
 	}
 
-	t.Run("bubbles up errors from readRenderedSpecFromFile", func(t *testing.T) {
+	t.Run("ensure proper error handling on read failure", func(t *testing.T) {
 		mockReadWriter.EXPECT().ReadFile(gomock.Any()).Return(nil, errors.New("read gone wrong"))
 		_, err := s.Read(Current)
 		require.ErrorIs(err, ErrReadingRenderedSpec)
@@ -262,7 +262,7 @@ func Test_readRenderedSpecFromFile(t *testing.T) {
 		require.ErrorIs(err, ErrMissingRenderedSpec)
 	})
 
-	t.Run("error reading file returns an error containing the file path", func(t *testing.T) {
+	t.Run("error reading file when it does exist", func(t *testing.T) {
 		mockReader.EXPECT().ReadFile(filePath).Return(nil, errors.New("cannot read"))
 
 		_, err := readRenderedSpecFromFile(mockReader, filePath)

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -289,11 +289,282 @@ func Test_readRenderedSpecFromFile(t *testing.T) {
 	})
 }
 
+func Test_writeRenderedToFile(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWriter := fileio.NewMockWriter(ctrl)
+	filePath := "path/to/write"
+	spec := createRenderedTestSpec("test-image")
+
+	marshaled, err := json.Marshal(spec)
+	require.NoError(err)
+
+	t.Run("returns an error when the write fails", func(t *testing.T) {
+		writeErr := errors.New("some failure")
+		mockWriter.EXPECT().WriteFile(filePath, marshaled, fileio.DefaultFilePermissions).Return(writeErr)
+
+		err = writeRenderedToFile(mockWriter, spec, filePath)
+		require.ErrorIs(err, ErrWritingRenderedSpec)
+	})
+
+	t.Run("writes a rendered spec", func(t *testing.T) {
+		mockWriter.EXPECT().WriteFile(filePath, marshaled, fileio.DefaultFilePermissions).Return(nil)
+
+		err = writeRenderedToFile(mockWriter, spec, filePath)
+		require.NoError(err)
+	})
+}
+
+func TestUpgrade(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	desiredPath := "test/desired.json"
+	currentPath := "test/current.json"
+	rollbackPath := "test/rollback/json"
+	s := &SpecManager{
+		log:              log.NewPrefixLogger("test"),
+		deviceReadWriter: mockReadWriter,
+		desiredPath:      desiredPath,
+		currentPath:      currentPath,
+		rollbackPath:     rollbackPath,
+	}
+
+	specErr := errors.New("error with spec")
+
+	emptySpec, err := createEmptyTestSpec()
+	require.NoError(err)
+
+	t.Run("error reading desired spec", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(nil, specErr)
+
+		err := s.Upgrade()
+		require.ErrorIs(err, ErrReadingRenderedSpec)
+	})
+
+	t.Run("error writing desired spec to current", func(t *testing.T) {
+		desiredSpec, err := createTestSpec("flightctl-device:v2")
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+		mockReadWriter.EXPECT().WriteFile(currentPath, desiredSpec, gomock.Any()).Return(specErr)
+
+		err = s.Upgrade()
+		require.ErrorIs(err, ErrWritingRenderedSpec)
+	})
+
+	t.Run("error writing the rollback spec", func(t *testing.T) {
+		desiredSpec, err := createTestSpec("flightctl-device:v2")
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+		mockReadWriter.EXPECT().WriteFile(currentPath, desiredSpec, gomock.Any()).Return(nil)
+		mockReadWriter.EXPECT().WriteFile(rollbackPath, emptySpec, gomock.Any()).Return(specErr)
+
+		err = s.Upgrade()
+		require.ErrorIs(err, ErrWritingRenderedSpec)
+	})
+
+	t.Run("clears out the rollback spec", func(t *testing.T) {
+		desiredSpec, err := createTestSpec("flightctl-device:v2")
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+		mockReadWriter.EXPECT().WriteFile(currentPath, desiredSpec, gomock.Any()).Return(nil)
+		mockReadWriter.EXPECT().WriteFile(rollbackPath, emptySpec, gomock.Any()).Return(nil)
+
+		err = s.Upgrade()
+		require.NoError(err)
+	})
+}
+
+func TestIsOSUpdate(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	desiredPath := "test/desired.json"
+	currentPath := "test/current.json"
+	s := &SpecManager{
+		log:              log.NewPrefixLogger("test"),
+		deviceReadWriter: mockReadWriter,
+		desiredPath:      desiredPath,
+		currentPath:      currentPath,
+	}
+
+	emptySpec, err := createEmptyTestSpec()
+	require.NoError(err)
+
+	specErr := errors.New("error with spec")
+
+	t.Run("error reading current spec", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(currentPath).Return(nil, specErr)
+
+		_, err := s.IsOSUpdate()
+		require.ErrorIs(err, ErrReadingRenderedSpec)
+	})
+
+	t.Run("error reading desired spec", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(currentPath).Return(emptySpec, nil)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(nil, specErr)
+
+		_, err := s.IsOSUpdate()
+		require.ErrorIs(err, ErrReadingRenderedSpec)
+	})
+
+	t.Run("both specs are empty", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(currentPath).Return(emptySpec, nil)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(emptySpec, nil)
+
+		osUpdate, err := s.IsOSUpdate()
+		require.NoError(err)
+		require.Equal(false, osUpdate)
+	})
+
+	t.Run("current and desired os images are the same", func(t *testing.T) {
+		image := "flightctl-device:v2"
+
+		currentSpec, err := createTestSpec(image)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(currentPath).Return(currentSpec, nil)
+
+		desiredSpec, err := createTestSpec(image)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+
+		osUpdate, err := s.IsOSUpdate()
+		require.NoError(err)
+		require.Equal(false, osUpdate)
+	})
+
+	t.Run("current and desired os images are different", func(t *testing.T) {
+		currentImage := "flightctl-device:v2"
+		desiredImage := "flightctl-deivce:v3"
+
+		currentSpec, err := createTestSpec(currentImage)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(currentPath).Return(currentSpec, nil)
+
+		desiredSpec, err := createTestSpec(desiredImage)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+
+		osUpdate, err := s.IsOSUpdate()
+		require.NoError(err)
+		require.Equal(true, osUpdate)
+	})
+}
+
+func TestCheckOsReconciliation(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+	mockBootcClient := container.NewMockBootcClient(ctrl)
+
+	desiredPath := "test/desired.json"
+	s := &SpecManager{
+		log:              log.NewPrefixLogger("test"),
+		deviceReadWriter: mockReadWriter,
+		bootcClient:      mockBootcClient,
+		desiredPath:      desiredPath,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	emptySpec, err := json.Marshal(&v1alpha1.RenderedDeviceSpec{})
+	require.NoError(err)
+
+	t.Run("error getting bootc status", func(t *testing.T) {
+		bootcErr := errors.New("bootc problem")
+		mockBootcClient.EXPECT().Status(ctx).Return(nil, bootcErr)
+
+		_, _, err := s.CheckOsReconciliation(ctx)
+		require.ErrorIs(err, ErrGettingBootcStatus)
+	})
+
+	t.Run("error reading desired spec", func(t *testing.T) {
+		bootcStatus := &container.BootcHost{}
+		mockBootcClient.EXPECT().Status(ctx).Return(bootcStatus, nil)
+
+		readErr := errors.New("unable to read file")
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(emptySpec, readErr)
+
+		_, _, err = s.CheckOsReconciliation(ctx)
+		require.ErrorIs(err, ErrReadingRenderedSpec)
+	})
+
+	t.Run("desired os is not set in the spec", func(t *testing.T) {
+		bootedImage := "flightctl-device:v1"
+
+		bootcStatus := &container.BootcHost{}
+		bootcStatus.Status.Booted.Image.Image.Image = bootedImage
+		mockBootcClient.EXPECT().Status(ctx).Return(bootcStatus, nil)
+
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(emptySpec, nil)
+
+		bootedOSImage, desiredImageIsBooted, err := s.CheckOsReconciliation(ctx)
+		require.NoError(err)
+		require.Equal(bootedOSImage, bootedImage)
+		require.Equal(false, desiredImageIsBooted)
+	})
+
+	t.Run("booted image and desired image are different", func(t *testing.T) {
+		bootedImage := "flightctl-device:v1"
+		desiredImage := "flightctl-device:v2"
+
+		bootcStatus := &container.BootcHost{}
+		bootcStatus.Status.Booted.Image.Image.Image = bootedImage
+		mockBootcClient.EXPECT().Status(ctx).Return(bootcStatus, nil)
+
+		desiredSpec, err := createTestSpec(desiredImage)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+
+		bootedOSImage, desiredImageIsBooted, err := s.CheckOsReconciliation(ctx)
+		require.NoError(err)
+		require.Equal(bootedOSImage, bootedImage)
+		require.Equal(false, desiredImageIsBooted)
+	})
+
+	t.Run("booted image and desired image are the same", func(t *testing.T) {
+		image := "flightctl-device:v2"
+
+		bootcStatus := &container.BootcHost{}
+		bootcStatus.Status.Booted.Image.Image.Image = image
+		mockBootcClient.EXPECT().Status(ctx).Return(bootcStatus, nil)
+
+		desiredSpec, err := createTestSpec(image)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(desiredPath).Return(desiredSpec, nil)
+
+		bootedOSImage, desiredImageIsBooted, err := s.CheckOsReconciliation(ctx)
+		require.NoError(err)
+		require.Equal(bootedOSImage, image)
+		require.Equal(true, desiredImageIsBooted)
+	})
+}
+
 func createTestSpec(image string) ([]byte, error) {
+	spec := createRenderedTestSpec(image)
+	return json.Marshal(spec)
+}
+
+func createRenderedTestSpec(image string) *v1alpha1.RenderedDeviceSpec {
 	spec := v1alpha1.RenderedDeviceSpec{
 		Os: &v1alpha1.DeviceOSSpec{
 			Image: image,
 		},
 	}
-	return json.Marshal(spec)
+	return &spec
+}
+
+func createEmptyTestSpec() ([]byte, error) {
+	return json.Marshal(&v1alpha1.RenderedDeviceSpec{})
 }

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -188,7 +188,7 @@ func TestEnsure(t *testing.T) {
 	t.Run("error checking if file exists", func(t *testing.T) {
 		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, fileErr)
 		err := s.Ensure()
-		require.ErrorIs(err, fileErr)
+		require.ErrorIs(err, ErrCheckingFileExists)
 	})
 
 	t.Run("error writing file when it does not exist", func(t *testing.T) {

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -138,7 +138,7 @@ func TestInitialize(t *testing.T) {
 		// current
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 		err := s.Initialize()
-		require.ErrorContains(err, "writing current rendered spec:")
+		require.ErrorIs(err, writeErr)
 	})
 
 	t.Run("error writing desired file", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestInitialize(t *testing.T) {
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 
 		err := s.Initialize()
-		require.ErrorContains(err, "writing desired rendered spec:")
+		require.ErrorIs(err, writeErr)
 	})
 
 	t.Run("error writing rollback file", func(t *testing.T) {
@@ -160,7 +160,7 @@ func TestInitialize(t *testing.T) {
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 
 		err := s.Initialize()
-		require.ErrorContains(err, "writing rollback rendered spec:")
+		require.ErrorIs(err, writeErr)
 	})
 
 	t.Run("successful initialization", func(t *testing.T) {
@@ -182,19 +182,19 @@ func TestEnsure(t *testing.T) {
 		deviceReadWriter: mockReadWriter,
 	}
 
+	fileErr := errors.New("invalid file")
+
 	t.Run("error checking if file exists", func(t *testing.T) {
-		errMsg := "unable to check if file exists"
-		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, errors.New(errMsg))
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, fileErr)
 		err := s.Ensure()
-		require.ErrorContains(err, errMsg)
+		require.ErrorIs(err, fileErr)
 	})
 
 	t.Run("error writing file when it does not exist", func(t *testing.T) {
-		errMsg := "write failure"
 		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, nil)
-		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(errMsg))
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(fileErr)
 		err := s.Ensure()
-		require.ErrorContains(err, errMsg)
+		require.ErrorIs(err, fileErr)
 	})
 
 	t.Run("files are written when they don't exist", func(t *testing.T) {

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -3,6 +3,8 @@ package spec
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -11,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestBootstrapCheckRollback(t *testing.T) {
@@ -91,6 +94,126 @@ func TestBootstrapCheckRollback(t *testing.T) {
 		require.Equal(wantIsRollback, isRollback)
 	})
 
+}
+
+func TestNewManager(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+	mockBootcClient := container.NewMockBootcClient(ctrl)
+	logger := log.NewPrefixLogger("test")
+	backoff := wait.Backoff{}
+
+	t.Run("constructs file paths for the spec files", func(t *testing.T) {
+		manager := NewManager(
+			"device-name",
+			"test/directory/structure/",
+			mockReadWriter,
+			mockBootcClient,
+			backoff,
+			logger,
+		)
+
+		require.Equal("test/directory/structure/current.json", manager.currentPath)
+		require.Equal("test/directory/structure/desired.json", manager.desiredPath)
+		require.Equal("test/directory/structure/rollback.json", manager.rollbackPath)
+	})
+}
+
+func TestInitialize(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	s := &SpecManager{
+		deviceReadWriter: mockReadWriter,
+	}
+
+	writeErr := fmt.Errorf("write failure")
+
+	t.Run("error writing current file", func(t *testing.T) {
+		// current
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
+		err := s.Initialize()
+		require.ErrorContains(err, "writing current rendered spec:")
+	})
+
+	t.Run("error writing desired file", func(t *testing.T) {
+		// current
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		// desired
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
+
+		err := s.Initialize()
+		require.ErrorContains(err, "writing desired rendered spec:")
+	})
+
+	t.Run("error writing rollback file", func(t *testing.T) {
+		// current
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		// desired
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		// rollback
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
+
+		err := s.Initialize()
+		require.ErrorContains(err, "writing rollback rendered spec:")
+	})
+
+	t.Run("successful initialization", func(t *testing.T) {
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Times(3).Return(nil)
+		err := s.Initialize()
+		require.NoError(err)
+	})
+}
+
+func TestEnsure(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	s := &SpecManager{
+		log:              log.NewPrefixLogger("test"),
+		deviceReadWriter: mockReadWriter,
+	}
+
+	t.Run("error checking if file exists", func(t *testing.T) {
+		errMsg := "unable to check if file exists"
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, errors.New(errMsg))
+		err := s.Ensure()
+		require.ErrorContains(err, errMsg)
+	})
+
+	t.Run("error writing file when it does not exist", func(t *testing.T) {
+		errMsg := "write failure"
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, nil)
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(errMsg))
+		err := s.Ensure()
+		require.ErrorContains(err, errMsg)
+	})
+
+	t.Run("files are written when they don't exist", func(t *testing.T) {
+		// First two files checked exist
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Times(2).Return(true, nil)
+		// Third file does not exist, so then expect a write
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Times(1).Return(false, nil)
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		err := s.Ensure()
+		require.NoError(err)
+	})
+
+	t.Run("no files are written when they all exist", func(t *testing.T) {
+		mockReadWriter.EXPECT().FileExists(gomock.Any()).Times(3).Return(true, nil)
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		err := s.Ensure()
+		require.NoError(err)
+	})
 }
 
 func createTestSpec(image string) ([]byte, error) {

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -138,7 +138,8 @@ func TestInitialize(t *testing.T) {
 		// current
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 		err := s.Initialize()
-		require.ErrorIs(err, writeErr)
+
+		require.ErrorIs(err, ErrWritingSpec)
 	})
 
 	t.Run("error writing desired file", func(t *testing.T) {
@@ -148,7 +149,7 @@ func TestInitialize(t *testing.T) {
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 
 		err := s.Initialize()
-		require.ErrorIs(err, writeErr)
+		require.ErrorIs(err, ErrWritingSpec)
 	})
 
 	t.Run("error writing rollback file", func(t *testing.T) {
@@ -160,7 +161,7 @@ func TestInitialize(t *testing.T) {
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(writeErr)
 
 		err := s.Initialize()
-		require.ErrorIs(err, writeErr)
+		require.ErrorIs(err, ErrWritingSpec)
 	})
 
 	t.Run("successful initialization", func(t *testing.T) {
@@ -194,7 +195,7 @@ func TestEnsure(t *testing.T) {
 		mockReadWriter.EXPECT().FileExists(gomock.Any()).Return(false, nil)
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(fileErr)
 		err := s.Ensure()
-		require.ErrorIs(err, fileErr)
+		require.ErrorIs(err, ErrWritingSpec)
 	})
 
 	t.Run("files are written when they don't exist", func(t *testing.T) {

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -133,7 +132,7 @@ func TestInitialize(t *testing.T) {
 		deviceReadWriter: mockReadWriter,
 	}
 
-	writeErr := fmt.Errorf("write failure")
+	writeErr := errors.New("write failure")
 
 	t.Run("error writing current file", func(t *testing.T) {
 		// current


### PR DESCRIPTION
Continued enhancements for the spec manager tests.  Adds new defined/shared error types and adds tests for the following functionality:
- Reading / Writing spec files
- Upgrade
- IsOSUpdate
- CheckOsReconciliation