### PR TITLE
EDM-556: add device engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lestrrat-go/jwx/v2 v2.1.0
-	github.com/lthibault/jitterbug v2.0.0+incompatible
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/oapi-codegen/nethttp-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,6 @@ github.com/lestrrat-go/jwx/v2 v2.1.0 h1:0zs7Ya6+39qoit7gwAf+cYm1zzgS3fceIdo7RmQ5
 github.com/lestrrat-go/jwx/v2 v2.1.0/go.mod h1:Xpw9QIaUGiIUD1Wx0NcY1sIHwFf8lDuZn/cmxtXYRys=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lthibault/jitterbug v2.0.0+incompatible h1:qouq51IKzlMx25+15jbxhC/d79YyTj0q6XFoptNqaUw=
-github.com/lthibault/jitterbug v2.0.0+incompatible/go.mod h1:2l7akWd27PScEs6YkjyUVj/8hKgNhbbQ3KiJgJtlf6o=
 github.com/mackerelio/go-osstat v0.2.5 h1:+MqTbZUhoIt4m8qzkVoXUJg1EuifwlAJSk4Yl2GXh+o=
 github.com/mackerelio/go-osstat v0.2.5/go.mod h1:atxwWF+POUZcdtR1wnsUcQxTytoHG4uhl2AKKzrOajY=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -21,6 +21,8 @@ const (
 	DefaultSpecFetchInterval = util.Duration(60 * time.Second)
 	// DefaultStatusUpdateInterval is the default interval between two status updates
 	DefaultStatusUpdateInterval = util.Duration(60 * time.Second)
+	// MinSyncInterval is the minimum interval allowed for the spec fetch and status update
+	MinSyncInterval = util.Duration(2 * time.Second)
 	// DefaultConfigDir is the default directory where the device's configuration is stored
 	DefaultConfigDir = "/etc/flightctl"
 	// DefaultConfigFile is the default path to the agent's configuration file
@@ -183,6 +185,10 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
+	if err := cfg.validateSyncIntervals(); err != nil {
+		return err
+	}
+
 	requiredFields := []struct {
 		value     string
 		name      string
@@ -230,4 +236,14 @@ func (cfg *Config) String() string {
 		return "<error>"
 	}
 	return string(contents)
+}
+
+func (cfg *Config) validateSyncIntervals() error {
+	if cfg.SpecFetchInterval < MinSyncInterval {
+		return fmt.Errorf("minimum spec fetch interval is %s have %s", MinSyncInterval, cfg.SpecFetchInterval)
+	}
+	if cfg.StatusUpdateInterval < MinSyncInterval {
+		return fmt.Errorf("minimum status update interval is %s have %s", MinSyncInterval, cfg.StatusUpdateInterval)
+	}
+	return nil
 }

--- a/internal/agent/device/engine.go
+++ b/internal/agent/device/engine.go
@@ -1,0 +1,120 @@
+package device
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/util"
+)
+
+type Engine struct {
+	fetchSpecInterval  util.Duration
+	fetchSpecFn        func(context.Context)
+	pushStatusInterval util.Duration
+	pushStatusFn       func(context.Context)
+
+	clock Clock
+	// startedCh is used to signal when the ticker has started used for testing
+	startedCh chan struct{}
+}
+
+// NewEngine creates a new device engine.
+func NewEngine(
+	fetchSpecInterval util.Duration,
+	fetchSpecFn func(context.Context),
+	pushStatusInterval util.Duration,
+	pushStatusFn func(context.Context),
+) *Engine {
+	return &Engine{
+		fetchSpecInterval:  fetchSpecInterval,
+		fetchSpecFn:        fetchSpecFn,
+		pushStatusInterval: pushStatusInterval,
+		pushStatusFn:       pushStatusFn,
+		clock:              &realClock{},
+		startedCh:          make(chan struct{}),
+	}
+}
+
+func (e *Engine) calculateTickerInterval() time.Duration {
+	var minInterval util.Duration
+	if e.pushStatusInterval < e.fetchSpecInterval {
+		minInterval = e.pushStatusInterval
+	} else {
+		minInterval = e.fetchSpecInterval
+	}
+
+	if minInterval <= 0 {
+		// default to 1 second
+		minInterval = util.Duration(1 * time.Second)
+	}
+
+	// return half of the min interval
+	return time.Duration(minInterval / 2)
+}
+
+func (e *Engine) next(interval util.Duration, lastSync time.Time, now time.Time) bool {
+	return now.Sub(lastSync) >= time.Duration(interval)
+}
+
+func (e *Engine) Run(ctx context.Context) error {
+	// track the last time the spec and status were synced to ensure even distribution
+	var lastSpecSync, lastStatusSync time.Time
+
+	tickerInterval := e.calculateTickerInterval()
+	timeTicker := e.clock.NewTicker(tickerInterval)
+	defer timeTicker.Stop()
+	close(e.startedCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-timeTicker.C():
+			if now.IsZero() {
+				// clock was stopped
+				return nil
+			}
+			// spec
+			if e.next(e.fetchSpecInterval, lastSpecSync, now) {
+				lastSpecSync = now
+				e.fetchSpecFn(ctx)
+			}
+
+			// status
+			if e.next(e.pushStatusInterval, lastStatusSync, now) {
+				lastStatusSync = now
+				e.pushStatusFn(ctx)
+			}
+		}
+	}
+}
+
+// Clock interface allows us to mock time in tests.
+type Clock interface {
+	Now() time.Time
+	NewTicker(d time.Duration) Ticker
+}
+
+// Tick is an interface that resembles time.Ticker.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// realClock is a Clock interface implementation that uses the real time package.
+type realClock struct{}
+
+func (r *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (r *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{time.NewTicker(d)}
+}
+
+type realTicker struct {
+	*time.Ticker
+}
+
+func (r *realTicker) C() <-chan time.Time {
+	return r.Ticker.C
+}

--- a/internal/agent/device/engine_test.go
+++ b/internal/agent/device/engine_test.go
@@ -1,0 +1,131 @@
+package device
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+type testTaskType string
+
+const (
+	fetchSpec  testTaskType = "FetchSpec"
+	pushStatus testTaskType = "PushStatus"
+)
+
+func TestEngineDistribution(t *testing.T) {
+	require := require.New(t)
+
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mockClock := newMockClock(startTime)
+
+	var (
+		mu     sync.Mutex
+		events []testTaskType
+	)
+
+	fetchSpecFn := func(ctx context.Context) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, fetchSpec)
+	}
+	pushStatusFn := func(ctx context.Context) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, pushStatus)
+	}
+
+	startCh := make(chan struct{})
+	fetchSpecInterval := 100 * time.Millisecond
+	fetchStatusInterval := 100 * time.Millisecond
+	engine := Engine{
+		fetchSpecInterval:  util.Duration(fetchSpecInterval),
+		fetchSpecFn:        fetchSpecFn,
+		pushStatusInterval: util.Duration(fetchStatusInterval),
+		pushStatusFn:       pushStatusFn,
+		clock:              mockClock,
+		startedCh:          startCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		err := engine.Run(ctx)
+		require.NoError(err)
+	}()
+	<-startCh // wait for ticker to start
+
+	// simulate time passing 1000 intervals of 100ms
+	for i := 0; i < 1000; i++ {
+		// advance time +100 ms,
+		mockClock.Advance(100 * time.Millisecond)
+	}
+
+	cancel()
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 1; i < len(events); i++ {
+		require.NotEqual(events[i], events[i-1], "sequence must alternate")
+	}
+}
+
+type mockClock struct {
+	now   time.Time
+	ticks map[time.Duration]*mockTicker
+}
+
+type mockTicker struct {
+	c          chan time.Time
+	d          time.Duration
+	nextTickAt time.Time // next time to send into c channel.
+	clock      *mockClock
+}
+
+func newMockClock(start time.Time) *mockClock {
+	return &mockClock{
+		now:   start,
+		ticks: make(map[time.Duration]*mockTicker),
+	}
+}
+
+func (m *mockClock) Now() time.Time {
+	return m.now
+}
+
+// NewTicker creates a a mock ticker, storing its nextTickAt as now + duration.
+func (m *mockClock) NewTicker(d time.Duration) Ticker {
+	t := &mockTicker{
+		c:          make(chan time.Time, 1),
+		d:          d,
+		nextTickAt: m.now.Add(d),
+		clock:      m,
+	}
+	m.ticks[d] = t
+	return t
+}
+
+func (m *mockTicker) C() <-chan time.Time {
+	return m.c
+}
+
+func (m *mockTicker) Stop() {
+	close(m.c)
+}
+
+func (m *mockClock) Advance(d time.Duration) {
+	m.now = m.now.Add(d)
+	// check how many intervals (dur) we crossed,
+	// send ticks for each crossing.
+	for dur, t := range m.ticks {
+		for !t.nextTickAt.After(m.now) {
+			// send a tick
+			t.c <- t.nextTickAt
+			// move forward by its interval.
+			t.nextTickAt = t.nextTickAt.Add(dur)
+		}
+	}
+}

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -2,7 +2,6 @@ package os
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -44,12 +43,7 @@ func (m *manager) Status(ctx context.Context, status *v1alpha1.DeviceStatus) err
 		return err
 	}
 
