### PR TITLE
EDM-1413: Set image tag for installed quadlets based off of rpm version

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -7,7 +7,7 @@ Requires=flightctl-db.service flightctl-kv.service
 
 [Container]
 ContainerName=flightctl-api
-Image=quay.io/flightctl/flightctl-api:0.6.0-main-35-g6e173b7
+Image=quay.io/flightctl/flightctl-api:latest
 Network=flightctl.network
 EnvironmentFile=/etc/flightctl/flightctl-api/env
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -6,7 +6,7 @@ Requires=flightctl-db.service flightctl-kv.service
 
 [Container]
 ContainerName=flightctl-periodic
-Image=quay.io/flightctl/flightctl-periodic:0.6.0-main-35-g6e173b7
+Image=quay.io/flightctl/flightctl-periodic:latest
 Network=flightctl.network
 Environment=HOME=/root
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -7,7 +7,7 @@ Requires=flightctl-api.service
 
 [Container]
 ContainerName=flightctl-ui
-Image=quay.io/flightctl/flightctl-ui:0.6.0-main-30-gfaedf0a
+Image=quay.io/flightctl/flightctl-ui:latest
 Network=flightctl.network
 EnvironmentFile=/etc/flightctl/flightctl-ui/env
 

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -6,7 +6,7 @@ Requires=flightctl-db.service flightctl-kv.service
 
 [Container]
 ContainerName=flightctl-worker
-Image=quay.io/flightctl/flightctl-worker:0.6.0-main-35-g6e173b7
+Image=quay.io/flightctl/flightctl-worker:latest
 Network=flightctl.network
 Environment=HOME=/root
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 # Directory path for source files
 : ${SOURCE_DIR:="deploy"}
+: ${IMAGE_TAG:="latest"}
 
 # Load shared functions
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
@@ -15,6 +16,30 @@ export CONFIG_WRITEABLE_DIR
 export QUADLET_FILES_OUTPUT_DIR
 export SYSTEMD_UNIT_OUTPUT_DIR
 
+update_image_tags() {
+    local image_tag="$1"
+    # Check if the image tag is provided
+    if [[ -z "$image_tag" ]]; then
+        echo "Error: No image tag provided"
+        exit 1
+    fi
+    # Check if the image tag is latest - this is the default tag so no need to write
+    if [[ "$image_tag" == "latest" ]]; then
+        echo "Using :latest image tag"
+        return
+    fi
+
+    echo "Setting container image tags to: $image_tag"
+
+    # Find all container files for flightctl services and update image tags
+    find "${QUADLET_FILES_OUTPUT_DIR}" -name "flightctl-*.container" | while read -r container_file; do
+        if grep -q "Image=quay.io/flightctl/" "$container_file"; then
+            sed -i "s|Image=quay.io/flightctl/\([^:]*\):latest|Image=quay.io/flightctl/\1:${image_tag}|" "$container_file"
+            echo "Updated $container_file"
+        fi
+    done
+}
+
 render_files() {
     render_service "api" "${SOURCE_DIR}"
     render_service "periodic" "${SOURCE_DIR}"
@@ -22,6 +47,8 @@ render_files() {
     render_service "db" "${SOURCE_DIR}"
     render_service "kv" "${SOURCE_DIR}"
     render_service "ui" "${SOURCE_DIR}"
+
+    update_image_tags "${IMAGE_TAG}"
 
     # Create writeable directories for certs and services that generate files
     mkdir -p "${CONFIG_WRITEABLE_DIR}/pki"

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -128,7 +128,12 @@ The flightctl-services package provides installation and setup of files for runn
     done
 
     # flightctl-services sub-package steps
-    # Run the install script to move the quadlet files
+    # Run the install script to move the quadlet files.
+    #
+    # The IMAGE_TAG is derived from the RPM version, which may include tildes (~)
+    # for proper version sorting (e.g., 0.5.1~rc1-1). However, the tagged images
+    # always use hyphens (-) instead of tildes (~). To ensure valid image tags we need
+    # to transform the version string by replacing tildes with hyphens.
     CONFIG_READONLY_DIR="%{buildroot}%{_datadir}/flightctl" \
     CONFIG_WRITEABLE_DIR="%{buildroot}%{_sysconfdir}/flightctl" \
     QUADLET_FILES_OUTPUT_DIR="%{buildroot}%{_datadir}/containers/systemd" \

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -133,6 +133,7 @@ The flightctl-services package provides installation and setup of files for runn
     CONFIG_WRITEABLE_DIR="%{buildroot}%{_sysconfdir}/flightctl" \
     QUADLET_FILES_OUTPUT_DIR="%{buildroot}%{_datadir}/containers/systemd" \
     SYSTEMD_UNIT_OUTPUT_DIR="%{buildroot}/usr/lib/systemd/system" \
+    IMAGE_TAG=$(echo %{version} | tr '~' '-') \
     deploy/scripts/install.sh
 
     # Copy files needed for post install into the build root
@@ -236,13 +237,14 @@ rm -rf /usr/share/sosreport
 
 %changelog
 
-* Thu Apr 3 2025 Ori Amizur <oamizur@redhat.com> - 0.6.0-1
+* Fri Apr 11 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-3
+- Add versioning to container images within flightctl-services sub-package
+* Thu Apr 3 2025 Ori Amizur <oamizur@redhat.com> - 0.6.0-2
 - Add sos report plugin support
 * Mon Mar 31 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-1
 - Add services sub-package for installation of containerized flightctl services
 * Fri Feb 7 2025 Miguel Angel Ajo <majopela@redhat.com> - 0.4.0-1
 - Add selinux support for console pty access
-
 * Mon Nov 4 2024 Miguel Angel Ajo <majopela@redhat.com> - 0.3.0-1
 - Move the Release field to -1 so we avoid auto generating packages
   with -5 all the time.


### PR DESCRIPTION
Updates the quadlets image tags such that:

- Tags used in the quadlets bundled in the RPM are set from the RPM version
- Tags used for local dev are :latest

One note:  Because we don't build and push containers as part of the pull request build the constructed RPM tags for the PR triggered COPR builds won't reference current tags.  The build will run, but the installable RPM won't work and code will need to be merged into main before an RPM referencing it is usable.  This could be solved by pushing images per PR or possibly falling back to :latest or some other value but my priority right now is removing the hardcoded tags for the 0.6.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated container images for the API, periodic operations, UI, and worker components to always deploy the latest releases.
  - Enhanced the installation process with dynamic image tag support.
  - Improved the packaging system with refined image versioning and updated changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->