### PR TITLE
EDM-1712: Migrating HTTP Metrics 

### DIFF
--- a/cmd/flightctl-api/main.go
+++ b/cmd/flightctl-api/main.go
@@ -144,13 +144,19 @@ func main() {
 		log.Fatalf("failed connecting to Redis queue: %v", err)
 	}
 
+	// Initialize HTTP collector for metrics
+	var httpCollector *metrics.HTTPCollector
+	if cfg.Prometheus != nil {
+		httpCollector = metrics.NewHTTPCollector(cfg)
+	}
+
 	// create the agent service listener as tcp (combined HTTP+gRPC)
 	agentListener, err := net.Listen("tcp", cfg.Service.AgentEndpointAddress)
 	if err != nil {
 		log.Fatalf("creating listener: %s", err)
 	}
 
-	agentserver := agentserver.New(log, cfg, store, ca, agentListener, provider, agentTlsConfig)
+	agentserver := agentserver.New(log, cfg, store, ca, agentListener, provider, agentTlsConfig, httpCollector)
 
 	go func() {
 		listener, err := middleware.NewTLSListener(cfg.Service.Address, tlsConfig)
@@ -158,7 +164,7 @@ func main() {
 			log.Fatalf("creating listener: %s", err)
 		}
 		// we pass the grpc server for now, to let the console sessions to establish a connection in grpc
-		server := apiserver.New(log, cfg, store, ca, listener, provider, agentserver.GetGRPCServer())
+		server := apiserver.New(log, cfg, store, ca, listener, provider, agentserver.GetGRPCServer(), httpCollector)
 		if err := server.Run(ctx); err != nil {
 			log.Fatalf("Error running server: %s", err)
 		}
@@ -173,8 +179,14 @@ func main() {
 	}()
 
 	if cfg.Prometheus != nil {
+		var collectors []metrics.NamedCollector
+		collectors = append(collectors, metrics.NewSystemCollector(ctx))
+		if httpCollector != nil {
+			collectors = append(collectors, httpCollector)
+		}
+
 		go func() {
-			metricsServer := instrumentation.NewMetricsServer(log, cfg, metrics.NewSystemCollector(ctx))
+			metricsServer := instrumentation.NewMetricsServer(log, cfg, collectors...)
 			if err := metricsServer.Run(ctx); err != nil {
 				log.Fatalf("Error running server: %s", err)
 			}

--- a/internal/instrumentation/metrics/http.go
+++ b/internal/instrumentation/metrics/http.go
@@ -1,0 +1,136 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HTTPCollector implements NamedCollector and gathers HTTP request metrics
+type HTTPCollector struct {
+	sloMax float64
+
+	requestsTotal *prometheus.CounterVec
+	latencies     *prometheus.HistogramVec
+	errorsTotal   *prometheus.CounterVec
+}
+
+// NewHTTPCollector creates a new HTTP metrics collector with the provided configuration
+func NewHTTPCollector(cfg *config.Config) *HTTPCollector {
+	if cfg.Prometheus == nil {
+		return nil
+	}
+
+	return &HTTPCollector{
+		sloMax: cfg.Prometheus.SloMax,
+		requestsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "flightctl_api_requests_total",
+				Help: "Total number of HTTP API requests",
+			},
+			[]string{"source"},
+		),
+		latencies: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "flightctl_api_latencies_seconds",
+				Help:    "Duration of HTTP API requests (binned in buckets)",
+				Buckets: cfg.Prometheus.ApiLatencyBins,
+			},
+			[]string{"status", "code", "source"},
+		),
+		errorsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "flightctl_api_errors_total",
+				Help: "Count of failed HTTP requests (4xx, 5xx)",
+			},
+			[]string{"code", "bucket", "source"},
+		),
+	}
+}
+
+func (h *HTTPCollector) MetricsName() string {
+	return "http"
+}
+
+func (h *HTTPCollector) Describe(ch chan<- *prometheus.Desc) {
+	h.requestsTotal.Describe(ch)
+	h.latencies.Describe(ch)
+	h.errorsTotal.Describe(ch)
+}
+
+func (h *HTTPCollector) Collect(ch chan<- prometheus.Metric) {
+	h.requestsTotal.Collect(ch)
+	h.latencies.Collect(ch)
+	h.errorsTotal.Collect(ch)
+}
+
+// loggingResponseWriter wraps http.ResponseWriter to capture the status code
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
+	return &loggingResponseWriter{
+		ResponseWriter: w,
+		statusCode:     0,
+	}
+}
+
+func (lw *loggingResponseWriter) WriteHeader(statusCode int) {
+	lw.statusCode = statusCode
+	lw.ResponseWriter.WriteHeader(statusCode)
+}
+
+// AgentServerMiddleware returns middleware for instrumenting agent server requests
+func (h *HTTPCollector) AgentServerMiddleware(next http.Handler) http.Handler {
+	return h.serverMiddleware(next, true)
+}
+
+// APIServerMiddleware returns middleware for instrumenting API server requests
+func (h *HTTPCollector) APIServerMiddleware(next http.Handler) http.Handler {
+	return h.serverMiddleware(next, false)
+}
+
+// serverMiddleware provides HTTP request instrumentation
+func (h *HTTPCollector) serverMiddleware(next http.Handler, agentServer bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Determine source label
+		source := "api"
+		if agentServer {
+			source = "agent"
+		}
+
+		// Increment total requests counter
+		h.requestsTotal.WithLabelValues(source).Inc()
+
+		lw := newLoggingResponseWriter(w)
+		next.ServeHTTP(lw, r)
+
+		statusCode := lw.statusCode
+		if statusCode == 0 {
+			statusCode = 200 // Default to 200 if no status was set
+		}
+
+		statusClass := statusCode - statusCode%100
+		thisLatency := time.Since(start).Seconds()
+
+		// Record latency with labels
+		status := "success"
+		if statusClass >= 400 {
+			status = "error"
+		}
+		h.latencies.WithLabelValues(status, fmt.Sprintf("%d", statusCode), source).Observe(thisLatency)
+
+		// Record errors with labels
+		if statusClass >= 400 {
+			bucket := fmt.Sprintf("%dxx", statusClass/100)
+			h.errorsTotal.WithLabelValues(fmt.Sprintf("%d", statusCode), bucket, source).Inc()
+		}
+	})
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -119,7 +119,7 @@ func NewTestApiServer(log logrus.FieldLogger, cfg *config.Config, store store.St
 		return nil, nil, fmt.Errorf("NewTLSListener: error creating TLS certs: %w", err)
 	}
 
-	return apiserver.New(log, cfg, store, ca, listener, queuesProvider, nil), listener, nil
+	return apiserver.New(log, cfg, store, ca, listener, queuesProvider, nil, nil), listener, nil
 }
 
 // NewTestServer creates a new test server and returns the server and the listener listening on localhost's next available port.
@@ -136,7 +136,7 @@ func NewTestAgentServer(log logrus.FieldLogger, cfg *config.Config, store store.
 		return nil, nil, fmt.Errorf("NewTestAgentServer: error creating TLS certs: %w", err)
 	}
 
-	return agentserver.New(log, cfg, store, ca, listener, queuesProvider, tlsConfig), listener, nil
+	return agentserver.New(log, cfg, store, ca, listener, queuesProvider, tlsConfig, nil), listener, nil
 }
 
 // NewTestStore creates a new test store and returns the store and the database name.


### PR DESCRIPTION
This is a draft commit to introduce service-level metrics for the HTTP API. Final metrics definitions are still under discussion and subject to change.