### PR TITLE
EDM-1702: Fetch organization id from context in ListRepositories

### DIFF
--- a/internal/api_server/middleware/middleware.go
+++ b/internal/api_server/middleware/middleware.go
@@ -8,6 +8,8 @@ import (
 	"github.com/flightctl/flightctl/internal/auth"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/reqid"
 	chi "github.com/go-chi/chi/v5/middleware"
 )
@@ -54,6 +56,14 @@ func AddEventMetadataToCtx(next http.Handler) http.Handler {
 			}
 		}
 		ctx = context.WithValue(ctx, consts.EventActorCtxKey, fmt.Sprintf("user:%s", userName))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func AddOrgIDToCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = util.WithOrganizationID(ctx, store.NullOrgId)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -172,6 +172,7 @@ func (s *Server) Run(ctx context.Context) error {
 		fcmiddleware.RequestSizeLimiter(s.cfg.Service.HttpMaxUrlLength, s.cfg.Service.HttpMaxNumHeaders),
 		fcmiddleware.RequestID,
 		fcmiddleware.AddEventMetadataToCtx,
+		fcmiddleware.AddOrgIDToCtx,
 		middleware.Logger,
 		middleware.Recoverer,
 	)

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -16,4 +16,7 @@ const (
 	DelayDeviceRenderCtxKey    ctxKey = "delayDeviceRender"
 	EventSourceComponentCtxKey ctxKey = "event_source"
 	EventActorCtxKey           ctxKey = "event_actor"
+
+	// Organization
+	OrganizationIDCtxKey ctxKey = "organization_id"
 )

--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -36,4 +36,7 @@ var (
 	ErrSignature       = errors.New("signature error")
 	ErrSignCert        = errors.New("error signing certificate")
 	ErrEncodeCert      = errors.New("error encoding certificate")
+
+	// organization
+	ErrOrgIDInvalid = errors.New("invalid organization ID")
 )

--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -38,5 +38,5 @@ var (
 	ErrEncodeCert      = errors.New("error encoding certificate")
 
 	// organization
-	ErrOrgIDInvalid = errors.New("invalid organization ID")
+	ErrInvalidOrganizationID = errors.New("invalid organization ID")
 )

--- a/internal/service/organization.go
+++ b/internal/service/organization.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"context"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/google/uuid"
+)
+
+// GetAllOrganizations returns a list of ALL organizations.
+//
+// Usage is currently intended for internal purposes only such as fetching
+// organizations for tasks that require unscoped knowledge of all organizations
+func (h *ServiceHandler) ListAllOrganizationIDs(ctx context.Context) ([]uuid.UUID, api.Status) {
+	// For now, we only have a single hardcoded default organization
+	return []uuid.UUID{store.NullOrgId}, api.StatusOK()
+}

--- a/internal/service/organization.go
+++ b/internal/service/organization.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// GetAllOrganizations returns a list of ALL organizations.
+// ListAllOrganizationIDs returns a list of ALL organizations.
 //
 // Usage is currently intended for internal purposes only such as fetching
 // organizations for tasks that require unscoped knowledge of all organizations

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -6,8 +6,10 @@ import (
 	"reflect"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
 )
 
