### PR TITLE
EDM-1743: agent/console: add bubblewrap based sandbox for console sessions

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -42,6 +42,14 @@ runs:
           protoc --version
           rm -rf protoc.zip
           echo "::endgroup::"
+      
+      - name: Install bubblewrap for unit tests
+        shell: bash
+        if: ${{ inputs.unit_tests == 'true' }}
+        run: |
+          sudo apt install -y bubblewrap apparmor-profiles
+          sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/bwrap || true
+          sudo apparmor_parser /etc/apparmor.d/bwrap
 
       - name: Fix container storage driver
         shell: bash

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,6 +30,8 @@ jobs:
       - name: Setup all dependencies
         if: ${{ steps.filter.outputs.notdocs == 'true' }}
         uses: ./.github/actions/setup-dependencies
+        with:
+          unit_tests: 'true'
 
       - name: Running Unit tests
         if: ${{ steps.filter.outputs.notdocs == 'true' }}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -7,7 +7,7 @@ Flight Control is a service for declarative, GitOps-driven management of edge de
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `podman-compose` and `go-rpm-macros` (in case one needs to build RPM's)
+* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `bubblewrap`, `podman-compose` and `go-rpm-macros` (in case one needs to build RPM's)
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/internal/agent/device/console/session.go
+++ b/internal/agent/device/console/session.go
@@ -37,14 +37,31 @@ func (s *session) close() error {
 }
 
 func (s *session) buildBashCommand(ctx context.Context, metadata *api.DeviceConsoleSessionMetadata) *exec.Cmd {
-	var args []string
+	args := []string{
+		"--ro-bind", "/usr", "/usr", // Bind /usr read-only
+		"--ro-bind", "/bin", "/bin", // Required for /bin/bash or POSIX tools
+		"--ro-bind", "/lib", "/lib", // Required for dynamic linker and libc
+		"--ro-bind", "/lib64", "/lib64", // Required for 64-bit libraries
+		"--bind", "/etc", "/etc", // Provide read/write access to system config files
+		"--bind", "/var", "/var", // Provide read/write access to system state, logs, DBs
+		"--bind", "/sys", "/sys", // Required for block/network interface introspection
+		"--bind", "/run", "/run", // Needed for runtime sockets (D-Bus, systemd)
+		"--bind", "/var/tmp", "/var/tmp", // For sos report and other tools using /var/tmp
+		"--bind", "/root", "/root", // Access to root user's home
+		"--dev-bind", "/dev", "/dev", // Provide /dev access: required for journalctl, interactive tty, and system diagnostics
+		"--proc", "/proc", // Mount /proc for ps, top, etc.
+		"--tmpfs", "/tmp", // Provide isolated writable /tmp
+		"--setenv", "SYSTEMD_IGNORE_CHROOT", "1", // Disable chroot detection to enable full systemctl functionality
+		"/bin/bash",
+	}
+
 	if metadata.TTY {
 		args = append(args, "-i", "-l")
 	}
 	if metadata.Command != nil && metadata.Command.Command != "" {
 		args = append(args, "-c", strings.Join(append([]string{metadata.Command.Command}, metadata.Command.Args...), " "))
 	}
-	ret := s.executor.CommandContext(ctx, "bash", args...)
+	ret := s.executor.CommandContext(ctx, "bwrap", args...)
 	if metadata.Term != nil {
 		ret.Env = append(ret.Env, "TERM="+*metadata.Term)
 	}


### PR DESCRIPTION
This PR adds bubblewrap-based isolation to the console process. It introduces a lightweight sandbox framework using bubblewrap, which is available for free as part of rpm-ostree based systems.

Console sessions are isolated into a dedicated mount namespace with controlled filesystem bindings, limiting accidental modification of critical system paths while maintaining full systemctl/firewall-cmd and debugging capabilities. This isolation also helps reduce the SELinux policy footprint by limiting resource exposure in the filesystem namespace.

In the future, we will also be able to create more limited console sessions for non-admin users.

ref. https://github.com/containers/bubblewrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced sandboxing for shell sessions using Bubblewrap, enhancing process isolation and security.

- **Chores**
  - Updated dependency installation steps to include Bubblewrap and AppArmor profiles.
  - Added automated configuration for Bubblewrap AppArmor profile in the setup workflow.
  - Updated developer documentation to include Bubblewrap as a required package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->