### PR TITLE
EDM-1880: Remove dropped setting which prevented the secret generation

### DIFF
--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
 {{ $password := include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-db-pguser-keycloak" "namespace" (default .Release.Namespace .Values.db.namespace) "key" "password" "context" $) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
+{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
 {{- $demoUserPassword := (include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-demouser-secret" "namespace" .Release.Namespace "key" "password" "context" $)) }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Fix the local deploymen with Keycloak.

Alternative to https://github.com/flightctl/flightctl/pull/1435/commits since the Bot started to add more and more unrelated changes, and the solution is not working anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated secret generation logic to always create necessary secrets when the global target is "standalone" and authentication type is "builtin," improving deployment consistency without altering secret content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->