### PR TITLE
EDM-1659: Minimize the e2e test set executed under the sanity label

### DIFF
--- a/test/e2e/agent/agent_application_test.go
+++ b/test/e2e/agent/agent_application_test.go
@@ -172,7 +172,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 
 		})
 
-		It("should install an inline compose application and manage its lifecycle with env vars", Label("80990", "sanity"), func() {
+		It("should install an inline compose application and manage its lifecycle with env vars", Label("80990"), func() {
 			By("Creating the first application")
 			newRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
@@ -288,7 +288,7 @@ var _ = Describe("VM Agent behaviour during the application lifecycle", func() {
 			}, TIMEOUT).Should(Equal(envVarValue))
 		})
 
-		It("Agent pre-update validations should fail the version, and trigger the rollback for various invalid configurations", Label("80998", "sanity"), func() {
+		It("Agent pre-update validations should fail the version, and trigger the rollback for various invalid configurations", Label("80998"), func() {
 			By("Create initial application")
 			initialRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -35,7 +35,7 @@ var _ = Describe("VM Agent behavior", func() {
 	})
 
 	Context("vm", func() {
-		It("Verify VM agent", Label("80455", "sanity"), func() {
+		It("Verify VM agent", Label("80455"), func() {
 			By("should print QR output to console")
 			// Wait for the top-most part of the QR output to appear
 			Eventually(harness.VM.GetConsoleOutput, TIMEOUT, POLLING).Should(ContainSubstring("████████████████████████████████"))
@@ -51,7 +51,7 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(stdout.String()).To(ContainSubstring("Active: active (running)"))
 		})
 
-		It("Verifying generation of enrollment request link", Label("75518", "sanity"), func() {
+		It("Verifying generation of enrollment request link", Label("75518"), func() {
 			By("should be reporting device status on enrollment request")
 			// Get the enrollment Request ID from the console output
 			enrollmentID := harness.GetEnrollmentIDFromConsole()
@@ -71,7 +71,7 @@ var _ = Describe("VM Agent behavior", func() {
 			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
 				enrollmentID).ShouldNot(BeNil())
 		})
-		It("Should report a message when a device is assigned to multiple fleets", Label("75992", "sanity"), func() {
+		It("Should report a message when a device is assigned to multiple fleets", Label("75992"), func() {
 			const (
 				fleet1Name  = "fleet1"
 				fleet2Name  = "fleet2"

--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -33,7 +33,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 	})
 
 	Context("updates", func() {
-		It("should update to the requested image", Label("75523", "sanity"), func() {
+		It("should update to the requested image", Label("75523"), func() {
 			By("Verifying update to agent  with requested image")
 			device, newImageReference := harness.WaitForBootstrapAndUpdateToVersion(deviceId, ":v2")
 
@@ -161,7 +161,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 
 			logrus.Info("Went back to base image and checked that there is no application now👌")
 		})
-		It("Should resolve to the latest version when multiple updates are applied", Label("77672", "sanity"), func() {
+		It("Should resolve to the latest version when multiple updates are applied", Label("77672"), func() {
 			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceId)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -71,7 +71,7 @@ var _ = Describe("CLI - device console", Serial, func() {
 		cs2.Close()
 	})
 
-	It("keeps console sessions open during a device update", Label("81786", "sanity"), func() {
+	It("keeps console sessions open during a device update", Label("81786"), func() {
 		const sessionsToOpen = 4
 		const expectedRenderedVersion = 2 + sessionsToOpen*2
 
@@ -112,7 +112,7 @@ var _ = Describe("CLI - device console", Serial, func() {
 		Expect(out).To(ContainSubstring("not found"))
 	})
 
-	It("allows tuning spec-fetch-interval", Label("82538", "sanity"), func() {
+	It("allows tuning spec-fetch-interval", Label("82538"), func() {
 		const (
 			cfgFile              = "/etc/flightctl/config.yaml"
 			specFetchKey         = "spec-fetch-interval"
@@ -161,7 +161,7 @@ var _ = Describe("CLI - device console", Serial, func() {
 		}, 2*time.Minute, 10*time.Second).Should(BeTrue())
 	})
 
-	It("recovers from image pull network disruption", Label("82541", "sanity"), func() {
+	It("recovers from image pull network disruption", Label("82541"), func() {
 		const disruptionTime = 1 * time.Minute
 		_, _ = harness.WaitForBootstrapAndUpdateToVersion(deviceID, ":v4")
 
@@ -194,7 +194,7 @@ var _ = Describe("CLI - device console", Serial, func() {
 			Should(WithTransform((*v1alpha1.Device).IsUpdatedToDeviceSpec, BeTrue()))
 	})
 
-	It("recovers from image pull network connection error", Label("83029", "sanity"), func() {
+	It("recovers from image pull network connection error", Label("83029"), func() {
 		logrus.Infof("Simulating network failure")
 		err := harness.SimulateNetworkFailure()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -92,7 +92,7 @@ var _ = Describe("cli operation", func() {
 	})
 
 	Context("Plural names for resources and autocompletion in the cli work well", func() {
-		It("Should let you list resources by plural names", Label("80453", "sanity"), func() {
+		It("Should let you list resources by plural names", Label("80453"), func() {
 			deviceID := harness.StartVMAndEnroll()
 			By("Should let you list devices")
 			out, err := harness.CLI("get", "devices")

--- a/test/e2e/parametrisable_templates/parametrisable_templates_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 	Context("parametrisable_templates", func() {
 		It(`Verifies that Flightctl fleet resource supports parametrisable device
 		    templates to configure items that are specific to an individual device
-			or a group of devices selected by labels`, Label("75486", "sanity"), func() {
+			or a group of devices selected by labels`, Label("75486"), func() {
 
 			By("Create a fleet with template variables in InlineConfigProviderSpec")
 			err := configProviderSpec.FromInlineConfigProviderSpec(inlineConfigValidWithFunction)


### PR DESCRIPTION
Narrowing down the the e2e sanity test set to improve the pre-PR check duration. 
The full suite continues to run daily in QE CI and remains available for local execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed the "sanity" label from multiple end-to-end test cases across agent, CLI, and parametrisable templates test suites. Test logic and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->