### PR TITLE
EDM-622: Fix local registry deploy targets

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -6,7 +6,7 @@ cluster: bin/e2e-certs/ca.pem
 clean-cluster:
 	kind delete cluster
 
-deploy: cluster build deploy-helm prepare-agent-config
+deploy: cluster build deploy-helm deploy-e2e-extras prepare-agent-config
 
 deploy-helm: git-server-container flightctl-api-container flightctl-worker-container flightctl-periodic-container
 	kubectl config set-context kind-kind

--- a/test/test.mk
+++ b/test/test.mk
@@ -51,7 +51,7 @@ deploy-e2e-extras: bin/.ssh/id_rsa.pub bin/e2e-certs/ca.pem
 in-cluster-e2e-test: build-cli deploy-e2e-extras bin/output/qcow2/disk.qcow2
 	$(MAKE) _e2e_test
 
-e2e-test: deploy deploy-e2e-extras bin/output/qcow2/disk.qcow2
+e2e-test: deploy bin/output/qcow2/disk.qcow2
 	$(MAKE) _e2e_test
 
 run-e2e-test:


### PR DESCRIPTION
Without the deploy-e2e-extras the local registry won't be deployed on Kind, so agent-vm scripts will fail.