### PR TITLE
EDM-390: Remove decommissioning device from fleet

### DIFF
--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -641,6 +641,12 @@ func (f FleetSelectorMatchingLogic) HandleDeleteAllFleets(ctx context.Context) e
 
 // Update a device's owner, which in effect updates the fleet (may require rollout to the device)
 func (f FleetSelectorMatchingLogic) updateDeviceOwner(ctx context.Context, device *api.Device, newOwnerFleet string) error {
+	// do not update decommissioning devices
+	if device.Spec != nil && device.Spec.Decommissioning != nil {
+		f.log.Debugf("SKipping update of device owner for decommissioned device: %s", device.Metadata.Name)
+		return nil
+	}
+
 	fieldsToNil := []string{}
 	newOwnerRef := util.SetResourceOwner(api.FleetKind, newOwnerFleet)
 	if len(newOwnerFleet) == 0 {


### PR DESCRIPTION
Remove decommissioning device from fleet by removing `Metadata.Owner` when handling decommissioning request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced device decommissioning process by adding the ability to record decommissioning details and clear device ownership information.
	- Improved ownership update logic to prevent changes on devices marked as decommissioning, ensuring integrity during fleet operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->