### PR TITLE
EDM-620: enable using specific rpm releases in e2e testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,7 @@ packages:
 
     upstream_package_name: flightctl
     downstream_package_name: flightctl
+    upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
 
 jobs:
   - job: copr_build
@@ -35,6 +36,8 @@ jobs:
       - centos-stream-9-aarch64
       - rhel-9-aarch64
       - rhel-9-x86_64
+      - epel-9-aarch64
+      - epel-9-x86_64
 
 
   - job: copr_build
@@ -54,3 +57,5 @@ jobs:
       - centos-stream-9-aarch64
       - rhel-9-aarch64
       - rhel-9-x86_64
+      - epel-9-aarch64
+      - epel-9-x86_64

--- a/hack/build_rpms.sh
+++ b/hack/build_rpms.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# if FLIGHTCTL_RPM is set, exit
+if [ -n "${FLIGHTCTL_RPM:-}" ]; then
+    echo "Skipping rpm build, as FLIGHTCTL_RPM is set to ${FLIGHTCTL_RPM}"
+    rm bin/rpm/* 2>/dev/null || true
+    exit 0
+fi
+
 # our RPM build process works in rpm bases systems so we wrap it if necessary
 if ! command -v packit 2>&1 >/dev/null ]; then
     echo "Building RPMs on a system without packtit, using container"

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -1,13 +1,13 @@
 %define debug_package %{nil}
 
 Name: flightctl
-Version: 0.0.1
-Release: 5%{?dist}
+Version: 0.3.0
+Release: 1%{?dist}
 Summary: Flightctl CLI
 
 License: XXX
 URL: https://github.com/flightctl/flightctl
-Source0: flightctl-0.0.1.tar.gz
+Source0: flightctl-0.3.0.tar.gz
 
 BuildRequires: golang
 BuildRequires: make
@@ -68,9 +68,12 @@ install -Dpm 0644 _flightctl-completion -t %{buildroot}/%{_datadir}/zsh/site-fun
 /usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
 
 %changelog
+* Mon Nov 4 2024 Miguel Angel Ajo <majopela@redhat.com> - 0.3.0-1
+- Move the Release field to -1 so we avoid auto generating packages
+  with -5 all the time.
 * Wed Aug 21 2024 Sam Batschelet <sbatsche@redhat.com> - 0.0.1-5
 - Add must-gather script to provide a simple mechanism to collect agent debug
 * Wed Aug 7 2024 Sam Batschelet <sbatsche@redhat.com> - 0.0.1-4
-- Add basic greenboot support for failed flightctl-agent service 
+- Add basic greenboot support for failed flightctl-agent service
 * Wed Mar 13 2024 Ricardo Noriega <rnoriega@redhat.com> - 0.0.1-3
 - New specfile for both CLI and agent packages

--- a/test/README.md
+++ b/test/README.md
@@ -228,6 +228,28 @@ export KUBEADMIN_PASS=your-oc-password-for-kubeadmin
 make in-cluster-e2e-test
 ```
 
+You can also use `FLIGHTCTL_RPM=release/0.3.0`, `FLIGHTCTL_RPM=devel/0.3.0.rc1-5.20241104145530808450.main.19.ga531984`
+or simply `FLIGHTCTL_RPM=release` or `FLIGHTCTL_RPM=devel` to consume an specific version/repository
+of the CLI and agent rpm.
+
+I.e. if you wanted to test the cluster along with the 0.3.0 release in
+https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/builds/, you would run:
+```bash
+export FLIGHTCTL_NS=flightctl
+export KUBEADMIN_PASS=your-oc-password-for-kubeadmin
+export FLIGHTCTL_RPM=release/0.3.0
+
+make in-cluster-e2e-test
+```
+
+If you wanted to test the cluster along with the latest devel build in
+https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl-dev/builds/, you could use run:
+```bash
+export FLIGHTCTL_RPM=devel/0.3.0.rc2-1.20241104145530808450.main.19.ga531984
+
+make in-cluster-e2e-test
+```
+
 #### If your host system is not suitable for bootc image builder
 
 * Install vagrant

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -10,12 +10,22 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
+ARG RPM_COPR=
+ARG RPM_PACKAGE=flightctl-agent
+
 COPY bin/e2e-certs/pki/CA/ca.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
 COPY bin/rpm/flightctl-agent-*.rpm /tmp/
-RUN dnf install -y /tmp/flightctl-agent-*.rpm && \
+
+RUN if [[ -z $RPM_COPR ]]; then \
+        dnf install -y /tmp/flightctl-agent-*.rpm ; \
+    else \
+        dnf copr -y enable ${RPM_COPR} &&  \
+        dnf install -y ${RPM_PACKAGE}; \
+    fi && \
     systemctl enable flightctl-agent.service
+
 
 RUN dnf install -y epel-release epel-next-release
 RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -31,6 +31,9 @@ This image is the base image for all other images. It contains the following ser
    with the `test/script/prepare_agent_config.sh` script to be connected to our local
    flightctl service.
 
+The installed flightctl-agent will be either a locally compiled rpm or a downloaded
+rpm based on the `FLIGHTCTL_RPM` variable, please see [test-docs](../../README.md) for more information.
+
 It is configured to trust our locally generated CA created in `test/scripts/create_e2e_certs.sh`
 
 ### v2

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -155,3 +155,37 @@ function try_login() {
     return 0
   fi
 }
+
+# Function to determine the correct COPR repository based on the FLIGHTCTL_RPM variable
+function copr_repo() {
+    # split FLIGHTCTL_RPM by the '/' character in two variables
+    local REPO_NAME=$(echo "${FLIGHTCTL_RPM}" | cut -d'/' -f1)
+    if [[ "${REPO_NAME}" == "release" ]]; then
+        echo "@redhat-et/flightctl"
+    else
+        echo "@redhat-et/flightctl-dev"
+    fi
+}
+
+# Function to append the RPM version to the specified package name based on the FLIGHTCTL_RPM variable
+function append_rpm_version() {
+    local pkgname="${1}"
+    # check if FLIGHTCTL_RPM contains the '/' character
+     if [[ "${FLIGHTCTL_RPM}" == *"/"* ]]; then
+        echo "${pkgname}-${FLIGHTCTL_RPM##*/}"
+    else
+        echo "${pkgname}"
+    fi
+}
+
+# Function to generate the package name for the flightctl agent with the appropriate version
+function package_agent() {
+    local VERSION=$(echo "${FLIGHTCTL_RPM}" | cut -d'/' -f2)
+    append_rpm_version "flightctl-agent"
+}
+
+# Function to generate the package name for the flightctl CLI with the appropriate version
+function package_cli() {
+    local VERSION=$(echo "${FLIGHTCTL_RPM}" | cut -d'/' -f2)
+    append_rpm_version "flightctl"
+}

