### PR TITLE
EDM-715: Quadlet configuration changes

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -49,9 +49,9 @@ deploy-quadlets:
 	deploy/scripts/deploy_quadlets.sh
 
 kill-db:
-	sudo systemctl stop flightctl-db-standalone.service
+	systemctl --user stop flightctl-db-standalone.service
 
 kill-kv:
-	sudo systemctl stop flightctl-kv-standalone.service
+	systemctl --user stop flightctl-kv-standalone.service
 
 .PHONY: deploy-db deploy cluster

--- a/deploy/podman/flightctl-api/flightctl-api-certs.volume
+++ b/deploy/podman/flightctl-api/flightctl-api-certs.volume
@@ -1,0 +1,2 @@
+[Volume]
+Name=flightctl-api-certs

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -7,7 +7,7 @@ Before=flightctl-periodic.service flightctl-worker.service
 
 [Container]
 ContainerName=flightctl-api
-Image=quay.io/flightctl/flightctl-api:latest
+Image=quay.io/flightctl/flightctl-api:0.4.0-rc3
 Network=flightctl.network
 Environment=HOME=/root
 Environment=FLIGHTCTL_DISABLE_AUTH=true
@@ -17,8 +17,8 @@ PublishPort=7443:7443
 PublishPort=7444:7444
 PublishPort=15690:15690
 PublishPort=15691:15691
-Volume=/etc/containers/systemd/flightctl-api/flightctl-api-config/config.yaml:/root/.flightctl/config.yaml
-Volume=flightctl-api-certs:/root/.flightctl/certs
+Volume=flightctl-api-certs:/root/.flightctl/certs:Z
+Volume=%h/.config/flightctl/flightctl-api-config/config.yaml:/root/.flightctl/config.yaml:Z
 
 [Service]
 Slice=flightctl.slice

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -27,4 +27,3 @@ RestartSec=30
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -27,3 +27,4 @@ RestartSec=30
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -7,7 +7,7 @@ Before=flightctl-periodic.service flightctl-worker.service
 
 [Container]
 ContainerName=flightctl-api
-Image=quay.io/flightctl/flightctl-api:0.4.0-rc3
+Image=quay.io/flightctl/flightctl-api:0.4.0
 Network=flightctl.network
 Environment=HOME=/root
 Environment=FLIGHTCTL_DISABLE_AUTH=true

--- a/deploy/podman/flightctl-db/flightctl-db.container
+++ b/deploy/podman/flightctl-db/flightctl-db.container
@@ -16,4 +16,3 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target

--- a/deploy/podman/flightctl-db/flightctl-db.container
+++ b/deploy/podman/flightctl-db/flightctl-db.container
@@ -16,3 +16,4 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target

--- a/deploy/podman/flightctl-db/flightctl-db.volume
+++ b/deploy/podman/flightctl-db/flightctl-db.volume
@@ -1,0 +1,2 @@
+[Volume]
+Name=flightctl-db

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -5,6 +5,7 @@ Description=FlightCtl Key Value service
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
 Exec=redis-server /usr/local/etc/redis/redis.conf
+Network=flightctl.network
 
 # The following is necessary so that the redis user which runs the redis process inside of the container
 # can have write access to the flightctl-kv volume

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -4,11 +4,15 @@ Description=FlightCtl Key Value service
 [Container]
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
-Environment=HOME=/root
+Exec=redis-server /usr/local/etc/redis/redis.conf
+
+# The following is necessary so that the redis user which runs the redis process inside of the container
+# can have write access to the flightctl-kv volume
+PodmanArgs="--userns=keep-id:uid=999,gid=999"
 
 PublishPort=6379:6379
-Volume=flightctl-redis:/var/lib/redis/data
-Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/etc/redis/redis.conf:Z
+Volume=flightctl-kv:/var/lib/redis/data:Z,U
+Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
 
 [Service]
 Type=notify

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -12,7 +12,7 @@ PodmanArgs="--userns=keep-id:uid=999,gid=999"
 
 PublishPort=6379:6379
 Volume=flightctl-kv:/var/lib/redis/data:Z,U
-Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
+Volume=%h/.config/flightctl/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
 
 [Service]
 Type=notify

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -7,7 +7,6 @@ Requires=flightctl-db.service
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
 Network=flightctl.network
