### PR TITLE
EDM-2136: prevent decommissioned device from re-enrolling

### DIFF
--- a/docs/user/managing-devices.md
+++ b/docs/user/managing-devices.md
@@ -847,6 +847,8 @@ When the device has completed its decommissioning steps, the `status.lifecycle.s
 flightctl delete devices/<some_device_name>
 ```
 
+**Important**: Once a device has been decommissioned, it cannot be re-enrolled. If a decommissioned device attempts to submit a new enrollment request, the request will be rejected with a 403 Forbidden error and the message "device has been decommissioned and cannot be re-enrolled". This prevents previously decommissioned devices from re-joining the fleet.
+
 ## Scheduling Updates and Downloads
 
 The Flight Control agent supports time-based scheduling for update and download operations using cron style expressions. This allows you to restrict system modifications to defined maintenance windows or operational periods.

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -61,6 +61,10 @@ func (m *MockStore) Organization() store.Organization {
 	return nil
 }
 
+func (m *MockStore) DecommissionedDevice() store.DecommissionedDevice {
+	return nil
+}
+
 func (m *MockStore) RunMigrations(context.Context) error {
 	return nil
 }

--- a/internal/instrumentation/metrics/domain/fleet_test.go
+++ b/internal/instrumentation/metrics/domain/fleet_test.go
@@ -162,6 +162,10 @@ func (m *MockFleetStoreWrapper) Organization() store.Organization {
 	return nil
 }
 
+func (m *MockFleetStoreWrapper) DecommissionedDevice() store.DecommissionedDevice {
+	return nil
+}
+
 func (m *MockFleetStoreWrapper) RunMigrations(context.Context) error {
 	return nil
 }

--- a/internal/instrumentation/metrics/domain/repository_test.go
+++ b/internal/instrumentation/metrics/domain/repository_test.go
@@ -35,6 +35,7 @@ func (m *MockRepositoryStore) ResourceSync() store.ResourceSync                 
 func (m *MockRepositoryStore) Event() store.Event                                         { return nil }
 func (m *MockRepositoryStore) Checkpoint() store.Checkpoint                               { return nil }
 func (m *MockRepositoryStore) Organization() store.Organization                           { return nil }
+func (m *MockRepositoryStore) DecommissionedDevice() store.DecommissionedDevice           { return nil }
 func (m *MockRepositoryStore) RunMigrations(context.Context) error                        { return nil }
 func (m *MockRepositoryStore) Close() error                                               { return nil }
 func (m *MockRepositoryStore) CheckHealth(context.Context) error                          { return nil }

