### PR TITLE
EDM-1191: docs/managing-devices: add section on pull secrets 

### DIFF
--- a/docs/user/building-images.md
+++ b/docs/user/building-images.md
@@ -107,6 +107,9 @@ ADD config.yaml /etc/flightctl/
 > [!NOTE]
 > If you have used Podman or Docker before to build application containers, you will notice this is a regular `Containerfile`, with the only difference that the base image referenced in `FROM` is bootable container (bootc) image. That means it already contains a Linux kernel. This allows you to reuse existing standard container build tools and workflows.
 
+> [!NOTE]
+If your device relies on an OS image from a private repository, [authentication credentials](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/index#configuring-container-pull-secrets_managing-users-groups-ssh-key-and-secrets-in-image-mode-for-rhel) (pull secrets) must be placed in the appropriate system path `/etc/ostree/auth.json`. Authentication must exist on the device before it can be consumed.
+
 > [!IMPORTANT]
 > When using Flight Control with a RHEL 9 base image, you need to disable the default automatic updates by adding the following command to the `Containerfile`:
 >

--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -229,6 +229,30 @@ spec:
 [...]
 ```
 
+### Using Image Pull Secrets
+
+If your device relies on containers from a private repository, [authentication credentials](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/index#configuring-container-pull-secrets_managing-users-groups-ssh-key-and-secrets-in-image-mode-for-rhel) (pull secrets) must be placed in the appropriate system paths.
+
+* **OS Image:** Uses `/etc/ostree/auth.json`
+* **Container Images:** Uses the system default for Podman, `/root/.config/containers/auth.json`
+
+#### Auth File Format
+
+The authentication file should follow this format:
+
+```json
+{
+  "auths": {
+    "registry.example.com": {
+      "auth": "base64-encoded-credentials"
+    }
+  }
+}
+```
+
+> [!NOTE]
+Authentication must exist on the device before it can be consumed.
+
 ## Managing OS Configuration
 
 With image-based Linux OSes, it is best practice to include OS-level / host configuration into the OS image for maximum consistency and repeatability. To update configuration, a new OS image should be created and devices updated to the new image.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -106,7 +106,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	osClient := os.NewClient(a.log, executer)
 
 	// create podman client
-	podmanClient := client.NewPodman(a.log, executer, backoff)
+	podmanClient := client.NewPodman(a.log, executer, deviceReadWriter, backoff)
 
 	// create systemd client
 	systemdClient := client.NewSystemd(executer)
@@ -157,7 +157,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	systemdManager := systemd.NewManager(a.log, systemdClient)
 
 	// create os manager
-	osManager := os.NewManager(a.log, osClient, podmanClient)
+	osManager := os.NewManager(a.log, osClient, deviceReadWriter, podmanClient)
 
 	// create status manager
 	statusManager := status.NewManager(

--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -95,12 +95,21 @@ func IsComposeAvailable() bool {
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	retry bool
+	retry          bool
+	pullSecretPath string
 }
 
 // WithRetry enables enables retry based on the backoff config provided.
 func WithRetry() ClientOption {
 	return func(opts *clientOptions) {
 		opts.retry = true
+	}
+}
+
+// WithPullSecret sets the path to the pull secret. If unset uses the default
+// path for the runtime.
+func WithPullSecret(path string) ClientOption {
+	return func(opts *clientOptions) {
+		opts.pullSecretPath = path
 	}
 }

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/sirupsen/logrus"
@@ -192,6 +193,9 @@ func TestListenForEvents(t *testing.T) {
 
 			log := log.NewPrefixLogger("test")
 			log.SetLevel(logrus.DebugLevel)
+			tmpDir := t.TempDir()
+			r := fileio.NewReader()
+			r.SetRootdir(tmpDir)
 			execMock := executer.NewMockExecuter(ctrl)
 
 			var testInspect []PodmanInspect
@@ -200,7 +204,7 @@ func TestListenForEvents(t *testing.T) {
 			inspectBytes, err := json.Marshal(testInspect)
 			require.NoError(err)
 
-			podman := client.NewPodman(log, execMock, newTestBackoff())
+			podman := client.NewPodman(log, execMock, r, newTestBackoff())
 			podmanMonitor := NewPodmanMonitor(log, execMock, podman, "")
 
 			// add test apps to the monitor
@@ -343,9 +347,12 @@ func TestApplicationAddRemove(t *testing.T) {
 			defer ctrl.Finish()
 
 			log := log.NewPrefixLogger("test")
+			tmpDir := t.TempDir()
+			reader := fileio.NewReader()
+			reader.SetRootdir(tmpDir)
 			execMock := executer.NewMockExecuter(ctrl)
 
-			podman := client.NewPodman(log, execMock, newTestBackoff())
+			podman := client.NewPodman(log, execMock, reader, newTestBackoff())
 			podmanMonitor := NewPodmanMonitor(log, execMock, podman, "")
 			testApp := createTestApplication(tc.appName, v1alpha1.ApplicationStatusPreparing)
 

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -161,7 +161,7 @@ func TestSync(t *testing.T) {
 				Steps: 1,
 			}
 
-			podmanClient := client.NewPodman(log, mockExec, backoff)
+			podmanClient := client.NewPodman(log, mockExec, readWriter, backoff)
 			policyManager := policy.NewManager(log)
 			consoleController := console.NewController(mockRouterService, deviceName, mockExec, log)
 			appController := applications.NewController(podmanClient, mockAppManager, readWriter, log)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section “Using Image Pull Secrets” in the device management guide, clarifying where to store authentication credentials for OS images and container images from private repositories.
  - Updated documentation on building images to include requirements for authentication credentials when using OS images from private repositories.

- **New Features**
  - Enhanced support for image authentication, ensuring smoother integration with private container registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->