### PR TITLE
NO-ISSUE: Move TPM Simulator to testing only

### DIFF
--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-tpm-tools/client"
 	pbattest "github.com/google/go-tpm-tools/proto/attest"
 	pbtpm "github.com/google/go-tpm-tools/proto/tpm"
-	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
@@ -55,14 +54,6 @@ func OpenTPM(devicePath string) (*TPM, error) {
 		return nil, err
 	}
 	return &TPM{devicePath: devicePath, channel: ch}, nil
-}
-
-func OpenTPMSimulator() (*TPM, error) {
-	simulator, err := simulator.Get()
-	if err != nil {
-		return &TPM{}, err
-	}
-	return &TPM{channel: simulator}, nil
 }
 
 func (t *TPM) Close() error {

--- a/internal/tpm/tpm_test.go
+++ b/internal/tpm/tpm_test.go
@@ -1,3 +1,5 @@
+//go:build amd64 || arm64
+
 package tpm
 
 import (
@@ -10,20 +12,29 @@ import (
 	"testing"
 
 	"github.com/google/go-tpm-tools/client"
+	"github.com/google/go-tpm-tools/simulator"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/stretchr/testify/require"
 )
-
-// These unit tests all use the tpm simulator from go-tpm-tools.
 
 type TestFixture struct {
 	tpm *TPM
 }
 
+func openTPMSimulator(t *testing.T) (*TPM, error) {
+	t.Helper()
+	require := require.New(t)
+
+	simulator, err := simulator.Get()
+	require.NoError(err)
+
+	return &TPM{channel: simulator}, nil
+}
+
 func setupTestFixture(t *testing.T) (*TestFixture, error) {
 	t.Helper()
 
-	tpm, err := OpenTPMSimulator()
+	tpm, err := openTPMSimulator(t)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open tpm simulator")
 	}


### PR DESCRIPTION
The TPM simulator does not build on all architectures (not supported on ppc64le and s390x) and is only used in testing, so we move it to the unit test file and only run the TPM tests where the simulator is supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of TPM simulator support, moving simulator initialization from the main package to test-only code.  
- **Tests**
  - Improved test reliability by adding a helper for TPM simulator setup, now limited to amd64 and arm64 architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->