### PR TITLE
Fix links to UI image versions, not helm charts

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -69,7 +69,7 @@ $ helm upgrade --install --version=<version-to-install> \
 ```
 
 Optionally, you may change the deployed UI version adding `--set ui.image.tag=<ui-version-to-install>`.
-Available versions can be found in [quay.io](https://quay.io/repository/flightctl/charts/flightctl-ui?tab=tags)
+Available versions can be found in [quay.io](https://quay.io/repository/flightctl/flightctl-ui?tab=tags)
 
 ### Flight Control on OpenShift
 
@@ -136,7 +136,7 @@ $ helm upgrade --install --version=<version-to-install> \
 ```
 
 Optionally, you may change the deployed UI version adding `--set ui.image.tag=<ui-version-to-install>`.
-Available versions can be found in [quay.io](https://quay.io/repository/flightctl/charts/flightctl-ocp-ui?tab=tags)
+Available versions can be found in [quay.io](https://quay.io/repository/flightctl/flightctl-ocp-ui?tab=tags)
 Verify your Flight Control Service is up and running:
 
 ```console

--- a/hack/check-commit-message.sh
+++ b/hack/check-commit-message.sh
@@ -12,7 +12,7 @@ error_msg="""Aborting commit: ${commit_message}
 Your commit message should start with a JIRA issue ('JIRA-1111') or a GitHub issue ('Fixes #39')
 with a following colon(:).
 i.e. 'MGMT-42: Summary of the commit message'
-You can also ignore the ticket checking with 'NO-ISSUE' for master only.
+You can also ignore the ticket checking with 'NO-ISSUE' for main only.
 
 Your message is preserved at '${commit_file}'
 """


### PR DESCRIPTION
Follow up to https://github.com/flightctl/flightctl/pull/601.

The links I added earlier were incorrect as they were pointing to the helm charts, and not to the UI applications themselves.