### PR TITLE
EDM-482: node-exporter conatainer failed to start due the Failed to open directory, disabling udev device properties

### DIFF
--- a/deploy/podman/observability.yaml
+++ b/deploy/podman/observability.yaml
@@ -53,6 +53,8 @@ volumes:
   prometheus_data: {}
 networks:
   flightctl-network:
+    driver: bridge
+
 
 
 

--- a/deploy/podman/prometheus/prometheus.yml
+++ b/deploy/podman/prometheus/prometheus.yml
@@ -16,4 +16,4 @@ scrape_configs:
          - targets: ['localhost:9093']
   - job_name: 'node'
     static_configs:
-         - targets: ['localhost:9100']
+         - targets: ['node_exporter:9100']


### PR DESCRIPTION
The prometheus container couldn't access the node_exporter container. Needed to change the node_exporter address to 'node_exporter' which is the internal DNS container name.