### PR TITLE
EDM-1320: api: improve compose spec validations

### DIFF
--- a/internal/agent/client/compose_test.go
+++ b/internal/agent/client/compose_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +15,7 @@ func TestParseComposeSpecFromDir(t *testing.T) {
 		name          string
 		files         map[string][]byte
 		expectedError error
-		expectedSpec  ComposeSpec
+		expectedSpec  common.ComposeSpec
 	}{
 		{
 			name: "single compose.yaml file",
@@ -25,8 +26,8 @@ services:
     image: nginx
 `),
 			},
-			expectedSpec: ComposeSpec{
-				Services: map[string]ComposeService{
+			expectedSpec: common.ComposeSpec{
+				Services: map[string]common.ComposeService{
 					"web": {Image: "nginx"},
 				},
 			},
@@ -45,8 +46,8 @@ services:
     image: nginx:latest
 `),
 			},
-			expectedSpec: ComposeSpec{
-				Services: map[string]ComposeService{
+			expectedSpec: common.ComposeSpec{
+				Services: map[string]common.ComposeService{
 					"web": {Image: "nginx:latest"},
 				},
 			},
@@ -65,8 +66,8 @@ services:
     image: apache
 `),
 			},
-			expectedSpec: ComposeSpec{
-				Services: map[string]ComposeService{
+			expectedSpec: common.ComposeSpec{
+				Services: map[string]common.ComposeService{
 					"web": {Image: "nginx"},
 				},
 			},
@@ -77,7 +78,7 @@ services:
 				"random-file.txt": []byte("not a compose file"),
 			},
 			expectedError: errors.ErrNoComposeFile,
-			expectedSpec:  ComposeSpec{},
+			expectedSpec:  common.ComposeSpec{},
 		},
 	}
 

--- a/internal/agent/device/applications/provider/image_test.go
+++ b/internal/agent/device/applications/provider/image_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/test/util"
@@ -129,7 +130,7 @@ services:
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
 				)
 			},
-			wantVerifyErr: errors.ErrHardCodedContainerName,
+			wantVerifyErr: validation.ErrHardCodedContainerName,
 		},
 		{
 			name:  "appType compose with no services",
@@ -152,32 +153,6 @@ image: quay.io/flightctl-tests/alpine:v1`,
 				)
 			},
 			wantVerifyErr: errors.ErrNoComposeServices,
-		},
-		{
-			name:  "appType compose tolerate tabs",
-			image: appImage,
-			labels: map[string]string{
-				AppTypeLabel: string(v1alpha1.AppTypeCompose),
-			},
-			spec: &v1alpha1.ApplicationProviderSpec{
-				Name: lo.ToPtr("app"),
-			},
-			composeSpec: `version: "3.8"
-services:
-	service1:
-    	image: quay.io/flightctl-tests/alpine:v1`,
-			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
-				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
-
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
-				)
-			},
 		},
 	}
 

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -259,12 +259,12 @@ func ensureCompose(ctx context.Context, log *log.PrefixLogger, podman *client.Po
 		return fmt.Errorf("parsing compose spec: %w", err)
 	}
 
