### PR TITLE
EDM-1046: applications/compose: ensure manually stopped containers are tracked in status

### DIFF
--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -28,6 +28,7 @@ const (
 	ContainerStatusCreated ContainerStatusType = "created"
 	ContainerStatusInit    ContainerStatusType = "init"
 	ContainerStatusRunning ContainerStatusType = "start"
+	ContainerStatusStop    ContainerStatusType = "stop"
 	ContainerStatusDie     ContainerStatusType = "die" // docker only
 	ContainerStatusDied    ContainerStatusType = "died"
 	ContainerStatusRemove  ContainerStatusType = "remove"

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -91,7 +91,7 @@ func (m *PodmanMonitor) Run(ctx context.Context) error {
 	ctx, m.cancelFn = context.WithCancel(ctx)
 
 	// list of podman events to listen for
-	events := []string{"create", "init", "start", "die", "sync", "remove", "exited"}
+	events := []string{"create", "init", "start", "stop", "die", "sync", "remove", "exited"}
 	m.cmd = m.client.EventsSinceCmd(ctx, events, m.bootTime)
 
 	stdoutPipe, err := m.cmd.StdoutPipe()

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -46,6 +46,24 @@ func TestListenForEvents(t *testing.T) {
 			expectedSummary: v1alpha1.ApplicationsSummaryStatusHealthy,
 		},
 		{
+			name: "single app multiple containers started  then one manual stop",
+			apps: []Application{
+				createTestApplication("app1", v1alpha1.ApplicationStatusPreparing),
+			},
+			events: []PodmanEvent{
+				mockPodmanEvent("app1", "app1-service-1", "init"),
+				mockPodmanEvent("app1", "app1-service-1", "create"),
+				mockPodmanEvent("app1", "app1-service-1", "start"),
+				mockPodmanEvent("app1", "app1-service-2", "init"),
+				mockPodmanEvent("app1", "app1-service-2", "create"),
+				mockPodmanEvent("app1", "app1-service-2", "start"),
+				mockPodmanEvent("app1", "app1-service-2", "stop"),
+			},
+			expectedReady:   "1/2",
+			expectedStatus:  v1alpha1.ApplicationStatusRunning,
+			expectedSummary: v1alpha1.ApplicationsSummaryStatusDegraded,
+		},
+		{
 			name: "single app start then die",
 			apps: []Application{
 				createTestApplication("app1", v1alpha1.ApplicationStatusPreparing),


### PR DESCRIPTION
Currently, the application tracks all containers that die or exit with a non-zero code when calculating Healthy status. This PR enhances the lifecycle event tracking to include containers that are manually stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new container status "stop" to enhance container lifecycle event tracking.
  - Updated Podman monitor to listen for the "stop" event.

- **Tests**
  - Added a test case for handling a scenario where a container is manually stopped within a multi-container application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->