### PR TITLE
EDM-1938: agent/dependency: ensure failed OCI layer cleanup

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -198,7 +198,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	osManager := os.NewManager(a.log, osClient, deviceReadWriter, podmanClient)
 
 	// create prefetch manager
-	prefetchManager := dependency.NewPrefetchManager(a.log, podmanClient, a.config.PullTimeout)
+	prefetchManager := dependency.NewPrefetchManager(a.log, podmanClient, deviceReadWriter, a.config.PullTimeout)
 
 	// create status manager
 	statusManager := status.NewManager(

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -521,6 +521,21 @@ func (p *Podman) Version(ctx context.Context) (*PodmanVersion, error) {
 	return &PodmanVersion{Major: major, Minor: minor}, nil
 }
 
+// GetImageCopyTmpDir returns the image copy tmp dir exposed by the podman info API.
+func (p *Podman) GetImageCopyTmpDir(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	args := []string{"info", "--format", "{{.Store.ImageCopyTmpDir}}"}
+	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
+	if exitCode != 0 {
+		return "", fmt.Errorf("get image copy tmpdir: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	tmpDir := strings.TrimSpace(stdout)
+	return tmpDir, nil
+}
+
 func IsPodmanRootless() bool {
 	return os.Geteuid() != 0
 }

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -206,8 +206,8 @@ allow flightctl_agent_t container_ro_file_t:dir { open read getattr search write
 allow flightctl_agent_t container_ro_file_t:file { open read getattr write };
 
 # Container runtime storage access
-allow flightctl_agent_t container_var_run_t:dir { read write search };
-allow flightctl_agent_t container_var_run_t:file { read open getattr };
+allow flightctl_agent_t container_var_run_t:dir { read getattr write search remove_name rmdir };
+allow flightctl_agent_t container_var_run_t:file { read open getattr unlink };
 
 # CGroup access for container management
 allow flightctl_agent_t cgroup_t:dir search;


### PR DESCRIPTION
This PR adds pruning of incomplete layers created during prefetching. These layers can be large and may eventually fill the filesystem. After exceeding the maximum poll steps (6), the manager removes all dangling layers in /var/tmp.

In the future if we introduce zstd chunking we may need to consider keeping some of these around. For now we can safely remove because there is no mechanism to continue pulling a failed OCI layer.

```
flightctl-agent[1659]: time="2025-08-08T21:24:08.512076Z" level=info msg="cleaned up 6 partial layer directories"
flightctl-agent[1659]: time="2025-08-08T21:24:25.518994Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:24:43.513575Z" level=info msg="Pulling image, please wait... (elapsed: 30.001134577s)"
flightctl-agent[1659]: time="2025-08-08T21:24:47.534735Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:25:13.513678Z" level=info msg="Pulling image, please wait... (elapsed: 1m0.001253824s)"
flightctl-agent[1659]: time="2025-08-08T21:25:14.540248Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:25:43.513710Z" level=info msg="Pulling image, please wait... (elapsed: 1m30.001289685s)"
flightctl-agent[1659]: time="2025-08-08T21:25:49.078316Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:26:13.513083Z" level=info msg="Pulling image, please wait... (elapsed: 2m0.000655331s)"
flightctl-agent[1659]: time="2025-08-08T21:26:34.836146Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:26:43.513041Z" level=info msg="Pulling image, please wait... (elapsed: 2m30.000622682s)"
flightctl-agent[1659]: time="2025-08-08T21:27:13.513012Z" level=info msg="Pulling image, please wait... (elapsed: 3m0.000593553s)"
flightctl-agent[1659]: time="2025-08-08T21:27:37.470970Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"
flightctl-agent[1659]: time="2025-08-08T21:27:37.521341Z" level=info msg="cleaned up 6 partial layer directories"
flightctl-agent[1659]: time="2025-08-08T21:27:54.541903Z" level=warning msg="A retriable error occurred: pull image: context deadline exceeded: code: 124: context deadline exceeded" file="agent/client/podman.go:651"

```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of partial image layers in the Podman temporary directory after interrupted pulls.
  * Introduced a method to directly retrieve the Podman image copy temporary directory.
* **Bug Fixes**
  * Enhanced handling of interrupted image pulls to avoid leftover temporary data.
* **Tests**
  * Added comprehensive tests for cleanup of partial image layers and updated existing tests accordingly.
* **Chores**
  * Expanded SELinux permissions to support removal operations on container runtime storage directories and files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->