### PR TITLE
EDM-1168: Make --rendered flag return the full device

### DIFF
--- a/docs/user/auth-resources.md
+++ b/docs/user/auth-resources.md
@@ -1,6 +1,6 @@
 # Authentication resources
 
-The table below contains the routes, names, resource names, and verbs for flightctl API endpoints:
+The table below contains the routes, names, resource names, and verbs for Flight Control API endpoints:
 
 |Route| Name| Resource| Verb |
 |-----|-----|---------|------|

--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -502,7 +502,7 @@ In particular, to only run an action if a given file or directory has changed du
 | Parameter | Description |
 | --------- | ----------- |
 | Path | An absolute path to a file or directory that must have changed during the update as condition for the action to be performed. Paths must be specified using forward slashes (`/`) and if the path is to a directory it must terminate with a forward slash `/`.<br/></br>If you specify a path to a file, the file must have changed to satisfy the condition.</br>If you specify a path to a directory, a file in that directory or any of its subdirectories must have changed to satisfy the condition.|
-| On | A list of file operations (`created`, `updated`, `removed`) to further limit the kind of changes to the specified path as condition for the action to be performed. |
+| Op | A list of file operations (`created`, `updated`, `removed`) to further limit the kind of changes to the specified path as condition for the action to be performed. |
 
 If you have specified a "path condition" for an action in the `afterUpdating` hook, you have the following variables that you can include in arguments to your command and that will be replaced with the absolute path(s) to the changed files:
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1,19 +1,29 @@
 # Troubleshooting
 
-## Viewing a Device's Effective Target Configuration
+## Verifying the effective device specification received by the device agent
 
-The device manifest returned by the `flightctl get device` command still only contains references to external configuration and secret objects. Only when the device agent queries the service, the service will replace the references with the actual configuration and secret data. While this better protects potentially sensitive data, it also makes troubleshooting faulty configurations hard. This is why a user can be authorized to query the effective configuration as rendered by the service to the agent.
-
-To query that configuration, use the following command.
+When viewing a device resource using the command
 
 ```console
-flightctl get device/${device_name} --rendered | jq
+flightctl get device/${device_name} -o yaml
 ```
 
-## Generate Device Log Bundle
+the output contains the device specification as specified by the user or the fleet controller based on the fleet's device template. That specification may contain references to configuration or secrets stored on external systems, such a Git or a Kubernetes cluster.
 
-The device includes a script which will generate a bundle of logs necessary to debug the agent. Run the command below on the device and include the tarball in the bug report. Note: This depends on an SSH connection to extract the tarball.
+Only when the device agent queries the service, the service replaces these references with the actual configuration and secret data. While this better protects potentially sensitive data, it also makes troubleshooting faulty configurations hard.
+
+Users with the `GetRenderedDevice` permission can run the following command to view the effective configuration as rendered by the service to the device agent:
+
+```console
+flightctl get device/${device_name} -o yaml --rendered
+```
+
+## Generating a device log bundle
+
+The device includes a script that generates a bundle of logs necessary to debug the agent. Run the command below on the device:
 
 ```console
 sudo flightctl-must-gather
 ```
+
+The output is a tarball named `must-gather-$timestamp.tgz`, whereby `$timestamp` is the current date and time. Include this tarball in the bug report.

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -89,7 +89,7 @@ func (o *GetOptions) Bind(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.Limit, "limit", o.Limit, "The maximum number of results returned in the list response.")
 	fs.StringVar(&o.Continue, "continue", o.Continue, "Query more results starting from the value of the 'continue' field in the previous response.")
 	fs.StringVar(&o.FleetName, "fleetname", o.FleetName, "Fleet name for accessing templateversions (use only when getting templateversions).")
-	fs.BoolVar(&o.Rendered, "rendered", false, "Return the rendered device configuration that is presented to the device (use only when getting devices).")
+	fs.BoolVar(&o.Rendered, "rendered", false, "Return the rendered device configuration that is presented to the device (use only when getting a single device).")
 	fs.BoolVarP(&o.Summary, "summary", "s", false, "Display summary information.")
 	fs.BoolVar(&o.SummaryOnly, "summary-only", false, "Display summary information only.")
 }
