### PR TITLE
NO-ISSUE: Fix helm error on acm install

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-config.yaml
@@ -35,7 +35,7 @@ data:
         {{- if .Values.api.baseUIUrl }}
         baseUIUrl:  {{ .Values.api.baseUIUrl }}
         {{- else if eq .Values.global.target "acm" }}
-        baseUIUrl:  https://console-openshift-console.{{ include "flightctl.getBaseDomain" (dict "noNs" "true") }}/edge
+        baseUIUrl:  https://console-openshift-console.{{ include "flightctl.getBaseDomain" (merge . (dict "noNs" "true")) }}/edge
         {{- else  }}
         baseUIUrl:  https://ui.{{ include "flightctl.getBaseDomain" . }}
         {{- end }}


### PR DESCRIPTION
```
Error: UPGRADE FAILED: template: flightctl/templates/flightctl-api-config.yaml:38:57: executing "flightctl/templates/flightctl-api-config.yaml" at <include "flightctl.getBaseDomain" (dict "noNs" "true")>: error calling include: template: flightctl/templates/_helpers.tpl:2:16: executing "flightctl.getBaseDomain" at <.Values.global.baseDomain>: nil pointer evaluating interface {}.global
```

when passing the dictionary with "noNS" we must also pass the current context to let it access .Values.global.baseDomain