### PR TITLE
NO-ISSUE: Update GH runner

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -2,10 +2,6 @@
 name: 'Setup environment'
 description: 'Setup CI environment for testing'
 inputs:
-  setup_podman4:
-    description: 'Setup podman4 from OpenSUSE repos'
-    required: false
-    default: ''
   setup_kvm:
     description: 'Setup kvm in the VM'
     required: false
@@ -26,10 +22,10 @@ runs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-          sudo apt-get update
-          sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
-                                  virtinst bridge-utils qemu qemu-system-x86 qemu-kvm \
-                                  swtpm apparmor-utils
+          sudo apt update -y
+          sudo apt install -y libvirt-clients libvirt-daemon-system libvirt-daemon libvirt-dev \
+                              virtinst bridge-utils qemu-system-x86 qemu-kvm \
+                              swtpm apparmor-utils
           sudo usermod -a -G kvm,libvirt,swtpm $USER
           echo "::endgroup::"
 
@@ -37,30 +33,27 @@ runs:
         shell: bash
         run: |
           echo "::group::Installing general dependencies"
-          sudo apt-get update -y # fix broken repo cache
-          sudo apt install -y make python3-pip libvirt-dev protobuf-compiler
+          sudo apt update -y # fix broken repo cache
+          sudo apt install -y make python3-pip podman podman-compose
+
           go install gotest.tools/gotestsum@latest
-          go get -u github.com/proglottis/gpgme
           go install go.uber.org/mock/mockgen@v0.4.0
           go install github.com/onsi/ginkgo/v2/ginkgo
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+
+          curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
+          sudo unzip -q protoc.zip bin/protoc -d /usr/local
+          sudo chmod a+x /usr/local/bin/protoc
+          protoc --version
+          rm -rf protoc.zip
           echo "::endgroup::"
 
-      - name: Install podman 4
-        if: inputs.setup_podman4 != ''
+      - name: Fix container storage driver
         shell: bash
         run: |
-          echo "::group::Upgrade Podman to version 4"
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-              https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
-          pip3 install podman-compose
-          echo "::endgroup::"
+          # Fix storage driver so it can be used with BIB (see https://github.com/osbuild/bootc-image-builder/issues/446)
+          sudo rm -rf /var/lib/containers/storage
+          sudo mkdir -p /etc/containers
+          echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
+

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   integration-tests:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,8 +30,6 @@ jobs:
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         uses: ./.github/actions/setup-dependencies
-        with:
-          setup_podman4: yes
 
       - name: Running Integration tests
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-docs:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ppa-build.yaml
+++ b/.github/workflows/ppa-build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_upload:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   # This line defines a job with the ID `check-links` that is stored within the `jobs` key.
   e2e:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,17 +38,7 @@ jobs:
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         uses: ./.github/actions/setup-dependencies
         with:
-          setup_podman4: yes
           setup_kvm: yes
-
-      - name: Fix swtpm in qemu/libvirt (broken apparmor profile and swtpm permissions)
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
-        run: |
-          sudo apparmor_status
-          sudo aa-complain /usr/bin/swtpm
-          sudo apparmor_parser -r /etc/apparmor.d/usr.bin.swtpm
-          sudo mkdir -p /var/lib/swtpm-localca
-          sudo chmod a+rwx /var/lib/swtpm-localca
 
       - name: Create kind cluster
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   # This line defines a job with the ID `check-links` that is stored within the `jobs` key.
   kind-cluster:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -16,7 +16,7 @@ jobs:
         arch: [amd64, arm64]
     env:
       NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04
             build: linux-amd64
           - runner: macos-latest
             build: darwin-arm64
@@ -75,7 +75,7 @@ jobs:
 
   publish:
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     needs: [verify]
     permissions:
       contents: write

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   generate-tags:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     outputs:
       image_tags: ${{ steps.get-tags.outputs.image_tags }}
       helm_tag: ${{ steps.get-tags.outputs.helm_tag }}
@@ -50,7 +50,7 @@ jobs:
           fi
 
   publish-helm-charts-containers:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     needs: [publish-flightctl-containers, generate-tags]
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
       matrix:
         image: ['api', 'periodic', 'worker']
     needs: [generate-tags]
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,8 +29,6 @@ jobs:
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         uses: ./.github/actions/setup-dependencies
-        with:
-          setup_podman4: yes
 
       - name: Running Unit tests
         if: ${{ steps.filter.outputs.notdocs == 'true' }}


### PR DESCRIPTION
We're currently using `ubuntu-latest` as GH runners, which currently still links to 22.04, but will soon automatically update to 24.04. See: https://github.com/actions/runner-images/issues/10636

This PR makes the switch now and pins the version to 24.04. As 24.04 comes with Podman 4.9, we can also remove the separate installation from SuSE repos.