### PR TITLE
Websocket Middleware Fix Backport

### DIFF
--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -198,7 +198,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		consoleSessionManager := console.NewConsoleSessionManager(serviceHandler, s.log, s.consoleEndpointReg)
 		ws := transport.NewWebsocketHandler(s.ca, s.log, consoleSessionManager)
-		ws.RegisterRoutes(router)
+		ws.RegisterRoutes(r)
 	})
 
 	srv := fcmiddleware.NewHTTPServer(router, s.log, s.cfg.Service.Address, s.cfg)


### PR DESCRIPTION
Backport of: https://github.com/flightctl/flightctl/pull/1107

Addresses an issue found with unauthenticated requests being allowed to the console websocket handler

[EDM-1452](https://issues.redhat.com/browse/EDM-1452)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved routing for WebSocket endpoints to ensure they are properly scoped within their designated route group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->