### PR TITLE
NO-ISSUE: Fix interactive console test that fails on debian

### DIFF
--- a/internal/agent/device/console/console_test.go
+++ b/internal/agent/device/console/console_test.go
@@ -279,10 +279,13 @@ func TestConsole(t *testing.T) {
 		}, 2*time.Second, 50*time.Millisecond, "Expected error to contain 'Success'")
 	})
 
-	t.Run("echo stdin with tty, close stdin", func(t *testing.T) {
+	t.Run("echo stdin with tty", func(t *testing.T) {
 		v := setupVars(t)
 		sessionID := uuid.New().String()
-		consoleDef := deviceConsole(sessionID, sessionMetadata(t, "xterm", nil, nil, true))
+		consoleDef := deviceConsole(sessionID, sessionMetadata(t, "xterm", &v1alpha1.TerminalSize{
+			Width:  256,
+			Height: 50,
+		}, nil, true))
 
 		mockStream(v)
 		mockCloseSend(v)


### PR DESCRIPTION
Interactive console test fails when echoing is truncated according to the screen width.  This change changes the terminal size to width: 256, height: 50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated a test case name and specified initial terminal dimensions in the console session test. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->