### PR TITLE
EDM-1519: Refactor post install steps

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-init.container
+++ b/deploy/podman/flightctl-api/flightctl-api-init.container
@@ -1,5 +1,7 @@
 [Unit]
 PartOf=flightctl.target
+After=flightctl-db.service
+Wants=flightctl-db.service
 
 [Container]
 Image=registry.access.redhat.com/ubi9/ubi-minimal

--- a/deploy/podman/flightctl-db/flightctl-db.container
+++ b/deploy/podman/flightctl-db/flightctl-db.container
@@ -14,6 +14,7 @@ Secret=flightctl-postgresql-user-password,type=env,target=POSTGRESQL_PASSWORD
 Volume=/usr/share/flightctl/flightctl-db/enable-superuser.sh:/usr/share/container-scripts/postgresql/start/enable-superuser.sh
 
 [Service]
+ExecStartPre=/usr/share/flightctl/init_host.sh
 Restart=always
 RestartSec=30
 

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -1,6 +1,8 @@
 [Unit]
 Description=Flight Control Key Value service
 PartOf=flightctl.target
+After=flightctl-db.service
+Wants=flightctl-db.service
 
 [Container]
 ContainerName=flightctl-kv

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -14,12 +14,6 @@ if ! deploy/scripts/install.sh; then
     exit 1
 fi
 
-# Run post installation script
-if ! deploy/scripts/post_install.sh; then
-    echo "Error: Installation failed"
-    exit 1
-fi
-
 start_service "flightctl.target"
 
 echo "Checking if all services are running..."

--- a/deploy/scripts/init_host.sh
+++ b/deploy/scripts/init_host.sh
@@ -5,24 +5,30 @@ set -eo pipefail
 # Load secret generation functions
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/secrets.sh
+source "${SCRIPT_DIR}"/init_utils.sh
+
+SERVICE_CONFIG_FILE="/etc/flightctl/service-config.yaml"
 
 write_default_base_domain() {
     # Write base domain to the config file
     base_domain="$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')"
     echo "Setting base domain to: ${base_domain}"
-    SERVICE_CONFIG_FILE="/etc/flightctl/service-config.yaml"
     sed -i "s/^\(\s*baseDomain\s*\):\s*.*$/\1: ${base_domain}/" "${SERVICE_CONFIG_FILE}"
 }
 
 main() {
-    echo "Configuring Flight Control post install"
+    echo "Configuring Flight Control"
 
     ensure_secrets
-    write_default_base_domain
 
-    sudo systemctl daemon-reload
+    base_domain=$(extract_value "baseDomain" "$SERVICE_CONFIG_FILE")
+    if [[ -z "$base_domain" ]]; then
+        write_default_base_domain
+    else
+        echo "Base domain already set to: $base_domain"
+    fi
 
-    echo "Post install configuration complete"
+    echo "Configuration complete"
 }
 
 main

--- a/deploy/scripts/shared.sh
+++ b/deploy/scripts/shared.sh
@@ -70,6 +70,8 @@ move_shared_files() {
 
     # Copy read only files
     cp "${source_dir}/scripts/init_utils.sh" "${CONFIG_READONLY_DIR}/init_utils.sh"
+    cp "${source_dir}/scripts/init_host.sh" "${CONFIG_READONLY_DIR}/init_host.sh"
+    cp "${source_dir}/scripts/secrets.sh" "${CONFIG_READONLY_DIR}/secrets.sh"
 }
 
 # Start a systemd service

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -142,10 +142,6 @@ The flightctl-services package provides installation and setup of files for runn
     IMAGE_TAG=$(echo %{version} | tr '~' '-') \
     deploy/scripts/install.sh
 
-    # Copy files needed for post install into the build root
-    cp deploy/scripts/post_install.sh %{buildroot}%{_datadir}/flightctl/post_install.sh
-    cp deploy/scripts/secrets.sh %{buildroot}%{_datadir}/flightctl/secrets.sh
-
     # Copy sos report flightctl plugin
     mkdir -p %{buildroot}/usr/share/sosreport
     cp packaging/sosreport/sos/report/plugins/flightctl.py %{buildroot}/usr/share/sosreport
@@ -171,9 +167,6 @@ fi
 %posttrans selinux
 
 %selinux_relabel_post -s %{selinuxtype}
-
-%post services
-%{_datadir}/flightctl/post_install.sh
 
 # File listings
 # No %files section for the main package, so it won't be built
@@ -240,8 +233,8 @@ rm -rf /usr/share/sosreport
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-cli-artifacts/init.sh
     %{_datadir}/containers/systemd/flightctl*
 
-    # Handle permissions for scripts run as part of the rpm post install
-    %attr(0755,root,root) %{_datadir}/flightctl/post_install.sh
+    # Handle permissions for scripts setting host config
+    %attr(0755,root,root) %{_datadir}/flightctl/init_host.sh
     %attr(0755,root,root) %{_datadir}/flightctl/secrets.sh
 
     # Files mounted to lib dir


### PR DESCRIPTION
Changes the rpm post install scripting to be moved to part of the services spinup.  This is necessary because when the rpm is installed in a bootc image build context the install process shouldn't contain installation-specific data like the generated podman secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Improved service startup reliability by ensuring certain services start only after required dependencies are available.
	- Updated deployment scripts to streamline initialization and remove unused post-installation steps.
	- Adjusted packaging to include new initialization scripts and remove obsolete post-install scripts.
	- Enhanced script logic for better configuration handling and clearer messaging during setup.
	- Expanded deployment script file management to include additional initialization and secret scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->