### PR TITLE
EDM-2160: render on resume

### DIFF
--- a/api/v1alpha1/util.go
+++ b/api/v1alpha1/util.go
@@ -452,6 +452,7 @@ var warningReasons = map[EventReason]struct{}{
 	EventReasonDeviceDiskCritical:              {},
 	EventReasonDeviceDiskWarning:               {},
 	EventReasonDeviceDisconnected:              {},
+	EventReasonDeviceConflictPaused:            {},
 	EventReasonDeviceSpecInvalid:               {},
 	EventReasonFleetInvalid:                    {},
 	EventReasonDeviceMultipleOwnersDetected:    {},

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -248,7 +248,7 @@ func shouldRenderDevice(ctx context.Context, event api.Event, log logrus.FieldLo
 
 	if lo.Contains([]api.EventReason{api.EventReasonReferencedRepositoryUpdated,
 		api.EventReasonResourceCreated,
-		api.EventReasonFleetRolloutDeviceSelected}, event.Reason) {
+		api.EventReasonFleetRolloutDeviceSelected, api.EventReasonDeviceConflictResolved}, event.Reason) {
 		return true
 	}
 

--- a/internal/worker_client/worker_client.go
+++ b/internal/worker_client/worker_client.go
@@ -80,6 +80,7 @@ var eventReasons = map[api.EventReason]struct{}{
 	api.EventReasonReferencedRepositoryUpdated: {},
 	api.EventReasonFleetRolloutDeviceSelected:  {},
 	api.EventReasonFleetRolloutBatchDispatched: {},
+	api.EventReasonDeviceConflictResolved:      {},
 }
 
 func shouldEmitEvent(reason api.EventReason) bool {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -710,7 +710,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 			pausedEvent := findEventByReason(finalEvents, api.EventReasonDeviceConflictPaused)
 			Expect(pausedEvent).ToNot(BeNil(), "DeviceConflictPaused event should be generated when transitioning from Online to ConflictPaused")
-			Expect(pausedEvent.Type).To(Equal(api.Normal))
+			Expect(pausedEvent.Type).To(Equal(api.Warning))
 			Expect(pausedEvent.Message).To(ContainSubstring("Device reconciliation is paused due to a state conflict between the service and the device's agent; manual intervention is required."))
 		})
 	})


### PR DESCRIPTION
makes sure we re-render device spec when it was resumed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device views now refresh automatically after resolving a conflict, ensuring lists and details reflect the latest state.
  * Conflict-resolved events are forwarded to background workers so downstream processing and notifications occur reliably.

* **Changes**
  * Devices entering a "conflict paused" state now emit a distinct warning event so paused reconciliations are visible.
  * Device-disconnected is no longer classified as a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->