### PR TITLE
NO-ISSUE: device/bootstrap: unset NOTIFY_SOCKET after bootstrap

### DIFF
--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -124,6 +124,11 @@ func (b *Bootstrap) Initialize(ctx context.Context) error {
 		b.log.Warnf("Failed setting status: %v", updateErr)
 	}
 
+	// unset NOTIFY_SOCKET on successful bootstrap to prevent subprocesses from
+	// using it.
+	// ref: https://bugzilla.redhat.com/show_bug.cgi?id=1781506
+	os.Unsetenv("NOTIFY_SOCKET")
+
 	b.log.Info("Bootstrap complete")
 	return nil
 }


### PR DESCRIPTION
We use NOTIFY_SOCKET to signal systemd that the service is ready. The problem is subprocess's which are invoked using os.exec consume the env and attempt to use the socket. This results in systemd spamming the logged complaint.

```
Nov 03 20:45:38 localhost.localdomain systemd[1]: flightctl-agent.service: Got notification message from PID 1281, but reception only permitted for main PID 817
```

This PR ensures that after successful bootstrap that the env is unset as it is no longer needed.