### PR TITLE
EDM-2058: agent/client: add retry transport and RequestHook

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -100,7 +100,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	executer := &executer.CommonExecuter{}
 
 	// create enrollment client
-	enrollmentClient, err := newEnrollmentClient(a.config)
+	enrollmentClient, err := newEnrollmentClient(a.config, a.log)
 	if err != nil {
 		return err
 	}
@@ -349,8 +349,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	return agent.Run(ctx)
 }
 
-func newEnrollmentClient(cfg *agent_config.Config) (client.Enrollment, error) {
-	httpClient, err := client.NewFromConfig(&cfg.EnrollmentService.Config)
+func newEnrollmentClient(cfg *agent_config.Config, log *log.PrefixLogger) (client.Enrollment, error) {
+	httpClient, err := client.NewFromConfig(&cfg.EnrollmentService.Config, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -16,6 +16,7 @@ import (
 	baseclient "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/container"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
 	"github.com/flightctl/flightctl/pkg/reqid"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -24,11 +25,22 @@ import (
 type RPCMetricsCallback func(operation string, durationSeconds float64, err error)
 
 // NewFromConfig returns a new Flight Control API client from the given config.
-func NewFromConfig(config *baseclient.Config) (*client.ClientWithResponses, error) {
+func NewFromConfig(config *baseclient.Config, log *log.PrefixLogger, opts ...HTTPClientOption) (*client.ClientWithResponses, error) {
+	options := &httpClientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	httpClient, err := baseclient.NewHTTPClientFromConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("NewFromConfig: creating HTTP client %w", err)
 	}
+
+	if options.retryConfig != nil {
+		retryTransport := NewRetryTransport(httpClient.Transport, log, *options.retryConfig)
+		httpClient.Transport = retryTransport
+	}
+
 	ref := client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 		req.Header.Set(middleware.RequestIDHeader, reqid.NextRequestID())
 		return nil
@@ -196,5 +208,19 @@ func WithPullSecret(path string) ClientOption {
 func Timeout(timeout time.Duration) ClientOption {
 	return func(opts *clientOptions) {
 		opts.timeout = timeout
+	}
+}
+
+// HTTPClientOption is a functional option for configuring the HTTP client
+type HTTPClientOption func(*httpClientOptions)
+
+type httpClientOptions struct {
+	retryConfig *poll.Config
+}
+
+// WithHTTPRetry configures custom retry settings for the HTTP client
+func WithHTTPRetry(config poll.Config) HTTPClientOption {
+	return func(opts *httpClientOptions) {
+		opts.retryConfig = &config
 	}
 }

--- a/internal/agent/client/transport.go
+++ b/internal/agent/client/transport.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
+)
+
+type contextKey string
+
+const responseHookKey contextKey = "responseHook"
+
+// ResponseHook is called before retry decision is made
+// Return true to continue with retry logic, false to stop retrying
+type ResponseHook func(resp *http.Response, attempt int) bool
+
+type RetryTransport struct {
+	transport  http.RoundTripper
+	pollConfig poll.Config
+	log        *log.PrefixLogger
+}
+
+func NewRetryTransport(transport http.RoundTripper, log *log.PrefixLogger, pollConfig poll.Config) *RetryTransport {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &RetryTransport{
+		transport:  transport,
+		log:        log,
+		pollConfig: pollConfig,
+	}
+}
+
+func (r *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= r.pollConfig.MaxSteps; attempt++ {
+		if body != nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
+
+		if attempt > 0 {
+			r.log.Debugf("Retry attempt %d/%d for %s %s", attempt, r.pollConfig.MaxSteps, req.Method, req.URL.Path)
+		}
+
+		resp, err = r.transport.RoundTrip(req)
+		if err != nil {
+			r.log.Debugf("Request failed with error: %v", err)
+			return nil, err
+		}
+
+		// fire hook if defined
+		if hook, ok := req.Context().Value(responseHookKey).(ResponseHook); ok {
+			if !hook(resp, attempt) {
+				return resp, nil
+			}
+		}
+
+		if !shouldRetry(resp.StatusCode) || attempt >= r.pollConfig.MaxSteps {
+			if shouldRetry(resp.StatusCode) && attempt >= r.pollConfig.MaxSteps {
+				r.log.Debugf("Max retry attempts reached (%d), returning response with status %d", r.pollConfig.MaxSteps, resp.StatusCode)
+			}
+			return resp, nil
+		}
+
+		wait := poll.CalculateBackoffDelay(&r.pollConfig, attempt+1)
+
+		// check Retry-After header
+		if retryAfter := r.parseRetryAfter(resp); retryAfter > 0 {
+			wait = retryAfter
+			r.log.Debugf("Using Retry-After header value: %v", wait)
+		}
+
+		r.log.Debugf("Request failed with status %d, retrying in %v", resp.StatusCode, wait)
+
+		resp.Body.Close()
+
+		select {
+		case <-time.After(wait):
+			// retry
+		case <-req.Context().Done():
+			// honor context
+			return nil, req.Context().Err()
+		}
+	}
+
+	return resp, err
+}
+
+func shouldRetry(statusCode int) bool {
+	// Retry on:
+	// - 429: Too Many Requests (rate limiting)
+	// - 5xx: All server errors (500-599)
+	if statusCode == http.StatusTooManyRequests || (statusCode >= 500 && statusCode < 600) {
+		return true
+	}
+	return false
+}
+
+// WithResponseHook creates a RequestEditorFn that adds a response hook to the request context
+// The hook will be called before retry decisions are made
+func WithResponseHook(hook ResponseHook) func(ctx context.Context, req *http.Request) error {
+	return func(ctx context.Context, req *http.Request) error {
+		*req = *req.WithContext(context.WithValue(req.Context(), responseHookKey, hook))
+		return nil
+	}
+}
+
+func (r *RetryTransport) parseRetryAfter(resp *http.Response) time.Duration {
+	retryAfter := resp.Header.Get("Retry-After")
+	if retryAfter == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(retryAfter); err == nil {
+		duration := time.Duration(seconds) * time.Second
+		// cap the retry-after to MaxDelay
+		if r.pollConfig.MaxDelay > 0 && duration > r.pollConfig.MaxDelay {
+			return r.pollConfig.MaxDelay
+		}
+		return duration
+	}
+
+	if t, err := http.ParseTime(retryAfter); err == nil {
+		duration := time.Until(t)
+		if duration < 0 {
+			return 0
+		}
+		// cap the retry-after to MaxDelay
+		if r.pollConfig.MaxDelay > 0 && duration > r.pollConfig.MaxDelay {
+			return r.pollConfig.MaxDelay
+		}
+		return duration
+	}
+
+	return 0
+}

--- a/internal/agent/client/transport_test.go
+++ b/internal/agent/client/transport_test.go
@@ -1,0 +1,261 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/poll"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryTransport_RetryOn429(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, err := w.Write([]byte("Rate limited"))
+			require.NoError(err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Success"))
+			require.NoError(err)
+		}
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Equal(3, attempts)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	require.Equal("Success", string(body))
+}
+
+func TestRetryTransport_RetryOn500(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte("Server error"))
+			require.NoError(err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Success"))
+			require.NoError(err)
+		}
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Equal(2, attempts)
+}
+
+func TestRetryTransport_NoRetryOnSuccess(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("Success"))
+		require.NoError(err)
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Equal(1, attempts)
+}
+
+func TestRetryTransport_NoRetryOnOtherErrors(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte("Bad request"))
+		require.NoError(err)
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+	require.Equal(1, attempts)
+}
+
+func TestRetryTransport_MaxRetriesExceeded(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, err := w.Write([]byte("Rate limited"))
+		require.NoError(err)
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal(4, attempts) // Initial + 3 retries (MaxSteps=3)
+}
+
+func TestRetryTransport_RequestBodyReuse(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	expectedBody := "test request body"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(err)
+		require.Equal(expectedBody, string(body))
+
+		if attempts == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Success"))
+			require.NoError(err)
+		}
+	}))
+	defer server.Close()
+
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log.NewPrefixLogger("test"), testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBufferString(expectedBody))
+	require.NoError(err)
+
+	resp, err := client.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Equal(2, attempts)
+}
+
+func TestRetryTransport_RetryAfterHeader(t *testing.T) {
+	require := require.New(t)
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, err := w.Write([]byte("Rate limited"))
+			require.NoError(err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Success"))
+			require.NoError(err)
+		}
+	}))
+	defer server.Close()
+
+	log := log.NewPrefixLogger("test")
+	testPollCfg := poll.Config{
+		BaseDelay: 10 * time.Millisecond,
+		MaxDelay:  100 * time.Millisecond,
+		MaxSteps:  3,
+	}
+	transport := NewRetryTransport(http.DefaultTransport, log, testPollCfg)
+
+	client := &http.Client{Transport: transport}
+
+	start := time.Now()
+	resp, err := client.Get(server.URL)
+	elapsed := time.Since(start)
+
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Equal(2, attempts)
+	// wait ~100ms (capped by MaxDelay) instead of 1 second
+	require.Greater(elapsed, 90*time.Millisecond)
+	require.Less(elapsed, 200*time.Millisecond)
+}

