### PR TITLE
EDM-2016: Add Activate Credential infra

### DIFF
--- a/internal/tpm/client_test.go
+++ b/internal/tpm/client_test.go
@@ -1023,7 +1023,7 @@ func generateEKCertWithRealPublicKey(tmpPublic *tpm2.TPM2BPublic) ([]byte, error
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageKeyAgreement,
+		KeyUsage:              x509.KeyUsageKeyEncipherment,
 		BasicConstraintsValid: true,
 	}
 
@@ -1095,7 +1095,7 @@ func generateEKCertWithRealECCPublicKey(tpmPublic *tpm2.TPM2BPublic) ([]byte, er
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageKeyEncipherment,
+		KeyUsage:              x509.KeyUsageKeyAgreement,
 		BasicConstraintsValid: true,
 	}
 

--- a/internal/tpm/mock_tpm.go
+++ b/internal/tpm/mock_tpm.go
@@ -236,6 +236,22 @@ func (mr *MockSessionMockRecorder) FlushAllTransientHandles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAllTransientHandles", reflect.TypeOf((*MockSession)(nil).FlushAllTransientHandles))
 }
 
+// GenerateChallenge mocks base method.
+func (m *MockSession) GenerateChallenge(secret []byte) ([]byte, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateChallenge", secret)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GenerateChallenge indicates an expected call of GenerateChallenge.
+func (mr *MockSessionMockRecorder) GenerateChallenge(secret any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateChallenge", reflect.TypeOf((*MockSession)(nil).GenerateChallenge), secret)
+}
+
 // GetEndorsementKeyCert mocks base method.
 func (m *MockSession) GetEndorsementKeyCert() ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -309,4 +325,19 @@ func (m *MockSession) Sign(keyType KeyType, digest []byte) ([]byte, error) {
 func (mr *MockSessionMockRecorder) Sign(keyType, digest any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockSession)(nil).Sign), keyType, digest)
+}
+
+// SolveChallenge mocks base method.
+func (m *MockSession) SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SolveChallenge", credentialBlob, encryptedSecret)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SolveChallenge indicates an expected call of SolveChallenge.
+func (mr *MockSessionMockRecorder) SolveChallenge(credentialBlob, encryptedSecret any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SolveChallenge", reflect.TypeOf((*MockSession)(nil).SolveChallenge), credentialBlob, encryptedSecret)
 }

