### PR TITLE
EDM-1568: docs: improve ACM registration with os upgrade

### DIFF
--- a/docs/user/registering-microshift-devices-acm.md
+++ b/docs/user/registering-microshift-devices-acm.md
@@ -77,6 +77,14 @@ spec:
         inline:
         - path: "/etc/flightctl/hooks.d/afterupdating/50-acm-registration.yaml"
           content: |
+            - run: /usr/bin/bash -c "until [ -f $KUBECONFIG ]; do sleep 1; done"
+              timeout: 5m
+              envVars:
+                KUBECONFIG: /var/lib/microshift/resources/kubeadmin/kubeconfig
+            - run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
+              timeout: 5m
+              envVars:
+                KUBECONFIG: /var/lib/microshift/resources/kubeadmin/kubeconfig
             - if:
               - path: /var/local/acm-import/crd.yaml
                 op: [created]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to include commands that wait for the kubeconfig file and ensure all pods are ready before proceeding during ACM device registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->