### PR TITLE
EDM-1138: Upgrade go to RH-supported (and FIPS-compatible) version

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.9'
+          go-version: '1.22'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22.9'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/workflows/ppa-build.yaml
+++ b/.github/workflows/ppa-build.yaml
@@ -14,7 +14,6 @@ jobs:
       - name: Dummy
         run: echo "Success"
 
-# jobs:
 #   build_and_upload:
 #     runs-on: "ubuntu-24.04"
 #     steps:

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22.9
 
       # Cache Go modules
       - name: Cache Go Modules

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.9
+          go-version: 1.22
 
       # Cache Go modules
       - name: Cache Go Modules

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -17,7 +17,7 @@ COPY ./Makefile .
 USER 0
 RUN git config --global --add safe.directory /app
 RUN make build-api
-    
+
 FROM registry.access.redhat.com/ubi9/ubi as certs
 RUN dnf update --nodocs -y  && dnf install ca-certificates tzdata --nodocs -y
 

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as builder
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -69,7 +69,6 @@ func (r DeviceSpec) Validate(fleetTemplate bool) []error {
 	}
 	if r.Systemd != nil {
 		for i, matchPattern := range *r.Systemd.MatchPatterns {
-			matchPattern := matchPattern
 			allErrs = append(allErrs, validation.ValidateString(&matchPattern, fmt.Sprintf("spec.systemd.matchPatterns[%d]", i), 1, 256, nil, "")...)
 		}
 	}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -7,7 +7,7 @@ Flight Control is a service for declarative, GitOps-driven management of edge de
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.21), `openssl`, `openssl-devel`, `podman-compose` and `go-rpm-macros` (in case one need to build RPM's)
+* `git`, `make`, and `go` (>= 1.22), `openssl`, `openssl-devel`, `podman-compose` and `go-rpm-macros` (in case one need to build RPM's)
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flightctl/flightctl
 
-go 1.22.9
+go 1.22
 
 require (
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flightctl/flightctl
 
-go 1.21
+go 1.22.9
 
 require (
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -129,7 +129,6 @@ func TestInitialization(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -255,7 +254,6 @@ func TestBootstrapCheckRollback(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -331,7 +329,6 @@ func TestEnsureBootedOS(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -121,7 +121,6 @@ func TestSync(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// mocks
 			ctrl := gomock.NewController(t)

--- a/internal/agent/device/hook/manager.go
+++ b/internal/agent/device/hook/manager.go
@@ -146,7 +146,6 @@ func (m *manager) executeActions(ctx context.Context, actions []api.HookAction, 
 		if action.If != nil {
 			conditionsMet := true
 			for j, condition := range *action.If {
-				condition := condition
 				conditionMet, err := checkCondition(&condition, actionCtx)
 				if err != nil {
 					return fmt.Errorf("failed to check %s hook action #%d condition #%d: %w", actionCtx.hook, i+1, j+1, err)

--- a/internal/agent/device/resource/common_test.go
+++ b/internal/agent/device/resource/common_test.go
@@ -61,7 +61,6 @@ func TestUpdateMonitor(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log := log.NewPrefixLogger("test")
 			updateIntervalCh := make(chan time.Duration, 1)

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -380,7 +380,6 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -862,7 +861,6 @@ func TestGetDesired(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl.Finish()
 			ctrl := gomock.NewController(t)

--- a/internal/tasks/device_disconnected.go
+++ b/internal/tasks/device_disconnected.go
@@ -47,7 +47,6 @@ func (t *DeviceDisconnected) Poll() {
 
 		var batch []string
 		for _, device := range devices.Items {
-			device := device
 			changed := t.serviceHandler.UpdateServiceSideDeviceStatus(ctx, device)
 			if changed {
 				batch = append(batch, *device.Metadata.Name)

--- a/internal/util/validation/formats_test.go
+++ b/internal/util/validation/formats_test.go
@@ -17,7 +17,6 @@ func TestValidateGenericName(t *testing.T) {
 		strings.Repeat("a", 63),
 	}
 	for _, val := range goodValues {
-		val := val
 		assert.Empty(ValidateGenericName(&val, "good.name"))
 	}
 
@@ -30,7 +29,6 @@ func TestValidateGenericName(t *testing.T) {
 		strings.Repeat("long", 16),
 	}
 	for _, val := range badValues {
-		val := val
 		assert.NotEmpty(ValidateGenericName(&val, "bad.name"), fmt.Sprintf("value: %q", val))
 	}
 }
@@ -52,7 +50,6 @@ func TestValidateOciImageReference(t *testing.T) {
 		"image:" + strings.Repeat("a", 128),
 	}
 	for _, val := range goodValues {
-		val := val
 		assert.Empty(ValidateOciImageReference(&val, "good.image.ref"))
 	}
 
@@ -63,7 +60,6 @@ func TestValidateOciImageReference(t *testing.T) {
 		"image:" + strings.Repeat("a", 129),
 	}
 	for _, val := range badValues {
-		val := val
 		assert.NotEmpty(ValidateOciImageReference(&val, "bad.image.ref"), fmt.Sprintf("value: %q", val))
 	}
 }
@@ -80,7 +76,6 @@ func TestValidateGitRevision(t *testing.T) {
 		strings.Repeat("a", 244),
 	}
 	for _, val := range goodValues {
-		val := val
 		assert.Empty(ValidateGitRevision(&val, "good.image.ref"))
 	}
 
@@ -90,7 +85,6 @@ func TestValidateGitRevision(t *testing.T) {
 		strings.Repeat("a", 245),
 	}
 	for _, val := range badValues {
-		val := val
 		assert.NotEmpty(ValidateGitRevision(&val, "bad.image.ref"), fmt.Sprintf("value: %q", val))
 	}
 }

--- a/pkg/executer/executer_linux.go
+++ b/pkg/executer/executer_linux.go
@@ -22,7 +22,7 @@ func (e *CommonExecuter) execute(ctx context.Context, cmd *exec.Cmd) (stdout str
 	cmd.Stderr = &stderrBytes
 	// Set Pdeathsig to SIGTERM to kill the process and its children when the parent process is killed.
 	// This should prevent orphaned processes and allow for the subprocess to gracefully terminate.
-	// ref. https://github.com/golang/go/blob/release-branch.go1.21/src/syscall/exec_linux.go#L91
+	// ref. https://github.com/golang/go/blob/release-branch.go1.22/src/syscall/exec_linux.go#L91
 	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM}
 
 	if err := cmd.Run(); err != nil {

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -143,7 +143,6 @@ var _ = Describe("Device Agent behavior", func() {
 				waitForFile("/etc/testdir/encoded", *dev.Metadata.Name, h.TestDirPath, lo.ToPtr("This text is encoded."), lo.ToPtr(0o1775))
 
 				for key, value := range secrets {
-					value := value
 					fname := filepath.Join("/etc/secret/secretMountPath", key)
 					waitForFile(fname, *dev.Metadata.Name, h.TestDirPath, &value, lo.ToPtr(0644))
 				}

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -165,7 +165,6 @@ var _ = Describe("FleetSelector", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(fleets.Items)).To(Equal(3))
 			for _, fleet := range fleets.Items {
-				fleet := fleet
 				fleet.Status.Conditions = []api.Condition{}
 				cond := api.SetStatusCondition(&fleet.Status.Conditions, condition)
 				Expect(cond).To(BeTrue())

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/flightctl/flightctl/tools
 
-go 1.21
+go 1.22.9
 
 require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/flightctl/flightctl/tools
 
-go 1.22.9
+go 1.22
 
 require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0


### PR DESCRIPTION
Right now it's 1.22.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the build environment, continuous integration workflows, and container configurations to Go 1.22 to enhance consistency and performance.
- **Documentation**
  - Updated developer guidelines to reflect the new Go version requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->