### PR TITLE
EDM-788: Add init script for PostgreSQL to set master user as superuser

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-db-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flightctl-db
+  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+data:
+  enable-superuser.sh: |
+    #!/bin/bash
+
+    _psql () { psql --set ON_ERROR_STOP=1 "$@" ; }
+
+    # Ensure POSTGRESQL_MASTER_USER is treated as a superuser
+    if [ -n "${POSTGRESQL_MASTER_USER}" ]; then
+      echo "Granting superuser privileges to ${POSTGRESQL_MASTER_USER}"
+      _psql -c "ALTER ROLE ${POSTGRESQL_MASTER_USER} WITH SUPERUSER;"
+    fi

--- a/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
@@ -42,6 +42,9 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/pgsql/data
               name: flightctl-db
+            - mountPath: /usr/share/container-scripts/postgresql/start/enable-superuser.sh
+              subPath: enable-superuser.sh
+              name: init-scripts
           resources:
             requests:
               cpu: {{ .Values.db.resources.requests.cpu}}
@@ -54,4 +57,7 @@ spec:
         - name: flightctl-db
           persistentVolumeClaim:
             claimName: flightctl-db
+        - name: init-scripts
+          configMap:
+            name: flightctl-db
 


### PR DESCRIPTION
- Added `enable-extensions.sh` script to initialize PostgreSQL with specified extensions.
- The script checks the `POSTGRESQL_EXTENSIONS` environment variable and enables each extension dynamically.
- Integrated the script into the `flightctl-db` ConfigMap and Deployment.