### PR TITLE
EDM-1809: added e2e for testing system-info-timeout

### DIFF
--- a/test/scripts/agent-images/Containerfile-e2e-v9.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v9.local
@@ -1,0 +1,11 @@
+# empty base image
+FROM localhost:5000/flightctl-device:base
+
+
+COPY ./test/scripts/agent-images/infinite.sh /usr/lib/flightctl/custom-info.d/infinite
+RUN chmod 755 /usr/lib/flightctl/custom-info.d/infinite
+RUN echo -e "\nsystem-info-custom:\n  - infinite\nsystem-info-timeout: 15s" >> /etc/flightctl/config.yaml
+
+# set the working directory to /
+WORKDIR /
+

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/../functions
 
 REGISTRY_ADDRESS=$(registry_address)
-IMAGE_LIST="base v2 v3 v4 v5 v6 v8"
+IMAGE_LIST="base v2 v3 v4 v5 v6 v8 v9"
 
 if is_acm_installed; then
     IMAGE_LIST="${IMAGE_LIST} v7"

--- a/test/scripts/agent-images/infinite.sh
+++ b/test/scripts/agent-images/infinite.sh
@@ -1,0 +1,2 @@
+#! bin/bash
+sleep infinite


### PR DESCRIPTION
per https://issues.redhat.com/browse/EDM-1809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new end-to-end test to validate system info timeout handling and custom OS image update flow for devices.
  * Added a new custom system info script and corresponding container image for testing system info timeout scenarios.
* **Chores**
  * Updated the image build script to include the new test image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->