### PR TITLE
EDM-1745: MacOS CLI downloaded instead of Linux

### DIFF
--- a/hack/build_multiarch_clis.sh
+++ b/hack/build_multiarch_clis.sh
@@ -97,19 +97,11 @@ build() {
 
 for GOARCH in amd64 arm64; do
   for GOOS in linux darwin windows; do
-    (
-      echo -e "\033[0;37m>>>> Start building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
-      build "$GOARCH" "$GOOS"
-      echo -e "\033[0;37m>>>> Finish building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
-    ) &> "build_${GOOS}_${GOARCH}.log" &
+    echo -e "\033[0;37m>>>> Start building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+    build "$GOARCH" "$GOOS"
+    echo -e "\033[0;37m>>>> Finish building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
   done
 done
-
-# Wait for all parallel jobs to complete
-wait
-cat build_*.log
-rm -f build_*.log
-
 
 echo -e "\033[0;37m>>>> building index.json\033[0m"
 


### PR DESCRIPTION
#### Parallel build should handle properly built files as at some point they all got the same name. Let's build sequentially instead. It takes just another second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build process for multi-architecture CLI tools to run sequentially, providing clearer start and finish messages in the console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->