@@ -97,11 +97,6 @@ func (o *GetOptions) Bind(fs *pflag.FlagSet) {
 func (o *GetOptions) Complete(cmd *cobra.Command, args []string) error {
 	if err := o.GlobalOptions.Complete(cmd, args); err != nil {
 		return err
-	}
-
-	// The RenderedDeviceSpec can only be printed as JSON or YAML, so default to JSON if not set
-	if o.Rendered && len(o.Output) == 0 {
-		o.Output = jsonFormat
 	}
 	return nil
 }
@@ -116,43 +111,38 @@ func (o *GetOptions) Validate(args []string) error {
 		return err
 	}
 	if len(name) > 0 && len(o.LabelSelector) > 0 {
-		return fmt.Errorf("cannot specify label selector when fetching a single resource")
+		return fmt.Errorf("cannot specify label selector when getting a single resource")
 	}
 	if len(name) > 0 && len(o.FieldSelector) > 0 {
-		return fmt.Errorf("cannot specify field selector when fetching a single resource")
+		return fmt.Errorf("cannot specify field selector when getting a single resource")
 	}
 	if o.Summary {
 		if kind != DeviceKind && kind != FleetKind {
-			return fmt.Errorf("summary can only be specified when fetching devices or fleets")
+			return fmt.Errorf("'--summary' can only be specified when getting a list of devices or fleets")
 		}
 		if kind == DeviceKind && len(name) > 0 {
-			return fmt.Errorf("cannot specify summary when fetching a single device")
+			return fmt.Errorf("cannot specify '--summary' when getting a single device")
 		}
 	}
 	if o.SummaryOnly {
 		if kind != DeviceKind {
-			return fmt.Errorf("summary-only can only be specified when fetching devices")
+			return fmt.Errorf("'--summary-only' can only be specified when getting a list of devices")
 		}
 		if len(name) > 0 {
-			return fmt.Errorf("cannot specify summary-only when fetching a single device")
+			return fmt.Errorf("cannot specify '--summary-only' when getting a single device")
 		}
 		if o.Limit > 0 || len(o.Continue) > 0 {
-			return fmt.Errorf("flags such as 'limit' and 'continue' are not supported when 'summary-only' is specified")
+			return fmt.Errorf("flags '--limit' and '--continue' are not supported when '--summary-only' is specified")
 		}
 	}
 	if kind == TemplateVersionKind && len(o.FleetName) == 0 {
-		return fmt.Errorf("fleetname must be specified when fetching templateversions")
+		return fmt.Errorf("a fleet name must be specified when getting a list of templateversions")
 	}
 	if len(o.Output) > 0 && !slices.Contains(legalOutputTypes, o.Output) {
 		return fmt.Errorf("output format must be one of (%s)", strings.Join(legalOutputTypes, ", "))
 	}
-	if o.Rendered {
-		if kind != DeviceKind || len(name) == 0 {
-			return fmt.Errorf("rendered must only be specified when fetching a specific device")
-		}
-		if o.Output != jsonFormat && o.Output != yamlFormat {
-			return fmt.Errorf("rendered output must be one of (json, yaml)")
-		}
+	if o.Rendered && (kind != DeviceKind || len(name) == 0) {
+		return fmt.Errorf("'--rendered' can only be used when getting a single device")
 	}
 	if o.Limit < 0 {
 		return fmt.Errorf("limit must be greater than 0")
@@ -328,7 +318,13 @@ func (o *GetOptions) printTable(response interface{}, kind string, name string) 
 			o.printDevicesSummaryTable(w, response.(*apiclient.ListDevicesResponse).JSON200.Summary)
 		}
 	case kind == DeviceKind && len(name) > 0:
-		o.printDevicesTable(w, *(response.(*apiclient.ReadDeviceResponse).JSON200))
+		var device api.Device
+		if o.Rendered {
+			device = *(response.(*apiclient.GetRenderedDeviceResponse).JSON200)
+		} else {
+			device = *(response.(*apiclient.ReadDeviceResponse).JSON200)
+		}
+		o.printDevicesTable(w, device)
 	case kind == EnrollmentRequestKind && len(name) == 0:
 		o.printEnrollmentRequestsTable(w, response.(*apiclient.ListEnrollmentRequestsResponse).JSON200.Items...)
 	case kind == EnrollmentRequestKind && len(name) > 0:
@@ -537,7 +533,7 @@ func (o *GetOptions) printResourceSyncsTable(w *tabwriter.Writer, resourcesyncs 
 }
 
 func (o *GetOptions) printCSRTable(w *tabwriter.Writer, csrs ...api.CertificateSigningRequest) {
-	fmt.Fprintln(w, "NAME\tAGE\tSIGNERNAME\tUSERNAME\tREQUESTEDDURATION\tCONDITION")
+	fmt.Fprintln(w, "NAME\tAGE\tSIGNERNAME\tREQUESTOR\tREQUESTEDDURATION\tCONDITION")
 
 	for _, csr := range csrs {
 		age := NoneString
@@ -557,6 +553,9 @@ func (o *GetOptions) printCSRTable(w *tabwriter.Writer, csrs ...api.CertificateS
 			condition = "Denied"
 		} else if api.IsStatusConditionTrue(csr.Status.Conditions, api.CertificateSigningRequestFailed) {
 			condition = "Failed"
+		}
+		if csr.Status != nil && csr.Status.Certificate != nil {
+			condition += ",Issued"
 		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised section titles and command examples in API and troubleshooting guides for improved clarity.
  - Enhanced descriptions for device configuration queries and log bundle generation.
  - Updated parameter name in device lifecycle hooks documentation for consistency.

- **Refactor**
  - Refined error messages and output headers in command interactions to provide clearer feedback when retrieving devices or fleets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->