### PR TITLE
EDM-1944: setting Enforcing selinux in microshift registration E2E test

### DIFF
--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -164,7 +164,13 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			Expect(stdout1.String()).NotTo(ContainSubstring("sleep infinity"))
 
 			logrus.Info("Went back to base image and checked that there is no application now👌")
+
+			By("The agent executable should have the proper SELinux domain after the upgrade")
+			stdout, err = harness.VM.RunSSH([]string{"sudo", "ls", "-Z", "/usr/bin/flightctl-agent"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring("flightctl_agent_exec_t"))
 		})
+
 		It("Should resolve to the latest version when multiple updates are applied", Label("77672"), func() {
 			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceId)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -98,16 +98,6 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				logrus.Infof("Created git repository %s", *httpRepoMetadata.Name)
 
-				// This step will be removed after selinux issue resolution (EDM-1579)
-				By("Set selinux permissive")
-				_, err = harness.VM.RunSSH([]string{"sudo", "sed", "-i", "s/^SELINUX=enforcing/SELINUX=permissive/", "/etc/selinux/config"}, nil)
-				Expect(err).ToNot(HaveOccurred())
-				_, err = harness.VM.RunSSH([]string{"sudo", "setenforce", "permissive"}, nil)
-				Expect(err).ToNot(HaveOccurred())
-				stdout, err := harness.VM.RunSSH([]string{"sudo", "getenforce"}, nil)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(stdout.String()).To(ContainSubstring("Permissive"))
-
 				By("Get the Pull-Secret")
 				out, err = exec.Command("bash", "-c", "oc get secret/pull-secret -n openshift-config -o json | jq '.data.\".dockerconfigjson\"' | base64 -di").CombinedOutput()
 				Expect(err).ToNot(HaveOccurred())
@@ -156,7 +146,7 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				By("Make sure the pull-secret was injected")
 				psPath := "/etc/crio/openshift-pull-secret"
 				readyMsg := "The file was found"
-				stdout, err = harness.WaitForFileInDevice(psPath, util.TIMEOUT, util.POLLING)
+				stdout, err := harness.WaitForFileInDevice(psPath, util.TIMEOUT, util.POLLING)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout.String()).To(ContainSubstring(readyMsg))
 

--- a/test/scripts/agent-images/Containerfile-e2e-v7.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v7.local
@@ -7,9 +7,6 @@ FROM localhost:5000/flightctl-device:base
 
 ADD test/scripts/agent-images/etc etc
 
-RUN mkdir -p /etc/systemd/system/flightctl-agent.service.d && \
-    printf "[Service]\nSELinuxContext=system_u:system_r:unconfined_t:s0\n" > /etc/systemd/system/flightctl-agent.service.d/override.conf
-
 RUN dnf install -y microshift && \
    systemctl enable microshift.service
 
@@ -28,6 +25,3 @@ RUN firewall-offline-cmd --zone=public --add-port=80/tcp && \
     firewall-offline-cmd --zone=public --add-port=443/tcp && \
     firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
     firewall-offline-cmd --zone=public --add-port=30000-32767/udp
-
-# This step will be removed after selinux issue resolution (EDM-1579)
-RUN sudo sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config


### PR DESCRIPTION
- Setting SElinux Enforcing in microshift registration E2E test, 
- adding SElinux label check after a device OS image upgrade.
The test was validated in OCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a verification step to ensure the agent executable has the correct SELinux security context during upgrade tests.
  * Removed temporary steps that set SELinux to permissive mode in enrollment tests.
  * Updated variable declaration style in test scripts for consistency.

* **Chores**
  * Cleaned up the container image build process by removing SELinux configuration steps no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->