### PR TITLE
EDM-1252: Update labels and migrating TCs to other files

### DIFF
--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -24,8 +24,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 	})
 
 	Context("updates", func() {
-		It("should update to the requested image", Label("updates", "rh-75523"), func() {
-
+		It("should update to the requested image", Label("75523"), func() {
+			By("Verifying update to agent  with requested image")
 			device, newImageReference := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v2")
 
 			currentImage := device.Status.Os.Image
@@ -61,7 +61,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			logrus.Info("Device updated to new image 🎉")
 		})
 
-		It("Should update to v4 with embedded application", Label("updates", "rh-77667"), func() {
+		It("Should update to v4 with embedded application", Label("77671"), func() {
+			By("Verifying update to agent  with embedded application")
 
 			device, newImageReference := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v4")
 

--- a/test/e2e/selectors/selectors_test.go
+++ b/test/e2e/selectors/selectors_test.go
@@ -62,197 +62,180 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Context("Basic Functionality Tests", Label("77917"), func() {
-		It("We can list devices and create resources", func() {
-			By("Listing devices", func() {
-				out, err := harness.CLI("get", "devices")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring("NAME"))
-			})
-			By("create a complete fleet", func() {
-				_, _ = harness.CLI("delete", "fleet")
-				out, err := harness.CLI("apply", "-f", util.GetTestExamplesYamlPath(fleetYAMLPath))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(MatchRegexp(resourceCreated))
-			})
-			By("create a device", func() {
-				By("Get device info from the yaml", func() {
-					deviceInfo = harness.GetDeviceByYaml(util.GetTestExamplesYamlPath(deviceYAMLPath))
-					deviceName = *deviceInfo.Metadata.Name
-					Expect(deviceName).ToNot(BeEmpty())
-				})
-				_, _ = harness.CLI("delete", "device")
-				out, err := harness.CLI("apply", "-R", "-f", util.GetTestExamplesYamlPath(deviceYAMLPath))
-				time.Sleep(30 * time.Second) // to establish fleet before adding device to it
-				Eventually(func() error {
-					_, err := harness.CLI("get", "fleet")
-					return err
-				}, "30s", "1s").Should(BeNil(), "Timeout waiting for fleet to be ready")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(MatchRegexp(resourceCreated))
-				Expect(out).To(ContainSubstring(fmt.Sprintf("%s/%s", deviceYAMLPath, deviceName)))
-			})
-			By("create a complete repo", func() {
-				out, err := harness.CLI("apply", "-f", util.GetTestExamplesYamlPath(repoYAMLPath))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(MatchRegexp(resourceCreated))
-			})
+	Context("Basic Functionality Tests", func() {
+		It("We can list devices and create resources", Label("77917"), func() {
+			By("Listing devices")
+			out, err := harness.CLI("get", "devices")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("NAME"))
+
+			By("create a complete fleet")
+			_, _ = harness.CLI("delete", "fleet")
+			out, err = harness.CLI("apply", "-f", util.GetTestExamplesYamlPath(fleetYAMLPath))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(resourceCreated))
+
+			By("Get device info from the yaml")
+			deviceInfo = harness.GetDeviceByYaml(util.GetTestExamplesYamlPath(deviceYAMLPath))
+			deviceName = *deviceInfo.Metadata.Name
+			Expect(deviceName).ToNot(BeEmpty())
+
+			_, _ = harness.CLI("delete", "device")
+			out, err = harness.CLI("apply", "-R", "-f", util.GetTestExamplesYamlPath(deviceYAMLPath))
+			time.Sleep(30 * time.Second) // to establish fleet before adding device to it
+			Eventually(func() error {
+				_, err := harness.CLI("get", "fleet")
+				return err
+			}, "30s", "1s").Should(BeNil(), "Timeout waiting for fleet to be ready")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(resourceCreated))
+			Expect(out).To(ContainSubstring(fmt.Sprintf("%s/%s", deviceYAMLPath, deviceName)))
+
+			By("create a complete repo")
+			out, err = harness.CLI("apply", "-f", util.GetTestExamplesYamlPath(repoYAMLPath))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(resourceCreated))
 		})
 
 		It("filters devices", func() {
 
-			By("filters devices by name", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.name=%s", deviceName))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by name")
+			out, err := harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.name=%s", deviceName))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by alias", func() {
-				deviceAlias = (*deviceInfo.Metadata.Labels)["alias"]
-				out, err := harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.alias=%s", deviceAlias))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by alias")
+			deviceAlias = (*deviceInfo.Metadata.Labels)["alias"]
+			out, err = harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.alias=%s", deviceAlias))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by nameOrAlias", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.nameOrAlias=%s", deviceAlias))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by nameOrAlias")
+			out, err = harness.CLI("get", "devices", "--field-selector", fmt.Sprintf("metadata.nameOrAlias=%s", deviceAlias))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by owner", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "metadata.owner=Fleet/default", "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by owner")
+			_, err = harness.CLI("get", "devices", "--field-selector", "metadata.owner=Fleet/default", "-owide")
+			Expect(err).ToNot(HaveOccurred())
 
-			By("filters devices by creation timestamp", func() {
-				startTimestamp, endTimestamp := generateTimestamps()
-				out, err := harness.CLI("get", "devices", "--field-selector",
-					fmt.Sprintf("metadata.creationTimestamp>=%s,metadata.creationTimestamp<%s", startTimestamp, endTimestamp), "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by creation timestamp")
+			startTimestamp, endTimestamp := generateTimestamps()
+			out, err = harness.CLI("get", "devices", "--field-selector",
+				fmt.Sprintf("metadata.creationTimestamp>=%s,metadata.creationTimestamp<%s", startTimestamp, endTimestamp), "-owide")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 		})
 	})
 
-	Context("Advanced Functionality Tests", Label("77947"), func() {
-		It("Advanced Functionality Tests", func() {
-			By("filters devices by multiple field selectors", func() {
-				startTimestamp, _ := generateTimestamps()
-				out, err := harness.CLI("get", "devices", "-l", "region=eu-west-1", "--field-selector",
-					fmt.Sprintf("metadata.creationTimestamp>=%s", startTimestamp))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+	Context("Advanced Functionality Tests", func() {
+		It("Advanced Functionality Tests", Label("77947"), func() {
+			By("filters devices by multiple field selectors")
+			startTimestamp, _ := generateTimestamps()
+			out, err := harness.CLI("get", "devices", "-l", "region=eu-west-1", "--field-selector",
+				fmt.Sprintf("metadata.creationTimestamp>=%s", startTimestamp))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("excludes devices by name", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "metadata.name!=device1-name")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(ContainSubstring("device1-name"))
-			})
+			By("excludes devices by name")
+			out, err = harness.CLI("get", "devices", "--field-selector", "metadata.name!=device1-name")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).ToNot(ContainSubstring("device1-name"))
 		})
 	})
 
-	Context("Label Selectors Tests", Label("78751"), func() {
-		It("Label Selectors Tests", func() {
-			By("filters devices by region in a set", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region in (test, eu-west-1)", "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+	Context("Label Selectors Tests", func() {
+		It("Label Selectors Tests", Label("78751"), func() {
+			By("filters devices by region in a set")
+			out, err := harness.CLI("get", "devices", "-l", "region in (test, eu-west-1)", "-owide")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by region not in a set", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region notin (test, eu-west-2)", "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by region not in a set")
+			out, err = harness.CLI("get", "devices", "-l", "region notin (test, eu-west-2)", "-owide")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by label existence", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region", "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by label existence")
+			out, err = harness.CLI("get", "devices", "-l", "region", "-owide")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by label non-existence", func() {
-				out, err := harness.CLI("get", "devices", "-l", "!region", "-owide")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(ContainSubstring(deviceName))
-			})
+			By("filters devices by label non-existence")
+			out, err = harness.CLI("get", "devices", "-l", "!region", "-owide")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).ToNot(ContainSubstring(deviceName))
 
-			By("filters devices by exact label match", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region=eu-west-1")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by exact label match")
+			out, err = harness.CLI("get", "devices", "-l", "region=eu-west-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 
-			By("filters devices by label mismatch", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region!=eu-west-1")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(ContainSubstring(deviceName))
-			})
+			By("filters devices by label mismatch")
+			out, err = harness.CLI("get", "devices", "-l", "region!=eu-west-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).ToNot(ContainSubstring(deviceName))
 
-			By("filters devices by label and field selector", func() {
-				out, err := harness.CLI("get", "devices", "-l", "region=eu-west-1", "--field-selector", "status.updated.status in (UpToDate, Unknown)")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(ContainSubstring(deviceName))
-			})
+			By("filters devices by label and field selector")
+			out, err = harness.CLI("get", "devices", "-l", "region=eu-west-1", "--field-selector", "status.updated.status in (UpToDate, Unknown)")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(deviceName))
 		})
 	})
 
-	Context("Negative Tests", Label("77948"), func() {
-		It("Negative Tests", func() {
-			By("returns an error for an invalid field selector", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "invalid.field")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(unknownSelector))
-			})
-			By("returns an error for an unsupported field selector", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "unsupported.field")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(unknownSelector))
-			})
-			By("returns an error for an invalid field selector syntax", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "metadata.name@=device1-name")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(failedToParse))
-			})
-			By("returns an error for an incorrect field type", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "metadata.name>10")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring("unsupported for type string"))
-				Expect(out).To(ContainSubstring("metadata.name"))
-			})
-			By("returns an error for filtering devices by deprecated contains operator", func() {
-				out, err := harness.CLI("get", "devices", "--field-selector", "metadata.labels contains region=eu-west-1")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring("field is marked as private and cannot be selected"))
-			})
-			By("returns an error for filtering devices by deprecated owner flag", func() {
-				out, err := harness.CLI("get", "devices", "--owner")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(unknownFlag))
-			})
-			By("returns an error for filtering devices by deprecated status-filter flag", func() {
-				out, err := harness.CLI("get", "devices", "--status-filter=updated.status=UpToDate")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(unknownFlag))
-			})
-			By("returns an error for bad syntax using =! operator", func() {
-				out, err := harness.CLI("get", "devices", "-l", "'region=!eu-west-1'")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(failedToParse))
-			})
-			By("returns an error for bad syntax using ! operator outside the quotes", func() {
-				out, err := harness.CLI("get", "devices", "-l", "!'region=eu-west-1'")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(failedToParse))
-			})
-			By("returns an error for bad syntax using ! operator at the start of the quotes", func() {
-				out, err := harness.CLI("get", "devices", "-l", "'!region=eu-west-1'")
-				Expect(err).To(HaveOccurred())
-				Expect(out).To(ContainSubstring(failedToParse))
-			})
+	Context("Negative Tests", func() {
+		It("Negative Tests", Label("77948"), func() {
+			By("returns an error for an invalid field selector")
+			out, err := harness.CLI("get", "devices", "--field-selector", "invalid.field")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(unknownSelector))
+
+			By("returns an error for an unsupported field selector")
+			out, err = harness.CLI("get", "devices", "--field-selector", "unsupported.field")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(unknownSelector))
+
+			By("returns an error for an invalid field selector syntax")
+			out, err = harness.CLI("get", "devices", "--field-selector", "metadata.name@=device1-name")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(failedToParse))
+
+			By("returns an error for an incorrect field type")
+			out, err = harness.CLI("get", "devices", "--field-selector", "metadata.name>10")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("unsupported for type string"))
+			Expect(out).To(ContainSubstring("metadata.name"))
+
+			By("returns an error for filtering devices by deprecated contains operator")
+			out, err = harness.CLI("get", "devices", "--field-selector", "metadata.labels contains region=eu-west-1")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("field is marked as private and cannot be selected"))
+
+			By("returns an error for filtering devices by deprecated owner flag")
+			out, err = harness.CLI("get", "devices", "--owner")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(unknownFlag))
+
+			By("returns an error for filtering devices by deprecated status-filter flag")
+			out, err = harness.CLI("get", "devices", "--status-filter=updated.status=UpToDate")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(unknownFlag))
+
+			By("returns an error for bad syntax using =! operator")
+			out, err = harness.CLI("get", "devices", "-l", "'region=!eu-west-1'")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(failedToParse))
+
+			By("returns an error for bad syntax using ! operator outside the quotes")
+			out, err = harness.CLI("get", "devices", "-l", "!'region=eu-west-1'")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(failedToParse))
+
+			By("returns an error for bad syntax using ! operator at the start of the quotes")
+			out, err = harness.CLI("get", "devices", "-l", "'!region=eu-west-1'")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring(failedToParse))
+
 		})
 	})
 })

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -28,7 +28,7 @@ import (
 
 const POLLING = "250ms"
 const TIMEOUT = "60s"
-const LONGTIMEOUT = "3m"
+const LONGTIMEOUT = "5m"
 
 type Harness struct {
 	VM        vm.TestVMInterface


### PR DESCRIPTION
1) Created Polarion tests for existing automated tests created by devs, added their labels
2) Added labels to existing tests that didn't have polarion IDs
3) Modified several automated tests to be steps in another test, as they are in polarion.
4) Removed tests that are duplicates of existing tests IE inline config online [check](https://github.com/flightctl/flightctl/blob/main/test/e2e/configuration/inline_config_test.go) 

17.03 update:
Inline_config tests fail, I am fixing them and moving them to inline_config_test.go
I removed duplicate TCs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Enhanced the test suite's structure and clarity for agent operations, update flows, and CLI functionalities.
	- Refined descriptive labels and step-by-step breakdowns for easier tracking and debugging.
	- Introduced new test cases for resource management in the CLI, including validations for fleet creation and application.
	- Removed outdated test contexts and reorganized tests for better focus on functionality.
	- Streamlined test organization and improved readability without impacting product behavior.
	- Increased timeout duration for certain operations to enhance reliability in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->