### PR TITLE
EDM-1830: Enrollment Request reapplication validation

### DIFF
--- a/test/data/examples/enrollmentrequest.yaml
+++ b/test/data/examples/enrollmentrequest.yaml
@@ -1,34 +1,14 @@
-apiVersion: flightctl.io/v1alpha1
-kind: EnrollmentRequest
-metadata:
-  name: ab238b7190128394809b809a0b980231984b098c0983408aa8a8a0809800991
-spec:
-  csr: |
-    -----BEGIN CERTIFICATE REQUEST-----
-    MIIBBjCBrQIBADBLMUkwRwYDVQQDE0AxM2Q2MzJkODYzNzNjYWFlZGE2NGRhNDA1
-    MmY5NTdmYWE3NDJmYzcwNTAwMjY3NDhiYzc5MDY1Yzg4MTlkMWIwMFkwEwYHKoZI
-    zj0CAQYIKoZIzj0DAQcDQgAEHBMC30NRJTJ3NWOlei9YWkBM/MzoNDGyMRKuzE0/
-    cKkyXVJexHq0xIn22YCNN3ZDNxxwW6LlQg3ijGnvStQOb6AAMAoGCCqGSM49BAMC
-    A0gAMEUCIQDSrxi6krdCKcLChdMB3w7IqmDlZhREGbHMCESVn6ssPAIgZL+QrJtw
-    8R+r4piaYvZktrsk3yCIuz3hI7loYmXP3d8=
+apiVersion: api.flightctl.io/v1alpha1  
+kind: EnrollmentRequest  
+metadata:  
+  name: 13d632d86373caaeda64da4052f957faa742fc7050026748bc79065c8819d1b0  
+spec:  
+  csr: |  
+    -----BEGIN CERTIFICATE REQUEST-----  
+    MIIBBjCBrQIBADBLMUkwRwYDVQQDE0AxM2Q2MzJkODYzNzNjYWFlZGE2NGRhNDA1  
+    MmY5NTdmYWE3NDJmYzcwNTAwMjY3NDhiYzc5MDY1Yzg4MTlkMWIwMFkwEwYHKoZI  
+    zj0CAQYIKoZIzj0DAQcDQgAEHBMC30NRJTJ3NWOlei9YWkBM/MzoNDGyMRKuzE0/  
+    cKkyXVJexHq0xIn22YCNN3ZDNxxwW6LlQg3ijGnvStQOb6AAMAoGCCqGSM49BAMC  
+    A0gAMEUCIQDSrxi6krdCKcLChdMB3w7IqmDlZhREGbHMCESVn6ssPAIgZL+QrJtw  
+    8R+r4piaYvZktrsk3yCIuz3hI7loYmXP3d8=  
     -----END CERTIFICATE REQUEST-----
-status:
-  certificate: |
-    -----BEGIN CERTIFICATE-----
-    MIIBujCCAWGgAwIBAgIIJaheZEBfOxgwCgYIKoZIzj0EAwIwGDEWMBQGA1UEAxMN
-    Y3NyLXNpZ25lci1jYTAeFw0yMzEwMTAxNzEwMzFaFw0yNDEwMDkxNzEwMzJaMEsx
-    STBHBgNVBAMTQDEzZDYzMmQ4NjM3M2NhYWVkYTY0ZGE0MDUyZjk1N2ZhYTc0MmZj
-    NzA1MDAyNjc0OGJjNzkwNjVjODgxOWQxYjAwWTATBgcqhkjOPQIBBggqhkjOPQMB
-    BwNCAAQcEwLfQ1ElMnc1Y6V6L1haQEz8zOg0MbIxEq7MTT9wqTJdUl7EerTEifbZ
-    gI03dkM3HHBbouVCDeKMae9K1A5vo2IwYDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0l
-    BAwwCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADArBgNVHSMEJDAigCANii2X78Cy
-    RcU4ryE6gW7EDWhb8AundrVmJ3wQyrPg7jAKBggqhkjOPQQDAgNHADBEAiBHvTby
-    aI2MfLGq4dZKfSxEePxWwmPFaPmN1dfw+53vdgIgX7SNGvrdB+CQBvrfJFKoDu+o
-    O6WEM3Wl62xKjRnCFDs=
-    -----END CERTIFICATE-----
-  conditions:
-    - lastTransitionTime: "2023-10-10T17:10:32Z"
-      message: Approved by auto approver
-      reason: AutoApproved
-      status: "True"
-      type: Approved

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -909,7 +909,7 @@ func (h *Harness) RunGetEvents(args ...string) (string, error) {
 	return h.CLI(allArgs...)
 }
 
-// ManageResource performs an operation ("apply" or "delete") on a specified resource.
+// ManageResource performs an operation ("apply", "delete", or "approve") on a specified resource.
 func (h *Harness) ManageResource(operation, resource string, args ...string) (string, error) {
 	switch operation {
 	case "apply":
@@ -923,6 +923,8 @@ func (h *Harness) ManageResource(operation, resource string, args ...string) (st
 			return h.CLI("delete", resource)
 		}
 		return h.CleanUpResources(resource)
+	case "approve":
+		return h.CLI("approve", resource)
 	default:
 		return "", fmt.Errorf("unsupported operation: %s", operation)
 	}


### PR DESCRIPTION
E2E for the bug https://issues.redhat.com/browse/EDM-1179

THe fix for the example ER applied and works as expected https://github.com/flightctl/flightctl/pull/1330/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end test to validate reapplication behavior for enrollment requests, ensuring proper error handling when attempting to reapply a previously deleted request.

* **Tests**
  * Enhanced test harness to support approval operations for resources.
  * Updated example enrollment request YAML for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->