### PR TITLE
EDM-1211: *: implement inline application provider

### DIFF
--- a/internal/agent/device/applications/controller.go
+++ b/internal/agent/device/applications/controller.go
@@ -112,7 +112,8 @@ func parseAppProviders(
 			}
 		}
 
-		if providerType == v1alpha1.ImageApplicationProviderType {
+		switch providerType {
+		case v1alpha1.ImageApplicationProviderType:
 			provider, err := NewImageProvider(log, podman, &providerSpec, readWriter)
 			if err != nil {
 				return nil, err
@@ -120,8 +121,18 @@ func parseAppProviders(
 			if err := provider.Verify(ctx); err != nil {
 				return nil, err
 			}
-
 			providers = append(providers, provider)
+		case v1alpha1.InlineApplicationProviderType:
+			provider, err := NewInlineProvider(log, podman, &providerSpec, readWriter)
+			if err != nil {
+				return nil, err
+			}
+			if err := provider.Verify(ctx); err != nil {
+				return nil, err
+			}
+			providers = append(providers, provider)
+		default:
+			return nil, fmt.Errorf("unsupported application provider type: %s", providerType)
 		}
 	}
 

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -324,7 +324,8 @@ func (m *PodmanMonitor) ExecuteActions(ctx context.Context) error {
 func (m *PodmanMonitor) drainActions() []lifecycle.Action {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	actions := m.actions
+	actions := make([]lifecycle.Action, len(m.actions))
+	copy(actions, m.actions)
 	// reset actions to ensure we don't execute the same actions again
 	m.actions = nil
 	return actions

--- a/internal/agent/device/fileio/managed_file.go
+++ b/internal/agent/device/fileio/managed_file.go
@@ -55,7 +55,7 @@ func (m *managedFile) decodeFile() error {
 	if m.contents != nil {
 		return nil
 	}
-	contents, err := decodeFileContents(m.file.Content, m.file.ContentEncoding)
+	contents, err := DecodeContent(m.file.Content, m.file.ContentEncoding)
 	if err != nil {
 		return err
 	}

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -300,7 +300,10 @@ func lookupGID(group string) (int, error) {
 	return gid, nil
 }
 
-func decodeFileContents(content string, encoding *v1alpha1.EncodingType) ([]byte, error) {
+// DecodeContents decodes the content based on the encoding type and returns the
+// decoded content as a byte slice.
+func DecodeContent(content string, encoding *v1alpha1.EncodingType) ([]byte,
+	error) {
 	if encoding == nil || *encoding == "plain" {
 		return []byte(content), nil
 	}

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -255,31 +255,12 @@ func renderApplication(_ context.Context, app *api.ApplicationProviderSpec) (*st
 	}
 	switch appType {
 	case api.ImageApplicationProviderType:
-		return renderImageApplicationProviderSpec(app)
+		return app.Name, app, nil
 	case api.InlineApplicationProviderType:
-		// TODO: implement
-		return nil, nil, nil
+		return app.Name, app, nil
 	default:
 		return nil, nil, fmt.Errorf("%w: unsupported application type: %q", ErrUnknownApplicationType, appType)
 	}
-}
-
-func renderImageApplicationProviderSpec(app *api.ApplicationProviderSpec) (*string, *api.ApplicationProviderSpec, error) {
-	imageProvider, err := app.AsImageApplicationProviderSpec()
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: failed getting application as ImageApplicationProviderSpec: %w", ErrUnknownApplicationType, err)
-	}
-
-	appName := lo.FromPtr(app.Name)
-	renderedApp := api.ApplicationProviderSpec{
-		Name:    app.Name,
-		EnvVars: app.EnvVars,
-	}
-	if err := renderedApp.FromImageApplicationProviderSpec(imageProvider); err != nil {
-		return &appName, nil, fmt.Errorf("failed rendering application %s: %w", appName, err)
-	}
-
-	return &appName, &renderedApp, nil
 }
 
 func (t *DeviceRenderLogic) renderGitConfig(ctx context.Context, configItem *api.ConfigProviderSpec, ignitionConfig **config_latest_types.Config) (*string, *string, error) {


### PR DESCRIPTION
```spec:
  applications:
  - appType: compose
    inline:
    - content: |
        version: "3.8"
        services:
          service1:
            image:  quay.io/flightctl-tests/alpine:v1
            command: ["sleep", "infinity"]
          service2:
            image:  quay.io/flightctl-tests/alpine:v1
            command: ["sleep", "infinity"]
          service3:
            image:  quay.io/flightctl-tests/alpine:v1
            command: ["sleep", "infinity"]
      path: docker-compose.yaml
    name: my-app
status:
  applications:
  - name: my-app
    ready: 3/3
    restarts: 0
    status: Running
  applicationsSummary:
    info: All application workloads are healthy.
    status: Healthy
```
build on #1000 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for inline application provider specifications, enabling the use of inline deployments alongside image-based ones.

- **Bug Fixes**
	- Resolved a typographical error in provider handling.
	- Improved error reporting to offer clearer feedback when unsupported application types are encountered.

- **Refactor**
	- Streamlined the application rendering and decoding logic for enhanced maintainability and more robust error handling.
	- Enhanced the handling of actions in the PodmanMonitor for better data encapsulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->