### PR TITLE
EDM-1875: Fix K8s Secrets Test in OpenShift Test Environments

### DIFF
--- a/deploy/helm/e2e-extras/templates/flightctl-worker-clusterrolebinding.yaml
+++ b/deploy/helm/e2e-extras/templates/flightctl-worker-clusterrolebinding.yaml
@@ -8,6 +8,10 @@ subjects:
   - kind: ServiceAccount
     name: flightctl-worker
     namespace: flightctl-internal
+  # Some test envs use a single namespace for everything
+  - kind: ServiceAccount
+    name: flightctl-worker
+    namespace: flightctl
 roleRef:
   kind: ClusterRole
   name: flightctl-worker

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -333,7 +333,7 @@ var _ = Describe("VM Agent behavior", func() {
 
 		})
 
-		It("K8s secret config source", func() {
+		It("K8s secret config source", Label("76687"), func() {
 			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
 			// Get the next expected rendered version


### PR DESCRIPTION
In those environments, flightctl can be deployed in a single namespace and we must give the flightctl-worker access to the secrets to be able to deploys apps that use them.

Also adding the test label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to support environments using a single namespace for all components.
* **Tests**
  * Added a label to an existing end-to-end test case for improved identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->