### PR TITLE
EDM-1323: api/validation/applications: ensure valid envVar keys

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -654,7 +654,7 @@ func (a ApplicationProviderSpec) Validate() []error {
 	// name must be 1–253 characters long, start with a letter or number, and contain no whitespace
 	allErrs = append(allErrs, validation.ValidateString(a.Name, "spec.applications[].name", 1, validation.DNS1123MaxLength, validation.GenericNameRegexp, validation.Dns1123LabelFmt)...)
 	// envVars keys and values must be between 1 and 253 characters
-	allErrs = append(allErrs, validation.ValidateStringMap(a.EnvVars, "spec.applications[].envVars", 1, validation.DNS1123MaxLength, nil, nil, "")...)
+	allErrs = append(allErrs, validation.ValidateStringMap(a.EnvVars, "spec.applications[].envVars", 1, validation.DNS1123MaxLength, validation.EnvVarNameRegexp, nil, "")...)
 	return allErrs
 }
 


### PR DESCRIPTION
```
apiVersion: v1alpha1
kind: Fleet
metadata:
  name: default
spec:
  selector:
    matchLabels:
      fleet: default
  template:
    metadata:
      labels:
        fleet: default
    spec:
      applications:
        - name: my-app
          appType: compose
          envVars:
            "-1": BAR
          inline:
            - content: |
                version: "3.8"
                services:
                  service1:
                    image:  quay.io/flightctl-tests/alpine:v1
                    command: ["sleep", "infinity"]
              path: podman-compose.yaml
```
```
bin/flightctl apply -f ../testing/applications/application-iniline.yaml 
fleet: applying ../testing/applications/application-iniline.yaml/default: 400 Bad Request
{"apiVersion":"v1alpha1","code":400,"kind":"Status","message":"spec.applications[].envVars: Invalid value: \"-1\": Invalidpattern (regex used for validation is '')","reason":"Bad Request","status":"Failure"}

Error: fleet: failed to apply ../testing/applications/application-iniline.yaml/default: 400 Bad Request
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for environment variable keys to ensure they follow the required naming pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->