### PR TITLE
EDM-1766: Create valid agent selinux policy

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -74,7 +74,6 @@ Requires: podman
 %description services
 The flightctl-services package provides installation and setup of files for running containerized Flight Control services
 
-
 %package otel-collector
 Summary: OpenTelemetry Collector for FlightCtl
 Requires:       podman
@@ -498,8 +497,6 @@ echo "Flightctl Observability Stack uninstalled."
      # Copy static configuration files (those not templated)
      install -m 0644 packaging/observability/prometheus.yml %{buildroot}/etc/prometheus/
      install -m 0644 packaging/observability/otelcol-config.yaml %{buildroot}/etc/otelcol/
-
-
 
      # Copy template source files to a temporary staging area for processing in %post
      install -m 0644 packaging/observability/grafana.ini.template %{buildroot}/opt/flightctl-observability/templates/

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -7,9 +7,6 @@
 # SELinux specifics
 %global selinuxtype targeted
 %define selinux_policyver 3.14.3-67
-%define agent_relabel_files() \
-    semanage fcontext -a -t flightctl_agent_exec_t "/usr/bin/flightctl-agent" ; \
-    restorecon -v /usr/bin/flightctl-agent
 
 Name:           flightctl
 Version:        0.6.0
@@ -54,8 +51,16 @@ The flightctl-agent package provides the management agent for the Flight Control
 Summary: SELinux policies for the Flight Control management agent
 BuildRequires: selinux-policy >= %{selinux_policyver}
 BuildRequires: selinux-policy-devel >= %{selinux_policyver}
+BuildRequires: container-selinux
 BuildArch: noarch
 Requires: selinux-policy >= %{selinux_policyver}
+
+# For restorecon
+Requires: policycoreutils
+# For semanage
+Requires: policycoreutils-python-utils
+# For policy macros
+Requires: container-selinux
 
 %description selinux
 The flightctl-selinux package provides the SELinux policy modules required by the Flight Control management agent.
@@ -68,6 +73,7 @@ Requires: podman
 
 %description services
 The flightctl-services package provides installation and setup of files for running containerized Flight Control services
+
 
 %package otel-collector
 Summary: OpenTelemetry Collector for FlightCtl
@@ -488,35 +494,35 @@ echo "Flightctl Observability Stack uninstalled."
      mkdir -p %{buildroot}/opt/flightctl-observability/templates # Staging for template files processed in %post
      mkdir -p %{buildroot}/usr/local/bin # For the reloader script
      mkdir -p %{buildroot}/usr/lib/systemd/system # For systemd units
-     
+
      # Copy static configuration files (those not templated)
      install -m 0644 packaging/observability/prometheus.yml %{buildroot}/etc/prometheus/
      install -m 0644 packaging/observability/otelcol-config.yaml %{buildroot}/etc/otelcol/
-     
 
-     
+
+
      # Copy template source files to a temporary staging area for processing in %post
      install -m 0644 packaging/observability/grafana.ini.template %{buildroot}/opt/flightctl-observability/templates/
      install -m 0644 packaging/observability/flightctl-grafana.container.template %{buildroot}/opt/flightctl-observability/templates/
      install -m 0644 packaging/observability/flightctl-prometheus.container.template %{buildroot}/opt/flightctl-observability/templates/
      install -m 0644 packaging/observability/flightctl-otel-collector.container.template %{buildroot}/opt/flightctl-observability/templates/
      install -m 0644 packaging/observability/flightctl-userinfo-proxy.container.template %{buildroot}/opt/flightctl-observability/templates/
-     
+
      # Copy non-templated Grafana datasource provisioning file
      install -m 0644 packaging/observability/grafana-datasources.yaml %{buildroot}/etc/grafana/provisioning/datasources/prometheus.yaml
 
      install -m 0644 packaging/observability/grafana-dashboards.yaml %{buildroot}/etc/grafana/provisioning/dashboards/flightctl.yaml
-     
+
      # Copy the reloader script and its systemd units
      install -m 0755 packaging/observability/render-templates.sh %{buildroot}/etc/flightctl/scripts
