### PR TITLE
EDM-2022: fix make agent vm - make e2e-agent-images dependent on depl…

### DIFF
--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -1,7 +1,7 @@
 
 bin/output/qcow2/disk.qcow2: bin/.e2e-agent-images
 
-bin/.e2e-agent-images: rpm bin/flightctl-agent bin/e2e-certs
+bin/.e2e-agent-images: deploy-e2e-extras rpm bin/flightctl-agent bin/e2e-certs
 	./test/scripts/agent-images/prepare_agent_config.sh
 	BUILD_TYPE=$(BUILD_TYPE) ./test/scripts/agent-images/create_agent_images.sh
 	./test/scripts/agent-images/create_application_image.sh


### PR DESCRIPTION
fix make agent-vm not running deploy-e2e-extras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Hardened end-to-end test setup for agent image creation by ensuring required test components are deployed before the build. This improves reliability and reduces flakiness without affecting runtime behavior.
* **Chores**
  * Updated test build workflow to include an additional preparation step, improving consistency and maintainability of test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->