### PR TITLE
EDM-617: ignition: user,group ensure parse int

### DIFF
--- a/pkg/ignition/ignition_wrapper.go
+++ b/pkg/ignition/ignition_wrapper.go
@@ -91,9 +91,9 @@ func userStringToNodeUser(user string) config_latest_types.NodeUser {
 	userConfig := config_latest_types.NodeUser{}
 	userID, err := strconv.Atoi(user)
 	if err != nil {
-		userConfig.ID = &userID
-	} else {
 		userConfig.Name = &user
+	} else {
+		userConfig.ID = &userID
 	}
 	return userConfig
 }
@@ -102,9 +102,9 @@ func groupStringToNodeGroup(group string) config_latest_types.NodeGroup {
 	groupConfig := config_latest_types.NodeGroup{}
 	groupID, err := strconv.Atoi(group)
 	if err != nil {
-		groupConfig.ID = &groupID
-	} else {
 		groupConfig.Name = &group
+	} else {
+		groupConfig.ID = &groupID
 	}
 	return groupConfig
 }


### PR DESCRIPTION
This PR fixed a bug where if a user name (string) was declared the ignition user.id was incorrectly always 0. Now it populates with the correct user.name.

```yaml
spec:
  config:
  - inline:
    - content: this file is for "root" user
      path: /tmp/file-for-root
    - content: this file is for "user" user
      group: user
      path: /tmp/file-for-user
      user: user
    name: inline-files
```

### before
```sh
$ ls -l /tmp/file-for-user 
-rw-r--r--. 1 root root 28 Oct 31 18:41 /tmp/file-for-user
```

### after
```sh
$ ls -l /tmp/file-for-user 
-rw-r--r--. 1 user user 28 Oct 31 19:01 /tmp/file-for-user
```