### PR TITLE
NO-ISSUE: agent: remove samber/lo as dep

### DIFF
--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -10,8 +10,8 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/hook"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
-	"github.com/samber/lo"
 )
 
 type Controller interface {
@@ -42,10 +42,10 @@ func NewController(
 }
 
 func (c *controller) Initialize(ctx context.Context, current *v1alpha1.RenderedDeviceSpec) {
-	if current == nil {
+	if current.Config == nil {
 		return
 	}
-	currentIgnition, err := parseAndConvertConfig(lo.FromPtr(current.Config))
+	currentIgnition, err := parseAndConvertConfig(*current.Config)
 	if err != nil {
 		c.log.Warnf("failed to parse current ignition: %+v", err)
 		return
@@ -62,7 +62,7 @@ func (c *controller) Sync(ctx context.Context, current, desired *v1alpha1.Render
 	// config
 	if desired.Config != nil {
 		c.log.Debug("syncing config data")
-		return c.ensureConfigData(ctx, lo.FromPtr(current.Config), lo.FromPtr(desired.Config))
+		return c.ensureConfigData(ctx, util.FromPtr(current.Config), util.FromPtr(desired.Config))
 	}
 
 	return nil
@@ -78,9 +78,22 @@ func parseAndConvertConfig(data string) (ignv3types.Config, error) {
 }
 
 func computeRemoval(currentFileList, desiredFileList []ignv3types.File) []string {
-	currentFiles := lo.Map(currentFileList, func(f ignv3types.File, _ int) string { return f.Path })
-	desiredFiles := lo.Map(desiredFileList, func(f ignv3types.File, _ int) string { return f.Path })
-	return lo.Without(currentFiles, desiredFiles...)
+	desiredFiles := getFilePaths(desiredFileList)
+	result := []string{}
+	desiredMap := make(map[string]bool)
+
+	for _, file := range desiredFiles {
+		desiredMap[file] = true
+	}
+
+	currentFiles := getFilePaths(currentFileList)
+	for _, file := range currentFiles {
+		if !desiredMap[file] {
+			result = append(result, file)
+		}
+	}
+
+	return result
 }
 
 func (c *controller) ensureConfigData(ctx context.Context, currentData, desiredData string) error {
@@ -157,4 +170,12 @@ func (c *controller) WriteIgnitionFiles(ctx context.Context, files []ignv3types.
 		}
 	}
 	return nil
+}
+
+func getFilePaths(currentFileList []ignv3types.File) []string {
+	result := make([]string, len(currentFileList))
+	for i, f := range currentFileList {
+		result[i] = f.Path
+	}
+	return result
 }

--- a/internal/agent/device/hook/actions.go
+++ b/internal/agent/device/hook/actions.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
-	"github.com/samber/lo"
 )
 
 const (
@@ -68,12 +68,12 @@ func (a *apiHookActionFactory) createExecutableActionHook(exec executer.Executer
 	if err != nil {
 		return nil, err
 	}
-	envVars := lo.FromPtr(spec.Executable.EnvVars)
+	envVars := util.FromPtr(spec.Executable.EnvVars)
 	if err = validateEnvVars(envVars); err != nil {
 		return nil, err
 	}
 	return newExecutableActionHook(spec.Executable.Run,
-		lo.FromPtr(spec.Executable.EnvVars),
+		util.FromPtr(spec.Executable.EnvVars),
 		exec,
 		actionTimeout,
 		spec.Executable.WorkDir,

--- a/internal/agent/device/hook/manager.go
+++ b/internal/agent/device/hook/manager.go
@@ -10,9 +10,9 @@ import (
 	"sync/atomic"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
-	"github.com/samber/lo"
 )
 
 var _ Manager = (*manager)(nil)
@@ -82,11 +82,11 @@ func (m *manager) createApiHookDefinition(hookSpec v1alpha1.DeviceUpdateHookSpec
 		actionHooks = append(actionHooks, newApiHookActionFactory(action))
 	}
 	return HookDefinition{
-		name:        lo.FromPtr(hookSpec.Name),
-		description: lo.FromPtr(hookSpec.Description),
+		name:        util.FromPtr(hookSpec.Name),
+		description: util.FromPtr(hookSpec.Description),
 		actionHooks: actionHooks,
-		ops:         lo.FromPtr(hookSpec.OnFile),
-		path:        lo.FromPtr(hookSpec.Path),
+		ops:         util.FromPtr(hookSpec.OnFile),
+		path:        util.FromPtr(hookSpec.Path),
 	}, nil
 }
 
@@ -134,18 +134,18 @@ func (m *manager) Sync(currentPtr, desiredPtr *v1alpha1.RenderedDeviceSpec) erro
 	m.log.Debug("Syncing hook manager")
 	defer m.log.Debug("Finished syncing hook manager")
 
-	current := lo.FromPtr(currentPtr)
-	desired := lo.FromPtr(desiredPtr)
+	current := util.FromPtr(currentPtr)
+	desired := util.FromPtr(desiredPtr)
 	if m.initialized.Load() && reflect.DeepEqual(current.Hooks, desired.Hooks) {
 		m.log.Debug("Hooks are equal. Nothing to update")
 		return nil
 	}
-	desiredHooks := lo.FromPtr(desired.Hooks)
-	beforeCreateMap, beforeUpdateMap, beforeRemoveMap, beforeRebootMap, err := m.generateOperationMaps(lo.FromPtr(desiredHooks.BeforeUpdating), defaultBeforeUpdateHooks()...)
+	desiredHooks := util.FromPtr(desired.Hooks)
+	beforeCreateMap, beforeUpdateMap, beforeRemoveMap, beforeRebootMap, err := m.generateOperationMaps(util.FromPtr(desiredHooks.BeforeUpdating), defaultBeforeUpdateHooks()...)
 	if err != nil {
 		return err
 	}
-	afterCreateMap, afterUpdateMap, afterRemoveMap, afterRebootMap, err := m.generateOperationMaps(lo.FromPtr(desiredHooks.AfterUpdating), defaultAfterUpdateHooks()...)
+	afterCreateMap, afterUpdateMap, afterRemoveMap, afterRebootMap, err := m.generateOperationMaps(util.FromPtr(desiredHooks.AfterUpdating), defaultAfterUpdateHooks()...)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,11 @@ func (m *manager) OnAfterReboot(ctx context.Context, path string) {
 func (m *manager) Errors() []error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return lo.Values(m.errors)
+	errs := make([]error, 0, len(m.errors))
+	for _, err := range m.errors {
+		errs = append(errs, err)
+	}
+	return errs
 }
 
 func (m *manager) Close() error {

--- a/internal/agent/device/status/containers.go
+++ b/internal/agent/device/status/containers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/pkg/executer"
-	"github.com/samber/lo"
 )
 
 const (
@@ -71,7 +70,10 @@ func podmanApplicationStatus(entry PodmanContainerListEntry) v1alpha1.Applicatio
 	case "running":
 		return v1alpha1.ApplicationStatusRunning
 	case "exited":
-		return lo.Ternary(entry.ExitCode == 0, v1alpha1.ApplicationStatusCompleted, v1alpha1.ApplicationStatusError)
+		if entry.ExitCode == 0 {
+			return v1alpha1.ApplicationStatusCompleted
+		}
+		return v1alpha1.ApplicationStatusError
 	default:
 		return v1alpha1.ApplicationStatusUnknown
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -119,6 +119,19 @@ func BoolToStr(b bool, ifTrue string, ifFalse string) string {
 	return ifFalse
 }
 
+func FromPtr[T any](x *T) T {
+	if x == nil {
+		return Empty[T]()
+	}
+
+	return *x
+}
+
+func Empty[T any]() T {
+	var zero T
+	return zero
+}
+
 func SingleQuote(input []string) []string {
 	output := make([]string, len(input))
 	for i, val := range input {


### PR DESCRIPTION
This PR is a minor cleanup from POC, removes `samber/lo` as a dependency for the agent binary, and adds FromPtr to util.