### PR TITLE
EDM-1958: Fix Device UpdateStatus event panics

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -332,6 +332,10 @@ func ComputeDeviceStatusChanges(ctx context.Context, oldDevice, newDevice *api.D
 
 	if hasStatusChanged(oldDevice, newDevice, api.DeviceUpdatedStatusUnknown, func(d *api.Device) api.DeviceUpdatedStatusType { return d.Status.Updated.Status }) {
 		var status api.EventReason
+		oldStatus := api.DeviceUpdatedStatusUnknown
+		if oldDevice.Status != nil {
+			oldStatus = oldDevice.Status.Updated.Status
+		}
 		switch {
 		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUnknown:
 			status = api.EventReasonDeviceDisconnected
@@ -339,7 +343,7 @@ func ComputeDeviceStatusChanges(ctx context.Context, oldDevice, newDevice *api.D
 			status = api.EventReasonDeviceContentUpdating
 		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusOutOfDate:
 			status = api.EventReasonDeviceContentOutOfDate
-		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUpToDate && oldDevice.Status.Updated.Status != api.DeviceUpdatedStatusUnknown:
+		case newDevice.Status.Updated.Status == api.DeviceUpdatedStatusUpToDate && oldStatus != api.DeviceUpdatedStatusUnknown:
 			status = api.EventReasonDeviceContentUpToDate
 		}
 		if !lo.IsEmpty(status) {

--- a/internal/service/event_handler_test.go
+++ b/internal/service/event_handler_test.go
@@ -206,6 +206,21 @@ func TestEventDeviceReplaceDeviceStatus1(t *testing.T) {
 	assert.Equal(t, 3, len(events.Items))
 }
 
+func TestEventHandler_HandleDeviceUpdatedEmptyOldDevice(t *testing.T) {
+	serviceHandler := serviceHandler()
+
+	ctx := context.Background()
+
+	device := prepareDevice(uuid.New(), "foo")
+	device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
+	oldDevice := &api.Device{}
+	serviceHandler.EventHandler.HandleDeviceUpdatedEvents(ctx, api.DeviceKind, uuid.New(), "foo", oldDevice, device, false, nil)
+
+	events, err := serviceHandler.store.Event().List(context.Background(), uuid.New(), store.ListParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(events.Items))
+}
+
 func TestEventDevicePatchDeviceStatus(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
See #1482 for the full details

Fixes a panic that can occur in extreme circumstances in Device UpdateStatus events.