### PR TITLE
EDM-2058: agent: do not drain workloads when process stops

### DIFF
--- a/internal/agent/client/systemd.go
+++ b/internal/agent/client/systemd.go
@@ -109,3 +109,44 @@ func (s *Systemd) ListUnitsByMatchPattern(ctx context.Context, matchPatterns []s
 	out := strings.TrimSpace(stdout)
 	return out, nil
 }
+
+// SystemdJob represents a systemd job from list-jobs
+type SystemdJob struct {
+	Job     string
+	Unit    string
+	JobType string
+	State   string
+}
+
+// ListJobs lists current systemd jobs in progress
+// This is more reliable than is-active for detecting pending shutdown/reboot
+func (s *Systemd) ListJobs(ctx context.Context) ([]SystemdJob, error) {
+	execCtx, cancel := context.WithTimeout(ctx, defaultSystemctlTimeout)
+	defer cancel()
+
+	args := []string{"list-jobs", "--no-pager", "--no-legend"}
+	stdout, stderr, exitCode := s.exec.ExecuteWithContext(execCtx, systemctlCommand, args...)
+	if exitCode != 0 {
+		return nil, fmt.Errorf("systemctl list-jobs: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	var jobs []SystemdJob
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) >= 4 {
+			jobs = append(jobs, SystemdJob{
+				Job:     fields[0],
+				Unit:    fields[1],
+				JobType: fields[2],
+				State:   fields[3],
+			})
+		}
+	}
+
+	return jobs, nil
+}

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -52,8 +52,8 @@ type Manager interface {
 	BeforeUpdate(ctx context.Context, desired *v1alpha1.DeviceSpec) error
 	// AfterUpdate is called after the application has been validated and is ready to be executed.
 	AfterUpdate(ctx context.Context) error
-	// Stop halts the application running on the device.
-	Stop(ctx context.Context) error
+	// Drain gracefully stops all applications during system shutdown.
+	Drain(ctx context.Context) error
 
 	dependency.OCICollector
 	status.Exporter

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -135,6 +135,20 @@ func (mr *MockManagerMockRecorder) CollectOCITargets(ctx, current, desired any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectOCITargets", reflect.TypeOf((*MockManager)(nil).CollectOCITargets), ctx, current, desired)
 }
 
+// Drain mocks base method.
+func (m *MockManager) Drain(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Drain", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Drain indicates an expected call of Drain.
+func (mr *MockManagerMockRecorder) Drain(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drain", reflect.TypeOf((*MockManager)(nil).Drain), ctx)
+}
+
 // Ensure mocks base method.
 func (m *MockManager) Ensure(ctx context.Context, provider provider.Provider) error {
 	m.ctrl.T.Helper()
@@ -180,20 +194,6 @@ func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
-}
-
-// Stop mocks base method.
-func (m *MockManager) Stop(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stop", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockManagerMockRecorder) Stop(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockManager)(nil).Stop), ctx)
 }
 
 // Update mocks base method.

--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -266,6 +266,10 @@ func (m *prefetchManager) setResult(image string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	task := m.tasks[image]
+	if task == nil {
+		m.log.Warnf("Attempted to set result for non-existent task: %s", image)
+		return
+	}
 	task.err = err
 	task.done = true
 }

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -3,7 +3,6 @@ package device
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -52,10 +51,8 @@ type Agent struct {
 	fetchSpecInterval    util.Duration
 	statusUpdateInterval util.Duration
 
-	once     sync.Once
-	cancelFn context.CancelFunc
-	backoff  wait.Backoff
-	log      *log.PrefixLogger
+	backoff wait.Backoff
+	log     *log.PrefixLogger
 }
 
 // NewAgent creates a new device agent.
@@ -102,7 +99,6 @@ func NewAgent(
 		osClient:               osClient,
 		podmanClient:           podmanClient,
 		prefetchManager:        prefetchManager,
-		cancelFn:               func() {},
 		backoff:                backoff,
 		log:                    log,
 	}
@@ -110,8 +106,6 @@ func NewAgent(
 
 // Run starts the device agent reconciliation loop.
 func (a *Agent) Run(ctx context.Context) error {
-	ctx, a.cancelFn = context.WithCancel(ctx)
-
 	// orchestrates periodic fetching of device specs and pushing status updates
 	engine := NewEngine(
 		a.fetchSpecInterval,
@@ -556,16 +550,6 @@ func (a *Agent) handlePrefetchNotReady(ctx context.Context, syncErr error) {
 	if updateStatusErr != nil {
 		a.log.Warnf("Failed to update status for image prefetch progress: %v", updateStatusErr)
 	}
-}
-
-// Stop ensures that the device agent stops reconciling during graceful shutdown.
-func (a *Agent) Stop(ctx context.Context) error {
-	a.once.Do(func() {
-		if a.cancelFn != nil {
-			a.cancelFn()
-		}
-	})
-	return nil
 }
 
 // ReloadConfig reloads the device agent configuration.

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -125,6 +125,9 @@ func IsRetryable(err error) bool {
 	case errors.Is(err, syscall.ECONNRESET):
 		// connection reset by peer is a transient network error
 		return true
+	case errors.Is(err, syscall.ENOSPC):
+		// no space left on device
+		return false
 	case errors.Is(err, ErrNoRetry):
 		return false
 	case errors.Is(err, ErrAuthenticationFailed):
@@ -186,6 +189,8 @@ func FromStderr(stderr string, exitCode int) error {
 		"unable to resolve host": ErrNetwork,
 		"network is unreachable": ErrNetwork,
 		"i/o timeout":            ErrNetwork,
+		// resources
+		"no space left on device": ErrNoRetry,
 		// context
 		"context canceled":          context.Canceled,
 		"context deadline exceeded": context.DeadlineExceeded,
@@ -193,6 +198,8 @@ func FromStderr(stderr string, exitCode int) error {
 		"short-name resolution enforced": ErrImageShortName,
 		// no such object
 		"no such object": ErrNotFound,
+		// systemd unit not found
+		"could not be found": ErrNotFound,
 	}
 	for check, err := range errMap {
 		if strings.Contains(stderr, check) {

--- a/internal/agent/identity/file.go
+++ b/internal/agent/identity/file.go
@@ -169,7 +169,7 @@ func (f *fileProvider) WipeCertificateOnly() error {
 	return nil
 }
 
-func (f *fileProvider) Close(_ context.Context) error {
+func (f *fileProvider) Close() error {
 	// no-op for file provider
 	return nil
 }

--- a/internal/agent/identity/identity.go
+++ b/internal/agent/identity/identity.go
@@ -55,7 +55,7 @@ type Provider interface {
 	// WipeCertificateOnly securely removes only the certificate (not keys or CSR)
 	WipeCertificateOnly() error
 	// Close cleans up any resources used by the provider
-	Close(ctx context.Context) error
+	Close() error
 }
 
 // NewProvider creates an identity provider

--- a/internal/agent/identity/mock_identity.go
+++ b/internal/agent/identity/mock_identity.go
@@ -44,17 +44,17 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // Close mocks base method.
-func (m *MockProvider) Close(ctx context.Context) error {
+func (m *MockProvider) Close() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", ctx)
+	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockProviderMockRecorder) Close(ctx any) *gomock.Call {
+func (mr *MockProviderMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProvider)(nil).Close), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProvider)(nil).Close))
 }
 
 // CreateGRPCClient mocks base method.

--- a/internal/agent/identity/tpm.go
+++ b/internal/agent/identity/tpm.go
@@ -454,9 +454,9 @@ func (t *tpmProvider) WipeCertificateOnly() error {
 	return nil
 }
 
-func (t *tpmProvider) Close(ctx context.Context) error {
+func (t *tpmProvider) Close() error {
 	if t.client != nil {
-		return t.client.Close(ctx)
+		return t.client.Close()
 	}
 	return nil
 }

--- a/internal/agent/shutdown/shutdown.go
+++ b/internal/agent/shutdown/shutdown.go
@@ -4,16 +4,26 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	shutdownScheduledPath = "/run/systemd/shutdown/scheduled"
+	runlevelPath          = "/run/utmp"
+
+	runlevel0 = "runlevel 0"
+	runlevel6 = "runlevel 6"
 )
 
 type Manager interface {
 	Run(context.Context)
-	Shutdown(context.Context)
 	Register(string, func(context.Context) error)
 }
 
@@ -44,12 +54,12 @@ func (m *manager) Run(ctx context.Context) {
 		select {
 		case s := <-signals:
 			m.log.Infof("Agent received shutdown signal: %s", s)
-			m.Shutdown(ctx)
+			m.shutdown(ctx)
 			m.cancelFn()
 			close(signals)
 		case <-ctx.Done():
 			m.log.Infof("Context has been cancelled, shutting down.")
-			m.Shutdown(ctx)
+			m.shutdown(ctx)
 			close(signals)
 		}
 	}(ctx)
@@ -57,7 +67,7 @@ func (m *manager) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (m *manager) Shutdown(ctx context.Context) {
+func (m *manager) shutdown(ctx context.Context) {
 	// ensure multiple calls to Shutdown are idempotent
 	m.once.Do(func() {
 		now := time.Now()
@@ -65,7 +75,7 @@ func (m *manager) Shutdown(ctx context.Context) {
 		ctx, cancel := context.WithTimeout(ctx, m.timeout)
 		defer cancel()
 		for name, fn := range m.registered {
-			m.log.Infof("Shutting down: %s", name)
+			m.log.Debugf("Executing shutdown handler: %s", name)
 			if err := fn(ctx); err != nil {
 				m.log.Errorf("Error shutting down: %s", err)
 			}
@@ -80,4 +90,62 @@ func (m *manager) Register(name string, fn func(context.Context) error) {
 		return
 	}
 	m.registered[name] = fn
+}
+
+// IsSystemShutdown checks if the system is shutting down or rebooting
+// by checking systemd targets and runlevels
+func IsSystemShutdown(ctx context.Context, systemdClient *client.Systemd, reader fileio.Reader, log *log.PrefixLogger) bool {
+	switch {
+	case isShuttingDownViaRunlevel(reader, log):
+		return true
+	case isShuttingDownViaSystemd(ctx, systemdClient, reader, log):
+		return true
+	default:
+		return false
+	}
+}
+
+func isShuttingDownViaSystemd(ctx context.Context, systemdClient *client.Systemd, reader fileio.Reader, log *log.PrefixLogger) bool {
+	exists, err := reader.PathExists(shutdownScheduledPath)
+	if err == nil && exists {
+		log.Info("System shutdown detected via scheduled file")
+		return true
+	}
+
+	shutdownJobs, err := systemdClient.ListJobs(ctx)
+	if err != nil {
+		log.Debugf("Failed to list systemd jobs: %v", err)
+		return false
+	}
+
+	// check if any shutdown-related jobs are starting
+	shutdownTargets := map[string]struct{}{
+		"shutdown.target": {},
+		"reboot.target":   {},
+		"poweroff.target": {},
+		"halt.target":     {},
+	}
+
+	for _, job := range shutdownJobs {
+		if _, isShutdownTarget := shutdownTargets[job.Unit]; isShutdownTarget && job.JobType == "start" {
+			log.Infof("System shutdown detected: %s job is %s", job.Unit, job.State)
+			return true
+		}
+	}
+
+	return false
+}
+
+func isShuttingDownViaRunlevel(reader fileio.Reader, log *log.PrefixLogger) bool {
+	runlevelBytes, err := reader.ReadFile(runlevelPath)
+	if err == nil {
+		runlevel := string(runlevelBytes)
+		// runlevel 0 = halt, 6 = reboot
+		if strings.Contains(runlevel, runlevel0) || strings.Contains(runlevel, runlevel6) {
+			log.Infof("System shutdown detected: runlevel change")
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/tpm/client.go
+++ b/internal/tpm/client.go
@@ -228,7 +228,7 @@ func (c *client) Clear() error {
 }
 
 // Close closes the TPM session.
-func (c *client) Close(ctx context.Context) error {
+func (c *client) Close() error {
 	if c.session != nil {
 		return c.session.Close()
 	}

--- a/internal/tpm/mock_tpm.go
+++ b/internal/tpm/mock_tpm.go
@@ -56,17 +56,17 @@ func (mr *MockClientMockRecorder) Clear() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockClient) Close(ctx context.Context) error {
+func (m *MockClient) Close() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", ctx)
+	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockClientMockRecorder) Close(ctx any) *gomock.Call {
+func (mr *MockClientMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
 }
 
 // GetSigner mocks base method.

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -5,7 +5,6 @@ import (
 	"crypto"
 	"regexp"
 
-	legacy "github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpm2"
 )
 
@@ -23,10 +22,10 @@ type Client interface {
 	UpdateNonce(nonce []byte) error
 	// Clear clears any stored TPM data
 	Clear() error
-	// Close closes the TPM session
-	Close(ctx context.Context) error
 	// VendorInfoCollector collects vendor information from the TPM
 	VendorInfoCollector(ctx context.Context) string
+	// Close closes the TPM session
+	Close() error
 }
 
 const (
@@ -111,65 +110,3 @@ type Session interface {
 
 // tpmIndexRegex matches explicitly tpm (not tpmrm!) and captures the tpm's index
 var tpmIndexRegex = regexp.MustCompile(`^tpm(\d+)$`)
-
-func createPCRSelection(selection [3]byte) *tpm2.TPMLPCRSelection {
-	return &tpm2.TPMLPCRSelection{
-		PCRSelections: []tpm2.TPMSPCRSelection{
-			{
-				Hash:      tpm2.TPMAlgSHA256,
-				PCRSelect: selection[:],
-			},
-		},
-	}
-}
-
-// createFullPCRSelection creates a PCR selection that includes all PCRs (0-23)
-func createFullPCRSelection() *tpm2.TPMLPCRSelection {
-	// PCRs 0-7 (all bits set)
-	// PCRs 8-15 (all bits set)
-	// PCRs 16-23 (all bits set)
-	return createPCRSelection([3]byte{0xFF, 0xFF, 0xFF})
-}
-
-// convertTPMLPCRSelectionToPCRSelection converts tpm2.TPMLPCRSelection to tpm2.PCRSelection
-// format expected by client.ReadPCRs function.
-func convertTPMLPCRSelectionToPCRSelection(tpmlSelection *tpm2.TPMLPCRSelection) legacy.PCRSelection {
-	if tpmlSelection == nil || len(tpmlSelection.PCRSelections) == 0 {
-		return legacy.PCRSelection{}
-	}
-
-	// Use the first PCR selection (most common case)
-	sel := tpmlSelection.PCRSelections[0]
-
-	// Convert bitmask to slice of PCR indices
-	var pcrs []int
-	for byteIdx, b := range sel.PCRSelect {
-		for bitIdx := 0; bitIdx < 8; bitIdx++ {
-			if b&(1<<bitIdx) != 0 {
-				pcrIndex := byteIdx*8 + bitIdx
-				pcrs = append(pcrs, pcrIndex)
-			}
-		}
-	}
-
-	// Convert hash algorithm from tpm2.TPMAlgID to legacy.Algorithm
-	var hash legacy.Algorithm
-	switch sel.Hash {
-	case tpm2.TPMAlgSHA1:
-		hash = legacy.AlgSHA1
-	case tpm2.TPMAlgSHA256:
-		hash = legacy.AlgSHA256
-	case tpm2.TPMAlgSHA384:
-		hash = legacy.AlgSHA384
-	case tpm2.TPMAlgSHA512:
-		hash = legacy.AlgSHA512
-	default:
-		// Default to SHA256 if unknown algorithm
-		hash = legacy.AlgSHA256
-	}
-
-	return legacy.PCRSelection{
-		Hash: hash,
-		PCRs: pcrs,
-	}
-}


### PR DESCRIPTION
the agent currently drains Podman workloads whenever its process stops.
this PR separates that behavior from node restarts or shutdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Detects pending system shutdown/reboot via system signals, enabling graceful, one-time draining of applications.
  - Integrates systemd job awareness to inform shutdown handling.

- Bug Fixes
  - Prevents crashes when updating missing dependency tasks.
  - Improves error handling: “no space left on device” is non-retryable; better mapping for “unit not found.”
  - More reliable shutdown sequencing and application drain behavior.

- Tests
  - Expanded coverage for shutdown detection, application drain lifecycle, podman monitor behavior, and TPM client closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->