### PR TITLE
EDM-623: Restore Prometheus default settings

### DIFF
--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -108,6 +108,8 @@ rabbitmq:
     type: ClusterIP
     amqpPort: 5672
     managementPort: 15672
+prometheus:
+  enabled: false
 ui:
   enabled: true
   api:


### PR DESCRIPTION
The default Prometheus settings are required for the `flightctl-api-config.yaml` template.