--- a/test/scripts/prepare_cli.sh
+++ b/test/scripts/prepare_cli.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eo pipefail
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "${SCRIPT_DIR}"/functions
+
+if [[ -z "${FLIGHTCTL_RPM}" ]]; then
+    echo -e "\e[32mCompiling the flightctl cli\e[0m"
+    make build-cli
+else
+    COPR_REPO=$(copr_repo)
+    PACKAGE_CLI=$(package_cli)
+    SYSVARIANT=$(rpm -qf /bin/bash | cut -d'.' -f 4) # el9, fc41, fc42, etc..: extracted from bash-5.2.32-1.fc41.x86_64
+
+    if [[ "${PACKAGE_CLI}" != "flightctl" ]]; then
+        PACKAGE_CLI="${PACKAGE_CLI}.${SYSVARIANT}"
+    fi
+    echo -e "\e[32mInstalling the CLI ${PACKAGE_CLI} rpm from copr ${COPR_REPO}, detected local system variant ${SYSVARIANT}\e[0m"
+
+    # disable any existing copr repo that could have been enabled before
+    sudo dnf copr disable -y @redhat-et/flightctl 2>/dev/null || true
+    sudo dnf copr disable -y @redhat-et/flightctl-dev 2>/dev/null || true
+
+    # enable the target corp repository
+    sudo dnf copr enable -y $(copr_repo)
+
+    # dnf download doesn't work, so we rip out the rpm and install it manually
+    sudo dnf remove -y flightctl || true
+
+    # if the package version has been specified, we must add the system variant to version
+    # otherwise dnf can't download the right package
+
+    sudo dnf install -y "${PACKAGE_CLI}"
+
+    # copy to our local bin directory, where the remaining of tests will consume it from
+    cp /usr/bin/flightctl bin/flightctl
+fi

--- a/test/test.mk
+++ b/test/test.mk
@@ -48,7 +48,8 @@ integration-test: deploy-db run-integration-test kill-db
 deploy-e2e-extras: bin/.ssh/id_rsa.pub bin/e2e-certs/ca.pem
 	test/scripts/deploy_e2e_extras_with_helm.sh
 
-in-cluster-e2e-test: build-cli deploy-e2e-extras bin/output/qcow2/disk.qcow2
+in-cluster-e2e-test: deploy-e2e-extras bin/output/qcow2/disk.qcow2
+	./test/scripts/prepare_cli.sh
 	$(MAKE) _e2e_test
 
 e2e-test: deploy deploy-e2e-extras bin/output/qcow2/disk.qcow2


### PR DESCRIPTION
Enables:
* testing of specific rpm builds via the `FLIGHTCTL_RPM` environment variable,
* the build of epel-9 as that is the repository pulled from the centos9 stream image.

In addition removes the "v" prefix from rpm builds, which is not standard via packit config change.
