### PR TITLE
EDM-996: flightctl-agent rpm should create /etc/flightctl/ directory

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -85,6 +85,7 @@ The flightctl-selinux package provides the SELinux policy modules required by th
 
 %install
     mkdir -p %{buildroot}/usr/bin
+    mkdir -p %{buildroot}/etc/flightctl
     cp bin/flightctl %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
@@ -152,6 +153,7 @@ fi
 
 %files agent -f licenses.list
     %license LICENSE
+    %dir /etc/flightctl
     %{_bindir}/flightctl-agent
     %{_bindir}/flightctl-must-gather
     /usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The agent package now includes a dedicated configuration directory to support enhanced system configuration management.
	- A new directory `/etc/flightctl` is created during the installation process for improved organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->