### PR TITLE
EDM-420: Enable to run devicesimulator on multiple hosts

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -44,6 +44,7 @@ func main() {
 	dataDir := pflag.String("data-dir", defaultDataDir(), "directory for storing simulator data")
 	labels := pflag.StringArray("label", []string{}, "label applied to simulated devices, in the format key=value")
 	numDevices := pflag.Int("count", 1, "number of devices to simulate")
+	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
 
@@ -77,7 +78,7 @@ func main() {
 	log.Infoln("creating agents")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	agents, agentsFolders := createAgents(log, *numDevices, agentConfigTemplate)
+	agents, agentsFolders := createAgents(log, *numDevices, *initialDeviceIndex, agentConfigTemplate)
 
 	sigShutdown := make(chan os.Signal, 1)
 	signal.Notify(sigShutdown, syscall.SIGINT, syscall.SIGTERM)
@@ -147,12 +148,12 @@ func createAgentConfigTemplate(dataDir string, configFile string) *agent.Config 
 	return agentConfigTemplate
 }
 
-func createAgents(log *logrus.Logger, numDevices int, agentConfigTemplate *agent.Config) ([]*agent.Agent, []string) {
+func createAgents(log *logrus.Logger, numDevices int, initialDeviceIndex int, agentConfigTemplate *agent.Config) ([]*agent.Agent, []string) {
 	log.Infoln("creating agents")
 	agents := make([]*agent.Agent, numDevices)
 	agentsFolders := make([]string, numDevices)
 	for i := 0; i < numDevices; i++ {
-		agentName := fmt.Sprintf("device-%04d", i)
+		agentName := fmt.Sprintf("device-%05d", initialDeviceIndex+i)
 		certDir := filepath.Join(agentConfigTemplate.ConfigDir, "certs")
 		agentDir := filepath.Join(agentConfigTemplate.DataDir, agentName)
 		// Cleanup if exists and initialize the agent's expected
@@ -172,6 +173,7 @@ func createAgents(log *logrus.Logger, numDevices int, agentConfigTemplate *agent
 		}
 
 		cfg := agent.NewDefault()
+		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent.DefaultConfigDir
 		cfg.DataDir = agent.DefaultConfigDir
 		cfg.EnrollmentService = agent.EnrollmentService{}


### PR DESCRIPTION
Today devicesimulator enables to run around 2,000 devices (exact number depends on host hardware).
As a first step to "Support 10K devices" let's enable devicesimulator to run on multiple hosts.

Later we should investigate the real bottlenecks and may try to minimize used resources to enable it run on a single host only.

### Enable to run devicesimulator on a `remote` machine

>
  `remote:`mkdir -p \~/.flightctl/certs/
  scp `build:`bin/agent/etc/flightctl/certs/* `remote:`\~/.flightctl/certs/
  scp `build:`bin/agent/etc/flightctl/config.yaml `remote:`\~/.flightctl/agent.yaml
  `remote:`mkdir -p \~/.config/flightctl
  scp `build:`\~/.config/flightctl/client.yaml `remote:`\~/.config/flightctl/client.yaml
  `remote:`mkdir \~/bin
  scp `build:`bin/devicesimulator `remote:`\~/bin/


### Run devicesimulator
#### To run 100 devices on each machine, on the 4th machine we should start with seed of 300, so the first device will be device-00300
> bin/devicesimulator --count=100 --seed=300

### Note
See https://github.com/flightctl/flightctl/pull/648 for discussions