### PR TITLE
EDM-1845: support embedding OrgID in certificates

### DIFF
--- a/internal/crypto/signer/signer.go
+++ b/internal/crypto/signer/signer.go
@@ -43,43 +43,34 @@ func NewCASigners(ca CA) *CASigners {
 	ret := &CASigners{
 		ca: ca,
 		signers: map[string]Signer{
-			cfg.ClientBootstrapSignerName: compose(
-				compose(
-					NewClientBootstrap,
-					WithOrgIDExtension,
-					WithSignerNameExtension,
-				)(ca),
-				WithCSRValidation,
-				WithCertificateReuse,
-				WithSignerNameValidation,
+			cfg.ClientBootstrapSignerName: WithSignerNameValidation(
+				WithCertificateReuse(
+					WithCSRValidation(
+						WithSignerNameExtension(
+							WithOrgIDExtension(NewClientBootstrap))(ca),
+					),
+				),
 			),
-			cfg.DeviceEnrollmentSignerName: compose(
-				compose(
-					NewSignerDeviceEnrollment,
-					WithOrgIDExtension,
-					WithSignerNameExtension,
-				)(ca),
-				WithCSRValidation,
-				WithCertificateReuse,
-				WithSignerNameValidation,
+			cfg.DeviceEnrollmentSignerName: WithSignerNameValidation(
+				WithCertificateReuse(
+					WithCSRValidation(
+						WithSignerNameExtension(WithOrgIDExtension(NewSignerDeviceEnrollment))(ca),
+					),
+				),
 			),
-			cfg.DeviceSvcClientSignerName: compose(
-				compose(
-					NewSignerDeviceSvcClient,
-					WithSignerNameExtension,
-				)(ca),
-				WithCSRValidation,
-				WithCertificateReuse,
-				WithSignerNameValidation,
+			cfg.DeviceSvcClientSignerName: WithSignerNameValidation(
+				WithCertificateReuse(
+					WithCSRValidation(
+						WithSignerNameExtension(NewSignerDeviceSvcClient)(ca),
+					),
+				),
 			),
-			cfg.ServerSvcSignerName: compose(
-				compose(
-					NewSignerServerSvc,
-					WithSignerNameExtension,
-				)(ca),
-				WithCSRValidation,
-				WithCertificateReuse,
-				WithSignerNameValidation,
+			cfg.ServerSvcSignerName: WithSignerNameValidation(
+				WithCertificateReuse(
+					WithCSRValidation(
+						WithSignerNameExtension(NewSignerServerSvc)(ca),
+					),
+				),
 			),
 		},
 	}
@@ -300,15 +291,6 @@ func WithOrgIDExtension(s func(CA) Signer) func(CA) Signer {
 			},
 		}
 	}
-}
-
-// Compose applies decorators sequentially to base and returns the composed value.
-// It is generic and works for both concrete Signers and Signer factory functions.
-func compose[T any](base T, decorators ...func(T) T) T {
-	for _, d := range decorators {
-		base = d(base)
-	}
-	return base
 }
 
 func WithSignerRestrictedPrefixes(restrictedPrefixes map[string]Signer, s Signer) Signer {

--- a/internal/crypto/signer/signer_chain_test.go
+++ b/internal/crypto/signer/signer_chain_test.go
@@ -1,0 +1,502 @@
+package signer
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config/ca"
+	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/util"
+	fccrypto "github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/google/uuid"
+)
+
+const mockSignerName = "mock"
+
+// mockCA implements CA to intercept IssueRequestedClientCertificate calls.
+type mockCA struct {
+	cfg              *ca.Config
+	signers          *CASigners
+	clientIssueCalls int
+}
+
+func newMockCA(t *testing.T) *mockCA {
+	t.Helper()
+	cfg := ca.NewDefault(t.TempDir())
+	m := &mockCA{cfg: cfg}
+	m.signers = NewCASigners(m)
+	return m
+}
+
+func (m *mockCA) Config() *ca.Config           { return m.cfg }
+func (m *mockCA) GetSigner(name string) Signer { return m.signers.GetSigner(name) }
+func (m *mockCA) PeerCertificateSignerFromCtx(ctx context.Context) Signer {
+	peer, err := PeerCertificateFromCtx(ctx)
+	if err != nil {
+		return nil
+	}
+	if name, err := GetSignerNameExtension(peer); err == nil && name != "" {
+		return m.GetSigner(name)
+	}
+	return nil
+}
+
+func (m *mockCA) IssueRequestedClientCertificate(ctx context.Context, csr *x509.CertificateRequest, expirySeconds int, opts ...certOption) (*x509.Certificate, error) {
+	m.clientIssueCalls++
+	cert := &x509.Certificate{Subject: csr.Subject}
+	for _, o := range opts {
+		_ = o(cert)
+	}
+	return cert, nil
+}
+
+func (m *mockCA) IssueRequestedServerCertificate(ctx context.Context, csr *x509.CertificateRequest, expirySeconds int, opts ...certOption) (*x509.Certificate, error) {
+	return &x509.Certificate{Subject: csr.Subject}, nil
+}
+
+// mockSigner is a minimal signer used to exercise wrapper chains only.
+// It returns nil on Verify and calls through to CA IssueRequestedClientCertificate on Sign.
+type mockSigner struct {
+	name             string
+	ca               CA
+	restrictedPrefix string
+}
+
+func (m *mockSigner) Name() string                                          { return m.name }
+func (m *mockSigner) Verify(ctx context.Context, request SignRequest) error { return nil }
+func (m *mockSigner) Sign(ctx context.Context, request SignRequest) (*x509.Certificate, error) {
+	x := request.X509()
+	return m.ca.IssueRequestedClientCertificate(ctx, &x, 0)
+}
+
+// Implement RestrictedSigner when a prefix is configured.
+func (m *mockSigner) RestrictedPrefix() string { return m.restrictedPrefix }
+
+func newMockSignerFactory(name, restrictedPrefix string) func(CA) Signer {
+	return func(ca CA) Signer {
+		return &mockSigner{name: name, ca: ca, restrictedPrefix: restrictedPrefix}
+	}
+}
+
+// Helper to register a signer into the mock CA by name.
+func (m *mockCA) registerSigner(name string, s Signer) { m.signers.signers[name] = s }
+func (m *mockCA) registerMockSigner(s Signer)          { m.registerSigner(mockSignerName, s) }
+
+func makeCSR(t *testing.T, cn string, orgID uuid.UUID) *x509.CertificateRequest {
+	t.Helper()
+	_, priv, err := fccrypto.NewKeyPair()
+	if err != nil {
+		t.Fatalf("newKeyPair: %v", err)
+	}
+	tpl := &x509.CertificateRequest{}
+	if cn != "" {
+		tpl.Subject = pkix.Name{CommonName: cn}
+	}
+	if orgID != uuid.Nil {
+		encodedOrg, err := asn1.Marshal(orgID.String())
+		if err != nil {
+			t.Fatalf("marshal org id: %v", err)
+		}
+		tpl.ExtraExtensions = append(tpl.ExtraExtensions, pkix.Extension{Id: OIDOrgID, Critical: false, Value: encodedOrg})
+	}
+	raw, err := x509.CreateCertificateRequest(rand.Reader, tpl, priv.(crypto.Signer))
+	if err != nil {
+		t.Fatalf("create csr: %v", err)
+	}
+	csr, err := x509.ParseCertificateRequest(raw)
+	if err != nil {
+		t.Fatalf("parse csr: %v", err)
+	}
+	return csr
+}
+
+func withOrgCtx(orgID uuid.UUID) context.Context {
+	return util.WithOrganizationID(context.Background(), orgID)
+}
+
+func TestSignerChains(t *testing.T) {
+	ca := newMockCA(t)
+	cfg := ca.Config()
+
+	type testCase struct {
+		name       string
+		build      func() (context.Context, SignRequest)
+		verifyOnly bool
+		wantErr    bool
+		assert     func(cert *x509.Certificate)
+	}
+
+	orgID := uuid.New()
+
+	cases := []testCase{
+		{
+			name: "bootstrap_success_injects_orgid_signername_and_adjusts_cn",
+			build: func() (context.Context, SignRequest) {
+				subject := "foo"
+				csr := makeCSR(t, subject, orgID)
+				req, err := NewSignRequest(
+					cfg.ClientBootstrapSignerName,
+					*csr,
+					WithResourceName(subject),
+				)
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				return withOrgCtx(orgID), req
+			},
+			assert: func(cert *x509.Certificate) {
+				if got, want := cert.Subject.CommonName, BootstrapCNFromName(cfg, "foo"); got != want {
+					t.Fatalf("CN not adjusted: got %q want %q", got, want)
+				}
+				if _, _, err := GetOrgIDExtensionFromCert(cert); err != nil {
+					t.Fatalf("OrgID extension missing: %v", err)
+				}
+				if _, err := GetSignerNameExtension(cert); err != nil {
+					t.Fatalf("SignerName extension missing: %v", err)
+				}
+			},
+		},
+		{
+			name: "device_enrollment_injects_orgid_signername_and_fingerprint",
+			build: func() (context.Context, SignRequest) {
+				fingerprint := "abcdef0123456789"
+				csr := makeCSR(t, fingerprint, orgID)
+				req, err := NewSignRequest(cfg.DeviceEnrollmentSignerName, *csr, WithResourceName(fingerprint))
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				return withOrgCtx(orgID), req
+			},
+			assert: func(cert *x509.Certificate) {
+				if _, _, err := GetOrgIDExtensionFromCert(cert); err != nil {
+					t.Fatalf("OrgID extension missing: %v", err)
+				}
+				if _, err := GetSignerNameExtension(cert); err != nil {
+					t.Fatalf("SignerName extension missing: %v", err)
+				}
+				if _, err := fccrypto.GetCertificateExtensionValueAsStr(cert, OIDDeviceFingerprint); err != nil {
+					t.Fatalf("Device fingerprint extension missing: %v", err)
+				}
+			},
+		},
+		{
+			name: "device_enrollment_peer_cert_gating_allows_bootstrap",
+			build: func() (context.Context, SignRequest) {
+				fingerprint := "abcdef0123456789"
+				csr := makeCSR(t, fingerprint, orgID)
+				req, err := NewSignRequest(cfg.DeviceEnrollmentSignerName, *csr, WithResourceName(fingerprint))
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				// Simulate peer cert signed by bootstrap signer
+				peer := &x509.Certificate{}
+				// Inject signer name extension for bootstrap on the mock peer cert via ExtraExtensions
+				peer.ExtraExtensions = append(peer.ExtraExtensions, pkix.Extension{Id: OIDSignerName, Value: mustASN1(t, cfg.ClientBootstrapSignerName)})
+				ctx := context.WithValue(withOrgCtx(orgID), consts.TLSPeerCertificateCtxKey, peer)
+				return ctx, req
+			},
+			verifyOnly: false,
+		},
+		{
+			name: "device_enrollment_peer_cert_gating_rejects_other_signers",
+			build: func() (context.Context, SignRequest) {
+				fingerprint := "abcdef0123456789"
+				csr := makeCSR(t, fingerprint, orgID)
+				req, err := NewSignRequest(cfg.DeviceEnrollmentSignerName, *csr, WithResourceName(fingerprint))
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				peer := &x509.Certificate{}
+				peer.ExtraExtensions = append(peer.ExtraExtensions, pkix.Extension{Id: OIDSignerName, Value: mustASN1(t, cfg.DeviceSvcClientSignerName)})
+				ctx := context.WithValue(withOrgCtx(orgID), consts.TLSPeerCertificateCtxKey, peer)
+				return ctx, req
+			},
+			verifyOnly: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, req := tc.build()
+			if tc.verifyOnly {
+				err := Verify(ctx, ca, req)
+				if tc.wantErr && err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !tc.wantErr && err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			cert, err := SignVerified(ctx, ca, req)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.assert != nil {
+				tc.assert(cert)
+			}
+		})
+	}
+}
+
+func TestSignerWrappers(t *testing.T) {
+	ca := newMockCA(t)
+	factory := newMockSignerFactory(mockSignerName, "")
+
+	type testCase struct {
+		name          string
+		chainedSigner func(func(CA) Signer, CA) Signer
+		build         func() (context.Context, SignRequest)
+		wantErrVerify bool
+		assert        func(cert *x509.Certificate)
+	}
+
+	orgID := uuid.New()
+
+	cases := []testCase{
+		{
+			name: "with_certificate_reuse_short_circuits",
+			chainedSigner: func(baseFactory func(CA) Signer, ca CA) Signer {
+				return WithCertificateReuse(baseFactory(ca))
+			},
+			build: func() (context.Context, SignRequest) {
+				ca.clientIssueCalls = 0
+				// Valid CSR (contents irrelevant due to reuse)
+				subject := "foo"
+				csr := makeCSR(t, subject, orgID)
+				preIssued := &x509.Certificate{Subject: pkix.Name{CommonName: "preissued"}}
+				req, err := NewSignRequest(
+					mockSignerName,
+					*csr,
+					WithResourceName(subject),
+					WithIssuedCertificate(preIssued),
+				)
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				return withOrgCtx(orgID), req
+			},
+			assert: func(cert *x509.Certificate) {
+				if cert.Subject.CommonName != "preissued" {
+					t.Fatalf("expected preissued cert to be returned, got %q", cert.Subject.CommonName)
+				}
+				if ca.clientIssueCalls != 0 {
+					t.Fatalf("expected no CA IssueRequestedClientCertificate calls, got %d", ca.clientIssueCalls)
+				}
+			},
+		},
+		{
+			name: "with_csr_validation_fails_on_tamper",
+			chainedSigner: func(baseFactory func(CA) Signer, ca CA) Signer {
+				return WithCSRValidation(baseFactory(ca))
+			},
+			build: func() (context.Context, SignRequest) {
+				csr := makeCSR(t, "foo", orgID)
+				tampered := *csr
+				tampered.Signature = []byte("bogus")
+				req, err := NewSignRequest(mockSignerName, tampered, WithResourceName("foo"))
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				return withOrgCtx(orgID), req
+			},
+			wantErrVerify: true,
+		},
+		{
+			name: "restricted_prefix_enforced",
+			chainedSigner: func(baseFactory func(CA) Signer, ca CA) Signer {
+				restricted := &mockSigner{name: "restricted", ca: ca, restrictedPrefix: ca.Config().DeviceCommonNamePrefix}
+				restrictedMap := map[string]Signer{restricted.RestrictedPrefix(): restricted}
+				return WithSignerRestrictedPrefixes(restrictedMap, baseFactory(ca))
+			},
+			build: func() (context.Context, SignRequest) {
+				cn := ca.Config().DeviceCommonNamePrefix + "abcdef0123456789"
+				csr := makeCSR(t, cn, orgID)
+				req, err := NewSignRequest(mockSignerName, *csr)
+				if err != nil {
+					t.Fatalf("NewSignRequest: %v", err)
+				}
+				return withOrgCtx(orgID), req
+			},
+			wantErrVerify: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := tc.chainedSigner(factory, ca)
+			ca.registerMockSigner(wrapped)
+			ctx, req := tc.build()
+			err := Verify(ctx, ca, req)
+			if tc.wantErrVerify {
+				if err == nil {
+					t.Fatalf("expected error from Verify(), got nil")
+				} else {
+					return // expected error, no need to sign
+				}
+
+			}
+			if !tc.wantErrVerify && err != nil {
+				t.Fatalf("unexpected error from Verify(): %v", err)
+			}
+
+			cert, err := Sign(ctx, ca, req)
+			if err != nil {
+				t.Fatalf("unexpected error from Sign(): %v", err)
+			}
+			if err == nil && tc.assert != nil {
+				tc.assert(cert)
+			}
+		})
+	}
+}
+
+func mustASN1(t *testing.T, v string) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(v)
+	if err != nil {
+		t.Fatalf("asn1: %v", err)
+	}
+	return b
+}
+
+func TestWithOrgIDExtension(t *testing.T) {
+	ca := newMockCA(t)
+	factory := newMockSignerFactory(mockSignerName, "")
+
+	type orgOpt struct {
+		has bool
+		id  uuid.UUID
+	}
+
+	ctxFrom := func(o orgOpt) context.Context {
+		if !o.has {
+			return context.Background()
+		}
+		return util.WithOrganizationID(context.Background(), o.id)
+	}
+
+	csrFrom := func(o orgOpt) *x509.CertificateRequest {
+		if !o.has {
+			return makeCSR(t, "foo", uuid.Nil)
+		}
+		return makeCSR(t, "foo", o.id)
+	}
+
+	type testCase struct {
+		name            string
+		ctxOrg          orgOpt
+		csrOrg          orgOpt
+		wantVerifyError bool
+		wantSignError   bool
+		wantSignedOrg   orgOpt
+	}
+
+	nonDefault := uuid.New()
+
+	cases := []testCase{
+		{
+			name:            "csr_absent_ctx_absent_valid_no_ext",
+			ctxOrg:          orgOpt{has: false},
+			csrOrg:          orgOpt{has: false},
+			wantVerifyError: false,
+			wantSignError:   false,
+			wantSignedOrg:   orgOpt{has: false},
+		},
+		{
+			name:            "csr_absent_ctx_default_valid_inject_context",
+			ctxOrg:          orgOpt{has: true, id: NullOrgID},
+			csrOrg:          orgOpt{has: false},
+			wantVerifyError: false,
+			wantSignError:   false,
+			wantSignedOrg:   orgOpt{has: true, id: NullOrgID},
+		},
+		{
+			name:            "csr_absent_ctx_non_default_valid_inject_context",
+			ctxOrg:          orgOpt{has: true, id: nonDefault},
+			csrOrg:          orgOpt{has: false},
+			wantVerifyError: false,
+			wantSignError:   false,
+			wantSignedOrg:   orgOpt{has: true, id: nonDefault},
+		},
+		{
+			name:            "csr_present_ctx_absent_verify_allows",
+			ctxOrg:          orgOpt{has: false},
+			csrOrg:          orgOpt{has: true, id: nonDefault},
+			wantVerifyError: false,
+			wantSignError:   false,
+			wantSignedOrg:   orgOpt{has: true, id: nonDefault},
+		},
+		{
+			name:            "csr_present_ctx_present_match_valid_inject_csr",
+			ctxOrg:          orgOpt{has: true, id: nonDefault},
+			csrOrg:          orgOpt{has: true, id: nonDefault},
+			wantVerifyError: false,
+			wantSignedOrg:   orgOpt{has: true, id: nonDefault},
+		},
+		{
+			name:            "csr_present_ctx_present_mismatch_verify_fails",
+			ctxOrg:          orgOpt{has: true, id: uuid.New()},
+			csrOrg:          orgOpt{has: true, id: nonDefault},
+			wantVerifyError: true,
+			wantSignError:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := WithOrgIDExtension(factory)(ca)
+			ca.registerMockSigner(wrapped)
+
+			csr := csrFrom(tc.csrOrg)
+			ctx := ctxFrom(tc.ctxOrg)
+
+			req, err := NewSignRequest(mockSignerName, *csr, WithResourceName("foo"))
+			if err != nil {
+				t.Fatalf("NewSignRequest: %v", err)
+			}
+
+			err = Verify(ctx, ca, req)
+			switch {
+			case tc.wantVerifyError && err == nil:
+				t.Fatalf("expected verify error, got nil")
+			case !tc.wantVerifyError && err != nil:
+				t.Fatalf("unexpected verify error: %v", err)
+			}
+
+			cert, err := Sign(ctx, ca, req)
+			switch {
+			case tc.wantSignError && err == nil:
+				t.Fatalf("expected sign error, got nil")
+			case tc.wantSignError && err != nil:
+				return // expected error, no need to check cert
+			case !tc.wantSignError && err != nil:
+				t.Fatalf("unexpected sign error: %v", err)
+			}
+
+			got, extExists, err := GetOrgIDExtensionFromCert(cert)
+			if err != nil {
+				t.Fatalf("GetOrgIDExtensionFromCert: %v", err)
+			}
+
+			switch {
+			case !tc.wantSignedOrg.has && extExists:
+				t.Fatalf("expected no OrgID extension, got %s", got)
+			case tc.wantSignedOrg.has && !extExists:
+				t.Fatalf("expected OrgID extension, got none")
+			case tc.wantSignedOrg.has && extExists && got != tc.wantSignedOrg.id:
+				t.Fatalf("expected OrgID %s, but got %s", tc.wantSignedOrg.id, got)
+			}
+
+		})
+	}
+}

