### PR TITLE
EDM-1869: Application errors  generate the associated event with Normal type instead of Warning

### DIFF
--- a/api/v1alpha1/util.go
+++ b/api/v1alpha1/util.go
@@ -440,6 +440,7 @@ var warningReasons = map[EventReason]struct{}{
 	EventReasonDeviceDiskCritical:              {},
 	EventReasonDeviceDiskWarning:               {},
 	EventReasonDeviceDisconnected:              {},
+	EventReasonDeviceContentOutOfDate:          {},
 	EventReasonDeviceSpecInvalid:               {},
 	EventReasonDeviceMultipleOwnersDetected:    {},
 	EventReasonInternalTaskFailed:              {},


### PR DESCRIPTION
This PR addresses the issue described in [EDM-1869](https://issues.redhat.com/browse/EDM-1869).

**Summary:** Application errors  generate the associated event with Normal type instead of Warning

**Description:** *Description of the problem:*

Application errors generate the associated event with Normal type instead of Warning

 

*How reproducible:*

100%

*Steps to reproduce:*

 
 #  Create and enroll a device
 # Define an invalid application. (image-app)
 # Check the list of events for the device (Warning    image-app is in status Error is shown)
 # Delete the application ( Normal    No application workloads are defined.)
 # Define an invalid application. (image-app-updated)
 # Check the list of events for the device

*Actual results:*

4 minutes ago    Device                cfo0vm4uef7g0odkl0c75k69kfda5k1rl2cl5p2alv9hfud9uoi0    *Normal*    The device has not been updated to the latest device spec: Failed to update to renderedVersion: 2: before update: prefetch: pulling oci target quay.io/rh_ee_camadorg/oci-app-ko-no: pull image: authentication failed: code: 125: Trying to pull quay.io/rh_ee_camadorg/oci-app-ko-no:latest......

*Expected results:*
 * THe type of the event should be Warning

 

Eg. Use the following YAML in the fleet/device spec:

 
{code:java}
applications:
- envVars: {}
  image: quay.io/rh_ee_camadorg/oci-app-ko
  name: image-app
{code}
 

 
{code:java}
applications:
- envVars: {}
  image: quay.io/rh_ee_camadorg/oci-app-ko-not-exist
  name: image-app-updated
{code}
 

Notes: Since the image is private, it will fail to be pulled and the device applications status will be in Error state. Using "oci-app" instead of "oci-app-ko" should resolve the issue.

After fixing - Update OCP-83588 TC

 
The events you should see:

    DeviceApplicationDegraded EventReason = "DeviceApplicationDegraded"
    DeviceApplicationError    EventReason = "DeviceApplicationError"
    DeviceApplicationHealthy  EventReason = "DeviceApplicationHealthy"

 

**Assignee:** Avishay Traeger (atraeger@redhat.com)