### PR TITLE
EDM-876 Fix helm template error

### DIFF
--- a/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-route.yaml
+++ b/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-route.yaml
@@ -22,7 +22,7 @@ spec:
     weight: 100
   port:
     targetPort: 8080-tcp
-  {{- if eq (include "flightctl.getUIHttpScheme" .) "https" }}
+  {{- if eq (include "flightctl.getHttpScheme" .) "https" }}
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
The template helper was renamed [here](https://github.com/flightctl/flightctl/pull/641/files#diff-0bd34c1193202c7f6d02e308bc8015a9ca54f331bd0262752d7b803874b79525R23) as the template was moved from the UI repo to flightcl main repo.