### PR TITLE
EDM-837: Document builds with RHEL base image

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -33,6 +33,7 @@ e.g.
 ECDSA
 EnrollmentRequest
 EnrollmentRequests
+EPEL
 FIDO
 filesystem
 firewalld


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved and reorganized instructions for building OS images with RHEL 9 base images, including a new dedicated subsection with a complete example.
  - Updated guidance on disabling automatic updates and enabling the EPEL repository.
  - Enhanced cleanup steps and clarified registry login instructions.
  - Refined podman-compose installation commands for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->