-	if err := spec.Verify(); err != nil {
-		return fmt.Errorf("validating compose spec: %w", err)
+	if errs := validation.ValidateComposeSpec(spec); len(errs) > 0 {
+		return fmt.Errorf("validating compose spec: %w", errors.Join(errs...))
 	}
 
-	for _, image := range spec.Images() {
-		if err := ensureImageExists(ctx, log, podman, image); err != nil {
+	for _, svc := range spec.Services {
+		if err := ensureImageExists(ctx, log, podman, svc.Image); err != nil {
 			return fmt.Errorf("pulling service image: %w", err)
 		}
 	}

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -29,9 +29,8 @@ var (
 	ErrAppLabel               = errors.New("required label not found")
 
 	// compose
-	ErrHardCodedContainerName = errors.New("hard coded container name")
-	ErrNoComposeFile          = errors.New("no valid compose file found")
-	ErrNoComposeServices      = errors.New("no services found in compose spec")
+	ErrNoComposeFile     = errors.New("no valid compose file found")
+	ErrNoComposeServices = errors.New("no services found in compose spec")
 
 	// container images
 	ErrImageShortName = errors.New("failed to resolve image short name: use the full name i.e registry/image:tag")

--- a/internal/api/common/common.go
+++ b/internal/api/common/common.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ComposeSpec represents a Docker Compose specification.
+type ComposeSpec struct {
+	Services map[string]ComposeService `json:"services"`
+}
+
+// ComposeService represents a service in a Docker Compose specification.
+type ComposeService struct {
+	Image         string `json:"image"`
+	ContainerName string `json:"container_name"`
+}
+
+// ParseComposeSpec parses YAML data into a ComposeSpec
+func ParseComposeSpec(data []byte) (*ComposeSpec, error) {
+	var spec ComposeSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("invalid compose YAML: %w", err)
+	}
+	return &spec, nil
+}

--- a/internal/util/validation/compose.go
+++ b/internal/util/validation/compose.go
@@ -1,0 +1,134 @@
+package validation
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/api/common"
+)
+
+var ErrHardCodedContainerName = errors.New("hardcoded container_name")
+
+func isAtRoot(path string) bool {
+	return filepath.Base(path) == path
+}
+
+func ValidateComposePaths(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	if len(paths) > 2 {
+		return errors.New("too many compose paths: only one base and one override allowed")
+	}
+
+	var base, override string
+	for _, path := range paths {
+		kind, err := getComposePathType(path)
+		if err != nil {
+			return err
+		}
+		switch kind {
+		case BaseCompose:
+			if base != "" {
+				return fmt.Errorf("multiple compose paths provided: %q and %q", base, path)
+			}
+			base = path
+		case OverrideCompose:
+			if override != "" {
+				return fmt.Errorf("multiple override compose paths provided: %q and %q", override, path)
+			}
+			override = path
+		}
+	}
+
+	if len(paths) == 1 {
+		if base == "" {
+			return fmt.Errorf("override path %q cannot be used without a base path", paths[0])
+		}
+		return nil
+	}
+
+	if getComposePrefix(base) != getComposePrefix(override) {
+		return fmt.Errorf("mismatched tool types: base is %q, override is %q", base, override)
+	}
+
+	return nil
+}
+
+// ValidateComposeSpec verifies the ComposeSpec for common issues
+func ValidateComposeSpec(spec *common.ComposeSpec) []error {
+	services := spec.Services
+	if len(services) == 0 {
+		return []error{fmt.Errorf("compose spec has no services")}
+	}
+
+	var errs []error
+	for name, service := range spec.Services {
+		containerName := service.ContainerName
+		if service.ContainerName != "" {
+			errs = append(errs, fmt.Errorf("service %s has a %w %q which is not supported", name, ErrHardCodedContainerName, containerName))
+		}
+		image := service.Image
+		if image == "" {
+			errs = append(errs, fmt.Errorf("service %s is missing an image", name))
+		}
+		if err := ValidateOciImageReferenceStrict(&image, "services."+name+".image"); err != nil {
+			errs = append(errs, err...)
+		}
+	}
+	return errs
+}
+
+func getComposePrefix(f string) string {
+	if strings.HasPrefix(f, "docker-") {
+		return "docker"
+	}
+	if strings.HasPrefix(f, "podman-") {
+		return "podman"
+	}
+	return ""
+}
+
+type ComposePathType int
+
+const (
+	InvalidCompose ComposePathType = iota
+	BaseCompose
+	OverrideCompose
+)
+
+func getComposePathType(path string) (ComposePathType, error) {
+	if !isAtRoot(path) {
+		return InvalidCompose, fmt.Errorf("compose file must be at root level: %q", path)
+	}
+
+	base := filepath.Base(path)
+
+	if !strings.HasSuffix(base, ".yaml") && !strings.HasSuffix(base, ".yml") {
+		return InvalidCompose, fmt.Errorf("compose path must have .yaml or .yml extension: %q", path)
+	}
+
+	if strings.Contains(base, ".override.") {
+		if strings.HasPrefix(base, "docker-compose.") || strings.HasPrefix(base, "podman-compose.") {
+			return OverrideCompose, nil
+		}
+		return InvalidCompose, fmt.Errorf("invalid override compose path: %q", path)
+	}
+
+	validBaseNames := []string{
+		"docker-compose.yaml",
+		"docker-compose.yml",
+		"podman-compose.yaml",
+		"podman-compose.yml",
+	}
+
+	for _, name := range validBaseNames {
+		if base == name {
+			return BaseCompose, nil
+		}
+	}
+
+	return InvalidCompose, fmt.Errorf("invalid compose path: %q, supported paths: %v", path, strings.Join(validBaseNames, ", "))
+}

--- a/internal/util/validation/formats.go
+++ b/internal/util/validation/formats.go
@@ -30,6 +30,10 @@ const (
 	OciImageDigestFmt          string = `[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`
 	OciImageReferenceFmt       string = `(` + OciImageNameFmt + `)(?:\:(` + OciImageTagFmt + `))?(?:\@(` + OciImageDigestFmt + `))?`
 	OciImageReferenceMaxLength int    = 2048
+
+	// short names (nginx:latest) are forbidden with strict mode
+	StrictOciImageNameFmt      string = OciImageDomainFmt + `\/` + ociNameCompFmt + `(?:\/` + ociNameCompFmt + `)*`
+	StrictOciImageReferenceFmt string = `(` + StrictOciImageNameFmt + `)(?:\:(` + OciImageTagFmt + `))?(?:\@(` + OciImageDigestFmt + `))?`
 )
 
 // capture(namePat)
@@ -37,12 +41,19 @@ const (
 // optional(literal("@"), capture(digestPat))
 
 var (
-	OciImageReferenceRegexp = regexp.MustCompile("^" + OciImageReferenceFmt + "$")
+	OciImageReferenceRegexp       = regexp.MustCompile("^" + OciImageReferenceFmt + "$")
+	StrictOciImageReferenceRegexp = regexp.MustCompile("^" + StrictOciImageReferenceFmt + "$")
 )
 
 // Validates an OCI image reference.
 func ValidateOciImageReference(s *string, path string) []error {
 	return ValidateString(s, path, 1, OciImageReferenceMaxLength, OciImageReferenceRegexp, OciImageReferenceFmt, "quay.io/flightctl/flightctl:latest")
+}
+
+// Validates an OCI image reference in strict mode.
+// This mode forbids short names (nginx:latest) and requires a domain name.
+func ValidateOciImageReferenceStrict(s *string, path string) []error {
+	return ValidateString(s, path, 1, OciImageReferenceMaxLength, StrictOciImageReferenceRegexp, StrictOciImageReferenceFmt, "quay.io/flightctl/flightctl:latest")
 }
 
 const (

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -336,102 +335,4 @@ func asErrors(errs field.ErrorList) []error {
 		return []error{}
 	}
 	return agg.Errors()
-}
-
-func isAtRoot(path string) bool {
-	return filepath.Base(path) == path
-}
-
-func ValidateComposePaths(paths []string) error {
-	if len(paths) == 0 {
-		return nil
-	}
-	if len(paths) > 2 {
-		return errors.New("too many compose paths: only one base and one override allowed")
-	}
-
-	var base, override string
-	for _, path := range paths {
-		kind, err := getComposePathType(path)
-		if err != nil {
-			return err
-		}
-		switch kind {
-		case BaseCompose:
-			if base != "" {
-				return fmt.Errorf("multiple compose paths provided: %q and %q", base, path)
-			}
-			base = path
-		case OverrideCompose:
-			if override != "" {
-				return fmt.Errorf("multiple override compose paths provided: %q and %q", override, path)
-			}
-			override = path
-		}
-	}
-
-	if len(paths) == 1 {
-		if base == "" {
-			return fmt.Errorf("override path %q cannot be used without a base path", paths[0])
-		}
-		return nil
-	}
-
-	if getComposePrefix(base) != getComposePrefix(override) {
-		return fmt.Errorf("mismatched tool types: base is %q, override is %q", base, override)
-	}
-
-	return nil
-}
-
-func getComposePrefix(f string) string {
-	if strings.HasPrefix(f, "docker-") {
-		return "docker"
-	}
-	if strings.HasPrefix(f, "podman-") {
-		return "podman"
-	}
-	return ""
-}
-
-type ComposePathType int
-
-const (
-	InvalidCompose ComposePathType = iota
-	BaseCompose
-	OverrideCompose
-)
-
-func getComposePathType(path string) (ComposePathType, error) {
-	if !isAtRoot(path) {
-		return InvalidCompose, fmt.Errorf("compose file must be at root level: %q", path)
-	}
-
-	base := filepath.Base(path)
-
-	if !strings.HasSuffix(base, ".yaml") && !strings.HasSuffix(base, ".yml") {
-		return InvalidCompose, fmt.Errorf("compose path must have .yaml or .yml extension: %q", path)
-	}
-
-	if strings.Contains(base, ".override.") {
-		if strings.HasPrefix(base, "docker-compose.") || strings.HasPrefix(base, "podman-compose.") {
-			return OverrideCompose, nil
-		}
-		return InvalidCompose, fmt.Errorf("invalid override compose path: %q", path)
-	}
-
-	validBaseNames := []string{
-		"docker-compose.yaml",
-		"docker-compose.yml",
-		"podman-compose.yaml",
-		"podman-compose.yml",
-	}
-
-	for _, name := range validBaseNames {
-		if base == name {
-			return BaseCompose, nil
-		}
-	}
-
-	return InvalidCompose, fmt.Errorf("invalid compose path: %q, supported paths: %v", path, strings.Join(validBaseNames, ", "))
 }


### PR DESCRIPTION
This PR move composes validation logic out of the agent into validation to allow for service pre flight checks on inline compose spec.  This should improve overall UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new validation structure for inline application content and Docker Compose specifications.
  - Added comprehensive validation functions for Docker and Podman Compose files, including checks for hardcoded container names and path validations.
  - Implemented a strict validation mode for OCI image references to enforce proper naming conventions.

- **Bug Fixes**
  - Enhanced error messaging to provide clearer guidance on configuration issues and container settings.

- **Refactor**
  - Streamlined validation logic for inline applications and Docker Compose files, resulting in more consistent and effective error reporting.
  - Transitioned to a centralized definition of Compose specifications by utilizing a common package, simplifying the code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->