### PR TITLE
RBAC Testing an admin role

### DIFF
--- a/test/data/examples/repository.yaml
+++ b/test/data/examples/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: flightctl.io/v1alpha1
+kind: Repository
+metadata:
+  name: default-{{test_id}}
+spec:
+  url: https://github.com/flightctl/flightctl.git
+  type: git

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 	Describe("Test Setup", Ordered, func() {
 
 		BeforeAll(func() {
-			isAcmInstalled, err := isAcmInstalled()
+			isAcmInstalled, err := util.IsAcmInstalled()
 			if err != nil {
 				GinkgoWriter.Printf("An error happened %v\n", err)
 			}
@@ -321,23 +321,6 @@ func getAcmNamespace() (string, error) {
 	GinkgoWriter.Printf("This is the Acm namespace: %s\n", outputClean)
 
 	return outputClean, nil
-}
-
-func isAcmInstalled() (bool, error) {
-	cmd := exec.Command("oc", "get", "multiclusterhub", "-A")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, err
-	}
-	outputString := string(output)
-	if outputString == "error: the server doesn't have a resource type \"multiclusterhub\"" {
-		return false, fmt.Errorf("ACM is not installed: %s", outputString)
-	}
-	if strings.Contains(outputString, "Running") || strings.Contains(outputString, "Paused") {
-		GinkgoWriter.Printf("The cluster has ACM installed\n")
-		return true, nil
-	}
-	return false, fmt.Errorf("multiclusterhub is not in Running status")
 }
 
 func waitForMicroshiftReady(harness *e2e.Harness, kubeconfigPath string) error {

--- a/test/e2e/rbac/rbac_suite_test.go
+++ b/test/e2e/rbac/rbac_suite_test.go
@@ -1,0 +1,76 @@
+package rbac_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRbac(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RBAC E2E Suite")
+}
+
+var (
+	flightCtlNs string
+)
+
+var _ = BeforeSuite(func() {
+	_, _, err := e2e.SetupWorkerHarness()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Check if ACM is installed before running any tests
+	isAcmInstalled, err := util.IsAcmInstalled()
+	if err != nil || !isAcmInstalled {
+		Skip("Skipping test suite because ACM is not installed.")
+	}
+})
+
+var _ = BeforeEach(func() {
+	flightCtlNs = os.Getenv("FLIGHTCTL_NS")
+	if flightCtlNs == "" {
+		Skip("FLIGHTCTL_NS environment variable should be set")
+	}
+
+	// Get the harness and context directly - no package-level variables
+	workerID := GinkgoParallelProcess()
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+
+	// Create test-specific context for proper tracing
+	ctx := util.StartSpecTracerForGinkgo(suiteCtx)
+
+	// Set the test context in the harness
+	harness.SetTestContext(ctx)
+
+	// Setup VM from pool, revert to pristine snapshot, and start agent
+	err := harness.SetupVMFromPoolAndStartAgent(workerID)
+	Expect(err).ToNot(HaveOccurred())
+
+	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
+})
+
+var _ = AfterEach(func() {
+	workerID := GinkgoParallelProcess()
+	GinkgoWriter.Printf("🔄 [AfterEach] Worker %d: Cleaning up test resources\n", workerID)
+
+	// Get the harness and context directly - no shared variables needed
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	// Clean up test resources BEFORE switching back to suite context
+	// This ensures we use the correct test ID for resource cleanup
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Now restore suite context for any remaining cleanup operations
+	harness.SetTestContext(suiteCtx)
+
+	GinkgoWriter.Printf("✅ [AfterEach] Worker %d: Test cleanup completed\n", workerID)
+})

--- a/test/e2e/rbac/rbac_test.go
+++ b/test/e2e/rbac/rbac_test.go
@@ -1,0 +1,202 @@
+package rbac_test
+
+import (
+	"context"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	nonAdminUser         = "demouser1"
+	adminRoleName        = "rbac-test-admin-role"
+	adminRoleBindingName = "rbac-test-admin-role-binding"
+	defaultNs            = "default"
+)
+
+var _ = Describe("RBAC Authorization Tests", Label("rbac", "authorization"), func() {
+	var (
+		harness           *e2e.Harness
+		suiteCtx          context.Context
+		defaultK8sContext string
+		k8sApiEndpoint    string
+	)
+
+	roles := []string{
+		adminRoleName,
+	}
+	roleBindings := []string{
+		adminRoleBindingName,
+	}
+	clusterRoles := []string{
+		adminRoleName,
+	}
+	clusterRoleBindings := []string{
+		adminRoleBindingName,
+	}
+	adminTestLabels := &map[string]string{"test": "rbac-admin"}
+	userTestLabels := &map[string]string{"test": "rbac-user"}
+
+	BeforeEach(func() {
+		var err error
+		// Get the harness and context set up by the suite
+		harness = e2e.GetWorkerHarness()
+		suiteCtx = e2e.GetWorkerContext()
+
+		// Get the default K8s context
+		defaultK8sContext, err = harness.GetDefaultK8sContext()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get default K8s context")
+		k8sApiEndpoint, err = harness.GetK8sApiEndpoint(suiteCtx, defaultK8sContext)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Kubernetes API endpoint")
+	})
+
+	AfterEach(func() {
+		err := harness.ChangeK8sContext(suiteCtx, defaultK8sContext)
+		Expect(err).ToNot(HaveOccurred(), "Failed to change K8s context")
+		login.LoginToAPIWithToken(harness)
+
+		harness.CleanupRoles(suiteCtx, harness.Cluster, roles, roleBindings, flightCtlNs)
+		harness.CleanupClusterRoles(suiteCtx, harness.Cluster, clusterRoles, clusterRoleBindings)
+	})
+
+	Context("FlightCtl user", func() {
+		adminRole := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      adminRoleName,
+				Namespace: flightCtlNs,
+			},
+		}
+		adminRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"flightctl.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+		}
+		adminRoleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      adminRoleBindingName,
+				Namespace: flightCtlNs,
+			},
+		}
+		adminRoleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     adminRoleName,
+		}
+		adminRoleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: nonAdminUser,
+			},
+		}
+		adminClusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: adminRoleName,
+			},
+		}
+		adminClusterRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"flightctl.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+		}
+		adminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: adminRoleBindingName,
+			},
+		}
+		adminClusterRoleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     adminRoleName,
+		}
+		adminClusterRoleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: nonAdminUser,
+			},
+		}
+
+		It("should have access full access with an admin role", Label("83842"), func() {
+			By("Login to the cluster as a user without a role")
+			err := login.LoginAsNonAdmin(harness, nonAdminUser, nonAdminUser, defaultK8sContext, k8sApiEndpoint)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that operations should fail without a role")
+			operations := []string{e2e.OperationCreate, e2e.OperationList}
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness, []string{"device", "fleet", "repository"}, false, userTestLabels, flightCtlNs, operations)
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests", "events"}, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating an admin role and a role binding")
+			createdAdminRole, err := harness.CreateRole(suiteCtx, harness.Cluster, flightCtlNs, adminRole)
+			Expect(err).ToNot(HaveOccurred())
+			createdAdminRoleBinding, err := harness.CreateRoleBinding(suiteCtx, harness.Cluster, flightCtlNs, adminRoleBinding)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that operations should succeed with admin role")
+			operations = []string{e2e.OperationAll}
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness, []string{"device", "fleet", "repository"}, true, adminTestLabels, flightCtlNs, operations)
+			Expect(err).ToNot(HaveOccurred())
+			err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests", "events"}, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Deleting the admin role and role binding")
+			err = harness.ChangeK8sContext(suiteCtx, defaultK8sContext)
+			Expect(err).ToNot(HaveOccurred(), "Failed to change K8s context")
+			err = harness.DeleteRole(suiteCtx, harness.Cluster, flightCtlNs, createdAdminRole.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete role")
+			err = harness.DeleteRoleBinding(suiteCtx, harness.Cluster, flightCtlNs, createdAdminRoleBinding.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete role binding")
+
+			By("Creating an admin role and a role binding in the default namespace")
+			adminRoleDefault := adminRole.DeepCopy()
+			adminRoleDefault.Namespace = defaultNs
+			createdAdminRole, err = harness.CreateRole(suiteCtx, harness.Cluster, defaultNs, adminRoleDefault)
+			Expect(err).ToNot(HaveOccurred())
+			adminRoleBindingDefault := adminRoleBinding.DeepCopy()
+			adminRoleBindingDefault.Namespace = defaultNs
+			createdAdminRoleBinding, err = harness.CreateRoleBinding(suiteCtx, harness.Cluster, defaultNs, adminRoleBindingDefault)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that operations should fail with admin role in the default namespace")
+			operations = []string{e2e.OperationCreate, e2e.OperationList}
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness, []string{"device", "fleet", "repository"}, false, adminTestLabels, defaultNs, operations)
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests", "events"}, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the admin role and role binding in the default namespace")
+			err = harness.DeleteRole(suiteCtx, harness.Cluster, defaultNs, createdAdminRole.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete role")
+			err = harness.DeleteRoleBinding(suiteCtx, harness.Cluster, defaultNs, createdAdminRoleBinding.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete role binding")
+
+			By("Creating an admin cluster role and a cluster role binding")
+			createdAdminClusterRole, err := harness.CreateClusterRole(suiteCtx, harness.Cluster, adminClusterRole)
+			Expect(err).ToNot(HaveOccurred())
+			createdAdminClusterRoleBinding, err := harness.CreateClusterRoleBinding(suiteCtx, harness.Cluster, adminClusterRoleBinding)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that operations should succeed with an admin cluster role")
+			operations = []string{e2e.OperationAll}
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness, []string{"device", "fleet", "repository"}, true, adminTestLabels, defaultNs, operations)
+			Expect(err).ToNot(HaveOccurred())
+			err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests", "events"}, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Deleting the admin cluster role and cluster role binding")
+			err = harness.DeleteClusterRole(suiteCtx, harness.Cluster, createdAdminClusterRole.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete cluster role")
+			err = harness.DeleteClusterRoleBinding(suiteCtx, harness.Cluster, createdAdminClusterRoleBinding.Name)
+			Expect(err).ToNot(HaveOccurred(), "Admin should be able to delete cluster role binding")
+		})
+	})
+})

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -87,6 +87,16 @@ const POLLINGLONG = "1s"
 const TIMEOUT = "5m"
 const LONGTIMEOUT = "10m"
 
