### PR TITLE
EDM-1069: Fix updating device after fleet update

### DIFF
--- a/internal/tasks/callback_manager.go
+++ b/internal/tasks/callback_manager.go
@@ -214,7 +214,7 @@ func (t *callbackManager) TemplateVersionCreatedCallback(orgId uuid.UUID, before
 	resourceRef := ResourceReference{
 		OrgID: orgId,
 		Kind:  api.FleetKind,
-		Name:  *templateVersion.Metadata.Name,
+		Name:  templateVersion.Spec.Fleet,
 	}
 	t.submitTask(FleetRolloutTask, resourceRef, FleetRolloutOpUpdate)
 }


### PR DESCRIPTION
The rollout task currently fails because the TemplateVersion name is passed instead of the Fleet name. The task then fails to find the fleet.