### PR TITLE
EDM-1740: agent/applications: add image reference to volume status

### DIFF
--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -4,20 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/api/common"
+	"github.com/flightctl/flightctl/internal/util/validation"
 )
 
 const (
-	ComposeOverrideFilename = "99-compose-flightctl-agent.override.yaml"
-	defaultPodmanTimeout    = 10 * time.Minute
+	ComposeOverrideFilename      = "99-compose-flightctl-agent.override.yaml"
+	ComposeDockerProjectLabelKey = "com.docker.compose.project"
+	defaultPodmanTimeout         = 10 * time.Minute
 )
 
 var (
@@ -236,4 +240,31 @@ func mergeFileIntoSpec(filePath string, reader fileio.Reader, spec *common.Compo
 	maps.Copy(spec.Volumes, partial.Volumes)
 
 	return nil
+}
+
+// NewComposeID generates a deterministic, lowercase, DNS-compatible ID with a fixed-length hash suffix.
+func NewComposeID(input string) string {
+	const suffixLength = 6
+	id := SanitizePodmanLabel(input)
+	hashValue := crc32.ChecksumIEEE([]byte(id))
+	suffix := strconv.AppendUint(nil, uint64(hashValue), 10)
+	maxLength := validation.DNS1123MaxLength - suffixLength - 1
+	if len(id) > maxLength {
+		id = id[:maxLength]
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(id) + 1 + suffixLength)
+
+	builder.WriteString(id)
+	builder.WriteByte('-')
+	builder.WriteString(string(suffix[:suffixLength]))
+
+	return builder.String()
+}
+
+// ComposeVolumeName generates a unique Compose-compatible volume name
+// based on the application and volume names.
+func ComposeVolumeName(appName, volumeName string) string {
+	return NewComposeID(appName + "-" + volumeName)
 }

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
-	"github.com/samber/lo"
 )
 
 const (
@@ -79,9 +78,8 @@ type Application interface {
 	RemoveWorkload(name string) bool
 	// IsEmbedded returns true if the application is embedded.
 	IsEmbedded() bool
-	// Volumes provides a list of the names of the volumes
-	// which are directly related to this application.
-	Volumes() []v1alpha1.ApplicationVolume
+	// Volume is a volume manager.
+	Volume() provider.VolumeManager
 	// Status reports the status of an application using the name as defined by
 	// the user. In the case there is no name provided it will be populated
 	// according to the rules of the application type.
@@ -102,9 +100,9 @@ type application struct {
 	appType   v1alpha1.AppType
 	path      string
 	workloads []Workload
+	volume    provider.VolumeManager
 	status    *v1alpha1.DeviceApplicationStatus
 	embedded  bool
-	volumes   []v1alpha1.ApplicationVolume
 }
 
 // NewApplication creates a new application from an application provider.
@@ -119,7 +117,7 @@ func NewApplication(provider provider.Provider) *application {
 			Name:   spec.Name,
 			Status: v1alpha1.ApplicationStatusUnknown,
 		},
-		volumes: lo.FromPtr(spec.Volumes),
+		volume: spec.Volume,
 	}
 }
 
@@ -166,8 +164,8 @@ func (a *application) IsEmbedded() bool {
 	return a.embedded
 }
 
-func (a *application) Volumes() []v1alpha1.ApplicationVolume {
-	return a.volumes
+func (a *application) Volume() provider.VolumeManager {
+	return a.volume
 }
 
 func (a *application) Status() (*v1alpha1.DeviceApplicationStatus, v1alpha1.DeviceApplicationsSummaryStatus, error) {
@@ -232,16 +230,8 @@ func (a *application) Status() (*v1alpha1.DeviceApplicationStatus, v1alpha1.Devi
 		a.status.Restarts = restarts
 	}
 
-	// TODO: report live volume status
-	if len(a.volumes) > 0 {
-		volumes := []v1alpha1.ApplicationVolumeStatus{}
-		for _, vol := range a.volumes {
-			volumes = append(volumes, v1alpha1.ApplicationVolumeStatus{Name: vol.Name})
-		}
-		a.status.Volumes = &volumes
-	} else {
-		a.status.Volumes = nil
-	}
+	// update volume status
+	a.volume.Status(a.status)
 
 	return a.status, summary, nil
 }

--- a/internal/agent/device/applications/lifecycle/compose_test.go
+++ b/internal/agent/device/applications/lifecycle/compose_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func TestNewComposeID(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := NewComposeID(tc.input)
+			result := client.NewComposeID(tc.input)
 			require.Equal(tc.expected, result)
 		})
 	}

