### PR TITLE
EDM-1818: Prefetch Manager Config Docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -180,6 +180,9 @@ ConfigMap
 STMicroelectronics
 Nuvoton
 UEFI
+AIA
+NVRAM
+RSA
  - docs/user/api-resources.md
 approvedBy
 creationTimestamp

--- a/docs/user/configuring-agent.md
+++ b/docs/user/configuring-agent.md
@@ -11,17 +11,18 @@ When the `flightctl-agent` starts, it reads its configuration from `/etc/flightc
 
 The agent's configuration file `/etc/flightctl/config.yaml` takes the following parameters:
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `enrollment-service` | `EnrollmentService` | Y | Connection details for the device owner's Flight Control service used by the agent to enroll the device. |
-| `spec-fetch-interval` | `Duration` | | Interval in which the agent polls the service for updates to its device specification. Default: `60s` |
+| Parameter | Type | Required | Description|
+| --------- | ---- | :------: |------------|
+| `enrollment-service`     | `EnrollmentService` | Y | Connection details for the device owner's Flight Control service used by the agent to enroll the device. |
+| `spec-fetch-interval`    | `Duration` | | Interval in which the agent polls the service for updates to its device specification. Default: `60s` |
 | `status-update-interval` | `Duration` | | Interval in which the agent reports its device status under normal conditions. The agent immediately sends status reports on major events related to the health of the system and application workloads as well as on the progress during a system update. Default: `60s` |
-| `default-labels` | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. Default: `{}` |
-| `system-info` | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault"]` |
-| `system-info-custom` | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
-| `system-info-timeout` | `Duration` | | The timeout for collecting system info. Default: `2m` |
-| `log-level` | `string` | | The level of logging: "panic", "fatal", "error", "warn"/"warning", "info", "debug", or "trace". Default: `info` |
-| `tpm` | `TPM` | | TPM configuration for hardware-based device identity. See [TPM Configuration](#tpm-configuration). Default: TPM disabled |
+| `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. Default: `{}` |
+| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault"]` |
+| `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
+| `system-info-timeout`    | `Duration` | | The timeout for collecting system info. Default: `2m` |
+| `pull-timeout`           | `Duration` | | The timeout for pulling a single OCI target. Default: `10m` |
+| `log-level`              | `string` | | The level of logging: "panic", "fatal", "error", "warn"/"warning", "info", "debug", or "trace". Default: `info` |
+| `tpm`                    | `TPM` | | TPM configuration for hardware-based device identity. See [TPM Configuration](#tpm-configuration). Default: TPM disabled |
 
 `Duration` values are strings of an integer value with appended unit of time ('s' for seconds, 'm' for minutes, or 'h' for hours). Examples: `30s`, `10m`, `24h`
 

--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -450,6 +450,9 @@ The following table shows the application runtimes and formats supported by Flig
 > [!NOTE]
 > Requires `podman-compose` to be installed on the device.
 
+> [!NOTE]
+> Image downloads adhere to the `pull-timeout` [configuration](configuring-agent.md#agent-configyaml-configuration-file).
+
 > [!TIP]
 > Short image names (e.g., `nginx`) are not supported. Use fully qualified references like `docker.io/nginx` to avoid ambiguity.
 
@@ -616,6 +619,9 @@ Volume images must follow the OCI artifact specification:
 > in the layer's `org.opencontainers.image.title` field. For single layer archives if the mount path
 > does not exist as a directory the single layer will be extracted as a file at that path, otherwise
 > it will be placed into the existing directory using the file name in the name field for the layer.
+
+> [!NOTE]
+> Artifact downloads adhere to the `pull-timeout` [configuration](configuring-agent.md#agent-configyaml-configuration-file).
 
 #### Device Requirements
 

--- a/docs/user/tpm-authentication.md
+++ b/docs/user/tpm-authentication.md
@@ -64,6 +64,33 @@ The Flight Control API server needs TPM manufacturer CA certificates to validate
 
 ### Obtaining TPM CA Certificates
 
+If direct access to the device is possible, required certs can be discovered by first obtaining the Endorsement Key cert
+and then following the Authority Information Access (AIA) chain. Well known TPM NVRAM index handles are [defined by the TCG](https://trustedcomputinggroup.org/wp-content/uploads/TCG_IWG_EKCredentialProfile_v2p4_r3.pdf).
+
+#### Example: Starting from a device
+
+Note: access to the TPM typically requires root privileges.
+Note: [TPM tools](https://tpm2-tools.readthedocs.io/en/latest/INSTALL/) must be installed. These are available via `dnf` also.
+
+```bash
+sudo tpm2_nvread 0x01c00002 -o rsa_ek_cert.der
+sudo openssl x509 -inform DER -in rsa_ek_cert.der -text -noout 
+```
+
+`0x01c00002` is the well-known address of the RSA EK Cert.
+
+Expected output:
+
+```bash
+...elided
+       X509v3 extensions:
+            ...elided
+            Authority Information Access: 
+                CA Issuers - URI:http://sw-center.st.com/STSAFE/stsafetpmrsaint10.crt
+```
+
+The intermediate cert can be downloaded as described in the following example, and used to find the root cert in the AIA chain.
+
 #### Example: Infineon TPM CA Certificates
 
 ```bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and alignment in the Flight Control agent configuration documentation.
  * Added documentation for the new pull-timeout configuration parameter, including its default value and purpose.
  * Clarified that image and artifact downloads are subject to the configured pull-timeout setting in the device management guide.
  * Added instructions for extracting TPM manufacturer CA certificates directly from a device, including step-by-step examples.
  * Updated global dictionary with technical terms "AIA," "NVRAM," and "RSA" for spelling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->