### PR TITLE
EDM-1591: rpm: add selinux policy update

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -7,9 +7,6 @@
 # SELinux specifics
 %global selinuxtype targeted
 %define selinux_policyver 3.14.3-67
-%define agent_relabel_files() \
-    semanage fcontext -a -t flightctl_agent_exec_t "/usr/bin/flightctl-agent" ; \
-    restorecon -v /usr/bin/flightctl-agent
 
 Name:           flightctl
 Version:        0.6.0
@@ -57,6 +54,11 @@ BuildRequires: selinux-policy >= %{selinux_policyver}
 BuildRequires: selinux-policy-devel >= %{selinux_policyver}
 BuildArch: noarch
 Requires: selinux-policy >= %{selinux_policyver}
+
+# For restorecon
+Requires: policycoreutils
+# For semanage
+Requires: policycoreutils-python-utils
 
 %description selinux
 The flightctl-selinux package provides the SELinux policy modules required by the Flight Control management agent.
@@ -198,7 +200,6 @@ cp /usr/share/sosreport/flightctl.py $INSTALL_DIR
 chmod 0644 $INSTALL_DIR/flightctl.py
 rm -rf /usr/share/sosreport
 
-
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2
 
@@ -242,6 +243,8 @@ rm -rf /usr/share/sosreport
 
 %changelog
 
+* Tue June 4 2025 Sam Batschelet <sbatsche@redhat.com> - 0.6.0-5
+- Ensure selinux required dependencies are enforced.
 * Tue Apr 15 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-4
 - Add ability to create an AAP Oauth Application within flightctl-services sub-package
 * Fri Apr 11 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-3

--- a/packaging/selinux/Makefile
+++ b/packaging/selinux/Makefile
@@ -1,19 +1,21 @@
-TARGET?=flightctl_agent
 MODULES?=${TARGET:=.pp.bz2}
-SHAREDIR?=/usr/share
+TARGET ?= flightctl_agent
+SHAREDIR ?= /usr/share
 
 all: ${MODULES}
 
+# Compress .pp file to .pp.bz2
 %.pp.bz2: %.pp
 	rm -f $@ || true
 	@echo Compressing $^ -\> $@
 	bzip2 -9 $^
 
-%.pp: %.te
+# Build .pp from .te and .fc using SELinux development Makefile
+%.pp: %.te %.fc
 	make -f ${SHAREDIR}/selinux/devel/Makefile $@
 
 clean:
-	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -f *~ *.tc *.pp *.mod *.pp.bz2
 	rm -rf tmp *.tar.gz
 
 man: install-policy

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -1,0 +1,2 @@
+/usr/bin/flightctl-agent                        --  gen_context(system_u:object_r:flightctl_agent_exec_t,s0)
+/var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -1,35 +1,16 @@
 policy_module(flightctl_agent, 1.0.0)
 
+# Type declarations
 type flightctl_agent_t;
-domain_type(flightctl_agent_t);
+type flightctl_agent_exec_t;
+type flightctl_agent_var_lib_t;
 
-require {
-    # Existing types from the policy
-    type init_t;
-    type devpts_t;
-    type ptmx_t;
-    type unreserved_port_t;
-    
-    attribute file_type;
-    attribute exec_type;
+# Temporarily mark the flightctl_agent_t domain as permissive.  This allows the
+# agent to operate without SELinux denials while logging all access attempts.
+permissive flightctl_agent_t;
 
+# Init domain setup
+init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
 
-    # Classes and permissions that will be used.
-    class file { read execute open };
-    class process transition;
-    class chr_file { open read write ioctl };
-    class tcp_socket { name_connect };
-}
-
-# Define the new file type for the flightctl-agent executable.
-# It must have the file and exec attributes.
-type flightctl_agent_exec_t, file_type, exec_type;
-
-# When a process running in init_t executes a file labeled flightctl_agent_exec_t,
-# have it transition into flightctl_agent_t.
-type_transition init_t flightctl_agent_exec_t:process flightctl_agent_t;
-
-# Allow the flightctl-agent process (running in flightctl_agent_t) to do what it needs.
-allow flightctl_agent_t devpts_t:chr_file open;
-allow flightctl_agent_t ptmx_t:chr_file { open read write ioctl };
-allow flightctl_agent_t unreserved_port_t:tcp_socket name_connect;  
+# File type for data directory
+files_type(flightctl_agent_var_lib_t)


### PR DESCRIPTION
This PR replaces the broken SELinux policy with a permissive definition to ensure a valid policy is applied. This provides a baseline we can build on as we incrementally develop a more secure and hardened policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced SELinux file context rules for the flightctl-agent binary and its data directory, enhancing security labeling.
- **Refactor**
	- Simplified and restructured the SELinux policy module for flightctl-agent, using higher-level macros and reducing explicit rules.
	- Improved and clarified SELinux packaging Makefile for more consistent build behavior.
- **Chores**
	- Updated package dependencies to explicitly require SELinux management tools for proper installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->