--- a/internal/tpm/server.go
+++ b/internal/tpm/server.go
@@ -812,9 +812,8 @@ func convertEKPublicKeyToTPMTPublic(publicKey crypto.PublicKey) (*tpm2.TPMTPubli
 
 // convertEKECDSAPublicKey converts an ECDSA public key to TPM format
 func convertEKECDSAPublicKey(key *ecdsa.PublicKey) (*tpm2.TPMTPublic, error) {
-	// we currently only check the well known indexes of RSA2048 and ECC P256.
-	// We could support more, but we'd need to ensure that the Template's match up and
-	// only the P256 template is currently defined
+	// Currently only RSA2048 and ECC P256 EK Certs are supported. Should support for more ECC curves be added, this will
+	// need to change.
 	switch key.Curve.Params().Name {
 	case "P-256":
 	default:
@@ -838,8 +837,10 @@ func convertEKECDSAPublicKey(key *ecdsa.PublicKey) (*tpm2.TPMTPublic, error) {
 
 // convertEKRSAPublicKey converts an RSA public key to TPM format
 func convertEKRSAPublicKey(key *rsa.PublicKey) (*tpm2.TPMTPublic, error) {
-	if key.Size() < 256 { // 2048 bits minimum
-		return nil, fmt.Errorf("RSA key too small: %d bits (minimum 2048)", key.Size()*8)
+	// Currently only RSA2048 and ECC P256 EK Certs are supported. Should support for more RSA Key sizes be added,
+	// this will need to change
+	if key.Size() != 256 {
+		return nil, fmt.Errorf("unsupported RSA key size: %d bits", key.Size()*8)
 	}
 
 	tpmPublic := tpm2.RSAEKTemplate

--- a/internal/tpm/session.go
+++ b/internal/tpm/session.go
@@ -440,35 +440,76 @@ func (s *tpmSession) Close() error {
 	return nil
 }
 
+// checkEKCertExists checks if an EK certificate exists at the given NVRAM index
+// without reading the actual certificate data
+func (s *tpmSession) checkEKCertExists(nvIndex uint32) bool {
+	readPublicCmd := tpm2.NVReadPublic{
+		NVIndex: tpm2.TPMHandle(nvIndex),
+	}
+
+	publicResp, err := readPublicCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return false // Index doesn't exist or not accessible
+	}
+
+	nvPublic, err := publicResp.NVPublic.Contents()
+	if err != nil {
+		return false
+	}
+
+	return nvPublic.DataSize > 0 // Has actual data
+}
+
+// detectEKAlgorithm determines the EK algorithm based on which certificate
+// exists in NVRAM, prioritizing RSA first
+func (s *tpmSession) detectEKAlgorithm() (KeyAlgorithm, error) {
+	// Try RSA first (maintaining current priority)
+	if s.checkEKCertExists(client.EKCertNVIndexRSA) {
+		return RSA, nil
+	}
+
+	// Try ECC second
+	if s.checkEKCertExists(client.EKCertNVIndexECC) {
+		return ECDSA, nil
+	}
+
+	return "", fmt.Errorf("no EK certificate found in NVRAM")
+}
+
 // endorsementKeyCert reads endorsement key certificate from TPM NVRAM using direct commands
 func (s *tpmSession) endorsementKeyCert() ([]byte, error) {
 	if s.conn == nil {
 		return nil, fmt.Errorf("cannot read endorsement key certificate: no connection available")
 	}
 
-	// Try reading certificates from standard NVRAM indexes
-	// First try RSA, then ECC
-	var errs []error
-
-	// Try RSA EK certificate
-	certData, err := s.readEKCertFromNVRAM(client.EKCertNVIndexRSA)
+	// Detect which EK certificate type is available
+	ekAlgo, err := s.detectEKAlgorithm()
 	if err != nil {
-		errs = append(errs, fmt.Errorf("reading RSA EK certificate from NVRAM: %w", err))
-	} else if len(certData) > 0 {
-		s.log.Debugf("Successfully read RSA EK certificate: %d bytes", len(certData))
-		return certData, nil
+		return nil, fmt.Errorf("no endorsement key certificate found: %w", err)
 	}
 
-	// Try ECC EK certificate
-	certData, err = s.readEKCertFromNVRAM(client.EKCertNVIndexECC)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("reading ECC EK certificate from NVRAM: %w", err))
-	} else if len(certData) > 0 {
-		s.log.Debugf("Successfully read ECC EK certificate: %d bytes", len(certData))
-		return certData, nil
+	// Read the certificate from the appropriate index
+	var nvIndex uint32
+	switch ekAlgo {
+	case RSA:
+		nvIndex = client.EKCertNVIndexRSA
+	case ECDSA:
+		nvIndex = client.EKCertNVIndexECC
+	default:
+		return nil, fmt.Errorf("unsupported EK algorithm: %s", ekAlgo)
 	}
 
-	return nil, fmt.Errorf("no endorsement key certificate found: %w", errors.Join(errs...))
+	certData, err := s.readEKCertFromNVRAM(nvIndex)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s EK certificate from NVRAM: %w", ekAlgo, err)
+	}
+
+	if len(certData) == 0 {
+		return nil, fmt.Errorf("endorsement key certificate is empty")
+	}
+
+	s.log.Debugf("Successfully read %s EK certificate: %d bytes", ekAlgo, len(certData))
+	return certData, nil
 }
 
 // readEKCertFromNVRAM reads a certificate from the specified NVRAM index using Owner hierarchy
@@ -847,4 +888,134 @@ func (s *tpmSession) updateStorageHierarchyPassword(currentPassword, newPassword
 	}
 
 	return nil
+}
+
+// ekPolicy implements the policy callback for Endorsement Key authorization
+// This authorizes the use of EK by executing PolicySecret with the Endorsement hierarchy
+func ekPolicy(t transport.TPM, handle tpm2.TPMISHPolicy, nonceTPM tpm2.TPM2BNonce) error {
+	cmd := tpm2.PolicySecret{
+		AuthHandle: tpm2.AuthHandle{
+			Handle: tpm2.TPMRHEndorsement,
+			Auth:   tpm2.PasswordAuth(nil),
+		},
+		PolicySession: handle,
+		NonceTPM:      nonceTPM,
+	}
+	_, err := cmd.Execute(t)
+	return err
+}
+
+func (s *tpmSession) GenerateChallenge(secret []byte) ([]byte, []byte, error) {
+	ekAlgo, err := s.detectEKAlgorithm()
+	if err != nil {
+		return nil, nil, fmt.Errorf("detecting EK algorithm: %w", err)
+	}
+
+	var template tpm2.TPMTPublic
+	switch ekAlgo {
+	case ECDSA:
+		template = tpm2.ECCEKTemplate
+	case RSA:
+		template = tpm2.RSAEKTemplate
+	default:
+		return nil, nil, fmt.Errorf("unsupported key algorithm for EK: %s", ekAlgo)
+	}
+
+	cmd := tpm2.CreatePrimary{
+		PrimaryHandle: tpm2.TPMRHEndorsement,
+		InPublic:      tpm2.New2B(template),
+	}
+
+	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating EK primary: %w", err)
+	}
+
+	ekHandle := &tpm2.NamedHandle{
+		Handle: resp.ObjectHandle,
+		Name:   resp.Name,
+	}
+	defer func() { _ = s.flushHandle(ekHandle) }()
+
+	lakHandle, err := s.LoadKey(LAK)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading LAK: %w", err)
+	}
+
+	makeCred := tpm2.MakeCredential{
+		Handle:     ekHandle.Handle,
+		Credential: tpm2.TPM2BDigest{Buffer: secret},
+		ObjectName: lakHandle.Name,
+	}
+	makeResp, err := makeCred.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, nil, fmt.Errorf("TPM2_MakeCredential failed: %w", err)
+	}
+
+	return makeResp.CredentialBlob.Buffer, makeResp.Secret.Buffer, nil
+}
+
+// SolveChallenge uses TPM2_ActivateCredential to decrypt a credential challenge using the LAK as the ActivateHandle
+func (s *tpmSession) SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error) {
+	if len(credentialBlob) == 0 {
+		return nil, fmt.Errorf("credential blob is empty")
+	}
+	if len(encryptedSecret) == 0 {
+		return nil, fmt.Errorf("encrypted secret is empty")
+	}
+
+	ekAlgo, err := s.detectEKAlgorithm()
+	if err != nil {
+		return nil, fmt.Errorf("detecting EK algorithm: %w", err)
+	}
+
+	var template tpm2.TPMTPublic
+	switch ekAlgo {
+	case ECDSA:
+		template = tpm2.ECCEKTemplate
+	case RSA:
+		template = tpm2.RSAEKTemplate
+	default:
+		return nil, fmt.Errorf("unsupported key algorithm for EK: %s", ekAlgo)
+	}
+
+	cmd := tpm2.CreatePrimary{
+		PrimaryHandle: tpm2.TPMRHEndorsement,
+		InPublic:      tpm2.New2B(template),
+	}
+
+	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, fmt.Errorf("creating EK primary: %w", err)
+	}
+
+	ekHandle := &tpm2.NamedHandle{
+		Handle: resp.ObjectHandle,
+		Name:   resp.Name,
+	}
+	defer func() { _ = s.flushHandle(ekHandle) }()
+
+	lakHandle, err := s.LoadKey(LAK)
+	if err != nil {
+		return nil, fmt.Errorf("loading LAK: %w", err)
+	}
+
+	activate := tpm2.ActivateCredential{
+		ActivateHandle: *lakHandle,
+		KeyHandle: tpm2.AuthHandle{
+			Handle: ekHandle.Handle,
+			Name:   ekHandle.Name,
+			// Activating with the EK requires usage of a policy. This policy is derived from go-tpm
+			Auth: tpm2.Policy(tpm2.TPMAlgSHA256, 16, ekPolicy),
+		},
+		CredentialBlob: tpm2.TPM2BIDObject{Buffer: credentialBlob},
+		Secret:         tpm2.TPM2BEncryptedSecret{Buffer: encryptedSecret},
+	}
+
+	activateResp, err := activate.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, fmt.Errorf("TPM2_ActivateCredential failed: %w", err)
+	}
+
+	return activateResp.CertInfo.Buffer, nil
 }

