### PR TITLE
EDM-655: applications: reduce scope of events api

### DIFF
--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -52,8 +52,6 @@ type PodmanEvent struct {
 	Image      string            `json:"Image"`
 	Name       string            `json:"Name"`
 	Status     string            `json:"Status"`
-	Time       int64             `json:"time"`
-	TimeNano   int64             `json:"timeNano"`
 	Type       string            `json:"Type"`
 	Attributes map[string]string `json:"Attributes"`
 }

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -232,13 +232,11 @@ func writeEvent(writer io.WriteCloser, event *PodmanEvent) error {
 
 func mockPodmanEvent(name, service, status string) PodmanEvent {
 	return PodmanEvent{
-		ID:       "8559c630e04ea852101467742e95b9e371fe6dd8c9195910354636d68d388a40",
-		Image:    "docker.io/library/alpine:latest",
-		Name:     fmt.Sprintf("%s-container", service),
-		Status:   status,
-		Time:     1727811620,
-		TimeNano: 1727811620360195353,
-		Type:     "container",
+		ID:     "8559c630e04ea852101467742e95b9e371fe6dd8c9195910354636d68d388a40",
+		Image:  "docker.io/library/alpine:latest",
+		Name:   fmt.Sprintf("%s-container", service),
+		Status: status,
+		Type:   "container",
 		Attributes: map[string]string{
 			"PODMAN_SYSTEMD_UNIT":                     "podman-compose@user.service",
 			"com.docker.compose.container-number":     "1",


### PR DESCRIPTION
We have had some serialization issues which could be the result of different versions of podman. Since the fields in question are not used this PR drops them.