### PR TITLE
EDM-417: Compute service-side statuses

### DIFF
--- a/api/v1alpha1/constructors.go
+++ b/api/v1alpha1/constructors.go
@@ -7,10 +7,6 @@ func NewDeviceStatus() DeviceStatus {
 				Type:   DeviceUpdating,
 				Status: ConditionStatusUnknown,
 			},
-			{
-				Type:   DeviceSpecValid,
-				Status: ConditionStatusUnknown,
-			},
 		},
 		Applications: []DeviceApplicationStatus{},
 		ApplicationsSummary: DeviceApplicationsSummaryStatus{

--- a/api/v1alpha1/properties.go
+++ b/api/v1alpha1/properties.go
@@ -1,0 +1,82 @@
+package v1alpha1
+
+import (
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/util"
+)
+
+// IsDisconnected() is true if the device never updated status or its last status update is older than disconnectTimeout.
+func (d *Device) IsDisconnected(disconnectTimeout time.Duration) bool {
+	return d == nil || (d.Status != nil && d.Status.LastSeen.Add(disconnectTimeout).Before(time.Now()))
+}
+
+// IsManaged() if the device has its owner field set.
+func (d *Device) IsManaged() bool {
+	return d != nil && d.Metadata.Owner != nil && len(util.DefaultIfNil(d.Metadata.Owner, "")) > 0
+}
+
+// IsManagedBy() is true if the device is managed by the given fleet.
+func (d *Device) IsManagedBy(f *Fleet) bool {
+	if f == nil || !d.IsManaged() {
+		return false
+	}
+	return f.Metadata.Name == util.StrToPtr(strings.TrimPrefix("Fleet/", *d.Metadata.Owner))
+}
+
+// IsUpdating() is true if the device's agent reports that it is updating.
+func (d *Device) IsUpdating() bool {
+	return d != nil && d.Status != nil && IsStatusConditionTrue(d.Status.Conditions, DeviceUpdating)
+}
+
+// IsRebooting() is true if the device's agent has the updating condition set with state Rebooting.
+func (d *Device) IsRebooting() bool {
+	if d == nil || d.Status == nil {
+		return false
+	}
+	updatingCondition := FindStatusCondition(d.Status.Conditions, DeviceUpdating)
+	if updatingCondition == nil {
+		return false
+	}
+	return updatingCondition.Status == ConditionStatusTrue && updatingCondition.Reason == string(UpdateStateRebooting)
+}
+
+// IsUpdatedToDeviceSpec() is true if the device's current rendered version matches its spec's rendered version.
+func (d *Device) IsUpdatedToDeviceSpec() bool {
+	if d == nil || d.Metadata.Annotations == nil {
+		// devices without a rendered version cannot be out-of-date
+		return true
+	}
+	if d.Status == nil {
+		// devices without status cannot be up to date
+		return false
+	}
+	renderedVersionString, ok := (*d.Metadata.Annotations)[DeviceAnnotationRenderedVersion]
+	if !ok {
+		// devices without a rendered version cannot be out-of-date
+		return true
+	}
+	return d.Status.Config.RenderedVersion == renderedVersionString
+}
+
+// IsUpdatedToFleetSpec() is true if the IsUpdatedToDeviceSpec() and
+// device spec's current rendered version matches its fleet's rendered version.
+func (d *Device) IsUpdatedToFleetSpec(f *Fleet) bool {
+	if !d.IsManagedBy(f) {
+		// a device cannot be up to date relative to a fleet it is not managed by
+		return false
+	}
+	if d.Metadata.Annotations == nil || f.Metadata.Annotations == nil {
+		return false
+	}
+	fleetTemplateVersion, ok := (*f.Metadata.Annotations)[FleetAnnotationTemplateVersion]
+	if !ok {
+		return false
+	}
+	deviceTemplateVersion, ok := (*d.Metadata.Annotations)[FleetAnnotationTemplateVersion]
+	if !ok {
+		return false
+	}
+	return d.IsUpdatedToDeviceSpec() && deviceTemplateVersion == fleetTemplateVersion
+}

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -428,7 +428,7 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1alpha1.RenderedD
 		statusUpdate.Status = v1alpha1.DeviceSummaryStatusDegraded
 		statusUpdate.Info = util.StrToPtr(fmt.Sprintf("Failed to sync device: %v", syncErr))
 
-		conditionUpdate.Reason = string(v1alpha1.UpdateStateRetrying)
+		conditionUpdate.Reason = string(v1alpha1.UpdateStateApplyingUpdate)
 		conditionUpdate.Message = fmt.Sprintf("Failed to update to renderedVersion: %s. Retrying", version)
 		conditionUpdate.Status = v1alpha1.ConditionStatusTrue
 	}

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -69,9 +69,9 @@ func IsRetryable(err error) bool {
 	case errors.Is(err, ErrAuthenticationFailed):
 		return false
 	default:
-		// this will need to be updated as we identify more errors that are not
-		// retryable but for now we will retry and mark degraded.
-		return true
+		// this will need to be updated as we identify more errors that are
+		// retryable but for now we will fail the update.
+		return false
 	}
 }
 

