### PR TITLE
EDM-642: EDM-240: add support for completed applications status

### DIFF
--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -155,6 +155,18 @@ func TestApplicationStatus(t *testing.T) {
 			expectedStatus:        v1alpha1.ApplicationStatusRunning,
 			expectedSummaryStatus: v1alpha1.ApplicationsSummaryStatusHealthy,
 		},
+		{
+			name: "app with single container has exited",
+			containers: []Container{
+				{
+					Name:   "container1",
+					Status: ContainerStatusExited,
+				},
+			},
+			expectedReady:         "0/1",
+			expectedStatus:        v1alpha1.ApplicationStatusCompleted,
+			expectedSummaryStatus: v1alpha1.ApplicationsSummaryStatusHealthy,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -123,6 +123,38 @@ func TestApplicationStatus(t *testing.T) {
 			expectedSummaryStatus: v1alpha1.ApplicationsSummaryStatusHealthy,
 			expectedRestarts:      3,
 		},
+		{
+			name: "app has all containers exited",
+			containers: []Container{
+				{
+					Name:   "container1",
+					Status: ContainerStatusExited,
+				},
+				{
+					Name:   "container2",
+					Status: ContainerStatusExited,
+				},
+			},
+			expectedReady:         "0/2",
+			expectedStatus:        v1alpha1.ApplicationStatusCompleted,
+			expectedSummaryStatus: v1alpha1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name: "app has one containers exited",
+			containers: []Container{
+				{
+					Name:   "container1",
+					Status: ContainerStatusRunning,
+				},
+				{
+					Name:   "container2",
+					Status: ContainerStatusExited,
+				},
+			},
+			expectedReady:         "1/2",
+			expectedStatus:        v1alpha1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1alpha1.ApplicationsSummaryStatusHealthy,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -160,16 +160,7 @@ func TestListenForEvents(t *testing.T) {
 
 			go podmanMonitor.listenForEvents(context.Background(), reader)
 
-			inspectCount := 0
-			for i := range tc.events {
-				event := tc.events[i]
-				if event.Status != "remove" {
-					inspectCount++
-				}
-			}
-
-			// inspect is called except where the event is a remove in which case we can't inspect a removed container
-			execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(string(inspectBytes), "", 0).Times(inspectCount)
+			execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(string(inspectBytes), "", 0).Times(len(tc.events))
 
 			// simulate events being written to the pipe
 			go func() {

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -225,6 +225,10 @@ func (f FleetRolloutsLogic) getDeviceApps(device *api.Device, templateVersion *a
 }
 
 func (f FleetRolloutsLogic) replaceEnvVarValueParameters(device *api.Device, app api.ApplicationSpec) (*api.ApplicationSpec, error) {
+	if app.EnvVars == nil {
+		return &app, nil
+	}
+
 	origEnvVars := *app.EnvVars
 	newEnvVars := make(map[string]string, len(origEnvVars))
 	for k, v := range origEnvVars {


### PR DESCRIPTION
This PR adds missing support for `Completed` application status. Completed is defined as a container which starts then exits with a 0 exit code. In this case it should not be considered an error but instead expected/success. The resulting status from the fix is below.

```yaml
    applications:
    - name: compose-oci-example-complete
      ready: 0/1
      restarts: 0
      status: Completed
    applicationsSummary:
      status: Healthy
```