### PR TITLE
EDM-1929: SELinux - Add var_t read/write permissions

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -53,6 +53,7 @@ files_read_usr_files(flightctl_agent_t)
 files_read_boot_files(flightctl_agent_t)
 files_read_generic_pids(flightctl_agent_t)
 files_read_var_lib_files(flightctl_agent_t)
+files_manage_var_files(flightctl_agent_t)
 
 # /etc management
 manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)


### PR DESCRIPTION
We at least need it for ACM and probably other things as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file management permissions for the agent, enhancing its control over system files under SELinux policies.

* **Style**
  * Corrected file formatting by adding a trailing newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->