### PR TITLE
EDM-1845: middleware agent cert OrgID support

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/instrumentation"
 	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks_client"
@@ -45,29 +46,32 @@ type AgentServer struct {
 	tlsConfig      *tls.Config
 	metrics        *instrumentation.ApiMetrics
 	grpcServer     *AgentGrpcServer
+	orgResolver    *org.Resolver
 }
 
 // New returns a new instance of a flightctl server.
 func New(
 	log logrus.FieldLogger,
 	cfg *config.Config,
-	store store.Store,
+	st store.Store,
 	ca *crypto.CAClient,
 	listener net.Listener,
 	queuesProvider queues.Provider,
 	tlsConfig *tls.Config,
 	metrics *instrumentation.ApiMetrics,
 ) *AgentServer {
+	resolver := org.NewResolver(st.Organization(), cacheExpirationTime)
 	return &AgentServer{
 		log:            log,
 		cfg:            cfg,
-		store:          store,
+		store:          st,
 		ca:             ca,
 		listener:       listener,
 		queuesProvider: queuesProvider,
 		tlsConfig:      tlsConfig,
 		metrics:        metrics,
 		grpcServer:     NewAgentGrpcServer(log, cfg),
+		orgResolver:    resolver,
 	}
 }
 
@@ -112,6 +116,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 
 		srv.SetKeepAlivesEnabled(false)
 		_ = srv.Shutdown(ctxTimeout)
+		s.orgResolver.Close()
 	}()
 
 	s.log.Printf("Listening on %s...", s.listener.Addr().String())
