### PR TITLE
NO-ISSUE: Fix broken link and correct outdated section

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The following is an opinionated way of getting started with Flight Control on a local Kind cluster. Please refer to [Installing the Flight Control Service](installing-service.md) and [Installing the Flight Control CLI](installing-cli.md) for the full documentation including other installation options.
+The following are the recommended ways of getting started with Flight Control. Choose the method that best matches your environment and additional requirements. Please refer to [Installing the Flight Control CLI](install-cli.md) for other installation options.
 
 ## Deploying a Local Kind Cluster
 


### PR DESCRIPTION
Getting started documentation had the following issues:
- installing-service.md does not exist.
- installing-cli.md does not exist either, the document name is "install-cli.md".
- it describes all ways of getting started, not only the option for the Kind cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the introductory section to present multiple recommended methods for starting Flight Control, allowing users to choose the most suitable option.
	- Removed the reference to the Flight Control Service installation documentation.
	- Updated the link to the Flight Control CLI installation guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->