### PR TITLE
EDM-240: ensure network cleanup if containers are stopped

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -201,9 +201,10 @@ func (p *Podman) ListNetworks(ctx context.Context, labels []string) ([]string, e
 	defer cancel()
 
 	args := []string{
-		"ps",
+		"network",
+		"ls",
 		"--format",
-		"{{.Networks}}",
+		"{{.Network.ID}}",
 	}
 	for _, label := range labels {
 		args = append(args, "--filter", fmt.Sprintf("label=%s", label))


### PR DESCRIPTION
previously we were using podman ps to check for networks the issue is if the container is stopped or died we will not cleanup the network. this PR resolves that by using network ls and filtering by label.