### PR TITLE
EDM-2058: agent retry and 404 handling 

### DIFF
--- a/internal/agent/client/client_test.go
+++ b/internal/agent/client/client_test.go
@@ -428,3 +428,133 @@ func TestNewFromConfigWithRetry(t *testing.T) {
 	require.Equal(3, attempts)
 	require.Equal(http.StatusOK, resp.StatusCode())
 }
+
+func TestManagementClient_DeviceNotFoundHandling(t *testing.T) {
+	require := require.New(t)
+
+	t.Run("returns ErrDeviceNotFound for 404 with device not found content", func(t *testing.T) {
+		// Create a test server that returns 404 with device not found content
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte(`Device of name "test-device" not found`))
+			require.NoError(err)
+		}))
+		defer server.Close()
+
+		// Create management client
+		config := &baseclient.Config{
+			Service: baseclient.Service{
+				Server: server.URL,
+			},
+		}
+
+		retryConfig := poll.Config{
+			BaseDelay: 10 * time.Millisecond,
+			Factor:    2.0,
+			MaxDelay:  100 * time.Millisecond,
+			MaxSteps:  3,
+		}
+
+		log := log.NewPrefixLogger("test")
+		httpClient, err := NewFromConfig(config, log, WithHTTPRetry(retryConfig))
+		require.NoError(err)
+		require.NotNil(httpClient)
+
+		// Create management client wrapper
+		managementClient := NewManagement(httpClient, nil)
+
+		// Call GetRenderedDevice
+		ctx := context.Background()
+		device, statusCode, err := managementClient.GetRenderedDevice(ctx, "test-device", nil)
+
+		// Verify the response
+		if err == nil {
+			t.Logf("Expected error but got nil. StatusCode: %d, Device: %v", statusCode, device)
+		}
+		require.Error(err)
+		require.Equal(ErrDeviceNotFound, err)
+		require.Equal(http.StatusNotFound, statusCode)
+		require.Nil(device)
+	})
+
+	t.Run("returns generic 404 for 404 without device not found content", func(t *testing.T) {
+		// Create a test server that returns 404 without device not found content
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte(`Resource not found`))
+			require.NoError(err)
+		}))
+		defer server.Close()
+
+		// Create management client
+		config := &baseclient.Config{
+			Service: baseclient.Service{
+				Server: server.URL,
+			},
+		}
+
+		retryConfig := poll.Config{
+			BaseDelay: 10 * time.Millisecond,
+			Factor:    2.0,
+			MaxDelay:  100 * time.Millisecond,
+			MaxSteps:  3,
+		}
+
+		log := log.NewPrefixLogger("test")
+		httpClient, err := NewFromConfig(config, log, WithHTTPRetry(retryConfig))
+		require.NoError(err)
+		require.NotNil(httpClient)
+
+		// Create management client wrapper
+		managementClient := NewManagement(httpClient, nil)
+
+		// Call GetRenderedDevice
+		ctx := context.Background()
+		device, statusCode, err := managementClient.GetRenderedDevice(ctx, "test-device", nil)
+
+		// Verify the response - should be generic 404, not ErrDeviceNotFound
+		require.NoError(err)
+		require.Equal(http.StatusNotFound, statusCode)
+		require.Nil(device)
+	})
+
+	t.Run("returns generic 404 for 404 with empty body", func(t *testing.T) {
+		// Create a test server that returns 404 with empty body
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			// No body written
+		}))
+		defer server.Close()
+
+		// Create management client
+		config := &baseclient.Config{
+			Service: baseclient.Service{
+				Server: server.URL,
+			},
+		}
+
+		retryConfig := poll.Config{
+			BaseDelay: 10 * time.Millisecond,
+			Factor:    2.0,
+			MaxDelay:  100 * time.Millisecond,
+			MaxSteps:  3,
+		}
+
+		log := log.NewPrefixLogger("test")
+		httpClient, err := NewFromConfig(config, log, WithHTTPRetry(retryConfig))
+		require.NoError(err)
+		require.NotNil(httpClient)
+
+		// Create management client wrapper
+		managementClient := NewManagement(httpClient, nil)
+
+		// Call GetRenderedDevice
+		ctx := context.Background()
+		device, statusCode, err := managementClient.GetRenderedDevice(ctx, "test-device", nil)
+
+		// Verify the response - should be generic 404, not ErrDeviceNotFound
+		require.NoError(err)
+		require.Equal(http.StatusNotFound, statusCode)
+		require.Nil(device)
+	})
+}

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -27,9 +28,11 @@ const (
 
 // defaultSpecPollConfig is the default poll configuration for the spec priority queue.
 var defaultSpecPollConfig = poll.Config{
-	BaseDelay: 30 * time.Second,
-	Factor:    1.5,
-	MaxDelay:  5 * time.Minute,
+	BaseDelay:    30 * time.Second,
+	Factor:       1.5,
+	MaxDelay:     5 * time.Minute,
+	JitterFactor: 0.1,
+	Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
 }
 
 type Manager interface {

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -774,7 +775,7 @@ func TestRollback(t *testing.T) {
 			readWriter.SetRootdir(tmpDir)
 			log := log.NewPrefixLogger("test")
 			mockPolicyManager := policy.NewMockManager(ctrl)
-			pub := publisher.New("testDevice", 10*time.Millisecond, wait.Backoff{}, log)
+			pub := publisher.New("testDevice", 10*time.Millisecond, wait.Backoff{}, log, nil)
 			cache := newCache(log)
 			queue := newQueueManager(
 				defaultSpecQueueMaxSize,
@@ -928,23 +929,40 @@ func TestGetDesired(t *testing.T) {
 		{
 			name: "spec from the api response has the same Version as desired",
 			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
-				renderedDesiredSpec := createTestRenderedDevice(image)
-				marshaledDesiredSpec, err := json.Marshal(renderedDesiredSpec)
-				require.NoError(err)
+				renderedDesiredSpec := newVersionedDevice("2") // same as cache desired version "2"
+				renderedDesiredSpec.Spec = &v1alpha1.DeviceSpec{
+					Os: &v1alpha1.DeviceOsSpec{
+						Image: image,
+					},
+				}
 
 				mpq.EXPECT().Add(gomock.Any(), gomock.Any())
 				mpq.EXPECT().Next(gomock.Any()).Return(renderedDesiredSpec, true)
-				mrw.EXPECT().WriteFile(desiredPath, marshaledDesiredSpec, gomock.Any()).Return(nil)
+				// No WriteFile expectation since version is the same, so no write should occur
 				mpm.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil)
 				require.NoError(devicePublisher.Push(renderedDesiredSpec))
 			},
-			expectedDevice: createTestRenderedDevice(image),
-			expectedError:  nil,
+			expectedDevice: func() *v1alpha1.Device {
+				device := newVersionedDevice("2")
+				device.Spec = &v1alpha1.DeviceSpec{
+					Os: &v1alpha1.DeviceOsSpec{
+						Image: image,
+					},
+				}
+				return device
+			}(),
+			expectedError: nil,
 		},
 		{
 			name: "error when writing the desired spec fails",
 			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
-				device := createTestRenderedDevice(image)
+				// Create a device with version "3" (newer than cache desired version "2")
+				device := newVersionedDevice("3")
+				device.Spec = &v1alpha1.DeviceSpec{
+					Os: &v1alpha1.DeviceOsSpec{
+						Image: image,
+					},
+				}
 				mpq.EXPECT().Add(gomock.Any(), gomock.Any())
 				mpq.EXPECT().Next(gomock.Any()).Return(device, true)
 				mpm.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil)
@@ -958,6 +976,28 @@ func TestGetDesired(t *testing.T) {
 			},
 			expectedDevice: nil,
 			expectedError:  errors.ErrWritingRenderedSpec,
+		},
+		{
+			name: "rejects older version than current desired",
+			setupMocks: func(mpq *MockPriorityQueue, mrw *fileio.MockReadWriter, mc *client.MockManagement, mpm *policy.MockManager) {
+				// Mock the Read(Desired) call that happens when no new spec is consumed
+				desiredSpec := newVersionedDevice("2")
+				marshaledDesiredSpec, err := json.Marshal(desiredSpec)
+				require.NoError(err)
+				mrw.EXPECT().ReadFile(desiredPath).Return(marshaledDesiredSpec, nil)
+
+				// Create a device with version "1" (older than cache desired version "2")
+				olderDevice := newVersionedDevice("1")
+				olderDevice.Spec = &v1alpha1.DeviceSpec{
+					Os: &v1alpha1.DeviceOsSpec{
+						Image: image,
+					},
+				}
+				mpq.EXPECT().Add(gomock.Any(), gomock.Any())
+				mpq.EXPECT().Next(gomock.Any()).Return(olderDevice, true)
+			},
+			expectedDevice: nil,
+			expectedError:  fmt.Errorf("version 1 is older than current desired version 2"),
 		},
 	}
 
@@ -995,7 +1035,8 @@ func TestGetDesired(t *testing.T) {
 
 			specResult, _, err := s.GetDesired(ctx)
 			if tc.expectedError != nil {
-				require.ErrorIs(err, tc.expectedError)
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedError.Error())
 				require.Nil(specResult)
 				return
 			}

--- a/internal/agent/identity/file.go
+++ b/internal/agent/identity/file.go
@@ -144,6 +144,25 @@ func (f *fileProvider) WipeCredentials() error {
 	return nil
 }
 
+func (f *fileProvider) WipeCertificateOnly() error {
+	var errs []error
+
+	// Only wipe the certificate file, not the key or CSR
+	if f.clientCertPath != "" {
+		f.log.Infof("Wiping certificate file %s", f.clientCertPath)
+		if err := f.rw.OverwriteAndWipe(f.clientCertPath); err != nil {
+			errs = append(errs, fmt.Errorf("failed to wipe certificate file %s: %w", f.clientCertPath, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to wipe certificate: %v", errs)
+	}
+
+	f.log.Info("Successfully wiped certificate file")
+	return nil
+}
+
 func (f *fileProvider) Close(_ context.Context) error {
 	// no-op for file provider
 	return nil

--- a/internal/agent/identity/identity.go
+++ b/internal/agent/identity/identity.go
@@ -47,6 +47,8 @@ type Provider interface {
 	CreateGRPCClient(config *base_client.Config) (grpc_v1.RouterServiceClient, error)
 	// WipeCredentials securely removes all stored credentials (certificates and keys)
 	WipeCredentials() error
+	// WipeCertificateOnly securely removes only the certificate (not keys or CSR)
+	WipeCertificateOnly() error
 	// Close cleans up any resources used by the provider
 	Close(ctx context.Context) error
 }

--- a/internal/agent/identity/identity_test.go
+++ b/internal/agent/identity/identity_test.go
@@ -1,0 +1,111 @@
+package identity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestFileProvider_WipeCertificateOnly(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock dependencies
+	mockRW := fileio.NewMockReadWriter(ctrl)
+	logger := log.NewPrefixLogger("test")
+
+	// Create file provider
+	provider := &fileProvider{
+		clientCertPath: "/tmp/test/client.crt",
+		clientKeyPath:  "/tmp/test/client.key",
+		rw:             mockRW,
+		log:            logger,
+	}
+
+	t.Run("wipes certificate file successfully", func(t *testing.T) {
+		// Mock the file operations
+		mockRW.EXPECT().OverwriteAndWipe("/tmp/test/client.crt").Return(nil)
+
+		// Call WipeCertificateOnly
+		err := provider.WipeCertificateOnly()
+
+		// Verify success
+		require.NoError(err)
+	})
+
+	t.Run("handles certificate file wipe error", func(t *testing.T) {
+		expectedError := errors.New("file operation failed")
+
+		// Mock the file operations to return an error
+		mockRW.EXPECT().OverwriteAndWipe("/tmp/test/client.crt").Return(expectedError)
+
+		// Call WipeCertificateOnly
+		err := provider.WipeCertificateOnly()
+
+		// Verify error is returned
+		require.Error(err)
+		require.Contains(err.Error(), "failed to wipe certificate")
+	})
+
+	t.Run("handles empty certificate path", func(t *testing.T) {
+		// Create provider with empty certificate path
+		provider := &fileProvider{
+			clientCertPath: "", // Empty path
+			clientKeyPath:  "/tmp/test/client.key",
+			rw:             mockRW,
+			log:            logger,
+		}
+
+		// Call WipeCertificateOnly
+		err := provider.WipeCertificateOnly()
+
+		// Should succeed without doing anything
+		require.NoError(err)
+	})
+}
+
+func TestTpmProvider_WipeCertificateOnly(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock dependencies
+	logger := log.NewPrefixLogger("test")
+
+	// Create TPM provider
+	provider := &tpmProvider{
+		certificateData: []byte("test-certificate-data"),
+		log:             logger,
+	}
+
+	t.Run("wipes certificate data from memory successfully", func(t *testing.T) {
+		// Call WipeCertificateOnly
+		err := provider.WipeCertificateOnly()
+
+		// Verify success
+		require.NoError(err)
+
+		// Verify certificate data is cleared
+		require.Nil(provider.certificateData)
+	})
+
+	t.Run("handles nil certificate data", func(t *testing.T) {
+		// Create provider with nil certificate data
+		provider := &tpmProvider{
+			certificateData: nil, // Already nil
+			log:             logger,
+		}
+
+		// Call WipeCertificateOnly
+		err := provider.WipeCertificateOnly()
+
+		// Should succeed without doing anything
+		require.NoError(err)
+		require.Nil(provider.certificateData)
+	})
+}

--- a/internal/agent/identity/mock_identity.go
+++ b/internal/agent/identity/mock_identity.go
@@ -101,21 +101,6 @@ func (mr *MockProviderMockRecorder) GenerateCSR(deviceName any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCSR", reflect.TypeOf((*MockProvider)(nil).GenerateCSR), deviceName)
 }
 
-// GenerateTCGCSR mocks base method.
-func (m *MockProvider) GenerateTCGCSR(deviceName, productModel, productSerial string, qualifyingData []byte) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTCGCSR", deviceName, productModel, productSerial, qualifyingData)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GenerateTCGCSR indicates an expected call of GenerateTCGCSR.
-func (mr *MockProviderMockRecorder) GenerateTCGCSR(deviceName, productModel, productSerial, qualifyingData any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTCGCSR", reflect.TypeOf((*MockProvider)(nil).GenerateTCGCSR), deviceName, productModel, productSerial, qualifyingData)
-}
-
 // GetDeviceName mocks base method.
 func (m *MockProvider) GetDeviceName() (string, error) {
 	m.ctrl.T.Helper()
@@ -171,6 +156,20 @@ func (m *MockProvider) StoreCertificate(certPEM []byte) error {
 func (mr *MockProviderMockRecorder) StoreCertificate(certPEM any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreCertificate", reflect.TypeOf((*MockProvider)(nil).StoreCertificate), certPEM)
+}
+
+// WipeCertificateOnly mocks base method.
+func (m *MockProvider) WipeCertificateOnly() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WipeCertificateOnly")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WipeCertificateOnly indicates an expected call of WipeCertificateOnly.
+func (mr *MockProviderMockRecorder) WipeCertificateOnly() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WipeCertificateOnly", reflect.TypeOf((*MockProvider)(nil).WipeCertificateOnly))
 }
 
 // WipeCredentials mocks base method.

--- a/internal/agent/identity/tpm.go
+++ b/internal/agent/identity/tpm.go
@@ -221,6 +221,14 @@ func (t *tpmProvider) WipeCredentials() error {
 	return nil
 }
 
+func (t *tpmProvider) WipeCertificateOnly() error {
+	// For TPM provider, only clear certificate data from memory
+	// The key and CSR remain in TPM storage
+	t.certificateData = nil
+	t.log.Info("Wiped TPM-stored certificate data from memory (key and CSR preserved)")
+	return nil
+}
+
 func (t *tpmProvider) Close(ctx context.Context) error {
 	if t.client != nil {
 		return t.client.Close(ctx)

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -3,6 +3,7 @@ package periodic
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/signal"
 	"sync"
@@ -128,9 +129,11 @@ func (s *Server) Run(ctx context.Context) error {
 		TasksMetadata:  periodicTasks,
 		ChannelManager: channelManager,
 		TaskBackoff: &poll.Config{
-			BaseDelay: 100 * time.Millisecond,
-			Factor:    3,
-			MaxDelay:  10 * time.Second,
+			BaseDelay:    100 * time.Millisecond,
+			Factor:       3,
+			MaxDelay:     10 * time.Second,
+			JitterFactor: 0.1,
+			Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
 		},
 	}
 	periodicTaskPublisher, err := NewPeriodicTaskPublisher(publisherConfig)

--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -107,6 +107,36 @@ func TestBackoffWithContext(t *testing.T) {
 			},
 			expectErr: ErrMaxSteps,
 		},
+		{
+			name:       "invalid jitter factor - negative",
+			ctxTimeout: 50 * time.Millisecond,
+			config: Config{
+				BaseDelay:    10 * time.Millisecond,
+				Factor:       2,
+				JitterFactor: -0.1,
+			},
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: errors.New("poll JitterFactor must be between 0.0 and 1.0"),
+		},
+		{
+			name:       "invalid jitter factor - too high",
+			ctxTimeout: 50 * time.Millisecond,
+			config: Config{
+				BaseDelay:    10 * time.Millisecond,
+				Factor:       2,
+				JitterFactor: 1.5,
+			},
+			operation: func() func(context.Context) (bool, error) {
+				return func(context.Context) (bool, error) {
+					return false, nil
+				}
+			},
+			expectErr: errors.New("poll JitterFactor must be between 0.0 and 1.0"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,10 +146,85 @@ func TestBackoffWithContext(t *testing.T) {
 
 			err := BackoffWithContext(ctx, tt.config, tt.operation())
 			if tt.expectErr != nil {
-				require.ErrorIs(err, tt.expectErr)
+				if tt.name == "invalid jitter factor - negative" || tt.name == "invalid jitter factor - too high" {
+					require.ErrorContains(err, tt.expectErr.Error())
+				} else {
+					require.ErrorIs(err, tt.expectErr)
+				}
 				return
 			}
 			require.NoError(err)
+		})
+	}
+}
+
+func TestCalculateBackoffDelay(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name     string
+		config   Config
+		tries    int
+		expected time.Duration
+	}{
+		{
+			name: "no jitter",
+			config: Config{
+				BaseDelay: 10 * time.Millisecond,
+				Factor:    2,
+				MaxDelay:  100 * time.Millisecond,
+			},
+			tries:    3,
+			expected: 40 * time.Millisecond, // 10 * 2^2 = 40ms
+		},
+		{
+			name: "with jitter - should be within range",
+			config: Config{
+				BaseDelay:    10 * time.Millisecond,
+				Factor:       2,
+				MaxDelay:     100 * time.Millisecond,
+				JitterFactor: 0.1, // 10% jitter
+			},
+			tries: 3,
+			// Expected base: 40ms, jitter range: ±4ms, so result should be 36-44ms
+			// We can't test exact value due to randomness, so we test range
+		},
+		{
+			name: "zero tries",
+			config: Config{
+				BaseDelay: 10 * time.Millisecond,
+				Factor:    2,
+			},
+			tries:    0,
+			expected: 0,
+		},
+		{
+			name: "negative tries",
+			config: Config{
+				BaseDelay: 10 * time.Millisecond,
+				Factor:    2,
+			},
+			tries:    -1,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateBackoffDelay(&tt.config, tt.tries)
+
+			if tt.name == "with jitter - should be within range" {
+				// For jitter test, check that result is within expected range
+				baseDelay := 40 * time.Millisecond // 10 * 2^2
+				jitterRange := time.Duration(float64(baseDelay) * tt.config.JitterFactor)
+				minDelay := baseDelay - jitterRange
+				maxDelay := baseDelay + jitterRange
+
+				require.GreaterOrEqual(result, minDelay, "jittered delay should be >= min")
+				require.LessOrEqual(result, maxDelay, "jittered delay should be <= max")
+			} else {
+				require.Equal(tt.expected, result)
+			}
 		})
 	}
 }

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -259,9 +260,11 @@ func NewBackoff() wait.Backoff {
 
 func NewPollConfig() poll.Config {
 	return poll.Config{
-		BaseDelay: 1 * time.Millisecond,
-		Factor:    1.0,
-		MaxDelay:  1 * time.Millisecond,
+		BaseDelay:    1 * time.Millisecond,
+		Factor:       1.0,
+		MaxDelay:     1 * time.Millisecond,
+		JitterFactor: 0.1,
+		Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
 	}
 }
 


### PR DESCRIPTION
1. added infinite retry for for enrollmentClient (as creating / getting ers is not a periodic task)
2. added 404 device not found handler when getting specs - this had to be implemented with a callback since publisher does not have access to identity providers (we need access to wipe the certificate and then restart the flightctl-agent)
3. server will not return an older spec than the one reported by agent unless there are consoles
4. added jitter for retry policy
5. even after the change that was recently merged to queue.go to ignore old versions we still need the spec manager to specifically ignore older versions for desired , without this the desired version can be downgraded (consider current=5 , desired =7 and incoming =6 , without the change desired will be downgraded to 6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery when the management service reports a specific "device not found": the agent will wipe only the device certificate and restart to re-enroll.
  * Enrollment and polling now use jittered backoff with per-run RNG seeding; enrollment also supports infinite HTTP retry.

* **Bug Fixes**
  * Rejects older desired versions to prevent accidental rollbacks.
  * Avoids redundant writes when desired and rendered versions match.

* **Tests**
  * Expanded coverage for jitter/backoff, nuanced device-not-found handling, and certificate-wipe behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->