### PR TITLE
EDM-2135: fixed resume command not returning an error

### DIFF
--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -167,7 +167,7 @@ func (o *ResumeOptions) runSingleResume(ctx context.Context, c *apiclient.Client
 			if response.JSON200.ResumedDevices == 1 {
 				fmt.Printf("Resume request for %s \"%s\" completed\n", DeviceKind, name)
 			} else {
-				fmt.Printf("failed resuming device %s, device doesnt exists or already resumed\n", name)
+				return fmt.Errorf("failed resuming device %s, device doesnt exists or already resumed", name)
 			}
 		case http.StatusBadRequest:
 			return fmt.Errorf("invalid request for device %s", name)

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -179,12 +179,12 @@ func TestResumeOptions_runSingleResume(t *testing.T) {
 			expectOutput: "Resume request for device \"test-device\" completed",
 		},
 		{
-			name:         "device not found",
-			deviceName:   "missing-device",
-			httpStatus:   http.StatusOK,
-			responseBody: `{"resumedDevices": 0}`,
-			expectError:  false,
-			expectOutput: "failed resuming device missing-device, device doesnt exists or already resumed",
+			name:          "device not found",
+			deviceName:    "missing-device",
+			httpStatus:    http.StatusOK,
+			responseBody:  `{"resumedDevices": 0}`,
+			expectError:   true,
+			errorContains: "failed resuming device missing-device, device doesnt exists or already resumed",
 		},
 		{
 			name:          "server error",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-device resume now returns an explicit error when the device doesn’t exist or is already resumed, instead of only printing a message—making failures explicit and script-friendly; bulk resume behavior unchanged.

* **Tests**
  * Updated tests to expect and validate an error for single-device resume failures, including the corresponding error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->