-Environment=HOME=/root
 Exec=redis-server /usr/local/etc/redis/redis.conf
 
 # The following is necessary so that the redis user which runs the redis process inside of the container

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -16,7 +16,7 @@ PodmanArgs="--userns=keep-id:uid=999,gid=999"
 
 PublishPort=6379:6379
 Volume=flightctl-kv:/var/lib/redis/data:Z,U
-Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
+Volume=%h/.config/flightctl/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
 
 [Service]
 Type=notify

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -26,3 +26,4 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -8,10 +8,15 @@ ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
 Network=flightctl.network
 Environment=HOME=/root
+Exec=redis-server /usr/local/etc/redis/redis.conf
+
+# The following is necessary so that the redis user which runs the redis process inside of the container
+# can have write access to the flightctl-kv volume
+PodmanArgs="--userns=keep-id:uid=999,gid=999"
 
 PublishPort=6379:6379
-Volume=flightctl-redis:/var/lib/redis/data
-Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/etc/redis/redis.conf:Z
+Volume=flightctl-kv:/var/lib/redis/data:Z,U
+Volume=/etc/containers/systemd/flightctl-kv/flightctl-kv-config/redis.conf:/usr/local/etc/redis/redis.conf:Z
 
 [Service]
 Type=notify

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -25,4 +25,3 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target

--- a/deploy/podman/flightctl-kv/flightctl-kv.volume
+++ b/deploy/podman/flightctl-kv/flightctl-kv.volume
@@ -1,0 +1,2 @@
+[Volume]
+Name=flightctl-kv

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -5,11 +5,10 @@ Requires=flightctl-db.service
 
 [Container]
 ContainerName=flightctl-periodic
-Image=quay.io/flightctl/flightctl-periodic:latest
+Image=quay.io/flightctl/flightctl-periodic:0.4.0-rc3
 Network=flightctl.network
 Environment=HOME=/root
-
-Volume=/etc/containers/systemd/flightctl-periodic/flightctl-periodic-config/config.yaml:/root/.flightctl/config.yaml
+Volume=%h/.config/flightctl/flightctl-periodic-config/config.yaml:/root/.flightctl/config.yaml:Z
 
 [Service]
 Restart=always

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -5,7 +5,7 @@ Requires=flightctl-db.service
 
 [Container]
 ContainerName=flightctl-periodic
-Image=quay.io/flightctl/flightctl-periodic:0.4.0-rc3
+Image=quay.io/flightctl/flightctl-periodic:0.4.0
 Network=flightctl.network
 Environment=HOME=/root
 Volume=%h/.config/flightctl/flightctl-periodic-config/config.yaml:/root/.flightctl/config.yaml:Z

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -17,3 +17,5 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target
+

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -17,5 +17,3 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target
-

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -5,7 +5,7 @@ Requires=flightctl-api.service
 
 [Container]
 ContainerName=flightctl-ui
-Image=quay.io/flightctl/flightctl-ui:latest
+Image=quay.io/flightctl/flightctl-ui:0.4.0-rc3
 Network=flightctl.network
 Environment=API_PORT=8080
 Environment=FLIGHTCTL_SERVER="https://flightctl-api:3443/"
@@ -17,7 +17,7 @@ Environment=OIDC_INSECURE_SKIP_VERIFY="true"
 
 PublishPort=8080:8080
 
-Volume=flightctl-api-certs:/app/certs
+Volume=flightctl-api-certs:/app/certs:Z
 
 [Service]
 Restart=always

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -26,3 +26,4 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -26,4 +26,3 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -5,7 +5,7 @@ Requires=flightctl-api.service
 
 [Container]
 ContainerName=flightctl-ui
-Image=quay.io/flightctl/flightctl-ui:0.4.0-rc3
+Image=quay.io/flightctl/flightctl-ui:0.4.0
 Network=flightctl.network
 Environment=API_PORT=8080
 Environment=FLIGHTCTL_SERVER="https://flightctl-api:3443/"

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -5,11 +5,10 @@ Requires=flightctl-db.service
 
 [Container]
 ContainerName=flightctl-worker
-Image=quay.io/flightctl/flightctl-worker:latest
+Image=quay.io/flightctl/flightctl-worker:0.4.0-rc3
 Network=flightctl.network
 Environment=HOME=/root
