### PR TITLE
EDM-1654: Add alertmanager configuration to UI deployment

### DIFF
--- a/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-cm.yaml
+++ b/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-cm.yaml
@@ -8,6 +8,9 @@ data:
   {{- if .Values.cliArtifacts.enabled }}
   FLIGHTCTL_CLI_ARTIFACTS_SERVER: {{ include "flightctl.getCliArtifactsUrl" . }}
   {{- end }}
+  {{- if .Values.alerts.enabled }}
+  FLIGHTCTL_ALERTMANAGER_PROXY: {{ include "flightctl.getAlertManagerProxyUrl" . }}
+  {{- end }}
   FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY: {{ .Values.api.insecureSkipTlsVerify | quote }}
   IS_RHEM: {{ .Values.isRHEM | quote }}
   AUTH_INSECURE_SKIP_VERIFY: {{ default ((.Values.global).auth).insecureSkipTlsVerify .Values.auth.insecureSkipTlsVerify | quote }}

--- a/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-deployment.yaml
+++ b/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-deployment.yaml
@@ -34,6 +34,13 @@ spec:
                 name: flightctl-ui
                 key: FLIGHTCTL_CLI_ARTIFACTS_SERVER
           {{- end }}
+          {{- if .Values.alerts.enabled }}
+          - name: FLIGHTCTL_ALERTMANAGER_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: flightctl-ui
+                key: FLIGHTCTL_ALERTMANAGER_PROXY
+          {{- end }}
           - name: FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY
             valueFrom:
               configMapKeyRef:

--- a/deploy/helm/flightctl/charts/ui/values.yaml
+++ b/deploy/helm/flightctl/charts/ui/values.yaml
@@ -41,6 +41,11 @@ api:
   url: https://flightctl-api:3443/
   insecureSkipTlsVerify: false
   caCert: ""
-## @param cliArtifacts.enabled Set to true if Cli artifacts are enabled in the UI
+## @param cliArtifacts.enabled Set to true if UI should allow downloading the Flight Control CLI artifacts
+## IMPORTANT: requires backend settings to be enabled as well
 cliArtifacts:
+  enabled: true
+## @param alerts.enabled Set to true if UI should display alerts
+## IMPORTANT: requires backend settings to be enabled as well
+alerts:
   enabled: true

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -112,6 +112,25 @@
   {{- end }}
 {{- end }}
 
+{{- define "flightctl.getAlertManagerProxyUrl" }}
+  {{- $baseDomain := (include "flightctl.getBaseDomain" . )}}
+  {{- $scheme := (include "flightctl.getHttpScheme" . )}}
+  {{- $exposeMethod := (include "flightctl.getServiceExposeMethod" . )}}
+  {{- if eq $exposeMethod "nodePort" }}
+    {{- printf "%s://%s:%v" $scheme $baseDomain .Values.global.nodePorts.alertmanagerProxy }}
+  {{- else if eq $exposeMethod "gateway" }}
+    {{- if and (eq $scheme "http") (not (eq (int .Values.global.gatewayPorts.http) 80))}}
+      {{- printf "%s://alertmanager-proxy.%s:%v" $scheme $baseDomain .Values.global.gatewayPorts.http }}
+    {{- else if and (eq $scheme "https") (not (eq (int .Values.global.gatewayPorts.tls) 443))}}
+      {{- printf "%s://alertmanager-proxy.%s:%v" $scheme $baseDomain .Values.global.gatewayPorts.tls }}
+    {{- else }}
+      {{- printf "%s://alertmanager-proxy.%s" $scheme $baseDomain }}
+    {{- end }}
+  {{- else }}
+    {{- printf "%s://alertmanager-proxy.%s" $scheme $baseDomain }}
+  {{- end }}
+{{- end }}
+
 {{/*
 Generates a random alphanumeric password in the format xxxxx-xxxxx-xxxxx-xxxxx.
 */}}

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-certs-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-certs-secret.yaml
@@ -3,10 +3,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flightctl-alertmanager-proxy-certs
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
+  {{- if .Values.api.caCert }}
   ca.crt: {{ .Values.api.caCert | quote }}
