### PR TITLE
EDM-2079: Fix cli-artifact access when deploying with nodeports

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -98,7 +98,7 @@
   {{- $scheme := (include "flightctl.getHttpScheme" . )}}
   {{- $exposeMethod := (include "flightctl.getServiceExposeMethod" . )}}
   {{- if eq $exposeMethod "nodePort" }}
-    {{- printf "%s://%s:%v" $scheme $baseDomain .Values.global.nodePorts.cliArtifacts }}
+    {{- printf "http://flightctl-cli-artifacts:8090" }}
   {{- else if eq $exposeMethod "gateway" }}
     {{- if and (eq $scheme "http") (not (eq (int .Values.global.gatewayPorts.http) 80))}}
       {{- printf "%s://cli-artifacts.%s:%v" $scheme $baseDomain .Values.global.gatewayPorts.http }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Fixed CLI artifacts URL generation in NodePort deployments; the URL now resolves to a stable internal address to ensure reliable artifact access.
- Chores
  - Standardized deployment configuration for artifact access in NodePort environments to improve consistency and reduce misconfiguration risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->