### PR TITLE
NO-ISSUE: Added rpmlint

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,6 +32,7 @@ jobs:
             docs/**
             .github/**
             examples/**
+            packaging/rpm/**
 
       - name: Setup all dependencies
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,7 @@ jobs:
             docs/**
             .github/**
             examples/**
+            packaging/rpm/**
 
       - name: Check commit message
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -62,6 +62,7 @@ jobs:
             docs/**
             .github/**
             examples/**
+            packaging/rpm/**
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -43,6 +43,7 @@ jobs:
             docs/**
             .github/**
             examples/**
+            packaging/rpm/**
 
       - name: Setup all dependencies
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/rpmlint.yaml
+++ b/.github/workflows/rpmlint.yaml
@@ -1,0 +1,31 @@
+name: "RPM Spec Lint"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 'release-*'
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  rpmlint:
+    runs-on: "ubuntu-24.04"
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf update -y
+          dnf install -y rpmlint rpm-build go-rpm-macros make
+
+      - uses: actions/checkout@v4
+
+      - name: Running RPM Spec Lint
+        run: |
+          echo "Running rpmlint directly to avoid any make/git interactions"
+          rpmlint packaging/rpm/flightctl.spec

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -31,6 +31,7 @@ jobs:
             docs/**
             .github/**
             examples/**
+            packaging/rpm/**
 
       - name: Setup all dependencies
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ help:
 	@echo "    generate:        regenerate all generated files"
 	@echo "    tidy:            tidy go mod"
 	@echo "    lint:            run golangci-lint"
+	@echo "    rpmlint:         run rpmlint on RPM spec file"
 	@echo "    lint-openapi:    run spectral to lint and rulecheck the OpenAPI spec"
 	@echo "    lint-docs:       run markdownlint on documentation"
 	@echo "    lint-diagrams:   verify that diagrams from Excalidraw have the source code embedded"
@@ -357,6 +358,20 @@ $(GOBIN)/golangci-lint:
 
 lint: tools
 	$(GOBIN)/golangci-lint run -v
+
+.PHONY: rpmlint
+rpmlint: check-rpmlint
+	@echo "Running rpmlint on RPM spec file"
+	rpmlint packaging/rpm/flightctl.spec
+
+.PHONY: rpmlint-ci
+rpmlint-ci:
+	@echo "Running rpmlint on RPM spec file (CI mode)"
+	rpmlint packaging/rpm/flightctl.spec
+
+.PHONY: check-rpmlint
+check-rpmlint:
+	@command -v rpmlint > /dev/null || (echo "rpmlint not found. Install with: sudo apt-get install rpmlint (Ubuntu/Debian) or sudo dnf install rpmlint (Fedora/RHEL)" && exit 1)
 
 .PHONY: lint-openapi
 lint-openapi:

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -108,7 +108,6 @@ OpenTelemetry Collector for metric collection. All components run in Podman cont
 managed by systemd and can be installed independently without requiring core FlightCtl
 services to be running. This package automatically includes the flightctl-otel-collector package.
 
-
 %files otel-collector
 # OpenTelemetry Collector specific files
 /etc/otelcol/otelcol-config.yaml


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a CI workflow to run RPM spec linting (manual trigger, pushes, and PRs).
  - Updated CI workflows to ignore packaging-only RPM changes so other test/lint/e2e jobs won’t run for packaging edits.
  - Added Makefile targets to run/verify RPM spec linting locally, including guidance if the lint tool is missing.
  - Minor packaging spec cleanup (whitespace).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->