### PR TITLE
EDM-1498: CVE-2025-22871 flightctl: Request smuggling due to acceptance of invalid chunked data in net/http

### DIFF
--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd
@@ -30,4 +30,4 @@ LABEL \
 COPY --from=build /app/bin/flightctl-alertmanager-proxy .
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 EXPOSE 8443
-CMD ./flightctl-alertmanager-proxy 
+CMD ./flightctl-alertmanager-proxy

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd
@@ -36,4 +36,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
-CMD ./flightctl-userinfo-proxy 
+CMD ./flightctl-userinfo-proxy

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
 COPY ./api api
 COPY ./cmd cmd

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.9
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.23.9 across all relevant components.
  * Upgraded the base image for build stages to use the latest Go toolset version.
  * Minor adjustments to container configuration formatting (trailing space and newline fixes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->