### PR TITLE
Create aap oauth app

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-config/create_aap_application.sh
+++ b/deploy/podman/flightctl-api/flightctl-api-config/create_aap_application.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+create_oauth_application() {
+    local oauth_token="$1"
+    local base_domain="$2"
+    local aap_url="$3"
+    local insecure_skip_tls="$4"
+
+    # The Organization ID is hardcoded to 1 for now which is the 'Default' aap managed
+    # organization that is created by default.
+    json_payload=$(cat <<EOF
+{
+  "name": "Flight Control",
+  "organization": 1,
+  "authorization_grant_type": "authorization-code",
+  "client_type": "public",
+  "redirect_uris": "https://$base_domain:443/callback",
+  "app_url": "https://$base_domain:443"
+}
+EOF
+)
+
+    echo "Creating OAuth Application"
+    echo "OAuth Application Payload: $json_payload"
+
+    # Use an array for curl options for better handling of spaces and special characters
+    curl_opts=(-s)
+    if [[ "$insecure_skip_tls" == "true" ]]; then
+        echo "Warning: using insecure TLS connection"
+        curl_opts+=(-k)
+    fi
+    if [ -f "$CERTS_SOURCE_PATH/auth/ca.crt" ]; then
+        echo "Using provided auth CA certificate"
+        curl_opts+=(--cacert "$CERTS_SOURCE_PATH/auth/ca.crt")
+    fi
+
+    oauth_output_file=$(mktemp)
+    http_status=$(curl "${curl_opts[@]}" -w "%{http_code}" -o "$oauth_output_file" -X POST "$aap_url/api/gateway/v1/applications/" \
+        -H "Authorization: Bearer $oauth_token" \
+        -H "Content-Type: application/json" \
+        --data-raw "$json_payload")
+    if [[ "$http_status" -lt 200 || "$http_status" -ge 300 ]]; then
+        echo "Error: API call failed with status $http_status"
+        cat "$oauth_output_file"
+        rm "$oauth_output_file"
+        exit 1
+    fi
+
+    echo "OAuth Application Result:"
+    cat "$oauth_output_file"
+    echo
+
+    client_id=$(grep -oP '"client_id":\s*"\K[^"]+' "$oauth_output_file")
+    if [[ -z "$client_id" || "$client_id" == "" ]]; then
+        echo "Error: Failed to get client_id from response." >&2
+        exit 1
+    fi
+
+    echo "Updating service config file with new client id: $client_id"
+    # Tempfile here is necessary because we cannot directly modify the mounted config file in place
+    tmpfile=$(mktemp)
+    trap 'rm -f "$tmpfile" "$oauth_output_file"' EXIT
+    if ! sed -E "s|^([[:space:]]*oAuthApplicationClientId:).*|\1 $client_id|" "$SERVICE_CONFIG_FILE" > "$tmpfile"; then
+        echo "Error: Failed to update config file" >&2
+        exit 1
+    fi
+    cat "$tmpfile" > "$SERVICE_CONFIG_FILE"
+    echo "OAuth Application created successfully"
+}

--- a/deploy/podman/flightctl-api/flightctl-api-init.container
+++ b/deploy/podman/flightctl-api/flightctl-api-init.container
@@ -4,11 +4,12 @@ PartOf=flightctl.target
 [Container]
 Image=registry.access.redhat.com/ubi9/ubi-minimal
 ContainerName=flightctl-api-init
+Network=flightctl.network
 Volume=/usr/share/flightctl/flightctl-api:/config-source:ro,z
 Volume=/usr/share/flightctl/init_utils.sh:/utils/init_utils.sh:ro,z
 Volume=/etc/flightctl/pki:/certs:rw,z
 Volume=/etc/flightctl/flightctl-api:/config-destination:rw,z
-Volume=/etc/flightctl/service-config.yaml:/service-config.yaml:ro,z
+Volume=/etc/flightctl/service-config.yaml:/service-config.yaml:rw,z
 Exec=/bin/sh /config-source/init.sh
 
 [Service]

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -7,3 +7,4 @@ global:
       apiUrl:
       externalApiUrl:
       oAuthApplicationClientId:
+      oAuthToken:

--- a/deploy/scripts/init_utils.sh
+++ b/deploy/scripts/init_utils.sh
@@ -8,5 +8,6 @@ set -eo pipefail
 extract_value() {
     local key="$1"
     local file="$2"
-    sed -n -E "s/^[[:space:]]*${key}:[[:space:]]*[\"']?([^\"'#]+)[\"']?.*$/\1/p" "$file"
+    # Extract the value then trim leading and trailing whitespace
+    sed -n -E "s/^[[:space:]]*${key}:[[:space:]]*[\"']?([^\"'#]+)[\"']?.*$/\1/p" "$file" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -226,6 +226,7 @@ rm -rf /usr/share/sosreport
     %{_datadir}/flightctl/flightctl-api/config.yaml.template
     %{_datadir}/flightctl/flightctl-api/env.template
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-api/init.sh
+    %attr(0755,root,root) %{_datadir}/flightctl/flightctl-api/create_aap_application.sh
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db/enable-superuser.sh
     %{_datadir}/flightctl/flightctl-kv/redis.conf
     %{_datadir}/flightctl/flightctl-ui/env.template
@@ -242,6 +243,8 @@ rm -rf /usr/share/sosreport
 
 %changelog
 
+* Tue Apr 15 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-4
+- Add ability to create an AAP Oauth Application within flightctl-services sub-package
 * Fri Apr 11 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-3
 - Add versioning to container images within flightctl-services sub-package
 * Thu Apr 3 2025 Ori Amizur <oamizur@redhat.com> - 0.6.0-2


### PR DESCRIPTION
Allows users to pass an oauth token to the quadlet scripting and we will create a Fight control oauth application for them.  An OAuth app is created when aap auth is enabled and a token is passed in the config and a client ID does not exist in the config.

This is quite a happy path implementation and does not gracefully handle many errors.  The created app requires a primary key identifier for an "Organization", rather than build out any additional logic for now the value has been hardcoded to the default aap managed organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added automation for creating OAuth applications in Ansible Automation Platform (AAP), including a new script and service configuration support.
- **Improvements**
  - Enhanced container setup with writable service configuration and dedicated network assignment.
  - Improved handling of extracted configuration values by trimming whitespace.
- **Configuration**
  - Updated service configuration to support OAuth tokens for AAP authentication.
- **Packaging**
  - Included the new OAuth application creation script in the RPM package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->