### PR TITLE
EDM-1872: validation for config-dir flag

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -579,6 +579,13 @@ var _ = Describe("cli login", func() {
 			invalidToken := "fake-token"
 			loginArgsToken := append(loginArgs, "--token", invalidToken)
 
+			By("Retry login using an empty config-dir flag")
+			loginArgs = append(loginArgs, "--config-dir")
+			logrus.Infof("Executing CLI with args: %v", loginArgs)
+			out, err = harness.CLI(loginArgs...)
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("Error: flag needs an argument: --config-dir"))
+
 			logrus.Infof("Executing CLI with args: %v", loginArgsToken)
 			out, _ = harness.CLI(loginArgsToken...)
 			if !strings.Contains(out, "Auth is disabled") {


### PR DESCRIPTION
Validation for the flag created as fix here:
https://github.com/flightctl/flightctl/pull/1268

https://issues.redhat.com/browse/EDM-991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end CLI tests to ensure fleet resources are present before listing.
  * Added a new test to validate error handling when the CLI login command is run with the `--config-dir` flag but without the required argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->