### PR TITLE
EDM-1358: Automation of e2e cluster registration to ACM

### DIFF
--- a/test/e2e/agent/agent_suite_test.go
+++ b/test/e2e/agent/agent_suite_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const TIMEOUT = "5m"
-const POLLING = "250ms"
+const POLLING = "125ms"
 const LONGTIMEOUT = "10m"
 
 // Define a type for messages.

--- a/test/e2e/configuration/inline_config_test.go
+++ b/test/e2e/configuration/inline_config_test.go
@@ -44,9 +44,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigs)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigs, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the online config, the content is empty.")
@@ -71,9 +69,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWithMode)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWithMode, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the correct permissions.")
@@ -88,9 +84,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWithUser)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWithUser, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the updated owner permissions.")
@@ -105,9 +99,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWithContent)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWithContent, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the updated content")
@@ -122,9 +114,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWithPath2)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWithPath2, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the updated content.")
@@ -138,10 +128,7 @@ var _ = Describe("Inline configuration tests", func() {
 
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
-
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWithName2)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWithName2, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Update device with inline config, add another file to inline config")
@@ -150,10 +137,7 @@ var _ = Describe("Inline configuration tests", func() {
 
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
-
-			UpdateDeviceConfigWithRetries(harness, deviceId, validConfigsWith2Files)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, validConfigsWith2Files, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the updated content.")
@@ -167,9 +151,7 @@ var _ = Describe("Inline configuration tests", func() {
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			UpdateDeviceConfigWithRetries(harness, deviceId, *combinedConfigs)
-
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, *combinedConfigs, newRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("The configuration file should have the updated content.")
@@ -281,16 +263,6 @@ var (
 	invalidInlineConfigRelativePath    = newInlineConfigProviderSpec(invalidInlineName1, []v1alpha1.FileSpec{invalidinlineConfigRelativePath})
 	invalidInlineConfigWithInvalidMode = newInlineConfigProviderSpec(invalidInlineName1, []v1alpha1.FileSpec{invalidInlineConfigInvalidMode})
 )
-
-func UpdateDeviceConfigWithRetries(harness *e2e.Harness, deviceId string, configs []v1alpha1.ConfigProviderSpec) {
-	harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-		device.Spec.Config = &configs
-		logrus.WithFields(logrus.Fields{
-			"deviceId": deviceId,
-			"config":   fmt.Sprintf("%+v", &device.Spec.Config),
-		}).Info("Updating device with new config")
-	})
-}
 
 func UpdateDeviceConfig(harness *e2e.Harness, deviceId string, configs []v1alpha1.ConfigProviderSpec) error {
 	err := harness.UpdateDevice(deviceId, func(device *v1alpha1.Device) {

--- a/test/e2e/hooks/hooks_test.go
+++ b/test/e2e/hooks/hooks_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			deviceSpecConfig := []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
 
-			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, deviceSpecConfig, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			stdout, err := harness.VM.RunSSH([]string{"sudo", "cat", inlinePath}, nil)
@@ -85,7 +85,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
 
-			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, deviceSpecConfig, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the embedded sshd hook is triggered and sshd config reloaded by trying to ssh with any user")
@@ -103,7 +103,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
 
-			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, deviceSpecConfig, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Update the sshd config")
@@ -117,7 +117,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			configProviderSpec := []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec, inlineConfigProviderSpec1}
 
-			err = UpdateDeviceConfigWithRetries(harness, deviceId, configProviderSpec, nextRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, configProviderSpec, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = harness.VM.RunSSH([]string{"pwd"}, nil)
@@ -133,7 +133,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			deviceSpecConfig = []v1alpha1.ConfigProviderSpec{}
 
-			err = UpdateDeviceConfigWithRetries(harness, deviceId, deviceSpecConfig, nextRenderedVersion)
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, deviceSpecConfig, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = harness.VM.RunSSH([]string{"pwd"}, nil)
@@ -289,18 +289,4 @@ var inlineConfigSpec7 = v1alpha1.FileSpec{
 var inlineConfigValidLifecycle = v1alpha1.InlineConfigProviderSpec{
 	Inline: []v1alpha1.FileSpec{inlineConfigSpec4, inlineConfigSpec5, inlineConfigSpec6, inlineConfigSpec7},
 	Name:   inlineConfigLifecycleName,
-}
-
-// UpdateDeviceConfigWithRetries updates the configuration of a device with retries using the provided harness and config specs.
-// It applies the provided configuration and waits for the device to reach the specified rendered version.
-func UpdateDeviceConfigWithRetries(harness *e2e.Harness, deviceId string, configs []v1alpha1.ConfigProviderSpec, nextRenderedVersion int) error {
-	harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-		device.Spec.Config = &configs
-		logrus.WithFields(logrus.Fields{
-			"deviceId": deviceId,
-			"config":   fmt.Sprintf("%+v", &device.Spec.Config),
-		}).Info("Updating device with new config")
-	})
-	err := harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
-	return err
 }

--- a/test/e2e/microshift_acm_enrollment/data/acm-hook.yaml
+++ b/test/e2e/microshift_acm_enrollment/data/acm-hook.yaml
@@ -1,0 +1,12 @@
+- if:
+  - path: /var/local/acm-import/crd.yaml
+    op: [created]
+  run: kubectl apply -f /var/local/acm-import/crd.yaml
+  envVars:
+    KUBECONFIG: /var/lib/microshift/resources/kubeadmin/kubeconfig
+- if:
+  - path: /var/local/acm-import/import.yaml
+    op: [created]
+  run: kubectl apply -f /var/local/acm-import/import.yaml
+  envVars:
+    KUBECONFIG: /var/lib/microshift/resources/kubeadmin/kubeconfig

--- a/test/e2e/microshift_acm_enrollment/data/content.yaml
+++ b/test/e2e/microshift_acm_enrollment/data/content.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-cluster-import-agent-registration-sa
+  namespace: multicluster-engine
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: managed-cluster-import-agent-registration-sa-token
+  namespace: multicluster-engine
+  annotations:
+    kubernetes.io/service-account.name: "managed-cluster-import-agent-registration-sa"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managedcluster-import-controller-agent-registration-client
+rules:
+- nonResourceURLs: ["/agent-registration/*"]
+  verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: managed-cluster-import-agent-registration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: managedcluster-import-controller-agent-registration-client
+subjects:
+  - kind: ServiceAccount
+    name: managed-cluster-import-agent-registration-sa
+    namespace: multicluster-engine

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_suite_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_suite_test.go
@@ -1,0 +1,13 @@
+package microshift
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMicroshift(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "microshift ACM enrollment E2E Suite")
+}

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -1,0 +1,380 @@
+package microshift
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Microshift cluster ACM enrollment tests", func() {
+
+	Describe("Test Setup", Ordered, func() {
+
+		BeforeAll(func() {
+			isAcmInstalled, err := isAcmInstalled()
+			if err != nil {
+				logrus.Warnf("An error happened %v", err)
+			}
+			if !isAcmInstalled {
+				Skip("Skipping test suite because ACM is not installed.")
+			}
+		})
+
+		var (
+			harness  *e2e.Harness
+			deviceId string
+		)
+
+		BeforeEach(func() {
+			harness = e2e.NewTestHarness()
+			deviceId = harness.StartVMAndEnroll()
+		})
+
+		AfterEach(func() {
+			if harness != nil { // when the test is skipped harness is nil
+				harness.Cleanup(false)
+				err := harness.CleanUpAllResources()
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		Context("microshift", func() {
+			It(`Verifies that a microshift cluster can enroll to acm`, Label("75967"), func() {
+				By("Getting the host")
+				out, err := exec.Command("bash", "-c", "oc get route -n multicluster-engine agent-registration -o=jsonpath=\"{.spec.host}\"").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				agentRegistrationHost := string(out)
+				logrus.Infof("This is the agent registration host: %s", agentRegistrationHost)
+
+				By("Getting the ca_cert")
+				out, err = exec.Command("bash", "-c", "oc get configmap -n kube-system kube-root-ca.crt -o=jsonpath=\"{.data['ca\\.crt']}\" | base64 -w0").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				caCrt := string(out)
+				logrus.Infof("This is the caCrt: %s", caCrt)
+
+				By("Applying resources")
+				_, err = exec.Command("bash", "-c", "oc apply -f $(pwd)/data/content.yaml").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Infof("Enrollment resources were applied")
+
+				By("Get the token")
+				out, err = exec.Command("bash", "-c", "oc get secret -n multicluster-engine managed-cluster-import-agent-registration-sa-token -o=jsonpath='{.data.token}' | base64 -d").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				token := string(out)
+				logrus.Infof("This is the token: %s", token)
+
+				By("Create the acm-registration repository")
+				httpRepoUrl := fmt.Sprintf("https://%s", agentRegistrationHost)
+				httpRepoConfig := v1alpha1.HttpConfig{
+					CaCrt: &caCrt,
+					Token: &token,
+				}
+				httpRepoSpec := v1alpha1.HttpRepoSpec{
+					HttpConfig: httpRepoConfig,
+
+					Type: v1alpha1.Http,
+
+					Url: httpRepoUrl,
+
+					ValidationSuffix: &validationSuffix,
+				}
+
+				err = httpRepositoryspec.FromHttpRepoSpec(httpRepoSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = harness.CreateRepository(httpRepositoryspec, httpRepoMetadata)
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Infof("Created git repository %s", *httpRepoMetadata.Name)
+
+				// This step will be removed after selinux issue resolution (EDM-1579)
+				By("Set selinux permissive")
+				_, err = harness.VM.RunSSH([]string{"sudo", "sed", "-i", "s/^SELINUX=enforcing/SELINUX=permissive/", "/etc/selinux/config"}, nil)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = harness.VM.RunSSH([]string{"sudo", "setenforce", "permissive"}, nil)
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := harness.VM.RunSSH([]string{"sudo", "getenforce"}, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout.String()).To(ContainSubstring("Permissive"))
+
+				By("Get the Pull-Secret")
+				out, err = exec.Command("bash", "-c", "oc get secret/pull-secret -n openshift-config -o json | jq '.data.\".dockerconfigjson\"' | base64 -di").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				pullSecret := string(out)
+				logrus.Infof("This is the pull-secret %s", pullSecret)
+
+				By("Upgrade to the microshift image, and add the pull-secret to the device")
+				nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+				deviceImage := fmt.Sprintf("%s/flightctl-device:v7", harness.RegistryEndpoint())
+				var osImageSpec = v1alpha1.DeviceOsSpec{
+					Image: deviceImage,
+				}
+
+				var inlineConfigSpec = v1alpha1.FileSpec{
+					Path:    inlinePath,
+					Content: pullSecret,
+				}
+
+				var pullSecretInlineConfig = v1alpha1.InlineConfigProviderSpec{
+					Inline: []v1alpha1.FileSpec{inlineConfigSpec},
+					Name:   "pull-secret",
+				}
+
+				inlineConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+				err = inlineConfigProviderSpec.FromInlineConfigProviderSpec(pullSecretInlineConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+				deviceSpecConfig := []v1alpha1.ConfigProviderSpec{inlineConfigProviderSpec}
+
+				var deviceSpec v1alpha1.DeviceSpec
+
+				deviceSpec.Os = &osImageSpec
+				deviceSpec.Config = &deviceSpecConfig
+
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+
+					device.Spec = &deviceSpec
+					logrus.Infof("Updating %s with a new image and pull-secret configuration", deviceId)
+				})
+
+				By("Wait for the device to get the fleet configuration")
+				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Make sure the pull-secret was injected")
+				psPath := "/etc/crio/openshift-pull-secret"
+				stdout, err = harness.WaitForFileInDevice(psPath, util.TIMEOUT, util.POLLING)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout.String()).To(ContainSubstring(psPath))
+
+				By("Wait for the kubeconfig to be in place")
+				kubeconfigPath := "/var/lib/microshift/resources/kubeadmin/kubeconfig"
+				readyMsg := "The file was found"
+				stdout, err = harness.WaitForFileInDevice(kubeconfigPath, util.TIMEOUT, util.POLLING)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout.String()).To(ContainSubstring(readyMsg))
+
+				By("Wait for microshift cluster pods to become ready")
+				err = waitForMicroshiftReady(harness, kubeconfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create the acm-registration fleet")
+				testFleetDeviceSpec, err := createAcmRegistrationFleetDeviceSpec(harness, inlineConfigProviderSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = harness.CreateOrUpdateTestFleet(testFleetName, testFleetSelector, testFleetDeviceSpec)
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Infof("The fleet %s is created", testFleetName)
+
+				By("Patch the mch of the hub cluster with annotation: mch-imageRepository=brew.registry.redhat.io")
+				acmNamespace, err := getAcmNamespace()
+				Expect(err).ToNot(HaveOccurred())
+
+				args := fmt.Sprintf("oc annotate mch multiclusterhub -n %s mch-imageRepository='quay.io:443/acm-d'", acmNamespace)
+
+				_, err = exec.Command("bash", "-c", args).CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Info("The multiclusterhub is patched")
+
+				By("Enable the auto-approver")
+				_, err = exec.Command("bash", "-c", "oc patch clustermanager cluster-manager --type=merge -p '{\"spec\":{\"registrationConfiguration\":{\"featureGates\":[{\"feature\": \"ManagedClusterAutoApproval\", \"mode\": \"Enable\"}], \"autoApproveUsers\":[\"system:serviceaccount:multicluster-engine:agent-registration-bootstrap\"]}}}'").CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				logrus.Info("The auto-approver is enabled")
+
+				By("Check that the device status is Online")
+				_, err = harness.CheckDeviceStatus(deviceId, v1alpha1.DeviceSummaryStatusOnline)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Add the fleet selector and the team label to the device")
+				nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+				Expect(err).ToNot(HaveOccurred())
+
+				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+					device.Metadata.Labels = &map[string]string{
+						fleetSelectorKey: fleetSelectorValue,
+					}
+					logrus.Infof("Updating %s with label %s=%s", deviceId,
+						fleetSelectorKey, fleetSelectorValue)
+				})
+
+				By("Wait for the device to get the fleet configuration")
+				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait for the klusterlet and registration pods to be ready")
+				cmd := []string{
+					"sudo", "oc", "wait",
+					"--for=condition=Ready", "pods",
+					"--all", "-A", "--timeout=30s",
+					fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
+				}
+				_, err = harness.VM.RunSSH(cmd, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Check that the cluster is registered in acm")
+				err = harness.WaitForClusterRegistered(deviceId, util.DURATION_TIMEOUT)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})
+
+var (
+	testFleetName          = "fleet-acm"
+	fleetSelectorKey       = util.Fleet
+	fleetSelectorValue     = "acm"
+	httpRepoName           = "acm-registration"
+	validationSuffix       = "/agent-registration/crds/v1"
+	inlineConfigNameSecond = "apply-acm-manifests"
+	inlinePath             = "/etc/crio/openshift-pull-secret"
+	inlinePathSecond       = "/etc/flightctl/hooks.d/afterupdating/50-acm-registration.yaml"
+	httpSuffix             = "/agent-registration/crds/v1"
+	httpSuffixSecond       = "/agent-registration/manifests/{{.metadata.name}}"
+	httpConfigPath         = "/var/local/acm-import/crd.yaml"
+	httpConfigPathSecond   = "/var/local/acm-import/import.yaml"
+	httpConfigName         = "acm-crd"
+	httpConfigNameSecond   = "acm-import"
+)
+
+var httpConfigvalid = v1alpha1.HttpConfigProviderSpec{
+	HttpRef: struct {
+		FilePath   string  `json:"filePath"`
+		Repository string  `json:"repository"`
+		Suffix     *string `json:"suffix,omitempty"`
+	}{
+		FilePath:   httpConfigPath,
+		Repository: httpRepoName,
+		Suffix:     &httpSuffix,
+	},
+	Name: httpConfigName,
+}
+var httpConfigvalidSecond = v1alpha1.HttpConfigProviderSpec{
+	HttpRef: struct {
+		FilePath   string  `json:"filePath"`
+		Repository string  `json:"repository"`
+		Suffix     *string `json:"suffix,omitempty"`
+	}{
+		FilePath:   httpConfigPathSecond,
+		Repository: httpRepoName,
+		Suffix:     &httpSuffixSecond,
+	},
+	Name: httpConfigNameSecond,
+}
+
+var mode = 0644
+var modePointer = &mode
+
+var testFleetSelector = v1alpha1.LabelSelector{
+	MatchLabels: &map[string]string{fleetSelectorKey: fleetSelectorValue},
+}
+
+var httpRepositoryspec v1alpha1.RepositorySpec
+
+var httpRepoMetadata = v1alpha1.ObjectMeta{
+	Name: &httpRepoName,
+}
+
+func createAcmRegistrationFleetDeviceSpec(harness *e2e.Harness, pullSecretinlineConfigProviderSpec v1alpha1.ConfigProviderSpec) (v1alpha1.DeviceSpec, error) {
+	hookFile := fmt.Sprintf("%s/test/e2e/microshift_acm_enrollment/data/acm-hook.yaml", util.GetTopLevelDir())
+	inlineContentSecondByte, err := os.ReadFile(hookFile)
+	if err != nil {
+		return v1alpha1.DeviceSpec{}, fmt.Errorf("failed to read hook file: %w", err)
+	}
+	inlineContentSecond := string(inlineContentSecondByte)
+
+	inlineConfigSecondSpec := v1alpha1.FileSpec{
+		Path:    inlinePathSecond,
+		Mode:    modePointer,
+		Content: inlineContentSecond,
+	}
+
+	inlineConfigValidSecond := v1alpha1.InlineConfigProviderSpec{
+		Inline: []v1alpha1.FileSpec{inlineConfigSecondSpec},
+		Name:   inlineConfigNameSecond,
+	}
+
+	httpConfigProviderSpec := v1alpha1.ConfigProviderSpec{}
+	err = httpConfigProviderSpec.FromHttpConfigProviderSpec(httpConfigvalid)
+	if err != nil {
+		return v1alpha1.DeviceSpec{}, fmt.Errorf("failed to read httpConfigProviderSpec: %w", err)
+	}
+
+	httpConfigProviderSpecSecond := v1alpha1.ConfigProviderSpec{}
+	err = httpConfigProviderSpecSecond.FromHttpConfigProviderSpec(httpConfigvalidSecond)
+	if err != nil {
+		return v1alpha1.DeviceSpec{}, fmt.Errorf("failed to read second httpConfigProviderSpec: %w", err)
+	}
+
+	inlineConfigProviderSpecSecond := v1alpha1.ConfigProviderSpec{}
+	err = inlineConfigProviderSpecSecond.FromInlineConfigProviderSpec(inlineConfigValidSecond)
+	if err != nil {
+		return v1alpha1.DeviceSpec{}, fmt.Errorf("failed to read inlineConfigProviderSpec: %w", err)
+	}
+
+	return harness.CreateFleetDeviceSpec("v7", pullSecretinlineConfigProviderSpec, inlineConfigProviderSpecSecond, httpConfigProviderSpec, httpConfigProviderSpecSecond)
+}
+
+func getAcmNamespace() (string, error) {
+	cmd := exec.Command("bash", "-c", "oc get mch -A -ojson | jq '.items[0].metadata.namespace'")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get acm namespac %w", err)
+	}
+	outputClean := string(output)
+	outputClean = strings.ReplaceAll(outputClean, "\\\"", "")
+	outputClean = strings.ReplaceAll(outputClean, "\n", "")
+	logrus.Infof("This is the Acm namespace: %s", outputClean)
+
+	return outputClean, nil
+}
+
+func isAcmInstalled() (bool, error) {
+	cmd := exec.Command("oc", "get", "multiclusterhub", "-A")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	outputString := string(output)
+	if outputString == "error: the server doesn't have a resource type \"multiclusterhub\"" {
+		return false, fmt.Errorf("ACM is not installed: %s", outputString)
+	}
+	if strings.Contains(outputString, "Running") || strings.Contains(outputString, "Paused") {
+		logrus.Infof("The cluster has ACM installed")
+		return true, nil
+	}
+	return false, fmt.Errorf("multiclusterhub is not in Running status")
+}
+
+func waitForMicroshiftReady(harness *e2e.Harness, kubeconfigPath string) error {
+	timeout := util.DURATION_TIMEOUT
+	interval := 10 * time.Second
+	start := time.Now()
+	var err error
+
+	for time.Since(start) < timeout {
+		cmd := []string{
+			"sudo", "oc", "wait",
+			"--for=condition=Ready", "pods",
+			"--all", "-A", "--timeout=300s",
+			fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
+		}
+
+		_, err = harness.VM.RunSSH(cmd, nil)
+		if err == nil {
+			break // success
+		}
+		time.Sleep(interval)
+	}
+
+	return err
+}

--- a/test/scripts/agent-images/Containerfile-e2e-v7.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v7.local
@@ -1,0 +1,33 @@
+# localhost:5000/flightctl-device:v7
+#     $(IP):5000/flightctl-device:v7
+#
+# Image built on top of our E2E base image which also includes microshift
+
+FROM localhost:5000/flightctl-device:base
+
+ADD test/scripts/agent-images/etc etc
+
+RUN mkdir -p /etc/systemd/system/flightctl-agent.service.d && \
+    printf "[Service]\nSELinuxContext=system_u:system_r:unconfined_t:s0\n" > /etc/systemd/system/flightctl-agent.service.d/override.conf
+
+RUN dnf install -y microshift && \
+   systemctl enable microshift.service
+
+# Create the required directory structure in /var/crio instead of /opt/crio
+RUN mkdir -p /var/crio
+
+RUN rm -rf /opt && ln -s /var /opt
+RUN ln -snf /run /var/run
+
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48
+    # Application-specific firewall configuration
+RUN firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+
+# This step will be removed after selinux issue resolution (EDM-1579)
+RUN sudo sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -9,6 +9,12 @@ source "${SCRIPT_DIR}"/../functions
 REGISTRY_ADDRESS=$(registry_address)
 IMAGE_LIST="base v2 v3 v4 v5 v6"
 
+if is_acm_installed; then
+    IMAGE_LIST="${IMAGE_LIST} v7"
+    sed -i 's|<memory unit="MiB">512</memory>|<memory unit="MiB">2048</memory>|' test/harness/e2e/vm/domain-template.xml # increate the memory only for microshift cluster registration test
+    echo "IMAGE_LIST=${IMAGE_LIST}"
+fi
+
 # Create the file and add the registry configuration
 cp "${SCRIPT_DIR}"/Containerfile-e2e-base.local.template "${SCRIPT_DIR}"/Containerfile-e2e-base.local
 sudo tee -a "${SCRIPT_DIR}"/Containerfile-e2e-base.local <<EOF
@@ -82,6 +88,9 @@ build_qcow2_image() {
                     build \
                     --type qcow2 \
                     --local "${REGISTRY_ADDRESS}/flightctl-device:base"
+    if is_acm_installed; then
+        sudo qemu-img resize "$(pwd)"/bin/output/qcow2/disk.qcow2 +5G # increasing disk size for microshift registration to acm test only
+    fi
 }
 
 case "$BUILD_TYPE" in

--- a/test/scripts/agent-images/etc/yum.repos.d/flightctl.repo
+++ b/test/scripts/agent-images/etc/yum.repos.d/flightctl.repo
@@ -1,0 +1,11 @@
+[copr:copr.fedorainfracloud.org:group_redhat-et:flightctl-dev]
+name=Copr repo for flightctl-dev owned by @redhat-et
+baseurl=https://download.copr.fedorainfracloud.org/results/@redhat-et/flightctl-dev/rhel-9-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@redhat-et/flightctl-dev/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+

--- a/test/scripts/agent-images/etc/yum.repos.d/microshift.repo
+++ b/test/scripts/agent-images/etc/yum.repos.d/microshift.repo
@@ -1,0 +1,15 @@
+# MicroShift repository configuration for testing
+# These repositories provide the required packages for MicroShift installation
+# in the e2e test environment
+
+[rhocp]
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.15/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[fast-datapath]
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/fast-datapath/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -2,7 +2,7 @@
 
 # Variables
 VM_NAME="test-vm"
-VM_RAM=8192                # RAM in MB
+VM_RAM=10240                # RAM in MB necessary to run the flightctl e2e
 VM_CPUS=8                  # Number of CPUs
 VM_DISK_SIZE=30          # Disk size
 NETWORK_NAME="baremetal-0"   # Network name
@@ -54,7 +54,7 @@ echo "Copying ${DISK_PATH_SRC} to ${DISK_PATH}..."
 cp ${DISK_PATH_SRC} ${DISK_PATH}
 
 # Resize the VM image
-qemu-img resize ${DISK_PATH} +15G
+qemu-img resize ${DISK_PATH} +20G  # bumping for the increased number of agent-images to be saved
 
 # Create the VM
 echo "Creating virtual machine ${VM_NAME}..."

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -148,8 +148,12 @@ function try_login() {
   if ! bin/flightctl login "${FLIGHTCTL_API_ENDPOINT}" --insecure-skip-tls-verify; then
     echo "Trying token login"
     TOKEN=$(get_token)
-    bin/flightctl login "${FLIGHTCTL_API_ENDPOINT}" --insecure-skip-tls-verify --token "${TOKEN} 2>/dev/null"
-    return 0
+    if ! bin/flightctl login "${FLIGHTCTL_API_ENDPOINT}" --insecure-skip-tls-verify --token "${TOKEN}"; then
+      echo "Trying standalone login"
+      PASS=$(kubectl get secret keycloak-demouser-secret -n "${FLIGHTCTL_NS}" -o json | jq -r '.data.password' | base64 -d)
+      bin/flightctl login -k "${FLIGHTCTL_API_ENDPOINT}" -u demouser -p ${PASS} 2>/dev/null
+      return 0
+    fi
   fi
 }
 
@@ -185,5 +189,18 @@ function package_agent() {
 function package_cli() {
     local VERSION=$(echo "${FLIGHTCTL_RPM}" | cut -d'/' -f2)
     append_rpm_version "flightctl"
+}
+
+# Function to check if acm is installed in the env
+function is_acm_installed() {
+  local output
+  output=$(oc get multiclusterhub -A 2>/dev/null) || return 1
+  echo "output=${output}"
+
+  if echo "$output" | grep -qE 'Paused|Running'; then
+    return 0
+  else
+    return 1
+  fi
 }
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import "time"
+
 // Resource types
 const (
 	Device                    = "device"
@@ -36,6 +38,7 @@ var ResourceTypes = [...]string{
 const TIMEOUT = "5m"
 const POLLING = "250ms"
 const LONGTIMEOUT = "10m"
+const DURATION_TIMEOUT = 5 * time.Minute
 
 // Define a type for messages.
 type Message string


### PR DESCRIPTION
Automation of a device microshift cluster to ACM.
The test will be executed only in QE ci. It will be skipped if ACM is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive end-to-end tests for Microshift ACM enrollment, including automated environment setup, configuration, and registration checks.
  - Introduced new Kubernetes resource manifests and configuration files to support ACM registration workflows in testing.
  - Added new YUM repository configurations for flightctl and Microshift in the test environment.
  - Added a new container image setup for advanced Microshift/ACM testing scenarios.

- **Enhancements**
  - Increased VM memory and disk allocation for end-to-end tests to improve stability and support more agent images.
  - Improved login logic in test scripts for more reliable authentication fallback.
  - Extended test harness with new methods for device configuration, command execution, and readiness checks.
  - Updated test scripts to conditionally build and resize images based on ACM installation status.

- **Bug Fixes**
  - Adjusted polling intervals and timeouts in tests for faster and more reliable execution.

- **Refactor**
  - Simplified and consolidated device configuration update logic in tests for improved maintainability.

- **Tests**
  - Added and reorganized multiple end-to-end test suites and helper functions to validate ACM and Microshift integration scenarios.

- **Chores**
  - Added new configuration and manifest files required for advanced test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->