### PR TITLE
NO-ISSUE: Console sessions are not terminated in case a close request arrives from server

### DIFF
--- a/internal/agent/device/console/outgoing_streams.go
+++ b/internal/agent/device/console/outgoing_streams.go
@@ -54,7 +54,7 @@ func (o *outgoingStreams) run(wg *sync.WaitGroup) {
 		err := o.streamClient.Send(&grpc_v1.StreamRequest{
 			Payload: msg,
 		})
-		if err != nil {
+		if err != nil && err != io.EOF {
 			o.log.Errorf("failed sending outgoing message: %v", err)
 			return
 		}
@@ -122,7 +122,7 @@ func (o *outgoingStdStream) run(parentWg, childWg *sync.WaitGroup) {
 		}
 		if err != nil {
 			if err != io.EOF {
-				o.log.Errorf("sending data: %v", err)
+				o.log.Warnf("sending data: %v", err)
 			}
 			if n == 0 {
 				return
@@ -162,7 +162,7 @@ func (o *outgoingErrorStream) emit(err error) {
 		exitCode = actual.ExitCode()
 	default:
 		o.log.Errorf("unexpected error type %T: %v", err, err)
-		exitCode = 555
+		exitCode = 255
 	}
 	status := metav1.Status{
 		Status: lo.Ternary[string](exitCode == 0, metav1.StatusSuccess, metav1.StatusFailure),


### PR DESCRIPTION
If a close request arrives from server, the bash process may be left alive in the agent.
This change causes the bash process to terminate and clean up the session.
Also, when a websocket is closed and the remote stream running on the agent has not been closed, make sure that the reader from the stream terminates by returning from the gRPC call when the websocket is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for outgoing streams to prevent unnecessary error logs and handle end-of-stream scenarios more gracefully.
	- Fixed potential deadlocks in channel forwarding for device console sessions, ensuring smoother session termination.

- **New Features**
	- Added explicit cancellation support for incoming streams and command execution, allowing sessions to be cancelled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->