### PR TITLE
EDM-1811: Fix server certificate name mismatch for api in quadlets de…

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -13,7 +13,7 @@ service:
   altNames:
     - {{BASE_DOMAIN}}
     - flightctl-api
-  srvCertFile: {{SRV_CERT_FILE}}
+  srvCertificateFile: {{SRV_CERT_FILE}}
   srvKeyFile: {{SRV_KEY_FILE}}
 kv:
   hostname: flightctl-kv


### PR DESCRIPTION
…ployment

Aligns a modified value in the config seen here: https://github.com/flightctl/flightctl/blob/release-0.8/internal/config/config.go#L45

Root issue is the config.go key was changed but the quadlets api config was not - which breaks the deployment when it tries to read passed server certs.