### PR TITLE
EDM-773: Update charts to support deployment via ACM operator

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -14,6 +14,8 @@
 {{- define "flightctl.getOpenShiftAPIUrl" }}
   {{- if .Values.global.auth.k8s.externalOpenShiftApiUrl }}
     {{- printf .Values.global.auth.k8s.externalOpenShiftApiUrl }}
+  {{- else if .Values.global.apiUrl }}
+    {{- printf .Values.global.apiUrl }}
   {{- else }}
     {{- $openShiftBaseDomain := (lookup "config.openshift.io/v1" "DNS" "" "cluster").spec.baseDomain }}
     {{- printf "https://api.%s:6443" $openShiftBaseDomain }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -14,6 +14,7 @@
 ## @param global.auth.insecureSkipTlsVerify True if verification of authority TLS cert should be skipped.
 ## @param global.auth.k8s.apiUrl API URL of k8s cluster that will be used as authentication authority
 ## @param global.auth.k8s.externalOpenShiftApiUrl API URL of OpenShift cluster that can be accessed by external client to retrieve auth token
+## @param global.apiUrl is an alternative to global.auth.k8s.externalOpenShiftApiUrl with the same meaning, used by the multiclusterhub operator
 ## @param global.auth.k8s.externalApiToken In case flightctl is not running within a cluster, you can provide api token
 ## @param global.auth.k8s.rbacNs Namespace that should be used for the RBAC checks
 ## @param global.auth.oidc.oidcAuthority The base URL for the Keycloak realm that is reachable by flightctl services. Example: https://keycloak.foo.internal/realms/flightctl
@@ -26,7 +27,6 @@
 ## @param global.exposeServicesMethod How the FCTL services should be exposed. Can be either nodePort or route
 ## @param global.nodePorts Node port numbers for FCTL services
 
-
 global:
   target: "standalone" # standalone, acm
   baseDomain: ""
@@ -35,6 +35,7 @@ global:
     key: ""
   storageClassName: ""
   imagePullSecretName: ""
+  apiUrl: "" # alternative to global.auth.k8s.externalOpenShiftApiUrl used by multiclusterhub operator
   auth:
     type: "builtin" # builtin, k8s, oidc, none
     caCert: ""


### PR DESCRIPTION
In alignment with the PR here:
  https://github.com/stolostron/multiclusterhub-operator/pull/1877/

Co-Authored-By: rawagner <rawagner@redhat.com>
(cherry picked from commit 1f37b2a49673fb2e970d96ec013106647bb9471f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Added new configuration parameters for multi-cluster deployments
	- Introduced `global.apiUrl` for flexible API URL configuration
	- Extended service exposure methods to include "gateway" alongside "nodePort" and "route"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->