### PR TITLE
EDM-390: Add decommission spec to rendered device config

### DIFF
--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -604,6 +604,7 @@ func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name str
 		Console:         console,
 		Applications:    device.RenderedApplications.Data,
 		UpdatePolicy:    device.Spec.Data.UpdatePolicy,
+		Decommission:    device.Spec.Data.Decommissioning,
 	}
 
 	return &renderedConfig, nil


### PR DESCRIPTION
This adds the decommission request to the rendered device spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced device configuration retrieval to include decommissioning status
	- Added visibility into device's current state through rendered specification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->