### PR TITLE
NO-ISSUE: device: improve context cancel handling

### DIFF
--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -124,6 +124,11 @@ func (a *Agent) sync(ctx context.Context, current, desired *v1alpha1.RenderedDev
 }
 
 func (a *Agent) syncSpec(ctx context.Context, syncFn func(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error) {
+	if err := ctx.Err(); err != nil {
+		a.log.Debugf("Context error: %v", err)
+		return
+	}
+
 	startTime := time.Now()
 	a.log.Debug("Starting sync of device spec")
 	defer func() {
@@ -181,7 +186,7 @@ func (a *Agent) syncSpecFn(ctx context.Context, desired *v1alpha1.RenderedDevice
 		return err
 	}
 
-	if err := a.specManager.Upgrade(); err != nil {
+	if err := a.specManager.Upgrade(ctx); err != nil {
 		return err
 	}
 

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -161,7 +161,11 @@ func (s *manager) IsRollingBack(ctx context.Context) (bool, error) {
 	return bootedOSImage == rollback.Os.Image && bootedOSImage != desired.Os.Image, nil
 }
 
-func (s *manager) Upgrade() error {
+func (s *manager) Upgrade(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// only upgrade if the device is in the process of reconciling the desired spec
 	if s.IsUpgrading() {
 		desired, err := s.Read(Desired)

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -213,17 +213,17 @@ func (mr *MockManagerMockRecorder) SetUpgradeFailed() *gomock.Call {
 }
 
 // Upgrade mocks base method.
-func (m *MockManager) Upgrade() error {
+func (m *MockManager) Upgrade(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade")
+	ret := m.ctrl.Call(m, "Upgrade", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockManagerMockRecorder) Upgrade() *gomock.Call {
+func (mr *MockManagerMockRecorder) Upgrade(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockManager)(nil).Upgrade))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockManager)(nil).Upgrade), ctx)
 }
 
 // MockPriorityQueue is a mock of PriorityQueue interface.

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -33,7 +33,7 @@ type Manager interface {
 	Read(specType Type) (*v1alpha1.RenderedDeviceSpec, error)
 	// Upgrade updates the current rendered spec to the desired rendered spec
 	// and resets the rollback spec.
-	Upgrade() error
+	Upgrade(ctx context.Context) error
 	// SetUpgradeFailed marks the desired rendered spec as failed.
 	SetUpgradeFailed()
 	// IsUpdating returns true if the device is in the process of reconciling the desired spec.

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -378,7 +378,8 @@ func TestUpgrade(t *testing.T) {
 
 			tc.setupMocks(mockReadWriter, mockPriorityQueue)
 
-			err := s.Upgrade()
+			ctx := context.Background()
+			err := s.Upgrade(ctx)
 
 			if tc.expectedError != nil {
 				require.ErrorIs(err, tc.expectedError)


### PR DESCRIPTION
This PR improves the handling of context cancellation around image upgrades. When we apply the upgrade a SIGINT is sent to the agent process. This change helps to halt future progress by returning when the ctx error is observed. The net result can be an invalid upgrade.