### PR TITLE
EDM-1591: rpm: add policy update

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -7,9 +7,6 @@
 # SELinux specifics
 %global selinuxtype targeted
 %define selinux_policyver 3.14.3-67
-%define agent_relabel_files() \
-    semanage fcontext -a -t flightctl_agent_exec_t "/usr/bin/flightctl-agent" ; \
-    restorecon -v /usr/bin/flightctl-agent
 
 Name:           flightctl
 Version:        0.6.0
@@ -56,6 +53,11 @@ BuildRequires: selinux-policy >= %{selinux_policyver}
 BuildRequires: selinux-policy-devel >= %{selinux_policyver}
 BuildArch: noarch
 Requires: selinux-policy >= %{selinux_policyver}
+
+# For restorecon
+Requires: policycoreutils
+# For semanage
+Requires: policycoreutils-python-utils
 
 %description selinux
 The flightctl-selinux package provides the SELinux policy modules required by the Flight Control management agent.
@@ -196,7 +198,6 @@ mkdir -p $INSTALL_DIR
 cp /usr/share/sosreport/flightctl.py $INSTALL_DIR
 chmod 0644 $INSTALL_DIR/flightctl.py
 rm -rf /usr/share/sosreport
-
 
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2

--- a/packaging/selinux/Makefile
+++ b/packaging/selinux/Makefile
@@ -1,19 +1,18 @@
-TARGET?=flightctl_agent
-MODULES?=${TARGET:=.pp.bz2}
-SHAREDIR?=/usr/share
+TARGET ?= flightctl_agent
+SHAREDIR ?= /usr/share
 
-all: ${MODULES}
+all: ${TARGET}.pp.bz2
 
 %.pp.bz2: %.pp
 	rm -f $@ || true
-	@echo Compressing $^ -\> $@
-	bzip2 -9 $^
+	@echo Compressing $^ -> $@
+	bzip2 -9 -f $^
 
-%.pp: %.te
-	make -f ${SHAREDIR}/selinux/devel/Makefile $@
+%.pp: %.te %.fc
+	make -f ${SHAREDIR}/selinux/devel/Makefile
 
 clean:
-	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -f *~ *.tc *.pp *.mod *.pp.bz2
 	rm -rf tmp *.tar.gz
 
 man: install-policy

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -1,0 +1,2 @@
+/usr/bin/flightctl-agent                        --  gen_context(system_u:object_r:flightctl_agent_exec_t,s0)
+/var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -1,35 +1,126 @@
 policy_module(flightctl_agent, 1.0.0)
 
+
+# Security Enhanced Linux Reference
+# https://pages.cs.wisc.edu/~matyas/selinux-policy/
+# https://access.redhat.com/articles/6999267
+
+# Initialize types
 type flightctl_agent_t;
-domain_type(flightctl_agent_t);
+type flightctl_agent_exec_t;
+type flightctl_agent_var_lib_t;
+type flightctl_agent_tmp_t;
 
