### PR TITLE
EDM-1087: Handle configuration changes

### DIFF
--- a/api/v1alpha1/consts.go
+++ b/api/v1alpha1/consts.go
@@ -45,6 +45,8 @@ const (
 	FleetAnnotationRolloutApprovalMethod = "fleet-controller/rolloutApprovalMethod"
 	// A report specifying the completion report of the last batch
 	FleetAnnotationLastBatchCompletionReport = "fleet-controller/lastBatchCompletionReport"
+	// A frozen digest of device selection definition during rollout
+	FleetAnnotationDeviceSelectionConfigDigest = "fleet-controller/deviceSelectionConfigDigest"
 
 	RepositoryAPIVersion = "v1alpha1"
 	RepositoryKind       = "Repository"

--- a/internal/rollout/disruption_budget/reconciler.go
+++ b/internal/rollout/disruption_budget/reconciler.go
@@ -17,7 +17,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const DisruptionBudgetReconcilationInterval = 30 * time.Second
+const (
+	DisruptionBudgetReconcilationInterval = 30 * time.Second
+	maxItemsToRender                      = 1000
+)
 
 type Reconciler interface {
 	Reconcile(ctx context.Context)
@@ -70,24 +73,6 @@ func (r *reconciler) reconcileSelectionDevices(ctx context.Context, orgId uuid.U
 		return fmt.Errorf("template version doesn't exist")
 	}
 	listParams := store.ListParams{
-		Limit: numToRender,
-
-		// The list of labels is converted to MatchExpressions.  In case that the label does not exist
-		// (nil value), then the query requests explicitly that the label should not exist.
-		LabelSelector: selector.NewLabelSelectorOrDie(strings.Join(lo.MapToSlice(key, func(k string, v any) string {
-			if v == nil {
-				return api.MatchExpression{
-					Key:      k,
-					Operator: api.DoesNotExist,
-				}.String()
-			}
-			return api.MatchExpression{
-				Key:      k,
-				Operator: api.In,
-				Values:   lo.ToPtr([]string{v.(string)}),
-			}.String()
-		}), ",")),
-
 		// The query should get only devices that are ready for rendering
 		// but have not been rendered yet.  It means that the annotation 'device-controller/templateVersion'
 		// is equal to the expected template version but the annotation 'device-controller/renderedTemplateVersion'
@@ -106,13 +91,49 @@ func (r *reconciler) reconcileSelectionDevices(ctx context.Context, orgId uuid.U
 		}, ",")),
 		FieldSelector: selector.NewFieldSelectorFromMapOrDie(map[string]string{"metadata.owner": util.ResourceOwner(api.FleetKind, lo.FromPtr(fleet.Metadata.Name))}),
 	}
