### PR TITLE
EDM-390: Update device lifecycle status immediately upon user request

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -51,8 +51,9 @@ func ReplaceDeviceStatus(ctx context.Context, st store.Store, log logrus.FieldLo
 			return nil, err
 		}
 	}
-	if oldDevice.Status.Lifecycle.Status == api.DeviceLifecycleStatusEnrolled && device.Status.Lifecycle.Status == api.DeviceLifecycleStatusUnknown {
-		device.Status.Lifecycle.Status = api.DeviceLifecycleStatusEnrolled
+	// do not overwrite valid service-side lifecycle status with placeholder device-side status
+	if device.Status.Lifecycle.Status == api.DeviceLifecycleStatusUnknown {
+		device.Status.Lifecycle.Status = oldDevice.Status.Lifecycle.Status
 	}
 	oldDevice.Status = device.Status
 	UpdateServiceSideStatus(ctx, st, log, orgId, oldDevice)


### PR DESCRIPTION
Updates device lifecycle status immediately upon user request to decommission.
 **This PR is required to unblock UI for Tech Preview**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device status management to ensure that valid statuses are maintained when handling updates.
  - Enhanced the decommission process by validating a device’s current state before processing decommissioning requests, preventing duplicate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->