### PR TITLE
EDM-2016: TPM Activate Credential Agent Side

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -374,7 +374,7 @@ func newEnrollmentClient(cfg *agent_config.Config, log *log.PrefixLogger) (clien
 	return client.NewEnrollment(httpClient, cfg.GetEnrollmentMetricsCallback()), nil
 }
 
-func (a *Agent) tryLoadTPM(writer fileio.ReadWriter) (*tpm.Client, error) {
+func (a *Agent) tryLoadTPM(writer fileio.ReadWriter) (tpm.Client, error) {
 	if !a.config.TPM.Enabled {
 		a.log.Info("TPM device identity is disabled. Skipping TPM setup.")
 		return nil, nil

--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	client "github.com/flightctl/flightctl/internal/api/client/agent"
@@ -46,10 +45,6 @@ func NewFromConfig(config *baseclient.Config, log *log.PrefixLogger, opts ...HTT
 		return nil
 	})
 	return client.NewClientWithResponses(config.Service.Server, client.WithHTTPClient(httpClient), ref)
-}
-
-func NewGRPCClientFromConfig(config *baseclient.Config) (grpc_v1.RouterServiceClient, error) {
-	return baseclient.NewGRPCClientFromConfig(config, "")
 }
 
 // Management is the client interface for managing devices.

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -252,6 +252,8 @@ func (m *LifecycleManager) verifyEnrollment(ctx context.Context) (bool, error) {
 		}
 	}
 	if !approved {
+		// While pending approval, take the time to verify the identity. The provider
+		// is responsible for determining whether proof is required
 		ctx, cancel := context.WithTimeout(ctx, identityProofTimeout)
 		defer cancel()
 		if err := m.identityProvider.ProveIdentity(ctx, enrollmentRequest); err != nil {

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -1,0 +1,221 @@
+package lifecycle
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/internal/agent/device/status"
+	"github.com/flightctl/flightctl/internal/agent/identity"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// generateTestCertificate creates a valid test certificate for testing
+func generateTestCertificate(t *testing.T) string {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "test-device",
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: nil,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	return string(certPEM)
+}
+
+func TestLifecycleManager_verifyEnrollment(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupMocks     func(*client.MockEnrollment, *identity.MockProvider)
+		expectedResult bool
+		expectedError  string
+	}{
+		{
+			name: "identity proof required and succeeds",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							// No "Approved" condition, so identity proof is required
+						},
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+				mockIdentity.EXPECT().ProveIdentity(gomock.Any(), enrollmentRequest).Return(nil)
+			},
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name: "identity proof fails with ErrIdentityProofFailed",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							// No "Approved" condition, so identity proof is required
+						},
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+				mockIdentity.EXPECT().ProveIdentity(gomock.Any(), enrollmentRequest).Return(identity.ErrIdentityProofFailed)
+			},
+			expectedResult: false,
+			expectedError:  "proving identity: identity proof failed",
+		},
+		{
+			name: "identity proof fails with other error",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							// No "Approved" condition, so identity proof is required
+						},
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+				mockIdentity.EXPECT().ProveIdentity(gomock.Any(), enrollmentRequest).Return(errors.New("network error"))
+			},
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name: "enrollment denied",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							{
+								Type:    "Denied",
+								Reason:  "PolicyViolation",
+								Message: "Device does not meet policy requirements",
+							},
+						},
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+			},
+			expectedResult: false,
+			expectedError:  "enrollment request denied: reason: PolicyViolation, message: Device does not meet policy requirements",
+		},
+		{
+			name: "enrollment failed",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							{
+								Type:    "Failed",
+								Reason:  "ProcessingError",
+								Message: "Failed to process enrollment request",
+							},
+						},
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+			},
+			expectedResult: false,
+			expectedError:  "enrollment request failed: reason: ProcessingError, message: Failed to process enrollment request",
+		},
+		{
+			name: "enrollment approved with certificate",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				certificate := generateTestCertificate(t)
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							{
+								Type: "Approved",
+							},
+						},
+						Certificate: &certificate,
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+				mockIdentity.EXPECT().StoreCertificate([]byte(certificate)).Return(nil)
+			},
+			expectedResult: true,
+			expectedError:  "",
+		},
+		{
+			name: "enrollment approved but no certificate yet",
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+				enrollmentRequest := &v1alpha1.EnrollmentRequest{
+					Status: &v1alpha1.EnrollmentRequestStatus{
+						Conditions: []v1alpha1.Condition{
+							{
+								Type: "Approved",
+							},
+						},
+						Certificate: nil,
+					},
+				}
+				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
+			},
+			expectedResult: false,
+			expectedError:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEnrollment := client.NewMockEnrollment(ctrl)
+			mockIdentity := identity.NewMockProvider(ctrl)
+			mockStatus := status.NewMockManager(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			manager := &LifecycleManager{
+				deviceName:       "test-device",
+				enrollmentClient: mockEnrollment,
+				identityProvider: mockIdentity,
+				statusManager:    mockStatus,
+				deviceReadWriter: mockReadWriter,
+				backoff:          wait.Backoff{},
+				log:              log.NewPrefixLogger("test"),
+			}
+
+			tt.setupMocks(mockEnrollment, mockIdentity)
+
+			ctx := context.Background()
+			result, err := manager.verifyEnrollment(ctx)
+
+			require.Equal(t, tt.expectedResult, result)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}

