### PR TITLE
EDM-848: revert tzdata host mount

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
@@ -53,9 +53,6 @@ spec:
               name: flightctl-api-config
               subPath: config.yaml
               readOnly: true
-            - mountPath: /usr/share/zoneinfo
-              name: tzdata
-              readOnly: true
 
       restartPolicy: Always
       volumes:
@@ -65,7 +62,4 @@ spec:
         - name: flightctl-api-config
           configMap:
             name: flightctl-api-config
-        - name: tzdata
-          hostPath:
-            path: /usr/share/zoneinfo
 {{ end }}


### PR DESCRIPTION
This PR reverts the addition of a host mount on tzdata. tzdata is used by the API server to validate time zones. But this approach breaks in OCP as the pod does not have proper permissions.