### PR TITLE
NO-ISSUE: Install CLI document

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -59,6 +59,7 @@ KVM
 lifecycle
 lifecycle-bound
 linux
+macOS
 metadata
 microservices
 MicroShift
@@ -236,4 +237,3 @@ yaml
  - docs/user/rollout-policies.md
 rollouts
 BatchSequence
-macOS

--- a/.spelling
+++ b/.spelling
@@ -236,3 +236,4 @@ yaml
  - docs/user/rollout-policies.md
 rollouts
 BatchSequence
+macOS

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -45,7 +45,8 @@ Welcome to the Flight Control user documentation.
 
 * Installing and Configuring the Flight Control Service and UI
   * [Configuring Flight Control to use k8s auth](kubernetes-auth.md)
-* Installing and Using the Flight Control CLI
+* [Installing the Flight Control CLI](install-cli.md)
+* Using the Flight Control CLI
 * [Configuring the Flight Control Agent](configuring-agent.md)
 * [Troubleshooting](troubleshooting.md)
 

--- a/docs/user/install-cli.md
+++ b/docs/user/install-cli.md
@@ -4,7 +4,7 @@ To install `flightctl` on Linux, Mac OS and Windows operating systems you have t
 
 ## Download archive
 
-1. Click the **❔** (question mark) icon in the upper part of the web console page and select "Command Like Tools" to be taken to the CLI downloads page.
+1. Click the **❔** (question mark) icon in the upper part of the web console page and select "Command Line Tools" to be taken to the CLI downloads page.
 
 2. Choose a downloadable archive using proper architecture and OS. Click the file to download it.
 
@@ -80,4 +80,4 @@ After installation, verify that `flightctl` is working correctly:
   flightctl version
   ```
 
-> Note: If you get a "command not found" error, ensure the binary is in your PATH.
+> Note: If you get a "command not found" error, ensure the binary is in your `PATH`.

--- a/docs/user/install-cli.md
+++ b/docs/user/install-cli.md
@@ -1,0 +1,83 @@
+# Installing the Flight Control CLI
+
+To install `flightctl` on Linux, Mac OS and Windows operating systems you have to download and install the `flightctl` binary file.
+
+## Download archive
+
+1. Click the **❔** (question mark) icon in the upper part of the web console page and select "Command Like Tools" to be taken to the CLI downloads page.
+
+2. Choose a downloadable archive using proper architecture and OS. Click the file to download it.
+
+## Installation
+
+1. Install `flightctl`
+
+* For **Linux** OS
+
+  * Decompress the archive file
+
+    ```shell
+    tar -xvf <flightctl-os-arch>.tar.gz
+    ```
+
+  * Run the following command to make the `flightctl` binary executable
+
+    ```shell
+    chmod +x flightctl
+    ```
+
+  * Move the `flightctl` binary to a directory in your `PATH` environment variable. Usually it would be `/usr/local/bin` or `~/bin`.
+
+    Don't forget to update `PATH` in the case you want to move the binary to another directory.
+
+    To check `PATH` use:
+
+    ```shell
+    echo $PATH
+    ```
+
+  * For **Windows** OS
+
+    * Decompress the archive file
+
+    * Move the `flightctl.exe` binary to a directory in your `PATH` environment variable. Usually it would be `C:\Program Files\flightctl\`.
+
+      Don't forget to update `PATH` in the case you want to move it to another directory.
+
+      To check `PATH` use:
+
+      ```shell
+      path
+      ```
+
+  * For **Mac OS**
+
+    * Decompress the archive file
+
+    * Move the `flightctl` binary to a directory in your `PATH` environment variable. Usually it would be `/usr/local/bin` or `~/bin`.
+
+      Don't forget to update `PATH` in the case you want to move the binary to another directory.
+
+      To check `PATH` use:
+
+      ```shell
+      echo $PATH
+      ```
+
+## Verification
+
+After installation, verify that `flightctl` is working correctly:
+
+* **Linux and Mac OS**:
+
+  ```shell
+  flightctl version
+  ```
+
+* **Windows**:
+
+  ```shell
+  flightctl version
+  ```
+
+> Note: If you get a "command not found" error, ensure the binary is in your PATH.

--- a/docs/user/install-cli.md
+++ b/docs/user/install-cli.md
@@ -1,6 +1,6 @@
 # Installing the Flight Control CLI
 
-To install `flightctl` on Linux, Mac OS and Windows operating systems you have to download and install the `flightctl` binary file.
+To install `flightctl` on Linux, macOS and Windows operating systems you have to download and install the `flightctl` binary file.
 
 ## Download archive
 
@@ -50,7 +50,7 @@ To install `flightctl` on Linux, Mac OS and Windows operating systems you have t
       path
       ```
 
-  * For **Mac OS**
+  * For **macOS**
 
     * Decompress the archive file
 
@@ -68,16 +68,8 @@ To install `flightctl` on Linux, Mac OS and Windows operating systems you have t
 
 After installation, verify that `flightctl` is working correctly:
 
-* **Linux and Mac OS**:
-
-  ```shell
-  flightctl version
-  ```
-
-* **Windows**:
-
-  ```shell
-  flightctl version
-  ```
+```shell
+flightctl version
+```
 
 > Note: If you get a "command not found" error, ensure the binary is in your `PATH`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new installation guide for the Flight Control CLI with step-by-step instructions for Linux, macOS, and Windows.
  - Updated the administration documentation to separate installation and usage instructions for the Flight Control CLI, enhancing clarity.
  - Updated spelling configuration to include "macOS" as an accepted term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->