### PR TITLE
EDM-603: Add prometheus target filters

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-prometheus-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-prometheus-config.yaml
@@ -13,4 +13,8 @@ data:
         kubernetes_sd_configs:
           - role: pod
 
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            action: keep
+            regex: 1569[0-2]
         scheme: http


### PR DESCRIPTION
Filter discovered pods by port to only scrape those that use ports 15690 (API), 15691 (DB), and 15692 (RabbitMQ) and avoid unnecessary unconnected targets.