### PR TITLE
NO-ISSUE: test: remove use of podman-next

### DIFF
--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -30,9 +30,6 @@ RUN if [[ -z $RPM_COPR ]]; then \
     fi && \
     systemctl enable flightctl-agent.service
 
-RUN dnf copr -y enable rhcontainerbot/podman-next && \
-    dnf install -y --allowerasing podman
-
 RUN dnf install -y epel-release epel-next-release
 RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \
     dnf install -y firewalld && \

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -31,6 +31,7 @@ RUN if [[ -z $RPM_COPR ]]; then \
     systemctl enable flightctl-agent.service
 
 RUN dnf install -y epel-release epel-next-release
+RUN dnf install -y python-dotenv
 RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \
     dnf install -y firewalld && \
     systemctl enable firewalld.service && \


### PR DESCRIPTION
We originally used `podman-next` because stream9 did not yet ship podman v5.5, which was required for volume support. Now that Stream9 includes podman 5.5, this PR removes the dependency on `podman-next`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified package installation process in test container images by removing the use of an additional repository for Podman.
  * Added installation of the python-dotenv package in test container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->