--- a/internal/agent/device/applications/lifecycle/lifecycle.go
+++ b/internal/agent/device/applications/lifecycle/lifecycle.go
@@ -40,5 +40,10 @@ type Action struct {
 	// Embedded is true if the application is embedded in the device
 	Embedded bool
 	// Volumes is a list of volume names related to this application
-	Volumes []string
+	Volumes []Volume
+}
+
+type Volume struct {
+	ID        string
+	Reference string
 }

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
-	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
@@ -69,7 +68,7 @@ func TestManager(t *testing.T) {
 			}),
 			desired: &v1alpha1.DeviceSpec{},
 			setupMocks: func(mockExec *executer.MockExecuter, mockReadWriter *fileio.MockReadWriter) {
-				id := lifecycle.NewComposeID("app-remove")
+				id := client.NewComposeID("app-remove")
 				gomock.InOrder(
 					// start current app
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", testImage}).Return("", "", 0),
@@ -96,7 +95,7 @@ func TestManager(t *testing.T) {
 				{Content: compose2, Path: "podman-compose.yaml"},
 			}),
 			setupMocks: func(mockExec *executer.MockExecuter, mockReadWriter *fileio.MockReadWriter) {
-				id := lifecycle.NewComposeID("app-update")
+				id := client.NewComposeID("app-update")
 				gomock.InOrder(
 					// verify current app
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", testImage}).Return("", "", 0),
@@ -171,7 +170,7 @@ func TestManager(t *testing.T) {
 			require.NoError(err)
 
 			for _, appName := range tc.wantAppNames {
-				id := lifecycle.NewComposeID(appName)
+				id := client.NewComposeID(appName)
 				log.Debugf("Checking for app: %v", manager.podmanMonitor.apps)
 				_, ok := manager.podmanMonitor.apps[id]
 				require.True(ok)
@@ -205,7 +204,7 @@ func mockExecPodmanEvents(mockExec *executer.MockExecuter) *gomock.Call {
 
 func mockExecPodmanComposeUp(mockExec *executer.MockExecuter, name string, hasOverride, hasAgentOverride bool) *gomock.Call {
 	workDir := fmt.Sprintf("/etc/compose/manifests/%s", name)
-	id := lifecycle.NewComposeID(name)
+	id := client.NewComposeID(name)
 	args := []string{"compose", "-p", id, "-f", "docker-compose.yaml"}
 	if hasOverride {
 		args = append(args, "-f", "docker-compose.override.yaml")
@@ -226,7 +225,7 @@ func mockExecPodmanNetworkList(mockExec *executer.MockExecuter, name string) *go
 			[]string{
 				"network", "ls",
 				"--format", "{{.Network.ID}}",
-				"--filter", "label=com.docker.compose.project=" + lifecycle.NewComposeID(name),
+				"--filter", "label=com.docker.compose.project=" + client.NewComposeID(name),
 			},
 		).
 		Return("", "", 0)

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -329,18 +329,18 @@ func (mr *MockApplicationMockRecorder) Status() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockApplication)(nil).Status))
 }
 
-// Volumes mocks base method.
-func (m *MockApplication) Volumes() []v1alpha1.ApplicationVolume {
+// Volume mocks base method.
+func (m *MockApplication) Volume() provider.VolumeManager {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Volumes")
-	ret0, _ := ret[0].([]v1alpha1.ApplicationVolume)
+	ret := m.ctrl.Call(m, "Volume")
+	ret0, _ := ret[0].(provider.VolumeManager)
 	return ret0
 }
 
-// Volumes indicates an expected call of Volumes.
-func (mr *MockApplicationMockRecorder) Volumes() *gomock.Call {
+// Volume indicates an expected call of Volume.
+func (mr *MockApplicationMockRecorder) Volume() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Volumes", reflect.TypeOf((*MockApplication)(nil).Volumes))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Volume", reflect.TypeOf((*MockApplication)(nil).Volume))
 }
 
 // Workload mocks base method.

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -46,7 +47,7 @@ func NewPodmanMonitor(
 ) *PodmanMonitor {
 	return &PodmanMonitor{
 		client:   podman,
-		compose:  lifecycle.NewCompose(log, podman),
+		compose:  lifecycle.NewCompose(log, writer, podman),
 		apps:     make(map[string]Application),
 		bootTime: bootTime,
 		log:      log,
@@ -185,7 +186,7 @@ func (m *PodmanMonitor) Ensure(app Application) error {
 		ID:       appID,
 		Path:     app.Path(),
 		Embedded: app.IsEmbedded(),
-		Volumes:  lifecycle.ComposeVolumeNames(appName, app.Volumes()),
+		Volumes:  provider.ToLifecycleVolumes(app.Volume().List()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -212,7 +213,7 @@ func (m *PodmanMonitor) Remove(app Application) error {
 		Type:    lifecycle.ActionRemove,
 		Name:    appName,
 		ID:      appID,
-		Volumes: lifecycle.ComposeVolumeNames(appName, app.Volumes()),
+		Volumes: provider.ToLifecycleVolumes(app.Volume().List()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -230,16 +231,15 @@ func (m *PodmanMonitor) Update(app Application) error {
 	}
 
 	m.apps[appID] = app
-	appName := app.Name()
 
 	// currently we don't support updating embedded applications
 	action := lifecycle.Action{
 		AppType: app.AppType(),
 		Type:    lifecycle.ActionUpdate,
-		Name:    appName,
+		Name:    app.Name(),
 		ID:      appID,
 		Path:    app.Path(),
-		Volumes: lifecycle.ComposeVolumeNames(appName, app.Volumes()),
+		Volumes: provider.ToLifecycleVolumes(app.Volume().List()),
 	}
 
 	m.actions = append(m.actions, action)
@@ -397,7 +397,7 @@ func (m *PodmanMonitor) handleEvent(ctx context.Context, data []byte) {
 		return
 	}
 
-	projectName, ok := event.Attributes["com.docker.compose.project"]
+	projectName, ok := event.Attributes[client.ComposeDockerProjectLabelKey]
 	if !ok {
 		m.log.Debugf("Application name not found in event attributes: %v", event)
 		return
@@ -414,6 +414,16 @@ func (m *PodmanMonitor) handleEvent(ctx context.Context, data []byte) {
 }
 
 func (m *PodmanMonitor) updateAppStatus(ctx context.Context, app Application, event *client.PodmanEvent) {
+	if event.Type == "container" {
+		m.updateContainerStatus(ctx, app, event)
+		return
+	}
+	if event.Type == "volume" {
+		app.Volume().UpdateStatus(event)
+	}
+}
+
+func (m *PodmanMonitor) updateContainerStatus(ctx context.Context, app Application, event *client.PodmanEvent) {
 	inspectData, err := m.inspectContainer(ctx, event.ID)
 	if err != nil {
 		if errors.Is(err, errors.ErrNotFound) {

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -45,8 +45,8 @@ type ApplicationSpec struct {
 	EnvVars map[string]string
 	// Embedded is true if the application is embedded in the device
 	Embedded bool
-	// Volumes is a list of external volume names associated with this application
-	Volumes *[]v1alpha1.ApplicationVolume
+	// Volume manager.
+	Volume VolumeManager
 	// ImageProvider is the spec for the image provider
 	ImageProvider *v1alpha1.ImageApplicationProviderSpec
 	// InlineProvider is the spec for the inline provider

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -43,3 +43,4 @@ RUN useradd -ms /bin/bash user && \
 ## Add your flightctl configuration and certificates
 ADD bin/agent/etc/flightctl/config.yaml /etc/flightctl/
 ADD bin/agent/etc/flightctl/certs/* /etc/flightctl/certs/
+RUN  mkdir -p /etc/containers/registries.conf.d/ && echo -e '[[registry]]\nlocation = "192.168.1.42:5000"\ninsecure = true' > /etc/containers/registries.conf.d/flightctl-e2e.conf


### PR DESCRIPTION
This is a followup to #1265 

```yaml
status:
  applications:
  - name: my-inline
    ready: 1/1
    restarts: 0
    status: Running
    volumes:
    - name: my-inline-data
      reference: quay.io/rawagner/models/gpt2
  - name: my-image-app
    ready: 1/1
    restarts: 0
    status: Running
    volumes:
    - name: my-image-data
      reference: quay.io/rawagner/models/gemma
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified volume management system using a VolumeManager interface, providing improved handling and status tracking for application volumes.
  - Enhanced Podman volume handling to automatically create and refresh image-backed volumes before application operations.

- **Refactor**
  - Replaced direct volume lists with a VolumeManager abstraction across applications, lifecycle, and provider modules.
  - Updated application interfaces and status updates to use the new volume management approach.
  - Consolidated deterministic Compose ID generation into a single location for consistent usage.

- **Bug Fixes**
  - Improved error handling during volume removal to aggregate and report multiple errors.

- **Tests**
  - Updated and refactored tests to use the new VolumeManager abstraction and deterministic ID generation.

- **Chores**
  - Removed unused imports and cleaned up code to reflect the new volume management structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->