### PR TITLE
EDM-668: Change verification to Kubernetes qualified name verification

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -170,7 +170,7 @@ func (r ResourceAlertRule) Validate(specSampleInterval string) []error {
 func (c GitConfigProviderSpec) Validate() []error {
 	allErrs := []error{}
 	allErrs = append(allErrs, validation.ValidateGenericName(&c.Name, "spec.config[].name")...)
-	allErrs = append(allErrs, validation.ValidateResourceNameReference(&c.GitRef.Repository, "spec.config[].gitRef.repository")...)
+	allErrs = append(allErrs, validation.ValidateResourceDNSNameReference(&c.GitRef.Repository, "spec.config[].gitRef.repository")...)
 	allErrs = append(allErrs, validation.ValidateGitRevision(&c.GitRef.TargetRevision, "spec.config[].gitRef.targetRevision")...)
 	allErrs = append(allErrs, validation.ValidateString(&c.GitRef.Path, "spec.config[].gitRef.path", 0, 2048, nil, "")...)
 	return allErrs
@@ -325,10 +325,10 @@ func (r Repository) Validate() []error {
 
 func (r ResourceSync) Validate() []error {
 	allErrs := []error{}
-	allErrs = append(allErrs, validation.ValidateResourceName(r.Metadata.Name)...)
+	allErrs = append(allErrs, validation.ValidateDNSResourceName(r.Metadata.Name)...)
 	allErrs = append(allErrs, validation.ValidateLabels(r.Metadata.Labels)...)
 	allErrs = append(allErrs, validation.ValidateAnnotations(r.Metadata.Annotations)...)
-	allErrs = append(allErrs, validation.ValidateResourceNameReference(&r.Spec.Repository, "spec.repository")...)
+	allErrs = append(allErrs, validation.ValidateResourceDNSNameReference(&r.Spec.Repository, "spec.repository")...)
 	allErrs = append(allErrs, validation.ValidateGitRevision(&r.Spec.TargetRevision, "spec.targetRevision")...)
 	allErrs = append(allErrs, validation.ValidateString(&r.Spec.Path, "spec.path", 0, 2048, nil, "")...)
 	return allErrs

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -20,8 +20,26 @@ func ValidateResourceName(name *string) []error {
 	return ValidateResourceNameReference(name, "metadata.name")
 }
 
-// ValidateResourceRef validates that metadata.name is not empty and is a valid name in K8s.
+// ValidateResourceNameReference validates that metadata.name is not empty and is a valid name in K8s.
 func ValidateResourceNameReference(name *string, path string) []error {
+	errs := field.ErrorList{}
+	if name == nil {
+		errs = append(errs, field.Required(fieldPathFor(path), ""))
+	} else {
+		for _, msg := range k8sutilvalidation.IsQualifiedName(*name) {
+			errs = append(errs, field.Invalid(fieldPathFor(path), *name, msg))
+		}
+	}
+	return asErrors(errs)
+}
+
+// ValidateDNSResourceName validates that metadata.name is not empty and is a valid DNS name in K8s.
+func ValidateDNSResourceName(name *string) []error {
+	return ValidateResourceDNSNameReference(name, "metadata.name")
+}
+
+// ValidateResourceDNSNameReference validates that metadata.name is not empty and is a valid DNS subdomain name in K8s.
+func ValidateResourceDNSNameReference(name *string, path string) []error {
 	errs := field.ErrorList{}
 	if name == nil {
 		errs = append(errs, field.Required(fieldPathFor(path), ""))


### PR DESCRIPTION
Validation should use https://pkg.go.dev/k8s.io/apimachinery@v0.31.1/pkg/util/validation#IsQualifiedName instead of  
https://pkg.go.dev/k8s.io/apimachinery@v0.31.1/pkg/api/validation#NameIsDNSSubdomain

Is there any reason why 'NameIsDNSSubdomain' was used in the first place?
IsQualifiedName includes NameIsDNSSubdomain.