### PR TITLE
EDM-TBD: Bug fix for setting lifecycle to Enrolled when using agent-vm

### DIFF
--- a/internal/agent/device/status/status.go
+++ b/internal/agent/device/status/status.go
@@ -180,6 +180,14 @@ func SetDeviceSummary(summaryStatus v1alpha1.DeviceSummaryStatus) UpdateStatusFn
 	}
 }
 
+func SetDeviceLifecycleStatus(lifecyclestatus v1alpha1.DeviceLifecycleStatus) UpdateStatusFn {
+	return func(status *v1alpha1.DeviceStatus) error {
+		status.Lifecycle.Status = lifecyclestatus.Status
+		status.Lifecycle.Info = lifecyclestatus.Info
+		return nil
+	}
+}
+
 func SetConfig(configStatus v1alpha1.DeviceConfigStatus) UpdateStatusFn {
 	return func(status *v1alpha1.DeviceStatus) error {
 		status.Config.RenderedVersion = configStatus.RenderedVersion


### PR DESCRIPTION
Adds enrollment lifecycle status on device-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Devices now automatically update their lifecycle status to "Enrolled" during initialization, ensuring a current enrollment state.
  - Enhanced support for updating lifecycle status details provides clearer device status information for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->