### PR TITLE
NO-ISSUE: packaging: add flightctl agent version to must-gather

### DIFF
--- a/packaging/must-gather/flightctl-must-gather
+++ b/packaging/must-gather/flightctl-must-gather
@@ -39,6 +39,9 @@ echo "### Disk Usage (du -h /) ###" >> "$output_file"
 du -h / >> "$output_file"
 echo "" >> "$output_file"
 
+echo "### flightctl agent version (flightctl-agent version) ###" >> "$output_file"
+flightctl-agent version >> "$output_file"
+
 echo "### bootc version (bootc --version) ###" >> "$output_file"
 bootc --version >> "$output_file"
 echo "" >> "$output_file"


### PR DESCRIPTION
This assists users in debug. Although the agent prints the version in the logs this makes it easier to find.