### PR TITLE
NO-ISSUE: Upgrade Redis image tag to 9.6 in values.acm.yaml

### DIFF
--- a/deploy/helm/flightctl/values.acm.yaml
+++ b/deploy/helm/flightctl/values.acm.yaml
@@ -9,7 +9,7 @@ db:
 kv:
   image:
     image: registry.redhat.io/rhel9/redis-7
-    tag: 9.5-1736454843
+    tag: 9.6
 
 alertmanager:
   image:

--- a/deploy/helm/flightctl/values.acm.yaml
+++ b/deploy/helm/flightctl/values.acm.yaml
@@ -9,7 +9,7 @@ db:
 kv:
   image:
     image: registry.redhat.io/rhel9/redis-7
-    tag: 9.6
+    tag: 9.6-1752567986
 
 alertmanager:
   image:

--- a/deploy/helm/flightctl/values.acm.yaml
+++ b/deploy/helm/flightctl/values.acm.yaml
@@ -4,7 +4,7 @@ global:
 db:
   image:
     image: registry.redhat.io/rhel9/postgresql-16
-    tag: 9.6
+    tag: 9.6-1752571367
 
 kv:
   image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL and Redis image versions in deployment configuration to newer specific build tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->