### PR TITLE
NO-ISSUE: Specify only image without the tag

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/values.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/values.yaml
@@ -18,7 +18,8 @@ realm:
   webOrigins: ""
 db:
   ## @param db.image The container image to use for the Keycloak database
-  image: quay.io/sclorg/postgresql-16-c9s:latest
+  image: quay.io/sclorg/postgresql-16-c9s
+  tag: latest
   ## @param imagePullPolicy The container imagePullPolicy to use for the Keycloak database
   imagePullPolicy: IfNotPresent
 directAccessGrantsEnabled: true

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -74,7 +74,7 @@ global:
 
 db:
   image:
-    image: quay.io/sclorg/postgresql-16-c9s:latest
+    image: quay.io/sclorg/postgresql-16-c9s
     tag: latest
     pullPolicy: Always
   masterUser: admin


### PR DESCRIPTION
In following the getting-started guide with the local kind cluster ([link](https://github.com/flightctl/flightctl/blob/main/docs/user/getting-started.md#standalone-flight-control-with-built-in-keycloak)), the DB pod failed to pull the image as it was resolving the full image to `quay.io/sclorg/postgresql-16-c9s:latest:latest`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the database container image configuration to separate the image reference from its version tag. This change enhances clarity and supports more reliable, flexible deployments without altering end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->