### PR TITLE
EDM-1880: "make clean && AUTH=true make deploy" fails with keycloak errors

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
@@ -37,5 +37,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "keycloak.shouldGenerateSecrets" -}}
-{{ and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{ and (ne .Values.global.generateSecrets false) (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 {{- end -}}

--- a/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
@@ -1,27 +1,41 @@
 {{/*
-Looks up a password from an existing Secret, otherwise returns a randomly generated password.
-
-Usage:
-{{ include "lookupOrGeneratePassword" (dict "secret" "secretName" "namespace" "secretNamespace" "key" "keyName" "context" $) }}
-
-Params:
-  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
-  - namespace - String - Required - Namespace of the 'Secret' resource where the password is stored.
-  - key - String - Required - Name of the key in the secret.
-  - context - Context - Required - Parent context.
+Create chart name and version as used by the chart label.
 */}}
-{{- define "keycloak.lookupOrGeneratePassword" -}}
-{{- $password := "" }}
-{{- $namespace := (default .context.Release.Namespace .namespace | trunc 63 | trimSuffix "-") }}
-{{- $secretData := (lookup "v1" "Secret" $namespace .secret).data }}
-{{- if $secretData }}
-  {{- if hasKey $secretData .key }}
-    {{- $password = index $secretData .key }}
-  {{- else -}}
-    {{- printf "\nERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
-  {{- end -}}
-{{- else -}}
-  {{- $password = (include "flightctl.generatePassword" .context) }}
-{{- end -}}
-{{- printf "%s" $password -}}
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "keycloak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "keycloak.labels" -}}
+helm.sh/chart: {{ include "keycloak.chart" . }}
+{{ include "keycloak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "keycloak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "keycloak.shouldGenerateSecrets" -}}
+{{ and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 {{- end -}}

--- a/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/charts/keycloak/templates/_helpers.tpl
@@ -1,27 +1,39 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "keycloak.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{- define "keycloak.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
 {{- define "keycloak.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
+{{/*
+Common labels
+*/}}
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
@@ -29,13 +41,16 @@ helm.sh/chart: {{ include "keycloak.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
+{{- end -}}
 
+{{/*
+Selector labels
+*/}}
 {{- define "keycloak.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "keycloak.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
 
 {{- define "keycloak.shouldGenerateSecrets" -}}
-{{ and (ne .Values.global.generateSecrets false) (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{ and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 {{- end -}}

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{- if include "keycloak.shouldGenerateSecrets" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{- if include "keycloak.shouldGenerateSecrets" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{- if include "keycloak.shouldGenerateSecrets" . -}}
 {{ $password := include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-db-pguser-keycloak" "namespace" (default .Release.Namespace .Values.db.namespace) "key" "password" "context" $) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 {{ $password := include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-db-pguser-keycloak" "namespace" (default .Release.Namespace .Values.db.namespace) "key" "password" "context" $) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
@@ -1,5 +1,4 @@
 {{- if include "keycloak.shouldGenerateSecrets" . -}}
-{{ $password := include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-db-pguser-keycloak" "namespace" (default .Release.Namespace .Values.db.namespace) "key" "password" "context" $) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +12,5 @@ data:
   hostname: {{ printf "keycloak-db.%s" .Release.Namespace | b64enc | quote }}
   database: {{ printf "keycloak" | b64enc | quote }}
   username: {{ printf "keycloak" | b64enc | quote }}
-  password: {{ $password }}
+  password: {{ include "flightctl.generatePassword" . }}
 {{ end }}

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
 {{- $demoUserPassword := (include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-demouser-secret" "namespace" .Release.Namespace "key" "password" "context" $)) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
@@ -1,5 +1,5 @@
 {{- if include "keycloak.shouldGenerateSecrets" . -}}
-{{- $demoUserPassword := (include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-demouser-secret" "namespace" .Release.Namespace "key" "password" "context" $)) }}
+{{- $demoUserPassword := (include "flightctl.generatePassword" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   username: {{ print "demouser" | b64enc | quote }}
-  password: {{ print $demoUserPassword }}
+  password: {{ $demoUserPassword }}
 ---
 apiVersion: v1
 kind: Secret
@@ -1998,6 +1998,48 @@ stringData:
         },
         {
           "id": "daae575c-1c7d-411b-b107-72b3d3d6f95a",
+          "alias": "http challenge",
+          "description": "An authentication flow for challenges, for example for browserless authenticators.",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            {
+              "authenticator": "no-cookie-redirect-authenticator",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 10,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-spnego",
+              "authenticatorFlow": false,
+              "requirement": "DISABLED",
+              "priority": 20,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "identity-provider-redirector",
+              "authenticatorFlow": false,
+              "requirement": "ALTERNATIVE",
+              "priority": 30,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            },
+            {
+              "authenticator": "auth-http-challenge",
+              "authenticatorFlow": false,
+              "requirement": "REQUIRED",
+              "priority": 40,
+              "autheticatorFlow": false,
+              "userSetupAllowed": false
+            }
+          ]
+        },
+        {
+          "id": "1023773f-183d-48b1-973b-8340387c999a",
           "alias": "registration",
           "description": "registration flow",
           "providerId": "basic-flow",
@@ -2005,54 +2047,20 @@ stringData:
           "builtIn": true,
           "authenticationExecutions": [
             {
+              "authenticatorConfig": "Recaptcha",
               "authenticator": "registration-page-form",
-              "authenticatorFlow": true,
+              "authenticatorFlow": false,
               "requirement": "REQUIRED",
               "priority": 10,
-              "autheticatorFlow": true,
-              "flowAlias": "registration form",
-              "userSetupAllowed": false
-            }
-          ]
-        },
-        {
-          "id": "b64610ea-6573-4658-9dfa-841ead769568",
-          "alias": "registration form",
-          "description": "registration form",
-          "providerId": "form-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-            {
-              "authenticator": "registration-user-creation",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 20,
-              "autheticatorFlow": false,
-              "userSetupAllowed": false
-            },
-            {
-              "authenticator": "registration-password-action",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 50,
-              "autheticatorFlow": false,
-              "userSetupAllowed": false
-            },
-            {
-              "authenticator": "registration-recaptcha-action",
-              "authenticatorFlow": false,
-              "requirement": "DISABLED",
-              "priority": 60,
               "autheticatorFlow": false,
               "userSetupAllowed": false
             }
           ]
         },
         {
-          "id": "6a577d68-ea39-468a-b593-5bca3681724b",
+          "id": "133c2a4a-2f6f-4aa4-b3d1-a6d9e5e83b3e",
           "alias": "reset credentials",
-          "description": "Reset credentials for a user if they forgot their password or something",
+          "description": "Reset credentials for a user if they forgot their password.",
           "providerId": "basic-flow",
           "topLevel": true,
           "builtIn": true,
@@ -2090,56 +2098,47 @@ stringData:
               "userSetupAllowed": false
             }
           ]
-        },
-        {
-          "id": "4b6090e5-809c-4ecd-b425-6a848953a740",
-          "alias": "saml ecp",
-          "description": "SAML ECP Profile Authentication Flow",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-            {
-              "authenticator": "http-basic-authenticator",
-              "authenticatorFlow": false,
-              "requirement": "REQUIRED",
-              "priority": 10,
-              "autheticatorFlow": false,
-              "userSetupAllowed": false
-            }
-          ]
         }
       ],
       "authenticatorConfig": [
         {
-          "id": "46416c49-d026-43c7-9b0b-d516ccd98dc4",
+          "id": "1516417a-a918-430e-8a1b-55913b04e4a1",
+          "alias": "Recaptcha",
+          "config": {
+            "site.key": "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI",
+            "secret": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe",
+            "use_nocaptcha": "true"
+          }
+        },
+        {
+          "id": "24c51e4a-a855-419d-8e64-691a3b83e245",
           "alias": "create unique user config",
           "config": {
             "require.password.update.after.registration": "false"
           }
         },
         {
-          "id": "df2bc52e-48c0-41c1-875d-494fe2522168",
+          "id": "2534176a-a8b3-4c82-9349-9d34f715eb1c",
           "alias": "review profile config",
           "config": {
-            "update.profile.on.first.login": "missing"
+            "update.profile.on.first.login": "review"
           }
         }
       ],
       "requiredActions": [
         {
-          "alias": "CONFIGURE_TOTP",
-          "name": "Configure OTP",
-          "providerId": "CONFIGURE_TOTP",
-          "enabled": true,
+          "alias": "terms_and_conditions",
+          "name": "Terms and Conditions",
+          "providerId": "terms_and_conditions",
+          "enabled": false,
           "defaultAction": false,
           "priority": 10,
           "config": {}
         },
         {
-          "alias": "TERMS_AND_CONDITIONS",
-          "name": "Terms and Conditions",
-          "providerId": "TERMS_AND_CONDITIONS",
+          "alias": "VERIFY_EMAIL",
+          "name": "Verify Email",
+          "providerId": "VERIFY_EMAIL",
           "enabled": false,
           "defaultAction": false,
           "priority": 20,
@@ -2155,21 +2154,30 @@ stringData:
           "config": {}
         },
         {
-          "alias": "UPDATE_PROFILE",
-          "name": "Update Profile",
-          "providerId": "UPDATE_PROFILE",
+          "alias": "CONFIGURE_TOTP",
+          "name": "Configure OTP",
+          "providerId": "CONFIGURE_TOTP",
           "enabled": true,
           "defaultAction": false,
           "priority": 40,
           "config": {}
         },
         {
-          "alias": "VERIFY_EMAIL",
-          "name": "Verify Email",
-          "providerId": "VERIFY_EMAIL",
+          "alias": "UPDATE_PROFILE",
+          "name": "Update Profile",
+          "providerId": "UPDATE_PROFILE",
           "enabled": true,
           "defaultAction": false,
           "priority": 50,
+          "config": {}
+        },
+        {
+          "alias": "VERIFY_PROFILE",
+          "name": "Verify Profile",
+          "providerId": "VERIFY_PROFILE",
+          "enabled": false,
+          "defaultAction": false,
+          "priority": 60,
           "config": {}
         },
         {
@@ -2178,75 +2186,38 @@ stringData:
           "providerId": "delete_account",
           "enabled": false,
           "defaultAction": false,
-          "priority": 60,
-          "config": {}
-        },
-        {
-          "alias": "webauthn-register",
-          "name": "Webauthn Register",
-          "providerId": "webauthn-register",
-          "enabled": true,
-          "defaultAction": false,
           "priority": 70,
-          "config": {}
-        },
-        {
-          "alias": "webauthn-register-passwordless",
-          "name": "Webauthn Register Passwordless",
-          "providerId": "webauthn-register-passwordless",
-          "enabled": true,
-          "defaultAction": false,
-          "priority": 80,
-          "config": {}
-        },
-        {
-          "alias": "delete_credential",
-          "name": "Delete Credential",
-          "providerId": "delete_credential",
-          "enabled": true,
-          "defaultAction": false,
-          "priority": 100,
           "config": {}
         },
         {
           "alias": "update_user_locale",
           "name": "Update User Locale",
           "providerId": "update_user_locale",
-          "enabled": true,
+          "enabled": false,
           "defaultAction": false,
           "priority": 1000,
           "config": {}
         }
       ],
-      "browserFlow": "browser",
-      "registrationFlow": "registration",
-      "directGrantFlow": "direct grant",
-      "resetCredentialsFlow": "reset credentials",
-      "clientAuthenticationFlow": "clients",
-      "dockerAuthenticationFlow": "docker auth",
-      "firstBrokerLoginFlow": "first broker login",
+      "passwordPolicy": "notExpired(180) and notUsername(undefined) and notEmail(undefined) and length(8) and digits(1) and upperCase(1) and lowerCase(1) and specialChars(1)",
+      "loginTheme": "keycloak",
+      "accountTheme": "keycloak",
+      "adminTheme": "keycloak",
+      "emailTheme": "keycloak",
       "attributes": {
-        "cibaBackchannelTokenDeliveryMode": "poll",
-        "cibaExpiresIn": "120",
-        "cibaAuthRequestedUserHint": "login_hint",
-        "oauth2DeviceCodeLifespan": "600",
-        "clientOfflineSessionMaxLifespan": "0",
-        "oauth2DevicePollingInterval": "5",
-        "clientSessionIdleTimeout": "0",
-        "parRequestUriLifespan": "60",
-        "clientSessionMaxLifespan": "0",
-        "clientOfflineSessionIdleTimeout": "0",
-        "cibaInterval": "5",
-        "realmReusableOtpCode": "false"
-      },
-      "keycloakVersion": "25.0.1",
-      "userManagedAccessAllowed": false,
-      "organizationsEnabled": false,
-      "clientProfiles": {
-        "profiles": []
-      },
-      "clientPolicies": {
-        "policies": []
+        "ciba.auth.requested.user.hint": "login_hint",
+        "oauth2.device.verification.user.code.supported.charsets": "base-20",
+        "pkceCodeChallengeMethod": "S256",
+        "ciba.expires.in": "120",
+        "ciba.pooling.interval": "5",
+        "displayHTML": "true",
+        "rememberMe": "true",
+        "bruteForceProtected": "true",
+        "registrationAllowed": "true",
+        "verifyEmail": "true",
+        "resetPasswordAllowed": "true",
+        "editUsernameAllowed": "true",
+        "user-profile-enabled": "true"
       }
     }
 {{ end }}

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.global.target "standalone") (eq .Values.global.auth.type "builtin") }}
+{{- if include "keycloak.shouldGenerateSecrets" . -}}
 {{- $demoUserPassword := (include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-demouser-secret" "namespace" .Release.Namespace "key" "password" "context" $)) }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This PR addresses the issue described in [EDM-1880](https://issues.redhat.com/browse/EDM-1880).

**Summary:** "make clean && AUTH=true make deploy" fails with keycloak errors

**Description:** *Description of the problem:*

Using latest "main" with commit {*}de0bc05848f8eeb1c492f0dc22b85e6f52db2b45{*}, it's not possible to start the dev environment with authentication enabled. Everything works well if auth is disabled.

*How reproducible:*

100%

*Steps to reproduce:*
 # make clean && AUTH=true make deploy

*Actual results:*

The script does not complete. 

The keycloak pods in the flightctl-external namespace have errors.

 
{code:java}
camadorg@camadorg-thinkpadp1gen7:~$ kubectl get pods -n flightctl-external
NAME                                      READY   STATUS                       RESTARTS      AGE
flightctl-api-84454db466-75k6z            0/1     CrashLoopBackOff             5 (25s ago)   3m41s
flightctl-cli-artifacts-6b74fd86d-7hgmq   1/1     Running                      0             3m41s
keycloak-74f56c76fd-dzsp2                 0/1     ContainerCreating            0             3m41s
keycloak-db-0                             0/1     CreateContainerConfigError   0             3m41s{code}
Describing the keycloak-74... pod shows an error too.
{code:java}
Warning FailedMount 81s (x9 over 3m29s) kubelet MountVolume.SetUp failed for volume "keycloak-claim" : secret "keycloak-realm" not found  {code}
Describing the keycloak-db-9 pod shows another error related to secrets

 
{code:java}
Warning  Failed     20s (x143 over 30m)  kubelet            Error: secret "keycloak-db-pgadmin" not found
{code}
 

 

 

*Expected results:*

The script should complete and the FLight Control deployment should be working.

**Assignee:** Asaf Ben Natan (abennata@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and simplified secret generation logic for Keycloak-related deployments.
  * Standardized naming and labeling conventions across Keycloak resources.
  * Removed password lookup and generation from templates, improving maintainability.
* **New Features**
  * Enhanced Keycloak authentication flows with new HTTP challenge flow and updated registration and reset credential processes.
  * Added Recaptcha support and updated required actions for improved security and user experience.
  * Updated realm-level settings including password policies, themes, and various authentication-related attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->