### PR TITLE
EDM-1016: Add TPM functionality and unit tests to support attestation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,10 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-configfs-tsm v0.2.2 // indirect
+	github.com/google/go-sev-guest v0.9.3 // indirect
+	github.com/google/go-tdx-guest v0.3.1 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/logger v1.1.1 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -131,6 +134,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -142,6 +146,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,12 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/certificate-transparency-go v1.1.2 h1:4hE0GEId6NAW28dFpC+LrRGwQX5dtmXQGDbg8+/MZOM=
+github.com/google/certificate-transparency-go v1.1.2/go.mod h1:3OL+HKDqHPUfdKrHVQxO6T8nDLO0HF7LRTlkIWXaWvQ=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=
 github.com/google/gnostic-models v0.6.9/go.mod h1:CiWsm0s6BSQd1hRn8/QmxqB6BesYcbSZxsz9b0KuDBw=
+github.com/google/go-attestation v0.5.0 h1:jXtAWT2sw2Yu8mYU0BC7FDidR+ngxFPSE+pl6IUu3/0=
+github.com/google/go-attestation v0.5.0/go.mod h1:0Tik9y3rzV649Jcr7evbljQHQAsIlJucyqQjYDBqktU=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -166,6 +170,8 @@ github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/go-tpm-tools v0.4.4 h1:oiQfAIkc6xTy9Fl5NKTeTJkBTlXdHsxAofmQyxBKY98=
 github.com/google/go-tpm-tools v0.4.4/go.mod h1:T8jXkp2s+eltnCDIsXR84/MTcVU9Ja7bh3Mit0pa4AY=
+github.com/google/go-tspi v0.3.0 h1:ADtq8RKfP+jrTyIWIZDIYcKOMecRqNJFOew2IT0Inus=
+github.com/google/go-tspi v0.3.0/go.mod h1:xfMGI3G0PhxCdNVcYr1C4C+EizojDg/TXuX5by8CiHI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -175,6 +181,7 @@ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQu
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/renameio v1.0.1 h1:Lh/jXZmvZxb0BBeSY5VKEfidcbcbenKjZFzM/q0fSeU=
 github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWUAweKUpk=
+github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -466,6 +473,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -1,18 +1,52 @@
 package tpm
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"os"
 
+	"github.com/google/go-tpm-tools/client"
+	pbattest "github.com/google/go-tpm-tools/proto/attest"
+	pbtpm "github.com/google/go-tpm-tools/proto/tpm"
 	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
 
+const (
+	MinNonceLength     = 8
+	TpmSystemPath      = "/dev/tpm/tpm0"
+	TpmVersionInfoPath = "/sys/class/tpm/tpm0/tpm_version_major"
+)
+
 type TPM struct {
 	devicePath string
 	channel    io.ReadWriteCloser
+}
+
+// Note: this may be a hardware TPM or a software or emulated TPM available to the system
+func TpmExists() bool {
+	if _, err := os.Stat(TpmSystemPath); err == nil {
+		return true
+	}
+	return false
+}
+
+func ValidateTpmVersion2() error {
+	if !TpmExists() {
+		return fmt.Errorf("no TPM detected at %s", TpmSystemPath)
+	}
+	versionBytes, err := os.ReadFile(TpmVersionInfoPath)
+	if err != nil {
+		return err
+	}
+	versionStr := string(bytes.TrimSpace(versionBytes))
+	if versionStr != "2" {
+		return fmt.Errorf("TPM is not version 2.0")
+	}
+	return nil
 }
 
 func OpenTPM(devicePath string) (*TPM, error) {
@@ -50,4 +84,45 @@ func (t *TPM) GetPCRValues(measurements map[string]string) error {
 		measurements[key] = hex.EncodeToString(val)
 	}
 	return nil
+}
+
+// The local attestation key (LAK) is an asymmetric key that persists for the device's lifecycle (but not lifetime) and can be zeroized if needed when the device transfers ownership. (The IAK by contrast persists for the device's lifetime across uses and owners.) This key can only be used to sign TPM-internal data, ex. attestations. This is considered a Restricted signing key by the TPM.
+// Key attributes:
+// Restricted: yes
+// Sign: yes
+// Decrypt: no
+// FixedTPM: yes (cannot migrate or be duplicated)
+// SensitiveDataOrigin: yes (was created in the TPM)
+func (t *TPM) CreateLAK() (*client.Key, error) {
+	// AttestationKeyECC generates and loads a key from AKTemplateECC in the Owner (aka 'Storage') hierarchy.
+	return client.AttestationKeyECC(t.channel)
+}
+
+func (t *TPM) GetAttestation(nonce []byte, ak *client.Key) (*pbattest.Attestation, error) {
+	// TODO - may want to use CertChainFetcher in the AttestOpts in the future
+	// see https://pkg.go.dev/github.com/google/go-tpm-tools/client#AttestOpts
+
+	if len(nonce) < MinNonceLength {
+		return nil, fmt.Errorf("nonce does not meet minimum length of %d bytes", MinNonceLength)
+	}
+	if ak == nil {
+		return nil, fmt.Errorf("no attestation key provided")
+	}
+
+	return ak.Attest(client.AttestOpts{Nonce: nonce})
+}
+
+func (t *TPM) GetQuote(nonce []byte, ak *client.Key, pcr_selection *tpm2.PCRSelection) (*pbtpm.Quote, error) {
+	if len(nonce) < MinNonceLength {
+		return nil, fmt.Errorf("nonce does not meet minimum length of %d bytes", MinNonceLength)
+	}
+
+	if ak == nil {
+		return nil, fmt.Errorf("no attestation key provided")
+	}
+	if pcr_selection == nil {
+		return nil, fmt.Errorf("no pcr selection provided")
+	}
+
+	return ak.Quote(*pcr_selection, nonce)
 }

