### PR TITLE
NO-ISSUE: Use proper tag 9.6 for rhel9/PostgreSQL-16

### DIFF
--- a/deploy/helm/flightctl/values.acm.yaml
+++ b/deploy/helm/flightctl/values.acm.yaml
@@ -4,7 +4,7 @@ global:
 db:
   image:
     image: registry.redhat.io/rhel9/postgresql-16
-    tag: 1-181
+    tag: 9.6
 
 kv:
   image:


### PR DESCRIPTION
Solves: https://github.com/flightctl/flightctl/pull/870#discussion_r2113400524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the PostgreSQL database image version used in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->