### PR TITLE
EDM-1742: Fix issue with update policy validation

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -990,9 +990,15 @@ func validateTimeZone(timeZone string) []error {
 }
 
 func validateGraceDuration(schedule cron.Schedule, duration string) error {
+	// validating the duration first so that we can potentially report more issues
+	// to the caller if malformed duration is also applied
 	graceDuration, err := time.ParseDuration(duration)
 	if err != nil {
 		return fmt.Errorf("invalid duration: %w", err)
+	}
+
+	if schedule == nil {
+		return fmt.Errorf("invalid schedule: cannot validate grace duration")
 	}
 
 	start := time.Now()


### PR DESCRIPTION
When an update policy containing both a schedule and a startGraceDuration is validated, a nil pointer error can occur if the schedule itself is invalid. The end result is a http status of 500 rather than a 400 bad request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure errors are returned if the schedule is missing or invalid when setting grace durations.

- **Tests**
  - Added tests to verify validation for different combinations of cron schedules and grace durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->