+// Operation constants for RBAC testing
+const (
+	OperationCreate = "create"
+	OperationUpdate = "update"
+	OperationGet    = "get"
+	OperationList   = "list"
+	OperationDelete = "delete"
+	OperationAll    = "all"
+)
+
 type Harness struct {
 	Client    *apiclient.ClientWithResponses
 	Context   context.Context
@@ -557,6 +567,12 @@ func (h *Harness) parseImageReference(image string) (string, string) {
 
 func (h *Harness) CleanUpAllTestResources() error {
 	return h.CleanUpTestResources(util.ResourceTypes[:]...)
+}
+
+func (h *Harness) CleanUpResource(resourceType string, resourceName string) (string, error) {
+	logrus.Infof("Deleting resource %s of resource type %s", resourceName, resourceType)
+	resource := resourceType + "/" + resourceName
+	return h.CLI("delete", resource)
 }
 
 // CleanUpTestResources deletes only resources that have the test label for the current test
@@ -1440,6 +1456,35 @@ func (h *Harness) addTestLabelToResource(metadata *v1alpha1.ObjectMeta) {
 	(*metadata.Labels)["test-id"] = testID
 }
 
+// TODO: Modify addTestLabelsToYAML to include other labels and remove addLabelsToYAML
+func (h *Harness) AddLabelsToYAML(yamlContent string, addLabels map[string]string) (string, error) {
+	// Parse the YAML document
+	var resource map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlContent), &resource); err != nil {
+		return "", fmt.Errorf("failed to parse yaml document: %w", err)
+	}
+
+	// Add labels to metadata
+	if metadata, ok := resource["metadata"].(map[string]interface{}); ok {
+		if labels, ok := metadata["labels"].(map[string]interface{}); ok {
+			for key, value := range addLabels {
+				labels[key] = value
+			}
+		} else {
+			metadata["labels"] = addLabels
+		}
+	} else {
+		resource["metadata"] = map[string]interface{}{"labels": addLabels}
+	}
+
+	// Marshal back to YAML
+	modifiedDoc, err := yaml.Marshal(resource)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal modified yaml: %w", err)
+	}
+	return string(modifiedDoc), nil
+}
+
 func (h *Harness) addTestLabelToEnrollmentApprovalRequest(approval *v1alpha1.EnrollmentRequestApproval) {
 	testID := h.GetTestIDFromContext()
 
@@ -1926,5 +1971,225 @@ func (h *Harness) CreateGitRepositoryWithContent(repoName, filePath, content str
 		}
 	}
 