-	osImage := bootcInfo.GetBootedImage()
-	if osImage == "" {
-		return fmt.Errorf("getting booted os image: %w", err)
-	}
-
-	status.Os.Image = osImage
+	status.Os.Image = bootcInfo.GetBootedImage()
 	status.Os.ImageDigest = bootcInfo.GetBootedImageDigest()
 	return nil
 }

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -135,7 +135,7 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 		cancel()
 	}()
 
-	fetchSpecInterval := util.Duration(1 * time.Second)
+	fetchSpecInterval := util.Duration(2 * time.Second)
 	statusUpdateInterval := util.Duration(2 * time.Second)
 
 	os.Setenv(agent.TestRootDirEnvKey, testDirPath)


### PR DESCRIPTION
This PR adds an engine that properly handles equal distribution of events between spec and status. The current implementation does provide a 50/50 distribution over time. But as with a coin toss you can get 5+ heads in a row this can result in unexpected delays in the reconciliation of new spec and or status updates. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Simplified agent task management by consolidating periodic synchronization tasks into a single, more efficient engine.
  - Removed dependency on `jitterbug` package, streamlining the codebase.

- **New Features**
  - Introduced a new `Engine` for managing periodic device specification and status synchronization tasks.
  - Added a minimum synchronization interval to enhance configuration validation.

- **Bug Fixes**
  - Simplified error handling in the status retrieval process, improving code clarity.

- **Tests**
  - Added comprehensive test suite for the new task management engine, ensuring reliable time-based task distribution.

The changes improve the agent's performance and maintainability by simplifying its internal task scheduling mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->