### PR TITLE
EDM-2064: Fix CLI version showing -dirty by cleaning git working tree

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -107,31 +107,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Prepare version variables
-        id: version-vars
-        run: |
-          set -euo pipefail
-          SOURCE_GIT_TAG=$(git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
-          if [ ! -d ".git" ]; then
-            SOURCE_GIT_TREE_STATE=clean
-          elif git diff --quiet; then
-            SOURCE_GIT_TREE_STATE=clean
-          else
-            SOURCE_GIT_TREE_STATE=dirty
-          fi
-          SOURCE_GIT_COMMIT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
-
-          {
-            echo "git_tag=${SOURCE_GIT_TAG}"
-            echo "git_tree_state=${SOURCE_GIT_TREE_STATE}"
-            echo "git_commit=${SOURCE_GIT_COMMIT}"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "Calculated version variables:"
-          echo "  SOURCE_GIT_TAG: ${SOURCE_GIT_TAG}"
-          echo "  SOURCE_GIT_TREE_STATE: ${SOURCE_GIT_TREE_STATE}"
-          echo "  SOURCE_GIT_COMMIT: ${SOURCE_GIT_COMMIT}"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -170,10 +145,6 @@ jobs:
             org.flightctl.flightctl-${{ matrix.image }}.github.run_id=${{ github.run_id }}
             org.flightctl.flightctl-${{ matrix.image }}.github.sha=${{ github.sha }}
             org.flightctl.flightctl-${{ matrix.image }}.github.ref_name=${{ github.ref_name }}
-          build-args: |
-            SOURCE_GIT_TAG=${{ steps.version-vars.outputs.git_tag }}
-            SOURCE_GIT_TREE_STATE=${{ steps.version-vars.outputs.git_tree_state }}
-            SOURCE_GIT_COMMIT=${{ steps.version-vars.outputs.git_commit }}
           extra-args: |
             --ulimit nofile=10000:10000
           containerfiles: Containerfile.${{ matrix.image }}

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,19 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -31,6 +22,14 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,19 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
-
 # Switch to root for build operations
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -31,6 +21,14 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,5 +1,9 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 # Switch to root for build operations
 USER 0
 
@@ -26,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,13 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +22,12 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app
+RUN git add . && git stash -u && git stash drop || true
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -26,8 +26,10 @@ COPY ./test ./test
 COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app
-RUN git add . && git stash -u && git stash drop || true
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -28,9 +31,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,13 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -32,6 +24,12 @@ COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
 COPY ./packaging ./packaging
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app
+RUN git add . && git stash -u && git stash drop || true
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
 
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+# Accept build args to avoid warnings (not used by .git solution)
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE  
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -31,6 +28,13 @@ COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
 COPY ./packaging ./packaging
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -26,13 +31,6 @@ COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
 COPY ./packaging ./packaging
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -5,7 +5,6 @@ WORKDIR /app
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -28,8 +27,10 @@ COPY ./packaging ./packaging
 COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app
-RUN git add . && git stash -u && git stash drop || true
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -5,7 +5,6 @@ WORKDIR /app
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -27,8 +26,10 @@ COPY ./test ./test
 COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app
-RUN git add . && git stash -u && git stash drop || true
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -1,13 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -31,6 +23,12 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app
+RUN git add . && git stash -u && git stash drop || true
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,19 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -31,6 +22,14 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,19 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -31,6 +22,14 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -4,6 +4,11 @@ ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
 
+# Convert build args to environment variables for make to use
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
 # Switch to root for build operations
 USER 0
 
@@ -25,13 +30,6 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
-# Make sure that version extraction works
-COPY .git .git
-
-# Fix git permissions and clean working tree for version calculation
-RUN git config --global --add safe.directory /app && \
-    git reset --hard HEAD && \
-    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,13 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+# Accept build args to avoid warnings (not used by .git solution)
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
 ARG SOURCE_GIT_COMMIT
-
-# Convert build args to environment variables for make to use
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
@@ -30,6 +27,13 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+
+# Make sure that version extraction works
+COPY .git .git
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
 
 # Switch to root for build operations
 USER 0
@@ -27,9 +30,8 @@ COPY .git .git
 
 # Fix git permissions and clean working tree for version calculation
 RUN git config --global --add safe.directory /app && \
-    git add . && \
-    git stash -u && \
-    (git stash drop || true)
+    git reset --hard HEAD && \
+    git clean -fdx
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,19 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
-ARG SOURCE_GIT_TAG
-ARG SOURCE_GIT_TREE_STATE
-ARG SOURCE_GIT_COMMIT
-
-# Convert ARGs to ENV so make can use them
-ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
-ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
-ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
 
 # Switch to root for build operations
 USER 0
 
 # Copy dependencies first (most stable)
-COPY go.* ./
 COPY go.mod go.sum ./
 
 # Download dependencies (cached layer)
@@ -31,6 +22,14 @@ COPY ./hack ./hack
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./test ./test
+# Make sure that version extraction works
+COPY .git .git
+
+# Fix git permissions and clean working tree for version calculation
+RUN git config --global --add safe.directory /app && \
+    git add . && \
+    git stash -u && \
+    (git stash drop || true)
 
 # Use BuildKit cache mounts for Go caching
 RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,10 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
-SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
-SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
+# Check ENV first; if unset or empty, fallback to git (robust for CI/env quirks)
+SOURCE_GIT_TAG := $(if $(strip $(SOURCE_GIT_TAG)),$(SOURCE_GIT_TAG),$(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown"))
+SOURCE_GIT_TREE_STATE := $(if $(strip $(SOURCE_GIT_TREE_STATE)),$(SOURCE_GIT_TREE_STATE),$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo clean ) || echo dirty))
+SOURCE_GIT_COMMIT := $(if $(strip $(SOURCE_GIT_COMMIT)),$(SOURCE_GIT_COMMIT),$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo unknown))
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
 SOURCE_GIT_TAG_NO_V := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//')
 MAJOR := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$1}')

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-# Check ENV first; if unset or empty, fallback to git (robust for CI/env quirks)
-SOURCE_GIT_TAG := $(if $(strip $(SOURCE_GIT_TAG)),$(SOURCE_GIT_TAG),$(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown"))
-SOURCE_GIT_TREE_STATE := $(if $(strip $(SOURCE_GIT_TREE_STATE)),$(SOURCE_GIT_TREE_STATE),$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo clean ) || echo dirty))
-SOURCE_GIT_COMMIT := $(if $(strip $(SOURCE_GIT_COMMIT)),$(SOURCE_GIT_COMMIT),$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo unknown))
+
+SOURCE_GIT_TAG ?= $(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
+SOURCE_GIT_TREE_STATE ?= $(shell git diff --quiet && echo clean || echo dirty)
+SOURCE_GIT_COMMIT ?= $(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo unknown)
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
 SOURCE_GIT_TAG_NO_V := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//')
 MAJOR := $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$1}')


### PR DESCRIPTION
## EDM-2064: Fix CLI version showing -dirty

**Problem**: CLI artifacts downloaded from UI showed `v0.9.2-dirty` instead of clean `v0.9.2`

**Root Cause**: Selective COPY in containers caused git to perceive working tree as dirty

**Solution**: 
- Remove duplicated version calculation from GitHub Actions workflow
- Add git stash technique to clean working tree state in containers  
- Make Makefile single source of truth for versioning

**Tested**: ✅ CLI artifacts now show clean versions without `-dirty` suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Reduced files copied during container builds to improve caching and build stability.
  - Stopped exporting git metadata as runtime environment variables for publish job; git metadata no longer passed to that CI container build.

- Refactor
  - Hardened version-extraction during image builds and adjusted Makefile to derive normalized tag and major version.

Impact
- More reproducible, cache-friendly builds with no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->