### PR TITLE
NO-ISSUE: publisher: call stop() before wg.Done() to fix flaky cancellation test

### DIFF
--- a/internal/agent/device/publisher/publisher.go
+++ b/internal/agent/device/publisher/publisher.go
@@ -142,8 +142,8 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 }
 
 func (n *publisher) Run(ctx context.Context, wg *sync.WaitGroup) {
-	defer n.stop()
 	defer wg.Done()
+	defer n.stop()
 	n.log.Debug("Starting publisher")
 	ticker := time.NewTicker(n.interval)
 	defer ticker.Stop()


### PR DESCRIPTION
The  https://github.com/flightctl/flightctl/blob/51136f73343ed090b721c44f6d357c87965dd693/internal/agent/device/publisher/publisher_test.go#L201-L236 used to fail sometimes at
https://github.com/flightctl/flightctl/blob/51136f73343ed090b721c44f6d357c87965dd693/internal/agent/device/publisher/publisher_test.go#L234-L235

due to the race condition
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal shutdown sequencing for the device publisher; changes only affect internal exit ordering and do not alter public interfaces.
* **Chores**
  * Internal reliability tuning and cleanup with no user-facing behavior changes or API impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->