### PR TITLE
NO-ISSUE: Fail early in Makefile if no Git tags are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
+ifeq ($(shell git tag -l | grep -c .),0)
+$(error No Git tags found – are you working on a shallow clone/fork?)
+endif
+
 SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)


### PR DESCRIPTION
Adding a fail-fast validation in the `Makefile` to detect when no Git tags are present and exit early with a concise message.

By default, when a GitHub repository is forked and cloned, the fork does not include tags. As a result, the current `Makefile` logic causes `git describe` to fail repeatedly, printing the following error endlessly during the build or installation process:
```
fatal: No names found, cannot describe anything.
```

The build still tries to proceed the execution without proper initialization.
With this update, the Makefile now fails early and cleanly with a clear error message:
```
Makefile:14: *** No Git tags found – are you working on a shallow clone?.  Stop.

```