### PR TITLE
EDM-704: Automate of Polarion test case 75991 - A flightctl resource status is reported

### DIFF
--- a/test/e2e/agent/agent_suite_test.go
+++ b/test/e2e/agent/agent_suite_test.go
@@ -9,6 +9,19 @@ import (
 
 const TIMEOUT = "1m"
 const POLLING = "250ms"
+const LONGTIMEOUT = "10m"
+
+// Define a type for messages.
+type Message string
+
+const (
+	UpdateRenderedVersionSuccess Message = "Updated to desired renderedVersion: 2"
+)
+
+// String returns the string representation of a message.
+func (m Message) String() string {
+	return string(m)
+}
 
 func TestAgent(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -63,4 +65,205 @@ var _ = Describe("VM Agent behavior", func() {
 				enrollmentID).ShouldNot(BeNil())
 		})
 	})
+
+	Context("status", Label("75991"), func() {
+		It("should report the correct device status after an inline config is added", func() {
+			deviceId, device := harness.EnrollAndWaitForOnlineStatus()
+
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+				// Create ConfigProviderSpec.
+				var configProviderSpec v1alpha1.ConfigProviderSpec
+				err := configProviderSpec.FromInlineConfigProviderSpec(validInlineConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
+				logrus.Infof("Updating %s with config %s", deviceId, device.Spec.Config)
+			})
+
+			logrus.Infof("Waiting for the device to pick the config")
+			harness.WaitForDeviceContents(deviceId, "the device is upgrading to renderedVersion: 2",
+				func(device *v1alpha1.Device) bool {
+					for _, condition := range device.Status.Conditions {
+						if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+							condition.Message == UpdateRenderedVersionSuccess.String() {
+							return true
+						}
+					}
+					return false
+				}, TIMEOUT)
+
+			// The device should have the online config.
+			stdout, err := harness.VM.RunSSH([]string{"cat", "/etc/motd"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring("This system is managed by flightctl."))
+
+			// The status should be "Online"
+			logrus.Infof("The device has the config %s", device.Spec.Config)
+			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+		})
+
+		It("should report the correct device status when trying to upgrade to a not existing image", func() {
+			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+			var newImageReference string
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				currentImage := device.Status.Os.Image
+				logrus.Infof("Current image for %s is %s", deviceId, currentImage)
+				repo, _ := parseImageReference(currentImage)
+				newImageReference = repo + ":not-existing"
+				device.Spec.Os = &v1alpha1.DeviceOSSpec{Image: newImageReference}
+				logrus.Infof("Updating %s to image %s", deviceId, device.Spec.Os.Image)
+			})
+
+			harness.WaitForDeviceContents(deviceId, "Failed to update to renderedVersion: 2. Retrying",
+				func(device *v1alpha1.Device) bool {
+					return conditionExists(device, "Updating", "True", "Retry")
+				}, "2m")
+
+			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Degraded")))
+		})
+
+		It(`should show an error when trying to update a device with
+			"a reference to a not existing git repo, and report 'Online' status`, Label("git"), func() {
+			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				logrus.Infof("Current device is %s", deviceId)
+
+				// Create ConfigProviderSpec.
+				var configProviderSpec v1alpha1.ConfigProviderSpec
+				err := configProviderSpec.FromGitConfigProviderSpec(gitConfigInvalidRepo)
+				Expect(err).ToNot(HaveOccurred())
+
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
+				logrus.Infof("Updating %s with config %s", deviceId, device.Spec.Config)
+			})
+
+			// Check the http config error is detected.
+			harness.WaitForDeviceContents(deviceId, `Error: failed fetching specified Repository definition`,
+				func(device *v1alpha1.Device) bool {
+					return conditionExists(device, "SpecValid", "False", "Invalid")
+				}, "2m")
+
+			// The behaviour will change after EDM-418.
+			harness.WaitForDeviceContents(deviceId, "the device is updated to renderedVersion: 1",
+				func(device *v1alpha1.Device) bool {
+					return conditionExists(device, "Updating", "False", "Updated")
+				}, "2m")
+			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+		})
+
+		It(`should show an error when trying to update a device with a httpConfigProviderSpec
+			with invalid Path, and report 'Online' status`, func() {
+			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+			// Create the http repository.
+			_, err := model.NewRepositoryFromApiResource(&httpRepo)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update the device with the http invalid config.
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				logrus.Infof("current device is %s", deviceId)
+				// Create ConfigProviderSpec.
+				var configProviderSpec v1alpha1.ConfigProviderSpec
+				err := configProviderSpec.FromHttpConfigProviderSpec(httpConfigInvalidPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
+				logrus.Infof("updating %s with config %s", deviceId, device.Spec.Config)
+			})
+
+			// Check the http config error is detected.
+			harness.WaitForDeviceContents(deviceId, "Error: sending HTTP Request",
+				func(device *v1alpha1.Device) bool {
+					return conditionExists(device, "SpecValid", "False", "Invalid")
+				}, "2m")
+
+			// The behaviour will change after EDM-418.
+			harness.WaitForDeviceContents(deviceId, "the device is updated to renderedVersion: 1",
+				func(device *v1alpha1.Device) bool {
+					return conditionExists(device, "Updating", "False", "Updated")
+				}, "2m")
+			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+		})
+
+		It("should report 'Unknown' after the device vm is powered-off", func() {
+			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+			// Shutdown the vm.
+			err := harness.VM.Shutdown()
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Unknown")))
+		})
+	})
 })
