### PR TITLE
EDM-1762: ensure pullspec auth if passed via config

### DIFF
--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -1,16 +1,20 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"os/exec"
+	"strings"
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	client "github.com/flightctl/flightctl/internal/api/client/agent"
 	baseclient "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/container"
+	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -70,6 +74,98 @@ func IsComposeAvailable() bool {
 		}
 	}
 	return false
+}
+
+type PullSecret struct {
+	// Absolute path to the pull secret
+	Path string
+	// Cleanup function for temporary files, or no-op
+	Cleanup func()
+}
+
+// ResolvePullSecret returns the image pull secret path, preferring inline spec
+// auth then falling back to on disk.  Cleanup removes tmp files generated from
+// inline spec if found and is otherwise a no-op.
+func ResolvePullSecret(
+	log *log.PrefixLogger,
+	rw fileio.ReadWriter,
+	desired *v1alpha1.DeviceSpec,
+	authPath string,
+) (*PullSecret, bool, error) {
+	specContent, found, err := authFromSpec(log, desired, authPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if found {
+		exists, err := rw.PathExists(authPath)
+		if err != nil {
+			return nil, false, err
+		}
+		if exists {
+			diskContent, err := rw.ReadFile(authPath)
+			if err != nil {
+				return nil, false, fmt.Errorf("reading existing auth file: %w", err)
+			}
+
+			if bytes.Equal(diskContent, specContent) {
+				log.Debugf("Using on-disk pull secret (identical to spec): %s", authPath)
+				return &PullSecret{Path: authPath, Cleanup: func() {}}, true, nil
+			}
+		}
+		path, cleanup, err := fileio.WriteTmpFile(rw, "os_auth_", "auth.json", specContent, 0600)
+		if err != nil {
+			return nil, false, fmt.Errorf("writing inline auth file: %w", err)
+		}
+		log.Debugf("Using inline auth from device spec")
+		return &PullSecret{Path: path, Cleanup: cleanup}, true, nil
+	}
+
+	exists, err := rw.PathExists(authPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if exists {
+		log.Debugf("Using on-disk pull secret: %s", authPath)
+		return &PullSecret{Path: authPath, Cleanup: func() {}}, true, nil
+	}
+
+	return nil, false, nil
+}
+
+func authFromSpec(log *log.PrefixLogger, device *v1alpha1.DeviceSpec, authPath string) ([]byte, bool, error) {
+	if device.Config == nil {
+		return nil, false, nil
+	}
+
+	for _, provider := range *device.Config {
+		pType, err := provider.Type()
+		if err != nil {
+			return nil, false, fmt.Errorf("provider type: %v", err)
+		}
+		if pType != v1alpha1.InlineConfigProviderType {
+			// agent should only ever see inline config
+			log.Errorf("Invalid config provider type: %s", pType)
+			continue
+		}
+		spec, err := provider.AsInlineConfigProviderSpec()
+		if err != nil {
+			return nil, false, fmt.Errorf("convert inline config provider: %v", err)
+		}
+
+		for _, file := range spec.Inline {
+			if strings.TrimSpace(file.Path) == authPath {
+				// ensure content is properly decoded
+				contents, err := fileio.DecodeContent(file.Content, file.ContentEncoding)
+				if err != nil {
+					log.Errorf("decode content: %v", err)
+					continue
+				}
+				return contents, true, nil
+			}
+		}
+	}
+
+	return nil, false, nil
 }
 
 // ClientOption is a functional option for configuring the client.

--- a/internal/agent/client/client_test.go
+++ b/internal/agent/client/client_test.go
@@ -1,0 +1,378 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePullSecret(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name                 string
+		deviceSpec           *v1alpha1.DeviceSpec
+		authPath             string
+		setupOnDiskAuth      func(fileio.ReadWriter) // function to write an on-disk auth file
+		expectedFound        bool
+		expectedError        bool
+		expectTmpFileCleanup bool
+	}{
+		{
+			name: "inline auth found in device spec",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/containers/auth.json",
+						Content: `{"auths":{"registry.redhat.io":{"username":"user","password":"pass"}}}`,
+					},
+				}),
+			}),
+			authPath:             "/etc/containers/auth.json",
+			expectedFound:        true,
+			expectTmpFileCleanup: true,
+		},
+		{
+			name: "inline auth found with whitespace in path",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "  /etc/containers/auth.json  ",
+						Content: `{"auths":{"example.com":{"auth":"dXNlcjpwYXNz"}}}`,
+					},
+				}),
+			}),
+			authPath:             "/etc/containers/auth.json",
+			expectedFound:        true,
+			expectTmpFileCleanup: true,
+		},
+		{
+			name: "multiple config providers - auth found in second provider",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "other-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/other/config.yaml",
+						Content: "some: config",
+					},
+				}),
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/containers/auth.json",
+						Content: `{"auths":{"quay.io":{"username":"test","password":"secret"}}}`,
+					},
+				}),
+			}),
+			authPath:             "/etc/containers/auth.json",
+			expectedFound:        true,
+			expectTmpFileCleanup: true,
+		},
+		{
+			name: "no inline auth - on-disk file exists",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "other-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/other/config.json",
+						Content: `{"other": "config"}`,
+					},
+				}),
+			}),
+			authPath: "/etc/containers/auth.json",
+			setupOnDiskAuth: func(rw fileio.ReadWriter) {
+				// create the on-disk auth file
+				err := rw.WriteFile("/etc/containers/auth.json", []byte(`{"auths":{"on-disk.registry":{"auth":"disktoken"}}}`), 0644)
+				if err != nil {
+					panic(err)
+				}
+			},
+			expectedFound: true,
+		},
+		{
+			name: "no inline auth - on-disk file does not exist",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "other-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/other/file.txt",
+						Content: "content",
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedFound: false,
+		},
+		{
+			name:          "nil device config",
+			deviceSpec:    &v1alpha1.DeviceSpec{Config: nil},
+			authPath:      "/etc/containers/auth.json",
+			expectedFound: false,
+		},
+		{
+			name: "empty config providers",
+			deviceSpec: &v1alpha1.DeviceSpec{
+				Config: &[]v1alpha1.ConfigProviderSpec{},
+			},
+			authPath: "/etc/containers/auth.json",
+			setupOnDiskAuth: func(rw fileio.ReadWriter) {
+				err := rw.WriteFile("/etc/containers/auth.json", []byte(`{"auths":{"empty-config.registry":{"auth":"emptytoken"}}}`), 0644)
+				if err != nil {
+					panic(err)
+				}
+			},
+			expectedFound: true,
+		},
+		{
+			name: "config provider with AsInlineConfigProviderSpec error",
+			deviceSpec: &v1alpha1.DeviceSpec{
+				Config: &[]v1alpha1.ConfigProviderSpec{
+					{}, // invalid provider
+				},
+			},
+			authPath:      "/etc/containers/auth.json",
+			expectedFound: false,
+			expectedError: true,
+		},
+		{
+			name: "multiple files in inline config - auth not found",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "system-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/systemd/system/myservice.service",
+						Content: "[Unit]\nDescription=My Service",
+					},
+					{
+						Path:    "/etc/hostname",
+						Content: "myhost",
+					},
+				}),
+			}),
+			authPath: "/etc/containers/auth.json",
+			setupOnDiskAuth: func(rw fileio.ReadWriter) {
+				err := rw.WriteFile("/etc/containers/auth.json", []byte(`{"auths":{"fallback.registry":{"auth":"fallbacktoken"}}}`), 0644)
+				if err != nil {
+					panic(err)
+				}
+			},
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			rw := fileio.NewReadWriter(fileio.WithTestRootDir(tmpDir))
+
+			// write an on-disk auth file if set
+			if tt.setupOnDiskAuth != nil {
+				tt.setupOnDiskAuth(rw)
+			}
+			log := log.NewPrefixLogger("test")
+
+			result, found, err := ResolvePullSecret(log, rw, tt.deviceSpec, tt.authPath)
+			if tt.expectedError {
+				require.Error(err)
+				require.Nil(result)
+				require.False(found)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tt.expectedFound, found)
+
+			if !tt.expectedFound {
+				require.Nil(result)
+			} else {
+				require.NotNil(result)
+
+				// read the auth file content to verify it's correct
+				require.NotEmpty(result.Path)
+				content, err := rw.ReadFile(result.Path)
+				require.NoError(err)
+				require.NotEmpty(content)
+				require.NotNil(result.Cleanup)
+
+				// verify cleanup removes the file for temporary files
+				if tt.expectTmpFileCleanup {
+					exists, err := rw.PathExists(result.Path)
+					require.NoError(err)
+					require.True(exists)
+
+					result.Cleanup()
+					exists, err = rw.PathExists(result.Path)
+					require.NoError(err)
+					require.False(exists, "temporary file should be removed after cleanup")
+				} else {
+					// for on-disk files, cleanup should be a no-op
+					result.Cleanup()
+					exists, err := rw.PathExists(result.Path)
+					require.NoError(err)
+					require.True(exists, "on-disk file should not be removed by cleanup")
+				}
+			}
+		})
+	}
+}
+
+func TestAuthFromSpec(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name          string
+		deviceSpec    *v1alpha1.DeviceSpec
+		authPath      string
+		expectedAuth  string
+		expectedFound bool
+		expectedError bool
+	}{
+		{
+			name: "auth found in first provider",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/containers/auth.json",
+						Content: `{"auths":{"registry.com":{"auth":"token123"}}}`,
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  `{"auths":{"registry.com":{"auth":"token123"}}}`,
+			expectedFound: true,
+		},
+		{
+			name: "auth found with path trimming",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "  /etc/containers/auth.json  \n\t",
+						Content: `{"auths":{"example.org":{"username":"test"}}}`,
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  `{"auths":{"example.org":{"username":"test"}}}`,
+			expectedFound: true,
+		},
+		{
+			name: "auth not found different path",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "registry-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/containers/registries.conf",
+						Content: "unqualified-search-registries = ['docker.io']",
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  "",
+			expectedFound: false,
+		},
+		{
+			name: "nil config",
+			deviceSpec: &v1alpha1.DeviceSpec{
+				Config: nil,
+			},
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  "",
+			expectedFound: false,
+		},
+		{
+			name: "empty providers",
+			deviceSpec: &v1alpha1.DeviceSpec{
+				Config: &[]v1alpha1.ConfigProviderSpec{},
+			},
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  "",
+			expectedFound: false,
+		},
+		{
+			name: "provider conversion error handled",
+			deviceSpec: &v1alpha1.DeviceSpec{
+				Config: &[]v1alpha1.ConfigProviderSpec{
+					{}, // invalid provider
+					createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+						{
+							Path:    "/etc/containers/auth.json",
+							Content: `{"auths":{"valid.registry":{"auth":"validtoken"}}}`,
+						},
+					}),
+				},
+			},
+			authPath:      "/etc/containers/auth.json",
+			expectedFound: false,
+			expectedError: true,
+		},
+		{
+			name: "multiple providers - auth found in second",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "hostname-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/hostname",
+						Content: "testhost",
+					},
+				}),
+				createInlineConfigProvider(require, "auth-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/containers/auth.json",
+						Content: `{"auths":{"second.registry":{"password":"secret"}}}`,
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  `{"auths":{"second.registry":{"password":"secret"}}}`,
+			expectedFound: true,
+		},
+		{
+			name: "multiple files in provider - auth found",
+			deviceSpec: createDeviceSpecWithInlineConfig([]v1alpha1.ConfigProviderSpec{
+				createInlineConfigProvider(require, "multi-config", []v1alpha1.FileSpec{
+					{
+						Path:    "/etc/systemd/system/test.service",
+						Content: "[Unit]\nDescription=Test",
+					},
+					{
+						Path:    "/etc/containers/auth.json",
+						Content: `{"auths":{"multi.registry":{"token":"abc123"}}}`,
+					},
+					{
+						Path:    "/etc/motd",
+						Content: "Welcome to the system",
+					},
+				}),
+			}),
+			authPath:      "/etc/containers/auth.json",
+			expectedAuth:  `{"auths":{"multi.registry":{"token":"abc123"}}}`,
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := log.NewPrefixLogger("test")
+			auth, found, err := authFromSpec(log, tt.deviceSpec, tt.authPath)
+			if tt.expectedError {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+			require.Equal(tt.expectedFound, found)
+			require.Equal(tt.expectedAuth, string(auth))
+		})
+	}
+}
+
+func createInlineConfigProvider(require *require.Assertions, name string, files []v1alpha1.FileSpec) v1alpha1.ConfigProviderSpec {
+	var provider v1alpha1.ConfigProviderSpec
+	err := provider.FromInlineConfigProviderSpec(v1alpha1.InlineConfigProviderSpec{
+		Name:   name,
+		Inline: files,
+	})
+	require.NoError(err)
+	return provider
+}
+
+func createDeviceSpecWithInlineConfig(providers []v1alpha1.ConfigProviderSpec) *v1alpha1.DeviceSpec {
+	return &v1alpha1.DeviceSpec{
+		Config: &providers,
+	}
+}

