### PR TITLE
Console on websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/go-tpm-tools v0.4.4
 	github.com/google/renameio v1.0.1
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/lestrrat-go/jwx/v2 v2.1.0
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwnKaMyD8uC+34TLdndZMAKk=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/internal/api_server/agentserver/grpc.go
+++ b/internal/api_server/agentserver/grpc.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/flightctl/flightctl/api/grpc/v1"
 	"github.com/flightctl/flightctl/internal/api_server/middleware"
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/console"
 	"github.com/flightctl/flightctl/internal/consts"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/sirupsen/logrus"
@@ -45,7 +46,7 @@ func NewAgentGrpcServer(
 }
 
 func (s *AgentGrpcServer) Run(ctx context.Context) error {
-	s.log.Printf("Initializing Agent-side gRPC server: %s", s.cfg.Service.AgentGrpcAddress)
+	s.log.Infof("Initializing Agent-side gRPC server: %s", s.cfg.Service.AgentGrpcAddress)
 	tlsCredentials := credentials.NewTLS(s.tlsConfig)
 	server := grpc.NewServer(
 		grpc.Creds(tlsCredentials),
@@ -68,11 +69,34 @@ func (s *AgentGrpcServer) Run(ctx context.Context) error {
 }
 
 type streamCtx struct {
-	cancel context.CancelFunc
-	stream pb.RouterService_StreamServer
-	closed bool // one side closed the connection and we should not accept any more messages
+	cancel  context.CancelFunc
+	stream  pb.RouterService_StreamServer
+	session *console.ConsoleSession // we let the console sessions coexist for a while until UI gets fully migrated out of gRPC
+	closed  bool                    // one side closed the connection and we should not accept any more messages
 }
 
+// This function is called by the console session manager to signal that it is ready to accept connections
+// from the agent. This is a way to provide the gRPC service with the session UUID and the channels
+func (s *AgentGrpcServer) StartSession(session *console.ConsoleSession) error {
+	sctx := streamCtx{
+		cancel:  nil,
+		stream:  nil,
+		closed:  false,
+		session: session,
+	}
+	s.log.Infof("the console manager started the session %s for device %s, waiting for stream", session.UUID, session.DeviceName)
+	// we store the session in the map, so when the agent connects we can start forwarding
+	// bytes between the two client and the device agent
+	s.pendingStreams.Store(session.UUID, sctx)
+	return nil
+}
+
+// This function is called by the console session manager to signal that the session has been closed
+// from the other side
+func (s *AgentGrpcServer) CloseSession(session *console.ConsoleSession) error {
+	s.log.Infof("the console manager closed the session %s for device %s", session.UUID, session.DeviceName)
+	return nil
+}
 func (s *AgentGrpcServer) Stream(stream pb.RouterService_StreamServer) error {
 	ctx := stream.Context()
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -108,42 +132,113 @@ func (s *AgentGrpcServer) Stream(stream pb.RouterService_StreamServer) error {
 	if loaded {
 		s.log.Infof("client %s connected to session %s", clientName, sessionId)
 		otherSideStream := actual.(streamCtx).stream
-		if actual.(streamCtx).closed || otherSideStream == nil {
+		otherSideSession := actual.(streamCtx).session
+		if actual.(streamCtx).closed || otherSideStream == nil && otherSideSession == nil {
 			// the other side closed the connection, we should not accept any more messages
 			s.log.Infof("client %s, attempted connection to %s which was already closed", clientName, sessionId)
 			return nil
 		}
-		err := forward(ctx, stream, otherSideStream)
-		if errors.Is(err, io.EOF) {
-			// one side closed the connection, we should not accept any more messages
-			s.log.Infof("one client disconnected from session %s, closing", sessionId)
-
-			// we try to send a close message to both sides, no error checking, best effort
-			err := stream.Send(&pb.StreamResponse{Closed: true})
-			if err != nil {
-				s.log.Warningf("sending close message to stream %s: %s", sessionId, err)
-			}
-
-			err = otherSideStream.Send(&pb.StreamResponse{Closed: true})
-			if err != nil {
-				s.log.Warningf("sending close message to stream %s: %s", sessionId, err)
-			}
-
-			// free the other stream reference, and mark this one as closed
-			stctx := actual.(streamCtx)
-			stctx.stream = nil
-			stctx.closed = true
-			s.pendingStreams.Store(sessionId, stctx)
-			return nil
-		} else {
-			actual.(streamCtx).cancel()
-			return err
+		// TODO(majopela): handling of the gRPC<->gRPC communication, we should remove this once the console UI is fully migrated to the new ws API
+		if otherSideStream != nil {
+			s.log.Infof("client %s connected to session %s, forwarding gRPC<->gRPC", clientName, sessionId)
+			return s.forwardGrpcOnlyStream(ctx, stream, otherSideStream, sessionId, actual)
 		}
+		// There is a ws console session on the other side, we should forward the ws connection to the console session
+		if otherSideSession != nil {
+			s.log.Infof("client %s connected to session %s, forwarding ws console session", clientName, sessionId)
+			return s.forwardConsoleSession(ctx, stream, otherSideSession, sessionId, actual)
+		}
+
 	} else {
 		// the map did not have a value, we are the first client, so we wait for the second
 		s.log.Infof("client %s waiting for peer %s", clientName, sessionId)
 		<-ctx.Done()
 		return nil
+	}
+	return nil
+}
+
+func (s *AgentGrpcServer) forwardConsoleSession(ctx context.Context, stream pb.RouterService_StreamServer, otherSideSession *console.ConsoleSession, sessionId string, actual any) error {
+	return s.forwardChannels(ctx, stream, otherSideSession)
+}
+
+func (s *AgentGrpcServer) forwardChannels(ctx context.Context, a pb.RouterService_StreamServer, b *console.ConsoleSession) error {
+	g, _ := errgroup.WithContext(ctx)
+	g.Go(func() error { return s.pipeStreamToChannel(ctx, a, b.RecvCh) })
+	g.Go(func() error { return s.pipeChannelToStream(ctx, b.SendCh, a) })
+	return g.Wait()
+}
+
+func (s *AgentGrpcServer) pipeStreamToChannel(ctx context.Context, a pb.RouterService_StreamServer, ch chan []byte) error {
+	defer close(ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return io.EOF
+		default:
+			msg, err := a.Recv()
+			if err != nil {
+				return err
+			}
+
+			payload := msg.GetPayload()
+			closed := msg.GetClosed()
+			ch <- payload
+			if closed {
+				return io.EOF
+			}
+		}
+	}
+}
+
+func (s *AgentGrpcServer) pipeChannelToStream(ctx context.Context, ch chan []byte, a pb.RouterService_StreamServer) error {
+	for {
+		select {
+		case <-ctx.Done():
+			_ = a.Send(&pb.StreamResponse{Payload: []byte{}, Closed: true})
+			return io.EOF
+
+		case payload, ok := <-ch:
+			if !ok {
+				_ = a.Send(&pb.StreamResponse{Payload: []byte{}, Closed: true})
+				return io.EOF
+			}
+			if err := a.Send(&pb.StreamResponse{Payload: payload}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// TODO: this path provides support for the existing gRPC<->gRPC communication, we should remove it
+// once the console UI is fully migrated to the new ws API
+func (s *AgentGrpcServer) forwardGrpcOnlyStream(ctx context.Context, stream pb.RouterService_StreamServer, otherSideStream pb.RouterService_StreamServer, sessionId string, actual any) error {
+	err := forward(ctx, stream, otherSideStream)
+	if errors.Is(err, io.EOF) {
+		// one side closed the connection, we should not accept any more messages
+		// we try to send a close message to both sides, no error checking, best effort
+		// free the other stream reference, and mark this one as closed
+		s.log.Infof("one client disconnected from session %s, closing", sessionId)
+
+		err := stream.Send(&pb.StreamResponse{Closed: true})
+		if err != nil {
+			s.log.Warningf("sending close message to stream %s: %s", sessionId, err)
+		}
+
+		err = otherSideStream.Send(&pb.StreamResponse{Closed: true})
+		if err != nil {
+			s.log.Warningf("sending close message to stream %s: %s", sessionId, err)
+		}
+
+		stctx := actual.(streamCtx)
+		stctx.stream = nil
+		stctx.closed = true
+		s.pendingStreams.Store(sessionId, stctx)
+		return nil
+	} else {
+		actual.(streamCtx).cancel()
+		return err
 	}
 }
 

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -1,0 +1,107 @@
+package console
+
+import (
+	"context"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const ChannelSize = 2048
+
+type ConsoleSession struct {
+	UUID       string
+	OrgId      uuid.UUID
+	DeviceName string
+	SendCh     chan []byte
+	RecvCh     chan []byte
+}
+
+type InternalSessionRegistration interface {
+	// Register a session with a given UUID and channels
+	// Those channels will be used to read from and write to the session
+	// in a way that this interface down to the gRPC session is abstracted
+	StartSession(*ConsoleSession) error
+	CloseSession(*ConsoleSession) error
+}
+
+type ConsoleSessionManager struct {
+	store           store.Store
+	log             logrus.FieldLogger
+	callbackManager tasks.CallbackManager
+	configStorage   tasks.ConfigStorage
+	// This one is the gRPC Handler of the agent for now, in the next iteration
+	// this should be split so we funnel traffic through a queue in valkey
+	sessionRegistration InternalSessionRegistration
+}
+
+func NewConsoleSessionManager(store store.Store, callbackManager tasks.CallbackManager, configStorage tasks.ConfigStorage, log logrus.FieldLogger, sessionRegistration InternalSessionRegistration) *ConsoleSessionManager {
+	return &ConsoleSessionManager{
+		store:               store,
+		log:                 log,
+		callbackManager:     callbackManager,
+		configStorage:       configStorage,
+		sessionRegistration: sessionRegistration,
+	}
+}
+
+func (m *ConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.UUID, deviceName string) (*ConsoleSession, error) {
+
+	session := &ConsoleSession{
+		OrgId:      orgId,
+		DeviceName: deviceName,
+		UUID:       uuid.New().String(),
+		SendCh:     make(chan []byte, ChannelSize),
+		RecvCh:     make(chan []byte, ChannelSize),
+	}
+	// TODO(majopela): This still signals console session creation through an annotation on the device
+	// we should move this to a separate table in the database
+	if _, err := m.store.Device().Get(ctx, orgId, deviceName); err != nil {
+		return nil, err
+	}
+
+	annotations := map[string]string{api.DeviceAnnotationConsole: session.UUID}
+	if err := m.store.Device().UpdateAnnotations(ctx, orgId, deviceName, annotations, []string{}); err != nil {
+		return nil, err
+	}
+
+	// tell the gRPC service, or the message queue (in the future) that there is a session waiting, and provide
+	// the channels to read and write to the websocket session
+	if err := m.sessionRegistration.StartSession(session); err != nil {
+		m.log.Errorf("Failed to start session %s for device %s: %v, rolling back device annotation", session.UUID, deviceName, err)
+		// if we fail to register the session we should remove the annotation (best effort)
+		deleteAnnotations := []string{api.DeviceAnnotationConsole}
+		err = m.store.Device().UpdateAnnotations(ctx, orgId, deviceName, map[string]string{}, deleteAnnotations)
+		if err != nil {
+			m.log.Errorf("Failed to remove annotation from device %s: %v", deviceName, err)
+		}
+		return nil, err
+	}
+	return session, nil
+}
+
+func (m *ConsoleSessionManager) CloseSession(ctx context.Context, session *ConsoleSession) error {
+	closeSessionErr := m.sessionRegistration.CloseSession(session)
+	// make sure the device exists
+	device, err := m.store.Device().Get(ctx, session.OrgId, session.DeviceName)
+	if err != nil {
+		return err
+	}
+
+	// if the device is still attached to the same session, remove the annotation
+	if device.Metadata.Annotations != nil {
+		annotation, ok := (*device.Metadata.Annotations)[api.DeviceAnnotationConsole]
+		if ok && annotation == session.UUID {
+			deleteAnnotations := []string{api.DeviceAnnotationConsole}
+
+			if err := m.store.Device().UpdateAnnotations(ctx, session.OrgId, session.DeviceName, map[string]string{}, deleteAnnotations); err != nil {
+				return err
+			}
+		}
+	}
+	// we still want to signal if there was an error closing the session
+	return closeSessionErr
+}

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -2,14 +2,57 @@ package service
 
 import (
 	"context"
+	"net/http"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/go-chi/chi"
 	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 )
 
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true // Allow connections from any origin
+	},
+}
+
+func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Request) {
+	// Extract the device name from the URL
+	deviceName := chi.URLParam(r, "name")
+	h.log.Printf("WebSocket connection requested for device: %s", deviceName)
+
+	// Upgrade the HTTP connection to a WebSocket
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		h.log.Errorf("Failed to upgrade connection to WebSocket: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	h.log.Printf("WebSocket connection established for device: %s", deviceName)
+
+	for {
+		// Read message from the WebSocket connection
+		messageType, message, err := conn.ReadMessage()
+		if err != nil {
+			h.log.Printf("WebSocket connection closed for device %s: %v", deviceName, err)
+			break
+		}
+
+		// Log the message received (for debugging)
+		h.log.Printf("Received message from %s: %s", deviceName, string(message))
+
+		// Echo the message back to the client
+		err = conn.WriteMessage(messageType, message)
+		if err != nil {
+			h.log.Printf("Failed to write message to %s: %v", deviceName, err)
+			break
+		}
+	}
+}
 func (h *ServiceHandler) RequestConsole(ctx context.Context, request server.RequestConsoleRequestObject) (server.RequestConsoleResponseObject, error) {
 	orgId := store.NullOrgId
 

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -2,13 +2,16 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/api/server"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
@@ -20,39 +23,115 @@ var upgrader = websocket.Upgrader{
 }
 
 func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Request) {
-	// Extract the device name from the URL
+	orgId := store.NullOrgId
 	deviceName := chi.URLParam(r, "name")
-	h.log.Printf("WebSocket connection requested for device: %s", deviceName)
+
+	h.log.Debugf("websocket console connection requested for device: %s", deviceName)
+	consoleSession, err := h.consoleSessionManager.StartSession(r.Context(), orgId, deviceName)
+	// check for errors
+	if err != nil {
+		switch err {
+		case flterrors.ErrResourceNotFound:
+			h.log.Errorf("console requested for unknown device: %s", deviceName)
+			http.Error(w, "Device not found", http.StatusNotFound)
+		default:
+			h.log.Errorf("There was an error retrieving DB from database during console request: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
 
 	// Upgrade the HTTP connection to a WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		h.log.Errorf("Failed to upgrade connection to WebSocket: %v", err)
+		http.Error(w,
+			fmt.Sprintf("Failed to upgrade connection to WebSocket: %v", err),
+			http.StatusInternalServerError)
 		return
 	}
-	defer conn.Close()
 
-	h.log.Printf("WebSocket connection established for device: %s", deviceName)
+	stopWriter := make(chan struct{})
 
-	for {
-		// Read message from the WebSocket connection
-		messageType, message, err := conn.ReadMessage()
-		if err != nil {
-			h.log.Printf("WebSocket connection closed for device %s: %v", deviceName, err)
-			break
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	// go routine to read from the websocket connection and send to the console session
+	go func() {
+		defer func() {
+			// ensure that the other go func ends now
+			close(stopWriter)
+			// tell the console session that we are done
+			close(consoleSession.SendCh)
+			wg.Done()
+		}()
+
+		for {
+			// Read message from the WebSocket connection
+			msgType, message, err := conn.ReadMessage()
+			if err != nil {
+				h.log.Infof("websocket console session %s closed for device %s: %v", consoleSession.UUID, deviceName, err)
+				break
+			}
+			// if it's binary or text message, forward it to the console session
+			if msgType == websocket.BinaryMessage || msgType == websocket.TextMessage {
+				consoleSession.SendCh <- message
+			} else {
+				h.log.Warningf("Received unexpected message type %d from console websocket session %s for device %s",
+					msgType, consoleSession.UUID, deviceName)
+			}
 		}
+	}()
 
-		// Log the message received (for debugging)
-		h.log.Printf("Received message from %s: %s", deviceName, string(message))
+	// go routine to read from the console session and write to the websocket connection
+	go func() {
+		defer func() {
+			h.log.Debugf("Sending close message to console websocket for %s", deviceName)
 
-		// Echo the message back to the client
-		err = conn.WriteMessage(messageType, message)
-		if err != nil {
-			h.log.Printf("Failed to write message to %s: %v", deviceName, err)
-			break
+			if err := conn.WriteControl(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+				time.Now().Add(time.Second*5),
+			); err != nil {
+				h.log.Errorf("Failed to write close message to console websocket for session %s: %v", consoleSession.UUID, err)
+			}
+
+			// close the websocket connection so that the other go routine ends
+			conn.Close()
+			wg.Done()
+		}()
+
+		for {
+			select {
+			case <-stopWriter:
+				h.log.Debugf("The console from the device channel has been closed for session %s", consoleSession.UUID)
+				return
+
+			case message, ok := <-consoleSession.RecvCh:
+				if !ok {
+					h.log.Debugf("The console channel from the device  has been closed for session %s", consoleSession.UUID)
+					return
+				}
+
+				// echo the message received from the device console back to the websocket client
+				if err := conn.WriteMessage(websocket.BinaryMessage, message); err != nil {
+					h.log.Errorf("Failed to write message to console websocket for %s: %v", deviceName, err)
+					// make sure that the reader goroutine is also stopped
+					return
+				}
+			}
 		}
+	}()
+
+	wg.Wait()
+	h.log.Infof("Ending console session %s to device %s", consoleSession.UUID, deviceName)
+	err = h.consoleSessionManager.CloseSession(r.Context(), consoleSession)
+	if err != nil {
+		h.log.Errorf("Error closing console session %s for device %s: %v", consoleSession.UUID, deviceName, err)
 	}
 }
+
+// TODO(majopela): remove this request handler and API call once the UI is migrated to the new websocket API
 func (h *ServiceHandler) RequestConsole(ctx context.Context, request server.RequestConsoleRequestObject) (server.RequestConsoleResponseObject, error) {
 	orgId := store.NullOrgId
 

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,6 +18,13 @@ type ServiceHandler struct {
 	consoleGrpcEndpoint string
 	agentEndpoint       string
 	uiUrl               string
+}
+
+type WebsocketHandler struct {
+	store           store.Store
+	ca              *crypto.CA
+	log             logrus.FieldLogger
+	callbackManager tasks.CallbackManager
 }
 
 // Make sure we conform to servers Service interface
@@ -32,4 +40,18 @@ func NewServiceHandler(store store.Store, callbackManager tasks.CallbackManager,
 		agentEndpoint:       agentEndpoint,
 		uiUrl:               uiUrl,
 	}
+}
+
+func NewWebsocketHandler(store store.Store, ca *crypto.CA, log logrus.FieldLogger, callbackManager tasks.CallbackManager) *WebsocketHandler {
+	return &WebsocketHandler{
+		store:           store,
+		ca:              ca,
+		log:             log,
+		callbackManager: callbackManager,
+	}
+}
+
+func (h *WebsocketHandler) RegisterRoutes(r chi.Router) {
+	// Websocket handler for console
+	r.Get("/ws/v1/devices/{name}/console", h.HandleDeviceConsole)
 }

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/flightctl/flightctl/internal/api/server"
+	"github.com/flightctl/flightctl/internal/console"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
@@ -21,10 +22,10 @@ type ServiceHandler struct {
 }
 
 type WebsocketHandler struct {
-	store           store.Store
-	ca              *crypto.CA
-	log             logrus.FieldLogger
-	callbackManager tasks.CallbackManager
+	store                 store.Store
+	ca                    *crypto.CA
+	log                   logrus.FieldLogger
+	consoleSessionManager *console.ConsoleSessionManager
 }
 
 // Make sure we conform to servers Service interface
@@ -42,12 +43,12 @@ func NewServiceHandler(store store.Store, callbackManager tasks.CallbackManager,
 	}
 }
 
-func NewWebsocketHandler(store store.Store, ca *crypto.CA, log logrus.FieldLogger, callbackManager tasks.CallbackManager) *WebsocketHandler {
+func NewWebsocketHandler(store store.Store, ca *crypto.CA, log logrus.FieldLogger, consoleSessionManager *console.ConsoleSessionManager) *WebsocketHandler {
 	return &WebsocketHandler{
-		store:           store,
-		ca:              ca,
-		log:             log,
-		callbackManager: callbackManager,
+		store:                 store,
+		ca:                    ca,
+		log:                   log,
+		consoleSessionManager: consoleSessionManager,
 	}
 }
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -119,7 +119,7 @@ func NewTestApiServer(log logrus.FieldLogger, cfg *config.Config, store store.St
 
 	metrics := instrumentation.NewApiMetrics(cfg)
 
-	return apiserver.New(log, cfg, store, ca, listener, provider, metrics), listener, nil
+	return apiserver.New(log, cfg, store, ca, listener, provider, metrics, nil), listener, nil
 }
 
 // NewTestServer creates a new test server and returns the server and the listener listening on localhost's next available port.


### PR DESCRIPTION
1. This is keeping  the gRPC <-> gRPC transport for the console until UI migrates to websocket,
to avoid any release issues.
2. for the reason in (1) and to prove I am not breaking it, I am not doing the flightctl console ....  cmdline change in the same PR
3. This still continues to use the same annotation mechanisms, single console at once

but it's preparing for a few things:
a) Doing multiple consoles eventually, I create a ConsoleManager class
b) Moving from in-process channels for console comm (tx/rx), to distributed (through two queues per connection in redis/valkey)
that last thing would allow for horizontally scaling flightctl-api (or eventually splitting out the agent service) without breaking the console

can be tested with:
```
$ podman run --net=host --rm -ti ghcr.io/vi/websocat:nightly --binary -E -k wss://api.10.0.2.2.nip.io:3443/ws/v1/devices/o18jbk21am279cspp77lhb9f55eechk5v3on22booki0igbl1vb0/console
bash: cannot set terminal process group (2692): Inappropriate ioctl for device
bash: no job control in this shell
[root@localhost /]#

[root@localhost /]#
```