--- a/internal/agent/identity/doc.go
+++ b/internal/agent/identity/doc.go
@@ -1,0 +1,3 @@
+package identity
+
+//go:generate go run -modfile=../../../tools/go.mod go.uber.org/mock/mockgen -source=identity.go -destination=mock_identity.go -package=identity

--- a/internal/agent/identity/file.go
+++ b/internal/agent/identity/file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
+	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	baseclient "github.com/flightctl/flightctl/internal/client"
@@ -68,6 +69,11 @@ func (f *fileProvider) GenerateCSR(deviceName string) ([]byte, error) {
 		return nil, fmt.Errorf("private key does not implement crypto.Signer")
 	}
 	return fccrypto.MakeCSR(signer, deviceName)
+}
+
+func (f *fileProvider) ProveIdentity(ctx context.Context, enrollmentRequest *v1alpha1.EnrollmentRequest) error {
+	// no-op for file provider since identity is proven by CSR signing with private key
+	return nil
 }
 
 func (f *fileProvider) StoreCertificate(certPEM []byte) error {

--- a/internal/agent/identity/mock_identity.go
+++ b/internal/agent/identity/mock_identity.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
+	v1alpha1 "github.com/flightctl/flightctl/api/v1alpha1"
 	client "github.com/flightctl/flightctl/internal/agent/client"
 	client0 "github.com/flightctl/flightctl/internal/client"
 	gomock "go.uber.org/mock/gomock"
@@ -142,6 +143,20 @@ func (m *MockProvider) Initialize(ctx context.Context) error {
 func (mr *MockProviderMockRecorder) Initialize(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockProvider)(nil).Initialize), ctx)
