### PR TITLE
NO-ISSUE: fixed e2e publish

### DIFF
--- a/.github/workflows/publish-e2e-containers.yaml
+++ b/.github/workflows/publish-e2e-containers.yaml
@@ -79,6 +79,13 @@ jobs:
           containerfiles: ${{ matrix.image.containerfile }}
           context: .
 
+      - name: Login to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.QUAY_ORG }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+
       - name: Push to Quay.io
         id: push
         uses: redhat-actions/push-to-registry@v2.7


### PR DESCRIPTION
fixes deployment of e2e containers for cache reasons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release pipeline to authenticate to the container registry before pushing end-to-end images, improving publish reliability and reducing failures due to authorization issues. Streamlines CI workflow, speeds up subsequent steps, and ensures consistent delivery of E2E containers across environments. No user-facing changes. Builds and deployments remain functionally identical, with improved security by using authenticated pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->