### PR TITLE
EDM-1044: Add part 1 of hooks e2e tests and small disconnected adaptations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vscode/
 /.idea/
 /reports/
+/test/scripts/agent-images/Containerfile-e2e-base.local
 /packaging/rpm/flightctl-*.tar.gz
 /packaging/rpm/flightctl-*-build/
 /packaging/rpm/flightctl-*-vendor.tar.bz2

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -3,10 +3,10 @@ package cli_test
 import (
 	"crypto/rand"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
 	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,33 +36,11 @@ func TestCLI(t *testing.T) {
 var _ = Describe("cli operation", func() {
 	var (
 		harness *e2e.Harness
-		token   string
 	)
 
 	BeforeEach(func() {
 		harness = e2e.NewTestHarness()
-
-		// construct the flightctl login arguments
-		loginArgs := []string{"login", "${API_ENDPOINT}", "--insecure-skip-tls-verify"}
-		if token != "" {
-			loginArgs = append(loginArgs, "--token", token)
-		}
-		// attempt login
-		out, err := harness.CLI(loginArgs...)
-
-		// if openshift authentication is required, try to obtain a token
-		if strings.Contains(out, "You must provide one of the following options to log in") {
-			token, err = harness.SH("oc", "whoami", "-t")
-			token = strings.Trim(token, "\n")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(token).ToNot(BeEmpty(), "token from oc whoami should not be empty")
-			loginArgs = append(loginArgs, "--token", token)
-			out, err = harness.CLI(loginArgs...)
-
-		}
-		Expect(err).ToNot(HaveOccurred())
-		out = strings.Trim(out, "\n.")
-		Expect(out).To(BeElementOf("Auth is disabled", "Login successful"))
+		login.LoginToAPIWithToken(harness)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/hooks/hooks_suite_test.go
+++ b/test/e2e/hooks/hooks_suite_test.go
@@ -1,0 +1,13 @@
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHooks(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hooks E2E Suite")
+}

--- a/test/e2e/hooks/hooks_test.go
+++ b/test/e2e/hooks/hooks_test.go
@@ -1,0 +1,297 @@
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Device lifecycles and embedded hooks tests", func() {
+	var (
+		harness  *e2e.Harness
+		deviceId string
+	)
+
+	BeforeEach(func() {
+		harness = e2e.NewTestHarness()
+		deviceId = harness.StartVMAndEnroll()
+	})
+
+	AfterEach(func() {
+		harness.Cleanup(true)
+		err := harness.CleanUpAllResources()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("hooks", func() {
+		It(`Verifies that lifecycles hooks are triggered after the device and agent events`, Label("78753"), func() {
+
+			By("Update the device image to one containing an embedded hook")
+			_, err := harness.CheckDeviceStatus(deviceId, v1alpha1.DeviceSummaryStatusOnline)
+			Expect(err).ToNot(HaveOccurred())
+
+			nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceImage := fmt.Sprintf("%s/flightctl-device:v6", harness.RegistryEndpoint())
+
+			var osImageSpec = v1alpha1.DeviceOsSpec{
+				Image: deviceImage,
+			}
+
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+				device.Spec.Os = &osImageSpec
+
+				logrus.Infof("Updating %s with Os image", osImageSpec)
+			})
+
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Add an inline configuration for sshd")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			inlineConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+			err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValid)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpecConfig := []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			stdout, err := harness.VM.RunSSH([]string{"sudo", "cat", inlinePath}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring(sshdConfigurationContent))
+			logrus.Infof("the configuration %s was found in the device", inlineConfigName)
+
+			By("Check that the embedded sshd hook is triggered and sshd config reloaded trying to login with user and password")
+			_, err = harness.VM.RunSSHWithUser([]string{"pwd"}, nil, rootUser)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(tooManyAuthFailuresError))
+
+			By("Update the sshd config")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValid2)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that the embedded sshd hook is triggered and sshd config reloaded by trying to ssh with any user")
+			_, err = harness.VM.RunSSH([]string{"pwd"}, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(noPasswordLoginError))
+
+			By("Verify that an embedded hook precedes an inline config hook with the same name")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValid3)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Update the sshd config")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			inlineConfigProviderSpec1 := v1alpha1.ConfigProviderSpec{}
+
+			err = inlineConfigProviderSpec1.FromInlineConfigProviderSpec(inlineConfigValid)
+			Expect(err).ToNot(HaveOccurred())
+
+			configProviderSpec := []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec, inlineConfigProviderSpec1}
+
+			err = UpdateDeviceConfigWithRetries(harness, deviceId, configProviderSpec, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = harness.VM.RunSSH([]string{"pwd"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = harness.VM.RunSSHWithUser([]string{"pwd"}, nil, rootUser)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(tooManyAuthFailuresError))
+
+			By("Remove the inline hook")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{}
+
+			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = harness.VM.RunSSH([]string{"pwd"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check pre/after update and pre/after reboot hooks from inline config works")
+			nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			deviceImage = fmt.Sprintf("%s/flightctl-device:base", harness.RegistryEndpoint())
+
+			osImageSpec.Image = deviceImage
+			err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(inlineConfigValidLifecycle)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+			deviceSpec.Os = &osImageSpec
+			deviceSpec.Config = &deviceSpecConfig
+
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+				device.Spec = &deviceSpec
+				logrus.Infof("Updating %s with a new image and configuration %s", deviceId, inlineConfigLifecycleName)
+			})
+
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that in the device logs the hooks were triggered")
+			logs, err := harness.VM.RunSSH([]string{"sudo", "journalctl", "--no-hostname", "-u", "flightctl-agent"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logs.String()).To(ContainSubstring("this is a test message from afterupdating hook"))
+			Expect(logs.String()).To(ContainSubstring("this is a test message from afterrebooting hook"))
+			Expect(logs.String()).To(ContainSubstring("this is a test message from beforerebooting hook"))
+			Expect(logs.String()).To(ContainSubstring("this is a test message from beforeupdating hook"))
+		})
+	})
+})
+
+var (
+	inlinePath                = "/etc/ssh/sshd_config.d/custom-ssh.conf"
+	inlineConfigName          = "sshd-inline-config"
+	inlineConfigName3         = "sshd-hook-inline-config"
+	inlineConfigLifecycleName = "lifecycle-hook-inline-config"
+	rootUser                  = "root"
+	hookPath                  = "/etc/flightctl/hooks.d/afterupdating/custom-hook.yaml"
+	deviceSpec                v1alpha1.DeviceSpec
+	noPasswordLoginError      = "user@localhost: Permission denied"
+	tooManyAuthFailuresError  = "Too many authentication failures"
+)
+
+var sshdConfigurationContent = `
+# Custom SSH Configuration
+PasswordAuthentication yes
+ClientAliveInterval 300
+MaxAuthTries 1
+`
+
+var sshdConfigurationContent2 = `
+# Custom SSH Configuration
+PermitRootLogin yes
+PasswordAuthentication no
+ClientAliveInterval 300
+MaxAuthTries 2
+`
+var sshdHook = `
+- if:
+  - path: /etc/ssh/sshd_config.d/
+    op: [created, updated, removed]
+  run: sudo sshd -t
+`
+var mode = 0644
+var modePointer = &mode
+var inlineConfigSpec = v1alpha1.FileSpec{
+	Path:    inlinePath,
+	Mode:    modePointer,
+	Content: sshdConfigurationContent,
+}
+
+var inlineConfigValid = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigSpec},
+	Name:   inlineConfigName,
+}
+
+var inlineConfigSpec2 = v1alpha1.FileSpec{
+	Path:    inlinePath,
+	Mode:    modePointer,
+	Content: sshdConfigurationContent2,
+}
+var inlineConfigValid2 = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigSpec2},
+	Name:   inlineConfigName,
+}
+
+var inlineConfigSpec3 = v1alpha1.FileSpec{
+	Path:    hookPath,
+	Mode:    modePointer,
+	Content: sshdHook,
+}
+
+var inlineConfigValid3 = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigSpec3},
+	Name:   inlineConfigName3,
+}
+
+var (
+	afterUpdatingContent = `
+- run: /usr/bin/logger "this is a test message from afterupdating hook"
+`
+	afterUpdatingPath     = "/etc/flightctl/hooks.d/afterupdating/display-hook.yaml"
+	afterRebootingContent = `
+- run: /usr/bin/logger "this is a test message from afterrebooting hook"
+`
+	afterRebootingPath     = "/etc/flightctl/hooks.d/afterrebooting/display-hook.yaml"
+	beforeRebootingContent = `
+- run: /usr/bin/logger "this is a test message from beforerebooting hook"
+`
+	beforeRebootingPath   = "/etc/flightctl/hooks.d/beforerebooting/display-hook.yaml"
+	beforeUpdatingContent = `
+- run: /usr/bin/logger "this is a test message from beforeupdating hook"
+`
+	beforeUpdatingPath = "/etc/flightctl/hooks.d/beforeupdating/display-hook.yaml"
+)
+
+var inlineConfigSpec4 = v1alpha1.FileSpec{
+	Path:    afterUpdatingPath,
+	Mode:    modePointer,
+	Content: afterUpdatingContent,
+}
+var inlineConfigSpec5 = v1alpha1.FileSpec{
+	Path:    afterRebootingPath,
+	Mode:    modePointer,
+	Content: afterRebootingContent,
+}
+var inlineConfigSpec6 = v1alpha1.FileSpec{
+	Path:    beforeRebootingPath,
+	Mode:    modePointer,
+	Content: beforeRebootingContent,
+}
+var inlineConfigSpec7 = v1alpha1.FileSpec{
+	Path:    beforeUpdatingPath,
+	Mode:    modePointer,
+	Content: beforeUpdatingContent,
+}
+
+var inlineConfigValidLifecycle = v1alpha1.InlineConfigProviderSpec{
+	Inline: []v1alpha1.FileSpec{inlineConfigSpec4, inlineConfigSpec5, inlineConfigSpec6, inlineConfigSpec7},
+	Name:   inlineConfigLifecycleName,
+}
+
+func UpdateDeviceConfigWithRetries(harness *e2e.Harness, deviceId string, configs []v1alpha1.ConfigProviderSpec, nextRenderedVersion int) error {
+	harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+		device.Spec.Config = &configs
+		logrus.WithFields(logrus.Fields{
+			"deviceId": deviceId,
+			"config":   fmt.Sprintf("%+v", &device.Spec.Config),
+		}).Info("Updating device with new config")
+	})
+	err := harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+	return err
+}

