### PR TITLE
NO-ISSUE: COPR packages for Fedora 42 are not building

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,6 +20,7 @@ jobs:
     targets:
       - fedora-eln-aarch64
       - centos-stream-9-x86_64
+      - fedora-42-x86_64
     module_hotfixes: true
 
   - job: copr_build
@@ -33,6 +34,8 @@ jobs:
       - fedora-40-x86_64
       - fedora-41-aarch64
       - fedora-41-x86_64
+      - fedora-42-aarch64
+      - fedora-42-x86_64
       - fedora-rawhide-aarch64
       - fedora-rawhide-x86_64
       - fedora-eln-aarch64
@@ -56,6 +59,8 @@ jobs:
       - fedora-40-x86_64
       - fedora-41-aarch64
       - fedora-41-x86_64
+      - fedora-42-aarch64
+      - fedora-42-x86_64
       - fedora-rawhide-aarch64
       - fedora-rawhide-x86_64
       - fedora-eln-aarch64


### PR DESCRIPTION
https://github.com/flightctl/flightctl/issues/1131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded build and release targets to include Fedora 42 (x86_64 and aarch64) for improved compatibility and broader platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->