### PR TITLE
EDM-649: Improve checks and error message for enrollment CSRs

### DIFF
--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/flterrors"
 	oscrypto "github.com/openshift/library-go/pkg/crypto"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -23,11 +22,8 @@ const ClientBootstrapCommonNamePrefix = "client-enrollment-"
 const AdminCommonName = "flightctl-admin"
 const DeviceCommonNamePrefix = "device:"
 
-func BootstrapCNFromName(name string) (string, error) {
-	if len(name) < 16 {
-		return "", flterrors.ErrCNLength
-	}
-	return ClientBootstrapCommonNamePrefix + name, nil
+func BootstrapCNFromName(name string) string {
+	return ClientBootstrapCommonNamePrefix + name
 }
 
 func CNFromDeviceFingerprint(fingerprint string) (string, error) {

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -39,10 +39,7 @@ func signApprovedCertificateSigningRequest(ca *crypto.CA, request api.Certificat
 	if u == "" {
 		u = uuid.NewString()
 	}
-	csr.Subject.CommonName, err = crypto.BootstrapCNFromName(u)
-	if err != nil {
-		return nil, fmt.Errorf("cn: %s does not meet requirement: %w", u, err)
-	}
+	csr.Subject.CommonName = crypto.BootstrapCNFromName(u)
 
 	expiry := DefaultEnrollmentCertExpirySeconds
 	if request.Spec.ExpirationSeconds != nil {

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -262,7 +262,8 @@ func (h *ServiceHandler) ReplaceCertificateSigningRequest(ctx context.Context, r
 			approveResp, _ := h.ApproveCertificateSigningRequest(ctx, approveReq)
 			_, ok := approveResp.(server.ApproveCertificateSigningRequest200JSONResponse)
 			if !ok {
-				return server.ReplaceCertificateSigningRequest400JSONResponse{Message: "CSR created but could not be approved"}, nil
+				msg := fmt.Sprintf("enrollment CSR for %s could not be auto-approved: %s", request.Name, approveResp)
+				return server.ReplaceCertificateSigningRequest400JSONResponse{Message: msg}, nil
 			}
 		}
 		if created {


### PR DESCRIPTION
This PR adds a check that a CSR with a specific name does not already exist, and also clarifies the error message when an enrollment request cannot be auto-approved.

Additionally it removes two checks which seem extraneous (but let me know if we do need these):
- checking that the CN for an enrollment certificate is 16 chars long (AFAIU this name is allowed to be anything)
- ~~checking that the `Name` for a CSR resource is valid in kubernetes (AFAIU this name is allowed to be anything)~~