### PR TITLE
EDM-1870: enable client and agent deployment from brew build in e2e

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -301,6 +301,24 @@ export FLIGHTCTL_RPM=devel/0.3.0.rc2-1.20241104145530808450.main.19.ga531984
 make in-cluster-e2e-test
 ```
 
+#### Using Brew Registry Builds
+
+You can also use RPMs from the Red Hat Brew registry by specifying a `BREW_BUILD_URL`. This is useful for testing
+specific builds from the Red Hat internal build system.
+
+To use a brew build for both the agent image and CLI, set the `BREW_BUILD_URL` environment variable:
+
+```bash
+export FLIGHTCTL_NS=flightctl
+export KUBEADMIN_PASS=your-oc-password-for-kubeadmin
+export BREW_BUILD_URL=brew-registry-build-url
+
+make in-cluster-e2e-test
+```
+
+The `BREW_BUILD_URL` should be a valid URL to the Red Hat Brew system task page. Both the agent image and CLI will be built
+using the RPMs downloaded from the specified brew URL.
+
 #### If your host system is not suitable for bootc image builder
 
 * Create a test vm. Note the ssh command in the cmd output.

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("VM Agent behavior", func() {
 	Context("vm", func() {
-		It("Verify VM agent", Label("80455"), func() {
+		It("Verify VM agent", Label("80455", "rpm-sanity"), func() {
 			// Get harness directly - no shared package-level variable
 			harness := e2e.GetWorkerHarness()
 

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -13,6 +13,7 @@ FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG RPM_COPR=
 ARG RPM_PACKAGE=flightctl-agent
 ARG REGISTRY_ADDRESS
+ARG BREW_BUILD_URL=
 
 # Fail early when the build argument is missing
 RUN test -n "${REGISTRY_ADDRESS}" || (echo "REGISTRY_ADDRESS build arg is required" >&2 && exit 1)
@@ -20,16 +21,23 @@ RUN test -n "${REGISTRY_ADDRESS}" || (echo "REGISTRY_ADDRESS build arg is requir
 COPY bin/e2e-certs/pki/CA/ca.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
-COPY bin/rpm/flightctl-*.rpm /tmp/
+# Copy entire bin directory to /tmp for build process
+COPY bin/ /tmp/bin/
 
-RUN if [[ -z $RPM_COPR ]]; then \
-        dnf install -y /tmp/flightctl-agent-*.rpm /tmp/flightctl-selinux-*.rpm ; \
-    else \
-        dnf copr -y enable ${RPM_COPR} &&  \
+RUN if [[ -n "$BREW_BUILD_URL" ]]; then \
+        echo "Installing RPMs from brew URL: ${BREW_BUILD_URL}"; \
+        dnf install -y /tmp/bin/brew-rpm/flightctl-agent-*.rpm /tmp/bin/brew-rpm/flightctl-selinux-*.rpm /tmp/bin/brew-rpm/flightctl-debuginfo-*.rpm; \
+    elif [[ -n "$RPM_COPR" ]]; then \
+        echo "Installing RPMs from COPR repository: ${RPM_COPR}" && \
+        dnf copr -y enable ${RPM_COPR} && \
         dnf install -y ${RPM_PACKAGE}; \
+    else \
+        echo "Installing local RPMs" && \
+        dnf install -y /tmp/bin/rpm/flightctl-agent-*.rpm /tmp/bin/rpm/flightctl-selinux-*.rpm; \
     fi && \
-    systemctl enable flightctl-agent.service
-
+    systemctl enable flightctl-agent.service && \
+    echo "Cleaning up build files from /tmp/bin" && \
+    rm -rf /tmp/bin
 
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
@@ -70,4 +78,3 @@ RUN mkdir -p /etc/containers/registries.conf.d/ && \
     echo "[[registry]]" > /etc/containers/registries.conf.d/custom-registry.conf && \
     echo "location = \"${REGISTRY_ADDRESS}\"" >> /etc/containers/registries.conf.d/custom-registry.conf && \
     echo "insecure = true" >> /etc/containers/registries.conf.d/custom-registry.conf
-RUN  mkdir -p /etc/containers/registries.conf.d/ && echo -e '[[registry]]\nlocation = "10.100.102.70:5000"\ninsecure = true' > /etc/containers/registries.conf.d/flightctl-e2e.conf

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -3,7 +3,7 @@ bin/output/qcow2/disk.qcow2: bin/.e2e-agent-images
 
 bin/.e2e-agent-images: deploy-e2e-extras rpm bin/flightctl-agent bin/e2e-certs
 	./test/scripts/agent-images/prepare_agent_config.sh
-	BUILD_TYPE=$(BUILD_TYPE) ./test/scripts/agent-images/create_agent_images.sh
+	BUILD_TYPE=$(BUILD_TYPE) BREW_BUILD_URL=$(BREW_BUILD_URL) ./test/scripts/agent-images/create_agent_images.sh
 	./test/scripts/agent-images/create_application_image.sh
 	touch bin/.e2e-agent-images
 
@@ -15,4 +15,5 @@ clean-e2e-agent-images:
 	rm -rf bin/dnf-cache
 	rm -rf bin/osbuild-cache
 	rm -rf bin/rpm
+	rm -rf bin/brew-rpm
 

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -226,3 +226,74 @@ function get_ocp_nodes_network() {
   done
 }
 
+# download_brew_rpms downloads RPMs from brew registry to a target directory
+# Usage: download_brew_rpms <target_dir> [required_patterns...]
+# Environment Variables:
+#   BREW_BUILD_URL - Full URL to brew page (required)
+# Example: BREW_BUILD_URL="https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=68817381" download_brew_rpms "bin/brew-rpm" "flightctl-agent-*" "flightctl-selinux*"
+download_brew_rpms() {
+    local target_dir="$1"
+    shift 1
+    local required_patterns=("$@")
+
+    # Check if BREW_BUILD_URL is set
+    if [[ -z "${BREW_BUILD_URL:-}" ]]; then
+        echo "ERROR: BREW_BUILD_URL environment variable is required"
+        return 1
+    fi
+
+    mkdir -p "${target_dir}"
+    echo "🧹 Cleaning ${target_dir} directory of old builds..."
+    rm -f "${target_dir}"/*.rpm "${target_dir}"/flightctl 2>/dev/null || true
+
+    cd "${target_dir}"
+
+    # Use BREW_BUILD_URL directly
+    local brew_url="${BREW_BUILD_URL}"
+    echo "Using BREW_BUILD_URL: ${brew_url}"
+
+    # Fetch and validate brew page
+    echo "Fetching RPM URLs from brew..."
+    local brew_page
+    brew_page=$(curl -k -s "${brew_url}")
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to fetch brew page from URL: ${brew_url}"
+        return 1
+    fi
+
+    local rpm_urls
+    rpm_urls=$(echo "${brew_page}" | grep -oP 'https://[^"]+\.rpm')
+
+    if [[ -z "${rpm_urls}" ]]; then
+        echo "ERROR: No RPM URLs found in brew page"
+        echo "Brew URL: ${brew_url}"
+        echo "Brew page content:"
+        echo "${brew_page}" | head -20
+        return 1
+    fi
+
+    # Download RPMs
+    echo "Downloading RPMs..."
+    while IFS= read -r url; do
+        local filename=$(basename "$url")
+        echo "Downloading $filename..."
+        if wget --no-check-certificate -O "$filename" "$url"; then
+            echo "✅ Successfully downloaded $filename"
+        else
+            echo "❌ Failed to download $filename"
+            return 1
+        fi
+    done <<< "${rpm_urls}"
+
+    # Verify required patterns
+    for pattern in "${required_patterns[@]}"; do
+        if ! ls ${pattern} >/dev/null 2>&1; then
+            echo "ERROR: Required RPM pattern '${pattern}' not found in brew page"
+            echo "Brew URL: ${brew_url}"
+            return 1
+        fi
+    done
+
+    cd - > /dev/null
+    return 0
+}


### PR DESCRIPTION
Enabling E2E test with Brew builds using a BREW_BUILD_URL. 

```
BREW_BUILD_URL=<brew-build-url> make in-cluster-e2e-test
```
Also adding the label rpm-sanity, including tests for:
agent, client, server version check, 
agent SElinux label, 
fips is enabled, 
version output show the right tag.

```
make run-e2e-test GINKGO_LABEL_FILTER="rpm-sanity"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Expanded testing guide with Brew registry RPM usage (BREW_BUILD_URL), VM deployment/SSH workflow (KUBECONFIG_PATH, VM disk sizing override), and duplicated Brew instructions added in two locations.

- Tests
  - Added FIPS runtime compliance test, strengthened version checks to validate client/server/agent (agent==server), and applied rpm-sanity labels to relevant tests; expanded e2e harness with VM pool, Git server and CLI/version helpers.

- Chores
  - Test image/build tooling now supports Brew/COPR/local RPM sources, adds RPM download/install flow, and improves image rebuild/sync messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->