### PR TITLE
EDM-1504: fixing event struct

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -594,9 +594,9 @@ var _ = Describe("cli operation", func() {
 				page, err := getEventsPage(harness, limit, "1", jsonFlag)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(page.Items).To(HaveLen(1))
-				Expect(page.Metadata.Continue).ToNot(BeEmpty())
+				Expect(page.Metadata.Continue).ToNot(BeNil(), "expected non-nil continue token")
 
-				nextPage, err := getEventsPage(harness, "--continue", page.Metadata.Continue, jsonFlag)
+				nextPage, err := getEventsPage(harness, "--continue", *page.Metadata.Continue, jsonFlag)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nextPage.Items).ToNot(BeEmpty())
 			})
@@ -776,53 +776,29 @@ func GetVersionByPrefix(output, prefix string) string {
 	return ""
 }
 
-type EventsPage struct {
-	Items    []json.RawMessage `json:"items"`
-	Metadata struct {
-		Continue string `json:"continue"`
-	} `json:"metadata"`
-}
-
-type EventWithTimestamp struct {
-	Metadata struct {
-		CreationTimestamp string `json:"creationTimestamp"`
-	} `json:"metadata"`
-}
-
-func getEventsPage(harness *e2e.Harness, args ...string) (EventsPage, error) {
-	var page EventsPage
-
+func getEventsPage(harness *e2e.Harness, args ...string) (v1alpha1.EventList, error) {
 	out, err := harness.RunGetEvents(args...)
 	if err != nil {
-		return page, err
+		return v1alpha1.EventList{}, err
 	}
 
+	var page v1alpha1.EventList
 	err = json.Unmarshal([]byte(out), &page)
 	if err != nil {
-		return page, err
+		return v1alpha1.EventList{}, err
 	}
 
 	return page, nil
 }
 
-func extractTimestamps(events []json.RawMessage) ([]time.Time, error) {
+func extractTimestamps(events []v1alpha1.Event) ([]time.Time, error) {
 	var timestamps []time.Time
 
-	for _, raw := range events {
-		var event EventWithTimestamp
-		if err := json.Unmarshal(raw, &event); err != nil {
-			return nil, err
+	for _, event := range events {
+		if event.Metadata.CreationTimestamp == nil {
+			return nil, fmt.Errorf("event missing CreationTimestamp")
 		}
-
-		ts, err := time.Parse(time.RFC3339Nano, event.Metadata.CreationTimestamp)
-		if err != nil {
-			ts, err = time.Parse(time.RFC3339, event.Metadata.CreationTimestamp)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		timestamps = append(timestamps, ts)
+		timestamps = append(timestamps, *event.Metadata.CreationTimestamp)
 	}
 
 	return timestamps, nil


### PR DESCRIPTION
Fixing the event struct in my test to avoid types drift as suggested by @hexfusion 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved test code for CLI events API by using strongly typed event structures, enhancing type safety and error handling.
  - Simplified timestamp extraction and pagination logic for better reliability in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->