### PR TITLE
NO-ISSUE: Reassign the qcow image back to the current user

### DIFF
--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -128,6 +128,8 @@ build_qcow2_image() {
     if is_acm_installed; then
         sudo qemu-img resize "$(pwd)"/bin/output/qcow2/disk.qcow2 +5G # increasing disk size for microshift registration to acm test only
     fi
+    # Reset the owner to the user running make
+    sudo chown -R "${USER}:$(id -gn ${USER})" "$(pwd)"/bin/output
 }
 
 case "$BUILD_TYPE" in


### PR DESCRIPTION
Sudo is invoked purely for the build process and not so that the output image is owned by root so it seems appropriate to assign it back to the build user in the script itself.