### PR TITLE
NO-ISSUE: Specify Go 1.23 toolchain for hermetic builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/flightctl/flightctl
 
 go 1.23
 
+toolchain go1.23.6
+
 require (
 	github.com/ccoveille/go-safecast v1.1.0
 	github.com/containers/image/v5 v5.30.1


### PR DESCRIPTION
Add `toolchain go1.23.6` to go.mod to ensure hermetic build environments (e.g., Konflux, CPaaS) use the correct Go version explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go toolchain version to 1.23.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->