### PR TITLE
EDM-1045: Adding E2E tests for finalizing parametrisable device templates

### DIFF
--- a/test/e2e/configuration/inline_config_test.go
+++ b/test/e2e/configuration/inline_config_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Inline configuration tests", Ordered, func() {
 	AfterEach(func() {
 		err := harness.CleanUpAllResources()
 		Expect(err).ToNot(HaveOccurred())
+		harness.Cleanup(true)
 	})
 
 	Context("Inline config tests", func() {

--- a/test/e2e/parametrisable_templates/parametrisable_templates_suite_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_suite_test.go
@@ -1,0 +1,13 @@
+package parametrisabletemplates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestParametrisableTemplates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ParametrisableTemplates E2E Suite")
+}

--- a/test/e2e/parametrisable_templates/parametrisable_templates_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_test.go
@@ -1,0 +1,440 @@
+package parametrisabletemplates
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Template variables in the device configuraion", func() {
+	var (
+		harness  *e2e.Harness
+		deviceId string
+	)
+
+	BeforeEach(func() {
+		harness = e2e.NewTestHarness()
+		deviceId = harness.StartVMAndEnroll()
+	})
+
+	AfterEach(func() {
+		harness.Cleanup(true)
+		err := harness.CleanUpAllResources()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("parametrisable_templates", func() {
+		It(`Verifies that Flightctl fleet resource supports parametrisable device
+		    templates to configure items that are specific to an individual device
+			or a group of devices selected by labels`, Label("75486"), func() {
+
+			By("Create a fleet with template variables in InlineConfigProviderSpec")
+			err := configProviderSpec.FromInlineConfigProviderSpec(inlineConfigValidWithFunction)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.CreateTestFleetWithConfig(fleetTestName, testFleetSelector, configProviderSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that the device status is Online")
+			CheckDeviceOnlineStatus(harness, deviceId)
+
+			By("Add the fleet selector and the team label to the device")
+			nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				device.Metadata.Labels = &map[string]string{
+					fleetSelectorKey: fleetSelectorValue,
+					teamLabelKey:     teamLabelValue,
+				}
+				logrus.Infof("Updating %s with label %s=%s and %s=%s", deviceId,
+					fleetSelectorKey, fleetSelectorValue, teamLabelKey, teamLabelValue)
+			})
+
+			By("Verify the Device is updated with the labels")
+			response, err := harness.Client.ReadDeviceWithResponse(harness.Context, deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			device := response.JSON200
+			Expect(device).ToNot(BeNil(), "failed to read updated device")
+			responseSelectorLabelValue := (*device.Metadata.Labels)[fleetSelectorKey]
+			Expect(responseSelectorLabelValue).To(ContainSubstring(fleetSelectorValue))
+			responseTeamLabelValue := (*device.Metadata.Labels)[teamLabelKey]
+			Expect(responseTeamLabelValue).To(ContainSubstring(teamLabelValue))
+
+			By("Wait for the device to get the fleet configuration")
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify that the template variable is replaced in the configuration update")
+			response, err = harness.Client.ReadDeviceWithResponse(harness.Context, deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			device = response.JSON200
+			Expect(device).ToNot(BeNil(), "failed to read updated device")
+			inlineConfigPathResponse, err := harness.GetDeviceInlineConfig(device, inlineConfigName)
+			Expect(err).ToNot(HaveOccurred())
+			if len(inlineConfigPathResponse.Inline) > 0 {
+				Expect(inlineConfigPathResponse.Inline[0].Path).To(ContainSubstring(teamLabelValue))
+				Expect(inlineConfigPathResponse.Inline[0].Content).To(ContainSubstring(defaultTeamLabelValue))
+			}
+		})
+
+		It(`Verifies that if a device is missing a parametrisable device label
+		    an error is generated, but it will reconcile if the label is provided`,
+			Label("75600"), func() {
+
+				By("Check the device status is Online")
+				CheckDeviceOnlineStatus(harness, deviceId)
+
+				By("Create a fleet with a template variable")
+				err := configProviderSpec.FromInlineConfigProviderSpec(inlineConfigValidWithFunction)
+				Expect(err).ToNot(HaveOccurred())
+				err = harness.CreateTestFleetWithConfig(fleetTestName, testFleetSelector, configProviderSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Associate the device to the fleet without adding the team label")
+				nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					(*device.Metadata.Labels)[fleetSelectorKey] = fleetSelectorValue
+					logrus.Infof("Updating %s with label %s=%s", deviceId,
+						fleetSelectorKey, fleetSelectorValue)
+				})
+
+				By("Check the device will fail to reconcile")
+				harness.WaitForDeviceContents(deviceId, `The device could not be updated to the fleet`,
+					func(device *v1alpha1.Device) bool {
+						return device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusOutOfDate
+					}, "2m")
+				resp, err := harness.Client.ReadDeviceStatusWithResponse(harness.Context, deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				device := resp.JSON200
+				Expect((*device.Metadata.Annotations)["fleet-controller/lastRolloutError"]).NotTo(BeNil())
+				Expect(device.Status.Updated.Status).To(Equal(v1alpha1.DeviceUpdatedStatusOutOfDate))
+				Expect((*device.Metadata.Annotations)["fleet-controller/lastRolloutError"]).To(ContainSubstring("no entry for key \"team\""))
+
+				By("Add the team label to the device")
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					(*device.Metadata.Labels)[teamLabelKey] = teamLabelValue
+					logrus.Infof("Updating %s with label %s=%s", deviceId,
+						teamLabelKey, teamLabelValue)
+				})
+				resp, err = harness.Client.ReadDeviceStatusWithResponse(harness.Context, deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				device = resp.JSON200
+				Expect((*device.Metadata.Labels)[teamLabelKey]).To(ContainSubstring(teamLabelValue))
+
+				By("Check the device now reconciles")
+				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify that the template variable is replaced in the configuration update")
+				response, err := harness.Client.ReadDeviceWithResponse(harness.Context, deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				device = response.JSON200
+				Expect(device).ToNot(BeNil(), "failed to read updated device")
+				inlineConfigResponse, err := harness.GetDeviceInlineConfig(device, inlineConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				if len(inlineConfigResponse.Inline) > 0 {
+					Expect(inlineConfigResponse.Inline[0].Path).To(ContainSubstring(teamLabelValue))
+					Expect(inlineConfigResponse.Inline[0].Content).To(ContainSubstring(defaultTeamLabelValue))
+				}
+			})
+
+		It(`Verifies that the template variables are replaced in the different configurations
+		    and work with the helper functions`,
+			Label("78684"), func() {
+
+				By("Check the device status")
+				CheckDeviceOnlineStatus(harness, deviceId)
+
+				By("Create a git and a http repository")
+				err := harness.CreateRepository(gitRepositorySpec, gitMetadata)
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Infof("Created git repository %s", *gitMetadata.Name)
+
+				err = harness.CreateRepository(httpRepositoryspec, httpRepoMetadata)
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Infof("Created http repository %s", *httpRepoMetadata.Name)
+
+				By("Create the device spec adding inline. git, http configs")
+				httpConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+				err = httpConfigProviderSpec.FromHttpConfigProviderSpec(httpConfigvalid)
+				Expect(err).ToNot(HaveOccurred())
+
+				gitConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+				err = gitConfigProviderSpec.FromGitConfigProviderSpec(gitConfigvalid)
+				Expect(err).ToNot(HaveOccurred())
+
+				inlineConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+				err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValid)
+				Expect(err).ToNot(HaveOccurred())
+
+				configProviderSpec := []v1alpha1.ConfigProviderSpec{gitConfigProviderSpec, inlineConfigProviderSpec, httpConfigProviderSpec}
+
+				logrus.Infof("this is the configProviderSpec %s", configProviderSpec)
+				deviceImage := fmt.Sprintf("%s/flightctl-device:{{ .metadata.labels.alias }}", harness.RegistryEndpoint())
+
+				var osImageSpec = v1alpha1.DeviceOsSpec{
+					Image: deviceImage,
+				}
+
+				deviceSpec.Os = &osImageSpec
+				deviceSpec.Config = &configProviderSpec
+
+				By("Create a fleet with parametrisable templates in the os image, inlineconfig, gitconfig")
+				err = harness.CreateOrUpdateTestFleet(fleetTestName, testFleetSelector, deviceSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Add all the labels to the device")
+				nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					device.Metadata.Labels = &map[string]string{
+						fleetSelectorKey: fleetSelectorValue,
+						teamLabelKey:     teamLabelValue,
+						aliasKey:         deviceAlias,
+						configLabelKey:   configLabelValue,
+						revisionLabelKey: revisionLabelValue,
+						suffixLabelKey:   suffixLabelValue,
+					}
+					logrus.Infof("Updating %s with labels", deviceId)
+				})
+
+				By("Wait for the device to pick the fleet config")
+				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Check that the template variables are replaced in the device configurations")
+				response, err := harness.Client.ReadDeviceWithResponse(harness.Context, deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				device := response.JSON200
+				Expect(device).ToNot(BeNil(), "failed to read updated device")
+
+				inlineConfigResponse, err := harness.GetDeviceInlineConfig(device, inlineConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				if len(inlineConfigResponse.Inline) > 0 {
+					Expect(inlineConfigResponse.Inline[0].Path).To(ContainSubstring(teamLabelValue))
+					Expect(inlineConfigResponse.Inline[0].Content).To(ContainSubstring(teamLabelValue))
+				}
+
+				gitConfigResponse, err := harness.GetDeviceGitConfig(device, gitConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gitConfigResponse.GitRef.Path).To(ContainSubstring(configLabelValue))
+				Expect(*gitConfigResponse.GitRef.MountPath).To(ContainSubstring(teamLabelValue))
+				Expect(gitConfigResponse.GitRef.TargetRevision).To(ContainSubstring(revisionLabelValue))
+
+				httpConfigResponse, err := harness.GetDeviceHttpConfig(device, httpConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(httpConfigResponse.HttpRef.FilePath).To(ContainSubstring(configLabelValue))
+				Expect(*httpConfigResponse.HttpRef.Suffix).To(ContainSubstring(suffixLabelValue))
+
+				By("Check that the template variable is replaced in the device os image")
+				deviceOsImage, err := harness.GetDeviceOsImage(device)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deviceOsImage).To(ContainSubstring(deviceAlias))
+
+				By("Test that the template variable is replaced in target-revision parameter")
+				nextGeneration, err := harness.PrepareNextDeviceGeneration(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					(*device.Metadata.Labels)[revisionLabelKey] = branchTargetRevision
+					logrus.Infof("Updating the device with label %s=%s", revisionLabelKey, branchTargetRevision)
+				})
+
+				err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)
+				Expect(err).ToNot(HaveOccurred())
+
+				gitConfigResponse, err = harness.GetDeviceGitConfig(device, gitConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gitConfigResponse.GitRef.TargetRevision).To(ContainSubstring(revisionLabelValue))
+
+				By("Update the fleet inline config with a template variable with getOrDefault function")
+				nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				inlineConfigProviderSpec = v1alpha1.ConfigProviderSpec{}
+				err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValid)
+				Expect(err).ToNot(HaveOccurred())
+
+				deviceSpec.Config = &[]v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+				err = harness.CreateOrUpdateTestFleet(fleetTestName, testFleetSelector, deviceSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Remove the team label from the device and check that the config variable is replaced by the default")
+				nextGeneration, err = harness.PrepareNextDeviceGeneration(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				logrus.Infof("Removing %s labels", teamLabelKey)
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					device.Metadata.Labels = &map[string]string{
+						fleetSelectorKey: fleetSelectorValue,
+						aliasKey:         deviceAlias,
+						configLabelKey:   configLabelValue,
+						revisionLabelKey: revisionLabelValue,
+						suffixLabelKey:   suffixLabelValue,
+					}
+					logrus.Infof("Updating %s with labels", deviceId)
+				})
+
+				By("Wait for the device to pick the fleet config")
+				err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Check that the default variables are replaced in the config")
+				response, err = harness.Client.ReadDeviceWithResponse(harness.Context, deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				device = response.JSON200
+				Expect(device).ToNot(BeNil(), "failed to read updated device")
+				logrus.Infof("The device labels are %s", *device.Metadata.Labels)
+
+				inlineConfigResponse, err = harness.GetDeviceInlineConfig(device, inlineConfigName)
+				Expect(err).ToNot(HaveOccurred())
+				if len(inlineConfigResponse.Inline) > 0 {
+					Expect(inlineConfigResponse.Inline[0].Path).To(ContainSubstring(defaultTeamLabelValue))
+					Expect(inlineConfigResponse.Inline[0].Content).To(ContainSubstring(defaultTeamLabelValue))
+				}
+
+			})
+	})
+})
+
+var (
+	fleetSelectorKey      = "fleet"
+	fleetSelectorValue    = "test"
+	fleetTestName         = "fleet-test"
+	inlinePath            = "/var/home/user/{{ getOrDefault .metadata.labels \"team\" \"c\" }}.txt"
+	inlineContent         = "{{ getOrDefault .metadata.labels \"team\" \"c\" }}"
+	teamLabelKey          = "team"
+	inlineConfigName      = "inline-config"
+	teamLabelValue        = "a"
+	defaultTeamLabelValue = "c"
+	contentWithFunction   = "{{ replace \"a\" \"c\" .metadata.labels.team }}"
+	pathWithFunction      = "/var/home/user/{{ upper .metadata.labels.team | lower }}/test.txt"
+	repoTestName          = "git-repo"
+	repoTestUrl           = "https://github.com/flightctl/flightctl-demos"
+	deviceAlias           = "base"
+	mountPath             = "/var/home/user/{{ .metadata.labels.team }}/file.txt"
+	branchTargetRevision  = "demo"
+	httpRepoName          = "http-repo"
+	gitRepoConfigPath     = "/{{ .metadata.labels.config }}/bootc/fedora-bootc/Containerfile"
+	httpConfigPath        = "/var/home/user/{{ .metadata.labels.config }}"
+	configLabelKey        = "config"
+	configLabelValue      = "images"
+	revisionLabelKey      = "revision"
+	revisionLabelValue    = "main"
+	suffix                = "{{ .metadata.labels.suffix }}"
+	gitConfigName         = "git-config"
+	httpConfigName        = "http-config"
+	revision              = "{{ .metadata.labels.revision }}"
+	suffixLabelValue      = ""
+	suffixLabelKey        = "suffix"
+	aliasKey              = "alias"
+)
+
+var mode = 0644
+var modePointer = &mode
+
+var inlineConfigSpec = v1alpha1.FileSpec{
+	Path:    inlinePath,
+	Mode:    modePointer,
+	Content: inlineContent,
+}
+
+var inlineConfigWithFunctionSpec = v1alpha1.FileSpec{
+	Path:    pathWithFunction,
+	Mode:    modePointer,
+	Content: contentWithFunction,
+}
+
+var configProviderSpec v1alpha1.ConfigProviderSpec
+
+var inlineConfigValid = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigSpec},
+	Name:   inlineConfigName,
+}
+var inlineConfigValidWithFunction = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigWithFunctionSpec},
+	Name:   inlineConfigName,
+}
+
+var testFleetSelector = v1alpha1.LabelSelector{
+	MatchLabels: &map[string]string{fleetSelectorKey: fleetSelectorValue},
+}
+
+var deviceSpec v1alpha1.DeviceSpec
+
+var gitRepositorySpec v1alpha1.RepositorySpec
+var _ = gitRepositorySpec.FromGenericRepoSpec(v1alpha1.GenericRepoSpec{
+	Url:  repoTestUrl,
+	Type: v1alpha1.Git,
+})
+
+var gitMetadata = v1alpha1.ObjectMeta{
+	Name:   &repoTestName,
+	Labels: &map[string]string{},
+}
+
+var httpRepoSpec = v1alpha1.HttpRepoSpec{
+	Type: v1alpha1.Http,
+	Url:  repoTestUrl,
+}
+
+var httpRepositoryspec v1alpha1.RepositorySpec
+
+var _ = httpRepositoryspec.FromHttpRepoSpec(httpRepoSpec)
+
+var httpRepoMetadata = v1alpha1.ObjectMeta{
+	Name: &httpRepoName,
+}
+
+var gitConfigvalid = v1alpha1.GitConfigProviderSpec{
+	GitRef: struct {
+		MountPath      *string `json:"mountPath,omitempty"`
+		Path           string  `json:"path"`
+		Repository     string  `json:"repository"`
+		TargetRevision string  `json:"targetRevision"`
+	}{
+		MountPath:      &mountPath,
+		Path:           gitRepoConfigPath,
+		Repository:     repoTestName,
+		TargetRevision: revision,
+	},
+	Name: gitConfigName,
+}
+
+var httpConfigvalid = v1alpha1.HttpConfigProviderSpec{
+	HttpRef: struct {
+		FilePath   string  `json:"filePath"`
+		Repository string  `json:"repository"`
+		Suffix     *string `json:"suffix,omitempty"`
+	}{
+		FilePath:   httpConfigPath,
+		Repository: httpRepoName,
+		Suffix:     &suffix,
+	},
+	Name: httpConfigName,
+}
+
+func CheckDeviceOnlineStatus(harness *e2e.Harness, deviceId string) *v1alpha1.Device {
+	response := harness.GetDeviceWithStatusSystem(deviceId)
+	Expect(response).ToNot(BeNil())
+	Expect(response.JSON200).ToNot(BeNil())
+	device := response.JSON200
+	Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusOnline))
+	return device
+}

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -363,6 +363,7 @@ func (h *Harness) WaitForDeviceContents(deviceId string, description string, con
 		return errors.New("not updated")
 	}, timeout, "2s").Should(BeNil())
 }
