### PR TITLE
EDM-1800: agent: implement new poll backoff for podman and queue 

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -103,7 +103,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: this needs tuned
+	// TODO: replace wait with poll
 	backoff := wait.Backoff{
 		Cap:      1 * time.Minute,
 		Duration: 10 * time.Second,
@@ -112,9 +112,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	pollBackoff := poll.Config{
+		MaxDelay:  1 * time.Minute,
 		BaseDelay: 10 * time.Second,
 		Factor:    1.5,
-		MaxDelay:  1 * time.Minute,
+		MaxSteps:  6,
 	}
 
 	// create os client

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -110,6 +110,15 @@ func (a *Agent) Run(ctx context.Context) error {
 		Steps:    6,
 	}
 
+<<<<<<< HEAD
+=======
+	pollBackoff := poll.Config{
+		BaseDelay: 10 * time.Second,
+		Factor:    1.5,
+		MaxDelay:  1 * time.Minute,
+	}
+
+>>>>>>> 5d370239 (impl)
 	// create os client
 	osClient := os.NewClient(a.log, executer)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/flightctl/flightctl/internal/experimental"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -110,20 +111,17 @@ func (a *Agent) Run(ctx context.Context) error {
 		Steps:    6,
 	}
 
-<<<<<<< HEAD
-=======
 	pollBackoff := poll.Config{
 		BaseDelay: 10 * time.Second,
 		Factor:    1.5,
 		MaxDelay:  1 * time.Minute,
 	}
 
->>>>>>> 5d370239 (impl)
 	// create os client
 	osClient := os.NewClient(a.log, executer)
 
 	// create podman client
-	podmanClient := client.NewPodman(a.log, executer, deviceReadWriter, backoff)
+	podmanClient := client.NewPodman(a.log, executer, deviceReadWriter, pollBackoff)
 
 	// create systemd client
 	systemdClient := client.NewSystemd(executer)

