### PR TITLE
EDM-885: RPM versioning

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -16,8 +16,14 @@ jobs:
         arch: [amd64, arm64]
     env:
       NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: "ubuntu-24.04"
+    runs-on: ${{ matrix.os == 'darwin' && 'macos-latest' || 'ubuntu-24.04' }}
     steps:
+      - name: Install Go (if macOS)
+        if: ${{ matrix.os == 'darwin' }}
+        run: |
+          brew install go
+          go version
+
       - name: "Checkout"
         uses: actions/checkout@v4
 
@@ -27,10 +33,10 @@ jobs:
           GOOS: ${{ matrix.os }}
         run: |
           make build-cli
-          SHA=$(sha256sum bin | awk '{ print $1 }')
+          SHA=$(shasum -a 256 bin/flightctl | awk '{ print $1 }')
           echo $SHA > ${{ env.NAME }}-sha256.txt
-          tar cvf ${{ env.NAME }}.tar.gz  bin
-          mv bin ${{ env.NAME }}
+          mv bin/flightctl ${{ env.NAME }}
+          tar cvf ${{ env.NAME }}.tar.gz ${{ env.NAME }}
 
       - name: "Save tar binary"
         uses: actions/upload-artifact@v4
@@ -53,24 +59,26 @@ jobs:
   verify:
     strategy:
       matrix:
-        env:
-          - runner: ubuntu-24.04
-            build: linux-amd64
-          - runner: macos-latest
-            build: darwin-arm64
-    runs-on: ${{ matrix.env.runner }}
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+    env:
+      NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os == 'darwin' && 'macos-latest' || 'ubuntu-24.04' }}
+    if: ${{ !(matrix.os == 'linux' && matrix.arch == 'arm64') }}
     needs: [build]
 
     steps:
       - name: "Load binary"
         uses: actions/download-artifact@v4
         with:
-          name: flightctl-${{ matrix.env.build }}
+          name: ${{ env.NAME }}
 
       - name: "Verify"
         run: |
-          chmod +x flightctl-${{ matrix.env.build }}
-          ./flightctl-${{ matrix.env.build }} version
+          chmod +x ${{ env.NAME }}
+          ls -l
+          file ${{ env.NAME }}
+          ./${{ env.NAME }} version
           exit $?
 
   publish:

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -16,14 +16,8 @@ jobs:
         arch: [amd64, arm64]
     env:
       NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os == 'darwin' && 'macos-latest' || 'ubuntu-24.04' }}
+    runs-on: "ubuntu-24.04"
     steps:
-      - name: Install Go (if macOS)
-        if: ${{ matrix.os == 'darwin' }}
-        run: |
-          brew install go
-          go version
-
       - name: "Checkout"
         uses: actions/checkout@v4
 
@@ -59,26 +53,24 @@ jobs:
   verify:
     strategy:
       matrix:
-        os: [linux, darwin]
-        arch: [amd64, arm64]
-    env:
-      NAME: flightctl-${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os == 'darwin' && 'macos-latest' || 'ubuntu-24.04' }}
-    if: ${{ !(matrix.os == 'linux' && matrix.arch == 'arm64') }}
+        env:
+          - runner: ubuntu-24.04
+            build: linux-amd64
+          - runner: macos-latest
+            build: darwin-arm64
+    runs-on: ${{ matrix.env.runner }}
     needs: [build]
 
     steps:
       - name: "Load binary"
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.NAME }}
+          name: flightctl-${{ matrix.env.build }}
 
       - name: "Verify"
         run: |
-          chmod +x ${{ env.NAME }}
-          ls -l
-          file ${{ env.NAME }}
-          ./${{ env.NAME }} version
+          chmod +x flightctl-${{ matrix.env.build }}
+          ./flightctl-${{ matrix.env.build }} version
           exit $?
 
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /.vscode/
 /.idea/
 /reports/
