### PR TITLE
NO-ISSUE: add resources cleaning after cli tests

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -46,6 +46,8 @@ var _ = Describe("cli operation", func() {
 	})
 
 	AfterEach(func() {
+		err := harness.CleanUpAllResources()
+		Expect(err).ToNot(HaveOccurred())
 		harness.Cleanup(false) // do not print console on error
 	})
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -27,11 +27,11 @@ const (
 )
 
 var ResourceTypes = [...]string{
-	Device,
+	ResourceSync,
 	Fleet,
+	Device,
 	EnrollmentRequest,
 	Repository,
-	ResourceSync,
 	CertificateSigningRequest,
 }
 


### PR DESCRIPTION
Adding resources cleaning in the cli tests afterEach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cleanup of resources after each CLI operation test to ensure a cleaner test environment.
  * Adjusted resource type ordering for better consistency in test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->