### PR TITLE
NO-ISSUE: Fix keycloak-db-pvc.yaml label indent

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pvc.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pvc.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: keycloak
     {{ if .Values.global.appCode }}
-      paas.redhat.com/appcode: {{ .Values.global.appCode }}
+    paas.redhat.com/appcode: {{ .Values.global.appCode }}
     {{ end }}
 spec:
   accessModes:


### PR DESCRIPTION
Fixes:
```
➜  staging helm upgrade --install --version=0.3.0-rc2 --namespace flightctl--runtime-ext flightctl oci://quay.io/flightctl/charts/flightctl --values values.yaml
Release "flightctl" does not exist. Installing it now.
Pulled: quay.io/flightctl/charts/flightctl:0.3.0-rc2
Digest: sha256:651c45c913b24c93fb0ad0639f5ece861a744a8f8d1b05e029c065be71d111a3
Error: YAML parse error on flightctl/charts/keycloak/templates/keycloak-db-pvc.yaml: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
```