### PR TITLE
EDM-1993: Add restart configuration and polling for files

### DIFF
--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-init.container
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-init.container
@@ -17,6 +17,7 @@ Exec=/bin/sh /config-source/init.sh
 [Service]
 Type=oneshot
 RemainAfterExit=true
+Restart=on-failure
 RestartSec=5s
 
 [Install]

--- a/deploy/podman/flightctl-api/flightctl-api-init.container
+++ b/deploy/podman/flightctl-api/flightctl-api-init.container
@@ -17,6 +17,7 @@ Exec=/bin/sh /config-source/init.sh
 [Service]
 Type=oneshot
 RemainAfterExit=true
+Restart=on-failure
 RestartSec=5s
 
 [Install]

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/init.sh
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/init.sh
@@ -34,6 +34,9 @@ sed '/^\s*listen\s*\[::\]:8090/d' "$NGINX_CONFIG_OUTPUT" > "${NGINX_CONFIG_OUTPU
 # Removes IPv4 listen directive for the IPv6 configuration
 sed '/^\s*listen\s*8090 ssl/d' "$NGINX_CONFIG_OUTPUT" > "${NGINX_CONFIG_OUTPUT}.ipv6"
 
+# Wait for certificates
+wait_for_files "$CERTS_SOURCE_PATH/server.crt" "$CERTS_SOURCE_PATH/server.key"
+
 # Handle server certificates
 #
 # The CLI artifacts container runs as user 1001 by default,

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
@@ -17,6 +17,7 @@ Exec=/bin/sh /config-source/init.sh
 [Service]
 Type=oneshot
 RemainAfterExit=true
+Restart=on-failure
 RestartSec=5s
 
 [Install]

--- a/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
@@ -55,19 +55,12 @@ sed -i "s|{{AUTH_CLIENT_ID}}|${AUTH_CLIENT_ID}|g" "$ENV_OUTPUT"
 sed -i "s|{{INTERNAL_AUTH_URL}}|${AUTH_URL}|g" "$ENV_OUTPUT"
 sed -i "s|{{AUTH_INSECURE_SKIP_VERIFY}}|${AUTH_INSECURE_SKIP_VERIFY}|g" "$ENV_OUTPUT"
 
-# Handle server certificates
-if [ -f "$CERTS_SOURCE_PATH/server.crt" ]; then
-  cp "$CERTS_SOURCE_PATH/server.crt" "$CERTS_DEST_PATH/server.crt"
-else
-  echo "Warning: Server certificate not found at $CERTS_SOURCE_PATH/server.crt"
-  exit 1
-fi
-if [ -f "$CERTS_SOURCE_PATH/server.key" ]; then
-  cp "$CERTS_SOURCE_PATH/server.key" "$CERTS_DEST_PATH/server.key"
-else
-  echo "Warning: Server key not found at $CERTS_SOURCE_PATH/server.key"
-  exit 1
-fi
+# Wait for certificates
+wait_for_files "$CERTS_SOURCE_PATH/server.crt" "$CERTS_SOURCE_PATH/server.key"
+
+# Copy certificates to destination path
+cp "$CERTS_SOURCE_PATH/server.crt" "$CERTS_DEST_PATH/server.crt"
+cp "$CERTS_SOURCE_PATH/server.key" "$CERTS_DEST_PATH/server.key"
 
 if [ -f "$CERTS_SOURCE_PATH/auth/ca.crt" ]; then
   echo "Using provided auth CA certificate"

--- a/deploy/podman/flightctl-ui/flightctl-ui-init.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui-init.container
@@ -18,6 +18,7 @@ Exec=/bin/sh /config-source/init.sh
 Type=oneshot
 RemainAfterExit=true
 TimeoutStartSec=5s
+Restart=on-failure
 RestartSec=5s
 
 [Install]

--- a/deploy/scripts/init_utils.sh
+++ b/deploy/scripts/init_utils.sh
@@ -11,3 +11,40 @@ extract_value() {
     # Extract the value then trim leading and trailing whitespace
     sed -n -E "s/^[[:space:]]*${key}:[[:space:]]*[\"']?([^\"'#]+)[\"']?.*$/\1/p" "$file" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
+
+# Wait for files with backoff
+wait_for_files() {
+    local files=("$@")
+    local max_attempts=5
+    local attempt=1
+    local wait_time=2
+
+    while [ $attempt -le $max_attempts ]; do
+        local all_files_exist=true
+        for file in "${files[@]}"; do
+            if [ ! -f "$file" ]; then
+                all_files_exist=false
+                break
+            fi
+        done
+
+        if [ "$all_files_exist" = true ]; then
+            echo "All files found: ${files[*]}"
+            return 0
+        fi
+
+        echo "Attempt $attempt/$max_attempts: Files not ready, waiting ${wait_time}s..."
+        sleep $wait_time
+        attempt=$((attempt + 1))
+        wait_time=$((wait_time * 2))
+    done
+
+    echo "Error: Not all files found after $max_attempts attempts"
+    echo "Missing files:"
+    for file in "${files[@]}"; do
+        if [ ! -f "$file" ]; then
+            echo "  - $file"
+        fi
+    done
+    return 1
+}


### PR DESCRIPTION
Currently, there is a race condition where:
1.  `flightctl-api` starts
2. `flightctl-ui-init` starts (has a dependency on `flightctl-api`, but the dependency only tracks the container spinning up and nothing about what the service is doing)
3. `flightctl-ui-init` checks for presence of of server cert and key file which the api writes and dies if they do not exist
4. `flightctl-api` writes the certs `flightctl-ui-init` needs but it is too late

The ui-init is currently not configured to restart nor wait for the generated files.  This change:
- Adds a restart on-failure condition to init containers, which previously had a RestartSec  configuration but actually weren't configured to restart
- Adds a simple file polling mechanism - this is probably overkill, but hopefully provides more clarity on what is going on when we actually see this case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of initialization by waiting for required certificates before proceeding in relevant components.
  - Enabled automatic restart on failure for multiple initialization services to reduce transient startup errors.

- Chores
  - Introduced a shared utility to wait for files with exponential backoff, enhancing robustness across initialization scripts.

These changes collectively reduce race conditions during startup and improve service resilience without altering existing functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->