-
-Volume=/etc/containers/systemd/flightctl-worker/flightctl-worker-config/config.yaml:/root/.flightctl/config.yaml
+Volume=%h/.config/flightctl/flightctl-worker-config/config.yaml:/root/.flightctl/config.yaml:Z
 
 [Service]
 Restart=always

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -17,4 +17,3 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
-WantedBy=default.target

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -17,3 +17,4 @@ Slice=flightctl.slice
 
 [Install]
 WantedBy=flightctl.slice
+WantedBy=default.target

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -5,7 +5,7 @@ Requires=flightctl-db.service
 
 [Container]
 ContainerName=flightctl-worker
-Image=quay.io/flightctl/flightctl-worker:0.4.0-rc3
+Image=quay.io/flightctl/flightctl-worker:0.4.0
 Network=flightctl.network
 Environment=HOME=/root
 Volume=%h/.config/flightctl/flightctl-worker-config/config.yaml:/root/.flightctl/config.yaml:Z

--- a/deploy/scripts/clean_quadlets.sh
+++ b/deploy/scripts/clean_quadlets.sh
@@ -4,27 +4,28 @@ source deploy/scripts/env.sh
 
 # Stop services running from the slice or standalone
 for service in flightctl.slice 'flightctl-*-standalone.service'; do
-    if sudo systemctl is-active --quiet "$service"; then
+    if systemctl --user is-active --quiet "$service"; then
         echo "Stopping $service..."
-        sudo systemctl stop "$service" || echo "Warning: Failed to stop $service"
+        systemctl stop --user "$service" || echo "Warning: Failed to stop $service"
     fi
 done
 
 # Remove copied files
 if [ -d "$SYSTEMD_DIR" ]; then
-    sudo rm -rf $SYSTEMD_DIR/flightctl* || echo "Warning: Failed to remove quadlet files"
+    rm -rf $SYSTEMD_DIR/flightctl* || echo "Warning: Failed to remove quadlet files"
+    rm -rf $CONFIG_DIR/flightctl-* || echo "Warning: Failed to remove quadlet config files"
 fi
 
 # Remove volumes
 for volume in flightctl-db flightctl-api-certs flightctl-redis; do
-    if sudo podman volume inspect "$volume" >/dev/null 2>&1; then
+    if podman volume inspect "$volume" >/dev/null 2>&1; then
         echo "Removing volume $volume"
-        sudo podman volume rm "$volume" || echo "Warning: Failed to remove $volume"
+        podman volume rm "$volume" || echo "Warning: Failed to remove $volume"
     fi
 done
 
 # Remove networks
-if sudo podman network inspect flightctl >/dev/null 2>&1; then
+if podman network inspect flightctl >/dev/null 2>&1; then
     echo "Removing network"
-    sudo podman network rm flightctl || echo "Warning: Failed to remove network"
+    podman network rm flightctl || echo "Warning: Failed to remove network"
 fi

