### PR TITLE
EDM-1929: SELinux - Allow managing var_t directories as well

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -54,6 +54,7 @@ files_read_boot_files(flightctl_agent_t)
 files_read_generic_pids(flightctl_agent_t)
 files_read_var_lib_files(flightctl_agent_t)
 files_manage_var_files(flightctl_agent_t)
+files_manage_var_dirs(flightctl_agent_t)
 
 # /etc management
 manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)


### PR DESCRIPTION
We previously only could manage files and read directories, but not create directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SELinux policy to extend permissions for managing variable directories used by the agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->