-     
+
      install -m 0755 packaging/observability/flightctl-render-observability %{buildroot}/usr/local/bin/
      install -m 0644 packaging/observability/observability.defs %{buildroot}/etc/flightctl/definitions/
      install -m 0644 packaging/observability/otel-collector.defs %{buildroot}/etc/flightctl/definitions/
-     
+
      # Copy the observability network quadlet
      install -m 0644 packaging/observability/flightctl-observability.network %{buildroot}/etc/containers/systemd/
-     
+
      # Install systemd targets for service grouping
      install -m 0644 packaging/observability/flightctl-otel-collector.target %{buildroot}/usr/lib/systemd/system/
      install -m 0644 packaging/observability/flightctl-observability.target %{buildroot}/usr/lib/systemd/system/
@@ -529,18 +535,18 @@ echo "Flightctl Observability Stack uninstalled."
 %selinux_relabel_pre -s %{selinuxtype}
 
 %post selinux
-
-%selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2
-%agent_relabel_files
+# Install SELinux module - fail RPM installation if this fails
+if ! semodule -s %{selinuxtype} -i %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2; then
+    echo "ERROR: Failed to install flightctl SELinux policy (AST failure or compatibility issue)" >&2
+    exit 1
+fi
 
 %postun selinux
-
 if [ $1 -eq 0 ]; then
-    %selinux_modules_uninstall -s %{selinuxtype} flightctl_agent
+    semodule -s %{selinuxtype} -r flightctl_agent 2>/dev/null || :
 fi
 
 %posttrans selinux
-
 %selinux_relabel_post -s %{selinuxtype}
 
 # File listings
@@ -622,6 +628,8 @@ rm -rf /usr/share/sosreport
     /usr/lib/systemd/system/flightctl.target
 
 %changelog
+* Tue Jul 15 2025 Sam Batschelet <sbatsche@redhat.com> - 0.9.0-2
+- Improve selinux policy deps and install
 * Sun Jul 6 2025 Ori Amizur <oamizur@redhat.com> - 0.9.0-1
 - Add support for Flight Control standalone observability stack
 * Tue Apr 15 2025 Dakota Crowder <dcrowder@redhat.com> - 0.6.0-4

--- a/packaging/selinux/Makefile
+++ b/packaging/selinux/Makefile
@@ -1,16 +1,32 @@
-TARGET?=flightctl_agent
-MODULES?=${TARGET:=.pp.bz2}
-SHAREDIR?=/usr/share
+TARGET ?= flightctl_agent
+MODULES ?= ${TARGET:=.pp.bz2}
+SHAREDIR ?= /usr/share
+CI_RPM_IMAGE ?= quay.io/flightctl/ci-rpm-builder:latest
+
+.PHONY: all clean man install-policy install
 
 all: ${MODULES}
 
+# Containerized build
+ifeq ($(USE_CONTAINER),1)
+%.pp.bz2: %.pp
+	@echo "Compressing $^ -> $@ in container"
+	podman run --rm -v $(CURDIR):/work:Z $(CI_RPM_IMAGE) bash -c "cd /work && bzip2 -9 -f $^"
+
+%.pp: %.te %.fc
+	@echo "Building $@ in container"
+	podman run --rm -v $(CURDIR):/work:Z $(CI_RPM_IMAGE) bash -c "cd /work && make -f /usr/share/selinux/devel/Makefile $@"
+
+else
 %.pp.bz2: %.pp
 	rm -f $@ || true
-	@echo Compressing $^ -\> $@
+	@echo Compressing $^ -> $@
 	bzip2 -9 -f $^
 
 %.pp: %.te %.fc
 	make -f ${SHAREDIR}/selinux/devel/Makefile $@
+
+endif
 
 clean:
 	rm -f *~ *.tc *.pp *.mod *.pp.bz2

--- a/packaging/selinux/Makefile
+++ b/packaging/selinux/Makefile
@@ -7,13 +7,13 @@ all: ${MODULES}
 %.pp.bz2: %.pp
 	rm -f $@ || true
 	@echo Compressing $^ -\> $@
