### PR TITLE
NO-ISSUE: Add 'ev' alias for Events in CLI commands

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -44,6 +44,7 @@ var (
 		ResourceSyncKind:              "rs",
 		TemplateVersionKind:           "tv",
 		CertificateSigningRequestKind: "csr",
+		EventKind:                     "ev",
 	}
 )
 


### PR DESCRIPTION
Events are the only ResourceKind without an alias and I find myself all the time thinking `fc get ev` should work...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "event" resource type, including its plural form and short name, enhancing resource management options in the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->