--- a/test/e2e/hooks/sshd-hook.yaml
+++ b/test/e2e/hooks/sshd-hook.yaml
@@ -1,0 +1,4 @@
+- if:
+  - path: /etc/ssh/sshd_config.d/
+    op: [created, updated, removed]
+  run: sudo systemctl reload sshd

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -752,3 +752,33 @@ func (h Harness) CreateRepository(repositorySpec v1alpha1.RepositorySpec, metada
 	_, err := h.Client.CreateRepositoryWithResponse(h.Context, repository)
 	return err
 }
+
+// Check that the device summary status is equal to the status input
+func (h Harness) CheckDeviceStatus(deviceId string, status v1alpha1.DeviceSummaryStatusType) (*v1alpha1.Device, error) {
+	response := h.GetDeviceWithStatusSystem(deviceId)
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("device.JSON200 response is nil")
+	}
+	device := response.JSON200
+	deviceStaus := device.Status.Summary.Status
+	if deviceStaus != status {
+		return nil, fmt.Errorf("the device status is notOnline but %s", deviceStaus)
+	}
+	return device, nil
+}
+
+// Get device with response
+func (h Harness) GetDevice(deviceId string) (*v1alpha1.Device, error) {
+	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device with response: %s", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+	device := response.JSON200
+	return device, nil
+}

