### PR TITLE
EDM-1550: agent/device/applications: simplify volume override and naming

### DIFF
--- a/internal/agent/device/applications/lifecycle/lifecycle.go
+++ b/internal/agent/device/applications/lifecycle/lifecycle.go
@@ -42,12 +42,3 @@ type Action struct {
 	// Volumes is a list of volume names related to this application
 	Volumes []string
 }
-
-// convertVolumeNames converts a list of volume names into a unique compose label format
-func convertVolumeNames(src []string) []string {
-	var out []string
-	for _, name := range src {
-		out = append(out, NewComposeID(name))
-	}
-	return out
-}

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -185,7 +185,7 @@ func (m *PodmanMonitor) Ensure(app Application) error {
 		ID:       appID,
 		Path:     app.Path(),
 		Embedded: app.IsEmbedded(),
-		Volumes:  volumeNames(app.Volumes()),
+		Volumes:  lifecycle.ComposeVolumeNames(appName, app.Volumes()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -204,14 +204,15 @@ func (m *PodmanMonitor) Remove(app Application) error {
 	}
 
 	delete(m.apps, appID)
+	appName := app.Name()
 
 	// currently we don't support removing embedded applications
 	action := lifecycle.Action{
 		AppType: app.AppType(),
 		Type:    lifecycle.ActionRemove,
-		Name:    app.Name(),
+		Name:    appName,
 		ID:      appID,
-		Volumes: volumeNames(app.Volumes()),
+		Volumes: lifecycle.ComposeVolumeNames(appName, app.Volumes()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -229,15 +230,16 @@ func (m *PodmanMonitor) Update(app Application) error {
 	}
 
 	m.apps[appID] = app
+	appName := app.Name()
 
 	// currently we don't support updating embedded applications
 	action := lifecycle.Action{
 		AppType: app.AppType(),
 		Type:    lifecycle.ActionUpdate,
-		Name:    app.Name(),
+		Name:    appName,
 		ID:      appID,
 		Path:    app.Path(),
-		Volumes: volumeNames(app.Volumes()),
+		Volumes: lifecycle.ComposeVolumeNames(appName, app.Volumes()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -491,12 +493,4 @@ func (m *PodmanMonitor) resolveStatus(status string, inspectData []client.Podman
 		}
 	}
 	return initialStatus
-}
-
-func volumeNames(volumes []v1alpha1.ApplicationVolume) []string {
-	names := make([]string, len(volumes))
-	for i, v := range volumes {
-		names[i] = v.Name
-	}
-	return names
 }

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -140,32 +140,13 @@ func (p *imageProvider) Install(ctx context.Context) error {
 	}
 
 	labels := []string{fmt.Sprintf("com.docker.compose.project=%s", p.spec.ID)}
-	if err := ensurePodmanVolumes(ctx, p.log, p.readWriter, p.podman, p.spec.ImageProvider.Volumes, labels); err != nil {
+	if err := ensurePodmanVolumes(ctx, p.log, p.spec.Name, p.readWriter, p.podman, p.spec.ImageProvider.Volumes, labels); err != nil {
 		return fmt.Errorf("creating volumes: %w", err)
 	}
 
-	spec, err := client.ParseComposeSpecFromDir(p.readWriter, p.spec.Path)
-	if err != nil {
-		p.log.WithError(err).Errorf("Failed to parse Compose spec from path: %q", p.spec.Path)
-		return err
+	if err := writeComposeOverride(p.log, p.spec.Path, p.spec.Name, p.spec.Volumes, p.readWriter, client.ComposeOverrideFilename); err != nil {
+		return fmt.Errorf("writing override file %w", err)
 	}
-
-	p.log.Debugf("Successfully parsed Compose spec from %q with %d services and %d volumes",
-		p.spec.Path, len(spec.Services), len(spec.Volumes))
-
-	patched, renamed := patchRenamedVolumesInComposeSpec(p.log, spec, p.spec.Volumes)
-
-	if len(renamed) == 0 {
-		p.log.Debug("No volume names matched for renaming; skipping override file generation.")
-	} else {
-		p.log.Debugf("Volumes renamed: %v", renamed)
-	}
-
-	if err := writeComposeOverrideDiff(p.log, p.spec.Path, spec, patched, renamed, p.readWriter, client.ComposeOverrideFilename); err != nil {
-		p.log.WithError(err).Errorf("Failed to write Compose override file to %q", client.ComposeOverrideFilename)
-		return err
-	}
-	p.log.Debugf("Compose override diff written (if any changes) to %q", client.ComposeOverrideFilename)
 
 	return nil
 }

--- a/internal/agent/device/applications/provider/volume_test.go
+++ b/internal/agent/device/applications/provider/volume_test.go
@@ -5,172 +5,83 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
-	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/stretchr/testify/require"
 )
 
-func TestWriteComposeOverrideDiff(t *testing.T) {
+func TestWriteComposeOverride(t *testing.T) {
 	require := require.New(t)
+
 	tests := []struct {
 		name     string
-		base     *common.ComposeSpec
-		patched  *common.ComposeSpec
-		renamed  map[string]string
+		appName  string
+		volumes  *[]v1alpha1.ApplicationVolume
 		expected string
 		written  bool
 	}{
 		{
-			name: "no changes",
-			base: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svc1": {
-						Image:   "alpine",
-						Volumes: []string{"vol1:/data"},
-					},
-				},
-			},
-			patched: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svc1": {
-						Image:   "alpine",
-						Volumes: []string{"vol1:/data"},
-					},
-				},
-			},
-			renamed: nil,
+			name:    "no volumes",
+			appName: "testapp",
+			volumes: nil,
 			written: false,
 		},
 		{
-			name: "volume renamed",
-			base: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1": {External: true},
+			name:    "single volume",
+			appName: "testapp",
+			volumes: &[]v1alpha1.ApplicationVolume{
+				{
+					Name: "vol1",
 				},
 			},
-			patched: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1-renamed": {External: true},
-				},
-			},
-			renamed: map[string]string{"vol1": "vol1-renamed"},
 			expected: `volumes:
-  vol1-renamed:
-    external: true`,
+  vol1:
+    external: true
+    name: testapp-vol1-258737`,
 			written: true,
 		},
 		{
-			name: "volume and service references renamed",
-			base: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svc1": {
-						Image:   "nginx",
-						Volumes: []string{"vol1:/mnt"},
-					},
-				},
+			name:    "multiple volumes",
+			appName: "app1",
+			volumes: &[]v1alpha1.ApplicationVolume{
+				{Name: "data"},
+				{Name: "cache"},
 			},
-			patched: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1-renamed": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svc1": {
-						Image:   "nginx",
-						Volumes: []string{"vol1-renamed:/mnt"},
-					},
-				},
-			},
-			renamed: map[string]string{"vol1": "vol1-renamed"},
-			expected: `services:
-  svc1:
-    image: nginx
-    volumes:
-    - vol1-renamed:/mnt
-volumes:
-  vol1-renamed:
-    external: true`,
+			expected: `volumes:
+  cache:
+    external: true
+    name: app1-cache-300518
+  data:
+    external: true
+    name: app1-data-254868`,
 			written: true,
 		},
 		{
-			name: "multiple services with one referencing renamed volume",
-			base: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svcA": {
-						Image:   "busybox",
-						Volumes: []string{}, // no volumes
-					},
-					"svcB": {
-						Image:   "nginx",
-						Volumes: []string{"vol1:/mnt"},
-					},
-					"svcC": {
-						Image:   "redis",
-						Volumes: []string{}, // no volumes
-					},
-				},
-			},
-			patched: &common.ComposeSpec{
-				Volumes: map[string]common.ComposeVolume{
-					"vol1-renamed": {External: true},
-				},
-				Services: map[string]common.ComposeService{
-					"svcA": {
-						Image:   "busybox",
-						Volumes: []string{},
-					},
-					"svcB": {
-						Image:   "nginx",
-						Volumes: []string{"vol1-renamed:/mnt"},
-					},
-					"svcC": {
-						Image:   "redis",
-						Volumes: []string{},
-					},
-				},
-			},
-			renamed: map[string]string{"vol1": "vol1-renamed"},
-			expected: `services:
-  svcB:
-    image: nginx
-    volumes:
-    - vol1-renamed:/mnt
-volumes:
-  vol1-renamed:
-    external: true`,
-			written: true,
+			name:    "empty volumes slice",
+			appName: "empty",
+			volumes: &[]v1alpha1.ApplicationVolume{},
+			written: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := "/etc/compose/manifest/test-app"
 			tmpDir := t.TempDir()
 			log := log.NewPrefixLogger("test")
-			readWriter := fileio.NewReadWriter()
-			readWriter.SetRootdir(tmpDir)
-			err := writeComposeOverrideDiff(log, root, tt.base, tt.patched, tt.renamed, readWriter, client.ComposeOverrideFilename)
+			writer := fileio.NewReadWriter()
+			writer.SetRootdir(tmpDir)
+
+			err := writeComposeOverride(log, "/etc/compose/manifest", tt.appName, tt.volumes, writer, client.ComposeOverrideFilename)
 			require.NoError(err)
 
-			path := filepath.Join(root, client.ComposeOverrideFilename)
-			exists, err := readWriter.PathExists(path)
+			path := filepath.Join("/etc/compose/manifest", client.ComposeOverrideFilename)
+			exists, err := writer.PathExists(path)
 			require.NoError(err)
 			require.Equal(tt.written, exists)
 
 			if tt.written {
-				bytes, err := readWriter.ReadFile(path)
+				bytes, err := writer.ReadFile(path)
 				require.NoError(err)
 				require.Equal(strings.TrimSpace(tt.expected), strings.TrimSpace(string(bytes)))
 			}


### PR DESCRIPTION
This PR is a followup to #1159 and improves volume naming and greatly simplifies the volume override mechanism. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified and simplified volume naming to consistently generate unique names based on application and volume.
  - Streamlined Compose override file generation to map only external volumes, removing complex patching logic.
  - Simplified error handling and removed unnecessary debug logging in volume management.

- **Tests**
  - Refactored tests to focus on the new override file generation approach and unique volume naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->