+  {{- else }}
+  ca.crt: ""
+  {{- end }}
   {{- if or (and .Values.global.auth .Values.global.auth.caCert) (and .Values.auth .Values.auth.caCert) }}
   ca_oidc.crt: {{ default .Values.global.auth.caCert .Values.auth.caCert | quote }}
   {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.alertmanagerProxy.enabled (eq .Values.global.target "acm") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    flightctl.service: flightctl-alertmanager-proxy
+  name: flightctl-alertmanager-proxy-{{ .Release.Namespace }}
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-clusterrolebinding.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.alertmanagerProxy.enabled (eq .Values.global.target "acm") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    flightctl.service: flightctl-alertmanager-proxy
+  name: flightctl-alertmanager-proxy-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: flightctl-alertmanager-proxy
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: flightctl-alertmanager-proxy-{{ .Release.Namespace }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-config.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flightctl-alertmanager-proxy-config
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |-
     service:

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
@@ -93,14 +93,13 @@ spec:
           secret:
             secretName: flightctl-alertmanager-proxy-certs
             defaultMode: 0440
+            optional: true
             items:
               - key: ca.crt
                 path: ca.crt
-                optional: true
               {{- if or (and .Values.global.auth .Values.global.auth.caCert) (and .Values.auth .Values.auth.caCert) }}
               - key: ca_oidc.crt
                 path: ca_oidc.crt
-                optional: true
               {{- end }}
         - name: flightctl-alertmanager-proxy-config
           configMap:

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         flightctl.service: flightctl-alertmanager-proxy
     spec:
+      serviceAccountName: flightctl-alertmanager-proxy
       initContainers:
         - name: init-certs
           image: "registry.access.redhat.com/ubi9/ubi-minimal:latest"

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     flightctl.service: flightctl-alertmanager-proxy
   name: flightctl-alertmanager-proxy
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -47,7 +47,7 @@ spec:
             - name: HOME
               value: "/root"
             - name: ALERTMANAGER_URL
-              value: "http://flightctl-alertmanager:9093"
+              value: "http://flightctl-alertmanager.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:9093"
             {{- if eq .Values.global.auth.type "none" }}
             - name: FLIGHTCTL_DISABLE_AUTH
               value: "true"
@@ -96,6 +96,7 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
+                optional: true
               {{- if or (and .Values.global.auth .Values.global.auth.caCert) (and .Values.auth .Values.auth.caCert) }}
               - key: ca_oidc.crt
                 path: ca_oidc.crt

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-route.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-route.yaml
@@ -11,7 +11,7 @@ metadata:
     shard: internal
   {{- end }}
   name: flightctl-alertmanager-proxy-route
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   host: alertmanager-proxy.{{ include "flightctl.getBaseDomain" . }}
   port:

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-service.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     flightctl.service: flightctl-alertmanager-proxy
   name: flightctl-alertmanager-proxy
-  namespace: {{ default .Release.Namespace .Values.global.internalNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if and .Values.global.nodePorts.alertmanagerProxy (eq (include "flightctl.getServiceExposeMethod" .) "nodePort") }}
   type: NodePort

--- a/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-serviceaccount.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alertmanager-proxy-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.alertmanagerProxy.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    flightctl.service: flightctl-alertmanager-proxy
+  name: flightctl-alertmanager-proxy
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Properly configures the UI deployment with the Alertmanager proxy URL.
Updated to fix the deployment for ACM, as there were no ClusterRoles for the Alertmanager proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to enable or disable alert display in the UI.
  * The UI now supports displaying alerts when enabled and properly configured.
  * Introduced an AlertManager proxy component with associated permissions, service account, and deployment to support alert functionality.
  * Added dynamic environment variable configuration for alert proxy integration in the UI deployment.

* **Documentation**
  * Improved descriptions for configuration options related to CLI artifact downloads and alert display in the Helm values file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->