### PR TITLE
EDM-953: Use approved Postgres

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         flightctl.service: flightctl-db
     spec:
+      {{- if .Values.global.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
       containers:
         - env:
             - name: PGPASSWORD

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -31,6 +31,7 @@ global:
     cert: ""
     key: ""
   storageClassName: ""
+  imagePullSecretName: ""
   auth:
     type: "builtin" # builtin, openshift, oidc, none
     openShiftApiUrl: ""


### PR DESCRIPTION
Allow setting an alternate image via variables to "make deploy".  For example:
IMAGE_PULL_SECRET_PATH="/path/to/pull/secret.yaml" SQL_IMAGE="registry.redhat.io/rhel8/postgresql-12" SQL_VERSION="1-181"