### PR TITLE
Revert "EDM-1184: changed SELinux policy to allow systemd to start the service

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -1,7 +1,6 @@
 policy_module(flightctl_agent, 1.0.0)
 
 type flightctl_agent_t;
-type flightctl_agent_exec_t;
 domain_type(flightctl_agent_t);
 
 require {
@@ -22,10 +21,12 @@ require {
     class tcp_socket { name_connect };
 }
 
-role system_r types flightctl_agent_t;
+# Define the new file type for the flightctl-agent executable.
+# It must have the file and exec attributes.
+type flightctl_agent_exec_t, file_type, exec_type;
 
-allow init_t flightctl_agent_t:process transition;
-allow init_t flightctl_agent_exec_t:file { execute getattr read open };
+# When a process running in init_t executes a file labeled flightctl_agent_exec_t,
+# have it transition into flightctl_agent_t.
 type_transition init_t flightctl_agent_exec_t:process flightctl_agent_t;
 
 # Allow the flightctl-agent process (running in flightctl_agent_t) to do what it needs.


### PR DESCRIPTION
This is a manual backport of #1162 

This reverts commit b8ae5f0496e1eae5ace104bcbae5027cf2f61b7b.