### PR TITLE
EDM-1393: Adding e2e inline application testing

### DIFF
--- a/test/e2e/agent/agent_application_test.go
+++ b/test/e2e/agent/agent_application_test.go
@@ -2,13 +2,20 @@ package agent_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	fileName      = "podman-compose.yaml"
+	inlineAppName = "my-app"
 )
 
 var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
@@ -158,6 +165,178 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			out, err = harness.CheckRunningContainers()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(ContainSubstring(ZeroContainers))
+
+		})
+
+		It("should install an inline compose application and manage its lifecycle with env vars", Label("80990"), func() {
+			By("Creating the first application")
+			newRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			containerAmount := 3
+			inlineAppComposeYaml := fmt.Sprintf(inlineAppComposeYamlInitial, AlpineImage, AlpineImage, AlpineImage)
+			inlineApp := createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			err = harness.UpdateApplication(true, deviceId, inlineAppName, inlineApp, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify the Device resource after update")
+			updatedDevice, err := harness.GetDevice(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			logrus.Infof("Updated Device Resource: %+v", updatedDevice)
+
+			By("Wait for the device to receive the initial inline app configuration")
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check if the application directory exists on the device")
+			err = harness.CheckApplicationDirectoryExist(inlineAppName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that the compose file is copied to the device")
+			err = harness.CheckApplicationComposeFileExist(inlineAppName, filepath.Join("/", fileName))
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Read the compose file content to verify")
+			stdout, err := harness.VM.RunSSH([]string{"cat", filepath.Join(ComposeManifestPath, inlineAppName, fileName)}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring(inlineAppComposeYaml))
+
+			By("Wait for the inline app to report running status")
+			WaitForApplicationRunningStatus(harness, deviceId, inlineAppName)
+
+			By(fmt.Sprintf("Ensure %d/%d containers are up", containerAmount, containerAmount))
+			stdout, err = harness.VM.RunSSH([]string{"sudo", "podman", "ps", "--format", "\"{{.Image}}\""}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring(AlpineImage))
+			Expect(strings.Count(stdout.String(), AlpineImage)).To(Equal(containerAmount))
+
+			By("Check the application status in the device spec")
+			Eventually(func() v1alpha1.ApplicationStatusType {
+				status, err := harness.CheckApplicationStatus(deviceId, inlineAppName)
+				Expect(err).ToNot(HaveOccurred())
+				return status
+			}, TIMEOUT).Should(Equal(v1alpha1.ApplicationStatusRunning))
+			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlUpdated, NginxImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+
+			By("Update the application with the new compose file")
+			err = harness.UpdateDevice(deviceId, func(d *v1alpha1.Device) {
+				err := updateDeviceApplicationFromInline(d, inlineAppName, inlineApp)
+				if err != nil {
+					logrus.Errorf("Failed to update application %s on device %s: %v", inlineAppName, deviceId, err)
+				} else {
+					logrus.Infof("Successfully updated application %s on device %s", inlineAppName, deviceId)
+				}
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Wait for the device to apply the updated configuration")
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Ensure the application is updated with the new image")
+			Eventually(func() string {
+				stdout, err := harness.VM.RunSSH([]string{"sudo", "podman", "ps", "--format", "\"{{.Image}}\""}, nil)
+				Expect(err).ToNot(HaveOccurred())
+				return stdout.String()
+			}, TIMEOUT).Should(ContainSubstring(NginxImage))
+			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Remove the application from the spec")
+			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{}
+			})
+
+			By("Wait for device to pick up the removal config")
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Ensure all containers are stopped")
+			output, err := harness.CheckRunningContainers()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strings.TrimSpace(output)).To(Equal("0"))
+
+			By("Ensure the application folder is deleted")
+			err = harness.CheckApplicationDirectoryExist(inlineAppName)
+			Expect(err).To(HaveOccurred()) // Expect an error because the directory should be gone
+			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Add the first application again , now with an environment variable")
+			envVarName := "MY_ENV_VAR"
+			envVarValue := "my-value"
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlWithEnv, AlpineImage, envVarName, envVarValue, AlpineImage, AlpineImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			err = harness.UpdateApplication(true, deviceId, inlineAppName, inlineApp, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for the device to receive the application with the env var")
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that the env var is injected into the app container")
+			Eventually(func() string {
+				value, err := harness.CheckEnvInjectedToApplication(envVarName, AlpineImage)
+				Expect(err).ToNot(HaveOccurred())
+				return value
+			}, TIMEOUT).Should(Equal(envVarValue))
+		})
+
+		It("Agent pre-update validations should fail the version, and trigger the rollback for various invalid configurations", Label("80998"), func() {
+			By("Create initial application")
+			initialRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			inlineAppComposeYaml := fmt.Sprintf(inlineAppComposeYamlInitial, AlpineImage, AlpineImage, AlpineImage)
+			inlineApp := createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			err = harness.UpdateApplication(true, deviceId, inlineAppName, inlineApp, nil)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, initialRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Update application with duplicate names")
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlWithDuplicateNames, AlpineImage, AlpineImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			apiError := harness.UpdateApplication(false, deviceId, inlineAppName, inlineApp, nil)
+			Expect(apiError).To(HaveOccurred())
+			Expect(apiError.Error()).To(ContainSubstring("invalid compose YAML"))
+
+			By("Update application with bad path")
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlBadPath, AlpineImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, "test-app")
+			apiError = harness.UpdateApplication(false, deviceId, inlineAppName, inlineApp, nil)
+			Expect(apiError).To(HaveOccurred())
+			Expect(apiError.Error()).To(ContainSubstring("compose path must have .yaml or .yml extension"))
+
+			By("Update application with bad YAML structure")
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlBadStructure, NginxImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			apiError = harness.UpdateApplication(false, deviceId, inlineAppName, inlineApp, nil)
+			Expect(apiError).To(HaveOccurred())
+			Expect(apiError.Error()).To(ContainSubstring("compose spec has no services"))
+
+			By("Update application with invalid environment variables")
+			inlineAppComposeYaml = fmt.Sprintf(inlineAppComposeYamlInitial, AlpineImage, AlpineImage, AlpineImage)
+			inlineApp = createInlineApplicationSpec(inlineAppComposeYaml, fileName)
+			apiError = harness.UpdateApplication(false, deviceId, inlineAppName, inlineApp, map[string]string{"-1": "test", "!": "test"})
+			Expect(apiError).To(HaveOccurred())
+			Expect(apiError.Error()).To(ContainSubstring("envVars: Invalid value"))
+
+			By("Attempt to create an application with non-base64 content and contentEncoding: base64")
+			invalidContent := "Not encoded string"
+			inlineApp = v1alpha1.InlineApplicationProviderSpec{
+				Inline: []v1alpha1.ApplicationContent{
+					{
+						Content:         &invalidContent,
+						Path:            "Chart.yaml",
+						ContentEncoding: lo.ToPtr(v1alpha1.EncodingType("base64")),
+					},
+				},
+			}
+			apiError = harness.UpdateApplication(false, deviceId, inlineAppName, inlineApp, nil)
+			Expect(apiError).To(HaveOccurred())
+			Expect(apiError.Error()).To(ContainSubstring("decode base64 content: illegal base64 data"))
 		})
 	})
 })
