### PR TITLE
EDM-1813: Publish containers for new microservices

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -95,7 +95,7 @@ jobs:
   publish-flightctl-containers:
     strategy:
       matrix:
-        image: ['api', 'periodic', 'worker', 'cli-artifacts']
+        image: ['api', 'periodic', 'worker', 'cli-artifacts', 'alert-exporter', 'alertmanager-proxy']
     needs: [generate-tags]
     runs-on: "ubuntu-24.04"
     steps:


### PR DESCRIPTION
flightctl-alert-exporter and flightctl-alertmanager-proxy were recently added but their images weren't being pushed to quay.