### PR TITLE
EDM-1958: Device UpdateStatus Event Panics

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -332,6 +332,10 @@ func ComputeDeviceStatusChanges(ctx context.Context, oldDevice, newDevice *api.D
 
 	if hasStatusChanged(oldDevice, newDevice, api.DeviceUpdatedStatusUnknown, func(d *api.Device) api.DeviceUpdatedStatusType { return d.Status.Updated.Status }) {
 		var status api.EventReason
+		oldStatus := api.DeviceUpdatedStatusUnknown
+		if oldDevice.Status != nil {
+			oldStatus = oldDevice.Status.Updated.Status
+		}
 		switch {
 		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUnknown:
 			status = api.EventReasonDeviceDisconnected
@@ -339,7 +343,7 @@ func ComputeDeviceStatusChanges(ctx context.Context, oldDevice, newDevice *api.D
 			status = api.EventReasonDeviceContentUpdating
 		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusOutOfDate:
 			status = api.EventReasonDeviceContentOutOfDate
-		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUpToDate && oldDevice.Status.Updated.Status != api.DeviceUpdatedStatusUnknown:
+		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUpToDate && oldStatus != api.DeviceUpdatedStatusUnknown:
 			status = api.EventReasonDeviceContentUpToDate
 		}
 		if !lo.IsEmpty(status) {

--- a/internal/service/event_handler_test.go
+++ b/internal/service/event_handler_test.go
@@ -206,6 +206,21 @@ func TestEventDeviceReplaceDeviceStatus1(t *testing.T) {
 	assert.Equal(t, 3, len(events.Items))
 }
 
+func TestEventHandler_HandleDeviceUpdatedEmptyOldDevice(t *testing.T) {
+	serviceHandler := serviceHandler()
+
+	ctx := context.Background()
+
+	device := prepareDevice(uuid.New(), "foo")
+	device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
+	oldDevice := &api.Device{}
+	serviceHandler.EventHandler.HandleDeviceUpdatedEvents(ctx, api.DeviceKind, uuid.New(), "foo", oldDevice, device, false, nil)
+
+	events, err := serviceHandler.store.Event().List(context.Background(), uuid.New(), store.ListParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(events.Items))
+}
+
 func TestEventDevicePatchDeviceStatus(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
I was running some large scale device simulator tests that updated the number of allowed DB connections from 100 to 200. 200 connections also happens to be the `maxConnections` limit for the db deployment. As the number of onboarded devices rose I started to see errors like: 
```
failed to connect to `host=flightctl-db.flightctl-internal.svc.cluster.local user=flightctl_app database=flightctl`: server error (FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute (SQLSTATE 53300))\n[46.537ms]
```
This caused a lot of weird issue as a query could succeed and then another query in the same routine could fail, but one issue in particular stood out. 

```
Event Callback panicked: runtime error: invalid memory address or nil pointer dereference

goroutine 24172189 [running]:
runtime/debug.Stack()
    /usr/lib/golang/src/runtime/debug/stack.go:26 +0x5e
github.com/flightctl/flightctl/internal/store.SafeEventCallback.func1()
    /app/internal/store/common.go:335 +0x46
panic({0x2168b20?, 0x3a63330?})
    /usr/lib/golang/src/runtime/panic.go:791 +0x132
github.com/flightctl/flightctl/internal/service/common.ComputeDeviceStatusChanges({0x0?, 0x0?}, 0xc03a3858f0, 0xc04541d1f0, ...)
    /app/internal/service/common/device.go:342 +0x4f1
github.com/flightctl/flightctl/internal/service.(*EventHandler).HandleDeviceUpdatedEvents(0xc00091c080, ...)
    /app/internal/service/event_handler.go:88 +0x11d
github.com/flightctl/flightctl/internal/service.(*ServiceHandler).callbackDeviceUpdated(...)
    /app/internal/service/device.go:514
github.com/flightctl/flightctl/internal/store.(*DeviceStore).callEventCallback.func1()
    /app/internal/store/device.go:87 +0x75
github.com/flightctl/flightctl/internal/store.SafeEventCallback({0x2861520?, 0xc000069180?}, 0xc0388f8a80?)
    /app/internal/store/common.go:338 +0x56
github.com/flightctl/flightctl/internal/store.(*DeviceStore).callEventCallback(0x283e950?, ...)
    /app/internal/store/device.go:86 +0xcd
github.com/flightctl/flightctl/internal/store.(*DeviceStore).UpdateStatus(0xc0003455c0, ...)
    /app/internal/store/device.go:551 +0x254
github.com/flightctl/flightctl/internal/service.(*ServiceHandler).ReplaceDeviceStatus(0xc000276070, ...)
```
I've updated the code to highlight what was causing this issue, but I didn't want to make any real changes without discussing it. 

High level overview of how this error manifests:

1. ReplaceDeviceStatus: 
    i. Get Current Device - succeeds
    ii. Apply updates from API request
2. UpdateStatus
    i. Get Current Device - fails
    ii. Update Current Device - succeeds
3. HandleEvent logic - panics.

In general I thought it best to lean towards raising the event (perhaps even re-raising everything) in this odd case, but I noticed that we prefered to treat `device.Status == nil` as `Unknown` (of various types) in most instances which can lead to missed events. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device status update logic to prevent potential errors when handling devices with missing status information.

* **Tests**
  * Added a new test to ensure correct event handling when updating a device with empty previous status data.

* **Chores**
  * Enhanced error logging and control flow during device status updates for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->