### PR TITLE
NO-ISSUE: Add function to dynamically retrieve OCP nodes network

### DIFF
--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "${SCRIPT_DIR}"/functions
+
 # Variables
 VM_NAME="test-vm"
 VM_RAM=10240                # RAM in MB necessary to run the flightctl e2e
 VM_CPUS=8                  # Number of CPUs
 VM_DISK_SIZE=30          # Disk size
-NETWORK_NAME="baremetal-0"   # Network name
+NETWORK_NAME="$(get_ocp_nodes_network)"   # Network name
+NETWORK_NAME=${NETWORK_NAME:-baremetal-0}
 ISO_URL="https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-9-latest.x86_64.qcow2"
 DISK_PATH="/var/lib/libvirt/images/${VM_NAME}.qcow2"
 DISK_PATH_SRC="/var/lib/libvirt/images/${VM_NAME}_src.qcow2"

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -204,3 +204,16 @@ function is_acm_installed() {
   fi
 }
 
+# Function to get the ocp nodes network name
+function get_ocp_nodes_network() {
+  local vm_name
+  vm_name=$(sudo virsh list --name | grep 'master-0')
+  [ -z "$vm_name" ] && return 1
+
+  local network_name
+  network_name=$(sudo virsh domiflist "$vm_name" | awk 'NR > 2 && $3 != "" {print $3; exit}')
+  [ -z "$network_name" ] && return 1
+
+  echo "$network_name"
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The VM creation script now automatically detects and uses the appropriate network name for OpenShift cluster nodes, improving compatibility with different environments. If detection fails, it defaults to "baremetal-0".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->