### PR TITLE
NO-ISSUE: packit rpm build for fedora-eln-aarch64 is temporarily impossible

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,3 +1,4 @@
+# TODO https://issues.redhat.com/browse/EDM-1668: Revert fedora-eln-* ASAP
 packages:
   flightctl:
     specfile_path: packaging/rpm/flightctl.spec
@@ -10,15 +11,17 @@ packages:
     upstream_package_name: flightctl
     downstream_package_name: flightctl
     upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
+
 actions:
   get-current-version:
     - bash -c 'git describe --tags | sed "s/^v//; s/-/~/g"'
+
 jobs:
   - job: copr_build
     trigger: pull_request
     enable_net: True # this is necessary for go modules to download the sources
     targets:
-      - fedora-eln-aarch64
+      # - fedora-eln-aarch64
       - fedora-42-x86_64
       - centos-stream-9-x86_64
     module_hotfixes: true
@@ -38,8 +41,8 @@ jobs:
       - fedora-42-x86_64
       - fedora-rawhide-aarch64
       - fedora-rawhide-x86_64
-      - fedora-eln-aarch64
-      - fedora-eln-x86_64
+      # - fedora-eln-aarch64
+      # - fedora-eln-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
       - rhel-9-aarch64
@@ -63,8 +66,8 @@ jobs:
       - fedora-42-x86_64
       - fedora-rawhide-aarch64
       - fedora-rawhide-x86_64
-      - fedora-eln-aarch64
-      - fedora-eln-x86_64
+      # - fedora-eln-aarch64
+      # - fedora-eln-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
       - rhel-9-aarch64


### PR DESCRIPTION
ELN build is temporarily impossible due to problem with packages.
Commenting it out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Temporarily disabled specific build targets in the build configuration for pull requests, commits, and releases. No impact on core functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->