### PR TITLE
EDM-500: EDM-999: agent: ensure rollback on failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	go.uber.org/mock v0.4.0
 	golang.org/x/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
-	golang.org/x/net v0.27.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.24.0
 	golang.org/x/term v0.22.0
@@ -137,6 +136,7 @@ require (
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/mod v0.19.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -342,9 +342,6 @@ func (m *PodmanMonitor) Status() ([]v1alpha1.DeviceApplicationStatus, v1alpha1.D
 		}
 		statuses = append(statuses, *appStatus)
 
-		m.log.Debugf("Application %s status: %s", app.Name(), appStatus.Status)
-		m.log.Debugf("Application %s summary status: %s", app.Name(), appSummary.Status)
-
 		// phases can get worse but not better
 		switch appSummary.Status {
 		case v1alpha1.ApplicationsSummaryStatusError:

--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -74,7 +74,7 @@ func (b *Bootstrap) Initialize(ctx context.Context) error {
 		versionInfo.GitCommit,
 	)
 
-	if err := b.ensureSpecFiles(); err != nil {
+	if err := b.ensureSpecFiles(ctx); err != nil {
 		return err
 	}
 
@@ -156,7 +156,7 @@ func (b *Bootstrap) updateStatus(ctx context.Context) {
 	}
 }
 
-func (b *Bootstrap) ensureSpecFiles() error {
+func (b *Bootstrap) ensureSpecFiles(ctx context.Context) error {
 	if b.lifecycle.IsInitialized() {
 		// it is unexpected to have a missing spec files when the device is
 		// enrolled. reset the spec files to empty if they are missing to allow
@@ -167,7 +167,7 @@ func (b *Bootstrap) ensureSpecFiles() error {
 		}
 	} else {
 		b.log.Info("Device is not enrolled, initializing spec files")
-		if err := b.specManager.Initialize(); err != nil {
+		if err := b.specManager.Initialize(ctx); err != nil {
 			return fmt.Errorf("initializing spec files: %w", err)
 		}
 	}
@@ -236,7 +236,8 @@ func (b *Bootstrap) checkRollback(ctx context.Context) error {
 	}
 
 	b.log.Warn("Starting spec rollback")
-	if err := b.specManager.Rollback(); err != nil {
+	// rollback and set the version to failed
+	if err := b.specManager.Rollback(ctx, spec.WithSetFailed()); err != nil {
 		return fmt.Errorf("failed spec rollback: %w", err)
 	}
 	b.log.Info("Spec rollback complete, resuming bootstrap")

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -111,7 +111,7 @@ func TestInitialization(t *testing.T) {
 			) {
 				gomock.InOrder(
 					mockLifecycleInitializer.EXPECT().IsInitialized().Return(false),
-					mockSpecManager.EXPECT().Initialize().Return(nil),
+					mockSpecManager.EXPECT().Initialize(gomock.Any()).Return(nil),
 					mockStatusManager.EXPECT().Collect(gomock.Any()).Return(nil),
 					mockStatusManager.EXPECT().Get(gomock.Any()).Return(&v1alpha1.DeviceStatus{}),
 					mockLifecycleInitializer.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(nil),
@@ -211,7 +211,7 @@ func TestBootstrapCheckRollback(t *testing.T) {
 					mockSpecManager.EXPECT().OSVersion(spec.Desired).Return(desiredOS),
 					mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil, nil),
 					mockSpecManager.EXPECT().IsRollingBack(gomock.Any()).Return(true, nil),
-					mockSpecManager.EXPECT().Rollback().Return(nil),
+					mockSpecManager.EXPECT().Rollback(context.TODO(), gomock.Any()).Return(nil),
 					mockSpecManager.EXPECT().RenderedVersion(spec.Desired).Return("2"),
 					mockStatusManager.EXPECT().UpdateCondition(gomock.Any(), gomock.Any()).Return(nil),
 				)
@@ -237,7 +237,7 @@ func TestBootstrapCheckRollback(t *testing.T) {
 					mockSpecManager.EXPECT().OSVersion(spec.Desired).Return(desiredOS),
 					mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil, nil),
 					mockSpecManager.EXPECT().IsRollingBack(gomock.Any()).Return(true, nil),
-					mockSpecManager.EXPECT().Rollback().Return(mockErr),
+					mockSpecManager.EXPECT().Rollback(context.TODO(), gomock.Any()).Return(mockErr),
 				)
 			},
 			expectedError: mockErr,
@@ -313,7 +313,7 @@ func TestEnsureBootedOS(t *testing.T) {
 				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("unexpected-booted-image", false, nil)
 				mockSpecManager.EXPECT().IsRollingBack(gomock.Any()).Return(true, nil)
-				mockSpecManager.EXPECT().Rollback().Return(nil)
+				mockSpecManager.EXPECT().Rollback(gomock.Any(), gomock.Any()).Return(nil)
 				mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil, nil)
 				mockSpecManager.EXPECT().RenderedVersion(spec.Desired).Return("2")
 				mockStatusManager.EXPECT().UpdateCondition(gomock.Any(), gomock.Any()).Return(nil)

--- a/internal/agent/device/config/controller_test.go
+++ b/internal/agent/device/config/controller_test.go
@@ -169,7 +169,7 @@ func TestComputeRemoval(t *testing.T) {
 	}
 }
 
-func expectCreateFile(mockWriter *fileio.MockWriter, mockManagedFile *fileio.MockManagedFile, f string) {
+func expectCreateFile(mockWriter *fileio.MockWriter, mockManagedFile *fileio.MockManagedFile, _ string) {
 	mockWriter.EXPECT().CreateManagedFile(gomock.Any()).Return(mockManagedFile, nil)
 	mockManagedFile.EXPECT().IsUpToDate().Return(false, nil)
 	mockManagedFile.EXPECT().Exists().Return(false, nil)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -108,7 +108,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	// orchestrates periodic fetching of device specs and pushing status updates
 	engine := NewEngine(
 		a.fetchSpecInterval,
-		func(ctx context.Context) { a.syncSpec(ctx, a.syncSpecFn) },
+		a.syncDeviceSpec,
 		a.statusUpdateInterval,
 		a.statusUpdate,
 	)
@@ -187,7 +187,7 @@ func (a *Agent) sync(ctx context.Context, current, desired *v1alpha1.RenderedDev
 	return nil
 }
 
-func (a *Agent) syncSpec(ctx context.Context, syncFn func(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error) {
+func (a *Agent) syncDeviceSpec(ctx context.Context) {
 	startTime := time.Now()
 	a.log.Debug("Starting sync of device spec")
 	defer func() {
@@ -205,35 +205,62 @@ func (a *Agent) syncSpec(ctx context.Context, syncFn func(ctx context.Context, d
 		return
 	}
 
-	if err := syncFn(ctx, desired); err != nil {
+	current, err := a.specManager.Read(spec.Current)
+	if err != nil {
+		a.log.Errorf("Failed to get current spec: %v", err)
+		return
+	}
+
+	if err := a.sync(ctx, current, desired); err != nil {
 		// if context is canceled return to exit the sync loop
 		if errors.Is(err, context.Canceled) {
 			return
 		}
+
+		if err := a.rollbackSpec(ctx, current, desired); err != nil {
+			a.log.Errorf("Failed to rollback: %v", err)
+			return
+		}
+
 		a.handleSyncError(ctx, desired, err)
 		return
-	}
-}
-
-func (a *Agent) syncSpecFn(ctx context.Context, desired *v1alpha1.RenderedDeviceSpec) error {
-	current, err := a.specManager.Read(spec.Current)
-	if err != nil {
-		return err
-	}
-
-	if err := a.sync(ctx, current, desired); err != nil {
-		return err
 	}
 
 	// reconciliation is a success, upgrade the current spec
 	if err := a.specManager.Upgrade(ctx); err != nil {
-		return err
+		a.log.Errorf("Failed to upgrade spec: %v", err)
+		return
 	}
 
 	if err := a.updatedStatus(ctx, desired); err != nil {
 		a.log.Warnf("Failed updating status: %v", err)
 	}
+}
 
+func (a *Agent) rollbackSpec(ctx context.Context, current, desired *v1alpha1.RenderedDeviceSpec) error {
+	a.log.Warnf("Attempting to roll back to previous renderedVersion: %s", current.RenderedVersion)
+	updateErr := a.statusManager.UpdateCondition(ctx, v1alpha1.Condition{
+		Type:    v1alpha1.DeviceUpdating,
+		Status:  v1alpha1.ConditionStatusTrue,
+		Reason:  string(v1alpha1.UpdateStateRollingBack),
+		Message: "The device is rolling back to the previous renderedVersion: " + current.RenderedVersion,
+	})
+	if updateErr != nil {
+		a.log.Warnf("Failed setting status: %v", updateErr)
+	}
+
+	if err := a.specManager.Rollback(ctx); err != nil {
+		return err
+	}
+
+	// note: we are explicitly reversing the order of the current and desired to
+	// ensure a clean rollback state.
+	if err := a.sync(ctx, desired, current); err != nil {
+		// log error and continue to ensure the device is in a consistent state
+		a.log.Errorf("Failed to sync roll back spec: %v", err)
+	}
+
+	a.log.Warnf("Rolled back to previous renderedVersion: %s", current.RenderedVersion)
 	return nil
 }
 
@@ -479,7 +506,9 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1alpha1.RenderedD
 		conditionUpdate.Message = fmt.Sprintf("Failed to update to renderedVersion: %s", version)
 		conditionUpdate.Status = v1alpha1.ConditionStatusFalse
 
-		a.specManager.SetUpgradeFailed()
+		if err := a.specManager.SetUpgradeFailed(desired.RenderedVersion); err != nil {
+			a.log.Errorf("Failed to set upgrade failed: %v", err)
+		}
 		a.log.Error(lo.FromPtr(statusUpdate.Info))
 	} else {
 		statusUpdate.Status = v1alpha1.DeviceSummaryStatusDegraded

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -99,13 +99,12 @@ func (w *writer) copyFile(src, dst string) error {
 	}
 	defer srcFile.Close()
 
-	var dstTarget string
+	dstTarget := dst
 	dstInfo, err := os.Stat(dst)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("failed to stat destination: %w", err)
 		}
-		dstTarget = dst
 	} else {
 		if dstInfo.IsDir() {
 			// destination is a directory, append the source file's base name
@@ -115,7 +114,7 @@ func (w *writer) copyFile(src, dst string) error {
 
 	dstFile, err := os.Create(dstTarget)
 	if err != nil {
-		return fmt.Errorf("failed to create destination file: %w", err)
+		return fmt.Errorf("failed to create destination file %s: %w", dstTarget, err)
 	}
 	defer dstFile.Close()
 

--- a/internal/agent/device/fileio/writer_test.go
+++ b/internal/agent/device/fileio/writer_test.go
@@ -1,0 +1,32 @@
+package fileio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFile(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+
+	currentBytes := []byte("current")
+	desiredBytes := []byte("desired")
+	rw := NewReadWriter()
+	rw.SetRootdir(tmpDir)
+	err := rw.WriteFile("current", currentBytes, 0644)
+	require.NoError(err)
+	err = rw.WriteFile("desired", desiredBytes, 0644)
+	require.NoError(err)
+
+	err = rw.CopyFile("current", "desired")
+	require.NoError(err)
+
+	current, err := rw.ReadFile("current")
+	require.NoError(err)
+	require.Equal(currentBytes, current)
+
+	desired, err := rw.ReadFile("desired")
+	require.NoError(err)
+	require.Equal(currentBytes, desired)
+}

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -131,17 +131,17 @@ func (mr *MockManagerMockRecorder) GetDesired(ctx any) *gomock.Call {
 }
 
 // Initialize mocks base method.
-func (m *MockManager) Initialize() error {
+func (m *MockManager) Initialize(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize")
+	ret := m.ctrl.Call(m, "Initialize", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Initialize indicates an expected call of Initialize.
-func (mr *MockManagerMockRecorder) Initialize() *gomock.Call {
+func (mr *MockManagerMockRecorder) Initialize(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockManager)(nil).Initialize))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockManager)(nil).Initialize), ctx)
 }
 
 // IsOSUpdate mocks base method.
@@ -231,17 +231,22 @@ func (mr *MockManagerMockRecorder) RenderedVersion(specType any) *gomock.Call {
 }
 
 // Rollback mocks base method.
-func (m *MockManager) Rollback() error {
+func (m *MockManager) Rollback(ctx context.Context, opts ...RollbackOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback")
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Rollback", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Rollback indicates an expected call of Rollback.
-func (mr *MockManagerMockRecorder) Rollback() *gomock.Call {
+func (mr *MockManagerMockRecorder) Rollback(ctx any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockManager)(nil).Rollback))
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockManager)(nil).Rollback), varargs...)
 }
 
 // SetClient mocks base method.
@@ -257,15 +262,17 @@ func (mr *MockManagerMockRecorder) SetClient(arg0 any) *gomock.Call {
 }
 
 // SetUpgradeFailed mocks base method.
-func (m *MockManager) SetUpgradeFailed() {
+func (m *MockManager) SetUpgradeFailed(version string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetUpgradeFailed")
+	ret := m.ctrl.Call(m, "SetUpgradeFailed", version)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SetUpgradeFailed indicates an expected call of SetUpgradeFailed.
-func (mr *MockManagerMockRecorder) SetUpgradeFailed() *gomock.Call {
+func (mr *MockManagerMockRecorder) SetUpgradeFailed(version any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeFailed", reflect.TypeOf((*MockManager)(nil).SetUpgradeFailed))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeFailed", reflect.TypeOf((*MockManager)(nil).SetUpgradeFailed), version)
 }
 
 // Status mocks base method.
@@ -346,7 +353,7 @@ func (mr *MockPriorityQueueMockRecorder) CheckPolicy(ctx, policyType, version an
 }
 
 // IsFailed mocks base method.
-func (m *MockPriorityQueue) IsFailed(version string) bool {
+func (m *MockPriorityQueue) IsFailed(version int64) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFailed", version)
 	ret0, _ := ret[0].(bool)
@@ -375,7 +382,7 @@ func (mr *MockPriorityQueueMockRecorder) Next(ctx any) *gomock.Call {
 }
 
 // Remove mocks base method.
-func (m *MockPriorityQueue) Remove(version string) {
+func (m *MockPriorityQueue) Remove(version int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Remove", version)
 }
@@ -387,7 +394,7 @@ func (mr *MockPriorityQueueMockRecorder) Remove(version any) *gomock.Call {
 }
 
 // SetFailed mocks base method.
-func (m *MockPriorityQueue) SetFailed(version string) {
+func (m *MockPriorityQueue) SetFailed(version int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetFailed", version)
 }

--- a/internal/agent/device/spec/queue.go
+++ b/internal/agent/device/spec/queue.go
@@ -73,7 +73,11 @@ func (m *queueManager) Add(ctx context.Context, spec *v1alpha1.RenderedDeviceSpe
 		return
 	}
 
-	item := newItem(spec)
+	item, err := newItem(spec)
+	if err != nil {
+		m.log.Errorf("Failed to create queue item: %v", err)
+		return
+	}
 	version := item.Version
 	if _, failed := m.failedVersions[version]; failed {
 		m.log.Debugf("Skipping adding failed template version: %d", version)
@@ -95,8 +99,8 @@ func (m *queueManager) Add(ctx context.Context, spec *v1alpha1.RenderedDeviceSpe
 	m.queue.Add(item)
 }
 
-func (m *queueManager) Remove(version string) {
-	m.queue.Remove(stringToInt64(version))
+func (m *queueManager) Remove(version int64) {
+	m.queue.Remove(version)
 }
 
 func (m *queueManager) Next(ctx context.Context) (*v1alpha1.RenderedDeviceSpec, bool) {
@@ -113,7 +117,7 @@ func (m *queueManager) Next(ctx context.Context) (*v1alpha1.RenderedDeviceSpec, 
 	requeue, exists := m.requeueLookup[item.Version]
 	if exists && now.Before(requeue.nextAvailable) {
 		m.queue.Add(item)
-		m.log.Debugf("Template version %d is not yet ready. Available after: %s", item.Version, requeue.nextAvailable.Format(time.RFC3339))
+		m.log.Debugf("Template version %d requeue is currently in backoff. Available after: %s", item.Version, requeue.nextAvailable.Format(time.RFC3339))
 		return nil, false
 	}
 	if m.updatePolicy(ctx, requeue) {
@@ -134,7 +138,10 @@ func (m *queueManager) Next(ctx context.Context) (*v1alpha1.RenderedDeviceSpec, 
 }
 
 func (m *queueManager) CheckPolicy(ctx context.Context, policyType policy.Type, version string) error {
-	v := stringToInt64(version)
+	v, err := stringToInt64(version)
+	if err != nil {
+		return err
+	}
 	requeue, exists := m.requeueLookup[v]
 	if !exists {
 		// this would be very unexpected so we would need to requeue the version
@@ -158,9 +165,8 @@ func (m *queueManager) CheckPolicy(ctx context.Context, policyType policy.Type, 
 	}
 }
 
-func (m *queueManager) SetFailed(version string) {
-	v := stringToInt64(version)
-	m.setFailed(v)
+func (m *queueManager) SetFailed(version int64) {
+	m.setFailed(version)
 }
 
 func (m *queueManager) setFailed(version int64) {
@@ -169,8 +175,8 @@ func (m *queueManager) setFailed(version int64) {
 	m.queue.Remove(version)
 }
 
-func (m *queueManager) IsFailed(version string) bool {
-	_, ok := m.failedVersions[stringToInt64(version)]
+func (m *queueManager) IsFailed(version int64) bool {
+	_, ok := m.failedVersions[version]
 	return ok
 }
 
@@ -315,15 +321,13 @@ func (q *queue) Clear() {
 }
 
 func (q *queue) Remove(version int64) {
-	if _, ok := q.items[version]; ok {
-		delete(q.items, version)
-		q.log.Debugf("Forgetting item version %v", version)
-	}
+	q.log.Tracef("Removing item version: %d", version)
+	delete(q.items, version)
 
 	// ensure heap removal
 	for i, heapItem := range q.heap {
 		if heapItem.Version == version {
-			q.log.Debugf("Removing item version from heap: %d", version)
+			q.log.Tracef("Removing item version from heap: %d", version)
 			heap.Remove(&q.heap, i)
 			break
 		}
@@ -336,11 +340,15 @@ type Item struct {
 }
 
 // newItem creates a new queue item.
-func newItem(data *v1alpha1.RenderedDeviceSpec) *Item {
+func newItem(data *v1alpha1.RenderedDeviceSpec) (*Item, error) {
+	version, err := stringToInt64(data.RenderedVersion)
+	if err != nil {
+		return nil, err
+	}
 	return &Item{
 		Spec:    data,
-		Version: stringToInt64(data.RenderedVersion),
-	}
+		Version: version,
+	}, nil
 }
 
 // ItemHeap is a priority queue that orders items by version.
@@ -370,7 +378,16 @@ func (h *ItemHeap) Pop() interface{} {
 	return item
 }
 
-func stringToInt64(s string) int64 {
-	i, _ := strconv.ParseInt(s, 10, 64)
-	return i
+func stringToInt64(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("convert string to int64: %w", err)
+	}
+	if i < 0 {
+		return 0, fmt.Errorf("version number cannot be negative: %d", i)
+	}
+	return i, nil
 }

--- a/internal/agent/device/spec/queue_test.go
+++ b/internal/agent/device/spec/queue_test.go
@@ -127,8 +127,11 @@ func TestRequeueThreshold(t *testing.T) {
 	// add item to queue
 	q.Add(ctx, item)
 
+	version, err := stringToInt64(item.RenderedVersion)
+	require.NoError(err)
+
 	// ensure item is immediately available
-	status := q.requeueLookup[stringToInt64(item.RenderedVersion)]
+	status := q.requeueLookup[version]
 	require.NotNil(status)
 	require.Equal(0, status.tries, "tries should be zero")
 	require.True(status.nextAvailable.IsZero(), "nextAvailable should be zero")
@@ -137,7 +140,7 @@ func TestRequeueThreshold(t *testing.T) {
 	q.Add(ctx, item)
 
 	// ensure item is immediately available
-	status = q.requeueLookup[stringToInt64(item.RenderedVersion)]
+	status = q.requeueLookup[version]
 	require.NotNil(status)
 	require.Equal(0, status.tries, "tries should be zero")
 	require.True(status.nextAvailable.IsZero(), "nextAvailable should be zero")

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -29,7 +29,7 @@ const (
 type Manager interface {
 	// Initialize initializes the current, desired and rollback spec files on
 	// disk. If the files already exist, they are overwritten.
-	Initialize() error
+	Initialize(ctx context.Context) error
 	// Ensure ensures that spec files exist on disk and re initializes them if they do not.
 	Ensure() error
 	// RenderedVersion returns the rendered version of the specified spec type.
@@ -42,7 +42,7 @@ type Manager interface {
 	// and resets the rollback spec.
 	Upgrade(ctx context.Context) error
 	// SetUpgradeFailed marks the desired rendered spec as failed.
-	SetUpgradeFailed()
+	SetUpgradeFailed(version string) error
 	// IsUpdating returns true if the device is in the process of reconciling the desired spec.
 	IsUpgrading() bool
 	// IsOSUpdate returns true if an OS update is in progress by checking the current rendered spec.
@@ -56,7 +56,7 @@ type Manager interface {
 	// ClearRollback clears the rollback rendered spec.
 	ClearRollback() error
 	// Rollback reverts the device to the state of the rollback rendered spec.
-	Rollback() error
+	Rollback(ctx context.Context, opts ...RollbackOption) error
 	// SetClient sets the management API client.
 	SetClient(client.Management)
 	// GetDesired returns the desired rendered device spec from the management API.
@@ -72,11 +72,11 @@ type PriorityQueue interface {
 	// Next returns the next spec to process
 	Next(ctx context.Context) (*v1alpha1.RenderedDeviceSpec, bool)
 	// Remove removes a spec from the scheduler
-	Remove(version string)
+	Remove(version int64)
 	// SetFailed marks a rendered spec version as failed
-	SetFailed(version string)
+	SetFailed(version int64)
 	// IsFailed returns true if a version is marked as failed
-	IsFailed(version string) bool
+	IsFailed(version int64) bool
 	// CheckPolicy validates the update policy is ready to process.
 	CheckPolicy(ctx context.Context, policyType policy.Type, version string) error
 }


### PR DESCRIPTION
This PR allows for spec to rollback to the previous version. Without this functionality, it can be possible for devices to get into a state where it can not be reconciled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced context handling across multiple agent components.
	- Improved error management and rollback mechanisms in device specification management.
	- Added unit tests for file copying functionality.

- **Bug Fixes**
	- Refined synchronization and upgrade processes with more robust error handling.
	- Updated type conversions and version management in spec queue.

- **Refactor**
	- Standardized method signatures to include context parameters.
	- Improved type safety in version handling.
	- Simplified error management in various agent components.

- **Chores**
	- Updated dependency management in Go module configuration.
	- Removed debug logging statements to reduce verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->