### PR TITLE
NO-ISSUE: Move Jaeger helm from flightctl to e2e-extras

### DIFF
--- a/deploy/helm/e2e-extras/templates/NOTES.txt
+++ b/deploy/helm/e2e-extras/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{- if .Values.jaeger.enabled }}
+You can access the Jaeger UI for distributed tracing at http://localhost:{{ .Values.global.nodePorts.jaegerUi }}
+
+To set up port forwarding for Jaeger UI, run:
+    kubectl port-forward -n {{ default .Release.Namespace .Values.global.internalNamespace }} svc/jaeger-ui 16686:16686
+{{- end }} 

--- a/deploy/helm/e2e-extras/templates/jaeger-all-in-one.yaml
+++ b/deploy/helm/e2e-extras/templates/jaeger-all-in-one.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 10001
       containers:
       - name: jaeger-all-in-one
-        image: "jaegertracing/all-in-one:{{ .Values.jaeger.image.tag }}"
+        image: "{{ .Values.jaeger.image.image }}:{{ .Values.jaeger.image.tag }}"
         imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.jaeger.image.pullPolicy }}
         ports:
         - containerPort: 16686
@@ -86,16 +86,14 @@ metadata:
   labels:
     flightctl.service: jaeger-all-in-one
 spec:
-  {{- if eq (include "flightctl.getServiceExposeMethod" .) "nodePort" }}
   type: NodePort
-  {{- end }}
   selector:
     flightctl.service: jaeger-all-in-one
   ports:
   - port: 16686
     targetPort: 16686
     name: ui
-    {{- if and .Values.global.nodePorts.jaegerUi (eq (include "flightctl.getServiceExposeMethod" .) "nodePort") }}
+    {{- if .Values.global.nodePorts.jaegerUi }}
     nodePort: {{ .Values.global.nodePorts.jaegerUi }}
     {{- end }}
 ---

--- a/deploy/helm/e2e-extras/values.dev.yaml
+++ b/deploy/helm/e2e-extras/values.dev.yaml
@@ -3,9 +3,16 @@ global:
     registry: 5000
     gitserver: 3222
     prometheus: 9090
+    jaegerUi: 16686
 registry:
   image: quay.io/flightctl/e2eregistry:2
   route: false
   hostName: ""
 gitserver:
   image: localhost/git-server:latest
+jaeger:
+  enabled: true
+  storageType: memory
+  maxTraces: 50000
+  otlpEnabled: true
+  logLevel: info

--- a/deploy/helm/e2e-extras/values.yaml
+++ b/deploy/helm/e2e-extras/values.yaml
@@ -3,6 +3,10 @@ global:
     registry: ""
     gitserver: ""
     prometheus: ""
+    jaegerUi: ""
+  imagePullPolicy: IfNotPresent
+  imagePullSecretName: ""
+  internalNamespace: ""
 registry:
   image: quay.io/flightctl/e2eregistry:2
   route: true
@@ -11,3 +15,20 @@ gitserver:
   image: localhost/git-server:latest
 prometheus:
   image: quay.io/prometheus/prometheus:v2.54.1
+jaeger:
+  enabled: false
+  image:
+    image: jaegertracing/all-in-one
+    tag: "1.35"
+    pullPolicy: ""
+  storageType: memory
+  maxTraces: 50000
+  otlpEnabled: true
+  logLevel: info
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+      cpu: "200m"

--- a/deploy/helm/flightctl/templates/NOTES.txt
+++ b/deploy/helm/flightctl/templates/NOTES.txt
@@ -6,14 +6,6 @@ You can access the Flight Control UI at {{ include "flightctl.getUIUrl" . }}
 {{- end }}
 You can access the Flight Control API at {{ include "flightctl.getApiUrl" . }}
 
-{{- if .Values.jaeger.enabled }}
-You can access the Jaeger UI for distributed tracing at http://localhost:{{ .Values.global.nodePorts.jaegerUi }}
-
-To set up port forwarding for Jaeger UI, run:
-    kubectl port-forward -n {{ default .Release.Namespace .Values.global.internalNamespace }} svc/jaeger-ui 16686:16686
-{{- end }}
-
-
 {{- if and (eq .Values.global.auth.type "builtin") (not (eq .Values.global.target "acm")) }}
 A demo user "demouser" has been created for you. You can retrieve its password by running:
 

