### PR TITLE
Emit single device disconnected event; add summary to alerts

### DIFF
--- a/internal/alert_exporter/alertmanager_utils.go
+++ b/internal/alert_exporter/alertmanager_utils.go
@@ -333,6 +333,9 @@ func alertToAlertmanagerAlert(alert *AlertInfo) AlertmanagerAlert {
 			"resource":  alert.ResourceName,
 			"org_id":    alert.OrgID,
 		},
+		Annotations: map[string]string{
+			"summary": alert.Summary,
+		},
 		StartsAt: alert.StartsAt,
 	}
 	if alert.EndsAt != nil {

--- a/internal/alert_exporter/event_processor.go
+++ b/internal/alert_exporter/event_processor.go
@@ -298,6 +298,7 @@ func (c *CheckpointContext) setAlert(event api.Event, reason string, group []str
 		c.alerts[k][reason].ResourceKind = event.InvolvedObject.Kind
 		c.alerts[k][reason].OrgID = store.NullOrgId.String()
 		c.alerts[k][reason].Reason = reason
+		c.alerts[k][reason].Summary = event.Message
 		c.alerts[k][reason].StartsAt = *event.Metadata.CreationTimestamp
 		c.alerts[k][reason].EndsAt = nil
 

--- a/internal/alert_exporter/exporter.go
+++ b/internal/alert_exporter/exporter.go
@@ -52,6 +52,7 @@ type AlertInfo struct {
 	ResourceKind string
 	OrgID        string
 	Reason       string
+	Summary      string
 	StartsAt     time.Time
 	EndsAt       *time.Time
 }


### PR DESCRIPTION
Fix two bugs:
1. EDM-1996: Emit single event for disconnected device
    We previously emitted 3 events because each property that became
    "unknown" triggered a separate event. We now make sure to emit only one.
2. EDM-1997: Annotate alerts with the event message
    Add a "summary" to each alert with a human-readable message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Alerts now include a summary derived from event messages, improving context and readability in downstream alerting systems.
- Bug Fixes
  - Prevents duplicate “Device Disconnected” notifications when multiple status fields change in the same update, ensuring a single notification per update.
- Tests
  - Added tests to verify deduplication, ensuring only one “Device Disconnected” event is emitted per update cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->