### PR TITLE
Fix docs path filter

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,8 +25,7 @@ jobs:
             notdocs:
               - '!.spelling'
               - '!README.md'
-              - '!docs/**.md'
-              - '!docs/**.svg'
+              - '!docs/**'
 
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -22,8 +22,7 @@ jobs:
             docs:
               - '.spelling'
               - 'README.md'
-              - 'docs/**.md'
-              - 'docs/**.svg'
+              - 'docs/**'
 
       - name: Running Markdown Linter
         if: ${{ steps.filter.outputs.docs == 'true' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,8 +33,7 @@ jobs:
             notdocs:
               - '!.spelling'
               - '!README.md'
-              - '!docs/*.md'
-              - '!docs/*.svg'
+              - '!docs/**'
 
       - name: Check commit message
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -26,8 +26,7 @@ jobs:
             notdocs:
               - '!.spelling'
               - '!README.md'
-              - '!docs/*.md'
-              - '!docs/*.svg'
+              - '!docs/**'
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -26,8 +26,7 @@ jobs:
             notdocs:
               - '!.spelling'
               - '!README.md'
-              - '!docs/*.md'
-              - '!docs/*.svg'
+              - '!docs/**'
 
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,8 +24,7 @@ jobs:
             notdocs:
               - '!.spelling'
               - '!README.md'
-              - '!docs/**.md'
-              - '!docs/**.svg'
+              - '!docs/**'
 
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.spelling
+++ b/.spelling
@@ -118,6 +118,11 @@ webhooks
 workflows
 X.509
 YAML
+timestamp
+substring
+timestamps
+boolean
+quay.io
  - docs/user/api-resources.md
 approvedBy
 creationTimestamp
@@ -171,3 +176,13 @@ usr
  - docs/user/registering-microshift-devices-acm.md
 Pre-requisite
 import.yaml
+ - docs/user/field-selectors.md
+DoesNotExist
+DoubleEquals
+GreaterThan
+GreaterThanOrEquals
+LessThan
+LessThanOrEquals
+NotContains
+NotEquals
+NotIn

--- a/docs/user/field-selectors.md
+++ b/docs/user/field-selectors.md
@@ -9,13 +9,30 @@ Flight Control resources provide a set of metadata fields that can be selected.
 
 Each resource supports the following metadata fields:
 
-- metadata.name
-- metadata.owner
-- metadata.labels
-- metadata.annotations
-- metadata.creationTimestamp
+- `metadata.name`
+- `metadata.owner`
+- `metadata.labels`
+- `metadata.annotations`
+- `metadata.creationTimestamp`
 
-> **Note:** While `metadata.labels` can be selected using Field Selectors, for more extensive label querying options, consider using Label Selectors.
+> ![NOTE] While `metadata.labels` can be selected using Field Selectors, for more extensive label querying options, consider using Label Selectors.
+
+### List of Additional Supported Fields
+
+In addition to the metadata fields, each resource has its own unique set of fields that can be selected, offering further flexibility in filtering and selection based on resource-specific attributes.
+
+The following table lists the fields supported for filtering for each resource kind:
+
+| Kind                            | Fields                                              |
+|---------------------------------|-----------------------------------------------------|
+| **Certificate Signing Request** | `status.certificate`                                |
+| **Device**                      | `status.summary.status`<br/>`status.applicationsSummary.status`<br/>`status.updated.status`<br/>`status.lastSeen` |
+| **Enrollment Request**          | `status.approval.approved`<br/>`status.certificate` |
+| **Fleet**                       | `spec.template.spec.os.image`                       |
+| **Repository**                  | `spec.type`<br/>`spec.url`                          |
+| **Resource Sync**               | `spec.repository`                                   |
+
+### Examples
 
 #### Example 1: Excluding a Specific Device by Name
 
@@ -26,71 +43,17 @@ flightctl get devices --field-selector 'metadata.name!=c3tkb18x9fw32fzx5l556n0p0
 ```
 
 #### Example 2: Filter by Owner, Labels, and Creation Timestamp
+
 This command retrieves devices owned by `Fleet/pos-fleet`, located in the `us` region, and created in 2024:
+
 ```bash
 flightctl get devices --field-selector 'metadata.owner=Fleet/pos-fleet, metadata.labels contains region=us, metadata.creationTimestamp >= 2024-01-01T00:00:00Z, metadata.creationTimestamp < 2025-01-01T00:00:00Z'
 ```
 
-### List of Additional Supported Fields
-
-In addition to the metadata fields, each resource has its own unique set of fields that can be selected, offering further flexibility in filtering and selection based on resource-specific attributes.
-
-The following table lists the fields supported for filtering for each resource kind:
-
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left; vertical-align:top;">Kind</th>
-      <th style="text-align:left;">Fields</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="vertical-align:top;"><strong>Device</strong></td>
-      <td>
-        status.summary.status<br>
-        status.applicationsSummary.status<br>
-        status.updated.status<br>
-        status.lastSeen
-      </td>
-    </tr>
-    <tr>
-      <td style="vertical-align:top;"><strong>Fleet</strong></td>
-      <td>
-        spec.template.spec.os.image
-      </td>
-    </tr>
-    <tr>
-      <td style="vertical-align:top;"><strong>Enrollment Request</strong></td>
-      <td>
-        status.approval.approved<br>
-        status.certificate
-      </td>
-    </tr>
-    <tr>
-      <td style="vertical-align:top;"><strong>Resource Sync</strong></td>
-      <td>
-        spec.repository
-      </td>
-    </tr>
-    <tr>
-      <td style="vertical-align:top;"><strong>Repository</strong></td>
-      <td>
-        spec.type<br>
-        spec.url
-      </td>
-    </tr>
-    <tr>
-      <td style="vertical-align:top;"><strong>Certificate Signing Request</strong></td>
-      <td>
-        status.certificate
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 #### Example 3: Filter by Owner, Labels, and Device Status
+
 This command retrieves devices owned by `Fleet/pos-fleet`, located in the `us` region, and with a `status.updated.status` of either `Unknown` or `OutOfDate`:
+
 ```bash
 flightctl get devices --field-selector 'metadata.owner=Fleet/pos-fleet, metadata.labels contains region=us, status.updated.status in (Unknown, OutOfDate)'
 ```
@@ -106,15 +69,16 @@ flightctl get device --field-selector='text'
 
 Error: listing devices: 400, message: unknown or unsupported selector: unable to resolve selector name "text". Supported selectors are: [metadata.alias metadata.annotations metadata.creationTimestamp metadata.labels metadata.name metadata.nameoralias metadata.owner status.applicationsSummary.status status.lastSeen status.summary.status status.updated.status]
 ```
+
 In this example, the field `text` is not a valid field for filtering. The error message provides a list of supported fields that can be used with `--field-selector` for the `device` resource.
 
 You can then use one of the supported fields, as shown below:
+
 ```bash
 flightctl get devices --field-selector 'metadata.alias contains cluster'
 ```
+
 In this command, the `metadata.alias` field is checked with the containment operator `contains` to see if it contains the value `cluster`.
-
-
 
 ## Supported operators
 
@@ -134,18 +98,14 @@ In this command, the `metadata.alias` field is checked with the containment oper
 | Contains             | `contains`     | Checks if a field contains a value                    |
 | NotContains          | `notcontains`  | Checks if a field does not contain a value            |
 
-
 ### Operators Usage by Field Type
 
 Each field type supports a specific subset of operators, listed below:
 
-
-| **Field Type** | **Supported Operators**                                                                                      | **Value**                                 |
-|----------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| Field Type | Supported Operators                                                                                      | Value                                 |
+|------------|----------------------------------------------------------------------------------------------------------|--------------------------------------|
 | **String** | `Equals`: Matches if the field value is an exact match to the specified string.<br> `DoubleEquals`: Matches if the field value is an exact match to the specified string (alternative to `Equals`).<br> `NotEquals`: Matches if the field value is not an exact match to the specified string.<br> `In`: Matches if the field value matches at least one string in the list.<br> `NotIn`: Matches if the field value does not match any of the strings in the list.<br> `Contains`: Matches if the field value contains the specified substring.<br> `NotContains`: Matches if the field value does not contain the specified substring.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | Text string                       |
-| **Timestamp**    | `Equals`: Matches if the field value is an exact match to the specified timestamp.<br> `DoubleEquals`: Matches if the field value is an exact match to the specified timestamp (alternative to `Equals`).<br> `NotEquals`: Matches if the field value is not an exact match to the specified timestamp.<br> `GreaterThan`: Matches if the field value is after the specified timestamp.<br> `GreaterThanOrEquals`: Matches if the field value is after or equal to the specified timestamp.<br> `LessThan`: Matches if the field value is before the specified timestamp.<br> `LessThanOrEquals`: Matches if the field value is before or equal to the specified timestamp.<br> `In`: Matches if the field value matches at least one timestamp in the list.<br> `NotIn`: Matches if the field value does not match any of the timestamps in the list.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | RFC3339 format           |
-| **Number**    | `Equals`: Matches if the field value equals the specified number.<br> `DoubleEquals`: Matches if the field value equals the specified number (alternative to `Equals`).<br> `NotEquals`: Matches if the field value does not equal to the specified number.<br> `GreaterThan`: Matches if the field value is greater than the specified number.<br> `GreaterThanOrEquals`: Matches if the field value is greater than or equal to the specified number.<br> `LessThan`: Matches if the field value is less than the specified number.<br> `LessThanOrEquals`: Matches if the field value is less than or equal to the specified number.<br> `In`: Matches if the field value equals at least one number in the list.<br> `NotIn`: Matches if the field value does not equal any numbers in the list.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | Number format           |            |
+| **Timestamp**    | `Equals`: Matches if the field value is an exact match to the specified timestamp.<br> `DoubleEquals`: Matches if the field value is an exact match to the specified timestamp (alternative to `Equals`).<br> `NotEquals`: Matches if the field value is not an exact match to the specified timestamp.<br> `GreaterThan`: Matches if the field value is after the specified timestamp.<br> `GreaterThanOrEquals`: Matches if the field value is after or equal to the specified timestamp.<br> `LessThan`: Matches if the field value is before the specified timestamp.<br> `LessThanOrEquals`: Matches if the field value is before or equal to the specified timestamp.<br> `In`: Matches if the field value matches at least one timestamp in the list.<br> `NotIn`: Matches if the field value does not match any of the timestamps in the list.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | RFC 3339 format           |
+| **Number**    | `Equals`: Matches if the field value equals the specified number.<br> `DoubleEquals`: Matches if the field value equals the specified number (alternative to `Equals`).<br> `NotEquals`: Matches if the field value does not equal to the specified number.<br> `GreaterThan`: Matches if the field value is greater than the specified number.<br> `GreaterThanOrEquals`: Matches if the field value is greater than or equal to the specified number.<br> `LessThan`: Matches if the field value is less than the specified number.<br> `LessThanOrEquals`: Matches if the field value is less than or equal to the specified number.<br> `In`: Matches if the field value equals at least one number in the list.<br> `NotIn`: Matches if the field value does not equal any numbers in the list.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | Number format |
 | **Boolean**      | `Equals`: Matches if the value is `true` or `false`.<br> `DoubleEquals`: Matches if the value is `true` or `false` (alternative to `Equals`).<br> `NotEquals`: Matches if the value is the opposite of the specified value.<br> `In`: Matches if the value (`true` or `false`) is in the list.<br><i>**Note:** The list can only contain `true` or `false`, so this operator is limited in use.</i><br> `NotIn`: Matches if the value is not in the list.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present. | Boolean format (`true`, `false`)                 |
-| **Array**        | `Contains`: Matches if the array contains the specified value.<br> `NotContains`: Matches if the array does not contain the specified value.<br> `In`: Matches if the array overlaps with the specified values.<br> `NotIn`: Matches if the array does not overlap with the specified values.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present.<br><br><i>**Note:** Using `Array[Index]` treats the element as the type defined for the array elements (e.g., string, timestamp, number, boolean).</i> | Array element    |
-
-
+| **Array**        | `Contains`: Matches if the array contains the specified value.<br> `NotContains`: Matches if the array does not contain the specified value.<br> `In`: Matches if the array overlaps with the specified values.<br> `NotIn`: Matches if the array does not overlap with the specified values.<br> `Exists`: Matches if the field is present.<br> `DoesNotExist`: Matches if the field is not present.<br><br><i>**Note:** Using `Array[Index]` treats the element as the type defined for the array elements (e.g., string, timestamp, number, boolean).</i> | Array element |

--- a/docs/user/introduction.md
+++ b/docs/user/introduction.md
@@ -39,7 +39,7 @@ Features and use cases Flight Control aims to support:
 
 **Label Selector** - A way for users to group or filter their devices and other resources based on their assigned labels, e.g. "all devices having 'site=factory-berlin' and 'device-type=autonomous-forklift').
 
-**Field Selector** - A way for users to filter and select Flight Control objects based on the values of specific resource fields. Field selectors follow the same syntax, principles, and support the same operators as Kubernetes Field and Label selectors. 
+**Field Selector** - A way for users to filter and select Flight Control objects based on the values of specific resource fields. Field selectors follow the same syntax, principles, and support the same operators as Kubernetes Field and Label selectors.
 
 **Service** -  The Flight Control Service handles user and agent authentication and authorization, device enrollment and inventory, rolling out updates to devices, and rolling up status from devices.
 


### PR DESCRIPTION
Fixes the issue where path-filter does not correctly handle `**` globs.
Fixes lint-docs and spellcheck-docs issues that escaped due to this.