### PR TITLE
EDM-1010: Fix template variable for inline config path

### DIFF
--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -392,7 +392,7 @@ func (f FleetRolloutsLogic) replaceInlineConfigParameters(device *api.Device, co
 		var decodedBytes []byte
 		var err error
 
-		file.Path, err = replaceParametersInString(file.Path, device)
+		inlineSpec.Inline[fileIndex].Path, err = replaceParametersInString(file.Path, device)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed replacing parameters in path for file %d in inline config %s: %w", fileIndex, inlineSpec.Name, err))
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected path assignment logic in fleet rollout configuration processing to ensure accurate file path updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->