### PR TITLE
NO-ISSUE: redeploy kind pods for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOBASE=$(shell pwd)
 GOBIN=$(GOBASE)/bin
 GO_BUILD_FLAGS := ${GO_BUILD_FLAGS}
 ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
-GO_FILES := $(shell find ./ -name ".go" -not -path "./bin" -not -path "./packaging/*")
+GO_FILES := $(shell find ./ -name "*.go" -not -path "./bin" -not -path "./packaging/*")
 GO_CACHE := -v $${HOME}/go/flightctl-go-cache:/opt/app-root/src/go:Z -v $${HOME}/go/flightctl-go-cache/.cache:/opt/app-root/src/.cache:Z
 TIMEOUT ?= 30m
 GOOS := $(shell go env GOOS)
@@ -48,6 +48,7 @@ help:
 	@echo "    unit-test:       run unit tests"
 	@echo "    test:            run all tests"
 	@echo "    deploy:          deploy flightctl-server and db as pods in kind"
+	@echo "    redeploy-*       redeploy the api,worker,periodic containers in kind"
 	@echo "    deploy-db:       deploy only the database as a container, for testing"
 	@echo "    deploy-mq:       deploy only the message queue broker as a container"
 	@echo "    deploy-quadlets: deploy FlightCtl using Quadlets"
@@ -124,11 +125,6 @@ build-containers: flightctl-api-container flightctl-worker-container flightctl-p
 .PHONY: build-containers
 
 
-update-server-container: bin/.flightctl-server-container
-	kind load docker-image localhost/flightctl-server:latest
-	kubectl delete pod -l flightctl.service=flightctl-server -n flightctl-external
-	kubectl rollout status deployment flightctl-server -n flightctl-external -w --timeout=30s
-	kubectl logs -l flightctl.service=flightctl-server -n flightctl-external -f
 bin:
 	mkdir -p bin
 

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -19,6 +19,15 @@ clean-cluster:
 
 deploy: cluster build deploy-helm deploy-e2e-extras prepare-agent-config
 
+redeploy-api: flightctl-api-container
+	test/scripts/redeploy.sh api
+
+redeploy-worker: flightctl-worker-container
+	test/scripts/redeploy.sh worker
+
+redeploy-periodic: flightctl-periodic-container
+	test/scripts/redeploy.sh periodic
+
 deploy-helm: git-server-container flightctl-api-container flightctl-worker-container flightctl-periodic-container
 	kubectl config set-context kind-kind
 	test/scripts/install_helm.sh

--- a/test/scripts/redeploy.sh
+++ b/test/scripts/redeploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eo pipefail
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+source "${SCRIPT_DIR}"/functions
+
+IMAGE=${1}
+
+case $IMAGE in
+    api|worker|periodic)
+        ;;
+
+    *) echo "Usage: $0 <api|worker|periodic>"
+       exit 1
+esac
+
+podman tag flightctl-${IMAGE}:latest localhost/flightctl-${IMAGE}:latest
+for suffix in periodic api worker ; do
+    kind_load_image localhost/flightctl-${IMAGE}:latest
+done
+
+# switch for api worker and periodic handling, we need to kill the pods to reload
+case $IMAGE in
+    api)
+        oc delete pod -n flightctl-external -l flightctl.service=flightctl-api
+        sleep 5
+        oc logs -f -n flightctl-external -l flightctl.service=flightctl-api
+        ;;
+    worker)
+        oc delete pod -n flightctl-internal -l flightctl.service=flightctl-worker
+        sleep 5
+        oc logs -f -n flightctl-internal -l flightctl.service=flightctl-worker
+        ;;
+    periodic)
+        oc delete pod -n flightctl-internal -l flightctl.service=flightctl-periodic
+        sleep 5
+        oc logs -f -n flightctl-internal -l flightctl.service=flightctl-periodic
+        ;;
+esac
+


### PR DESCRIPTION
This commit introduces a few targets to help with re-deployment of api/worker/periodic services on development, avoiding the need to re-deploy the kind cluster in full.