--- a/internal/tpm/session.go
+++ b/internal/tpm/session.go
@@ -440,9 +440,9 @@ func (s *tpmSession) Close() error {
 	return nil
 }
 
-// checkEKCertExists checks if an EK certificate exists at the given NVRAM index
+// isEKCertPresent checks if an EK certificate exists at the given NVRAM index
 // without reading the actual certificate data
-func (s *tpmSession) checkEKCertExists(nvIndex uint32) bool {
+func (s *tpmSession) isEKCertPresent(nvIndex uint32) bool {
 	readPublicCmd := tpm2.NVReadPublic{
 		NVIndex: tpm2.TPMHandle(nvIndex),
 	}
@@ -463,13 +463,11 @@ func (s *tpmSession) checkEKCertExists(nvIndex uint32) bool {
 // detectEKAlgorithm determines the EK algorithm based on which certificate
 // exists in NVRAM, prioritizing RSA first
 func (s *tpmSession) detectEKAlgorithm() (KeyAlgorithm, error) {
-	// Try RSA first (maintaining current priority)
-	if s.checkEKCertExists(client.EKCertNVIndexRSA) {
+	if s.isEKCertPresent(client.EKCertNVIndexRSA) {
 		return RSA, nil
 	}
 
-	// Try ECC second
-	if s.checkEKCertExists(client.EKCertNVIndexECC) {
+	if s.isEKCertPresent(client.EKCertNVIndexECC) {
 		return ECDSA, nil
 	}
 

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -75,6 +75,10 @@ type Session interface {
 	GetPublicKey(keyType KeyType) (*tpm2.TPM2BPublic, error)
 	// GetEndorsementKeyCert returns the endorsement key certificate
 	GetEndorsementKeyCert() ([]byte, error)
+	// GenerateChallenge creates a credential challenge used to prove ownership
+	GenerateChallenge(secret []byte) ([]byte, []byte, error)
+	// SolveChallenge decrypts the encryptedSecret to prove ownership of the credentials
+	SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error)
 	// FlushAllTransientHandles aggressively flushes all transient handles
 	FlushAllTransientHandles() error
 	// Clear performs a best-effort clear of the TPM, resetting keys and auth


### PR DESCRIPTION
Adds the functionality to generate a credential blob and solve it. Adds a test to ensure the credentials are able to be generated and solved. This does not hook it up to anywhere yet. 

It is important that we know what type (ECC or RSA) of EK cert we've sent so that we can construct the TPM Public portion properly. For that reason I had to change the EKCert retrieval code a bit.

In the future the server will call `CreateCredentialChallenge` with the contents of the ER's CSR and the agent will solve the challenge. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ECC-based Endorsement Key flows added alongside RSA (supports P-256/P-384/P-521).
  * New API to create TPM credential challenges that returns credential blob, encrypted secret, and expected secret.
  * Session-level abilities to generate and solve credential challenges.

* **Bug Fixes**
  * Improved session cleanup to flush keys and surface aggregated errors.

* **Tests**
  * End-to-end simulator tests and mocks updated to exercise RSA and ECC challenge flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->