### PR TITLE
NO-ISSUE: stop rollout in case a device has multiple owners

### DIFF
--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -147,7 +147,8 @@ func (f FleetRolloutsLogic) RolloutDevice(ctx context.Context) error {
 	}
 
 	if api.IsStatusConditionTrue(device.Status.Conditions, api.ConditionTypeDeviceMultipleOwners) {
-		f.log.Warnf("Device has multiple owners, skipping rollout")
+		f.log.Errorf("Device %s has multiple owners, skipping rollout", f.resourceRef.Name)
+		return nil
 	}
 
 	ownerName, isFleetOwner, err := getOwnerFleet(device)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of devices with multiple owners by skipping rollout processing and logging an error message for clearer issue visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->