### PR TITLE
EDM-1241: Token fails to be refreshed if no auth ca file is provided

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -205,9 +205,11 @@ func (o *LoginOptions) Run(ctx context.Context, args []string) error {
 	if token == "" {
 		return fmt.Errorf("failed to retrieve auth token")
 	}
-	authCAFile, err = filepath.Abs(o.AuthCAFile)
-	if err != nil && authCAFile != "" {
-		return fmt.Errorf("failed to get the absolute path of %s: %w", o.AuthCAFile, err)
+	if o.AuthCAFile != "" {
+		authCAFile, err = filepath.Abs(o.AuthCAFile)
+		if err != nil {
+			return fmt.Errorf("failed to get the absolute path of %s: %w", o.AuthCAFile, err)
+		}
 	}
 	o.clientConfig.AuthInfo.AuthType = o.authConfig.AuthType
 	o.clientConfig.AuthInfo.AccessToken = token


### PR DESCRIPTION
If the parameter auth CA is missing from command line during CLI login, the current working directory is taken instead.
This fix preserves the value of the AuthCAFile if it is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the login process by ensuring that optional authentication parameters are only validated when provided. This change prevents unnecessary error messages, offering a smoother login experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->