### PR TITLE
EDM-546: Fix device spec comparisons

### DIFF
--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -298,7 +298,7 @@ func (h *ServiceHandler) PatchDevice(ctx context.Context, request server.PatchDe
 		return server.PatchDevice400JSONResponse{Message: err.Error()}, nil
 	case flterrors.ErrResourceNotFound:
 		return server.PatchDevice404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict, flterrors.ErrUpdatingResourceWithOwnerNotAllowed:
 		return server.PatchDevice409JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"slices"
 	"strings"
 
+	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"gorm.io/gorm"
 )
 
@@ -296,4 +300,114 @@ func retryUpdate(fn func() (bool, error)) error {
 		i++
 	}
 	return err
+}
+
+func configsAreEqual(c1, c2 *[]api.DeviceSpec_Config_Item) bool {
+	return slices.EqualFunc(lo.FromPtr(c1), lo.FromPtr(c2), func(item1 api.DeviceSpec_Config_Item, item2 api.DeviceSpec_Config_Item) bool {
+		value1, err := item1.ValueByDiscriminator()
+		if err != nil {
+			return false
+		}
+		value2, err := item2.ValueByDiscriminator()
+		if err != nil {
+			return false
+		}
+		return reflect.DeepEqual(value1, value2)
+	})
+}
+
+func applicationsAreEqual(c1, c2 *[]api.ApplicationSpec) bool {
+	return slices.EqualFunc(lo.FromPtr(c1), lo.FromPtr(c2), func(item1 api.ApplicationSpec, item2 api.ApplicationSpec) bool {
+		type1, err := item1.Type()
+		if err != nil {
+			return false
+		}
+		type2, err := item2.Type()
+		if err != nil {
+			return false
+		}
+
+		if type1 != type2 {
+			return false
+		}
+		switch type1 {
+		case string(api.ImageApplicationProviderType):
+			imageSpec1, err := item1.AsImageApplicationProvider()
+			if err != nil {
+				return false
+			}
+			imageSpec2, err := item2.AsImageApplicationProvider()
+			if err != nil {
+				return false
+			}
+			return reflect.DeepEqual(imageSpec1, imageSpec2)
+		default:
+			return false
+		}
+	})
+}
+
+func resourcesAreEqual(c1, c2 *[]api.ResourceMonitor) bool {
+	return slices.EqualFunc(lo.FromPtr(c1), lo.FromPtr(c2), func(item1 api.ResourceMonitor, item2 api.ResourceMonitor) bool {
+		value1, err := item1.ValueByDiscriminator()
+		if err != nil {
+			return false
+		}
+		value2, err := item2.ValueByDiscriminator()
+		if err != nil {
+			return false
+		}
+		return reflect.DeepEqual(value1, value2)
+	})
+}
+
+func DeviceSpecsAreEqual(d1, d2 api.DeviceSpec) bool {
+	// Check OS
+	if !reflect.DeepEqual(d1.Os, d2.Os) {
+		return false
+	}
+
+	// Check Config
+	if !configsAreEqual(d1.Config, d2.Config) {
+		return false
+	}
+
+	// Check Hooks
+	if !reflect.DeepEqual(d1.Hooks, d2.Hooks) {
+		return false
+	}
+
+	// Check Applications
+	if !applicationsAreEqual(d1.Applications, d2.Applications) {
+		return false
+	}
+
+	// Check Containers
+	if !reflect.DeepEqual(d1.Containers, d2.Containers) {
+		return false
+	}
+
+	// Check Systemd
+	if !reflect.DeepEqual(d1.Systemd, d2.Systemd) {
+		return false
+	}
+
+	// Check Resources
+	if !resourcesAreEqual(d1.Resources, d2.Resources) {
+		return false
+	}
+
+	return true
+}
+
+func FleetSpecsAreEqual(f1, f2 api.FleetSpec) bool {
+	if !reflect.DeepEqual(f1.Selector, f2.Selector) {
+		return false
+	}
+
+	if !reflect.DeepEqual(f1.Template.Metadata, f2.Template.Metadata) {
+		return false
+	}
+
+	return DeviceSpecsAreEqual(f1.Template.Spec, f2.Template.Spec)
 }

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -233,7 +232,7 @@ func (s *DeviceStore) createDevice(device *model.Device) (bool, error) {
 }
 
 func (s *DeviceStore) updateDevice(fromAPI bool, existingRecord, device *model.Device, fieldsToUnset []string) (bool, error) {
-	sameSpec := reflect.DeepEqual(existingRecord.Spec, device.Spec)
+	sameSpec := DeviceSpecsAreEqual(device.Spec.Data, existingRecord.Spec.Data)
 
 	// Update the generation if the spec was updated
 	if !sameSpec {

--- a/internal/store/fleet.go
+++ b/internal/store/fleet.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
@@ -249,12 +248,12 @@ func (s *FleetStore) updateFleet(existingRecord, fleet *model.Fleet) (bool, erro
 		return false, flterrors.ErrResourceVersionConflict
 	}
 
-	sameSpec := reflect.DeepEqual(existingRecord.Spec, fleet.Spec)
+	sameSpec := FleetSpecsAreEqual(fleet.Spec.Data, existingRecord.Spec.Data)
 
 	// Update the generation if the spec was updated
 	fleet.Generation = lo.Ternary(!sameSpec, lo.ToPtr(lo.FromPtr(existingRecord.Generation)+1), existingRecord.Generation)
 
-	sameTemplateSpec := reflect.DeepEqual(existingRecord.Spec.Data.Template.Spec, fleet.Spec.Data.Template.Spec)
+	sameTemplateSpec := DeviceSpecsAreEqual(fleet.Spec.Data.Template.Spec, existingRecord.Spec.Data.Template.Spec)
 	if fleet.Spec.Data.Template.Metadata == nil {
 		fleet.Spec.Data.Template.Metadata = &api.ObjectMeta{}
 	}


### PR DESCRIPTION
There are a couple instances where we need to understand if device specs are being updated by the user.  reflect.DeepEqual doesn't work properly here because oneOf is translated to json.RawMessage, and comparing JSONs isn't reliable because properties aren't always sorted the same way. Instead, we use reflect.DeepEqual where possible, and unmarshal when necessary.