+/packaging/rpm/flightctl-*.tar.gz
+/packaging/rpm/flightctl-*-build/
+/packaging/rpm/flightctl-*-vendor.tar.bz2

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,8 +4,8 @@ packages:
 
     # add or remove files that should be synced
     files_to_sync:
-        - packaging/rpm/flightctl.spec
-        - .packit.yaml
+      - packaging/rpm/flightctl.spec
+      - .packit.yaml
 
     upstream_package_name: flightctl
     downstream_package_name: flightctl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOBASE=$(shell pwd)
-GOBIN=$(GOBASE)/bin
+GOBIN=$(GOBASE)/bin/
 GO_BUILD_FLAGS := ${GO_BUILD_FLAGS}
 ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
 GO_FILES := $(shell find ./ -name "*.go" -not -path "./bin" -not -path "./packaging/*")
@@ -83,8 +83,11 @@ build: bin build-cli
 		./cmd/flightctl-periodic \
 		./cmd/flightctl-worker
 
-build-cli:
+build-cli: bin
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl
+
+build-agent: bin
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-agent
 
 build-api: bin
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-api

--- a/hack/build_rpms.sh
+++ b/hack/build_rpms.sh
@@ -8,15 +8,16 @@ if [ -n "${FLIGHTCTL_RPM:-}" ]; then
 fi
 
 # our RPM build process works in rpm bases systems so we wrap it if necessary
-if ! command -v packit 2>&1 >/dev/null ]; then
-    echo "Building RPMs on a system without packtit, using container"
+if ! command -v packit >/dev/null 2>&1; then
+    echo "Building RPMs on a system without packit, using container"
     cat >bin/build_rpms.sh <<EOF
-#!/usr/bin/env bash
-cd /work
+if ! dnf install -y go-rpm-macros; then
+    echo "Failed to install go-rpm-macros package"
+    exit 1
+fi
 ./hack/build_rpms_packit.sh
 EOF
-    podman run --privileged --rm -t -v $(pwd):/work quay.io/flightctl/ci-rpm-builder:latest bash /work/bin/build_rpms.sh
+    podman run --privileged --rm -t -v "$(pwd)":/work quay.io/flightctl/ci-rpm-builder:latest bash /work/bin/build_rpms.sh
 else
     ./hack/build_rpms_packit.sh
 fi
-

--- a/hack/build_rpms_packit.sh
+++ b/hack/build_rpms_packit.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -x
+set -ex
 # this only works on rpm based systems, for non-rpm this is wrapped by build_rpms.sh
 packit 2>/dev/null >/dev/null || (echo "Installing packit" && sudo dnf install -y packit)