--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -8,14 +8,17 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/flightctl/flightctl/internal/util/validation"
+	"github.com/samber/lo"
 )
 
 const (
@@ -189,6 +192,63 @@ func ParseComposeSpecFromDir(reader fileio.Reader, dir string) (*common.ComposeS
 	_, err = readFirstExistingFile(OverrideComposeFiles, dir, reader, spec)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(spec.Services) == 0 {
+		return nil, errors.ErrNoComposeServices
+	}
+
+	return spec, nil
+}
+
+// ParseComposeSpecFromSpec parses a Compose specification from a slice of inline application content,
+// as used in inline application providers.
+func ParseComposeFromSpec(contents []v1alpha1.ApplicationContent) (*common.ComposeSpec, error) {
+	spec := &common.ComposeSpec{
+		Services: make(map[string]common.ComposeService),
+		Volumes:  make(map[string]common.ComposeVolume),
+	}
+
+	var baseFound bool
+	for _, c := range contents {
+		filename := c.Path
+		if filename == "" {
+			continue
+		}
+
+		contentBytes, err := fileio.DecodeContent(lo.FromPtr(c.Content), c.ContentEncoding)
+		if err != nil {
+			return nil, fmt.Errorf("decoding content %q: %w", filename, err)
+		}
+
+		isBase := slices.Contains(BaseComposeFiles, filename)
+		isOverride := slices.Contains(OverrideComposeFiles, filename)
+
+		if !isBase && !isOverride {
+			continue
+		}
+
+		partial, err := common.ParseComposeSpec(contentBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing compose spec from %q: %w", filename, err)
+		}
+
+		// First match from BaseComposeFiles takes precedence
+		if isBase && !baseFound {
+			maps.Copy(spec.Services, partial.Services)
+			maps.Copy(spec.Volumes, partial.Volumes)
+			baseFound = true
+			continue
+		}
+
+		if isOverride && baseFound {
+			maps.Copy(spec.Services, partial.Services)
+			maps.Copy(spec.Volumes, partial.Volumes)
+		}
+	}
+
+	if !baseFound {
+		return nil, fmt.Errorf("%w: no base compose file found in inline spec (expected one of: %s)", errors.ErrNoComposeFile, strings.Join(BaseComposeFiles, ", "))
 	}
 
 	if len(spec.Services) == 0 {

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -241,9 +241,6 @@ func TestApplicationStatus(t *testing.T) {
 			mockExec := executer.NewMockExecuter(ctrl)
 			podman := client.NewPodman(log, mockExec, readWriter, util.NewBackoff())
 
-			appImage := "quay.io/flightctl-tests/alpine:v1"
-			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0)
-
 			spec := v1alpha1.InlineApplicationProviderSpec{
 				Inline: []v1alpha1.ApplicationContent{
 					{

--- a/internal/agent/device/applications/controller.go
+++ b/internal/agent/device/applications/controller.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
@@ -35,14 +36,29 @@ func (c *Controller) Sync(ctx context.Context, current, desired *v1alpha1.Device
 	c.log.Debug("Syncing device applications")
 	defer c.log.Debug("Finished syncing device applications")
 
-	currentAppProviders, err := provider.FromDeviceSpec(ctx, c.log, c.podman, c.readWriter, current)
+	currentAppProviders, err := provider.FromDeviceSpec(
+		ctx,
+		c.log,
+		c.podman,
+		c.readWriter,
+		current,
+		provider.WithVerify(),
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("current app providers: %w", err)
 	}
 
-	desiredAppProviders, err := provider.FromDeviceSpec(ctx, c.log, c.podman, c.readWriter, desired, provider.WithEmbedded())
+	desiredAppProviders, err := provider.FromDeviceSpec(
+		ctx,
+		c.log,
+		c.podman,
+		c.readWriter,
+		desired,
+		provider.WithVerify(),
+		provider.WithEmbedded(),
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("desired app providers: %w", err)
 	}
 
 	return syncProviders(ctx, c.log, c.manager, currentAppProviders, desiredAppProviders)

--- a/internal/agent/device/applications/controller_test.go
+++ b/internal/agent/device/applications/controller_test.go
@@ -48,11 +48,9 @@ func TestParseAppProviders(t *testing.T) {
 				imageConfig string,
 			) {
 				gomock.InOrder(
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", gomock.Any()).Return("/mount", "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 				)
 			},
 			apps: []testApp{{name: "app1", image: "quay.io/org/app1:latest"}},
@@ -69,7 +67,6 @@ func TestParseAppProviders(t *testing.T) {
 				imageConfig string,
 			) {
 				gomock.InOrder(
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 				)
 			},
@@ -86,7 +83,6 @@ func TestParseAppProviders(t *testing.T) {
 				imageConfig string,
 			) {
 				gomock.InOrder(
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 				)
 			},
@@ -101,11 +97,9 @@ func TestParseAppProviders(t *testing.T) {
 				imageConfig string,
 			) {
 				gomock.InOrder(
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", gomock.Any()).Return("/mount", "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 				)
 			},
 			apps: []testApp{{name: "", image: "quay.io/org/app1:latest"}},
@@ -131,23 +125,17 @@ func TestParseAppProviders(t *testing.T) {
 				imageConfig string,
 			) {
 				gomock.InOrder(
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", gomock.Any()).Return("/mount", "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", gomock.Any()).Return("/mount", "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).Return(imageConfig, "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", gomock.Any()).Return("/mount", "", 0),
 					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return(imageConfig, "", 0),
 				)
 			},
 			apps: []testApp{
@@ -162,7 +150,6 @@ func TestParseAppProviders(t *testing.T) {
 			wantIDPrefix: []string{"app1-", "quay_io_org_app2_latest", "app2"},
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			log := log.NewPrefixLogger("test")
@@ -194,14 +181,17 @@ func TestParseAppProviders(t *testing.T) {
 			tc.setupMocks(execMock, imageConfig)
 
 			providers, err := provider.FromDeviceSpec(ctx, log, mockPodman, readWriter, spec, provider.WithProviderTypes(v1alpha1.ImageApplicationProviderType))
-			if tc.wantErr != nil {
-				require.ErrorIs(err, tc.wantErr)
-				return
-			}
 			require.NoError(err)
 			require.Equal(len(tc.apps), len(providers))
 			// ensure name is populated
 			for i, provider := range providers {
+				// verify deps
+				err := provider.Verify(ctx)
+				if tc.wantErr != nil {
+					require.ErrorIs(err, tc.wantErr)
+					return
+				}
+				require.NoError(err)
 				require.NotEmpty(provider.Name())
 				if len(tc.wantNames) > 0 {
 					require.Equal(tc.wantNames[i], provider.Name())
@@ -317,18 +307,14 @@ func TestControllerSync(t *testing.T) {
 			) {
 				gomock.InOrder(
 					// app1
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app1Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app1Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app1Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app1Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app1Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app1Image).Return("", "", 0),
 
 					// app2
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app2Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app2Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app2Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app2Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app2Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app2Image).Return("", "", 0),
 
 					// ensure app1
 					mockAppManager.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil),
@@ -371,39 +357,28 @@ func TestControllerSync(t *testing.T) {
 				gomock.InOrder(
 					// rendered version 1 -> 2
 					// app1
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", app1Image).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app1Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app1Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app1Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app1Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app1Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app1Image).Return("", "", 0),
 
 					// app2
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", app2Image).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app2Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app2Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app2Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app2Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app2Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app2Image).Return("", "", 0),
 
 					// ensure app1
 					mockAppManager.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil),
 					// ensure app2
 					mockAppManager.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil),
-
 					// rendered version 2 -> 3
 					// app1
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", app1Image).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app1Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app1Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app1Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
-
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app1Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app1Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app1Image).Return("", "", 0),
 					// app2
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", app2Image).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", app2Image}).Return(app1Labels, "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", app2Image}).Return("/mount", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", app2Image}).Return("", "", 0),
-					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "exists", gomock.Any()).Return("", "", 0),
-
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", app2Image).Return(app1Labels, "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "unshare", "podman", "image", "mount", app2Image).Return("/mount", "", 0),
+					mockExecuter.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "image", "unmount", app2Image).Return("", "", 0),
 					// remove app1
 					mockAppManager.EXPECT().Remove(gomock.Any(), gomock.Any()).Return(nil),
 					// remove app2

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -463,6 +464,10 @@ func (m *mockProvider) Spec() *provider.ApplicationSpec {
 		Name:   m.name,
 		Volume: volManager,
 	}
+}
+
+func (m *mockProvider) OCITargets(pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+	return nil, nil
 }
 
 func (m *mockProvider) Verify(ctx context.Context) error {

--- a/internal/agent/device/applications/provider/image_test.go
+++ b/internal/agent/device/applications/provider/image_test.go
@@ -42,7 +42,6 @@ func TestImageProvider(t *testing.T) {
 			composeSpec: util.NewComposeSpec(),
 			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
 				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
 				)
 			},
@@ -60,7 +59,6 @@ func TestImageProvider(t *testing.T) {
 			composeSpec: util.NewComposeSpec(),
 			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
 				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
 				)
 			},
@@ -81,12 +79,10 @@ func TestImageProvider(t *testing.T) {
 			composeSpec: util.NewComposeSpec(),
 			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
 				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
 
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
 				)
@@ -124,7 +120,6 @@ services:
     image: quay.io/flightctl-tests/alpine:v1`,
 			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
 				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),
@@ -146,7 +141,6 @@ services:
 image: quay.io/flightctl-tests/alpine:v1`,
 			setupMocks: func(mockExec *executer.MockExecuter, appLabels string) {
 				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"inspect", appImage}).Return(appLabels, "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"unshare", "podman", "image", "mount", appImage}).Return("/mount", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "unmount", appImage}).Return("", "", 0),

--- a/internal/agent/device/applications/provider/inline_test.go
+++ b/internal/agent/device/applications/provider/inline_test.go
@@ -26,7 +26,6 @@ func TestInlineProvider(t *testing.T) {
 		image         string
 		spec          *v1alpha1.ApplicationProviderSpec
 		content       []v1alpha1.ApplicationContent
-		setupMocks    func(*executer.MockExecuter)
 		wantVerifyErr error
 	}{
 		{
@@ -46,11 +45,6 @@ func TestInlineProvider(t *testing.T) {
 					Path:    "docker-compose.yml",
 				},
 			},
-			setupMocks: func(mockExec *executer.MockExecuter) {
-				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", appImage}).Return("", "", 0),
-				)
-			},
 		},
 		{
 			name:  "invalid compose path",
@@ -64,9 +58,6 @@ func TestInlineProvider(t *testing.T) {
 					Content: lo.ToPtr(util.NewComposeSpec()),
 					Path:    "invalid-compose.yml",
 				},
-			},
-			setupMocks: func(mockExec *executer.MockExecuter) {
-				gomock.InOrder()
 			},
 			wantVerifyErr: errors.ErrNoComposeFile,
 		},
