### PR TITLE
NO-ISSUE: Pull CI RPM Builder image before using it

### DIFF
--- a/hack/build_rpms.sh
+++ b/hack/build_rpms.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CI_RPM_IMAGE=${CI_RPM_IMAGE:-quay.io/flightctl/ci-rpm-builder:latest}
+
 # if FLIGHTCTL_RPM is set, exit
 if [ -n "${FLIGHTCTL_RPM:-}" ]; then
     echo "Skipping rpm build, as FLIGHTCTL_RPM is set to ${FLIGHTCTL_RPM}"
@@ -17,7 +19,8 @@ if ! dnf install -y go-rpm-macros; then
 fi
 ./hack/build_rpms_packit.sh
 EOF
-    podman run --privileged --rm -t -v "$(pwd)":/work quay.io/flightctl/ci-rpm-builder:latest bash /work/bin/build_rpms.sh
+    podman pull "${CI_RPM_IMAGE}"
+    podman run --privileged --rm -t -v "$(pwd)":/work "${CI_RPM_IMAGE}" bash /work/bin/build_rpms.sh
 else
     ./hack/build_rpms_packit.sh
 fi


### PR DESCRIPTION
Otherwise it could attempt to use a stale image that does not contain all the necessary packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build process by allowing a configurable container image for RPM builds, enabling easier customization while maintaining consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->