### PR TITLE
EDM-1213: Replace e2eregistry docker image with flightctl quay.io copy

### DIFF
--- a/deploy/helm/e2e-extras/values.dev.yaml
+++ b/deploy/helm/e2e-extras/values.dev.yaml
@@ -4,7 +4,7 @@ global:
     gitserver: 3222
     prometheus: 9090
 registry:
-  image: docker.io/library/registry:2
+  image: quay.io/flightctl/e2eregistry:2
   route: false
   hostName: ""
 gitserver:

--- a/deploy/helm/e2e-extras/values.yaml
+++ b/deploy/helm/e2e-extras/values.yaml
@@ -4,7 +4,7 @@ global:
     gitserver: ""
     prometheus: ""
 registry:
-  image: docker.io/library/registry:2
+  image: quay.io/flightctl/e2eregistry:2
   route: true
   hostName: ""
 gitserver:

--- a/test/scripts/deploy_e2e_extras_with_helm.sh
+++ b/test/scripts/deploy_e2e_extras_with_helm.sh
@@ -11,7 +11,7 @@ if in_kind; then
     ARGS="--values ./deploy/helm/e2e-extras/values.dev.yaml"
     # in github CI load docker-image does not seem to work for our images
     kind_load_image localhost/git-server:latest
-    kind_load_image docker.io/library/registry:2
+    kind_load_image quay.io/flightctl/e2eregistry:2
 fi
 
 REPOADDR=$(registry_address)


### PR DESCRIPTION
Replacing e2eregistry docker image with flightctl quay.io copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the registry container image to pull from a new provider, ensuring future deployments reference the correct image source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->