### PR TITLE
EDM-1920: Add containerized integration tests to work around Fedora 42 netavark/quadlet issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ test/e2e/cli/*.key
 flightctl-*.rpm
 *.tar
 .claude/
+/output/
+dump.rdb
+appendonlydir/

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,0 +1,143 @@
+FROM ubuntu:22.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install PostgreSQL, Redis, and other dependencies (excluding old Go)
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        make \
+        gcc \
+        postgresql \
+        postgresql-contrib \
+        redis-server \
+        procps \
+        wget \
+        tar \
+        curl \
+        openssh-client \
+        sudo \
+        && apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+# Install Go 1.23 from official source
+RUN wget https://go.dev/dl/go1.23.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz && \
+    rm go1.23.6.linux-amd64.tar.gz
+
+# Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOROOT="/usr/local/go"
+
+# Initialize PostgreSQL database with UTF8 encoding
+RUN mkdir -p /var/lib/postgresql/data /var/run/postgresql && \
+    chown postgres:postgres /var/lib/postgresql/data /var/run/postgresql && \
+    sudo -u postgres /usr/lib/postgresql/*/bin/initdb -D /var/lib/postgresql/data --encoding=UTF8 --locale=C.UTF-8
+
+# Configure PostgreSQL to accept connections and ensure UTF8 encoding
+RUN echo "host all all 127.0.0.1/32 trust" >> /var/lib/postgresql/data/pg_hba.conf && \
+    echo "host all all ::1/128 trust" >> /var/lib/postgresql/data/pg_hba.conf && \
+    echo "local all all trust" >> /var/lib/postgresql/data/pg_hba.conf && \
+    echo "listen_addresses = '*'" >> /var/lib/postgresql/data/postgresql.conf && \
+    echo "unix_socket_directories = '/var/run/postgresql'" >> /var/lib/postgresql/data/postgresql.conf && \
+    echo "client_encoding = 'UTF8'" >> /var/lib/postgresql/data/postgresql.conf
+
+# Install Alertmanager
+RUN cd /tmp && \
+    wget https://github.com/prometheus/alertmanager/releases/download/v0.28.1/alertmanager-0.28.1.linux-amd64.tar.gz && \
+    tar -xzf alertmanager-0.28.1.linux-amd64.tar.gz && \
+    mv alertmanager-0.28.1.linux-amd64/alertmanager /usr/local/bin/ && \
+    mv alertmanager-0.28.1.linux-amd64/amtool /usr/local/bin/ && \
+    rm -rf /tmp/alertmanager-* && \
+    mkdir -p /etc/alertmanager /var/lib/alertmanager
+
+# Create Alertmanager configuration
+RUN echo 'global:' > /etc/alertmanager/alertmanager.yml && \
+    echo '  resolve_timeout: 5m' >> /etc/alertmanager/alertmanager.yml && \
+    echo 'route:' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  receiver: "null"' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  group_by: ["alertname"]' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  group_wait: 30s' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  group_interval: 5m' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  repeat_interval: 12h' >> /etc/alertmanager/alertmanager.yml && \
+    echo 'receivers:' >> /etc/alertmanager/alertmanager.yml && \
+    echo '  - name: "null"' >> /etc/alertmanager/alertmanager.yml
+
+# Create SSH configuration for tests
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null && \
+    echo "StrictHostKeyChecking no" >> /root/.ssh/config && \
+    echo "UserKnownHostsFile /dev/null" >> /root/.ssh/config
+
+# Create startup script
+RUN echo '#!/bin/bash' > /start-services.sh && \
+    echo 'set -e' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Start PostgreSQL' >> /start-services.sh && \
+    echo 'echo "Starting PostgreSQL..."' >> /start-services.sh && \
+    echo 'sudo -u postgres /usr/lib/postgresql/*/bin/postgres -D /var/lib/postgresql/data -p 5432 &' >> /start-services.sh && \
+    echo 'PG_PID=$!' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Wait for PostgreSQL to be ready' >> /start-services.sh && \
+    echo 'for i in {1..30}; do' >> /start-services.sh && \
+    echo '  if sudo -u postgres pg_isready -p 5432 >/dev/null 2>&1; then' >> /start-services.sh && \
+    echo '    echo "PostgreSQL is ready!"' >> /start-services.sh && \
+    echo '    break' >> /start-services.sh && \
+    echo '  fi' >> /start-services.sh && \
+    echo '  echo "Waiting for PostgreSQL... ($i/30)"' >> /start-services.sh && \
+    echo '  sleep 1' >> /start-services.sh && \
+    echo 'done' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Start Redis' >> /start-services.sh && \
+    echo 'echo "Starting Redis..."' >> /start-services.sh && \
+    echo 'mkdir -p /workspace/output' >> /start-services.sh && \
+    echo 'cd /workspace/output && redis-server --daemonize yes --requirepass adminpass --appendonly yes' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Start Alertmanager' >> /start-services.sh && \
+    echo 'echo "Starting Alertmanager..."' >> /start-services.sh && \
+    echo 'alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/var/lib/alertmanager --web.listen-address=:9093 &' >> /start-services.sh && \
+    echo 'AM_PID=$!' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Wait for Alertmanager to be ready' >> /start-services.sh && \
+    echo 'for i in {1..30}; do' >> /start-services.sh && \
+    echo '  if curl -s http://localhost:9093/-/ready >/dev/null 2>&1; then' >> /start-services.sh && \
+    echo '    echo "Alertmanager is ready!"' >> /start-services.sh && \
+    echo '    break' >> /start-services.sh && \
+    echo '  fi' >> /start-services.sh && \
+    echo '  echo "Waiting for Alertmanager... ($i/30)"' >> /start-services.sh && \
+    echo '  sleep 1' >> /start-services.sh && \
+    echo 'done' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo '# Create database and users' >> /start-services.sh && \
+    echo 'echo "Setting up database users..."' >> /start-services.sh && \
+    echo 'sudo -u postgres createuser -s flightctl_app || true' >> /start-services.sh && \
+    echo 'sudo -u postgres createuser -s admin || true' >> /start-services.sh && \
+    echo 'sudo -u postgres createuser -s flightctl_migrator || true' >> /start-services.sh && \
+    echo 'sudo -u postgres createdb flightctl || true' >> /start-services.sh && \
+    echo 'sudo -u postgres psql -c "ALTER USER flightctl_app PASSWORD '\''adminpass'\'';" || true' >> /start-services.sh && \
+    echo 'sudo -u postgres psql -c "ALTER USER admin PASSWORD '\''adminpass'\'';" || true' >> /start-services.sh && \
+    echo 'sudo -u postgres psql -c "ALTER USER flightctl_migrator PASSWORD '\''adminpass'\'';" || true' >> /start-services.sh && \
+    echo 'sudo -u postgres psql -d flightctl -c "ALTER USER flightctl_app CREATEDB; GRANT CREATE ON SCHEMA public TO flightctl_app; GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO flightctl_app; GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO flightctl_app; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO flightctl_app; ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO flightctl_app;" || true' >> /start-services.sh && \
+    echo '' >> /start-services.sh && \
+    echo 'echo "All services are ready!"' >> /start-services.sh && \
+    echo 'echo "PostgreSQL: ✓"' >> /start-services.sh && \
+    echo 'echo "Redis: ✓"' >> /start-services.sh && \
+    echo 'echo "Alertmanager: ✓"' >> /start-services.sh && \
+    echo 'exec "$@"' >> /start-services.sh && \
+    chmod +x /start-services.sh
+
+# Set up workspace
+WORKDIR /workspace
+
+# Environment variables
+ENV CGO_ENABLED=1
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV SSH_KNOWN_HOSTS=/root/.ssh/known_hosts
+
+# Default command
+ENTRYPOINT ["/start-services.sh"]
+CMD ["bash"]

--- a/hack/run-integration-tests-container.sh
+++ b/hack/run-integration-tests-container.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+# Build the integration test container
+echo "Building integration test container..."
+podman build -f Dockerfile.integration-test -t flightctl-integration-test .
+
+# Set default test pattern if not provided
+TEST_PATTERN="${1:-./test/integration/...}"
+# Support for test filtering (like -run TestName)
+TEST_RUN="${2:-}"
+
+echo "Running integration tests with pattern: $TEST_PATTERN"
+if [ -n "$TEST_RUN" ]; then
+    echo "Filtering tests with: -run $TEST_RUN"
+fi
+
+# Create reports directory on host to avoid permission issues
+mkdir -p reports
+
+# Run the container with everything inside
+podman run --rm --privileged \
+    -v "$(pwd):/workspace" \
+    -e FLIGHTCTL_KV_PASSWORD=adminpass \
+    -e FLIGHTCTL_POSTGRESQL_MASTER_PASSWORD=adminpass \
+    -e FLIGHTCTL_POSTGRESQL_USER_PASSWORD=adminpass \
+    -e DB_APP_PASSWORD=adminpass \
+    -e DB_MIGRATION_PASSWORD=adminpass \
+    -e CGO_ENABLED=1 \
+    -e TRACE_TESTS=false \
+    -e GORM_TRACE_ENFORCE_FATAL=true \
+    -e GORM_TRACE_INCLUDE_QUERY_VARIABLES=true \
+    flightctl-integration-test \
+    bash -c "
+        # Change to workspace directory
+        cd /workspace
+        
+        # Services are already started by the entrypoint
+        echo 'PostgreSQL and Redis are ready!'
+        
+        # Reports directory already exists on host
+        echo 'Reports directory is ready'
+        
+        # Run the integration tests
+        go run -modfile=tools/go.mod gotest.tools/gotestsum \
+            --format=pkgname \
+            --junitfile reports/junit_integration_test.xml \
+            -- \
+            -count=1 -race \
+            -coverprofile=reports/integration-coverage.out \
+            -timeout 30m \
+            ${TEST_RUN:+-run $TEST_RUN} \
+            $TEST_PATTERN
+    "
+
+echo "Integration tests completed!"
+echo "Reports available in ./reports/"

--- a/test/test.mk
+++ b/test/test.mk
@@ -95,10 +95,19 @@ run-test: unit-test run-intesgration-test
 bin/e2e-certs/ca.pem bin/.ssh/id_rsa.pub:
 	test/scripts/create_e2e_certs.sh
 
+# Usage: make container-integration-test [TEST_PATTERN="./test/integration/..."] [TEST_RUN="pattern"]
+# Run integration tests in a Fedora 41 container with all dependencies included
+# Examples:
+#   make container-integration-test
+#   make container-integration-test TEST_PATTERN="./test/integration/alerts/..."
+#   make container-integration-test TEST_PATTERN="./test/integration/service/..." TEST_RUN="TestServiceValidation"
+container-integration-test:
+	./hack/run-integration-tests-container.sh "$(or $(TEST_PATTERN),./test/integration/...)" "$(TEST_RUN)"
+
 git-server-container: bin/.ssh/id_rsa.pub
 	test/scripts/prepare_git_server.sh
 
-.PHONY: test run-test git-server-container
+.PHONY: test run-test git-server-container container-integration-test
 
 $(REPORTS):
 	-mkdir -p $(REPORTS)


### PR DESCRIPTION
  ## Summary
  - Work around Fedora 42 netavark and quadlet compatibility issues that prevent integration tests from running
  - Provide Ubuntu 22.04 containerized environment as a solution for running integration tests
  - Achieve 100% integration test suite success rate (8/8 test suites passing)

  ## Problem
  Integration tests fail to run on Fedora 42 due to breaking changes in netavark and quadlet components with no available workaround. This blocks development for users on Fedora 42.

  ## Solution
  Created a self-contained Fedora 41 container that includes all dependencies and services needed for integration tests, bypassing the Fedora 42 compatibility issues entirely.

  ## Changes
  - **New Files:**
    - `Dockerfile.integration-test` - Ubuntu 22.04 container with PostgreSQL, Redis, and Alertmanager
    - `hack/run-integration-tests-container.sh` - Script to build and run containerized tests
    - `output/` - Directory for build artifacts and temporary files
  - **Modified Files:**
    - `test/test.mk` - Add `container-integration-test` Make target with usage documentation
    - `.gitignore` - Exclude Redis data files and output directory

 ## Test Results
  All 8 integration test suites now pass:
  - ✅ kvstore, rollout/disruption_budget, rollout/device_selection, service, store, agent
  - ✅ alerts
  - ✅ tasks

  ## Usage
  ```bash
  # Run all integration tests (works on Fedora 42)
  make container-integration-test

  # Run specific test patterns
  make container-integration-test TEST_PATTERN="./test/integration/alerts/..."
  make container-integration-test TEST_PATTERN="./test/integration/service/..." TEST_RUN="TestServiceValidation"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository to ignore additional files and directories.
  * Added a new container image setup for integration testing, including all required services and dependencies.
  * Introduced a script to automate building and running integration tests within the container, with test reports output to the host.
  * Added a Makefile target to easily run integration tests in the new containerized environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->