### PR TITLE
NO-ISSUE: pull and push e2e images to their own org

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -30,6 +30,7 @@ env:
   QUAY_TESTS_ORG: quay.io/flightctl-tests
   REGISTRY: quay.io
   REGISTRY_OWNER: flightctl
+  REGISTRY_OWNER_TESTS: flightctl-tests
   GITHUB_ACTIONS: true
 
 jobs:

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -20,6 +20,7 @@ env:
   QUAY_ORG: quay.io/flightctl
   REGISTRY: quay.io
   REGISTRY_OWNER: flightctl
+  REGISTRY_OWNER_TESTS: flightctl-tests
   GITHUB_ACTIONS: true
 
 jobs:

--- a/.github/workflows/publish-e2e-containers.yaml
+++ b/.github/workflows/publish-e2e-containers.yaml
@@ -6,8 +6,11 @@ on:
       - main
 
 env:
-  QUAY_ORG: quay.io/flightctl
+  QUAY_TESTS_ORG: quay.io/flightctl-tests
   QUAY: quay.io
+  REGISTRY: quay.io
+  REGISTRY_OWNER: flightctl
+  REGISTRY_OWNER_TESTS: flightctl-tests
   # Enable BuildKit for cache mounts
   DOCKER_BUILDKIT: 1
   BUILDKIT_PROGRESS: plain
@@ -84,8 +87,8 @@ jobs:
         uses: redhat-actions/podman-login@v1
         with:
           registry: ${{ env.QUAY }}
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_TESTS_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_TESTS_INFRA_ROBOT_PASSWORD }}
 
       - name: Push to Quay.io
         id: push
@@ -93,6 +96,6 @@ jobs:
         with:
           image: ${{ matrix.image.name }}
           tags: cache
-          registry: ${{ env.QUAY_ORG }}
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+          registry: ${{ env.QUAY_TESTS_ORG }}
+          username: ${{ secrets.QUAY_FLIGHTCTL_TESTS_INFRA_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_FLIGHTCTL_TESTS_INFRA_ROBOT_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ export BUILDKIT_PROGRESS=plain
 # This allows the CI pipeline to easily override them.
 REGISTRY       ?= localhost
 REGISTRY_OWNER ?= flightctl
+REGISTRY_OWNER_TESTS ?= flightctl-tests
 GITHUB_ACTIONS ?= false
 
 # --- Cache Configuration ---
@@ -120,6 +121,7 @@ help:
 	@echo "Environment Variables for CI:"
 	@echo "    REGISTRY:        container registry (default: localhost)"
 	@echo "    REGISTRY_OWNER:  registry owner/organization (default: flightctl)"
+	@echo "    REGISTRY_OWNER_TESTS:  test registry owner/organization (default: flightctl-tests)"
 	@echo "    REGISTRY_USER:   registry username for login"
 	@echo "    GITHUB_ACTIONS:  set to 'true' to enable container build caching"
 	@echo ""

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -61,8 +61,8 @@ build_single_image() {
     # Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
     if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
         REGISTRY="${REGISTRY:-localhost}"
-        REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
-        CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/flightctl-device")
+        REGISTRY_OWNER_TESTS="${REGISTRY_OWNER_TESTS:-flightctl-tests}"
+        CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER_TESTS}/flightctl-device")
     else
         CACHE_FLAGS=()
     fi

--- a/test/scripts/agent-images/create_application_image.sh
+++ b/test/scripts/agent-images/create_application_image.sh
@@ -14,8 +14,8 @@ for img in $IMAGE_LIST; do
    # Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
    if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
        REGISTRY="${REGISTRY:-localhost}"
-       REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
-       CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/sleep-app")
+       REGISTRY_OWNER_TESTS="${REGISTRY_OWNER_TESTS:-flightctl-tests}"
+       CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER_TESTS}/sleep-app")
    else
        CACHE_FLAGS=()
    fi

--- a/test/scripts/prepare_git_server.sh
+++ b/test/scripts/prepare_git_server.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # Use GitHub Actions cache when GITHUB_ACTIONS=true, otherwise no caching
 if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
     REGISTRY="${REGISTRY:-localhost}"
-    REGISTRY_OWNER="${REGISTRY_OWNER:-flightctl}"
-    CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER}/git-server")
+    REGISTRY_OWNER_TESTS="${REGISTRY_OWNER_TESTS:-flightctl-tests}"
+    CACHE_FLAGS=("--cache-from=${REGISTRY}/${REGISTRY_OWNER_TESTS}/git-server")
 else
     CACHE_FLAGS=()
 fi


### PR DESCRIPTION
push and pull e2e used images to/from their own flightctl-tests org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - E2E and smoke workflows now expose a test registry owner variable for downstream steps.
  - Container publishing targets a dedicated test registry with test-specific credentials for isolation.
  - Test image build/prepare scripts use the test registry owner for cache sources to improve build reliability.

- Chores
  - Added a configurable test registry owner to build tooling and help output.
  - Updated CI workflows and scripts to align with the new test registry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->