### PR TITLE
EDM-1992: Agent SystemInfo smart collection

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -296,6 +296,7 @@ func createAgents(log *logrus.Logger, numDevices int, initialDeviceIndex int, ag
 			Server:               agentConfigTemplate.ManagementService.Config.Service.Server,
 			CertificateAuthority: filepath.Join(cfg.ConfigDir, agent_config.CacertFile),
 		}
+		cfg.SystemInfo = []string{}
 
 		cfg.SetEnrollmentMetricsCallback(rpcMetricsCallback)
 		if err := cfg.Complete(); err != nil {

--- a/cmd/flightctl-agent/main.go
+++ b/cmd/flightctl-agent/main.go
@@ -122,7 +122,7 @@ func (s *systemInfoCmd) Execute() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	exec := &executer.CommonExecuter{}
-	info, err := systeminfo.Collect(ctx, s.log, exec, reader, nil, s.hardwareMapPath, systeminfo.WithAllDefault(), systeminfo.WithAllCustom())
+	info, err := systeminfo.Collect(ctx, s.log, exec, reader, nil, s.hardwareMapPath, systeminfo.WithAll())
 	if err != nil {
 		s.log.Fatalf("Error collecting system info: %v", err)
 	}

--- a/cmd/flightctl-agent/main.go
+++ b/cmd/flightctl-agent/main.go
@@ -122,7 +122,7 @@ func (s *systemInfoCmd) Execute() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	exec := &executer.CommonExecuter{}
-	info, err := systeminfo.Collect(ctx, s.log, exec, reader, nil, s.hardwareMapPath, systeminfo.WithAllCustom())
+	info, err := systeminfo.Collect(ctx, s.log, exec, reader, nil, s.hardwareMapPath, systeminfo.WithAllDefault(), systeminfo.WithAllCustom())
 	if err != nil {
 		s.log.Fatalf("Error collecting system info: %v", err)
 	}

--- a/internal/agent/device/systeminfo/manager_test.go
+++ b/internal/agent/device/systeminfo/manager_test.go
@@ -1,0 +1,135 @@
+package systeminfo
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestReloadConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialKeys     []string
+		newKeys         []string
+		expectCollected bool
+		expectRecollect bool
+	}{
+		{
+			name:            "no change in info keys",
+			initialKeys:     []string{infoKeyNetInterfaceDefault, infoKeyCPUCores},
+			newKeys:         []string{infoKeyNetInterfaceDefault, infoKeyCPUCores},
+			expectCollected: true,
+			expectRecollect: false,
+		},
+		{
+			name:            "change within same collector type - network",
+			initialKeys:     []string{infoKeyNetInterfaceDefault},
+			newKeys:         []string{infoKeyNetMACDefault},
+			expectCollected: true,
+			expectRecollect: false,
+		},
+		{
+			name:            "change within same collector type - CPU",
+			initialKeys:     []string{infoKeyCPUCores},
+			newKeys:         []string{infoKeyCPUModel},
+			expectCollected: true,
+			expectRecollect: false,
+		},
+		{
+			name:            "change to different collector type",
+			initialKeys:     []string{infoKeyCPUCores},
+			newKeys:         []string{infoKeyMemoryTotalKb},
+			expectCollected: false,
+			expectRecollect: true,
+		},
+		{
+			name:            "add key requiring same collector",
+			initialKeys:     []string{infoKeyNetInterfaceDefault},
+			newKeys:         []string{infoKeyNetInterfaceDefault, infoKeyNetMACDefault},
+			expectCollected: true,
+			expectRecollect: false,
+		},
+		{
+			name:            "add key requiring different collector",
+			initialKeys:     []string{infoKeyCPUCores},
+			newKeys:         []string{infoKeyCPUCores, infoKeyGPU},
+			expectCollected: false,
+			expectRecollect: true,
+		},
+		{
+			name:            "remove key but keep collector active",
+			initialKeys:     []string{infoKeyNetInterfaceDefault, infoKeyNetMACDefault},
+			newKeys:         []string{infoKeyNetInterfaceDefault},
+			expectCollected: true,
+			expectRecollect: false,
+		},
+		{
+			name:            "remove key that disables collector",
+			initialKeys:     []string{infoKeyCPUCores, infoKeyMemoryTotalKb},
+			newKeys:         []string{infoKeyCPUCores},
+			expectCollected: false,
+			expectRecollect: true,
+		},
+		{
+			name:            "empty to non-empty",
+			initialKeys:     []string{},
+			newKeys:         []string{infoKeyCPUCores},
+			expectCollected: false,
+			expectRecollect: true,
+		},
+		{
+			name:            "non-empty to empty",
+			initialKeys:     []string{infoKeyCPUCores},
+			newKeys:         []string{},
+			expectCollected: false,
+			expectRecollect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			tmpDir := t.TempDir()
+			dataDir := filepath.Join("etc", "flightctl")
+			readWriter := fileio.NewReadWriter()
+			readWriter.SetRootdir(tmpDir)
+			err := readWriter.MkdirAll(dataDir, 0755)
+			require.NoError(err)
+
+			ctrl := gomock.NewController(t)
+			mockExecuter := executer.NewMockExecuter(ctrl)
+			log := log.NewPrefixLogger("test")
+			collectTimeout := util.Duration(5 * time.Second)
+
+			manager := NewManager(log, mockExecuter, readWriter, dataDir, tt.initialKeys, nil, collectTimeout)
+
+			// Simulate that data has been collected
+			manager.collected = true
+
+			cfg := &config.Config{
+				SystemInfo: tt.newKeys,
+			}
+
+			err = manager.ReloadConfig(context.Background(), cfg)
+			require.NoError(err)
+
+			if tt.expectRecollect {
+				require.False(manager.collected, "collected flag should be false when recollection is needed")
+			} else {
+				require.Equal(tt.expectCollected, manager.collected, "collected flag should match expected value")
+			}
+
+			require.Equal(tt.newKeys, manager.infoKeys, "info keys should be updated")
+		})
+	}
+}

