### PR TITLE
EDM-1674: Automate Resources deletion validations work well

### DIFF
--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -1442,6 +1442,9 @@ func (h Harness) ManageResource(operation, resource string, args ...string) (str
 			deleteArgs := append([]string{"delete", resource}, args...)
 			return h.CLI(deleteArgs...)
 		}
+		if len(args) == 0 {
+			return h.CLI("delete", resource)
+		}
 		return h.CleanUpResources(resource)
 	default:
 		return "", fmt.Errorf("unsupported operation: %s", operation)

--- a/test/integration/store/enrollmentrequest_test.go
+++ b/test/integration/store/enrollmentrequest_test.go
@@ -2,8 +2,6 @@ package store_test
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
@@ -13,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/test/util"
 	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -20,32 +19,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
-
-func createEnrollmentRequests(numEnrollmentRequests int, ctx context.Context, store store.Store, orgId uuid.UUID) {
-	for i := 1; i <= numEnrollmentRequests; i++ {
-		resource := api.EnrollmentRequest{
-			Metadata: api.ObjectMeta{
-				Name:   lo.ToPtr(fmt.Sprintf("myenrollmentrequest-%d", i)),
-				Labels: &map[string]string{"key": fmt.Sprintf("value-%d", i)},
-			},
-			Spec: api.EnrollmentRequestSpec{
-				Csr: "csr string",
-			},
-			Status: &api.EnrollmentRequestStatus{
-				Certificate: lo.ToPtr("cert"),
-			},
-		}
-
-		_, err := store.EnrollmentRequest().Create(ctx, orgId, &resource)
-		if err != nil {
-			log.Fatalf("creating enrollmentrequest: %v", err)
-		}
-		_, err = store.EnrollmentRequest().UpdateStatus(ctx, orgId, &resource)
-		if err != nil {
-			log.Fatalf("updating enrollmentrequest status: %v", err)
-		}
-	}
-}
 
 var _ = Describe("enrollmentRequestStore create", func() {
 	var (
@@ -65,7 +38,7 @@ var _ = Describe("enrollmentRequestStore create", func() {
 		numEnrollmentRequests = 3
 		storeInst, cfg, dbName, _ = store.PrepareDBForUnitTests(ctx, log)
 
-		createEnrollmentRequests(numEnrollmentRequests, ctx, storeInst, orgId)
+		util.CreateTestEnrolmentRequests(numEnrollmentRequests, ctx, storeInst, orgId)
 	})
 
 	AfterEach(func() {

--- a/test/integration/store/resourcesync_test.go
+++ b/test/integration/store/resourcesync_test.go
@@ -2,8 +2,6 @@ package store_test
 
 import (
 	"context"
-	"fmt"
-	"log"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/config"
@@ -21,26 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
-
-func createResourceSyncs(ctx context.Context, numResourceSyncs int, storeInst store.Store, orgId uuid.UUID) {
-	for i := 1; i <= numResourceSyncs; i++ {
-		resource := api.ResourceSync{
-			Metadata: api.ObjectMeta{
-				Name:   lo.ToPtr(fmt.Sprintf("myresourcesync-%d", i)),
-				Labels: &map[string]string{"key": fmt.Sprintf("value-%d", i)},
-			},
-			Spec: api.ResourceSyncSpec{
-				Repository: "myrepo",
-				Path:       "my/path",
-			},
-		}
-
-		_, err := storeInst.ResourceSync().Create(ctx, orgId, &resource)
-		if err != nil {
-			log.Fatalf("creating resourcesync: %v", err)
-		}
-	}
-}
 
 var _ = Describe("ResourceSyncStore create", func() {
 	var (
@@ -60,7 +38,7 @@ var _ = Describe("ResourceSyncStore create", func() {
 		numResourceSyncs = 3
 		storeInst, cfg, dbName, _ = store.PrepareDBForUnitTests(ctx, log)
 
-		createResourceSyncs(ctx, 3, storeInst, orgId)
+		testutil.CreateTestResourceSyncs(ctx, 3, storeInst, orgId)
 	})
 
 	AfterEach(func() {

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -188,6 +188,52 @@ func CreateRepositories(ctx context.Context, numRepositories int, storeInst stor
 	return nil
 }
 
+func CreateTestEnrolmentRequests(numEnrollmentRequests int, ctx context.Context, store store.Store, orgId uuid.UUID) {
+	for i := 1; i <= numEnrollmentRequests; i++ {
+		resource := api.EnrollmentRequest{
+			Metadata: api.ObjectMeta{
+				Name:   lo.ToPtr(fmt.Sprintf("myenrollmentrequest-%d", i)),
+				Labels: &map[string]string{"key": fmt.Sprintf("value-%d", i)},
+			},
+			Spec: api.EnrollmentRequestSpec{
+				Csr: "csr string",
+			},
+			Status: &api.EnrollmentRequestStatus{
+				Certificate: lo.ToPtr("cert"),
+			},
+		}
+
+		_, err := store.EnrollmentRequest().Create(ctx, orgId, &resource)
+		if err != nil {
+			log.Fatalf("creating enrollmentrequest: %v", err)
+		}
+		_, err = store.EnrollmentRequest().UpdateStatus(ctx, orgId, &resource)
+		if err != nil {
+			log.Fatalf("updating enrollmentrequest status: %v", err)
+		}
+	}
+}
+
+func CreateTestResourceSyncs(ctx context.Context, numResourceSyncs int, storeInst store.Store, orgId uuid.UUID) {
+	for i := 1; i <= numResourceSyncs; i++ {
+		resource := api.ResourceSync{
+			Metadata: api.ObjectMeta{
+				Name:   lo.ToPtr(fmt.Sprintf("myresourcesync-%d", i)),
+				Labels: &map[string]string{"key": fmt.Sprintf("value-%d", i)},
+			},
+			Spec: api.ResourceSyncSpec{
+				Repository: "myrepo",
+				Path:       "my/path",
+			},
+		}
+
+		_, err := storeInst.ResourceSync().Create(ctx, orgId, &resource)
+		if err != nil {
+			log.Fatalf("creating resourcesync: %v", err)
+		}
+	}
+}
+
 func NewBackoff() wait.Backoff {
 	return wait.Backoff{
 		Steps: 1,


### PR DESCRIPTION
Automated test for new validations added by @noga-magen 
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-82540

Doing deletion with manageresources, to avoid it's error handling that forces it to clean no matter what - In this case i just need the harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced end-to-end CLI tests to validate error handling when attempting to delete resources without specifying names.
  - Added table-driven tests to ensure delete commands fail appropriately for various resource types if no name is provided.
  - Improved test utilities by introducing helper functions for creating EnrollmentRequest and ResourceSync resources.
  - Updated integration tests to use shared utility functions for resource creation, reducing code duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->