### PR TITLE
EDM-1675: Create observability backend stanalone quadlets

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -95,7 +95,7 @@ jobs:
   publish-flightctl-containers:
     strategy:
       matrix:
-        image: ['api', 'periodic', 'worker', 'cli-artifacts', 'alert-exporter', 'alertmanager-proxy']
+        image: ['api', 'periodic', 'worker', 'cli-artifacts', 'alert-exporter', 'alertmanager-proxy', 'userinfo-proxy']
     needs: [generate-tags]
     runs-on: "ubuntu-24.04"
     steps:

--- a/.spelling
+++ b/.spelling
@@ -152,6 +152,19 @@ OpenTelemetry
 OTLP
 crontab
 datasets
+grafana
+oauth
+grpc
+dns
+zipkin
+backends
+ansible
+openid
+pki
+uid
+idp
+systemctl
+enablement
  - docs/user/api-resources.md
 approvedBy
 creationTimestamp
@@ -247,3 +260,11 @@ alertmanager
 DeviceDisconnected
 DeviceCPUCritical
 programmatically
+ - docs/user/standalone-observability.md
+UserInfo
+Pre-configured
+is_superuser
+is_platform_auditor
+flightctl-api
+flightctl-kv
+IdPs

--- a/Containerfile.userinfo
+++ b/Containerfile.userinfo
@@ -1,0 +1,39 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+WORKDIR /app
+COPY ./api api
+COPY ./cmd cmd
+COPY ./deploy deploy
+COPY ./hack hack
+COPY ./internal internal
+COPY ./go.* ./
+COPY ./pkg pkg
+COPY ./test test
+COPY ./Makefile .
+# make sure that version extraction works
+COPY .git .git
+
+USER 0
+RUN make build-userinfo-proxy
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+RUN microdnf update --nodocs -y  && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
+WORKDIR /app
+LABEL \
+  com.redhat.component="flightctl-userinfo-proxy-container" \
+  description="Flight Control UserInfo proxy for Grafana authentication" \
+  io.k8s.description="Flight Control UserInfo proxy for Grafana authentication" \
+  io.k8s.display-name="Flight Control UserInfo Proxy" \
+  name="flightctl-userinfo-proxy" \
+  summary="Flight Control UserInfo proxy for Grafana authentication"
+COPY --from=build /app/bin/flightctl-userinfo-proxy .
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+CMD ./flightctl-userinfo-proxy 

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,9 @@ help:
 	@echo "    deploy:          deploy flightctl-server and db as pods in kind"
 	@echo "    redeploy-*       redeploy the api,worker,periodic,alert-exporter containers in kind"
 	@echo "    deploy-db:       deploy only the database as a container, for testing"
-	@echo "    deploy-mq:       deploy only the message queue broker as a container"
-	@echo "    deploy-quadlets: deploy the Flight Control service using Quadlets"
+	@echo "    deploy-kv:       deploy only the key-value store as a container, for testing"
+	@echo "    deploy-quadlets: deploy the complete Flight Control service using Quadlets"
+	@echo "                     (includes proper startup ordering: DB -> KV -> other services)"
 	@echo "    clean:           clean up all containers and volumes"
 	@echo "    cluster:         create a kind cluster and load the flightctl-server image"
 	@echo "    clean-cluster:   kill the kind cluster only"
@@ -81,7 +82,8 @@ build: bin build-cli
 		./cmd/flightctl-periodic \
 		./cmd/flightctl-worker \
 		./cmd/flightctl-alert-exporter \
-		./cmd/flightctl-alertmanager-proxy
+		./cmd/flightctl-alertmanager-proxy \
+		./cmd/flightctl-userinfo-proxy
 
 bin/flightctl-agent: bin $(GO_FILES)
 	CGO_CFLAGS='-flto' GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) \
@@ -110,6 +112,9 @@ build-alert-exporter: bin
 
 build-alertmanager-proxy: bin
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-alertmanager-proxy
+
+build-userinfo-proxy: bin
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-userinfo-proxy
 
 # rebuild container only on source changes
 bin/.flightctl-api-container: bin Containerfile.api go.mod go.sum $(GO_FILES)
@@ -146,6 +151,11 @@ bin/.flightctl-multiarch-cli-container: bin Containerfile.cli-artifacts go.mod g
 	podman build -f Containerfile.cli-artifacts $(GO_CACHE) -t flightctl-cli-artifacts:latest
 	touch bin/.flightctl-multiarch-cli-container
 
+bin/.flightctl-userinfo-proxy-container: bin Containerfile.userinfo go.mod go.sum $(GO_FILES)
+	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
+	podman build -f Containerfile.userinfo $(GO_CACHE) -t flightctl-userinfo-proxy:latest
+	touch bin/.flightctl-userinfo-proxy-container
+
 flightctl-api-container: bin/.flightctl-api-container
 
 flightctl-worker-container: bin/.flightctl-worker-container
@@ -158,7 +168,9 @@ flightctl-alertmanager-proxy-container: bin/.flightctl-alertmanager-proxy-contai
 
 flightctl-multiarch-cli-container: bin/.flightctl-multiarch-cli-container
 
-build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container
+flightctl-userinfo-proxy-container: bin/.flightctl-userinfo-proxy-container
+
+build-containers: flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container
 
 .PHONY: build-containers build-cli build-multiarch-clis
 
@@ -173,7 +185,7 @@ bin/.rpm: bin $(shell find ./ -name "*.go" -not -path "./packaging/*") packaging
 
 rpm: bin/.rpm
 
-.PHONY: rpm build build-api build-periodic build-worker build-alert-exporter build-alertmanager-proxy
+.PHONY: rpm build build-api build-periodic build-worker build-alert-exporter build-alertmanager-proxy build-userinfo-proxy
 
 # cross-building for deb pkg
 bin/amd64:
@@ -212,7 +224,8 @@ clean: clean-agent-vm clean-e2e-agent-images clean-quadlets
 clean-quadlets:
 	sudo deploy/scripts/clean_quadlets.sh
 
-.PHONY: tools flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container
+.PHONY: tools flightctl-api-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-userinfo-proxy-container
+
 tools: $(GOBIN)/golangci-lint
 
 $(GOBIN)/golangci-lint:

--- a/cmd/flightctl-userinfo-proxy/main.go
+++ b/cmd/flightctl-userinfo-proxy/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Config holds the configuration for the userinfo proxy
+type Config struct {
+	ListenPort          string
+	UpstreamURL         string
+	SkipTLSVerification bool
+}
+
+// UserInfoResponse represents the OpenID Connect UserInfo response
+type UserInfoResponse struct {
+	Sub               string   `json:"sub"`
+	Name              string   `json:"name,omitempty"`
+	GivenName         string   `json:"given_name,omitempty"`
+	FamilyName        string   `json:"family_name,omitempty"`
+	PreferredUsername string   `json:"preferred_username,omitempty"`
+	Email             string   `json:"email,omitempty"`
+	EmailVerified     bool     `json:"email_verified,omitempty"`
+	Picture           string   `json:"picture,omitempty"`
+	Groups            []string `json:"groups,omitempty"`
+	Roles             []string `json:"roles,omitempty"`
+	UpdatedAt         int64    `json:"updated_at,omitempty"`
+}
+
+func main() {
+	config := loadConfig()
+
+	http.HandleFunc("/userinfo", makeUserInfoHandler(config))
+	http.HandleFunc("/health", healthHandler)
+
+	log.Printf("Starting UserInfo proxy server on port %s", config.ListenPort)
+	log.Printf("Proxying to upstream: %s", config.UpstreamURL)
+	log.Printf("TLS verification: %s", map[bool]string{true: "enabled", false: "disabled"}[!config.SkipTLSVerification])
+
+	// Create server with proper timeouts to prevent DoS attacks
+	server := &http.Server{
+		Addr:              ":" + config.ListenPort,
+		ReadHeaderTimeout: 10 * time.Second, // Time to read request headers
+		ReadTimeout:       30 * time.Second, // Time to read entire request
+		WriteTimeout:      30 * time.Second, // Time to write response
+		IdleTimeout:       60 * time.Second, // Time to keep idle connections open
+	}
+
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatal("Server failed to start:", err)
+	}
+}
+
+func loadConfig() *Config {
+	config := &Config{
+		ListenPort:          getEnv("USERINFO_LISTEN_PORT", "8080"),
+		UpstreamURL:         getEnv("USERINFO_UPSTREAM_URL", ""),
+		SkipTLSVerification: getBoolEnv("USERINFO_SKIP_TLS_VERIFY", false),
+	}
+
+	if config.UpstreamURL == "" {
+		log.Fatal("USERINFO_UPSTREAM_URL environment variable is required")
+	}
+
+	return config
+}
+
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getBoolEnv(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		switch strings.ToLower(value) {
+		case "true", "1", "yes", "on":
+			return true
+		case "false", "0", "no", "off":
+			return false
+		default:
+			log.Printf("Warning: Invalid boolean value for %s: %s, using default: %v", key, value, defaultValue)
+			return defaultValue
+		}
+	}
+	return defaultValue
+}
+
+// AAPResponse represents the response from Ansible Automation Platform user API
+type AAPResponse struct {
+	Count    int       `json:"count"`
+	Next     *string   `json:"next"`
+	Previous *string   `json:"previous"`
+	Results  []AAPUser `json:"results"`
+}
+
+// AAPUser represents a user from Ansible Automation Platform
+type AAPUser struct {
+	ID          int    `json:"id"`
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	IsSuperuser bool   `json:"is_superuser"`
+	IsAuditor   bool   `json:"is_platform_auditor"`
+}
+
+func makeUserInfoHandler(config *Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Only allow GET requests
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Extract Authorization header
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "Authorization header required", http.StatusUnauthorized)
+			return
+		}
+
+		// Proxy request to upstream AAP
+		aapResp, err := proxyToUpstream(config, authHeader)
+		if err != nil {
+			log.Printf("Error proxying to upstream AAP: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Transform AAP response to UserInfo format
+		userInfo, err := transformToUserInfo(aapResp)
+		if err != nil {
+			log.Printf("Error transforming response: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Return JSON response
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(userInfo); err != nil {
+			log.Printf("Error encoding response: %v", err)
+		}
+	}
+}
+
+func proxyToUpstream(config *Config, authHeader string) (*AAPResponse, error) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: config.SkipTLSVerification}, // #nosec G402
+		},
+
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", config.UpstreamURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Authorization", authHeader)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("upstream returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result AAPResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding JSON: %w", err)
+	}
+
+	return &result, nil
+}
+
+func transformToUserInfo(aapResp *AAPResponse) (*UserInfoResponse, error) {
+	if len(aapResp.Results) == 0 {
+		return nil, fmt.Errorf("no user found in IdP response")
+	}
+
+	// Take the first user from results
+	user := aapResp.Results[0]
+
+	userInfo := &UserInfoResponse{
+		Sub:               fmt.Sprintf("%d", user.ID),
+		Email:             user.Email,
+		EmailVerified:     true, // Assume verified since it's from IdP
+		PreferredUsername: user.Username,
+		UpdatedAt:         time.Now().Unix(),
+	}
+
+	// Build full name from first and last name
+	if user.FirstName != "" || user.LastName != "" {
+		userInfo.Name = strings.TrimSpace(user.FirstName + " " + user.LastName)
+		userInfo.GivenName = user.FirstName
+		userInfo.FamilyName = user.LastName
+	} else {
+		userInfo.Name = user.Username
+		userInfo.GivenName = user.Username
+	}
+
+	// Determine Grafana role based on IdP permissions
+	if user.IsSuperuser {
+		userInfo.Roles = []string{"Admin"}
+		userInfo.Groups = []string{"admin"}
+	} else if user.IsAuditor {
+		userInfo.Roles = []string{"Editor"}
+		userInfo.Groups = []string{"auditor"}
+	} else {
+		userInfo.Roles = []string{"Viewer"}
+		userInfo.Groups = []string{"user"}
+	}
+
+	return userInfo, nil
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status": "healthy",
+		"time":   time.Now().Format(time.RFC3339),
+	})
+}

