### PR TITLE
EDM-390: Update device lifecycle status based on Condition

### DIFF
--- a/api/v1alpha1/properties.go
+++ b/api/v1alpha1/properties.go
@@ -80,3 +80,16 @@ func (d *Device) IsUpdatedToFleetSpec(f *Fleet) bool {
 	}
 	return d.IsUpdatedToDeviceSpec() && deviceTemplateVersion == fleetTemplateVersion
 }
+
+// IsDecommissioning() is true if the device has added a DeviceDecommissioning ConditionType to its Conditions.
+func (d *Device) IsDecommissioning() bool {
+	if d.Status == nil || d.Status.Conditions == nil {
+		return false
+	}
+
+	decommissioningCondition := FindStatusCondition(d.Status.Conditions, DeviceDecommissioning)
+	if decommissioningCondition == nil {
+		return false
+	}
+	return decommissioningCondition.Status == ConditionStatusTrue
+}


### PR DESCRIPTION
When the device sets a `DeviceDecommission` `Condition`, the service side will update the `LifecycleStatus` to `Decommissioning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to check if a device is in the process of decommissioning.
	- Enhanced device lifecycle status management to handle decommissioning state.

- **Improvements**
	- Introduced explicit handling for devices undergoing decommissioning.
	- Added informative status updates for decommissioning devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->