### PR TITLE
EDM-1293: Deploy a pod with CLI tools

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -109,8 +109,7 @@ jobs:
     name: Verify Binaries on windows
     strategy:
       matrix:
-        # Support of "windows-arm64" will be removed from 1.26
-        # Windows 11 dropped support of arm64
+        # GitHub Actions does not provide a native Windows ARM64 runner
         arch: [ "amd64" ]
     runs-on: "windows-latest"
     needs: build

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -3,7 +3,6 @@ WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-COPY ./.git .git
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +12,8 @@ COPY ./go.* ./
 COPY ./pkg pkg
 COPY ./test test
 COPY ./Makefile .
+# make sure that version extraction works
+COPY .git .git
 
 USER 0
 RUN git config --global --add safe.directory /app

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -8,64 +8,61 @@ COPY ./internal internal
 COPY ./go.* ./
 COPY ./pkg pkg
 COPY ./test test
+COPY ./packaging packaging
 COPY ./Makefile .
 # make sure that version extraction works
 COPY .git .git
 
 USER 0
-RUN make multiarch-build-cli
+RUN dnf install --nodocs -y jq
+RUN make build-multiarch-clis
 
 FROM registry.access.redhat.com/ubi9/ubi as certs
-RUN dnf install --nodocs -y nginx && dnf clean all
-
+RUN dnf install --nodocs -y nginx && \
+    rm -f /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf && \
+    dnf clean all
 
 ENV USER_UID=1001 \
     USER_NAME=server \
     HOME=/home/server \
-    NGINX_CONF_PATH=/etc/nginx/nginx.conf
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    ENTRYPOINT_PATH=/usr/local/bin/entrypoint.sh
 
-COPY packaging/containers/cli-artifacts/nginx.conf ${NGINX_CONF_PATH}
+COPY --from=builder /app/packaging/containers/cli-artifacts/nginx.conf ${NGINX_CONF_PATH}
+COPY --from=builder /app/packaging/containers/cli-artifacts/entrypoint.sh ${ENTRYPOINT_PATH}
 
 USER root
 
-RUN mkdir -p ${HOME} && \
+RUN mkdir -p ${HOME}/src/gh-archives \
     chown ${USER_UID}:0 ${HOME} && \
-    chmod ug+rwx ${HOME} && \
-    sed '/^\s*listen\s*\[::\]:8080/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv4 && \
-    sed '/^\s*listen\s*8080/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv6 && \
-    chmod a+rwx ${NGINX_CONF_PATH} && \
-    chmod a+rwx ${NGINX_CONF_PATH}.ipv* && \
-    chmod -R a+rwx /var/lib/nginx && \
+    chmod 755 ${HOME} && \
+    sed '/^\s*listen\s*\[::\]:8090/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv4 && \
+    sed '/^\s*listen\s*8090/d' ${NGINX_CONF_PATH} > ${NGINX_CONF_PATH}.ipv6 && \
+    chmod 755 ${NGINX_CONF_PATH} ${NGINX_CONF_PATH}.ipv* && \
+    chmod -R 755 /var/lib/nginx && \
     chown -R ${USER_UID}:0 /root && \
     chown -R ${USER_UID}:0 /var/lib/nginx && \
-    chmod -R a+rwx /var/log/nginx && \
+    chmod -R 755 /var/log/nginx && \
     chown -R ${USER_UID}:0 /var/log/nginx && \
-    chmod -R a+rwx /var/run && \
-    chown -R ${USER_UID}:0 /var/run
+    chmod -R 775 /var/run && \
+    chown -R ${USER_UID}:0 /var/run && \
+    chmod +x ${ENTRYPOINT_PATH}
 
 USER ${USER_UID}
 
 WORKDIR ${HOME}/src
 
-COPY --from=builder /app/bin/clis/archives/ ./
+COPY --from=builder /app/bin/clis/gh-archives/ ${HOME}/src/gh-archives/
+
+USER root
+RUN chmod -R 755 ${HOME}/src/gh-archives/ && \
+    chown -R ${USER_UID}:0 ${HOME}/src/gh-archives/
+USER ${USER_UID}
 
 LABEL io.k8s.display-name="Flight Control CLI multiarch artifacts with server" \
       io.k8s.description="Flight Control is a service for declarative management of fleets of edge devices and their workloads." \
       io.openshift.tags="flightctl,cli-artifacts"
 
+EXPOSE 8090
 
