### PR TITLE
EDM-1012: Set OutOfDate info if rollout failed

### DIFF
--- a/api/v1alpha1/consts.go
+++ b/api/v1alpha1/consts.go
@@ -11,9 +11,10 @@ const (
 	DeviceKind       = "Device"
 	DeviceListKind   = "DeviceList"
 
-	DeviceAnnotationConsole         = "device-controller/console"
-	DeviceAnnotationRenderedVersion = "device-controller/renderedVersion"
-	DeviceAnnotationTemplateVersion = "fleet-controller/templateVersion"
+	DeviceAnnotationConsole          = "device-controller/console"
+	DeviceAnnotationRenderedVersion  = "device-controller/renderedVersion"
+	DeviceAnnotationTemplateVersion  = "fleet-controller/templateVersion"
+	DeviceAnnotationLastRolloutError = "fleet-controller/lastRolloutError"
 
 	// TODO: make configurable
 	// DeviceDisconnectedTimeout is the duration after which a device is considered to be not reporting and set to unknown status.

--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -184,7 +184,14 @@ func updateServerSideDeviceUpdatedStatus(ctx context.Context, st store.Store, lo
 			device.Status.Updated.Info = util.StrToPtr("The device has been updated to the fleet's latest device spec.")
 		} else {
 			device.Status.Updated.Status = api.DeviceUpdatedStatusOutOfDate
-			device.Status.Updated.Info = util.StrToPtr("The device has not yet been scheduled for update to the fleet's latest device spec.")
+			errorMessage := "The device has not yet been scheduled for update to the fleet's latest device spec."
+			if device.Metadata.Annotations != nil {
+				lastRolloutError, ok := (*device.Metadata.Annotations)[api.DeviceAnnotationLastRolloutError]
+				if ok && lastRolloutError != "" {
+					errorMessage = fmt.Sprintf("The device could not be updated to the fleet's latest device spec: %s", lastRolloutError)
+				}
+			}
+			device.Status.Updated.Info = util.StrToPtr(errorMessage)
 		}
 	} else {
 		device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -184,6 +184,13 @@ func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, dev
 	errs = append(errs, appErrs...)
 
 	if len(errs) > 0 {
+		annotations := map[string]string{
+			api.DeviceAnnotationLastRolloutError: errors.Join(errs...).Error(),
+		}
+		err := f.devStore.UpdateAnnotations(ctx, f.resourceRef.OrgID, *device.Metadata.Name, annotations, nil)
+		if err != nil {
+			errs = append(errs, err)
+		}
 		return fmt.Errorf("failed generating device spec for %s/%s: %w", f.resourceRef.OrgID, *device.Metadata.Name, errors.Join(errs...))
 	}
 
@@ -215,7 +222,7 @@ func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, dev
 	annotations := map[string]string{
 		api.DeviceAnnotationTemplateVersion: *templateVersion.Metadata.Name,
 	}
-	err = f.devStore.UpdateAnnotations(ctx, f.resourceRef.OrgID, *device.Metadata.Name, annotations, nil)
+	err = f.devStore.UpdateAnnotations(ctx, f.resourceRef.OrgID, *device.Metadata.Name, annotations, []string{api.DeviceAnnotationLastRolloutError})
 	if err != nil {
 		return fmt.Errorf("failed updating templateVersion annotation: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new device annotation for tracking rollout errors
	- Enhanced error reporting for device fleet rollouts

- **Bug Fixes**
	- Improved device update status messaging to provide more detailed error information
	- Implemented mechanism to clear previous rollout errors on successful updates

- **Improvements**
	- Better visibility into device specification generation and rollout processes
	- More informative status tracking for device updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->