### PR TITLE
EDM-2020: fixed group by incorrect

### DIFF
--- a/internal/instrumentation/metrics/domain/fleet_test.go
+++ b/internal/instrumentation/metrics/domain/fleet_test.go
@@ -175,11 +175,11 @@ func (m *MockFleetStoreWrapper) CheckHealth(context.Context) error {
 }
 
 func TestFleetCollector(t *testing.T) {
-	// Provide mock SQL results for org/status aggregation
+	// Provide mock SQL results for org/status aggregation using RolloutInProgress condition reasons
 	mockResults := []store.CountByRolloutStatusResult{
-		{OrgID: "org1", Status: "Ready", Count: 2},
-		{OrgID: "org1", Status: "Progressing", Count: 1},
-		{OrgID: "org2", Status: "Ready", Count: 3},
+		{OrgID: "org1", Status: "Active", Count: 2},
+		{OrgID: "org1", Status: "Suspended", Count: 1},
+		{OrgID: "org2", Status: "Inactive", Count: 3},
 	}
 
 	mockFleetStore := &MockFleetStore{
@@ -239,8 +239,8 @@ func TestFleetCollectorWithOrgFilter(t *testing.T) {
 	// Test that org filtering works correctly
 	mockFleetStore := &MockFleetStore{
 		rolloutStatusCounts: []store.CountByRolloutStatusResult{
-			{OrgID: "org1", Status: "1", Count: 1},
-			{OrgID: "org1", Status: "2", Count: 1},
+			{OrgID: "org1", Status: "Active", Count: 1},
+			{OrgID: "org1", Status: "Waiting", Count: 1},
 		},
 	}
 

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -920,7 +920,7 @@ func (s *DeviceStore) CountByOrgAndStatus(ctx context.Context, orgId *uuid.UUID,
 	if groupByFleet {
 		selectList = append(selectList, "owner as fleet")
 	}
-	groupList := []string{"org_id", "status"}
+	groupList := []string{"org_id", statusField}
 	if groupByFleet {
 		groupList = append(groupList, "owner")
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Status counts and dashboards now reflect the selected status type (summary, application, update) with consistent grouping, fixing mismatched totals.

- Refactor
  - Internal rollout status computation unified with displayed status values so reports and counts match actual rollout state (Active, Suspended, Inactive).

- Tests
  - Test fixtures and expectations updated to use named rollout status labels (Active, Suspended, Inactive) instead of numeric/current-batch values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->