### PR TITLE
EDM-941: updating application doesn't result in new application deployed on device

### DIFF
--- a/internal/agent/device/applications/provider/embedded.go
+++ b/internal/agent/device/applications/provider/embedded.go
@@ -60,7 +60,7 @@ func (p *embeddedProvider) OCITargets(pullSecret *client.PullSecret) ([]dependen
 				targets = append(targets, dependency.OCIPullTarget{
 					Type:       dependency.OCITypeImage,
 					Reference:  svc.Image,
-					PullPolicy: v1alpha1.PullIfNotPresent,
+					PullPolicy: v1alpha1.PullAlways,
 					PullSecret: pullSecret,
 				})
 			}

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -64,7 +64,7 @@ func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.Appli
 }
 
 func (p *imageProvider) OCITargets(pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
-	policy := v1alpha1.PullIfNotPresent
+	policy := v1alpha1.PullAlways
 	var targets []dependency.OCIPullTarget
 	targets = append(targets, dependency.OCIPullTarget{
 		Type:       dependency.OCITypeImage,

--- a/internal/agent/device/applications/provider/inline.go
+++ b/internal/agent/device/applications/provider/inline.go
@@ -71,11 +71,11 @@ func (p *inlineProvider) OCITargets(pullSecret *client.PullSecret) ([]dependency
 	for _, svc := range spec.Services {
 		if svc.Image != "" {
 			targets = append(targets, dependency.OCIPullTarget{
-				Type:       dependency.OCITypeImage,
-				Reference:  svc.Image,
-				PullPolicy: v1alpha1.PullIfNotPresent,
-				PullSecret: pullSecret,
-			})
+			Type:       dependency.OCITypeImage,
+			Reference:  service.Image,
+			PullPolicy: v1alpha1.PullAlways,
+			PullSecret: pullSecret,
+		})
 		}
 	}
 

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -340,7 +340,7 @@ func extractVolumeTargets(vols *[]v1alpha1.ApplicationVolume, pullSecret *client
 			return nil, fmt.Errorf("getting image volume spec: %w", err)
 		}
 
-		policy := v1alpha1.PullIfNotPresent
+		policy := v1alpha1.PullAlways
 		if spec.Image.PullPolicy != nil {
 			policy = *spec.Image.PullPolicy
 		}


### PR DESCRIPTION
This PR addresses the issue described in [EDM-941](https://issues.redhat.com/browse/EDM-941).

**Summary:** updating application doesn't result in new application deployed on device

**Description:** *Description of the problem:*

This is most likely caused by the logic based on updating only on tag update (new tag?).

While it might make sense to tag all version of the Standard Operating Environment system, it doesn't for applications, where most of the times you push always to latest tag (alternatively to beta for new functionalities).

There is also most likely some image caching involved somewhere, because on removing and readding the application to the device configuration, I would expect flightctl to pull the latest version of the tag, while it is not what's happening.

*How reproducible:*

 

*Steps to reproduce:*
 # Add application to device configuration

 #  

Update application image on container registry

 #  

No update triggered on application on device

 # removing the application from device configuration and readding it doesn't make the trick either

*Actual results:*

 

*Expected results:*

Application updates on devices triggered by new sha values of tag (in the end that's already supported on podman autoupdate)

**Assignee:** Asaf Ben Natan (abennata@redhat.com)