### PR TITLE
NO-ISSUE: Cancel Github Action jobs on new PR commit

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -8,6 +8,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -8,6 +8,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint-docs:
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/lint-openapi.yaml
+++ b/.github/workflows/lint-openapi.yaml
@@ -8,6 +8,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint-openapi:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read
@@ -23,7 +27,7 @@ jobs:
         run: |
           commits=${{ github.event.pull_request.commits }}
           if [[ -n "$commits" ]]; then
-            # Prepare enough depth for diffs with master
+            # Prepare enough depth for diffs with main
             git fetch --depth="$(( commits + 1 ))"
           fi
 

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -14,6 +14,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -8,6 +8,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -9,6 +9,10 @@ on:
       - '*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   setup:
     name: Set Up Shared Environment

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,6 +7,10 @@ on:
       - 'release-*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
This mainly just avoids unnecessary failure notifications when a stale commit's job fails. I'm not sure what the limits are for open source free actions but it should also help us stay below those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow efficiency by adding concurrency controls to all GitHub Actions workflows. For non-main branches, only the latest run will proceed, with in-progress runs automatically canceled. Main branch runs are unaffected.
  * Updated a comment in the code quality workflow to reference the "main" branch instead of "master".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->