### PR TITLE
EDM-1657: Adapt DescribeTable to report as single TC

### DIFF
--- a/test/e2e/selectors/selectors_test.go
+++ b/test/e2e/selectors/selectors_test.go
@@ -25,6 +25,25 @@ const (
 	RetryInterval   = "1s"
 )
 
+// FieldSelectorTestParams defines the parameters for field selector tests, including arguments, expected match status, and expected output.
+type FieldSelectorTestParams struct {
+	Args        []string
+	ShouldMatch bool
+	Expected    string
+}
+
+// EntryCase creates a test case for field selector tests with the given description, arguments, expected match status, and expected output.
+func EntryCase(desc string, args []string, shouldMatch bool, expected string) TestCase[FieldSelectorTestParams] {
+	return TestCase[FieldSelectorTestParams]{
+		Description: desc,
+		Params: FieldSelectorTestParams{
+			Args:        args,
+			ShouldMatch: shouldMatch,
+			Expected:    expected,
+		},
+	}
+}
+
 func TestFieldSelectors(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Field Selectors E2E Suite")
@@ -37,23 +56,19 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 		deviceBInfo   v1alpha1.Device
 		deviceAName   string
 		deviceBName   string
-		deviceAlias   string
 		DeviceARegion string
 	)
 
-	// Setup for the suite
 	BeforeAll(func() {
 		harness = e2e.NewTestHarness()
 		login.LoginToAPIWithToken(harness)
 		logrus.Infof("Harness Created")
 	})
 
-	// Cleanup after each test
 	AfterEach(func() {
 		harness.Cleanup(false)
 	})
 
-	// Cleanup after the suite
 	AfterAll(func() {
 		err := harness.CleanUpAllResources()
 		Expect(err).ToNot(HaveOccurred())
@@ -67,12 +82,8 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			Expect(out).To(ContainSubstring("NAME"))
 
 			By("create a complete fleet")
-			// Creating fleet
 			_, _ = harness.ManageResource("delete", "fleet")
 			out, err = harness.ManageResource("apply", fleetYAMLPath)
-			// Verifying fleet is valid
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(MatchRegexp(resourceCreated))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(MatchRegexp(resourceCreated))
 
@@ -85,9 +96,7 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			Expect(deviceAName).ToNot(BeEmpty())
 			Expect(deviceBName).ToNot(BeEmpty())
 
-			// deleting previous devices
 			_, _ = harness.ManageResource("delete", "device")
-			// Creating new devices
 			out, err = harness.ManageResource("apply", deviceAYAMLPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(MatchRegexp(resourceCreated))
@@ -98,158 +107,72 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			logrus.Infof("Device Created: %s", deviceAName)
 			logrus.Infof("Device Created: %s", deviceBName)
 
-			// to establish fleet before adding device to it
 			Eventually(func() error {
 				out, err = harness.CLI("get", "device")
 				return err
 			}, DefaultTimeout, RetryInterval).Should(BeNil(), "Timeout waiting for fleet to be ready")
 			Expect(out).To(ContainSubstring("defaultDevice"))
-
-			By("filters devices by name")
-			out, err = harness.RunGetDevices("--field-selector", fmt.Sprintf("metadata.name=%s", deviceAName))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by alias")
-			deviceAlias = (*deviceInfo.Metadata.Labels)["alias"]
-			out, err = harness.RunGetDevices("--field-selector", fmt.Sprintf("metadata.alias=%s", deviceAlias))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by nameOrAlias")
-			out, err = harness.RunGetDevices("--field-selector", fmt.Sprintf("metadata.nameOrAlias=%s", deviceAlias))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by owner")
-			_, err = harness.RunGetDevices("--field-selector", "metadata.owner=Fleet/default", "-owide")
-			Expect(err).ToNot(HaveOccurred())
-
-			By("filters devices by creation timestamp")
-			startTimestamp, endTimestamp := GetCurrentYearBounds()
-			out, err = harness.RunGetDevices("--field-selector",
-				fmt.Sprintf("metadata.creationTimestamp>=%s,metadata.creationTimestamp<%s", startTimestamp, endTimestamp), "-owide")
-			Expect(out).To(ContainSubstring(deviceAName))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
 		})
-	})
 
