### PR TITLE
EDM-1151: Automation of policy update enforcement

### DIFF
--- a/test/e2e/agent/agent_application_test.go
+++ b/test/e2e/agent/agent_application_test.go
@@ -44,7 +44,8 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			By("Add the application spec to the device")
 
 			// Make sure the device status right after bootstrap is Online
-			response := harness.GetDeviceWithStatusSystem(deviceId)
+			response, err := harness.GetDeviceWithStatusSystem(deviceId)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
 			device = response.JSON200
 			Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusOnline))
@@ -61,7 +62,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			}
 
 			// Update the device with the application config
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 				// Create applicationSpec.
 				var applicationSpec v1alpha1.ApplicationProviderSpec
@@ -71,6 +72,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 				device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{applicationSpec}
 				logrus.Infof("Updating %s with application %s", deviceId, sleepAppImage)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("Waiting for the device to pick the config")
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
@@ -115,7 +117,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 				"SOME_KEY": "SOME_KEY",
 			}
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 				// Create applicationSpec.
 				var updateApplicationSpec v1alpha1.ApplicationProviderSpec
@@ -127,6 +129,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 				device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{updateApplicationSpec}
 				logrus.Infof("Updating %s with application %s", deviceId, updateImage)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the device received the new config")
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
@@ -155,11 +158,11 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			By("Delete the application from the fleet configuration")
 			logrus.Infof("Removing all the applications from %s", deviceId)
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{}
 				logrus.Infof("Updating %s removing application %s", deviceId, updateImage)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the device received the new config")
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)
@@ -249,9 +252,10 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Remove the application from the spec")
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{}
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Wait for device to pick up the removal config")
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, newRenderedVersion)

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -68,8 +69,11 @@ var _ = Describe("VM Agent behavior", func() {
 			logrus.Infof("Waiting for device %s to report status", enrollmentID)
 
 			// wait for the device to pickup enrollment and report measurements on device status
-			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-				enrollmentID).ShouldNot(BeNil())
+			Eventually(func() *apiclient.GetDeviceResponse {
+				resp, err := harness.GetDeviceWithStatusSystem(enrollmentID)
+				Expect(err).ToNot(HaveOccurred())
+				return resp
+			}, TIMEOUT, POLLING).ShouldNot(BeNil())
 		})
 		It("Should report a message when a device is assigned to multiple fleets", Label("75992"), func() {
 			const (
@@ -84,7 +88,8 @@ var _ = Describe("VM Agent behavior", func() {
 			currentVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 			// ensure we start with an empty template
-			harness.SetLabelsForDevice(deviceId, nil)
+			err = harness.SetLabelsForDevice(deviceId, nil)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("creating the first fleet")
 			var configProviderSpec v1alpha1.ConfigProviderSpec
@@ -115,10 +120,11 @@ var _ = Describe("VM Agent behavior", func() {
 			defer func() { _ = harness.DeleteFleet(fleet2Name) }()
 
 			By("setting multiple labels for a device with conflicting fleets a condition should be applied")
-			harness.SetLabelsForDevice(deviceId, map[string]string{
+			err = harness.SetLabelsForDevice(deviceId, map[string]string{
 				fleet1Label: fleet1Value,
 				fleet2Label: fleet2Value,
 			})
+			Expect(err).ToNot(HaveOccurred())
 			harness.WaitForDeviceContents(deviceId, "multiple owners condition should be applied", func(device *v1alpha1.Device) bool {
 				return e2e.ConditionStatusExists(device.Status.Conditions, v1alpha1.ConditionTypeDeviceMultipleOwners, v1alpha1.ConditionStatusTrue)
 			}, TIMEOUT)
@@ -134,7 +140,8 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(device.Metadata.Owner).To(BeNil(), fmt.Sprintf("%+v", *device))
 
 			By("resetting the labels should remove the condition from the device")
-			harness.SetLabelsForDevice(deviceId, nil)
+			err = harness.SetLabelsForDevice(deviceId, nil)
+			Expect(err).ToNot(HaveOccurred())
 			harness.WaitForDeviceContents(deviceId, "multiple owners condition should be removed", func(device *v1alpha1.Device) bool {
 				return e2e.ConditionStatusExists(device.Status.Conditions, v1alpha1.ConditionTypeDeviceMultipleOwners, v1alpha1.ConditionStatusFalse)
 			}, TIMEOUT)
@@ -143,9 +150,10 @@ var _ = Describe("VM Agent behavior", func() {
 			expectedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			harness.SetLabelsForDevice(deviceId, map[string]string{
+			err = harness.SetLabelsForDevice(deviceId, map[string]string{
 				fleet1Label: fleet1Value,
 			})
+			Expect(err).ToNot(HaveOccurred())
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, expectedVersion)
 			Expect(err).ToNot(HaveOccurred())
 			device, err = harness.GetDevice(deviceId)
@@ -157,10 +165,11 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(*device.Metadata.Owner).To(Equal(fmt.Sprintf("Fleet/%s", fleet1Name)))
 
 			By("readding both labels should add the multiple owners condition back")
-			harness.SetLabelsForDevice(deviceId, map[string]string{
+			err = harness.SetLabelsForDevice(deviceId, map[string]string{
 				fleet1Label: fleet1Value,
 				fleet2Label: fleet2Value,
 			})
+			Expect(err).ToNot(HaveOccurred())
 			harness.WaitForDeviceContents(deviceId, "multiple owners condition should be reapplied", func(device *v1alpha1.Device) bool {
 				return e2e.ConditionStatusExists(device.Status.Conditions, v1alpha1.ConditionTypeDeviceMultipleOwners, v1alpha1.ConditionStatusTrue)
 			}, TIMEOUT)
@@ -183,7 +192,7 @@ var _ = Describe("VM Agent behavior", func() {
 
 			By("should report the correct device status after an inline config is added")
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 				// Create ConfigProviderSpec.
 				var configProviderSpec v1alpha1.ConfigProviderSpec
@@ -193,6 +202,7 @@ var _ = Describe("VM Agent behavior", func() {
 				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
 				logrus.Infof("Updating %s with config %s", deviceId, device.Spec.Config)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			logrus.Infof("Waiting for the device to pick the config")
 			harness.WaitForDeviceContents(deviceId, fmt.Sprintf("the device is updated to renderedVersion: %s", strconv.Itoa(newRenderedVersion)),
@@ -214,7 +224,7 @@ var _ = Describe("VM Agent behavior", func() {
 			// The status should be "Online"
 			logrus.Infof("The device has the config %s", device.Spec.Config)
 			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusOnline))
 
 			By("should report the correct device status when trying to upgrade to a not existing image")
 			previousRenderedVersion := newRenderedVersion
@@ -224,7 +234,7 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			var newImageReference string
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				currentImage := device.Status.Os.Image
 				logrus.Infof("Current image for %s is %s", deviceId, currentImage)
 				repo, _ := parseImageReference(currentImage)
@@ -232,6 +242,7 @@ var _ = Describe("VM Agent behavior", func() {
 				device.Spec.Os = &v1alpha1.DeviceOsSpec{Image: newImageReference}
 				logrus.Infof("Updating %s to image %s", deviceId, device.Spec.Os.Image)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)
 			Expect(err).ToNot(HaveOccurred())
@@ -249,7 +260,7 @@ var _ = Describe("VM Agent behavior", func() {
 			By(`should show an error when trying to update a device with
 				"a reference to a not existing git repo, and report 'Online' status`)
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				logrus.Infof("Current device is %s", deviceId)
 
 				// Create ConfigProviderSpec.
@@ -260,6 +271,7 @@ var _ = Describe("VM Agent behavior", func() {
 				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
 				logrus.Infof("Updating %s with config %s", deviceId, device.Spec.Config)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			// Check the http config error is detected.
 			harness.WaitForDeviceContents(deviceId, `Error: failed fetching specified Repository definition`,
@@ -272,7 +284,7 @@ var _ = Describe("VM Agent behavior", func() {
 					return e2e.ConditionExists(device, v1alpha1.ConditionTypeDeviceUpdating, v1alpha1.ConditionStatusFalse, string(v1alpha1.UpdateStateError))
 				}, TIMEOUT)
 			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
+				deviceId).Should(Equal(v1alpha1.DeviceSummaryStatusOnline))
 
 			By(`should show an error when trying to update a device with a httpConfigProviderSpec
 			with invalid Path, and report 'Online' status`)
@@ -281,7 +293,7 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Update the device with the http invalid config.
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				logrus.Infof("current device is %s", deviceId)
 				// Create ConfigProviderSpec.
 				var configProviderSpec v1alpha1.ConfigProviderSpec
@@ -291,6 +303,7 @@ var _ = Describe("VM Agent behavior", func() {
 				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{configProviderSpec}
 				logrus.Infof("updating %s with config %s", deviceId, device.Spec.Config)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			// Check the http config error is detected.
 			harness.WaitForDeviceContents(deviceId, "Error: sending HTTP Request",
@@ -321,7 +334,8 @@ var _ = Describe("VM Agent behavior", func() {
 			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 			nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
-			harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v9")
+			_, _, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v9")
+			Expect(err).ToNot(HaveOccurred())
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -333,7 +347,8 @@ var _ = Describe("VM Agent behavior", func() {
 			// wait for the device to pickup enrollment and report measurements on device status
 			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(deviceId).ShouldNot(BeNil())
 
-			response := harness.GetDeviceWithStatusSystem(deviceId)
+			response, err := harness.GetDeviceWithStatusSystem(deviceId)
+			Expect(err).ToNot(HaveOccurred())
 			device := response.JSON200
 
 			// Ensure the infinite key exists in CustomInfo

--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -11,7 +13,6 @@ import (
 	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,7 +36,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 	Context("updates", func() {
 		It("should update to the requested image", Label("75523"), func() {
 			By("Verifying update to agent  with requested image")
-			device, newImageReference := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v2")
+			device, newImageReference, err := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v2")
+			Expect(err).ToNot(HaveOccurred())
 
 			currentImage := device.Status.Os.Image
 			logrus.Infof("Current image is: %s", currentImage)
@@ -73,7 +75,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 		It("Should update to v4 with embedded application", Label("77671", "sanity"), func() {
 			By("Verifying update to agent  with embedded application")
 
-			device, newImageReference := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v4")
+			device, newImageReference, err := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v4")
+			Expect(err).ToNot(HaveOccurred())
 
 			currentImage := device.Status.Os.Image
 			logrus.Infof("Current image is: %s", currentImage)
@@ -116,7 +119,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 
 			logrus.Info("We expect podman containers with sleep infinity process to be present but not running 👌")
 
-			device, newImageReference = harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":base")
+			device, newImageReference, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":base")
+			Expect(err).ToNot(HaveOccurred())
 
 			currentImage = device.Status.Os.Image
 			logrus.Infof("Current image is: %s", currentImage)
@@ -194,16 +198,11 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			for i, factory := range configFactories {
 				specVersion := i + 1
 				By(fmt.Sprintf("Applying spec: %d", specVersion))
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-					var configProviderSpec v1alpha1.ConfigProviderSpec
-					err := factory(&configProviderSpec)
-					Expect(err).ToNot(HaveOccurred())
-					// append, not overwrite, new specs
-					specs := lo.FromPtr(device.Spec.Config)
-					specs = append(specs, configProviderSpec)
-					device.Spec.Config = &specs
-					logrus.Infof("Updating %s with config %+v", deviceId, *device.Spec.Config)
-				})
+				var configProviderSpec v1alpha1.ConfigProviderSpec
+				err := factory(&configProviderSpec)
+				Expect(err).ToNot(HaveOccurred())
+				err = harness.AddConfigToDeviceWithRetries(deviceId, configProviderSpec)
+				Expect(err).ToNot(HaveOccurred())
 				expectedVersion := currentVersion + 1
 				desc := fmt.Sprintf("Updating to desired renderedVersion: %d", expectedVersion)
 				By(fmt.Sprintf("Waiting for update %d to be picked up", specVersion))
@@ -225,7 +224,8 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			Expect(err).NotTo(HaveOccurred())
 			initialImage := dev.Status.Os.Image
 			// The v8 image should contain a bad compose file
-			harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v8")
+			_, _, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v8")
+			Expect(err).ToNot(HaveOccurred())
 
 			harness.WaitForDeviceContents(deviceId, "device image should be updated to the new image", func(device *v1alpha1.Device) bool {
 				return device.Spec.Os.Image != initialImage
@@ -272,6 +272,97 @@ var _ = Describe("VM Agent behavior during updates", func() {
 				}, TIMEOUT)
 			*/
 		})
+		It("Should respect the spec's update schedule", Label("79220", "sanity"), func() {
+			const everyMinuteExpression = "* * * * *"
+			startGracePeriod := "1m"
+
+			// function for generating a cron expression to execute in a specified number of minutes from the current time
+			inNMinutes := func(minutes int) string {
+				now := time.Now().Add(time.Duration(minutes) * time.Minute)
+				return fmt.Sprintf("%d * * * *", now.Minute())
+			}
+			// cron is time based and since we can't control when this specific test will run, we do our best to ensure
+			// that this test will always succeed whenever it is run.
+			yesterday := time.Now().AddDate(0, 0, -1)
+			// To ensure an update won't ever occur, we set the update time to midnight yesterday.
+			wontUpdatePolicy := fmt.Sprintf("0 0 %d %d *", yesterday.Day(), yesterday.Month())
+			currentVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceId)
+			Expect(err).NotTo(HaveOccurred())
+			expectedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Updating the device with a policy that won't trigger should prevent an update from occurring")
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{newInlineConfigVersion(expectedVersion)}
+				device.Spec.UpdatePolicy = &v1alpha1.DeviceUpdatePolicySpec{
+					UpdateSchedule: &v1alpha1.UpdateSchedule{
+						At:                 wontUpdatePolicy,
+						StartGraceDuration: &startGracePeriod,
+					},
+					DownloadSchedule: &v1alpha1.UpdateSchedule{
+						At:                 wontUpdatePolicy,
+						StartGraceDuration: &startGracePeriod,
+					},
+				}
+			})
+			Expect(err).ToNot(HaveOccurred())
+			harness.WaitForDeviceContents(deviceId, "the update should be registered but not applied", func(device *v1alpha1.Device) bool {
+				return device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusOutOfDate
+			}, TIMEOUT)
+
+			// A reasonable amount of time spent polling to ensure the spec doesn't change
+			harness.EnsureDeviceContents(deviceId, "the spec contents should not apply", func(device *v1alpha1.Device) bool {
+				return device.Status.Config.RenderedVersion == strconv.Itoa(currentVersion)
+			}, "1m30s")
+
+			By("Reducing the policies, the spec should be applied")
+			// pick a time two minutes in the future so that we can confirm that we wait at least some time before applying the update
+			inTwoMinutes := inNMinutes(2)
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				device.Spec.UpdatePolicy.UpdateSchedule.At = inTwoMinutes
+				device.Spec.UpdatePolicy.DownloadSchedule.At = inTwoMinutes
+			})
+			Expect(err).ToNot(HaveOccurred())
+			expectedVersion++
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, expectedVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			currentVersion, err = harness.GetCurrentDeviceRenderedVersion(deviceId)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currentVersion).To(Equal(expectedVersion))
+			expectedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("applying another spec, the update should be applied quickly")
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				// change the spec to update every minute so that we don't have to wait as long
+				device.Spec.UpdatePolicy.UpdateSchedule.At = everyMinuteExpression
+				device.Spec.UpdatePolicy.DownloadSchedule.At = everyMinuteExpression
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{newInlineConfigVersion(expectedVersion)}
+			})
+			Expect(err).ToNot(HaveOccurred())
+			// eventually the next update should be applied
+			err = harness.WaitForDeviceNewRenderedVersion(deviceId, expectedVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedVersion++
+			inTwoMinutes = inNMinutes(2)
+			By("applying an immediate download policy and an eventual update policy, the process should stall at updating")
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				device.Spec.UpdatePolicy.UpdateSchedule.At = inTwoMinutes
+				device.Spec.UpdatePolicy.DownloadSchedule.At = everyMinuteExpression
+				device.Spec.Config = &[]v1alpha1.ConfigProviderSpec{newInlineConfigVersion(expectedVersion)}
+			})
+			Expect(err).ToNot(HaveOccurred())
+			harness.WaitForDeviceContents(deviceId, "status should indicate that we are blocked by updating", func(device *v1alpha1.Device) bool {
+				cond := v1alpha1.FindStatusCondition(device.Status.Conditions, v1alpha1.ConditionTypeDeviceUpdating)
+				if cond == nil {
+					return false
+				}
+				return cond.Reason == string(v1alpha1.UpdateStateApplyingUpdate) &&
+					strings.Contains(cond.Message, "update policy not ready")
+			}, TIMEOUT)
+		})
 	})
 })
 
@@ -310,4 +401,17 @@ func isDeviceUpdateObserved(device *v1alpha1.Device, expectedVersion int) bool {
 		v1alpha1.UpdateStateApplyingUpdate,
 	}
 	return slices.Contains(validReasons, v1alpha1.UpdateState(cond.Reason))
+}
+
+func newInlineConfigVersion(version int) v1alpha1.ConfigProviderSpec {
+	configCopy := inlineConfig
+	configCopy.Content = fmt.Sprintf("%s %d", configCopy.Content, version)
+	cfg := v1alpha1.InlineConfigProviderSpec{
+		Inline: []v1alpha1.FileSpec{configCopy},
+		Name:   validInlineConfig.Name,
+	}
+	var provider v1alpha1.ConfigProviderSpec
+	err := provider.FromInlineConfigProviderSpec(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	return provider
 }

--- a/test/e2e/hooks/hooks_test.go
+++ b/test/e2e/hooks/hooks_test.go
@@ -47,12 +47,12 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 				Image: deviceImage,
 			}
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				device.Spec.Os = &osImageSpec
 
 				logrus.Infof("Updating %s with Os image", osImageSpec)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
@@ -157,11 +157,11 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 			deviceSpec.Os = &osImageSpec
 			deviceSpec.Config = &deviceSpecConfig
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				device.Spec = &deviceSpec
 				logrus.Infof("Updating %s with a new image and configuration %s", deviceId, inlineConfigLifecycleName)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -143,11 +143,11 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				deviceSpec.Os = &osImageSpec
 				deviceSpec.Config = &deviceSpecConfig
 
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 					device.Spec = &deviceSpec
 					logrus.Infof("Updating %s with a new image and pull-secret configuration", deviceId)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for the device to get the fleet configuration")
 				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
@@ -201,13 +201,14 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				nextRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 				Expect(err).ToNot(HaveOccurred())
 
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 					device.Metadata.Labels = &map[string]string{
 						fleetSelectorKey: fleetSelectorValue,
 					}
 					logrus.Infof("Updating %s with label %s=%s", deviceId,
 						fleetSelectorKey, fleetSelectorValue)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for the device to get the fleet configuration")
 				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)

--- a/test/e2e/parametrisable_templates/parametrisable_templates_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 			nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
-			harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 				device.Metadata.Labels = &map[string]string{
 					fleetSelectorKey: fleetSelectorValue,
 					teamLabelKey:     teamLabelValue,
@@ -58,6 +58,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				logrus.Infof("Updating %s with label %s=%s and %s=%s", deviceId,
 					fleetSelectorKey, fleetSelectorValue, teamLabelKey, teamLabelValue)
 			})
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify the Device is updated with the labels")
 			device, err := harness.GetDevice(deviceId)
@@ -101,12 +102,13 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 				Expect(err).ToNot(HaveOccurred())
 
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 					(*device.Metadata.Labels)[fleetSelectorKey] = fleetSelectorValue
 					logrus.Infof("Updating %s with label %s=%s", deviceId,
 						fleetSelectorKey, fleetSelectorValue)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Check the device will fail to reconcile")
 				harness.WaitForDeviceContents(deviceId, `The device could not be updated to the fleet`,
@@ -121,12 +123,13 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				Expect((*device.Metadata.Annotations)["fleet-controller/lastRolloutError"]).To(ContainSubstring("no entry for key \"team\""))
 
 				By("Add the team label to the device")
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 					(*device.Metadata.Labels)[teamLabelKey] = teamLabelValue
 					logrus.Infof("Updating %s with label %s=%s", deviceId,
 						teamLabelKey, teamLabelValue)
 				})
+				Expect(err).ToNot(HaveOccurred())
 				resp, err = harness.Client.GetDeviceStatusWithResponse(harness.Context, deviceId)
 				Expect(err).ToNot(HaveOccurred())
 				device = resp.JSON200
@@ -197,7 +200,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 				Expect(err).ToNot(HaveOccurred())
 
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 					device.Metadata.Labels = &map[string]string{
 						fleetSelectorKey: fleetSelectorValue,
@@ -209,6 +212,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 					}
 					logrus.Infof("Updating %s with labels", deviceId)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for the device to pick the fleet config")
 				err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
@@ -242,11 +246,12 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				nextGeneration, err := harness.PrepareNextDeviceGeneration(deviceId)
 				Expect(err).ToNot(HaveOccurred())
 
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 					(*device.Metadata.Labels)[revisionLabelKey] = branchTargetRevision
 					logrus.Infof("Updating the device with label %s=%s", revisionLabelKey, branchTargetRevision)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)
 				Expect(err).ToNot(HaveOccurred())
@@ -276,7 +281,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				logrus.Infof("Removing %s labels", teamLabelKey)
-				harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+				err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
 
 					device.Metadata.Labels = &map[string]string{
 						fleetSelectorKey: fleetSelectorValue,
@@ -287,6 +292,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 					}
 					logrus.Infof("Updating %s with labels", deviceId)
 				})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for the device to pick the fleet config")
 				err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -3,14 +3,12 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -180,7 +178,6 @@ func (h *Harness) ReadPrimaryVMAgentLogs(since string) (string, error) {
 	return logs, err
 }
 
-// ReadClientConfig returns the client config for at the specified location. The default config path is used if no path i
 // ReadClientConfig returns the client config for at the specified location. The default config path is used if no path is
 // specified
 func (h *Harness) ReadClientConfig(filePath string) (*client.Config, error) {
@@ -378,36 +375,6 @@ func (h *Harness) StartMultipleVMAndEnroll(count int) ([]string, error) {
 	return enrollmentIDs, nil
 }
 
-func (h *Harness) GetDeviceWithStatusSystem(enrollmentID string) *apiclient.GetDeviceResponse {
-	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
-	Expect(err).NotTo(HaveOccurred())
-	// we keep waiting for a 200 response, with filled in Status.SystemInfo
-	if device.JSON200 == nil || device.JSON200.Status == nil || device.JSON200.Status.SystemInfo.IsEmpty() {
-		return nil
-	}
-	return device
-}
-
-func (h *Harness) GetDeviceWithStatusSummary(enrollmentID string) v1alpha1.DeviceSummaryStatusType {
-	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
-	Expect(err).NotTo(HaveOccurred())
-	// we keep waiting for a 200 response, with filled in Status.SystemInfo
-	if device == nil || device.JSON200 == nil || device.JSON200.Status == nil || device.JSON200.Status.Summary.Status == "" {
-		return ""
-	}
-	return device.JSON200.Status.Summary.Status
-}
-
-func (h *Harness) GetDeviceWithUpdateStatus(enrollmentID string) v1alpha1.DeviceUpdatedStatusType {
-	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
-	Expect(err).NotTo(HaveOccurred())
-	// we keep waiting for a 200 response, with filled in Status.SystemInfo
-	if device == nil || device.JSON200 == nil || device.JSON200.Status == nil {
-		return ""
-	}
-	return device.JSON200.Status.Updated.Status
-}
-
 func (h *Harness) ApiEndpoint() string {
 	ep := os.Getenv("API_ENDPOINT")
 	Expect(ep).NotTo(BeEmpty(), "API_ENDPOINT environment variable must be set")
@@ -506,104 +473,31 @@ func updateResourceWithRetries(updateFunc func() error) {
 	}, TIMEOUT, "1s").Should(BeNil())
 }
 
-func (h *Harness) UpdateDeviceWithRetries(deviceId string, updateFunction func(*v1alpha1.Device)) {
-	updateResourceWithRetries(func() error {
-		return h.UpdateDevice(deviceId, updateFunction)
-	})
+func checkForResourceChange[T any](resource T, lastResource string) string {
+	yamlData, err := yaml.Marshal(resource)
+	yamlString := string(yamlData)
+	Expect(err).ToNot(HaveOccurred())
+	if yamlString != lastResource {
+		fmt.Println("")
+		fmt.Println("======================= Resource change ========================== ")
+		fmt.Println(yamlString)
+		fmt.Println("================================================================== ")
+	}
+	return yamlString
 }
 
-func (h *Harness) UpdateDevice(deviceId string, updateFunction func(*v1alpha1.Device)) error {
-	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
-	Expect(err).NotTo(HaveOccurred())
-	if response.JSON200 == nil {
-		logrus.Errorf("An error happened retrieving device: %+v", response)
-		return fmt.Errorf("device %s not found: %v", deviceId, response.Status())
-	}
-	device := response.JSON200
-
-	updateFunction(device)
-
-	resp, err := h.Client.ReplaceDeviceWithResponse(h.Context, deviceId, *device)
-	if err != nil {
-		logrus.Errorf("Unexpected error updating device %s: %v", deviceId, err)
-		return err
-	}
-
-	// if a conflict happens (the device updated status or object since we read it) we retry
-	if resp.JSON409 != nil {
-		logrus.Warningf("Conflict updating device %s: %+v", deviceId, resp.JSON409)
-	}
-
-	// response code 200 = updated, we are expecting to update... something else is unexpected
-	if resp.StatusCode() != 200 {
-		logrus.Errorf("Unexpected http status code received: %d", resp.StatusCode())
-		logrus.Errorf("Unexpected http response: %s", string(resp.Body))
-		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode(), string(resp.Body))
-	}
-
-	return nil
-}
-
-func (h *Harness) UpdateApplication(withRetries bool, deviceId string, appName string, appProvider any, envVars map[string]string) error {
-	logrus.Infof("UpdateApplication called with deviceId=%s, appName=%s, withRetries=%v", deviceId, appName, withRetries)
-
-	updateFunc := func(device *v1alpha1.Device) {
-		logrus.Infof("Starting update for device: %s", *device.Metadata.Name)
-		var appSpec v1alpha1.ApplicationProviderSpec
-		var err error
-
-		switch spec := appProvider.(type) {
-		case v1alpha1.InlineApplicationProviderSpec:
-			logrus.Infof("Processing InlineApplicationProviderSpec for %s", appName)
-			err = appSpec.FromInlineApplicationProviderSpec(spec)
-		case v1alpha1.ImageApplicationProviderSpec:
-			logrus.Infof("Processing ImageApplicationProviderSpec for %s", appName)
-			err = appSpec.FromImageApplicationProviderSpec(spec)
-		default:
-			logrus.Errorf("Unsupported application provider type: %T for %s", appProvider, appName)
-			return
+func ensureResourceContents[T any](id string, description string, fetch func(string) (T, error), condition func(T) bool, timeout string) {
+	lastResourcePrint := ""
+	Consistently(func() error {
+		logrus.Infof("Ensuring condition: %q stays consistent", description)
+		resource, err := fetch(id)
+		Expect(err).NotTo(HaveOccurred())
+		lastResourcePrint = checkForResourceChange(resource, lastResourcePrint)
+		if condition(resource) {
+			return nil
 		}
-
-		if err != nil {
-			logrus.Errorf("Error converting application provider spec: %v", err)
-			return
-		}
-
-		appSpec.Name = &appName
-		appType := v1alpha1.AppTypeCompose
-		appSpec.AppType = &appType
-
-		if envVars != nil {
-			logrus.Infof("Setting environment variables for app %s: %v", appName, envVars)
-			appSpec.EnvVars = &envVars
-		}
-
-		if device.Spec.Applications == nil {
-			logrus.Infof("device.Spec.Applications is nil, initializing with app %s", appName)
-			device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{appSpec}
-			return
-		}
-
-		for i, a := range *device.Spec.Applications {
-			if a.Name != nil && *a.Name == appName {
-				logrus.Infof("Updating existing application %s at index %d", appName, i)
-				(*device.Spec.Applications)[i] = appSpec
-				return
-			}
-		}
-
-		logrus.Infof("Appending new application %s to device %s", appName, *device.Metadata.Name)
-		*device.Spec.Applications = append(*device.Spec.Applications, appSpec)
-	}
-
-	if withRetries {
-		logrus.Info("Updating device with retries...")
-		h.UpdateDeviceWithRetries(deviceId, updateFunc)
-		return nil
-	}
-
-	logrus.Info("Updating device without retries...")
-	return h.UpdateDevice(deviceId, updateFunc)
+		return fmt.Errorf("resource: %s not updated", id)
+	}, timeout, "2s").Should(BeNil())
 }
 
 func waitForResourceContents[T any](id string, description string, fetch func(string) (T, error), condition func(T) bool, timeout string) {
@@ -614,34 +508,13 @@ func waitForResourceContents[T any](id string, description string, fetch func(st
 		resource, err := fetch(id)
 		Expect(err).NotTo(HaveOccurred())
 
-		yamlData, err := yaml.Marshal(resource)
-		yamlString := string(yamlData)
-		Expect(err).ToNot(HaveOccurred())
-		if yamlString != lastResourcePrint {
-			fmt.Println("")
-			fmt.Println("======================= Resource change ========================== ")
-			fmt.Println(yamlString)
-			fmt.Println("================================================================== ")
-			lastResourcePrint = yamlString
-		}
+		lastResourcePrint = checkForResourceChange(resource, lastResourcePrint)
 
 		if condition(resource) {
 			return nil
 		}
 		return fmt.Errorf("resource: %s not updated", id)
 	}, timeout, "2s").Should(BeNil())
-}
-
-func (h *Harness) WaitForDeviceContents(deviceId string, description string, condition func(*v1alpha1.Device) bool, timeout string) {
-	waitForResourceContents(deviceId, description, func(id string) (*v1alpha1.Device, error) {
-		response, err := h.Client.GetDeviceWithResponse(h.Context, id)
-		Expect(err).NotTo(HaveOccurred())
-		if response.JSON200 == nil {
-			logrus.Errorf("An error happened retrieving device: %+v", response)
-			return nil, errors.New("device not found???")
-		}
-		return response.JSON200, nil
-	}, condition, timeout)
 }
 
 func (h *Harness) EnrollAndWaitForOnlineStatus() (string, *v1alpha1.Device) {
@@ -665,31 +538,12 @@ func (h *Harness) EnrollAndWaitForOnlineStatus() (string, *v1alpha1.Device) {
 	logrus.Infof("The device %s is reporting its status", deviceId)
 
 	// Check the device status.
-	response := h.GetDeviceWithStatusSystem(deviceId)
+	response, err := h.GetDeviceWithStatusSystem(deviceId)
+	Expect(err).NotTo(HaveOccurred())
 	device := response.JSON200
 	Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusOnline))
 	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
 	return deviceId, device
-}
-
-func (h *Harness) WaitForBootstrapAndUpdateToVersion(deviceId string, version string) (*v1alpha1.Device, string) {
-	// Check the device status right after bootstrap
-	response := h.GetDeviceWithStatusSystem(deviceId)
-	device := response.JSON200
-	Expect(device.Status.Summary.Status).To(Equal(v1alpha1.DeviceSummaryStatusType("Online")))
-
-	var newImageReference string
-
-	h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-		currentImage := device.Status.Os.Image
-		logrus.Infof("current image for %s is %s", deviceId, currentImage)
-		repo, _ := h.parseImageReference(currentImage)
-		newImageReference = repo + version
-		device.Spec.Os = &v1alpha1.DeviceOsSpec{Image: newImageReference}
-		logrus.Infof("updating %s to image %s", deviceId, device.Spec.Os.Image)
-	})
-
-	return device, newImageReference
 }
 
 func (h *Harness) parseImageReference(image string) (string, string) {
@@ -703,136 +557,6 @@ func (h *Harness) parseImageReference(image string) (string, string) {
 	repo := strings.Join(parts[:len(parts)-1], ":")
 
 	return repo, tag
-}
-
-func (h *Harness) GetCurrentDeviceGeneration(deviceId string) (deviceRenderedVersionInt int64, err error) {
-	var deviceGeneration int64 = -1
-	logrus.Infof("Waiting for the device to be UpToDate")
-	h.WaitForDeviceContents(deviceId, "The device is UpToDate",
-		func(device *v1alpha1.Device) bool {
-			for _, condition := range device.Status.Conditions {
-				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
-					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
-					deviceGeneration = *device.Metadata.Generation
-
-					return true
-				}
-			}
-			return false
-		}, TIMEOUT)
-
-	if deviceGeneration <= 0 {
-		return deviceGeneration, fmt.Errorf("invalid generation: %d", deviceGeneration)
-
-	}
-	logrus.Infof("The device current generation is %d", deviceGeneration)
-
-	return deviceGeneration, nil
-}
-
-func (h *Harness) PrepareNextDeviceGeneration(deviceId string) (int64, error) {
-	currentGeneration, err := h.GetCurrentDeviceGeneration(deviceId)
-	if err != nil {
-		return -1, err
-	}
-	return currentGeneration + 1, nil
-}
-
-var (
-	InvalidRenderedVersionErr = fmt.Errorf("invalid rendered version")
-)
-
-func GetRenderedVersion(device *v1alpha1.Device) (int, error) {
-	if device == nil || device.Status == nil {
-		return -1, fmt.Errorf("invalid device: %+v", device)
-	}
-	version, err := strconv.Atoi(device.Status.Config.RenderedVersion)
-	if err != nil {
-		return -1, fmt.Errorf("failed to convert current rendered version '%s': %w", device.Status.Config.RenderedVersion, err)
-	}
-	if version <= 0 {
-		return -1, fmt.Errorf("version: %d: %w", version, InvalidRenderedVersionErr)
-	}
-	return version, nil
-}
-
-func (h *Harness) GetCurrentDeviceRenderedVersion(deviceId string) (int, error) {
-	deviceRenderedVersion := -1
-	var renderedVersionError error
-
-	logrus.Infof("Waiting for the device to be UpToDate")
-	h.WaitForDeviceContents(deviceId, "The device is UpToDate",
-		func(device *v1alpha1.Device) bool {
-			for _, condition := range device.Status.Conditions {
-				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
-					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
-					deviceRenderedVersion, renderedVersionError = GetRenderedVersion(device)
-					// try until we get a valid rendered version
-					return !errors.Is(renderedVersionError, InvalidRenderedVersionErr)
-				}
-			}
-			return false
-		}, TIMEOUT)
-	if renderedVersionError != nil {
-		return -1, renderedVersionError
-	}
-	logrus.Infof("The device current renderedVersion is %d", deviceRenderedVersion)
-	return deviceRenderedVersion, nil
-}
-
-func (h *Harness) PrepareNextDeviceVersion(deviceId string) (int, error) {
-	currentVersion, err := h.GetCurrentDeviceRenderedVersion(deviceId)
-	if err != nil {
-		return -1, err
-	}
-	return currentVersion + 1, nil
-}
-
-func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVersionInt int) (err error) {
-	// Check that the device was already approved
-	Eventually(h.GetDeviceWithStatusSummary, LONGTIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeEmpty())
-	logrus.Infof("The device %s was approved", deviceId)
-
-	// Wait for the device to pickup the new config and report measurements on device status.
-	logrus.Infof("Waiting for the device to pick the config")
-	UpdateRenderedVersionSuccessMessage := fmt.Sprintf("%s %d", util.UpdateRenderedVersionSuccess.String(), newRenderedVersionInt)
-	h.WaitForDeviceContents(deviceId, UpdateRenderedVersionSuccessMessage,
-		func(device *v1alpha1.Device) bool {
-			for _, condition := range device.Status.Conditions {
-				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
-					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
-					device.Status.Config.RenderedVersion == strconv.Itoa(newRenderedVersionInt) {
-					return true
-				}
-			}
-			return false
-		}, LONGTIMEOUT)
-
-	return nil
-}
-
-func (h *Harness) WaitForDeviceNewGeneration(deviceId string, newGeneration int64) (err error) {
-	// Check that the device was already approved
-	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeEmpty())
-	logrus.Infof("The device %s was approved", deviceId)
-
-	// Wait for the device to pickup the new config and report measurements on device status.
-	logrus.Infof("Waiting for the device to pick the config")
-	h.WaitForDeviceContents(deviceId, "Waiting fot the device generation",
-		func(device *v1alpha1.Device) bool {
-			for _, condition := range device.Status.Conditions {
-				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
-					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
-					newGeneration == *device.Metadata.Generation {
-					return true
-				}
-			}
-			return false
-		}, LONGTIMEOUT)
-
-	return nil
 }
 
 func (h *Harness) CleanUpResources(resourceType string) (string, error) {
@@ -929,98 +653,6 @@ func (h *Harness) GetCertificateSigningRequestByYaml(csrYaml string) v1alpha1.Ce
 	return getYamlResourceByFile[v1alpha1.CertificateSigningRequest](csrYaml)
 }
 
-// getDeviceConfig is a generic helper function to retrieve device configurations
-func GetDeviceConfig[T any](device *v1alpha1.Device, configType v1alpha1.ConfigProviderType,
-	asConfig func(v1alpha1.ConfigProviderSpec) (T, error)) (T, error) {
-
-	var config T
-	if device.Spec == nil || device.Spec.Config == nil {
-		return config, fmt.Errorf("device spec or config is nil")
-	}
-
-	if len(*device.Spec.Config) > 0 {
-		for _, configItem := range *device.Spec.Config {
-			// Check config type
-			itemType, err := configItem.Type()
-			if err != nil {
-				return config, fmt.Errorf("failed to get config type: %w", err)
-			}
-			if itemType == configType {
-				// Convert to the expected config type
-				config, err := asConfig(configItem)
-				if err != nil {
-					return config, fmt.Errorf("failed to convert config: %w", err)
-				}
-
-				return config, nil
-			}
-		}
-	}
-
-	// If we don't find the config, return an error
-	return config, fmt.Errorf("%s config not found in the device", configType)
-}
-
-// Get InlineConfig
-func (h *Harness) GetDeviceInlineConfig(device *v1alpha1.Device, configName string) (v1alpha1.InlineConfigProviderSpec, error) {
-	return GetDeviceConfig(device, v1alpha1.InlineConfigProviderType,
-		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.InlineConfigProviderSpec, error) {
-			inlineConfig, err := c.AsInlineConfigProviderSpec()
-			if err != nil {
-				return inlineConfig, fmt.Errorf("failed to cast config type: %w", err)
-			}
-			if inlineConfig.Name == configName {
-				logrus.Infof("Inline configuration found %s", configName)
-				return inlineConfig, nil
-			}
-			return v1alpha1.InlineConfigProviderSpec{}, fmt.Errorf("inline config not found")
-		})
-}
-
-// Get GitConfig
-func (h *Harness) GetDeviceGitConfig(device *v1alpha1.Device, configName string) (v1alpha1.GitConfigProviderSpec, error) {
-	return GetDeviceConfig(device, v1alpha1.GitConfigProviderType,
-		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.GitConfigProviderSpec, error) {
-			gitConfig, err := c.AsGitConfigProviderSpec()
-			if err != nil {
-				return gitConfig, fmt.Errorf("failed to cast config type: %w", err)
-			}
-			if gitConfig.Name == configName {
-				logrus.Infof("Git configuration found %s", configName)
-				return gitConfig, nil
-			}
-			return v1alpha1.GitConfigProviderSpec{}, fmt.Errorf("git config not found")
-		})
-}
-
-// Get HttpConfig
-func (h *Harness) GetDeviceHttpConfig(device *v1alpha1.Device, configName string) (v1alpha1.HttpConfigProviderSpec, error) {
-	return GetDeviceConfig(device, v1alpha1.HttpConfigProviderType,
-		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.HttpConfigProviderSpec, error) {
-			httpConfig, err := c.AsHttpConfigProviderSpec()
-			if err != nil {
-				return httpConfig, fmt.Errorf("failed to cast config type: %w", err)
-			}
-			if httpConfig.Name == configName {
-				logrus.Infof("Http configuration found %s", configName)
-				return httpConfig, nil
-			}
-			return v1alpha1.HttpConfigProviderSpec{}, fmt.Errorf("http config not found")
-		})
-}
-
-// Get an http config of a device resource
-func (h *Harness) GetDeviceOsImage(device *v1alpha1.Device) (image string, err error) {
-	if device.Spec == nil {
-		return "", fmt.Errorf("device spec is nil")
-	}
-	if device.Spec.Os == nil {
-		return "", fmt.Errorf("device os spec is nil")
-	}
-
-	return device.Spec.Os.Image, nil
-}
-
 // Create a repository resource
 func (h *Harness) CreateRepository(repositorySpec v1alpha1.RepositorySpec, metadata v1alpha1.ObjectMeta) error {
 	var repository = v1alpha1.Repository{
@@ -1051,173 +683,6 @@ func (h *Harness) ReplaceRepository(repositorySpec v1alpha1.RepositorySpec, meta
 func (h *Harness) DeleteRepository(name string) error {
 	_, err := h.Client.DeleteRepository(h.Context, name)
 	return err
-}
-
-// Check that the device summary status is equal to the status input
-func (h *Harness) CheckDeviceStatus(deviceId string, status v1alpha1.DeviceSummaryStatusType) (*v1alpha1.Device, error) {
-	response := h.GetDeviceWithStatusSystem(deviceId)
-	if response == nil {
-		return nil, fmt.Errorf("device response is nil")
-	}
-	if response.JSON200 == nil {
-		return nil, fmt.Errorf("device.JSON200 response is nil")
-	}
-	device := response.JSON200
-	deviceStaus := device.Status.Summary.Status
-	if deviceStaus != status {
-		return nil, fmt.Errorf("the device status is notOnline but %s", deviceStaus)
-	}
-	return device, nil
-}
-
-// Get device with response
-func (h *Harness) GetDevice(deviceId string) (*v1alpha1.Device, error) {
-	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get device with response: %s", err)
-	}
-	if response == nil {
-		return nil, fmt.Errorf("device response is nil")
-	}
-	device := response.JSON200
-	return device, nil
-}
-
-func (h *Harness) SetLabelsForDevice(deviceId string, labels map[string]string) {
-	h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-		if len(labels) == 0 {
-			device.Metadata.Labels = nil
-			return
-		}
-		devLabels := make(map[string]string, len(labels))
-		for key, value := range labels {
-			devLabels[key] = value
-		}
-		device.Metadata.Labels = &devLabels
-	})
-}
-
-func (h *Harness) SetLabelsForDevicesByIndex(deviceIDs []string, labelsList []map[string]string, fleetName string) error {
-	if len(deviceIDs) != len(labelsList) {
-		return fmt.Errorf("mismatched lengths: deviceIDs (%d) and labelsList (%d)", len(deviceIDs), len(labelsList))
-	}
-
-	for i, deviceID := range deviceIDs {
-		labels := labelsList[i]
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels["fleet"] = fleetName
-		h.SetLabelsForDevice(deviceID, labels)
-	}
-	return nil
-}
-
-func (h *Harness) GetSelectedDevicesForBatch(fleetName string) ([]*v1alpha1.Device, error) {
-	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
-	listDeviceParams := &v1alpha1.ListDevicesParams{
-		LabelSelector: &labelSelector,
-	}
-	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list devices: %s", err)
-	}
-	if response == nil {
-		return nil, fmt.Errorf("device response is nil")
-	}
-	devices := response.JSON200.Items
-
-	var result []*v1alpha1.Device
-
-	for _, device := range devices {
-		annotations := device.Metadata.Annotations
-		if annotations == nil {
-			continue
-		}
-		if _, ok := (*annotations)["fleet-controller/selectedForRollout"]; ok {
-			deviceCopy := device
-			result = append(result, &deviceCopy)
-		}
-	}
-
-	return result, nil
-}
-
-func (h *Harness) GetUnavailableDevicesPerGroup(fleetName string, groupBy []string) (map[string][]*v1alpha1.Device, error) {
-	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
-	listDeviceParams := &v1alpha1.ListDevicesParams{
-		LabelSelector: &labelSelector,
-	}
-
-	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list devices: %s", err)
-	}
-	if response == nil {
-		return nil, fmt.Errorf("device response is nil")
-	}
-
-	devices := response.JSON200.Items
-	result := make(map[string][]*v1alpha1.Device)
-
-	for _, device := range devices {
-		// Check if device is unavailable
-		if device.Status != nil && (device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpdating ||
-			device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUnknown) {
-			// Generate group key based on labels
-			groupKey := ""
-
-			if device.Metadata.Labels != nil {
-				labelValues := []string{}
-				for _, key := range groupBy {
-					value, exists := (*device.Metadata.Labels)[key]
-					if exists {
-						labelValues = append(labelValues, value)
-					} else {
-						labelValues = append(labelValues, "")
-					}
-				}
-				groupKey = strings.Join(labelValues, ":")
-			}
-
-			// Add device to the appropriate group
-			if _, exists := result[groupKey]; !exists {
-				result[groupKey] = []*v1alpha1.Device{}
-			}
-			deviceCopy := device
-			result[groupKey] = append(result[groupKey], &deviceCopy)
-		}
-	}
-
-	return result, nil
-}
-
-func (h *Harness) GetUpdatedDevices(fleetName string) ([]*v1alpha1.Device, error) {
-	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
-	listDeviceParams := &v1alpha1.ListDevicesParams{
-		LabelSelector: &labelSelector,
-	}
-
-	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list devices: %s", err)
-	}
-	if response == nil {
-		return nil, fmt.Errorf("device response is nil")
-	}
-
-	devices := response.JSON200.Items
-	var result []*v1alpha1.Device
-
-	for _, device := range devices {
-		// Check if device has been updated
-		if device.Status != nil && device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
-			deviceCopy := device
-			result = append(result, &deviceCopy)
-		}
-	}
-
-	return result, nil
 }
 
 func tcpNetworkTableRule(ip, port string, remove bool) []string {
@@ -1486,20 +951,6 @@ func ConditionStatusExists(conditions []v1alpha1.Condition, condType v1alpha1.Co
 	})
 }
 
-// UpdateDeviceConfigWithRetries updates the configuration of a device with retries using the provided harness and config specs.
-// It applies the provided configuration and waits for the device to reach the specified rendered version.
-func (h *Harness) UpdateDeviceConfigWithRetries(deviceId string, configs []v1alpha1.ConfigProviderSpec, nextRenderedVersion int) error {
-	h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
-		device.Spec.Config = &configs
-		logrus.WithFields(logrus.Fields{
-			"deviceId": deviceId,
-			"config":   device.Spec.Config,
-		}).Info("Updating device with new config")
-	})
-	err := h.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
-	return err
-}
-
 func (h *Harness) WaitForClusterRegistered(deviceId string, timeout time.Duration) error {
 	start := time.Now()
 
@@ -1517,7 +968,10 @@ func (h *Harness) WaitForClusterRegistered(deviceId string, timeout time.Duratio
 		}
 
 		// Check device status
-		response := h.GetDeviceWithStatusSystem(deviceId)
+		response, err := h.GetDeviceWithStatusSystem(deviceId)
+		if err != nil {
+			return err
+		}
 		if response == nil {
 			// If response is nil, retry
 			if time.Since(start) > timeout {

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -1,0 +1,640 @@
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+func (h *Harness) GetDeviceWithStatusSystem(enrollmentID string) (*apiclient.GetDeviceResponse, error) {
+	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
+	if err != nil {
+		return nil, err
+	}
+	// we keep waiting for a 200 response, with filled in Status.SystemInfo
+	if device.JSON200 == nil || device.JSON200.Status == nil || device.JSON200.Status.SystemInfo.IsEmpty() {
+		return nil, nil
+	}
+	return device, nil
+}
+
+func (h *Harness) GetDeviceWithStatusSummary(enrollmentID string) (v1alpha1.DeviceSummaryStatusType, error) {
+	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
+	if err != nil {
+		return "", err
+	}
+	// we keep waiting for a 200 response, with filled in Status.SystemInfo
+	if device == nil || device.JSON200 == nil || device.JSON200.Status == nil || device.JSON200.Status.Summary.Status == "" {
+		return "", nil
+	}
+	return device.JSON200.Status.Summary.Status, nil
+}
+
+func (h *Harness) GetDeviceWithUpdateStatus(enrollmentID string) (v1alpha1.DeviceUpdatedStatusType, error) {
+	device, err := h.Client.GetDeviceWithResponse(h.Context, enrollmentID)
+	if err != nil {
+		return "", err
+	}
+	// we keep waiting for a 200 response, with filled in Status.SystemInfo
+	if device == nil || device.JSON200 == nil || device.JSON200.Status == nil {
+		return "", nil
+	}
+	return device.JSON200.Status.Updated.Status, nil
+}
+
+func (h *Harness) UpdateDeviceWithRetries(deviceId string, updateFunction func(*v1alpha1.Device)) error {
+	// this needs to be changed so that we don't use Eventually as our polling mechanism so that we can simply return
+	// the underlying error if one exists
+	updateResourceWithRetries(func() error {
+		return h.UpdateDevice(deviceId, updateFunction)
+	})
+	return nil
+}
+
+func (h *Harness) UpdateDevice(deviceId string, updateFunction func(*v1alpha1.Device)) error {
+	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
+	if err != nil {
+		return err
+	}
+	if response.JSON200 == nil {
+		logrus.Errorf("An error happened retrieving device: %+v", response)
+		return fmt.Errorf("device %s not found: %v", deviceId, response.Status())
+	}
+	device := response.JSON200
+
+	updateFunction(device)
+
+	resp, err := h.Client.ReplaceDeviceWithResponse(h.Context, deviceId, *device)
+	if err != nil {
+		logrus.Errorf("Unexpected error updating device %s: %v", deviceId, err)
+		return err
+	}
+
+	// if a conflict happens (the device updated status or object since we read it) we retry
+	if resp.JSON409 != nil {
+		logrus.Warningf("Conflict updating device %s: %+v", deviceId, resp.JSON409)
+	}
+
+	// response code 200 = updated, we are expecting to update... something else is unexpected
+	if resp.StatusCode() != 200 {
+		logrus.Errorf("Unexpected http status code received: %d", resp.StatusCode())
+		logrus.Errorf("Unexpected http response: %s", string(resp.Body))
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+
+	return nil
+}
+
+func (h *Harness) UpdateApplication(withRetries bool, deviceId string, appName string, appProvider any, envVars map[string]string) error {
+	logrus.Infof("UpdateApplication called with deviceId=%s, appName=%s, withRetries=%v", deviceId, appName, withRetries)
+
+	updateFunc := func(device *v1alpha1.Device) {
+		logrus.Infof("Starting update for device: %s", *device.Metadata.Name)
+		var appSpec v1alpha1.ApplicationProviderSpec
+		var err error
+
+		switch spec := appProvider.(type) {
+		case v1alpha1.InlineApplicationProviderSpec:
+			logrus.Infof("Processing InlineApplicationProviderSpec for %s", appName)
+			err = appSpec.FromInlineApplicationProviderSpec(spec)
+		case v1alpha1.ImageApplicationProviderSpec:
+			logrus.Infof("Processing ImageApplicationProviderSpec for %s", appName)
+			err = appSpec.FromImageApplicationProviderSpec(spec)
+		default:
+			logrus.Errorf("Unsupported application provider type: %T for %s", appProvider, appName)
+			return
+		}
+
+		if err != nil {
+			logrus.Errorf("Error converting application provider spec: %v", err)
+			return
+		}
+
+		appSpec.Name = &appName
+		appType := v1alpha1.AppTypeCompose
+		appSpec.AppType = &appType
+
+		if envVars != nil {
+			logrus.Infof("Setting environment variables for app %s: %v", appName, envVars)
+			appSpec.EnvVars = &envVars
+		}
+
+		if device.Spec.Applications == nil {
+			logrus.Infof("device.Spec.Applications is nil, initializing with app %s", appName)
+			device.Spec.Applications = &[]v1alpha1.ApplicationProviderSpec{appSpec}
+			return
+		}
+
+		for i, a := range *device.Spec.Applications {
+			if a.Name != nil && *a.Name == appName {
+				logrus.Infof("Updating existing application %s at index %d", appName, i)
+				(*device.Spec.Applications)[i] = appSpec
+				return
+			}
+		}
+
+		logrus.Infof("Appending new application %s to device %s", appName, *device.Metadata.Name)
+		*device.Spec.Applications = append(*device.Spec.Applications, appSpec)
+	}
+
+	if withRetries {
+		logrus.Info("Updating device with retries...")
+		return h.UpdateDeviceWithRetries(deviceId, updateFunc)
+	}
+
+	logrus.Info("Updating device without retries...")
+	return h.UpdateDevice(deviceId, updateFunc)
+}
+
+func (h *Harness) fetchDeviceContents(deviceId string) (*v1alpha1.Device, error) {
+	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		logrus.Errorf("An error happened retrieving device: %+v", response)
+		return nil, errors.New("device not found???")
+	}
+	return response.JSON200, nil
+}
+
+func (h *Harness) WaitForDeviceContents(deviceId string, description string, condition func(*v1alpha1.Device) bool, timeout string) {
+	waitForResourceContents(deviceId, description, func(id string) (*v1alpha1.Device, error) {
+		return h.fetchDeviceContents(id)
+	}, condition, timeout)
+}
+
+// EnsureDeviceContents ensures that the contents of the device match the specified condition for the entire timeout
+func (h *Harness) EnsureDeviceContents(deviceId string, description string, condition func(*v1alpha1.Device) bool, timeout string) {
+	ensureResourceContents(deviceId, description, func(id string) (*v1alpha1.Device, error) {
+		return h.fetchDeviceContents(id)
+	}, condition, timeout)
+}
+
+func (h *Harness) WaitForBootstrapAndUpdateToVersion(deviceId string, version string) (*v1alpha1.Device, string, error) {
+	// Check the device status right after bootstrap
+	response, err := h.GetDeviceWithStatusSystem(deviceId)
+	if err != nil {
+		return nil, "", err
+	}
+	device := response.JSON200
+	if device.Status.Summary.Status != v1alpha1.DeviceSummaryStatusOnline {
+		return nil, "", fmt.Errorf("device: %q is not online", deviceId)
+	}
+
+	var newImageReference string
+
+	err = h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+		currentImage := device.Status.Os.Image
+		logrus.Infof("current image for %s is %s", deviceId, currentImage)
+		repo, _ := h.parseImageReference(currentImage)
+		newImageReference = repo + version
+		device.Spec.Os = &v1alpha1.DeviceOsSpec{Image: newImageReference}
+		logrus.Infof("updating %s to image %s", deviceId, device.Spec.Os.Image)
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return device, newImageReference, nil
+}
+
+func (h *Harness) GetCurrentDeviceGeneration(deviceId string) (deviceRenderedVersionInt int64, err error) {
+	var deviceGeneration int64 = -1
+	logrus.Infof("Waiting for the device to be UpToDate")
+	h.WaitForDeviceContents(deviceId, "The device is UpToDate",
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
+					deviceGeneration = *device.Metadata.Generation
+
+					return true
+				}
+			}
+			return false
+		}, TIMEOUT)
+
+	if deviceGeneration <= 0 {
+		return deviceGeneration, fmt.Errorf("invalid generation: %d", deviceGeneration)
+
+	}
+	logrus.Infof("The device current generation is %d", deviceGeneration)
+
+	return deviceGeneration, nil
+}
+
+func (h *Harness) PrepareNextDeviceGeneration(deviceId string) (int64, error) {
+	currentGeneration, err := h.GetCurrentDeviceGeneration(deviceId)
+	if err != nil {
+		return -1, err
+	}
+	return currentGeneration + 1, nil
+}
+
+var (
+	InvalidRenderedVersionErr = fmt.Errorf("invalid rendered version")
+)
+
+func GetRenderedVersion(device *v1alpha1.Device) (int, error) {
+	if device == nil || device.Status == nil {
+		return -1, fmt.Errorf("invalid device: %+v", device)
+	}
+	version, err := strconv.Atoi(device.Status.Config.RenderedVersion)
+	if err != nil {
+		return -1, fmt.Errorf("failed to convert current rendered version '%s': %w", device.Status.Config.RenderedVersion, err)
+	}
+	if version <= 0 {
+		return -1, fmt.Errorf("version: %d: %w", version, InvalidRenderedVersionErr)
+	}
+	return version, nil
+}
+
+func (h *Harness) GetCurrentDeviceRenderedVersion(deviceId string) (int, error) {
+	deviceRenderedVersion := -1
+	var renderedVersionError error
+
+	logrus.Infof("Waiting for the device to be UpToDate")
+	h.WaitForDeviceContents(deviceId, "The device is UpToDate",
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
+					deviceRenderedVersion, renderedVersionError = GetRenderedVersion(device)
+					// try until we get a valid rendered version
+					return !errors.Is(renderedVersionError, InvalidRenderedVersionErr)
+				}
+			}
+			return false
+		}, TIMEOUT)
+	if renderedVersionError != nil {
+		return -1, renderedVersionError
+	}
+	logrus.Infof("The device current renderedVersion is %d", deviceRenderedVersion)
+	return deviceRenderedVersion, nil
+}
+
+func (h *Harness) PrepareNextDeviceVersion(deviceId string) (int, error) {
+	currentVersion, err := h.GetCurrentDeviceRenderedVersion(deviceId)
+	if err != nil {
+		return -1, err
+	}
+	return currentVersion + 1, nil
+}
+
+func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVersionInt int) (err error) {
+	// Check that the device was already approved
+	Eventually(func() v1alpha1.DeviceSummaryStatusType {
+		res, err := h.GetDeviceWithStatusSummary(deviceId)
+		Expect(err).ToNot(HaveOccurred())
+		return res
+	}, LONGTIMEOUT, POLLING).ShouldNot(BeEmpty())
+	logrus.Infof("The device %s was approved", deviceId)
+
+	// Wait for the device to pickup the new config and report measurements on device status.
+	logrus.Infof("Waiting for the device to pick the config")
+	UpdateRenderedVersionSuccessMessage := fmt.Sprintf("%s %d", util.UpdateRenderedVersionSuccess.String(), newRenderedVersionInt)
+	h.WaitForDeviceContents(deviceId, UpdateRenderedVersionSuccessMessage,
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
+					device.Status.Config.RenderedVersion == strconv.Itoa(newRenderedVersionInt) {
+					return true
+				}
+			}
+			return false
+		}, LONGTIMEOUT)
+
+	return nil
+}
+
+func (h *Harness) WaitForDeviceNewGeneration(deviceId string, newGeneration int64) (err error) {
+	// Check that the device was already approved
+	Eventually(func() v1alpha1.DeviceSummaryStatusType {
+		res, err := h.GetDeviceWithStatusSummary(deviceId)
+		Expect(err).ToNot(HaveOccurred())
+		return res
+	}, LONGTIMEOUT, POLLING).ShouldNot(BeEmpty())
+	logrus.Infof("The device %s was approved", deviceId)
+
+	// Wait for the device to pickup the new config and report measurements on device status.
+	logrus.Infof("Waiting for the device to pick the config")
+	h.WaitForDeviceContents(deviceId, "Waiting fot the device generation",
+		func(device *v1alpha1.Device) bool {
+			for _, condition := range device.Status.Conditions {
+				if condition.Type == "Updating" && condition.Reason == "Updated" && condition.Status == "False" &&
+					device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate &&
+					newGeneration == *device.Metadata.Generation {
+					return true
+				}
+			}
+			return false
+		}, LONGTIMEOUT)
+
+	return nil
+}
+
+// GetDeviceConfig is a generic helper function to retrieve device configurations
+func GetDeviceConfig[T any](device *v1alpha1.Device, configType v1alpha1.ConfigProviderType,
+	asConfig func(v1alpha1.ConfigProviderSpec) (T, error)) (T, error) {
+
+	var config T
+	if device.Spec == nil || device.Spec.Config == nil {
+		return config, fmt.Errorf("device spec or config is nil")
+	}
+
+	if len(*device.Spec.Config) > 0 {
+		for _, configItem := range *device.Spec.Config {
+			// Check config type
+			itemType, err := configItem.Type()
+			if err != nil {
+				return config, fmt.Errorf("failed to get config type: %w", err)
+			}
+			if itemType == configType {
+				// Convert to the expected config type
+				config, err := asConfig(configItem)
+				if err != nil {
+					return config, fmt.Errorf("failed to convert config: %w", err)
+				}
+
+				return config, nil
+			}
+		}
+	}
+
+	// If we don't find the config, return an error
+	return config, fmt.Errorf("%s config not found in the device", configType)
+}
+
+// Get InlineConfig
+func (h *Harness) GetDeviceInlineConfig(device *v1alpha1.Device, configName string) (v1alpha1.InlineConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.InlineConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.InlineConfigProviderSpec, error) {
+			inlineConfig, err := c.AsInlineConfigProviderSpec()
+			if err != nil {
+				return inlineConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if inlineConfig.Name == configName {
+				logrus.Infof("Inline configuration found %s", configName)
+				return inlineConfig, nil
+			}
+			return v1alpha1.InlineConfigProviderSpec{}, fmt.Errorf("inline config not found")
+		})
+}
+
+// Get GitConfig
+func (h *Harness) GetDeviceGitConfig(device *v1alpha1.Device, configName string) (v1alpha1.GitConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.GitConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.GitConfigProviderSpec, error) {
+			gitConfig, err := c.AsGitConfigProviderSpec()
+			if err != nil {
+				return gitConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if gitConfig.Name == configName {
+				logrus.Infof("Git configuration found %s", configName)
+				return gitConfig, nil
+			}
+			return v1alpha1.GitConfigProviderSpec{}, fmt.Errorf("git config not found")
+		})
+}
+
+// Get HttpConfig
+func (h *Harness) GetDeviceHttpConfig(device *v1alpha1.Device, configName string) (v1alpha1.HttpConfigProviderSpec, error) {
+	return GetDeviceConfig(device, v1alpha1.HttpConfigProviderType,
+		func(c v1alpha1.ConfigProviderSpec) (v1alpha1.HttpConfigProviderSpec, error) {
+			httpConfig, err := c.AsHttpConfigProviderSpec()
+			if err != nil {
+				return httpConfig, fmt.Errorf("failed to cast config type: %w", err)
+			}
+			if httpConfig.Name == configName {
+				logrus.Infof("Http configuration found %s", configName)
+				return httpConfig, nil
+			}
+			return v1alpha1.HttpConfigProviderSpec{}, fmt.Errorf("http config not found")
+		})
+}
+
+// Get an http config of a device resource
+func (h *Harness) GetDeviceOsImage(device *v1alpha1.Device) (image string, err error) {
+	if device.Spec == nil {
+		return "", fmt.Errorf("device spec is nil")
+	}
+	if device.Spec.Os == nil {
+		return "", fmt.Errorf("device os spec is nil")
+	}
+
+	return device.Spec.Os.Image, nil
+}
+
+// Check that the device summary status is equal to the status input
+func (h *Harness) CheckDeviceStatus(deviceId string, status v1alpha1.DeviceSummaryStatusType) (*v1alpha1.Device, error) {
+	response, err := h.GetDeviceWithStatusSystem(deviceId)
+	if err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("device.JSON200 response is nil")
+	}
+	device := response.JSON200
+	deviceStaus := device.Status.Summary.Status
+	if deviceStaus != status {
+		return nil, fmt.Errorf("the device status is notOnline but %s", deviceStaus)
+	}
+	return device, nil
+}
+
+// Get device with response
+func (h *Harness) GetDevice(deviceId string) (*v1alpha1.Device, error) {
+	response, err := h.Client.GetDeviceWithResponse(h.Context, deviceId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device with response: %s", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+	if response.JSON200 == nil {
+		return nil, fmt.Errorf("device not found")
+	}
+	device := response.JSON200
+	return device, nil
+}
+
+func (h *Harness) SetLabelsForDevice(deviceId string, labels map[string]string) error {
+	return h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+		if len(labels) == 0 {
+			device.Metadata.Labels = nil
+			return
+		}
+		devLabels := make(map[string]string, len(labels))
+		for key, value := range labels {
+			devLabels[key] = value
+		}
+		device.Metadata.Labels = &devLabels
+	})
+}
+
+func (h *Harness) SetLabelsForDevicesByIndex(deviceIDs []string, labelsList []map[string]string, fleetName string) error {
+	if len(deviceIDs) != len(labelsList) {
+		return fmt.Errorf("mismatched lengths: deviceIDs (%d) and labelsList (%d)", len(deviceIDs), len(labelsList))
+	}
+
+	for i, deviceID := range deviceIDs {
+		labels := labelsList[i]
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels["fleet"] = fleetName
+		err := h.SetLabelsForDevice(deviceID, labels)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *Harness) GetSelectedDevicesForBatch(fleetName string) ([]*v1alpha1.Device, error) {
+	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
+	listDeviceParams := &v1alpha1.ListDevicesParams{
+		LabelSelector: &labelSelector,
+	}
+	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %s", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+	devices := response.JSON200.Items
+
+	var result []*v1alpha1.Device
+
+	for _, device := range devices {
+		annotations := device.Metadata.Annotations
+		if annotations == nil {
+			continue
+		}
+		if _, ok := (*annotations)["fleet-controller/selectedForRollout"]; ok {
+			deviceCopy := device
+			result = append(result, &deviceCopy)
+		}
+	}
+
+	return result, nil
+}
+
+func (h *Harness) GetUnavailableDevicesPerGroup(fleetName string, groupBy []string) (map[string][]*v1alpha1.Device, error) {
+	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
+	listDeviceParams := &v1alpha1.ListDevicesParams{
+		LabelSelector: &labelSelector,
+	}
+
+	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %s", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+
+	devices := response.JSON200.Items
+	result := make(map[string][]*v1alpha1.Device)
+
+	for _, device := range devices {
+		// Check if device is unavailable
+		if device.Status != nil && (device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpdating ||
+			device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUnknown) {
+			// Generate group key based on labels
+			groupKey := ""
+
+			if device.Metadata.Labels != nil {
+				labelValues := []string{}
+				for _, key := range groupBy {
+					value, exists := (*device.Metadata.Labels)[key]
+					if exists {
+						labelValues = append(labelValues, value)
+					} else {
+						labelValues = append(labelValues, "")
+					}
+				}
+				groupKey = strings.Join(labelValues, ":")
+			}
+
+			// Add device to the appropriate group
+			if _, exists := result[groupKey]; !exists {
+				result[groupKey] = []*v1alpha1.Device{}
+			}
+			deviceCopy := device
+			result[groupKey] = append(result[groupKey], &deviceCopy)
+		}
+	}
+
+	return result, nil
+}
+
+func (h *Harness) GetUpdatedDevices(fleetName string) ([]*v1alpha1.Device, error) {
+	labelSelector := fmt.Sprintf("fleet=%s", fleetName)
+	listDeviceParams := &v1alpha1.ListDevicesParams{
+		LabelSelector: &labelSelector,
+	}
+
+	response, err := h.Client.ListDevicesWithResponse(h.Context, listDeviceParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %s", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("device response is nil")
+	}
+
+	devices := response.JSON200.Items
+	var result []*v1alpha1.Device
+
+	for _, device := range devices {
+		// Check if device has been updated
+		if device.Status != nil && device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusUpToDate {
+			deviceCopy := device
+			result = append(result, &deviceCopy)
+		}
+	}
+
+	return result, nil
+}
+
+func (h *Harness) AddConfigToDeviceWithRetries(deviceId string, config v1alpha1.ConfigProviderSpec) error {
+	return h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+		specs := lo.FromPtr(device.Spec.Config)
+		specs = append(specs, config)
+		device.Spec.Config = &specs
+		logrus.WithFields(logrus.Fields{
+			"deviceId": deviceId,
+			"config":   device.Spec.Config,
+		}).Info("Updating device with new config")
+	})
+}
+
+// UpdateDeviceConfigWithRetries updates the configuration of a device with retries using the provided harness and config specs.
+// It applies the provided configuration and waits for the device to reach the specified rendered version.
+func (h *Harness) UpdateDeviceConfigWithRetries(deviceId string, configs []v1alpha1.ConfigProviderSpec, nextRenderedVersion int) error {
+	err := h.UpdateDeviceWithRetries(deviceId, func(device *v1alpha1.Device) {
+		device.Spec.Config = &configs
+		logrus.WithFields(logrus.Fields{
+			"deviceId": deviceId,
+			"config":   device.Spec.Config,
+		}).Info("Updating device with new config")
+	})
+	if err != nil {
+		return err
+	}
+	return h.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+}


### PR DESCRIPTION
Adds e2e tests for behavior around the update policy of a device.

* Adds an e2e test for update policies 
* Migrates device specific functions into it's own class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new end-to-end tests verifying device updates respect configured update and download schedules.
  * Introduced helper functions for creating inline config specs and generating cron expressions for scheduling.
  * Expanded test utilities with comprehensive device management and status-checking methods for automated testing.

* **Refactor**
  * Simplified and generalized resource update and wait logic, replacing device-specific helpers with reusable functions.

* **Chores**
  * Improved code organization by moving device-related test helpers into a dedicated file.
  * Enhanced test robustness by adding explicit error handling and assertions across multiple test suites.
  * Cleaned up unused imports and redundant code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->