-require {
-    # Existing types from the policy
-    type init_t;
-    type devpts_t;
-    type ptmx_t;
-    type unreserved_port_t;
-    
-    attribute file_type;
-    attribute exec_type;
+# Initialize domain
+init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
+files_type(flightctl_agent_var_lib_t)
+files_tmp_file(flightctl_agent_tmp_t)
 
+permissive flightctl_agent_t;
 
-    # Classes and permissions that will be used.
-    class file { read execute open };
-    class process transition;
-    class chr_file { open read write ioctl };
-    class tcp_socket { name_connect };
-}
+gen_require(`
+    type install_t, install_exec_t;
+    type hostname_t, hostname_exec_t;
+    type container_runtime_t, container_runtime_exec_t;
+    type container_var_lib_t;
+    type etc_t, home_root_t, root_t, fs_t;
+    type tmp_t;
+')
 
-# Define the new file type for the flightctl-agent executable.
-# It must have the file and exec attributes.
-type flightctl_agent_exec_t, file_type, exec_type;
+# File Access
+# ------------------------------------------------------------------------------
 
-# When a process running in init_t executes a file labeled flightctl_agent_exec_t,
-# have it transition into flightctl_agent_t.
-type_transition init_t flightctl_agent_exec_t:process flightctl_agent_t;
+# /var/lib/flightctl management
+manage_dirs_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+manage_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+manage_lnk_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+files_var_lib_filetrans(flightctl_agent_t, flightctl_agent_var_lib_t, dir, "flightctl")
 
-# Allow the flightctl-agent process (running in flightctl_agent_t) to do what it needs.
-allow flightctl_agent_t devpts_t:chr_file open;
-allow flightctl_agent_t ptmx_t:chr_file { open read write ioctl };
-allow flightctl_agent_t unreserved_port_t:tcp_socket name_connect;  
+# Container storage and system files
+admin_pattern(flightctl_agent_t, container_var_lib_t, container_var_lib_t)
+files_read_etc_files(flightctl_agent_t)
+files_read_etc_runtime_files(flightctl_agent_t)
+files_read_var_lib_files(flightctl_agent_t)
+files_read_boot_files(flightctl_agent_t)
+files_read_usr_files(flightctl_agent_t)
+files_read_generic_pids(flightctl_agent_t)
+
+# Full /etc directory management for configuration files
+manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)
+manage_files_pattern(flightctl_agent_t, etc_t, etc_t)
+manage_lnk_files_pattern(flightctl_agent_t, etc_t, etc_t)
+
+# Hardware/system information
+# ref. https://pages.cs.wisc.edu/~matyas/selinux-policy/kernel_kernel.html
+kernel_read_system_state(flightctl_agent_t)
+kernel_read_network_state(flightctl_agent_t)
+kernel_read_all_proc(flightctl_agent_t)
+kernel_read_all_sysctls(flightctl_agent_t)
+
+# Device access
+# ref. https://pages.cs.wisc.edu/~matyas/selinux-policy/kernel_devices.html
+dev_read_sysfs(flightctl_agent_t)
+dev_read_kmsg(flightctl_agent_t)
+
+# Temporary file access
+# ref. https://pages.cs.wisc.edu/~matyas/selinux-policy/kernel_files.html
+files_tmp_filetrans(flightctl_agent_t, flightctl_agent_tmp_t, { file dir })
+manage_dirs_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
+manage_files_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
+
+# Access /home symlink
+allow flightctl_agent_t home_root_t:lnk_file read;
+
+# Read root filesystem directory for disk usage collection (/sysroot access)
+allow flightctl_agent_t root_t:dir { read search open getattr };
+
+# Get filesystem statistics for disk usage monitoring
+allow flightctl_agent_t root_t:filesystem getattr;
+allow flightctl_agent_t fs_t:filesystem getattr;
+
+# Process Management
+# ------------------------------------------------------------------------------
+
+# Allow flightctl_agent_t to execute bootc, rpm-ostree, and similar tools
+# that are labeled install_exec_t, transitioning them into install_t
+domtrans_pattern(flightctl_agent_t, install_exec_t, install_t)
+
+# Allow invocation of /usr/bin/hostname or similar, transitioning to hostname_t
+domtrans_pattern(flightctl_agent_t, hostname_exec_t, hostname_t)
+
+# Allow execution of container runtimes like podman or runc, labeled container_runtime_exec_t,
+# with processes running under container_runtime_t
+domtrans_pattern(flightctl_agent_t, container_runtime_exec_t, container_runtime_t)
+
+# Allow the agent to use file descriptors shared with its child processes
+allow flightctl_agent_t { install_t hostname_t container_runtime_t }:fd use;
+allow { install_t hostname_t container_runtime_t } flightctl_agent_t:fd use;
+
+# Allow the agent to send basic signals to its child processe
+allow flightctl_agent_t { install_t hostname_t container_runtime_t }:process { sigchld signal sigkill sigstop signull };
+
+# Allow execution of all binaries labeled under core command types like bin_t
+corecmd_exec_all_executables(flightctl_agent_t)
+
+# Network Access
+# ------------------------------------------------------------------------------
+
+# Socket creation
+allow flightctl_agent_t self:{ tcp_socket udp_socket netlink_route_socket } create_stream_socket_perms;
+
+corenet_tcp_connect_all_ports(flightctl_agent_t)
+corenet_sendrecv_all_client_packets(flightctl_agent_t)
+sysnet_dns_name_resolve(flightctl_agent_t)
+
+# System Capabilities and Services
+# ------------------------------------------------------------------------------
+
+# Process capabilities
+allow flightctl_agent_t self:capability { dac_override chown setuid setgid sys_admin };
+allow flightctl_agent_t self:process { fork signal sigchld execmem setfscreate getsched setsched };
+
+# Allow reading /var/run/utmp to gather login/session information
+init_read_utmp(flightctl_agent_t)
+
+# Allow reading system localization files
+miscfiles_read_localization(flightctl_agent_t)


### PR DESCRIPTION
The policy follows the principle of least privilege. The agent handles orchestration and API communication while child processes (bootc, podman, hostname) run in their proper domains via domtrans_pattern. Each component gets only the permissions it directly needs. 

This was a best effort attempt and we should consider adding checks for selinux failures to e2e. 

refs
- https://pages.cs.wisc.edu/~matyas/selinux-policy/
- https://access.redhat.com/articles/6999267

```sh
[root@localhost ~]# ls -Z /usr/bin/flightctl-agent 
system_u:object_r:flightctl_agent_exec_t:s0 /usr/bin/flightctl-agent
```