### PR TITLE
NO-ISSUE: Add podManagementPolicy field to kv statefulset

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-kv-statefulset.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-kv-statefulset.yaml
@@ -39,6 +39,7 @@ spec:
   selector:
     matchLabels:
       flightctl.service: flightctl-kv
+  podManagementPolicy: OrderedReady
   template:
     metadata:
       labels:


### PR DESCRIPTION
If we do not specify the field, it is generated by OCP which then causes issues with helm upgrade/ACM operator reconciliation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted deployment settings to enforce a sequential pod start-up, ensuring each service instance is fully operational before the next begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->