### PR TITLE
EDM-681: Allow field selector when 'summaryOnly' is enabled

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -142,8 +142,8 @@ func (o *GetOptions) Validate(args []string) error {
 			return fmt.Errorf("cannot specify summary when fetching a single resource")
 		}
 		if o.SummaryOnly {
-			if len(o.StatusFilter) > 0 || len(o.Continue) > 0 || o.Limit > 0 {
-				return fmt.Errorf("only the 'owner' and 'selector' flags are supported when 'summary-only' is specified")
+			if o.Limit > 0 || len(o.Continue) > 0 {
+				return fmt.Errorf("flags such as 'limit' and 'continue' are not supported when 'summary-only' is specified")
 			}
 		}
 	}

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -75,19 +75,41 @@ func (h *ServiceHandler) ListDevices(ctx context.Context, request server.ListDev
 		return server.ListDevices400JSONResponse{Message: err.Error()}, nil
 	}
 
+	statusFilter := []string{}
+	if request.Params.StatusFilter != nil {
+		for _, filter := range *request.Params.StatusFilter {
+			statusFilter = append(statusFilter, fmt.Sprintf("status.%s", filter))
+		}
+	}
+
+	filterMap, err := ConvertFieldFilterParamsToMap(statusFilter)
+	if err != nil {
+		return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to convert status filter: %v", err)}, nil
+	}
+
+	var fieldSelector k8sselector.Selector
+	if request.Params.FieldSelector != nil {
+		if fieldSelector, err = fields.ParseSelector(*request.Params.FieldSelector); err != nil {
+			return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to parse field selector: %v", err)}, nil
+		}
+	}
+
 	// Check if SummaryOnly is true
 	if request.Params.SummaryOnly != nil && *request.Params.SummaryOnly {
 		// Check for unsupported parameters
-		if request.Params.StatusFilter != nil ||
-			request.Params.Limit != nil ||
-			request.Params.Continue != nil {
+		if request.Params.Limit != nil ||
+			request.Params.Continue != nil ||
+			request.Params.SortBy != nil {
 			return server.ListDevices400JSONResponse{
-				Message: "Only 'owner' and 'labelSelector' parameters are supported when 'summaryOnly' is true",
+				Message: "parameters such as 'limit', 'continue', and 'sortBy' are not supported when 'summaryOnly' is true",
 			}, nil
 		}
+
 		result, err := h.store.Device().Summary(ctx, orgId, store.ListParams{
-			Labels: labelMap,
-			Owners: util.OwnerQueryParamsToArray(request.Params.Owner),
+			Labels:        labelMap,
+			Filter:        filterMap,
+			Owners:        util.OwnerQueryParamsToArray(request.Params.Owner),
+			FieldSelector: fieldSelector,
 		})
 
 		switch err {
@@ -101,28 +123,9 @@ func (h *ServiceHandler) ListDevices(ctx context.Context, request server.ListDev
 		}
 	}
 
-	statusFilter := []string{}
-	if request.Params.StatusFilter != nil {
-		for _, filter := range *request.Params.StatusFilter {
-			statusFilter = append(statusFilter, fmt.Sprintf("status.%s", filter))
-		}
-	}
-
-	filterMap, err := ConvertFieldFilterParamsToMap(statusFilter)
-	if err != nil {
-		return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to convert status filter: %v", err)}, nil
-	}
-
 	cont, err := store.ParseContinueString(request.Params.Continue)
 	if err != nil {
 		return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to parse continue parameter: %v", err)}, nil
-	}
-
-	var fieldSelector k8sselector.Selector
-	if request.Params.FieldSelector != nil {
-		if fieldSelector, err = fields.ParseSelector(*request.Params.FieldSelector); err != nil {
-			return server.ListDevices400JSONResponse{Message: fmt.Sprintf("failed to parse field selector: %v", err)}, nil
-		}
 	}
 
 	var sortField *store.SortField


### PR DESCRIPTION
We initially decided that summaryOnly, when listing devices, would raise an error if the end-user attempted to use flags such as limit and continue for pagination. The logic behind this decision was that summaryOnly does not return a list of devices, so pagination is not applicable.

However, field selectors, such as metadata.owner and others, should be usable with summaryOnly. Even when applying a status filter inside the field-selector query, there is no reason to disallow filtering by it.