### PR TITLE
EDM-695: Logger verbosity flag was added (-v)

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -47,7 +47,7 @@ func main() {
 	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))")
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
-	logLevel := pflag.StringP("v", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
+	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
 	pflag.Usage = func() {
 		fmt.Fprintf(pflag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
-	"github.com/sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -47,6 +47,7 @@ func main() {
 	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))")
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
+	logLevel := pflag.StringP("v", "v", "info", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
 	pflag.Usage = func() {
 		fmt.Fprintf(pflag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
@@ -54,6 +55,12 @@ func main() {
 		pflag.PrintDefaults()
 	}
 	pflag.Parse()
+
+	logLvl, err := logrus.ParseLevel(*logLevel)
+	if err != nil {
+		logLvl = logrus.DebugLevel
+	}
+	log.SetLevel(logLvl)
 
 	log.Infoln("command line flags:")
 	pflag.CommandLine.VisitAll(func(flg *pflag.Flag) {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
-	logrus "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
 )

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -47,7 +47,7 @@ func main() {
 	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))")
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
-	logLevel := pflag.StringP("v", "v", "info", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
+	logLevel := pflag.StringP("v", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
 	pflag.Usage = func() {
 		fmt.Fprintf(pflag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
@@ -58,7 +58,9 @@ func main() {
 
 	logLvl, err := logrus.ParseLevel(*logLevel)
 	if err != nil {
-		logLvl = logrus.DebugLevel
+		fmt.Fprintf(os.Stderr, "Invalid log level: %s\n\n", *logLevel)
+		pflag.Usage()
+		os.Exit(1)
 	}
 	log.SetLevel(logLvl)
 


### PR DESCRIPTION
Logger verbosity level may be supplied via -v flag

It may be one of "fatal", "error", "warn", "warning", "info", "debug"

Default: "debug"