### PR TITLE
NO-ISSUE: TPM simulator is not supported on ppc64le and s390x, i.e. !(amd64 || argm64)

### DIFF
--- a/internal/tpm/nosimulator.go
+++ b/internal/tpm/nosimulator.go
@@ -1,0 +1,9 @@
+//go:build !(amd64 || arm64)
+
+package tpm
+
+import "errors"
+
+func OpenTPMSimulator() (*TPM, error) {
+	return &TPM{}, errors.New("TPM simulator not supported")
+}

--- a/internal/tpm/simulator.go
+++ b/internal/tpm/simulator.go
@@ -1,0 +1,15 @@
+//go:build amd64 || arm64
+
+package tpm
+
+import (
+	tpmSimulator "github.com/google/go-tpm-tools/simulator"
+)
+
+func OpenTPMSimulator() (*TPM, error) {
+	simulator, err := tpmSimulator.Get()
+	if err != nil {
+		return &TPM{}, err
+	}
+	return &TPM{channel: simulator}, nil
+}

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-tpm-tools/client"
 	pbattest "github.com/google/go-tpm-tools/proto/attest"
 	pbtpm "github.com/google/go-tpm-tools/proto/tpm"
-	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -55,14 +54,6 @@ func OpenTPM(devicePath string) (*TPM, error) {
 		return nil, err
 	}
 	return &TPM{devicePath: devicePath, channel: ch}, nil
-}
-
-func OpenTPMSimulator() (*TPM, error) {
-	simulator, err := simulator.Get()
-	if err != nil {
-		return &TPM{}, err
-	}
-	return &TPM{channel: simulator}, nil
 }
 
 func (t *TPM) Close() error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for TPM simulator functionality, now available only on supported platforms.
- **Bug Fixes**
  - Provides clear error messaging when TPM simulator is not supported on the current platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->