### PR TITLE
NO-ISSUE: Add io.openshift.tags to db-setup container

### DIFF
--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -28,6 +28,7 @@ LABEL \
   description="Flight Control Database Setup Tools" \
   io.k8s.description="Flight Control Database Setup Tools" \
   io.k8s.display-name="Flight Control Database Setup" \
+  io.openshift.tags="flightctl,db-setup" \
   name="flightctl-db-setup" \
   summary="Flight Control Database Setup Tools"
 


### PR DESCRIPTION
Added the `io.openshift.tags` label to the db-setup container image.
This is required because the image is based on `ubi9/ubi` (not micro) and fails Conforma policy checks without the label.
The same was also applied to the cli-artifacts container image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new metadata tags to the container image for improved identification and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->