### PR TITLE
EDM-1833: agent/client/podman: add ArtifactExists

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -212,6 +212,16 @@ func (p *Podman) ImageExists(ctx context.Context, image string) bool {
 	return exitCode == 0
 }
 
+// ArtifactExists returns true if the artifact exists in storage otherwise false.
+func (p *Podman) ArtifactExists(ctx context.Context, artifact string) bool {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	args := []string{"artifact", "inspect", artifact}
+	_, _, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
+	return exitCode == 0
+}
+
 // EventsSinceCmd returns a command to get podman events since the given time. After creating the command, it should be started with exec.Start().
 // When the events are in sync with the current time a sync event is emitted.
 func (p *Podman) EventsSinceCmd(ctx context.Context, events []string, sinceTime string) *exec.Cmd {

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -379,13 +379,21 @@ func (s *manager) getDeviceFromQueue(ctx context.Context) (*v1alpha1.Device, boo
 
 	// if this is a new version ensure we persist it to disk
 	if desired.Version() != s.cache.getRenderedVersion(Desired) {
-		s.log.Infof("Writing new desired rendered spec to disk version: %s", desired.Version())
+		if s.isNewDesiredVersion(desired) {
+			s.log.Infof("Writing new desired rendered spec to disk version: %s", desired.Version())
+		}
+
 		if err := s.write(Desired, desired); err != nil {
 			return nil, false, err
 		}
 	}
 
 	return desired, false, nil
+}
+
+// isNewDesiredVersion returns true if this is the first time observing this desired version.
+func (s *manager) isNewDesiredVersion(desired *v1alpha1.Device) bool {
+	return s.lastConsumedDevice == nil || s.lastConsumedDevice.Version() != desired.Version()
 }
 
 func (s *manager) IsOSUpdate() bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for checking the existence of both images and artifacts in Podman storage.
  * Enhanced handling of different OCI target types when verifying if a target already exists, with improved error handling for invalid types.
* **Tests**
  * Extended test coverage to include OCI artifact targets alongside image targets.
  * Simplified collector function signatures in tests for improved clarity.
* **Bug Fixes**
  * Improved logging conditions when updating device specifications to reduce unnecessary log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->