### PR TITLE
EDM-1054: Remove ownership change check in store

### DIFF
--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -180,10 +180,6 @@ func (s *GenericStore[P, M, A, AL]) createResource(ctx context.Context, resource
 }
 
 func (s *GenericStore[P, M, A, AL]) updateResource(ctx context.Context, fromAPI bool, existing, resource P, fieldsToUnset []string) (bool, error) {
-	if fromAPI && (util.DefaultIfNil(resource.GetOwner(), "<NIL>") != util.DefaultIfNil(existing.GetOwner(), "<NIL>")) {
-		return false, flterrors.ErrUpdatingResourceWithOwnerNotAllowed
-	}
-
 	sameSpec := resource.HasSameSpecAs(existing)
 	if !sameSpec {
 		if fromAPI {

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -460,53 +460,6 @@ var _ = Describe("FleetStore create", func() {
 			Expect(*updatedFleet.Metadata.Generation).To(Equal(int64(2)))
 		})
 
-		It("CreateOrUpdate wrong owner", func() {
-			fleet, err := storeInst.Fleet().Get(ctx, orgId, "myfleet-1")
-			Expect(err).ToNot(HaveOccurred())
-			fleet.Spec.Template.Spec.Os = &api.DeviceOsSpec{Image: "my new OS"}
-			fleet.Status = nil
-
-			called := false
-			callback := store.FleetStoreCallback(func(uuid.UUID, *api.Fleet, *api.Fleet) {
-				called = true
-			})
-			fleet.Metadata.Owner = util.StrToPtr("test")
-			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, fleet, nil, false, callback)
-			Expect(called).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			updatedFleet, err := storeInst.Fleet().Get(ctx, orgId, "myfleet-1")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(updatedFleet.ApiVersion).To(Equal(api.FleetAPIVersion))
-			Expect(updatedFleet.Kind).To(Equal(api.FleetKind))
-			Expect(lo.FromPtr(updatedFleet.Spec.Selector.MatchLabels)["key"]).To(Equal("value-1"))
-			Expect(updatedFleet.Status.Conditions).ToNot(BeNil())
-			Expect(updatedFleet.Status.Conditions).To(BeEmpty())
-			Expect(*updatedFleet.Metadata.Generation).To(Equal(int64(2)))
-			Expect(updatedFleet.Metadata.Owner).ToNot(BeNil())
-			Expect(*updatedFleet.Metadata.Owner).To(Equal("test"))
-
-			updatedFleet.Metadata.Owner = util.StrToPtr("test2")
-			called = false
-			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, updatedFleet, nil, true, callback)
-			Expect(err).To(HaveOccurred())
-			Expect(called).To(BeFalse())
-			Expect(err).Should(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
-
-			updatedFleet.Metadata.Owner = nil
-			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, updatedFleet, nil, true, callback)
-			Expect(err).To(HaveOccurred())
-			Expect(called).To(BeFalse())
-			Expect(err).Should(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
-
-			updatedFleet.Metadata.Owner = util.StrToPtr("test")
-			updatedFleet.Spec.Template.Spec.Os = &api.DeviceOsSpec{Image: "my new OS2"}
-			_, _, err = storeInst.Fleet().CreateOrUpdate(ctx, orgId, updatedFleet, nil, true, callback)
-			Expect(err).To(HaveOccurred())
-			Expect(called).To(BeFalse())
-			Expect(err).Should(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
-		})
-
 		It("UpdateStatus", func() {
 			condition := api.Condition{
 				Type:               api.FleetValid,


### PR DESCRIPTION
A check for ownership change was added when creating the generic update methods. This check is not necessary because the owner property is set to nil at the service level of all resources to prevent users from modifying it. Because the service layer sets the owner to nil, the check fails for any resource with an owner because the code compares the nil owner to the existing owner and thinks that the owner is being modified. The solution is to remove the redundant check, which is the way it was before the generic methods were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed restrictions on updating resource ownership from the API
	- Increased flexibility in resource management by allowing owner changes during updates
	- Removed test case for handling incorrect owner updates in the `FleetStore` test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->