### PR TITLE
EDM-2097: Cherry-pick RPM links fix to release-0.9

### DIFF
--- a/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-cm.yaml
+++ b/deploy/helm/flightctl/charts/ui/templates/flightctl-ui-cm.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   FLIGHTCTL_SERVER: {{ .Values.api.url | quote }}
   {{- if .Values.cliArtifacts.enabled }}
-  FLIGHTCTL_CLI_ARTIFACTS_SERVER: {{ include "flightctl.getCliArtifactsUrl" . }}
+  FLIGHTCTL_CLI_ARTIFACTS_SERVER: {{ include "flightctl.getInternalCliArtifactsUrl" . }}
   {{- end }}
   {{- if .Values.alerts.enabled }}
   FLIGHTCTL_ALERTMANAGER_PROXY: {{ include "flightctl.getAlertManagerProxyUrl" . }}

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -93,6 +93,10 @@
   {{- end }}
 {{- end }}
 
+{{- define "flightctl.getInternalCliArtifactsUrl" }}
+  {{- print "http://flightctl-cli-artifacts:8090"}}
+{{- end }}
+
 {{- define "flightctl.getCliArtifactsUrl" }}
   {{- $baseDomain := (include "flightctl.getBaseDomain" . )}}
   {{- $scheme := (include "flightctl.getHttpScheme" . )}}


### PR DESCRIPTION
Cherry-pick commit 4d10fc5b from main to release-0.9

Fixes RPM links in flightctl UI of a local deployment by using internal CLI artifacts server URL.

Changes:
- Uses `flightctl.getInternalCliArtifactsUrl` for UI config  
- Adds helper function for internal CLI artifacts URL