### PR TITLE
EDM-632: device/applications: add embedded compose support

### DIFF
--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -24,11 +24,11 @@ func NewManager(log *log.PrefixLogger, exec executer.Executer, podmanClient *cli
 }
 
 // Add an application to be managed
-func (m *manager) Add(app Application) error {
+func (m *manager) Ensure(app Application) error {
 	appType := app.Type()
 	switch appType {
 	case AppCompose:
-		return m.podmanMonitor.add(app)
+		return m.podmanMonitor.ensure(app)
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
@@ -68,4 +68,8 @@ func (m *manager) ExecuteActions(ctx context.Context) error {
 
 func (m *manager) Status() ([]v1alpha1.DeviceApplicationStatus, v1alpha1.DeviceApplicationsSummaryStatus, error) {
 	return m.podmanMonitor.Status()
+}
+
+func (m *manager) Stop(ctx context.Context) error {
+	return m.podmanMonitor.Stop(ctx)
 }

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -89,18 +89,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// Add mocks base method.
-func (m *MockManager) Add(app Application) error {
+// Ensure mocks base method.
+func (m *MockManager) Ensure(app Application) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Add", app)
+	ret := m.ctrl.Call(m, "Ensure", app)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Add indicates an expected call of Add.
-func (mr *MockManagerMockRecorder) Add(app any) *gomock.Call {
+// Ensure indicates an expected call of Ensure.
+func (mr *MockManagerMockRecorder) Ensure(app any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockManager)(nil).Add), app)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), app)
 }
 
 // ExecuteActions mocks base method.
@@ -145,6 +145,20 @@ func (m *MockManager) Status() ([]v1alpha1.DeviceApplicationStatus, v1alpha1.Dev
 func (mr *MockManagerMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status))
+}
+
+// Stop mocks base method.
+func (m *MockManager) Stop(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stop", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockManagerMockRecorder) Stop(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockManager)(nil).Stop), ctx)
 }
 
 // Update mocks base method.
@@ -223,6 +237,20 @@ func (m *MockApplication) EnvVars() map[string]string {
 func (mr *MockApplicationMockRecorder) EnvVars() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvVars", reflect.TypeOf((*MockApplication)(nil).EnvVars))
+}
+
+// IsEmbedded mocks base method.
+func (m *MockApplication) IsEmbedded() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEmbedded")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEmbedded indicates an expected call of IsEmbedded.
+func (mr *MockApplicationMockRecorder) IsEmbedded() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmbedded", reflect.TypeOf((*MockApplication)(nil).IsEmbedded))
 }
 
 // Name mocks base method.

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -112,19 +112,70 @@ func (m *PodmanMonitor) Run(ctx context.Context) error {
 	return nil
 }
 