--- a/test/scripts/agent-images/Containerfile-e2e-base.local.template
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local.template
@@ -1,0 +1,43 @@
+# localhost:5000/flightctl-device:base
+#     ${IP}:5000/flightctl-device:base
+#
+# Base bootc image used for E2E testing and agent-vm with the following features:
+#
+# * User/pw: user/user
+# * Trust on our E2E CA Certificate
+# * flightctl-agent configured to talk to our e2e kind flightctl-server
+# * greenboot and podman-compose installed with podman service enabled
+
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
+ARG RPM_COPR=
+ARG RPM_PACKAGE=flightctl-agent
+
+COPY bin/e2e-certs/pki/CA/ca.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
+COPY bin/rpm/flightctl-*.rpm /tmp/
+
+RUN if [[ -z $RPM_COPR ]]; then \
+        dnf install -y /tmp/flightctl-agent-*.rpm /tmp/flightctl-selinux-*.rpm ; \
+    else \
+        dnf copr -y enable ${RPM_COPR} &&  \
+        dnf install -y ${RPM_PACKAGE}; \
+    fi && \
+    systemctl enable flightctl-agent.service
+
+
+RUN dnf install -y epel-release epel-next-release
+RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \
+    dnf install -y firewalld && \
+    systemctl enable firewalld.service && \
+    systemctl enable podman.service
+
+
+RUN useradd -ms /bin/bash user && \
+    echo "user:user" | chpasswd && \
+    echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+## Add your flightctl configuration and certificates
+ADD bin/agent/etc/flightctl/config.yaml /etc/flightctl/
+ADD bin/agent/etc/flightctl/certs/* /etc/flightctl/certs/

--- a/test/scripts/agent-images/Containerfile-e2e-v6.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v6.local
@@ -1,0 +1,9 @@
+# localhost:5000/flightctl-device:v6
+#     $(IP):5000/flightctl-device:v6
+#
+# Image built on top of our E2E base image which also includes an embedded
+# hook that will trigger sshd reload after each configuration update
+
+FROM localhost:5000/flightctl-device:base
+
+COPY ./test/e2e/hooks/sshd-hook.yaml /usr/lib/flightctl/hooks.d/afterupdating/sshd-hook.yaml

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -7,7 +7,13 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/../functions
 
 REGISTRY_ADDRESS=$(registry_address)
-IMAGE_LIST="base v2 v3 v4 v5"
+IMAGE_LIST="base v2 v3 v4 v5 v6"
+
+# Create the file and add the registry configuration
+cp "${SCRIPT_DIR}"/Containerfile-e2e-base.local.template "${SCRIPT_DIR}"/Containerfile-e2e-base.local
+sudo tee -a "${SCRIPT_DIR}"/Containerfile-e2e-base.local <<EOF
+RUN  mkdir -p /etc/containers/registries.conf.d/ && echo -e '[[registry]]\nlocation = "${REGISTRY_ADDRESS}"\ninsecure = true' > /etc/containers/registries.conf.d/flightctl-e2e.conf
+EOF
 
 # if FLIGHTCTL_RPM is not empty
 if [ -n "${FLIGHTCTL_RPM:-}" ]; then

--- a/test/scripts/agent-images/custom-hook.yaml
+++ b/test/scripts/agent-images/custom-hook.yaml
@@ -1,0 +1,4 @@
+- if:
+  - path: /etc/ssh/sshd_config.d/
+    op: [created, updated, removed]
+  run: sudo systemctl reload sshd

--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -64,8 +64,8 @@ virt-install \
   --vcpus $VM_CPUS \
   --disk path=$DISK_PATH,size=${VM_DISK_SIZE},format=qcow2 \
   --os-variant centos-stream9  \
-  --network network=$NETWORK_NAME,model=virtio \
   --network network="default" \
+  --network network=$NETWORK_NAME,model=virtio \
   --import \
   --cpu host-model \
   --graphics none \

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -135,11 +135,11 @@ function get_endpoints() {
 
 function get_token() {
   if ! oc whoami -t 2>/dev/null; then
-    if [ -z "${KUBEADMIN_PASSWORD}" ]; then
-      echo "KUBEADMIN_PASSWORD is not set. Please set it to the kubeadmin password, or login as kubeadmin before calling this script" >&2
+    if [ -z "${KUBEADMIN_PASS}" ]; then
+      echo "KUBEADMIN_PASS is not set. Please set it to the kubeadmin password, or login as kubeadmin before calling this script" >&2
       exit 1
     fi
-    oc login -u kubeadmin -p ${KUBEADMIN_PASSWORD} >/dev/null
+    oc login -u kubeadmin -p ${KUBEADMIN_PASS} >/dev/null
     oc whoami -t
   fi
 }

--- a/test/scripts/run_e2e_tests.sh
+++ b/test/scripts/run_e2e_tests.sh
@@ -17,7 +17,7 @@ export API_ENDPOINT=https://$(get_endpoint_host flightctl-api-route)
 export REGISTRY_ENDPOINT=$(registry_address)
 
 if [[ "${GINKGO_FOCUS}" != "" ]]; then
-	"${GOBIN}/ginkgo" run --focus "${GINKGO_FOCUS}" --timeout 30m --race -vv --junit-report ${REPORTS}/junit_e2e_test.xml --github-output ${GO_E2E_DIRS}
+	"${GOBIN}/ginkgo" run --focus "${GINKGO_FOCUS}" --timeout 60m --race -vv --junit-report ${REPORTS}/junit_e2e_test.xml --github-output ${GO_E2E_DIRS}
 else
-	"${GOBIN}/ginkgo" run --timeout 30m --race -vv --junit-report ${REPORTS}/junit_e2e_test.xml --github-output ${GO_E2E_DIRS}
+	"${GOBIN}/ginkgo" run --timeout 60m --race -vv --junit-report ${REPORTS}/junit_e2e_test.xml --github-output ${GO_E2E_DIRS}
 fi


### PR DESCRIPTION
Adding:
-  hooks lifecycle test case;
-  template flightctl-device base Containerfile to inject the registry configuration before the e2e test images creation;
-  support harness functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced container image templates to support a more robust end-to-end testing environment.
  - Added automated triggers for reloading SSH configurations upon file changes.

- **Tests**
  - Deployed new test suites to verify device lifecycle hooks and end-to-end functionality.
  - Streamlined login flows and improved status checks within the test harness.

- **Chores**
  - Refined internal scripts and configuration settings, including updates to version control exclusions and network setups.
  - Expanded image versioning in scripts to include a new version for container images.
  - Updated environment variable references for consistency in scripts.
  - Increased timeout duration for end-to-end tests to enhance testing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->