### PR TITLE
EDM-1987: Disallow label updates for owned fleets

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -31,7 +31,7 @@ Welcome to the Flight Control user documentation.
   * [Monitoring Device Resources](managing-devices.md#monitoring-device-resources)
   * [Accessing Devices Remotely](managing-devices.md#accessing-devices-remotely)
   * [Scheduling Updates and Downloads](managing-devices.md#scheduling-updates-and-downloads)
-* **[Alerts and Monitoring](alerts-monitoring.md)** - How to monitor device health and manage alerts.
+* **[Alerts and Monitoring](alerts.md)** - How to monitor device health and manage alerts.
 * **[Metrics Configuration](metrics.md)** - How to configure and use the metrics system for monitoring Flight Control.
 * **[Managing Device Fleets](managing-fleets.md)** - How to manage fleets of devices.
   * [Understanding Fleets](managing-fleets.md#understanding-fleets)


### PR DESCRIPTION
Fleets are owned by ResourceSyncs, which are responsible for syncing the entire fleet to Flight Control, including its labels. Therefore, users should not be allowed to modify the labels of an owned fleet.

Also, fix a broken link in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevent updating a Fleet’s spec or labels when the resource is owned, returning a clear error instead of allowing unintended changes.
  - Improved ownership checks to consistently block prohibited updates from all sources.

- **Documentation**
  - Updated the Alerts and Monitoring link to point to the correct destination.

- **Tests**
  - Added integration tests to verify that spec and label updates are rejected for owned Fleet resources and that the resource remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->