-EXPOSE 8080
-
-ENTRYPOINT if [[ -d "/proc/sys/net/ipv4" && -d "/proc/sys/net/ipv6" ]]; \
-    then \
-    nginx -g "daemon off;"; \
-    elif [[ -d "/proc/sys/net/ipv4" ]]; \
-    then \
-    nginx -c /etc/nginx/nginx.conf.ipv4 -g "daemon off;"; \
-    elif [[ -d "/proc/sys/net/ipv6" ]]; \
-    then \
-    nginx -c /etc/nginx/nginx.conf.ipv6 -g "daemon off;"; \
-    else \
-    echo "unable to identify IP configuration"; \
-    exit -1; \
-    fi
+ENTRYPOINT ${ENTRYPOINT_PATH}

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -9,6 +9,8 @@ COPY ./go.* ./
 COPY ./pkg pkg
 COPY ./test test
 COPY ./Makefile .
+# make sure that version extraction works
+COPY .git .git
 
 USER 0
 RUN make build-periodic

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -9,6 +9,8 @@ COPY ./go.* ./
 COPY ./pkg pkg
 COPY ./test test
 COPY ./Makefile .
+# make sure that version extraction works
+COPY .git .git
 
 USER 0
 RUN make build-worker

--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,12 @@ build: bin build-cli
 
 bin/flightctl-agent: bin $(GO_FILES)
 	CGO_CFLAGS='-flto' GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) \
-		./cmd/flightctl-agent 
+		./cmd/flightctl-agent
 
 build-cli: bin
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl
 
-multiarch-build-cli: bin
+build-multiarch-clis: bin
 	./hack/build_multiarch_clis.sh
 
 build-agent: bin
