### PR TITLE
NO-ISSUE: Override UBI inherited labels for Flightctl images

### DIFF
--- a/Containerfile.api
+++ b/Containerfile.api
@@ -24,6 +24,13 @@ RUN dnf update --nodocs -y  && dnf install ca-certificates tzdata --nodocs -y
 
 FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
+LABEL \
+  com.redhat.component="flightctl-api-container" \
+  description="Flightctl Edge management API server" \
+  io.k8s.description="Flightctl Edge management API server" \
+  io.k8s.display-name="Flightctl API Server" \
+  name="flightctl-api" \
+  summary="Flightctl Edge management API server"
 COPY --from=build /app/bin/flightctl-api .
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -60,10 +60,14 @@ RUN chmod -R 755 ${HOME}/src/gh-archives/ && \
     chmod 666 ${HOME}/src/gh-archives/index.json
 USER ${USER_UID}
 
-LABEL io.k8s.display-name="Flight Control CLI multiarch artifacts with server" \
-      io.k8s.description="Flight Control is a service for declarative management of fleets of edge devices and their workloads." \
-      io.openshift.tags="flightctl,cli-artifacts"
-
+LABEL \
+  com.redhat.component="flightctl-cli-artifacts-container" \
+  description="Container image exposing multi-arch Flightctl CLI binaries over HTTP" \
+  io.k8s.description="Container image exposing multi-arch Flightctl CLI binaries over HTTP" \
+  io.k8s.display-name="Flight Control CLI multiarch artifacts with server" \
+  io.openshift.tags="flightctl,cli-artifacts" \
+  name="flightctl-cli-artifacts" \
+  summary="Container image exposing multi-arch Flightctl CLI binaries over HTTP"
 EXPOSE 8090
 
 ENTRYPOINT ${ENTRYPOINT_PATH}

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -20,6 +20,13 @@ RUN microdnf update --nodocs -y  && microdnf install ca-certificates --nodocs -y
 
 FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
+LABEL \
+  com.redhat.component="flightctl-periodic-container" \
+  description="Flightctl Edge management service, periodic job worker" \
+  io.k8s.description="Flightctl Edge management service, periodic job worker" \
+  io.k8s.display-name="Flightctl Periodic Job Manager" \
+  name="flightctl-periodic" \
+  summary="Flightctl Edge management service, periodic job worker"
 COPY --from=build /app/bin/flightctl-periodic .
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-periodic

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -20,6 +20,13 @@ RUN microdnf update --nodocs -y  && microdnf install ca-certificates --nodocs -y
 
 FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
+LABEL \
+  com.redhat.component="flightctl-worker-container" \
+  description="Flightctl Edge management service, async job worker" \
+  io.k8s.description="Flightctl Edge management service, async job worker" \
+  io.k8s.display-name="Flightctl Asynchronous Job Worker" \
+  name="flightctl-worker" \
+  summary="Flightctl Edge management service, async job worker"
 COPY --from=build /app/bin/flightctl-worker .
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-worker


### PR DESCRIPTION
To comply with release policies, override the following inherited labels in the container images:
- com.redhat.component
- description
- io.k8s.description
- io.k8s.display-name
- name
- summary

Adjusted values based on product definitions for:
- flightctl-api
- flightctl-periodic
- flightctl-worker
- flightctl-cli
- flightctl-cli-artifacts

This ensures accurate metadata and resolves Conforma policy violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added and expanded metadata labels in container images to provide enhanced descriptive information, including component names, descriptions, display names, summaries, and Kubernetes-specific labels. No changes were made to application functionality or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->