### PR TITLE
Update values.acm.yaml - fix non-existing psql-16 image tag

### DIFF
--- a/deploy/helm/flightctl/values.acm.yaml
+++ b/deploy/helm/flightctl/values.acm.yaml
@@ -4,7 +4,7 @@ global:
 db:
   image:
     image: registry.redhat.io/rhel9/postgresql-16
-    tag: 1-181
+    tag: 9.5
 
 kv:
   image:


### PR DESCRIPTION
`tag: 1.181` does not exist for image `rhel9/postgresql-16` and leads to image pull backoff errors, not working deployment.  I had to switch the tag and went with `9.5` which worked for me.