### PR TITLE
EDM-707: device/applications/compose: enforce service container_name is not supported

### DIFF
--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -17,11 +17,12 @@ import (
 const defaultPodmanTimeout = 2 * time.Minute
 
 type ComposeSpec struct {
-	Services map[string]ComposeService `yaml:"services"`
+	Services map[string]ComposeService `json:"services"`
 }
 
 type ComposeService struct {
-	Image string `yaml:"image"`
+	Image         string `json:"image"`
+	ContainerName string `json:"container_name"`
 }
 
 type Compose struct {
@@ -199,6 +200,10 @@ func mergeFileIntoSpec(filePath string, reader fileio.Reader, spec *ComposeSpec)
 func (c *ComposeSpec) Verify() error {
 	var errs []error
 	for name, service := range c.Services {
+		containerName := service.ContainerName
+		if service.ContainerName != "" {
+			errs = append(errs, fmt.Errorf("service %s has a hard coded container_name %s which is not supported", name, containerName))
+		}
 		image := service.Image
 		if image == "" {
 			errs = append(errs, fmt.Errorf("service %s is missing an image", name))

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -92,6 +92,7 @@ func (m *PodmanMonitor) Run(ctx context.Context) error {
 
 	// list of podman events to listen for
 	events := []string{"create", "init", "start", "stop", "die", "sync", "remove", "exited"}
+	m.log.Debugf("Replaying podman events since boot time: %s", m.bootTime)
 	m.cmd = m.client.EventsSinceCmd(ctx, events, m.bootTime)
 
 	stdoutPipe, err := m.cmd.StdoutPipe()


### PR DESCRIPTION
Podman dynamically generates container names to avoid conflicts. However, hardcoding a container_name in the compose spec can cause unexpected issues if shared between applications.

This PR introduces pre-update validation to return an error when a compose spec contains a hardcoded container_name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Updated JSON serialization for compose service definitions.
	- Added validation to prevent hard-coded container names.

- **Logging**
	- Enhanced debug logging for Podman event monitoring, providing more visibility into boot-time event replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->