### PR TITLE
NO-ISSUE: provide a way for users to easily contrib to docs

### DIFF
--- a/hack/check-commits.sh
+++ b/hack/check-commits.sh
@@ -18,10 +18,17 @@ revs=$(git rev-list "${master_branch}".."${current_branch}")
 
 for commit in ${revs};
 do
-    commit_message=$(git cat-file commit ${commit} | sed '1,/^$/d')
-    tmp_commit_file="$(mktemp)"
-    echo "${commit_message}" > ${tmp_commit_file}
-    ${__dir}/check-commit-message.sh "${tmp_commit_file}"
+   # Check if the commit only modifies files in the docs/ directory
+    modified_files=$(git diff-tree --no-commit-id --name-only -r "${commit}")
+    if echo "${modified_files}" | grep -qvE '^docs/'; then
+        # If any file is outside docs/, validate the commit message
+        commit_message=$(git cat-file commit "${commit}" | sed '1,/^$/d')
+        tmp_commit_file="$(mktemp)"
+        echo "${commit_message}" > "${tmp_commit_file}"
+        ${__dir}/check-commit-message.sh "${tmp_commit_file}"
+    else
+        echo "Skipping validation for commit ${commit} as it only modifies files in docs/"
+    fi
 done
 
 


### PR DESCRIPTION
This is an experiment which would make document only external contributors not have to jump through the commit message hoop.

```sh
git diff-tree --no-commit-id --name-only -r 117607c8d34bb3f0e9824a2050c80e82f5670068
hack/check-commits.sh

git diff-tree --no-commit-id --name-only -r 425c592
.spelling
docs/user/managing-devices.md
```