### PR TITLE
EDM-1659: e2e speed up, build files only

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -1,4 +1,4 @@
-name: "E2E testing"
+name: "E2E testing (Parallel Build)"
 
 on:
   workflow_dispatch:
@@ -18,10 +18,33 @@ permissions:
   contents: read
   pull-requests: read
 
+
+env:
+  # Enable BuildKit for cache mounts
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+  # Define the total number of parallel nodes for Ginkgo
+  GINKGO_TOTAL_NODES: 1
+  # Set the registry for container caching
+  QUAY_ORG: quay.io/flightctl
+  REGISTRY: quay.io
+  REGISTRY_OWNER: flightctl
+  GITHUB_ACTIONS: true
+
 jobs:
-  # This line defines a job with the ID `check-links` that is stored within the `jobs` key.
-  e2e:
+  e2e-tests:
     runs-on: "ubuntu-24.04"
+    outputs: # <-- Add this section
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    # =================================================================
+    # This matrix will create 4 independent jobs that run in parallel.
+    # Each job will execute all the steps below.
+    # =================================================================
+    strategy:
+      fail-fast: false
+      matrix:
+        ginkgo_node: [1]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,11 +69,84 @@ jobs:
         with:
           tool-cache: false
 
+      - name: Restore APT cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        id: cache-apt-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /var/cache/apt
+            /var/lib/apt
+          key: ${{ runner.os }}-apt-e2e-${{ hashFiles('.github/actions/setup-dependencies/action.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-e2e-
+
+      - name: Set permissions for APT after restore
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: sudo mkdir -p /var/cache/apt /var/lib/apt && sudo chown -R root:root /var/cache/apt /var/lib/apt
+
+      - name: Restore Go modules cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        id: cache-go-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Restore DNF cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        id: cache-dnf-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-e2e
+          restore-keys: |
+            ${{ runner.os }}-dnf-
+
+      - name: Set permissions for DNF after restore
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: sudo mkdir -p /var/cache/dnf /var/lib/dnf && sudo chown -R root:root /var/cache/dnf /var/lib/dnf
+
+      - name: Restore bootc-image-builder cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        id: cache-bootc-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            bin/dnf-cache
+            bin/osbuild-cache
+          key: ${{ runner.os }}-bootc-cache-e2e-${{ hashFiles('test/scripts/agent-images/Containerfile-e2e-base.local') }}
+          restore-keys: |
+            ${{ runner.os }}-bootc-cache-e2e-
+
+
       - name: Setup all dependencies
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
         with:
           setup_kvm: yes
+
+      - name: Pull cache images
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          # Try to pull cache images to warm up the build
+          # || true prevents failure if the cache doesn't exist yet (e.g., first run)
+          podman pull ${{ env.QUAY_ORG }}/flightctl-api:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-db-setup:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-worker:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-periodic:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-alert-exporter:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-alertmanager-proxy:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-cli-artifacts:cache || true
+          podman pull ${{ env.QUAY_ORG }}/flightctl-userinfo-proxy:cache || true
+          podman pull ${{ env.QUAY_ORG }}/git-server:cache || true
+          podman pull ${{ env.QUAY_ORG }}/sleep-app:cache || true
 
       - name: Create kind cluster
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
@@ -60,30 +156,114 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: DISABLE_FIPS="true" make deploy
 
-      - name: Deploy the E2E side services, registry and git
+      - name: Prepare the E2E test environment
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        run: make deploy-e2e-extras
+        run: make prepare-e2e-test
 
-      - name: Make rpm, and agent images
+      - name: Set permissions for APT before save
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        run: |
-          make e2e-agent-images
+        run: sudo mkdir -p /var/cache/apt /var/lib/apt && sudo chown -R runner:runner /var/cache/apt /var/lib/apt
+
+      - name: Save APT cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /var/cache/apt
+            /var/lib/apt
+          key: ${{ steps.cache-apt-restore.outputs.cache-primary-key }}
+
+      - name: Set permissions for APT after save
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: sudo mkdir -p /var/cache/apt /var/lib/apt && sudo chown -R root:root /var/cache/apt /var/lib/apt
+
+      - name: Save Go modules cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ steps.cache-go-restore.outputs.cache-primary-key }}
+
+      - name: Set permissions for DNF before save
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: sudo mkdir -p /var/cache/dnf /var/lib/dnf && sudo chown -R runner:runner /var/cache/dnf /var/lib/dnf
+
+      - name: Save DNF cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-e2e
+
+      - name: Set permissions for DNF after save
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: sudo mkdir -p /var/cache/dnf /var/lib/dnf && sudo chown -R root:root /var/cache/dnf /var/lib/dnf
+
+      - name: Save bootc-image-builder cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            bin/dnf-cache
+            bin/osbuild-cache
+          key: ${{ steps.cache-bootc-restore.outputs.cache-primary-key }}
+
+      # Note: Container images are now cached via registry-based caching
+      # The cache images are automatically pushed during the build process
+      # No manual cache save/restore needed for containers
 
       - name: Make sure the images are owned by the runner user
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
-          sudo chown -R runner:runner bin/output|| true
+          sudo mkdir -p bin/output && sudo chown -R runner:runner bin/output
 
-      - name: Run E2E Tests
+      # =================================================================
+      # This step now uses manual test splitting to run a
+      # specific slice of the tests on each parallel job.
+      # =================================================================
+      - name: Run E2E Test Slice
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        run:  make run-e2e-test VERBOSE=true # use DEBUG_VM_CONSOLE=1 to see the VM console output
+        run: make run-e2e-test VERBOSE=true # use DEBUG_VM_CONSOLE=1 to see the VM console output
         env:
-          GINKGO_LABEL_FILTER: ${{ inputs.label_filter || 'sanity' }}   # Filter to run only specific tests
+          GINKGO_LABEL_FILTER: ${{ inputs.label_filter || 'sanity' }}
+          GINKGO_TOTAL_NODES: ${{ env.GINKGO_TOTAL_NODES }}
+          GINKGO_NODE: ${{ matrix.ginkgo_node }}
 
+      # =================================================================
+      # This step now uploads logs to a unique artifact for each job
+      # to prevent them from overwriting each other.
+      # =================================================================
       - name: Collect and Upload Logs
         if: always() && steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/actions/collect-logs
         with:
           namespace-external: 'flightctl-external'
           namespace-internal: 'flightctl-internal'
-          log-directory: 'e2e-logs'
+          log-directory: 'e2e-logs-node-${{ matrix.ginkgo_node }}'
+
+  # Summary job that depends on all matrix jobs completing
+  e2e:
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: always()
+    steps:
+      - name: Check E2E Test Results
+        run: |
+          if [[ "${{ needs.e2e-tests.outputs.any_changed }}" != "true" ]]; then
+              echo "E2E tests were skipped (docs-only or ignored paths)"
+              exit 0
+          fi
+          if [[ "${{ needs.e2e-tests.result }}" == "success" ]]; then
+            echo "All E2E tests passed!"
+            exit 0
+          elif [[ "${{ needs.e2e-tests.result }}" == "skipped" ]]; then
+            echo "E2E tests were skipped (docs-only changes)"
+            exit 0
+          else
+            echo "E2E tests failed or were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -12,6 +12,16 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  # Enable BuildKit for cache mounts
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+
+  QUAY_ORG: quay.io/flightctl
+  REGISTRY: quay.io
+  REGISTRY_OWNER: flightctl
+  GITHUB_ACTIONS: true
+
 jobs:
   # This line defines a job with the ID `check-links` that is stored within the `jobs` key.
   smoke:
@@ -37,6 +47,39 @@ jobs:
       - name: Setup all dependencies
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
+
+      - name: Cache Go modules
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Cache DNF packages
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-smoke
+          restore-keys: |
+            ${{ runner.os }}-dnf-
+
+      - name: Cache bootc-image-builder
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            bin/dnf-cache
+            bin/osbuild-cache
+          key: ${{ runner.os }}-bootc-cache-smoke-${{ hashFiles('test/scripts/agent-images/Containerfile-e2e-base.local') }}
+          restore-keys: |
+            ${{ runner.os }}-bootc-cache-smoke-
 
       - name: Create cluster
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -77,6 +77,26 @@ jobs:
       - name: Install Dependencies
         run: go mod tidy
 
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Cache DNF packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-cli
+          restore-keys: |
+            ${{ runner.os }}-dnf-
+
       - name: Build
         run: |
           DISABLE_FIPS="true" GOOS="${{ matrix.os }}" GOARCH="${{ matrix.arch }}" make build-cli

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -12,6 +12,9 @@ on:
 env:
   QUAY_ORG: quay.io/flightctl
   QUAY_CHARTS: quay.io/flightctl/charts
+  # Enable BuildKit for cache mounts
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
 
 jobs:
   generate-tags:
@@ -20,7 +23,7 @@ jobs:
       image_tags: ${{ steps.get-tags.outputs.image_tags }}
       helm_tag: ${{ steps.get-tags.outputs.helm_tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -51,7 +54,7 @@ jobs:
             fi
 
             # The images tags are taken from git
-            image_tags=( ${latest_tag}-${GITHUB_SHA} ${latest_tag} ${version} )
+            image_tags=( ${latest_tag}-${GITHUB_SHA} ${latest_tag} ${version} cache )
             echo "image_tags=${image_tags[@]}" >> $GITHUB_OUTPUT
             echo "image_tags=${image_tags[@]}"
 
@@ -64,7 +67,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     needs: [publish-flightctl-containers, generate-tags]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup all dependencies
         uses: ./.github/actions/setup-dependencies
@@ -99,10 +102,36 @@ jobs:
     needs: [generate-tags]
     runs-on: "ubuntu-24.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.12.4
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Cache DNF packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-${{ matrix.image }}
+          restore-keys: |
+            ${{ runner.os }}-dnf-
 
       - name: Build
         id: build
@@ -118,6 +147,10 @@ jobs:
             org.flightctl.flightctl-${{ matrix.image }}.github.ref_name=${{ github.ref_name }}
           extra-args: |
             --ulimit nofile=10000:10000
+            --mount=type=cache,target=/opt/app-root/src/go/pkg/mod
+            --mount=type=cache,target=/opt/app-root/src/.cache/go-build
+            --mount=type=cache,target=/var/cache/dnf
+            --mount=type=cache,target=/var/lib/dnf
           containerfiles: Containerfile.${{ matrix.image }}
           context: .
 

--- a/.github/workflows/publish-e2e-containers.yaml
+++ b/.github/workflows/publish-e2e-containers.yaml
@@ -1,0 +1,84 @@
+name: Push E2E containers
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  QUAY_ORG: quay.io/flightctl
+  # Enable BuildKit for cache mounts
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+
+jobs:
+  publish-flightctl-e2e-containers:
+    strategy:
+      matrix:
+        image: 
+          - {name: 'git-server', containerfile: 'test/scripts/agent-images/Containerfile.git-server'}
+          - {name: 'sleep-app', containerfile: 'test/scripts/agent-images/Containerfile.sleep-app'}
+        
+    runs-on: "ubuntu-24.04"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.12.4
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Cache DNF packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-${{ matrix.image.name }}
+          restore-keys: |
+            ${{ runner.os }}-dnf-
+
+      - name: Build
+        id: build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ matrix.image.name }}
+          tags: cache
+          labels: |
+            org.flightctl.flightctl-${{ matrix.image.name }}.github.repository=${{ github.repository }}
+            org.flightctl.flightctl-${{ matrix.image.name }}.github.actor=${{ github.actor }}
+            org.flightctl.flightctl-${{ matrix.image.name }}.github.run_id=${{ github.run_id }}
+            org.flightctl.flightctl-${{ matrix.image.name }}.github.sha=${{ github.sha }}
+            org.flightctl.flightctl-${{ matrix.image.name }}.github.ref_name=${{ github.ref_name }}
+          extra-args: |
+            --ulimit nofile=10000:10000
+            --mount=type=cache,target=/opt/app-root/src/go/pkg/mod
+            --mount=type=cache,target=/opt/app-root/src/.cache/go-build
+            --mount=type=cache,target=/var/cache/dnf
+            --mount=type=cache,target=/var/lib/dnf
+          containerfiles: ${{ matrix.image.containerfile }}
+          context: .
+
+      - name: Push to Quay.io
+        id: push
+        uses: redhat-actions/push-to-registry@v2.7
+        with:
+          image: ${{ matrix.image.name }}
+          tags: cache
+          registry: ${{ env.QUAY_ORG }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ test/e2e/cli/*.key
 /packaging/rpm/flightctl-*-vendor.tar.bz2
 flightctl-*.rpm
 *.tar
+/packaging/rpm/flightctl-*/
+**/*.test
 
 # All temporary files should be created here
 /.output/

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,22 +1,49 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN make build-alert-exporter
 
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-alert-exporter
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+# Use BuildKit cache mounts for microdnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    microdnf update --nodocs -y && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alert-exporter-container" \
@@ -25,7 +52,6 @@ LABEL \
   io.k8s.display-name="Flight Control Alert Exporter" \
   name="flightctl-alert-exporter" \
   summary="Flight Control Edge management service, alert exporter"
-
 COPY --from=build /app/bin/flightctl-alert-exporter .
-
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-alert-exporter

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,22 +1,49 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN make build-alertmanager-proxy
 
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-alertmanager-proxy
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+# Use BuildKit cache mounts for microdnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    microdnf update --nodocs -y && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alertmanager-proxy-container" \
@@ -25,9 +52,7 @@ LABEL \
   io.k8s.display-name="Flight Control Alertmanager Proxy" \
   name="flightctl-alertmanager-proxy" \
   summary="Flight Control Edge management service, alertmanager proxy"
-
 COPY --from=build /app/bin/flightctl-alertmanager-proxy .
-
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 EXPOSE 8443
-
-CMD ./flightctl-alertmanager-proxy 
+CMD ./flightctl-alertmanager-proxy

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -3,24 +3,46 @@ WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN git config --global --add safe.directory /app
-RUN make build-api
 
+# Copy dependencies first (most stable)
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-api
+
+FROM registry.access.redhat.com/ubi9/ubi as certs
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf update --nodocs -y && dnf install ca-certificates tzdata --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-api-container" \
@@ -29,7 +51,8 @@ LABEL \
   io.k8s.display-name="Flight Control API Server" \
   name="flightctl-api" \
   summary="Flight Control Edge management API server"
-
 COPY --from=build /app/bin/flightctl-api .
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 
 CMD ./flightctl-api

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,24 +1,53 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./packaging packaging
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN dnf install --nodocs -y jq
-RUN make build-multiarch-clis
+
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
+
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+COPY ./packaging ./packaging
+
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install --nodocs -y jq
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-multiarch-clis
 
 FROM registry.access.redhat.com/ubi9/ubi as certs
-RUN dnf install --nodocs -y nginx && \
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install --nodocs -y nginx && \
     rm -f /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf && \
     dnf clean all
 

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -3,21 +3,39 @@ WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN git config --global --add safe.directory /app
-RUN make build-db-migrate
+
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
+
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-db-migrate
 
 FROM registry.access.redhat.com/ubi9/ubi
 
@@ -33,7 +51,10 @@ LABEL \
   summary="Flight Control Database Setup Tools"
 
 # Install required tools for database operations
-RUN dnf install -y postgresql gettext && dnf clean all
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y postgresql gettext && dnf clean all
 
 # Copy the migration binary from the build stage
 COPY --from=build /app/bin/flightctl-db-migrate /usr/local/bin/flightctl-db-migrate

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,22 +1,49 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN make build-periodic
 
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-periodic
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+# Use BuildKit cache mounts for microdnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    microdnf update --nodocs -y && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-periodic-container" \
@@ -25,7 +52,6 @@ LABEL \
   io.k8s.display-name="Flight Control Periodic Job Manager" \
   name="flightctl-periodic" \
   summary="Flight Control Edge management service, periodic job worker"
-
 COPY --from=build /app/bin/flightctl-periodic .
-
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-periodic

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,22 +1,49 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN make build-userinfo-proxy
 
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-userinfo-proxy
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+# Use BuildKit cache mounts for microdnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    microdnf update --nodocs -y && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-userinfo-proxy-container" \
@@ -25,8 +52,8 @@ LABEL \
   io.k8s.display-name="Flight Control UserInfo Proxy" \
   name="flightctl-userinfo-proxy" \
   summary="Flight Control UserInfo proxy for Grafana authentication"
-
 COPY --from=build /app/bin/flightctl-userinfo-proxy .
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 
 EXPOSE 8080
 

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,22 +1,49 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-COPY ./api api
-COPY ./cmd cmd
-COPY ./deploy deploy
-COPY ./hack hack
-COPY ./internal internal
-COPY ./go.* ./
-COPY ./pkg pkg
-COPY ./test test
-COPY ./Makefile .
-# make sure that version extraction works
-COPY .git .git
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Switch to root for build operations
 USER 0
-RUN make build-worker
 
+# Copy dependencies first (most stable)
+COPY go.* ./
+COPY go.mod go.sum ./
 
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-worker
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
+# Use BuildKit cache mounts for microdnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    microdnf update --nodocs -y && microdnf install ca-certificates --nodocs -y
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-worker-container" \
@@ -25,7 +52,6 @@ LABEL \
   io.k8s.display-name="Flight Control Asynchronous Job Worker" \
   name="flightctl-worker" \
   summary="Flight Control Edge management service, async job worker"
-
 COPY --from=build /app/bin/flightctl-worker .
-
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-worker

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,47 @@
+# Enable BuildKit for all container builds
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
+# --- Container Registry Configuration ---
+# Use environment variables if they exist, otherwise use these defaults.
+# This allows the CI pipeline to easily override them.
+REGISTRY       ?= localhost
+REGISTRY_OWNER ?= flightctl
+GITHUB_ACTIONS ?= false
+
+# --- Cache Configuration ---
+# Always use caching with localhost defaults for local builds
+# In CI, REGISTRY and REGISTRY_OWNER will be overridden
+CACHE_FLAGS_TEMPLATE := --cache-from=$(REGISTRY)/$(REGISTRY_OWNER)/%
+
+# Function to generate cache flags for a specific image
+# Only returns cache flags if GITHUB_ACTIONS is true
+ ifeq ($(GITHUB_ACTIONS),true)
+ define CACHE_FLAGS_FOR_IMAGE
+ $(subst %,$(1),$(CACHE_FLAGS_TEMPLATE))
+ endef
+ else
+ define CACHE_FLAGS_FOR_IMAGE
+ 
+ endef
+ endif
+
+
+
 GOBASE=$(shell pwd)
 GOBIN=$(GOBASE)/bin/
 GO_BUILD_FLAGS := ${GO_BUILD_FLAGS}
 ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
 GO_FILES := $(shell find ./ -name "*.go" -not -path "./bin" -not -path "./packaging/*")
-GO_CACHE := -v $${HOME}/go/flightctl-go-cache:/opt/app-root/src/go:Z -v $${HOME}/go/flightctl-go-cache/.cache:/opt/app-root/src/.cache:Z
 TIMEOUT ?= 30m
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest)
+SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
-SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
+SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
 SOURCE_GIT_TAG_NO_V := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//')
 MAJOR := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$1}')
@@ -75,10 +104,27 @@ help:
 	@echo "    deploy-quadlets: deploy the complete Flight Control service using Quadlets"
 	@echo "                     (includes proper startup ordering: DB -> KV -> other services)"
 	@echo "    clean:           clean up all containers and volumes"
+	@echo "    clean-all:       full cleanup including containers and bin directory"
+	@echo "    rebuild-containers: force rebuild all containers"
 	@echo "    cluster:         create a kind cluster and load the flightctl-server image"
 	@echo "    clean-cluster:   kill the kind cluster only"
 	@echo "    clean-quadlets:  clean up all systemd services and quadlet files"
 	@echo "    rpm/deb:         generate rpm or debian packages"
+	@echo ""
+	@echo "CI/CD Targets:"
+	@echo "    login:           login to container registry (requires REGISTRY_USER env var)"
+	@echo "    push-containers: push all containers to registry"
+	@echo "    ci-build:        full CI build and push process"
+	@echo ""
+	@echo "Environment Variables for CI:"
+	@echo "    REGISTRY:        container registry (default: localhost)"
+	@echo "    REGISTRY_OWNER:  registry owner/organization (default: flightctl)"
+	@echo "    REGISTRY_USER:   registry username for login"
+	@echo "    GITHUB_ACTIONS:  set to 'true' to enable container build caching"
+	@echo ""
+	@echo "Caching Strategy:"
+	@echo "    Uses GitHub Actions cache (type=gha) for CI builds"
+	@echo "    Cache flags only added when GITHUB_ACTIONS=true"
 
 .PHONY: publish
 publish: build-containers
@@ -141,77 +187,107 @@ build-userinfo-proxy: bin
 build-devicesimulator: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/devicesimulator
 
-# rebuild container only on source changes
-bin/.flightctl-base-container: bin hack/build_flightctl-base.sh
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	buildah unshare hack/build_flightctl-base.sh
-	touch bin/.flightctl-base-container
-
-bin/.flightctl-api-container: bin Containerfile.api go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build \
+# Container builds - Environment-aware caching
+flightctl-api-container: Containerfile.api go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-api) \
 		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
 		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
-		-f Containerfile.api $(GO_CACHE) -t flightctl-api:latest
-	touch bin/.flightctl-api-container
+		-f Containerfile.api -t flightctl-api:latest
 
-bin/.flightctl-db-setup-container: bin Containerfile.db-setup deploy/scripts/setup_database_users.sh deploy/scripts/setup_database_users.sql
-	podman build \
+flightctl-db-setup-container: Containerfile.db-setup deploy/scripts/setup_database_users.sh deploy/scripts/setup_database_users.sql
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-db-setup) \
 		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
 		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
 		-f Containerfile.db-setup \
 		-t flightctl-db-setup:latest .
-	touch bin/.flightctl-db-setup-container
 
-bin/.flightctl-worker-container: bin Containerfile.worker go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.worker $(GO_CACHE) -t flightctl-worker:latest
-	touch bin/.flightctl-worker-container
+flightctl-worker-container: Containerfile.worker go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-worker) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.worker -t flightctl-worker:latest
 
-bin/.flightctl-periodic-container: bin Containerfile.periodic go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.periodic $(GO_CACHE) -t flightctl-periodic:latest
-	touch bin/.flightctl-periodic-container
+flightctl-periodic-container: Containerfile.periodic go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-periodic) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.periodic -t flightctl-periodic:latest
 
-bin/.flightctl-alert-exporter-container: bin Containerfile.alert-exporter go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.alert-exporter $(GO_CACHE) -t flightctl-alert-exporter:latest
-	touch bin/.flightctl-alert-exporter-container
+flightctl-alert-exporter-container: Containerfile.alert-exporter go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-alert-exporter) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.alert-exporter -t flightctl-alert-exporter:latest
 
-bin/.flightctl-alertmanager-proxy-container: bin Containerfile.alertmanager-proxy go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.alertmanager-proxy $(GO_CACHE) -t flightctl-alertmanager-proxy:latest
-	touch bin/.flightctl-alertmanager-proxy-container
+flightctl-alertmanager-proxy-container: Containerfile.alertmanager-proxy go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-alertmanager-proxy) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.alertmanager-proxy -t flightctl-alertmanager-proxy:latest
 
-bin/.flightctl-multiarch-cli-container: bin Containerfile.cli-artifacts go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.cli-artifacts $(GO_CACHE) -t flightctl-cli-artifacts:latest
-	touch bin/.flightctl-multiarch-cli-container
+flightctl-multiarch-cli-container: Containerfile.cli-artifacts go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-cli-artifacts) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.cli-artifacts -t flightctl-cli-artifacts:latest
 
-bin/.flightctl-userinfo-proxy-container: bin Containerfile.userinfo-proxy go.mod go.sum $(GO_FILES)
-	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.userinfo-proxy $(GO_CACHE) -t flightctl-userinfo-proxy:latest
-	touch bin/.flightctl-userinfo-proxy-container
+flightctl-userinfo-proxy-container: Containerfile.userinfo-proxy go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-userinfo-proxy) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.userinfo-proxy -t flightctl-userinfo-proxy:latest
 
-flightctl-base-container: bin/.flightctl-base-container
+.PHONY: flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container
 
-flightctl-api-container: bin/.flightctl-api-container
+# --- Registry Operations ---
+# The login target expects REGISTRY_USER via environment variable and
+# REGISTRY_PASSWORD via standard input for security.
+login:
+	@echo "--- Logging into registry: $(REGISTRY) ---"
+	@if [ -z "$(REGISTRY_USER)" ]; then \
+		echo "Error: REGISTRY_USER environment variable not set."; \
+		exit 1; \
+	fi
+	@echo "Piping password to podman login for user $(REGISTRY_USER)..."
+	@cat /dev/stdin | podman login -u "$(REGISTRY_USER)" --password-stdin $(REGISTRY)
 
-flightctl-db-setup-container: bin/.flightctl-db-setup-container
+# Push all containers to registry
+push-containers: login
+	@echo "--- Pushing all containers to registry ---"
+	podman push flightctl-api:latest
+	podman push flightctl-db-setup:latest
+	podman push flightctl-worker:latest
+	podman push flightctl-periodic:latest
+	podman push flightctl-alert-exporter:latest
+	podman push flightctl-alertmanager-proxy:latest
+	podman push flightctl-cli-artifacts:latest
+	podman push flightctl-userinfo-proxy:latest
 
-flightctl-worker-container: bin/.flightctl-worker-container
+# A convenience target to run the full CI process.
+ci-build: build-containers push-containers
+	@echo "--- CI Build & Push Complete ---"
 
-flightctl-periodic-container: bin/.flightctl-periodic-container
+# Force rebuild all containers
+rebuild-containers: clean-containers build-containers
 
-flightctl-alert-exporter-container: bin/.flightctl-alert-exporter-container
-
-flightctl-alertmanager-proxy-container: bin/.flightctl-alertmanager-proxy-container
-
-flightctl-multiarch-cli-container: bin/.flightctl-multiarch-cli-container
-
-flightctl-userinfo-proxy-container: bin/.flightctl-userinfo-proxy-container
+# Clean only containers (preserve cluster and other artifacts)
+clean-containers:
+	- podman rmi flightctl-api:latest || true
+	- podman rmi flightctl-db-setup:latest || true
+	- podman rmi flightctl-worker:latest || true
+	- podman rmi flightctl-periodic:latest || true
+	- podman rmi flightctl-alert-exporter:latest || true
+	- podman rmi flightctl-alertmanager-proxy:latest || true
+	- podman rmi flightctl-cli-artifacts:latest || true
+	- podman rmi flightctl-userinfo-proxy:latest || true
 
 build-containers: flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container
 
@@ -259,10 +335,15 @@ deb: bin/arm64 bin/amd64 bin/riscv64
 clean: clean-agent-vm clean-e2e-agent-images clean-quadlets
 	- kind delete cluster
 	- rm -r ~/.flightctl
-	- rm -f -r bin
 	- rm -f -r $(shell uname -m)
 	- rm -f -r obj-*-linux-gnu
 	- rm -f -r debian
+# Qcow2 disk depends on the touch file
+bin/output/qcow2/disk.qcow2: bin/.e2e-agent-images
+
+# Full cleanup including bin directory and all artifacts
+clean-all: clean clean-containers
+	- rm -f -r bin
 
 clean-quadlets:
 	sudo deploy/scripts/clean_quadlets.sh

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -10,6 +10,7 @@ ifeq ($(SPEC_FETCH_INTERVAL),)
 	SPEC_FETCH_INTERVAL := 0m2s
 endif
 
+# Create kind cluster if it doesn't exist (idempotent)
 cluster: bin/e2e-certs/ca.pem
 	test/scripts/install_kind.sh
 	kind get clusters | grep kind || test/scripts/create_cluster.sh
@@ -17,7 +18,7 @@ cluster: bin/e2e-certs/ca.pem
 clean-cluster:
 	kind delete cluster
 
-deploy: cluster build-cli deploy-helm deploy-e2e-extras prepare-agent-config
+deploy: cluster build-containers build-cli deploy-helm prepare-agent-config
 
 redeploy-api: flightctl-api-container
 	test/scripts/redeploy.sh api
@@ -34,7 +35,7 @@ redeploy-alert-exporter: flightctl-alert-exporter-container
 redeploy-alertmanager-proxy: flightctl-alertmanager-proxy-container
 	test/scripts/redeploy.sh alertmanager-proxy
 
-deploy-helm: git-server-container flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container
+deploy-helm: flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container
 	kubectl config set-context kind-kind
 	test/scripts/install_helm.sh
 	test/scripts/deploy_with_helm.sh --db-size $(DB_SIZE)

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -415,13 +415,13 @@ echo "Flightctl Observability Stack uninstalled."
     SOURCE_GIT_COMMIT=$(echo %{version} | awk -F'[-~]g' '{print $2}') \
     SOURCE_GIT_TAG_NO_V=%{version} \
     %if 0%{?rhel} == 9
-        make build-cli build-agent
+        %make_build build-cli build-agent
     %else
-        DISABLE_FIPS="true" make build-cli build-agent
+        DISABLE_FIPS="true" %make_build build-cli build-agent
     %endif
 
     # SELinux modules build
-    make --directory packaging/selinux
+    %make_build --directory packaging/selinux
 
 %install
     mkdir -p %{buildroot}/usr/bin

--- a/test/scripts/Containerfile.gitserver
+++ b/test/scripts/Containerfile.gitserver
@@ -1,6 +1,9 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-RUN dnf install -y git git-core openssh-server
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y git git-core openssh-server
 RUN ssh-keygen -A
 
 

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -30,9 +30,18 @@ RUN if [[ -z $RPM_COPR ]]; then \
     fi && \
     systemctl enable flightctl-agent.service
 
-RUN dnf install -y epel-release epel-next-release
-RUN dnf install -y python-dotenv
-RUN dnf install -y greenboot greenboot-default-health-checks podman-compose && \
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y epel-release epel-next-release
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y python-dotenv
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y greenboot greenboot-default-health-checks podman-compose && \
     dnf install -y firewalld && \
     systemctl enable firewalld.service && \
     systemctl enable podman.service

--- a/test/scripts/agent-images/Containerfile-e2e-v7.local
+++ b/test/scripts/agent-images/Containerfile-e2e-v7.local
@@ -7,7 +7,10 @@ FROM localhost:5000/flightctl-device:base
 
 ADD test/scripts/agent-images/etc etc
 
-RUN dnf install -y microshift && \
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y microshift && \
    systemctl enable microshift.service
 
 # Create the required directory structure in /var/crio instead of /opt/crio

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -1,14 +1,18 @@
 
-bin/output/qcow2/disk.qcow2: e2e-agent-images
+bin/output/qcow2/disk.qcow2: bin/.e2e-agent-images
 
-e2e-agent-images: bin rpm bin/e2e-certs
+bin/.e2e-agent-images: rpm bin/flightctl-agent bin/e2e-certs
 	./test/scripts/agent-images/prepare_agent_config.sh
 	BUILD_TYPE=$(BUILD_TYPE) ./test/scripts/agent-images/create_agent_images.sh
 	./test/scripts/agent-images/create_application_image.sh
+	touch bin/.e2e-agent-images
 
 .PHONY: e2e-agent-images
 
 clean-e2e-agent-images:
 	sudo rm -f bin/output/qcow2/disk.qcow2
 	rm -f bin/.e2e-agent-images
+	rm -rf bin/dnf-cache
+	rm -rf bin/osbuild-cache
+	rm -rf bin/rpm
 

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -53,7 +53,21 @@ build_single_image() {
       args="${args:+${args} }--build-arg=REGISTRY_ADDRESS=${REGISTRY_ADDRESS}"
     fi
 
-    podman build ${args:+${args}} -f "${containerfile_path}" -t "${container_name}" .
+    # Add standard build arguments for caching and versioning
+    args="${args:+${args} }--build-arg=SOURCE_GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --tags --exclude latest 2>/dev/null || echo "latest")}"
+    args="${args:+${args} }--build-arg=SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE:-$( ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty' )}"
+    args="${args:+${args} }--build-arg=SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT:-$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")}"
+
+    # Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
+    if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+        REGISTRY="${REGISTRY:-localhost}"
+        REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
+        CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/flightctl-device")
+    else
+        CACHE_FLAGS=()
+    fi
+
+    podman build ${args:+${args}} "${CACHE_FLAGS[@]}" -f "${containerfile_path}" -t "${container_name}" .
     podman tag "${container_name}" "${FINAL_REF}"
     podman push "${FINAL_REF}"
 }
@@ -99,27 +113,71 @@ build_qcow2_image() {
     echo -e "\033[32mProducing qcow2 image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
 
     mkdir -p bin/output
+    
     # Check if qcow2 is already up to date
-    CONTAINER_CREATE_DATE=$(podman inspect -f '{{.Created}}' ${REGISTRY_ADDRESS}/flightctl-device:base)
-    if [[ -f bin/output/qcow2/disk.qcow2 ]]; then
-        QCOW_CREATE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2 "+%Y-%m-%d %H:%M:%S")
+    # Also check if the touch file is newer than the qcow2 (indicating a forced rebuild)
+    if [[ -f bin/output/qcow2/disk.qcow2 ]] && [[ -f bin/.e2e-agent-images ]]; then
+        TOUCH_FILE_DATE=$(date -u -r bin/.e2e-agent-images "+%Y-%m-%d %H:%M:%S")
+        QCOW_FILE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2 "+%Y-%m-%d %H:%M:%S")
+        
+        # Convert to timestamps for comparison
+        TOUCH_TIMESTAMP=$(date -d "${TOUCH_FILE_DATE}" +%s 2>/dev/null || echo "0")
+        QCOW_FILE_TIMESTAMP=$(date -d "${QCOW_FILE_DATE}" +%s 2>/dev/null || echo "0")
+        
+        # If qcow2 is newer than the touch file, we can skip rebuilding
+        if [[ ${QCOW_FILE_TIMESTAMP} -gt ${TOUCH_TIMESTAMP} ]]; then
+            echo -e "\033[32mqcow2 is newer than touch file, skipping rebuild (touch: ${TOUCH_FILE_DATE}, qcow2: ${QCOW_FILE_DATE})\033[m"
+            return
+        fi
     fi
-
-    if [[ -n "${QCOW_CREATE_DATE}" && "${CONTAINER_CREATE_DATE}" < "${QCOW_CREATE_DATE}" ]]; then
-        echo -e "\033[32mqcow2 is already up to date with the container \033[m"
-        return
+    
+    if [[ -f bin/output/qcow2/disk.qcow2 ]]; then
+        # Get container image ID and creation date
+        CONTAINER_ID=$(podman images --format "table {{.ID}}" --noheading ${REGISTRY_ADDRESS}/flightctl-device:base 2>/dev/null | head -1)
+        if [[ -n "${CONTAINER_ID}" ]]; then
+            CONTAINER_CREATE_DATE=$(podman inspect -f '{{.Created}}' ${CONTAINER_ID} 2>/dev/null || echo "")
+            if [[ -n "${CONTAINER_CREATE_DATE}" ]]; then
+                QCOW_CREATE_DATE=$(date -u -r bin/output/qcow2/disk.qcow2 "+%Y-%m-%d %H:%M:%S")
+                
+                # Convert dates to timestamps for proper comparison
+                # Handle the container date format: "2025-07-30 16:40:33.146810998 +0000 UTC"
+                CONTAINER_DATE_CLEAN=$(echo "${CONTAINER_CREATE_DATE}" | sed 's/\.[0-9]* +0000 UTC//')
+                CONTAINER_TIMESTAMP=$(date -d "${CONTAINER_DATE_CLEAN}" +%s 2>/dev/null || echo "0")
+                QCOW_TIMESTAMP=$(date -d "${QCOW_CREATE_DATE}" +%s 2>/dev/null || echo "0")
+                
+                if [[ ${QCOW_TIMESTAMP} -gt ${CONTAINER_TIMESTAMP} ]]; then
+                    echo -e "\033[32mqcow2 is already up to date with the container (container: ${CONTAINER_CREATE_DATE}, qcow2: ${QCOW_CREATE_DATE})\033[m"
+                    return
+                else
+                    echo -e "\033[33mqcow2 is older than container, rebuilding (container: ${CONTAINER_CREATE_DATE}, qcow2: ${QCOW_CREATE_DATE})\033[m"
+                fi
+            else
+                echo -e "\033[33mCould not get container creation date, rebuilding\033[m"
+            fi
+        else
+            echo -e "\033[33mContainer image not found, rebuilding\033[m"
+        fi
+    else
+        echo -e "\033[33mqcow2 file not found, building\033[m"
     fi
 
     # Pull the image and build the qcow2
     echo -e "\033[32mPulling ${REGISTRY_ADDRESS}/flightctl-device:base to /var/lib/containers/storage\033[m"
     sudo podman pull "${REGISTRY_ADDRESS}/flightctl-device:base"
     echo -e "\033[32m Producing qcow image for ${REGISTRY_ADDRESS}/flightctl-device:base \033[m"
+    
+    # Create cache directories if they don't exist
+    mkdir -p "$(pwd)/bin/dnf-cache"
+    mkdir -p "$(pwd)/bin/osbuild-cache"
+    
     sudo podman run --rm \
                     -it \
                     --privileged \
                     --pull=newer \
                     --security-opt label=type:unconfined_t \
                     -v "$(pwd)"/bin/output:/output \
+                    -v "$(pwd)"/bin/dnf-cache:/var/cache/dnf:Z \
+                    -v "$(pwd)"/bin/osbuild-cache:/var/cache/osbuild:Z \
                     -v /var/lib/containers/storage:/var/lib/containers/storage \
                     quay.io/centos-bootc/bootc-image-builder:latest \
                     build \

--- a/test/scripts/agent-images/create_application_image.sh
+++ b/test/scripts/agent-images/create_application_image.sh
@@ -11,7 +11,20 @@ IMAGE_LIST=$(ls $SCRIPT_DIR | grep Containerfile-sleep-app | cut -d '-' -f 4)
 for img in $IMAGE_LIST; do
    FINAL_REF="${REGISTRY_ADDRESS}/sleep-app:${img}"
    echo -e "\033[32mCreating image ${FINAL_REF} \033[m"
-   podman build -f "${SCRIPT_DIR}"/Containerfile-sleep-app-"${img}" -t localhost:5000/sleep-app:${img} .
+   # Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
+   if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+       REGISTRY="${REGISTRY:-localhost}"
+       REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
+       CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/sleep-app")
+   else
+       CACHE_FLAGS=()
+   fi
+
+   podman build "${CACHE_FLAGS[@]}" \
+   	--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --tags --exclude latest 2>/dev/null || echo "latest")} \
+   	--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE:-$( ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty' )} \
+   	--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT:-$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")} \
+   	-f "${SCRIPT_DIR}"/Containerfile-sleep-app-"${img}" -t localhost:5000/sleep-app:${img} .
    podman tag "localhost:5000/sleep-app:${img}" "${FINAL_REF}"
    podman push "${FINAL_REF}"
 done

--- a/test/scripts/deploy_e2e_extras_with_helm.sh
+++ b/test/scripts/deploy_e2e_extras_with_helm.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}"/functions
 if in_kind; then
     ARGS="--values ./deploy/helm/e2e-extras/values.dev.yaml"
     # in github CI load docker-image does not seem to work for our images
-    kind_load_image localhost/git-server:latest
+    # Note: git-server is built by build-e2e-containers, so we only load the registry here
     kind_load_image quay.io/flightctl/e2eregistry:2
 fi
 

--- a/test/scripts/e2e_cleanup.sh
+++ b/test/scripts/e2e_cleanup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the project root directory
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "🔄 [Cleanup] Starting global E2E test cleanup..."
+
+# Find all flightctl e2e VMs using virsh
+echo "🔄 [Cleanup] Finding flightctl e2e VMs..."
+if ! vm_output=$(virsh list --all --name 2>/dev/null); then
+    echo "⚠️  [Cleanup] Failed to list VMs: virsh may not be available or accessible"
+    exit 0
+fi
+
+# Filter for flightctl e2e VMs
+flightctl_vms=()
+while IFS= read -r vm_name; do
+    if [[ -n "$vm_name" && "$vm_name" == flightctl-e2e-* ]]; then
+        flightctl_vms+=("$vm_name")
+    fi
+done <<< "$vm_output"
+
+echo "🔍 [Cleanup] Found ${#flightctl_vms[@]} flightctl e2e VMs: ${flightctl_vms[*]}"
+
+# Clean up each VM
+for vm_name in "${flightctl_vms[@]}"; do
+    echo "🔄 [Cleanup] Cleaning up VM: $vm_name"
+    
+    # 1. Delete pristine snapshot (ignore errors)
+    echo "🔄 [Cleanup] Deleting pristine snapshot for $vm_name"
+    if ! virsh snapshot-delete "$vm_name" "pristine" --metadata 2>/dev/null; then
+        echo "⚠️  [Cleanup] Failed to delete pristine snapshot for $vm_name (may not exist)"
+    fi
+    
+    # 2. Destroy the VM if it's running (ignore errors)
+    echo "🔄 [Cleanup] Destroying VM: $vm_name"
+    if ! virsh destroy "$vm_name" 2>/dev/null; then
+        echo "⚠️  [Cleanup] Failed to destroy $vm_name (may not be running)"
+    fi
+    
+    # 3. Undefine the domain (try multiple approaches)
+    echo "🔄 [Cleanup] Undefining domain: $vm_name"
+    if virsh undefine "$vm_name" 2>/dev/null; then
+        echo "✅ [Cleanup] Successfully cleaned up VM: $vm_name"
+    elif virsh undefine "$vm_name" --nvram 2>/dev/null; then
+        echo "✅ [Cleanup] Successfully cleaned up VM: $vm_name (with NVRAM)"
+    elif virsh undefine "$vm_name" --remove-all-storage --nvram 2>/dev/null; then
+        echo "✅ [Cleanup] Successfully cleaned up VM: $vm_name (with storage and NVRAM)"
+    else
+        echo "❌ [Cleanup] Failed to undefine $vm_name with all approaches"
+    fi
+done
+
+# Clean up temporary directories in /tmp
+echo "🔄 [Cleanup] Cleaning up temporary directories..."
+if tmp_dirs=$(find /tmp -maxdepth 1 -name "flightctl-e2e-worker-*" -type d 2>/dev/null); then
+    if [[ -n "$tmp_dirs" ]]; then
+        echo "🔍 [Cleanup] Found temporary directories:"
+        echo "$tmp_dirs"
+        echo "🔄 [Cleanup] Removing temporary directories..."
+        # Use find with -delete for safer removal
+        if find /tmp -maxdepth 1 -name "flightctl-e2e-worker-*" -type d -exec rm -rf {} + 2>/dev/null; then
+            echo "✅ [Cleanup] Successfully removed temporary directories"
+        else
+            echo "⚠️  [Cleanup] Failed to remove some temporary directories"
+        fi
+    else
+        echo "✅ [Cleanup] No temporary directories found"
+    fi
+else
+    echo "⚠️  [Cleanup] Failed to search for temporary directories"
+fi
+
+echo "✅ [Cleanup] Global test cleanup completed"

--- a/test/scripts/e2e_startup.sh
+++ b/test/scripts/e2e_startup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the project root directory (where the bin/ directory is located)
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FLIGHTCTL_BIN="${PROJECT_ROOT}/bin/flightctl"
+
+# Check if flightctl binary exists
+if [[ ! -x "${FLIGHTCTL_BIN}" ]]; then
+    echo "❌ [Startup] Error: flightctl binary not found at ${FLIGHTCTL_BIN}"
+    echo "    Please run 'make build-cli' first to build the flightctl CLI"
+    exit 1
+fi
+
+echo "🔄 [Startup] Starting global E2E environment setup..."
+
+# Resource types to clean up (in order of dependencies)
+RESOURCE_TYPES=(
+    "resourcesync"
+    "fleet"
+    "device"
+    "enrollmentrequest"
+    "repository"
+    "certificatesigningrequest"
+)
+
+# Function to clean up resources of a specific type
+cleanup_resource_type() {
+    local resource_type="$1"
+    echo "🔄 [Startup] Cleaning up ${resource_type} resources..."
+    
+    # Get all resources of this type
+    local resources
+    if ! resources=$("${FLIGHTCTL_BIN}" get "$resource_type" -o name 2>/dev/null); then
+        echo "⚠️  [Startup] Warning: failed to get $resource_type resources (API may not be ready)"
+        return 0
+    fi
+    
+    resources=$(echo "$resources" | tr -d '\r' | grep -v '^$' || true)
+    
+    if [[ -z "$resources" ]]; then
+        echo "ℹ️  [Startup] No $resource_type resources found to delete"
+        return 0
+    fi
+    
+    echo "🔍 [Startup] Found $resource_type resources to delete:"
+    echo "$resources"
+    
+    # Delete the resources
+    if ! echo "$resources" | xargs "${FLIGHTCTL_BIN}" delete "$resource_type" 2>/dev/null; then
+        echo "⚠️  [Startup] Warning: failed to delete some $resource_type resources"
+        return 0
+    fi
+    
+    echo "✅ [Startup] Successfully deleted $resource_type resources"
+}
+
+# Clean up all resource types
+for resource_type in "${RESOURCE_TYPES[@]}"; do
+    cleanup_resource_type "$resource_type"
+done
+
+echo "✅ [Startup] Global E2E environment setup completed"

--- a/test/scripts/prepare_git_server.sh
+++ b/test/scripts/prepare_git_server.sh
@@ -2,8 +2,18 @@
 set -euo pipefail
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
-podman build -f test/scripts/Containerfile.gitserver -t localhost/git-server:latest .
+# Build git-server container with proper caching
+# Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
+if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+    REGISTRY="${REGISTRY:-localhost}"
+    REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
+    CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/git-server")
+else
+    CACHE_FLAGS=()
+fi
 
+podman build "${CACHE_FLAGS[@]}" \
+	-f test/scripts/Containerfile.gitserver -t localhost/git-server:latest .
 
 # can be tested with: 
 # podman run -d --restart always -p 1213:22 --name gitserver --cap-add sys_chroot localhost/git-server:latest

--- a/test/scripts/run_e2e_tests.sh
+++ b/test/scripts/run_e2e_tests.sh
@@ -8,6 +8,13 @@ GO_E2E_DIRS=("${@:2}")
 GINKGO_FOCUS=${GINKGO_FOCUS:-""}
 #Filtering e2e tests by labels
 GINKGO_LABEL_FILTER=${GINKGO_LABEL_FILTER:-""}
+#Parallel execution - default to 1 but can be overridden
+GINKGO_PROCS=${GINKGO_PROCS:-1}
+#Output interceptor mode for parallel execution - 'dup' shows output from all nodes
+GINKGO_OUTPUT_INTERCEPTOR_MODE=${GINKGO_OUTPUT_INTERCEPTOR_MODE:-"dup"}
+# Manual test splitting variables
+GINKGO_TOTAL_NODES=${GINKGO_TOTAL_NODES:-1}
+GINKGO_NODE=${GINKGO_NODE:-1}
 FOCUS_FLAG=""
 
 
@@ -18,19 +25,126 @@ GOBIN=$(go env GOBIN)
 export API_ENDPOINT=https://$(get_endpoint_host flightctl-api-route)
 export REGISTRY_ENDPOINT=$(registry_address)
 
-CMD=("${GOBIN}/ginkgo" run)
+# Handle manual test splitting if enabled
+if [[ "${GINKGO_TOTAL_NODES}" -gt 1 ]]; then
+    echo "Manual test splitting enabled: Node ${GINKGO_NODE} of ${GINKGO_TOTAL_NODES}"
+    
+    # Generate a list of all tests that would run
+    echo "Generating list of all tests..."
+    TEMP_TEST_LIST=$(mktemp)
+    
+    # Build the base ginkgo command to discover tests
+    DISCOVER_CMD=("${GOBIN}/ginkgo" "run" "--dry-run" "--json-report" "discovery.json")
+    
+    if [[ -n "${GINKGO_FOCUS}" ]]; then
+        DISCOVER_CMD+=("--focus" "${GINKGO_FOCUS}")
+    fi
+    
+    if [[ -n "${GINKGO_LABEL_FILTER}" ]]; then
+        DISCOVER_CMD+=("--label-filter" "${GINKGO_LABEL_FILTER}")
+    fi
+    
+    DISCOVER_CMD+=("${GO_E2E_DIRS[@]}")
+    
+    # Run the discovery command and generate JSON report
+    # We ignore the exit code because some test suites might have issues, but we still want to parse the JSON
+    "${DISCOVER_CMD[@]}" > /dev/null 2>&1 || true
+    
+    # Parse the JSON report to extract test names with sanity label
+    # Use jq to extract just the LeafNodeText (test description) for focus patterns
+    # Sort and deduplicate to ensure consistent distribution
+    jq -r '
+        .[] | 
+        .SpecReports[]? | 
+        select(.LeafNodeLabels != null and (.LeafNodeLabels | contains(["sanity"]))) |
+        .LeafNodeText
+    ' discovery.json | sort -u > "${TEMP_TEST_LIST}"
+    
+    # Clean up the JSON file
+    rm -f discovery.json
+    
+    # Count total tests
+    TOTAL_TESTS=$(wc -l < "${TEMP_TEST_LIST}")
+    echo "Total tests found: ${TOTAL_TESTS}"
+    
+    # Extract tests for this specific node using awk
+    NODE_TESTS=$(mktemp)
+    awk -v node="${GINKGO_NODE}" -v total="${GINKGO_TOTAL_NODES}" 'NR % total == node - 1' "${TEMP_TEST_LIST}" > "${NODE_TESTS}"
+    
+    # Count tests for this node
+    NODE_TEST_COUNT=$(wc -l < "${NODE_TESTS}")
+    echo "Tests for node ${GINKGO_NODE}: ${NODE_TEST_COUNT}"
+    
+    # Check if this node has any tests to run
+    if [[ "${NODE_TEST_COUNT}" -eq 0 ]]; then
+        echo "No tests assigned to node ${GINKGO_NODE}. Skipping execution."
+        rm -f "${TEMP_TEST_LIST}" "${NODE_TESTS}"
+        exit 0
+    fi
+    
+    # Display which tests this node will run
+    echo "Node ${GINKGO_NODE} will run the following tests:"
+    cat "${NODE_TESTS}"
+    
+    # Combine all tests for this node into a single focus pattern
+    # Use regex OR (|) to match any of the tests
+    if [[ -s "${NODE_TESTS}" ]]; then
+        # Read all tests, escape regex metacharacters, and join them with | for regex OR
+        FOCUS_PATTERN=$(sed 's/[[\.*^$()+?{|\\]/\\&/g' "${NODE_TESTS}" | paste -sd '|')
+        echo "Focus pattern for node ${GINKGO_NODE}: ${FOCUS_PATTERN}"
+        GINKGO_FOCUS="${FOCUS_PATTERN}"
+    fi
+    
+    # Clean up temporary files
+    rm -f "${TEMP_TEST_LIST}" "${NODE_TESTS}"
+fi
+
+# Build the ginkgo command using guard patterns for each flag
+CMD=("${GOBIN}/ginkgo" "run")
 
 if [[ -n "${GINKGO_FOCUS}" ]]; then
-  CMD+=("--focus" "${GINKGO_FOCUS}")
+    CMD+=("--focus" "${GINKGO_FOCUS}")
 fi
 
 if [[ -n "${GINKGO_LABEL_FILTER}" ]]; then
-  CMD+=("--label-filter" "${GINKGO_LABEL_FILTER}")
+    CMD+=("--label-filter" "${GINKGO_LABEL_FILTER}")
 fi
 
-CMD+=(--timeout 120m --race -vv --junit-report "${REPORTS}/junit_e2e_test.xml" --github-output)
+# Add standard flags
+CMD+=(--timeout 120m --race -vv -nodes="${GINKGO_PROCS}" --show-node-events --trace --force-newlines --output-interceptor-mode "${GINKGO_OUTPUT_INTERCEPTOR_MODE}" --github-output --output-dir "${REPORTS}" --junit-report junit_e2e_test.xml --keep-separate-reports)
 
+# Add progress polling flags for parallel execution
+if [[ "${GINKGO_PROCS}" -gt 1 ]]; then
+    CMD+=(--poll-progress-after=2m --poll-progress-interval=30s)
+fi
+
+# Add the test directories last
 CMD+=("${GO_E2E_DIRS[@]}")
 
-# Run the command
-"${CMD[@]}"
+echo "Running e2e tests with ${GINKGO_PROCS} parallel processes..."
+echo "Output interceptor mode: ${GINKGO_OUTPUT_INTERCEPTOR_MODE} (dup=show all output, swap=clean output)"
+echo "Reports will be saved to: ${REPORTS}"
+echo "Individual worker reports will be preserved with --keep-separate-reports"
+
+# Step 1: Run startup
+echo "🔄 [Test Execution] Step 1: Running startup..."
+if ! test/scripts/e2e_startup.sh; then
+    echo "❌ [Test Execution] Startup failed, exiting"
+    exit 1
+fi
+echo "✅ [Test Execution] Startup completed successfully"
+
+# Step 2: Run the tests
+echo "🔄 [Test Execution] Step 2: Running tests..."
+TEST_EXIT_CODE=0
+"${CMD[@]}" || TEST_EXIT_CODE=$?
+
+# Step 3: Run cleanup (always run, even if tests failed)
+echo "🔄 [Test Execution] Step 3: Running cleanup..."
+if ! test/scripts/e2e_cleanup.sh; then
+    echo "⚠️  [Test Execution] Cleanup failed, but continuing..."
+fi
+echo "✅ [Test Execution] Cleanup completed"
+
+# Exit with the test exit code
+exit $TEST_EXIT_CODE

--- a/test/scripts/services-images/Containerfile.services
+++ b/test/scripts/services-images/Containerfile.services
@@ -2,9 +2,10 @@ FROM quay.io/centos-bootc/centos-bootc:stream9
 
 # Copy  and install the locally built services rpm
 COPY /bin/rpm/flightctl-services-*.rpm /tmp/flightctl-services.rpm
-RUN dnf -y install /tmp/flightctl-services.rpm && \
-    dnf clean all && \
-    rm -rf /tmp/* /var/cache/dnf
+# Use BuildKit cache mounts for dnf package caching
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf -y install /tmp/flightctl-services.rpm
 
 RUN systemctl enable flightctl.target
 

--- a/test/scripts/setup_e2e_environment.sh
+++ b/test/scripts/setup_e2e_environment.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Setup script for e2e test environment
+# This script ensures the base disk is in the correct location for libvirt access
+
+set -e
+
+echo "🔧 Setting up e2e test environment..."
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Create user-level libvirt images directory
+LIBVIRT_IMAGES_DIR="$HOME/.local/share/libvirt/images"
+mkdir -p "$LIBVIRT_IMAGES_DIR"
+
+# Check if base disk exists in project directory
+PROJECT_BASE_DISK="$PROJECT_ROOT/bin/output/qcow2/disk.qcow2"
+LIBVIRT_BASE_DISK="$LIBVIRT_IMAGES_DIR/base-disk.qcow2"
+
+if [ ! -f "$PROJECT_BASE_DISK" ]; then
+    echo "❌ Base disk not found at $PROJECT_BASE_DISK"
+    echo "Please build the project first: make build"
+    exit 1
+fi
+
+# Check if we need to copy the base disk
+if [ ! -f "$LIBVIRT_BASE_DISK" ] || [ "$PROJECT_BASE_DISK" -nt "$LIBVIRT_BASE_DISK" ]; then
+    echo "📋 Copying base disk to libvirt images directory..."
+    cp "$PROJECT_BASE_DISK" "$LIBVIRT_BASE_DISK"
+    echo "✅ Base disk copied to $LIBVIRT_BASE_DISK"
+else
+    echo "✅ Base disk already up to date in libvirt images directory"
+fi
+
+# Verify libvirt can access the directory
+echo "🔍 Verifying libvirt access..."
+if [ -r "$LIBVIRT_BASE_DISK" ]; then
+    echo "✅ Base disk is readable"
+else
+    echo "❌ Base disk is not readable"
+    exit 1
+fi
+
+echo "🎉 e2e test environment setup complete!"
+echo "Base disk location: $LIBVIRT_BASE_DISK" 

--- a/test/test.mk
+++ b/test/test.mk
@@ -29,6 +29,8 @@ _integration_test: $(REPORTS)
 
 _e2e_test: $(REPORTS)
 	sudo chown $(shell whoami):$(shell whoami) -R bin/output
+	sudo chmod a+x test/scripts/setup_e2e_environment.sh test/scripts/e2e_cleanup.sh test/scripts/e2e_startup.sh
+	test/scripts/setup_e2e_environment.sh
 	test/scripts/run_e2e_tests.sh "$(REPORTS)" $(GO_E2E_DIRS)
 
 _unit_test: $(REPORTS)
@@ -71,8 +73,25 @@ deploy-e2e-extras: bin/.ssh/id_rsa.pub bin/e2e-certs/ca.pem
 deploy-e2e-ocp-test-vm:
 	sudo --preserve-env=VM_DISK_SIZE_INC test/scripts/create_vm_libvirt.sh ${KUBECONFIG_PATH}
 
-prepare-e2e-test: deploy-e2e-extras bin/output/qcow2/disk.qcow2
+prepare-e2e-test: deploy-e2e-extras bin/output/qcow2/disk.qcow2 build-e2e-containers
 	./test/scripts/prepare_cli.sh
+
+# Build E2E containers with Docker caching
+build-e2e-containers: git-server-container e2e-agent-images
+	@echo "Building E2E containers with Docker caching..."
+
+# Ensure git-server container is built with proper caching
+git-server-container: bin/e2e-certs/ca.pem
+	@echo "Building git-server container with Docker caching..."
+	test/scripts/prepare_git_server.sh
+	@if test/scripts/functions in_kind; then \
+		echo "Loading git-server into kind cluster..."; \
+		source test/scripts/functions && kind_load_image localhost/git-server:latest; \
+	fi
+
+# Build E2E agent images with proper caching
+e2e-agent-images: bin/.e2e-agent-images
+	@echo "E2E agent images already built and up to date"
 
 in-cluster-e2e-test: prepare-e2e-test
 	$(MAKE) _e2e_test
@@ -80,9 +99,13 @@ in-cluster-e2e-test: prepare-e2e-test
 e2e-test: deploy bin/output/qcow2/disk.qcow2
 	$(MAKE) _e2e_test
 
+# Run e2e tests with optional parallel execution
+# Set GINKGO_PROCS to control number of parallel processes (defaults to number of CPU cores)
+# Set GINKGO_OUTPUT_INTERCEPTOR_MODE to control parallel output (defaults to "dup" for full output)
+# Example: make run-e2e-test GO_E2E_DIRS=test/e2e/agent GINKGO_PROCS=4
+# Example: make run-e2e-test GO_E2E_DIRS=test/e2e/agent GINKGO_OUTPUT_INTERCEPTOR_MODE=swap
 run-e2e-test:
 	$(ENV_TRACE_FLAGS) $(MAKE) _e2e_test
-
 
 view-coverage: $(REPORTS)/unit-coverage.out $(REPORTS)/unit-coverage.out
 	# TODO: merge unit and integration coverage reports
@@ -92,11 +115,11 @@ test: unit-test integration-test e2e-test
 
 run-test: unit-test run-intesgration-test
 
+# Create E2E certificates and SSH keys
 bin/e2e-certs/ca.pem bin/.ssh/id_rsa.pub:
 	test/scripts/create_e2e_certs.sh
 
-git-server-container: bin/.ssh/id_rsa.pub
-	test/scripts/prepare_git_server.sh
+
 
 .PHONY: test run-test git-server-container
 


### PR DESCRIPTION
support for multi node e2e + parallelism - does not change actual test files to support multi-node/parallelism this will be in a separate PR:

1. make file - use podman cache
2. container files- remove flightctl-base which was an attempt to cache builds this is done locally by podman cache , and not locally is done with the --cache-from flag
4. e2e is separated from normal deploy (previously make deploy built some e2e stuff)
5. github pipeline files use the node split , use cache , build cache tags for caching purposes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallelized E2E test runs with per-node logs, aggregated results and a workflow to publish E2E support containers.

* **Tests**
  * Per-node test slicing, richer reporting, startup/cleanup lifecycle, setup helpers, and improved e2e image/build orchestration.

* **Refactor**
  * Container builds moved to multi-stage, cache-friendly images with CA and build metadata provisioning; Makefile reorganized for CI-friendly container targets.

* **Chores**
  * BuildKit enabled across CI, broad caching added to workflows and scripts; minor .gitignore updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->