--- a/deploy/helm/flightctl/templates/flightctl-alert-exporter-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alert-exporter-config.yaml
@@ -21,10 +21,10 @@ data:
     alertmanager:
         hostname: flightctl-alertmanager.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local
         port: 9093
-    {{ if .Values.jaeger.enabled }}
+    {{ if .Values.global.tracing.enabled }}
     tracing:
         enabled: true
-        endpoint: jaeger-collector.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:4318
-        insecure: true
+        endpoint: {{ .Values.global.tracing.endpoint }}
+        insecure: {{ .Values.global.tracing.insecure }}
     {{ end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-config.yaml
@@ -66,10 +66,10 @@ data:
         sloMax: 4.0
         apiLatencyBins: [0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.1, 1]
     {{ end }}
-    {{ if .Values.jaeger.enabled }}
+    {{ if .Values.global.tracing.enabled }}
     tracing:
         enabled: true
-        endpoint: jaeger-collector.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:4318
-        insecure: true
+        endpoint: {{ .Values.global.tracing.endpoint }}
+        insecure: {{ .Values.global.tracing.insecure }}
     {{ end }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-periodic-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-periodic-config.yaml
@@ -15,10 +15,10 @@ data:
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local
         port: 6379
-    {{ if .Values.jaeger.enabled }}
+    {{ if .Values.global.tracing.enabled }}
     tracing:
         enabled: true
-        endpoint: jaeger-collector.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:4318
-        insecure: true
+        endpoint: {{ .Values.global.tracing.endpoint }}
+        insecure: {{ .Values.global.tracing.insecure }}
     {{ end }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-config.yaml
@@ -15,10 +15,10 @@ data:
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local
         port: 6379
-    {{ if .Values.jaeger.enabled }}
+    {{ if .Values.global.tracing.enabled }}
     tracing:
         enabled: true
-        endpoint: jaeger-collector.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:4318
-        insecure: true
+        endpoint: {{ .Values.global.tracing.endpoint }}
+        insecure: {{ .Values.global.tracing.insecure }}
     {{ end }}
 {{ end }}

--- a/deploy/helm/flightctl/values.dev.yaml
+++ b/deploy/helm/flightctl/values.dev.yaml
@@ -3,6 +3,10 @@ global:
     type: "none"
     oidc:
       oidcAuthority: http://keycloak.flightctl-external.svc.cluster.local:8081/realms/flightctl
+  tracing:
+    enabled: true
+    endpoint: jaeger-collector.flightctl-internal.svc.cluster.local:4318
+    insecure: true
   internalNamespace: flightctl-internal
   storageClassName: standard
   exposeServicesMethod: "nodePort"
@@ -58,12 +62,6 @@ alertmanagerProxy:
     tag: latest
 prometheus:
   enabled: true
-jaeger:
-  enabled: true
-  storageType: memory
-  maxTraces: 50000
-  otlpEnabled: true
-  logLevel: info
 ui:
   enabled: false
 

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -57,6 +57,10 @@ global:
       externalApiUrl: ""
   metrics:
     enabled: true
+  tracing:
+    enabled: false
+    endpoint: jaeger-collector.flightctl-internal.svc.cluster.local:4318
+    insecure: true
   internalNamespace: ""
   clusterLevelSecretAccess: false
   appCode: ""
@@ -69,7 +73,6 @@ global:
     ui: 9000
     keycloak: 8081
     alertmanagerProxy: 8443
-    jaegerUi: 16686
   gatewayPorts:
     tls: 443
     http: 80
@@ -156,23 +159,6 @@ alertmanagerProxy:
     pullPolicy: ""
 prometheus:
   enabled: false
-jaeger:
-  enabled: false
-  image:
-    image: jaegertracing/all-in-one
-    tag: "1.35"
-    pullPolicy: ""
-  storageType: memory
-  maxTraces: 50000
-  otlpEnabled: true
-  logLevel: info
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "50m"
-    limits:
-      memory: "512Mi"
-      cpu: "200m"
 ui:
   enabled: true
   api:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Jaeger tracing integration to the e2e-extras deployment, including options for enabling Jaeger, setting storage type, trace limits, OTLP support, and log level.
  * Provided user instructions for accessing the Jaeger UI when enabled.

* **Improvements**
  * Made tracing configuration more flexible and generic for flightctl deployments by introducing a global tracing block and removing Jaeger-specific settings.
  * Enhanced image configuration options for Jaeger in e2e-extras.

* **Removals**
  * Removed Jaeger-specific configuration and access instructions from flightctl deployments, consolidating tracing settings under a single global section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->