### PR TITLE
NO-ISSUE: add e2e test report filter

### DIFF
--- a/test/e2e/basic_operations/basic_operations_test.go
+++ b/test/e2e/basic_operations/basic_operations_test.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	suiteCtx context.Context
+	ctx      context.Context
 )
 
 func TestBasicOperations(t *testing.T) {
@@ -28,7 +29,7 @@ var _ = BeforeSuite(func() {
 	suiteCtx = testutil.InitSuiteTracerForGinkgo("Basic Operations E2E Suite")
 })
 
-var _ = Describe("Basic Operations", Label("sanity", "82220"), func() {
+var _ = Describe("Basic Operations", Label("integration", "82220"), func() {
 	const createdResource = "201 Created"
 
 	var (
@@ -36,7 +37,8 @@ var _ = Describe("Basic Operations", Label("sanity", "82220"), func() {
 	)
 
 	BeforeEach(func() {
-		_ = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		harness = e2e.NewTestHarness(ctx)
 	})
 
 	DescribeTable("Create a resource from example file",

--- a/test/e2e/field_selectors/field_selectors_operators_test.go
+++ b/test/e2e/field_selectors/field_selectors_operators_test.go
@@ -4,11 +4,12 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/e2e/resources"
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Field Selectors Operators", Label("sanity", "82198"), func() {
+var _ = Describe("Field Selectors Extension Operators", Label("integration", "82198"), func() {
 	var (
 		harness              *e2e.Harness
 		expectedDevices      []*api.Device
@@ -20,6 +21,8 @@ var _ = Describe("Field Selectors Operators", Label("sanity", "82198"), func() {
 		expectedDevices = nil
 		expectedFleets = nil
 		expectedRepositories = nil
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		harness = e2e.NewTestHarness(ctx)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/field_selectors/field_selectors_suite_test.go
+++ b/test/e2e/field_selectors/field_selectors_suite_test.go
@@ -1,16 +1,27 @@
 package field_selectors
 
 import (
+	"context"
 	"testing"
 
+	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+var (
+	suiteCtx context.Context
+	ctx      context.Context
+)
+
 func TestFieldSelector(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Field selectors E2E Suite")
+	RunSpecs(t, "Field selectors Extension E2E Suite")
 }
+
+var _ = BeforeSuite(func() {
+	suiteCtx = testutil.InitSuiteTracerForGinkgo("Field Selectors Extension E2E Suite")
+})
 
 const (
 	templateImage    = "quay.io/redhat/rhde:9.2"

--- a/test/e2e/field_selectors/field_selectors_test.go
+++ b/test/e2e/field_selectors/field_selectors_test.go
@@ -4,11 +4,12 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/e2e/resources"
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Field Selectors", Label("sanity", "82219"), func() {
+var _ = Describe("Field Selectors Extension", Label("integration", "82219"), func() {
 	var (
 		harness              *e2e.Harness
 		expectedDevices      []*api.Device
@@ -20,6 +21,8 @@ var _ = Describe("Field Selectors", Label("sanity", "82219"), func() {
 		expectedDevices = nil
 		expectedFleets = nil
 		expectedRepositories = nil
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		harness = e2e.NewTestHarness(ctx)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/label_selectors/label_selectors_test.go
+++ b/test/e2e/label_selectors/label_selectors_test.go
@@ -1,6 +1,7 @@
 package label_selectors
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,17 +9,27 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/e2e/resources"
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var (
+	suiteCtx context.Context
+	ctx      context.Context
+)
+
+var _ = BeforeSuite(func() {
+	suiteCtx = testutil.InitSuiteTracerForGinkgo("Label Selectors E2E Suite")
+})
 
 func TestLabelSelectors(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Label Selectors E2E Suite")
 }
 
-var _ = Describe("Label Selectors", Label("sanity", "78751"), func() {
+var _ = Describe("Label Selectors", Label("integration", "78751"), func() {
 	var (
 		harness         *e2e.Harness
 		expectedDevices []*api.Device
@@ -31,6 +42,8 @@ var _ = Describe("Label Selectors", Label("sanity", "78751"), func() {
 
 	BeforeEach(func() {
 		expectedDevices = nil
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		harness = e2e.NewTestHarness(ctx)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/selectors/selectors_test.go
+++ b/test/e2e/selectors/selectors_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			Expect(out).To(ContainSubstring("defaultDevice"))
 		})
 
-		It("Field selector filters", func() {
+		It("Field selector filters", Label("77947", "sanity"), func() {
 			start, end := GetCurrentYearBounds()
 			tests := Cases(
 				EntryCase("filters devices by name", []string{"--field-selector", fmt.Sprintf("metadata.name=%s", deviceAName)}, true, deviceAName),
@@ -148,7 +148,7 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			})
 		})
 
-		It("Label selector filters", func() {
+		It("Label selector filters", Label("78751", "sanity"), func() {
 			tests := Cases(
 				EntryCase("filters by region in set", []string{"-l", fmt.Sprintf("region in (test, %s)", DeviceARegion), "-owide"}, true, deviceAName),
 				EntryCase("filters by region not in set", []string{"-l", "region notin (test, eu-west-2)", "-owide"}, true, deviceAName),
@@ -169,7 +169,7 @@ var _ = Describe("Field Selectors in Flight Control", Ordered, func() {
 			})
 		})
 
-		It("Negative field selector and label cases", func() {
+		It("Negative field selector and label cases", Label("77948", "sanity"), func() {
 			tests := Cases(
 				EntryCase("invalid field selector", []string{"--field-selector", "invalid.field"}, false, unknownSelector),
 				EntryCase("unsupported field selector", []string{"--field-selector", "unsupported.field"}, false, unknownSelector),

--- a/test/scripts/filter_e2e_output.py
+++ b/test/scripts/filter_e2e_output.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import xml.etree.ElementTree as ET
+import argparse
+import os
+
+# Default file paths
+report_file_path = 'junit_e2e_test.xml'
+DEFAULT_INPUT = os.path.join('reports', report_file_path)
+DEFAULT_OUTPUT = DEFAULT_INPUT
+
+# Substrings to filter from <testcase name>
+FILTER_NAME_SUBSTRINGS = [
+    "[BeforeSuite]",
+    "[AfterSuite]",
+    "[DeferCleanup (Suite)]",
+    "[DeferCleanup (Container)]",
+    "Extension",
+    "Label Selectors",
+    "Basic Operations",
+]
+
+def filter_junit_xml(input_path, output_path, name_substrings):
+    try:
+        tree = ET.parse(input_path)
+        root = tree.getroot()
+
+        filtered_testcases_count = 0
+        removed_testcase_names = []
+
+        for testsuite in root.findall('testsuite'):
+            testcases_to_remove = []
+            for testcase in testsuite.findall('testcase'):
+                name = testcase.get('name', '')
+                if any(keyword in name for keyword in name_substrings):
+                    testcases_to_remove.append(testcase)
+                    removed_testcase_names.append(name)
+
+            for testcase in testcases_to_remove:
+                testsuite.remove(testcase)
+                filtered_testcases_count += 1
+
+            # Update the count of tests in the testsuite
+            current_tests = int(testsuite.get('tests', '0'))
+            testsuite.set('tests', str(current_tests - len(testcases_to_remove)))
+
+        # Write the filtered tree to output
+        tree.write(output_path, encoding='utf-8', xml_declaration=True)
+
+        print(f"✅ Removed {filtered_testcases_count} test case(s) by name match.")
+        if removed_testcase_names:
+            print("🗑️ Removed test cases:")
+            for name in removed_testcase_names:
+                print(f"  - {name}")
+        print(f"📄 Output saved to: {output_path}")
+
+    except FileNotFoundError:
+        print(f"❌ Error: File not found at {input_path}")
+    except ET.ParseError as e:
+        print(f"❌ XML Parse Error: {e}")
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Remove test cases from JUnit XML by partial name match.")
+    parser.add_argument(
+        "--input-file",
+        default=DEFAULT_INPUT,
+        help=f"Path to input JUnit XML file (default: {DEFAULT_INPUT})"
+    )
+    parser.add_argument(
+        "--output-file",
+        default=DEFAULT_OUTPUT,
+        help=f"Path to save filtered JUnit XML file (default: {DEFAULT_OUTPUT})"
+    )
+    args = parser.parse_args()
+
+    filter_junit_xml(args.input_file, args.output_file, FILTER_NAME_SUBSTRINGS)

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -207,11 +207,11 @@ function is_acm_installed() {
 # Function to get the ocp nodes network name
 function get_ocp_nodes_network() {
   local vm_name
-  vm_name=$(sudo virsh list --name | grep 'master-0')
+  vm_name=$(sudo virsh list --name | grep 'master-0' | head -n 1)
   [ -z "$vm_name" ] && return 1
 
   local network_name
-  network_name=$(sudo virsh domiflist "$vm_name" | awk 'NR > 2 && $3 != "" {print $3; exit}')
+  network_name=$(sudo virsh domiflist "$vm_name" | awk 'NR > 2 && $3 != "" && $3 != "provisioning-0" {print $3; exit}')
   [ -z "$network_name" ] && return 1
 
   echo "$network_name"


### PR DESCRIPTION
1. Adding a script to filter from the e2e test results xml the entries:
```
FILTER_SUBSTRINGS = [
    "[BeforeSuite]",
    "[AfterSuite]",
    "[DeferCleanup (Suite)]",
    "[DeferCleanup (Container)]",
    "Extension",
    "Label Selectors",
    "Basic Operations",
]
```
2. Re-adding the forgotten polarion label in selectors test
3. Initializing harness in Selectors Extension, Label Selectors, Basic Operations E2E. and adding the "integration" label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to filter specific test cases from JUnit XML reports, allowing cleaner test output files.
- **Bug Fixes**
  - Improved the selection criteria for VM and network interface names to prevent ambiguous or unintended matches in network-related scripts.
- **Enhancements**
  - Added tracing context initialization and test harness setup to multiple end-to-end test suites, improving test reliability and diagnostics.
  - Updated test suite labels from "sanity" to "integration" and refined test descriptions for better clarity and organization.
  - Added unique identifiers as labels to select end-to-end test cases for improved test management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->