### PR TITLE
NO-ISSUE: Redirect http keycloak to https

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-route.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-route.yaml
@@ -15,7 +15,7 @@ spec:
     targetPort: 8080
   tls:
     termination: edge
-    insecureEdgeTerminationPolicy: None
+    insecureEdgeTerminationPolicy: Redirect
     {{- if (.Values.global.baseDomainTls).cert }}
     certificate: {{ .Values.global.baseDomainTls.cert | quote }}
     key: {{ .Values.global.baseDomainTls.key | quote }}


### PR DESCRIPTION
Otherwise if you access http://auth.$(baseDomain) you get
an ugly "Application is not ready" error from OpenShift.