### PR TITLE
EDM-1872: fixing CI failure - dependancy on fleet from other test

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -102,6 +102,8 @@ var _ = Describe("cli operation", func() {
 			Expect(out).To(ContainSubstring(deviceID))
 
 			By("Should let you list fleets")
+			_, err = harness.CLIWithStdin(completeFleetYaml, "apply", "-f", "-")
+			Expect(err).ToNot(HaveOccurred())
 			out, err = harness.CLI("get", "fleets")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(ContainSubstring("e2e-test-fleet"))


### PR DESCRIPTION
Fix to CI issue.
Removing dependancy on previous test for an existing fleet
https://reportportal-ecosystem-qe.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#edge-management-qe/launches/latest/24853/1246002/1246005/log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end tests to ensure fleet resources are created before verifying CLI autocompletion and listing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->