### PR TITLE
EDM-1533: Clarify event output headers in CLI

### DIFF
--- a/internal/cli/display/table.go
+++ b/internal/cli/display/table.go
@@ -334,7 +334,7 @@ func (f *TableFormatter) printCSRTable(w *tabwriter.Writer, csrs ...api.Certific
 }
 
 func (f *TableFormatter) printEventsTable(w *tabwriter.Writer, events ...api.Event) error {
-	f.printHeaderRowLn(w, "AGE", "KIND", "NAME", "TYPE", "MESSAGE")
+	f.printHeaderRowLn(w, "AGE", "INVOLVEDOBJECT.KIND", "INVOLVEDOBJECT.NAME", "TYPE", "MESSAGE")
 	for _, e := range events {
 		f.printTableRowLn(w,
 			humanize.Time(*e.Metadata.CreationTimestamp),


### PR DESCRIPTION
Changed column headers in `get events` output from "KIND" and "NAME" to "INVOLVEDOBJECT.KIND" and "INVOLVEDOBJECT.NAME" to avoid confusion with event metadata fields. This makes it clear that the columns refer to the object the event is about, not the event itself, and aligns better with field selector expectations.