-	Context("Advanced Functionality Tests", func() {
-		It("Advanced Functionality Tests", Label("77947", "sanity"), func() {
-			By("filters devices by multiple field selectors")
-			startTimestamp, _ := GetCurrentYearBounds()
-			out, err := harness.RunGetDevices(
-				"-l", fmt.Sprintf("region=%s", DeviceARegion),
-				"--field-selector", fmt.Sprintf("metadata.creationTimestamp>=%s", startTimestamp),
+		It("Field selector filters", func() {
+			start, end := GetCurrentYearBounds()
+			tests := Cases(
+				EntryCase("filters devices by name", []string{"--field-selector", fmt.Sprintf("metadata.name=%s", deviceAName)}, true, deviceAName),
+				EntryCase("filters devices by alias", []string{"--field-selector", fmt.Sprintf("metadata.alias=%s", (*deviceInfo.Metadata.Labels)["alias"])}, true, deviceAName),
+				EntryCase("filters devices by nameOrAlias", []string{"--field-selector", fmt.Sprintf("metadata.nameOrAlias=%s", (*deviceInfo.Metadata.Labels)["alias"])}, true, deviceAName),
+				EntryCase("filters devices by owner", []string{"--field-selector", "metadata.owner=Fleet/default", "-owide"}, true, ""),
+				EntryCase("filters devices by creation timestamp", []string{"--field-selector", fmt.Sprintf("metadata.creationTimestamp>=%s,metadata.creationTimestamp<%s", start, end), "-owide"}, true, deviceAName),
 			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("excludes devices by name")
-			out, err = harness.RunGetDevices("--field-selector", "metadata.name!=device1-name")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).ToNot(ContainSubstring("device1-name"))
+			RunTable(tests, func(params FieldSelectorTestParams) {
+				out, err := harness.CLI(append([]string{"get", "device"}, params.Args...)...)
+				if params.ShouldMatch {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out).To(ContainSubstring(params.Expected))
+				} else {
+					Expect(out).ToNot(ContainSubstring(params.Expected))
+				}
+			})
 		})
-	})
 
-	Context("Label Selectors Tests", func() {
-		It("Label Selectors Tests", Label("78751", "sanity"), func() {
-			By("filters devices by region in a set")
-			out, err := harness.RunGetDevices(
-				"-l", fmt.Sprintf("region in (test, %s)", DeviceARegion),
-				"-owide")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by region not in a set")
-			out, err = harness.RunGetDevices("-l", "region notin (test, eu-west-2)", "-owide")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by label existence")
-			out, err = harness.RunGetDevices("-l", "region", "-owide")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by label non-existence")
-			out, err = harness.RunGetDevices("-l", "!region")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).ToNot(ContainSubstring(deviceAName))
-
-			By("filters devices by exact label match")
-			out, err = harness.RunGetDevices("-l", fmt.Sprintf("region=%s", DeviceARegion))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
-
-			By("filters devices by label mismatch")
-			out, err = harness.RunGetDevices("-l", fmt.Sprintf("region!=%s", DeviceARegion))
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).ToNot(ContainSubstring(deviceAName))
-
-			By("filters devices by label and field selector")
-			out, err = harness.RunGetDevices(
-				"-l", fmt.Sprintf("region=%s", DeviceARegion),
-				"--field-selector", "status.updated.status in (UpToDate, Unknown)",
+		It("Label selector filters", func() {
+			tests := Cases(
+				EntryCase("filters by region in set", []string{"-l", fmt.Sprintf("region in (test, %s)", DeviceARegion), "-owide"}, true, deviceAName),
+				EntryCase("filters by region not in set", []string{"-l", "region notin (test, eu-west-2)", "-owide"}, true, deviceAName),
+				EntryCase("filters by label existence", []string{"-l", "region", "-owide"}, true, deviceAName),
+				EntryCase("filters by label non-existence", []string{"-l", "!region"}, false, deviceAName),
+				EntryCase("filters by exact label match", []string{"-l", fmt.Sprintf("region=%s", DeviceARegion)}, true, deviceAName),
+				EntryCase("filters by label mismatch", []string{"-l", fmt.Sprintf("region!=%s", DeviceARegion)}, false, deviceAName),
+				EntryCase("filters by label and field selector", []string{"-l", fmt.Sprintf("region=%s", DeviceARegion), "--field-selector", "status.updated.status in (UpToDate, Unknown)"}, true, deviceAName),
 			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring(deviceAName))
+			RunTable(tests, func(params FieldSelectorTestParams) {
+				out, err := harness.CLI(append([]string{"get", "device"}, params.Args...)...)
+				if params.ShouldMatch {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out).To(ContainSubstring(params.Expected))
+				} else {
+					Expect(out).ToNot(ContainSubstring(params.Expected))
+				}
+			})
 		})
-	})
 
-	Context("Negative Tests", func() {
-		It("Negative Tests", Label("77948", "sanity"), func() {
-			By("returns an error for an invalid field selector")
-			out, err := harness.RunGetDevices("--field-selector", "invalid.field")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(unknownSelector))
-
-			By("returns an error for an unsupported field selector")
-			out, err = harness.RunGetDevices("--field-selector", "unsupported.field")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(unknownSelector))
-
-			By("returns an error for an invalid field selector syntax")
-			out, err = harness.RunGetDevices("--field-selector", "metadata.name@=device1-name")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(failedToParse))
-
-			By("returns an error for an incorrect field type")
-			out, err = harness.RunGetDevices("--field-selector", "metadata.name>10")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring("unsupported for type string"))
-			Expect(out).To(ContainSubstring("metadata.name"))
-
-			By("returns an error for filtering devices by deprecated contains operator")
-			out, err = harness.RunGetDevices("--field-selector", fmt.Sprintf("metadata.labels contains region=%s", DeviceARegion))
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring("field is marked as private and cannot be selected"))
-
-			By("returns an error for filtering devices by deprecated owner flag")
-			out, err = harness.RunGetDevices("--owner")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(unknownFlag))
-
-			By("returns an error for filtering devices by deprecated status-filter flag")
-			out, err = harness.RunGetDevices("--status-filter=updated.status=UpToDate")
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(unknownFlag))
-
-			By("returns an error for bad syntax using =! operator")
-			out, err = harness.RunGetDevices("-l", fmt.Sprintf("'region!=%s'", DeviceARegion))
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(failedToParse))
-
-			By("returns an error for bad syntax using ! operator outside the quotes")
-			out, err = harness.RunGetDevices("-l", fmt.Sprintf("!'region=%s'", DeviceARegion))
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(failedToParse))
-
-			By("returns an error for bad syntax using ! operator at the start of the quotes")
-			out, err = harness.RunGetDevices("-l", fmt.Sprintf("'!region=%s'", DeviceARegion))
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring(failedToParse))
+		It("Negative field selector and label cases", func() {
+			tests := Cases(
+				EntryCase("invalid field selector", []string{"--field-selector", "invalid.field"}, false, unknownSelector),
+				EntryCase("unsupported field selector", []string{"--field-selector", "unsupported.field"}, false, unknownSelector),
+				EntryCase("invalid selector syntax", []string{"--field-selector", "metadata.name@=device1-name"}, false, failedToParse),
+				EntryCase("incorrect field type", []string{"--field-selector", "metadata.name>10"}, false, "unsupported for type string"),
+				EntryCase("deprecated contains operator", []string{"--field-selector", fmt.Sprintf("metadata.labels contains region=%s", DeviceARegion)}, false, "field is marked as private and cannot be selected"),
+				EntryCase("deprecated owner flag", []string{"--owner"}, false, unknownFlag),
+				EntryCase("deprecated status-filter flag", []string{"--status-filter=updated.status=UpToDate"}, false, unknownFlag),
+				EntryCase("bad syntax =!", []string{"-l", fmt.Sprintf("'region!=%s'", DeviceARegion)}, false, failedToParse),
+				EntryCase("bad syntax ! outside quotes", []string{"-l", fmt.Sprintf("!'region=%s'", DeviceARegion)}, false, failedToParse),
+				EntryCase("bad syntax ! at start of quotes", []string{"-l", fmt.Sprintf("'!region=%s'", DeviceARegion)}, false, failedToParse),
+			)
+			RunTable(tests, func(params FieldSelectorTestParams) {
+				out, err := harness.CLI(append([]string{"get", "device"}, params.Args...)...)
+				Expect(err).To(HaveOccurred())
+				Expect(out).To(ContainSubstring(params.Expected))
+			})
 		})
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -296,6 +296,10 @@ type TestCase[T any] struct {
 	Params      T
 }
 
+func Cases[T any](items ...TestCase[T]) []TestCase[T] {
+	return items
+}
+
 // RunTable executes the provided run function for each test case in the cases slice.
 func RunTable[T any](cases []TestCase[T], runFunc func(T)) {
 	for _, tc := range cases {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined end-to-end tests for field and label selectors using a new table-driven testing approach, improving readability and maintainability.
- **Tests**
  - Introduced a generic utility for running parameterized test cases with descriptive names.
  - Consolidated multiple selector-related test cases into a structured table format without altering test coverage or logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->