### PR TITLE
NO-ISSUE: console: simplify exec test case

### DIFF
--- a/internal/agent/device/console/console_test.go
+++ b/internal/agent/device/console/console_test.go
@@ -45,7 +45,7 @@ func (suite *ConsoleControllerSuite) SetupTest() {
 		},
 	}
 
-	suite.testCommand = exec.Command("bash", "-i", "-l")
+	suite.testCommand = exec.Command("echo", "testing")
 }
 
 func (suite *ConsoleControllerSuite) TearDownTest() {


### PR DESCRIPTION
Console tests are running an interactive shell that appears to be breaking local unit tests. This PR makes the exec command a simple echo.