### PR TITLE
EDM-1756: Add ability to clear hierarchy

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -59,7 +59,7 @@ const (
 	// DefaultTPMDevicePath is the default TPM device path
 	DefaultTPMDevicePath = "/dev/tpm0"
 	// DefaultTPMKeyBlobFile is the default filename for TPM key blob persistence
-	DefaultTPMKeyBlobFile = "ldevid-blob.yaml"
+	DefaultTPMKeyBlobFile = "tpm-blob.yaml"
 	// TestRootDirEnvKey is the environment variable key used to set the file system root when testing.
 	TestRootDirEnvKey = "FLIGHTCTL_TEST_ROOT_DIR"
 )

--- a/internal/tpm/persistence.go
+++ b/internal/tpm/persistence.go
@@ -182,3 +182,7 @@ func (p *persistence) clearPassword() error {
 		blob.Password = nil
 	})
 }
+
+func (p *persistence) erase() error {
+	return p.rw.RemoveFile(p.path)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to fully clear and reset TPM credentials and state, including persistent data removal.
* **Bug Fixes**
  * Improved reliability of credential wiping by ensuring TPM state is cleared, not just in-memory data.
* **Tests**
  * Introduced comprehensive tests to validate TPM clearing, fallback scenarios, and re-initialization after a clear operation.
* **Chores**
  * Updated default TPM key blob filename for persistence from "ldevid-blob.yaml" to "tpm-blob.yaml".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->