### PR TITLE
NO-ISSUE: update timeout due to ci failures

### DIFF
--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -140,7 +140,7 @@ var _ = Describe("VM Agent behavior", func() {
 					// returning true if it is reported an error status or if the device is rolled back to the previous version
 					return e2e.ConditionExists(device, "Updating", "False", string(v1alpha1.UpdateStateError)) ||
 						(e2e.ConditionExists(device, "Updating", "False", string(v1alpha1.UpdateStateUpdated)) && (device.Status.Config.RenderedVersion == strconv.Itoa(previousRenderedVersion)))
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithUpdateStatus, TIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceUpdatedStatusOutOfDate))
@@ -164,12 +164,12 @@ var _ = Describe("VM Agent behavior", func() {
 			harness.WaitForDeviceContents(deviceId, `Error: failed fetching specified Repository definition`,
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "SpecValid", "False", "Invalid")
-				}, "2m")
+				}, TIMEOUT)
 
 			harness.WaitForDeviceContents(deviceId, fmt.Sprintf("Failed to update to renderedVersion: %s", strconv.Itoa(newRenderedVersion)),
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "False", string(v1alpha1.UpdateStateError))
-				}, "2m")
+				}, TIMEOUT)
 			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
 
@@ -195,12 +195,12 @@ var _ = Describe("VM Agent behavior", func() {
 			harness.WaitForDeviceContents(deviceId, "Error: sending HTTP Request",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "SpecValid", "False", "Invalid")
-				}, "2m")
+				}, TIMEOUT)
 
 			harness.WaitForDeviceContents(deviceId, fmt.Sprintf("Failed to update to renderedVersion: %s", strconv.Itoa(newRenderedVersion)),
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "False", string(v1alpha1.UpdateStateError))
-				}, "2m")
+				}, TIMEOUT)
 			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusOnline))
 

--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -40,7 +40,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			harness.WaitForDeviceContents(deviceId, "The device is preparing an update to renderedVersion: 2",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateApplyingUpdate))
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusOnline))
@@ -48,7 +48,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			harness.WaitForDeviceContents(deviceId, "the device is rebooting",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateRebooting))
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusRebooting))
@@ -62,7 +62,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 						}
 					}
 					return false
-				}, "2m")
+				}, TIMEOUT)
 			logrus.Info("Device updated to new image 🎉")
 		})
 
@@ -78,14 +78,14 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			harness.WaitForDeviceContents(deviceId, "The device is preparing an update to renderedVersion: 2",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateApplyingUpdate))
-				}, "2m")
+				}, TIMEOUT)
 
 			Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
 
 			harness.WaitForDeviceContents(deviceId, "the device is rebooting",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateRebooting))
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Rebooting")))
@@ -99,7 +99,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 						}
 					}
 					return false
-				}, "4m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
@@ -121,14 +121,14 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			harness.WaitForDeviceContents(deviceId, "The device is preparing an update to renderedVersion: 3",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateApplyingUpdate))
-				}, "1m")
+				}, TIMEOUT)
 
 			Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
 
 			harness.WaitForDeviceContents(deviceId, "the device is rebooting",
 				func(device *v1alpha1.Device) bool {
 					return e2e.ConditionExists(device, "Updating", "True", string(v1alpha1.UpdateStateRebooting))
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Rebooting")))
@@ -142,7 +142,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 						}
 					}
 					return false
-				}, "2m")
+				}, TIMEOUT)
 
 			Eventually(harness.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
 				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				cmd := []string{
 					"sudo", "oc", "wait",
 					"--for=condition=Ready", "pods",
-					"--all", "-A", "--timeout=30s",
+					"--all", "-A", "--timeout=300s",
 					fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 				}
 				_, err = harness.VM.RunSSH(cmd, nil)

--- a/test/e2e/parametrisable_templates/parametrisable_templates_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				harness.WaitForDeviceContents(deviceId, `The device could not be updated to the fleet`,
 					func(device *v1alpha1.Device) bool {
 						return device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusOutOfDate
-					}, "2m")
+					}, testutil.TIMEOUT)
 				resp, err := harness.Client.GetDeviceStatusWithResponse(harness.Context, deviceId)
 				Expect(err).ToNot(HaveOccurred())
 				device := resp.JSON200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test timeouts to use a consistent symbolic constant for improved maintainability.
  - Increased the timeout duration for pod readiness checks in ACM enrollment tests to enhance test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->