### PR TITLE
EDM-1428: Add reload support for configuration changes

### DIFF
--- a/cmd/flightctl-agent/main.go
+++ b/cmd/flightctl-agent/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent"
+	"github.com/flightctl/flightctl/internal/agent/config"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -58,17 +59,17 @@ func main() {
 
 type agentCmd struct {
 	log        *log.PrefixLogger
-	config     *agent.Config
+	config     *config.Config
 	configFile string
 }
 
 func NewAgentCommand() *agentCmd {
 	a := &agentCmd{
 		log:    log.NewPrefixLogger(""),
-		config: agent.NewDefault(),
+		config: config.NewDefault(),
 	}
 
-	flag.StringVar(&a.configFile, "config", agent.DefaultConfigFile, "Path to the agent's configuration file.")
+	flag.StringVar(&a.configFile, "config", config.DefaultConfigFile, "Path to the agent's configuration file.")
 	flag.Parse()
 
 	a.config.ConfigDir = filepath.Dir(a.configFile)
@@ -88,7 +89,7 @@ func NewAgentCommand() *agentCmd {
 }
 
 func (a *agentCmd) Execute() error {
-	agentInstance := agent.New(a.log, a.config)
+	agentInstance := agent.New(a.log, a.config, a.configFile)
 	if err := agentInstance.Run(context.Background()); err != nil {
 		a.log.Fatalf("running device agent: %v", err)
 	}
@@ -157,7 +158,7 @@ func printUsage() {
 func printAgentHelp() {
 	fs := flag.NewFlagSet("agent", flag.ExitOnError)
 	var configFile string
-	fs.StringVar(&configFile, "config", agent.DefaultConfigFile, "Path to the agent's configuration file.")
+	fs.StringVar(&configFile, "config", config.DefaultConfigFile, "Path to the agent's configuration file.")
 	fmt.Printf("Usage of %s (agent mode):\n", os.Args[0])
 	fs.PrintDefaults()
 }

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -1,4 +1,4 @@
-package agent
+package config
 
 import (
 	"encoding/json"

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -1,4 +1,4 @@
-package agent
+package config
 
 import (
 	"os"

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
 	"github.com/flightctl/flightctl/internal/agent/device/applications"
 	"github.com/flightctl/flightctl/internal/agent/device/config"
 	"github.com/flightctl/flightctl/internal/agent/device/console"
@@ -123,6 +124,14 @@ func (a *Agent) Stop(ctx context.Context) error {
 			a.cancelFn()
 		}
 	})
+	return nil
+}
+
+func (a *Agent) ReloadLogLevel(ctx context.Context, config *agent_config.Config) error {
+	if config.LogLevel != "" {
+		a.log.Infof("updating log level to %s", config.LogLevel)
+		a.log.Level(config.LogLevel)
+	}
 	return nil
 }
 

--- a/internal/agent/reload/reader.go
+++ b/internal/agent/reload/reader.go
@@ -1,0 +1,83 @@
+package reload
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+
+	"github.com/flightctl/flightctl/internal/agent/config"
+	"sigs.k8s.io/yaml"
+)
+
+type reader struct {
+	baseConfigFile string
+	configDir      string
+}
+
+func newReader(baseConfigFile, configDir string) *reader {
+	return &reader{
+		baseConfigFile: baseConfigFile,
+		configDir:      configDir,
+	}
+}
+
+func (r *reader) readFile(filename string) (*config.Config, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var ret config.Config
+	if err = yaml.Unmarshal(b, &ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+func overrideIfNotEmpty[T any](dst *T, src T) {
+	var empty T
+	if !reflect.DeepEqual(empty, src) {
+		*dst = src
+	}
+}
+
+func (r *reader) overrideConfigs(base, overrides *config.Config) (*config.Config, error) {
+	overrideIfNotEmpty(&base.LogLevel, overrides.LogLevel)
+	overrideIfNotEmpty(&base.LogPrefix, overrides.LogPrefix)
+
+	// TODO add all config values
+	return base, nil
+}
+
+func (r *reader) readConfig() (*config.Config, error) {
+	cfg, err := r.readFile(r.baseConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	confSubdir := filepath.Join(r.configDir, "conf.d")
+	entries, err := os.ReadDir(confSubdir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, err
+	}
+	re := regexp.MustCompile(`^.*[.]ya?ml$`)
+	for _, entry := range entries {
+		if !re.MatchString(entry.Name()) {
+			continue
+		}
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(confSubdir, entry.Name())
+		overrideConf, err := r.readFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if cfg, err = r.overrideConfigs(cfg, overrideConf); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}

--- a/internal/agent/reload/reload.go
+++ b/internal/agent/reload/reload.go
@@ -1,0 +1,82 @@
+package reload
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const reloadTimeout = 60 * time.Second
+
+type Callback func(ctx context.Context, config *config.Config) error
+
+type Manager interface {
+	Run(context.Context)
+	Reload(context.Context)
+	Register(Callback)
+}
+
+type manager struct {
+	mu             sync.Mutex
+	reloadMu       sync.Mutex
+	callbacks      []Callback
+	baseConfigFile string
+	configDir      string
+	log            *log.PrefixLogger
+}
+
+func (m *manager) Run(ctx context.Context) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGHUP)
+	defer signal.Stop(signals)
+	for {
+		select {
+		case <-signals:
+			m.Reload(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *manager) Reload(ctx context.Context) {
+	m.log.Info("reloading config")
+	defer m.log.Info("config reloaded")
+	m.reloadMu.Lock()
+	defer m.reloadMu.Unlock()
+	timeoutCtx, cancel := context.WithTimeout(ctx, reloadTimeout)
+	defer cancel()
+
+	r := newReader(m.baseConfigFile, m.configDir)
+	cfg, err := r.readConfig()
+	if err != nil {
+		m.log.Errorf("failed to read config: %v", err)
+		return
+	}
+	registered := m.callbacks
+	for _, f := range registered {
+		if err := f(timeoutCtx, cfg); err != nil {
+			m.log.Errorf("Failed to reload device: %v", err)
+		}
+	}
+}
+
+func (m *manager) Register(c Callback) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callbacks = append(m.callbacks, c)
+}
+
+func New(baseConfigFile, configDir string, log *log.PrefixLogger) Manager {
+	return &manager{
+		log:            log,
+		configDir:      configDir,
+		baseConfigFile: baseConfigFile,
+	}
+}

--- a/internal/agent/reload/reload_test.go
+++ b/internal/agent/reload/reload_test.go
@@ -1,0 +1,69 @@
+package reload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+var mu sync.Mutex
+
+func sendSignal(t *testing.T) {
+	// Simulate sending a SIGHUP signal
+	signal := syscall.SIGHUP
+	err := syscall.Kill(os.Getpid(), signal)
+	require.NoError(t, err, "Failed to send SIGHUP signal")
+}
+
+func runTest(t *testing.T, dir, expected string) {
+	mu.Lock()
+	defer mu.Unlock()
+	log := log.NewPrefixLogger("test")
+	configFile := filepath.Join(dir, "config.yaml")
+	reloader := New(configFile, dir, log)
+	var (
+		called   atomic.Bool
+		received atomic.Pointer[string]
+	)
+	reloader.Register(func(ctx context.Context, config *config.Config) error {
+		received.Store(&config.LogLevel)
+		called.Store(true)
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	go reloader.Run(ctx)
+	time.Sleep(5 * time.Millisecond)
+	sendSignal(t)
+	require.Eventually(t, func() bool { return called.Load() }, time.Second, 5*time.Millisecond)
+	require.Equal(t, expected, lo.FromPtr(received.Load()))
+}
+
+func TestReloader(t *testing.T) {
+	const testDir = "testdata"
+	t.Run("No level definition", func(t *testing.T) {
+		runTest(t, filepath.Join(testDir, "t1"), "")
+	})
+	t.Run("Only top level definition", func(t *testing.T) {
+		runTest(t, filepath.Join(testDir, "t2"), "warning")
+	})
+	t.Run("With single override", func(t *testing.T) {
+		runTest(t, filepath.Join(testDir, "t3"), "debug")
+	})
+	t.Run("With 2 overrides", func(t *testing.T) {
+		runTest(t, filepath.Join(testDir, "t4"), "info")
+	})
+	t.Run("With illegal file name", func(t *testing.T) {
+		runTest(t, filepath.Join(testDir, "t5"), "warning")
+	})
+}

--- a/internal/agent/reload/testdata/t1/config.yaml
+++ b/internal/agent/reload/testdata/t1/config.yaml
@@ -1,0 +1,2 @@
+spec-fetch-interval: 0m2s
+status-update-interval: 0m2s

--- a/internal/agent/reload/testdata/t2/config.yaml
+++ b/internal/agent/reload/testdata/t2/config.yaml
@@ -1,0 +1,3 @@
+log-level: warning
+spec-fetch-interval: 0m2s
+status-update-interval: 0m2s

--- a/internal/agent/reload/testdata/t3/conf.d/01.yaml
+++ b/internal/agent/reload/testdata/t3/conf.d/01.yaml
@@ -1,0 +1,1 @@
+log-level: debug

--- a/internal/agent/reload/testdata/t3/config.yaml
+++ b/internal/agent/reload/testdata/t3/config.yaml
@@ -1,0 +1,3 @@
+log-level: warning
+spec-fetch-interval: 0m2s
+status-update-interval: 0m2s

--- a/internal/agent/reload/testdata/t4/conf.d/01.yaml
+++ b/internal/agent/reload/testdata/t4/conf.d/01.yaml
@@ -1,0 +1,1 @@
+log-level: debug

--- a/internal/agent/reload/testdata/t4/conf.d/02.yml
+++ b/internal/agent/reload/testdata/t4/conf.d/02.yml
@@ -1,0 +1,1 @@
+log-level: info

--- a/internal/agent/reload/testdata/t4/config.yaml
+++ b/internal/agent/reload/testdata/t4/config.yaml
@@ -1,0 +1,3 @@
+log-level: warning
+spec-fetch-interval: 0m2s
+status-update-interval: 0m2s

--- a/internal/agent/reload/testdata/t5/conf.d/01.yam
+++ b/internal/agent/reload/testdata/t5/conf.d/01.yam
@@ -1,0 +1,1 @@
+log-level: debug

--- a/internal/agent/reload/testdata/t5/config.yaml
+++ b/internal/agent/reload/testdata/t5/config.yaml
@@ -1,0 +1,3 @@
+log-level: warning
+spec-fetch-interval: 0m2s
+status-update-interval: 0m2s

--- a/packaging/systemd/flightctl-agent.service
+++ b/packaging/systemd/flightctl-agent.service
@@ -27,5 +27,7 @@ RestartSteps=20
 KillMode=process 
 KillSignal=SIGINT
 
+ExecReload=/bin/kill -HUP $MAINPID
+
 [Install]
 WantedBy=multi-user.target

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	apiserver "github.com/flightctl/flightctl/internal/api_server"
 	"github.com/flightctl/flightctl/internal/auth"
@@ -31,7 +32,7 @@ type TestHarness struct {
 	// internals for agent
 	cancelAgentCtx context.CancelFunc
 	agentFinished  chan struct{}
-	agentConfig    *agent.Config
+	agentConfig    *agent_config.Config
 
 	// internals for server
 	serverListener net.Listener
@@ -140,8 +141,8 @@ func NewTestHarness(testDirPath string, goRoutineErrorHandler func(error)) (*Tes
 	fetchSpecInterval := util.Duration(2 * time.Second)
 	statusUpdateInterval := util.Duration(2 * time.Second)
 
-	os.Setenv(agent.TestRootDirEnvKey, testDirPath)
-	cfg := agent.NewDefault()
+	os.Setenv(agent_config.TestRootDirEnvKey, testDirPath)
+	cfg := agent_config.NewDefault()
 	// TODO: remove the cert/key modifications from default, and start storing
 	// the test harness files for those in the testDir/etc/flightctl/certs path
 	cfg.EnrollmentService = config.EnrollmentService{
@@ -194,7 +195,7 @@ func (h *TestHarness) Cleanup() {
 	// stop any pending API requests
 	h.cancelCtx()
 	// unset env var for the test dir path
-	os.Unsetenv(agent.TestRootDirEnvKey)
+	os.Unsetenv(agent_config.TestRootDirEnvKey)
 	h.ctrl.Finish()
 }
 
@@ -213,7 +214,7 @@ func (h *TestHarness) StopAgent() {
 
 func (h *TestHarness) StartAgent() {
 	agentLog := log.NewPrefixLogger("")
-	agentInstance := agent.New(agentLog, h.agentConfig)
+	agentInstance := agent.New(agentLog, h.agentConfig, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h.agentFinished = make(chan struct{})


### PR DESCRIPTION
Add support for configuration changes on reload. This will affect changes for log-level only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic reloading of agent configuration via SIGHUP signal, including live updates to log level without restarting the service.
  - Systemd service now supports configuration reloads using the `systemctl reload` command.

- **Bug Fixes**
  - Improved configuration encapsulation and loading, supporting layered overrides from multiple config files.

- **Documentation**
  - Updated service documentation to reflect new reload capability.

- **Tests**
  - Introduced comprehensive tests for configuration reload functionality and log level updates.

- **Chores**
  - Refactored internal configuration management for improved modularity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->