### PR TITLE
Reformat output of flightctl version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --exclude latest --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
+SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
-MAJOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$1}')
-MINOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$2}')
-PATCH := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$3}')
+SOURCE_GIT_TAG_NO_V := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//')
+MAJOR := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$1}')
+MINOR := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$2}')
+PATCH := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$3}')
 
 GO_LD_FLAGS := -ldflags "\
 	-X github.com/flightctl/flightctl/pkg/version.majorFromGit=$(MAJOR) \

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -2,10 +2,19 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/flightctl/flightctl/pkg/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	legalVersionOutputTypes = []string{jsonFormat, yamlFormat}
 )
 
 type VersionOptions struct {
@@ -22,16 +31,60 @@ func NewCmdVersion() *cobra.Command {
 	o := DefaultVersionOptions()
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print Flightctl version information",
+		Short: "Print flightctl version information.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.Validate(args); err != nil {
+				return err
+			}
 			return o.Run(cmd.Context(), args)
 		},
+		SilenceUsage: true,
 	}
+	o.Bind(cmd.Flags())
 	return cmd
+}
+
+func (o *VersionOptions) Bind(fs *pflag.FlagSet) {
+	fs.StringVarP(&o.Output, "output", "o", o.Output, fmt.Sprintf("Output format. One of: (%s).", strings.Join(legalVersionOutputTypes, ", ")))
+}
+
+func (o *VersionOptions) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *VersionOptions) Validate(args []string) error {
+	if len(o.Output) > 0 && !slices.Contains(legalVersionOutputTypes, o.Output) {
+		return fmt.Errorf("output format must be one of (%s)", strings.Join(legalVersionOutputTypes, ", "))
+	}
+	return nil
 }
 
 func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 	versionInfo := version.Get()
-	fmt.Printf("Flightctl Version: %s\n", versionInfo.String())
+
+	switch o.Output {
+	case "":
+		fmt.Printf("flightctl version: %s\n", versionInfo.String())
+	case "yaml":
+		marshalled, err := yaml.Marshal(&versionInfo)
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(marshalled))
+	default:
+		// There is a bug in the program if we hit this case.
+		// However, we follow a policy of never panicking.
+		return fmt.Errorf("VersionOptions were not validated: --output=%q should have been rejected", o.Output)
+	}
+
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,7 +38,10 @@ type Info struct {
 }
 
 func (info Info) String() string {
-	return fmt.Sprintf("%s-%s", info.BuildDate, info.GitVersion)
+	if info.GitTreeState != "clean" {
+		return fmt.Sprintf("%s-%s", info.GitVersion, info.GitTreeState)
+	}
+	return info.GitVersion
 }
 
 func Get() Info {


### PR DESCRIPTION
Updates output of `flightctl version` command to align with the version of containers and Helm Chart.
Prints more detailed build information when running `flightctl version` command with `-o yaml` or `-o json` flags.
Removes "v" prefix when printing major version.
