### PR TITLE
Document how to modify the deployed UI version

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -68,6 +68,9 @@ $ helm upgrade --install --version=<version-to-install> \
 
 ```
 
+Optionally, you may change the deployed UI version adding `--set ui.image.tag=<ui-version-to-install>`.
+Available versions can be found in [quay.io](https://quay.io/repository/flightctl/charts/flightctl-ui?tab=tags)
+
 ### Flight Control on OpenShift
 
 #### Standalone Flight Control with built-in Keycloak
@@ -132,6 +135,8 @@ $ helm upgrade --install --version=<version-to-install> \
 
 ```
 
+Optionally, you may change the deployed UI version adding `--set ui.image.tag=<ui-version-to-install>`.
+Available versions can be found in [quay.io](https://quay.io/repository/flightctl/charts/flightctl-ocp-ui?tab=tags)
 Verify your Flight Control Service is up and running:
 
 ```console


### PR DESCRIPTION
At the moment, the UI version that is deployed as part of the flightctl main chart is [fixed](https://github.com/flightctl/flightctl/blob/main/deploy/helm/flightctl/Chart.yaml#L13).

For customers wanting to use the UI, we document how they can override the default version and where to find the available helm chart versions.