--- a/internal/agent/identity/file.go
+++ b/internal/agent/identity/file.go
@@ -94,7 +94,7 @@ func (f *fileProvider) CreateManagementClient(config *baseclient.Config, metrics
 		return nil, fmt.Errorf("management client certificate does not exist at %q - device needs re-enrollment", config.GetClientCertificatePath())
 	}
 
-	httpClient, err := client.NewFromConfig(config)
+	httpClient, err := client.NewFromConfig(config, f.log)
 	if err != nil {
 		return nil, fmt.Errorf("create management client: %w", err)
 	}


### PR DESCRIPTION
```
hook404 := client.WithResponseHook(func(resp *http.Response, attempt int) bool {
    if resp.StatusCode == 404 {
        log.Errorf("Device not found (404) on attempt %d", attempt)
        // Run special logic for 404
        handleMissingDevice("device-123")
        // Don't retry on 404s
        return false  
    }
    return true // Continue with normal retry logic
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds automatic HTTP retry with exponential backoff for network calls, improving reliability under transient errors (e.g., 429 and 5xx).
  - Honors Retry-After headers and caps delays to prevent long waits.
  - Retries preserve request bodies for safe re-attempts on POST/other methods.
  - Enhanced retry logging for better observability during network issues.

- Chores
  - Internal updates to adopt the new retry-capable HTTP client across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->