--- a/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
+++ b/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
@@ -7,6 +7,7 @@ Requires=flightctl-db.service flightctl-kv.service flightctl-alertmanager.servic
 [Container]
 ContainerName=flightctl-alert-exporter
 Image=quay.io/flightctl/flightctl-alert-exporter:latest
+Pull=newer
 Network=flightctl.network
 Environment=HOME=/root
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
@@ -8,6 +8,7 @@ Wants=flightctl-alertmanager-proxy-init.service
 [Container]
 ContainerName=flightctl-alertmanager-proxy
 Image=quay.io/flightctl/flightctl-alertmanager-proxy:latest
+Pull=newer
 Network=flightctl.network
 PublishPort=8443:8443
 EnvironmentFile=/etc/flightctl/flightctl-alertmanager-proxy/env

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -8,6 +8,7 @@ Requires=flightctl-db.service flightctl-kv.service
 [Container]
 ContainerName=flightctl-api
 Image=quay.io/flightctl/flightctl-api:latest
+Pull=newer
 Network=flightctl.network
 EnvironmentFile=/etc/flightctl/flightctl-api/env
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts.container
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts.container
@@ -7,6 +7,7 @@ PartOf=flightctl.target
 [Container]
 ContainerName=flightctl-cli-artifacts
 Image=quay.io/flightctl/flightctl-cli-artifacts:latest
+Pull=newer
 Network=flightctl.network
 EnvironmentFile=/etc/flightctl/flightctl-cli-artifacts/env
 Volume=flightctl-cli-artifacts-certs:/app/certs:ro,z

--- a/deploy/podman/flightctl-db/flightctl-db-config/enable-superuser.sh
+++ b/deploy/podman/flightctl-db/flightctl-db-config/enable-superuser.sh
@@ -4,8 +4,33 @@ set -e
 
 _psql () { psql --set ON_ERROR_STOP=1 "$@" ; }
 
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to be fully initialized..."
+# wait up to 120 s
+for _ in {1..120}; do
+    pg_isready -U postgres && break
+    echo "PostgreSQL not ready, waiting…"
+    sleep 1
+done
+pg_isready -U postgres || { echo "PostgreSQL did not become ready"; exit 1; }
+
+echo "PostgreSQL is ready, configuring permissions..."
+
 # Ensure POSTGRESQL_MASTER_USER is treated as a superuser
 if [ -n "${POSTGRESQL_MASTER_USER}" ]; then
     echo "Granting superuser privileges to ${POSTGRESQL_MASTER_USER}"
-    _psql -c "ALTER ROLE $(echo "SELECT quote_ident('${POSTGRESQL_MASTER_USER}');" | _psql -t -A) WITH SUPERUSER;"
+    
+    # Check if user exists, create if it doesn't
+    if ! _psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '${POSTGRESQL_MASTER_USER}'" | grep -q 1; then
+        echo "Creating master user ${POSTGRESQL_MASTER_USER}"
+        _psql -U postgres -c "CREATE ROLE \"${POSTGRESQL_MASTER_USER}\" WITH LOGIN PASSWORD '${POSTGRESQL_MASTER_PASSWORD}';"
+    fi
+    
+    # Grant superuser privileges
+    _psql -U postgres -c "ALTER ROLE \"${POSTGRESQL_MASTER_USER}\" WITH SUPERUSER CREATEDB CREATEROLE;"
+    echo "Successfully granted superuser privileges to ${POSTGRESQL_MASTER_USER}"
+else
+    echo "POSTGRESQL_MASTER_USER not set, skipping superuser configuration"
 fi
+
+echo "Database configuration completed successfully"

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -7,6 +7,7 @@ Requires=flightctl-db.service flightctl-kv.service
 [Container]
 ContainerName=flightctl-periodic
 Image=quay.io/flightctl/flightctl-periodic:latest
+Pull=newer
 Network=flightctl.network
 Environment=HOME=/root
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -8,6 +8,7 @@ Requires=flightctl-api.service
 [Container]
 ContainerName=flightctl-ui
 Image=quay.io/flightctl/flightctl-ui:latest
+Pull=newer
 Network=flightctl.network
 EnvironmentFile=/etc/flightctl/flightctl-ui/env
 

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -7,6 +7,7 @@ Requires=flightctl-db.service flightctl-kv.service
 [Container]
 ContainerName=flightctl-worker
 Image=quay.io/flightctl/flightctl-worker:latest
+Pull=newer
 Network=flightctl.network
 Environment=HOME=/root
 Secret=flightctl-postgresql-master-password,type=env,target=DB_PASSWORD

--- a/deploy/podman/flightctl.target
+++ b/deploy/podman/flightctl.target
@@ -1,26 +1,26 @@
 [Unit]
 Description=Flight Control Services Group
 
-# Requires= directives ensures these services are started with this unit.
+# Wants= directives starts these services with this unit (soft dependency).
 # After= directives delays this unit until these services start.
 #
 # Note: The exact startup order among the services is controlled by
 # additional directives defined within the .container files
-Requires=flightctl-network.service
-Requires=flightctl-db.service
-Requires=flightctl-kv.service
-Requires=flightctl-api-init.service
-Requires=flightctl-api.service
-Requires=flightctl-worker.service
-Requires=flightctl-periodic.service
-Requires=flightctl-alert-exporter.service
-Requires=flightctl-alertmanager.service
-Requires=flightctl-alertmanager-proxy-init.service
-Requires=flightctl-alertmanager-proxy.service
-Requires=flightctl-ui-init.service
-Requires=flightctl-ui.service
-Requires=flightctl-cli-artifacts-init.service
-Requires=flightctl-cli-artifacts.service
+Wants=flightctl-network.service
+Wants=flightctl-db.service
+Wants=flightctl-kv.service
+Wants=flightctl-api-init.service
+Wants=flightctl-api.service
+Wants=flightctl-worker.service
+Wants=flightctl-periodic.service
+Wants=flightctl-alert-exporter.service
+Wants=flightctl-alertmanager.service
+Wants=flightctl-alertmanager-proxy-init.service
+Wants=flightctl-alertmanager-proxy.service
+Wants=flightctl-ui-init.service
+Wants=flightctl-ui.service
+Wants=flightctl-cli-artifacts-init.service
+Wants=flightctl-cli-artifacts.service
 
 After=network.target
 After=flightctl-network.service

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -12,3 +12,35 @@ global:
       oidcAuthority:
       externalOidcAuthority:
       oidcClientId:
+
+observability:
+  grafana:
+    image:
+    published_port:
+
+    oauth:
+      enabled:
+
+      provider_type:
+
+      auth_url:
+      token_url:
+      api_url:
+
+      client_id:
+
+      local_admin_user:
+      local_admin_password:
+
+  prometheus:
+    image:
+
+  otel_collector:
+    image:
+    http_port:
+    grpc_port:
+
+  userinfo_proxy:
+    image:
+    upstream_url:
+    skip_tls_verify:

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -14,35 +14,123 @@ if ! deploy/scripts/install.sh; then
     exit 1
 fi
 
+echo "Ensuring secrets are available..."
+# Always ensure secrets exist before starting services
+if ! "${CONFIG_READONLY_DIR}/init_host.sh"; then
+    echo "Error: Failed to initialize secrets"
+    exit 1
+fi
+
+echo "Starting all FlightCtl services via target..."
 start_service "flightctl.target"
 
-echo "Checking if all services are running..."
-
-timeout --foreground 300s bash -c '
-    expected_services=("flightctl-api" "flightctl-worker" "flightctl-periodic" "flightctl-alert-exporter" "flightctl-db" "flightctl-kv" "flightctl-alertmanager" "flightctl-alertmanager-proxy" "flightctl-cli-artifacts" "flightctl-ui")
-
+echo "Waiting for services to initialize..."
+# Wait for database to be ready first
+timeout --foreground 120s bash -c '
     while true; do
