### PR TITLE
EDM-1697: Fix multiple owners removal

### DIFF
--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -444,7 +444,8 @@ func (f FleetSelectorMatchingLogic) handleDeviceWithPotentialOverlap(ctx context
 			if err != nil {
 				return nil, err
 			}
-
+		}
+		if api.IsStatusConditionTrue(device.Status.Conditions, api.DeviceMultipleOwners) {
 			condition := api.Condition{
 				Type:   api.DeviceMultipleOwners,
 				Status: api.ConditionStatusFalse,

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -187,11 +187,13 @@ var _ = Describe("FleetSelector", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "nofleet", lo.ToPtr("Fleet/fleet4"), nil, &map[string]string{"key4": "val4"})
 			// Match no fleet with no labels
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "nolabels", lo.ToPtr("Fleet/fleet4"), nil, &map[string]string{})
+			// Match no fleet with no previous owner
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "nolabels-noowner", nil, nil, &map[string]string{})
 
 			// All devices had multiple owners
 			devices, err := deviceStore.List(ctx, orgId, listParams)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(devices.Items)).To(Equal(6))
+			Expect(len(devices.Items)).To(Equal(7))
 			for _, device := range devices.Items {
 				condition := api.Condition{Type: api.DeviceMultipleOwners, Status: api.ConditionStatusTrue, Message: "overlap"}
 				err = deviceStore.SetServiceConditions(ctx, orgId, *device.Metadata.Name, []api.Condition{condition})
@@ -218,7 +220,7 @@ var _ = Describe("FleetSelector", func() {
 			// Check device ownership and annotations
 			devices, err = deviceStore.List(ctx, orgId, listParams)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(devices.Items)).To(Equal(6))
+			Expect(len(devices.Items)).To(Equal(7))
 
 			for _, device := range devices.Items {
 				switch *device.Metadata.Name {
@@ -238,6 +240,9 @@ var _ = Describe("FleetSelector", func() {
 					Expect(device.Metadata.Owner).To(BeNil())
 					Expect(api.IsStatusConditionTrue(device.Status.Conditions, api.DeviceMultipleOwners)).To(BeFalse())
 				case "nolabels":
+					Expect(device.Metadata.Owner).To(BeNil())
+					Expect(api.IsStatusConditionTrue(device.Status.Conditions, api.DeviceMultipleOwners)).To(BeFalse())
+				case "nolabels-noowner":
 					Expect(device.Metadata.Owner).To(BeNil())
 					Expect(api.IsStatusConditionTrue(device.Status.Conditions, api.DeviceMultipleOwners)).To(BeFalse())
 				}


### PR DESCRIPTION
* Fixes a minor issue where devices with no owner couldn't have their MultipleOwners condition removed

Reproduction Steps:
1. Create fleet 1 with selector labels: `label1 = value`
2. Create fleet 2 with selector labels: `label2 = value`
3. Create device with labels: `label1 = value, label2 = value`
Ensure that no owner is applied to the device and that it has the multiple owners condition
5. Remove all labels from the device
**Note bug is here**. Previously the multiple owners condition would stay attached, but now it is set to false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of devices without labels or owners to ensure correct owner updates and condition resets.

- **Tests**
  - Enhanced test coverage by adding a scenario for devices with no labels and no owner, verifying correct behavior in these cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->