### PR TITLE
EDM-1967: TPM e2e test

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
 )
 
 // Test constants
@@ -99,7 +98,7 @@ var _ = Describe("CLI - device console", func() {
 		}
 
 		By("waiting for the update to finish")
-		eventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
+		util.EventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
 			WithArguments(harness, resources.Devices, deviceID).
 			Should(WithTransform((*v1alpha1.Device).IsUpdatedToDeviceSpec, BeTrue()))
 
@@ -159,7 +158,7 @@ var _ = Describe("CLI - device console", func() {
 			Since:    logLookbackDuration,
 			LastBoot: true,
 		}
-		eventuallySlow(harness.VM.JournalLogs).
+		util.EventuallySlow(harness.VM.JournalLogs).
 			WithArguments(opts).
 			Should(And(
 				ContainSubstring("No new template version from management service"),
@@ -199,7 +198,7 @@ var _ = Describe("CLI - device console", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		GinkgoWriter.Printf("Waiting for image pull activity\n")
-		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
+		util.EventuallySlow(harness.ReadPrimaryVMAgentLogs).
 			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(ContainSubstring("Pulling image"))
 
@@ -214,7 +213,7 @@ var _ = Describe("CLI - device console", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		GinkgoWriter.Printf("Network disruption fixed. Waiting for the device to finish updating\n")
-		eventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
+		util.EventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
 			WithArguments(harness, resources.Devices, deviceID).
 			Should(WithTransform((*v1alpha1.Device).IsUpdatedToDeviceSpec, BeTrue()))
 	})
@@ -236,12 +235,12 @@ var _ = Describe("CLI - device console", func() {
 			WithArguments(harness, resources.Devices, deviceID).
 			Should(WithTransform((*v1alpha1.Device).IsUpdating, BeTrue()))
 
-		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
+		util.EventuallySlow(harness.ReadPrimaryVMAgentLogs).
 			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(ContainSubstring("Pulling image"))
 
 		GinkgoWriter.Printf("Waiting for image pull failure. It will take a while...\n")
-		eventuallySlow(harness.ReadPrimaryVMAgentLogs).
+		util.EventuallySlow(harness.ReadPrimaryVMAgentLogs).
 			WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
 			Should(And(
 				ContainSubstring("Error"),
@@ -257,7 +256,7 @@ var _ = Describe("CLI - device console", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		GinkgoWriter.Printf("Waiting for the device to finish updating\n")
-		eventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
+		util.EventuallySlow(resources.GetJSONByName[*v1alpha1.Device]).
 			WithArguments(harness, resources.Devices, deviceID).
 			Should(WithTransform((*v1alpha1.Device).IsUpdatedToDeviceSpec, BeTrue()))
 	})
@@ -302,10 +301,6 @@ var _ = Describe("CLI - device console", func() {
 		Expect(out).To(ContainSubstring("Error:"))
 	})
 })
-
-func eventuallySlow(actual any) types.AsyncAssertion {
-	return Eventually(actual).WithTimeout(LONG_TIMEOUT).WithPolling(LONG_POLLING)
-}
 
 // -----------------------------------------------------------------------------
 // Helper functions

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -137,13 +137,13 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 				By("Make sure the pull-secret was injected")
 				psPath := "/etc/crio/openshift-pull-secret"
 				readyMsg := "The file was found"
-				stdout, err := harness.WaitForFileInDevice(psPath, util.TIMEOUT, util.POLLING)
+				stdout, err := harness.WaitForFileInDevice(psPath, util.TIMEOUT_5M, util.SHORT_POLLING)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout.String()).To(ContainSubstring(readyMsg))
 
 				By("Wait for the kubeconfig to be in place")
 				kubeconfigPath := "/var/lib/microshift/resources/kubeadmin/kubeconfig"
-				stdout, err = harness.WaitForFileInDevice(kubeconfigPath, util.TIMEOUT, util.POLLING)
+				stdout, err = harness.WaitForFileInDevice(kubeconfigPath, util.TIMEOUT_5M, util.SHORT_POLLING)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stdout.String()).To(ContainSubstring(readyMsg))
 

--- a/test/e2e/parametrisable_templates/parametrisable_templates_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Template variables in the device configuraion", func() {
 				harness.WaitForDeviceContents(deviceId, `The device could not be updated to the fleet`,
 					func(device *v1alpha1.Device) bool {
 						return device.Status.Updated.Status == v1alpha1.DeviceUpdatedStatusOutOfDate
-					}, testutil.TIMEOUT)
+					}, testutil.TIMEOUT_5M)
 				resp, err := harness.Client.GetDeviceStatusWithResponse(harness.Context, deviceId)
 				Expect(err).ToNot(HaveOccurred())
 				device := resp.JSON200

--- a/test/e2e/tpm/README.md
+++ b/test/e2e/tpm/README.md
@@ -1,0 +1,87 @@
+# TPM E2E Tests
+
+This directory contains End-to-End tests for TPM (Trusted Platform Module) device authentication and attestation functionality.
+
+## Overview
+
+The TPM tests validate that devices can:
+- Enroll using TPM-based cryptographic identity
+- Generate and submit TPM attestation data
+- Perform integrity verification using TPM hardware
+- Maintain secure communication using TPM-signed credentials
+
+## Environment Configuration
+
+The test behavior automatically adjusts based on the TPM hardware type:
+
+### Virtual TPM (Default)
+```bash
+# Test with virtual TPM (software TPM in VMs)
+go test ./test/e2e/tpm
+# or explicitly:
+FLIGHTCTL_REAL_TPM=false go test ./test/e2e/tpm
+```
+
+**Expected Results:**
+- TPM functionality works correctly (enrollment, attestation, communication)
+- Integrity verification shows "Failed" status (expected due to lack of chain of trust)
+- Test validates that all TPM operations work despite verification failure
+
+### Real Hardware TPM
+```bash
+# Test with real hardware TPM devices
+FLIGHTCTL_REAL_TPM=true go test ./test/e2e/tpm
+```
+
+**Expected Results:**
+- TPM functionality works correctly (enrollment, attestation, communication)  
+- Integrity verification shows "Verified" status (full chain of trust validation)
+- Test validates complete TPM security chain
+
+## Test Structure
+
+The test suite includes:
+
+1. **TPM Device Detection** - Verifies `/dev/tpm0` presence and accessibility
+2. **TPM Functionality Check** - Tests basic TPM operations (`tpm2_startup`, `tpm2_getrandom`)
+3. **Agent Configuration** - Configures FlightCtl agent to use TPM for device identity
+4. **Enrollment Process** - Validates TPM-based device enrollment with attestation data
+5. **Integrity Verification** - Checks TPM-based integrity verification status
+6. **Ongoing Operations** - Verifies continued TPM usage for device communication
+
+## Key Features
+
+- **Automatic Hardware Detection**: Test assertions adapt based on `FLIGHTCTL_REAL_TPM` environment variable
+- **Comprehensive Logging**: Detailed logs help debug TPM setup and operation issues
+- **Reusable Functions**: TPM setup functions in `harness_device.go` can be used by other test suites
+- **Production Ready**: Clean output with minimal debugging noise in normal operation
+
+## Dependencies
+
+- TPM 2.0 hardware (real or virtual)
+- `tpm2-tools` package for TPM utilities
+- FlightCtl agent with TPM support compiled in
+- VM or hardware with TPM device accessible as `/dev/tpm0`
+
+## Troubleshooting
+
+### Virtual TPM Issues
+- Ensure VM has virtual TPM enabled
+- Verify `/dev/tpm0` device exists
+- Check that `tpm2-tools` are installed
+
+### Real TPM Issues  
+- Verify TPM is enabled in BIOS/UEFI
+- Check TPM ownership and clear state if needed
+- Ensure proper permissions on `/dev/tpm0`
+- Validate TPM certificates and chain of trust
+
+### Common Problems
+- **"TPM device identity is disabled"**: Check that agent config contains TPM section
+- **"Using file-based identity provider"**: Agent not reading TPM config or TPM initialization failed
+- **Integrity verification stuck**: TPM attestation process may be taking longer than expected
+
+For detailed debugging, check agent logs:
+```bash
+sudo journalctl -u flightctl-agent -f
+```

--- a/test/e2e/tpm/tpm_suite_test.go
+++ b/test/e2e/tpm/tpm_suite_test.go
@@ -1,0 +1,35 @@
+package tpm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTPM(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TPM E2E Suite")
+}
+
+const (
+	// Eventually polling timeout/interval constants
+	TIMEOUT      = time.Minute
+	LONG_TIMEOUT = 10 * time.Minute
+	POLLING      = time.Second
+	LONG_POLLING = 10 * time.Second
+)
+
+// Initialize suite-specific settings
+func init() {
+	SetDefaultEventuallyTimeout(TIMEOUT)
+	SetDefaultEventuallyPollingInterval(POLLING)
+}
+
+var _ = BeforeSuite(func() {
+	// Setup VM and harness for this worker
+	_, _, err := e2e.SetupWorkerHarness()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/e2e/tpm/tpm_test.go
+++ b/test/e2e/tpm/tpm_test.go
@@ -1,0 +1,315 @@
+// Package tpm provides E2E tests for TPM (Trusted Platform Module) device authentication and attestation functionality.
+//
+// ENVIRONMENT CONFIGURATION:
+// Set FLIGHTCTL_REAL_TPM=true to test with real hardware TPM devices (expects "Verified" status)
+// Set FLIGHTCTL_REAL_TPM=false or leave unset to test with virtual TPM (expects "Failed" status)
+//
+// IMPORTANT NOTES:
+// - Virtual TPM (software TPM in VMs) verification shows "Failed" status due to lack of chain of trust
+// - Real hardware TPM devices show "Verified" status when properly configured
+// - The test validates TPM functionality (enrollment, attestation data) works correctly in both cases
+// - Test assertions automatically adjust based on FLIGHTCTL_REAL_TPM environment variable
+//
+// USAGE EXAMPLES:
+// # Test with virtual TPM (default behavior)
+// go test ./test/e2e/tpm
+//
+// # Test with real hardware TPM
+// FLIGHTCTL_REAL_TPM=true go test ./test/e2e/tpm
+package tpm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	logLookbackDuration = "10 minutes ago"
+)
+
+// isRealTPMDevice returns true if testing with real TPM hardware (expects "Verified" status)
+// Set environment variable FLIGHTCTL_REAL_TPM=true to test with real hardware TPM devices
+func isRealTPMDevice() bool {
+	return strings.ToLower(os.Getenv("FLIGHTCTL_REAL_TPM")) == "true"
+}
+
+// getExpectedTPMStatus returns the expected TPM integrity status based on hardware type
+func getExpectedTPMStatus() v1alpha1.DeviceIntegrityCheckStatusType {
+	if isRealTPMDevice() {
+		return v1alpha1.DeviceIntegrityCheckStatusVerified
+	}
+	return v1alpha1.DeviceIntegrityCheckStatusFailed
+}
+
+// getExpectedIntegrityStatus returns the expected overall integrity status based on hardware type
+func getExpectedIntegrityStatus() v1alpha1.DeviceIntegrityStatusSummaryType {
+	if isRealTPMDevice() {
+		return v1alpha1.DeviceIntegrityStatusVerified
+	}
+	return v1alpha1.DeviceIntegrityStatusFailed
+}
+
+var _ = Describe("TPM Device Authentication", func() {
+	var (
+		ctx      context.Context
+		harness  *e2e.Harness
+		workerID int
+	)
+
+	BeforeEach(func() {
+		// Get the harness and context directly - no package-level variables
+		workerID = GinkgoParallelProcess()
+		harness = e2e.GetWorkerHarness()
+		suiteCtx := e2e.GetWorkerContext()
+
+		GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+
+		// Create test-specific context for proper tracing
+		ctx = util.StartSpecTracerForGinkgo(suiteCtx)
+
+		// Set the test context in the harness
+		harness.SetTestContext(ctx)
+
+		// Setup device with TPM using the new harness function
+		err := harness.SetupDeviceWithTPM(workerID)
+		Expect(err).ToNot(HaveOccurred())
+
+		GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
+
+		// Login to API
+		login.LoginToAPIWithToken(harness)
+	})
+
+	AfterEach(func() {
+		workerID := GinkgoParallelProcess()
+		GinkgoWriter.Printf("🔄 [AfterEach] Worker %d: Cleaning up test resources\n", workerID)
+
+		// Get the harness and context directly - no shared variables needed
+		harness := e2e.GetWorkerHarness()
+		suiteCtx := e2e.GetWorkerContext()
+
+		// Create test-specific context for cleanup (same as BeforeEach does)
+		// This ensures we have the test ID needed for resource cleanup
+		ctx := util.StartSpecTracerForGinkgo(suiteCtx)
+		harness.SetTestContext(ctx)
+
+		err := harness.CleanUpTestResources()
+		Expect(err).ToNot(HaveOccurred())
+
+		GinkgoWriter.Printf("✅ [AfterEach] Worker %d: Test cleanup completed\n", workerID)
+	})
+
+	Context("TPM Enrollment", func() {
+		// NOTE: Test behavior depends on environment variable FLIGHTCTL_REAL_TPM:
+		// - FLIGHTCTL_REAL_TPM=false (default): Virtual TPM - expects "Failed" verification status
+		// - FLIGHTCTL_REAL_TPM=true: Real hardware TPM - expects "Verified" verification status
+		// Virtual TPM verification shows "Failed" due to lack of chain of trust (expected behavior)
+		// Test validates TPM enrollment and attestation functionality works correctly in both cases
+		It("Should enroll device with TPM enabled and verify attestation", Label("83974", "tpm", "sanity"), func() {
+			By("verifying TPM device presence")
+			stdout, err := harness.VM.RunSSH([]string{"ls", "-la", "/dev/tpm*"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout.String()).To(ContainSubstring("/dev/tpm0"))
+
+			By("verifying TPM version")
+			_, err = harness.VM.RunSSH([]string{"sudo", "tpm2_startup", "-c"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying agent reports TPM usage in logs")
+			util.EventuallySlow(harness.ReadPrimaryVMAgentLogs).
+				WithArguments(logLookbackDuration, util.FLIGHTCTL_AGENT_SERVICE).
+				Should(ContainSubstring("Using TPM-based identity provider"))
+
+			By("waiting for enrollment request with TPM attestation")
+			var enrollmentID string
+
+			Eventually(func() error {
+				enrollmentID = harness.GetEnrollmentIDFromServiceLogs("flightctl-agent")
+				if enrollmentID == "" {
+					return errors.New("enrollment ID not found in agent logs")
+				}
+
+				logrus.Infof("Enrollment ID found in VM console output: %s", enrollmentID)
+				return nil
+			}, util.TIMEOUT, util.POLLING).Should(Succeed())
+
+			// Wait for enrollment request to be created with TPM attestation data
+			Eventually(func() error {
+				enrollmentRequest := harness.WaitForEnrollmentRequest(enrollmentID)
+				if enrollmentRequest == nil {
+					return errors.New("enrollment request not found")
+				}
+
+				// Check if device status has system info
+				if enrollmentRequest.Spec.DeviceStatus == nil {
+					return errors.New("device status is nil")
+				}
+
+				if enrollmentRequest.Spec.DeviceStatus.SystemInfo.IsEmpty() {
+					return errors.New("system info is empty")
+				}
+
+				logrus.Infof("Enrollment request with TPM attestation data created successfully!")
+				logrus.Infof("Device status present with SystemInfo")
+
+				// Check for TPM-related information in SystemInfo
+				systemInfo := enrollmentRequest.Spec.DeviceStatus.SystemInfo
+				logrus.Infof("SystemInfo available keys: %+v", systemInfo)
+
+				// Check TPM attestation data
+				err = harness.VerifyEnrollmentTPMAttestationData(systemInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				logrus.Infof("TPM attestation data found in enrollment request")
+				return nil
+			}, util.TIMEOUT, 5*util.POLLING).Should(Succeed())
+
+			By("approving enrollment and waiting for device online")
+			deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+			By("checking TPM key persistence")
+			Eventually(func() error {
+				_, err := harness.VM.RunSSH([]string{"ls", "-la", "/var/lib/flightctl/tpm-blob.yaml"}, nil)
+				return err
+			}, util.TIMEOUT, 5*util.POLLING).Should(Succeed())
+
+			// NOTE: Verification status depends on TPM hardware type and environment configuration
+			tpmType := "Virtual"
+			expectedStatus := "Failed"
+			if isRealTPMDevice() {
+				tpmType = "Real Hardware"
+				expectedStatus = "Verified"
+			}
+			logrus.Infof("Testing with %s TPM - expecting %s integrity verification status", tpmType, expectedStatus)
+
+			By(fmt.Sprintf("verifying TPM integrity verification reports %s status (%s TPM)", expectedStatus, tpmType))
+
+			var device *v1alpha1.Device
+			// Wait for integrity verification to complete
+			Eventually(func() bool {
+				// Refresh device status
+				resp, err := harness.Client.GetDeviceWithResponse(harness.Context, deviceId)
+				if err != nil || resp.JSON200 == nil {
+					logrus.Infof("Failed to get device response: err=%v, resp=%v", err, resp)
+					return false
+				}
+				device = resp.JSON200
+
+				// Debug device integrity status
+				if device.Status == nil {
+					logrus.Infof("Device status is nil")
+					return false
+				}
+
+				logrus.Infof("Device integrity status: %s", device.Status.Integrity.Status)
+
+				if device.Status.Integrity.Tpm == nil {
+					logrus.Infof("Device TPM integrity is nil")
+					return false
+				}
+
+				logrus.Infof("TPM integrity status: %s", device.Status.Integrity.Tpm.Status)
+
+				if device.Status.Integrity.DeviceIdentity != nil {
+					logrus.Infof("Device identity integrity status: %s", device.Status.Integrity.DeviceIdentity.Status)
+				} else {
+					logrus.Infof("Device identity integrity is nil")
+				}
+
+				// Check that verification completes with expected status
+				integrityComplete := device.Status.Integrity.Tpm != nil &&
+					device.Status.Integrity.Tpm.Status != "" &&
+					device.Status.Integrity.DeviceIdentity != nil &&
+					device.Status.Integrity.DeviceIdentity.Status != ""
+
+				logrus.Infof("Integrity verification complete: %t", integrityComplete)
+				return integrityComplete
+			}, 2*util.TIMEOUT, 5*util.POLLING).Should(BeTrue())
+
+			// Verify TPM integrity structure is present and has expected status
+			Expect(device.Status.Integrity.Tpm).ToNot(BeNil())
+			Expect(device.Status.Integrity.DeviceIdentity).ToNot(BeNil())
+
+			// Check integrity status based on TPM hardware type
+			expectedTPMStatus := getExpectedTPMStatus()
+			expectedIntegrityStatus := getExpectedIntegrityStatus()
+
+			Expect(device.Status.Integrity.Tpm.Status).To(Equal(expectedTPMStatus))
+			Expect(device.Status.Integrity.DeviceIdentity.Status).To(Equal(expectedTPMStatus))
+			Expect(device.Status.Integrity.Status).To(Equal(expectedIntegrityStatus))
+
+			logrus.Infof("%s TPM integrity verification completed as expected - TPM: %s, Device Identity: %s, Overall: %s",
+				tpmType,
+				device.Status.Integrity.Tpm.Status,
+				device.Status.Integrity.DeviceIdentity.Status,
+				device.Status.Integrity.Status)
+
+			By("verifying TPM attestation data is present in device system info")
+			err = harness.VerifyDeviceTPMAttestationData(device)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying TPM-based identity is used for communication")
+			// Make a config change to verify TPM-signed communication works
+			newRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Add a simple inline config to trigger a rendered version update
+			testConfig := v1alpha1.ConfigProviderSpec{}
+			testFilePath := "/tmp/tpm-test-marker"
+			testFileContent := fmt.Sprintf("TPM test marker - %d", time.Now().Unix())
+
+			inlineConfig := v1alpha1.InlineConfigProviderSpec{
+				Name: "tpm-test-config",
+				Inline: []v1alpha1.FileSpec{
+					{
+						Path:    testFilePath,
+						Content: testFileContent,
+						Mode:    lo.ToPtr(0644),
+					},
+				},
+			}
+			err = testConfig.FromInlineConfigProviderSpec(inlineConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Update device config and wait for it to be applied using TPM-signed communication
+			err = harness.UpdateDeviceConfigWithRetries(deviceId, []v1alpha1.ConfigProviderSpec{testConfig}, newRenderedVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify the configuration was actually applied to confirm TPM-signed communication worked
+			var configOutput *bytes.Buffer
+			configOutput, err = harness.VM.RunSSH([]string{"cat", testFilePath}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configOutput.String()).To(ContainSubstring("TPM test marker"))
+			logrus.Infof("Configuration successfully applied via TPM-signed communication: %s", strings.TrimSpace(configOutput.String()))
+
+			By("verifying TPM communication is working for device updates")
+			// The fact that configuration was successfully applied proves TPM is working
+			// We don't need to check logs since they contain historical startup messages
+			// that predate the TPM configuration being applied
+
+			logrus.Infof("✅ TPM verification PASSED:")
+			logrus.Infof("  - Device enrolled with TPM attestation data")
+			logrus.Infof("  - TPM integrity verification completed (%s TPM)", tpmType)
+			logrus.Infof("  - Configuration successfully applied via TPM-signed communication")
+			logrus.Infof("  - All TPM functionality verified working correctly")
+
+			// Optional: Check that the test marker file still exists as final verification
+			_, err = harness.VM.RunSSH([]string{"test", "-f", testFilePath}, nil)
+			Expect(err).ToNot(HaveOccurred(), "TPM-applied configuration file should still exist")
+		})
+	})
+})

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"fmt"
+)
+
+// StartFlightCtlAgent starts the flightctl-agent service
+func (h *Harness) StartFlightCtlAgent() error {
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "start", "flightctl-agent"}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start flightctl-agent: %w", err)
+	}
+	return nil
+}
+
+// StopFlightCtlAgent stops the flightctl-agent service
+func (h *Harness) StopFlightCtlAgent() error {
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "stop", "flightctl-agent"}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to stop flightctl-agent: %w", err)
+	}
+	return nil
+}
+
+// RestartFlightCtlAgent restarts the flightctl-agent service
+func (h *Harness) RestartFlightCtlAgent() error {
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "restart", "flightctl-agent"}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to restart flightctl-agent: %w", err)
+	}
+	return nil
+}
+
+// ReloadFlightCtlAgent reloads the flightctl-agent service
+func (h *Harness) ReloadFlightCtlAgent() error {
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "reload", "flightctl-agent"}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to reload flightctl-agent: %w", err)
+	}
+	return nil
+}

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -3,15 +3,20 @@ package e2e
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
+	agentcfg "github.com/flightctl/flightctl/internal/agent/config"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 func (h *Harness) GetDeviceWithStatusSystem(enrollmentID string) (*apiclient.GetDeviceResponse, error) {
@@ -655,5 +660,199 @@ func (h *Harness) ResetAgent() error {
 	if err != nil {
 		return fmt.Errorf("failed to send SIGHUP to agent: %w", err)
 	}
+	return nil
+}
+
+// SetAgentConfig configures the agent by writing the configuration file.
+// This method should be called before starting the agent.
+func (h *Harness) SetAgentConfig(cfg *agentcfg.Config) error {
+	// Marshal the config to YAML
+	configBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal agent config: %w", err)
+	}
+
+	// Write the config to the VM (using correct agent config filename)
+	stdout, err := h.VM.RunSSH([]string{
+		"sudo", "mkdir", "-p", "/etc/flightctl",
+		"&&",
+		"echo", fmt.Sprintf("'%s'", string(configBytes)),
+		"|",
+		"sudo", "tee", "/etc/flightctl/config.yaml",
+	}, nil)
+	if err != nil {
+		logrus.Errorf("Failed to write agent config: %v, stdout: %s", err, stdout)
+		return fmt.Errorf("failed to write agent config: %w", err)
+	}
+
+	return nil
+}
+
+// WaitForTPMInitialization waits for TPM hardware to be ready in the VM.
+// This should be called after VM setup but before agent configuration.
+func (h *Harness) WaitForTPMInitialization() error {
+	logrus.Info("Waiting for TPM hardware initialization...")
+	time.Sleep(20 * time.Second)
+	return nil
+}
+
+// VerifyTPMFunctionality checks that TPM device is accessible and functional.
+func (h *Harness) VerifyTPMFunctionality() error {
+	// Check TPM device presence
+	stdout, err := h.VM.RunSSH([]string{"sh", "-lc", "ls -la /dev/tpm*"}, nil)
+	if err != nil || !strings.Contains(stdout.String(), "/dev/tpm0") {
+		// Check if we're expecting TPM hardware to be available
+		realTPM := strings.ToLower(os.Getenv("FLIGHTCTL_REAL_TPM")) == "true"
+		skipTPM := strings.ToLower(os.Getenv("FLIGHTCTL_SKIP_TPM")) == "true"
+
+		if realTPM && !skipTPM {
+			// Real TPM was expected but not found
+			return fmt.Errorf("TPM device /dev/tpm0 not available (FLIGHTCTL_REAL_TPM=true but no TPM device found)")
+		}
+
+		// No TPM device found but not in real TPM mode - this is expected for CI/virtual environments
+		logrus.Info("No TPM device found (/dev/tpm0), skipping TPM hardware verification (expected in CI environments)")
+		return nil
+	}
+
+	// Test TPM functionality
+	_, _ = h.VM.RunSSH([]string{"sh", "-lc", "sudo tpm2_startup -c || true"}, nil)
+
+	_, err = h.VM.RunSSH([]string{"sudo", "tpm2_getrandom", "8"}, nil)
+	if err != nil {
+		return fmt.Errorf("TPM getrandom test failed: %w", err)
+	}
+
+	logrus.Info("TPM functionality verified successfully")
+	return nil
+}
+
+// EnableTPMForDevice configures the agent to use TPM for device identity.
+// This reads existing agent config, updates TPM settings, and writes it back.
+func (h *Harness) EnableTPMForDevice() error {
+	// Get existing agent config or create default
+	stdout, err := h.VM.RunSSH([]string{"cat", "/etc/flightctl/config.yaml"}, nil)
+	var agentConfig *agentcfg.Config
+
+	if err == nil && stdout.Len() > 0 {
+		// Parse existing config
+		agentConfig = &agentcfg.Config{}
+		err = yaml.Unmarshal(stdout.Bytes(), agentConfig)
+		if err != nil {
+			logrus.Warnf("Failed to parse existing config, using default: %v", err)
+			agentConfig = &agentcfg.Config{}
+		}
+	} else {
+		// No existing config, create new
+		agentConfig = &agentcfg.Config{}
+	}
+
+	// Configure TPM settings
+	agentConfig.TPM = agentcfg.TPM{
+		Enabled:         true,
+		DevicePath:      "/dev/tpm0",
+		StorageFilePath: filepath.Join(agentcfg.DefaultDataDir, agentcfg.DefaultTPMKeyFile),
+		AuthEnabled:     true,
+	}
+
+	// Write the updated config
+	err = h.SetAgentConfig(agentConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set TPM agent config: %w", err)
+	}
+
+	logrus.Info("TPM configuration enabled for device")
+	return nil
+}
+
+// SetupDeviceWithTPM prepares a device VM with TPM functionality enabled.
+// This handles the complete TPM setup process in the correct order.
+func (h *Harness) SetupDeviceWithTPM(workerID int) error {
+	// 1. Setup VM from pool (includes agent start)
+	err := h.SetupVMFromPoolAndStartAgent(workerID)
+	if err != nil {
+		return fmt.Errorf("failed to setup VM: %w", err)
+	}
+
+	// 2. Stop agent immediately to configure TPM first
+	err = h.StopFlightCtlAgent()
+	if err != nil {
+		return fmt.Errorf("failed to stop agent: %w", err)
+	}
+
+	// 3. Wait for TPM hardware initialization
+	err = h.WaitForTPMInitialization()
+	if err != nil {
+		return fmt.Errorf("TPM initialization failed: %w", err)
+	}
+
+	// 4. Verify TPM is functional
+	err = h.VerifyTPMFunctionality()
+	if err != nil {
+		return fmt.Errorf("TPM verification failed: %w", err)
+	}
+
+	// 5. Configure agent for TPM
+	err = h.EnableTPMForDevice()
+	if err != nil {
+		return fmt.Errorf("TPM configuration failed: %w", err)
+	}
+
+	// 6. Start agent with TPM configuration
+	err = h.StartFlightCtlAgent()
+	if err != nil {
+		return fmt.Errorf("failed to start agent with TPM: %w", err)
+	}
+
+	// 7. Brief wait for agent to initialize with TPM
+	time.Sleep(10 * time.Second)
+
+	logrus.Info("Device TPM setup completed successfully")
+	return nil
+}
+
+// VerifyEnrollmentTPMAttestationData checks for TPM attestation data in enrollment request SystemInfo
+// Returns error if no TPM attestation data is found
+func (h *Harness) VerifyEnrollmentTPMAttestationData(systemInfo v1alpha1.DeviceSystemInfo) error {
+	// Look for TPM attestation data - check for either key name that might be used
+	_, hasAttestation := systemInfo.Get("attestation")
+	if !hasAttestation {
+		logrus.Infof("No 'attestation' key found, checking for other TPM-related keys...")
+		tpmVendorInfo, hasTmpVendorInfo := systemInfo.Get("tpmVendorInfo")
+		if hasTmpVendorInfo {
+			logrus.Infof("Found 'tpmVendorInfo' key: %s", tpmVendorInfo)
+			logrus.Infof("TPM attestation data found in enrollment request: %s...", tpmVendorInfo)
+			return nil
+		}
+		return errors.New("no TPM attestation data found in enrollment request")
+	}
+
+	logrus.Infof("TPM attestation data found in enrollment request")
+	return nil
+}
+
+// VerifyDeviceTPMAttestationData checks for TPM attestation data in device SystemInfo
+// Virtual TPM provides "tpmVendorInfo", real TPM provides "attestation"
+// Returns error if attestation data is missing or empty
+func (h *Harness) VerifyDeviceTPMAttestationData(device *v1alpha1.Device) error {
+	// Check for TPM vendor info in system info (virtual TPM provides tpmVendorInfo instead of full attestation)
+	tpmVendorInfo, hasTmpVendorInfo := device.Status.SystemInfo.Get("tpmVendorInfo")
+	if hasTmpVendorInfo {
+		if tpmVendorInfo == "" {
+			return fmt.Errorf("tpmVendorInfo is empty in device system info")
+		}
+		logrus.Infof("TPM vendor info found in device system info: %s", tpmVendorInfo)
+		return nil
+	}
+
+	// For real TPM devices, check for full attestation data
+	deviceAttestation, hasAttestation := device.Status.SystemInfo.Get("attestation")
+	if !hasAttestation {
+		return fmt.Errorf("no TPM attestation data found in device system info")
+	}
+	if deviceAttestation == "" {
+		return fmt.Errorf("attestation data is empty in device system info")
+	}
+	logrus.Infof("TPM attestation data found in device system info: %.50s...", deviceAttestation)
 	return nil
 }

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -41,6 +41,17 @@ const (
 	DeviceContentOutOfDate   = "DeviceContentOutOfDate"
 	DeviceContentUpToDate    = "DeviceContentUpToDate"
 	DeviceUpdateFailed       = "DeviceUpdateFailed"
+
+	// Eventually polling timeout/interval constants
+	TIMEOUT      = time.Minute
+	LONG_TIMEOUT = 10 * time.Minute
+	POLLING      = time.Second
+	LONG_POLLING = 10 * time.Second
+
+	DURATION_TIMEOUT = 5 * time.Minute
+	SHORT_POLLING    = "250ms"
+	TIMEOUT_5M       = "5m"
+	LONGTIMEOUT      = "10m"
 )
 
 var ResourceTypes = [...]string{
@@ -65,11 +76,6 @@ var DefaultSystemInfo = []string{
 	"netIpDefault",
 	"netMacDefault",
 }
-
-const TIMEOUT = "5m"
-const POLLING = "250ms"
-const LONGTIMEOUT = "10m"
-const DURATION_TIMEOUT = 5 * time.Minute
 
 const E2E_NAMESPACE = "flightctl-e2e"
 const E2E_REGISTRY_NAME = "registry"

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -29,6 +29,8 @@ import (
 	"github.com/flightctl/flightctl/pkg/queues"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -437,4 +439,8 @@ func RunTable[T any](cases []TestCase[T], runFunc func(T)) {
 		By("Case: " + tc.Description)
 		runFunc(tc.Params)
 	}
+}
+
+func EventuallySlow(actual any) types.AsyncAssertion {
+	return Eventually(actual).WithTimeout(LONG_TIMEOUT).WithPolling(LONG_POLLING)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - New TPM end-to-end suite covering device detection, enrollment, attestation, integrity checks, TPM-backed identity flows, TPM-signed config delivery, and timing-validated log checks; supports virtual and real TPM via environment flag.
- **Chores**
  - Harness helpers to enable/verify/configure TPM on devices and manage the agent service; TPM-first device setup and restart flow.
- **Tests (misc)**
  - Centralized timeout/polling constants, new long-running assertion helper, and increased timeouts for select tests.
- **Documentation**
  - Added TPM E2E README with modes, prerequisites, usage, expectations, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->