### PR TITLE
EDM-1039: Make CLI code Windows compatible

### DIFF
--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Create cluster
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         run: make cluster
-      
+
       - name: Deploy
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         run: make deploy

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -22,40 +22,55 @@ jobs:
     name: Build Binaries
     strategy:
       matrix:
-        os_arch: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64" ]
+        tag: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64", "windows-arm64" ]
+        include:
+          # Linux builds
+          - &linux-base
+            os: linux
+            zip: .tar.gz
+            ext: ""
+          - <<: *linux-base
+            tag: linux-amd64
+            arch: amd64
+          - <<: *linux-base
+            tag: linux-arm64
+            arch: arm64
+
+          # macOS builds
+          - &mac-base
+            os: darwin
+            zip: .zip
+            ext: ""
+          - <<: *mac-base
+            tag: mac-amd64
+            arch: amd64
+          - <<: *mac-base
+            tag: mac-arm64
+            arch: arm64
+
+          # Windows builds
+          - &windows-base
+            os: windows
+            zip: .zip
+            ext: .exe
+          - <<: *windows-base
+            tag: windows-amd64
+            arch: amd64
+          - <<: *windows-base
+            tag: windows-arm64
+            arch: arm64
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - name: Set up Environment Variables
-        run: |
-          # Split os-arch into os and arch
-          IFS="-" read -r GOOS GOARCH <<< "${{ matrix.os_arch }}"
-          # Export variables to GITHUB_ENV for subsequent steps
-          {
-            echo "GOOS=$GOOS"
-            echo "GOARCH=$GOARCH"
-          } >> $GITHUB_ENV
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
 
-      # Cache Go modules
-      - name: Cache Go Modules
-        uses: actions/cache@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          fetch-depth: 0
 
       # Install dependencies
       - name: Install Dependencies
@@ -63,34 +78,51 @@ jobs:
 
       - name: Build
         run: |
-          GOOS="${GOOS}" GOARCH="${GOARCH}" make build-cli
-          SHA=$(shasum -a 256 bin/flightctl | awk '{ print $1 }')
-          echo "${SHA}" > "flightctl-${{ matrix.os_arch }}-sha256.txt"
-          mv bin/flightctl "flightctl-${{ matrix.os_arch }}"
-          tar cvf "flightctl-${{ matrix.os_arch }}.tar.gz" "flightctl-${{ matrix.os_arch }}"
+          GOOS="${{ matrix.os }}" GOARCH="${{ matrix.arch }}" make build-cli
+          mv "bin/flightctl${{ matrix.ext }}" "flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}"
+          SHA=$(shasum -a 256 flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }} | cut -d' ' -f1)
+          echo ${SHA} > flightctl-${{ matrix.os }}-${{ matrix.arch}}-sha256.txt
+          if [ "${{ matrix.zip }}" = ".zip" ]; then
+            zip flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.zip }} flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}
+          else
+            tar cvf flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.zip }} flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}
+          fi
 
-      - name: Save tar binary
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save zip
         uses: actions/upload-artifact@v4
         with:
-          name: flightctl-${{ matrix.os_arch }}.tar.gz
-          path: flightctl-${{ matrix.os_arch }}.tar.gz
+          name: flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.zip }}
+          path: flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.zip }}
 
       - name: Save binary
         uses: actions/upload-artifact@v4
         with:
-          name: flightctl-${{ matrix.os_arch }}
-          path: flightctl-${{ matrix.os_arch }}
+          name: flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}
+          path: flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}
 
       - name: Save checksum
         uses: actions/upload-artifact@v4
         with:
-          name: flightctl-${{ matrix.os_arch }}-sha256.txt
-          path: flightctl-${{ matrix.os_arch }}-sha256.txt
+          path: flightctl-${{ matrix.os }}-${{ matrix.arch}}-sha256.txt
+          name: flightctl-${{ matrix.os }}-${{ matrix.arch}}-sha256.txt
+
+  verify-windows:
+    name: Verify Binaries on windows
+    strategy:
+      matrix:
+        arch: [ "amd64", "arm64" ]
+    runs-on: "windows-latest"
+    needs: build
+    steps:
+      - name: Load binary
+        uses: actions/download-artifact@v4
+        with:
+          name: flightctl-windows-${{ matrix.arch }}.exe
+      - name: Verify
+        run: .\flightctl-windows-${{ matrix.arch }}.exe version
 
   verify:
