### PR TITLE
EDM-1214: Perform better validation of CSR and enrollment requests

### DIFF
--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -281,9 +282,14 @@ func createCsr(o *CertificateOptions, name string, priv crypto.PrivateKey) ([]by
 		return nil, err
 	}
 
-	// the CN is going to be a FC-generated UUID, populated at signing time
+	if name == "" {
+		name = uuid.NewString()
+	}
 	template := &x509.CertificateRequest{
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		Subject: pkix.Name{
+			CommonName: name,
+		},
 	}
 
 	csrInner, err := x509.CreateCertificateRequest(rand.Reader, template, priv)

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	oscrypto "github.com/openshift/library-go/pkg/crypto"
@@ -22,13 +23,27 @@ const ClientBootstrapCommonNamePrefix = "client-enrollment-"
 const AdminCommonName = "flightctl-admin"
 const DeviceCommonNamePrefix = "device:"
 
+var allowedPrefixes = [...]string{
+	DeviceCommonNamePrefix,
+	ClientBootstrapCommonNamePrefix,
+}
+
 func BootstrapCNFromName(name string) string {
+
+	for _, prefix := range allowedPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return name
+		}
+	}
 	return ClientBootstrapCommonNamePrefix + name
 }
 
 func CNFromDeviceFingerprint(fingerprint string) (string, error) {
 	if len(fingerprint) < 16 {
 		return "", errors.New("device fingerprint must have 16 characters at least")
+	}
+	if strings.HasPrefix(fingerprint, DeviceCommonNamePrefix) {
+		return fingerprint, nil
 	}
 	return DeviceCommonNamePrefix + fingerprint, nil
 }


### PR DESCRIPTION
1. Add comparisons between ASN.1 and JSON CSR metadata
2. Add checks between mTLS identity and requested CSR identity to allow the use of the CSR interface for renewals
3. Make adding prefixes one-off and allow for prefixes in CN comparisons
4. This should allow the use of CSR interface for renewals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation checks during certificate signing requests to ensure proper handling of Common Names (CN), preventing identity mismatches and unauthorized certificate renewals.
  - Improved error handling to provide clearer feedback on CN discrepancies.
  - Strengthened validation in enrollment requests to ensure only valid and expected CNs are processed, reducing the risk of identity theft.
  - Added checks for specific prefixes in names and fingerprints to streamline processing.
  - Introduced a new method to validate Certificate Signing Request (CSR) parameters, enhancing error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->