### PR TITLE
EDM-1846: CLI organizations support

### DIFF
--- a/cmd/flightctl/main.go
+++ b/cmd/flightctl/main.go
@@ -28,6 +28,7 @@ func NewFlightCtlCommand() *cobra.Command {
 	cmd.AddCommand(cli.NewCmdDelete())
 	cmd.AddCommand(cli.NewCmdApprove())
 	cmd.AddCommand(cli.NewCmdCSRConfig())
+	cmd.AddCommand(cli.NewCmdConfig())
 	cmd.AddCommand(cli.NewCmdDecommission())
 	cmd.AddCommand(cli.NewCmdDeny())
 	cmd.AddCommand(cli.NewCmdLogin())

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
@@ -103,7 +102,7 @@ func (o *ApplyOptions) Validate(args []string) error {
 }
 
 func (o *ApplyOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -9,7 +9,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -91,7 +90,7 @@ func (o *ApproveOptions) Validate(args []string) error {
 }
 
 func (o *ApproveOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ccoveille/go-safecast"
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	fccrypto "github.com/flightctl/flightctl/pkg/crypto"
@@ -171,7 +170,7 @@ func (o *CertificateOptions) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flightctl/flightctl/internal/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type ConfigOptions struct {
+	GlobalOptions
+}
+
+func DefaultConfigOptions() *ConfigOptions {
+	return &ConfigOptions{
+		GlobalOptions: DefaultGlobalOptions(),
+	}
+}
+
+func NewCmdConfig() *cobra.Command {
+	o := DefaultConfigOptions()
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage CLI configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+
+	cmd.AddCommand(NewCmdConfigCurrentOrganization())
+	cmd.AddCommand(NewCmdConfigSetOrganization())
+
+	return cmd
+}
+
+func (o *ConfigOptions) Bind(fs *pflag.FlagSet) {
+	o.GlobalOptions.Bind(fs)
+}
+
+// NewCmdConfigCurrentOrganization creates a command to display the current organization
+func NewCmdConfigCurrentOrganization() *cobra.Command {
+	o := DefaultConfigOptions()
+	cmd := &cobra.Command{
+		Use:   "current-organization",
+		Short: "Display the current organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.ValidateCmd(args); err != nil {
+				return err
+			}
+			return o.RunCurrentOrganization(cmd.Context(), args)
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+// NewCmdConfigSetOrganization creates a command to set the current organization
+func NewCmdConfigSetOrganization() *cobra.Command {
+	o := DefaultConfigOptions()
+	cmd := &cobra.Command{
+		Use:   "set-organization <organization-id>",
+		Short: "Set the current organization (empty string to unset)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.ValidateCmd(args); err != nil {
+				return err
+			}
+			return o.RunSetOrganization(cmd.Context(), args)
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+func (o *ConfigOptions) Complete(cmd *cobra.Command, args []string) error {
+	return o.GlobalOptions.Complete(cmd, args)
+}
+
+func (o *ConfigOptions) RunCurrentOrganization(ctx context.Context, args []string) error {
+	config, err := client.ParseConfigFile(o.ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	if config.Organization == "" {
+		fmt.Println("No current organization set")
+	} else {
+		fmt.Println(config.Organization)
+	}
+	return nil
+}
+
+func (o *ConfigOptions) RunSetOrganization(ctx context.Context, args []string) error {
+	organizationId := args[0]
+
+	// Validate organization ID unless it's empty (empty string unsets the organization)
+	if organizationId != "" {
+		if err := validateOrganizationID(organizationId); err != nil {
+			return fmt.Errorf("cannot set organization: %w", err)
+		}
+	}
+
+	config, err := client.ParseConfigFile(o.ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+	if config.Organization == organizationId {
+		fmt.Println("Current organization unchanged")
+		return nil
+	}
+
+	config.Organization = organizationId
+
+	if err := config.Persist(o.ConfigFilePath); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	if organizationId == "" {
+		fmt.Println("Current organization unset")
+	} else {
+		fmt.Printf("Current organization set to: %s\n", organizationId)
+	}
+	return nil
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/client"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestConfig creates a minimal valid flightctl config at the given path
+// and sets the provided current organization value.
+func writeTestConfig(t *testing.T, path string, org string) {
+	t.Helper()
+	cfg := client.NewDefault()
+	cfg.Service.Server = "https://api.example.com" // minimal valid value
+	cfg.Organization = org
+	require.NoError(t, cfg.Persist(path))
+}
+
+// captureOutput redirects stdout while fn is executed and returns what was written.
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+func TestRunCurrentOrganization(t *testing.T) {
+	const uuid = "00000000-0000-0000-0000-000000000000"
+
+	tests := []struct {
+		name           string
+		orgInConfig    string
+		expectedOutput string
+	}{
+		{name: "org set", orgInConfig: uuid, expectedOutput: uuid + "\n"},
+		{name: "org not set", orgInConfig: "", expectedOutput: "No current organization set\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "client.yaml")
+			writeTestConfig(t, configPath, tc.orgInConfig)
+
+			opts := DefaultConfigOptions()
+			opts.ConfigFilePath = configPath
+
+			got := captureOutput(t, func() {
+				require.NoError(t, opts.RunCurrentOrganization(context.Background(), nil))
+			})
+			require.Equal(t, tc.expectedOutput, got)
+		})
+	}
+}
+
+func TestRunCurrentOrganization_NoConfigFile(t *testing.T) {
+	opts := DefaultConfigOptions()
+	// Point to a non-existing file inside temp dir
+	opts.ConfigFilePath = filepath.Join(t.TempDir(), "missing.yaml")
+
+	err := opts.RunCurrentOrganization(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestRunSetOrganization(t *testing.T) {
+	const uuid = "00000000-0000-0000-0000-000000000000"
+
+	tests := []struct {
+		name           string
+		arg            string
+		initialOrg     string
+		wantErr        bool
+		expectedOutput string
+		expectedFinal  string
+	}{
+		{
+			name:           "unset",
+			arg:            "",
+			initialOrg:     "some-old-org",
+			expectedOutput: "Current organization unset\n",
+			expectedFinal:  "",
+		},
+		{
+			name:           "set valid uuid",
+			arg:            uuid,
+			initialOrg:     "",
+			expectedOutput: "Current organization set to: " + uuid + "\n",
+			expectedFinal:  uuid,
+		},
+		{
+			name:           "set valid uuid",
+			arg:            uuid,
+			initialOrg:     uuid,
+			expectedOutput: "Current organization unchanged\n",
+			expectedFinal:  uuid,
+		},
+		{
+			name:       "invalid org",
+			arg:        "invalid",
+			initialOrg: "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "client.yaml")
+			writeTestConfig(t, configPath, tc.initialOrg)
+
+			opts := DefaultConfigOptions()
+			opts.ConfigFilePath = configPath
+
+			var gotOutput string
+			err := func() error {
+				return func() error {
+					var runErr error
+					gotOutput = captureOutput(t, func() {
+						runErr = opts.RunSetOrganization(context.Background(), []string{tc.arg})
+					})
+					return runErr
+				}()
+			}()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedOutput, gotOutput)
+
+			cfg, cfgErr := client.ParseConfigFile(configPath)
+			require.NoError(t, cfgErr)
+			require.Equal(t, tc.expectedFinal, cfg.Organization)
+		})
+	}
+}
+
+func TestRunSetOrganization_NoConfigFile(t *testing.T) {
+	opts := DefaultConfigOptions()
+	opts.ConfigFilePath = filepath.Join(t.TempDir(), "missing.yaml")
+
+	err := opts.RunSetOrganization(context.Background(), []string{""})
+	require.Error(t, err)
+}

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -345,7 +345,7 @@ func (o *ConsoleOptions) connectViaWS(ctx context.Context, config *client.Config
 }
 
 func (o *ConsoleOptions) emitUpgradeFailureError(ctx context.Context, name string, origErr error) {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating client: %v\n", err)
 		return

--- a/internal/cli/decommission.go
+++ b/internal/cli/decommission.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -95,7 +94,7 @@ func (o *DecommissionOptions) Validate(args []string) error {
 }
 
 func (o *DecommissionOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -97,7 +96,7 @@ func (o *DeleteOptions) Validate(args []string) error {
 }
 
 func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/deny.go
+++ b/internal/cli/deny.go
@@ -8,7 +8,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -80,7 +79,7 @@ func (o *DenyOptions) Validate(args []string) error {
 }
 
 func (o *DenyOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/enrollmentconfig.go
+++ b/internal/cli/enrollmentconfig.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/flightctl/flightctl/internal/client"
 	fccrypto "github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -76,7 +75,7 @@ func (o *EnrollmentConfigOptions) Validate(args []string) error {
 }
 
 func (o *EnrollmentConfigOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/google/uuid"
 )
 
 const (
@@ -14,37 +15,40 @@ const (
 )
 
 const (
+	CertificateSigningRequestKind = "certificatesigningrequest"
 	DeviceKind                    = "device"
 	EnrollmentRequestKind         = "enrollmentrequest"
+	EventKind                     = "event"
 	FleetKind                     = "fleet"
+	OrganizationKind              = "organization"
 	RepositoryKind                = "repository"
 	ResourceSyncKind              = "resourcesync"
 	TemplateVersionKind           = "templateversion"
-	CertificateSigningRequestKind = "certificatesigningrequest"
-	EventKind                     = "event"
 )
 
 var (
 	pluralKinds = map[string]string{
+		CertificateSigningRequestKind: "certificatesigningrequests",
 		DeviceKind:                    "devices",
 		EnrollmentRequestKind:         "enrollmentrequests",
+		EventKind:                     "events",
 		FleetKind:                     "fleets",
+		OrganizationKind:              "organizations",
 		RepositoryKind:                "repositories",
 		ResourceSyncKind:              "resourcesyncs",
 		TemplateVersionKind:           "templateversions",
-		CertificateSigningRequestKind: "certificatesigningrequests",
-		EventKind:                     "events",
 	}
 
 	shortnameKinds = map[string]string{
+		CertificateSigningRequestKind: "csr",
 		DeviceKind:                    "dev",
 		EnrollmentRequestKind:         "er",
+		EventKind:                     "ev",
 		FleetKind:                     "flt",
+		OrganizationKind:              "org",
 		RepositoryKind:                "repo",
 		ResourceSyncKind:              "rs",
 		TemplateVersionKind:           "tv",
-		CertificateSigningRequestKind: "csr",
-		EventKind:                     "ev",
 	}
 )
 
@@ -98,6 +102,13 @@ func validateHttpResponse(responseBody []byte, statusCode int, expectedStatusCod
 			return fmt.Errorf("%d %s", statusCode, string(responseBody))
 		}
 		return fmt.Errorf("%d %s", statusCode, responseError.Message)
+	}
+	return nil
+}
+
+func validateOrganizationID(orgID string) error {
+	if _, err := uuid.Parse(orgID); err != nil {
+		return fmt.Errorf("invalid organization ID %q: %w", orgID, err)
 	}
 	return nil
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -12,7 +12,6 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/cli/display"
-	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -116,7 +115,7 @@ func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 	clientVersion := version.Get()
 
 	var serverVersion *api.Version
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.BuildClient()
 	if err == nil {
 		var response *apiclient.GetVersionResponse
 		response, err = c.GetVersionWithResponse(ctx)


### PR DESCRIPTION
# Summary

1. **`flightctl config` sub-commands**

   • `flightctl config current-organization`  
     Prints the organization UUID currently stored in the CLI config file.  

   • `flightctl config set-organization <organization-uuid>`  
     Persists `<organization-uuid>` as the default organization in the user’s config file.  
     – Pass an empty string to unset.  
     – Basic validation rejects malformed UUIDs.

2. **Listing accessible organizations**

   • `flightctl get organizations` (alias: `orgs`)  
     Returns every organization the client is allowed to see.  

3. **Global flag `--org`**

   • Available on every CLI command (wired through `GlobalOptions`).  
   • Precedence order:  
     1. `--org` flag (highest)  
     2. Value stored in the `client.yaml`
     3. None 
   • Enables ad-hoc overrides without touching the persisted config, e.g.:

     ```bash
     flightctl device list --org 00000000-0000-0000-0000-000000000001
     ```

---

## Usage Examples

```bash
# Show current org
$ flightctl config current-organization
00000000-0000-0000-0000-000000000000

# Change default org (persist in client.yaml)
$ flightctl config set-organization 00000000-0000-0000-0000-000000000001
Current organization set to: 00000000-0000-0000-0000-000000000001

# Unset
$ flightctl config set-organization ""
Current organization unset

# List organizations
$ flightctl get orgs
NAME                                 DISPLAY NAME   EXTERNAL ID   OWNER
00000000-0000-0000-0000-000000000000 My Org         <none>        <none>
00000000-0000-0000-0000-000000000001 Other Org      <none>        <none>

# List devices in a different org (does not touch config file)
$ flightctl device list --org 00000000-0000-0000-0000-000000000001
```

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to view and set the current organization in the configuration.
  * Introduced support for listing organizations via the CLI.
  * Added a new CLI flag to override the organization for requests.
  * Enabled automatic inclusion of organization ID as a query parameter in API requests.

* **Enhancements**
  * Improved validation and error messages for organization-related operations.
  * Refined output formatting for organization lists in the CLI.
  * Modularized validation logic for resource retrieval commands.
  * Updated client creation to incorporate organization overrides seamlessly.

* **Bug Fixes**
  * Enhanced client creation to support organization overrides and configuration consistency.

* **Tests**
  * Added comprehensive tests for organization-related CLI configuration commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->