### PR TITLE
EDM-1318: Bug fix removing client cert creation at startup

### DIFF
--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -133,16 +133,12 @@ func (caClient *CAClient) MakeServerCertificate(hostnames []string, expiryDays i
 }
 
 func (caClient *CAClient) EnsureClientCertificate(certFile, keyFile string, subjectName string, expireDays int) (*TLSCertificateConfig, bool, error) {
-	certConfig, err := GetClientCertificate(certFile, keyFile, subjectName)
+	certConfig, err := caClient.MakeClientCertificate(certFile, keyFile, subjectName, expireDays)
 	if err != nil {
-		certConfig, err := caClient.MakeClientCertificate(certFile, keyFile, subjectName, expireDays)
-		if err != nil {
-			return nil, false, err
-		}
-		err = certConfig.WriteCertConfigFile(certFile, keyFile)
-		return certConfig, err == nil, err // true indicates we wrote the files.
+		return nil, false, err
 	}
-	return certConfig, false, nil
+	err = certConfig.WriteCertConfigFile(certFile, keyFile)
+	return certConfig, err == nil, err // true indicates we wrote the files.
 }
 
 func GetClientCertificate(certFile, keyFile string, subjectName string) (*TLSCertificateConfig, error) {


### PR DESCRIPTION
creating a ca using the MakeClientCertificate function which creates a certificate using CSR API. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized the certificate generation process by streamlining error handling.
	- Now consistently saves certificate configuration after successful generation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->