### PR TITLE
EDM-1242: Fix network policy for UI and Keycloak

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-network-policy.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-network-policy.yaml
@@ -11,7 +11,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           policy-group.network.openshift.io/ingress: ""
-      podSelector: {}
   podSelector:
     matchLabels:
       app: keycloak

--- a/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-network-policy.yaml
+++ b/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-network-policy.yaml
@@ -10,7 +10,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           policy-group.network.openshift.io/ingress: ""
-      podSelector: {}
   podSelector:
     matchLabels:
       role: frontend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated network policy configurations to simplify ingress rules by removing unnecessary empty pod selectors. This change clarifies how traffic is allowed from selected namespaces. No impact on application functionality is expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->