### PR TITLE
EDM-390: Set enrolled devices to 'Enrolled' lifecycle status

### DIFF
--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -79,10 +79,13 @@ func approveAndSignEnrollmentRequest(ca *crypto.CA, enrollmentRequest *v1alpha1.
 }
 
 func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, orgId uuid.UUID, enrollmentRequest *v1alpha1.EnrollmentRequest) error {
+	status := v1alpha1.NewDeviceStatus()
+	status.Lifecycle = v1alpha1.DeviceLifecycleStatus{Status: "Enrolled"}
 	apiResource := &v1alpha1.Device{
 		Metadata: v1alpha1.ObjectMeta{
 			Name: enrollmentRequest.Metadata.Name,
 		},
+		Status: &status,
 	}
 	if errs := apiResource.Validate(); len(errs) > 0 {
 		return fmt.Errorf("failed validating new device: %w", errors.Join(errs...))


### PR DESCRIPTION
Set enrolled devices to 'Enrolled' lifecycle status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced device enrollment process by adding a default "Enrolled" status to newly created devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->