### PR TITLE
EDM-2056: Fix rollout policy test in OCP

### DIFF
--- a/test/e2e/rollout/rollout_suite_test.go
+++ b/test/e2e/rollout/rollout_suite_test.go
@@ -11,7 +11,7 @@ import (
 
 const TIMEOUT = "5m"
 const POLLING = "125ms"
-const LONGTIMEOUT = "10m"
+const LONGTIMEOUT = "15m"
 
 func TestRollout(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/e2e/rollout/rollout_test.go
+++ b/test/e2e/rollout/rollout_test.go
@@ -226,9 +226,12 @@ var _ = Describe("Rollout Policies", func() {
 			}
 
 			By("Simulating a failure in the first batch")
-			DeferCleanup(func() { _ = tc.harness.FixNetworkFailure() })
-			err = tc.harness.SimulateNetworkFailure()
-			Expect(err).ToNot(HaveOccurred())
+			for _, harness := range tc.harnesses {
+				h := harness // capture per-iteration
+				DeferCleanup(func() { _ = h.FixNetworkFailure() })
+				err = h.SimulateNetworkFailure()
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			err = tc.harness.CreateOrUpdateTestFleet(fleetName, createFleetSpec(bsq2, lo.ToPtr(api.Percentage(SuccessThreshold)), deviceSpec))
 			Expect(err).ToNot(HaveOccurred())
@@ -244,8 +247,11 @@ var _ = Describe("Rollout Policies", func() {
 			Expect(rolloutStatus.Reason).To(Equal(api.RolloutSuspendedReason), "Rollout should be paused when success threshold is not met")
 
 			By("Fixing the failed device and verifying the rollout continues")
-			err = tc.harness.FixNetworkFailure()
-			Expect(err).ToNot(HaveOccurred())
+			for _, harness := range tc.harnesses {
+				h := harness // capture per-iteration
+				err = h.FixNetworkFailure()
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			// Wait for rollout to continue
 			By("Verifying that the rollout is resumed")


### PR DESCRIPTION
Fixing TC 79650, failing in OCP after the speedup PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Rollout e2e scenarios now run across multiple harness instances, improving network-failure simulation, recovery and cleanup coverage.
  * Increased a long-running test timeout to 15 minutes.
  * Strengthened failure and rollback validation across instances.

* **Chores**
  * E2E test runner: removed per-worker report preservation and made test-focus pattern generation robust to special characters.
  * Minor formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->