@@ -124,16 +124,22 @@ bin/.flightctl-periodic-container: bin Containerfile.periodic go.mod go.sum $(GO
 	podman build -f Containerfile.periodic $(GO_CACHE) -t flightctl-periodic:latest
 	touch bin/.flightctl-periodic-container
 
+bin/.flightctl-multiarch-cli-container: bin Containerfile.cli-artifacts go.mod go.sum $(GO_FILES)
+	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
+	podman build -f Containerfile.cli-artifacts $(GO_CACHE) -t flightctl-cli-artifacts:latest
+	touch bin/.flightctl-multiarch-cli-container
+
 flightctl-api-container: bin/.flightctl-api-container
 
 flightctl-worker-container: bin/.flightctl-worker-container
 
 flightctl-periodic-container: bin/.flightctl-periodic-container
 
+flightctl-multiarch-cli-container: bin/.flightctl-multiarch-cli-container
 
-build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container
+build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-multiarch-cli-container
 
-.PHONY: build-containers build-cli multiarch-build-cli
+.PHONY: build-containers build-cli build-multiarch-clis
 
 
 bin:

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -28,7 +28,7 @@ redeploy-worker: flightctl-worker-container
 redeploy-periodic: flightctl-periodic-container
 	test/scripts/redeploy.sh periodic
 
-deploy-helm: git-server-container flightctl-api-container flightctl-worker-container flightctl-periodic-container
+deploy-helm: git-server-container flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-multiarch-cli-container
 	kubectl config set-context kind-kind
 	test/scripts/install_helm.sh
 	test/scripts/deploy_with_helm.sh --db-size $(DB_SIZE)

--- a/deploy/helm/flightctl/templates/flightctl-cli-artifacts-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-cli-artifacts-deployment.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.cliArtifacts.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    flightctl.service: flightctl-cli-artifacts
+  name: flightctl-cli-artifacts
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      flightctl.service: flightctl-cli-artifacts
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        flightctl.service: flightctl-cli-artifacts
+    spec:
+      containers:
+        - name: flightctl-cli-artifacts
+          image: {{ .Values.cliArtifacts.image.image }}:{{ default .Chart.AppVersion .Values.cliArtifacts.image.tag }}
+          imagePullPolicy: {{ .Values.cliArtifacts.image.pullPolicy }}
+          ports:
+            - containerPort: 8090
+              name: cli-artifacts
+              protocol: TCP
+          env:
+            - name: CLI_ARTIFACTS_BASE_URL
+              value: {{ quote .Values.cliArtifacts.baseUrl }}
+      restartPolicy: Always
+{{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-cli-artifacts-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-cli-artifacts-service.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.cliArtifacts.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    flightctl.service: flightctl-cli-artifacts
+  name: flightctl-cli-artifacts
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if and .Values.global.nodePorts.cliArtifacts (eq (include "flightctl.getServiceExposeMethod" .) "nodePort") }}
+  type: NodePort
+  {{- end }}
+  ports:
+    - name: "flightctl-cli-artifacts"
+      port: 8090
+      targetPort: 8090
+      {{- if and .Values.global.nodePorts.cliArtifacts (eq (include "flightctl.getServiceExposeMethod" .) "nodePort") }}
+      nodePort: {{ .Values.global.nodePorts.cliArtifacts }}
+      {{- end }}
+  selector:
+    flightctl.service: flightctl-cli-artifacts
+{{ end }}

--- a/deploy/helm/flightctl/values.dev.yaml
+++ b/deploy/helm/flightctl/values.dev.yaml
@@ -25,6 +25,13 @@ api:
     tag: latest
     pullPolicy: IfNotPresent
   baseUIUrl: "http://localhost:9000"
+cliArtifacts:
+  enabled: true
+  image:
+    image: localhost/flightctl-cli-artifacts
+    tag: latest
+    pullPolicy: IfNotPresent
+  baseUrl: "http://localhost:8090"
 worker:
   image:
     image: localhost/flightctl-worker

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -63,6 +63,7 @@ global:
   gatewayClass: ""
   nodePorts:
     api: 3443
+    cliArtifacts: 8090
     agent: 7443
     grpc: 7444
     ui: 9000
@@ -110,6 +111,13 @@ api:
     tag: ""
   agentGrpcBaseURL: "" # grpcs://agent-grpc.flightctl.example.com
   baseUIUrl: "" # ui.flightctl.example.com
+cliArtifacts:
+  enabled: true
+  image:
+    image: quay.io/flightctl/flightctl-cli-artifacts
+    pullPolicy: Always
+    tag: ""
+  baseUrl: https://cli.{{ include "flightctl.getBaseDomain" . }}:{{ .Values.global.nodePorts.cliArtifacts }}/
 worker:
   enabled: true
   image:

--- a/hack/build_multiarch_clis.sh
+++ b/hack/build_multiarch_clis.sh
@@ -9,58 +9,153 @@ set -euo pipefail
 # │   ├── amd64
 # │   │   ├── linux
 # │   │   │   └── flightctl.tar.gz
-# │   │   └── mac
+# │   │   ├── mac
+# │   │   │   └── flightctl.zip
+# │   │   └── windows
 # │   │       └── flightctl.zip
 # │   └── arm64
 # │       ├── linux
 # │       │   └── flightctl.tar.gz
-# │       └── mac
+# │       ├── mac
+# │       │   └── flightctl.zip
+# │       └── windows
 # │           └── flightctl.zip
-# ├── gh-archives
-# │   ├── flightctl-darwin-amd64.zip
-# │   ├── flightctl-darwin-amd64.zip.sha256
-# │   ├── flightctl-darwin-arm64.zip
-# │   ├── flightctl-darwin-arm64.zip.sha256
-# │   ├── flightctl-linux-amd64.tar.gz
-# │   ├── flightctl-linux-amd64.tar.gz.sha256
-# │   ├── flightctl-linux-arm64.tar.gz
-# │   └── flightctl-linux-arm64.tar.gz.sha256
+# ├── binaries
+# │   ├── amd64
+# │   │   ├── linux
+# │   │   │   └── flightctl
+# │   │   ├── mac
+# │   │   │   └── flightctl
+# │   │   └── windows
+# │   │       └── flightctl.exe
+# │   └── arm64
+# │       ├── linux
+# │       │   └── flightctl
+# │       ├── mac
+# │       │   └── flightctl
+# │       └── windows
+# │           └── flightctl.exe
+# └── gh-archives
+#     ├── amd64
+#     │   ├── linux
+#     │   │   ├── flightctl-linux-amd64.tar.gz
+#     │   │   └── flightctl-linux-amd64.tar.gz.sha256
+#     │   ├── mac
+#     │   │   ├── flightctl-darwin-amd64.zip
+#     │   │   └── flightctl-darwin-amd64.zip.sha256
+#     │   └── windows
+#     │       ├── flightctl-windows-amd64.zip
+#     │       └── flightctl-windows-amd64.zip.sha256
+#     └── arm64
+#         ├── linux
+#         │   ├── flightctl-linux-arm64.tar.gz
+#         │   └── flightctl-linux-arm64.tar.gz.sha256
+#         ├── mac
+#         │   ├── flightctl-darwin-arm64.zip
+#         │   └── flightctl-darwin-arm64.zip.sha256
+#         └── windows
+#             ├── flightctl-windows-arm64.zip
+#             └── flightctl-windows-arm64.zip.sha256
 
+build() {
+  local GOARCH=$1
+  local GOOS=$2
+
+  GOARCH="${GOARCH}" GOOS="${GOOS}" make build-cli
+
+  local OS="${GOOS}"
+  local TGZ=".tar.gz"
+  local EXE=""
+
+  if [ "${GOOS}" == "darwin" ]; then
+    OS="mac"
+    TGZ=".zip"
+  elif [ "${GOOS}" == "windows" ]; then
+    TGZ=".zip"
+    EXE=".exe"
+  fi
+
+  local BIN="bin/clis/binaries/${GOARCH}/${OS}"
+  local ARCHIVES="bin/clis/archives/${GOARCH}/${OS}"
+  local GH_ARCHIVES="bin/clis/gh-archives/${GOARCH}/${OS}"
+  local GH_OUT="${GH_ARCHIVES}/flightctl-${GOOS}-${GOARCH}${TGZ}"
+
+  mkdir -p "${BIN}" "${ARCHIVES}" "${GH_ARCHIVES}"
+
+  cp "bin/flightctl${EXE}" "${BIN}/"
+  cp "bin/flightctl${EXE}" "flightctl-${GOOS}-${GOARCH}${EXE}"
+
+  if [ "${GOOS}" == "linux" ]; then
+    tar -zhcf "${ARCHIVES}/flightctl.tar.gz" -C "${BIN}" flightctl
+  else
+    zip -9 -r -q -j "${ARCHIVES}/flightctl.zip" "${BIN}/flightctl${EXE}"
+  fi
+
+  cp "${ARCHIVES}/flightctl${TGZ}" "${GH_OUT}"
+  sha256sum "${GH_OUT}" | awk '{ print $1 }' > "${GH_OUT}.sha256"
+}
 
 for GOARCH in amd64 arm64; do
   for GOOS in linux darwin windows; do
-    echo -e "\033[0;37m>>>> building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
-    GOARCH="${GOARCH}" GOOS="${GOOS}" make build-cli
-    OS="${GOOS}"
-    TGZ=".tar.gz"
-    EXE=""
-    if [ "${GOOS}" == "darwin" ]; then
-      OS="mac"
-      TGZ=".zip"
-    elif [ "${GOOS}" == "windows" ]; then
-      TGZ=".zip"
-      EXE=".exe"
-    fi
-    BIN="bin/clis/binaries/${GOARCH}/${OS}"
-    ARCHIVES="bin/clis/archives/${GOARCH}/${OS}"
-    GH_ARCHIVES="bin/clis/gh-archives/${GOARCH}/${OS}"
-    GH_OUT="${GH_ARCHIVES}/flightctl-${GOOS}-${GOARCH}${TGZ}"
-
-    mkdir -p "${BIN}"
-    mkdir -p "${ARCHIVES}"
-    mkdir -p "${GH_ARCHIVES}"
-
-    cp "bin/flightctl${EXE}" "${BIN}/"
-    cp "bin/flightctl${EXE}" "flightctl-${GOOS}-${GOARCH}${EXE}"
-
-    if [ "${GOOS}" == "linux" ]; then
-      tar -zhcf "${ARCHIVES}/flightctl.tar.gz" -C "${BIN}" flightctl
-    else
-      zip -9 -r -q -j "${ARCHIVES}/flightctl.zip" "${BIN}/flightctl${EXE}"
-    fi
-    cp "${ARCHIVES}/flightctl${TGZ}" "${GH_OUT}"
-    sha256sum "${GH_OUT}" | awk '{ print $1 }' > "${GH_OUT}.sha256"
+    (
+      echo -e "\033[0;37m>>>> Start building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+      build "$GOARCH" "$GOOS"
+      echo -e "\033[0;37m>>>> Finish building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+    ) &> "build_${GOOS}_${GOARCH}.log" &
   done
 done
+
+# Wait for all parallel jobs to complete
+wait
+cat build_*.log
+rm -f build_*.log
+
+
+echo -e "\033[0;37m>>>> building index.json\033[0m"
+
+SOURCE_DIR="bin/clis/gh-archives"
+OUTPUT_JSON="index.json"
+PLACEHOLDER_BASE_URL="{{CLI_ARTIFACTS_BASE_URL}}"
+
+cd "$SOURCE_DIR"
+
+# Build JSON array of artifact entries
+artifacts=$(find . -type f | while read -r file; do
+  filename=$(basename "$file")
+
+  # Skip index.json and .sha256 files
+  [[ "$filename" == "$OUTPUT_JSON" || "$filename" == *.sha256 ]] && continue
+
+  # Extract arch and os from path
+  parts=(${file//\// })
+  arch="${parts[1]}"
+  os="${parts[2]}"
+
+  # Read SHA256 if it exists
+  sha256_file="${file}.sha256"
+  sha256_content=""
+  [[ -f "$sha256_file" ]] && sha256_content=$(cat "$sha256_file")
+
+  # Emit artifact JSON object
+  jq -n \
+    --arg os "$os" \
+    --arg arch "$arch" \
+    --arg filename "$filename" \
+    --arg sha256 "$sha256_content" \
+    '{
+      os: $os,
+      arch: $arch,
+      filename: $filename,
+      sha256: $sha256
+    }'
+done | jq -s '.')
+
+# Write final JSON with baseUrl as placeholder
+jq -n \
+  --arg baseUrl "$PLACEHOLDER_BASE_URL" \
+  --argjson artifacts "$artifacts" \
+  '{baseUrl: $baseUrl, artifacts: $artifacts}' > "$OUTPUT_JSON"
+
+cd -
 
 echo -e "\033[0;32mAll CLI binaries have been built in bin/clis/binaries and archived in bin/clis/archives and bin/clis/gh-archives\033[0m"

--- a/hack/publish_containers.sh
+++ b/hack/publish_containers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -x -e
 
-CONTAINER_IMAGES="flightctl-api flightctl-worker flightctl-periodic"
+CONTAINER_IMAGES="flightctl-api flightctl-worker flightctl-periodic cli-artifacts"
 
 
 GIT_REF=$(git rev-parse --short HEAD)

--- a/packaging/containers/cli-artifacts/entrypoint.sh
+++ b/packaging/containers/cli-artifacts/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+if [ -d "/proc/sys/net/ipv4" ] && [ -d "/proc/sys/net/ipv6" ]; then
+    CONFIG_FILE="/etc/nginx/nginx.conf"
+elif [ -d "/proc/sys/net/ipv4" ]; then
+    CONFIG_FILE="/etc/nginx/nginx.conf.ipv4"
+elif [ -d "/proc/sys/net/ipv6" ]; then
+    CONFIG_FILE="/etc/nginx/nginx.conf.ipv6"
+else
+    echo "Unable to identify IP configuration"
+    exit 1
+fi
+
+sed "s|{{CLI_ARTIFACTS_BASE_URL}}|${CLI_ARTIFACTS_BASE_URL}|g" < /home/server/src/gh-archives/index.json > /tmp/index.json && \
+cat /tmp/index.json > /home/server/src/gh-archives/index.json
+
+
+exec nginx -c "${CONFIG_FILE}" -g "daemon off;"

--- a/packaging/containers/cli-artifacts/nginx.conf
+++ b/packaging/containers/cli-artifacts/nginx.conf
@@ -23,18 +23,15 @@ http {
     default_type        application/octet-stream;
 
     server {
-        listen       8080 default_server;
-        listen       [::]:8080 default_server;
+        listen       8090 default_server;
+        listen       [::]:8090 default_server;
         server_name  _;
-        root         /home/server/src;
+        root         /home/server/src/gh-archives;
 
-        # Enable autoindex for directory listing
         location / {
-            autoindex on;
-            autoindex_exact_size off; # Optional: human-readable file sizes
-            autoindex_localtime on;   # Optional: display file modification times in local timezone
+            autoindex off;
+            index index.json;
+            try_files $uri $uri/ =404;
         }
-
     }
-
 }

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -56,7 +56,7 @@ kubectl create namespace flightctl-e2e      --context kind-kind 2>/dev/null || t
 # if we are only deploying the database, we don't need inject the server container
 if [ -z "$ONLY_DB" ]; then
 
-  for suffix in periodic api worker ; do
+  for suffix in periodic api worker cli-artifacts ; do
     kind_load_image localhost/flightctl-${suffix}:latest
   done
 

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -12,6 +12,9 @@ nodes:
   - containerPort: 3443 # flightctl API
     hostPort: 3443
     protocol: TCP
+  - containerPort: 8090 # flightctl CLI artifacts
+    hostPort: 8090
+    protocol: TCP
   - containerPort: 7443 # flightctl agent endpoint API
     hostPort: 7443
     protocol: TCP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - CLI artifacts are now supported and enabled by default, with a dedicated service accessible on port 8090.
  - Deployment configurations have been updated to include the new CLI artifacts container, offering seamless integration.
  - A new Helm template for managing CLI artifacts has been introduced, enhancing deployment capabilities.
  - The multiarch CLI build process has been enhanced for more efficient binary production and improved artifact metadata generation.
  - A new entrypoint script for Nginx configuration has been introduced to manage CLI artifacts.

- **Bug Fixes**
  - Updated Nginx configuration to ensure proper handling of requests and error management.

- **Chores**
  - Various improvements to build scripts and container configurations for better organization and clarity.
  - Updated GitHub Actions workflow comments for clarity regarding Windows ARM64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->