### PR TITLE
Add isACMRunning return value to isAcmInstalled

### DIFF
--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_test.go
@@ -19,11 +19,11 @@ var _ = Describe("Microshift cluster ACM enrollment tests", func() {
 	Describe("Test Setup", Ordered, func() {
 
 		BeforeAll(func() {
-			isAcmInstalled, err := util.IsAcmInstalled()
+			_, isAcmRunning, err := util.IsAcmInstalled()
 			if err != nil {
 				GinkgoWriter.Printf("An error happened %v\n", err)
 			}
-			if !isAcmInstalled {
+			if !isAcmRunning {
 				Skip("Skipping test suite because ACM is not installed.")
 			}
 		})

--- a/test/e2e/rbac/rbac_suite_test.go
+++ b/test/e2e/rbac/rbac_suite_test.go
@@ -24,7 +24,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Check if ACM is installed before running any tests
-	isAcmInstalled, err := util.IsAcmInstalled()
+	isAcmInstalled, _, err := util.IsAcmInstalled()
 
 	if err != nil {
 		GinkgoWriter.Printf("Error while checking if ACM is installed: %s", err)


### PR DESCRIPTION
To better ditinguish between the two.
Also output the status of the multiclusterhub in case it's not in running status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup now distinguishes ACM being installed vs actively running, so suite skips are more accurate.
  * Installed-but-not-running ACM is treated separately, reducing false negatives for paused/non-running instances.
  * Improved logging and diagnostics during environment checks for clearer troubleshooting.
  * No changes to product behavior; these updates improve test reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->