### PR TITLE
NO-ISSUE: Remove old reference to grpc-management-endpoint

### DIFF
--- a/docs/user/auth-resources.md
+++ b/docs/user/auth-resources.md
@@ -22,7 +22,6 @@ The table below contains the routes, names, resource names, and verbs for flight
 |`PUT /api/v1/devices/{name}/status`|`ReplaceDeviceStatus`|`devices/status`|`update`|
 |`GET /api/v1/devices/{name}/rendered`|`GetRenderedDeviceSpec`|`devices/rendered`|`get`|
 |`PUT /api/v1/devices/{name}/decommission`|`DecommissionDevice`|`devices/decommission`|`update`|
-|`GET /api/v1/devices/{name}/console`|`DeviceConsole`|`devices/console`|`get`|
 |`GET /ws/v1/devices/{name}/console`|`DeviceConsole`|`devices/console`|`get`|
 |`POST /api/v1/enrollmentrequests`|`CreateEnrollmentRequest`|`enrollmentrequests`|`create`|
 |`GET /api/v1/enrollmentrequests`|`ListEnrollmentRequests`|`enrollmentrequests`|`list`|

--- a/docs/user/building-images.md
+++ b/docs/user/building-images.md
@@ -82,7 +82,6 @@ enrollment-service:
     certificate-authority-data: LS0tLS1CRUdJTiBD...
     server: https://agent-api.flightctl.127.0.0.1.nip.io:7443
   enrollment-ui-endpoint: https://ui.flightctl.127.0.0.1.nip.io:8081
-  grpc-management-endpoint: grpcs://agent-grpc.flightctl.127.0.0.1.nip.io:7444
 ```
 
 ### Building the OS Image (bootc)


### PR DESCRIPTION
The example `config.yaml` shown as the output for `flightctl certificate request --signer=enrollment --expiration=365d --output=embedded > config.yaml` contains a reference to the removed `grpc-management-endpoint`.

The latest generated config has this format:
```
enrollment-service:
  authentication:
    client-certificate-data: ...
    client-key-data: ...
  enrollment-ui-endpoint: http://<IP>.nip.io:9000
  service:
    certificate-authority-data: ...
    server: https://agent-api.<IP>.nip.io:7443/
management-service:
  authentication: {}
  service:
    server: ""
```

The `management-service` section is not mentioned in the docs, but since it's empty I think it's OK not to show it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the OS image building guide by refining the configuration example, removing an unnecessary parameter to simplify the setup process.
  - Removed a specific API endpoint for device console access, shifting functionality to a WebSocket-based approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->