--- a/internal/tpm/tpm_test.go
+++ b/internal/tpm/tpm_test.go
@@ -1,0 +1,131 @@
+package tpm
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/google/go-tpm-tools/client"
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/stretchr/testify/require"
+)
+
+// These unit tests all use the tpm simulator from go-tpm-tools.
+
+type TestFixture struct {
+	tpm *TPM
+}
+
+func setupTestFixture(t *testing.T) (*TestFixture, error) {
+	t.Helper()
+
+	tpm, err := OpenTPMSimulator()
+	if err != nil {
+		return nil, fmt.Errorf("unable to open tpm simulator")
+	}
+
+	return &TestFixture{tpm: tpm}, nil
+}
+
+func setupTestData(t *testing.T) (*TPM, *client.Key, []byte, *tpm2.PCRSelection) {
+	t.Helper()
+	require := require.New(t)
+
+	f, err := setupTestFixture(t)
+	require.NoError(err)
+
+	key, err := f.tpm.CreateLAK()
+	require.NoError(err)
+
+	nonce := make([]byte, 8)
+	_, err = io.ReadFull(rand.Reader, nonce)
+	require.NoError(err)
+
+	selection := client.FullPcrSel(tpm2.AlgSHA256)
+
+	return f.tpm, key, nonce, &selection
+}
+
+func TestLAK(t *testing.T) {
+	tpm, key, _, _ := setupTestData(t)
+	defer func() {
+		tpm.Close()
+		key.Close()
+	}()
+
+	// This template is based on that used for AK ECC key creation in go-tpm-tools, see:
+	// https://github.com/google/go-tpm-tools/blob/3e063ade7f302972d7b893ca080a75efa3db5506/client/template.go#L108
+	//
+	// For more template options, see https://pkg.go.dev/github.com/google/go-tpm/legacy/tpm2#Public
+	params := tpm2.ECCParams{
+		Symmetric: nil,
+		CurveID:   tpm2.CurveNISTP256,
+		Point: tpm2.ECPoint{
+			XRaw: make([]byte, 32),
+			YRaw: make([]byte, 32),
+		},
+	}
+	params.Sign = &tpm2.SigScheme{
+		Alg:  tpm2.AlgECDSA,
+		Hash: tpm2.AlgSHA256,
+	}
+	template := tpm2.Public{
+		Type:          tpm2.AlgECC,
+		NameAlg:       tpm2.AlgSHA256,
+		Attributes:    tpm2.FlagSignerDefault,
+		ECCParameters: &params,
+	}
+
+	pub := key.PublicArea()
+	if !pub.MatchesTemplate(template) {
+		t.Errorf("local attestation key does not match template")
+	}
+}
+
+func TestGetQuote(t *testing.T) {
+	require := require.New(t)
+	tpm, key, nonce, selection := setupTestData(t)
+	defer func() {
+		tpm.Close()
+		key.Close()
+	}()
+
+	_, err := tpm.GetQuote(nonce, key, selection)
+	require.NoError(err)
+}
+
+func TestGetAttestation(t *testing.T) {
+	// Skip this test when running in a CI environment where the event log file is not available
+	_, err := os.ReadFile("/sys/kernel/security/tpm0/binary_bios_measurements")
+	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
+		t.Skip("Skipping test: TCG Event Log not available")
+	}
+
+	require := require.New(t)
+	tpm, key, nonce, _ := setupTestData(t)
+	defer func() {
+		tpm.Close()
+		key.Close()
+	}()
+
+	_, err = tpm.GetAttestation(nonce, key)
+	require.NoError(err)
+}
+
+func TestGetPCRValues(t *testing.T) {
+	require := require.New(t)
+	tpm, key, _, _ := setupTestData(t)
+	defer func() {
+		tpm.Close()
+		key.Close()
+	}()
+
+	measurements := make(map[string]string)
+
+	err := tpm.GetPCRValues(measurements)
+	require.NoError(err)
+}


### PR DESCRIPTION
This PR adds and tests some TPM functionality that can be used in a future PR to do the following agent-side:
- Detect whether a TPM is present
- Get a Quote or Attestation from the TPM
- Generate an Attestation Key to be used for signing the Attestation, as well as potentially for the device ID

Note: According to the [TCG's guide to keys for identity and attestation](https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf), it is best practice to separate the Attestation Key from the DeviceID key. However, the `go-tpm-tools` library (which seems to be the best option for TPM interaction in Go) [does not yet seem to support](https://github.com/google/go-tpm-tools/blob/v0.4.5/client/keys.go#L194) generating this DeviceID key as a non-primary key. So we may temporarily need to use the Attestation Key for both purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TPM detection and version validation.
  - Introduced capabilities to create local attestation keys and generate TPM quotes with nonce validation.
  - Enabled attestation data retrieval using TPM keys.

- **Tests**
  - Added unit tests covering TPM key creation, quote generation, attestation retrieval, and PCR value reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->