### PR TITLE
EDM-722: applications: improve beforeUpdate validations

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -142,7 +142,13 @@ func (a *Agent) Run(ctx context.Context) error {
 	hookManager := hook.NewManager(deviceReadWriter, executer, a.log)
 
 	// create application manager
-	applicationManager := applications.NewManager(a.log, executer, podmanClient, systemClient)
+	applicationManager := applications.NewManager(
+		a.log,
+		deviceReadWriter,
+		executer,
+		podmanClient,
+		systemClient,
+	)
 
 	// register the application manager with the shutdown manager
 	shutdownManager.Register("applications", applicationManager.Stop)

--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -5,12 +5,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/util/validation"
+	"sigs.k8s.io/yaml"
 )
 
 const defaultPodmanTimeout = 2 * time.Minute
+
+type ComposeSpec struct {
+	Services map[string]ComposeService `yaml:"services"`
+}
+
+type ComposeService struct {
+	Image string `yaml:"image"`
+}
 
 type Compose struct {
 	*Podman
@@ -96,4 +108,118 @@ func (p *Compose) Down(ctx context.Context, path string) error {
 		}
 	}
 	return nil
+}
+
+// ParseComposeSpecFromDir reads a compose spec from the given directory and will perform a merge of the base {docker,podman}-compose.yaml and -override.yaml files.
+func ParseComposeSpecFromDir(reader fileio.Reader, dir string) (*ComposeSpec, error) {
+	// check for docker-compose.yaml or podman-compose.yaml and override files
+	//
+	// Note: podman nor docker handle merge files from other packages for
+	// example podman-compose and docker-compose.override.yaml. for now we will
+	// do the same but I will leave this note here for further consideration.
+	baseFiles := []string{
+		"docker-compose.yaml",
+		"docker-compose.yml",
+		"podman-compose.yaml",
+		"podman-compose.yml",
+	}
+	overrideFiles := []string{
+		"docker-compose.override.yaml",
+		"docker-compose.override.yml",
+		"podman-compose.override.yaml",
+		"podman-compose.override.yml",
+	}
+
+	spec := &ComposeSpec{Services: make(map[string]ComposeService)}
+
+	// ensure base
+	found, err := readFirstExistingFile(baseFiles, dir, reader, spec)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.ErrNoComposeFile
+	}
+
+	// merge override
+	_, err = readFirstExistingFile(overrideFiles, dir, reader, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spec.Services) == 0 {
+		return nil, errors.ErrNoComposeServices
+	}
+
+	return spec, nil
+}
+
+func readFirstExistingFile(files []string, dir string, reader fileio.Reader, spec *ComposeSpec) (bool, error) {
+	for _, filename := range files {
+		filePath := filepath.Join(dir, filename)
+
+		exists, err := reader.PathExists(filePath)
+		if err != nil {
+			return false, fmt.Errorf("checking if file exists: %w", err)
+		}
+		if !exists {
+			continue
+		}
+
+		// merge file into spec
+		if err := mergeFileIntoSpec(filePath, reader, spec); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	// no files found
+	return false, nil
+}
+
+// mergeFileIntoSpec serializes the compose file at filePath and merges it into the spec.
+func mergeFileIntoSpec(filePath string, reader fileio.Reader, spec *ComposeSpec) error {
+	content, err := reader.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading compose file %s: %w", filePath, err)
+	}
+
+	var partial ComposeSpec
+	if err := yaml.Unmarshal(content, &partial); err != nil {
+		return fmt.Errorf("unmarshaling compose YAML from %s: %w", filePath, err)
+	}
+
+	for name, svc := range partial.Services {
+		spec.Services[name] = svc
+	}
+	return nil
+}
+
+// Verify validates the compose spec.
+func (c *ComposeSpec) Verify() error {
+	var errs []error
+	for name, service := range c.Services {
+		image := service.Image
+		if image == "" {
+			errs = append(errs, fmt.Errorf("service %s is missing an image", name))
+		}
+		if err := validation.ValidateOciImageReference(&image, "services."+name+".image"); err != nil {
+			errs = append(errs, err...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// Images returns a map of service names to their images.
+func (c *ComposeSpec) Images() map[string]string {
+	images := make(map[string]string)
+	for name, service := range c.Services {
+		images[name] = service.Image
+	}
+	return images
 }

--- a/internal/agent/client/compose_test.go
+++ b/internal/agent/client/compose_test.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseComposeSpecFromDir(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name          string
+		files         map[string][]byte
+		expectedError error
+		expectedSpec  ComposeSpec
+	}{
+		{
+			name: "single compose.yaml file",
+			files: map[string][]byte{
+				"docker-compose.yaml": []byte(`
+services:
+  web:
+    image: nginx
+`),
+			},
+			expectedSpec: ComposeSpec{
+				Services: map[string]ComposeService{
+					"web": {Image: "nginx"},
+				},
+			},
+		},
+		{
+			name: "single compose.yml file with yml override",
+			files: map[string][]byte{
+				"docker-compose.yml": []byte(`
+services:
+  web:
+    image: nginx
+`),
+				"docker-compose.override.yml": []byte(`
+services:
+  web:
+    image: nginx:latest
+`),
+			},
+			expectedSpec: ComposeSpec{
+				Services: map[string]ComposeService{
+					"web": {Image: "nginx:latest"},
+				},
+			},
+		},
+		{
+			name: "multiple compose files priority .yaml",
+			files: map[string][]byte{
+				"docker-compose.yaml": []byte(`
+services:
+  web:
+    image: nginx
+`),
+				"docker-compose.yml": []byte(`
+services:
+  web:
+    image: apache
+`),
+			},
+			expectedSpec: ComposeSpec{
+				Services: map[string]ComposeService{
+					"web": {Image: "nginx"},
+				},
+			},
+		},
+		{
+			name: "no compose files",
+			files: map[string][]byte{
+				"random-file.txt": []byte("not a compose file"),
+			},
+			expectedError: errors.ErrNoComposeFile,
+			expectedSpec:  ComposeSpec{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			readerWriter := fileio.NewReadWriter()
+			readerWriter.SetRootdir(tmpDir)
+			for filename, content := range tt.files {
+				if err := readerWriter.WriteFile(filename, content, fileio.DefaultFilePermissions); err != nil {
+					require.NoError(err)
+				}
+			}
+			spec, err := ParseComposeSpecFromDir(readerWriter, "/")
+			if tt.expectedError != nil {
+				require.ErrorIs(err, tt.expectedError)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tt.expectedSpec, *spec)
+		})
+	}
+}

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -87,7 +87,8 @@ func (p *Podman) pullImage(ctx context.Context, image string) (string, error) {
 	return out, nil
 }
 
-// Inspect returns the JSON output of the image inspection.
+// Inspect returns the JSON output of the image inspection. The expectation is
+// that the image exists in local container storage.
 func (p *Podman) Inspect(ctx context.Context, image string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()

--- a/internal/agent/device/applications/controller.go
+++ b/internal/agent/device/applications/controller.go
@@ -167,7 +167,7 @@ func parseApps(ctx context.Context, podman *client.Podman, spec *v1alpha1.Render
 				name = provider.Image
 			}
 
-			appType, err := TypeFromImage(ctx, podman, provider.Image)
+			appType, err := typeFromImage(ctx, podman, provider.Image)
 			if err != nil {
 				return nil, fmt.Errorf("%w from image: %w", errors.ErrParseAppType, err)
 			}

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -3,10 +3,13 @@ package applications
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 )
@@ -15,17 +18,20 @@ var _ Manager = (*manager)(nil)
 
 type manager struct {
 	podmanMonitor *PodmanMonitor
+	readWriter    fileio.ReadWriter
 	log           *log.PrefixLogger
 }
 
 func NewManager(
 	log *log.PrefixLogger,
+	readWriter fileio.ReadWriter,
 	exec executer.Executer,
 	podmanClient *client.Podman,
 	systemClient client.System,
 ) Manager {
 	bootTime := systemClient.BootTime()
 	return &manager{
+		readWriter:    readWriter,
 		podmanMonitor: NewPodmanMonitor(log, exec, podmanClient, bootTime),
 		log:           log,
 	}
@@ -62,6 +68,125 @@ func (m *manager) Update(app Application) error {
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
+}
+
+// BeforeUpdate prepares the manager for reconciliation.
+func (m *manager) BeforeUpdate(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error {
+	if desired.Applications == nil {
+		m.log.Debug("No applications to pre-check")
+		return nil
+	}
+	m.log.Info("Pre-checking application dependencies")
+	defer m.log.Info("Finished pre-checking application dependencies")
+
+	// ensure dependencies for image based application manifests
+	imageProviders, err := ImageProvidersFromSpec(desired)
+	if err != nil {
+		return fmt.Errorf("%w: parsing image providers: %w", errors.ErrNoRetry, err)
+	}
+
+	if err := m.pullAppPackages(ctx, imageProviders); err != nil {
+		return fmt.Errorf("pulling application packages: %w", err)
+	}
+
+	// images must be pulled before parsing apps
+	apps, err := parseApps(ctx, m.podmanMonitor.client, desired)
+	if err != nil {
+		return fmt.Errorf("parsing apps: %w", err)
+	}
+
+	// validate image based application specs and pull images
+	imageBasedApps := apps.ImageBased()
+	if err := m.ensureApps(ctx, imageBasedApps); err != nil {
+		return fmt.Errorf("ensuring apps: %w", err)
+	}
+
+	return nil
+}
+
+// pullAppPackages pulls the images for the application packages to ensure authentication works and the images are available.
+func (m *manager) pullAppPackages(ctx context.Context, imageProviders []v1alpha1.ImageApplicationProvider) error {
+	for _, imageProvider := range imageProviders {
+		// pull the image if it does not exist. it is possible that the image
+		// tag such as latest in which case it will be pulled later. but we
+		// don't want to require calling out the network on every sync.
+		if m.podmanMonitor.client.ImageExists(ctx, imageProvider.Image) {
+			m.log.Debugf("Image %q already exists in container storage", imageProvider.Image)
+			continue
+		}
+
+		providerImage := imageProvider.Image
+		_, err := m.podmanMonitor.client.Pull(ctx, providerImage, client.WithRetry())
+		if err != nil {
+			m.log.Warnf("Failed to pull image %q: %v", providerImage, err)
+			return err
+		}
+		m.log.Infof("Pulled image based application package: %s", providerImage)
+
+		addType, err := typeFromImage(ctx, m.podmanMonitor.client, providerImage)
+		if err != nil {
+			return fmt.Errorf("%w: getting application type: %w", errors.ErrNoRetry, err)
+		}
+		if err := ensureDependenciesFromType(addType); err != nil {
+			return fmt.Errorf("%w: ensuring dependencies: %w", errors.ErrNoRetry, err)
+		}
+	}
+	return nil
+}
+
+// ensureApps validates and pulls images for image based applications.
+func (m *manager) ensureApps(ctx context.Context, imageBasedApps []*application[*v1alpha1.ImageApplicationProvider]) error {
+	appTmpDir, err := os.MkdirTemp("", "app_temp")
+	if err != nil {
+		return fmt.Errorf("error creating tmp dir: %w", err)
+	}
+	// cleanup tmp dir
+	defer func() {
+		if err := m.readWriter.RemoveAll(appTmpDir); err != nil {
+			m.log.Errorf("cleaning up temporary directory %q: %v", appTmpDir, err)
+		}
+	}()
+
+	// validate compose specs and pull images
+	m.log.Infof("Validating compose specs and pulling service images")
+	// TODO: this validation should be encapsulated by the application type
+	for _, app := range imageBasedApps {
+		containerImage := app.provider.Image
+		appPath, err := app.Path()
+		if err != nil {
+			return fmt.Errorf("getting app path: %w", err)
+		}
+		appDir := filepath.Join(appTmpDir, appPath)
+		if err := copyImageManifests(ctx, m.log, m.readWriter, m.podmanMonitor.client, containerImage, appDir); err != nil {
+			return fmt.Errorf("copying compose image manifests: %w", err)
+		}
+
+		spec, err := client.ParseComposeSpecFromDir(m.readWriter, appDir)
+		if err != nil {
+			return fmt.Errorf("parsing compose spec: %w", err)
+		}
+
+		if err := spec.Verify(); err != nil {
+			return fmt.Errorf("validating compose spec: %w", err)
+		}
+
+		// pull service level images
+		images := spec.Images()
+		for _, image := range images {
+			if m.podmanMonitor.client.ImageExists(ctx, image) {
+				m.log.Debugf("Image %q already exists in container storage", image)
+				continue
+			}
+
+			m.log.Infof("Pulling compose application service image: %s", image)
+			_, err := m.podmanMonitor.client.Pull(ctx, image, client.WithRetry())
+			if err != nil {
+				return fmt.Errorf("error pulling image %s: %w", image, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // AfterUpdate executes actions generated by the manager during reconciliation.

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -103,6 +103,20 @@ func (mr *MockManagerMockRecorder) AfterUpdate(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterUpdate", reflect.TypeOf((*MockManager)(nil).AfterUpdate), ctx)
 }
 
+// BeforeUpdate mocks base method.
+func (m *MockManager) BeforeUpdate(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BeforeUpdate", ctx, desired)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BeforeUpdate indicates an expected call of BeforeUpdate.
+func (mr *MockManagerMockRecorder) BeforeUpdate(ctx, desired any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeforeUpdate", reflect.TypeOf((*MockManager)(nil).BeforeUpdate), ctx, desired)
+}
+
 // Ensure mocks base method.
 func (m *MockManager) Ensure(app Application) error {
 	m.ctrl.T.Helper()

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -91,7 +91,7 @@ func (m *PodmanMonitor) Run(ctx context.Context) error {
 	ctx, m.cancelFn = context.WithCancel(ctx)
 
 	// list of podman events to listen for
-	events := []string{"init", "start", "die", "sync", "remove", "exited"}
+	events := []string{"create", "init", "start", "die", "sync", "remove", "exited"}
 	m.cmd = m.client.EventsSinceCmd(ctx, events, m.bootTime)
 
 	stdoutPipe, err := m.cmd.StdoutPipe()
@@ -462,6 +462,7 @@ func (m *PodmanMonitor) updateAppStatus(ctx context.Context, app Application, ev
 	}
 
 	// add new container
+	m.log.Debugf("Adding container: %s to app %s", event.Name, app.Name())
 	app.AddContainer(Container{
 		ID:       event.ID,
 		Image:    event.Image,

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -25,6 +25,11 @@ var (
 	ErrParseAppType           = errors.New("failed to parse application type")
 	ErrAppDependency          = errors.New("failed to resolve application dependency")
 	ErrUnsupportedAppProvider = errors.New("unsupported application provider")
+	ErrNoComposeFile          = errors.New("no compose file found")
+	ErrNoComposeServices      = errors.New("no services found in compose spec")
+
+	// container images
+	ErrImageShortName = errors.New("failed to resolve image short name: use the full name i.e registry/image:tag")
 
 	// spec
 	ErrMissingRenderedSpec  = errors.New("missing rendered spec")
@@ -141,6 +146,8 @@ func FromStderr(stderr string, exitCode int) error {
 		// context
 		"context canceled":          context.Canceled,
 		"context deadline exceeded": context.DeadlineExceeded,
+		// container image resolution
+		"short-name resolution enforced": ErrImageShortName,
 	}
 	for check, err := range errMap {
 		if strings.Contains(stderr, check) {

--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -72,7 +72,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			harness.WaitForDeviceContents(deviceId, "The device is preparing an update to renderedVersion: 2",
 				func(device *v1alpha1.Device) bool {
 					return conditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateApplyingUpdate))
-				}, "1m")
+				}, "2m")
 
 			Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
 


### PR DESCRIPTION
This PR improves beforeUpdate validation and dependency management for applications. 
- pull all compose images beforeUpdate
- ensure clear message for image short name resolution  i.e `mysql` vs docker.io/mysql
- before basic validation of compose spec
- improve observabilty of containers that are created but fail to start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for Compose specification parsing and validation.
  - Introduced new methods for managing application dependencies and image handling.
  - Enhanced monitoring to track container creation events.
  - Added new error variables for improved error reporting related to Compose files and container images.

- **Improvements**
  - Updated application manager with streamlined pre-update checks.
  - Improved error handling for scenarios related to compose files and container images.
  - Extended timeout duration for specific test conditions.

- **Bug Fixes**
  - Refined application status tracking and container management.

- **Documentation**
  - Clarified method comments for better understanding of system behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->