@@ -29,7 +31,10 @@ func (h *ServiceHandler) CreateRepository(ctx context.Context, repo api.Reposito
 }
 
 func (h *ServiceHandler) ListRepositories(ctx context.Context, params api.ListRepositoriesParams) (*api.RepositoryList, api.Status) {
-	orgId := store.NullOrgId
+	orgId, ok := util.OrganizationIDValue(ctx)
+	if !ok {
+		return nil, api.StatusBadRequest(flterrors.ErrOrgIDInvalid.Error())
+	}
 
 	listParams, status := prepareListParams(params.Continue, params.LabelSelector, params.FieldSelector, params.Limit)
 	if status != api.StatusOK() {

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -33,7 +33,7 @@ func (h *ServiceHandler) CreateRepository(ctx context.Context, repo api.Reposito
 func (h *ServiceHandler) ListRepositories(ctx context.Context, params api.ListRepositoriesParams) (*api.RepositoryList, api.Status) {
 	orgId, ok := util.OrganizationIDValue(ctx)
 	if !ok {
-		return nil, api.StatusBadRequest(flterrors.ErrOrgIDInvalid.Error())
+		return nil, api.StatusBadRequest(flterrors.ErrInvalidOrganizationID.Error())
 	}
 
 	listParams, status := prepareListParams(params.Continue, params.LabelSelector, params.FieldSelector, params.Limit)

--- a/internal/service/repository_test.go
+++ b/internal/service/repository_test.go
@@ -23,9 +23,9 @@ type RepositoryStore struct {
 }
 
 func (s *RepositoryStore) Repository() store.Repository {
-	repo := DummyRepository{RepositoryVal: s.RepositoryVal, ReturnErr: s.ReturnErr}
-	s.DummyRepository = &repo
-	return s.DummyRepository
+	repo := &DummyRepository{RepositoryVal: s.RepositoryVal, ReturnErr: s.ReturnErr}
+	s.DummyRepository = repo
+	return repo
 }
 
 func (s *RepositoryStore) Event() store.Event {
@@ -237,7 +237,7 @@ func TestListRepositoriesNoOrgID(t *testing.T) {
 
 	_, status := serviceHandler.ListRepositories(context.Background(), api.ListRepositoriesParams{})
 	require.Equal(int32(400), status.Code)
-	require.Equal(flterrors.ErrOrgIDInvalid.Error(), status.Message)
+	require.Equal(flterrors.ErrInvalidOrganizationID.Error(), status.Message)
 }
 
 func TestListRepositoriesStoreError(t *testing.T) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,6 +6,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	"github.com/google/uuid"
 )
 
 type Service interface {
@@ -109,4 +110,7 @@ type Service interface {
 	CreateEvent(ctx context.Context, event *api.Event)
 	ListEvents(ctx context.Context, params api.ListEventsParams) (*api.EventList, api.Status)
 	DeleteEventsOlderThan(ctx context.Context, cutoffTime time.Time) (int64, api.Status)
+
+	// Organization
+	ListAllOrganizationIDs(ctx context.Context) ([]uuid.UUID, api.Status)
 }

--- a/internal/service/traced_service.go
+++ b/internal/service/traced_service.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/instrumentation"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -543,6 +544,12 @@ func (t *TracedService) ListEvents(ctx context.Context, params api.ListEventsPar
 func (t *TracedService) DeleteEventsOlderThan(ctx context.Context, cutoffTime time.Time) (int64, api.Status) {
 	ctx, span := startSpan(ctx, "DeleteEventsOlderThan")
 	resp, st := t.inner.DeleteEventsOlderThan(ctx, cutoffTime)
+	endSpan(span, st)
+	return resp, st
+}
+func (t *TracedService) ListAllOrganizationIDs(ctx context.Context) ([]uuid.UUID, api.Status) {
+	ctx, span := startSpan(ctx, "ListAllOrganizationIDs")
+	resp, st := t.inner.ListAllOrganizationIDs(ctx)
 	endSpan(span, st)
 	return resp, st
 }

--- a/internal/tasks/repotester.go
+++ b/internal/tasks/repotester.go
@@ -23,8 +23,14 @@ type API interface {
 
 type RepoTester struct {
 	log                    logrus.FieldLogger
-	serviceHandler         service.Service
+	serviceHandler         RepoTesterService
 	TypeSpecificRepoTester TypeSpecificRepoTester
+}
+
+type RepoTesterService interface {
+	ListAllOrganizationIDs(ctx context.Context) ([]uuid.UUID, api.Status)
+	ListRepositories(ctx context.Context, params api.ListRepositoriesParams) (*api.RepositoryList, api.Status)
+	ReplaceRepositoryStatus(ctx context.Context, name string, repository api.Repository) (*api.Repository, api.Status)
 }
 
 func NewRepoTester(log logrus.FieldLogger, serviceHandler service.Service) *RepoTester {

--- a/internal/tasks/repotester_test.go
+++ b/internal/tasks/repotester_test.go
@@ -1,0 +1,188 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRepoTesterService struct {
+	orgsToReturn  []uuid.UUID
+	orgsStatus    api.Status
+	reposToReturn *api.RepositoryList
+	reposStatus   api.Status
+	replaceStatus api.Status
+	repoToReturn  *api.Repository
+
+	listReposCallCount     int
+	listReposContexts      []context.Context
+	replaceStatusCallCount int
+}
+
+func (m *mockRepoTesterService) ListAllOrganizationIDs(ctx context.Context) ([]uuid.UUID, api.Status) {
+	return m.orgsToReturn, m.orgsStatus
+}
+
+func (m *mockRepoTesterService) ListRepositories(ctx context.Context, params api.ListRepositoriesParams) (*api.RepositoryList, api.Status) {
+	m.listReposCallCount = m.listReposCallCount + 1
+	m.listReposContexts = append(m.listReposContexts, ctx)
+	return m.reposToReturn, m.reposStatus
+}
+
+func (m *mockRepoTesterService) ReplaceRepositoryStatus(ctx context.Context, name string, repository api.Repository) (*api.Repository, api.Status) {
+	m.replaceStatusCallCount = m.replaceStatusCallCount + 1
+	return m.repoToReturn, m.replaceStatus
+}
+
+type mockTypeSpecificRepoTester struct {
+}
+
+func (m *mockTypeSpecificRepoTester) TestAccess(repository *api.Repository) error {
+	return nil
+}
+
+func TestTestRepositories(t *testing.T) {
+	log := log.NewPrefixLogger("test")
+	orgID := uuid.New()
+	orgIDTwo := uuid.New()
+	repoName := "my-repo"
+	repoURL := "https://github.com/flightctl/test-repo"
+
+	testCases := []struct {
+		name                      string
+		repoType                  api.RepoSpecType
+		orgsStatus                api.Status
+		orgsToReturn              []uuid.UUID
+		testAccessError           error
+		expectedConditionMsg      string
+		expectedListReposCalls    int
+		expectedStatusUpdateCalls int
+	}{
+		{
+			name:                      "Org fetch failure",
+			orgsStatus:                api.Status{Code: 500, Message: "Broken"},
+			orgsToReturn:              []uuid.UUID{},
+			repoType:                  api.Git,
+			testAccessError:           nil,
+			expectedConditionMsg:      "",
+			expectedListReposCalls:    0,
+			expectedStatusUpdateCalls: 0,
+		},
+		{
+			name:                      "Git repo accessible",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{orgID},
+			repoType:                  api.Git,
+			testAccessError:           nil,
+			expectedConditionMsg:      "Accessible",
+			expectedListReposCalls:    1,
+			expectedStatusUpdateCalls: 1,
+		},
+		{
+			name:                      "Git repo inaccessible",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{orgID},
+			repoType:                  api.Git,
+			testAccessError:           errors.New("auth failed"),
+			expectedConditionMsg:      "Inaccessible: auth failed",
+			expectedListReposCalls:    1,
+			expectedStatusUpdateCalls: 1,
+		},
+		{
+			name:                      "HTTP repo accessible",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{orgID},
+			repoType:                  api.Http,
+			testAccessError:           nil,
+			expectedConditionMsg:      "Accessible",
+			expectedListReposCalls:    1,
+			expectedStatusUpdateCalls: 1,
+		},
+		{
+			name:                      "HTTP repo inaccessible",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{orgID},
+			repoType:                  api.Http,
+			testAccessError:           errors.New("404 not found"),
+			expectedConditionMsg:      "Inaccessible: 404 not found",
+			expectedListReposCalls:    1,
+			expectedStatusUpdateCalls: 1,
+		},
+		{
+			name:                      "No orgs",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{},
+			repoType:                  api.Git,
+			testAccessError:           nil,
+			expectedConditionMsg:      "",
+			expectedListReposCalls:    0,
+			expectedStatusUpdateCalls: 0,
+		},
+		{
+			name:                      "Two orgs",
+			orgsStatus:                api.Status{Code: 200},
+			orgsToReturn:              []uuid.UUID{orgID, orgIDTwo},
+			repoType:                  api.Git,
+			testAccessError:           nil,
+			expectedConditionMsg:      "Accessible",
+			expectedListReposCalls:    2,
+			expectedStatusUpdateCalls: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := context.Background()
+
+			spec := api.RepositorySpec{}
+			spec.FromGenericRepoSpec(api.GenericRepoSpec{
+				Url:  repoURL,
+				Type: tc.repoType,
+			})
+			repo := api.Repository{
+				Metadata: api.ObjectMeta{Name: &repoName},
+				Spec:     spec,
+			}
+			mockService := &mockRepoTesterService{
+				orgsToReturn:      tc.orgsToReturn,
+				orgsStatus:        tc.orgsStatus,
+				reposToReturn:     &api.RepositoryList{Items: []api.Repository{repo}},
+				reposStatus:       api.Status{Code: 200},
+				replaceStatus:     api.Status{Code: 200},
+				repoToReturn:      &repo,
+				listReposContexts: []context.Context{},
+			}
+			mockTypeTester := &mockTypeSpecificRepoTester{}
+			repoTester := &RepoTester{
+				log:                    log,
+				serviceHandler:         mockService,
+				TypeSpecificRepoTester: mockTypeTester,
+			}
+
+			repoTester.TestRepositories(ctx)
+
+			if tc.orgsStatus.Code != 200 {
+				require.Equal(0, mockService.listReposCallCount)
+				require.Equal(0, mockService.replaceStatusCallCount)
+				return
+			}
+
+			require.Equal(tc.expectedListReposCalls, mockService.listReposCallCount)
+			require.Equal(tc.expectedStatusUpdateCalls, mockService.replaceStatusCallCount)
+
+			// Verify organization ids were added to context
+			for i, ctx := range mockService.listReposContexts {
+				orgIDFromCtx, ok := util.OrganizationIDValue(ctx)
+				require.True(ok)
+				require.Equal(tc.orgsToReturn[i], orgIDFromCtx)
+			}
+		})
+	}
+}

--- a/internal/tasks/repotester_test.go
+++ b/internal/tasks/repotester_test.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
@@ -58,8 +57,6 @@ func TestTestRepositories(t *testing.T) {
 		repoType                  api.RepoSpecType
 		orgsStatus                api.Status
 		orgsToReturn              []uuid.UUID
-		testAccessError           error
-		expectedConditionMsg      string
 		expectedListReposCalls    int
 		expectedStatusUpdateCalls int
 	}{
@@ -68,58 +65,14 @@ func TestTestRepositories(t *testing.T) {
 			orgsStatus:                api.Status{Code: 500, Message: "Broken"},
 			orgsToReturn:              []uuid.UUID{},
 			repoType:                  api.Git,
-			testAccessError:           nil,
-			expectedConditionMsg:      "",
 			expectedListReposCalls:    0,
 			expectedStatusUpdateCalls: 0,
-		},
-		{
-			name:                      "Git repo accessible",
-			orgsStatus:                api.Status{Code: 200},
-			orgsToReturn:              []uuid.UUID{orgID},
-			repoType:                  api.Git,
-			testAccessError:           nil,
-			expectedConditionMsg:      "Accessible",
-			expectedListReposCalls:    1,
-			expectedStatusUpdateCalls: 1,
-		},
-		{
-			name:                      "Git repo inaccessible",
-			orgsStatus:                api.Status{Code: 200},
-			orgsToReturn:              []uuid.UUID{orgID},
-			repoType:                  api.Git,
-			testAccessError:           errors.New("auth failed"),
-			expectedConditionMsg:      "Inaccessible: auth failed",
-			expectedListReposCalls:    1,
-			expectedStatusUpdateCalls: 1,
-		},
-		{
-			name:                      "HTTP repo accessible",
-			orgsStatus:                api.Status{Code: 200},
-			orgsToReturn:              []uuid.UUID{orgID},
-			repoType:                  api.Http,
-			testAccessError:           nil,
-			expectedConditionMsg:      "Accessible",
-			expectedListReposCalls:    1,
-			expectedStatusUpdateCalls: 1,
-		},
-		{
-			name:                      "HTTP repo inaccessible",
-			orgsStatus:                api.Status{Code: 200},
-			orgsToReturn:              []uuid.UUID{orgID},
-			repoType:                  api.Http,
-			testAccessError:           errors.New("404 not found"),
-			expectedConditionMsg:      "Inaccessible: 404 not found",
-			expectedListReposCalls:    1,
-			expectedStatusUpdateCalls: 1,
 		},
 		{
 			name:                      "No orgs",
 			orgsStatus:                api.Status{Code: 200},
 			orgsToReturn:              []uuid.UUID{},
 			repoType:                  api.Git,
-			testAccessError:           nil,
-			expectedConditionMsg:      "",
 			expectedListReposCalls:    0,
 			expectedStatusUpdateCalls: 0,
 		},
@@ -128,8 +81,6 @@ func TestTestRepositories(t *testing.T) {
 			orgsStatus:                api.Status{Code: 200},
 			orgsToReturn:              []uuid.UUID{orgID, orgIDTwo},
 			repoType:                  api.Git,
-			testAccessError:           nil,
-			expectedConditionMsg:      "Accessible",
 			expectedListReposCalls:    2,
 			expectedStatusUpdateCalls: 2,
 		},

--- a/internal/tasks/repotester_test.go
+++ b/internal/tasks/repotester_test.go
@@ -162,7 +162,7 @@ func TestTestRepositories(t *testing.T) {
 				log:            log,
 				serviceHandler: mockService,
 			}
-			getRepoTesterForType = func(_ logrus.FieldLogger, _ api.RepoSpecType) (TypeSpecificRepoTester, error) {
+			GetRepoTesterForType = func(_ logrus.FieldLogger, _ api.RepoSpecType) (TypeSpecificRepoTester, error) {
 				return &mockTypeSpecificRepoTester{}, nil
 			}
 			repoTester.TestRepositories(ctx)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,12 +1,15 @@
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"golang.org/x/exp/constraints"
 	"k8s.io/klog/v2"
@@ -317,4 +320,13 @@ func Clone[T any](t *T) *T {
 	}
 	ret := *t
 	return &ret
+}
+
+func WithOrganizationID(ctx context.Context, orgID uuid.UUID) context.Context {
+	return context.WithValue(ctx, consts.OrganizationIDCtxKey, orgID)
+}
+
+func OrganizationIDValue(ctx context.Context) (uuid.UUID, bool) {
+	orgID, ok := ctx.Value(consts.OrganizationIDCtxKey).(uuid.UUID)
+	return orgID, ok
 }

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -85,7 +85,13 @@ var _ = Describe("RepoTester", func() {
 		Expect(err).ToNot(HaveOccurred())
 		serviceHandler = service.NewServiceHandler(stores, callbackManager, kvStore, nil, log, "", "")
 		repotestr = tasks.NewRepoTester(log, serviceHandler)
-		repotestr.TypeSpecificRepoTester = &MockRepoTester{}
+
+		// Override the GetRepoTesterForType function to return our mock tester
+		origGetter := tasks.GetRepoTesterForType
+		tasks.GetRepoTesterForType = func(_ logrus.FieldLogger, _ api.RepoSpecType) (tasks.TypeSpecificRepoTester, error) {
+			return &MockRepoTester{}, nil
+		}
+		DeferCleanup(func() { tasks.GetRepoTesterForType = origGetter })
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This PR contains a few changes realted to multi org work.  The changes are focused around a single endpoint `ListRepositories`.  The endpoint was chosen because it is relatively well scoped, but  invoked by periodic tasks which have been identified as needing work related to multi org support.  The PR proposes the following:

- The organization id in the service layer will be pulled from `context`
  - A middleware layer in the api assigns the null org id - in the future this may be a header such as `X-Organization-Id`
  - Callers such as tasks will be responsible for updating the context as they do not make HTTP requests and bypass the middleware
- Tasks that do NOT exist under the scope of a single organization will be provided a service method to query all organizations, and use existing methods to perform operations in the task at a per-organization level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for organization-specific repository listing and testing, enabling operations to be scoped by organization ID.
  - Added the ability to retrieve all organization IDs for broader administrative tasks.
  - Added middleware to inject organization ID into request contexts for consistent request handling.

- **Bug Fixes**
  - Improved error handling for repository listing requests without a valid organization ID.

- **Tests**
  - Added comprehensive tests for organization-aware repository listing and repository tester functionality, including error scenarios.

- **Chores**
  - Enhanced internal utilities for managing organization IDs within application contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->