### PR TITLE
EDM-1213: Use alpine from quay.io

### DIFF
--- a/test/scripts/agent-images/test-podman-compose-sleep-work-v2.yaml
+++ b/test/scripts/agent-images/test-podman-compose-sleep-work-v2.yaml
@@ -1,6 +1,6 @@
 services:
   service1:
-    image: alpine
+    image: quay.io/flightctl-tests/alpine:v1
     environment:
       - FFO=$FFO
       - SIMPLE=$SIMPLE

--- a/test/scripts/agent-images/test-podman-compose-sleep-work.yaml
+++ b/test/scripts/agent-images/test-podman-compose-sleep-work.yaml
@@ -3,11 +3,11 @@ version: '3'
 
 services:
   service1:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]
   service2:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]
   service3:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]

--- a/test/scripts/agent-images/test-podman-compose-sleep.yaml
+++ b/test/scripts/agent-images/test-podman-compose-sleep.yaml
@@ -2,13 +2,13 @@ version: '3'
 
 services:
   service1:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]
 
   service2:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]
 
   service3:
-    image: alpine
+    image:  quay.io/flightctl-tests/alpine:v1
     command: ["sleep", "infinity"]


### PR DESCRIPTION
Replacing Alpine docker base application e2e test image with a clone from quay.io: quay.io/flightctl-tests/alpine:v1.

![image](https://github.com/user-attachments/assets/d70ad5ce-ff43-42fe-badb-9197cad534f4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container image references across several service configurations to use a versioned Alpine image from a dedicated registry, ensuring enhanced consistency and stability during deployments. The service commands remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->