### PR TITLE
EDM-412: Fix podman build typo

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -286,7 +286,7 @@ Note this is a regular `Containerfile` that you're used to from Docker/Podman, w
 For example, as a user of Quay who has the privileges to push images into the `quay.io/${YOUR_QUAY_ORG}/centos-bootc-flightctl` repository, build the bootc image like this:
 
 ```console
-$ sudo podman build -t quay.io/${YOUR_QUAY_ORG}/centos-bootc-flightctl:v1
+$ sudo podman build -t quay.io/${YOUR_QUAY_ORG}/centos-bootc-flightctl:v1 .
 
 [...]
 ```


### PR DESCRIPTION
IMO ideally we should make the documentation here the same as what's in `building-images.md` in this [section](https://github.com/flightctl/flightctl/blob/main/docs/user/building-images.md#building-the-os-image-bootc) as they are describing the same command, i.e.

```
$ OCI_REGISTRY=quay.io
$ OCI_IMAGE_REPO=${OCI_REGISTRY}/your_org/centos-bootc-flightctl
$ OCI_IMAGE_TAG=v1
$ sudo podman build -t ${OCI_IMAGE_REPO}:${OCI_IMAGE_TAG} .
```
...but I didn't try to do this here in case it introduces too much complexity in the getting started doc.