### PR TITLE
EDM-922: Fine-tune HTTP server settings

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -1,0 +1,70 @@
+name: 'Collect Logs and Upload'
+description: 'Collect logs from Kubernetes pods and upload them as artifacts'
+inputs:
+  namespace-external:
+    description: 'The external namespace for logs'
+    required: true
+    default: 'flightctl-external'
+  namespace-internal:
+    description: 'The internal namespace for logs'
+    required: true
+    default: 'flightctl-internal'
+  log-directory:
+    description: 'The directory to store log files'
+    required: false
+    default: 'logs'
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect logs
+      id: collect_logs
+      shell: bash
+      continue-on-error: true
+      if: always()
+      run: |
+        mkdir -p ${{ inputs.log-directory }}
+        # Cleanup logs older than 7 days
+        find ${{ inputs.log-directory }} -type f -name "*.log" -mtime +7 -delete
+
+        timestamp=$(date +%Y%m%d_%H%M%S)
+
+        log_files_collected=false
+
+        for deployment in flightctl-api flightctl-db flightctl-periodic flightctl-worker; do
+          echo "Collecting logs for $deployment..."
+          namespace=""
+          if [[ "$deployment" == "flightctl-api" ]]; then
+            namespace="${{ inputs.namespace-external }}"
+          else
+            namespace="${{ inputs.namespace-internal }}"
+          fi
+          if kubectl logs -n $namespace deployment/$deployment --previous --all-containers=true \
+             > ${{ inputs.log-directory }}/${deployment}_${timestamp}.log; then
+            log_files_collected=true
+          else
+            echo "Error collecting logs for $deployment"
+          fi
+        done
+
+        for statefulset in flightctl-kv flightctl-rabbitmq; do
+          echo "Collecting logs for $statefulset..."
+          if kubectl logs -n ${{ inputs.namespace-internal }} statefulset/$statefulset --all-containers=true \
+             > ${{ inputs.log-directory }}/${statefulset}_${timestamp}.log; then
+            log_files_collected=true
+          else
+            echo "Error collecting logs for $statefulset"
+          fi
+        done
+
+        if [[ "$log_files_collected" == false ]]; then
+          echo "No log files were collected."
+        fi
+        echo "log_files_collected=$log_files_collected" >> $GITHUB_OUTPUT
+    - name: Upload logs as artifacts
+      if: always() && steps.collect_logs.outputs.log_files_collected == 'true'
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: deploy-logs
+        path: ${{ inputs.log-directory }}
+        retention-days: 7

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -64,3 +64,11 @@ jobs:
       - name: Run E2E Tests
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         run:  make run-e2e-test VERBOSE=true # use DEBUG_VM_CONSOLE=1 to see the VM console output
+
+      - name: Collect and Upload Logs
+        if: always() && steps.filter.outputs.notdocs == 'true'
+        uses: ./.github/actions/collect-logs
+        with:
+          namespace-external: 'flightctl-external'
+          namespace-internal: 'flightctl-internal'
+          log-directory: 'logs'

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -72,3 +72,11 @@ jobs:
       - name: Simulator run
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         run: bin/devicesimulator --config bin/agent/etc/flightctl/config.yaml --count 1 --stop-after 1m
+
+      - name: Collect and Upload Logs
+        if: always() && steps.filter.outputs.notdocs == 'true'
+        uses: ./.github/actions/collect-logs
+        with:
+          namespace-external: 'flightctl-external'
+          namespace-internal: 'flightctl-internal'
+          log-directory: 'logs'

--- a/deploy/helm/flightctl/templates/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-config.yaml
@@ -17,6 +17,13 @@ data:
         address: :3443
         agentEndpointAddress: :7443
         agentGrpcAddress: :7444
