### PR TITLE
Enable flightctl-api access to to ingress

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-networkpolicy.yaml
@@ -1,0 +1,18 @@
+{{ if not .Values.api.nodePorts.api }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-api-from-ingress
+  namespace:  {{ .Release.Namespace }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-api
+  policyTypes:
+  - Ingress
+ {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.api.nodePorts.api }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,3 +21,4 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+{{ end }}


### PR DESCRIPTION
Otherwise once network policies are enabled, the flightctl services can talk to each other, but ingress can't talk to our API endpoints.

Fixes: https://issues.redhat.com/browse/EDM-463