### PR TITLE
EDM-1049: CLI installed from RPM (COPR repo) and binary (GH) show the…

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/pkg/version"
@@ -115,6 +116,10 @@ func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		serviceVersion = o.processResponse(nil, err)
 	} else {
+		// Call a function with a context timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
 		response, err := c.GetVersionWithResponse(ctx)
 		serviceVersion = o.processResponse(response, err)
 	}

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -77,7 +77,7 @@ The flightctl-selinux package provides the SELinux policy modules required by th
 
     SOURCE_GIT_TAG=$(echo %{version} | tr '~' '-')\
     SOURCE_GIT_TREE_STATE=clean \
-    SOURCE_GIT_COMMIT=$(echo %{version} | awk -F'-g' '{print $2}') \
+    SOURCE_GIT_COMMIT=$(echo %{version} | awk -F'[-~]g' '{print $2}') \
     SOURCE_GIT_TAG_NO_V=%{version} \
     make build-cli build-agent
 

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -23,7 +23,7 @@ URL:            %{gourl}
 
 Source0:        1%{?dist}
 
-BuildRequires:  golang
+BuildRequires:  go
 BuildRequires:  make
 BuildRequires:  git
 BuildRequires:  openssl-devel
@@ -65,7 +65,7 @@ The flightctl-selinux package provides the SELinux policy modules required by th
 
 %prep
 %goprep -A
-%setup -q %{forgesetupargs}
+%setup -q %{forgesetupargs} -n flightctl-0.4.0~27~gdabba65d
 
 %build
     # if this is a buggy version of go we need to set GOPROXY as workaround
@@ -75,9 +75,9 @@ The flightctl-selinux package provides the SELinux policy modules required by th
         export GOPROXY='https://proxy.golang.org,direct'
     fi
 
-    SOURCE_GIT_TAG=%{version} \
+    SOURCE_GIT_TAG=$(echo %{version} | tr '~' '-')\
     SOURCE_GIT_TREE_STATE=clean \
-    SOURCE_GIT_COMMIT=$(echo %{version} | awk -F'~g' '{print $2}') \
+    SOURCE_GIT_COMMIT=$(echo %{version} | awk -F'-g' '{print $2}') \
     SOURCE_GIT_TAG_NO_V=%{version} \
     make build-cli build-agent
 
@@ -166,10 +166,8 @@ fi
 %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2
 
 %changelog
-
 * Fri Feb 7 2025 Miguel Angel Ajo <majopela@redhat.com> - 0.4.0-1
 - Add selinux support for console pty access
-
 * Mon Nov 4 2024 Miguel Angel Ajo <majopela@redhat.com> - 0.3.0-1
 - Move the Release field to -1 so we avoid auto generating packages
   with -5 all the time.


### PR DESCRIPTION
… wrong version info

A version should be specified in spec:
```spec
BuildRequires:  golang = 1.21.13
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to require a more general Go package name.
	- Enhanced the build process with specific directory naming and improved versioning.
	- Introduced a timeout mechanism for version retrieval to enhance error handling and control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->