+        httpReadTimeout: {{ .Values.api.httpReadTimeout | default "5m" | quote }}
+        httpReadHeaderTimeout: {{ .Values.api.httpReadHeaderTimeout | default "5m" | quote }}
+        httpWriteTimeout: {{ .Values.api.httpWriteTimeout | default "5m" | quote }}
+        httpMaxNumHeaders: {{ default 32 .Values.api.httpMaxNumHeaders }}
+        httpMaxHeaderBytes: {{ default 33010 .Values.api.httpMaxHeaderBytes }}
+        httpMaxUrlLength: {{ default 2000 .Values.api.httpMaxUrlLength }}
+        httpMaxRequestSize: {{ default 53137200 .Values.api.httpMaxRequestSize }}
         {{- if eq (include "flightctl.getServiceExposeMethod" .) "nodePort" }}
         baseUrl: https://api.{{ include "flightctl.getBaseDomain" . }}:{{ .Values.global.nodePorts.api }}/
         baseAgentEndpointUrl: https://agent-api.{{ include "flightctl.getBaseDomain" . }}:{{ .Values.global.nodePorts.agent }}/

--- a/internal/api_server/middleware/server_test.go
+++ b/internal/api_server/middleware/server_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Low level server behavior", func() {
 		listener, err = middleware.NewTLSListener("", tlsConfig)
 		Expect(err).ToNot(HaveOccurred())
 
-		srv := middleware.NewHTTPServerWithTLSContext(testTLSCNServer{}, serverLog, listener.Addr().String())
+		srv := middleware.NewHTTPServerWithTLSContext(testTLSCNServer{}, serverLog, listener.Addr().String(), config)
 
 		go func() {
 			defer GinkgoRecover()

--- a/internal/api_server/middleware/tls.go
+++ b/internal/api_server/middleware/tls.go
@@ -3,10 +3,12 @@ package middleware
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -18,17 +20,19 @@ type contextKey string
 
 const TLSCommonNameContextKey contextKey = "tls-cn"
 
-func NewHTTPServer(router http.Handler, log logrus.FieldLogger, address string) *http.Server {
+func NewHTTPServer(router http.Handler, log logrus.FieldLogger, address string, cfg *config.Config) *http.Server {
 	return &http.Server{
-		Addr:         address,
-		Handler:      router,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              address,
+		Handler:           router,
+		ReadTimeout:       time.Duration(cfg.Service.HttpReadTimeout),
+		ReadHeaderTimeout: time.Duration(cfg.Service.HttpReadHeaderTimeout),
+		WriteTimeout:      time.Duration(cfg.Service.HttpWriteTimeout),
+		MaxHeaderBytes:    cfg.Service.HttpMaxHeaderBytes,
 	}
 }
 
-func NewHTTPServerWithTLSContext(router http.Handler, log logrus.FieldLogger, address string) *http.Server {
-	server := NewHTTPServer(router, log, address)
+func NewHTTPServerWithTLSContext(router http.Handler, log logrus.FieldLogger, address string, cfg *config.Config) *http.Server {
+	server := NewHTTPServer(router, log, address, cfg)
 	server.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
 		tc := c.(*tls.Conn)
 		// We need to ensure TLS handshake is complete before
@@ -77,4 +81,22 @@ func ValidateClientTlsCert(ctx context.Context) (context.Context, error) {
 		return ctx, status.Error(codes.Unauthenticated, "failed to verify client certificate")
 	}
 	return ctx, nil
+}
+
+// RequestSizeLimiter returns a middleware that limits the URL length and the number of request headers.
+func RequestSizeLimiter(maxURLLength int, maxNumHeaders int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(r.URL.String()) > maxURLLength {
+				http.Error(w, fmt.Sprintf("URL too long, exceeds %d characters", maxURLLength), http.StatusRequestURITooLong)
+				return
+			}
+			if len(r.Header) > maxNumHeaders {
+				http.Error(w, fmt.Sprintf("Request has too many headers, exceeds %d", maxNumHeaders), http.StatusRequestEntityTooLarge)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }


### PR DESCRIPTION
Also collect logs in smoke/e2e github workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a GitHub Action for collecting logs from Kubernetes pods and uploading them as artifacts.
  - Added new steps in E2E and smoke testing workflows to collect and upload logs post-testing.
  - Enhanced API configuration with new HTTP timeout and limit parameters.

- **Bug Fixes**
  - Improved request handling by adding middleware for request size and header limits.

- **Documentation**
  - Updated configuration structures to include new HTTP-related settings and improved JSON handling for duration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->