### PR TITLE
NO-ISSUE: Fix Prometheus Nodeport in Kind

### DIFF
--- a/deploy/helm/flightctl/values.kind.yaml
+++ b/deploy/helm/flightctl/values.kind.yaml
@@ -15,7 +15,7 @@ api:
     api: 3443 # this is also mapped in /test/scripts/kind_cluster.yaml as an extraPortMapping
     agent: 7443 # this is also mapped in /test/scripts/kind_cluster.yaml as an extraPortMapping
     grpc: 7444 # this is also mapped in /test/scripts/kind_cluster.yaml as an extraPortMapping
-    prometheus: 15690
+    prometheus: 9090
   baseUIUrl: "http://localhost:9000"
 worker:
   image:


### PR DESCRIPTION
When merging main with #537, I accidentally changed the Prometheus server nodeport to the API server target port. Re-align this value with the 9090 value that kind and prometheus expect.