### PR TITLE
EDM-1247: Use plural selectors for labels endpoint

### DIFF
--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -237,7 +237,7 @@ func (s *DeviceStore) List(ctx context.Context, orgId uuid.UUID, listParams List
 func (s *DeviceStore) Labels(ctx context.Context, orgId uuid.UUID, listParams ListParams) (api.LabelList, error) {
 	var labels []model.DeviceLabel
 
-	resolver, err := selector.NewCompositeSelectorResolver(&model.Device{}, &model.DeviceLabel{})
+	resolver, err := selector.NewCompositeSelectorResolver(&model.DeviceLabel{}, &model.Device{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create selector resolver: %w", err)
 	}

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -44,8 +44,8 @@ type Device struct {
 type DeviceLabel struct {
 	OrgID      uuid.UUID `gorm:"primaryKey;type:uuid;index:,composite:device_label_org_device" selector:"metadata.orgid,hidden,private"`
 	DeviceName string    `gorm:"primaryKey;index:,composite:device_label_org_device" selector:"metadata.name"`
-	LabelKey   string    `gorm:"primaryKey;index:,composite:device_label_key" selector:"metadata.label.key"`
-	LabelValue string    `gorm:"index" selector:"metadata.label.value"`
+	LabelKey   string    `gorm:"primaryKey;index:,composite:device_label_key" selector:"metadata.labels.key"`
+	LabelValue string    `gorm:"index" selector:"metadata.labels.value"`
 
 	// Foreign Key Constraint with CASCADE DELETE
 	Device Device `gorm:"foreignKey:OrgID,DeviceName;references:OrgID,Name;constraint:OnDelete:CASCADE"`

--- a/internal/store/model/selectors.go
+++ b/internal/store/model/selectors.go
@@ -70,17 +70,17 @@ func (m *Device) ListSelectors() selector.SelectorNameSet {
 }
 
 func (m *DeviceLabel) MapSelectorName(name selector.SelectorName) []selector.SelectorName {
-	if strings.EqualFold("metadata.label.keyOrValue", name.String()) {
+	if strings.EqualFold("metadata.labels.keyOrValue", name.String()) {
 		return []selector.SelectorName{
-			selector.NewSelectorName("metadata.label.key"),
-			selector.NewSelectorName("metadata.label.value"),
+			selector.NewSelectorName("metadata.labels.key"),
+			selector.NewSelectorName("metadata.labels.value"),
 		}
 	}
 	return nil
 }
 
 func (m *DeviceLabel) ListSelectors() selector.SelectorNameSet {
-	return selector.NewSelectorFieldNameSet().Add(selector.NewSelectorName("metadata.label.keyOrValue"))
+	return selector.NewSelectorFieldNameSet().Add(selector.NewSelectorName("metadata.labels.keyOrValue"))
 }
 
 func (m *Fleet) ResolveSelector(name selector.SelectorName) (*selector.SelectorField, error) {


### PR DESCRIPTION
The new selectors for the labels endpoint were using singular terms:
- `metadata.label.key`
- `metadata.label.value`
- `metadata.label.keyOrValue`

Updated them to use the correct plural form:
- `metadata.labels.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced metadata labeling consistency to ensure accurate display and querying of label data.
  - Optimized the processing sequence for device-label relationships to improve overall label configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->