-rm $(uname -m)/flightctl-*.rpm 2>/dev/null || true
-rm bin/rpm/* 2>/dev/null || true
+rm -f "$(uname -m)"/flightctl-*.rpm 2>/dev/null || true
+rm -f bin/rpm/* 2>/dev/null || true
 mkdir -p bin/rpm
 # save the spec as packit will modify it locally to inject versioning and we don't want that
 cp packaging/rpm/flightctl.spec /tmp

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -1,74 +1,117 @@
+# Disable debug information package creation
 %define debug_package %{nil}
 
-Name: flightctl
-Version: 0.3.0
-Release: 1%{?dist}
-Summary: Flightctl CLI
+# Define the Go Import Path
+%global goipath github.com/flightctl/flightctl
 
-License: XXX
-URL: https://github.com/flightctl/flightctl
-Source0: flightctl-0.3.0.tar.gz
+Name:           flightctl
+Version:        0.3.0
+Release:        1%{?dist}
+Summary:        Flightctl is a manager of the edge device fleets.
 
-BuildRequires: golang
-BuildRequires: make
-BuildRequires: git
-BuildRequires: openssl-devel
+%gometa
+
+License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT
+URL:            %{gourl}
+
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  golang
+BuildRequires:  make
+BuildRequires:  git
+BuildRequires:  openssl-devel
+
 Requires: openssl
 
+# Skip description for the main package since it won't be created
 %description
+# Main package is empty and not created.
+
+# cli sub-package
+%package cli
+Summary: Flightctl CLI
+%description cli
 Flightctl is a command line interface for managing edge device fleets.
 
-
+# agent sub-package
 %package agent
 Summary: Flightctl Agent
+
+Requires: bootc
+
 %description agent
 Flightctl Agent is a component of the flightctl tool.
 
 %prep
-%setup -q -n flightctl-0.0.1
+%goprep -A
+%setup -q %{forgesetupargs}
 
 %build
-
-# if this is a buggy version of go we need to set GOPROXY as workaround
-# see https://github.com/golang/go/issues/61928
-GOENVFILE=$(go env GOROOT)/go.env
-if [[ ! -f "{$GOENVFILE}" ]]; then
-    export GOPROXY='https://proxy.golang.org,direct'
-fi
-make build
+    # if this is a buggy version of go we need to set GOPROXY as workaround
+    # see https://github.com/golang/go/issues/61928
+    GOENVFILE=$(go env GOROOT)/go.env
+    if [[ ! -f "${GOENVFILE}" ]]; then
+        export GOPROXY='https://proxy.golang.org,direct'
+    fi
+    SOURCE_GIT_TAG=%{release} SOURCE_GIT_TREE_STATE=clean SOURCE_GIT_COMMIT=%{release} SOURCE_GIT_TAG_NO_V=%{version} make build-cli build-agent
 
 %install
-mkdir -p %{buildroot}/usr/bin
-cp bin/flightctl %{buildroot}/usr/bin
-mkdir -p %{buildroot}/usr/lib/systemd/system
-mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
-mkdir -p %{buildroot}/usr/lib/flightctl/hooks.d/{afterupdating,beforeupdating,afterrebooting,beforerebooting}
-mkdir -p %{buildroot}/usr/lib/greenboot/check/required.d
-install -m 0755 packaging/greenboot/flightctl-agent-running-check.sh %{buildroot}/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
-cp bin/flightctl-agent %{buildroot}/usr/bin
-cp packaging/must-gather/flightctl-must-gather %{buildroot}/usr/bin
-cp packaging/hooks.d/afterupdating/00-default.yaml %{buildroot}/usr/lib/flightctl/hooks.d/afterupdating
-cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
-bin/flightctl completion bash > flightctl-completion.bash
-install -Dpm 0644 flightctl-completion.bash -t %{buildroot}/%{_datadir}/bash-completion/completions/flightctl-completion.bash
-bin/flightctl completion fish > flightctl-completion.fish
-install -Dpm 0644 flightctl-completion.fish -t %{buildroot}/%{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
-bin/flightctl completion zsh > _flightctl-completion
-install -Dpm 0644 _flightctl-completion -t %{buildroot}/%{_datadir}/zsh/site-functions/_flightctl-completion
+    mkdir -p %{buildroot}/usr/bin
+    cp bin/flightctl %{buildroot}/usr/bin
+    mkdir -p %{buildroot}/usr/lib/systemd/system
+    mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
+    mkdir -p %{buildroot}/usr/lib/flightctl/hooks.d/{afterupdating,beforeupdating,afterrebooting,beforerebooting}
+    mkdir -p %{buildroot}/usr/lib/greenboot/check/required.d
+    install -m 0755 packaging/greenboot/flightctl-agent-running-check.sh %{buildroot}/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
+    cp bin/flightctl-agent %{buildroot}/usr/bin
+    cp packaging/must-gather/flightctl-must-gather %{buildroot}/usr/bin
+    cp packaging/hooks.d/afterupdating/00-default.yaml %{buildroot}/usr/lib/flightctl/hooks.d/afterupdating
+    cp packaging/systemd/flightctl-agent.service %{buildroot}/usr/lib/systemd/system
+    bin/flightctl completion bash > flightctl-completion.bash
+    install -Dpm 0644 flightctl-completion.bash -t %{buildroot}/%{_datadir}/bash-completion/completions
+    bin/flightctl completion fish > flightctl-completion.fish
+    install -Dpm 0644 flightctl-completion.fish -t %{buildroot}/%{_datadir}/fish/vendor_completions.d/
+    bin/flightctl completion zsh > _flightctl-completion
+    install -Dpm 0644 _flightctl-completion -t %{buildroot}/%{_datadir}/zsh/site-functions/
 
-%files
-/usr/bin/flightctl
-%{_datadir}/bash-completion/completions/flightctl-completion.bash
-%{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
-%{_datadir}/zsh/site-functions/_flightctl-completion
+    rm -f licenses.list
 
-%files agent
-/usr/bin/flightctl-agent
-/usr/bin/flightctl-must-gather
-/usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml
-/usr/lib/systemd/system/flightctl-agent.service
-%{_sharedstatedir}/flightctl
-/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
+    find -type f -name LICENSE -or -name License | while read LICENSE_FILE; do
+        echo "%{_datadir}/licenses/%{NAME}/${LICENSE_FILE}" >> licenses.list
+    done
+    mkdir -vp "%{buildroot}%{_datadir}/licenses/%{NAME}"
+    cp LICENSE "%{buildroot}%{_datadir}/licenses/%{NAME}"
+
+    mkdir -vp "%{buildroot}%{_docdir}/%{NAME}"
+
+    for DOC in docs examples .markdownlint-cli2.yaml README.md; do
+        cp -vr "${DOC}" "%{buildroot}%{_docdir}/%{NAME}/${DOC}"
+    done
+
+%check
+    %{buildroot}%{_bindir}/flightctl-agent version
+
+# File listings
+# No %files section for the main package, so it won't be built
+
+%files cli -f licenses.list
+    %{_bindir}/flightctl
+    %license LICENSE
+    %{_datadir}/bash-completion/completions/flightctl-completion.bash
+    %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
+    %{_datadir}/zsh/site-functions/_flightctl-completion
+
+%files agent -f licenses.list
+    %license LICENSE
+    %{_bindir}/flightctl-agent
+    %{_bindir}/flightctl-must-gather
+    /usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml
+    /usr/lib/systemd/system/flightctl-agent.service
+    %{_sharedstatedir}/flightctl
+    /usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
+    %{_docdir}/%{NAME}/*
+    %{_docdir}/%{NAME}/.markdownlint-cli2.yaml
+
 
 %changelog
 * Mon Nov 4 2024 Miguel Angel Ajo <majopela@redhat.com> - 0.3.0-1


### PR DESCRIPTION
Agent versions are now populated with the best values we can fetch.

* Updated RPM specification file with more detailed package descriptions and licensing information. Created two sub-packages **cli** and **agent** instead of using **main** package. Started to use **go-rpm-macros**.
* Updated .gitignore to exclude RPM packaging-related files (would be better to build RPMs outside of the working tree, but it requires much more work, so a separate card is required)
* Modified .packit.yaml configuration for consistent indentation
* Updated Makefile with a new **build-agent** target; Added trailing slash to GOBIN, so executable will reside inside **bin**; Updated workflow .github/workflows/publish-cli-bins.yaml to behave accordingly
* Updated hack/build_rpms.sh and hack/build_rpms_packit.sh with better error handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for CLI binary releases to enhance compatibility with multiple operating systems.
	- Improved RPM packaging configuration for better organization and clarity.
	- Enhanced build scripts for RPM and CLI binaries to ensure robustness and error handling.

- **New Features**
	- Added a new build target for the `flightctl-agent`.
	- Expanded RPM package to include CLI and agent components.
	- Updated package summary to reflect management of edge device fleets.

- **Bug Fixes**
	- Corrected script error handling in build scripts.
	- Fixed file removal commands in packaging scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->