### PR TITLE
EDM-1620: Use `filepath.Dir` do determine the config's directory

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -428,7 +428,7 @@ func (c *Config) Persist(filename string) error {
 	if err != nil {
 		return fmt.Errorf("encoding config: %w", err)
 	}
-	directory := filename[:strings.LastIndex(filename, "/")]
+	directory := filepath.Dir(filename)
 	if err := os.MkdirAll(directory, 0700); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability and compatibility of file path handling for configuration persistence, ensuring better support across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->