### PR TITLE
NO-ISSUE: Add output in case of an error in IsAcmInstalled

### DIFF
--- a/test/e2e/rbac/rbac_suite_test.go
+++ b/test/e2e/rbac/rbac_suite_test.go
@@ -25,7 +25,11 @@ var _ = BeforeSuite(func() {
 
 	// Check if ACM is installed before running any tests
 	isAcmInstalled, err := util.IsAcmInstalled()
-	if err != nil || !isAcmInstalled {
+
+	if err != nil {
+		GinkgoWriter.Printf("Error while checking if ACM is installed: %s", err)
+	}
+	if !isAcmInstalled {
 		Skip("Skipping test suite because ACM is not installed.")
 	}
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -186,7 +186,7 @@ func IsAcmInstalled() (bool, error) {
 	cmd := exec.Command("oc", "get", "multiclusterhub", "-A")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("error getting multiclusterhub: %w, %s", err, string(output))
 	}
 	outputString := string(output)
 	if outputString == "error: the server doesn't have a resource type \"multiclusterhub\"" {


### PR DESCRIPTION
Help debug issues where RBAC test is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E RBAC checks now log environment-check errors separately and only skip when the prerequisite is actually missing, reducing unnecessary skips.
  * Diagnostic failures now include command output for faster troubleshooting of environment verification.
  * No user-facing changes; improvements target test reliability and developer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->