### PR TITLE
NO-ISSUE: fix deploy target

### DIFF
--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -150,6 +150,10 @@ if [[ "${LOGGED_IN}" == "false" ]]; then
 fi
 
 
-"${SCRIPT_DIR}"/setup_telemetry_gateway_certs.sh \
+# Setup telemetry gateway certificates (non-blocking)
+if ! "${SCRIPT_DIR}"/setup_telemetry_gateway_certs.sh \
   --sans "DNS:localhost,DNS:flightctl-telemetry-gateway.flightctl-external.svc,DNS:flightctl-telemetry-gateway.flightctl-external.svc.cluster.local,DNS:telemetry-gateway.${IP}.nip.io,IP:127.0.0.1" \
-  --force-rotate
+  --force-rotate; then
+  echo "WARNING: Failed to setup telemetry gateway certificates. Deployment will continue without them."
+  echo "You can manually run the certificate setup later if needed."
+fi


### PR DESCRIPTION
fixes deploy script:
1. retries fetching the certificate after approval
2. allows the telemetry server deploy to fail but does not fail the full deploy script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now continues if telemetry certificate setup fails, showing clear warnings instead of stopping.
  * Certificate retrieval is more reliable with a short retry loop, reducing intermittent failures during setup.

* **Chores**
  * Improved logging around telemetry certificate setup with guidance for manual follow-up.
  * Added inline notes clarifying the non-blocking behavior during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->