-	devices, err := r.store.Device().List(ctx, orgId, listParams)
-	if err != nil {
-		return err
+	if len(key) > 0 {
+		// The list of labels is converted to MatchExpressions.  In case that the label does not exist
+		// (nil value), then the query requests explicitly that the label should not exist.
+		var labelSelectorParts []string
+		for k, v := range key {
+			switch val := v.(type) {
+			case nil:
+				labelSelectorParts = append(labelSelectorParts, api.MatchExpression{
+					Key:      k,
+					Operator: api.DoesNotExist,
+				}.String())
+			case string:
+				labelSelectorParts = append(labelSelectorParts, api.MatchExpression{
+					Key:      k,
+					Operator: api.In,
+					Values:   lo.ToPtr([]string{val}),
+				}.String())
+			default:
+				return fmt.Errorf("unexpected type %T for label %s", v, k)
+			}
+		}
+		listParams.LabelSelector = selector.NewLabelSelectorOrDie(strings.Join(labelSelectorParts, ","))
 	}
-	for _, d := range devices.Items {
-		r.log.Infof("%v/%s: sending device to rendering", orgId, lo.FromPtr(d.Metadata.Name))
-		r.callbackManager.DeviceSourceUpdated(orgId, lo.FromPtr(d.Metadata.Name))
+	remaining := lo.Ternary(numToRender > 0, numToRender, math.MaxInt)
+	for {
+		listParams.Limit = util.Min(remaining, maxItemsToRender)
+		devices, err := r.store.Device().List(ctx, orgId, listParams)
+		if err != nil {
+			return err
+		}
+		for _, d := range devices.Items {
+			r.log.Infof("%v/%s: sending device to rendering", orgId, lo.FromPtr(d.Metadata.Name))
+			r.callbackManager.DeviceSourceUpdated(orgId, lo.FromPtr(d.Metadata.Name))
+		}
+		remaining = remaining - len(devices.Items)
+		if devices.Metadata.Continue == nil || remaining == 0 {
+			break
+		}
+		cont, err := store.ParseContinueString(devices.Metadata.Continue)
+		if err != nil {
+			return fmt.Errorf("failed to parse continuation for paging: %w", err)
+		}
+		listParams.Continue = cont
 	}
 	return nil
 }
@@ -121,6 +142,12 @@ func (r *reconciler) reconcileFleet(ctx context.Context, orgId uuid.UUID, fleet 
 	r.log.Infof("disruption budget: starting reconciling fleet %v/%s", orgId, lo.FromPtr(fleet.Metadata.Name))
 	defer r.log.Infof("disruption budget: finished reconciling fleet %v/%s", orgId, lo.FromPtr(fleet.Metadata.Name))
 
+	if fleet.Spec.RolloutPolicy == nil || fleet.Spec.RolloutPolicy.DisruptionBudget == nil {
+		if err := r.reconcileSelectionDevices(ctx, orgId, fleet, nil, 0); err != nil {
+			return fmt.Errorf("reconcileSelectionDevices: %w", err)
+		}
+		return nil
+	}
 	maxUnavailable := fleet.Spec.RolloutPolicy.DisruptionBudget.MaxUnavailable
 	minAvailable := fleet.Spec.RolloutPolicy.DisruptionBudget.MinAvailable
 	if maxUnavailable == nil && minAvailable == nil {
@@ -142,7 +169,7 @@ func (r *reconciler) reconcileFleet(ctx context.Context, orgId uuid.UUID, fleet 
 		}
 		if numToRender > 0 {
 			if err = r.reconcileSelectionDevices(ctx, orgId, fleet, count.key, numToRender); err != nil {
-				return fmt.Errorf("reconcileSelectionDevices: %v", err)
+				return fmt.Errorf("reconcileSelectionDevices: %w", err)
 			}
 		}
 	}
@@ -160,9 +187,6 @@ func (r *reconciler) Reconcile(ctx context.Context) {
 	}
 	for i := range fleetList.Items {
 		fleet := &fleetList.Items[i]
-		if fleet.Spec.RolloutPolicy == nil || fleet.Spec.RolloutPolicy.DisruptionBudget == nil {
-			continue
-		}
 		annotations := lo.FromPtr(fleet.Metadata.Annotations)
 		if annotations == nil {
 			continue

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -74,11 +74,17 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		}
 		t.ownerFleet = &owner
 
-		if device.Metadata.Annotations == nil {
+		annotations := lo.FromPtr(device.Metadata.Annotations)
+		tvString, exists := util.GetFromMap(annotations, api.DeviceAnnotationTemplateVersion)
+		if !exists {
 			return fmt.Errorf("device has no templateversion annotation")
 		}
-		tvString := (*device.Metadata.Annotations)[api.DeviceAnnotationTemplateVersion]
 		t.templateVersion = &tvString
+		renderedTemplateVersion, exists := annotations[api.DeviceAnnotationRenderedTemplateVersion]
+		if exists && tvString == renderedTemplateVersion {
+			// Skipping since this template version was already rendered
+			return nil
+		}
 	}
 
 	ignitionConfig, referencedRepos, renderErr := t.renderConfig(ctx)

--- a/test/integration/rollout/disruption_budget/disruptions_budget_test.go
+++ b/test/integration/rollout/disruption_budget/disruptions_budget_test.go
@@ -184,6 +184,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 		})
 		It("One fleet - one device with matching fleet - non matching disruption budget", func() {
 			initTest(nil, 1, true, false)
+			mockCallbackManager.EXPECT().DeviceSourceUpdated(gomock.Any(), gomock.Any())
 			reconciler := disruption_budget.NewReconciler(storeInst, mockCallbackManager, log)
 			reconciler.Reconcile(ctx)
 		})


### PR DESCRIPTION
Rollout definition might change. This might cause the rollout management to malfunction. Some examples:

1. The number of batches may be reduced. So if there were 10 batches in the previous definition, and after the change there are 5 batches, and there is rollout in progress at batch 7, then the system wouldn't be able to handle it, because with the definition batch 7 is not defined.
2. The device selection definition was completely erased during rollout. This might cause that some devices will never be rolled out.
3. disruption budget definition was erased. This might cause the remaining devices during a rollout to never be rendered.

For device selection there are 2 cases:
- If existing definition was updated, then the rollout will start from the beginning
- If existing definition was erased, then all traces (annotations) of rollout management are erased from fleet. Then the current TV is sent for rollout.  The last operation will not have any affect if all fleet devices are already rolled out.

For disruption budget, handling is added for devices that their template version and rendered template version do not match - even if there is no disruption budget defined for the fleet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new constant for serialized device selection configuration.
  - Introduced methods for improved batch sequence management, including serialization and update checks.
  - Enhanced annotation filtering mechanism for rollout criteria.
  - Added support for absolute limits in batch sequences.

- **Improvements**
  - Strengthened error handling and control flow in the reconciliation processes.
  - Improved handling of device selection and pagination for larger datasets.
  - Enhanced device rendering logic with improved error handling and checks.

- **Tests**
  - Expanded integration tests to verify updated device selection definitions and interactions with mock callback managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->