### PR TITLE
NO-ISSUE: Move GRPC consts to separate package

### DIFF
--- a/internal/agent/device/console/console.go
+++ b/internal/agent/device/console/console.go
@@ -8,7 +8,7 @@ import (
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
 	"github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/api_server/agentserver"
+	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 	"golang.org/x/sync/errgroup"
@@ -78,8 +78,8 @@ func (c *ConsoleController) Sync(ctx context.Context, desired *v1alpha1.Rendered
 	}
 	c.log.Infof("starting console for session %s", desired.Console.SessionID)
 	// add key-value pairs of metadata to context, for now we are ignoring the Console.GRPCEndpoint
-	ctx = metadata.AppendToOutgoingContext(ctx, agentserver.SessionIDKey, desired.Console.SessionID)
-	ctx = metadata.AppendToOutgoingContext(ctx, agentserver.ClientNameKey, c.deviceName)
+	ctx = metadata.AppendToOutgoingContext(ctx, consts.GrpcSessionIDKey, desired.Console.SessionID)
+	ctx = metadata.AppendToOutgoingContext(ctx, consts.GrpcClientNameKey, c.deviceName)
 
 	stdin, stdout, err := c.bashProcess(ctx)
 	if err != nil {

--- a/internal/api_server/agentserver/grpc.go
+++ b/internal/api_server/agentserver/grpc.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/flightctl/flightctl/api/grpc/v1"
 	"github.com/flightctl/flightctl/internal/api_server/middleware"
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/consts"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -20,9 +21,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
-
-const SessionIDKey = "session-id"
-const ClientNameKey = "client-name"
 
 type AgentGrpcServer struct {
 	pb.UnimplementedRouterServiceServer
@@ -82,16 +80,16 @@ func (s *AgentGrpcServer) Stream(stream pb.RouterService_StreamServer) error {
 		return status.Error(codes.InvalidArgument, "missing metadata")
 	}
 
-	sessionIds := md.Get(SessionIDKey)
+	sessionIds := md.Get(consts.GrpcSessionIDKey)
 	if len(sessionIds) != 1 {
-		return status.Error(codes.InvalidArgument, "missing "+SessionIDKey)
+		return status.Error(codes.InvalidArgument, "missing "+consts.GrpcSessionIDKey)
 	}
 	sessionId := sessionIds[0]
 
 	// this should eventually come from the TLS context
-	clientNames := md.Get(ClientNameKey)
+	clientNames := md.Get(consts.GrpcClientNameKey)
 	if len(clientNames) != 1 {
-		return status.Error(codes.InvalidArgument, "missing "+ClientNameKey)
+		return status.Error(codes.InvalidArgument, "missing "+consts.GrpcClientNameKey)
 	}
 	clientName := clientNames[0]
 

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
-	"github.com/flightctl/flightctl/internal/api_server/agentserver"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -123,8 +123,8 @@ func (o *ConsoleOptions) connectViaGRPC(ctx context.Context, grpcEndpoint, sessi
 		return fmt.Errorf("creating grpc client: %w", err)
 	}
 	// add key-value pairs of metadata to context
-	ctx = metadata.AppendToOutgoingContext(ctx, agentserver.SessionIDKey, sessionID)
-	ctx = metadata.AppendToOutgoingContext(ctx, agentserver.ClientNameKey, "flightctl-cli")
+	ctx = metadata.AppendToOutgoingContext(ctx, consts.GrpcSessionIDKey, sessionID)
+	ctx = metadata.AppendToOutgoingContext(ctx, consts.GrpcClientNameKey, "flightctl-cli")
 	ctx = metadata.AppendToOutgoingContext(ctx, common.AuthHeader, fmt.Sprintf("Bearer %s", token))
 
 	stream, err := client.Stream(ctx)

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,0 +1,7 @@
+package consts
+
+const (
+	// GRPC
+	GrpcSessionIDKey  = "session-id"
+	GrpcClientNameKey = "client-name"
+)


### PR DESCRIPTION
The agent console was importing api_server for a couple consts, which was causing all the gorm and postgres modules to be included in the agent.  Moving these consts causes the agent to go from 35 to 24MB.