--- a/internal/service/agent/handler.go
+++ b/internal/service/agent/handler.go
@@ -76,7 +76,7 @@ func (s *AgentServiceHandler) GetRenderedDeviceSpec(ctx context.Context, request
 		Name:   request.Name,
 		Params: request.Params,
 	}
-	return common.GetRenderedDeviceSpec(ctx, s.store, serverRequest, s.agentGrpcEndpoint)
+	return common.GetRenderedDeviceSpec(ctx, s.store, s.log, serverRequest, s.agentGrpcEndpoint)
 }
 
 // (PUT /api/v1/devices/{name}/status)
@@ -92,7 +92,7 @@ func (s *AgentServiceHandler) ReplaceDeviceStatus(ctx context.Context, request a
 		Name: request.Name,
 		Body: request.Body,
 	}
-	return common.ReplaceDeviceStatus(ctx, s.store, serverRequest)
+	return common.ReplaceDeviceStatus(ctx, s.store, s.log, serverRequest)
 }
 
 // (POST /api/v1/enrollmentrequests)

--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -2,18 +2,36 @@ package common
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 )
 
-func ReplaceDeviceStatus(ctx context.Context, st store.Store, request server.ReplaceDeviceStatusRequestObject) (server.ReplaceDeviceStatusResponseObject, error) {
+const (
+	ApplicationStatusInfoHealthy = "All application workloads healthy."
+	DeviceStatusInfoHealthy      = "All system resources healthy."
+	DeviceStatusInfoRebooting    = "The device is rebooting."
+)
+
+func ReplaceDeviceStatus(ctx context.Context, st store.Store, log logrus.FieldLogger, request server.ReplaceDeviceStatusRequestObject) (server.ReplaceDeviceStatusResponseObject, error) {
 	orgId := store.NullOrgId
 
 	device := request.Body
+	if errs := validateDeviceStatus(device); len(errs) > 0 {
+		return server.ReplaceDeviceStatus400JSONResponse{Message: errors.Join(errs...).Error()}, nil
+	}
 	device.Status.LastSeen = time.Now()
+	UpdateServiceSideStatus(ctx, st, log, orgId, device)
 
 	result, err := st.Device().UpdateStatus(ctx, orgId, device)
 	switch err {
@@ -30,7 +48,154 @@ func ReplaceDeviceStatus(ctx context.Context, st store.Store, request server.Rep
 	}
 }
 
-func GetRenderedDeviceSpec(ctx context.Context, st store.Store, request server.GetRenderedDeviceSpecRequestObject, consoleGrpcEndpoint string) (server.GetRenderedDeviceSpecResponseObject, error) {
+func validateDeviceStatus(_ *api.Device) []error {
+	allErrs := []error{}
+	// TODO: implement validation of agent's status updates
+	return allErrs
+}
+
+func UpdateServiceSideStatus(ctx context.Context, st store.Store, log logrus.FieldLogger, orgId uuid.UUID, device *api.Device) bool {
+	if device == nil {
+		return false
+	}
+	if device.Status == nil {
+		status := api.NewDeviceStatus()
+		device.Status = &status
+	}
+
+	deviceStatusChanged := updateServerSideDeviceStatus(device)
+	updatedStatusChanged := updateServerSideDeviceUpdatedStatus(ctx, st, log, orgId, device)
+	applicationStatusChanged := updateServerSideApplicationStatus(device)
+	return deviceStatusChanged || updatedStatusChanged || applicationStatusChanged
+}
+
+func updateServerSideDeviceStatus(device *api.Device) bool {
+	lastDeviceStatus := device.Status.Summary.Status
+	if device.IsDisconnected(api.DeviceDisconnectedTimeout) {
+		device.Status.Summary.Status = api.DeviceSummaryStatusUnknown
+		device.Status.Summary.Info = util.StrToPtr(fmt.Sprintf("The device is disconnected (last seen more than %s).", humanize.Time(time.Now().Add(-api.DeviceDisconnectedTimeout))))
+		return device.Status.Summary.Status != lastDeviceStatus
+	}
+	if device.IsRebooting() {
+		device.Status.Summary.Status = api.DeviceSummaryStatusRebooting
+		device.Status.Summary.Info = util.StrToPtr(DeviceStatusInfoRebooting)
+		return device.Status.Summary.Status != lastDeviceStatus
+	}
+
+	resourceErrors := []string{}
+	resourceDegradations := []string{}
+	switch device.Status.Resources.Cpu {
+	case api.DeviceResourceStatusCritical:
+		resourceErrors = append(resourceErrors, "CPU utilization reached critical level") // TODO: add current threshold (>X% for more than Y minutes)
+	case api.DeviceResourceStatusWarning:
+		resourceDegradations = append(resourceDegradations, "CPU utilization reached warning level") // TODO: add current threshold (>X% for more than Y minutes)
+	}
+	switch device.Status.Resources.Memory {
+	case api.DeviceResourceStatusCritical:
+		resourceErrors = append(resourceErrors, "Memory utilization reached critical level") // TODO: add current threshold (>X% for more than Y minutes)
+	case api.DeviceResourceStatusWarning:
+		resourceDegradations = append(resourceDegradations, "Memory utilization reached warning level") // TODO: add current threshold (>X% for more than Y minutes)
+	}
+	switch device.Status.Resources.Disk {
+	case api.DeviceResourceStatusCritical:
+		resourceErrors = append(resourceErrors, "Disk utilization reached critical level") // TODO: add current threshold (>X% for more than Y minutes)
+	case api.DeviceResourceStatusWarning:
+		resourceDegradations = append(resourceDegradations, "Disk utilization reached warning level") // TODO: add current threshold (>X% for more than Y minutes)
+	}
+
+	switch {
+	case len(resourceErrors) > 0:
+		device.Status.Summary.Status = api.DeviceSummaryStatusError
+		device.Status.Summary.Info = util.StrToPtr(strings.Join(resourceErrors, ", "))
+	case len(resourceDegradations) > 0:
+		device.Status.Summary.Status = api.DeviceSummaryStatusDegraded
+		device.Status.Summary.Info = util.StrToPtr(strings.Join(resourceDegradations, ", "))
+	default:
+		device.Status.Summary.Status = api.DeviceSummaryStatusOnline
+		device.Status.Summary.Info = util.StrToPtr(DeviceStatusInfoHealthy)
+	}
+	return device.Status.Summary.Status != lastDeviceStatus
+}
+
+func updateServerSideDeviceUpdatedStatus(ctx context.Context, st store.Store, log logrus.FieldLogger, orgId uuid.UUID, device *api.Device) bool {
+	lastUpdateStatus := device.Status.Updated.Status
+	if device.IsUpdating() {
+		if device.IsDisconnected(api.DeviceDisconnectedTimeout) {
+			device.Status.Updated.Status = api.DeviceUpdatedStatusUnknown
+			device.Status.Updated.Info = util.StrToPtr(fmt.Sprintf("The device is disconnected (last seen more than %s) and had an update in progress at that time.", humanize.Time(time.Now().Add(-api.DeviceDisconnectedTimeout))))
+		} else {
+			var agentInfoMessage string
+			if updateCondition := api.FindStatusCondition(device.Status.Conditions, api.DeviceUpdating); updateCondition != nil {
+				agentInfoMessage = updateCondition.Message
+			}
+			device.Status.Updated.Status = api.DeviceUpdatedStatusUpdating
+			device.Status.Updated.Info = util.StrToPtr(util.DefaultString(agentInfoMessage, "The device is updating to the latest device spec."))
+		}
+		return device.Status.Updated.Status != lastUpdateStatus
+	}
+	if !device.IsUpdatedToDeviceSpec() {
+		device.Status.Updated.Status = api.DeviceUpdatedStatusOutOfDate
+		device.Status.Updated.Info = util.StrToPtr("There is a newer device spec for this device.")
+		return device.Status.Updated.Status != lastUpdateStatus
+	}
+	if device.IsManaged() {
+		f, err := st.Fleet().Get(ctx, orgId, *device.Metadata.Name, store.WithSummary(false))
+		if err != nil {
+			log.Errorf("Failed to get fleet for device %q: %v", *device.Metadata.Name, err)
+			return false
+		}
+		if device.IsUpdatedToFleetSpec(f) {
+			device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
+			device.Status.Updated.Info = util.StrToPtr("The device has been updated to the fleet's latest device spec.")
+		} else {
+			device.Status.Updated.Status = api.DeviceUpdatedStatusOutOfDate
+			device.Status.Updated.Info = util.StrToPtr("The device has not yet been scheduled for update to the fleet's latest device spec.")
+		}
+	} else {
+		device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
+		device.Status.Updated.Info = util.StrToPtr("The device has been updated to the latest device spec.")
+	}
+	return device.Status.Updated.Status != lastUpdateStatus
+}
+
+func updateServerSideApplicationStatus(device *api.Device) bool {
+	lastApplicationSummaryStatus := device.Status.ApplicationsSummary.Status
+	if device.IsDisconnected(api.DeviceDisconnectedTimeout) {
+		device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusUnknown
+		device.Status.ApplicationsSummary.Info = util.StrToPtr(fmt.Sprintf("The device is disconnected (last seen more than %s).", humanize.Time(time.Now().Add(-api.DeviceDisconnectedTimeout))))
+		return device.Status.ApplicationsSummary.Status != lastApplicationSummaryStatus
+	}
+	if device.IsRebooting() {
+		device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusDegraded
+		device.Status.ApplicationsSummary.Info = util.StrToPtr(DeviceStatusInfoRebooting)
+		return device.Status.ApplicationsSummary.Status != lastApplicationSummaryStatus
+	}
+
+	appErrors := []string{}
+	appDegradations := []string{}
+	for _, app := range device.Status.Applications {
+		switch app.Status {
+		case api.ApplicationStatusError:
+			appErrors = append(appErrors, "%s is in status %s", app.Name, string(app.Status))
+		case api.ApplicationStatusPreparing, api.ApplicationStatusStarting:
+			appDegradations = append(appDegradations, "%s is in status %s", app.Name, string(app.Status))
+		}
+	}
+	switch {
+	case len(appErrors) > 0:
+		device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusError
+		device.Status.ApplicationsSummary.Info = util.StrToPtr(strings.Join(appErrors, ", "))
+	case len(appDegradations) > 0:
+		device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusDegraded
+		device.Status.ApplicationsSummary.Info = util.StrToPtr(strings.Join(appDegradations, ", "))
+	default:
+		device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
+		device.Status.ApplicationsSummary.Info = util.StrToPtr(ApplicationStatusInfoHealthy)
+	}
+	return device.Status.ApplicationsSummary.Status != lastApplicationSummaryStatus
+}
+
+func GetRenderedDeviceSpec(ctx context.Context, st store.Store, _ logrus.FieldLogger, request server.GetRenderedDeviceSpecRequestObject, consoleGrpcEndpoint string) (server.GetRenderedDeviceSpecResponseObject, error) {
 	orgId := store.NullOrgId
 
 	result, err := st.Device().GetRendered(ctx, orgId, request.Name, request.Params.KnownRenderedVersion, consoleGrpcEndpoint)

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -58,7 +58,7 @@ var _ = Describe("VM Agent behavior", func() {
 
 			// Approve the enrollment and wait for the device details to be populated by the agent
 			harness.ApproveEnrollment(enrollmentID, testutil.TestEnrollmentApproval())
-			logrus.Infof("Waiting for device %s to report status so we can check TPM PCRs again", enrollmentID)
+			logrus.Infof("Waiting for device %s to report status", enrollmentID)
 
 			// wait for the device to pickup enrollment and report measurements on device status
 			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
@@ -119,11 +119,11 @@ var _ = Describe("VM Agent behavior", func() {
 
 			harness.WaitForDeviceContents(deviceId, "Failed to update to renderedVersion: 2. Retrying",
 				func(device *v1alpha1.Device) bool {
-					return conditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateRetrying))
+					return conditionExists(device, "Updating", "False", string(v1alpha1.UpdateStateError))
 				}, "2m")
 
-			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Degraded")))
+			Eventually(harness.GetDeviceWithUpdateStatus, TIMEOUT, POLLING).WithArguments(
+				deviceId).Should(Equal(v1alpha1.DeviceUpdatedStatusOutOfDate))
 		})
 
 		It(`should show an error when trying to update a device with
@@ -189,7 +189,7 @@ var _ = Describe("VM Agent behavior", func() {
 					return conditionExists(device, "Updating", "False", "Updated")
 				}, "2m")
 			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusOnline))
 		})
 
 		It("should report 'Unknown' after the device vm is powered-off", func() {
@@ -199,7 +199,7 @@ var _ = Describe("VM Agent behavior", func() {
 			err := harness.VM.Shutdown()
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
-				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Unknown")))
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusUnknown))
 		})
 	})
 })

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -383,6 +383,6 @@ func (h *Harness) EnrollAndWaitForOnlineStatus() (string, *v1alpha1.Device) {
 	device := response.JSON200
 	Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusOnline))
 	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
-	Expect(device.Status.Updated.Status).To(Equal(v1alpha1.DeviceUpdatedStatusUnknown))
+	Expect(device.Status.Updated.Status).To(Equal(v1alpha1.DeviceUpdatedStatusUpToDate))
 	return deviceId, device
 }

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -331,7 +331,7 @@ func (h *Harness) UpdateDeviceWithRetries(deviceId string, updateFunction func(*
 }
 
 func (h *Harness) WaitForDeviceContents(deviceId string, description string, condition func(*v1alpha1.Device) bool, timeout string) {
-	lastStatusPrint := ""
+	lastResourcePrint := ""
 
 	Eventually(func() error {
 		logrus.Infof("Waiting for condition: %q to be met", description)
@@ -343,15 +343,15 @@ func (h *Harness) WaitForDeviceContents(deviceId string, description string, con
 		}
 		device := response.JSON200
 
-		yamlData, err := yaml.Marshal(device.Status)
+		yamlData, err := yaml.Marshal(device)
 		yamlString := string(yamlData)
 		Expect(err).ToNot(HaveOccurred())
-		if yamlString != lastStatusPrint {
+		if yamlString != lastResourcePrint {
 			fmt.Println("")
-			fmt.Println("======================= Device status change ===================== ")
+			fmt.Println("======================= Device resource change ===================== ")
 			fmt.Println(yamlString)
 			fmt.Println("================================================================== ")
-			lastStatusPrint = yamlString
+			lastResourcePrint = yamlString
 		}
 
 		if condition(device) {
@@ -383,6 +383,5 @@ func (h *Harness) EnrollAndWaitForOnlineStatus() (string, *v1alpha1.Device) {
 	device := response.JSON200
 	Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusOnline))
 	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
-	Expect(device.Status.Updated.Status).To(Equal(v1alpha1.DeviceUpdatedStatusUpToDate))
 	return deviceId, device
 }


### PR DESCRIPTION
This PR implement the service-side logic for updating the device summary status, device update status, and application summary status based on the information provided by the agent and information only available service-side.

Depends on PR #675 (which centralizes API consts to break import cycles).

User documentation is in PR #637.