-func (m *PodmanMonitor) Stop() {
+func (m *PodmanMonitor) Stop(ctx context.Context) error {
+	var errs []error
 	m.once.Do(func() {
-		m.cancelFn()
-		if err := m.cmd.Wait(); err != nil {
-			m.log.Errorf("Failed to wait for podman events: %v", err)
+		m.log.Info("Stopping podman monitor")
+		if err := m.drain(ctx); err != nil {
+			errs = append(errs, err)
 		}
+		m.log.Infof("podman drain complete")
+		m.cancelFn()
+
+		// its possible that we call stop before the monitor has been
+		// initialized
+		if m.cmd != nil {
+			if err := m.cmd.Wait(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to wait for podman events: %v", err))
+			}
+		}
+		m.log.Info("Podman monitor stopped!!")
 	})
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
 }
 
-// add ensures that and application is added to the monitor. if the application
+func (m *PodmanMonitor) getApps() []Application {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	apps := make([]Application, 0, len(m.apps))
+	for _, app := range m.apps {
+		apps = append(apps, app)
+	}
+	return apps
+}
+
+func (m *PodmanMonitor) drain(ctx context.Context) error {
+	var errs []error
+
+	apps := m.getApps()
+	m.log.Infof("Draining %d applications", len(apps))
+	for _, app := range apps {
+		if err := m.remove(app); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := m.ExecuteActions(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// ensures that and application is added to the monitor. if the application
 // is added for the first time an Add action is queued to be executed by the
 // lifecycle manager. so additional adds for the same app will be idempotent.
-func (m *PodmanMonitor) add(app Application) error {
+func (m *PodmanMonitor) ensure(app Application) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -142,9 +193,10 @@ func (m *PodmanMonitor) add(app Application) error {
 	}
 
 	action := lifecycle.Action{
-		Handler: handler,
-		Type:    lifecycle.ActionAdd,
-		Name:    appName,
+		Handler:  handler,
+		Type:     lifecycle.ActionAdd,
+		Name:     appName,
+		Embedded: app.IsEmbedded(),
 	}
 
 	m.actions = append(m.actions, action)
@@ -168,6 +220,7 @@ func (m *PodmanMonitor) remove(app Application) error {
 
 	delete(m.apps, appName)
 
+	// currently we don't support removing embedded applications
 	action := lifecycle.Action{
 		Handler: handler,
 		Type:    lifecycle.ActionRemove,
@@ -197,6 +250,7 @@ func (m *PodmanMonitor) update(app Application) error {
 		return err
 	}
 
+	// currently we don't support updating embedded applications
 	action := lifecycle.Action{
 		Handler: handler,
 		Type:    lifecycle.ActionUpdate,

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -119,7 +119,7 @@ func (m *PodmanMonitor) Stop(ctx context.Context) error {
 		if err := m.drain(ctx); err != nil {
 			errs = append(errs, err)
 		}
-		m.log.Infof("podman drain complete")
+		m.log.Infof("Podman drain complete")
 		m.cancelFn()
 
 		// its possible that we call stop before the monitor has been
@@ -129,7 +129,7 @@ func (m *PodmanMonitor) Stop(ctx context.Context) error {
 				errs = append(errs, fmt.Errorf("failed to wait for podman events: %v", err))
 			}
 		}
-		m.log.Info("Podman monitor stopped!!")
+		m.log.Info("Podman monitor stopped")
 	})
 
 	if len(errs) > 0 {
@@ -379,7 +379,6 @@ func (m *PodmanMonitor) Status() ([]v1alpha1.DeviceApplicationStatus, v1alpha1.D
 
 func (m *PodmanMonitor) listenForEvents(ctx context.Context, stdoutPipe io.ReadCloser) {
 	defer func() {
-		m.log.Info("Podman application monitor stopped")
 		stdoutPipe.Close()
 	}()
 

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -150,7 +150,7 @@ func TestListenForEvents(t *testing.T) {
 
 			// add test apps to the monitor
 			for _, testApp := range tc.apps {
-				err = podmanMonitor.add(testApp)
+				err = podmanMonitor.ensure(testApp)
 				require.NoError(err)
 			}
 

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -36,6 +36,7 @@ type Reader interface {
 	SetRootdir(path string)
 	PathFor(filePath string) string
 	ReadFile(filePath string) ([]byte, error)
+	ReadDir(dirPath string) ([]fs.DirEntry, error)
 	FileExists(filePath string) (bool, error)
 }
 

--- a/internal/agent/device/fileio/mock_fileio.go
+++ b/internal/agent/device/fileio/mock_fileio.go
@@ -289,6 +289,21 @@ func (mr *MockReaderMockRecorder) PathFor(filePath any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathFor", reflect.TypeOf((*MockReader)(nil).PathFor), filePath)
 }
 
+// ReadDir mocks base method.
+func (m *MockReader) ReadDir(dirPath string) ([]fs.DirEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", dirPath)
+	ret0, _ := ret[0].([]fs.DirEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir.
+func (mr *MockReaderMockRecorder) ReadDir(dirPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockReader)(nil).ReadDir), dirPath)
+}
+
 // ReadFile mocks base method.
 func (m *MockReader) ReadFile(filePath string) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -409,6 +424,21 @@ func (m *MockReadWriter) PathFor(filePath string) string {
 func (mr *MockReadWriterMockRecorder) PathFor(filePath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathFor", reflect.TypeOf((*MockReadWriter)(nil).PathFor), filePath)
+}
+
+// ReadDir mocks base method.
+func (m *MockReadWriter) ReadDir(dirPath string) ([]fs.DirEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", dirPath)
+	ret0, _ := ret[0].([]fs.DirEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir.
+func (mr *MockReadWriterMockRecorder) ReadDir(dirPath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockReadWriter)(nil).ReadDir), dirPath)
 }
 
 // ReadFile mocks base method.

--- a/internal/agent/device/fileio/reader.go
+++ b/internal/agent/device/fileio/reader.go
@@ -2,6 +2,7 @@ package fileio
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 )
@@ -31,6 +32,19 @@ func (r *reader) PathFor(filePath string) string {
 // ReadFile reads the file at the provided path
 func (r *reader) ReadFile(filePath string) ([]byte, error) {
 	return os.ReadFile(r.PathFor(filePath))
+}
+
+// ReadDir reads the directory at the provided path and returns a slice of fs.DirEntry. If the directory
+// does not exist, it returns an empty slice and no error.
+func (r *reader) ReadDir(dirPath string) ([]fs.DirEntry, error) {
+	entries, err := os.ReadDir(r.PathFor(dirPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []fs.DirEntry{}, nil
+		}
+		return nil, err
+	}
+	return entries, nil
 }
 
 // FileExists checks if a path exists and returns a boolean indicating existence,

--- a/internal/agent/device/hook/manager.go
+++ b/internal/agent/device/hook/manager.go
@@ -194,12 +194,12 @@ func (m *manager) Run(ctx context.Context) {
 		select {
 		case job, ok := <-m.backgroundJobs:
 			if !ok {
-				m.log.Warn("Background jobs channel closed")
+				m.log.Warn("Hooks manager: jobs channel closed")
 				return
 			}
 			job(ctx)
 		case <-ctx.Done():
-			m.log.Info("Hooks manager: context closed")
+			m.log.Debug("Hooks manager: context closed")
 			return
 		}
 	}

--- a/internal/agent/device/hook/manager.go
+++ b/internal/agent/device/hook/manager.go
@@ -199,7 +199,7 @@ func (m *manager) Run(ctx context.Context) {
 			}
 			job(ctx)
 		case <-ctx.Done():
-			m.log.Info("Background jobs context closed")
+			m.log.Info("Hooks manager: context closed")
 			return
 		}
 	}

--- a/internal/agent/shutdown/shutdown.go
+++ b/internal/agent/shutdown/shutdown.go
@@ -1,0 +1,82 @@
+package shutdown
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+type Manager interface {
+	Run(context.Context)
+	Shutdown(context.Context)
+	Register(string, func(context.Context) error)
+}
+
+type manager struct {
+	once       sync.Once
+	registered map[string]func(context.Context) error
+	cancelFn   context.CancelFunc
+	timeout    time.Duration
+	log        *log.PrefixLogger
+}
+
+func New(log *log.PrefixLogger, timeout time.Duration, cancelFn context.CancelFunc) Manager {
+	return &manager{
+		registered: make(map[string]func(context.Context) error),
+		timeout:    timeout,
+		cancelFn:   cancelFn,
+		log:        log,
+	}
+}
+
+func (m *manager) Run(ctx context.Context) {
+	defer m.log.Infof("Agent shutdown complete")
+	// handle teardown
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	go func(ctx context.Context) {
+		select {
+		case s := <-signals:
+			m.log.Infof("Agent received shutdown signal: %s", s)
+			m.Shutdown(ctx)
+			close(signals)
+			m.cancelFn()
+		case <-ctx.Done():
+			m.log.Infof("Context has been cancelled, shutting down.")
+			m.Shutdown(ctx)
+			close(signals)
+		}
+	}(ctx)
+
+	<-ctx.Done()
+}
+
+func (m *manager) Shutdown(ctx context.Context) {
+	// ensure multiple calls to Shutdown are idempotent
+	m.once.Do(func() {
+		now := time.Now()
+		// give the agent time to shutdown gracefully
+		ctx, cancel := context.WithTimeout(ctx, m.timeout)
+		defer cancel()
+		for name, fn := range m.registered {
+			m.log.Infof("Shutting down: %s", name)
+			if err := fn(ctx); err != nil {
+				m.log.Errorf("Error shutting down: %s", err)
+			}
+		}
+		m.log.Infof("Shutdown complete in %s", time.Since(now))
+	})
+}
+
+func (m *manager) Register(name string, fn func(context.Context) error) {
+	if _, ok := m.registered[name]; ok {
+		m.log.Warnf("Shutdown function %s already registered", name)
+		return
+	}
+	m.registered[name] = fn
+}

--- a/test/scripts/agent-images/Containerfile-e2e-v3.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v3.local
@@ -1,7 +1,7 @@
 # localhost:5000/flightctl-device:v3
 #     $(IP):5000/flightctl-device:v3
 #
-# Image built on top of our E2E base image which also includes on dummy servive
+# Image built on top of our E2E base image which also includes on dummy service
 #
 # * test-e2e-another-dummy which just runs a sleep 3600 for 1h
 

--- a/test/scripts/agent-images/Containerfile-e2e-v4.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v4.local
@@ -1,0 +1,9 @@
+# localhost:5000/flightctl-device:v4
+#     $(IP):5000/flightctl-device:v4
+#
+# Image built on top of our E2E base image which also includes an embedded
+# compose application with 3 sleep containers
+
+FROM localhost:5000/flightctl-device:base
+
+COPY ./test/scripts/agent-images/test-podman-compose-sleep.yaml  /usr/local/etc/compose/manifests/embedded-demo-app/podman-compose.yaml

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/../functions
 
 REGISTRY_ADDRESS=$(registry_address)
-IMAGE_LIST="base v2 v3"
+IMAGE_LIST="base v2 v3 v4"
 
 # if FLIGHTCTL_RPM is not empty
 if [ -n "${FLIGHTCTL_RPM:-}" ]; then

--- a/test/scripts/agent-images/test-podman-compose-sleep.yaml
+++ b/test/scripts/agent-images/test-podman-compose-sleep.yaml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  service1:
+    image: alpine
+    command: ["sleep", "infinity"]
+
+  service2:
+    image: alpine
+    command: ["sleep", "infinity"]
+
+  service3:
+    image: alpine
+    command: ["sleep", "infinity"]


### PR DESCRIPTION
This PR adds embedded compose application support.

Embeded applications are expected to be written to a sub directory of `/usr/local/etc/compose/manifests` where the sub directory is the application's name.

```
/usr/local/etc/compose/manifests/embedded-demo-app/podman-compose.yaml
```

The agent will start the application in the same way it handles image based applications and will also report its status. Below is an embedded application `embedded-demo-app` along side a declared OCI image-based application `compose-oci-example` in status.

```
bin/flightctl get devices/aupiu13663re92hg9q61cajan83gjp8e6tubpa01ncq9a0kgu6eg -o json | jq .status.applications
[
  {
    "name": "embedded-demo-app",
    "ready": "3/3",
    "restarts": 0,
    "status": "Running"
  },
  {
    "name": "compose-oci-example",
    "ready": "3/3",
    "restarts": 0,
    "status": "Running"
  },
]
```

This PR also adds a shutdown manager which greatly improves graceful termination and ensures draining applications before shutdown. This is very important for embedded apps because if we don't drain them they will potentially start on reboot even if removed from the image.

But also in general we want to ensure we gracefully terminate all applications. A similar approach is used with the kubelet.

```
time="2024-11-07T16:57:55.501666Z" level=info msg="Agent received shutdown signal: interrupt"
time="2024-11-07T16:57:55.501711Z" level=info msg="Shutting down: applications"
time="2024-11-07T16:57:55.501725Z" level=info msg="Stopping podman monitor"
time="2024-11-07T16:57:55.502417Z" level=info msg="Draining 1 applications"
time="2024-11-07T16:58:08.682052Z" level=info msg="Removed network a3afb4b240d1d1bcec0e8efe77ecb29d77d6b22ffe3b78cd76fac5c7defd53ce"
time="2024-11-07T16:58:08.686757Z" level=info msg="Podman drain complete"
time="2024-11-07T16:58:08.687210Z" level=info msg="Podman monitor stopped!!"
time="2024-11-07T16:58:08.687343Z" level=info msg="Shutting down: agent"
time="2024-11-07T16:58:08.687413Z" level=info msg="Shutdown complete in 13.185708161s"
time="2024-11-07T16:58:08.687467Z" level=info msg="Hooks manager: context closed"
time="2024-11-07T16:58:08.687551Z" level=info msg="Disk monitor stopped"
time="2024-11-07T16:58:08.688072Z" level=info msg="CPU monitor stopped"
time="2024-11-07T16:58:08.688149Z" level=info msg="Agent shutdown complete"
```
