### PR TITLE
Edm 1538 enable deletion of multiple resources via cli

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/flightctl/flightctl/internal/client"
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -27,9 +28,9 @@ func DefaultDeleteOptions() *DeleteOptions {
 func NewCmdDelete() *cobra.Command {
 	o := DefaultDeleteOptions()
 	cmd := &cobra.Command{
-		Use:       "delete (TYPE | TYPE/NAME)",
-		Short:     "Delete resources by resources or owner.",
-		Args:      cobra.ExactArgs(1),
+		Use:       "delete (TYPE NAME [NAME...] | TYPE/NAME)",
+		Short:     "Delete one or more resources by name.",
+		Args:      cobra.MinimumNArgs(1),
 		ValidArgs: getValidResourceKinds(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {
@@ -67,9 +68,15 @@ func (o *DeleteOptions) Validate(args []string) error {
 		return err
 	}
 
-	kind, _, err := parseAndValidateKindName(args[0])
+	kind, name, err := parseAndValidateKindName(args[0])
 	if err != nil {
 		return err
+	}
+	if len(name) == 0 && len(args) < 2 {
+		return fmt.Errorf("name must be specified when deleting %s", kind)
+	}
+	if len(name) > 0 && len(args) > 1 {
+		return fmt.Errorf("invalid format: cannot mix TYPE/NAME syntax with additional resource names. Use either 'delete TYPE/NAME' or 'delete TYPE NAME [NAME...]'")
 	}
 	if kind == TemplateVersionKind && len(o.FleetName) == 0 {
 		return fmt.Errorf("fleetname must be specified when deleting templateversions")
@@ -88,42 +95,63 @@ func (o *DeleteOptions) Run(ctx context.Context, args []string) error { //nolint
 		return err
 	}
 
-	var response interface{}
-
-	switch {
-	case kind == DeviceKind && len(name) > 0:
-		response, err = c.DeleteDeviceWithResponse(ctx, name)
-	case kind == DeviceKind && len(name) == 0:
-		response, err = c.DeleteDevicesWithResponse(ctx)
-	case kind == EnrollmentRequestKind && len(name) > 0:
-		response, err = c.DeleteEnrollmentRequestWithResponse(ctx, name)
-	case kind == EnrollmentRequestKind && len(name) == 0:
-		response, err = c.DeleteEnrollmentRequestsWithResponse(ctx)
-	case kind == FleetKind && len(name) > 0:
-		response, err = c.DeleteFleetWithResponse(ctx, name)
-	case kind == FleetKind && len(name) == 0:
-		response, err = c.DeleteFleetsWithResponse(ctx)
-	case kind == TemplateVersionKind && len(name) > 0:
-		response, err = c.DeleteTemplateVersionWithResponse(ctx, o.FleetName, name)
-	case kind == TemplateVersionKind && len(name) == 0:
-		response, err = c.DeleteTemplateVersionsWithResponse(ctx, o.FleetName)
-	case kind == RepositoryKind && len(name) > 0:
-		response, err = c.DeleteRepositoryWithResponse(ctx, name)
-	case kind == RepositoryKind && len(name) == 0:
-		response, err = c.DeleteRepositoriesWithResponse(ctx)
-	case kind == ResourceSyncKind && len(name) > 0:
-		response, err = c.DeleteResourceSyncWithResponse(ctx, name)
-	case kind == ResourceSyncKind && len(name) == 0:
-		response, err = c.DeleteResourceSyncsWithResponse(ctx)
-	case kind == CertificateSigningRequestKind && len(name) > 0:
-		response, err = c.DeleteCertificateSigningRequestWithResponse(ctx, name)
-	case kind == CertificateSigningRequestKind && len(name) == 0:
-		response, err = c.DeleteCertificateSigningRequestsWithResponse(ctx)
-	default:
-		return fmt.Errorf("unsupported resource kind: %s", kind)
+	if len(args) == 1 {
+		response, err := o.deleteOne(ctx, c, kind, name)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s/%s deleted\n", kind, name)
+		return processDeletionReponse(response, err, kind, name)
 	}
 
-	return processDeletionReponse(response, err, kind, name)
+	names := args[1:]
+
+	return o.deleteMultiple(ctx, c, kind, names)
+	
+}
+
+func (o *DeleteOptions) deleteMultiple(ctx context.Context, c *apiclient.ClientWithResponses, kind string, names []string) error {
+	var err error
+
+	for _, name := range names {
+		response, deleteErr := o.deleteOne(ctx, c, kind, name)
+		
+		processErr := processDeletionReponse(response, deleteErr, kind, name)
+		if processErr != nil {
+			fmt.Printf("Error: %v\n", processErr)
+			err = processErr
+		} else {
+			fmt.Printf("%s \"%s\" deleted\n", kind, name)
+		}
+	}
+	
+	return err
+}
+
+func (o *DeleteOptions) deleteOne(ctx context.Context, c *apiclient.ClientWithResponses, kind string, name string) (interface{}, error) {
+	var response interface{}
+	var err error
+
+	switch kind {
+	case DeviceKind:
+		response, err = c.DeleteDeviceWithResponse(ctx, name)
+	case EnrollmentRequestKind:
+		response, err = c.DeleteEnrollmentRequestWithResponse(ctx, name)
+	case FleetKind:
+		response, err = c.DeleteFleetWithResponse(ctx, name)
+	case TemplateVersionKind:
+		response, err = c.DeleteTemplateVersionWithResponse(ctx, o.FleetName, name)
+	case RepositoryKind:
+		response, err = c.DeleteRepositoryWithResponse(ctx, name)
+	case ResourceSyncKind:
+		response, err = c.DeleteResourceSyncWithResponse(ctx, name)
+	case CertificateSigningRequestKind:
+		response, err = c.DeleteCertificateSigningRequestWithResponse(ctx, name)
+	default:
+		return nil, fmt.Errorf("unsupported resource kind: %s", kind)
+	}
+
+	return response, err
 }
 
 func processDeletionReponse(response interface{}, err error, kind string, name string) error {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -25,11 +25,12 @@ import (
 const (
 	jsonFormat = "json"
 	yamlFormat = "yaml"
+	nameFormat = "name"
 	wideFormat = "wide"
 )
 
 var (
-	legalOutputTypes = []string{jsonFormat, yamlFormat, wideFormat}
+	legalOutputTypes = []string{jsonFormat, yamlFormat, nameFormat, wideFormat}
 )
 
 type GetOptions struct {
@@ -146,9 +147,6 @@ func (o *GetOptions) Validate(args []string) error {
 	if o.Rendered && (kind != DeviceKind || len(name) == 0) {
 		return fmt.Errorf("'--rendered' can only be used when getting a single device")
 	}
-	if kind == EventKind && len(name) > 0 {
-		return fmt.Errorf("you cannot get a single event")
-	}
 	if o.Limit < 0 {
 		return fmt.Errorf("limit must be greater than 0")
 	}
@@ -245,13 +243,6 @@ func (o *GetOptions) Run(ctx context.Context, args []string) error { //nolint:go
 			Continue:      util.ToPtrWithNilDefault(o.Continue),
 		}
 		response, err = c.ListCertificateSigningRequestsWithResponse(ctx, &params)
-	case kind == EventKind:
-		params := api.ListEventsParams{
-			FieldSelector: util.ToPtrWithNilDefault(o.FieldSelector),
-			Limit:         util.ToPtrWithNilDefault(o.Limit),
-			Continue:      util.ToPtrWithNilDefault(o.Continue),
-		}
-		response, err = c.ListEventsWithResponse(ctx, &params)
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", kind)
 	}
@@ -309,6 +300,8 @@ func (o *GetOptions) processResponse(response interface{}, err error, kind strin
 		}
 		fmt.Printf("%s\n", string(marshalled))
 		return nil
+	case nameFormat:
+		return o.printNames(response, kind, name)
 	default:
 		return o.printTable(response, kind, name)
 	}
@@ -361,8 +354,6 @@ func (o *GetOptions) printTable(response interface{}, kind string, name string) 
 		o.printCSRTable(w, response.(*apiclient.ListCertificateSigningRequestsResponse).JSON200.Items...)
 	case kind == CertificateSigningRequestKind && len(name) > 0:
 		o.printCSRTable(w, *(response.(*apiclient.GetCertificateSigningRequestResponse).JSON200))
-	case kind == EventKind:
-		o.printEventsTable(w, response.(*apiclient.ListEventsResponse).JSON200.Items...)
 	default:
 		return fmt.Errorf("unknown resource type %s", kind)
 	}
@@ -583,15 +574,58 @@ func (o *GetOptions) printCSRTable(w *tabwriter.Writer, csrs ...api.CertificateS
 	}
 }
 
-func (o *GetOptions) printEventsTable(w *tabwriter.Writer, events ...api.Event) {
-	fmt.Fprintln(w, "AGE\tKIND\tNAME\tTYPE\tMESSAGE")
-	for _, e := range events {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			humanize.Time(*e.Metadata.CreationTimestamp),
-			e.InvolvedObject.Kind,
-			e.InvolvedObject.Name,
-			e.Type,
-			e.Message,
-		)
+func (o *GetOptions) printNames(response interface{}, kind string, name string) error {
+	switch {
+	case kind == DeviceKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListDevicesResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == DeviceKind && len(name) > 0:
+		var device api.Device
+		if o.Rendered {
+			device = *(response.(*apiclient.GetRenderedDeviceResponse).JSON200)
+		} else {
+			device = *(response.(*apiclient.GetDeviceResponse).JSON200)
+		}
+		fmt.Println(*device.Metadata.Name)
+	case kind == EnrollmentRequestKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListEnrollmentRequestsResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == EnrollmentRequestKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetEnrollmentRequestResponse).JSON200.Metadata.Name)
+	case kind == FleetKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListFleetsResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == FleetKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetFleetResponse).JSON200.Metadata.Name)
+	case kind == TemplateVersionKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListTemplateVersionsResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == TemplateVersionKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetTemplateVersionResponse).JSON200.Metadata.Name)
+	case kind == RepositoryKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListRepositoriesResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == RepositoryKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetRepositoryResponse).JSON200.Metadata.Name)
+	case kind == ResourceSyncKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListResourceSyncsResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == ResourceSyncKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetResourceSyncResponse).JSON200.Metadata.Name)
+	case kind == CertificateSigningRequestKind && len(name) == 0:
+		for _, item := range response.(*apiclient.ListCertificateSigningRequestsResponse).JSON200.Items {
+			fmt.Println(*item.Metadata.Name)
+		}
+	case kind == CertificateSigningRequestKind && len(name) > 0:
+		fmt.Println(*response.(*apiclient.GetCertificateSigningRequestResponse).JSON200.Metadata.Name)
+	default:
+		return fmt.Errorf("unknown resource type %s", kind)
 	}
