### PR TITLE
EDM-1735: Device disconnected alertManager test

### DIFF
--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -2339,3 +2339,34 @@ func (h *Harness) getVersionByPrefix(output, prefix string) string {
 	}
 	return ""
 }
+
+// GetToken Gets the OpenShift auth token, returning it or an error.
+func (h *Harness) GetToken() (string, error) {
+	if !util.BinaryExistsOnPath("oc") {
+		return "", fmt.Errorf("oc binary not found on PATH")
+	}
+	cmd := exec.Command("oc", "whoami", "-t")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get token: %v, output: %s", err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// StartAgent starts the flightctl agent on the VM.
+func (h *Harness) StartAgent() error {
+	if h.VM == nil {
+		return fmt.Errorf("VM is not initialized")
+	}
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "start", util.FLIGHTCTL_AGENT_SERVICE}, nil)
+	return err
+}
+
+// StopAgent stops the flightctl agent on the VM.
+func (h *Harness) StopAgent() error {
+	if h.VM == nil {
+		return fmt.Errorf("VM is not initialized")
+	}
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "stop", util.FLIGHTCTL_AGENT_SERVICE}, nil)
+	return err
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/EDM-1735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying alert lifecycle during agent restarts: confirms DeviceDisconnected alerts appear when the agent stops and clear after reconnection.
  * Uses extended timeouts and polling to ensure stability across restart scenarios.
  * Validates baseline counts, alert surge during outage, and return to baseline after recovery, strengthening regression coverage for CLI-driven workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->