### PR TITLE
EDM-659: agent/fileio: ensure ignition gid, uid and mode

### DIFF
--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -50,6 +50,7 @@ var (
 
 	// io
 	ErrReadingPath = errors.New("failed reading path")
+	ErrPathIsDir   = errors.New("provided path is a directory")
 )
 
 // TODO: tighten up the retryable errors ideally all retryable errors should be explicitly defined

--- a/internal/agent/device/fileio/managed_file_test.go
+++ b/internal/agent/device/fileio/managed_file_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	ign3types "github.com/coreos/ignition/v2/config/v3_4/types"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestExists(t *testing.T) {
 				},
 			},
 			pathExists:    false,
-			expectedError: ErrPathIsDir,
+			expectedError: errors.ErrPathIsDir,
 		},
 	}
 
@@ -73,6 +74,8 @@ func TestExists(t *testing.T) {
 
 func TestIsUpToDate(t *testing.T) {
 	require := require.New(t)
+	testUid, testGid, err := getUserIdentity()
+	require.NoError(err)
 	tests := []struct {
 		name string
 		// current is the current managed file instance
@@ -83,24 +86,40 @@ func TestIsUpToDate(t *testing.T) {
 	}{
 		{
 			name:         "file is up to date",
-			current:      createTestFile("up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A"),
-			desired:      createTestFile("up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A"),
+			current:      createTestFile("up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
+			desired:      createTestFile("up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
 			wantUpToDate: true,
 		},
 		{
-			name:    "file is not up to date",
-			current: createTestFile("not_up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A"),
-			desired: createTestFile("not_up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl%20v2.%0A"),
+			name:    "file content is not up to date",
+			current: createTestFile("not_up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
+			desired: createTestFile("not_up_to_date", "data:,This%20system%20is%20managed%20by%20flightctl%20v2.%0A", int(DefaultFilePermissions), testUid, testGid),
 		},
 		{
 			name:    "file does not exist",
 			current: nil,
-			desired: createTestFile("does_not_exist", "data:,This%20system%20is%20managed%20by%20flightctl.%0A"),
+			desired: createTestFile("does_not_exist", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
+		},
+		{
+			name:    "file with different permissions",
+			current: createTestFile("diff_perms", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", 0o644, testUid, testGid),
+			desired: createTestFile("diff_perms", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", 0o755, testUid, testGid),
+		},
+		{
+			name:    "file with different user",
+			current: createTestFile("diff_user", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
+			desired: createTestFile("diff_user", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid+1, testGid),
+		},
+		{
+			name:    "file with different group",
+			current: createTestFile("diff_group", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid),
+			desired: createTestFile("diff_group", "data:,This%20system%20is%20managed%20by%20flightctl.%0A", int(DefaultFilePermissions), testUid, testGid+1),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
+			t.Log(tmpDir)
 			writer := NewWriter()
 			writer.SetRootdir(tmpDir)
 			if tt.current != nil {
@@ -122,15 +141,23 @@ func TestIsUpToDate(t *testing.T) {
 	}
 }
 
-func createTestFile(path, data string) *ign3types.File {
+func createTestFile(path, data string, mode, user, group int) *ign3types.File {
 	return &ign3types.File{
 		Node: ign3types.Node{
 			Path: path,
+			User: ign3types.NodeUser{
+				ID: &user,
+			},
+			Group: ign3types.NodeGroup{
+				ID: &group,
+			},
 		},
+
 		FileEmbedded1: ign3types.FileEmbedded1{
 			Contents: ign3types.Resource{
 				Source: util.StrToPtr(data),
 			},
+			Mode: util.IntToPtr(mode),
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where managed files did not consider mode or user and group changes. The result was an ignition file that maintains the same content but different perms would not update on disk