### PR TITLE
EDM-1888: Bootc based services container for local rpm container depl…

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,7 @@ packages:
     upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
 actions:
   get-current-version:
-    - bash -c 'git describe --tags | sed "s/^v//; s/-/~/g"'
+    - bash -c 'echo ${PACKIT_CURRENT_VERSION:-$(git describe --tags | sed "s/^v//; s/-/~/g")}'
 jobs:
   - job: copr_build
     trigger: pull_request

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -83,4 +83,35 @@ kill-alertmanager-proxy:
 show-podman-secret:
 	sudo podman secret inspect $(SECRET_NAME) --showsecret | jq '.[] | .SecretData'
 
-.PHONY: deploy-db deploy cluster
+# Can set the image tag to a specific version by using the PACKIT_CURRENT_VERSION variable
+# which builds the rpm with the specified version.
+#
+# Example cmd:
+# PACKIT_CURRENT_VERSION=latest make services-container
+services-container: PACKIT_CURRENT_VERSION ?= latest
+services-container: rpm
+	@test -f bin/rpm/flightctl-services-*.rpm || (echo "No RPM file found - RPM build failed" && exit 1)
+	sudo podman build -t flightctl-services:latest -f test/scripts/services-images/Containerfile.services .
+
+run-services-container:
+	@if ! sudo podman image exists localhost/flightctl-services:latest; then \
+		echo "Container image not found, building flightctl-services container..."; \
+		$(MAKE) services-container; \
+	else \
+		echo "Using existing flightctl-services container image"; \
+	fi
+	sudo podman run -d --privileged --replace \
+	--name flightctl-services \
+	-p 443:443 \
+	-p 3443:3443 \
+	-p 8090:8090 \
+	-p 8443:8443 \
+	-p 9093:9093 \
+	localhost/flightctl-services:latest
+
+clean-services-container:
+	sudo podman stop flightctl-services || true
+	sudo podman rm flightctl-services || true
+	sudo podman rmi localhost/flightctl-services:latest || true
+
+PHONY: deploy-db deploy cluster services-container run-services-container clean-services-container

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -104,6 +104,7 @@ run-services-container:
 	--name flightctl-services \
 	-p 443:443 \
 	-p 3443:3443 \
+	-p 7443:7443 \
 	-p 8090:8090 \
 	-p 8443:8443 \
 	-p 9093:9093 \

--- a/docs/developer/service-quadlets.md
+++ b/docs/developer/service-quadlets.md
@@ -229,6 +229,38 @@ sudo systemctl start flightctl.target
 sudo systemctl enable flightctl.target # To enable starting on reboot
 ```
 
+### Running the Services Container
+
+A containerized approach is offered to run all services within a single container.  This is particularly useful for testing RPM builds and service integration without affecting the host system.
+
+Start all Flight Control services in a container:
+
+```bash
+make run-services-container
+```
+
+This command:
+
+- Automatically builds the container if it doesn't exist
+- Runs the container with privileged access (required for systemd)
+- Starts the `flightctl.target` systemd target inside the container
+
+
+### Managing the Services Container
+
+```bash
+# Check if container is running
+sudo podman ps | grep flightctl-services
+
+# Access container shell, helpful in debugging the rpm install or service issues
+sudo podman exec -it flightctl-services bash
+# Then see what is running inside the container
+sudo podman ps
+
+# Stop and clean up container
+make clean-services-container
+```
+
 ## Contributing: Adding a New Quadlet
 
 Follow these steps to add a new service to the Flight Control Quadlets:

--- a/test/scripts/services-images/Containerfile.services
+++ b/test/scripts/services-images/Containerfile.services
@@ -1,0 +1,11 @@
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
+# Copy  and install the locally built services rpm
+COPY /bin/rpm/flightctl-services-*.rpm /tmp/flightctl-services.rpm
+RUN dnf -y install /tmp/flightctl-services.rpm && \
+    dnf clean all && \
+    rm -rf /tmp/* /var/cache/dnf
+
+RUN systemctl enable flightctl.target
+
+RUN bootc container lint


### PR DESCRIPTION
Adds commands to more easily run the locally built services rpm in a privileged podman container.  Uses :latest tagged images by default, but pulls in committed code from the local branch (e.g. quadlet service config changes).

After running `make run-services-container` services are exposed on localhost, can login like:
```shell
$ bin/flightctl login -k https://localhost:3443
```

Or visit https://localhost in the browser to see the ui (note: https:// prefix is important)

Usage looks something like the following - note the Flight Control podman service containers are running _inside_ another container, and to see them we first exec into the outer container.
```shell
$ make run-services-container
... <builds and runs>
$ sudo podman ps
CONTAINER ID  IMAGE                                COMMAND     CREATED         STATUS         PORTS                                                                                                                 NAMES
abb3af741fc9  localhost/flightctl-services:latest  /sbin/init  21 seconds ago  Up 20 seconds  0.0.0.0:443->443/tcp, 0.0.0.0:3443->3443/tcp, 0.0.0.0:8090->8090/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:9093->9093/tcp  flightctl-services
$ sudo podman exec -it flightctl-services bash
bash-5.1# sudo podman ps
CONTAINER ID  IMAGE                                                  COMMAND               CREATED             STATUS             PORTS                                           NAMES
7e19a51c1e33  quay.io/sclorg/postgresql-16-c9s:20250214              run-postgresql        About a minute ago  Up About a minute  5432/tcp                                        flightctl-db
dc21e49bc925  quay.io/prometheus/alertmanager:v0.28.1                --config.file=/us...  About a minute ago  Up 58 seconds      9093/tcp                                        flightctl-alertmanager
c99a80c4ec53  docker.io/library/redis:7.4.1                          /bin/sh -c redis-...  About a minute ago  Up 59 seconds      6379/tcp                                        flightctl-kv
f9227a5000ac  quay.io/flightctl/flightctl-alertmanager-proxy:latest  /bin/sh -c ./flig...  54 seconds ago      Up 54 seconds      0.0.0.0:8443->8443/tcp                          flightctl-alertmanager-proxy
b8fe664ea49e  quay.io/flightctl/flightctl-api:latest                 /bin/sh -c ./flig...  35 seconds ago      Up 35 seconds      0.0.0.0:3443->3443/tcp, 0.0.0.0:7443->7443/tcp  flightctl-api
ecc23e257fa9  quay.io/flightctl/flightctl-alert-exporter:latest      /bin/sh -c ./flig...  35 seconds ago      Up 35 seconds                                                      flightctl-alert-exporter
421d41c893b3  quay.io/flightctl/flightctl-periodic:latest            /bin/sh -c ./flig...  35 seconds ago      Up 35 seconds                                                      flightctl-periodic
5d25b5326a00  quay.io/flightctl/flightctl-worker:latest              /bin/sh -c ./flig...  35 seconds ago      Up 34 seconds                                                      flightctl-worker
29c647633946  quay.io/flightctl/flightctl-ui:latest                  /bin/sh -c ./flig...  31 seconds ago      Up 30 seconds      0.0.0.0:443->8080/tcp                           flightctl-ui
0725b402a537  quay.io/flightctl/flightctl-cli-artifacts:latest                             29 seconds ago      Up 29 seconds      0.0.0.0:8090->8090/tcp                          flightctl-cli-artifacts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Makefile targets to build, run, and clean a containerized environment for Flight Control services using Podman.
  * Introduced a new container image build process for Flight Control services.
  * Enhanced documentation with instructions for running and managing the services container.

* **Chores**
  * Improved version handling by allowing an environment variable to override the default version detection during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->