### PR TITLE
EDM-390: View lifecycle status of devices

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -392,7 +392,7 @@ func (o *GetOptions) printDevicesSummaryTable(w *tabwriter.Writer, summary *api.
 
 func (o *GetOptions) printDevicesTable(w *tabwriter.Writer, devices ...api.Device) {
 	if o.Output == wideFormat {
-		fmt.Fprintln(w, "NAME\tALIAS\tOWNER\tSYSTEM\tUPDATED\tAPPLICATIONS\tLAST SEEN\tLABELS")
+		fmt.Fprintln(w, "NAME\tALIAS\tOWNER\tSYSTEM\tUPDATED\tAPPLICATIONS\tLAST SEEN\tLIFECYCLE\tLABELS")
 	} else {
 		fmt.Fprintln(w, "NAME\tALIAS\tOWNER\tSYSTEM\tUPDATED\tAPPLICATIONS\tLAST SEEN")
 	}
@@ -415,6 +415,7 @@ func (o *GetOptions) printDevicesTable(w *tabwriter.Writer, devices ...api.Devic
 			lastSeen,
 		)
 		if o.Output == wideFormat {
+			fmt.Fprintf(w, "\t%s", d.Status.Lifecycle.Status)
 			fmt.Fprintf(w, "\t%s\n", strings.Join(util.LabelMapToArray(d.Metadata.Labels), ","))
 		} else {
 			fmt.Fprintln(w)


### PR DESCRIPTION
The output looks like this:

![Screenshot from 2024-12-19 16-49-29](https://github.com/user-attachments/assets/9c028160-d7fa-40ab-8a3c-ec57bef21bd9)