+	return nil
+}
+
+// ChangeK8sContext changes the kubernetes context
+func (h *Harness) ChangeK8sContext(ctx context.Context, k8sContext string) error {
+	if !util.BinaryExistsOnPath("oc") {
+		return fmt.Errorf("oc binary not found in PATH")
+	}
+	cmd := exec.CommandContext(ctx, "oc", "config", "use-context", k8sContext)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Check if the error is due to context timeout
+		if ctx.Err() == context.DeadlineExceeded {
+			GinkgoWriter.Printf("❌ Failed to change K8s context to %s: context timeout\n", k8sContext)
+			return fmt.Errorf("failed to change K8s context to %s: context timeout", k8sContext)
+		}
+		GinkgoWriter.Printf("❌ Failed to change K8s context to %s: %v\n", k8sContext, err)
+		return fmt.Errorf("failed to change K8s context to %s: %w", k8sContext, err)
+	} else {
+		GinkgoWriter.Printf("✅ Changed context to %s: %s\n", k8sContext, output)
+		return nil
+	}
+}
+
+func (h *Harness) CreateResource(resourceType string) (string, string, []byte, error) {
+	uniqueResourceYAML, err := util.CreateUniqueYAMLFile(resourceType+".yaml", h.GetTestIDFromContext())
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer util.CleanupTempYAMLFile(uniqueResourceYAML)
+
+	// ManageResource applies the resource to the cluster with test labels
+	applyOutput, err := h.ManageResource("apply", uniqueResourceYAML)
+	if err != nil {
+		return applyOutput, "", nil, err
+	}
+	if strings.Contains(applyOutput, "201 Created") || strings.Contains(applyOutput, "200 OK") {
+		var resource interface{}
+		var resourceName *string
+
+		switch resourceType {
+		case "device":
+			device := h.GetDeviceByYaml(uniqueResourceYAML)
+			updatedDevice, err := h.GetDevice(*device.Metadata.Name)
+			Expect(err).ToNot(HaveOccurred())
+			resource = updatedDevice
+			resourceName = updatedDevice.Metadata.Name
+		case "fleet":
+			fleet := h.GetFleetByYaml(uniqueResourceYAML)
+			updatedFleet, err := h.GetFleet(*fleet.Metadata.Name)
+			Expect(err).ToNot(HaveOccurred())
+			resource = updatedFleet
+			resourceName = updatedFleet.Metadata.Name
+		case "repository":
+			repo := h.GetRepositoryByYaml(uniqueResourceYAML)
+			updatedRepo, err := h.GetRepository(*repo.Metadata.Name)
+			Expect(err).ToNot(HaveOccurred())
+			resource = updatedRepo
+			resourceName = updatedRepo.Metadata.Name
+		default:
+			return applyOutput, "", nil, fmt.Errorf("Unsupported resource type: %s", resourceType)
+		}
+
+		// Remove resourceVersion before marshaling to avoid conflicts
+		switch resource := resource.(type) {
+		case *v1alpha1.Device:
+			resource.Metadata.ResourceVersion = nil
+		case *v1alpha1.Fleet:
+			resource.Metadata.ResourceVersion = nil
+		case *v1alpha1.Repository:
+			resource.Metadata.ResourceVersion = nil
+		}
+
+		resourceData, err := yaml.Marshal(resource)
+		if err != nil {
+			return applyOutput, "", nil, err
+		}
+		return applyOutput, *resourceName, resourceData, nil
+	} else {
+		GinkgoWriter.Printf("Apply output: %s\n", applyOutput)
+		return applyOutput, "", nil, fmt.Errorf("Failed to create a %s", resourceType)
+	}
+}
+
+// GetDefaultK8sContext returns the a K8s context with default in its name
+func (h *Harness) GetDefaultK8sContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "get-contexts", "-o", "name")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get contexts: %v", err)
+	}
+
+	contexts := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, context := range contexts {
+		if strings.Contains(context, "default") {
+			GinkgoWriter.Printf("🔍 [DEBUG] Found default context: %s\n", context)
+			return context, nil
+		}
+	}
+	return "", fmt.Errorf("no context with 'default' in name found")
+}
+
+// GetK8sApiEndpoint returns the API endpoint for a given K8s context
+func (h *Harness) GetK8sApiEndpoint(ctx context.Context, k8sContext string) (string, error) {
+	if !util.BinaryExistsOnPath("oc") {
+		return "", fmt.Errorf("oc binary not found on PATH")
+	}
+	if err := h.ChangeK8sContext(ctx, k8sContext); err != nil {
+		return "", fmt.Errorf("failed to change K8s context to %s: %w", k8sContext, err)
+	}
+	cmd := exec.Command("bash", "-c", "oc whoami --show-server")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get Kubernetes API endpoint: %v", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// ExecuteResourceOperations tests all CRUD operations for the given resource types
+// shouldSucceed determines whether the operations are expected to succeed or fail
+func ExecuteResourceOperations(ctx context.Context, harness *Harness, resourceTypes []string, shouldSucceed bool, testLabels *map[string]string, namespace string, operations []string) error {
+	for _, resourceType := range resourceTypes {
+		By(fmt.Sprintf("Testing %s operations - should %s", resourceType, map[bool]string{true: "succeed", false: "fail"}[shouldSucceed]))
+
+		// Check if OperationAll is in the operations list
+		operationsToExecute := operations
+		for _, op := range operations {
+			if op == OperationAll {
+				operationsToExecute = []string{OperationCreate, OperationUpdate, OperationGet, OperationList, OperationDelete}
+				break
+			}
+		}
+
+		// Execute operations in the order they appear in operationsToExecute
+		var resourceName string
+		var resourceData []byte
+		var err error
+
+		for _, operation := range operationsToExecute {
+			if err = executeResourceOperation(harness, operation, resourceType, &resourceName, &resourceData, shouldSucceed, testLabels); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// executeResourceOperation handles a single operation for a resource type
+func executeResourceOperation(harness *Harness, operation, resourceType string, resourceName *string, resourceData *[]byte, shouldSucceed bool, testLabels *map[string]string) error {
+	var output string
+	var err error
+	var operationName string
+
+	switch operation {
+	case OperationCreate:
+		operationName = "creating"
+		GinkgoWriter.Printf("Testing creating a %s", resourceType)
+		output, *resourceName, *resourceData, err = harness.CreateResource(resourceType)
+	case OperationUpdate:
+		operationName = "updating"
+		GinkgoWriter.Printf("Testing updating a %s", resourceType)
+		updatedResourceData, updateErr := harness.AddLabelsToYAML(string(*resourceData), *testLabels)
+		if updateErr != nil {
+			return fmt.Errorf("failed to add labels to YAML: %w", updateErr)
+		}
+		output, err = harness.CLIWithStdin(updatedResourceData, "apply", "-f", "-")
+	case OperationGet:
+		operationName = "getting specific"
+		GinkgoWriter.Printf("Testing getting a specific %s", resourceType)
+		output, err = harness.GetResourcesByName(resourceType, *resourceName)
+	case OperationList:
+		operationName = "listing"
+		GinkgoWriter.Printf("Testing listing %s", resourceType)
+		output, err = harness.GetResourcesByName(resourceType)
+	case OperationDelete:
+		operationName = "deleting"
+		GinkgoWriter.Printf("Testing deleting a %s", resourceType)
+		output, err = harness.CLI("delete", resourceType, *resourceName)
+	default:
+		return fmt.Errorf("unknown operation: %s", operation)
+	}
+
+	return validateResourceOperationResult(operationName, resourceType, output, err, shouldSucceed)
+}
+
+// validateResourceOperationResult validates the result of an operation based on shouldSucceed flag
+func validateResourceOperationResult(operationName, resourceType, output string, err error, shouldSucceed bool) error {
+	if shouldSucceed {
+		if err != nil {
+			return fmt.Errorf("%s %s should succeed but failed: %w", operationName, resourceType, err)
+		}
+	} else {
+		if err == nil {
+			return fmt.Errorf("%s %s should fail but succeeded", operationName, resourceType)
+		}
+		if !strings.Contains(output, "403") {
+			return fmt.Errorf("%s %s should fail with error code 403, got: %s", operationName, resourceType, output)
+		}
+	}
+	return nil
+}
+
+// ExecuteReadOnlyResourceOperations tests read-only operations for the given resource types
+// shouldSucceed determines whether the operations are expected to succeed or fail
+func ExecuteReadOnlyResourceOperations(harness *Harness, resourceTypes []string, shouldSucceed bool) error {
+	for _, resourceType := range resourceTypes {
+		By(fmt.Sprintf("Testing %s operations - should %s", resourceType, map[bool]string{true: "succeed", false: "fail"}[shouldSucceed]))
+		By(fmt.Sprintf("Testing listing %s", resourceType))
+		_, err := harness.GetResourcesByName(resourceType)
+		if shouldSucceed {
+			if err != nil {
+				return fmt.Errorf("admin should be able to list %s but failed: %w", resourceType, err)
+			}
+		} else {
+			if err == nil {
+				return fmt.Errorf("listing %s should fail but succeeded", resourceType)
+			}
+
+		}
+	}
 	return nil
 }

--- a/test/harness/e2e/harness_rbac.go
+++ b/test/harness/e2e/harness_rbac.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sirupsen/logrus"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (h *Harness) CreateRole(ctx context.Context, kubernetesClient kubernetes.Interface, flightCtlNs string, role *rbacv1.Role) (*rbacv1.Role, error) {
+	if ctx == nil {
+		return nil, errors.New("context cannot be nil")
+	}
+	if role == nil {
+		return nil, errors.New("role parameter cannot be nil")
+	}
+	if flightCtlNs == "" {
+		return nil, errors.New("namespace cannot be empty")
+	}
+
+	role, err := kubernetesClient.RbacV1().Roles(flightCtlNs).Create(ctx, role, metav1.CreateOptions{})
+	return role, err
+}
+
+func (h *Harness) CreateClusterRole(ctx context.Context, kubernetesClient kubernetes.Interface, clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	if ctx == nil {
+		return nil, errors.New("context cannot be nil")
+	}
+	if clusterRole == nil {
+		return nil, errors.New("clusterRole cannot be nil")
+	}
+
+	clusterRole, err := kubernetesClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+	return clusterRole, err
+}
+
+func (h *Harness) CreateClusterRoleBinding(ctx context.Context, kubernetesClient kubernetes.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+
+	if ctx == nil {
+		return nil, errors.New("context cannot be nil")
+	}
+	if clusterRoleBinding == nil {
+		return nil, errors.New("clusterRoleBinding cannot be nil")
+	}
+
+	clusterRoleBinding, err := kubernetesClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+	return clusterRoleBinding, err
+}
+
+func (h *Harness) CreateRoleBinding(ctx context.Context, kubernetesClient kubernetes.Interface, flightCtlNs string, roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	if ctx == nil {
+		return nil, errors.New("context cannot be nil")
+	}
+	if roleBinding == nil {
+		return nil, errors.New("roleBinding cannot be nil")
+	}
+	if flightCtlNs == "" {
+		return nil, errors.New("namespace cannot be empty")
+	}
+	roleBinding, err := kubernetesClient.RbacV1().RoleBindings(flightCtlNs).Create(ctx, roleBinding, metav1.CreateOptions{})
+	return roleBinding, err
+}
+
+func (h *Harness) CleanupRoles(ctx context.Context, kubernetesClient kubernetes.Interface, roles []string, roleBindings []string, flightCtlNs string) {
+	for _, role := range roles {
+		err := h.DeleteRole(ctx, kubernetesClient, flightCtlNs, role)
+		if err != nil {
+			logrus.Errorf("Failed to delete role %s: %v", role, err)
+		} else {
+			logrus.Infof("Deleted role %s", role)
+		}
+	}
+	for _, roleBinding := range roleBindings {
+		err := h.DeleteRoleBinding(ctx, kubernetesClient, flightCtlNs, roleBinding)
+		if err != nil {
+			logrus.Errorf("Failed to delete role binding %s: %v", roleBinding, err)
+		} else {
+			logrus.Infof("Deleted role binding %s", roleBinding)
+		}
+	}
+}
+
+func (h *Harness) CleanupClusterRoles(ctx context.Context, kubernetesClient kubernetes.Interface, clusterRoles []string, clusterRoleBindings []string) {
+	for _, clusterRole := range clusterRoles {
+		err := h.DeleteClusterRole(ctx, kubernetesClient, clusterRole)
+		if err != nil {
+			logrus.Errorf("Failed to delete cluster role %s: %v", clusterRole, err)
+		}
+	}
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		err := h.DeleteClusterRoleBinding(ctx, kubernetesClient, clusterRoleBinding)
+		if err != nil {
+			logrus.Errorf("Failed to delete cluster role binding %s: %v", clusterRoleBinding, err)
+		}
+	}
+}
+
+func (h *Harness) DeleteRole(ctx context.Context, client kubernetes.Interface, namespace string, roleName string) error {
+	return client.RbacV1().Roles(namespace).Delete(ctx, roleName, metav1.DeleteOptions{})
+}
+
+func (h *Harness) DeleteClusterRole(ctx context.Context, client kubernetes.Interface, clusterRoleName string) error {
+	return client.RbacV1().ClusterRoles().Delete(ctx, clusterRoleName, metav1.DeleteOptions{})
+}
+
+func (h *Harness) DeleteRoleBinding(ctx context.Context, client kubernetes.Interface, namespace string, roleBindingName string) error {
+	return client.RbacV1().RoleBindings(namespace).Delete(ctx, roleBindingName, metav1.DeleteOptions{})
+}
+
+func (h *Harness) DeleteClusterRoleBinding(ctx context.Context, client kubernetes.Interface, clusterRoleBindingName string) error {
+	return client.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBindingName, metav1.DeleteOptions{})
+}

--- a/test/harness/e2e/harness_repository.go
+++ b/test/harness/e2e/harness_repository.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+)
+
+func (h *Harness) GetRepository(repositoryName string) (*v1alpha1.Repository, error) {
+	response, err := h.Client.GetRepositoryWithResponse(h.Context, repositoryName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository: %w", err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("repository response is nil")
+	}
+	if response.JSON200 != nil {
+		return response.JSON200, nil
+	}
+	status := 0
+	if response.HTTPResponse != nil {
+		status = response.HTTPResponse.StatusCode
+	}
+	body := string(response.Body)
+	return nil, fmt.Errorf("failed to get repository %q: status=%d body=%s", repositoryName, status, body)
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
@@ -174,6 +175,26 @@ func (t *testProvider) Subscribe(ctx context.Context, handler queues.PubSubHandl
 func (t *testProvider) Publish(ctx context.Context, payload []byte) error {
 	t.pubsubQueue <- payload
 	return nil
+}
+
+func IsAcmInstalled() (bool, error) {
+	if !BinaryExistsOnPath("oc") {
+		return false, fmt.Errorf("oc not found on PATH")
+	}
+	cmd := exec.Command("oc", "get", "multiclusterhub", "-A")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	outputString := string(output)
+	if outputString == "error: the server doesn't have a resource type \"multiclusterhub\"" {
+		return false, fmt.Errorf("ACM is not installed: %s", outputString)
+	}
+	if strings.Contains(outputString, "Running") || strings.Contains(outputString, "Paused") {
+		logrus.Infof("The cluster has ACM installed")
+		return true, nil
+	}
+	return false, fmt.Errorf("multiclusterhub is not in Running status")
 }
 
 // NewTestServer creates a new test server and returns the server and the listener listening on localhost's next available port.


### PR DESCRIPTION
First test for RBAC.
Creating a role with creating,listing and getting flightctl resources and a a role binding to a user with no prior permissions.

Making sure the user can:
Create, update, list, get a specific and delete a:
 - Device
 - Fleet
 - Repository

Create and list:
- Enrollment requests
- Events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added comprehensive end-to-end RBAC suites exercising namespace- and cluster-scoped permissions with per-test VM/agent isolation, setup/teardown, and gating to skip when ACM isn’t available.
- Refactor
  - Centralized ACM presence detection into a shared test utility for consistent test gating across suites.
- Chores
  - Expanded test harness and tooling: RBAC and resource lifecycle helpers, YAML label tooling, Kubernetes context utilities, non-admin login helper, repository fetch helper, and an example Repository test manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->