### PR TITLE
Update CLI version command to use context and print version field names

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -74,6 +74,9 @@ func (o *VersionOptions) Bind(fs *pflag.FlagSet) {
 }
 
 func (o *VersionOptions) Complete(cmd *cobra.Command, args []string) error {
+	if err := o.GlobalOptions.Complete(cmd, args); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/transport/version.go
+++ b/internal/transport/version.go
@@ -11,7 +11,7 @@ import (
 func (h *TransportHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
 	versionInfo := version.Get()
 	v := api.Version{
-		Version: versionInfo.GitVersion,
+		Version: versionInfo.String(),
 	}
 	SetResponse(w, v, api.StatusOK())
 }


### PR DESCRIPTION
- **New Feature**
	- Enabled the `--context/-c` flag to work with the version command, too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the version display to clearly separate client and server details, ensuring the server version is shown only when available.

- **Bug Fixes**
	- Enhanced error messaging to provide clearer feedback when issues occur while retrieving version information.
	- Improved error handling for server connectivity issues, ensuring messages are printed to standard error without treating them as critical errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->