### PR TITLE
EDM-2145: The SSL certificate implementation for Flight Control's external database support

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -196,6 +196,8 @@ renderedVersion
 quadlets
 PEM
 NSING
+multiline
+flightctl-api
  - docs/user/api-resources.md
 approvedBy
 creationTimestamp
@@ -382,3 +384,5 @@ PL
 pgSQL
 values.yaml
 values.dev.yaml
+CN
+SAN

--- a/deploy/helm/flightctl/README.md.gotmpl
+++ b/deploy/helm/flightctl/README.md.gotmpl
@@ -162,7 +162,7 @@ helm uninstall my-{{ .Name }}
 
 ## Usage
 
-After installation, {{ .Name }} will be available in your cluster. 
+After installation, {{ .Name }} will be available in your cluster.
 
 {{ if eq .Name "flightctl" }}
 ### Accessing Flight Control
@@ -189,6 +189,40 @@ global:
     k8s:
       apiUrl: "https://api.cluster.example.com:6443"
 ```
+
+### TLS/SSL Certificate Configuration
+
+When using external PostgreSQL databases with TLS/SSL, Flight Control supports multiple certificate management options:
+
+#### Option 1: Kubernetes ConfigMap/Secret (Production)
+
+```bash
+# Create certificate resources
+kubectl create configmap postgres-ca-cert \
+  --from-file=ca-cert.pem=/path/to/ca-cert.pem
+
+kubectl create secret generic postgres-client-certs \
+  --from-file=client-cert.pem=/path/to/client-cert.pem \
+  --from-file=client-key.pem=/path/to/client-key.pem
+```
+
+```yaml
+# Configure in values.yaml
+db:
+  external: "enabled"
+  hostname: "postgres.example.com"
+  sslmode: "verify-ca"
+  sslConfigMap: "postgres-ca-cert"     # ConfigMap containing CA certificate
+  sslSecret: "postgres-client-certs"   # Secret containing client certificates
+```
+
+**TLS/SSL Modes:**
+- `disable` - No TLS/SSL (not recommended for production)
+- `require` - TLS/SSL required, no certificate verification
+- `verify-ca` - TLS/SSL required, verify server certificate against CA
+- `verify-full` - TLS/SSL required, verify certificate and hostname
+
+For complete TLS/SSL configuration details, see the [external database documentation](https://docs.flightctl.io/user/external-database/).
 {{ end }}
 
 For more detailed configuration options, see the [Values](#values) section below.
@@ -221,7 +255,7 @@ To use these files:
 # Development deployment
 helm install my-flightctl oci://quay.io/flightctl/charts/flightctl -f values.dev.yaml
 
-# ACM integration deployment  
+# ACM integration deployment
 helm install my-flightctl oci://quay.io/flightctl/charts/flightctl -f values.acm.yaml
 
 # Combine multiple values files (later files override earlier ones)

--- a/deploy/helm/flightctl/templates/_db-migration-job.tpl
+++ b/deploy/helm/flightctl/templates/_db-migration-job.tpl
@@ -212,10 +212,12 @@ spec:
         - mountPath: /root/.flightctl/
           name: flightctl-db-migration-config
           readOnly: true
+        {{- include "flightctl.dbSslVolumeMounts" $ctx | nindent 8 }}
       volumes:
       - name: flightctl-db-migration-config
         configMap:
           name: flightctl-db-migration-config
+      {{- include "flightctl.dbSslVolumes" $ctx | nindent 6 }}
 {{- end }}
 
 

--- a/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-api-deployment.yaml
@@ -104,6 +104,7 @@ spec:
               name: flightctl-api-k8s-token
               readOnly: true
             {{- end}}
+            {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
 
       restartPolicy: Always
       volumes:
@@ -118,4 +119,5 @@ spec:
           secret:
             secretName: flightctl-api-k8s-token
         {{- end}}
+        {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-periodic-deployment.yaml
@@ -55,10 +55,12 @@ spec:
               name: flightctl-periodic-config
               subPath: config.yaml
               readOnly: true
+            {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
 
       restartPolicy: Always
       volumes:
         - name: flightctl-periodic-config
           configMap:
             name: flightctl-periodic-config
+        {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-worker-deployment.yaml
@@ -62,9 +62,11 @@ spec:
               name: flightctl-worker-config
               subPath: config.yaml
               readOnly: true
+            {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
       restartPolicy: Always
       volumes:
         - name: flightctl-worker-config
           configMap:
             name: flightctl-worker-config
+        {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{ end }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -115,12 +115,10 @@ db:
   type: "pgsql"
   # -- SSL mode for database connections (disable, allow, prefer, require, verify-ca, verify-full)
   sslmode: ""
-  # -- SSL client certificate file path
-  sslcert: ""
-  # -- SSL client key file path
-  sslkey: ""
-  # -- SSL root certificate file path (CA certificate)
-  sslrootcert: ""
+  # -- ConfigMap containing CA certificate (automatically mounted at /etc/ssl/postgres/)
+  sslConfigMap: ""
+  # -- Secret containing client certificates (automatically mounted at /etc/ssl/postgres/)
+  sslSecret: ""
   # Internal database deployment configuration (ignored when external: "enabled")
   image:
     # -- PostgreSQL container image


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Add SSL/TLS support for external PostgreSQL across API, worker, periodic, and migration jobs with configurable certificate mounting via Kubernetes ConfigMap/Secret.

- Documentation
  - Expand Helm and external-database docs with TLS/SSL configuration, supported modes, setup options (production/dev), certificate generation, testing, and troubleshooting; update values/schema references for new TLS options.

- Chores
  - Update spelling dictionary with entries: multiline, flightctl-api, CN, SAN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->