### PR TITLE
EDM-973: packaging/rpm: make firewalld a hard dependency

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -38,6 +38,7 @@ Flightctl is a command line interface for managing edge device fleets.
 Summary: Flightctl Agent
 
 Requires: bootc
+Requires: firewalld
 
 %description agent
 Flightctl Agent is a component of the flightctl tool.


### PR DESCRIPTION
The default hooks that are shipped with the RPM depend of firewalld this PR makes it a required dependency. While we could try to evaluate if firewalld exists if we are going to be opinionated on the hook itself we should support it out of the box. 

This is meant to be a discussion as well as there are various solutions but `systemd` and `nmcli` are included already by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the agent’s dependency management to require a firewall service, ensuring that the necessary firewall package is installed alongside the agent for seamless operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->