### PR TITLE
EDM-966: reduce scope of bootc API

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -25,8 +25,7 @@ type Spec struct {
 }
 
 type ImageSpec struct {
-	Image     string `json:"image"`
-	Transport string `json:"transport"`
+	Image string `json:"image"`
 }
 
 type Status struct {
@@ -37,23 +36,12 @@ type Status struct {
 }
 
 type ImageStatus struct {
-	Image        ImageDetails  `json:"image"`
-	CachedUpdate *bool         `json:"cachedUpdate"`
-	Incompatible bool          `json:"incompatible"`
-	Pinned       bool          `json:"pinned"`
-	Ostree       OstreeDetails `json:"ostree"`
+	Image ImageDetails `json:"image"`
 }
 
 type ImageDetails struct {
 	Image       ImageSpec `json:"image"`
-	Version     string    `json:"version"`
-	Timestamp   string    `json:"timestamp"`
 	ImageDigest string    `json:"imageDigest"`
-}
-
-type OstreeDetails struct {
-	Checksum     string `json:"checksum"`
-	DeploySerial int    `json:"deploySerial"`
 }
 
 type BootcClient interface {

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -20,8 +20,6 @@ func TestBootcHost(t *testing.T) {
 
 	// spec image
 	require.Equal("quay.io/flightctl/flightctl-agent-basic-nginx", status.Spec.Image.Image)
-	// transport
-	require.Equal("registry", status.Spec.Image.Transport)
 	// booted
 	require.Equal("quay.io/flightctl/flightctl-agent-fedora", status.Status.Booted.Image.Image.Image)
 	// booted digest
@@ -30,16 +28,6 @@ func TestBootcHost(t *testing.T) {
 	require.Equal("quay.io/flightctl/flightctl-agent-basic-nginx", status.Status.Rollback.Image.Image.Image)
 	// staged image
 	require.Equal("quay.io/flightctl/flightctl-agent-basic-nginx", status.Status.Staged.Image.Image.Image)
-	// version
-	require.Equal("stream9.20240224.0", status.Status.Staged.Image.Version)
-	// timestamp
-	require.Equal("", status.Status.Staged.Image.Timestamp)
-	// ostree checksum
-	require.Equal("f627c830e921afe918402486d5fe8a7ffaf3bd8c0d21311cba28facc9b17b9e2", status.Status.Staged.Ostree.Checksum)
-	// pinned
-	require.Equal(false, status.Status.Staged.Pinned)
-	// deploy serial
-	require.Equal(4, status.Status.Staged.Ostree.DeploySerial)
 }
 
 func TestIsOsImageReconciled(t *testing.T) {


### PR DESCRIPTION
This PR reduces the scope of the bootc API to barebones to reduce surface area of breakage and only uses the types we explicitly use.