+}
+
+// ProveIdentity mocks base method.
+func (m *MockProvider) ProveIdentity(ctx context.Context, enrollmentRequest *v1alpha1.EnrollmentRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProveIdentity", ctx, enrollmentRequest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProveIdentity indicates an expected call of ProveIdentity.
+func (mr *MockProviderMockRecorder) ProveIdentity(ctx, enrollmentRequest any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProveIdentity", reflect.TypeOf((*MockProvider)(nil).ProveIdentity), ctx, enrollmentRequest)
 }
 
 // StoreCertificate mocks base method.

--- a/internal/agent/identity/tpm.go
+++ b/internal/agent/identity/tpm.go
@@ -12,21 +12,26 @@ import (
 	"time"
 
 	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
+	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
 	agent_client "github.com/flightctl/flightctl/internal/api/client/agent"
 	base_client "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	certutil "k8s.io/client-go/util/cert"
 )
 
 var _ Provider = (*tpmProvider)(nil)
 
 // tpmProvider implements identity management using TPM-based keys
 type tpmProvider struct {
-	client          *tpm.Client
+	client          tpm.Client
+	config          *agent_config.Config
 	log             *log.PrefixLogger
 	deviceName      string
 	certificateData []byte
@@ -34,11 +39,13 @@ type tpmProvider struct {
 
 // newTPMProvider creates a new TPM-based identity provider
 func newTPMProvider(
-	client *tpm.Client,
+	client tpm.Client,
+	config *agent_config.Config,
 	log *log.PrefixLogger,
 ) *tpmProvider {
 	return &tpmProvider{
 		client: client,
+		config: config,
 		log:    log,
 	}
 }
@@ -69,6 +76,207 @@ func (t *tpmProvider) GenerateCSR(deviceName string) ([]byte, error) {
 	// Use default qualifying data (nonce) for attestation freshness
 	qualifyingData := make([]byte, 8)
 	return t.client.MakeCSR(deviceName, qualifyingData)
+}
+
+// isTPMVerificationNeeded checks if TPM verification is necessary for the enrollment request
+func (t *tpmProvider) isTPMVerificationNeeded(enrollmentRequest *v1alpha1.EnrollmentRequest) bool {
+	if enrollmentRequest.Status != nil {
+		if condition := v1alpha1.FindStatusCondition(enrollmentRequest.Status.Conditions, v1alpha1.ConditionTypeEnrollmentRequestTPMVerified); condition != nil {
+			if condition.Status == v1alpha1.ConditionStatusTrue {
+				t.log.Debug("TPM already verified, skipping identity proof")
+				return false
+			}
+			// if verification of the request failed, do not perform any additional verification
+			if condition.Reason == v1alpha1.TPMVerificationFailedReason {
+				t.log.Debug("TPM verification failed failed, identity proof not allowed")
+				return false
+			}
+			t.log.Debugf("TPM verification condition found but status is %s, reason: %s", condition.Status, condition.Reason)
+		}
+	}
+	return true
+}
+
+// handleTPMChallenge handles the complete TPM challenge-response flow
+func (t *tpmProvider) handleTPMChallenge(ctx context.Context, stream grpc_v1.Enrollment_TPMChallengeClient, enrollmentRequestName string) error {
+	challengeRequest := &grpc_v1.AgentChallenge{
+		Payload: &grpc_v1.AgentChallenge_ChallengeRequest{
+			ChallengeRequest: &grpc_v1.ChallengeRequest{
+				EnrollmentRequestName: enrollmentRequestName,
+			},
+		},
+	}
+
+	if err := stream.Send(challengeRequest); err != nil {
+		return fmt.Errorf("failed to send challenge request: %w", err)
+	}
+
+	t.log.Debug("Sent TPM challenge request, waiting for challenge")
+
+	serverMsg, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("failed to receive challenge from server: %w", err)
+	}
+
+	switch payload := serverMsg.Payload.(type) {
+	case *grpc_v1.ServerChallenge_Challenge:
+		return t.processChallenge(ctx, stream, payload.Challenge)
+	case *grpc_v1.ServerChallenge_Error:
+		return fmt.Errorf("server error: %s", payload.Error.Message)
+	default:
+		return fmt.Errorf("unexpected server message type")
+	}
+}
+
+// processChallenge handles the challenge solving and response
+func (t *tpmProvider) processChallenge(ctx context.Context, stream grpc_v1.Enrollment_TPMChallengeClient, challenge *grpc_v1.Challenge) error {
+	t.log.Debug("Received TPM challenge, solving with TPM")
+
+	secret, err := t.client.SolveChallenge(challenge.CredentialBlob, challenge.EncryptedSecret)
+	if err != nil {
+		return fmt.Errorf("failed to solve TPM challenge: %w", err)
+	}
+
+	challengeResponse := &grpc_v1.AgentChallenge{
+		Payload: &grpc_v1.AgentChallenge_ChallengeResponse{
+			ChallengeResponse: &grpc_v1.ChallengeResponse{
+				Secret: secret,
+			},
+		},
+	}
+
+	if err := stream.Send(challengeResponse); err != nil {
+		return fmt.Errorf("failed to send challenge response: %w", err)
+	}
+
+	t.log.Debug("Sent TPM challenge response, waiting for result")
+
+	finalMsg, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("failed to receive final result: %w", err)
+	}
+
+	switch finalPayload := finalMsg.Payload.(type) {
+	case *grpc_v1.ServerChallenge_Success:
+		t.log.Info("TPM challenge completed successfully")
+		return nil
+	case *grpc_v1.ServerChallenge_Error:
+		return fmt.Errorf("TPM challenge failed: %s: %w", finalPayload.Error.Message, ErrIdentityProofFailed)
+	default:
+		return fmt.Errorf("unexpected server response type: %T", finalPayload)
+	}
+}
+
+func (t *tpmProvider) ProveIdentity(ctx context.Context, enrollmentRequest *v1alpha1.EnrollmentRequest) error {
+	if !t.isTPMVerificationNeeded(enrollmentRequest) {
+		return nil
+	}
+
+	enrollmentRequestName := lo.FromPtr(enrollmentRequest.Metadata.Name)
+	if enrollmentRequestName == "" {
+		return fmt.Errorf("enrollment request name is empty")
+	}
+
+	t.log.Debug("Starting TPM challenge-response protocol for identity proof")
+	grpcClient, closeConn, err := t.createEnrollmentGRPCClient()
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+	defer func() {
+		if err := closeConn(); err != nil {
+			t.log.Warnf("Failed to close gRPC connection: %v", err)
+		}
+	}()
+
+	stream, err := grpcClient.TPMChallenge(ctx)
+	if err != nil {
+		return fmt.Errorf("starting TPM challenge stream: %w", err)
+	}
+
+	return t.handleTPMChallenge(ctx, stream, enrollmentRequestName)
+}
+
+// createTLSConfig creates a TLS configuration from a client config
+func (t *tpmProvider) createTLSConfig(config *base_client.Config, clientCerts ...tls.Certificate) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: config.Service.InsecureSkipVerify, //nolint:gosec
+	}
+
+	if len(clientCerts) > 0 {
+		tlsConfig.Certificates = clientCerts
+	}
+
+	if config.Service.TLSServerName != "" {
+		tlsConfig.ServerName = config.Service.TLSServerName
+	} else {
+		if u, err := url.Parse(config.Service.Server); err == nil {
+			tlsConfig.ServerName = u.Hostname()
+		}
+	}
+
+	if len(config.Service.CertificateAuthorityData) > 0 {
+		caPool, err := certutil.NewPoolFromBytes(config.Service.CertificateAuthorityData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CA certificates: %w", err)
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	return tlsConfig, nil
+}
+
+// createGRPCConnection creates a gRPC connection using the provided config
+func (t *tpmProvider) createGRPCConnection(config *base_client.Config, clientCerts ...tls.Certificate) (*grpc.ClientConn, error) {
+	tlsConfig, err := t.createTLSConfig(config, clientCerts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clean up the endpoint for gRPC
+	grpcEndpoint := config.Service.Server
+	grpcEndpoint = strings.TrimPrefix(grpcEndpoint, "http://")
+	grpcEndpoint = strings.TrimPrefix(grpcEndpoint, "https://")
+	grpcEndpoint = strings.TrimSuffix(grpcEndpoint, "/")
+
+	conn, err := grpc.NewClient(grpcEndpoint,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+
+	return conn, nil
+}
+
+// createEnrollmentGRPCClient creates a gRPC client for the enrollment service
+func (t *tpmProvider) createEnrollmentGRPCClient() (grpc_v1.EnrollmentClient, func() error, error) {
+	// Use the enrollment configuration to create a gRPC connection
+	enrollConfig := t.config.EnrollmentService.Config.DeepCopy()
+	if err := enrollConfig.Flatten(); err != nil {
+		return nil, nil, err
+	}
+
+	var clientCerts []tls.Certificate
+	if len(enrollConfig.AuthInfo.ClientCertificateData) > 0 && len(enrollConfig.AuthInfo.ClientKeyData) > 0 {
+		cert, err := tls.X509KeyPair(enrollConfig.AuthInfo.ClientCertificateData, enrollConfig.AuthInfo.ClientKeyData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loading enrollment client certificate: %w", err)
+		}
+		clientCerts = append(clientCerts, cert)
+	}
+
+	conn, err := t.createGRPCConnection(enrollConfig, clientCerts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eClient := grpc_v1.NewEnrollmentClient(conn)
+	return eClient, conn.Close, nil
 }
 
 func (t *tpmProvider) StoreCertificate(certPEM []byte) error {
@@ -168,46 +376,12 @@ func (t *tpmProvider) CreateGRPCClient(config *base_client.Config) (grpc_v1.Rout
 		return nil, err
 	}
 
-	grpcEndpoint := configCopy.Service.Server
-
-	tlsConfig := &tls.Config{
-		Certificates:       []tls.Certificate{*tlsCert},
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: configCopy.Service.InsecureSkipVerify, //nolint:gosec
-	}
-
-	if configCopy.Service.CertificateAuthorityData != nil {
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(configCopy.Service.CertificateAuthorityData)
-		tlsConfig.RootCAs = caCertPool
-	}
-
-	if configCopy.Service.TLSServerName != "" {
-		tlsConfig.ServerName = configCopy.Service.TLSServerName
-	} else {
-		u, err := url.Parse(grpcEndpoint)
-		if err == nil {
-			tlsConfig.ServerName = u.Hostname()
-		}
-	}
-
-	// our transport is http, but the grpc library has special encoding for the endpoint
-	grpcEndpoint = strings.TrimPrefix(grpcEndpoint, "http://")
-	grpcEndpoint = strings.TrimPrefix(grpcEndpoint, "https://")
-	grpcEndpoint = strings.TrimSuffix(grpcEndpoint, "/")
-
-	grpcClient, err := grpc.NewClient(grpcEndpoint,
-		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                30 * time.Second, // Send keepalive ping every 30s
-			Timeout:             10 * time.Second, // Wait 10s for server response
-			PermitWithoutStream: true,             // Send even if no active RPCs
-		}))
+	conn, err := t.createGRPCConnection(configCopy, *tlsCert)
 	if err != nil {
 		return nil, fmt.Errorf("creating gRPC client: %w", err)
 	}
 
-	router := grpc_v1.NewRouterServiceClient(grpcClient)
+	router := grpc_v1.NewRouterServiceClient(conn)
 	return router, nil
 }
 

--- a/internal/agent/identity/tpm.go
+++ b/internal/agent/identity/tpm.go
@@ -82,13 +82,13 @@ func (t *tpmProvider) GenerateCSR(deviceName string) ([]byte, error) {
 func (t *tpmProvider) isTPMVerificationNeeded(enrollmentRequest *v1alpha1.EnrollmentRequest) bool {
 	if enrollmentRequest.Status != nil {
 		if condition := v1alpha1.FindStatusCondition(enrollmentRequest.Status.Conditions, v1alpha1.ConditionTypeEnrollmentRequestTPMVerified); condition != nil {
-			if condition.Status == v1alpha1.ConditionStatusTrue {
-				t.log.Debug("TPM already verified, skipping identity proof")
-				return false
-			}
 			// if verification of the request failed, do not perform any additional verification
 			if condition.Reason == v1alpha1.TPMVerificationFailedReason {
-				t.log.Debug("TPM verification failed failed, identity proof not allowed")
+				t.log.Debug("TPM verification failed, identity proof not allowed")
+				return false
+			}
+			if condition.Status == v1alpha1.ConditionStatusTrue {
+				t.log.Debug("TPM already verified, skipping identity proof")
 				return false
 			}
 			t.log.Debugf("TPM verification condition found but status is %s, reason: %s", condition.Status, condition.Reason)

--- a/internal/agent/identity/tpm_test.go
+++ b/internal/agent/identity/tpm_test.go
@@ -1,0 +1,234 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	grpc_v1 "github.com/flightctl/flightctl/api/grpc/v1"
+	api "github.com/flightctl/flightctl/api/v1alpha1"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/internal/tpm"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	testSecretCorrect = "test-secret-123"
+	testSecretWrong   = "wrong-secret"
+	testDeviceName    = "test-device"
+)
+
+var testEnrollmentRequest = "test-enrollment-request"
+
+func TestTPMProvider_IsTPMVerificationNeeded(t *testing.T) {
+	tests := []struct {
+		name           string
+		enrollmentReq  *api.EnrollmentRequest
+		expectedResult bool
+	}{
+		{
+			name: "no status",
+			enrollmentReq: &api.EnrollmentRequest{
+				Metadata: api.ObjectMeta{Name: &testEnrollmentRequest},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "already verified",
+			enrollmentReq: &api.EnrollmentRequest{
+				Metadata: api.ObjectMeta{Name: &testEnrollmentRequest},
+				Status: &api.EnrollmentRequestStatus{
+					Conditions: []api.Condition{
+						{
+							Type:   api.ConditionTypeEnrollmentRequestTPMVerified,
+							Status: api.ConditionStatusTrue,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "verification failed",
+			enrollmentReq: &api.EnrollmentRequest{
+				Metadata: api.ObjectMeta{Name: &testEnrollmentRequest},
+				Status: &api.EnrollmentRequestStatus{
+					Conditions: []api.Condition{
+						{
+							Type:   api.ConditionTypeEnrollmentRequestTPMVerified,
+							Status: api.ConditionStatusFalse,
+							Reason: api.TPMVerificationFailedReason,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "challenge required",
+			enrollmentReq: &api.EnrollmentRequest{
+				Metadata: api.ObjectMeta{Name: &testEnrollmentRequest},
+				Status: &api.EnrollmentRequestStatus{
+					Conditions: []api.Condition{
+						{
+							Type:   api.ConditionTypeEnrollmentRequestTPMVerified,
+							Status: api.ConditionStatusFalse,
+							Reason: api.TPMChallengeRequiredReason,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "challenge failed",
+			enrollmentReq: &api.EnrollmentRequest{
+				Metadata: api.ObjectMeta{Name: &testEnrollmentRequest},
+				Status: &api.EnrollmentRequestStatus{
+					Conditions: []api.Condition{
+						{
+							Type:   api.ConditionTypeEnrollmentRequestTPMVerified,
+							Status: api.ConditionStatusFalse,
+							Reason: api.TPMChallengeFailedReason,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &tpmProvider{
+				log: log.NewPrefixLogger("test"),
+			}
+
+			result := provider.isTPMVerificationNeeded(tt.enrollmentReq)
+			require.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestTPMProvider_ProcessChallenge(t *testing.T) {
+	tests := []struct {
+		name               string
+		challenge          *grpc_v1.Challenge
+		setupMocks         func(*tpm.MockClient, *grpc_v1.MockEnrollment_TPMChallengeClient)
+		expectError        bool
+		expectedErrMessage string
+	}{
+		{
+			name: "success",
+			challenge: &grpc_v1.Challenge{
+				CredentialBlob:  []byte("valid-credential-blob"),
+				EncryptedSecret: []byte("valid-encrypted-secret"),
+			},
+			setupMocks: func(mockClient *tpm.MockClient, mockStream *grpc_v1.MockEnrollment_TPMChallengeClient) {
+				mockClient.EXPECT().SolveChallenge([]byte("valid-credential-blob"), []byte("valid-encrypted-secret")).Return([]byte(testSecretCorrect), nil)
+				mockStream.EXPECT().Send(gomock.Any()).Return(nil)
+				mockStream.EXPECT().Recv().Return(&grpc_v1.ServerChallenge{
+					Payload: &grpc_v1.ServerChallenge_Success{
+						Success: &grpc_v1.ChallengeComplete{},
+					},
+				}, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "fail to solve challenge",
+			challenge: &grpc_v1.Challenge{
+				CredentialBlob:  []byte("invalid-credential-blob"),
+				EncryptedSecret: []byte("invalid-encrypted-secret"),
+			},
+			setupMocks: func(mockClient *tpm.MockClient, mockStream *grpc_v1.MockEnrollment_TPMChallengeClient) {
+				mockClient.EXPECT().SolveChallenge([]byte("invalid-credential-blob"), []byte("invalid-encrypted-secret")).Return(nil, errors.New("TPM challenge solve failed"))
+			},
+			expectError:        true,
+			expectedErrMessage: "failed to solve TPM challenge",
+		},
+		{
+			name: "failed to send challenge response",
+			challenge: &grpc_v1.Challenge{
+				CredentialBlob:  []byte("valid-credential-blob"),
+				EncryptedSecret: []byte("valid-encrypted-secret"),
+			},
+			setupMocks: func(mockClient *tpm.MockClient, mockStream *grpc_v1.MockEnrollment_TPMChallengeClient) {
+				mockClient.EXPECT().SolveChallenge([]byte("valid-credential-blob"), []byte("valid-encrypted-secret")).Return([]byte(testSecretCorrect), nil)
+				mockStream.EXPECT().Send(gomock.Any()).Return(status.Error(codes.Internal, "send failed"))
+			},
+			expectError:        true,
+			expectedErrMessage: "failed to send challenge response",
+		},
+		{
+			name: "failed to receive final result",
+			challenge: &grpc_v1.Challenge{
+				CredentialBlob:  []byte("valid-credential-blob"),
+				EncryptedSecret: []byte("valid-encrypted-secret"),
+			},
+			setupMocks: func(mockClient *tpm.MockClient, mockStream *grpc_v1.MockEnrollment_TPMChallengeClient) {
+				mockClient.EXPECT().SolveChallenge([]byte("valid-credential-blob"), []byte("valid-encrypted-secret")).Return([]byte(testSecretCorrect), nil)
+				mockStream.EXPECT().Send(gomock.Any()).Return(nil)
+				mockStream.EXPECT().Recv().Return(nil, status.Error(codes.Internal, "receive failed"))
+			},
+			expectError:        true,
+			expectedErrMessage: "failed to receive final result",
+		},
+		{
+			name: "challenge failure",
+			challenge: &grpc_v1.Challenge{
+				CredentialBlob:  []byte("valid-credential-blob"),
+				EncryptedSecret: []byte("valid-encrypted-secret"),
+			},
+			setupMocks: func(mockClient *tpm.MockClient, mockStream *grpc_v1.MockEnrollment_TPMChallengeClient) {
+				mockClient.EXPECT().SolveChallenge([]byte("valid-credential-blob"), []byte("valid-encrypted-secret")).Return([]byte(testSecretWrong), nil)
+				mockStream.EXPECT().Send(gomock.Any()).Return(nil)
+				mockStream.EXPECT().Recv().Return(&grpc_v1.ServerChallenge{
+					Payload: &grpc_v1.ServerChallenge_Error{
+						Error: &grpc_v1.ChallengeError{
+							Message: "Challenge verification failed",
+						},
+					},
+				}, nil)
+			},
+			expectError:        true,
+			expectedErrMessage: "TPM challenge failed: Challenge verification failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := tpm.NewMockClient(ctrl)
+			mockStream := grpc_v1.NewMockEnrollment_TPMChallengeClient(ctrl)
+
+			provider := &tpmProvider{
+				client: mockClient,
+				config: agent_config.NewDefault(),
+				log:    log.NewPrefixLogger("test"),
+			}
+
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockClient, mockStream)
+			}
+
+			ctx := context.Background()
+			err := provider.processChallenge(ctx, mockStream, tt.challenge)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.expectedErrMessage != "" {
+					require.Contains(t, err.Error(), tt.expectedErrMessage)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/tpm/mock_tpm.go
+++ b/internal/tpm/mock_tpm.go
@@ -10,11 +10,150 @@
 package tpm
 
 import (
+	context "context"
+	crypto "crypto"
 	reflect "reflect"
 
 	tpm2 "github.com/google/go-tpm/tpm2"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MockClient is a mock of Client interface.
+type MockClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockClientMockRecorder
+}
+
+// MockClientMockRecorder is the mock recorder for MockClient.
+type MockClientMockRecorder struct {
+	mock *MockClient
+}
+
+// NewMockClient creates a new mock instance.
+func NewMockClient(ctrl *gomock.Controller) *MockClient {
+	mock := &MockClient{ctrl: ctrl}
+	mock.recorder = &MockClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClient) EXPECT() *MockClientMockRecorder {
+	return m.recorder
+}
+
+// Clear mocks base method.
+func (m *MockClient) Clear() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockClientMockRecorder) Clear() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockClient)(nil).Clear))
+}
+
+// Close mocks base method.
+func (m *MockClient) Close(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockClientMockRecorder) Close(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), ctx)
+}
+
+// GetSigner mocks base method.
+func (m *MockClient) GetSigner() crypto.Signer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSigner")
+	ret0, _ := ret[0].(crypto.Signer)
+	return ret0
+}
+
+// GetSigner indicates an expected call of GetSigner.
+func (mr *MockClientMockRecorder) GetSigner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSigner", reflect.TypeOf((*MockClient)(nil).GetSigner))
+}
+
+// MakeCSR mocks base method.
+func (m *MockClient) MakeCSR(deviceName string, qualifyingData []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeCSR", deviceName, qualifyingData)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeCSR indicates an expected call of MakeCSR.
+func (mr *MockClientMockRecorder) MakeCSR(deviceName, qualifyingData any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeCSR", reflect.TypeOf((*MockClient)(nil).MakeCSR), deviceName, qualifyingData)
+}
+
+// Public mocks base method.
+func (m *MockClient) Public() crypto.PublicKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Public")
+	ret0, _ := ret[0].(crypto.PublicKey)
+	return ret0
+}
+
+// Public indicates an expected call of Public.
+func (mr *MockClientMockRecorder) Public() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Public", reflect.TypeOf((*MockClient)(nil).Public))
+}
+
+// SolveChallenge mocks base method.
+func (m *MockClient) SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SolveChallenge", credentialBlob, encryptedSecret)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SolveChallenge indicates an expected call of SolveChallenge.
+func (mr *MockClientMockRecorder) SolveChallenge(credentialBlob, encryptedSecret any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SolveChallenge", reflect.TypeOf((*MockClient)(nil).SolveChallenge), credentialBlob, encryptedSecret)
+}
+
+// UpdateNonce mocks base method.
+func (m *MockClient) UpdateNonce(nonce []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNonce", nonce)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateNonce indicates an expected call of UpdateNonce.
+func (mr *MockClientMockRecorder) UpdateNonce(nonce any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNonce", reflect.TypeOf((*MockClient)(nil).UpdateNonce), nonce)
+}
+
+// VendorInfoCollector mocks base method.
+func (m *MockClient) VendorInfoCollector(ctx context.Context) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VendorInfoCollector", ctx)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// VendorInfoCollector indicates an expected call of VendorInfoCollector.
+func (mr *MockClientMockRecorder) VendorInfoCollector(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VendorInfoCollector", reflect.TypeOf((*MockClient)(nil).VendorInfoCollector), ctx)
+}
 
 // MockStorage is a mock of Storage interface.
 type MockStorage struct {

--- a/internal/tpm/session.go
+++ b/internal/tpm/session.go
@@ -67,8 +67,9 @@ func (s *tpmSession) initialize() error {
 		return fmt.Errorf("ensuring SRK: %w", err)
 	}
 	s.handles[SRK] = srkHandle
-	// flush the SRK after initialization to free up transient space. The SRK
-	// isn't needed after loading.
+	// The SRK occupies transient space. After initialization the LAK and LDevID will be loaded
+	// into the TPM's transient memory and the SRK will no longer be needed. The SRK
+	// is flushed to free up space for other keys.
 	defer func() {
 		if err := s.flushKey(SRK); err != nil {
 			s.log.Errorf("Error flushing SRK key: %v", err)

--- a/internal/tpm/session_test.go
+++ b/internal/tpm/session_test.go
@@ -99,7 +99,6 @@ func TestTpmSession_LoadKey(t *testing.T) {
 			keyType: LAK,
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -114,7 +113,6 @@ func TestTpmSession_LoadKey(t *testing.T) {
 			keyType: LDevID,
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -132,7 +130,6 @@ func TestTpmSession_LoadKey(t *testing.T) {
 			keyType: LDevID,
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -147,7 +144,6 @@ func TestTpmSession_LoadKey(t *testing.T) {
 			keyType: LAK,
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -161,7 +157,7 @@ func TestTpmSession_LoadKey(t *testing.T) {
 			name:    "no SRK available",
 			keyType: LDevID,
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
-				session.srk = nil
+				delete(session.handles, SRK)
 			},
 			wantErr: errors.New("ensuring SRK is loaded"),
 		},
@@ -230,7 +226,6 @@ func TestTpmSession_Sign(t *testing.T) {
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				// Pre-populate SRK to avoid creation attempt
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -300,7 +295,6 @@ func TestTpmSession_CertifyKey(t *testing.T) {
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				// Pre-populate SRK to avoid creation attempt
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -316,7 +310,6 @@ func TestTpmSession_CertifyKey(t *testing.T) {
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				// Pre-populate SRK to avoid creation attempt
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -384,7 +377,6 @@ func TestTpmSession_GetPublicKey(t *testing.T) {
 			setupMocks: func(mockStorage *MockStorage, session *tpmSession) {
 				// Pre-populate SRK to avoid creation attempt
 				_, _, srkHandle := createValidTPMObjects()
-				session.srk = srkHandle
 				session.handles[SRK] = srkHandle
 				// Enable valid SRK response in mock connection
 				session.conn.(*mockReadWriteCloser).validSRK = true
@@ -472,7 +464,6 @@ func TestTpmSession_Close(t *testing.T) {
 
 			// After close, handles should be cleared regardless of TPM operation success
 			require.Empty(t, session.handles)
-			require.Nil(t, session.srk)
 
 			if tt.wantErr != nil {
 				require.Error(t, err)

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -1,11 +1,33 @@
 package tpm
 
 import (
+	"context"
+	"crypto"
 	"regexp"
 
 	legacy "github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpm2"
 )
+
+// Client defines the interface for interacting with the TPM
+type Client interface {
+	// Public returns the public key corresponding to the LDevID private key
+	Public() crypto.PublicKey
+	// MakeCSR generates a TCG-CSR-IDEVID structure for enrollment requests
+	MakeCSR(deviceName string, qualifyingData []byte) ([]byte, error)
+	// SolveChallenge uses TPM2_ActivateCredential to decrypt an encrypted secret
+	SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error)
+	// GetSigner returns the crypto.Signer interface for this client
+	GetSigner() crypto.Signer
+	// UpdateNonce updates the nonce used for TPM operations
+	UpdateNonce(nonce []byte) error
+	// Clear clears any stored TPM data
+	Clear() error
+	// Close closes the TPM session
+	Close(ctx context.Context) error
+	// VendorInfoCollector collects vendor information from the TPM
+	VendorInfoCollector(ctx context.Context) string
+}
 
 const (
 	MinNonceLength = 8


### PR DESCRIPTION
Adds the agent side of the TPM Credential Activation flow. 

1. Converts tpm.Client into an interface for mockability within tests
2. Flushes the SRK after loading both the LAK and LDevID to free up some transient space
3. Implements the Agent side of the Activate Credential handshake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - TPM-backed challenge-response identity verification during device enrollment.

- Improvements
  - Enrollment now includes a 60s identity-proof step with clearer error handling and logging.
  - Improved TLS/gRPC handling for enrollment endpoints, including client-certificate support and endpoint sanitization.

- Refactor
  - Unified TPM client abstraction and centralized TPM session/handle management.

- Tests
  - Expanded unit tests covering enrollment verification and TPM challenge flows.

- Documentation
  - Added mock-generation support for identity provider testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->