### PR TITLE
Replace unsupported dorny/paths-filter with tj-actions/changed-files

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -18,22 +18,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            notdocs:
-              - '!.spelling'
-              - '!README.md'
-              - '!docs/**'
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          since_last_remote_commit: 'true'
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            .github/**
+            examples/**
 
       - name: Setup all dependencies
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
 
       - name: Running Integration tests
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make integration-test VERBOSE=true
         env:
           DISABLE_FIPS: true

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -14,25 +14,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
         with:
-          filters: |
-            docs:
-              - '.spelling'
-              - 'README.md'
-              - 'docs/**'
+          since_last_remote_commit: 'true'
+          files: |
+            .spelling
+            README.md
+            docs/**
 
       - name: Running Markdown Linter
-        if: ${{ steps.filter.outputs.docs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint-docs
 
       - name: Running Spellchecker
-        if: ${{ steps.filter.outputs.docs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make spellcheck-docs
 
       - name: Verifying diagrams have source embedded
-        if: ${{ steps.filter.outputs.docs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint-diagrams

--- a/.github/workflows/lint-openapi.yaml
+++ b/.github/workflows/lint-openapi.yaml
@@ -14,16 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
         with:
-          filters: |
-            api:
-              - '.spectral.yaml'
-              - 'api/**/openapi.yaml'
+          since_last_remote_commit: 'true'
+          files: |
+            .spectral.yaml
+            api/**/openapi.yaml
 
       - name: Running Spectral Linter
-        if: ${{ steps.filter.outputs.api == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint-openapi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,39 +18,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Checkout
-        run: |
-          commits=${{ github.event.pull_request.commits }}
-          if [[ -n "$commits" ]]; then
-            # Prepare enough depth for diffs with master
-            git fetch --depth="$(( commits + 1 ))"
-          fi
+          fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
         with:
-          filters: |
-            notdocs:
-              - '!.spelling'
-              - '!README.md'
-              - '!docs/**'
+          since_last_remote_commit: 'true'
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            .github/**
+            examples/**
 
       - name: Check commit message
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: hack/check-commits.sh
 
       - name: Setup all dependencies
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
 
       - name: Check that generated files have been updated and that go.mod is tidy
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           make generate
           make tidy
           git diff --exit-code
 
       - name: Running Linter
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -2,12 +2,12 @@ name: "E2E testing"
 
 on:
   workflow_dispatch:
-    inputs:  
-      label_filter:  
+    inputs:
+      label_filter:
         description: 'Ginkgo label filter expression to filter e2e tests'
-        required: false  
+        required: false
         default: 'sanity' #By default, only tests labeled with 'sanity' will run.
-        type: string 
+        type: string
   push:
     branches:
       - main
@@ -28,56 +28,60 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
         with:
-          filters: |
-            notdocs:
-              - '!.spelling'
-              - '!README.md'
-              - '!docs/**'
+          since_last_remote_commit: 'true'
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            .github/**
+            examples/**
 
       - name: Free Disk Space (Ubuntu)
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
 
       - name: Setup all dependencies
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
         with:
           setup_kvm: yes
 
       - name: Create kind cluster
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make cluster
 
       - name: Deploy the flightctl server
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: DISABLE_FIPS="true" make deploy
 
       - name: Deploy the E2E side services, registry and git
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make deploy-e2e-extras
 
       - name: Make rpm, and agent images
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           make e2e-agent-images
 
       - name: Make sure the images are owned by the runner user
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           sudo chown -R runner:runner bin/output|| true
 
       - name: Run E2E Tests
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run:  make run-e2e-test VERBOSE=true # use DEBUG_VM_CONSOLE=1 to see the VM console output
-        env:  
+        env:
           GINKGO_LABEL_FILTER: ${{ inputs.label_filter || 'sanity' }}   # Filter to run only specific tests
 
       - name: Collect and Upload Logs
-        if: always() && steps.filter.outputs.notdocs == 'true'
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/collect-logs
         with:
           namespace-external: 'flightctl-external'

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -19,63 +19,68 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            notdocs:
-              - '!.spelling'
-              - '!README.md'
-              - '!docs/**'
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          since_last_remote_commit: 'true'
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            .github/**
+            examples/**
 
       - name: Setup all dependencies
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
 
       - name: Create cluster
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make cluster
 
       - name: Deploy
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: DISABLE_FIPS="true" make deploy
 
       - name: Check
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           kubectl get pods --all-namespaces
 
       - name: Apply device
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/flightctl apply -f examples/device.yaml
 
       - name: Apply fleet
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/flightctl apply -f examples/fleet.yaml
 
       - name: Apply enrollmentrequest
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/flightctl apply -f examples/enrollmentrequest.yaml
 
       - name: Apply repository
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/flightctl apply -f examples/repository-flightctl.yaml
 
       - name: Apply resourcesync
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/flightctl apply -f examples/resourcesync.yaml
 
       - name: Build the simulator
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: DISABLE_FIPS="true" make build-devicesimulator
 
       - name: Simulator run
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: bin/devicesimulator --config bin/agent/etc/flightctl/config.yaml --count 1 --stop-after 1m
 
       - name: Collect and Upload Logs
-        if: always() && steps.filter.outputs.notdocs == 'true'
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/collect-logs
         with:
           namespace-external: 'flightctl-external'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,24 +17,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            notdocs:
-              - '!.spelling'
-              - '!README.md'
-              - '!docs/**'
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          since_last_remote_commit: 'true'
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            .github/**
+            examples/**
 
       - name: Setup all dependencies
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
         with:
           unit_tests: 'true'
 
       - name: Running Unit tests
-        if: ${{ steps.filter.outputs.notdocs == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make unit-test
         env:
           DISABLE_FIPS: "true"

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ For more information, please refer to:
 <br><br>
 
 [![Watch the demo](docs/images/demo-thumbnail.png)](https://www.youtube.com/watch?v=WzNG_uWnmzk)
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI change detection unified to a single "Get changed files" check, fetching full history and ignoring non-code paths to reduce unnecessary runs.
- Tests
  - Unit, integration, lint, smoke, and E2E jobs now run only when relevant files change.
  - E2E and smoke log collection expanded with internal/external namespaces and dedicated log directories for easier troubleshooting.
- Documentation
  - Minor README formatting update (whitespace only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->