### PR TITLE
EDM-889: Restructure client config

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -221,7 +221,7 @@ func (o *LoginOptions) Run(ctx context.Context, args []string) error {
 		}
 	}
 	o.clientConfig.AuthInfo.AuthType = o.authConfig.AuthType
-	o.clientConfig.AuthInfo.AccessToken = token
+	o.clientConfig.AuthInfo.Token = token
 	o.clientConfig.AuthInfo.AuthCAFile = authCAFile
 	o.clientConfig.AuthInfo.ClientId = o.ClientId
 	o.clientConfig.AuthInfo.AuthURL = o.authConfig.AuthURL

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -82,7 +82,7 @@ func (o *LoginOptions) Bind(fs *pflag.FlagSet) {
 
 	fs.StringVarP(&o.AccessToken, "token", "t", o.AccessToken, "Bearer token for authentication to the API server")
 	fs.BoolVarP(&o.Web, "web", "w", o.Web, "Login via browser")
-	fs.StringVarP(&o.ClientId, "client-id", "", o.ClientId, "ClientId to be used for Oauth2 requests")
+	fs.StringVarP(&o.ClientId, "client-id", "", o.ClientId, "ClientId to be used for OAuth2 requests")
 	fs.StringVarP(&o.CAFile, "certificate-authority", "", o.CAFile, "Path to a cert file for the certificate authority")
 	fs.StringVarP(&o.AuthCAFile, "auth-certificate-authority", "", o.AuthCAFile, "Path to a cert file for the auth certificate authority")
 	fs.BoolVarP(&o.InsecureSkipVerify, "insecure-skip-tls-verify", "k", o.InsecureSkipVerify, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
@@ -125,10 +125,14 @@ func (o *LoginOptions) Init(args []string) error {
 		}
 	}
 	o.authProvider, err = client.CreateAuthProvider(client.AuthInfo{
-		AuthType:   o.authConfig.AuthType,
-		AuthCAFile: o.AuthCAFile,
-		ClientId:   o.ClientId,
-		AuthURL:    o.authConfig.AuthURL,
+		AuthProvider: &client.AuthProviderConfig{
+			Name: o.authConfig.AuthType,
+			Config: map[string]string{
+				client.AuthUrlKey:      o.authConfig.AuthURL,
+				client.AuthCAFileKey:   o.AuthCAFile,
+				client.AuthClientIdKey: o.ClientId,
+			},
+		},
 	}, o.InsecureSkipVerify)
 	return err
 }
@@ -198,6 +202,13 @@ func (o *LoginOptions) Run(ctx context.Context, args []string) error {
 		}
 		return nil
 	}
