### PR TITLE
NO-ISSUE: Allow to resize the agent-vm disks

### DIFF
--- a/deploy/agent-vm.mk
+++ b/deploy/agent-vm.mk
@@ -2,14 +2,19 @@ VMNAME ?= flightctl-device-default
 VMRAM ?= 512
 VMCPUS ?= 1
 VMDISK = /var/lib/libvirt/images/$(VMNAME).qcow2
+VMDISKSIZE_DEFAULT := 10G
+VMDISKSIZE ?= $(VMDISKSIZE_DEFAULT)
 VMWAIT ?= 0
 CONTAINER_NAME ?= flightctl-device-no-bootc:base
 
 BUILD_TYPE := bootc
 
 agent-vm: bin/output/qcow2/disk.qcow2
-	@echo "Booting Agent VM from $(VMDISK)"
+	@echo "Booting Agent VM from $(VMDISK) with disk size $(VMDISKSIZE)"
 	sudo cp bin/output/qcow2/disk.qcow2 $(VMDISK)
+	@if [ "$(VMDISKSIZE)" != "$(VMDISKSIZE_DEFAULT)" ]; then \
+		sudo qemu-img resize $(VMDISK) $(VMDISKSIZE); \
+	fi
 	sudo chown libvirt:libvirt $(VMDISK) 2>/dev/null || true
 	sudo virt-install --name $(VMNAME) \
 		--tpm backend.type=emulator,backend.version=2.0,model=tpm-tis \

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -90,9 +90,11 @@ make agent-vm agent-vm-console # user/password is user/user
 ```
 
 The agent-vm target accepts multiple parameters:
+
 - VMNAME: the name of the VM to create (default: flightctl-device-default)
 - VMCPUS: the number of CPUs to allocate to the VM (default: 1)
-- VMMEM: the amount of memory to allocate to the VM (default: 512)
+- VMRAM: the amount of memory to allocate to the VM (default: 512)
+- VMDISKSIZE: the disk size for the VM (default: 10G)
 - VMWAIT: the amount of minutes to wait on the console during first boot (default: 0)
 
 It is possible to create multiple VMs with different names:

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -31,6 +31,7 @@ type TestVM struct {
 	hasCloudInit   bool
 	cloudInitArgs  string
 	MemoryFilePath string // Path for external snapshot memory file
+	DiskSizeGB     int
 }
 
 type TestVMInterface interface {

--- a/test/harness/e2e/vm/vm_linux.go
+++ b/test/harness/e2e/vm/vm_linux.go
@@ -18,6 +18,9 @@ import (
 	"libvirt.org/go/libvirt"
 )
 
+// Default disk size in GB for VM instances
+const DefaultDiskSizeGB = 10
+
 //go:embed domain-template.xml
 var domainTemplate string
 
@@ -319,6 +322,12 @@ func (v *VMInLibvirt) parseDomainTemplate() (domainXML string, err error) {
 		Name            string
 		CloudInitCDRom  string
 		CloudInitSMBios string
+		DiskSize        string
+	}
+
+	diskSize := v.TestVM.DiskSizeGB
+	if diskSize <= 0 {
+		diskSize = DefaultDiskSizeGB
 	}
 
 	templateParams := TemplateParams{
@@ -326,6 +335,7 @@ func (v *VMInLibvirt) parseDomainTemplate() (domainXML string, err error) {
 		Port:          strconv.Itoa(v.TestVM.SSHPort),
 		PIDFile:       v.pidFile,
 		Name:          v.TestVM.VMName,
+		DiskSize:      strconv.Itoa(diskSize),
 	}
 
 	err = v.ParseCloudInit()


### PR DESCRIPTION
Some tests using the `agent-vm` VMs were failing with insufficient disk space.

I kept the default disk size of 10GB, and added an optional parameter to specify a different disk size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable Agent VM disk size with a 10G default; disk image auto-resizes when a non-default size is specified and startup message shows the selected size.
- Documentation
  - Agent VM parameters updated to reflect RAM naming and the new disk size option; defaults clarified.
- Tests
  - Test harness updated to accept a VM disk-size parameter and provides a 10GB default for Linux tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->