### PR TITLE
EDM-1038: Create container with all CLI artifacts for publishing

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -80,7 +80,7 @@ jobs:
   publish-flightctl-containers:
     strategy:
       matrix:
-        image: ['api', 'periodic', 'worker']
+        image: ['api', 'periodic', 'worker', 'cli-artifacts']
     needs: [generate-tags]
     runs-on: "ubuntu-24.04"
     steps:

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,0 +1,71 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+WORKDIR /app
+COPY ./api api
+COPY ./cmd cmd
+COPY ./deploy deploy
+COPY ./hack hack
+COPY ./internal internal
+COPY ./go.* ./
+COPY ./pkg pkg
+COPY ./test test
+COPY ./Makefile .
+# make sure that version extraction works
+COPY .git .git
+
+USER 0
+RUN make multiarch-build-cli
+
+FROM registry.access.redhat.com/ubi9/ubi as certs
+RUN dnf install --nodocs -y nginx && dnf clean all
+
+
+ENV USER_UID=1001 \
+    USER_NAME=server \
+    HOME=/home/server \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf
+
+COPY packaging/containers/cli-artifacts/nginx.conf ${NGINX_CONF_PATH}
+
+USER root
+
+RUN mkdir -p ${HOME} && \
+    chown ${USER_UID}:0 ${HOME} && \
+    chmod ug+rwx ${HOME} && \
+    sed '/^\s*listen\s*\[::\]:8080/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv4 && \
+    sed '/^\s*listen\s*8080/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv6 && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH}.ipv* && \
+    chmod -R a+rwx /var/lib/nginx && \
+    chown -R ${USER_UID}:0 /root && \
+    chown -R ${USER_UID}:0 /var/lib/nginx && \
+    chmod -R a+rwx /var/log/nginx && \
+    chown -R ${USER_UID}:0 /var/log/nginx && \
+    chmod -R a+rwx /var/run && \
+    chown -R ${USER_UID}:0 /var/run
+
+USER ${USER_UID}
+
+WORKDIR ${HOME}/src
+
+COPY --from=builder /app/bin/clis/archives/ ./
+
+LABEL io.k8s.display-name="Flightctl Client Multiarch Artifacts with Server" \
+      io.k8s.description="FlightCtl is an edge management system for edge devices and servers." \
+      io.openshift.tags="flightctl,cli-artifacts"
+
+
+EXPOSE 8080
+
+ENTRYPOINT if [[ -d "/proc/sys/net/ipv4" && -d "/proc/sys/net/ipv6" ]]; \
+    then \
+    nginx -g "daemon off;"; \
+    elif [[ -d "/proc/sys/net/ipv4" ]]; \
+    then \
+    nginx -c /etc/nginx/nginx.conf.ipv4 -g "daemon off;"; \
+    elif [[ -d "/proc/sys/net/ipv6" ]]; \
+    then \
+    nginx -c /etc/nginx/nginx.conf.ipv6 -g "daemon off;"; \
+    else \
+    echo "unable to identify IP configuration"; \
+    exit -1; \
+    fi

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ build: bin build-cli
 build-cli: bin
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl
 
+multiarch-build-cli: bin
+	./hack/build_multiarch_clis.sh
+
 build-agent: bin
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-agent
 
@@ -122,7 +125,7 @@ flightctl-periodic-container: bin/.flightctl-periodic-container
 
 build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container
 
-.PHONY: build-containers
+.PHONY: build-containers build-cli multiarch-build-cli
 
 
 bin:

--- a/hack/build_multiarch_clis.sh
+++ b/hack/build_multiarch_clis.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script generates an archive of CLI binary files in the following format:
+#
+# $ tree bin/clis/
+# bin/clis/
+# ├── archives
+# │   ├── amd64
+# │   │   ├── linux
+# │   │   │   └── flightctl.tar.gz
+# │   │   └── mac
+# │   │       └── flightctl.zip
+# │   └── arm64
+# │       ├── linux
+# │       │   └── flightctl.tar.gz
+# │       └── mac
+# │           └── flightctl.zip
+# ├── gh-archives
+# │   ├── flightctl-darwin-amd64.zip
+# │   ├── flightctl-darwin-amd64.zip.sha256
+# │   ├── flightctl-darwin-arm64.zip
+# │   ├── flightctl-darwin-arm64.zip.sha256
+# │   ├── flightctl-linux-amd64.tar.gz
+# │   ├── flightctl-linux-amd64.tar.gz.sha256
+# │   ├── flightctl-linux-arm64.tar.gz
+# │   └── flightctl-linux-arm64.tar.gz.sha256
+
+
+for GOARCH in amd64 arm64; do
+  for GOOS in linux darwin; do
+    echo -e "\033[0;37m>>>> building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+    GOARCH="${GOARCH}" GOOS="${GOOS}" make build-cli
+    OS="${GOOS}"
+    if [ "${GOOS}" == "darwin" ]; then
+      OS="mac"
+    fi
+
+    mkdir -p "bin/clis/tmp/${GOARCH}/${GOOS}"
+    cp "bin/flightctl" "bin/clis/tmp/${GOARCH}/${GOOS}/flightctl"
+    mkdir -p "bin/clis/archives/${GOARCH}/${OS}"
+    mkdir -p "bin/clis/gh-archives/"
+    if [ "${GOOS}" == "linux" ]; then
+      tar -zhcf "bin/clis/archives/${GOARCH}/${OS}/flightctl.tar.gz" -C "bin/clis/tmp/${GOARCH}/${GOOS}" flightctl
+      GH_OUT="bin/clis/gh-archives/flightctl-${GOOS}-${GOARCH}.tar.gz"
+      cp "bin/clis/archives/${GOARCH}/${OS}/flightctl.tar.gz" "${GH_OUT}"
+    else
+      zip -9 -r -q -j "bin/clis/archives/${GOARCH}/${OS}/flightctl.zip" "bin/clis/tmp/${GOARCH}/${GOOS}/flightctl"
+      GH_OUT="bin/clis/gh-archives/flightctl-${GOOS}-${GOARCH}.zip"
+      cp "bin/clis/archives/${GOARCH}/${OS}/flightctl.zip" "${GH_OUT}"
+    fi
+    sha256sum "${GH_OUT}" | awk '{ print $1 }' > "${GH_OUT}.sha256"
+  done
+done
+
+echo -e "\033[0;32mAll CLI binaries have been built and archived in bin/clis/archives and bin/clis/gh-archives\033[0m"

--- a/packaging/containers/cli-artifacts/nginx.conf
+++ b/packaging/containers/cli-artifacts/nginx.conf
@@ -1,0 +1,40 @@
+worker_processes auto;
+error_log /dev/stdout info;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /dev/stdout;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /home/server/src;
+
+        # Enable autoindex for directory listing
+        location / {
+            autoindex on;
+            autoindex_exact_size off; # Optional: human-readable file sizes
+            autoindex_localtime on;   # Optional: display file modification times in local timezone
+        }
+
+    }
+
+}


### PR DESCRIPTION
In the same format that [1] is created.

Later, down the road this can be used to publish to mirror.openshift.com or deployed + served through UI.

[1] https://catalog.redhat.com/software/containers/container-native-virtualization/virt-artifacts-server/6181a895be25a74c009233fb?container-tabs=dockerfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added CLI artifacts build and containerization process.
	- Introduced multi-architecture CLI binary builds for Linux and macOS.
	- Created new container workflow to publish CLI artifacts.

- **Chores**
	- Updated GitHub Actions workflow to include CLI artifacts image.
	- Added Nginx configuration for CLI artifacts container.
	- Implemented build script for multi-platform CLI binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->