### PR TITLE
NO-ISSUE: makefile: add make agent-container

### DIFF
--- a/deploy/agent-vm.mk
+++ b/deploy/agent-vm.mk
@@ -3,7 +3,9 @@ VMRAM ?= 512
 VMCPUS ?= 1
 VMDISK = /var/lib/libvirt/images/$(VMNAME).qcow2
 VMWAIT ?= 0
+CONTAINER_NAME ?= flightctl-device-no-bootc:base
 
+BUILD_TYPE := bootc
 
 agent-vm: bin/output/qcow2/disk.qcow2
 	@echo "Booting Agent VM from $(VMDISK)"
@@ -29,3 +31,14 @@ clean-agent-vm:
 	sudo rm -f $(VMDISK)
 
 .PHONY: clean-agent-vm
+
+agent-container: BUILD_TYPE := regular
+agent-container: bin/output/qcow2/disk.qcow2
+	@echo "Starting Agent Container flightctl-agent from $(CONTAINER_NAME)"
+	podman run -d --name flightctl-agent localhost:5000/"$(CONTAINER_NAME)"
+
+clean-agent-container:
+	podman stop flightctl-agent
+	podman rm flightctl-agent
+
+.PHONY: agent-container

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -114,6 +114,13 @@ make clean-agent-vm VMNAME=flightctl-device-2
 make clean-agent-vm VMNAME=flightctl-device-3
 ```
 
+To quickly create agent instances for testing/development in a containerized environment. This is particularly useful for testing lightweight agent deployments without setting up VMs.
+
+```
+make agent-container
+make clean-agent-container
+```
+
 Use the **[devicesimulator](devicesimulator.md)** to simulate load from devices
 
 ```

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -3,7 +3,7 @@ bin/output/qcow2/disk.qcow2: e2e-agent-images
 
 e2e-agent-images: bin rpm bin/e2e-certs
 	./test/scripts/agent-images/prepare_agent_config.sh
-	./test/scripts/agent-images/create_agent_images.sh
+	BUILD_TYPE=$(BUILD_TYPE) ./test/scripts/agent-images/create_agent_images.sh
 	./test/scripts/agent-images/create_application_image.sh
 
 .PHONY: e2e-agent-images

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -ex
+
+BUILD_TYPE=${BUILD_TYPE:-bootc}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 source "${SCRIPT_DIR}"/../functions
@@ -19,40 +21,73 @@ if [ -n "${FLIGHTCTL_RPM:-}" ]; then
     BUILD_ARGS="${BUILD_ARGS} --build-arg=RPM_PACKAGE=${RPM_PACKAGE}"
 fi
 
+build_images() {
+    for img in $IMAGE_LIST; do
+        containerfile_path="${SCRIPT_DIR}/Containerfile-e2e-${img}.local"
+        container_name="localhost:5000/flightctl-device:${img}"
 
+        if [ "$BUILD_TYPE" = "regular" ]; then
+            # create a temporary directory and cleanup on exit
+            tmpdir=$(mktemp -d)
+            trap 'rm -rf "$tmpdir" EXIT'
+            cp "${containerfile_path}" "$tmpdir/Containerfile"
+            echo 'CMD ["/usr/bin/flightctl-agent"]' >> "$tmpdir/Containerfile"
+            containerfile_path="$tmpdir/Containerfile"
+            container_name="localhost:5000/flightctl-device-no-bootc:${img}"
+        fi
 
-for img in $IMAGE_LIST; do
-   FINAL_REF="${REGISTRY_ADDRESS}/flightctl-device:${img}"
-   echo -e "\033[32mCreating image ${FINAL_REF} \033[m"
-   podman build ${BUILD_ARGS} -f "${SCRIPT_DIR}"/Containerfile-e2e-"${img}".local -t localhost:5000/flightctl-device:${img} .
-   podman tag "localhost:5000/flightctl-device:${img}" "${FINAL_REF}"
-   podman push "${FINAL_REF}"
-done
+        FINAL_REF="${REGISTRY_ADDRESS}/$(basename "${container_name}")"
 
-CONTAINER_CREATE_DATE=$(podman inspect -f '{{.Created}}' ${REGISTRY_ADDRESS}/flightctl-device:base)
-if [[ -f bin/output/qcow2/disk.qcow2 ]]; then
-	QCOW_CREATE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2  "+%Y-%m-%d %H:%M:%S")
-fi 
+        echo -e "\033[32mCreating image ${FINAL_REF} with BUILD_TYPE=${BUILD_TYPE} \033[m"
 
