### PR TITLE
EDM-2157: flightctl-db-migration and flightctl-api are in error when installing with an external db

### DIFF
--- a/deploy/helm/flightctl/templates/_db-migration-job.tpl
+++ b/deploy/helm/flightctl/templates/_db-migration-job.tpl
@@ -41,7 +41,8 @@ spec:
       restartPolicy: Never
       serviceAccountName: flightctl-db-migration
       initContainers:
-      {{- include "flightctl.databaseWaitInitContainer" (dict "context" $ctx "userType" "admin" "timeout" 120 "sleep" 2) | nindent 6 }}
+      {{- $userType := ternary "admin" "migration" (ne $ctx.Values.db.external "enabled") }}
+      {{- include "flightctl.databaseWaitInitContainer" (dict "context" $ctx "userType" $userType "timeout" 120 "sleep" 2) | nindent 6 }}
       {{- if ne $ctx.Values.db.external "enabled" }}
       {{- if not $isDryRun }}
       - name: setup-database-users


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Helm chart behavior for database migration jobs when using an external database. The job now selects the appropriate user type automatically, ensuring correct permissions and smoother initialization.
  - Enhances reliability of deployments by aligning the init/wait container with the correct database role based on configuration.
- **Chores**
  - Internal template logic simplified without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->