-    name: Verify Binaries
+    name: Verify Binaries on linux/macos
     strategy:
       matrix:
         os_arch: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64" ]

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/util"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/version"
@@ -232,7 +233,7 @@ func createAgents(log *logrus.Logger, numDevices int, initialDeviceIndex int, ag
 		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent.DefaultConfigDir
 		cfg.DataDir = agent.DefaultConfigDir
-		cfg.EnrollmentService = agent.EnrollmentService{}
+		cfg.EnrollmentService = config.EnrollmentService{}
 		cfg.EnrollmentService.Config = *client.NewDefault()
 		cfg.EnrollmentService.Config.Service = client.Service{
 			Server:               agentConfigTemplate.EnrollmentService.Config.Service.Server,
@@ -248,7 +249,7 @@ func createAgents(log *logrus.Logger, numDevices int, initialDeviceIndex int, ag
 		cfg.LogPrefix = agentName
 
 		// create managementService config
-		cfg.ManagementService = agent.ManagementService{}
+		cfg.ManagementService = config.ManagementService{}
 		cfg.ManagementService.Config = *client.NewDefault()
 		cfg.ManagementService.Service = client.Service{
 			Server:               agentConfigTemplate.ManagementService.Config.Service.Server,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/status"
 	"github.com/flightctl/flightctl/internal/agent/device/systemd"
 	"github.com/flightctl/flightctl/internal/agent/shutdown"
+	baseconfig "github.com/flightctl/flightctl/internal/config"
 	fcrypto "github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -281,7 +282,7 @@ func newEnrollmentClient(cfg *Config) (client.Enrollment, error) {
 	return client.NewEnrollment(httpClient), nil
 }
 
-func newGrpcClient(cfg *ManagementService) (grpc_v1.RouterServiceClient, error) {
+func newGrpcClient(cfg *baseconfig.ManagementService) (grpc_v1.RouterServiceClient, error) {
 	client, err := client.NewGRPCClientFromConfig(&cfg.Config)
 	if err != nil {
 		return nil, fmt.Errorf("creating gRPC client: %w", err)

--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -32,14 +32,6 @@ func NewGRPCClientFromConfig(config *baseclient.Config) (grpc_v1.RouterServiceCl
 	return baseclient.NewGRPCClientFromConfig(config, "")
 }
 
-type Config = baseclient.Config
-type AuthInfo = baseclient.AuthInfo
-type Service = baseclient.Service
-
-func NewDefault() *Config {
-	return baseclient.NewDefault()
-}
-
 // Management is the client interface for managing devices.
 type Management interface {
 	UpdateDeviceStatus(ctx context.Context, name string, device v1alpha1.Device, rcb ...client.RequestEditorFn) error

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	baseclient "github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
@@ -48,15 +49,12 @@ const (
 )
 
 type Config struct {
+	config.ServiceConfig
+
 	// ConfigDir is the directory where the device's configuration is stored
 	ConfigDir string `json:"-"`
 	// DataDir is the directory where the device's data is stored
 	DataDir string `json:"-"`
-
-	// EnrollmentService is the client configuration for connecting to the device enrollment server
-	EnrollmentService EnrollmentService `json:"enrollment-service,omitempty"`
-	// ManagementService is the client configuration for connecting to the device management server
-	ManagementService ManagementService `json:"management-service,omitempty"`
 
 	// SpecFetchInterval is the interval between two reads of the remote device spec
 	SpecFetchInterval util.Duration `json:"spec-fetch-interval,omitempty"`
@@ -83,42 +81,16 @@ type Config struct {
 	readWriter fileio.ReadWriter
 }
 
-type EnrollmentService struct {
-	client.Config
-
-	// EnrollmentUIEndpoint is the address of the device enrollment UI
-	EnrollmentUIEndpoint string `json:"enrollment-ui-endpoint,omitempty"`
-}
-
-type ManagementService struct {
-	client.Config
-}
-
-func (s *EnrollmentService) Equal(s2 *EnrollmentService) bool {
-	if s == s2 {
-		return true
-	}
-	return s.Config.Equal(&s2.Config) && s.EnrollmentUIEndpoint == s2.EnrollmentUIEndpoint
-}
-
-func (s *ManagementService) Equal(s2 *ManagementService) bool {
-	if s == s2 {
-		return true
-	}
-	return s.Config.Equal(&s2.Config)
-}
-
 func NewDefault() *Config {
 	c := &Config{
 		ConfigDir:            DefaultConfigDir,
 		DataDir:              DefaultDataDir,
-		EnrollmentService:    EnrollmentService{Config: *client.NewDefault()},
-		ManagementService:    ManagementService{Config: *client.NewDefault()},
 		StatusUpdateInterval: DefaultStatusUpdateInterval,
 		SpecFetchInterval:    DefaultSpecFetchInterval,
 		readWriter:           fileio.NewReadWriter(),
 		LogLevel:             logrus.InfoLevel.String(),
 		DefaultLabels:        make(map[string]string),
+		ServiceConfig:        config.NewServiceConfig(),
 	}
 
 	if value := os.Getenv(TestRootDirEnvKey); value != "" {
@@ -149,14 +121,14 @@ func (cfg *Config) SetEnrollmentMetricsCallback(cb func(operation string, duract
 // Complete fills in defaults for fields not set by the config file
 func (cfg *Config) Complete() error {
 	// If the enrollment service hasn't been specified, attempt using the default local dev env.
-	emptyEnrollmentService := EnrollmentService{}
+	emptyEnrollmentService := config.EnrollmentService{}
 	if cfg.EnrollmentService.Equal(&emptyEnrollmentService) {
-		cfg.EnrollmentService = EnrollmentService{Config: *client.NewDefault()}
-		cfg.EnrollmentService.Service = client.Service{
+		cfg.EnrollmentService = config.EnrollmentService{Config: *baseclient.NewDefault()}
+		cfg.EnrollmentService.Service = baseclient.Service{
 			Server:               DefaultManagementEndpoint,
 			CertificateAuthority: filepath.Join(cfg.ConfigDir, DefaultCertsDirName, CacertFile),
 		}
-		cfg.EnrollmentService.AuthInfo = client.AuthInfo{
+		cfg.EnrollmentService.AuthInfo = baseclient.AuthInfo{
 			ClientCertificate: filepath.Join(cfg.DataDir, DefaultCertsDirName, EnrollmentCertFile),
 			ClientKey:         filepath.Join(cfg.DataDir, DefaultCertsDirName, EnrollmentKeyFile),
 		}
@@ -168,10 +140,10 @@ func (cfg *Config) Complete() error {
 	}
 	// If the management service hasn't been specified, attempt using the same endpoint as the enrollment service,
 	// but clear the auth info.
-	emptyManagementService := ManagementService{}
+	emptyManagementService := config.ManagementService{}
 	if cfg.ManagementService.Equal(&emptyManagementService) {
 		cfg.ManagementService.Config = *cfg.EnrollmentService.Config.DeepCopy()
-		cfg.ManagementService.Config.AuthInfo = client.AuthInfo{}
+		cfg.ManagementService.Config.AuthInfo = baseclient.AuthInfo{}
 	}
 	return nil
 }

--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	"github.com/flightctl/flightctl/internal/agent/device/spec"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
+	baseclient "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/version"
@@ -32,7 +33,7 @@ type Bootstrap struct {
 	lifecycle        lifecycle.Initializer
 	systemClient     client.System
 
-	managementServiceConfig *client.Config
+	managementServiceConfig *baseclient.Config
 	managementClient        client.Management
 
 	log *log.PrefixLogger
@@ -46,7 +47,7 @@ func NewBootstrap(
 	statusManager status.Manager,
 	hookManager hook.Manager,
 	lifecycleInitializer lifecycle.Initializer,
-	managementServiceConfig *client.Config,
+	managementServiceConfig *baseclient.Config,
 	systemClient client.System,
 	log *log.PrefixLogger,
 ) *Bootstrap {

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	"github.com/flightctl/flightctl/internal/agent/device/spec"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
+	baseclient "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/stretchr/testify/require"
@@ -148,7 +149,7 @@ func TestInitialization(t *testing.T) {
 				hookManager:             mockHookManager,
 				lifecycle:               mockLifecycleInitializer,
 				deviceReadWriter:        mockReadWriter,
-				managementServiceConfig: &client.Config{},
+				managementServiceConfig: &baseclient.Config{},
 				systemClient:            mockSystemClient,
 				log:                     log.NewPrefixLogger("test"),
 			}

--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/ccoveille/go-safecast"
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/agent"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/internal/config"
 	fccrypto "github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -351,7 +352,7 @@ func createEmbeddedConfig(currentCsr *api.CertificateSigningRequest, priv crypto
 		return fmt.Errorf("base64 decoding CA data: %w", err)
 	}
 
-	config := &agent.Config{}
+	config := lo.ToPtr(config.NewServiceConfig())
 	config.EnrollmentService.AuthInfo.ClientCertificateData = *currentCsr.Status.Certificate
 	config.EnrollmentService.AuthInfo.ClientKeyData = pemPriv
 	config.EnrollmentService.Service.Server = response.JSON200.EnrollmentService.Service.Server
@@ -359,7 +360,7 @@ func createEmbeddedConfig(currentCsr *api.CertificateSigningRequest, priv crypto
 	config.EnrollmentService.EnrollmentUIEndpoint = response.JSON200.EnrollmentService.EnrollmentUiEndpoint
 	marshalled, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("marshalling agent config: %w", err)
+		return fmt.Errorf("marshalling agent service config: %w", err)
 	}
 
 	fmt.Print(string(marshalled))
@@ -367,7 +368,7 @@ func createEmbeddedConfig(currentCsr *api.CertificateSigningRequest, priv crypto
 }
 
 func createReferenceConfig(name string, response *apiclient.GetEnrollmentConfigResponse) error {
-	config := &agent.Config{}
+	config := lo.ToPtr(config.NewServiceConfig())
 	config.EnrollmentService.AuthInfo.ClientCertificate = filepath.Join(agentPath, name+".crt")
 	config.EnrollmentService.AuthInfo.ClientKey = filepath.Join(agentPath, name+".key")
 	config.EnrollmentService.Service.Server = response.JSON200.EnrollmentService.Service.Server
@@ -375,7 +376,7 @@ func createReferenceConfig(name string, response *apiclient.GetEnrollmentConfigR
 	config.EnrollmentService.EnrollmentUIEndpoint = response.JSON200.EnrollmentService.EnrollmentUiEndpoint
 	marshalled, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("marshalling agent config: %w", err)
+		return fmt.Errorf("marshalling agent service config: %w", err)
 	}
 
 	fmt.Print(string(marshalled))

--- a/internal/config/common.go
+++ b/internal/config/common.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"github.com/flightctl/flightctl/internal/client"
+)
+
+type ServiceConfig struct {
+	// EnrollmentService is the client configuration for connecting to the device enrollment server
+	EnrollmentService EnrollmentService `json:"enrollment-service,omitempty"`
+	// ManagementService is the client configuration for connecting to the device management server
+	ManagementService ManagementService `json:"management-service,omitempty"`
+}
+
+type EnrollmentService struct {
+	client.Config
+
+	// EnrollmentUIEndpoint is the address of the device enrollment UI
+	EnrollmentUIEndpoint string `json:"enrollment-ui-endpoint,omitempty"`
+}
+
+type ManagementService struct {
+	client.Config
+}
+
+func NewServiceConfig() ServiceConfig {
+	return ServiceConfig{
+		EnrollmentService: EnrollmentService{Config: *client.NewDefault()},
+		ManagementService: ManagementService{Config: *client.NewDefault()},
+	}
+}
+
+func (s *EnrollmentService) Equal(s2 *EnrollmentService) bool {
+	if s == s2 {
+		return true
+	}
+	return s.Config.Equal(&s2.Config) && s.EnrollmentUIEndpoint == s2.EnrollmentUIEndpoint
+}
+
+func (s *ManagementService) Equal(s2 *ManagementService) bool {
+	if s == s2 {
+		return true
+	}
+	return s.Config.Equal(&s2.Config)
+}

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -144,7 +144,7 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 	cfg := agent.NewDefault()
 	// TODO: remove the cert/key modifications from default, and start storing
 	// the test harness files for those in the testDir/etc/flightctl/certs path
-	cfg.EnrollmentService = agent.EnrollmentService{
+	cfg.EnrollmentService = config.EnrollmentService{
 		Config:               *client.NewDefault(),
 		EnrollmentUIEndpoint: "https://flightctl.ui/",
 	}


### PR DESCRIPTION
* "windows-amd64" and "windows-arm64" were added to a list of published artefacts + their verification.
* hack/build_multiarch_clis.sh script was streamlined
* CLI uses agent.Config{} in createEmbeddedConfig and createReferenceConfig functions. As a result the whole `agent` package was included with all linux-only stuff. That's why agent.Config (and a couple of related structs) was moved outside of agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded CLI binary builds to support Windows alongside Linux and macOS.
  - Updated automated workflows and build processes to generate, package, and verify multi-platform binaries with improved naming consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->