### PR TITLE
EDM-441: A missing device spec file should always cause an error status

### DIFF
--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -167,8 +167,7 @@ func (b *Bootstrap) ensureBootstrap(ctx context.Context) error {
 
 	currentSpec, err := b.specManager.Read(spec.Current)
 	if err != nil {
-		b.log.WithError(err).Warn("Failed to read current spec. It is expected in case this is the first run")
-		return nil
+		return err
 	}
 	b.configController.Initialize(ctx, currentSpec)
 	return nil


### PR DESCRIPTION
During bootstrap both desired spec and the current spec are read.  In case there is an error to read the current spec, the error is ignored. The fixes it, so in case there is an error to read the current spec, an error is returned.