### PR TITLE
EDM-1314: docs: add inline compose details

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -135,6 +135,7 @@ quay.io.
 API_URL
 madrid
 paris
+apptype
  - docs/user/api-resources.md
 approvedBy
 creationTimestamp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced guidance for managing application runtimes with updated details on Podman support, including clear specifications and user tips.
  - Introduced new sections on embedding applications and specifying inline application manifests, featuring examples and practical instructions.

- **Chores**
  - Adjusted spell-check settings to recognize the term "apptype," reducing unnecessary alerts during documentation validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->