### PR TITLE
NO-ISSUE: agent/console: isolate shell with bwrap and explicit bind mounts

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -34,7 +34,7 @@ runs:
         run: |
           echo "::group::Installing general dependencies"
           sudo apt update -y # fix broken repo cache
-          sudo apt install -y make python3-pip podman podman-compose libvirt-dev
+          sudo apt install -y make python3-pip podman podman-compose libvirt-dev bubblewrap
 
           curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
           sudo unzip -q protoc.zip bin/protoc -d /usr/local


### PR DESCRIPTION
This PR is an experiment using bubblewrap to create an isolated shell for the console. This will allow us to gate some of the functionality based on user permissions and also be declarative in our permissions required for selinux. generally feels much more powerful than chroot and we get it for free via bootc/rpm-ostree.

ref. https://github.com/containers/bubblewrap