+	o.clientConfig.AuthInfo.AuthProvider = &client.AuthProviderConfig{
+		Name: o.authConfig.AuthType,
+		Config: map[string]string{
+			client.AuthUrlKey:      o.authConfig.AuthURL,
+			client.AuthClientIdKey: o.ClientId,
+		},
+	}
 
 	token := o.AccessToken
 	if token == "" {
@@ -206,25 +217,24 @@ func (o *LoginOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 		token = authInfo.AccessToken
-		o.clientConfig.AuthInfo.RefreshToken = authInfo.RefreshToken
+		o.clientConfig.AuthInfo.AuthProvider.Config[client.AuthRefreshTokenKey] = authInfo.RefreshToken
 		if authInfo.ExpiresIn != nil {
-			o.clientConfig.AuthInfo.AccessTokenExpiry = time.Unix(time.Now().Unix()+*authInfo.ExpiresIn, 0).Format(time.RFC3339Nano)
+			o.clientConfig.AuthInfo.AuthProvider.Config[client.AuthAccessTokenExpiryKey] = time.Unix(time.Now().Unix()+*authInfo.ExpiresIn, 0).Format(time.RFC3339Nano)
 		}
 	}
 	if token == "" {
 		return fmt.Errorf("failed to retrieve auth token")
 	}
+	o.clientConfig.AuthInfo.Token = token
+
 	if o.AuthCAFile != "" {
 		authCAFile, err = filepath.Abs(o.AuthCAFile)
 		if err != nil {
 			return fmt.Errorf("failed to get the absolute path of %s: %w", o.AuthCAFile, err)
 		}
 	}
-	o.clientConfig.AuthInfo.AuthType = o.authConfig.AuthType
-	o.clientConfig.AuthInfo.Token = token
-	o.clientConfig.AuthInfo.AuthCAFile = authCAFile
-	o.clientConfig.AuthInfo.ClientId = o.ClientId
-	o.clientConfig.AuthInfo.AuthURL = o.authConfig.AuthURL
+	o.clientConfig.AuthInfo.AuthProvider.Config[client.AuthCAFileKey] = authCAFile
+
 	c, err := client.NewFromConfig(o.clientConfig, o.ConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)

--- a/internal/client/authorization.go
+++ b/internal/client/authorization.go
@@ -56,7 +56,7 @@ func (c *accessTokenRefresher) refresh() error {
 		return fmt.Errorf("failed to renew token: %w", err)
 	}
 	c.config.AuthInfo.RefreshToken = authInfo.RefreshToken
-	c.config.AuthInfo.AccessToken = authInfo.AccessToken
+	c.config.AuthInfo.Token = authInfo.AccessToken
 	if authInfo.ExpiresIn != nil {
 		c.config.AuthInfo.AccessTokenExpiry = time.Now().Add(time.Duration(*authInfo.ExpiresIn) * time.Second).Format(time.RFC3339Nano)
 	}
@@ -118,7 +118,7 @@ func (c *accessTokenRefresher) start() {
 var authorizer util.Singleton[accessTokenRefresher]
 
 func (c *accessTokenRefresher) accessToken() string {
-	return c.config.AuthInfo.AccessToken
+	return c.config.AuthInfo.Token
 }
 
 func (c *accessTokenRefresher) rewind() {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -46,7 +46,7 @@ type Config struct {
 // Service contains information how to connect to and authenticate the Flight Control API server.
 type Service struct {
 	// Server is the URL of the Flight Control API server (the part before /api/v1/...).
-	Server string `json:"server"`
+	Server string `json:"server,omitempty"`
 	// TLSServerName is passed to the server for SNI and is used in the client to check server certificates against.
 	// If TLSServerName is empty, the hostname used to contact the server is used.
 	// +optional
@@ -74,7 +74,7 @@ type AuthInfo struct {
 	ClientKeyData []byte `json:"client-key-data,omitempty" datapolicy:"security-key"`
 	// The authentication type (i.e. k8s, OIDC)
 	// +optional
-	AuthType string `json:"auth-type"`
+	AuthType string `json:"auth-type,omitempty"`
 	// Bearer token for authentication
 	// +optional
 	AccessToken string `json:"access-token,omitempty"`
@@ -83,16 +83,16 @@ type AuthInfo struct {
 	RefreshToken string `json:"refresh-token,omitempty"`
 	// The time the access token will expire
 	// +optional
-	AccessTokenExpiry string `json:"access-token-expiry"`
+	AccessTokenExpiry string `json:"access-token-expiry,omitempty"`
 	// CA file used for authentication
 	// +optional
-	AuthCAFile string `json:"auth-ca-file"`
+	AuthCAFile string `json:"auth-ca-file,omitempty"`
 	// Client ID used for authentication
 	// +optional
-	ClientId string `json:"client-id"`
+	ClientId string `json:"client-id,omitempty"`
 	// Authorization URL for authentication
 	// +optional
-	AuthURL string `json:"auth-url"`
+	AuthURL string `json:"auth-url,omitempty"`
 }
 
 func (c *Config) Equal(c2 *Config) bool {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -77,7 +77,7 @@ type AuthInfo struct {
 	AuthType string `json:"auth-type,omitempty"`
 	// Bearer token for authentication
 	// +optional
-	AccessToken string `json:"access-token,omitempty"`
+	Token string `json:"token,omitempty"`
 	// Use for refreshing the access token
 	// +optional
 	RefreshToken string `json:"refresh-token,omitempty"`


### PR DESCRIPTION
This PR changes the serialisation of client configs:

* Tags auth provider-specific fields as "omitempty", so they no longer pollute client configs that do not use an auth provider (but, e.g., agent client certs).
* Stores the bearer token again as "token" instead of "access-token", because not all bearer tokens are OAuth2 access tokens.
* Moves auth provider-specific fields into a sub-struct to keep them extensible and to separate them from the provider-agnostic fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined authentication configuration and token management to enhance clarity and ensure a smoother sign-in experience.
  
- **Bug Fixes**
  - Corrected minor display issues with authentication parameters for more consistent user interactions.
  
- **New Features**
  - Improved error handling during login, resulting in a more robust and reliable authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->