### PR TITLE
EDM-1329: agent/resource: calculate CPU usage with delta-based sampling

### DIFF
--- a/internal/agent/device/resource/cpu_test.go
+++ b/internal/agent/device/resource/cpu_test.go
@@ -2,105 +2,153 @@ package resource
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	procStatData = `cpu  5085309 2167763 1898394 153559678 869399 636486 449717 0 156334 0
-cpu0 422035 237451 164680 12724283 70955 47473 40517 0 13314 0
-cpu1 416332 186330 161674 12810448 71615 42559 26204 0 12359 0
-cpu2 415577 187217 152110 12828727 74139 40454 22049 0 13171 0
-cpu3 410703 187895 168448 12497106 76501 184172 201234 0 14252 0
-cpu4 426090 187033 170370 12810394 73040 37679 20057 0 12550 0
-cpu5 444768 193814 154113 12804104 68261 39532 20574 0 13176 0
-cpu6 429560 149927 144057 12869345 74354 37394 18782 0 12913 0
-cpu7 425436 197818 156839 12814785 71208 39612 21129 0 12935 0
-cpu8 433494 178256 156062 12833512 69394 37052 19303 0 13315 0
-cpu9 444353 165600 151326 12833850 77061 35924 17701 0 12705 0
-cpu10 426877 157700 167697 12837497 71765 43227 19872 0 13343 0
-cpu11 390080 138716 151011 12895622 71100 51402 22288 0 12296 0`
-)
-
 func TestCPUMonitor(t *testing.T) {
-	require := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	tmpDir := t.TempDir()
-	fakeStatPath := filepath.Join(tmpDir, "stat")
-	err := os.WriteFile(fakeStatPath, []byte(procStatData), 0600)
-	require.NoError(err)
-
-	log := log.NewPrefixLogger("test")
-	cpuMonitor := NewCPUMonitor(log)
-	cpuMonitor.statPath = fakeStatPath
-
-	go cpuMonitor.Run(ctx)
-
-	samplingInterval := 100 * time.Millisecond
-	monitorSpec := v1alpha1.CpuResourceMonitorSpec{
-		SamplingInterval: samplingInterval.String(),
-		MonitorType:      CPUMonitorType,
-		AlertRules: []v1alpha1.ResourceAlertRule{
-			{
-				Severity:    v1alpha1.ResourceAlertSeverityTypeCritical,
-				Percentage:  7, // 7% usage should never fire an alert
-				Duration:    "90ms",
-				Description: "Critical: CPU usage is above 7% for 90ms",
+	tests := []struct {
+		name         string
+		prev         *CPUUsage
+		snapshots    []*CPUUsage
+		alertRules   []v1alpha1.ResourceAlertRule
+		expectFiring []v1alpha1.ResourceAlertSeverityType
+		expectUsages []int64
+	}{
+		{
+			name: "below threshold",
+			prev: &CPUUsage{User: 1000, System: 1000, Idle: 8000},
+			snapshots: []*CPUUsage{
+				{User: 1005, System: 1005, Idle: 8090}, // prev -> 10%
+				{User: 1010, System: 1010, Idle: 8180}, // snapshot[0] -> 10%
 			},
-			{
-				Severity:    v1alpha1.ResourceAlertSeverityTypeWarning,
-				Percentage:  5, // 5% usage should always fire an alert
-				Duration:    "90ms",
-				Description: "Warning: CPU usage is above 5% for 90ms",
+			alertRules: []v1alpha1.ResourceAlertRule{
+				{Severity: v1alpha1.ResourceAlertSeverityTypeWarning, Percentage: 11, Duration: "1ms"},
 			},
-			{
-				Severity:    v1alpha1.ResourceAlertSeverityTypeInfo,
-				Percentage:  5, // 5% usage should never fire an alert because of duration
-				Duration:    "1h",
-				Description: "Warning: CPU usage is above 5% for 90ms",
+			expectFiring: nil,
+			expectUsages: []int64{10, 10},
+		},
+		{
+			name: "above warning",
+			prev: &CPUUsage{User: 1000, System: 1000, Idle: 8000},
+			snapshots: []*CPUUsage{
+				{User: 1004, System: 1004, Idle: 8086}, // prev -> 9%
+				{User: 1008, System: 1008, Idle: 8172}, // snapshot[0] -> 9%
+			},
+			alertRules: []v1alpha1.ResourceAlertRule{
+				{Severity: v1alpha1.ResourceAlertSeverityTypeWarning, Percentage: 5, Duration: "1ms"},
+			},
+			expectFiring: []v1alpha1.ResourceAlertSeverityType{v1alpha1.ResourceAlertSeverityTypeWarning},
+			expectUsages: []int64{9, 9},
+		},
+		{
+			name: "alert fires then clears",
+			prev: &CPUUsage{User: 1000, System: 1000, Idle: 8000},
+			snapshots: []*CPUUsage{
+				{User: 1010, System: 1010, Idle: 8080}, // prev -> 20%
+				{User: 1012, System: 1013, Idle: 8175}, // snapshot[0] -> 5% clear alert
+			},
+			alertRules: []v1alpha1.ResourceAlertRule{
+				{Severity: v1alpha1.ResourceAlertSeverityTypeWarning, Percentage: 11, Duration: "1ms"},
+			},
+			expectFiring: nil,
+			expectUsages: []int64{20, 5},
+		},
+		{
+			name: "zero delta",
+			prev: &CPUUsage{User: 1000, System: 1000, Idle: 8000},
+			snapshots: []*CPUUsage{
+				{User: 1000, System: 1000, Idle: 8000}, // prev -> 0%
+				{User: 1000, System: 1000, Idle: 8000}, // snapshot[0] -> 0%
+			},
+			alertRules: []v1alpha1.ResourceAlertRule{
+				{Severity: v1alpha1.ResourceAlertSeverityTypeCritical, Percentage: 1, Duration: "1ms"},
+			},
+			expectFiring: nil,
+			expectUsages: []int64{0, 0},
+		},
+		{
+			name: "warning and critical alerts fire",
+			prev: &CPUUsage{User: 1000, System: 1000, Idle: 8000},
+			snapshots: []*CPUUsage{
+				{User: 1030, System: 1030, Idle: 8040}, // prev -> 60%
+				{User: 1060, System: 1060, Idle: 8080}, // snapshot[0] -> 60%
+			},
+			alertRules: []v1alpha1.ResourceAlertRule{
+				{Severity: v1alpha1.ResourceAlertSeverityTypeWarning, Percentage: 20, Duration: "1ms"},
+				{Severity: v1alpha1.ResourceAlertSeverityTypeCritical, Percentage: 50, Duration: "1ms"},
+			},
+			expectUsages: []int64{60, 60},
+			expectFiring: []v1alpha1.ResourceAlertSeverityType{
+				v1alpha1.ResourceAlertSeverityTypeWarning,
+				v1alpha1.ResourceAlertSeverityTypeCritical,
 			},
 		},
 	}
 
-	rm := &v1alpha1.ResourceMonitor{}
-	err = rm.FromCpuResourceMonitorSpec(monitorSpec)
-	require.NoError(err)
-	updated, err := cpuMonitor.Update(rm)
-	require.NoError(err)
-	require.True(updated)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := context.Background()
 
-	var alerts []v1alpha1.ResourceAlertRule
-	require.Eventually(func() bool {
-		alerts = cpuMonitor.Alerts()
-		return len(alerts) == 1
-	}, retryTimeout, retryInterval, "alert add")
+			log := log.NewPrefixLogger("test")
+			log.SetLevel(logrus.TraceLevel)
+			collector := &fakeCPUCollector{snapshots: tt.snapshots}
 
-	deviceResourceStatusType, alertMsg := getHighestSeverityResourceStatusFromAlerts(CPUMonitorType, alerts)
-	require.NotEmpty(alertMsg) // ensure we have an alert message
+			cpuMonitor := &CPUMonitor{
+				log:       log,
+				alerts:    make(map[v1alpha1.ResourceAlertSeverityType]*Alert),
+				collector: collector,
+				prevUsage: tt.prev,
+			}
+			var maxDuration time.Duration
+			for _, rule := range tt.alertRules {
+				alert, err := NewAlert(rule)
+				require.NoError(err)
+				cpuMonitor.alerts[rule.Severity] = alert
 
-	require.Equal(v1alpha1.DeviceResourceStatusWarning, deviceResourceStatusType)
+				if d, err := time.ParseDuration(rule.Duration); err == nil && d > maxDuration {
+					maxDuration = d
+				}
+			}
 
-	// update the monitor to remove all alerts
-	monitorSpec.AlertRules = monitorSpec.AlertRules[:0]
-	rm = &v1alpha1.ResourceMonitor{}
-	err = rm.FromCpuResourceMonitorSpec(monitorSpec)
-	require.NoError(err)
+			for i, expected := range tt.expectUsages {
+				usage := &CPUUsage{}
+				cpuMonitor.sync(ctx, usage)
+				time.Sleep(maxDuration)
+				require.Equalf(expected, usage.UsedPercent, "sync %d: expected %d%% usage", i+1, expected)
+			}
 
-	updated, err = cpuMonitor.Update(rm)
-	require.NoError(err)
-	require.True(updated)
+			var gotSeverities []v1alpha1.ResourceAlertSeverityType
+			for _, alert := range cpuMonitor.Alerts() {
+				gotSeverities = append(gotSeverities, alert.Severity)
+			}
 
-	// ensure no alerts after clearing
-	require.Eventually(func() bool {
-		alerts := cpuMonitor.Alerts()
-		return len(alerts) == 0
-	}, retryTimeout, retryInterval, "alert remove")
+			for _, severity := range tt.expectFiring {
+				require.Contains(gotSeverities, severity)
+			}
+
+			require.ElementsMatch(tt.expectFiring, gotSeverities)
+		})
+	}
+}
+
+type fakeCPUCollector struct {
+	snapshots []*CPUUsage
+	index     int
+}
+
+func (f *fakeCPUCollector) CollectUsage(ctx context.Context, usage *CPUUsage) error {
+	if f.index >= len(f.snapshots) {
+		return nil
+	}
+	*usage = *f.snapshots[f.index]
+
+	f.index++
+	return nil
 }

--- a/internal/agent/device/resource/disk.go
+++ b/internal/agent/device/resource/disk.go
@@ -140,6 +140,7 @@ func (m *DiskMonitor) ensureAlerts(percentageUsed int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.log.Tracef("Disk usage: %d%%", percentageUsed)
 	for _, alert := range m.alerts {
 		alert.Sync(percentageUsed)
 	}

--- a/internal/agent/device/resource/memory.go
+++ b/internal/agent/device/resource/memory.go
@@ -115,6 +115,7 @@ func (m *MemoryMonitor) ensureAlerts(percentageUsed int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.log.Tracef("Memory usage: %d%%", percentageUsed)
 	for _, alert := range m.alerts {
 		alert.Sync(percentageUsed)
 	}

--- a/internal/agent/device/resource/mock_resource.go
+++ b/internal/agent/device/resource/mock_resource.go
@@ -146,20 +146,6 @@ func (mr *MockMonitorMockRecorder[T]) Alerts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Alerts", reflect.TypeOf((*MockMonitor[T])(nil).Alerts))
 }
 
-// CollectUsage mocks base method.
-func (m *MockMonitor[T]) CollectUsage(ctx context.Context, usage *T) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CollectUsage", ctx, usage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CollectUsage indicates an expected call of CollectUsage.
-func (mr *MockMonitorMockRecorder[T]) CollectUsage(ctx, usage any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectUsage", reflect.TypeOf((*MockMonitor[T])(nil).CollectUsage), ctx, usage)
-}
-
 // Run mocks base method.
 func (m *MockMonitor[T]) Run(ctx context.Context) {
 	m.ctrl.T.Helper()
@@ -185,4 +171,41 @@ func (m *MockMonitor[T]) Update(monitor *v1alpha1.ResourceMonitor) (bool, error)
 func (mr *MockMonitorMockRecorder[T]) Update(monitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockMonitor[T])(nil).Update), monitor)
+}
+
+// MockCollector is a mock of Collector interface.
+type MockCollector[T any] struct {
+	ctrl     *gomock.Controller
+	recorder *MockCollectorMockRecorder[T]
+}
+
+// MockCollectorMockRecorder is the mock recorder for MockCollector.
+type MockCollectorMockRecorder[T any] struct {
+	mock *MockCollector[T]
+}
+
+// NewMockCollector creates a new mock instance.
+func NewMockCollector[T any](ctrl *gomock.Controller) *MockCollector[T] {
+	mock := &MockCollector[T]{ctrl: ctrl}
+	mock.recorder = &MockCollectorMockRecorder[T]{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCollector[T]) EXPECT() *MockCollectorMockRecorder[T] {
+	return m.recorder
+}
+
+// CollectUsage mocks base method.
+func (m *MockCollector[T]) CollectUsage(ctx context.Context, usage *T) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CollectUsage", ctx, usage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CollectUsage indicates an expected call of CollectUsage.
+func (mr *MockCollectorMockRecorder[T]) CollectUsage(ctx, usage any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectUsage", reflect.TypeOf((*MockCollector[T])(nil).CollectUsage), ctx, usage)
 }

--- a/internal/agent/device/resource/resource.go
+++ b/internal/agent/device/resource/resource.go
@@ -36,8 +36,11 @@ type Manager interface {
 type Monitor[T any] interface {
 	Run(ctx context.Context)
 	Update(monitor *v1alpha1.ResourceMonitor) (bool, error)
-	CollectUsage(ctx context.Context, usage *T) error
 	Alerts() []v1alpha1.ResourceAlertRule
+}
+
+type Collector[T any] interface {
+	CollectUsage(ctx context.Context, usage *T) error
 }
 
 type ResourceManager struct {


### PR DESCRIPTION
My initial implementation was a bit naïve — it only took a single snapshot of CPU stats, which ended up reflecting the average CPU usage since boot. This gave inflated results, especially when the system was idle.

After digging in, I realized tracking the delta between successive readings gives a much more accurate view of real-time usage. I picked up this approach by looking at how tools like cargo calculate CPU usage in Rust and aligned more with how top calculates usage.

ref. https://github.com/rust-lang/cargo/blob/master/src/cargo/util/cpu.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced CPU monitoring with refined usage calculations and improved alert synchronization.
  - Introduced new computations to capture both total and active CPU time for better performance insights.
  - Upgraded disk monitoring with additional logging for clearer resource usage trends.
  - Expanded memory monitoring with improved logging for more transparent usage reporting.
  - Introduced a new interface for modular usage collection, separating concerns from the monitoring interface.

- **Bug Fixes**
  - Improved logging for disk and memory usage to enhance observability without altering existing functionality.

- **Tests**
  - Transitioned CPU monitoring tests to a table-driven approach for better modularity and clarity.
  - Enhanced test organization and clarity with new testing structures and logging improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->