--- a/internal/instrumentation/metrics/domain/resourcesync_test.go
+++ b/internal/instrumentation/metrics/domain/resourcesync_test.go
@@ -31,12 +31,13 @@ func (m *MockResourceSyncStore) Repository() store.Repository           { return
 func (m *MockResourceSyncStore) ResourceSync() store.ResourceSync {
 	return &MockResourceSync{results: m.results}
 }
-func (m *MockResourceSyncStore) Event() store.Event                  { return nil }
-func (m *MockResourceSyncStore) Checkpoint() store.Checkpoint        { return nil }
-func (m *MockResourceSyncStore) Organization() store.Organization    { return nil }
-func (m *MockResourceSyncStore) RunMigrations(context.Context) error { return nil }
-func (m *MockResourceSyncStore) Close() error                        { return nil }
-func (m *MockResourceSyncStore) CheckHealth(context.Context) error   { return nil }
+func (m *MockResourceSyncStore) Event() store.Event                               { return nil }
+func (m *MockResourceSyncStore) Checkpoint() store.Checkpoint                     { return nil }
+func (m *MockResourceSyncStore) Organization() store.Organization                 { return nil }
+func (m *MockResourceSyncStore) DecommissionedDevice() store.DecommissionedDevice { return nil }
+func (m *MockResourceSyncStore) RunMigrations(context.Context) error              { return nil }
+func (m *MockResourceSyncStore) Close() error                                     { return nil }
+func (m *MockResourceSyncStore) CheckHealth(context.Context) error                { return nil }
 
 type MockResourceSync struct {
 	results []store.CountByResourceSyncOrgAndStatusResult

--- a/internal/service/decommissioned_device_service.go
+++ b/internal/service/decommissioned_device_service.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// DecommissionedDeviceService handles all decommissioned device related operations
+type DecommissionedDeviceService struct {
+	store store.Store
+	log   logrus.FieldLogger
+}
+
+// NewDecommissionedDeviceService creates a new DecommissionedDeviceService
+func NewDecommissionedDeviceService(store store.Store, log logrus.FieldLogger) *DecommissionedDeviceService {
+	return &DecommissionedDeviceService{
+		store: store,
+		log:   log,
+	}
+}
+
+// GetDecommissionedDevice retrieves a decommissioned device by ID
+func (s *DecommissionedDeviceService) GetDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string) (*model.DecommissionedDevice, error) {
+	return s.store.DecommissionedDevice().GetDecommissionedDevice(ctx, orgId, deviceId)
+}
+
+// ListDecommissionedDevices lists decommissioned devices with pagination
+func (s *DecommissionedDeviceService) ListDecommissionedDevices(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) ([]model.DecommissionedDevice, error) {
+	return s.store.DecommissionedDevice().ListDecommissionedDevices(ctx, orgId, listParams)
+}
+
+// CreateDecommissionedDevice creates a new entry in the decommissioned devices table
+func (s *DecommissionedDeviceService) CreateDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string, certificateExpirationDate time.Time) error {
+	return s.store.DecommissionedDevice().CreateDecommissionedDevice(ctx, orgId, deviceId, certificateExpirationDate)
+}
+
+// HandleDeviceDecommission handles the complete decommission process for a device
+func (s *DecommissionedDeviceService) HandleDeviceDecommission(ctx context.Context, orgId uuid.UUID, deviceName string) {
+	// Try to get certificate expiration date from enrollment request
+	certExpiration, certErr := s.getCertificateExpirationFromEnrollmentRequest(ctx, orgId, deviceName)
+	if certErr != nil {
+		s.log.WithError(certErr).Warnf("Failed to get certificate expiration for decommissioned device %s, using current time", deviceName)
+		certExpiration = time.Now()
+	}
+
+	// Add to decommissioned devices table
+	if err := s.CreateDecommissionedDevice(ctx, orgId, deviceName, certExpiration); err != nil {
+		s.log.WithError(err).Errorf("Failed to add device %s to decommissioned devices table", deviceName)
+	} else {
+		s.log.Infof("Added device %s to decommissioned devices table with certificate expiration %v", deviceName, certExpiration)
+	}
+}
+
+// extractCertificateExpirationDate extracts the expiration date from a PEM-encoded certificate
+func (s *DecommissionedDeviceService) extractCertificateExpirationDate(certPEM string) (time.Time, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return time.Time{}, fmt.Errorf("failed to decode PEM block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return cert.NotAfter, nil
+}
+
+// getCertificateExpirationFromEnrollmentRequest retrieves the certificate expiration date from the enrollment request
+func (s *DecommissionedDeviceService) getCertificateExpirationFromEnrollmentRequest(ctx context.Context, orgId uuid.UUID, deviceName string) (time.Time, error) {
+	// Get the enrollment request for this device
+	enrollmentReq, err := s.store.EnrollmentRequest().Get(ctx, orgId, deviceName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to get enrollment request: %w", err)
+	}
+
+	if enrollmentReq.Status == nil || enrollmentReq.Status.Certificate == nil {
+		return time.Time{}, fmt.Errorf("no certificate found in enrollment request")
+	}
+
+	return s.extractCertificateExpirationDate(*enrollmentReq.Status.Certificate)
+}
+
+// IsDeviceDecommissioned checks if a device is in the decommissioned devices table
+func (s *DecommissionedDeviceService) IsDeviceDecommissioned(ctx context.Context, orgId uuid.UUID, deviceName string) (bool, error) {
+	_, err := s.store.DecommissionedDevice().GetDecommissionedDevice(ctx, orgId, deviceName)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, flterrors.ErrResourceNotFound) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -648,6 +648,12 @@ func (h *ServiceHandler) callbackDeviceUpdated(ctx context.Context, resourceKind
 // callbackDeviceDecommission is the device-specific callback that handles device decommission events
 func (h *ServiceHandler) callbackDeviceDecommission(ctx context.Context, resourceKind api.ResourceKind, orgId uuid.UUID, name string, oldResource, newResource interface{}, created bool, err error) {
 	h.eventHandler.HandleDeviceDecommissionEvents(ctx, resourceKind, orgId, name, oldResource, newResource, created, err)
+
+	// Add device to decommissioned devices table when decommissioning starts
+	// This callback is only called during decommission operations, so we always add the device
+	if err == nil {
+		h.decommissionedDeviceService.HandleDeviceDecommission(ctx, orgId, name)
+	}
 }
 
 // callbackDeviceDeleted is the device-specific callback that handles device deletion events

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -9,27 +9,29 @@ import (
 )
 
 type ServiceHandler struct {
-	eventHandler  *EventHandler
-	store         store.Store
-	ca            *crypto.CAClient
-	log           logrus.FieldLogger
-	workerClient  worker_client.WorkerClient
-	kvStore       kvstore.KVStore
-	agentEndpoint string
-	uiUrl         string
-	tpmCAPaths    []string
+	eventHandler                *EventHandler
+	decommissionedDeviceService *DecommissionedDeviceService
+	store                       store.Store
+	ca                          *crypto.CAClient
+	log                         logrus.FieldLogger
+	workerClient                worker_client.WorkerClient
+	kvStore                     kvstore.KVStore
+	agentEndpoint               string
+	uiUrl                       string
+	tpmCAPaths                  []string
 }
 
 func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tpmCAPaths []string) *ServiceHandler {
 	return &ServiceHandler{
-		eventHandler:  NewEventHandler(store, workerClient, log),
-		store:         store,
-		ca:            ca,
-		log:           log,
-		workerClient:  workerClient,
-		kvStore:       kvStore,
-		agentEndpoint: agentEndpoint,
-		uiUrl:         uiUrl,
-		tpmCAPaths:    tpmCAPaths,
+		eventHandler:                NewEventHandler(store, workerClient, log),
+		decommissionedDeviceService: NewDecommissionedDeviceService(store, log),
+		store:                       store,
+		ca:                          ca,
+		log:                         log,
+		workerClient:                workerClient,
+		kvStore:                     kvStore,
+		agentEndpoint:               agentEndpoint,
+		uiUrl:                       uiUrl,
+		tpmCAPaths:                  tpmCAPaths,
 	}
 }

--- a/internal/store/decommissioned_device.go
+++ b/internal/store/decommissioned_device.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// DecommissionedDevice interface defines methods for managing decommissioned devices
+type DecommissionedDevice interface {
+	InitialMigration(ctx context.Context) error
+	CreateDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string, certificateExpirationDate time.Time) error
+	GetDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string) (*model.DecommissionedDevice, error)
+	ListDecommissionedDevices(ctx context.Context, orgId uuid.UUID, listParams ListParams) ([]model.DecommissionedDevice, error)
+}
+
+// DecommissionedDeviceStore implements the DecommissionedDevice interface
+type DecommissionedDeviceStore struct {
+	dbHandler *gorm.DB
+	log       logrus.FieldLogger
+}
+
+// Make sure we conform to DecommissionedDevice interface
+var _ DecommissionedDevice = (*DecommissionedDeviceStore)(nil)
+
+// NewDecommissionedDevice creates a new DecommissionedDeviceStore instance
+func NewDecommissionedDevice(db *gorm.DB, log logrus.FieldLogger) DecommissionedDevice {
+	return &DecommissionedDeviceStore{dbHandler: db, log: log}
+}
+
+func (s *DecommissionedDeviceStore) getDB(ctx context.Context) *gorm.DB {
+	return s.dbHandler.WithContext(ctx)
+}
+
+func (s *DecommissionedDeviceStore) InitialMigration(ctx context.Context) error {
+	db := s.getDB(ctx)
+	return db.AutoMigrate(&model.DecommissionedDevice{})
+}
+
+// CreateDecommissionedDevice creates a new entry in the decommissioned devices table
+func (s *DecommissionedDeviceStore) CreateDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string, certificateExpirationDate time.Time) error {
+	decommissionedDevice := &model.DecommissionedDevice{
+		ID:                        deviceId,
+		OrgID:                     orgId,
+		CertificateExpirationDate: certificateExpirationDate,
+		DecommissionedAt:          time.Now(),
+	}
+
+	result := s.getDB(ctx).Create(decommissionedDevice)
+	return ErrorFromGormError(result.Error)
+}
+
+// GetDecommissionedDevice retrieves a decommissioned device by ID
+func (s *DecommissionedDeviceStore) GetDecommissionedDevice(ctx context.Context, orgId uuid.UUID, deviceId string) (*model.DecommissionedDevice, error) {
+	var decommissionedDevice model.DecommissionedDevice
+	result := s.getDB(ctx).Where("org_id = ? AND id = ?", orgId, deviceId).First(&decommissionedDevice)
+	if result.Error != nil {
+		return nil, ErrorFromGormError(result.Error)
+	}
+	return &decommissionedDevice, nil
+}
+
+// ListDecommissionedDevices lists decommissioned devices with pagination
+func (s *DecommissionedDeviceStore) ListDecommissionedDevices(ctx context.Context, orgId uuid.UUID, listParams ListParams) ([]model.DecommissionedDevice, error) {
+	var decommissionedDevices []model.DecommissionedDevice
+
+	query := s.getDB(ctx).Where("org_id = ?", orgId)
+
+	// Apply pagination
+	if listParams.Limit > 0 {
+		query = query.Limit(listParams.Limit)
+	}
+
+	// Apply deterministic ordering for stable pagination
+	query = query.Order("decommissioned_at DESC, id DESC")
+
+	result := query.Find(&decommissionedDevices)
+	if result.Error != nil {
+		return nil, ErrorFromGormError(result.Error)
+	}
+
+	return decommissionedDevices, nil
+}

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -72,6 +72,7 @@ type Device interface {
 	Count(ctx context.Context, orgId uuid.UUID, listParams ListParams) (int64, error)
 	UnmarkRolloutSelection(ctx context.Context, orgId uuid.UUID, fleetName string) error
 	MarkRolloutSelection(ctx context.Context, orgId uuid.UUID, listParams ListParams, limit *int) error
+
 	CompletionCounts(ctx context.Context, orgId uuid.UUID, owner string, templateVersion string, updateTimeout *time.Duration) ([]api.DeviceCompletionCount, error)
 	CountByLabels(ctx context.Context, orgId uuid.UUID, listParams ListParams, groupBy []string) ([]map[string]any, error)
 	Summary(ctx context.Context, orgId uuid.UUID, listParams ListParams) (*api.DevicesSummary, error)

--- a/internal/store/model/decommissioned_device.go
+++ b/internal/store/model/decommissioned_device.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DecommissionedDevice represents a device that has been decommissioned
+type DecommissionedDevice struct {
+	// Primary key - device name
+	ID string `gorm:"primaryKey"`
+
+	// Organization ID
+	OrgID uuid.UUID `gorm:"type:uuid;index"`
+
+	// Certificate expiration date
+	CertificateExpirationDate time.Time `gorm:"index"`
+
+	// Timestamp when the device was decommissioned
+	DecommissionedAt time.Time `gorm:"index"`
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ var (
 
 type Store interface {
 	Device() Device
+	DecommissionedDevice() DecommissionedDevice
 	EnrollmentRequest() EnrollmentRequest
 	CertificateSigningRequest() CertificateSigningRequest
 	Fleet() Fleet
@@ -37,6 +38,7 @@ type Store interface {
 
 type DataStore struct {
 	device                    Device
+	decommissionedDevice      DecommissionedDevice
 	enrollmentRequest         EnrollmentRequest
 	certificateSigningRequest CertificateSigningRequest
 	fleet                     Fleet
@@ -53,6 +55,7 @@ type DataStore struct {
 func NewStore(db *gorm.DB, log logrus.FieldLogger) Store {
 	return &DataStore{
 		device:                    NewDevice(db, log),
+		decommissionedDevice:      NewDecommissionedDevice(db, log),
 		enrollmentRequest:         NewEnrollmentRequest(db, log),
 		certificateSigningRequest: NewCertificateSigningRequest(db, log),
 		fleet:                     NewFleet(db, log),
@@ -72,6 +75,10 @@ func (s *DataStore) Repository() Repository {
 
 func (s *DataStore) Device() Device {
 	return s.device
+}
+
+func (s *DataStore) DecommissionedDevice() DecommissionedDevice {
+	return s.decommissionedDevice
 }
 
 func (s *DataStore) EnrollmentRequest() EnrollmentRequest {
@@ -157,6 +164,9 @@ func (s *DataStore) RunMigrationWithMigrationUser(ctx context.Context, cfg *conf
 
 func (s *DataStore) RunMigrations(ctx context.Context) error {
 	if err := s.Device().InitialMigration(ctx); err != nil {
+		return err
+	}
+	if err := s.DecommissionedDevice().InitialMigration(ctx); err != nil {
 		return err
 	}
 	if err := s.EnrollmentRequest().InitialMigration(ctx); err != nil {


### PR DESCRIPTION
add a decommissioned device table that is consulted upon new ER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enrollment requests from decommissioned devices are now blocked with 403 Forbidden and a clear message, preventing re-enrollment.
  - Devices are recorded as decommissioned when decommissioning starts, ensuring consistent enforcement.

- Documentation
  - Added Important notes clarifying that decommissioned devices cannot be re-enrolled and detailing the 403 Forbidden response and message.

- Tests
  - Added unit and integration tests covering decommissioned-device enrollment validation and expected API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->