@@ -169,6 +348,79 @@ const (
 
 	// ComposeManifestPath defines the file system path where compose manifests are stored, typically used in deployment setups.
 	ComposeManifestPath = "/etc/compose/manifests"
+
+	AlpineImage = "quay.io/flightctl-tests/alpine:v1"
+
+	NginxImage = "quay.io/flightctl-tests/nginx:v1"
+
+	inlineAppComposeYamlInitial = `
+version: "3.8"
+services:
+  service1:
+    image: %s
+    command: ["sleep", "infinity"]
+  service2:
+    image: %s
+    command: ["sleep", "infinity"]
+  service3:
+    image: %s
+    command: ["sleep", "infinity"]
+`
+
+	inlineAppComposeYamlUpdated = `
+version: "3.8"
+services:
+  app:
+    image: %s
+    ports:
+      - "80:80"
+`
+
+	inlineAppComposeYamlWithEnv = `
+version: "3.8"
+services:
+  service1:
+    image: %s
+    command: ["sleep", "infinity"]
+    environment:
+      - %s=%s
+  service2:
+    image: %s
+    command: ["sleep", "infinity"]
+  service3:
+    image: %s
+    command: ["sleep", "infinity"]
+`
+
+	inlineAppComposeYamlWithDuplicateNames = `
+version: "3.8"
+services:
+  service1:
+    image: %s
+    command: ["sleep", "infinity"]
+	name: test1
+  service2:
+    image: %s
+    command: ["sleep", "infinity"]
+	name: test2
+`
+
+	inlineAppComposeYamlBadPath = `
+version: "3.8"
+services:
+  service1:
+    image: %s
+    command: ["sleep", "infinity"]
+`
+
+	inlineAppComposeYamlBadStructure = `
+version: "3.8"
+services:
+app:
+image: %s
+ports:
+- "80:80"
+`
 )
 
 // WaitForApplicationRunningStatus waits for a specific application on a device to reach the "Running" status within a timeout.
@@ -183,4 +435,28 @@ func WaitForApplicationRunningStatus(h *e2e.Harness, deviceId string, applicatio
 			}
 			return false
 		}, TIMEOUT)
+}
+
+func createInlineApplicationSpec(content string, path string) v1alpha1.InlineApplicationProviderSpec {
+	return v1alpha1.InlineApplicationProviderSpec{
+		Inline: []v1alpha1.ApplicationContent{
+			{
+				Content: &content,
+				Path:    path,
+			},
+		},
+	}
+}
+
+func updateDeviceApplicationFromInline(device *v1alpha1.Device, inlineAppName string, inlineApp v1alpha1.InlineApplicationProviderSpec) error {
+	for i, app := range *device.Spec.Applications {
+		if app.Name != nil && *app.Name == inlineAppName {
+			err := (*device.Spec.Applications)[i].FromInlineApplicationProviderSpec(inlineApp)
+			if err != nil {
+				return fmt.Errorf("failed to update application %s from inline spec: %w", inlineAppName, err)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("application %s not found in device spec", inlineAppName)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new end-to-end test cases for application lifecycle, including installation, update, removal, and environment variable injection.
  - Introduced tests for agent pre-update validations, ensuring invalid configurations are properly rejected and trigger rollbacks.
  - Enhanced test coverage for error handling with various invalid application scenarios.
  - Extended test harness capabilities to manage applications and verify deployment status, file presence, and environment variable injection on devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->