### PR TITLE
EDM-773: Update charts to support deployment via ACM operator

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -1,6 +1,8 @@
 {{- define "flightctl.getBaseDomain" }}
   {{- if .Values.global.baseDomain }}
     {{- printf .Values.global.baseDomain }}
+  {{- else if .Values.hubConfig.ocpIngress }}
+    {{- printf .Values.hubConfig.ocpIngress }}
   {{- else }}
     {{- $openShiftBaseDomain := (lookup "config.openshift.io/v1" "DNS" "" "cluster").spec.baseDomain }}
     {{- if .noNs }}
@@ -14,6 +16,8 @@
 {{- define "flightctl.getOpenShiftAPIUrl" }}
   {{- if .Values.global.auth.openShiftApiUrl }}
     {{- printf .Values.global.auth.openShiftApiUrl }}
+  {{- else if .Values.hubConfig.apiUrl }}
+    {{- printf .Values.hubConfig.apiUrl }}
   {{- else }}
     {{- $openShiftBaseDomain := (lookup "config.openshift.io/v1" "DNS" "" "cluster").spec.baseDomain }}
     {{- printf "https://api.%s:6443" $openShiftBaseDomain }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -20,9 +20,10 @@
 ## @param global.internalNamespace Namespace where internal components are deployed
 ## @param global.clusterLevelSecretAccess Allow flightctl-worker to access secrets at the cluster level for embedding in device configs
 ## @param global.appCode This is only related to deployment in Red Hat's PAAS.
-## @param global.exposeServicesMethod How the FCTL services should be exposed. Can be either nodePort or route
+## @param global.exposeServicesMethod How the FCTL services should be exposed. Can be either nodePort, route or gateway
 ## @param global.nodePorts Node port numbers for FCTL services
-
+## @param hubConfig.ocpIngress Same as global.baseDomain but this property is expected to be set by ACM operator
+## @param hubConfig.apiUrl Same as global.auth.openShiftApiUrl but this property is expected to be set by ACM operator
 
 global:
   target: "standalone" # standalone, acm
@@ -57,6 +58,11 @@ global:
   gatewayPorts:
     tls: 443
     http: 80
+
+## @section ACM operator specific parameters
+hubConfig:
+  ocpIngress: ""
+  apiUrl: ""
 
 
 ## @section Component specific parameters


### PR DESCRIPTION
Depends on https://github.com/stolostron/multiclusterhub-operator/pull/1877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new configuration parameters for ACM operator:
		- `hubConfig.ocpIngress` for base domain configuration
		- `hubConfig.apiUrl` for OpenShift API URL configuration

- **Improvements**
	- Enhanced Helm template logic to support alternative configuration methods for base domain and API URL retrieval
	- Updated `global.exposeServicesMethod` to include "gateway" as a valid option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->