### PR TITLE
EDM-464: Bug fix for ER request response

### DIFF
--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -291,7 +291,7 @@ func (h *ServiceHandler) ReadEnrollmentRequestStatus(ctx context.Context, reques
 	}
 }
 
-// (POST /api/v1/enrollmentrequests/{name}/approval)
+// (PUT /api/v1/enrollmentrequests/{name}/approval)
 func (h *ServiceHandler) ApproveEnrollmentRequest(ctx context.Context, request server.ApproveEnrollmentRequestRequestObject) (server.ApproveEnrollmentRequestResponseObject, error) {
 	orgId := store.NullOrgId
 


### PR DESCRIPTION
Bug fix for [EDM-464](https://issues.redhat.com/browse/EDM-464).

The approval status in the 200 response was getting initialized with default values, including `approved:false`. This change passes the updated approval status back in the 200 response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the enrollment approval endpoint to use a PUT request for more precise operation.
  - Enhanced the approval workflow to return detailed status information upon successful processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->