@@ -86,9 +77,6 @@ func TestInlineProvider(t *testing.T) {
 					Path:    "docker-compose.yml",
 				},
 			},
-			setupMocks: func(mockExec *executer.MockExecuter) {
-				gomock.InOrder()
-			},
 			wantVerifyErr: errors.ErrInvalidSpec,
 		},
 		{
@@ -107,11 +95,6 @@ func TestInlineProvider(t *testing.T) {
 					Content: lo.ToPtr(util.NewComposeSpec("docker.io/override:latest")),
 					Path:    "podman-compose.override.yml",
 				},
-			},
-			setupMocks: func(mockExec *executer.MockExecuter) {
-				gomock.InOrder(
-					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"image", "exists", "docker.io/override:latest"}).Return("", "", 0),
-				)
 			},
 		},
 	}
@@ -140,7 +123,6 @@ func TestInlineProvider(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			tt.setupMocks(mockExec)
 			err = inlineProvider.Verify(ctx)
 			if tt.wantVerifyErr != nil {
 				require.Error(err)

--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -1,0 +1,20 @@
+package dependency
+
+import (
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+)
+
+type OCIType string
+
+const (
+	OCITypeImage    OCIType = "Image"
+	OCITypeArtifact OCIType = "Artifact"
+)
+
+type OCIPullTarget struct {
+	Type       OCIType
+	Reference  string
+	PullPolicy v1alpha1.ImagePullPolicy
+	PullSecret *client.PullSecret
+}


### PR DESCRIPTION
This PR sets the foundation for the followup PR which adds an aync OCI prefetch manager. The goal with this PR is to improve stability during times when auth required for OS or Applications is actually embedded in the inline config spec. In this case we will use the inline auth as long as the on disk auth does not exist of has different content.

tested manually

```
apiVersion: v1alpha1
kind: Fleet
metadata:
  name: default
spec:
  selector:
    matchLabels:
      fleet: default
  template:
    metadata:
      labels:
        fleet: default
    spec:
      os:
        image: quay.io/private/image:base
      applications: []
      config:
      - inline:
        - content: |-
            {
              "auths": {
                "quay.io": {
                  "auth": "c2Jhd",
                  "email": "my@auth.com"
                }
              }
            }
          path: /etc/ostree/auth.json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of container image pull secrets, supporting both inline and file-based secrets with automatic cleanup of temporary files.
  * Enhanced application update process to pull OCI images and artifacts based on provider dependencies and pull policies.
  * Added parsing and merging of Compose specifications from inline application content.
  * Introduced a unified interface for application providers to declare OCI dependencies.
  * Added functionality to write temporary files with cleanup support.

* **Bug Fixes**
  * Improved reliability in resolving and using pull secrets for image pulls.

* **Tests**
  * Added comprehensive unit tests for pull secret resolution and OCI dependency extraction.
  * Updated and streamlined application provider and manager tests for new image pulling logic.
  * Removed redundant mock expectations related to image existence checks in tests.

* **Refactor**
  * Simplified and consolidated image and artifact pulling logic across the application lifecycle.
  * Removed direct image existence checks and volume content ensuring from provider verification steps.
  * Shifted provider verification to an optional bulk step after creation.
  * Cleaned up test mocks by eliminating redundant image existence checks.
  * Updated application provider verification and error handling for improved clarity and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->