-	bzip2 -9 $^
+	bzip2 -9 -f $^
 
-%.pp: %.te
+%.pp: %.te %.fc
 	make -f ${SHAREDIR}/selinux/devel/Makefile $@
 
 clean:
-	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -f *~ *.tc *.pp *.mod *.pp.bz2
 	rm -rf tmp *.tar.gz
 
 man: install-policy

--- a/packaging/selinux/README.md
+++ b/packaging/selinux/README.md
@@ -1,0 +1,114 @@
+> **Note:** These steps are intended to be executed against a running `flightctl-agent` instance.
+> This allows you to test workflows and iteratively refine the SELinux policy in a live environment.
+> When developing the policy its important to not upgrade the OS image as the local overlay changes
+> made via dnf install -y --transient <package-name> will be lost. Once you have a policy ready for
+> upgrade testing copy the policy back to your repo commit and redeploy based on the directions below
+
+# Developing the SELinux Policy for `flightctl-agent`
+
+## Prerequisites
+
+To create an agent VM, run:
+
+```sh
+make agent-vm
+```
+When redeploying, clean up the previous build first:
+
+```sh
+make clean-agent-vm
+rm -rf bin/rpm
+make agent-vm
+```
+
+Install required development tools on the agent:
+
+```sh
+sudo dnf install -y --transient policycoreutils-devel setools-console make audit rsync
+```
+
+## Copy Policy To Agent
+
+Use your current policy as the base for development.
+
+```
+rsync -avz ./packaging/selinux/ user@<agent-ip>:~/selinux/
+```
+
+## Start Audit Logging
+Enable and start `auditd` so policy denials are recorded:
+
+```sh
+sudo systemctl enable --now auditd
+```
+
+## Temporarily Set the Agent to Permissive Mode
+
+To allow the agent to run without SELinux denials while you gather AVC logs or test workflows:
+
+### Set permissive mode for the agent domain:
+
+```sh
+sudo semanage permissive -a flightctl_agent_t
+```
+
+### Revert to enforcing mode once policy is updated:
+
+```sh
+sudo semanage permissive -d flightctl_agent_t
+```
+
+## Reproduce and Inspect AVCs
+
+Restart the service, perform actions against the agent then review recent denials and explanations:
+
+```sh
+sudo systemctl restart flightctl-agent
+sudo ausearch -m avc -ts recent -c flightctl-agent | audit2allow
+sudo ausearch -m avc -ts recent -c flightctl-agent | audit2why
+```
+
+## Build the Policy 
+
+Use a containerized build on the agent to ensure we do not install
+dependencies such as `selinux-policy-devel` which will not be available on the
+agent included in the RPM.
+
+```sh
+make USE_CONTAINER=1
+```
+
+## Install the Policy
+
+```sh
+sudo make install-policy
+```
+
+## Ensure Selinux Policy Is Applied
+
+After installing you should ensure that the policy is correctly applied.
+
+```sh
+ls -Z /usr/bin/flightctl-agent 
+system_u:object_r:flightctl_agent_exec_t:s0 /usr/bin/flightctl-agent
+```
+
+## Important Areas Of Concern
+
+The agent operates under a broad SELinux scope, so it's critical to test as many execution paths as possible. Key areas to focus on:
+
+- Console: Ensure execution of subsystem commands (bootc status, podman ps, systemctl status) works as expected.
+
+- Applications: Validate behavior for both declared and embedded applications, add and remove.
+
+- Hooks: Test execution of declared and embedded lifecycle hooks.
+
+## References
+
+- https://access.redhat.com/articles/6999267
+
+- https://pages.cs.wisc.edu/~matyas/selinux-policy/
+
+- https://linux.die.net/man/1/audit2allow
+
+- https://linux.die.net/man/8/audit2why

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -1,0 +1,2 @@
+/usr/bin/flightctl-agent                        --  gen_context(system_u:object_r:flightctl_agent_exec_t,s0)
+/var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -1,35 +1,220 @@
 policy_module(flightctl_agent, 1.0.0)
 