-if [[ "${CONTAINER_CREATE_DATE}" < "${QCOW_CREATE_DATE}" ]]; then
-    echo -e "\033[32mqcow2 is already up to date with the contaner \033[m"
-    exit 0
-fi
+        podman build ${BUILD_ARGS:+${BUILD_ARGS}} -f "${containerfile_path}" -t "${container_name}" .
+        podman tag "${container_name}" "${FINAL_REF}"
+        podman push "${FINAL_REF}"
+    done
+}
 
-echo -e "\033[32mProducing qcow2 image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
-mkdir -p bin/output
-# pull the image to the root user system storage in /var/lib/containers/storage
-echo -e "\033[32mPulling ${REGISTRY_ADDRESS}/flightctl-device:base to /var/lib/containers/storage\033[m"
-sudo podman pull "${REGISTRY_ADDRESS}/flightctl-device:base"
-echo -e "\033[32m Producing qcow image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
-sudo podman run --rm \
-                -it \
-                --privileged \
-                --pull=newer \
-                --security-opt label=type:unconfined_t \
-                -v $(pwd)/bin/output:/output \
-                -v /var/lib/containers/storage:/var/lib/containers/storage \
-                quay.io/centos-bootc/bootc-image-builder:latest \
-                build \
-                --type qcow2 \
-                --local "${REGISTRY_ADDRESS}/flightctl-device:base"
+build_qcow2_image() {
+    echo -e "\033[32mProducing qcow2 image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
+
+    mkdir -p bin/output
+    # Check if qcow2 is already up to date
+    CONTAINER_CREATE_DATE=$(podman inspect -f '{{.Created}}' ${REGISTRY_ADDRESS}/flightctl-device:base)
+    if [[ -f bin/output/qcow2/disk.qcow2 ]]; then
+        QCOW_CREATE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2 "+%Y-%m-%d %H:%M:%S")
+    fi
+
+    if [[ -n "${QCOW_CREATE_DATE}" && "${CONTAINER_CREATE_DATE}" < "${QCOW_CREATE_DATE}" ]]; then
+        echo -e "\033[32mqcow2 is already up to date with the container \033[m"
+        return
+    fi
+
+    # Pull the image and build the qcow2
+    echo -e "\033[32mPulling ${REGISTRY_ADDRESS}/flightctl-device:base to /var/lib/containers/storage\033[m"
+    sudo podman pull "${REGISTRY_ADDRESS}/flightctl-device:base"
+    echo -e "\033[32m Producing qcow image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
+    sudo podman run --rm \
+                    -it \
+                    --privileged \
+                    --pull=newer \
+                    --security-opt label=type:unconfined_t \
+                    -v "$(pwd)"/bin/output:/output \
+                    -v /var/lib/containers/storage:/var/lib/containers/storage \
+                    quay.io/centos-bootc/bootc-image-builder:latest \
+                    build \
+                    --type qcow2 \
+                    --local "${REGISTRY_ADDRESS}/flightctl-device:base"
+}
+
+case "$BUILD_TYPE" in
+    regular)
+        build_images
+        ;;
+    bootc)
+        build_images
+        build_qcow2_image
+        ;;
+    *)
+        echo "Unknown BUILD_TYPE: $BUILD_TYPE"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Developers building VM's to e2e test the agent waste a lot of time. This PR adds quick tooling to create nonbootable containers. An agent can enroll and do just about everything except upgrade.

### usage
```
make agent-container
make clean-agent-container
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for container management in the deployment process.
	- Introduced flexible image building with different build types (regular and bootc).
	- Enhanced script for creating agent images with more robust image construction logic.
	- New commands for creating and cleaning agent containers in the README documentation.

- **Improvements**
	- Updated deployment and testing scripts to support more versatile container and image workflows.
	- Added environment variable configuration for build type management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->