### PR TITLE
EDM-1453: agent: improve transient error handling

### DIFF
--- a/internal/agent/client/bootc.go
+++ b/internal/agent/client/bootc.go
@@ -37,9 +37,14 @@ func (b *bootc) Status(ctx context.Context) (*container.BootcHost, error) {
 		return nil, fmt.Errorf("bootc status: %w", errors.FromStderr(stderr, exitCode))
 	}
 
+	if !isJSON(stdout) {
+		b.log.Warnf("Non-JSON output from bootc status: %q", stdout)
+		return nil, errors.ErrBootcStatusInvalidJSON
+	}
+
 	var bootcHost container.BootcHost
 	if err := json.Unmarshal([]byte(stdout), &bootcHost); err != nil {
-		return nil, fmt.Errorf("unmarshalling config file: %w", err)
+		return nil, fmt.Errorf("unmarshalling bootc status: %w", err)
 	}
 
 	return &bootcHost, nil
@@ -107,4 +112,10 @@ func (b *bootc) UsrOverlay(ctx context.Context) error {
 		return fmt.Errorf("overlay image: %w", errors.FromStderr(stderr, exitCode))
 	}
 	return nil
+}
+
+// isJSON checks whether a string is valid JSON
+func isJSON(s string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(s), &js) == nil
 }

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -225,11 +225,15 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 			return
 		}
 
-		// if the device is not upgrading, we should never see a sync error
-		// because the device is in a steady state. this is a potential bug in
-		// the reconciliation loop.
 		if !a.specManager.IsUpgrading() {
-			a.log.Errorf("Steady state is no longer in sync: %v", syncErr)
+			// if the device is not upgrading, we should never see a sync error
+			// because the device is in a steady state. this is a potential bug in
+			// the reconciliation loop if the error is not retryable.
+			if !errors.IsRetryable(syncErr) {
+				a.log.Errorf("Steady state is no longer in sync: %v", syncErr)
+			} else {
+				a.log.Warnf("Retryable error observed during the steady state: %v", syncErr)
+			}
 			return
 		}
 
@@ -427,6 +431,7 @@ func (a *Agent) afterUpdate(ctx context.Context, current, desired *v1alpha1.Devi
 
 	_, isOSReconciled, err := a.specManager.CheckOsReconciliation(ctx)
 	if err != nil {
+		a.log.Errorf("Error checking is os reconciled: %v", err)
 		return err
 	}
 

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -77,6 +77,9 @@ var (
 	ErrDownloadPolicyNotReady = errors.New("download policy not ready")
 	ErrUpdatePolicyNotReady   = errors.New("update policy not ready")
 	ErrInvalidPolicyType      = errors.New("invalid policy type")
+
+	// bootc
+	ErrBootcStatusInvalidJSON = errors.New("bootc status did not return valid JSON")
 )
 
 // TODO: tighten up the retryable errors ideally all retryable errors should be explicitly defined
@@ -93,6 +96,11 @@ func IsRetryable(err error) bool {
 	case errors.Is(err, ErrNoContent):
 		// no content is a retryable error it means the server does not have a
 		// new template version
+		return true
+	case errors.Is(err, ErrBootcStatusInvalidJSON):
+		// this is a retryable error because it means the bootc status did not
+		// return valid JSON. this is a bug in the bootc status and we should
+		// retry the request as the error is transient.
 		return true
 	case errors.Is(err, ErrNoRetry):
 		return false


### PR DESCRIPTION
This PR adds fixes to a few common issues. One is the agent reconciles the current spec in the steady state every 5 minutes.  The expectation is that the entire loop is idempotent but there are circumstances where a retryable error occurs in this case do not log error just warn.

The other handles a transient case where bootc status --json returns a non json object. In this case we declare the error as retryable as the problem resolves on retry. The additional logging will improve debugging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when processing device status, ensuring invalid JSON responses are correctly identified and managed.
  - Enhanced logging to provide clearer warnings and errors based on the type of issue encountered during device synchronization.

- **New Features**
  - Added specific error messaging for invalid JSON responses from device status checks, allowing for more accurate troubleshooting.

- **Chores**
  - Updated error classification to ensure certain errors are retried automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->