### PR TITLE
NO-ISSUE: Run lint in a container

### DIFF
--- a/Containerfile.lint
+++ b/Containerfile.lint
@@ -1,0 +1,20 @@
+FROM golangci/golangci-lint:v1.61.0
+
+# Install libvirt and TPM development packages
+USER root
+RUN apt-get update && apt-get install -y \
+    libvirt-dev \
+    pkg-config \
+    swtpm \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy go.mod and go.sum to download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build go-tpm-tools to generate export data
+RUN go build -o /dev/null github.com/google/go-tpm-tools/simulator
+
+# Switch back to the original user
+USER golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -370,13 +370,19 @@ clean-quadlets:
 
 .PHONY: tools flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container
 
-tools: $(GOBIN)/golangci-lint
+# Use custom golangci-lint container with libvirt support
+LINT_IMAGE := flightctl-lint:latest
+LINT_CONTAINER := podman run --rm -v $(GOBASE):/app:Z -w /app --user 0 $(LINT_IMAGE)
 
-$(GOBIN)/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.61.0
+.PHONY: tools lint-image
+tools:
 
-lint: tools
-	$(GOBIN)/golangci-lint run -v
+lint-image:
+	podman build -f Containerfile.lint -t $(LINT_IMAGE)
+
+.PHONY: lint
+lint: lint-image
+	$(LINT_CONTAINER) golangci-lint run -v
 
 .PHONY: rpmlint
 rpmlint: check-rpmlint


### PR DESCRIPTION
"make lint" doesn't work on some systems. Run in a container so that it has a sterile environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Migrated linting to a containerized workflow for consistent, reproducible results across environments.
  - Introduced a dedicated lint container image and automated build step.
  - Updated development commands to run linting inside the container; removed the need to install linting tools locally.
  - Streamlines contributor setup and reduces host dependency issues.
  - No changes to application behavior or public interfaces; impact limited to development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->