-        missing_services=()
-
-        for service in "${expected_services[@]}"; do
-            if ! podman ps --quiet --filter "name=$service" | grep -q .; then
-                missing_services+=("$service")
-            fi
-        done
-
-        if [ ${#missing_services[@]} -eq 0 ]; then
-            echo "All services are running"
-            exit 0
+        if podman ps --quiet --filter "name=flightctl-db" | grep -q . && \
+           podman exec flightctl-db pg_isready -U postgres >/dev/null 2>&1; then
+            echo "Database is ready"
+            break
         fi
-
-        echo "Waiting for (${#missing_services[@]}/${#expected_services[@]}) services to start: ${missing_services[*]}"
-        sleep 10
+        echo "Waiting for database to become ready..."
+        sleep 3
     done
-' || {
-    echo "Timeout reached while waiting for services"
-    exit 1
-}
+'
 
-echo "Deployment completed. Please log in to Flight Control with the following command:"
-echo "Login: flightctl login --insecure-skip-tls-verify $(grep baseUrl $CONFIG_WRITEABLE_DIR/flightctl-api/config.yaml | awk '{print $2}')"
-echo "Console URL: $(grep baseUIUrl $CONFIG_WRITEABLE_DIR/flightctl-api/config.yaml | awk '{print $2}')"
+# Sync database password with secrets
+echo "Synchronizing database password with secrets..."
+DB_ACTUAL_PASSWORD=$(sudo podman exec flightctl-db printenv POSTGRESQL_MASTER_PASSWORD)
+if ! sudo podman run --rm --network flightctl \
+    --secret flightctl-postgresql-master-password,type=env,target=DB_PASSWORD \
+    quay.io/sclorg/postgresql-16-c9s:latest \
+    bash -c 'PGPASSWORD="$DB_PASSWORD" psql -h flightctl-db -U admin -d flightctl -c "SELECT 1" >/dev/null 2>&1'; then
+    
+    echo "Password mismatch detected! Fixing secret..."
+    sudo podman secret rm flightctl-postgresql-master-password
+    echo "$DB_ACTUAL_PASSWORD" | sudo podman secret create flightctl-postgresql-master-password -
+    echo "Secret updated to match database password"
+fi
+
+# Ensure admin has superuser privileges
+echo "Ensuring database admin has superuser privileges..."
+if sudo podman exec flightctl-db psql -U postgres -tAc "SELECT rolsuper FROM pg_roles WHERE rolname = 'admin'" | grep -q "f"; then
+    echo "Granting superuser privileges to admin user..."
+    sudo podman exec flightctl-db psql -U postgres -c "ALTER USER admin WITH SUPERUSER;"
+fi
+
+# Wait for key-value service
+timeout --foreground 60s bash -c '
+    while true; do
+        if podman ps --quiet --filter "name=flightctl-kv" | grep -q . && \
+           podman exec flightctl-kv redis-cli ping >/dev/null 2>&1; then
+            echo "Key-value service is ready"
+            break
+        fi
+        echo "Waiting for key-value service..."
+        sleep 2
+    done
+'
+
+# Restart any failed services due to initial password/permission issues
+echo "Restarting API services to apply fixes..."
+sudo systemctl restart flightctl-api.service flightctl-worker.service flightctl-periodic.service
+
+echo "Waiting for all services to be fully ready..."
+# Get all services from flightctl.target
+ALL_SERVICES=$(systemctl show flightctl.target -p Wants --value | tr ' ' '\n' | grep -E '^flightctl-.*\.service$' | sort)
+
+# Wait for core services to be ready
+start_time=$(date +%s)
+timeout_seconds=120
+
+while true; do
+    current_time=$(date +%s)
+    elapsed=$((current_time - start_time))
+    
+    if [ $elapsed -ge $timeout_seconds ]; then
+        echo "Timeout: Core services did not become ready within ${timeout_seconds} seconds"
+        exit 1
+    fi
+    
+    # Check if target is active
+    if ! systemctl is-active --quiet flightctl.target; then
+        echo "Waiting for flightctl.target to become active..."
+        sleep 3
+        continue
+    fi
+    
+    # Check each service
+    all_active=true
+    for service in ${ALL_SERVICES}; do
+        if ! systemctl is-active --quiet "$service"; then
+            echo "Waiting for service $service to become active..."
+            all_active=false
+            break
+        fi
+    done
+    
+    if $all_active; then
+        echo "All services are active and ready"
+        break
+    fi
+    
+    sleep 3
+done
+
+echo "Deployment completed successfully!"
+echo ""
+echo "FlightCtl services are running:"
+for service in ${ALL_SERVICES}; do
+    # Extract a human-readable name from the service name
+    service_name=$(echo "$service" | sed 's/flightctl-//g' | sed 's/\.service//g' | sed 's/-/ /g' | sed 's/\b\w/\u&/g')
+    if systemctl is-active --quiet "$service"; then
+        echo "  ✓ $service_name ($service)"
+    else
+        echo "  ✗ $service_name ($service) - not active"
+    fi
+done
+
+echo ""
+echo "You can check status with: sudo systemctl status flightctl.target"
+

--- a/docs/user/standalone-observability.md
+++ b/docs/user/standalone-observability.md
@@ -1,0 +1,1056 @@
+# FlightCtl Standalone Observability Stack
+
+This comprehensive guide covers the complete FlightCtl observability stack, including installation, configuration, management, and troubleshooting.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Service Management](#service-management) ⚠️ **Required Reading**
+3. [Architecture](#architecture)
+4. [Installation Scenarios](#installation-scenarios)
+5. [Components](#components)
+6. [Configuration](#configuration)
+7. [Container Network Architecture](#container-network-architecture)
+8. [Configuration Management](#configuration-management)
+9. [Sample Configurations](#sample-configurations)
+
+## Overview
+
+FlightCtl provides flexible observability solutions to meet different deployment scenarios. The system supports two main use cases:
+
+### Use Case 1: External Observability Stack Integration
+
+**Scenario**: You already have an existing observability stack (Prometheus, Grafana, Jaeger, etc.) and want to integrate FlightCtl telemetry into it.
+
+**Solution**: Deploy only the **OpenTelemetry Collector** as a bridge between FlightCtl and your external observability infrastructure.
+
+**Benefits**:
+
+- Minimal resource footprint
+- Integrates with existing monitoring workflows
+- Centralized observability across multiple systems
+- Flexible data routing and transformation
+
+### Use Case 2: Standalone Observability Stack
+
+**Scenario**: You need a complete, self-contained observability solution for FlightCtl.
+
+**Solution**: Deploy the **full observability stack** including:
+
+- **Grafana** for visualization and dashboards
+- **Prometheus** for metrics collection and storage (internal only)
+- **OpenTelemetry Collector** for telemetry data processing
+- **UserInfo Proxy** for AAP OAuth integration (optional)
+
+**Benefits**:
+
+- Complete out-of-the-box monitoring solution
+- Pre-configured FlightCtl dashboards
+- Integrated authentication with AAP
+- No external dependencies
+
+All components run as Podman containers managed by systemd, providing enterprise-grade reliability and integration with existing infrastructure.
+
+**Important**: Both the standalone OpenTelemetry collector and the full observability stack can be installed and operated independently without requiring core FlightCtl services (flightctl-api, flightctl-worker, flightctl-db, flightctl-kv) to be running. This allows you to set up observability infrastructure before or alongside your main FlightCtl deployment.
+
+## Service Management
+
+**🔑 Service management uses native systemd targets:**
+
+```bash
+# For OpenTelemetry collector only (minimal setup)
+sudo systemctl start flightctl-otel-collector.target
+sudo systemctl stop flightctl-otel-collector.target
+
+# For full observability stack (includes collector + Grafana + Prometheus)
+sudo systemctl start flightctl-observability.target  
+sudo systemctl stop flightctl-observability.target
+
+# For automatic startup on boot
+sudo systemctl enable flightctl-observability.target
+```
+
+**Configuration management is separate:**
+
+```bash
+# When you change /etc/flightctl/service-config.yaml
+sudo flightctl-render-observability      # Regenerate configs
+sudo systemctl restart flightctl-observability.target  # Apply changes
+```
+
+**Systemd targets provide:**
+
+- ✅ Proper dependency management and startup order
+- ✅ Network dependencies automatically handled  
+- ✅ Standard systemd enable/disable functionality
+- ✅ Integration with system boot process
+- ✅ **Grouped start/stop**: Stopping target stops all related services
+
+**❌ Do not use individual service commands:**
+
+- `systemctl start flightctl-grafana.service` (use targets instead)
+- `systemctl start flightctl-prometheus.service` (use targets instead)
+
+**Two-step process:**
+
+1. **Config changes**: `sudo flightctl-render-observability` (renders templates)
+2. **Service management**: `sudo systemctl start/stop/restart flightctl-observability.target`
+
+## Architecture
+
+### High-Level Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                    FlightCtl Observability Stack                │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─────────────┐    ┌──────────────┐    ┌─────────────────────┐ │
+│  │   Grafana   │    │  Prometheus  │    │ OpenTelemetry       │ │
+│  │ Dashboard   │◄───┤  Metrics     │◄───┤ Collector           │ │
+│  │ (Port 3000) │    │  (Port 9090) │    │ (Internal)          │ │
+│  └─────────────┘    └──────────────┘    └─────────────────────┘ │
+│         │                                                       │
+│         ▼                                                       │
+│  ┌─────────────┐                                                │
+│  │ UserInfo    │                                                │
+│  │ Proxy       │                                                │
+│  │ (Internal)  │                                                │
+│  └─────────────┘                                                │
+│         │                                                       │
+│         ▼                                                       │
+│  ┌─────────────┐                                                │
+│  │ Identity    │                                                │
+│  │ Provider    │                                                │
+│  │ (External)  │                                                │
+│  └─────────────┘                                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Container Network Architecture
+
+All observability components communicate within the `flightctl-observability` Podman network:
+
+```text
+flightctl-observability Network (Internal)
+├── flightctl-grafana:3000
+├── flightctl-prometheus:9090 (internal only)
+├── flightctl-otel-collector:4317 (gRPC), 4318 (HTTP)
+└── flightctl-userinfo-proxy:8080 (internal only)
+
+External Access (Published Ports)
+├── <host>:3000 → flightctl-grafana:3000 (full stack only)
+├── <host>:4317 → flightctl-otel-collector:4317 (gRPC)
+└── <host>:4318 → flightctl-otel-collector:4318 (HTTP)
+```
+
+**Key Design Principles:**
+
+- **Internal Communication**: Containers communicate via container names (e.g., `flightctl-prometheus:9090`)
+- **External Access**: Only OpenTelemetry collector always exposes external ports; Grafana only in full stack mode
+- **Security**: Prometheus and UserInfo proxy are internal-only for security
+- **Network Isolation**: All components isolated within the flightctl-observability network
+- **Flexibility**: OpenTelemetry collector can forward data to external systems or internal Prometheus
+
+**Network Configuration:**
+
+The observability services use a dedicated Podman network named `flightctl-observability` that is automatically created and managed by the system. This network:
+
+- Provides isolation from other FlightCtl services
+- Enables secure internal communication between observability components
+- Allows containers to reference each other by name (e.g., `flightctl-prometheus:9090`)
+- Is automatically created when the first observability service starts
+- Is shared between all observability components whether you install standalone OpenTelemetry collector or the full stack
+
+## Installation Order
+
+With the removal of dependencies on core FlightCtl services, you now have full flexibility in installation order:
+
+### Option 1: Observability First
+
+1. Install observability services (`flightctl-otel-collector` or `flightctl-observability`)
+2. Configure and start observability services
+3. Later install and configure core FlightCtl services
+4. Core services will automatically send telemetry to existing observability infrastructure
+
+### Option 2: Core Services First
+
+1. Install and configure core FlightCtl services
+2. Install observability services
+3. Observability services will automatically collect telemetry from running core services
+
+### Option 3: Simultaneous Installation
+
+1. Install both core services and observability services
+2. Configure and start all services in any order
+
+This flexibility allows you to set up monitoring infrastructure independently of your main FlightCtl deployment timeline.
+
+## Installation Scenarios
+
+### Scenario 1: External Observability Stack Integration
+
+**When to Use**: You already have an existing observability infrastructure (Prometheus, Grafana, Jaeger, etc.) and want to integrate FlightCtl telemetry into it.
+
+**Components Included**:
+
+- OpenTelemetry collector only (external ports 4317, 4318)
+
+**Prerequisites**:
+
+- Podman and systemd installed
+- External observability stack configured to receive OTLP data
+
+**Note**: OpenTelemetry collector can be installed and run independently of core FlightCtl services
+
+**Installation**:
+
+```bash
+# Install only the OpenTelemetry collector
+sudo dnf install flightctl-otel-collector
+
+# The package automatically:
+# 1. Checks prerequisites
+# 2. Generates collector configuration
+# 3. Configures systemd service (but does not start or enable it)
+
+# To start the collector service:
+sudo systemctl start flightctl-otel-collector.target
+
+# For automatic startup on boot:
+sudo systemctl enable flightctl-otel-collector.target
+
+**Note**: The installation process only configures the service but does not automatically start it. Use systemd targets to start the observability stack.
+```
+
+**Configuration**: Configure the collector to forward data to your external systems:
+
+```yaml
+# /etc/otelcol/otelcol-config.yaml
+exporters:
+  prometheus:
+    endpoint: "your-prometheus.company.com:9090"
+  jaeger:
+    endpoint: "your-jaeger.company.com:14250"
+```
+
+### Scenario 2: Standalone Observability Stack
+
+**When to Use**: You need a complete, self-contained observability solution for FlightCtl without external dependencies.
+
+**Components Included**:
+
+- Grafana dashboard (external port 3000)
+- Prometheus metrics (internal only - accessed via Grafana)
+- OpenTelemetry collector (external ports 4317, 4318)
+- UserInfo proxy (internal only, optional for AAP integration)
+
+**Prerequisites**:
+
+- Podman and systemd installed
+
+**Note**: Observability stack can be installed and run independently of core FlightCtl services
+
+**Installation**:
+
+```bash
+# Install the full observability package
+sudo dnf install flightctl-observability
+
+# The package automatically:
+# 1. Checks prerequisites
+# 2. Generates initial configuration
+# 3. Configures systemd services (but does not start or enable them)
+
+# To start all observability services:
+sudo systemctl start flightctl-observability.target
+
+# For automatic startup on boot:
+sudo systemctl enable flightctl-observability.target
+
+**Note**: The installation process only configures the services but does not automatically start them. Use systemd targets to start the observability stack.
+```
+
+**Access**:
+
+- Grafana dashboard: `http://<host>:3000` (default port, configurable)
+- Prometheus metrics: Available through Grafana (internal only)
+- OpenTelemetry collector: `<host>:4317` (gRPC), `<host>:4318` (HTTP)
+
+**Access Methods**:
+
+- **Local deployment**: `http://localhost:3000`
+- **Remote deployment**: `http://server-ip:3000` or `http://server-hostname:3000`
+- **Custom domain**: `http://grafana.yourdomain.com:3000` (with proper DNS/proxy setup)
+- **Custom port**: Configure `published_port` in service-config.yaml
+
+## Components
+
+### Grafana Dashboard
+
+**Purpose**: Web-based visualization and dashboards for metrics and logs.
+
+**Key Features**:
+
+- Pre-configured FlightCtl dashboards
+- OAuth integration with identity providers
+- HTTPS support with custom certificates
+- Automatic Prometheus data source configuration
+
+**Configuration**:
+
+- **Internal Address**: `flightctl-grafana:3000`
+- **External Access**: `http://<host>:3000` (configurable port)
+- **Data Storage**: `/var/lib/grafana`
+
+**Available Options in service-config.yaml**:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3000
+    oauth:
+      enabled: false
+      client_id: your-oauth-client-id
+      auth_url: https://your-aap.com/o/authorize
+      token_url: https://your-aap.com/o/token
+      api_url: http://flightctl-userinfo-proxy:8080
+      tls_skip_verify: false
+      local_admin_user: admin
+      local_admin_password: secure-password
+    protocol: http  # or https
+    https:
+      cert_file: /etc/grafana/certs/grafana.crt
+      cert_key: /etc/grafana/certs/grafana.key
+```
+
+### Prometheus Metrics
+
+**Purpose**: Time-series database for metrics collection and storage.
+
+**Key Features**:
+
+- Automatic FlightCtl service discovery
+- Configurable retention policies
+- Built-in query interface
+- Integration with Grafana
+
+**Configuration**:
+
+- **Internal Address**: `flightctl-prometheus:9090`
+- **External Access**: None (internal only - accessed via Grafana)
+- **Data Storage**: `/var/lib/prometheus`
+
+**Available Options in service-config.yaml**:
+
+```yaml
+observability:
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+    # No published_port - internal only
+```
+
+**Note**: Prometheus configuration is automatically generated to scrape FlightCtl services and the OpenTelemetry collector.
+
+### OpenTelemetry Collector
+
+**Purpose**: Unified telemetry data collection, processing, and forwarding.
+
+**Key Features**:
+
+- Multiple protocol support (OTLP, Jaeger, Zipkin)
+- Data transformation and filtering
+- Export to multiple backends
+- Resource detection and enrichment
+
+**Configuration**:
+
+- **Internal Address**: `flightctl-otel-collector:4317` (gRPC), `flightctl-otel-collector:4318` (HTTP)
+- **External Access**: `<host>:4317` (gRPC), `<host>:4318` (HTTP) - configurable ports
+- **Data Storage**: `/var/lib/otelcol`
+
+**Available Options in service-config.yaml**:
+
+```yaml
+observability:
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317  # External gRPC port
+    http_port: 4318  # External HTTP port
+```
+
+**Note**: OpenTelemetry collector configuration can be customized by editing `/etc/otelcol/otelcol-config.yaml` to configure receivers, processors, and exporters.
+
+### UserInfo Proxy
+
+**Purpose**: OAuth UserInfo endpoint proxy specifically designed for Ansible Automation Platform (AAP) integration with Grafana.
+
+**Key Features**:
+
+- AAP-specific OAuth UserInfo endpoint translation
+- Configurable TLS verification
+- AAP user structure to OpenID Connect UserInfo transformation
+- Grafana role mapping based on AAP permissions (is_superuser, is_platform_auditor)
+
+**Configuration**:
+
+- **Internal Address**: `flightctl-userinfo-proxy:8080`
+- **External Access**: None (internal only)
+
+**Available Options in service-config.yaml**:
+
+```yaml
+observability:
+  userinfo_proxy:
+    image: flightctl/userinfo-proxy:latest
+    upstream_url: https://your-aap-instance.com/api/gateway/v1/me/
+    skip_tls_verify: false  # Set to true for self-signed certificates
+```
+
+**Note**: UserInfo proxy is specifically designed for AAP (Ansible Automation Platform) integration and transforms AAP user API responses to OpenID Connect UserInfo format.
+
+## Configuration
+
+All observability configuration is centralized in `/etc/flightctl/service-config.yaml` under the `observability` section.
+
+### Complete Configuration Reference
+
+```yaml
+observability:
+  # Grafana Configuration
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3000  # External port - can be changed (e.g., 8080, 3001, etc.)
+    
+    # OAuth Integration
+    oauth:
+      enabled: true
+      client_id: your-oauth-client-id
+      auth_url: https://your-idp.com/o/authorize
+      token_url: https://your-idp.com/o/token
+      api_url: http://flightctl-userinfo-proxy:8080  # Internal container communication
+      tls_skip_verify: false  # Skip TLS verification for OAuth endpoints
+      local_admin_user: admin
+      local_admin_password: secure-password
+    
+    protocol: http  # or https
+    
+    # HTTPS Configuration (Optional - only needed when protocol: https)
+    https:
+      cert_file: /etc/grafana/certs/grafana.crt
+      cert_key: /etc/grafana/certs/grafana.key
+
+  # Prometheus Configuration (internal only)
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  # OpenTelemetry Collector Configuration
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317  # External gRPC port - configurable
+    http_port: 4318  # External HTTP port - configurable
+
+  # UserInfo Proxy Configuration (Optional - AAP specific)
+  userinfo_proxy:
+    image: flightctl/userinfo-proxy:latest
+    upstream_url: https://your-aap-instance.com/api/gateway/v1/me/
+    skip_tls_verify: false  # Skip TLS verification for upstream calls
+```
+
+### Key Configuration Principles
+
+1. **All configuration is in service-config.yaml**: No need to edit individual container files or environment variables
+2. **Automatic template generation**: The system automatically generates container configurations from your service-config.yaml
+3. **Hot configuration**: Use `sudo flightctl-render-observability` then restart services with systemd targets
+4. **Built-in validation**: The system automatically validates your configuration and provides clear error messages
+
+## Configuration Management
+
+### Configuration Management System
+
+FlightCtl separates configuration management from service management for better control.
+
+#### Configuration Rendering
+
+**Render Configuration Templates**:
+
+```bash
+sudo flightctl-render-observability
+```
+
+**What it does**:
+
+1. Validates prerequisites and configuration
+2. Automatically validates YAML syntax and configuration structure  
+3. Renders configuration templates from `/etc/flightctl/service-config.yaml`
+4. Reloads systemd daemon
+5. **Does NOT start or stop services**
+
+#### Service Management
+
+**Start/Stop Services**:
+
+```bash
+# Start services
+sudo systemctl start flightctl-observability.target       # Full stack
+sudo systemctl start flightctl-otel-collector.target      # OpenTelemetry only
+
+# Stop services  
+sudo systemctl stop flightctl-observability.target        # Full stack
+sudo systemctl stop flightctl-otel-collector.target       # OpenTelemetry only
+
+# Restart services (after config changes)
+sudo systemctl restart flightctl-observability.target     # Full stack
+sudo systemctl restart flightctl-otel-collector.target    # OpenTelemetry only
+
+# Enable automatic startup
+sudo systemctl enable flightctl-observability.target      # Full stack
+sudo systemctl enable flightctl-otel-collector.target     # OpenTelemetry only
+```
+
+These commands work whether you have the full observability stack, standalone OpenTelemetry collector, or any combination of components.
+
+### Configuration Workflow
+
+1. **Edit configuration**:
+
+   ```bash
+   sudo vim /etc/flightctl/service-config.yaml
+   ```
+
+2. **Render updated configuration**:
+
+   ```bash
+   sudo flightctl-render-observability
+   ```
+
+3. **Apply changes to running services**:
+
+   ```bash
+   sudo systemctl restart flightctl-observability.target
+   ```
+
+**Stop services (when needed)**:
+
+```bash
+sudo systemctl stop flightctl-observability.target
+```
+
+Use this command when you need to stop all observability services for maintenance or troubleshooting.
+
+## UserInfo Proxy Setup (AAP Integration)
+
+The UserInfo proxy enables Grafana OAuth integration specifically with Ansible Automation Platform (AAP) by translating AAP's user API responses to the standard OpenID Connect UserInfo format that Grafana expects.
+
+### Purpose and Benefits
+
+**Why Use UserInfo Proxy with AAP?**
+
+- **AAP-Specific Translation**: Converts AAP's user API responses to standard OAuth UserInfo format
+- **Permission Mapping**: Maps AAP user permissions (is_superuser, is_platform_auditor) to Grafana roles
+- **TLS Management**: Centralized TLS verification settings for AAP connections
+- **Grafana Integration**: Optimized for Grafana's OAuth requirements with AAP
+- **Security**: Internal-only service with no external exposure
+
+### Configuration
+
+The UserInfo proxy runs as an internal service and requires minimal configuration:
+
+```yaml
+observability:
+  grafana:
+    oauth:
+      enabled: true
+      client_id: your-oauth-client-id
+      auth_url: https://your-idp.com/o/authorize
+      token_url: https://your-idp.com/o/token
+      api_url: http://flightctl-userinfo-proxy:8080  # Points to internal proxy
+      
+  userinfo_proxy:
+    upstream_url: https://your-aap-instance.com/api/gateway/v1/me/  # Your AAP instance's user API endpoint
+    skip_tls_verify: false  # Set to true for self-signed certificates
+```
+
+### Communication Flow
+
+```text
+User Authentication Flow with AAP:
+1. User → Grafana → AAP (OAuth login)
+2. Grafana receives OAuth token from AAP
+3. Grafana calls api_url → UserInfo Proxy (internal)
+4. UserInfo Proxy → AAP User API (with token)
+5. UserInfo Proxy transforms AAP response → Grafana
+6. Grafana creates user session with mapped roles
+```
+
+### Response Transformation
+
+The proxy transforms AAP API responses to standard UserInfo format:
+
+**Input (AAP API Response)**:
+
+```json
+{
+  "count": 1,
+  "results": [{
+    "id": 123,
+    "username": "john.doe",
+    "email": "john.doe@company.com",
+    "first_name": "John",
+    "last_name": "Doe",
+    "is_superuser": true,
+    "is_platform_auditor": false
+  }]
+}
+```
+
+**Output (UserInfo Standard)**:
+
+```json
+{
+  "sub": "123",
+  "preferred_username": "john.doe",
+  "email": "john.doe@company.com",
+  "email_verified": true,
+  "name": "John Doe",
+  "given_name": "John",
+  "family_name": "Doe",
+  "roles": ["Admin"],
+  "groups": ["admin"],
+  "updated_at": 1640995200
+}
+```
+
+### TLS Configuration
+
+The proxy supports flexible TLS verification:
+
+```yaml
+userinfo_proxy:
+  upstream_url: https://your-aap-instance.com/api/gateway/v1/me/
+  skip_tls_verify: false  # Default: strict TLS verification
+```
+
+**When to use `skip_tls_verify: true`**:
+
+- Development environments
+- Self-signed certificates
+- Internal PKI that's not in system trust store
+- Testing scenarios
+
+**Production recommendation**: Always use `skip_tls_verify: false` with proper certificates.
+
+## Sample Configurations
+
+### External Observability Integration
+
+Minimal configuration for integrating with existing observability stack:
+
+```yaml
+observability:
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317
+    http_port: 4318
+```
+
+**Note**: Configure `/etc/otelcol/otelcol-config.yaml` to export to your external Prometheus, Jaeger, or other observability systems.
+
+**Management Commands Available**:
+
+Even when installing only the OpenTelemetry collector, you have access to the management commands:
+
+- `sudo flightctl-render-observability` - Render configuration templates from `service-config.yaml`
+- `sudo systemctl start/stop/restart flightctl-observability.target` - Manage observability services
+
+**Two-step process**: First render configuration with `flightctl-render-observability`, then manage services with systemd targets. This separation provides better control and follows systemd best practices.
+
+### Standalone Stack Configuration (No OAuth)
+
+Complete standalone stack with local authentication only:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3000
+    oauth:
+      enabled: false
+      local_admin_user: admin
+      local_admin_password: secure-password
+
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317
+    http_port: 4318
+```
+
+### OAuth Integration with AAP
+
+Complete OAuth setup with Ansible Automation Platform:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3000
+    oauth:
+      enabled: true
+      client_id: flightctl-grafana-client
+      auth_url: https://your-aap-instance.com/o/authorize
+      token_url: https://your-aap-instance.com/o/token
+      api_url: http://flightctl-userinfo-proxy:8080
+      tls_skip_verify: false
+      local_admin_user: admin
+      local_admin_password: fallback-password
+
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317
+    http_port: 4318
+
+  userinfo_proxy:
+    image: flightctl/userinfo-proxy:latest
+    upstream_url: https://your-aap-instance.com/api/gateway/v1/me/
+    skip_tls_verify: false
+```
+
+### Secure Grafana with Custom TLS Certificates
+
+Secure Grafana setup with custom TLS certificates:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3443
+    protocol: https
+    https:
+      cert_file: /etc/grafana/certs/grafana.crt
+      cert_key: /etc/grafana/certs/grafana.key
+    oauth:
+      enabled: true
+      client_id: flightctl-grafana-client
+      auth_url: https://your-aap-instance.com/o/authorize
+      token_url: https://your-aap-instance.com/o/token
+      api_url: http://flightctl-userinfo-proxy:8080
+      tls_skip_verify: false
+
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317
+    http_port: 4318
+
+  userinfo_proxy:
+    image: flightctl/userinfo-proxy:latest
+    upstream_url: https://your-aap-instance.com/api/gateway/v1/me/
+    skip_tls_verify: false
+```
+
+**Certificate Setup**:
+
+```bash
+# Place certificates in the expected location
+sudo mkdir -p /etc/grafana/certs
+sudo cp your-grafana.crt /etc/grafana/certs/grafana.crt
+sudo cp your-grafana.key /etc/grafana/certs/grafana.key
+sudo chown 472:472 /etc/grafana/certs/grafana.*
+sudo chmod 600 /etc/grafana/certs/grafana.key
+```
+
+### Development Environment with Self-Signed Certificates
+
+Development setup with relaxed TLS verification:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 3000
+    oauth:
+      enabled: true
+      client_id: dev-grafana-client
+      auth_url: https://dev-auth.local/o/authorize
+      token_url: https://dev-auth.local/o/token
+      api_url: http://flightctl-userinfo-proxy:8080
+      tls_skip_verify: true  # OK for development
+      local_admin_user: admin
+      local_admin_password: dev-password
+
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+
+  userinfo_proxy:
+    image: flightctl/userinfo-proxy:latest
+    upstream_url: https://dev-aap-instance.local/api/gateway/v1/me/
+    skip_tls_verify: true  # OK for development with self-signed certs
+```
+
+### External Integration Only
+
+For integrating with existing observability infrastructure:
+
+```yaml
+observability:
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 4317
+    http_port: 4318
+```
+
+**Note**: Customize `/etc/otelcol/otelcol-config.yaml` to export to your external Prometheus, Grafana, Jaeger, or other observability systems.
+
+### Custom Port Configuration
+
+Example with custom ports to avoid conflicts:
+
+```yaml
+observability:
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    published_port: 8080  # Use port 8080 instead of 3000
+    oauth:
+      enabled: false
+      local_admin_user: admin
+      local_admin_password: secure-password
+
+  prometheus:
+    image: docker.io/prom/prometheus:latest
+
+  otel_collector:
+    image: docker.io/otel/opentelemetry-collector-contrib:latest
+    grpc_port: 14317  # Use port 14317 instead of 4317
+    http_port: 14318  # Use port 14318 instead of 4318
+```
+
+**Access with custom ports**:
+
+- Grafana: `http://<host>:8080`
+- OpenTelemetry collector: `<host>:14317` (gRPC), `<host>:14318` (HTTP)
+
+## Configuration Reference
+
+This section provides detailed documentation for every configuration variable available in the FlightCtl observability stack.
+
+### Grafana Configuration Variables
+
+#### Container Configuration
+
+**`observability.grafana.image`**
+
+- **Type**: String
+- **Default**: `docker.io/grafana/grafana:latest`
+- **Description**: Container image for Grafana. Can specify a specific version tag for reproducible deployments.
+- **Example**: `docker.io/grafana/grafana:10.2.0`
+
+**`observability.grafana.published_port`**
+
+- **Type**: Integer
+- **Default**: `3000`
+- **Description**: External port where Grafana web interface will be accessible. Change this if port 3000 conflicts with other services.
+- **Example**: `8080`
+
+#### Protocol Configuration
+
+**`observability.grafana.protocol`**
+
+- **Type**: String
+- **Default**: `http`
+- **Valid Values**: `http`, `https`
+- **Description**: Protocol for Grafana web interface. Set to `https` to enable TLS encryption.
+- **Example**: `https`
+
+**`observability.grafana.https.cert_file`**
+
+- **Type**: String
+- **Default**: `/etc/grafana/certs/grafana.crt`
+- **Description**: Path to TLS certificate file. Only used when `protocol: https`. Certificate must be readable by Grafana container (UID 472).
+- **Required**: When `protocol: https`
+- **Example**: `/etc/grafana/certs/my-grafana.crt`
+
+**`observability.grafana.https.cert_key`**
+
+- **Type**: String
+- **Default**: `/etc/grafana/certs/grafana.key`
+- **Description**: Path to TLS private key file. Only used when `protocol: https`. Key must be readable by Grafana container (UID 472) and have restricted permissions (600).
+- **Required**: When `protocol: https`
+- **Example**: `/etc/grafana/certs/my-grafana.key`
+
+#### OAuth Configuration
+
+**`observability.grafana.oauth.enabled`**
+
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Enable OAuth authentication. When enabled, users will authenticate through external identity provider instead of local Grafana accounts.
+- **Example**: `true`
+
+**`observability.grafana.oauth.client_id`**
+
+- **Type**: String
+- **Default**: Empty
+- **Description**: OAuth client ID registered with your identity provider. Must match the client ID configured in your IdP.
+- **Required**: When `oauth.enabled: true`
+- **Example**: `flightctl-grafana-client`
+
+**`observability.grafana.oauth.auth_url`**
+
+- **Type**: String (URL)
+- **Default**: Empty
+- **Description**: OAuth authorization endpoint URL. Users will be redirected here to authenticate.
+- **Required**: When `oauth.enabled: true`
+- **Example**: `https://your-aap.com/o/authorize`
+
+**`observability.grafana.oauth.token_url`**
+
+- **Type**: String (URL)
+- **Default**: Empty
+- **Description**: OAuth token endpoint URL. Grafana exchanges authorization codes for access tokens here.
+- **Required**: When `oauth.enabled: true`
+- **Example**: `https://your-aap.com/o/token`
+
+**`observability.grafana.oauth.api_url`**
+
+- **Type**: String (URL)
+- **Default**: Empty
+- **Description**: OAuth user info API endpoint. Grafana calls this to get user information. For AAP integration, use the UserInfo proxy: `http://flightctl-userinfo-proxy:8080`
+- **Required**: When `oauth.enabled: true`
+- **Example**: `http://flightctl-userinfo-proxy:8080`
+
+**`observability.grafana.oauth.tls_skip_verify`**
+
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Skip TLS certificate verification when connecting to OAuth endpoints. Only use `true` in development environments with self-signed certificates.
+- **Security**: Always use `false` in production
+- **Example**: `true` (development only)
+
+**`observability.grafana.oauth.local_admin_user`**
+
+- **Type**: String
+- **Default**: `admin`
+- **Description**: Username for local Grafana admin account. This account can be used as fallback when OAuth is unavailable.
+- **Example**: `admin`
+
+**`observability.grafana.oauth.local_admin_password`**
+
+- **Type**: String
+- **Default**: `defaultadmin`
+- **Description**: Password for local Grafana admin account. Change this from the default for security.
+- **Security**: Use a strong password in production
+- **Example**: `secure-admin-password-123`
+
+### Prometheus Configuration Variables
+
+**`observability.prometheus.image`**
+
+- **Type**: String
+- **Default**: `docker.io/prom/prometheus:latest`
+- **Description**: Container image for Prometheus. Prometheus runs as internal-only service with no external ports.
+- **Example**: `docker.io/prom/prometheus:v2.45.0`
+
+### OpenTelemetry Collector Configuration Variables
+
+**`observability.otel_collector.image`**
+
+- **Type**: String
+- **Default**: `docker.io/otel/opentelemetry-collector-contrib:latest`
+- **Description**: Container image for OpenTelemetry Collector. The contrib version includes additional receivers, processors, and exporters.
+- **Example**: `docker.io/otel/opentelemetry-collector-contrib:0.88.0`
+
+**`observability.otel_collector.grpc_port`**
+
+- **Type**: Integer
+- **Default**: `4317`
+- **Description**: External port for OpenTelemetry gRPC receiver. Agents send telemetry data to this port using OTLP/gRPC protocol.
+- **Example**: `14317`
+
+**`observability.otel_collector.http_port`**
+
+- **Type**: Integer
+- **Default**: `4318`
+- **Description**: External port for OpenTelemetry HTTP receiver. Agents send telemetry data to this port using OTLP/HTTP protocol.
+- **Example**: `14318`
+
+### UserInfo Proxy Configuration Variables
+
+**`observability.userinfo_proxy.image`**
+
+- **Type**: String
+- **Default**: `flightctl/userinfo-proxy:latest`
+- **Description**: Container image for UserInfo proxy service. This service translates AAP user API responses to standard OAuth UserInfo format.
+- **Example**: `flightctl/userinfo-proxy:v1.0.0`
+
+**`observability.userinfo_proxy.upstream_url`**
+
+- **Type**: String (URL)
+- **Default**: Empty
+- **Description**: URL of upstream identity provider's user API endpoint. For AAP integration, this should point to the AAP user API endpoint.
+- **Required**: When using OAuth with AAP integration
+- **Example**: `https://your-aap.com/api/gateway/v1/me/`
+
+**`observability.userinfo_proxy.skip_tls_verify`**
+
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Skip TLS certificate verification when connecting to upstream user API. Only use `true` in development environments with self-signed certificates.
+- **Security**: Always use `false` in production
+- **Example**: `true` (development only)
+
+### Configuration Validation Rules
+
+#### Required Field Dependencies
+
+When certain features are enabled, additional fields become required:
+
+**OAuth Authentication** (`oauth.enabled: true`):
+
+- `oauth.client_id` - Must be configured in your IdP
+- `oauth.auth_url` - IdP authorization endpoint
+- `oauth.token_url` - IdP token endpoint  
+- `oauth.api_url` - User info endpoint (use UserInfo proxy for AAP)
+
+**HTTPS Protocol** (`protocol: https`):
+
+- `https.cert_file` - TLS certificate path
+- `https.cert_key` - TLS private key path
+
+**AAP Integration** (OAuth with UserInfo proxy):
+
+- `userinfo_proxy.upstream_url` - AAP user API endpoint
+
+#### Default Behavior
+
+- All fields are optional unless explicitly marked as required
+- System uses documented default values for unspecified fields
+- Empty sections (e.g., `prometheus: {}`) use all defaults
+- Services are only created if their configuration sections exist
+
+#### Security Guidelines
+
+**Production Recommendations**:
+
+- Change `local_admin_password` from default
+- Use `tls_skip_verify: false` and `skip_tls_verify: false`
+- Use `protocol: https` with valid certificates
+- Use specific image tags instead of `latest`
+- Use non-default ports if needed for security
+
+**Development Allowances**:
+
+- `tls_skip_verify: true` for self-signed certificates
+- `skip_tls_verify: true` for internal development IdPs
+- Default passwords acceptable for local development

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -314,9 +314,9 @@ func CanReadCertAndKey(certPath, keyPath string) (bool, error) {
 	case !certExists && !keyExists:
 		return false, nil
 	case !certExists:
-		return false, fmt.Errorf("certificate file missing or unreadable: %s (certificate and key must be provided as a pair)", certPath)
+		return false, fmt.Errorf("certificate file missing or unreadable: \"%s\" (certificate and key must be provided as a pair)", certPath)
 	case !keyExists:
-		return false, fmt.Errorf("key file missing or unreadable: %s (certificate and key must be provided as a pair)", keyPath)
+		return false, fmt.Errorf("key file missing or unreadable: \"%s\" (certificate and key must be provided as a pair)", keyPath)
 	default:
 		return true, nil
 	}

--- a/packaging/observability/flightctl-grafana.container.template
+++ b/packaging/observability/flightctl-grafana.container.template
@@ -1,0 +1,32 @@
+[Unit]
+Description=FlightCtl Grafana Dashboard
+After=flightctl-observability-network.service flightctl-prometheus.service
+Wants=flightctl-observability-network.service flightctl-prometheus.service
+PartOf=flightctl-observability.target
+
+[Container]
+Image=${GRAFANA_IMAGE}
+Pull=newer
+ContainerName=flightctl-grafana
+PublishPort=${GRAFANA_PUBLISHED_PORT}:3000
+
+# Volume for Grafana's primary data (database, compiled assets, plugins)
+Volume=/var/lib/grafana:/var/lib/grafana:rw,z
+
+# Mount custom grafana.ini file
+Volume=/etc/grafana/grafana.ini:/etc/grafana/grafana.ini:ro,z
+
+# Mount directory for data source provisioning
+Volume=/etc/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro,z
+
+# Mount directory for TLS certificates (if using HTTPS)
+Volume=/etc/grafana/certs:/etc/grafana/certs:ro,z
+
+Network=flightctl-observability
+
+[Service]
+Restart=on-failure
+ExecStartPre=mkdir -p /var/lib/grafana /etc/grafana /etc/grafana/provisioning /etc/grafana/provisioning/datasources /etc/grafana/certs
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/observability/flightctl-observability.network
+++ b/packaging/observability/flightctl-observability.network
@@ -1,0 +1,8 @@
+[Unit]
+Description=FlightCtl Observability Network
+PartOf=flightctl-otel-collector.target flightctl-observability.target
+
+[Network]
+NetworkName=flightctl-observability
+Driver=bridge
+IPAMDriver=host-local 

--- a/packaging/observability/flightctl-observability.target
+++ b/packaging/observability/flightctl-observability.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=FlightCtl Full Observability Stack Target
+Documentation=https://docs.flightctl.io/user/standalone-observability/
+Wants=flightctl-otel-collector.target flightctl-prometheus.service flightctl-grafana.service flightctl-userinfo-proxy.service
+After=flightctl-otel-collector.target flightctl-prometheus.service flightctl-grafana.service flightctl-userinfo-proxy.service
+
+[Install]
+WantedBy=multi-user.target 

--- a/packaging/observability/flightctl-otel-collector.container.template
+++ b/packaging/observability/flightctl-otel-collector.container.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=FlightCtl OpenTelemetry Collector
+After=flightctl-observability-network.service
+Wants=flightctl-observability-network.service
+PartOf=flightctl-otel-collector.target flightctl-observability.target
+
+[Container]
+Image=${OTEL_COLLECTOR_IMAGE}
+Pull=newer
+ContainerName=flightctl-otel-collector
+
+Volume=/etc/otelcol/config.yaml:/etc/otelcol-contrib/config.yaml:ro,z
+Volume=/var/lib/otelcol:/var/lib/otelcol:rw,z
+
+PublishPort=${OTEL_COLLECTOR_GRPC_PORT}:4317/tcp
+PublishPort=${OTEL_COLLECTOR_HTTP_PORT}:4318/tcp
+
+Network=flightctl-observability
+
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/observability/flightctl-otel-collector.target
+++ b/packaging/observability/flightctl-otel-collector.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=FlightCtl OpenTelemetry Collector Target
+Documentation=https://docs.flightctl.io/user/standalone-observability/
+Wants=flightctl-observability-network.service flightctl-otel-collector.service
+After=flightctl-observability-network.service flightctl-otel-collector.service
+
+[Install]
+WantedBy=multi-user.target 

--- a/packaging/observability/flightctl-prometheus.container.template
+++ b/packaging/observability/flightctl-prometheus.container.template
@@ -1,0 +1,21 @@
+[Unit]
+Description=FlightCtl Prometheus Metrics Server
+After=flightctl-observability-network.service
+Wants=flightctl-observability-network.service
+PartOf=flightctl-observability.target
+
+[Container]
+Image=${PROMETHEUS_IMAGE}
+Pull=newer
+ContainerName=flightctl-prometheus
+
+Volume=/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro,z
+Volume=/var/lib/prometheus:/prometheus:rw,z
+
+Network=flightctl-observability
+
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/observability/flightctl-render-observability
+++ b/packaging/observability/flightctl-render-observability
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -eo pipefail
+
+# FlightCtl Observability Configuration Renderer
+# This script updates observability configuration from service-config.yaml
+# Use systemd targets to start/stop services: systemctl start flightctl-observability.target
+
+echo "FlightCtl Observability Configuration Renderer"
+echo "=============================================="
+echo
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "This command must be run as root (use sudo)"
+    exit 1
+fi
+
+LOG_TAG="flightctl-observability-render"
+
+log() {
+    local level="$1"
+    shift
+    logger -t "$LOG_TAG" "$level: $*"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [$level] $*" >&2
+}
+
+check_prerequisites() {
+    log "INFO" "Checking prerequisites..."
+    
+    # Check if service-config.yaml exists
+    if [ ! -f "/etc/flightctl/service-config.yaml" ]; then
+        log "ERROR" "Configuration file /etc/flightctl/service-config.yaml not found"
+        exit 1
+    fi
+    
+    # Check what observability components are installed
+    local has_full_observability=false
+    local has_otel_only=false
+    
+    # Check if full observability stack is installed
+    if [ -f "/etc/flightctl/definitions/observability.defs" ]; then
+        has_full_observability=true
+    fi
+    
+    # Check if standalone OpenTelemetry collector is installed
+    if [ -f "/etc/flightctl/definitions/otel-collector.defs" ]; then
+        has_otel_only=true
+    fi
+    
+    if [ "$has_full_observability" = false ] && [ "$has_otel_only" = false ]; then
+        log "ERROR" "No observability components found. Please install flightctl-observability or flightctl-otel-collector package"
+        exit 1
+    fi
+    
+    log "INFO" "Prerequisites check passed"
+}
+
+render_observability_config() {
+    log "INFO" "Rendering observability configuration..."
+    
+    # Check if full observability stack definitions file exists
+    if [ -f "/etc/flightctl/definitions/observability.defs" ]; then
+        local config_file="/etc/flightctl/service-config.yaml"
+        local templates_dir="/opt/flightctl-observability/templates"
+        local definitions_file="/etc/flightctl/definitions/observability.defs"
+        
+        # Source shared logic and call rendering with observability specific definitions
+        if [ -f "/etc/flightctl/scripts/render-templates.sh" ]; then
+            if ! source /etc/flightctl/scripts/render-templates.sh; then
+                log "ERROR" "Failed to source render-templates.sh"
+                exit 1
+            fi
+            
+            if ! render_templates "$config_file" "$templates_dir" "$definitions_file"; then
+                log "ERROR" "Failed to render observability configuration"
+                exit 1
+            fi
+            log "INFO" "Observability configuration rendered successfully"
+        else
+            log "ERROR" "render-templates.sh not found"
+            exit 1
+        fi
+    else
+        log "INFO" "Full observability stack not installed, skipping"
+    fi
+}
+
+render_otel_collector_config() {
+    log "INFO" "Rendering OpenTelemetry collector configuration..."
+    
+    # Check if otel-collector definitions file exists
+    if [ -f "/etc/flightctl/definitions/otel-collector.defs" ]; then
+        local config_file="/etc/flightctl/service-config.yaml"
+        local templates_dir="/opt/flightctl-observability/templates"
+        local definitions_file="/etc/flightctl/definitions/otel-collector.defs"
+        
+        # Source shared logic and call rendering with otel-collector specific definitions
+        if [ -f "/etc/flightctl/scripts/render-templates.sh" ]; then
+            if ! source /etc/flightctl/scripts/render-templates.sh; then
+                log "ERROR" "Failed to source render-templates.sh"
+                exit 1
+            fi
+            
+            if ! render_templates "$config_file" "$templates_dir" "$definitions_file"; then
+                log "ERROR" "Failed to render OpenTelemetry collector configuration"
+                exit 1
+            fi
+            log "INFO" "OpenTelemetry collector configuration rendered successfully"
+        else
+            log "ERROR" "render-templates.sh not found"
+            exit 1
+        fi
+    else
+        log "INFO" "OpenTelemetry collector not installed, skipping"
+    fi
+}
+
+main() {
+    log "INFO" "Starting FlightCtl observability configuration rendering..."
+    
+    check_prerequisites
+    render_observability_config
+    render_otel_collector_config
+    
+    log "INFO" "FlightCtl observability configuration rendering completed successfully!"
+    echo ""
+    echo "Configuration has been updated. To start/restart services, use:"
+    echo "  sudo systemctl start flightctl-observability.target      # Full stack"
+    echo "  sudo systemctl start flightctl-otel-collector.target     # OpenTelemetry collector only"
+    echo ""
+    echo "To stop services, use:"
+    echo "  sudo systemctl stop flightctl-observability.target       # Full stack"
+    echo "  sudo systemctl stop flightctl-otel-collector.target      # OpenTelemetry collector only"
+}
+
+# Show usage if help is requested
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat << EOF
+FlightCtl Observability Configuration Renderer
+
+USAGE:
+    $0 [OPTIONS]
+
+DESCRIPTION:
+    Renders observability configuration templates from /etc/flightctl/service-config.yaml
+    and reloads systemd daemon. Does NOT start or stop services.
+
+    This script supports both full observability stack and standalone OpenTelemetry 
+    collector installations.
+
+    This script will:
+    1. Check prerequisites based on installed components
+    2. Render observability configuration templates (if full stack is installed)
+    3. Render OpenTelemetry collector configuration (if installed)
+    4. Reload systemd daemon
+
+    To start/stop services after rendering, use systemd targets:
+    - flightctl-observability.target (full stack)
+    - flightctl-otel-collector.target (OpenTelemetry collector only)
+
+OPTIONS:
+    -h, --help    Show this help message
+
+EXAMPLES:
+    # Render configuration
+    $0
+
+    # Start services after rendering
+    systemctl start flightctl-observability.target
+
+    # Stop services
+    systemctl stop flightctl-observability.target
+
+EOF
+    exit 0
+fi
+
+main "$@" 

--- a/packaging/observability/flightctl-userinfo-proxy.container.template
+++ b/packaging/observability/flightctl-userinfo-proxy.container.template
@@ -1,0 +1,32 @@
+[Unit]
+Description=FlightCtl UserInfo Proxy for OAuth Integration
+After=flightctl-observability-network.service
+Wants=flightctl-observability-network.service
+PartOf=flightctl-observability.target
+
+[Container]
+Image=${USERINFO_PROXY_IMAGE}
+Pull=newer
+ContainerName=flightctl-userinfo-proxy
+
+# Network configuration
+Network=flightctl-observability
+
+# Environment variables for configuration
+Environment=USERINFO_LISTEN_PORT=8080
+Environment=USERINFO_UPSTREAM_URL=${USERINFO_UPSTREAM_URL}
+Environment=USERINFO_SKIP_TLS_VERIFY=${USERINFO_SKIP_TLS_VERIFY}
+
+# Security
+User=1001:1001
+
+# Resource limits
+Memory=64m
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target 

--- a/packaging/observability/grafana-dashboards.yaml
+++ b/packaging/observability/grafana-dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'Flightctl Dashboards'
+    orgId: 1
+    folder: 'Provisioned Dashboards'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/flightctl

--- a/packaging/observability/grafana-datasources.yaml
+++ b/packaging/observability/grafana-datasources.yaml
@@ -1,0 +1,14 @@
+# /etc/grafana/provisioning/datasources/prometheus.yaml
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    # Access Prometheus via its container name within the 'flightctl' network
+    url: http://flightctl-prometheus:9090
+    isDefault: true # Make this the default data source
+    version: 1
+    editable: true # Allow editing this data source from the Grafana UI
+    jsonData:
+      timeInterval: "5s"

--- a/packaging/observability/grafana.ini.template
+++ b/packaging/observability/grafana.ini.template
@@ -1,0 +1,57 @@
+# /etc/grafana/grafana.ini
+[server]
+http_port = 3000
+# http_addr = 0.0.0.0 # Default
+
+# HTTPS Configuration
+protocol = ${GRAFANA_PROTOCOL}
+cert_file = ${GRAFANA_CERT_FILE}
+cert_key = ${GRAFANA_CERT_KEY}
+
+[paths]
+data = /var/lib/grafana
+logs = /var/log/grafana
+plugins = /var/lib/grafana/plugins
+provisioning = /etc/grafana/provisioning/
+
+[auth.anonymous]
+# set to true if you want to allow anonymous users to view dashboards
+enabled = false
+
+[auth.basic]
+# set to true if you want to use basic authentication
+enabled = true
+
+[users]
+# default admin user, default password is "admin"
+default_theme = dark
+
+[security]
+admin_user = ${GRAFANA_LOCAL_ADMIN_USER}
+admin_password = ${GRAFANA_LOCAL_ADMIN_PASSWORD}
+
+
+[session]
+provider = file
+
+[metrics]
+# Enable internal Grafana metrics, can be scraped by Prometheus
+enabled = true
+
+[auth]
+disable_login_form = ${GRAFANA_OAUTH_ENABLED}
+
+
+[auth.generic_oauth]
+enabled = ${GRAFANA_OAUTH_ENABLED}
+name = Flightctl SSO
+allow_sign_up = true
+client_id = ${GRAFANA_OAUTH_CLIENT_ID}
+auth_url = ${GRAFANA_OAUTH_AUTH_URL}
+token_url = ${GRAFANA_OAUTH_TOKEN_URL}
+api_url = ${GRAFANA_OAUTH_API_URL}
+scopes = read
+role_attribute_path = contains(roles[*], 'grafana-admin') && 'Admin', contains(roles[*], 'grafana-editor') && 'Editor', true && 'Viewer'
+tls_skip_verify_insecure = ${GRAFANA_TLS_SKIP_VERIFY}
+
+

--- a/packaging/observability/observability.defs
+++ b/packaging/observability/observability.defs
@@ -1,0 +1,25 @@
+# Format:
+# ENV_VAR                       | CONFIG_PATH                                 | DEFAULT                                      | TEMPLATE_FILE                                | OUTPUT_PATH
+
+GRAFANA_OAUTH_ENABLED          | .observability.grafana.oauth.enabled                       | false                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_OAUTH_CLIENT_ID        | .observability.grafana.oauth.client_id                     |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_OAUTH_AUTH_URL         | .observability.grafana.oauth.auth_url                      |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_OAUTH_TOKEN_URL        | .observability.grafana.oauth.token_url                     |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_OAUTH_API_URL          | .observability.grafana.oauth.api_url                       |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_LOCAL_ADMIN_USER       | .observability.grafana.oauth.local_admin_user              | admin                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_LOCAL_ADMIN_PASSWORD   | .observability.grafana.oauth.local_admin_password          | defaultadmin                                 | grafana.ini.template                          | /etc/grafana/grafana.ini
+
+GRAFANA_TLS_SKIP_VERIFY        | .observability.grafana.oauth.tls_skip_verify               | false                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_PROTOCOL               | .observability.grafana.protocol                            | http                                         | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_CERT_FILE              | .observability.grafana.https.cert_file                     | /etc/grafana/certs/grafana.crt               | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_CERT_KEY               | .observability.grafana.https.cert_key                      | /etc/grafana/certs/grafana.key               | grafana.ini.template                          | /etc/grafana/grafana.ini
+
+GRAFANA_IMAGE                  | .observability.grafana.image                               | docker.io/grafana/grafana:latest             | flightctl-grafana.container.template          | /etc/containers/systemd/flightctl-grafana.container
+GRAFANA_PUBLISHED_PORT         | .observability.grafana.published_port                      | 3000                                         | flightctl-grafana.container.template          | /etc/containers/systemd/flightctl-grafana.container
+
+PROMETHEUS_IMAGE               | .observability.prometheus.image                            | docker.io/prom/prometheus:latest             | flightctl-prometheus.container.template       | /etc/containers/systemd/flightctl-prometheus.container
+
+USERINFO_PROXY_IMAGE           | .observability.userinfo_proxy.image                       | flightctl/userinfo-proxy:latest              | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+USERINFO_UPSTREAM_URL          | .observability.userinfo_proxy.upstream_url                |                                              | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+USERINFO_SKIP_TLS_VERIFY       | .observability.userinfo_proxy.skip_tls_verify             | false                                        | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+

--- a/packaging/observability/otel-collector.defs
+++ b/packaging/observability/otel-collector.defs
@@ -1,0 +1,7 @@
+# Format:
+# ENV_VAR                       | CONFIG_PATH                                 | DEFAULT                                      | TEMPLATE_FILE                                | OUTPUT_PATH
+
+OTEL_COLLECTOR_IMAGE           | .observability.otel_collector.image        | docker.io/otel/opentelemetry-collector-contrib:latest | flightctl-otel-collector.container.template | /etc/containers/systemd/flightctl-otel-collector.container
+OTEL_COLLECTOR_GRPC_PORT       | .observability.otel_collector.grpc_port    | 4317                                                   | flightctl-otel-collector.container.template | /etc/containers/systemd/flightctl-otel-collector.container
+OTEL_COLLECTOR_HTTP_PORT       | .observability.otel_collector.http_port    | 4318                                                   | flightctl-otel-collector.container.template | /etc/containers/systemd/flightctl-otel-collector.container
+

--- a/packaging/observability/otelcol-config.yaml
+++ b/packaging/observability/otelcol-config.yaml
@@ -1,0 +1,34 @@
+# /etc/otelcol/config.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch: # Batching for efficiency
+
+exporters:
+  # Prometheus exporter: This exporter will expose ALL metrics received by the collector
+  # (from OTLP and hostmetrics) on its own Prometheus endpoint (8888) for Prometheus to scrape.
+  prometheus:
+    endpoint: "0.0.0.0:8888" # Collector listens on this port for Prometheus to scrape it
+    # Optional: You can configure labels, etc., here if needed.
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [] # Traces pipeline without debug exporter
+    metrics:
+      # Metrics pipeline: receives OTLP from agents, AND hostmetrics from the local machine
+      receivers: [otlp]
+      processors: [batch]
+      # Exporter: send all collected metrics to the Prometheus exporter
+      exporters: [prometheus] # Only prometheus exporter for metrics
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [] # Logs pipeline without debug exporter
+

--- a/packaging/observability/prometheus.yml
+++ b/packaging/observability/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090'] # Prometheus scrapes itself (for its own internal metrics)
+
+  # UPDATED: Prometheus now only scrapes the OpenTelemetry Collector for other metrics
+  - job_name: 'opentelemetry-collector'
+    static_configs:
+      - targets: ['flightctl-otel-collector:8888'] # OTel Collector's Prometheus exporter endpoint
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: '([^:]+)(?::\d+)?'
+        target_label: instance
+        replacement: '$1'
+

--- a/packaging/observability/render-templates.sh
+++ b/packaging/observability/render-templates.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# This is a logic library, not a standalone script.
+
+render_templates() {
+    local config_file="$1"
+    local templates_dir="$2"
+    local definitions_file="$3"
+
+    set -eo pipefail
+
+    LOG_TAG="flightctl-config-reloader"
+
+    log() {
+        local level="$1"
+        shift
+        logger -t "$LOG_TAG" "$level: $*"
+        echo "$level: $*" >&2
+    }
+
+    require_bin() {
+        command -v "$1" &>/dev/null || { log "ERROR" "Required binary '$1' not found"; exit 1; }
+    }
+
+    require_bin yq
+    require_bin envsubst
+
+    log "INFO" "Loading variable definitions from $definitions_file"
+
+    declare -A RENDER_MAP
+    declare -A SYSTEMD_SERVICES
+
+    # Step 1: Parse definitions
+    while IFS='|' read -r env_var config_path default_value template_file output_file; do
+        env_var=$(echo "$env_var" | xargs)
+        config_path=$(echo "$config_path" | xargs)
+        default_value=$(echo "$default_value" | xargs)
+        template_file=$(echo "$template_file" | xargs)
+        output_file=$(echo "$output_file" | xargs)
+
+        [[ "$env_var" =~ ^#.*$ || -z "$env_var" ]] && continue
+
+        value=$(yq e "$config_path" "$config_file" 2>/dev/null || echo "$default_value")
+        [[ "$value" == "null" || -z "$value" ]] && value="$default_value"
+
+        export "$env_var"="$value"
+
+        key="${template_file}__${output_file}"
+        RENDER_MAP["$key"]="$template_file|$output_file"
+
+        if [[ "$output_file" == *.container ]]; then
+            svc_name=$(basename "$output_file" .container).service
+            SYSTEMD_SERVICES["$svc_name"]=1
+        fi
+    done < "$definitions_file"
+
+    # Step 2: Render all
+    for pair in "${RENDER_MAP[@]}"; do
+        IFS='|' read -r template_file output_file <<< "$pair"
+        full_template_path="${templates_dir}/${template_file}"
+
+        # Special handling for UserInfo proxy - skip if not configured
+        if [[ "$template_file" == "flightctl-userinfo-proxy.container.template" ]]; then
+            if [[ -z "${USERINFO_UPSTREAM_URL:-}" ]]; then
+                log "INFO" "Skipping $template_file (USERINFO_UPSTREAM_URL not configured)"
+                # Remove the service from the restart list
+                unset SYSTEMD_SERVICES["flightctl-userinfo-proxy.service"]
+                continue
+            fi
+        fi
+
+        log "INFO" "Rendering $full_template_path -> $output_file"
+        envsubst < "$full_template_path" > "$output_file" || {
+            log "ERROR" "Failed to render $output_file"
+            exit 1
+        }
+
+        chmod 0644 "$output_file"
+        /usr/sbin/restorecon "$output_file" 2>/dev/null || log "WARNING" "restorecon failed on $output_file"
+    done
+
+    # Restore SELinux context for Grafana datasources file if it exists
+    if [[ -f "/etc/grafana/provisioning/datasources/prometheus.yaml" ]]; then
+                 /usr/sbin/restorecon "/etc/grafana/provisioning/datasources/prometheus.yaml" 2>/dev/null || log "WARNING" "restorecon failed on prometheus.yaml"
+    fi
+
+    # Step 3: Reload systemd (always needed for new unit files)
+    log "INFO" "Reloading systemd..."
+    systemctl daemon-reload
+
+    log "INFO" "Configuration templates rendered successfully"
+}


### PR DESCRIPTION
EDM-1678: Support observability SSO against AAP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standalone observability stack with Grafana, Prometheus, and OpenTelemetry Collector, including new systemd targets, container templates, and network configuration.
  * Added a UserInfo Proxy service for OpenID Connect integration with Ansible Automation Platform, including a new proxy server and container build.
  * Provided comprehensive user documentation for deploying and configuring the observability stack.
  * Added configuration options for observability components in the main service config.

* **Improvements**
  * Enhanced deployment scripts with explicit readiness checks for database and key-value store, improved secret synchronization, and service restarts.
  * Updated container configurations across services to pull newer images automatically.
  * Improved error messages for certificate and key file checks.
  * Modified systemd unit dependencies to use soft dependencies for Flight Control services.

* **Chores**
  * Added new RPM sub-packages for observability and OpenTelemetry Collector with lifecycle scripts and packaging support.
  * Added a template rendering script and a dedicated rendering command for observability configuration.
  * Extended spell-check dictionary with new domain-specific terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->