### PR TITLE
NO-ISSUE: Fix to disconnected-cluster.md helm command

### DIFF
--- a/docs/user/disconnected-cluster.md
+++ b/docs/user/disconnected-cluster.md
@@ -76,7 +76,7 @@ You need to download the helm chart first, as it is stored in quay.io
 
 ```shell
 #on machine connected to internet
-helm pull oci://quay.io/flightctl/charts/flightctl:${FCTL_VERSION}
+helm pull oci://quay.io/flightctl/charts/flightctl --version ${FCTL_VERSION}
 #copy the downloaded file to disconnected environment
 #on disconnected environment
 helm upgrade --install --namespace flightctl --create-namespace flightctl ./flightctl-${FCTL_VERSION}.tgz


### PR DESCRIPTION
Small fix to correct wrong syntax of helm command line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the user documentation to clarify the helm chart download command. The revised command now explicitly specifies the version via the `--version` flag, ensuring better alignment with standard helm usage and offering clearer instructions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->