### PR TITLE
EDM-1032: docs/user/hooks: add shell expansion example for envVar

### DIFF
--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -670,7 +670,7 @@ A run action takes the following parameters:
 | Parameter | Description |
 | --------- | ----------- |
 | Run | The absolute path to the command to run, followed by any flags or arguments.<br/><br/>Example: `/usr/bin/nmcli connection reload`.<br/><br/>Note that the command is not executed in a shell, so you cannot use shell variables like `$FOO_PATH` or chain commands (`\|` or `;`). However, it is possible to start a shell yourself if necessary by specifying the shell as command to run.<br/><br/>Example: `/usr/bin/bash -c 'echo foo'` |
-| EnvVars | (Optional) A list of key/value-pairs to set as environment variables for the command. |
+| EnvVars | (Optional) A list of key/value-pairs to set as environment variables for the command..<br/><br/>Note to use these variables `MY_VAR: value`, execute the command through a shell like `/bin/sh -c 'command "$MY_VAR"'`. |
 | WorkDir | (Optional) The directory the command will be run from. |
 | Timeout | (Optional) The maximum duration allowed for the action to complete. The duration must be be specified as a single positive integer followed by a time unit. Supported time units are `s` for seconds, `m` for minutes, and `h` for hours.<br/><br/>Default: 10s |
 | If | (Optional) A list of conditions that must be true for the action to be run (see below). If not provided, actions will run unconditionally. |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Run action parameters for using environment variables when executing commands via a shell (e.g., /bin/sh -c).
  * Added a note that shell-backed runs do not inherit the system environment; required variables must be provided via envVars.
  * Included a YAML example showing envVars alongside a shell-backed run command.
  * Applied these updates consistently across the Run action parameter sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->