--- a/internal/agent/device/systeminfo/manager_test.go
+++ b/internal/agent/device/systeminfo/manager_test.go
@@ -2,6 +2,7 @@ package systeminfo
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -15,83 +16,127 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func TestManager(t *testing.T) {
+	require := require.New(t)
+
+	// setup
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join("etc", "flightctl")
+	readWriter := fileio.NewReadWriter()
+	readWriter.SetRootdir(tmpDir)
+	err := readWriter.MkdirAll(dataDir, 0755)
+	require.NoError(err)
+	err = readWriter.MkdirAll("/proc/sys/kernel/random", 0755)
+	require.NoError(err)
+	log := log.NewPrefixLogger("test")
+
+	// set mock boot_id
+	mockBootID := "c4070599-f0f0-472d-8084-09b7274ebf18"
+	err = readWriter.WriteFile(bootIDPath, []byte(mockBootID), 0644)
+	require.NoError(err)
+
+	ctrl := gomock.NewController(t)
+	mockExecuter := executer.NewMockExecuter(ctrl)
+	bootTime := "2024-12-13 11:01:08"
+	collectTimeout := util.Duration(5 * time.Second)
+	mockExecuter.EXPECT().ExecuteWithContext(context.Background(), "uptime", "-s").Return(bootTime, "", 0).Times(2)
+
+	// initialize client new device
+	manager := NewManager(log, mockExecuter, readWriter, dataDir, nil, nil, collectTimeout)
+	err = manager.Initialize(context.Background())
+	require.NoError(err)
+	require.NotNil(manager)
+	require.NotEmpty(manager.BootTime())
+	require.False(manager.IsRebooted())
+	require.Equal(mockBootID, manager.BootID())
+
+	// test rebooted
+	// change bootID stored in system.json on disk
+	mockBootID2 := "c4070599-f0f0-472d-8084-09b7274ebf19"
+	mockStatus := &Boot{
+		Time: bootTime,
+		ID:   mockBootID2,
+	}
+	mockStatusBytes, err := json.Marshal(mockStatus)
+	require.NoError(err)
+	err = readWriter.WriteFile(filepath.Join(dataDir, SystemFileName), mockStatusBytes, 0644)
+	require.NoError(err)
+
+	// reinitialize client
+	manager = NewManager(log, mockExecuter, readWriter, dataDir, nil, nil, collectTimeout)
+	err = manager.Initialize(context.Background())
+	require.NoError(err)
+	require.NotEmpty(manager.BootTime())
+	require.Equal(mockBootID, manager.BootID())
+	require.True(manager.IsRebooted())
+}
+
 func TestReloadConfig(t *testing.T) {
 	tests := []struct {
-		name            string
-		initialKeys     []string
-		newKeys         []string
-		expectCollected bool
-		expectRecollect bool
+		name        string
+		initialKeys []string
+		newKeys     []string
+		expected    bool
 	}{
 		{
-			name:            "no change in info keys",
-			initialKeys:     []string{infoKeyNetInterfaceDefault, infoKeyCPUCores},
-			newKeys:         []string{infoKeyNetInterfaceDefault, infoKeyCPUCores},
-			expectCollected: true,
-			expectRecollect: false,
+			name:        "no change in info keys",
+			initialKeys: []string{netInterfaceDefaultKey, cpuCoresKey},
+			newKeys:     []string{netInterfaceDefaultKey, cpuCoresKey},
+			expected:    true,
 		},
 		{
-			name:            "change within same collector type - network",
-			initialKeys:     []string{infoKeyNetInterfaceDefault},
-			newKeys:         []string{infoKeyNetMACDefault},
-			expectCollected: true,
-			expectRecollect: false,
+			name:        "change within same collector type - network",
+			initialKeys: []string{netInterfaceDefaultKey},
+			newKeys:     []string{netMACDefaultKey},
+			expected:    true,
 		},
 		{
-			name:            "change within same collector type - CPU",
-			initialKeys:     []string{infoKeyCPUCores},
-			newKeys:         []string{infoKeyCPUModel},
-			expectCollected: true,
-			expectRecollect: false,
+			name:        "change within same collector type - CPU",
+			initialKeys: []string{cpuCoresKey},
+			newKeys:     []string{cpuModelKey},
+			expected:    true,
 		},
 		{
-			name:            "change to different collector type",
-			initialKeys:     []string{infoKeyCPUCores},
-			newKeys:         []string{infoKeyMemoryTotalKb},
-			expectCollected: false,
-			expectRecollect: true,
+			name:        "change to different collector type",
+			initialKeys: []string{cpuCoresKey},
+			newKeys:     []string{memoryTotalKbKey},
+			expected:    false,
 		},
 		{
-			name:            "add key requiring same collector",
-			initialKeys:     []string{infoKeyNetInterfaceDefault},
-			newKeys:         []string{infoKeyNetInterfaceDefault, infoKeyNetMACDefault},
-			expectCollected: true,
-			expectRecollect: false,
+			name:        "add key requiring same collector",
+			initialKeys: []string{netInterfaceDefaultKey},
+			newKeys:     []string{netInterfaceDefaultKey, netMACDefaultKey},
+			expected:    true,
 		},
 		{
-			name:            "add key requiring different collector",
-			initialKeys:     []string{infoKeyCPUCores},
-			newKeys:         []string{infoKeyCPUCores, infoKeyGPU},
-			expectCollected: false,
-			expectRecollect: true,
+			name:        "add key requiring different collector",
+			initialKeys: []string{cpuCoresKey},
+			newKeys:     []string{cpuCoresKey, gpuKey},
+			expected:    false,
 		},
 		{
-			name:            "remove key but keep collector active",
-			initialKeys:     []string{infoKeyNetInterfaceDefault, infoKeyNetMACDefault},
-			newKeys:         []string{infoKeyNetInterfaceDefault},
-			expectCollected: true,
-			expectRecollect: false,
+			name:        "remove key but keep collector active",
+			initialKeys: []string{netInterfaceDefaultKey, netMACDefaultKey},
+			newKeys:     []string{netInterfaceDefaultKey},
+			expected:    true,
 		},
 		{
-			name:            "remove key that disables collector",
-			initialKeys:     []string{infoKeyCPUCores, infoKeyMemoryTotalKb},
-			newKeys:         []string{infoKeyCPUCores},
-			expectCollected: false,
-			expectRecollect: true,
+			name:        "remove key that disables collector",
+			initialKeys: []string{cpuCoresKey, memoryTotalKbKey},
+			newKeys:     []string{cpuCoresKey},
+			expected:    true,
 		},
 		{
-			name:            "empty to non-empty",
-			initialKeys:     []string{},
-			newKeys:         []string{infoKeyCPUCores},
-			expectCollected: false,
-			expectRecollect: true,
+			name:        "empty to non-empty",
+			initialKeys: []string{},
+			newKeys:     []string{cpuCoresKey},
+			expected:    false,
 		},
 		{
-			name:            "non-empty to empty",
-			initialKeys:     []string{infoKeyCPUCores},
-			newKeys:         []string{},
-			expectCollected: false,
-			expectRecollect: true,
+			name:        "non-empty to empty",
+			initialKeys: []string{cpuCoresKey},
+			newKeys:     []string{},
+			expected:    true,
 		},
 	}
 
@@ -123,11 +168,7 @@ func TestReloadConfig(t *testing.T) {
 			err = manager.ReloadConfig(context.Background(), cfg)
 			require.NoError(err)
 
-			if tt.expectRecollect {
-				require.False(manager.collected, "collected flag should be false when recollection is needed")
-			} else {
-				require.Equal(tt.expectCollected, manager.collected, "collected flag should match expected value")
-			}
+			require.Equal(tt.expected, manager.collected)
 
 			require.Equal(tt.newKeys, manager.infoKeys, "info keys should be updated")
 		})


### PR DESCRIPTION
Changes System Info collection to only collect information that it will actually use. Currently, all system info is collected on startup and then, depending on the `system-info` config property, only partial values are displayed. This is particularly noticeable in instances where the network info is being collected as that can take upwards of 45 seconds to resolve. Now, that will only be collected in instances where it is specifically requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Modular, configurable system information collection with selectable categories (CPU, GPU, Memory, Network, BIOS, System, Kernel, Distribution).
  - Default collectors enabled by default; system-info command now uses the full default collection set.

- **Bug Fixes**
  - Prevented nil system-info lists by initializing them to an empty set.
  - Refresh of cached system info is now conditional — only invalidated when new collectors are added.
  - Boot JSON fields renamed: bootTime → time, bootID → id.

- **Tests**
  - Added coverage for collection-option mapping and collector behaviors; updated collection-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->