+	return nil
 }

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -165,6 +165,11 @@ var _ = Describe("cli operation", func() {
 			responseLabelValue := (*dev.JSON200.Metadata.Labels)[newTestKey]
 			Expect(responseLabelValue).To(ContainSubstring(newTestValue))
 
+			By("Verify Shell Expansion works")
+			out, err = harness.CLI("get", fmt.Sprintf("%s/%s", util.Device, devName), "-o", "name")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(devName))
+
 			By("Cleaning up Device")
 			_, err = harness.CLI("delete", fmt.Sprintf("%s/%s", util.Device, devName))
 			Expect(err).ToNot(HaveOccurred())
@@ -281,6 +286,46 @@ var _ = Describe("cli operation", func() {
 
 			_, err = harness.CLI("delete", fmt.Sprintf("%s/%s", util.CertificateSigningRequest, csrNewName))
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("CLI Multi-Device Delete", func() {
+		It("should delete multiple devices", Label("multiple-device-delete"), func() {
+			By("Creating multiple test devices")
+			err := harness.CleanUpAllResources()
+			Expect(err).ToNot(HaveOccurred())
+			
+			out, err := harness.CLI("apply", "-f", util.GetTestExamplesYamlPath("device.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(`(200 OK|201 Created)`))
+			device1 := harness.GetDeviceByYaml(util.GetTestExamplesYamlPath("device.yaml"))
+			device1Name := *device1.Metadata.Name
+			
+			out, err = harness.CLI("apply", "-f", util.GetTestExamplesYamlPath("device-b.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(MatchRegexp(`(200 OK|201 Created)`))
+			device2 := harness.GetDeviceByYaml(util.GetTestExamplesYamlPath("device-b.yaml"))
+			device2Name := *device2.Metadata.Name
+
+			devices, err := harness.CLI("get", "devices")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(devices).To(ContainSubstring(device1Name))
+			Expect(devices).To(ContainSubstring(device2Name))
+			
+			By("Deleting multiple devices at once")
+			out , err = harness.CLI("delete", fmt.Sprintf("%s %s %s", util.Device, device1Name, device2Name))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("deleted"))
+			
+			By("Verifying both devices were deleted")
+			dev1, err := harness.Client.GetDeviceWithResponse(harness.Context, device1Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dev1.JSON404).ToNot(BeNil(), "first device should not exist after deletion")
+			
+			dev2, err := harness.Client.GetDeviceWithResponse(harness.Context, device2Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dev2.JSON404).ToNot(BeNil(), "second device should not exist after deletion")
 		})
 	})
 


### PR DESCRIPTION
This PR enhances the flightctl delete command to support bulk deletion by allowing multiple resource names to be passed in a single invocation. For example:

flightctl delete device device1 device2

Additionally, the CLI supports shell expansions such as:

flightctl delete device $(flightctl get devices -o name)