--- a/internal/crypto/signer/signer_chain_test.go
+++ b/internal/crypto/signer/signer_chain_test.go
@@ -153,8 +153,8 @@ func TestSignerChains(t *testing.T) {
 				if got, want := cert.Subject.CommonName, BootstrapCNFromName(cfg, "foo"); got != want {
 					t.Fatalf("CN not adjusted: got %q want %q", got, want)
 				}
-				if _, _, err := GetOrgIDExtensionFromCert(cert); err != nil {
-					t.Fatalf("OrgID extension missing: %v", err)
+				if _, present, err := GetOrgIDExtensionFromCert(cert); !present || err != nil {
+					t.Fatalf("Failed to ensure OrgID ext. exists: present=%v err=%v", present, err)
 				}
 				if _, err := GetSignerNameExtension(cert); err != nil {
 					t.Fatalf("SignerName extension missing: %v", err)
@@ -173,8 +173,8 @@ func TestSignerChains(t *testing.T) {
 				return withOrgCtx(orgID), req
 			},
 			assert: func(cert *x509.Certificate) {
-				if _, _, err := GetOrgIDExtensionFromCert(cert); err != nil {
-					t.Fatalf("OrgID extension missing: %v", err)
+				if _, present, err := GetOrgIDExtensionFromCert(cert); !present || err != nil {
+					t.Fatalf("Failed to ensure OrgID ext. exists: present=%v err=%v", present, err)
 				}
 				if _, err := GetSignerNameExtension(cert); err != nil {
 					t.Fatalf("SignerName extension missing: %v", err)

--- a/internal/crypto/signer/signer_client_bootstrap.go
+++ b/internal/crypto/signer/signer_client_bootstrap.go
@@ -33,6 +33,7 @@ func (s *SignerClientBootstrap) Verify(ctx context.Context, request SignRequest)
 	if _, err := PeerCertificateFromCtx(ctx); err == nil {
 		return fmt.Errorf("bootstrap certificates cannot be requested using client certificates issued by the system")
 	}
+
 	return nil
 }
 

--- a/internal/crypto/signer/signer_device_enrollment.go
+++ b/internal/crypto/signer/signer_device_enrollment.go
@@ -83,7 +83,6 @@ func (s *SignerDeviceEnrollment) Sign(ctx context.Context, request SignRequest) 
 		ctx,
 		&x509CSR,
 		int(expirySeconds),
-		WithExtension(OIDOrgID, NullOrgId.String()),
 		WithExtension(OIDDeviceFingerprint, x509CSR.Subject.CommonName),
 	)
 }

--- a/internal/crypto/signer/signer_device_svc_client.go
+++ b/internal/crypto/signer/signer_device_svc_client.go
@@ -72,7 +72,6 @@ func (s *SignerDeviceSvcClient) Sign(ctx context.Context, request SignRequest) (
 		ctx,
 		&x509CSR,
 		int(expirySeconds),
-		WithExtension(OIDOrgID, NullOrgId.String()),
 		WithExtension(OIDDeviceFingerprint, fingerprint),
 	)
 }

--- a/pkg/crypto/csr.go
+++ b/pkg/crypto/csr.go
@@ -93,16 +93,18 @@ func ParseCSR(csrPEM []byte) (*x509.CertificateRequest, error) {
 	return csr, nil
 }
 
-// GetExtensionValueFromCSR retrieves the raw value of the extension identified
-// by oid from csr, searching both Extensions and ExtraExtensions. It returns
-// an error if the extension is missing.
-func GetExtensionValueFromCSR(csr *x509.CertificateRequest, oid asn1.ObjectIdentifier) ([]byte, error) {
+// GetCSRExtensionValueAsStr retrieves a specific extension from a CSR as a string.
+func GetCSRExtensionValueAsStr(csr *x509.CertificateRequest, oid asn1.ObjectIdentifier) (string, error) {
 	for _, ext := range append(csr.Extensions, csr.ExtraExtensions...) {
 		if ext.Id.Equal(oid) {
-			return ext.Value, nil
+			var s string
+			if _, err := asn1.Unmarshal(ext.Value, &s); err == nil {
+				return s, nil
+			}
+			return "", fmt.Errorf("unmarshalling extension %v", oid)
 		}
 	}
-	return nil, flterrors.ErrExtensionNotFound
+	return "", flterrors.ErrExtensionNotFound
 }
 
 func ValidateX509CSR(c *x509.CertificateRequest) error {


### PR DESCRIPTION
# Device OrgID Scoping

Each request is scoped to a single organization identified by an `OrgID` carried as an X.509 extension in the device’s peer certificate.  
The service middleware extracts the `OrgID` from the peer certificate and stores it in the request context (#1471); all authorization and data access for that request use that value.

If the certificate does not include an `OrgID`, the request is scoped to the default organization, making the change backward compatible and aligning with the current user scoping logic.

---

## Provisioning & Enrollment

**Bootstrap phase:**  
An operator creates a CSR and may include the OrgID as an X.509 extension. After approval, the server issues a short-lived peer certificate for the device.  
The new behavior is that the signed certificate includes the OrgID extension derived from the operator’s request and request context.

**Enrollment phase:**  
On the device’s first boot, it loads its short-lived bootstrap certificate and uses it as the peer certificate when making the Enrollment Request to the server.  
After the Enrollment Request is approved, the device retrieves the newly issued long-lived device certificate from the server. This certificate includes the OrgID, and all future requests will be scoped based on the OrgID in this certificate.

---

## Signing & Validation Rules

The API signer chain is updated to inject the OrgID extension based on the X.509 certificate signing request in the CSR/ER request body and the request context:

1. If both CSR and context contain OrgID **and they differ** → **fail verification/issuance**.
2. If CSR is **missing** OrgID and context has one → **use context OrgID**.
3. If CSR **has** OrgID → **use it**.
4. If neither has OrgID → **do not include OrgID** in the certificate.

---
# Demo using flightctl CLI

Below is an example of how the process works using the CLI. 
The support for org-scoped requests using CLI is implemented in #1424.
Requesting an enrollment certificate:
```bash
> flightctl certificate request --org=00000000-0000-0000-0000-000000000001 \
    --signer=enrollment \
    --expiration=365d
Creating new ECDSA key pair and writing to "/etc/flightctl/certs/client-enrollment.key".
Submitting certificate signing request "client-enrollment-f9d0355e"... success.
Waiting for certificate to be approved and issued.... success.
```
Inspecting the certificate content:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 5453664005379253296 (0x4baf4e84a4f6e430)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN=ca
        Validity
            Not Before: Aug 12 10:22:18 2025 GMT
            Not After : Aug 12 10:22:19 2026 GMT
        Subject: CN=client-enrollment-f9d0355e
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Authority Key Identifier:
                67:C6:52:51:92:6C:9A:33:5C:80:27:77:D2:98:2C:B1:9E:C2:9F:8C:2C:D1:03:B8:16:E5:A8:9C:2F:CE:DB:0B
            1.3.6.1.4.1.99999.1.2:
                .$00000000-0000-0000-0000-000000000001 <-- OrgID
            1.3.6.1.4.1.99999.1.1:
                ..flightctl.io/enrollment
```
The `1.3.6.1.4.1.99999.1.2` extension contains the OrgID, confirming that the certificate is correctly scoped to the specified organization.

After the device is booted, the Enrollment Request can be listed as a resource belonging to the same organization:
```bash
> flightctl get er --org=00000000-0000-0000-0000-000000000001
NAME                                                    APPROVAL        APPROVER        APPROVED LABELS
01l9bb80uf5himu7mjrec32rnig0sj1bek2ljhp0mvaf062moca0    Approved        unknown

> flightctl approve er/01l9bb80uf5himu7mjrec32rnig0sj1bek2ljhp0mvaf062moca0 --org=00000000-0000-0000-0000-000000000001
```
Once approved, the device belongs to that same organization:

```bash
> flightctl get dev --org=00000000-0000-0000-0000-000000000001
NAME                                                    ALIAS   OWNER   SYSTEM  UPDATED         APPLICATIONS    LAST SEEN
01l9bb80uf5himu7mjrec32rnig0sj1bek2ljhp0mvaf062moca0            <none>  Online  UpToDate        Healthy         27 seconds ago
```

**Note**: A default organization can be set for all flightctl requests to avoid specifying `--org` each time: `flightctl config set-organization 00000000-0000-0000-0000-000000000001`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Org ID handling added to certificate flows: Org IDs can be read from CSRs or context, embedded when present, and validated for consistency during issuance and verification.

* **Refactor**
  * Signer pipeline reorganized into decorator-style wrappers to centralize extension handling and wiring.

* **Changes**
  * Some issued certificates (device enrollment and certain clients) no longer include the Org ID extension.
  * Extension extraction now returns explicit presence vs absence.

* **Tests**
  * Adds comprehensive signer-chain tests covering issuance, verification, reuse, restrictions, and Org ID scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->