### PR TITLE
NO-ISSUE: Fix alertmanager-proxy deployment

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-certs-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-certs-secret.yaml
@@ -3,10 +3,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flightctl-alertmanager-proxy-certs
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
+  {{- if .Values.api.caCert }}
   ca.crt: {{ .Values.api.caCert | quote }}
+  {{- else }}
+  ca.crt: ""
+  {{- end }}
   {{- if or (and .Values.global.auth .Values.global.auth.caCert) (and .Values.auth .Values.auth.caCert) }}
   ca_oidc.crt: {{ default .Values.global.auth.caCert .Values.auth.caCert | quote }}
   {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flightctl-alertmanager-proxy-config
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |-
     service:

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     flightctl.service: flightctl-alertmanager-proxy
   name: flightctl-alertmanager-proxy
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -46,7 +46,7 @@ spec:
             - name: HOME
               value: "/root"
             - name: ALERTMANAGER_URL
-              value: "http://flightctl-alertmanager:9093"
+              value: "http://flightctl-alertmanager.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:9093"
             {{- if eq .Values.global.auth.type "none" }}
             - name: FLIGHTCTL_DISABLE_AUTH
               value: "true"
@@ -95,6 +95,7 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
+                optional: true
               {{- if or (and .Values.global.auth .Values.global.auth.caCert) (and .Values.auth .Values.auth.caCert) }}
               - key: ca_oidc.crt
                 path: ca_oidc.crt

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-route.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-route.yaml
@@ -11,7 +11,7 @@ metadata:
     shard: internal
   {{- end }}
   name: flightctl-alertmanager-proxy-route
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   host: alertmanager-proxy.{{ include "flightctl.getBaseDomain" . }}
   port:

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     flightctl.service: flightctl-alertmanager-proxy
   name: flightctl-alertmanager-proxy
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if and .Values.global.nodePorts.alertmanagerProxy (eq (include "flightctl.getServiceExposeMethod" .) "nodePort") }}
   type: NodePort


### PR DESCRIPTION
1. Make ca.crt optional
2. Move it to the external namespace (it was failing on reaching keycloak, but the proxy should be accessible to users so it should be in the external namespace)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated resource definitions to consistently use the Helm release namespace, removing fallback to internal namespace values.
  * Improved handling of certificate fields by conditionally including or setting empty values as appropriate.
  * Marked the certificate key in secret volumes as optional for more flexible deployments.
  * Updated environment variable for service discovery to use a fully qualified domain name format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->