+
 func (h *Harness) WaitForDeviceConfigUpdate(deviceId string, configs []v1alpha1.ConfigProviderSpec) error {
 
 	deviceRenderedVersion, err := h.PrepareNextDeviceVersion(deviceId)
@@ -392,6 +393,9 @@ func (h *Harness) EnrollAndWaitForOnlineStatus() (string, *v1alpha1.Device) {
 	deviceId := h.GetEnrollmentIDFromConsole()
 	logrus.Infof("Enrollment ID found in VM console output: %s", deviceId)
 	Expect(deviceId).NotTo(BeNil())
+
+	// Wait for the approve enrollment request response to not be nil
+	h.WaitForEnrollmentRequest(deviceId)
 
 	// Approve the enrollment and wait for the device details to be populated by the agent.
 	h.ApproveEnrollment(deviceId, util.TestEnrollmentApproval())
@@ -444,6 +448,39 @@ func (h *Harness) parseImageReference(image string) (string, string) {
 	repo := strings.Join(parts[:len(parts)-1], ":")
 
 	return repo, tag
+}
+
+func (h *Harness) GetCurrentDeviceGeneration(deviceId string) (deviceRenderedVersionInt int64, err error) {
+	var deviceGeneration int64 = -1
+	logrus.Infof("Waiting for the device to be UpToDate")
+	h.WaitForDeviceContents(deviceId, "The device is UpToDate",
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
+					deviceGeneration = *device.Metadata.Generation
+
+					return true
+				}
+			}
+			return false
+		}, TIMEOUT)
+
+	if deviceGeneration <= 0 {
+		return deviceGeneration, fmt.Errorf("invalid generation: %d", deviceGeneration)
+
+	}
+	logrus.Infof("The device current generation is %d", deviceGeneration)
+
+	return deviceGeneration, nil
+}
+
+func (h *Harness) PrepareNextDeviceGeneration(deviceId string) (int64, error) {
+	currentGeneration, err := h.GetCurrentDeviceGeneration(deviceId)
+	if err != nil {
+		return -1, err
+	}
+	return currentGeneration + 1, nil
 }
 
 func (h *Harness) GetCurrentDeviceRenderedVersion(deviceId string) (deviceRenderedVersionInt int, err error) {
@@ -499,6 +536,29 @@ func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVe
 				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
 					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
 					device.Status.Config.RenderedVersion == strconv.Itoa(newRenderedVersionInt) {
+					return true
+				}
+			}
+			return false
+		}, LONGTIMEOUT)
+
+	return nil
+}
+
+func (h *Harness) WaitForDeviceNewGeneration(deviceId string, newGeneration int64) (err error) {
+	// Check that the device was already approved
+	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+		deviceId).ShouldNot(BeEmpty())
+	logrus.Infof("The device %s was approved", deviceId)
+
+	// Wait for the device to pickup the new config and report measurements on device status.
+	logrus.Infof("Waiting for the device to pick the config")
+	h.WaitForDeviceContents(deviceId, "Waiting fot the device generation",
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
+					newGeneration == *device.Metadata.Generation {
 					return true
 				}
 			}
