### PR TITLE
NO-ISSUE: Make example enrollment request valid

### DIFF
--- a/examples/enrollmentrequest-waiting.yaml
+++ b/examples/enrollmentrequest-waiting.yaml
@@ -1,14 +1,16 @@
 apiVersion: flightctl.io/v1alpha1
 kind: EnrollmentRequest
 metadata:
-  name: 13d632d8633782719874da4052f957faa742fc7050026748bc79065c8819d1b
+  name: mul6f5j1qiak0nsm9bl4n3f32bo4eub6oemntql56daoupdli2n0
 spec:
   csr: |
     -----BEGIN CERTIFICATE REQUEST-----
-    MIIBBjCBrQIBADBLMUkwRwYDVQQDE0AxM2Q2MzJkODYzNzNjYWFlZGE2NGRhNDA1
-    MmY5NTdmYWE3NDJmYzcwNTAwMjY3NDhiYzc5MDY1Yzg4MTlkMWIwMFkwEwYHKoZI
-    zj0CAQYIKoZIzj0DAQcDQgAEHBMC30NRJTJ3NWOlei9YWkBM/MzoNDGyMRKuzE0/
-    cKkyXVJexHq0xIn22YCNN3ZDNxxwW6LlQg3ijGnvStQOb6AAMAoGCCqGSM49BAMC
-    A0gAMEUCIQDSrxi6krdCKcLChdMB3w7IqmDlZhREGbHMCESVn6ssPAIgZL+QrJtw
-    8R+r4piaYvZktrsk3yCIuz3hI7loYmXP3d8=
+    MIH5MIGhAgEAMD8xPTA7BgNVBAMTNG11bDZmNWoxcWlhazBuc205Ymw0bjNmMzJi
+    bzRldWI2b2VtbnRxbDU2ZGFvdXBkbGkybjAwWTATBgcqhkjOPQIBBggqhkjOPQMB
+    BwNCAAQgz9aKjmLWeUi99Q/24mpCy2IWiuDoO3J/4qQDM+/x0uXIvBgXudqS6/mp
+    5QznHfhp7069zBxTh06N/JDihG8FoAAwCgYIKoZIzj0EAwIDRwAwRAIgD5QFZRga
+    ICfPte70z4+B21S1uBKS+4KEk0Mkm5tfqZkCIBWE313fd0dBFy4Q+HkA8am51Wa9
+    J4rtbos8+pS+HJZ+
     -----END CERTIFICATE REQUEST-----
+default-labels:
+  example: "test"


### PR DESCRIPTION
With the new API validations, the examples for Enrollment requests are no longer valid.
I updated the  "enrollmentrequest-waiting" example so it can be used with `flightctl apply -f` to quickly simulate a device.

The current example would give the following error upon approval:
```
Error: approving enrollmentrequest/13d632d8633782719874da4052f957faa742fc7050026748bc79065c8819d1b: Error approving and signing enrollment request: approveAndSignEnrollmentRequest: attempt to supply a fake CN, possible identity theft, csr: device:13d632d86373caaeda64da4052f957faa742fc7050026748bc79065c8819d1b0, metadata device:13d632d8633782719874da4052f957faa742fc7050026748bc79065c8819d1b (400 Bad Request)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new default label for enrollment requests to enhance categorization.
- **Chores**
  - Updated the enrollment request identifier to a cleaner format.
  - Refreshed the certificate request content for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->