### PR TITLE
EDM-2098: SELinux - Allow read/write of bin_t domain

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -61,6 +61,10 @@ manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)
 manage_files_pattern(flightctl_agent_t, etc_t, etc_t)
 manage_lnk_files_pattern(flightctl_agent_t, etc_t, etc_t)
 
+manage_dirs_pattern(flightctl_agent_t, bin_t, bin_t)
+manage_files_pattern(flightctl_agent_t, bin_t, bin_t)
+manage_lnk_files_pattern(flightctl_agent_t, bin_t, bin_t)
+
 manage_dirs_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 manage_files_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
 manage_lnk_files_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)


### PR DESCRIPTION
There are certain directories in /etc (e.g. /etc/profile.d) that uses the file context of `bin_t` and the agent should be able to write there.

In general there is no reason the agent shouldn't be able to manage all bin files on the system, even though generally this would be handled by ostree/bootc.