@@ -139,7 +144,11 @@ func (s *AgentServer) prepareHTTPHandler(serviceHandler service.Service) (http.H
 	middlewares := [](func(http.Handler) http.Handler){
 		middleware.RequestSize(int64(s.cfg.Service.HttpMaxRequestSize)),
 		tlsmiddleware.RequestSizeLimiter(s.cfg.Service.HttpMaxUrlLength, s.cfg.Service.HttpMaxNumHeaders),
-		middleware.RequestID,
+		tlsmiddleware.RequestID,
+		tlsmiddleware.AddOrgIDToCtx(
+			s.orgResolver,
+			tlsmiddleware.CertOrgIDExtractor,
+		),
 		middleware.Logger,
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),

--- a/internal/api_server/middleware/middleware.go
+++ b/internal/api_server/middleware/middleware.go
@@ -89,7 +89,7 @@ func AddOrgIDToCtx(resolver *org.Resolver, extractor OrgIDExtractor) func(http.H
 			}
 
 			// Validate the organization ID
-			if err := resolver.Validate(ctx, orgID); err != nil {
+			if err := resolver.EnsureExists(ctx, orgID); err != nil {
 				if errors.Is(err, flterrors.ErrResourceNotFound) {
 					http.Error(w, fmt.Sprintf("Organization not found: %s", orgID), http.StatusNotFound)
 					return

--- a/internal/api_server/middleware/middleware_test.go
+++ b/internal/api_server/middleware/middleware_test.go
@@ -1,0 +1,225 @@
+package middleware
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/crypto/signer"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/org"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockOrgLookup mocks OrgLookup's GetByID.
+type mockOrgLookup struct {
+	t       *testing.T
+	wantID  uuid.UUID
+	respOrg *model.Organization
+	respErr error
+	called  bool
+}
+
+func (m *mockOrgLookup) GetByID(_ context.Context, id uuid.UUID) (*model.Organization, error) {
+	if m.t != nil && m.wantID != uuid.Nil && m.wantID != id {
+		m.t.Errorf("unexpected id: got %v, want %v", id, m.wantID)
+	}
+	m.called = true
+	return m.respOrg, m.respErr
+}
+
+// createCertWithOrgID returns an *x509.Certificate with the organization ID
+// stored in an extension identified by signer.OIDOrgID.
+func createCertWithOrgID(id uuid.UUID) *x509.Certificate {
+	encoded, _ := asn1.Marshal(id.String())
+	return &x509.Certificate{
+		Subject: pkix.Name{CommonName: "unit-test"},
+		ExtraExtensions: []pkix.Extension{{
+			Id:       signer.OIDOrgID,
+			Critical: false,
+			Value:    encoded,
+		}},
+	}
+}
+
+// contextWithCert returns a context containing the supplied certificate under
+// the consts.TLSPeerCertificateCtxKey key.
+func contextWithCert(cert *x509.Certificate) context.Context {
+	return context.WithValue(context.Background(), consts.TLSPeerCertificateCtxKey, cert)
+}
+
+// -----------------------------------------------------------------------------
+// Tests for the query extractor.
+// -----------------------------------------------------------------------------
+func TestExtractOrgIDFromRequestQuery(t *testing.T) {
+	validID := uuid.New()
+
+	cases := []struct {
+		name     string
+		rawQuery string
+		wantID   uuid.UUID
+		wantErr  bool
+	}{
+		{"no param returns default", "", org.DefaultID, false},
+		{"empty param returns default", "org_id=", org.DefaultID, false},
+		{"valid id", fmt.Sprintf("org_id=%s", validID), validID, false},
+		{"invalid uuid", "org_id=not-a-uuid", uuid.Nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/?"+tc.rawQuery, nil)
+			got, err := extractOrgIDFromRequestQuery(r)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, uuid.Nil, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantID, got)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests for the certificate extractor.
+// -----------------------------------------------------------------------------
+func TestExtractOrgIDFromRequestCert(t *testing.T) {
+	validID := uuid.New()
+
+	cases := []struct {
+		name    string
+		ctx     context.Context
+		wantID  uuid.UUID
+		wantErr bool
+	}{
+		{"no certificate", context.Background(), org.DefaultID, false},
+		{"cert without extension", contextWithCert(&x509.Certificate{}), org.DefaultID, false},
+		{"cert with valid extension", contextWithCert(createCertWithOrgID(validID)), validID, false},
+		{"cert with invalid uuid", contextWithCert(func() *x509.Certificate {
+			encoded, _ := asn1.Marshal("not-a-uuid")
+			return &x509.Certificate{ExtraExtensions: []pkix.Extension{{Id: signer.OIDOrgID, Value: encoded}}}
+		}()), uuid.Nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(tc.ctx)
+			got, err := extractOrgIDFromRequestCert(r)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantID, got)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests for AddOrgIDToCtx middleware. We focus on integration of the extractor
+// and the resolver plus context injection.
+// -----------------------------------------------------------------------------
+func TestAddOrgIDToCtx(t *testing.T) {
+	validID := uuid.New()
+
+	type storeResponse struct {
+		org *model.Organization
+		err error
+	}
+
+	cases := []struct {
+		name             string
+		extractor        func(*http.Request) (uuid.UUID, error)
+		storeResp        storeResponse
+		wantCode         int
+		wantCtxID        uuid.UUID
+		wantBodyContains string
+		expectNextCalled bool
+	}{
+		{
+			name:             "happy path",
+			extractor:        func(r *http.Request) (uuid.UUID, error) { return validID, nil },
+			storeResp:        storeResponse{org: &model.Organization{ID: validID}},
+			wantCode:         http.StatusTeapot,
+			wantCtxID:        validID,
+			expectNextCalled: true,
+		},
+		{
+			name:             "extractor error returns 400",
+			extractor:        func(r *http.Request) (uuid.UUID, error) { return uuid.Nil, fmt.Errorf("bad param") },
+			wantCode:         http.StatusBadRequest,
+			wantBodyContains: "bad param",
+		},
+		{
+			name:      "org not found returns 404",
+			extractor: func(r *http.Request) (uuid.UUID, error) { return validID, nil },
+			storeResp: storeResponse{err: flterrors.ErrResourceNotFound},
+			wantCode:  http.StatusNotFound,
+		},
+		{
+			name:             "resolver internal error returns 500",
+			extractor:        func(r *http.Request) (uuid.UUID, error) { return validID, nil },
+			storeResp:        storeResponse{err: fmt.Errorf("DB down")},
+			wantCode:         http.StatusInternalServerError,
+			wantBodyContains: "Failed to validate organization",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storeMock := &mockOrgLookup{t: t}
+			if tc.storeResp.org != nil || tc.storeResp.err != nil {
+				storeMock.respOrg = tc.storeResp.org
+				storeMock.respErr = tc.storeResp.err
+				storeMock.wantID = validID
+			}
+
+			resolver := org.NewResolver(storeMock, 5*time.Minute)
+			mw := AddOrgIDToCtx(resolver, tc.extractor)
+
+			var (
+				gotCtxID   uuid.UUID
+				nextCalled bool
+			)
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				gotCtxID, _ = util.GetOrgIdFromContext(r.Context())
+				w.WriteHeader(http.StatusTeapot)
+			})
+
+			rr := httptest.NewRecorder()
+			mw(next).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			assert.Equal(t, tc.wantCode, rr.Code)
+
+			if tc.expectNextCalled {
+				assert.True(t, nextCalled, "next handler should be called")
+				assert.Equal(t, tc.wantCtxID, gotCtxID)
+			} else {
+				assert.False(t, nextCalled, "next handler should not be called")
+			}
+
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, rr.Body.String(), tc.wantBodyContains)
+			}
+
+			if tc.storeResp.org != nil || tc.storeResp.err != nil {
+				assert.True(t, storeMock.called, "store mock should be called")
+			} else {
+				assert.False(t, storeMock.called, "store mock should not be called")
+			}
+		})
+	}
+}

--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -26,7 +26,7 @@ import (
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/config"
-	signer "github.com/flightctl/flightctl/internal/crypto/signer"
+	"github.com/flightctl/flightctl/internal/crypto/signer"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	fccrypto "github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/google/uuid"

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -94,7 +94,7 @@ func TestRunSetOrganization(t *testing.T) {
 		{
 			name:           "unset",
 			arg:            "",
-			initialOrg:     "some-old-org",
+			initialOrg:     uuid,
 			expectedOutput: "Current organization unset\n",
 			expectedFinal:  "",
 		},

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -92,7 +92,20 @@ func (o *GlobalOptions) ValidateCmd(args []string) error {
 // BuildClient constructs a FlightCTL API client using configuration derived
 // from the global options (config file path, organization override, etc.).
 func (o *GlobalOptions) BuildClient() (*apiclient.ClientWithResponses, error) {
-	return client.NewFromConfigFile(o.ConfigFilePath, client.WithOrganization(o.Organization))
+	organization := o.GetEffectiveOrganization()
+	return client.NewFromConfigFile(o.ConfigFilePath, client.WithOrganization(organization))
+}
+
+// GetEffectiveOrganization returns the organization ID to use for API requests.
+func (o *GlobalOptions) GetEffectiveOrganization() string {
+	if o.Organization != "" {
+		return o.Organization
+	}
+	config, err := client.ParseConfigFile(o.ConfigFilePath)
+	if err != nil {
+		return ""
+	}
+	return config.Organization
 }
 
 func (o *GlobalOptions) WithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
-	"github.com/google/uuid"
+	"github.com/flightctl/flightctl/internal/org"
 )
 
 const (
@@ -107,8 +107,8 @@ func validateHttpResponse(responseBody []byte, statusCode int, expectedStatusCod
 }
 
 func validateOrganizationID(orgID string) error {
-	if _, err := uuid.Parse(orgID); err != nil {
-		return fmt.Errorf("invalid organization ID %q: %w", orgID, err)
+	if _, err := org.Parse(orgID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
 	"google.golang.org/grpc"
@@ -472,6 +473,7 @@ func (c *Config) Validate() error {
 	validationErrors := make([]error, 0)
 	validationErrors = append(validationErrors, validateService(c.Service, c.baseDir, c.testRootDir)...)
 	validationErrors = append(validationErrors, validateAuthInfo(c.AuthInfo, c.baseDir, c.testRootDir)...)
+	validationErrors = append(validationErrors, validateOrganization(c.Organization, c.baseDir, c.testRootDir)...)
 	if len(validationErrors) > 0 {
 		return fmt.Errorf("invalid configuration: %v", utilerrors.NewAggregate(validationErrors).Error())
 	}
@@ -540,6 +542,17 @@ func validateAuthInfo(authInfo AuthInfo, baseDir string, testRootDir string) []e
 				defer clientKeyFile.Close()
 			}
 		}
+	}
+	return validationErrors
+}
+
+func validateOrganization(organization string, baseDir string, testRootDir string) []error {
+	validationErrors := make([]error, 0)
+	if organization == "" {
+		return validationErrors
+	}
+	if _, err := org.Parse(organization); err != nil {
+		validationErrors = append(validationErrors, err)
 	}
 	return validationErrors
 }

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -37,6 +37,7 @@ func TestValidConfig(t *testing.T) {
 		{name: "server with CA cert data", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthorityData: []byte(certData)}, testRootDir: testRootDir}},
 		{name: "server with absolute path to CA file", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthority: filepath.Join(configDir, certsDir, certFile)}, testRootDir: testRootDir}},
 		{name: "server with relative path to CA file", config: Config{Service: Service{Server: "https://localhost:3443", CertificateAuthority: filepath.Join(certsDir, certFile)}, baseDir: configDir, testRootDir: testRootDir}},
+		{name: "server with valid organization ID", config: Config{Service: Service{Server: "https://localhost:3443"}, Organization: "123e4567-e89b-12d3-a456-426614174000"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +61,8 @@ func TestInvalidConfig(t *testing.T) {
 		{name: "unreadable ca", config: Config{Service: Service{Server: "https://localhost", CertificateAuthority: "does_not_exist"}}, expectedErrorSubstring: "unable to read"},
 		{name: "unreadable cert", config: Config{Service: Service{Server: "https://localhost"}, AuthInfo: AuthInfo{ClientCertificate: "does_not_exist"}}, expectedErrorSubstring: "unable to read"},
 		{name: "unreadable key", config: Config{Service: Service{Server: "https://localhost"}, AuthInfo: AuthInfo{ClientCertificate: "cert", ClientKey: "does_not_exist"}}, expectedErrorSubstring: "unable to read"},
+		{name: "invalid organization ID", config: Config{Service: Service{Server: "https://localhost"}, Organization: "not-a-uuid"}, expectedErrorSubstring: "invalid organization ID"},
+		{name: "malformed organization UUID", config: Config{Service: Service{Server: "https://localhost"}, Organization: "12345678-1234-1234-1234-12345678901"}, expectedErrorSubstring: "invalid organization ID"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/crypto/signer/common.go
+++ b/internal/crypto/signer/common.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/flightctl/flightctl/internal/config/ca"
 	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/org"
 	fccrypto "github.com/flightctl/flightctl/pkg/crypto"
-	"github.com/google/uuid"
 )
 
 var (
-	NullOrgId            = uuid.MustParse("00000000-0000-0000-0000-000000000000")
+	NullOrgId            = org.DefaultID
 	OIDSignerName        = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1, 1}
 	OIDOrgID             = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1, 2}
 	OIDDeviceFingerprint = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1, 3}

--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -36,4 +36,7 @@ var (
 	ErrSignature       = errors.New("signature error")
 	ErrSignCert        = errors.New("error signing certificate")
 	ErrEncodeCert      = errors.New("error encoding certificate")
+
+	// certificate extensions
+	ErrExtensionNotFound = errors.New("certificate extension not found")
 )

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -1,0 +1,29 @@
+package org
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// DefaultID is the well-known UUID reserved for the default / system organization.
+// It is equivalent to the previous `store.NullOrgId` constant.
+var DefaultID = uuid.MustParse("00000000-0000-0000-0000-000000000000")
+
+// Parse validates that the supplied string is a valid UUID and returns it.
+func Parse(s string) (uuid.UUID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid organization ID %q: %w", s, err)
+	}
+	return id, nil
+}
+
+// MustParse is like Parse but panics on error (to be used with hard-coded strings).
+func MustParse(s string) uuid.UUID {
+	id, err := Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}

--- a/internal/org/resolver.go
+++ b/internal/org/resolver.go
@@ -1,0 +1,59 @@
+package org
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/jellydator/ttlcache/v3"
+)
+
+// OrgLookup retrieves an organization by ID.
+type OrgLookup interface {
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Organization, error)
+}
+
+// Resolver caches organization ID validation.
+type Resolver struct {
+	store OrgLookup
+	cache *ttlcache.Cache[uuid.UUID, bool]
+	ttl   time.Duration
+}
+
+// NewResolver constructs a new resolver. A TTL of zero disables expiration.
+func NewResolver(s OrgLookup, ttl time.Duration) *Resolver {
+	opts := []ttlcache.Option[uuid.UUID, bool]{}
+	if ttl > 0 {
+		opts = append(opts, ttlcache.WithTTL[uuid.UUID, bool](ttl))
+	}
+	c := ttlcache.New(opts...)
+	go c.Start()
+	return &Resolver{store: s, cache: c, ttl: ttl}
+}
+
+// Validate checks that the given organization ID exists. It caches positive
+// look-ups according to the configured TTL. Failed validations are not cached,
+// ensuring that newly created organizations are immediately accessible.
+func (r *Resolver) Validate(ctx context.Context, id uuid.UUID) error {
+	if item := r.cache.Get(id); item != nil {
+		return nil
+	}
+	// Cache miss – query the store.
+	if _, err := r.store.GetByID(ctx, id); err != nil {
+		return err
+	}
+	// Use configured TTL or disable expiration if TTL is not positive
+	cacheTTL := ttlcache.NoTTL
+	if r.ttl > 0 {
+		cacheTTL = r.ttl
+	}
+	r.cache.Set(id, true, cacheTTL)
+	return nil
+}
+
+// Close stops the cache and releases resources. Should be called when the resolver
+// is no longer needed to prevent goroutine leaks.
+func (r *Resolver) Close() {
+	r.cache.Stop()
+}

--- a/internal/org/resolver.go
+++ b/internal/org/resolver.go
@@ -32,10 +32,10 @@ func NewResolver(s OrgLookup, ttl time.Duration) *Resolver {
 	return &Resolver{store: s, cache: c, ttl: ttl}
 }
 
-// Validate checks that the given organization ID exists. It caches positive
+// EnsureExists checks that the given organization ID exists. It caches positive
 // look-ups according to the configured TTL. Failed validations are not cached,
 // ensuring that newly created organizations are immediately accessible.
-func (r *Resolver) Validate(ctx context.Context, id uuid.UUID) error {
+func (r *Resolver) EnsureExists(ctx context.Context, id uuid.UUID) error {
 	if item := r.cache.Get(id); item != nil {
 		return nil
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/instrumentation"
+	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/internal/store/selector"
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 var (
-	NullOrgId              = uuid.MustParse("00000000-0000-0000-0000-000000000000")
+	NullOrgId              = org.DefaultID
 	CurrentContinueVersion = 1
 )
 

--- a/pkg/crypto/csr.go
+++ b/pkg/crypto/csr.go
@@ -52,10 +52,9 @@ func ParseCSR(csrPEM []byte) (*x509.CertificateRequest, error) {
 	return csr, nil
 }
 
-// GetExtensionValueFromCSR returns the string value stored in the given extension
-// (identified by its ASN.1 OID) inside the provided x509.CertificateRequest. The
-// function searches both Extensions and ExtraExtensions slices. If the extension
-// is not found, or if unmarshalling fails, an error is returned.
+// GetExtensionValueFromCSR retrieves the raw value of the extension identified
+// by oid from csr, searching both Extensions and ExtraExtensions. It returns
+// an error if the extension is missing.
 func GetExtensionValueFromCSR(csr *x509.CertificateRequest, oid asn1.ObjectIdentifier) ([]byte, error) {
 	for _, ext := range append(csr.Extensions, csr.ExtraExtensions...) {
 		if ext.Id.Equal(oid) {

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 )
 
@@ -247,5 +248,5 @@ func GetExtensionValue(cert *x509.Certificate, oid asn1.ObjectIdentifier) (strin
 		}
 	}
 
-	return "", fmt.Errorf("extension with OID %v not found", oid)
+	return "", flterrors.ErrExtensionNotFound
 }


### PR DESCRIPTION
Update middleware to scope agents' requests based on OrgID certs. CSR verification by signers will be implemented in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved organization ID validation and extraction from API requests, supporting both query parameters and client certificates.
  * Enhanced certificate signing requests to include organization ID information as an ASN.1 extension.
  * Introduced caching for organization ID lookups to improve performance and resource management.
  * Added centralized method to determine effective organization for CLI client configuration.

* **Bug Fixes**
  * Standardized error handling for missing certificate extensions with a dedicated error variable.

* **Refactor**
  * Streamlined middleware for organization ID extraction and validation using modular extractors.
  * Unified organization ID handling across the application with internal parsing utilities replacing external UUID packages.
  * Updated middleware chains to improve organization ID context injection.

* **Tests**
  * Added comprehensive tests for organization ID extraction from requests and certificates, middleware integration, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->