### PR TITLE
NO-ISSUE:  Increment resource_version when marking/unmarking devices for rollout

### DIFF
--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -84,7 +84,7 @@ func (s *Server) Run() error {
 	// Rollout disruption budget
 	disruptionBudget := disruption_budget.NewReconciler(s.store, callbackManager, s.log)
 	disruptionBudgetThread := thread.New(
-		s.log.WithField("pkg", "disruption-allowance"), "Disruption budget", disruption_budget.DisruptionBudgetReconcilationInterval, func() { disruptionBudget.Reconcile(ctx) })
+		s.log.WithField("pkg", "disruption-budget"), "Disruption budget", disruption_budget.DisruptionBudgetReconcilationInterval, func() { disruptionBudget.Reconcile(ctx) })
 	disruptionBudgetThread.Start()
 	defer disruptionBudgetThread.Stop()
 


### PR DESCRIPTION
NO-ISSUE: Perform retry when deadlock occurs on marking/unmarking

NO-ISSUE:  Remove usage of fmt.Sprintf in CountByLabels to avoid SQL injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced device rollout selection management with improved error handling.
	- Implemented retry mechanisms for marking and unmarking device rollouts.
	- Optimized database queries for device counting by labels.
	- Improved security and performance of database interactions.
	- Updated logging for disruption budget tasks to reflect accurate descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->