@@ -573,4 +633,143 @@ func (h *Harness) GetEnrollmentRequestByYaml(erYaml string) v1alpha1.EnrollmentR
 // Wrapper function for CertificateSigningRequest
 func (h *Harness) GetCertificateSigningRequestByYaml(csrYaml string) v1alpha1.CertificateSigningRequest {
 	return getYamlResourceByFile[v1alpha1.CertificateSigningRequest](csrYaml)
+}
+
+// getDeviceConfig is a generic helper function to retrieve device configurations
+func GetDeviceConfig[T any](device *v1alpha1.Device, configType v1alpha1.ConfigProviderType,
+	asConfig func(v1alpha1.ConfigProviderSpec) (T, error)) (T, error) {
+
+	var config T
+	if device.Spec == nil || device.Spec.Config == nil {
+		return config, fmt.Errorf("device spec or config is nil")
+	}
+
+	if len(*device.Spec.Config) > 0 {
+		for _, configItem := range *device.Spec.Config {
+			// Check config type
+			itemType, err := configItem.Type()
+			if err != nil {
+				return config, fmt.Errorf("failed to get config type: %w", err)
+			}
+			if itemType == configType {
+				// Convert to the expected config type
+				config, err := asConfig(configItem)
+				if err != nil {
+					return config, fmt.Errorf("failed to convert config: %w", err)
+				}
+
+				return config, nil
+			}
+		}
+	}
+
+	// If we don't find the config, return an error
+	return config, fmt.Errorf("%s config not found in the device", configType)
+}
+
+// Get InlineConfig
+func (h *Harness) GetDeviceInlineConfig(device *v1alpha1.Device, configName string) (v1alpha1.InlineConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.InlineConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.InlineConfigProviderSpec, error) {
+			inlineConfig, err := c.AsInlineConfigProviderSpec()
+			if err != nil {
+				return inlineConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if inlineConfig.Name == configName {
+				logrus.Infof("Inline configuration found %s", configName)
+				return inlineConfig, nil
+			}
+			return v1alpha1.InlineConfigProviderSpec{}, fmt.Errorf("inline config not found")
+		})
+}
+
+// Get GitConfig
+func (h *Harness) GetDeviceGitConfig(device *v1alpha1.Device, configName string) (v1alpha1.GitConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.GitConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.GitConfigProviderSpec, error) {
+			gitConfig, err := c.AsGitConfigProviderSpec()
+			if err != nil {
+				return gitConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if gitConfig.Name == configName {
+				logrus.Infof("Git configuration found %s", configName)
+				return gitConfig, nil
+			}
+			return v1alpha1.GitConfigProviderSpec{}, fmt.Errorf("git config not found")
+		})
+}
+
+// Get HttpConfig
+func (h *Harness) GetDeviceHttpConfig(device *v1alpha1.Device, configName string) (v1alpha1.HttpConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.HttpConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.HttpConfigProviderSpec, error) {
+			httpConfig, err := c.AsHttpConfigProviderSpec()
+			if err != nil {
+				return httpConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if httpConfig.Name == configName {
+				logrus.Infof("Http configuration found %s", configName)
+				return httpConfig, nil
+			}
+			return v1alpha1.HttpConfigProviderSpec{}, fmt.Errorf("http config not found")
+		})
+}
+
+// Get an http config of a device resource
+func (h *Harness) GetDeviceOsImage(device *v1alpha1.Device) (image string, err error) {
+	if device.Spec == nil {
+		return "", fmt.Errorf("device spec is nil")
+	}
+	if device.Spec.Os == nil {
+		return "", fmt.Errorf("device os spec is nil")
+	}
+
+	return device.Spec.Os.Image, nil
+}
+
+// Create a test fleet resource
+func (h *Harness) CreateOrUpdateTestFleet(testFleetName string, testFleetSelector v1alpha1.LabelSelector, testFleetSpec v1alpha1.DeviceSpec) error {
+	var testFleet = v1alpha1.Fleet{
+		ApiVersion: v1alpha1.FleetAPIVersion,
+		Kind:       v1alpha1.FleetKind,
+		Metadata: v1alpha1.ObjectMeta{
+			Name:   &testFleetName,
+			Labels: &map[string]string{},
+		},
+		Spec: v1alpha1.FleetSpec{
+			Selector: &testFleetSelector,
+			Template: struct {
+				Metadata *v1alpha1.ObjectMeta "json:\"metadata,omitempty\""
+				Spec     v1alpha1.DeviceSpec  "json:\"spec\""
+			}{
+				Spec: testFleetSpec,
+			},
+		},
+	}
+	_, err := h.Client.ReplaceFleetWithResponse(h.Context, testFleetName, testFleet)
+	return err
+}
+
+// Create a test fleet with a configuration
+func (h *Harness) CreateTestFleetWithConfig(testFleetName string, testFleetSelector v1alpha1.LabelSelector, configProviderSpec v1alpha1.ConfigProviderSpec) error {
+	var testFleetSpec = v1alpha1.DeviceSpec{
+		Config: &[]v1alpha1.ConfigProviderSpec{
+			configProviderSpec,
+		},
+	}
+	err := h.CreateOrUpdateTestFleet(testFleetName, testFleetSelector, testFleetSpec)
+	return err
+}
+
+// Create a repository resource
+func (h Harness) CreateRepository(repositorySpec v1alpha1.RepositorySpec, metadata v1alpha1.ObjectMeta) error {
+	var repository = v1alpha1.Repository{
+		ApiVersion: v1alpha1.RepositoryAPIVersion,
+		Kind:       v1alpha1.RepositoryKind,
+
+		Metadata: metadata,
+		Spec:     repositorySpec,
+	}
+	_, err := h.Client.CreateRepositoryWithResponse(h.Context, repository)
+	return err
 }

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -29,6 +29,8 @@ RUN if [[ -z $RPM_COPR ]]; then \
 
 RUN dnf install -y epel-release epel-next-release
 RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \
+    dnf install -y firewalld && \
+    systemctl enable firewalld.service && \
     systemctl enable podman.service
 
 


### PR DESCRIPTION
Adding E2E tests for the feature "EDM-418 Finalizing parametrisable device template"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a comprehensive end-to-end test suite for validating parametrisable templates in device configurations.
  - Added tests for verifying the functionality of parametrisable device templates, including error handling and configuration checks.
  - Improved cleanup processes in the test suite to ensure proper resource management after each test.

- **New Features**
  - Enhanced device configuration management with improved update tracking and online status verification.

- **Chores**
  - Upgraded container security by activating firewall services during testing to ensure a more robust and secure environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->