### PR TITLE
EDM-1208: fix e2e cli tests in ocp and adjust timeout

### DIFF
--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -93,7 +93,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 						}
 					}
 					return false
-				}, "2m")
+				}, "4m")
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -51,7 +51,7 @@ var _ = Describe("cli operation", func() {
 		out, err := harness.CLI(loginArgs...)
 
 		// if openshift authentication is required, try to obtain a token
-		if strings.Contains(out, "You must obtain an API token by visiting") {
+		if strings.Contains(out, "You must provide one of the following options to log in") {
 			token, err = harness.SH("oc", "whoami", "-t")
 			token = strings.Trim(token, "\n")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -28,7 +28,7 @@ import (
 
 const POLLING = "250ms"
 const TIMEOUT = "60s"
-const LONGTIMEOUT = "2m"
+const LONGTIMEOUT = "3m"
 
 type Harness struct {
 	VM        vm.TestVMInterface

--- a/test/login/login.go
+++ b/test/login/login.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"encoding/base64"
 	"strings"
 
 	"github.com/flightctl/flightctl/test/harness/e2e"
@@ -17,7 +18,7 @@ func LoginToAPIWithToken(harness *e2e.Harness) {
 	}
 	// login
 	out, err := harness.CLI(loginArgs...)
-	if strings.Contains(out, "You must obtain an API token by visiting") {
+	if strings.Contains(out, "You must provide one of the following options to log in") {
 		token, err = harness.SH("oc", "whoami", "-t")
 		token = strings.TrimSpace(token)
 		// Validate Token Retrieval
@@ -25,10 +26,28 @@ func LoginToAPIWithToken(harness *e2e.Harness) {
 		Expect(token).ToNot(BeEmpty(), "Token from 'oc whoami' should not be empty")
 
 		// Retry login with the retrieved token
-		loginArgs = append(loginArgs, "--token", token)
+		loginArgsOcp := append(loginArgs, "--token", token)
+		out, err = harness.CLI(loginArgsOcp...)
+	}
+	// Case standalone
+	if strings.Contains(out, "the token provided is invalid or expired") || strings.Contains(out, "invalid JWT") {
+		password, e := harness.SH("oc", "get", "secret/keycloak-demouser-secret", "-n", "flightctl", "-o=jsonpath='{.data.password}'")
+		Expect(e).ToNot(HaveOccurred(), "Failed to retrieve password")
+		Expect(password).ToNot(BeEmpty(), "Password of demouser should not be empty")
+
+		// Decode password from base64
+		password = strings.ReplaceAll(password, "'", "")
+		decodedBytes, e := base64.StdEncoding.DecodeString(password)
+		Expect(e).ToNot(HaveOccurred(), "Failed to convert password")
+
+		// Convert the decoded bytes to a string
+		password = string(decodedBytes)
+
+		// Retry login with the retrieved password
+		loginArgs = append(loginArgs, "-k", "-u", "demouser", "-p", password)
 		out, err = harness.CLI(loginArgs...)
 	}
 	// Validate Login
 	Expect(err).ToNot(HaveOccurred())
-	Expect(strings.TrimSpace(out)).To(BeElementOf("Auth is disabled", "Login successful"))
+	Expect(strings.TrimSpace(out)).To(BeElementOf("Auth is disabled", "Login successful", "Login successful."))
 }


### PR DESCRIPTION
Cli tests are currently failing in ocp since some hardcoded output were modified. 
I am also adjusting the timeout of some tests, since they require more time when running in ocp.
Finally, adding standalone login to cli case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Extended wait times for update verification to improve overall test stability.
  - Refined authentication checks with enhanced fallback handling for login attempts, ensuring a more robust login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->