### PR TITLE
EDM-423: Fix lexer state for nested exists/notexists selectors

### DIFF
--- a/pkg/k8s/selector/fields/lexer.go
+++ b/pkg/k8s/selector/fields/lexer.go
@@ -96,16 +96,28 @@ func (l *lexer) Lex() (tok selector.Token, lit string) {
 func (l *lexer) updateContextForSyntaxChar(tok selector.Token) {
 	switch l.state.context {
 	case lhsOrOp:
-		l.state.context = lhs
+		// Transition to lhs unless the token is a comma
+		if tok != selector.CommaToken {
+			l.state.context = lhs
+		}
+
 	case op:
-		l.state.context = rhs
+		// Transition to rhs or reset to lhsOrOp on a comma
+		if tok == selector.CommaToken {
+			l.state.context = lhsOrOp
+		} else {
+			l.state.context = rhs
+		}
+
 	default:
+		// Handle tokens specific to nested structures
 		switch tok {
 		case selector.OpenParToken:
 			l.state.inParentheses++
 		case selector.ClosedParToken:
 			l.state.inParentheses--
 		case selector.CommaToken:
+			// Reset to lhsOrOp if not within parentheses
 			if l.state.inParentheses == 0 {
 				l.state.context = lhsOrOp
 			}

--- a/pkg/k8s/selector/fields/lexer_test.go
+++ b/pkg/k8s/selector/fields/lexer_test.go
@@ -47,6 +47,7 @@ func TestLexerSequence(t *testing.T) {
 		s string
 		t []selector.Token
 	}{
+
 		{"key in ( value )", []selector.Token{selector.IdentifierToken, selector.InToken, selector.OpenParToken, selector.IdentifierToken, selector.ClosedParToken}},
 		{"key notin ( value )", []selector.Token{selector.IdentifierToken, selector.NotInToken, selector.OpenParToken, selector.IdentifierToken, selector.ClosedParToken}},
 		{"key in ( value1, value2 )", []selector.Token{selector.IdentifierToken, selector.InToken, selector.OpenParToken, selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken, selector.ClosedParToken}},
@@ -60,6 +61,14 @@ func TestLexerSequence(t *testing.T) {
 		{"key contains a, key notcontains b", []selector.Token{selector.IdentifierToken, selector.ContainsToken, selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken, selector.NotContainsToken, selector.IdentifierToken}},
 		{"key contains a=b, key notcontains b", []selector.Token{selector.IdentifierToken, selector.ContainsToken, selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken, selector.NotContainsToken, selector.IdentifierToken}},
 		{"key contains a=b, key notcontains hello!", []selector.Token{selector.IdentifierToken, selector.ContainsToken, selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken, selector.NotContainsToken, selector.IdentifierToken}},
+		{"key, key=val", []selector.Token{selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken, selector.EqualsToken, selector.IdentifierToken}},
+		{"key=, key=val", []selector.Token{selector.IdentifierToken, selector.EqualsToken, selector.CommaToken, selector.IdentifierToken, selector.EqualsToken, selector.IdentifierToken}},
+		{"key, key", []selector.Token{selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken}},
+		{"key, !key", []selector.Token{selector.IdentifierToken, selector.CommaToken, selector.DoesNotExistToken, selector.IdentifierToken}},
+		{"!key, key", []selector.Token{selector.DoesNotExistToken, selector.IdentifierToken, selector.CommaToken, selector.IdentifierToken}},
+		{"!key,!key!=val", []selector.Token{selector.DoesNotExistToken, selector.IdentifierToken, selector.CommaToken, selector.DoesNotExistToken, selector.IdentifierToken, selector.NotEqualsToken, selector.IdentifierToken}},
+		{",", []selector.Token{selector.CommaToken}},
+		{"", []selector.Token{}},
 	}
 
 	for _, v := range testcases {

--- a/pkg/k8s/selector/fields/selector_test.go
+++ b/pkg/k8s/selector/fields/selector_test.go
@@ -25,8 +25,16 @@ func TestSelectorParse(t *testing.T) {
 		"x=a||y=b",
 		"x==a==b",
 		"x=msg:\\(hello!world\\)",
+		"x,x=a",
+		"!x,x!=a",
+		"x=,y=",
+		"!x,!y",
+		"x,y=",
+		"!x,y=",
+		"",
 	}
 	testBadStrings := []string{
+		",",
 		"!x=a",
 		"x<a",
 		"x<2024-10-24T10:00:00",


### PR DESCRIPTION
- Resolved an issue where the lexer state was incorrectly handled for nested selectors using 'exists' and 'notexists' tokens.
- Adjusted state transitions to ensure proper parsing of nested expressions.
- Added test cases to validate behavior with complex selector scenarios.