--- a/deploy/scripts/deploy_quadlet_service.sh
+++ b/deploy/scripts/deploy_quadlet_service.sh
@@ -11,7 +11,7 @@ deploy_service() {
     echo "Starting Deployment for $service_full_name"
 
     # Stop the service if it's running
-    systemctl --user stop $service_full_name || true
+    systemctl --user stop "$service_full_name" || true
 
     # Handle special handling for each service
     if [[ "$service_name" == "db" ]]; then
@@ -20,12 +20,12 @@ deploy_service() {
     else
         # Copy configuration files
         mkdir -p "$CONFIG_DIR/flightctl-$service_name-config"
-        cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf $CONFIG_DIR/flightctl-kv-config/redis.conf
+        cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf "$CONFIG_DIR/flightctl-kv-config/redis.conf"
     fi
 
-    mkdir -p $SYSTEMD_DIR
-    cp deploy/podman/flightctl-$service_name/flightctl-$service_name-standalone.container $SYSTEMD_DIR
-    cp deploy/podman/flightctl.network $SYSTEMD_DIR
+    mkdir -p "$SYSTEMD_DIR"
+    cp deploy/podman/flightctl-$service_name/flightctl-$service_name-standalone.container "$SYSTEMD_DIR"
+    cp deploy/podman/flightctl.network "$SYSTEMD_DIR"
 
     start_service $service_full_name
 

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -15,8 +15,8 @@ export PRIMARY_IP
 
 echo "Copying quadlet unit files"
 mkdir -p $SYSTEMD_DIR
-find deploy/podman -type f -name "*.slice" -exec cp {} $SYSTEMD_DIR \;
-find deploy/podman -type f -name "*.network" -exec cp {} $SYSTEMD_DIR \;
+cp deploy/podman/flightctl.slice $SYSTEMD_DIR
+cp deploy/podman/flightctl.network $SYSTEMD_DIR
 find deploy/podman -type f -name "*.container" -exec cp {} $SYSTEMD_DIR \;
 
 echo "Copying quadlet config files"

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -15,8 +15,23 @@ export PRIMARY_IP
 
 envsubst "\$PRIMARY_IP" < deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template > deploy/podman/flightctl-api/flightctl-api-config/config.yaml
 
-echo "Copying all quadlet files"
-sudo cp -r deploy/podman/flightctl* $SYSTEMD_DIR
+echo "Copying quadlet unit files"
+find deploy/podman -type f -name "*.slice" -exec cp {} $SYSTEMD_DIR \;
+find deploy/podman -type f -name "*.network" -exec cp {} $SYSTEMD_DIR \;
+find deploy/podman -type f -name "*.container" -exec cp {} $SYSTEMD_DIR \;
+
+echo "Copying quadlet config files"
+mkdir -p $CONFIG_DIR/flightctl-api-config
+cp deploy/podman/flightctl-api/flightctl-api-config/config.yaml $CONFIG_DIR/flightctl-api-config/config.yaml
+
+mkdir -p $CONFIG_DIR/flightctl-kv-config
+cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf $CONFIG_DIR/flightctl-kv-config/redis.conf
+
+mkdir -p $CONFIG_DIR/flightctl-periodic-config
+cp deploy/podman/flightctl-periodic/flightctl-periodic-config/config.yaml $CONFIG_DIR/flightctl-periodic-config/config.yaml
+
+mkdir -p $CONFIG_DIR/flightctl-worker-config
+cp deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml $CONFIG_DIR/flightctl-worker-config/config.yaml
 
 start_service flightctl.slice
 
@@ -24,13 +39,13 @@ echo "Waiting for database to be ready..."
 test/scripts/wait_for_postgres.sh podman
 
 echo "Granting superuser privileges to admin role"
-sudo podman exec flightctl-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
+podman exec flightctl-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
 
 echo "Checking if all services are running..."
 
 timeout --foreground 300s bash -c '
     while true; do
-        if sudo podman ps --quiet \
+        if podman ps --quiet \
             --filter "name=flightctl-api" \
             --filter "name=flightctl-worker" \
             --filter "name=flightctl-periodic" \

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -14,25 +14,25 @@ fi
 export PRIMARY_IP
 
 echo "Copying quadlet unit files"
-mkdir -p $SYSTEMD_DIR
-cp deploy/podman/flightctl.slice $SYSTEMD_DIR
-cp deploy/podman/flightctl.network $SYSTEMD_DIR
-find deploy/podman -type f -name "*.container" -exec cp {} $SYSTEMD_DIR \;
+mkdir -p "$SYSTEMD_DIR"
+cp deploy/podman/flightctl.slice "$SYSTEMD_DIR"
+cp deploy/podman/flightctl.network "$SYSTEMD_DIR"
+find deploy/podman -type f -name "*.container" -exec cp {} "$SYSTEMD_DIR" \;
 
 echo "Copying quadlet config files"
-mkdir -p $CONFIG_DIR
-mkdir -p $CONFIG_DIR/flightctl-api-config
-touch $CONFIG_DIR/flightctl-api-config/config.yaml
-envsubst "\$PRIMARY_IP" < deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template > $CONFIG_DIR/flightctl-api-config/config.yaml
+mkdir -p "$CONFIG_DIR"
+mkdir -p "$CONFIG_DIR/flightctl-api-config"
+touch "$CONFIG_DIR/flightctl-api-config/config.yaml"
+envsubst "\$PRIMARY_IP" < deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template > "$CONFIG_DIR/flightctl-api-config/config.yaml"
 
-mkdir -p $CONFIG_DIR/flightctl-kv-config
-cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf $CONFIG_DIR/flightctl-kv-config/redis.conf
+mkdir -p "$CONFIG_DIR/flightctl-kv-config"
+cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf "$CONFIG_DIR/flightctl-kv-config/redis.conf"
 
-mkdir -p $CONFIG_DIR/flightctl-periodic-config
-cp deploy/podman/flightctl-periodic/flightctl-periodic-config/config.yaml $CONFIG_DIR/flightctl-periodic-config/config.yaml
+mkdir -p "$CONFIG_DIR/flightctl-periodic-config"
+cp deploy/podman/flightctl-periodic/flightctl-periodic-config/config.yaml "$CONFIG_DIR/flightctl-periodic-config/config.yaml"
 
-mkdir -p $CONFIG_DIR/flightctl-worker-config
-cp deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml $CONFIG_DIR/flightctl-worker-config/config.yaml
+mkdir -p "$CONFIG_DIR/flightctl-worker-config"
+cp deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml "$CONFIG_DIR/flightctl-worker-config/config.yaml"
 
 start_service flightctl.slice
 

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -13,16 +13,17 @@ if ! PRIMARY_IP=$(bash -c 'source ./test/scripts/functions && get_ext_ip'); then
 fi
 export PRIMARY_IP
 
-envsubst "\$PRIMARY_IP" < deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template > deploy/podman/flightctl-api/flightctl-api-config/config.yaml
-
 echo "Copying quadlet unit files"
+mkdir -p $SYSTEMD_DIR
 find deploy/podman -type f -name "*.slice" -exec cp {} $SYSTEMD_DIR \;
 find deploy/podman -type f -name "*.network" -exec cp {} $SYSTEMD_DIR \;
 find deploy/podman -type f -name "*.container" -exec cp {} $SYSTEMD_DIR \;
 
 echo "Copying quadlet config files"
+mkdir -p $CONFIG_DIR
 mkdir -p $CONFIG_DIR/flightctl-api-config
-cp deploy/podman/flightctl-api/flightctl-api-config/config.yaml $CONFIG_DIR/flightctl-api-config/config.yaml
+touch $CONFIG_DIR/flightctl-api-config/config.yaml
+envsubst "\$PRIMARY_IP" < deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template > $CONFIG_DIR/flightctl-api-config/config.yaml
 
 mkdir -p $CONFIG_DIR/flightctl-kv-config
 cp deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf $CONFIG_DIR/flightctl-kv-config/redis.conf

--- a/deploy/scripts/env.sh
+++ b/deploy/scripts/env.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-export SYSTEMD_DIR="/etc/containers/systemd"
+export SYSTEMD_DIR="$HOME/.config/containers/systemd"
+export CONFIG_DIR="$HOME/.config/flightctl"
 
 # Reloads systemd config and start the service
 start_service() {
     local service_name=$1
-    sudo systemctl daemon-reload
+    systemctl --user daemon-reload
 
     echo "Starting $service_name"
-    sudo systemctl start "$service_name"
+    systemctl --user start "$service_name"
 }

--- a/test/scripts/wait_for_postgres.sh
+++ b/test/scripts/wait_for_postgres.sh
@@ -13,7 +13,7 @@ METHOD=${1:-"kubectl"}
 
 if [ "$METHOD" == "podman" ];
 then
-    until sudo podman exec flightctl-db pg_isready -U ${PG_USER} --dbname ${PG_DATABASE} --host ${PG_HOST} --port ${PG_PORT}; do sleep 1; done
+    until podman exec flightctl-db pg_isready -U ${PG_USER} --dbname ${PG_DATABASE} --host ${PG_HOST} --port ${PG_PORT}; do sleep 1; done
 else
     echo "Waiting for postgress deployment to be ready"
     kubectl rollout status deployment flightctl-db -n ${DB_NAMESPACE} -w --timeout=300s


### PR DESCRIPTION
Modifies the quadlets config in the following ways:
- Use rootless podman for running containers
  - Associated .container/.network/.volume files now moved to user owned `$HOME/.config/containers/systemd` rather than `/etc/containers/systemd`
  - This should be more inline with how we might deploy the quadlet services in prod contexts
- Moves config files before mounting into containers to a separate location
- Explicitly defines volumes our containers write to with .volume files
- More selective in copying files
- Uses the 0.4.0 tag for flightctl containers rather than :latest.  Eventually this should be configurable and/or work with locally built images

This pulls in some work done when building the containerized AAP installer PoC (which is no longer the path forward) but overall gets our quadlets config in a better place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
	- Added persistent storage options for key services to enhance data management.
- Chores
	- Updated container images to a fixed version (0.4.0) for improved stability.
	- Refined volume mappings with enhanced security settings.
	- Streamlined deployment scripts by removing elevated privilege requirements and switching to user-level execution.
	- Standardized service startup directives for more consistent launch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->