### PR TITLE
EDM-1747: Fix policy syncing

### DIFF
--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -297,12 +297,7 @@ func (a *Agent) statusUpdate(ctx context.Context) {
 }
 
 func (a *Agent) beforeUpdate(ctx context.Context, current, desired *v1alpha1.Device) error {
-	// to ensure that the agent is able to correct for an invalid policy, it is reconciled first.
-	// the new policy will go into affect on the next sync.
-	if err := a.policyManager.Sync(ctx, desired.Spec); err != nil {
-		return fmt.Errorf("policy: %w", err)
-	}
-
+	// the policy manager currently represents the state of the desired device
 	if err := a.specManager.CheckPolicy(ctx, policy.Download, desired.Version()); err != nil {
 		return fmt.Errorf("download policy: %w", err)
 	}

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -83,7 +83,6 @@ func TestSync(t *testing.T) {
 				gomock.InOrder(
 					mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil),
 					mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil),
-					mockPolicyManager.EXPECT().Sync(ctx, desired.Spec).Return(nil),
 					mockSpecManager.EXPECT().CheckPolicy(ctx, policy.Download, desired.Version()).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
 					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
@@ -124,7 +123,6 @@ func TestSync(t *testing.T) {
 					//
 					mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil),
 					mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil),
-					mockPolicyManager.EXPECT().Sync(ctx, current.Spec).Return(nil),
 					mockSpecManager.EXPECT().CheckPolicy(ctx, policy.Download, desired.Version()).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
 					mockSpecManager.EXPECT().IsOSUpdate().Return(false),

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -29,6 +29,7 @@ type manager struct {
 	devicePublisher  publisher.Subscription
 	cache            *cache
 	queue            PriorityQueue
+	policyManager    policy.Manager
 
 	lastConsumedDevice *v1alpha1.Device
 	log                *log.PrefixLogger
@@ -61,6 +62,7 @@ func NewManager(
 		osClient:         osClient,
 		cache:            newCache(log),
 		devicePublisher:  devicePublisher,
+		policyManager:    policyManager,
 		queue:            queue,
 		log:              log,
 	}
@@ -319,6 +321,13 @@ func (s *manager) consumeLatest(ctx context.Context) (bool, error) {
 			break
 		}
 		s.log.Debugf("New template version received from management service: %s", newDesired.Version())
+		// as the queue maintains some policy state we need to sync the policy state prior to adding versions to the queue
+		// otherwise policy state is delayed by a version and could lead to instances in which updating is stuck for a long time.
+		// we log an error if policy syncing fails, but we don't return an error as the mechanism for indicating to users
+		// that a spec is poorly defined doesn't exist here.
+		if err = s.policyManager.Sync(ctx, newDesired.Spec); err != nil {
+			s.log.Errorf("Failed to sync new device version %s policy manager: %v", newDesired.Version(), err)
+		}
 		s.queue.Add(ctx, newDesired)
 		s.lastConsumedDevice = newDesired
 		consumed = true

--- a/internal/agent/device/spec/queue.go
+++ b/internal/agent/device/spec/queue.go
@@ -122,6 +122,8 @@ func (m *queueManager) Next(ctx context.Context) (*v1alpha1.Device, bool) {
 		return nil, false
 	}
 
+	// currently it's useful to allow specs to be consumed if the download policy is satisfied
+	// even if the updatePolicy isn't
 	if !requeue.downloadPolicySatisfied && !requeue.updatePolicySatisfied {
 		m.log.Debugf("Template version %d policies are not satisfied skipping...", version)
 		m.queue.Add(item)

--- a/internal/agent/device/spec/queue_test.go
+++ b/internal/agent/device/spec/queue_test.go
@@ -1,7 +1,7 @@
 package spec
 
 import (
-	context "context"
+	"context"
 	"testing"
 	"time"
 
@@ -226,6 +226,26 @@ func TestPolicy(t *testing.T) {
 				// evaluate policy ready on retry Next
 				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Download).Return(true)
 				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Update).Return(false)
+			},
+			wantNext:           true,
+			wantDesiredVersion: "6",
+		},
+		{
+			name: "download not ready update ready on retry",
+			setupMocks: func(mockPolicyManager *policy.MockManager) {
+				// check policy during init Add
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Download).Return(false)
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Update).Return(false)
+				// check policy during Add
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Download).Return(false)
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Update).Return(false)
+
+				// evaluate policy first Next
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Download).Return(false)
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Update).Return(false)
+				// evaluate policy ready on retry Next
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Download).Return(false)
+				mockPolicyManager.EXPECT().IsReady(gomock.Any(), policy.Update).Return(true)
 			},
 			wantNext:           true,
 			wantDesiredVersion: "6",

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -894,13 +894,13 @@ func TestGetDesired(t *testing.T) {
 	// Define the test cases
 	testCases := []struct {
 		name           string
-		setupMocks     func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement)
+		setupMocks     func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager)
 		expectedDevice *v1alpha1.Device
 		expectedError  error
 	}{
 		{
 			name: "error reading desired spec",
-			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement) {
+			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
 				mrw.EXPECT().ReadFile(desiredPath).Return(nil, specErr)
 			},
 			expectedDevice: nil,
@@ -908,7 +908,7 @@ func TestGetDesired(t *testing.T) {
 		},
 		{
 			name: "desired spec is returned when management api returns no content",
-			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement) {
+			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
 				renderedDesiredSpec := createTestRenderedDevice(image)
 				marshaledDesiredSpec, err := json.Marshal(renderedDesiredSpec)
 				require.NoError(err)
@@ -923,7 +923,7 @@ func TestGetDesired(t *testing.T) {
 		},
 		{
 			name: "spec from the api response has the same Version as desired",
-			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement) {
+			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
 				renderedDesiredSpec := createTestRenderedDevice(image)
 				marshaledDesiredSpec, err := json.Marshal(renderedDesiredSpec)
 				require.NoError(err)
@@ -931,6 +931,7 @@ func TestGetDesired(t *testing.T) {
 				mpq.EXPECT().Add(gomock.Any(), gomock.Any())
 				mpq.EXPECT().Next(gomock.Any()).Return(renderedDesiredSpec, true)
 				mrw.EXPECT().WriteFile(desiredPath, marshaledDesiredSpec, gomock.Any()).Return(nil)
+				mpm.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil)
 				require.NoError(devicePublisher.Push(renderedDesiredSpec))
 			},
 			expectedDevice: createTestRenderedDevice(image),
@@ -938,10 +939,11 @@ func TestGetDesired(t *testing.T) {
 		},
 		{
 			name: "error when writing the desired spec fails",
-			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement) {
+			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
 				device := createTestRenderedDevice(image)
 				mpq.EXPECT().Add(gomock.Any(), gomock.Any())
 				mpq.EXPECT().Next(gomock.Any()).Return(device, true)
+				mpm.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil)
 
 				// API is returning a rendered version that is different from the read desired spec
 				apiResponse := newVersionedDevice("5")
@@ -962,6 +964,7 @@ func TestGetDesired(t *testing.T) {
 			mockClient := client.NewMockManagement(ctrl)
 			mockReadWriter := fileio.NewMockReadWriter(ctrl)
 			mockPriorityQueue := NewMockPriorityQueue(ctrl)
+			mockPolicyManager := policy.NewMockManager(ctrl)
 
 			log := log.NewPrefixLogger("test")
 
@@ -973,6 +976,7 @@ func TestGetDesired(t *testing.T) {
 				queue:            mockPriorityQueue,
 				cache:            newCache(log),
 				devicePublisher:  devicePublisher,
+				policyManager:    mockPolicyManager,
 			}
 
 			s.cache.current.renderedVersion = "1"
@@ -982,6 +986,7 @@ func TestGetDesired(t *testing.T) {
 				mockPriorityQueue,
 				mockReadWriter,
 				mockClient,
+				mockPolicyManager,
 			)
 
 			specResult, _, err := s.GetDesired(ctx)


### PR DESCRIPTION
After a discussion with @hexfusion it was decided to fix the existing issue in a non-invasive manner while a more comprehensive approach for a long term fix is designed for a future release. This change solves the existing problem by syncing policy updates immediately upon receiving a new version so that the most recent policy rules will be applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy synchronization to prevent update stalls by ensuring policy state is updated before processing new device specs.

* **Tests**
  * Enhanced test coverage for policy synchronization scenarios, including new and updated test cases to verify correct behavior when policy readiness states vary.
  * Adjusted existing tests to reflect changes in policy synchronization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->