### PR TITLE
NO-ISSUE: make packit replace -rc to ~rc in tags

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,7 +10,9 @@ packages:
     upstream_package_name: flightctl
     downstream_package_name: flightctl
     upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
-
+actions:
+  get-current-version:
+    - bash -c 'git describe --tags | sed "s/^v//; s/-/~/g"'
 jobs:
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated package configuration to improve version retrieval and tag formatting.
	- Modified version tag template to remove leading 'v'.
	- Added a new action to retrieve the current package version.
	- Enhanced GitHub Actions workflow to fetch complete history for all branches and tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->