### PR TITLE
EDM-643: docs/user: add expectations for floating tags

### DIFF
--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -438,6 +438,16 @@ spec:
 
 You can deploy, update, or undeploy applications on a device by updating the list of applications in the device's specification. The next time the agent checks in, it learns of the change in the specification, downloads any new or updated application packages and images from an OCI-compatible registry, and deploys them to the appropriate application runtime or removes them from that runtime.
 
+### Container Image Versioning and Floating Tags
+
+Flight Control uses a declarative API model that expects container images to be immutable for each rendered device version. Floating tags like `latest` are **not recommended** as they can change unexpectedly and cause version skew across your fleet. Changes to floating tags are not automatically reconciled by the service or agent, updates must be explicitly declared.
+
+**Best practices:**
+
+* Use explicit version tags `v1.2.3` or image digests `@sha256:abc123...`
+* When updating applications, explicitly declare new tags or digests in the device specification
+* This ensures consistent, predictable deployments and prevents unintended drift
+
 The following table shows the application runtimes and formats supported by Flight Control:
 
 ### Runtime: **Podman**
@@ -491,7 +501,7 @@ spec:
 [...]
   applications:
   - name: wordpress
-    image: quay.io/flightctl-demos/wordpress-app:latest
+    image: quay.io/flightctl-demos/wordpress-app:v1.2.3
     envVars:
       WORDPRESS_DB_HOST: "mysql"
       WORDPRESS_DB_USER: "user"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on container image versioning and the risks of floating tags (e.g., latest); recommends immutable references (explicit version tags or digests) and explicit updates in device specs. No functional changes.

* **Bug Fixes**
  * Improved VM snapshot revert behavior to ensure the VM is running, waits for stabilization, and handles console stream issues more robustly to reduce unreliable reverts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->