### PR TITLE
EDM-310: Move crypto constants to central configuration

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -150,7 +150,7 @@ func (s *AgentServer) prepareHTTPHandler(serviceHandler *service.ServiceHandler)
 	router := chi.NewRouter()
 	router.Use(middlewares...)
 
-	h := transport.NewAgentTransportHandler(serviceHandler, s.log)
+	h := transport.NewAgentTransportHandler(serviceHandler, s.ca, s.log)
 	server.HandlerFromMux(h, router)
 	return router, nil
 }

--- a/internal/api_server/middleware/server_test.go
+++ b/internal/api_server/middleware/server_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Low level server behavior", func() {
 		serverLog := log.InitLogs()
 		config := config.NewDefault()
 		config.Service.CertStore = tempDir
+		config.CA.InternalConfig.CertStore = tempDir
 
 		var serverCerts *crypto.TLSCertificateConfig
 
@@ -73,7 +74,7 @@ var _ = Describe("Low level server behavior", func() {
 	Context("TLS client peer CommonName", func() {
 		It("should be included as context in the request for client bootstrap", func() {
 			dataStr := requestFromTLSCNServer(ca.GetCABundleX509(), enrollmentCert, listener)
-			Expect(dataStr).To(Equal(crypto.ClientBootstrapCommonName))
+			Expect(dataStr).To(Equal(ca.Cfg.ClientBootstrapCommonName))
 		})
 	})
 

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/config/ca"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,12 +19,6 @@ const (
 	certsDir  = "certs"
 	certFile  = "some.crt"
 	certData  = "certdata"
-
-	caCertValidityDays          = 365 * 10
-	serverCertValidityDays      = 365 * 1
-	clientBootStrapValidityDays = 365 * 1
-	signerCertName              = "ca"
-	clientBootstrapCertName     = "client-enrollment"
 )
 
 func TestValidConfig(t *testing.T) {
@@ -120,9 +115,10 @@ func TestClientConfig(t *testing.T) {
 			configFile := filepath.Join(testDirPath, "client.yaml")
 
 			// generate the CA and client certs
-			ca, _, err := crypto.EnsureCA(filepath.Join(testDirPath, "ca.crt"), filepath.Join(testDirPath, "ca.key"), "", signerCertName, caCertValidityDays)
+			cfg := ca.NewDefault(testDirPath)
+			ca, _, err := crypto.EnsureCA(cfg)
 			require.NoError(err)
-			clientCert, _, err := ca.EnsureClientCertificate(filepath.Join(testDirPath, "client-enrollment.crt"), filepath.Join(testDirPath, "client-enrollment.key"), clientBootstrapCertName, clientBootStrapValidityDays)
+			clientCert, _, err := ca.EnsureClientCertificate(filepath.Join(testDirPath, "client-enrollment.crt"), filepath.Join(testDirPath, "client-enrollment.key"), cfg.ClientBootstrapCertName, cfg.ClientBootstrapValidityDays)
 			require.NoError(err)
 
 			// write client config to disk

--- a/internal/config/ca/ca.go
+++ b/internal/config/ca/ca.go
@@ -1,0 +1,53 @@
+package ca
+
+type CAIdType int
+
+const (
+	InternalCA CAIdType = iota + 1
+	AsyncInternalCA
+)
+
+type InternalCfg struct {
+	CertFile         string `json:"certFile,omitempty"`
+	KeyFile          string `json:"keyFile,omitempty"`
+	SignerCertName   string `json:"signerCertName,omitempty"`
+	SerialFile       string `json:"serialFile,omitempty"`
+	CertValidityDays int    `json:"certValidityDays,omitempty"`
+	CertStore        string `json:"certStore,omitempty"`
+}
+
+type Config struct {
+	CAType                          CAIdType     `json:"type,omitempty"`
+	AdminCommonName                 string       `json:"adminCommonName,omitempty"`
+	ClientBootstrapCommonName       string       `json:"clientBootstrapCommonName,omitempty"`
+	ClientBootstrapCertName         string       `json:"clientBootstrapCertName,omitempty"`
+	ClientBootstrapSignerName       string       `json:"clientBootstrapSignerName,omitempty"`
+	ClientBootstrapCommonNamePrefix string       `json:"clientBootstrapCommonNamePrefix,omitempty"`
+	ClientBootstrapValidityDays     int          `json:"clientBootStrapValidityDays,omitempty"`
+	DeviceCommonNamePrefix          string       `json:"deviceCommonNamePrefix,omitempty"`
+	InternalConfig                  *InternalCfg `json:"internalConfig,omitempty"`
+	ServerCertValidityDays          int          `json:"serverCertValidityDays,omitempty"`
+	ExtraAllowedPrefixes            []string     `json:"extraAllowedPrefixes,omitempty"`
+}
+
+func NewDefault(tempDir string) *Config {
+	c := &Config{
+		CAType:                          InternalCA,
+		AdminCommonName:                 "flightctl-admin",
+		ClientBootstrapCertName:         "client-enrollment",
+		ClientBootstrapCommonName:       "client-enrollment",
+		ClientBootstrapSignerName:       "client-enrollment",
+		ClientBootstrapCommonNamePrefix: "client-enrollment-",
+		ClientBootstrapValidityDays:     365,
+		ServerCertValidityDays:          365,
+		DeviceCommonNamePrefix:          "device:",
+		InternalConfig: &InternalCfg{
+			CertFile:         "ca.crt",
+			KeyFile:          "ca.key",
+			CertValidityDays: 3650,
+			SignerCertName:     "ca",
+			CertStore:        tempDir,
+		},
+	}
+	return c
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/config/ca"
 	"github.com/flightctl/flightctl/internal/util"
 	"sigs.k8s.io/yaml"
 )
@@ -21,6 +22,7 @@ type Config struct {
 	KV         *kvConfig         `json:"kv,omitempty"`
 	Auth       *authConfig       `json:"auth,omitempty"`
 	Prometheus *prometheusConfig `json:"prometheus,omitempty"`
+	CA         *ca.Config        `json:"ca,omitempty"`
 }
 
 type dbConfig struct {
@@ -33,26 +35,26 @@ type dbConfig struct {
 }
 
 type svcConfig struct {
-	Address               string        `json:"address,omitempty"`
-	AgentEndpointAddress  string        `json:"agentEndpointAddress,omitempty"`
-	CertStore             string        `json:"cert,omitempty"`
-	BaseUrl               string        `json:"baseUrl,omitempty"`
-	BaseAgentEndpointUrl  string        `json:"baseAgentEndpointUrl,omitempty"`
-	BaseUIUrl             string        `json:"baseUIUrl,omitempty"`
-	CaCertFile            string        `json:"caCertFile,omitempty"`
-	CaKeyFile             string        `json:"caKeyFile,omitempty"`
-	SrvCertFile           string        `json:"srvCertFile,omitempty"`
-	SrvKeyFile            string        `json:"srvKeyFile,omitempty"`
-	AltNames              []string      `json:"altNames,omitempty"`
-	LogLevel              string        `json:"logLevel,omitempty"`
-	HttpReadTimeout       util.Duration `json:"httpReadTimeout,omitempty"`
-	HttpReadHeaderTimeout util.Duration `json:"httpReadHeaderTimeout,omitempty"`
-	HttpWriteTimeout      util.Duration `json:"httpWriteTimeout,omitempty"`
-	HttpIdleTimeout       util.Duration `json:"httpIdleTimeout,omitempty"`
-	HttpMaxNumHeaders     int           `json:"httpMaxNumHeaders,omitempty"`
-	HttpMaxHeaderBytes    int           `json:"httpMaxHeaderBytes,omitempty"`
-	HttpMaxUrlLength      int           `json:"httpMaxUrlLength,omitempty"`
-	HttpMaxRequestSize    int           `json:"httpMaxRequestSize,omitempty"`
+	Address                string        `json:"address,omitempty"`
+	AgentEndpointAddress   string        `json:"agentEndpointAddress,omitempty"`
+	CertStore              string        `json:"cert,omitempty"`
+	BaseUrl                string        `json:"baseUrl,omitempty"`
+	BaseAgentEndpointUrl   string        `json:"baseAgentEndpointUrl,omitempty"`
+	BaseUIUrl              string        `json:"baseUIUrl,omitempty"`
+	SrvCertFile            string        `json:"srvCertificateFile,omitempty"`
+	SrvKeyFile             string        `json:"srvKeyFile,omitempty"`
+	ServerCertName         string        `json:"serverCertName,omitempty"`
+	ServerCertValidityDays int           `json:"serverCertValidityDays,omitempty"`
+	AltNames               []string      `json:"altNames,omitempty"`
+	LogLevel               string        `json:"logLevel,omitempty"`
+	HttpReadTimeout        util.Duration `json:"httpReadTimeout,omitempty"`
+	HttpReadHeaderTimeout  util.Duration `json:"httpReadHeaderTimeout,omitempty"`
+	HttpWriteTimeout       util.Duration `json:"httpWriteTimeout,omitempty"`
+	HttpIdleTimeout        util.Duration `json:"httpIdleTimeout,omitempty"`
+	HttpMaxNumHeaders      int           `json:"httpMaxNumHeaders,omitempty"`
+	HttpMaxHeaderBytes     int           `json:"httpMaxHeaderBytes,omitempty"`
+	HttpMaxUrlLength       int           `json:"httpMaxUrlLength,omitempty"`
+	HttpMaxRequestSize     int           `json:"httpMaxRequestSize,omitempty"`
 }
 
 type kvConfig struct {
@@ -118,20 +120,22 @@ func NewDefault() *Config {
 			Password: "adminpass",
 		},
 		Service: &svcConfig{
-			Address:               ":3443",
-			AgentEndpointAddress:  ":7443",
-			CertStore:             CertificateDir(),
-			BaseUrl:               "https://localhost:3443",
-			BaseAgentEndpointUrl:  "https://localhost:7443",
-			LogLevel:              "info",
-			HttpReadTimeout:       util.Duration(5 * time.Minute),
-			HttpReadHeaderTimeout: util.Duration(5 * time.Minute),
-			HttpWriteTimeout:      util.Duration(5 * time.Minute),
-			HttpIdleTimeout:       util.Duration(5 * time.Minute),
-			HttpMaxNumHeaders:     32,
-			HttpMaxHeaderBytes:    32 * 1024, // 32KB
-			HttpMaxUrlLength:      2000,
-			HttpMaxRequestSize:    50 * 1024 * 1024, // 50MB
+			Address:                ":3443",
+			AgentEndpointAddress:   ":7443",
+			CertStore:              CertificateDir(),
+			BaseUrl:                "https://localhost:3443",
+			BaseAgentEndpointUrl:   "https://localhost:7443",
+			ServerCertName:         "server",
+			ServerCertValidityDays: 365,
+			LogLevel:               "info",
+			HttpReadTimeout:        util.Duration(5 * time.Minute),
+			HttpReadHeaderTimeout:  util.Duration(5 * time.Minute),
+			HttpWriteTimeout:       util.Duration(5 * time.Minute),
+			HttpIdleTimeout:        util.Duration(5 * time.Minute),
+			HttpMaxNumHeaders:      32,
+			HttpMaxHeaderBytes:     32 * 1024, // 32KB
+			HttpMaxUrlLength:       2000,
+			HttpMaxRequestSize:     50 * 1024 * 1024, // 50MB
 		},
 		KV: &kvConfig{
 			Hostname: "localhost",
@@ -144,6 +148,8 @@ func NewDefault() *Config {
 			ApiLatencyBins: []float64{1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0},
 		},
 	}
+	c.CA = ca.NewDefault(CertificateDir())
+	// CA certs are stored in the same location as Server Certs by default
 	return c
 }
 

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -7,23 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/flightctl/flightctl/internal/config/ca"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	oscrypto "github.com/openshift/library-go/pkg/crypto"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
-
-// Wraps openshift/library-go/pkg/crypto to use ECDSA and simplify the interface
-const ClientBootstrapCommonName = "client-enrollment"
-const ClientBootstrapCommonNamePrefix = "client-enrollment-"
-const AdminCommonName = "flightctl-admin"
-const DeviceCommonNamePrefix = "device:"
-
-var allowedPrefixes = [...]string{
-	DeviceCommonNamePrefix,
-	ClientBootstrapCommonNamePrefix,
-}
 
 type CABackend interface {
 	IssueRequestedCertificateAsX509(csr *x509.CertificateRequest, expirySeconds int, usage []x509.ExtKeyUsage) (*x509.Certificate, error)
@@ -32,41 +23,49 @@ type CABackend interface {
 
 type CAClient struct {
 	caBackend CABackend
+	Cfg       *ca.Config
 }
 
 // EnsureCA() tries to load or generate a CA and connect to it.
 // If the CA is successfully loaded or generated it returns a valid CA instance, a flag signifying
 // was it loaded or generated and a nil error.
 // In case of errors a non-nil error is returned.
-func EnsureCA(certFile, keyFile, serialFile, subjectName string, expireDays int) (*CAClient, bool, error) {
-	caBackend, fresh, err := ensureInternalCA(certFile, keyFile, serialFile, subjectName, expireDays)
+func EnsureCA(cfg *ca.Config) (*CAClient, bool, error) {
+	caBackend, fresh, err := ensureInternalCA(cfg)
 	if err != nil {
 		return nil, fresh, err
 	}
 	ret := &CAClient{
 		caBackend: caBackend,
+		Cfg:       cfg,
 	}
 	return ret, fresh, nil
 }
 
-func BootstrapCNFromName(name string) string {
+func CertStorePath(fileName string, store string) string {
+	return filepath.Join(store, fileName)
+}
 
-	for _, prefix := range allowedPrefixes {
+func (caClient *CAClient) BootstrapCNFromName(name string) string {
+
+	cfg := caClient.Cfg
+	base := []string{cfg.ClientBootstrapCommonNamePrefix, cfg.DeviceCommonNamePrefix}
+	for _, prefix := range append(base, cfg.ExtraAllowedPrefixes...) {
 		if strings.HasPrefix(name, prefix) {
 			return name
 		}
 	}
-	return ClientBootstrapCommonNamePrefix + name
+	return caClient.Cfg.ClientBootstrapCommonNamePrefix + name
 }
 
-func CNFromDeviceFingerprint(fingerprint string) (string, error) {
+func (caClient *CAClient) CNFromDeviceFingerprint(fingerprint string) (string, error) {
 	if len(fingerprint) < 16 {
 		return "", errors.New("device fingerprint must have 16 characters at least")
 	}
-	if strings.HasPrefix(fingerprint, DeviceCommonNamePrefix) {
+	if strings.HasPrefix(fingerprint, caClient.Cfg.DeviceCommonNamePrefix) {
 		return fingerprint, nil
 	}
-	return DeviceCommonNamePrefix + fingerprint, nil
+	return caClient.Cfg.DeviceCommonNamePrefix + fingerprint, nil
 }
 
 type TLSCertificateConfig oscrypto.TLSCertificateConfig

--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -33,12 +33,12 @@ func approveAndSignEnrollmentRequest(ca *crypto.CAClient, enrollmentRequest *api
 		return fmt.Errorf("approveAndSignEnrollmentRequest: error parsing CSR: %w", err)
 	}
 
-	supplied, err := crypto.CNFromDeviceFingerprint(csr.Subject.CommonName)
+	supplied, err := ca.CNFromDeviceFingerprint(csr.Subject.CommonName)
 	if err != nil {
 		return fmt.Errorf("approveAndSignEnrollmentRequest: invalid CN supplied in CSR: %w", err)
 	}
 
-	desired, err := crypto.CNFromDeviceFingerprint(*enrollmentRequest.Metadata.Name)
+	desired, err := ca.CNFromDeviceFingerprint(*enrollmentRequest.Metadata.Name)
 	if err != nil {
 		return fmt.Errorf("approveAndSignEnrollmentRequest: error setting CN in CSR: %w", err)
 	}

--- a/internal/transport/agent/handler.go
+++ b/internal/transport/agent/handler.go
@@ -18,19 +18,20 @@ import (
 
 type AgentTransportHandler struct {
 	serviceHandler *service.ServiceHandler
+	ca             *crypto.CAClient
 	log            logrus.FieldLogger
 }
 
 // Make sure we conform to servers Service interface
 var _ agentServer.Transport = (*AgentTransportHandler)(nil)
 
-func ValidateDeviceAccessFromContext(ctx context.Context, name string, log logrus.FieldLogger) error {
+func ValidateDeviceAccessFromContext(ctx context.Context, name string, ca *crypto.CAClient, log logrus.FieldLogger) error {
 	cn, ok := ctx.Value(middleware.TLSCommonNameContextKey).(string)
 	if !ok {
 		log.Warningf("an attempt to access device %q without a CN in tls certificate has been detected", name)
 		return errors.New("no common name in certificate")
 	}
-	if expectedCn, err := crypto.CNFromDeviceFingerprint(name); err != nil {
+	if expectedCn, err := ca.CNFromDeviceFingerprint(name); err != nil {
 		return err
 	} else if cn != expectedCn {
 		log.Warningf("an attempt to access device %q with a certificate with CN %q has been detected", name, cn)
@@ -40,13 +41,13 @@ func ValidateDeviceAccessFromContext(ctx context.Context, name string, log logru
 	return nil
 }
 
-func ValidateEnrollmentAccessFromContext(ctx context.Context, log logrus.FieldLogger) error {
+func ValidateEnrollmentAccessFromContext(ctx context.Context, ca *crypto.CAClient, log logrus.FieldLogger) error {
 	cn, ok := ctx.Value(middleware.TLSCommonNameContextKey).(string)
 	if !ok {
 		return errors.New("no common name in certificate")
 	}
-	if cn != crypto.ClientBootstrapCommonName &&
-		!strings.HasPrefix(cn, crypto.ClientBootstrapCommonNamePrefix) {
+	if cn != ca.Cfg.ClientBootstrapCommonName &&
+		!strings.HasPrefix(cn, ca.Cfg.ClientBootstrapCommonNamePrefix) {
 		log.Errorf("an attempt to perform enrollment with a certificate with CN %q has been detected", cn)
 		return errors.New("invalid tls CN for enrollment request")
 	}
@@ -54,14 +55,14 @@ func ValidateEnrollmentAccessFromContext(ctx context.Context, log logrus.FieldLo
 	return nil
 }
 
-func NewAgentTransportHandler(serviceHandler *service.ServiceHandler, log logrus.FieldLogger) *AgentTransportHandler {
-	return &AgentTransportHandler{serviceHandler: serviceHandler, log: log}
+func NewAgentTransportHandler(serviceHandler *service.ServiceHandler, ca *crypto.CAClient, log logrus.FieldLogger) *AgentTransportHandler {
+	return &AgentTransportHandler{serviceHandler: serviceHandler, ca: ca, log: log}
 }
 
 // (GET /api/v1/devices/{name}/rendered)
 func (s *AgentTransportHandler) GetRenderedDevice(w http.ResponseWriter, r *http.Request, name string, params api.GetRenderedDeviceParams) {
 
-	if err := ValidateDeviceAccessFromContext(r.Context(), name, s.log); err != nil {
+	if err := ValidateDeviceAccessFromContext(r.Context(), name, s.ca, s.log); err != nil {
 		status := api.StatusUnauthorized(http.StatusText(http.StatusUnauthorized))
 		transport.SetResponse(w, status, status)
 		return
@@ -74,7 +75,7 @@ func (s *AgentTransportHandler) GetRenderedDevice(w http.ResponseWriter, r *http
 // (PUT /api/v1/devices/{name}/status)
 func (s *AgentTransportHandler) ReplaceDeviceStatus(w http.ResponseWriter, r *http.Request, name string) {
 
-	if err := ValidateDeviceAccessFromContext(r.Context(), name, s.log); err != nil {
+	if err := ValidateDeviceAccessFromContext(r.Context(), name, s.ca, s.log); err != nil {
 		status := api.StatusUnauthorized(http.StatusText(http.StatusUnauthorized))
 		transport.SetResponse(w, status, status)
 		return
@@ -112,7 +113,7 @@ func (s *AgentTransportHandler) PatchDeviceStatus(w http.ResponseWriter, r *http
 // (POST /api/v1/enrollmentrequests)
 func (s *AgentTransportHandler) CreateEnrollmentRequest(w http.ResponseWriter, r *http.Request) {
 
-	if err := ValidateEnrollmentAccessFromContext(r.Context(), s.log); err != nil {
+	if err := ValidateEnrollmentAccessFromContext(r.Context(), s.ca, s.log); err != nil {
 		status := api.StatusUnauthorized(http.StatusText(http.StatusUnauthorized))
 		transport.SetResponse(w, status, status)
 		return
@@ -131,7 +132,7 @@ func (s *AgentTransportHandler) CreateEnrollmentRequest(w http.ResponseWriter, r
 // (GET /api/v1/enrollmentrequests/{name})
 func (s *AgentTransportHandler) ReadEnrollmentRequest(w http.ResponseWriter, r *http.Request, name string) {
 
-	if err := ValidateEnrollmentAccessFromContext(r.Context(), s.log); err != nil {
+	if err := ValidateEnrollmentAccessFromContext(r.Context(), s.ca, s.log); err != nil {
 		status := api.StatusUnauthorized(http.StatusText(http.StatusUnauthorized))
 		transport.SetResponse(w, status, status)
 		return

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -80,6 +80,7 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 
 	// create certs
 	serverCfg.Service.CertStore = filepath.Join(testDirPath, "etc", "flightctl", "certs")
+	serverCfg.CA.InternalConfig.CertStore = serverCfg.Service.CertStore
 	ca, serverCerts, _, err := testutil.NewTestCerts(&serverCfg)
 	if err != nil {
 		return nil, fmt.Errorf("NewTestHarness: %w", err)

--- a/test/integration/tasks/repotester_test.go
+++ b/test/integration/tasks/repotester_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/config/ca"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/tasks"
 	"github.com/gliderlabs/ssh"
@@ -44,13 +45,14 @@ func TestHttpsMTLSRepo(t *testing.T) {
 	require := require.New(t)
 
 	testDirPath := t.TempDir()
-	ca, _, err := crypto.EnsureCA(filepath.Join(testDirPath, "ca.crt"), filepath.Join(testDirPath, "ca.key"), "", "ca", 1)
+	cfg := ca.NewDefault(testDirPath)
+	ca, _, err := crypto.EnsureCA(cfg)
 	require.NoError(err)
 
 	serverCerts, _, err := ca.EnsureServerCertificate(filepath.Join(testDirPath, "server.crt"), filepath.Join(testDirPath, "server.key"), []string{"localhost"}, 1)
 	require.NoError(err)
 
-	adminCert, _, err := ca.EnsureClientCertificate(filepath.Join(testDirPath, "client.crt"), filepath.Join(testDirPath, "client.key"), crypto.AdminCommonName, 1)
+	adminCert, _, err := ca.EnsureClientCertificate(filepath.Join(testDirPath, "client.crt"), filepath.Join(testDirPath, "client.key"), cfg.AdminCommonName, 1)
 	require.NoError(err)
 
 	_, tlsConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -175,7 +174,7 @@ func NewTestStore(cfg config.Config, log *logrus.Logger) (store.Store, string, e
 
 // NewTestCerts creates new test certificates in the service certstore and returns the CA, server certificate, and enrollment certificate.
 func NewTestCerts(cfg *config.Config) (*crypto.CAClient, *crypto.TLSCertificateConfig, *crypto.TLSCertificateConfig, error) {
-	ca, _, err := crypto.EnsureCA(filepath.Join(cfg.Service.CertStore, "ca.crt"), filepath.Join(cfg.Service.CertStore, "ca.key"), "", "ca", caCertValidityDays)
+	ca, _, err := crypto.EnsureCA(cfg.CA)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("NewTestCerts: Ensuring CA: %w", err)
 	}
@@ -185,12 +184,12 @@ func NewTestCerts(cfg *config.Config) (*crypto.CAClient, *crypto.TLSCertificateC
 		cfg.Service.AltNames = []string{"localhost", "127.0.0.1", "::"}
 	}
 
-	serverCerts, _, err := ca.EnsureServerCertificate(filepath.Join(cfg.Service.CertStore, "server.crt"), filepath.Join(cfg.Service.CertStore, "server.key"), cfg.Service.AltNames, serverCertValidityDays)
+	serverCerts, _, err := ca.EnsureServerCertificate(crypto.CertStorePath("server.crt", cfg.Service.CertStore), crypto.CertStorePath("server.key", cfg.Service.CertStore), cfg.Service.AltNames, serverCertValidityDays)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("NewTestCerts: Ensuring server certificate: %w", err)
 	}
 
-	enrollmentCerts, _, err := ca.EnsureClientCertificate(filepath.Join(cfg.Service.CertStore, "client-enrollment.crt"), filepath.Join(cfg.Service.CertStore, "client-enrollment.key"), clientBootstrapCertName, clientBootStrapValidityDays)
+	enrollmentCerts, _, err := ca.EnsureClientCertificate(crypto.CertStorePath("client-enrollment.crt", cfg.Service.CertStore), crypto.CertStorePath("client-enrollment.key", cfg.Service.CertStore), clientBootstrapCertName, clientBootStrapValidityDays)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("NewTestCerts: Ensuring client enrollment certificate: %w", err)
 	}


### PR DESCRIPTION
1. Make all magic numbers and strings configurable
2. Provide centralized crypto configuration to support different CA plugins
3. Make configuration honour CertStore in the model

Dealing with corruption in the PR (narrowed down to github this time, my repo appears fine).

Trying to figure out is it at PR level or github itself.