### PR TITLE
EDM-420: Start only one Podman Monitor per Agent

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/internal/agent/device"
+	"github.com/flightctl/flightctl/internal/agent/device/applications"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
@@ -72,6 +73,8 @@ func main() {
 	formattedLables := formatLabels(labels)
 
 	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile)
+
+	applications.UseSinglePodmanMonitor()
 
 	log.Infoln("starting device simulator")
 	defer log.Infoln("device simulator stopped")

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent"
 	"github.com/flightctl/flightctl/internal/agent/device"
-	"github.com/flightctl/flightctl/internal/agent/device/applications"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
@@ -73,8 +72,6 @@ func main() {
 	formattedLables := formatLabels(labels)
 
 	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile)
-
-	applications.UseSinglePodmanMonitor()
 
 	log.Infoln("starting device simulator")
 	defer log.Infoln("device simulator stopped")

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -18,7 +18,7 @@ type manager struct {
 
 func NewManager(log *log.PrefixLogger, exec executer.Executer, podmanClient *client.Podman) Manager {
 	return &manager{
-		podmanMonitor: NewPodmanMonitor(log, exec, podmanClient),
+		podmanMonitor: NewPodmanMonitor(log, exec, podmanClient, false),
 		log:           log,
 	}
 }

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -78,10 +78,10 @@ var podmanMonitorMutex sync.Mutex
 // NewPodmanMonitor - initialize a podman monitor
 // Only one podman monitor runs per agent.
 // This is especially important in a case of device simulator!
-func NewPodmanMonitor(log *log.PrefixLogger, exec executer.Executer, podman *client.Podman) *PodmanMonitor {
+func NewPodmanMonitor(log *log.PrefixLogger, exec executer.Executer, podman *client.Podman, reset bool) *PodmanMonitor {
 	podmanMonitorMutex.Lock()
 	defer podmanMonitorMutex.Unlock()
-	if podmanMonitor == nil {
+	if podmanMonitor == nil || reset {
 		podmanMonitor = &PodmanMonitor{
 			client:  podman,
 			boot:    client.NewBoot(exec),

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -59,7 +59,6 @@ type PodmanEvent struct {
 type PodmanMonitor struct {
 	mu          sync.Mutex
 	cmd         *exec.Cmd
-	once        sync.Once
 	cancelFn    context.CancelFunc
 	initialized bool
 

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -146,11 +146,7 @@ func TestListenForEvents(t *testing.T) {
 			require.NoError(err)
 
 			podman := client.NewPodman(log, execMock)
-			podmanMonitor := NewPodmanMonitor(log, execMock, podman)
-			defer func() {
-				err := podmanMonitor.Stop(context.Background())
-				require.NoError(err)
-			}()
+			podmanMonitor := NewPodmanMonitor(log, execMock, podman, true)
 
 			// add test apps to the monitor
 			for _, testApp := range tc.apps {

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -147,6 +147,7 @@ func TestListenForEvents(t *testing.T) {
 
 			podman := client.NewPodman(log, execMock)
 			podmanMonitor := NewPodmanMonitor(log, execMock, podman)
+			defer podmanMonitor.Stop(context.Background())
 
 			// add test apps to the monitor
 			for _, testApp := range tc.apps {

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -147,7 +147,10 @@ func TestListenForEvents(t *testing.T) {
 
 			podman := client.NewPodman(log, execMock)
 			podmanMonitor := NewPodmanMonitor(log, execMock, podman)
-			defer podmanMonitor.Stop(context.Background())
+			defer func() {
+				err := podmanMonitor.Stop(context.Background())
+				require.NoError(err)
+			}()
 
 			// add test apps to the monitor
 			for _, testApp := range tc.apps {


### PR DESCRIPTION
This is especially important for DeviceSimulator -- one monitor is enough and we don't need to kill others manually