### PR TITLE
EDM-842: transient networking error should not mark agent degraded

### DIFF
--- a/internal/agent/device/status/status.go
+++ b/internal/agent/device/status/status.go
@@ -114,7 +114,7 @@ func (m *StatusManager) Sync(ctx context.Context) error {
 		return nil
 	}
 	if err := m.managementClient.UpdateDeviceStatus(ctx, m.deviceName, *m.device); err != nil {
-		return fmt.Errorf("failed to update device status: %w", err)
+		m.log.Warnf("Failed to update device status: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
if a transient networking error occurred when trying to update status we will degrade the device. This PR changes this from a Degraded status to a warn log line.

```
  summary:
    info: 'failed to update device status: Put "https://agent-api.flightctl.edge-devices.net/api/v1/devices/a063e22i764jja1nurfcqlkqu101qios3nob5c3fqsas7er1j89g/status":
      dial tcp: lookup agent-api.flightctl.edge-devices.net on 192.168.124.1:53: read
      udp 192.168.124.58:37945->192.168.124.1:53: i/o timeout'
   status: Degraded
```