### PR TITLE
EDM-1962: Add a unit parameter to ReadPrimaryVMAgentLogs

### DIFF
--- a/test/e2e/agent/agent_updates_test.go
+++ b/test/e2e/agent/agent_updates_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -256,7 +257,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() string {
 				GinkgoWriter.Printf("Checking console output for rollback logs\n")
-				logs, err := harness.ReadPrimaryVMAgentLogs("")
+				logs, err := harness.ReadPrimaryVMAgentLogs("", util.FLIGHTCTL_AGENT_SERVICE)
 				Expect(err).NotTo(HaveOccurred())
 				return logs
 			}).

--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/harness/e2e/vm"
 	"github.com/flightctl/flightctl/test/login"
+	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -199,7 +200,7 @@ var _ = Describe("CLI - device console", func() {
 
 		GinkgoWriter.Printf("Waiting for image pull activity\n")
 		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
-			WithArguments(logLookbackDuration).
+			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(ContainSubstring("Pulling image"))
 
 		GinkgoWriter.Printf("Simulating network disruption for %s\n", disruptionTime)
@@ -236,12 +237,12 @@ var _ = Describe("CLI - device console", func() {
 			Should(WithTransform((*v1alpha1.Device).IsUpdating, BeTrue()))
 
 		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
-			WithArguments(logLookbackDuration).
+			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(ContainSubstring("Pulling image"))
 
 		GinkgoWriter.Printf("Waiting for image pull failure. It will take a while...\n")
 		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
-			WithArguments(logLookbackDuration).
+			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(And(
 				ContainSubstring("Error"),
 				Or(

--- a/test/e2e/hooks/hooks_test.go
+++ b/test/e2e/hooks/hooks_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -160,7 +161,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 
 			By("Check that in the device logs the hooks were triggered")
 			Eventually(harness.ReadPrimaryVMAgentLogs, "30s", POLLING).
-				WithArguments("").
+				WithArguments("", util.FLIGHTCTL_AGENT_SERVICE).
 				Should(
 					SatisfyAll(
 						ContainSubstring("this is a test message from afterupdating hook"),
@@ -216,7 +217,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 			DeferCleanup(func() {
 				if CurrentSpecReport().Failed() {
 					// Debug info for first file check failure
-					logs, err := harness.ReadPrimaryVMAgentLogs("")
+					logs, err := harness.ReadPrimaryVMAgentLogs("", "")
 					if err == nil {
 						lines := strings.Split(logs, "\n")
 						GinkgoWriter.Printf("=== FIRST FILE CHECK DEBUG (total %d lines) ===\n", len(lines))
@@ -249,7 +250,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 			})
 
 			Eventually(harness.ReadPrimaryVMAgentLogs, "30s", POLLING).
-				WithArguments("").
+				WithArguments("", "").
 				Should(
 					SatisfyAll(
 						ContainSubstring(templateHookDirectory),
@@ -282,7 +283,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 			DeferCleanup(func() {
 				if CurrentSpecReport().Failed() {
 					// Print full logs chunked to stdout to avoid Gomega size limits
-					logs, err := harness.ReadPrimaryVMAgentLogs("")
+					logs, err := harness.ReadPrimaryVMAgentLogs("", util.FLIGHTCTL_AGENT_SERVICE)
 					if err == nil {
 						lines := strings.Split(logs, "\n")
 						GinkgoWriter.Printf("=== SECOND FILE CHECK DEBUG (total %d lines) ===\n", len(lines))
@@ -328,7 +329,7 @@ var _ = Describe("Device lifecycles and embedded hooks tests", func() {
 			})
 
 			Eventually(harness.ReadPrimaryVMAgentLogs, "30s", POLLING).
-				WithArguments("").
+				WithArguments("", util.FLIGHTCTL_AGENT_SERVICE).
 				Should(
 					SatisfyAll(
 						ContainSubstring(firstFileUpdatedContents),

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -174,13 +174,13 @@ func kubernetesClient() (kubernetes.Interface, error) {
 }
 
 // ReadPrimaryVMAgentLogs reads flightctl-agent journalctl logs from the primary VM
-func (h *Harness) ReadPrimaryVMAgentLogs(since string) (string, error) {
+func (h *Harness) ReadPrimaryVMAgentLogs(since string, unit string) (string, error) {
 	if h.VM == nil {
 		return "", fmt.Errorf("VM is not initialized")
 	}
 	logs, err := h.VM.JournalLogs(vm.JournalOpts{
-		Unit:  "flightctl-agent",
 		Since: since,
+		Unit:  unit,
 	})
 
 	return logs, err
@@ -238,7 +238,7 @@ func (h *Harness) Cleanup(printConsole bool) {
 			fmt.Println("============ systemctl status flightctl-agent ============")
 			fmt.Println(stdout.String())
 			fmt.Println("=============== logs for flightctl-agent =================")
-			fmt.Println(h.ReadPrimaryVMAgentLogs(""))
+			fmt.Println(h.ReadPrimaryVMAgentLogs("", util.FLIGHTCTL_AGENT_SERVICE))
 			if printConsole {
 				fmt.Println("======================= VM Console =======================")
 				fmt.Println(h.VM.GetConsoleOutput())

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -74,6 +74,7 @@ const E2E_NAMESPACE = "flightctl-e2e"
 const E2E_REGISTRY_NAME = "registry"
 const KIND = "KIND"
 const OCP = "OCP"
+const FLIGHTCTL_AGENT_SERVICE = "flightctl-agent"
 
 // Define a type for messages.
 type Message string


### PR DESCRIPTION
It may happen that the log of the device is updated with the content a moment after we check for it.
Added a retry for the check for up to 5 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end log collection to target a specific agent service for more reliable, clearer diagnostics during test runs.
  * Updated the test harness and suites to pass a service/unit parameter when reading VM agent logs, improving cleanup and assertions.
  * Added a shared constant for the agent service name to centralize configuration.
  * Added log timestamp validation helpers to better verify timing and intervals in console tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->