### PR TITLE
EDM-1783: Keep rpms on github, because corp removes them after 14 days

### DIFF
--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -270,7 +270,7 @@ jobs:
   gpgcheck=0
   repo_gpgcheck=0
   type=rpm
-          EOF
+  EOF
           echo "Created .repo file:"
           cat rpm-repo/flightctl.repo
           echo "=============================="


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an automated workflow to update the RPM repository on GitHub Pages, including package downloads, metadata generation, and repository updates.
  * Repository README now includes usage instructions, package count, last update timestamp, and source build information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->