### PR TITLE
EDM-1075: api/properties: fix IsManagedBy

### DIFF
--- a/api/v1alpha1/properties.go
+++ b/api/v1alpha1/properties.go
@@ -22,7 +22,7 @@ func (d *Device) IsManagedBy(f *Fleet) bool {
 	if f == nil || !d.IsManaged() {
 		return false
 	}
-	return f.Metadata.Name == util.StrToPtr(strings.TrimPrefix("Fleet/", *d.Metadata.Owner))
+	return util.FromPtr(f.Metadata.Name) == strings.TrimPrefix(util.FromPtr(d.Metadata.Owner), "Fleet/")
 }
 
 // IsUpdating() is true if the device's agent reports that it is updating.


### PR DESCRIPTION
This bug fix addresses two issues with the IsManaged method: incorrect pointer comparison and inverted parameters for TrimPrefix. the result was status would improperly report `OutOfDate` even when it was UpToDate.

```
bin/flightctl get devices
NAME                                                    ALIAS   OWNER           SYSTEM  UPDATED         APPLICATIONS    LAST SEEN
n8e2pbp23lctuerg36qbski1nsjgqpdtfkrkkv86ullq65c18ndg            Fleet/default   Online  UpToDate        Healthy         now
```

Will follow up on some tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved device ownership comparison logic to ensure accurate fleet management checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->