### PR TITLE
EDM-2064: Extend EDM-1995 fix to all containers

### DIFF
--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +18,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN make build-alert-exporter
 
 

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +18,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN make build-alertmanager-proxy
 
 

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -14,6 +19,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN dnf install --nodocs -y jq
 RUN make build-multiarch-clis
 

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +18,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN make build-periodic
 
 

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +18,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN make build-userinfo-proxy
 
 

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
 WORKDIR /app
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
 COPY ./api api
 COPY ./cmd cmd
 COPY ./deploy deploy
@@ -13,6 +18,7 @@ COPY ./Makefile .
 COPY .git .git
 
 USER 0
+RUN git config --global --add safe.directory /app
 RUN make build-worker
 
 

--- a/Makefile
+++ b/Makefile
@@ -167,32 +167,56 @@ bin/.flightctl-db-setup-container: bin Containerfile.db-setup deploy/scripts/set
 
 bin/.flightctl-worker-container: bin Containerfile.worker go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.worker $(GO_CACHE) -t flightctl-worker:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.worker $(GO_CACHE) -t flightctl-worker:latest
 	touch bin/.flightctl-worker-container
 
 bin/.flightctl-periodic-container: bin Containerfile.periodic go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.periodic $(GO_CACHE) -t flightctl-periodic:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.periodic $(GO_CACHE) -t flightctl-periodic:latest
 	touch bin/.flightctl-periodic-container
 
 bin/.flightctl-alert-exporter-container: bin Containerfile.alert-exporter go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.alert-exporter $(GO_CACHE) -t flightctl-alert-exporter:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.alert-exporter $(GO_CACHE) -t flightctl-alert-exporter:latest
 	touch bin/.flightctl-alert-exporter-container
 
 bin/.flightctl-alertmanager-proxy-container: bin Containerfile.alertmanager-proxy go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.alertmanager-proxy $(GO_CACHE) -t flightctl-alertmanager-proxy:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.alertmanager-proxy $(GO_CACHE) -t flightctl-alertmanager-proxy:latest
 	touch bin/.flightctl-alertmanager-proxy-container
 
 bin/.flightctl-multiarch-cli-container: bin Containerfile.cli-artifacts go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.cli-artifacts $(GO_CACHE) -t flightctl-cli-artifacts:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.cli-artifacts $(GO_CACHE) -t flightctl-cli-artifacts:latest
 	touch bin/.flightctl-multiarch-cli-container
 
 bin/.flightctl-userinfo-proxy-container: bin Containerfile.userinfo-proxy go.mod go.sum $(GO_FILES)
 	mkdir -p $${HOME}/go/flightctl-go-cache/.cache
-	podman build -f Containerfile.userinfo-proxy $(GO_CACHE) -t flightctl-userinfo-proxy:latest
+	podman build \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f Containerfile.userinfo-proxy $(GO_CACHE) -t flightctl-userinfo-proxy:latest
 	touch bin/.flightctl-userinfo-proxy-container
 
 flightctl-base-container: bin/.flightctl-base-container


### PR DESCRIPTION
## Problem
CLI client downloaded from web console UI shows `v0.9.2-dirty` instead of clean `v0.9.2`.

## Solution
Extended EDM-1995 fix to all containers. Added missing:
- ARG declarations for version variables
- --build-arg passing in Makefile  
- Git safe.directory fix

## Files Changed
- All Containerfiles (cli-artifacts, worker, periodic, alert-exporter, etc.)
- Makefile (8 container build targets)

## Result
✅ CLI from web console now shows clean `v0.9.2`  
✅ Consistent version handling across all containers

**Resolves:** EDM-2064  
**Related:** EDM-1995