+
+var mode = 0644
+var modePointer = &mode
+
+var inlineConfig = v1alpha1.FileSpec{
+	Content: "This system is managed by flightctl.",
+	Mode:    modePointer,
+	Path:    "/etc/motd",
+}
+
+var validInlineConfig = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfig},
+	Name:   "valid-inline-config",
+}
+
+var name = "flightctl-demos"
+var repoMetadata = v1alpha1.ObjectMeta{
+	Name: &name,
+}
+
+var httpRepoSpec = v1alpha1.HttpRepoSpec{
+	Type: v1alpha1.RepoSpecType("http"),
+	Url:  "https://github.com/flightctl/flightctl-demos.git",
+}
+
+var spec v1alpha1.RepositorySpec
+var _ = spec.FromHttpRepoSpec(httpRepoSpec)
+
+var httpRepo = v1alpha1.Repository{
+	ApiVersion: "v1alpha1",
+	Kind:       "Repository",
+	Metadata:   repoMetadata,
+	Spec:       spec,
+}
+
+var mountPath = "/etc/config"
+var gitConfigInvalidRepo = v1alpha1.GitConfigProviderSpec{
+	GitRef: struct {
+		MountPath      *string `json:"mountPath,omitempty"`
+		Path           string  `json:"path"`
+		Repository     string  `json:"repository"`
+		TargetRevision string  `json:"targetRevision"`
+	}{
+		MountPath:      &mountPath,
+		Path:           "/configs/repo/config.yaml",
+		Repository:     "not-existing-repo",
+		TargetRevision: "main",
+	},
+	Name: "example-git-config-provider",
+}
+
+var suffix = "/some/suffix"
+var httpConfigInvalidPath = v1alpha1.HttpConfigProviderSpec{
+	HttpRef: struct {
+		FilePath   string  `json:"filePath"`
+		Repository string  `json:"repository"`
+		Suffix     *string `json:"suffix,omitempty"`
+	}{
+		FilePath:   "/invalid/path",
+		Repository: "flightctl-demos",
+		Suffix:     &suffix,
+	},
+	Name: "example-http-config-provider",
+}

--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -51,16 +51,24 @@ var _ = Describe("VM Agent behavior during updates", func() {
 					return conditionExists(device, "Updating", "True", "Update")
 				}, "1m")
 
+			Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+
 			harness.WaitForDeviceContents(deviceId, "the device is rebooting",
 				func(device *v1alpha1.Device) bool {
 					return conditionExists(device, "Updating", "True", "Rebooting")
 				}, "2m")
+
+			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Rebooting")))
 
 			harness.WaitForDeviceContents(deviceId, "status.Os.Image gets updated",
 				func(device *v1alpha1.Device) bool {
 					return device.Status.Os.Image == newImageReference &&
 						conditionExists(device, "Updating", "False", "Updated")
 				}, "2m")
+
+			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
 
 			// TODO(hexfusion): we were expecting this update status not to be unknown at this point
 			// related to: https://issues.redhat.com/browse/EDM-679


### PR DESCRIPTION
Adding agent status reporting test case: 75991. The tests are passing in both local and in ocp with vagrant env.
It verifies that flightctl-agent applies (or not) a configuration change to the device, and that the related status is correctly reported in the flightctl resource.
![image](https://github.com/user-attachments/assets/eadefcff-26ec-44ea-8cf6-5222a2a543af)