--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -25,6 +25,7 @@ const (
 	ComposeOverrideFilename      = "99-compose-flightctl-agent.override.yaml"
 	ComposeDockerProjectLabelKey = "com.docker.compose.project"
 	defaultPodmanTimeout         = 10 * time.Minute
+	defaultPodmanMaxRetryTimeout = 60 * time.Minute
 )
 
 var (

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -599,7 +599,7 @@ func SanitizePodmanLabel(name string) string {
 
 func retryWithBackoff(ctx context.Context, log *log.PrefixLogger, backoff poll.Config, operation func(context.Context) (string, error)) (string, error) {
 	var result string
-	err := poll.BackoffWithContext(ctx, backoff, defaultPodmanTimeout, func(ctx context.Context) (bool, error) {
+	err := poll.BackoffWithContext(ctx, backoff, defaultPodmanMaxRetryTimeout, func(ctx context.Context) (bool, error) {
 		var err error
 		result, err = operation(ctx)
 		if err != nil {

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -66,10 +66,17 @@ type Podman struct {
 	log        *log.PrefixLogger
 	timeout    time.Duration
 	readWriter fileio.ReadWriter
+<<<<<<< HEAD
 	backoff    wait.Backoff
 }
 
 func NewPodman(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter, backoff wait.Backoff) *Podman {
+=======
+	backoff    poll.Config
+}
+
+func NewPodman(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter, backoff poll.Config) *Podman {
+>>>>>>> 5d370239 (impl)
 	return &Podman{
 		log:        log,
 		exec:       exec,
@@ -596,9 +603,15 @@ func SanitizePodmanLabel(name string) string {
 	return result.String()
 }
 
+<<<<<<< HEAD
 func retryWithBackoff(ctx context.Context, log *log.PrefixLogger, backoff wait.Backoff, operation func(context.Context) (string, error)) (string, error) {
 	var result string
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+=======
+func retryWithBackoff(ctx context.Context, log *log.PrefixLogger, backoff poll.Config, operation func(context.Context) (string, error)) (string, error) {
+	var result string
+	err := poll.BackoffWithContext(ctx, backoff, defaultPodmanTimeout, func(ctx context.Context) (bool, error) {
+>>>>>>> 5d370239 (impl)
 		var err error
 		result, err = operation(ctx)
 		if err != nil {

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -15,7 +15,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/flightctl/flightctl/pkg/poll"
 )
 
 const (
@@ -62,21 +62,15 @@ type PodmanEvent struct {
 }
 
 type Podman struct {
-	exec       executer.Executer
-	log        *log.PrefixLogger
+	exec executer.Executer
+	log  *log.PrefixLogger
+	// timeout per client call
 	timeout    time.Duration
 	readWriter fileio.ReadWriter
-<<<<<<< HEAD
-	backoff    wait.Backoff
-}
-
-func NewPodman(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter, backoff wait.Backoff) *Podman {
-=======
 	backoff    poll.Config
 }
 
 func NewPodman(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter, backoff poll.Config) *Podman {
->>>>>>> 5d370239 (impl)
 	return &Podman{
 		log:        log,
 		exec:       exec,
@@ -603,15 +597,9 @@ func SanitizePodmanLabel(name string) string {
 	return result.String()
 }
 
-<<<<<<< HEAD
-func retryWithBackoff(ctx context.Context, log *log.PrefixLogger, backoff wait.Backoff, operation func(context.Context) (string, error)) (string, error) {
-	var result string
-	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-=======
 func retryWithBackoff(ctx context.Context, log *log.PrefixLogger, backoff poll.Config, operation func(context.Context) (string, error)) (string, error) {
 	var result string
 	err := poll.BackoffWithContext(ctx, backoff, defaultPodmanTimeout, func(ctx context.Context) (bool, error) {
->>>>>>> 5d370239 (impl)
 		var err error
 		result, err = operation(ctx)
 		if err != nil {

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -239,7 +239,7 @@ func TestApplicationStatus(t *testing.T) {
 			readWriter.SetRootdir(tmpDir)
 
 			mockExec := executer.NewMockExecuter(ctrl)
-			podman := client.NewPodman(log, mockExec, readWriter, util.NewBackoff())
+			podman := client.NewPodman(log, mockExec, readWriter, util.NewPollConfig())
 
 			spec := v1alpha1.InlineApplicationProviderSpec{
 				Inline: []v1alpha1.ApplicationContent{

--- a/internal/agent/device/applications/controller_test.go
+++ b/internal/agent/device/applications/controller_test.go
@@ -176,7 +176,7 @@ func TestParseAppProviders(t *testing.T) {
 
 			imageConfig, err := newImageConfig(tc.labels)
 			require.NoError(err)
-			mockPodman := client.NewPodman(log, execMock, readWriter, util.NewBackoff())
+			mockPodman := client.NewPodman(log, execMock, readWriter, util.NewPollConfig())
 
 			tc.setupMocks(execMock, imageConfig)
 
@@ -402,7 +402,7 @@ func TestControllerSync(t *testing.T) {
 			defer ctrl.Finish()
 			mockExecuter := executer.NewMockExecuter(ctrl)
 			mockAppManager := NewMockManager(ctrl)
-			podmanClient := client.NewPodman(log, mockExecuter, readWriter, util.NewBackoff())
+			podmanClient := client.NewPodman(log, mockExecuter, readWriter, util.NewPollConfig())
 
 			controller := NewController(podmanClient, mockAppManager, readWriter, log)
 

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -121,7 +121,7 @@ func TestManager(t *testing.T) {
 
 			mockReadWriter := fileio.NewMockReadWriter(ctrl)
 			mockExec := executer.NewMockExecuter(ctrl)
-			mockPodmanClient := client.NewPodman(log, mockExec, mockReadWriter, util.NewBackoff())
+			mockPodmanClient := client.NewPodman(log, mockExec, mockReadWriter, util.NewPollConfig())
 
 			tmpDir := t.TempDir()
 			readWriter.SetRootdir(tmpDir)
@@ -262,7 +262,7 @@ func TestBeforeUpdate(t *testing.T) {
 			rw.SetRootdir(tmpDir)
 
 			mockExec := executer.NewMockExecuter(ctrl)
-			podmanClient := client.NewPodman(log, mockExec, rw, util.NewBackoff())
+			podmanClient := client.NewPodman(log, mockExec, rw, util.NewPollConfig())
 
 			manager := &manager{
 				readWriter:    rw,

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -207,7 +207,7 @@ func TestListenForEvents(t *testing.T) {
 			inspectBytes, err := json.Marshal(testInspect)
 			require.NoError(err)
 
-			podman := client.NewPodman(log, execMock, rw, util.NewBackoff())
+			podman := client.NewPodman(log, execMock, rw, util.NewPollConfig())
 			podmanMonitor := NewPodmanMonitor(log, podman, "", rw)
 
 			// add test apps to the monitor
@@ -354,7 +354,7 @@ func TestApplicationAddRemove(t *testing.T) {
 			readWriter.SetRootdir(tmpDir)
 			execMock := executer.NewMockExecuter(ctrl)
 
-			podman := client.NewPodman(log, execMock, readWriter, util.NewBackoff())
+			podman := client.NewPodman(log, execMock, readWriter, util.NewPollConfig())
 			podmanMonitor := NewPodmanMonitor(log, podman, "", readWriter)
 			testApp := createTestApplication(require, tc.appName, v1alpha1.ApplicationStatusPreparing)
 

--- a/internal/agent/device/applications/provider/image_test.go
+++ b/internal/agent/device/applications/provider/image_test.go
@@ -165,7 +165,7 @@ image: quay.io/flightctl-tests/alpine:v1`,
 			require.NoError(err)
 			err = rw.WriteFile("/mount/podman-compose.yaml", []byte(tt.composeSpec), fileio.DefaultFilePermissions)
 			require.NoError(err)
-			podman := client.NewPodman(log, mockExec, rw, util.NewBackoff())
+			podman := client.NewPodman(log, mockExec, rw, util.NewPollConfig())
 
 			spec := v1alpha1.ImageApplicationProviderSpec{
 				Image: tt.image,

--- a/internal/agent/device/applications/provider/inline_test.go
+++ b/internal/agent/device/applications/provider/inline_test.go
@@ -109,7 +109,7 @@ func TestInlineProvider(t *testing.T) {
 			tmpDir := t.TempDir()
 			rw := fileio.NewReadWriter()
 			rw.SetRootdir(tmpDir)
-			podman := client.NewPodman(log, mockExec, rw, util.NewBackoff())
+			podman := client.NewPodman(log, mockExec, rw, util.NewPollConfig())
 
 			spec := v1alpha1.InlineApplicationProviderSpec{
 				Inline: tt.content,

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/test/util"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestInitialization(t *testing.T) {
@@ -159,7 +159,7 @@ func TestInitialization(t *testing.T) {
 			mockExecutor := executer.NewMockExecuter(ctrl)
 
 			log := log.NewPrefixLogger("test")
-			podmanClient := client.NewPodman(log, mockExecutor, mockReadWriter, wait.Backoff{})
+			podmanClient := client.NewPodman(log, mockExecutor, mockReadWriter, util.NewPollConfig())
 
 			b := &Bootstrap{
 				statusManager:           mockStatusManager,

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/systeminfo"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/test/util"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestSync(t *testing.T) {
@@ -185,11 +185,8 @@ func TestSync(t *testing.T) {
 			tmpDir := t.TempDir()
 			readWriter := fileio.NewReadWriter()
 			readWriter.SetRootdir(tmpDir)
-			backoff := wait.Backoff{
-				Steps: 1,
-			}
 
-			podmanClient := client.NewPodman(log, mockExec, readWriter, backoff)
+			podmanClient := client.NewPodman(log, mockExec, readWriter, util.NewPollConfig())
 			consoleController := console.NewController(mockRouterService, deviceName, mockExec, publisher.NewSubscription(), log)
 			appController := applications.NewController(podmanClient, mockAppManager, readWriter, log)
 			statusManager := status.NewManager(deviceName, log)

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/flightctl/flightctl/pkg/poll"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -102,6 +103,8 @@ func IsRetryable(err error) bool {
 		// this is a retryable error because it means the bootc status did not
 		// return valid JSON. this is a bug in the bootc status and we should
 		// retry the request as the error is transient.
+		return true
+	case errors.Is(err, poll.ErrMaxSteps):
 		return true
 	case errors.Is(err, ErrNoRetry):
 		return false

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -49,8 +49,7 @@ func NewManager(
 	queue := newPriorityQueue(
 		defaultSpecQueueMaxSize,
 		defaultSpecRequeueMaxRetries,
-		defaultSpecRequeueThreshold,
-		defaultSpecRequeueDelay,
+		defaultSpecPollConfig,
 		policyManager,
 		log,
 	)

--- a/internal/agent/device/spec/queue.go
+++ b/internal/agent/device/spec/queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/policy"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
 )
 
 // requeueState represents the state of a queued template version.
@@ -37,12 +38,8 @@ type queueManager struct {
 	// maxRetries is the number of times a template version can be requeued before being removed.
 	// A value of 0 means infinite retries.
 	maxRetries int
-	// delayThreshold is the number of times a template version can be requeued before enforcing a delay.
-	// A value of 0 means this is disabled.
-	delayThreshold int
-	// delayDuration is the duration to wait before the item is
-	// available to be retrieved form the queue.
-	delayDuration time.Duration
+	// pollConfig contains the backoff configuration for retries
+	pollConfig poll.Config
 
 	log *log.PrefixLogger
 }
@@ -51,8 +48,7 @@ type queueManager struct {
 func newPriorityQueue(
 	maxSize int,
 	maxRetries int,
-	delayThreshold int,
-	delayDuration time.Duration,
+	pollConfig poll.Config,
 	policyManager policy.Manager,
 	log *log.PrefixLogger,
 ) PriorityQueue {
@@ -62,8 +58,7 @@ func newPriorityQueue(
 		failedVersions: make(map[int64]struct{}),
 		requeueLookup:  make(map[int64]*requeueState),
 		maxRetries:     maxRetries,
-		delayThreshold: delayThreshold,
-		delayDuration:  delayDuration,
+		pollConfig:     pollConfig,
 		log:            log,
 	}
 }
@@ -205,15 +200,22 @@ func (m *queueManager) getOrCreateRequeueState(ctx context.Context, version int6
 }
 
 func (m *queueManager) shouldEnforceDelay(state *requeueState) bool {
-	if m.delayThreshold <= 0 || !m.queue.IsEmpty() || state.tries == 0 {
+	if !m.queue.IsEmpty() || state.tries == 0 {
 		return false
 	}
-	if state.tries >= m.delayThreshold && state.nextAvailable.IsZero() {
-		state.nextAvailable = time.Now().Add(m.delayDuration)
-		m.log.Debugf("Delay enforced until: %s", state.nextAvailable)
+
+	if state.nextAvailable.IsZero() {
+		// incremental delay based on tries
+		delay := m.calculateBackoffDelay(state.tries)
+		state.nextAvailable = time.Now().Add(delay)
+		m.log.Debugf("Incremental delay enforced for version: %d: until: %s", state.version, state.nextAvailable.Format(time.RFC3339))
 		return true
 	}
 	return false
+}
+
+func (m *queueManager) calculateBackoffDelay(tries int) time.Duration {
+	return poll.CalculateBackoffDelay(&m.pollConfig, tries)
 }
 
 func (m *queueManager) hasExceededMaxRetries(state *requeueState, version int64) bool {
@@ -224,9 +226,9 @@ func (m *queueManager) hasExceededMaxRetries(state *requeueState, version int64)
 	return false
 }
 
-// updatePolicy calls into the policyManager to check if the policys have been
+// updatePolicy calls into the policyManager to check if the policy have been
 // satisfied since the last call an updates accordingly returns true if the
-// polciy has changed.
+// policy has changed.
 func (m *queueManager) updatePolicy(ctx context.Context, requeue *requeueState) bool {
 	changed := false
 	if !requeue.downloadPolicySatisfied {

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/policy"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
 	"github.com/samber/lo"
 )
 
@@ -22,11 +23,14 @@ const (
 	defaultSpecRequeueMaxRetries = 0
 	// defaultSpecQueueMaxSize is the default maximum number of items in the queue.
 	defaultSpecQueueMaxSize = 1
-	// defaultSpecRequeueThreshold is the default number of retries before enforcing a requeue delay.
-	defaultSpecRequeueThreshold = 5
-	// defaultSpecRequeueDelay is the default delay between requeue attempts.
-	defaultSpecRequeueDelay = 5 * time.Minute
 )
+
+// defaultSpecPollConfig is the default poll configuration for the spec priority queue.
+var defaultSpecPollConfig = poll.Config{
+	BaseDelay: 30 * time.Second,
+	Factor:    1.5,
+	MaxDelay:  5 * time.Minute,
+}
 
 type Manager interface {
 	// Initialize initializes the current, desired and rollback device files on

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -119,8 +119,7 @@ func TestInitialize(t *testing.T) {
 	queue := newPriorityQueue(
 		defaultSpecQueueMaxSize,
 		defaultSpecRequeueMaxRetries,
-		defaultSpecRequeueThreshold,
-		defaultSpecRequeueDelay,
+		defaultSpecPollConfig,
 		mockPolicyManager,
 		log,
 	)
@@ -777,8 +776,7 @@ func TestRollback(t *testing.T) {
 			queue := newPriorityQueue(
 				defaultSpecQueueMaxSize,
 				defaultSpecRequeueMaxRetries,
-				defaultSpecRequeueThreshold,
-				defaultSpecRequeueDelay,
+				defaultSpecPollConfig,
 				mockPolicyManager,
 				log,
 			)

--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -11,6 +11,7 @@ var (
 	ErrInvalidBaseDelay = errors.New("BaseDelay must be greater than 0")
 	ErrInvalidTimeout   = errors.New("timeout must be greater than 0")
 	ErrTimeout          = errors.New("operation timed out")
+	ErrMaxSteps         = errors.New("max retry steps exceeded")
 )
 
 // Config defines parameters for exponential backoff polling.
@@ -21,32 +22,55 @@ type Config struct {
 	Factor float64
 	// Optional maximum delay between retries
 	MaxDelay time.Duration
+	// MaxSteps limits the number of retries. If 0, retries will continue until timeout.
+	MaxSteps int
+}
+
+// Validate checks if the configuration parameters are valid
+func (c *Config) Validate() error {
+	if c.BaseDelay <= 0 {
+		return ErrInvalidBaseDelay
+	}
+	if c.Factor <= 0 {
+		return errors.New("poll Factor must be greater than 0")
+	}
+	if c.MaxDelay > 0 && c.MaxDelay < c.BaseDelay {
+		return errors.New("poll MaxDelay must be greater than or equal to BaseDelay")
+	}
+	return nil
 }
 
 // BackoffWithContext repeatedly calls the operation until timeout is reached,
 // it returns true, an error, or the context is canceled. It waits between
 // attempts using exponential backoff, starting from Config.BaseDelay and
 // increasing by Config.Factor, capped by Config.MaxDelay if set.
-func BackoffWithContext(ctx context.Context, cfg *Config, timeout time.Duration, opFn func(context.Context) (bool, error)) error {
+func BackoffWithContext(ctx context.Context, cfg Config, timeout time.Duration, opFn func(context.Context) (bool, error)) error {
 	if timeout <= 0 {
 		return ErrInvalidTimeout
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	delay := cfg.BaseDelay
-	if delay <= 0 {
-		return fmt.Errorf("invalid Config: %w", ErrInvalidBaseDelay)
-	}
-
+	attempts := 0
 	for {
+
 		done, err := opFn(ctx)
 		if err != nil {
 			return err
 		}
 		if done {
 			return nil
+		}
+
+		attempts++
+		if cfg.MaxSteps > 0 && attempts >= cfg.MaxSteps {
+			return fmt.Errorf("%w: %d", ErrMaxSteps, cfg.MaxSteps)
 		}
 
 		select {
@@ -69,9 +93,18 @@ func CalculateBackoffDelay(cfg *Config, tries int) time.Duration {
 		return 0
 	}
 
+	// maxDurationFloat is the largest valid time.Duration value as a float64.
+	// used to prevent overflow when computing exponential delays.
+	const maxDurationFloat = float64(time.Duration(1<<63 - 1))
+
 	delay := float64(cfg.BaseDelay)
 	for i := 1; i < tries; i++ {
-		delay *= cfg.Factor
+		next := delay * cfg.Factor
+		if next > maxDurationFloat {
+			delay = maxDurationFloat
+			break
+		}
+		delay = next
 	}
 
 	delayDuration := time.Duration(delay)

--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -1,0 +1,85 @@
+package poll
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	ErrInvalidBaseDelay = errors.New("BaseDelay must be greater than 0")
+	ErrInvalidTimeout   = errors.New("timeout must be greater than 0")
+	ErrTimeout          = errors.New("operation timed out")
+)
+
+// Config defines parameters for exponential backoff polling.
+type Config struct {
+	// Initial delay before first retry
+	BaseDelay time.Duration
+	// Multiplier for delay on each retry
+	Factor float64
+	// Optional maximum delay between retries
+	MaxDelay time.Duration
+}
+
+// BackoffWithContext repeatedly calls the operation until timeout is reached,
+// it returns true, an error, or the context is canceled. It waits between
+// attempts using exponential backoff, starting from Config.BaseDelay and
+// increasing by Config.Factor, capped by Config.MaxDelay if set.
+func BackoffWithContext(ctx context.Context, cfg *Config, timeout time.Duration, opFn func(context.Context) (bool, error)) error {
+	if timeout <= 0 {
+		return ErrInvalidTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	delay := cfg.BaseDelay
+	if delay <= 0 {
+		return fmt.Errorf("invalid Config: %w", ErrInvalidBaseDelay)
+	}
+
+	for {
+		done, err := opFn(ctx)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		select {
+		case <-time.After(delay):
+			next := time.Duration(float64(delay) * cfg.Factor)
+			if cfg.MaxDelay > 0 && next > cfg.MaxDelay {
+				next = cfg.MaxDelay
+			}
+			delay = next
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// CalculateBackoffDelay calculates the backoff delay for a given number of tries
+// using exponential backoff with the provided configuration.
+func CalculateBackoffDelay(cfg *Config, tries int) time.Duration {
+	if tries <= 0 {
+		return 0
+	}
+
+	delay := float64(cfg.BaseDelay)
+	for i := 1; i < tries; i++ {
+		delay *= cfg.Factor
+	}
+
+	delayDuration := time.Duration(delay)
+
+	// cap max delay
+	if cfg.MaxDelay > 0 && delayDuration > cfg.MaxDelay {
+		delayDuration = cfg.MaxDelay
+	}
+
+	return delayDuration
+}

--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -10,8 +10,7 @@ import (
 var (
 	ErrInvalidBaseDelay = errors.New("BaseDelay must be greater than 0")
 	ErrInvalidTimeout   = errors.New("timeout must be greater than 0")
-	ErrTimeout          = errors.New("operation timed out")
-	ErrMaxSteps         = errors.New("max retry steps exceeded")
+	ErrMaxSteps         = errors.New("max poll retry steps exceeded")
 )
 
 // Config defines parameters for exponential backoff polling.

--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -1,0 +1,130 @@
+package poll
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffWithContext(t *testing.T) {
+	require := require.New(t)
+	opErr := errors.New("fatal op error")
+
+	type testCase struct {
+		name       string
+		ctxTimeout time.Duration
+		config     *Config
+		timeout    time.Duration
+		operation  func() func(context.Context) (bool, error)
+		expectErr  error
+	}
+
+	tests := []testCase{
+		{
+			name:       "immediate success",
+			ctxTimeout: 1 * time.Second,
+			config:     &Config{BaseDelay: 10 * time.Millisecond, Factor: 2},
+			timeout:    5 * time.Second,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return true, nil
+				}
+			},
+			expectErr: nil,
+		},
+		{
+			name:       "succeeds after retries",
+			ctxTimeout: 500 * time.Millisecond,
+			config:     &Config{BaseDelay: 10 * time.Millisecond, Factor: 2},
+			timeout:    5 * time.Second,
+			operation: func() func(context.Context) (bool, error) {
+				attempts := 0
+				return func(context.Context) (bool, error) {
+					attempts++
+					if attempts >= 3 {
+						return true, nil
+					}
+					return false, nil
+				}
+			},
+			expectErr: nil,
+		},
+		{
+			name:       "fails with permanent error",
+			ctxTimeout: 1 * time.Second,
+			config:     &Config{BaseDelay: 10 * time.Millisecond, Factor: 2},
+			timeout:    5 * time.Second,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, opErr
+				}
+			},
+			expectErr: opErr,
+		},
+		{
+			name:       "context timeout cancels retries",
+			ctxTimeout: 50 * time.Millisecond,
+			config:     &Config{BaseDelay: 30 * time.Millisecond, Factor: 2},
+			timeout:    5 * time.Second,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: context.DeadlineExceeded,
+		},
+		{
+			name:       "invalid base delay",
+			ctxTimeout: 50 * time.Millisecond,
+			config:     &Config{BaseDelay: 0, Factor: 2},
+			timeout:    5 * time.Second,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: ErrInvalidBaseDelay,
+		},
+		{
+			name:       "invalid timeout",
+			ctxTimeout: 50 * time.Millisecond,
+			config:     &Config{Factor: 2},
+			timeout:    0,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: ErrInvalidTimeout,
+		},
+		{
+			name:       "respects timeout",
+			ctxTimeout: 5 * time.Second, // parent should not interfere
+			config:     &Config{BaseDelay: 30 * time.Millisecond, Factor: 2},
+			timeout:    100 * time.Millisecond,
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tt.ctxTimeout)
+			defer cancel()
+
+			err := BackoffWithContext(ctx, tt.config, tt.timeout, tt.operation())
+			if tt.expectErr != nil {
+				require.ErrorIs(err, tt.expectErr)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/poll"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -237,6 +239,14 @@ func CreateTestResourceSyncs(ctx context.Context, numResourceSyncs int, storeIns
 func NewBackoff() wait.Backoff {
 	return wait.Backoff{
 		Steps: 1,
+	}
+}
+
+func NewPollConfig() poll.Config {
+	return poll.Config{
+		BaseDelay: 1 * time.Millisecond,
+		Factor:    1.0,
+		MaxDelay:  1 * time.Millisecond,
 	}
 }
 


### PR DESCRIPTION
This PR introduces a new pool package with the mid-term goal of eliminating the wait dependency from API machinery.
It also integrates this pool into the podman package and improves resync poll durations by adding incremental backoff logic.

```
Jul 03 13:08:35 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:35.652265Z" level=debug msg="Requeueing spec" file="agent/device/device.go:167"
Jul 03 13:08:35 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:35.652385Z" level=debug msg="Completed sync of device spec in 2.045987ms" file="agent/device/device.go:158"
Jul 03 13:08:35 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:35.652502Z" level=debug msg="Started collecting device status" file="agent/device/device.go:288"
Jul 03 13:08:35 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:35.657919Z" level=debug msg="No new template version from management service" file="device/publisher/publisher.go:124"
Jul 03 13:08:35 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:35.732994Z" level=debug msg="Completed pushing device status in: 80.487663ms" file="agent/device/device.go:291"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.650585Z" level=debug msg="Starting sync of device spec" file="agent/device/device.go:155"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651290Z" level=debug msg="Requeuing current desired spec from disk version: 1" file="device/spec/manager.go:353"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651396Z" level=trace msg="Skipping item with version 1 already in queue" file="device/spec/queue.go:294"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651462Z" level=trace msg="Popped item version 1, heap size now 0" file="device/spec/queue.go:317"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651553Z" level=debug msg="Evaluating template version: 1" file="device/spec/queue.go:116"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651640Z" level=trace msg="Added item version 1, heap size now 1" file="device/spec/queue.go:308"
Jul 03 13:08:37 localhost.localdomain flightctl-agent[1696]: time="2025-07-03T13:08:37.651698Z" level=debug msg="Template version 1 requeue is currently in backoff. Available after: 2025-07-03T13:09:42Z" file="device/spec/queue.go:121"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new exponential backoff polling mechanism, providing more flexible and configurable retry behavior for operations.
  * Added a unified polling configuration for application and spec management, replacing fixed delay thresholds.
  * Added a new polling configuration utility for test environments.
  * Added a maximum retry timeout for Podman client operations.

* **Bug Fixes**
  * Improved reliability of retry logic by capping maximum delays and supporting context-based cancellation.
  * Enhanced retryable error detection to include maximum retry step errors.

* **Tests**
  * Updated and expanded tests to validate new backoff and polling behavior, including edge cases and timing scenarios.

* **Chores**
  * Standardized polling configuration across tests for consistency.
  * Removed deprecated retry delay parameters and replaced them with unified poll configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->