### PR TITLE
NO-ISSUE: Add context flag in periodic server to indicate that it represents internal call.

### DIFF
--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -45,6 +45,7 @@ func (s *Server) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-periodic")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-periodic")
+	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	defer cancel()
 
 	queuesProvider, err := queues.NewRedisProvider(ctx, s.log, s.cfg.KV.Hostname, s.cfg.KV.Port, s.cfg.KV.Password)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal request handling for periodic checks. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->