### PR TITLE
EDM-1886: Fix baseDomain for Standalone Flight Control Deployments

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -1,15 +1,13 @@
 {{- define "flightctl.getBaseDomain" }}
   {{- if .Values.global.baseDomain }}
     {{- printf .Values.global.baseDomain }}
-  {{- else if eq .Values.global.target "acm" }}
+  {{- else }}
     {{- $openShiftBaseDomain := (lookup "config.openshift.io/v1" "DNS" "" "cluster").spec.baseDomain }}
     {{- if .noNs }}
       {{- printf "apps.%s" $openShiftBaseDomain }}
     {{- else }}
       {{- printf "%s.apps.%s" .Release.Namespace $openShiftBaseDomain }}
     {{- end }}
-  {{- else }}
-    {{- printf "flightctl.local" }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Reverts the changes done to calculate the baseDomain for Standalone deployments [here](https://github.com/flightctl/flightctl/commit/6e5a6b5c4bc98cb8888e3941388cf47421af6ba8#diff-0bd34c1193202c7f6d02e308bc8015a9ca54f331bd0262752d7b803874b79525R4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the domain resolution logic for Helm deployments, removing special handling for certain targets and consolidating conditions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->