+# Security Enhanced Linux Reference
+# https://pages.cs.wisc.edu/~matyas/selinux-policy/
+# https://access.redhat.com/articles/6999267
+
+
 type flightctl_agent_t;
-domain_type(flightctl_agent_t);
+type flightctl_agent_exec_t;
+type flightctl_agent_var_lib_t;
+type flightctl_agent_tmp_t;
 
-require {
-    # Existing types from the policy
-    type init_t;
-    type devpts_t;
-    type ptmx_t;
-    type unreserved_port_t;
-    
-    attribute file_type;
-    attribute exec_type;
+init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
+files_type(flightctl_agent_var_lib_t)
+files_tmp_file(flightctl_agent_tmp_t)
 
+gen_require(`
+    type install_t, install_exec_t;
+    type hostname_t, hostname_exec_t;
+    type kernel_t, sysfs_t, ptmx_t, devpts_t, unlabeled_t, nsfs_t;
+    type etc_t, tmp_t, home_root_t, root_t, fs_t, admin_home_t;
+    type container_var_lib_t, container_runtime_t, container_file_t, container_ro_file_t, container_var_run_t;
+    type var_t, var_run_t, device_t, var_log_t;
+    type sysctl_t, sysctl_irq_t;
+    type systemd_unit_file_t;
+    type tmpfs_t, cgroup_t;
+    type shadow_t, systemd_passwd_var_run_t, syslogd_var_run_t;
+    type proc_t, init_t, mail_spool_t;
+    attribute domain;
+')
 
-    # Classes and permissions that will be used.
-    class file { read execute open };
-    class process transition;
-    class chr_file { open read write ioctl };
-    class tcp_socket { name_connect };
-}
+## Basic file access permissions  ##
 
-# Define the new file type for the flightctl-agent executable.
-# It must have the file and exec attributes.
-type flightctl_agent_exec_t, file_type, exec_type;
+# System directories
+files_read_etc_files(flightctl_agent_t)
+files_read_etc_runtime_files(flightctl_agent_t)
+files_read_usr_files(flightctl_agent_t)
+files_read_boot_files(flightctl_agent_t)
+files_read_generic_pids(flightctl_agent_t)
+files_read_var_lib_files(flightctl_agent_t)
 
-# When a process running in init_t executes a file labeled flightctl_agent_exec_t,
-# have it transition into flightctl_agent_t.
-type_transition init_t flightctl_agent_exec_t:process flightctl_agent_t;
+# /etc management
+manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)
+manage_files_pattern(flightctl_agent_t, etc_t, etc_t)
+manage_lnk_files_pattern(flightctl_agent_t, etc_t, etc_t)
 
-# Allow the flightctl-agent process (running in flightctl_agent_t) to do what it needs.
-allow flightctl_agent_t devpts_t:chr_file open;
-allow flightctl_agent_t ptmx_t:chr_file { open read write ioctl };
-allow flightctl_agent_t unreserved_port_t:tcp_socket name_connect;  
+# /var/lib/flightctl management
+manage_dirs_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+manage_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+manage_lnk_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
+files_var_lib_filetrans(flightctl_agent_t, flightctl_agent_var_lib_t, dir, "flightctl")
+
+# /tmp management
+files_tmp_filetrans(flightctl_agent_t, flightctl_agent_tmp_t, { file dir })
+manage_dirs_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
+manage_files_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
+
+# Admin home (root) directory access
+userdom_manage_admin_dirs(flightctl_agent_t)
+userdom_manage_admin_files(flightctl_agent_t)
+userdom_search_admin_dir(flightctl_agent_t)
+allow flightctl_agent_t home_root_t:lnk_file read;
+
+# User home directory access
+userdom_search_user_home_dirs(flightctl_agent_t)
+userdom_manage_user_home_content(flightctl_agent_t)
+
+# System directory access
+allow flightctl_agent_t mail_spool_t:dir search;
+
+## Process management & capabilities  ##
+
+# Basic process capabilities
+allow flightctl_agent_t self:capability { dac_override chown setuid setgid sys_admin audit_write sys_resource dac_read_search sys_chroot mknod };
+allow flightctl_agent_t self:capability2 { mac_admin mac_override };
+allow flightctl_agent_t self:process { fork signal sigchld execmem setfscreate getsched setsched setpgid setcap setrlimit };
+
+# Process information access
+allow flightctl_agent_t domain:dir getattr;
+
+# Executable access
+corecmd_exec_all_executables(flightctl_agent_t)
+domtrans_pattern(flightctl_agent_t, install_exec_t, install_t)
+domtrans_pattern(flightctl_agent_t, hostname_exec_t, hostname_t)
+
+# User namespace creation for bubblewrap
+ifdef(`user_namespace',`
+    allow flightctl_agent_t self:user_namespace create;
+')
+
+## System information access  ##
+
+# Kernel and system state
+kernel_read_system_state(flightctl_agent_t)
+kernel_read_network_state(flightctl_agent_t)
+kernel_read_all_proc(flightctl_agent_t)
+kernel_read_all_sysctls(flightctl_agent_t)
+kernel_request_load_module(flightctl_agent_t)
+init_read_state(flightctl_agent_t)
+init_mmap_read_var_lib_files(flightctl_agent_t)
+init_read_var_lib_files(flightctl_agent_t)
+init_search_var_lib_dirs(flightctl_agent_t)
+
+# Device information
+dev_read_sysfs(flightctl_agent_t)
+dev_read_kmsg(flightctl_agent_t)
+
+## Networking permissions  ##
+
+# Network connections
+corenet_tcp_connect_all_ports(flightctl_agent_t)
+corenet_sendrecv_all_client_packets(flightctl_agent_t)
+sysnet_dns_name_resolve(flightctl_agent_t)
+
+# Socket permissions
+allow flightctl_agent_t self:{ tcp_socket udp_socket netlink_route_socket } { create bind connect read write getattr setattr lock append sendto recvfrom listen accept };
+allow flightctl_agent_t self:unix_dgram_socket { create connect read write getattr };
+allow flightctl_agent_t kernel_t:unix_dgram_socket sendto;
+
+# Netlink audit socket for namespace operations
+allow flightctl_agent_t self:netlink_audit_socket { create bind connect read write getattr setattr lock append sendto recvfrom nlmsg_relay };
+
+## System services access  ##
+
+# Authentication and user management
+auth_read_passwd(flightctl_agent_t)
+auth_read_shadow(flightctl_agent_t)
+init_read_utmp(flightctl_agent_t)
+allow flightctl_agent_t systemd_passwd_var_run_t:dir { search open read watch };
+allow flightctl_agent_t systemd_passwd_var_run_t:file { open read };
+
+# Localization and logging
+miscfiles_read_localization(flightctl_agent_t)
+logging_read_all_logs(flightctl_agent_t)
+logging_send_audit_msgs(flightctl_agent_t)
+
+# Journal access permissions
+allow flightctl_agent_t syslogd_var_run_t:dir { read search };
+allow flightctl_agent_t var_log_t:dir { read watch search };
+allow flightctl_agent_t var_log_t:file { read open getattr };
+
+# Systemd service management
+systemd_manage_all_unit_files(flightctl_agent_t)
+systemd_start_all_unit_files(flightctl_agent_t)
+allow flightctl_agent_t init_t:system status;
+
+# D-Bus system bus access
+dbus_system_bus_client(flightctl_agent_t)
+optional_policy(`
+    systemd_dbus_chat_hostnamed(flightctl_agent_t)
+')
+
+## Container runtime support  ##
+
+# Container storage and runtime
+container_read_share_files(flightctl_agent_t)
+container_manage_files(flightctl_agent_t)
+container_runtime_domtrans(flightctl_agent_t)
+admin_pattern(flightctl_agent_t, container_var_lib_t, container_var_lib_t)
+
+# Container storage overlay access
+allow flightctl_agent_t container_file_t:dir { open read getattr search write remove_name };
+allow flightctl_agent_t container_file_t:file { unlink open read getattr create write };
+allow flightctl_agent_t container_file_t:lnk_file { read getattr };
+
+# Container read-only storage access
+allow flightctl_agent_t container_ro_file_t:dir { open read getattr search write rmdir };
+allow flightctl_agent_t container_ro_file_t:file { open read getattr write };
+
+# Container runtime storage access
+allow flightctl_agent_t container_var_run_t:dir { read write search };
+allow flightctl_agent_t container_var_run_t:file { read open getattr };
+
+# CGroup access for container management
+allow flightctl_agent_t cgroup_t:dir search;
+
+# Container runtime process interaction
+allow flightctl_agent_t { install_t hostname_t container_runtime_t }:fd use;
+allow { install_t hostname_t container_runtime_t } flightctl_agent_t:fd use;
+allow flightctl_agent_t { install_t hostname_t container_runtime_t }:process { sigchld signal sigkill sigstop signull };
+
+# Container runtime transitions
+allow flightctl_agent_t container_runtime_t:process2 { nnp_transition nosuid_transition };
+allow flightctl_agent_t install_t:process2 { nnp_transition nosuid_transition };
+
+## Console & terminal access  ##
+
+# Terminal and PTY access for console sessions
+term_use_all_terms(flightctl_agent_t)
+allow flightctl_agent_t ptmx_t:chr_file { create read write open ioctl getattr setattr };
+allow flightctl_agent_t devpts_t:chr_file { create read write append open getattr ioctl setattr };
+allow flightctl_agent_t devpts_t:filesystem associate;
+allow flightctl_agent_t nsfs_t:file getattr;
+allow flightctl_agent_t unlabeled_t:dir search;
+
+## Filesystem & mount operations  ##
+
+# Filesystem mount operations for bubblewrap namespaces
+fs_mount_all_fs(flightctl_agent_t)
+fs_remount_all_fs(flightctl_agent_t)
+fs_unmount_all_fs(flightctl_agent_t)
+fs_getattr_all_fs(flightctl_agent_t)
+
+# Mount-on permissions for key directories (bubblewrap bind mounts)
+allow flightctl_agent_t { root_t etc_t var_t tmp_t device_t var_run_t sysfs_t admin_home_t }:dir mounton;
+allow flightctl_agent_t proc_t:dir { mounton write };
+
+# Tmpfs directory creation and mount-on permissions
+allow flightctl_agent_t tmpfs_t:dir { create write add_name mounton };
+
+# Special filesystem access for namespace operations
+allow flightctl_agent_t sysctl_t:file { mounton write };
+allow flightctl_agent_t sysctl_irq_t:dir { write mounton };
+
+## Device access (for bubblewrap)  ##
+
+# Device access for --dev-bind /dev /dev
+dev_rw_generic_chr_files(flightctl_agent_t)
+dev_rw_generic_blk_files(flightctl_agent_t)
+allow flightctl_agent_t device_t:dir { mounton read getattr search };  


### PR DESCRIPTION
The policy follows the principle of least privilege. The agent handles orchestration and API communication while child processes (bootc, podman, hostname) run in their proper domains via domtrans_pattern. Each component gets only the permissions it directly needs. 

This was a best effort attempt and we should consider adding checks for selinux failures to e2e. 

refs
- https://pages.cs.wisc.edu/~matyas/selinux-policy/
- https://access.redhat.com/articles/6999267

```sh
[root@localhost ~]# ls -Z /usr/bin/flightctl-agent 
system_u:object_r:flightctl_agent_exec_t:s0 /usr/bin/flightctl-agent
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive SELinux policy for the flightctl-agent, including detailed file contexts and expanded system permissions.
  * Added a README with step-by-step instructions for SELinux policy development and testing.
* **Improvements**
  * Enhanced RPM packaging for SELinux by refining dependency handling, error management, and installation scripts.
  * Updated SELinux policy build process to support containerized builds and improved Makefile targets.
* **Documentation**
  * Added detailed documentation for SELinux policy development and verification.
* **Other Changes**
  * Minor formatting and whitespace cleanups in packaging scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->