### PR TITLE
EDM-811: Enable status.lifecycle.status field selector for devices

### DIFF
--- a/docs/user/field-selectors.md
+++ b/docs/user/field-selectors.md
@@ -25,7 +25,7 @@ The following table lists the fields supported for filtering for each resource k
 | Kind                            | Fields                                              |
 |---------------------------------|-----------------------------------------------------|
 | **Certificate Signing Request** | `status.certificate`                                |
-| **Device**                      | `status.summary.status`<br/>`status.applicationsSummary.status`<br/>`status.updated.status`<br/>`status.lastSeen` |
+| **Device**                      | `status.summary.status`<br/>`status.applicationsSummary.status`<br/>`status.updated.status`<br/>`status.lastSeen`<br/>`status.lifecycle.status` |
 | **Enrollment Request**          | `status.approval.approved`<br/>`status.certificate` |
 | **Fleet**                       | `spec.template.spec.os.image`                       |
 | **Repository**                  | `spec.type`<br/>`spec.url`                          |

--- a/internal/store/model/selectors.go
+++ b/internal/store/model/selectors.go
@@ -19,6 +19,7 @@ var (
 		selector.NewSelectorName("status.applicationsSummary.status"): selector.String,
 		selector.NewSelectorName("status.updated.status"):             selector.String,
 		selector.NewSelectorName("status.lastSeen"):                   selector.Timestamp,
+		selector.NewSelectorName("status.lifecycle.status"):           selector.String,
 	}
 	fleetSpecSelectors = selectorToTypeMap{
 		selector.NewSelectorName("spec.template.spec.os.image"): selector.String,


### PR DESCRIPTION
This is needed for the UI to show relevant views of devices ("live" only, decommissioning/ed only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated field selectors documentation for "Device" resource.
	- Added new field `status.lifecycle.status` for filtering devices by lifecycle status.

- **New Features**
	- Enhanced device filtering capabilities with lifecycle status selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->