### PR TITLE
NO-ISSUE: properly handle wrapped errors

### DIFF
--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -189,10 +189,10 @@ func (o *CertificateOptions) Run(ctx context.Context, args []string) error {
 		}
 		return checkCsrCertReady(currentCsr), nil
 	})
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		fmt.Fprintln(os.Stderr, " success.")
-	case wait.ErrWaitTimeout:
+	case errors.Is(err, wait.ErrWaitTimeout):
 		return fmt.Errorf("timeout polling for certificate")
 	default:
 		return fmt.Errorf("polling for certificate: %w", err)

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -202,12 +202,12 @@ func (h *ServiceHandler) CreateCertificateSigningRequest(ctx context.Context, re
 	}
 
 	result, err := h.store.CertificateSigningRequest().Create(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		break
-	case flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.CreateCertificateSigningRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrDuplicateName:
+	case errors.Is(err, flterrors.ErrDuplicateName):
 		return server.CreateCertificateSigningRequest409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -236,10 +236,10 @@ func (h *ServiceHandler) DeleteCertificateSigningRequest(ctx context.Context, re
 	orgId := store.NullOrgId
 
 	err = h.store.CertificateSigningRequest().Delete(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteCertificateSigningRequest200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteCertificateSigningRequest404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -259,10 +259,10 @@ func (h *ServiceHandler) ReadCertificateSigningRequest(ctx context.Context, requ
 	orgId := store.NullOrgId
 
 	result, err := h.store.CertificateSigningRequest().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadCertificateSigningRequest200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadCertificateSigningRequest404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -283,10 +283,10 @@ func (h *ServiceHandler) PatchCertificateSigningRequest(ctx context.Context, req
 
 	currentObj, err := h.store.CertificateSigningRequest().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 			return server.PatchCertificateSigningRequest400JSONResponse{Message: err.Error()}, nil
-		case flterrors.ErrResourceNotFound:
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.PatchCertificateSigningRequest404JSONResponse{}, nil
 		default:
 			return nil, err
@@ -316,14 +316,14 @@ func (h *ServiceHandler) PatchCertificateSigningRequest(ctx context.Context, req
 	newObj.Metadata.ResourceVersion = nil
 
 	result, err := h.store.CertificateSigningRequest().Update(ctx, orgId, newObj)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		break
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.PatchCertificateSigningRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.PatchCertificateSigningRequest404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.PatchCertificateSigningRequest409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -363,16 +363,16 @@ func (h *ServiceHandler) ReplaceCertificateSigningRequest(ctx context.Context, r
 	}
 
 	result, created, err := h.store.CertificateSigningRequest().CreateOrUpdate(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		break
-	case flterrors.ErrResourceIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil):
 		return server.ReplaceCertificateSigningRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.ReplaceCertificateSigningRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceCertificateSigningRequest404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.ReplaceCertificateSigningRequest409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -426,12 +426,12 @@ func (h *ServiceHandler) UpdateCertificateSigningRequestApproval(ctx context.Con
 	}
 
 	oldCSR, err := h.store.CertificateSigningRequest().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		break
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.UpdateCertificateSigningRequestApproval400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.UpdateCertificateSigningRequestApproval404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -454,12 +454,12 @@ func (h *ServiceHandler) UpdateCertificateSigningRequestApproval(ctx context.Con
 	newCSR.Status.Conditions = newConditions
 
 	result, err := h.store.CertificateSigningRequest().UpdateStatus(ctx, orgId, newCSR)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		break
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.UpdateCertificateSigningRequestApproval404JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.UpdateCertificateSigningRequestApproval409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err

--- a/internal/service/common/enrollmentrequest.go
+++ b/internal/service/common/enrollmentrequest.go
@@ -36,12 +36,12 @@ func CreateEnrollmentRequest(ctx context.Context, st store.Store, request server
 	}
 
 	result, err := st.EnrollmentRequest().Create(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.CreateEnrollmentRequest201JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.CreateEnrollmentRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrDuplicateName:
+	case errors.Is(err, flterrors.ErrDuplicateName):
 		return server.CreateEnrollmentRequest409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -52,10 +52,10 @@ func ReadEnrollmentRequest(ctx context.Context, st store.Store, request server.R
 	orgId := store.NullOrgId
 
 	result, err := st.EnrollmentRequest().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadEnrollmentRequest200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadEnrollmentRequest404JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/service/console.go
+++ b/internal/service/console.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -41,8 +42,8 @@ func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Re
 	consoleSession, err := h.consoleSessionManager.StartSession(r.Context(), orgId, deviceName)
 	// check for errors
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceNotFound:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			h.log.Errorf("console requested for unknown device: %s", deviceName)
 			http.Error(w, "Device not found", http.StatusNotFound)
 		default:
@@ -157,8 +158,8 @@ func (h *ServiceHandler) RequestConsole(ctx context.Context, request server.Requ
 	// make sure the device exists
 	_, err = h.store.Device().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceNotFound:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.RequestConsole404JSONResponse{}, nil
 		default:
 			return nil, err

--- a/internal/service/enrollmentconfig.go
+++ b/internal/service/enrollmentconfig.go
@@ -49,10 +49,10 @@ func (h *ServiceHandler) GetEnrollmentConfig(ctx context.Context, request server
 
 		csr, err := h.store.CertificateSigningRequest().Get(ctx, orgId, *request.Params.Csr)
 		if err != nil {
-			switch err {
-			case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+			switch {
+			case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 				return server.GetEnrollmentConfig400JSONResponse{Message: err.Error()}, nil
-			case flterrors.ErrResourceNotFound:
+			case errors.Is(err, flterrors.ErrResourceNotFound):
 				return server.GetEnrollmentConfig404JSONResponse{}, nil
 			default:
 				return nil, err

--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -226,18 +226,18 @@ func (h *ServiceHandler) ReplaceEnrollmentRequest(ctx context.Context, request s
 	}
 
 	result, created, err := h.store.EnrollmentRequest().CreateOrUpdate(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		if created {
 			return server.ReplaceEnrollmentRequest201JSONResponse(*result), nil
 		} else {
 			return server.ReplaceEnrollmentRequest200JSONResponse(*result), nil
 		}
-	case flterrors.ErrResourceNameIsNil, flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceNameIsNil), errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.ReplaceEnrollmentRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceEnrollmentRequest404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.ReplaceEnrollmentRequest409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -259,10 +259,10 @@ func (h *ServiceHandler) PatchEnrollmentRequest(ctx context.Context, request ser
 
 	currentObj, err := h.store.EnrollmentRequest().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 			return server.PatchEnrollmentRequest400JSONResponse{Message: err.Error()}, nil
-		case flterrors.ErrResourceNotFound:
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.PatchEnrollmentRequest404JSONResponse{}, nil
 		default:
 			return nil, err
@@ -295,14 +295,14 @@ func (h *ServiceHandler) PatchEnrollmentRequest(ctx context.Context, request ser
 	newObj.Metadata.ResourceVersion = nil
 
 	result, err := h.store.EnrollmentRequest().Update(ctx, orgId, newObj)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.PatchEnrollmentRequest200JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.PatchEnrollmentRequest400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.PatchEnrollmentRequest404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict, flterrors.ErrUpdatingResourceWithOwnerNotAllowed:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict), errors.Is(err, flterrors.ErrUpdatingResourceWithOwnerNotAllowed):
 		return server.PatchEnrollmentRequest409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -322,10 +322,10 @@ func (h *ServiceHandler) DeleteEnrollmentRequest(ctx context.Context, request se
 	orgId := store.NullOrgId
 
 	err = h.store.EnrollmentRequest().Delete(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteEnrollmentRequest200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteEnrollmentRequest404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -345,10 +345,10 @@ func (h *ServiceHandler) ReadEnrollmentRequestStatus(ctx context.Context, reques
 	orgId := store.NullOrgId
 
 	result, err := h.store.EnrollmentRequest().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadEnrollmentRequestStatus200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadEnrollmentRequestStatus404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -371,12 +371,12 @@ func (h *ServiceHandler) ApproveEnrollmentRequest(ctx context.Context, request s
 		return server.ApproveEnrollmentRequest400JSONResponse{Message: errors.Join(errs...).Error()}, nil
 	}
 	enrollmentReq, err := h.store.EnrollmentRequest().Get(ctx, orgId, request.Name)
-	switch err {
+	switch {
 	default:
 		return nil, err
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ApproveEnrollmentRequest404JSONResponse{}, nil
-	case nil:
+	case err == nil:
 	}
 
 	// if the enrollment request was already approved we should not try to approve it one more time
@@ -412,10 +412,10 @@ func (h *ServiceHandler) ApproveEnrollmentRequest(ctx context.Context, request s
 		}
 	}
 	_, err = h.store.EnrollmentRequest().UpdateStatus(ctx, orgId, enrollmentReq)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ApproveEnrollmentRequest200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ApproveEnrollmentRequest404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -439,10 +439,10 @@ func (h *ServiceHandler) ReplaceEnrollmentRequestStatus(ctx context.Context, req
 	}
 
 	result, err := h.store.EnrollmentRequest().UpdateStatus(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReplaceEnrollmentRequestStatus200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceEnrollmentRequestStatus404JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/service/fleet.go
+++ b/internal/service/fleet.go
@@ -52,12 +52,12 @@ func (h *ServiceHandler) CreateFleet(ctx context.Context, request server.CreateF
 	}
 
 	result, err := h.store.Fleet().Create(ctx, orgId, request.Body, h.callbackManager.FleetUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.CreateFleet201JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.CreateFleet400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrDuplicateName:
+	case errors.Is(err, flterrors.ErrDuplicateName):
 		return server.CreateFleet409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -157,10 +157,10 @@ func (h *ServiceHandler) ReadFleet(ctx context.Context, request server.ReadFleet
 	orgId := store.NullOrgId
 
 	result, err := h.store.Fleet().Get(ctx, orgId, request.Name, store.WithSummary(util.DefaultBoolIfNil(request.Params.AddDevicesSummary, false)))
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadFleet200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadFleet404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -194,20 +194,20 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, request server.Replac
 	}
 
 	result, created, err := h.store.Fleet().CreateOrUpdate(ctx, orgId, request.Body, nil, true, h.callbackManager.FleetUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		if created {
 			return server.ReplaceFleet201JSONResponse(*result), nil
 		} else {
 			return server.ReplaceFleet200JSONResponse(*result), nil
 		}
-	case flterrors.ErrResourceIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil):
 		return server.ReplaceFleet400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.ReplaceFleet400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceFleet404JSONResponse{}, nil
-	case flterrors.ErrUpdatingResourceWithOwnerNotAllowed, flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrUpdatingResourceWithOwnerNotAllowed), errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.ReplaceFleet409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -236,10 +236,10 @@ func (h *ServiceHandler) DeleteFleet(ctx context.Context, request server.DeleteF
 	}
 
 	err = h.store.Fleet().Delete(ctx, orgId, request.Name, h.callbackManager.FleetUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteFleet200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteFleet404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -259,10 +259,10 @@ func (h *ServiceHandler) ReadFleetStatus(ctx context.Context, request server.Rea
 	orgId := store.NullOrgId
 
 	result, err := h.store.Fleet().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadFleetStatus200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadFleetStatus404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -282,10 +282,10 @@ func (h *ServiceHandler) ReplaceFleetStatus(ctx context.Context, request server.
 	orgId := store.NullOrgId
 
 	result, err := h.store.Fleet().UpdateStatus(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReplaceFleetStatus200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceFleetStatus404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -307,10 +307,10 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, request server.PatchFle
 
 	currentObj, err := h.store.Fleet().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 			return server.PatchFleet400JSONResponse{Message: err.Error()}, nil
-		case flterrors.ErrResourceNotFound:
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.PatchFleet404JSONResponse{}, nil
 		default:
 			return nil, err
@@ -349,14 +349,14 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, request server.PatchFle
 	}
 	result, err := h.store.Fleet().Update(ctx, orgId, newObj, nil, true, updateCallback)
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.PatchFleet200JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.PatchFleet400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.PatchFleet404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.PatchFleet409JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -38,12 +38,12 @@ func (h *ServiceHandler) CreateRepository(ctx context.Context, request server.Cr
 	}
 
 	result, err := h.store.Repository().Create(ctx, orgId, request.Body, h.callbackManager.RepositoryUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.CreateRepository201JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.CreateRepository400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrDuplicateName:
+	case errors.Is(err, flterrors.ErrDuplicateName):
 		return server.CreateRepository409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -135,10 +135,10 @@ func (h *ServiceHandler) ReadRepository(ctx context.Context, request server.Read
 	orgId := store.NullOrgId
 
 	result, err := h.store.Repository().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadRepository200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadRepository404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -169,20 +169,20 @@ func (h *ServiceHandler) ReplaceRepository(ctx context.Context, request server.R
 	}
 
 	result, created, err := h.store.Repository().CreateOrUpdate(ctx, orgId, request.Body, h.callbackManager.RepositoryUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		if created {
 			return server.ReplaceRepository201JSONResponse(*result), nil
 		} else {
 			return server.ReplaceRepository200JSONResponse(*result), nil
 		}
-	case flterrors.ErrResourceIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil):
 		return server.ReplaceRepository400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.ReplaceRepository400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceRepository404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.ReplaceRepository409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -202,10 +202,10 @@ func (h *ServiceHandler) DeleteRepository(ctx context.Context, request server.De
 	orgId := store.NullOrgId
 
 	err = h.store.Repository().Delete(ctx, orgId, request.Name, h.callbackManager.RepositoryUpdatedCallback)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteRepository200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteRepository404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -227,10 +227,10 @@ func (h *ServiceHandler) PatchRepository(ctx context.Context, request server.Pat
 
 	currentObj, err := h.store.Repository().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 			return server.PatchRepository400JSONResponse{Message: err.Error()}, nil
-		case flterrors.ErrResourceNotFound:
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.PatchRepository404JSONResponse{}, nil
 		default:
 			return nil, err
@@ -266,14 +266,14 @@ func (h *ServiceHandler) PatchRepository(ctx context.Context, request server.Pat
 	}
 	result, err := h.store.Repository().Update(ctx, orgId, newObj, updateCallback)
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.PatchRepository200JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.PatchRepository400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.PatchRepository404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.PatchRepository409JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/service/resourcesync.go
+++ b/internal/service/resourcesync.go
@@ -37,12 +37,12 @@ func (h *ServiceHandler) CreateResourceSync(ctx context.Context, request server.
 	}
 
 	result, err := h.store.ResourceSync().Create(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.CreateResourceSync201JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrIllegalResourceVersionFormat:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrIllegalResourceVersionFormat):
 		return server.CreateResourceSync400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrDuplicateName:
+	case errors.Is(err, flterrors.ErrDuplicateName):
 		return server.CreateResourceSync409JSONResponse{Message: err.Error()}, nil
 	default:
 		return nil, err
@@ -142,10 +142,10 @@ func (h *ServiceHandler) ReadResourceSync(ctx context.Context, request server.Re
 	orgId := store.NullOrgId
 
 	result, err := h.store.ResourceSync().Get(ctx, orgId, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadResourceSync200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadResourceSync404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -175,20 +175,20 @@ func (h *ServiceHandler) ReplaceResourceSync(ctx context.Context, request server
 	}
 
 	result, created, err := h.store.ResourceSync().CreateOrUpdate(ctx, orgId, request.Body)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		if created {
 			return server.ReplaceResourceSync201JSONResponse(*result), nil
 		} else {
 			return server.ReplaceResourceSync200JSONResponse(*result), nil
 		}
-	case flterrors.ErrResourceIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil):
 		return server.ReplaceResourceSync400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.ReplaceResourceSync400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReplaceResourceSync404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.ReplaceResourceSync409JSONResponse{}, nil
 	default:
 		return nil, err
@@ -207,10 +207,10 @@ func (h *ServiceHandler) DeleteResourceSync(ctx context.Context, request server.
 	}
 	orgId := store.NullOrgId
 	err = h.store.ResourceSync().Delete(ctx, orgId, request.Name, h.store.Fleet().UnsetOwner)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteResourceSync200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteResourceSync404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -232,10 +232,10 @@ func (h *ServiceHandler) PatchResourceSync(ctx context.Context, request server.P
 
 	currentObj, err := h.store.ResourceSync().Get(ctx, orgId, request.Name)
 	if err != nil {
-		switch err {
-		case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+		switch {
+		case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 			return server.PatchResourceSync400JSONResponse{Message: err.Error()}, nil
-		case flterrors.ErrResourceNotFound:
+		case errors.Is(err, flterrors.ErrResourceNotFound):
 			return server.PatchResourceSync404JSONResponse{}, nil
 		default:
 			return nil, err
@@ -265,14 +265,14 @@ func (h *ServiceHandler) PatchResourceSync(ctx context.Context, request server.P
 	newObj.Metadata.ResourceVersion = nil
 	result, err := h.store.ResourceSync().Update(ctx, orgId, newObj)
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.PatchResourceSync200JSONResponse(*result), nil
-	case flterrors.ErrResourceIsNil, flterrors.ErrResourceNameIsNil:
+	case errors.Is(err, flterrors.ErrResourceIsNil), errors.Is(err, flterrors.ErrResourceNameIsNil):
 		return server.PatchResourceSync400JSONResponse{Message: err.Error()}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.PatchResourceSync404JSONResponse{}, nil
-	case flterrors.ErrNoRowsUpdated, flterrors.ErrResourceVersionConflict:
+	case errors.Is(err, flterrors.ErrNoRowsUpdated), errors.Is(err, flterrors.ErrResourceVersionConflict):
 		return server.PatchResourceSync409JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/service/templateversion.go
+++ b/internal/service/templateversion.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -154,10 +155,10 @@ func (h *ServiceHandler) ReadTemplateVersion(ctx context.Context, request server
 	orgId := store.NullOrgId
 
 	result, err := h.store.TemplateVersion().Get(ctx, orgId, request.Fleet, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.ReadTemplateVersion200JSONResponse(*result), nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.ReadTemplateVersion404JSONResponse{}, nil
 	default:
 		return nil, err
@@ -183,10 +184,10 @@ func (h *ServiceHandler) DeleteTemplateVersion(ctx context.Context, request serv
 	}
 
 	err = h.store.TemplateVersion().Delete(ctx, orgId, request.Fleet, request.Name)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return server.DeleteTemplateVersion200JSONResponse{}, nil
-	case flterrors.ErrResourceNotFound:
+	case errors.Is(err, flterrors.ErrResourceNotFound):
 		return server.DeleteTemplateVersion404JSONResponse{}, nil
 	default:
 		return nil, err

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,12 +18,12 @@ const retryIterations = 10
 type CreateOrUpdateMode string
 
 func ErrorFromGormError(err error) error {
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return nil
-	case gorm.ErrRecordNotFound, gorm.ErrForeignKeyViolated:
+	case errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, gorm.ErrForeignKeyViolated):
 		return flterrors.ErrResourceNotFound
-	case gorm.ErrDuplicatedKey:
+	case errors.Is(err, gorm.ErrDuplicatedKey):
 		return flterrors.ErrDuplicateName
 	default:
 		return err


### PR DESCRIPTION
Since Go 1.13, errors can be wrapped using the fmt. Errorf function with the %w verb. Therefore, direct comparison of errors using the equality check fails on wrapped errors. The preferred way of checking for a specific error is to use the errors. Is function from the standard library as this function traverses the chain of the wrapped errors while checking for a specific error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling across multiple services by replacing direct error comparisons with `errors.Is()` function.
	- Improved error checking robustness and flexibility in various methods.
	- Streamlined error handling logic in multiple service components.

- **Chores**
	- Added `errors` package import to several files to support new error handling approach.

The changes focus on improving error handling mechanisms without altering core functionality, making the codebase more maintainable and idiomatic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->