### PR TITLE
EDM-2015: Refresh manufacturer cert paths

### DIFF
--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/org/resolvers"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -91,7 +92,7 @@ func main() {
 		Cache:  orgCache,
 	}
 	orgResolver := resolvers.BuildResolver(buildResolverOpts)
-	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(store, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver))
+	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(store, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver))
 
 	server := alert_exporter.New(cfg, log)
 	if err := server.Run(ctx, serviceHandler); err != nil {

--- a/cmd/flightctl-restore/main.go
+++ b/cmd/flightctl-restore/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/org/resolvers"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/sirupsen/logrus"
 )
@@ -75,7 +76,7 @@ func main() {
 		Cache:  orgCache,
 	}
 	orgResolver := resolvers.BuildResolver(buildResolverOpts)
-	serviceHandler := service.NewServiceHandler(storeInst, nil, kvStore, nil, log, "", "", []string{}, orgResolver)
+	serviceHandler := service.NewServiceHandler(storeInst, nil, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 
 	log.Println("Running post-restoration device preparation")
 	if err := serviceHandler.PrepareDevicesAfterRestore(ctx); err != nil {

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flightctl/flightctl/internal/rendered"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/poll"
@@ -90,7 +91,7 @@ func (s *Server) Run(ctx context.Context) error {
 		Cache:  orgCache,
 	}
 	orgResolver := resolvers.BuildResolver(buildResolverOpts)
-	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}, orgResolver))
+	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", tpm.NewDisabledCAVerifier(), orgResolver))
 
 	// Initialize the task executors
 	periodicTaskExecutors := InitializeTaskExecutors(s.log, serviceHandler, s.cfg, queuesProvider, nil)

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/org/resolvers"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/sirupsen/logrus"
 )
@@ -18,11 +19,11 @@ type ServiceHandler struct {
 	kvStore       kvstore.KVStore
 	agentEndpoint string
 	uiUrl         string
-	tpmCAPaths    []string
+	tmpVerifier   tpm.CAVerifier
 	orgResolver   resolvers.Resolver
 }
 
-func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tpmCAPaths []string, orgResolver resolvers.Resolver) *ServiceHandler {
+func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tmpVerifier tpm.CAVerifier, orgResolver resolvers.Resolver) *ServiceHandler {
 	return &ServiceHandler{
 		eventHandler:  NewEventHandler(store, workerClient, log),
 		store:         store,
@@ -32,7 +33,7 @@ func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClien
 		kvStore:       kvStore,
 		agentEndpoint: agentEndpoint,
 		uiUrl:         uiUrl,
-		tpmCAPaths:    tpmCAPaths,
+		tmpVerifier:   tmpVerifier,
 		orgResolver:   orgResolver,
 	}
 }

--- a/internal/tasks/device_disconnected_test.go
+++ b/internal/tasks/device_disconnected_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -20,7 +21,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	"gorm.io/gorm"
 )
 
@@ -53,7 +54,7 @@ func BenchmarkDeviceDisconnectedPoll(b *testing.B) {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		require.NoError(err)
 		orgResolver := util.NewOrgResolver(cfg, dbStore.Organization(), log)
-		serviceHandler := service.NewServiceHandler(dbStore, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler := service.NewServiceHandler(dbStore, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 
 		devices := generateMockDevices(deviceCount)
 		err = batchCreateDevices(ctx, db, devices, deviceCount)

--- a/internal/tpm/verifier.go
+++ b/internal/tpm/verifier.go
@@ -1,0 +1,137 @@
+package tpm
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrManufacturerCACertsNotConfigured = fmt.Errorf("TPM CA certificates not configured")
+)
+
+// CAPathProvider represents a function that returns a slice of CA file paths
+type CAPathProvider func() ([]string, error)
+
+// CAVerifier defines the interface required for verifying that a tpm based CSR is verified by expected
+// manufacturer certs
+type CAVerifier interface {
+	VerifyChain(csrBytes []byte) error
+}
+
+type verifier struct {
+	pathProvider    CAPathProvider
+	log             *logrus.Logger
+	mu              sync.Mutex
+	paths           []string
+	certPool        *x509.CertPool
+	refreshInterval time.Duration
+	ctx             context.Context
+}
+
+// NewCAVerifier returns a CAVerifier that will refresh it's known cert pool when required
+func NewCAVerifier(ctx context.Context, initialPaths []string, pathProvider CAPathProvider, logger *logrus.Logger) CAVerifier {
+	paths := slices.Clone(initialPaths)
+	// keep paths sorted for easy comparison
+	slices.Sort(paths)
+
+	v := &verifier{
+		pathProvider:    pathProvider,
+		log:             logger,
+		paths:           paths,
+		refreshInterval: time.Minute,
+		ctx:             ctx,
+	}
+
+	if len(initialPaths) > 0 {
+		if pool, err := LoadCAsFromPaths(initialPaths); err == nil {
+			v.certPool = pool
+		}
+	}
+
+	go v.periodicReload()
+
+	return v
+}
+
+// NewDisabledCAVerifier creates a verifier that always returns "not configured" error.
+// This is useful for tests and scenarios where TPM verification is not needed.
+func NewDisabledCAVerifier() CAVerifier {
+	return &disabledVerifier{}
+}
+
+type disabledVerifier struct{}
+
+func (d *disabledVerifier) VerifyChain(_ []byte) error {
+	return ErrManufacturerCACertsNotConfigured
+}
+
+// periodicReload runs in the background and reloads certificates at regular intervals
+func (v *verifier) periodicReload() {
+	ticker := time.NewTicker(v.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-v.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := v.reloadCertPool(); err != nil {
+				v.log.Errorf("Error reloading certificate pool: %v", err)
+			}
+		}
+	}
+}
+
+// VerifyChain performs validation on the supplied CSR to verify the CSR is genuine
+func (v *verifier) VerifyChain(csrBytes []byte) error {
+	v.mu.Lock()
+	pool := v.certPool
+	v.mu.Unlock()
+
+	if pool == nil {
+		return ErrManufacturerCACertsNotConfigured
+	}
+
+	return VerifyTCGCSRChainOfTrustWithRoots(csrBytes, pool)
+}
+
+func (v *verifier) reloadCertPool() error {
+	if v.pathProvider == nil {
+		return fmt.Errorf("no path provider configured")
+	}
+
+	paths, err := v.pathProvider()
+	if err != nil {
+		return fmt.Errorf("getting CA paths: %w", err)
+	}
+	if len(paths) == 0 {
+		return ErrManufacturerCACertsNotConfigured
+	}
+
+	pathClone := slices.Clone(paths)
+
+	// keep the paths sorted for easier comparison
+	slices.Sort(pathClone)
+
+	// Nothing changed, no need to reload
+	if slices.Equal(v.paths, pathClone) && v.certPool != nil {
+		return nil
+	}
+
+	v.paths = pathClone
+	newPool, err := LoadCAsFromPaths(v.paths)
+	if err != nil {
+		return fmt.Errorf("loading CA certificates: %w", err)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.certPool = newPool
+	return nil
+}

--- a/internal/tpm/verifier_test.go
+++ b/internal/tpm/verifier_test.go
@@ -1,0 +1,306 @@
+package tpm
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCAVerifier(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialPaths []string
+		pathProvider CAPathProvider
+		expectError  bool
+	}{
+		{
+			name:         "empty initial paths",
+			initialPaths: []string{},
+			pathProvider: func() ([]string, error) { return []string{}, nil },
+			expectError:  true, // should fail verification due to no certs
+		},
+		{
+			name:         "invalid initial paths",
+			initialPaths: []string{"/nonexistent/path"},
+			pathProvider: func() ([]string, error) { return []string{}, nil },
+			expectError:  true, // should fail verification due to no valid certs
+		},
+		{
+			name:         "nil path provider",
+			initialPaths: []string{},
+			pathProvider: nil,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			logger := logrus.New()
+			logger.SetLevel(logrus.ErrorLevel) // Reduce noise in tests
+
+			verifier := NewCAVerifier(ctx, tt.initialPaths, tt.pathProvider, logger)
+			require.NotNil(t, verifier)
+
+			// Test with dummy CSR bytes
+			err := verifier.VerifyChain([]byte("dummy"))
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVerifyChain(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	// Test with empty cert pool
+	verifier := NewCAVerifier(ctx, []string{}, nil, logger)
+	err := verifier.VerifyChain([]byte("dummy"))
+	assert.Error(t, err)
+	assert.Equal(t, ErrManufacturerCACertsNotConfigured, err)
+}
+
+func TestPeriodicReload(t *testing.T) {
+	callCount := 0
+	pathProvider := func() ([]string, error) {
+		callCount++
+		return []string{"/some/path"}, nil // Return valid format but invalid path
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	v := &verifier{
+		pathProvider:    pathProvider,
+		log:             logger,
+		paths:           []string{},
+		refreshInterval: 50 * time.Millisecond,
+		ctx:             ctx,
+	}
+
+	go v.periodicReload()
+
+	// Wait for a few reload cycles
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that periodic reloading is happening
+	assert.Greater(t, callCount, 2) // Should have called multiple times
+
+	// VerifyChain should not trigger additional reloads
+	initialCallCount := callCount
+	err := v.VerifyChain([]byte("dummy"))
+	assert.Error(t, err)                         // Should error due to cert loading failure
+	assert.Equal(t, initialCallCount, callCount) // Should not have triggered additional reload
+}
+
+func TestReloadOnPathChanges(t *testing.T) {
+	paths := []string{"/path1"}
+	pathProvider := func() ([]string, error) {
+		return paths, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	v := &verifier{
+		pathProvider:    pathProvider,
+		log:             logger,
+		paths:           []string{"/initial/path"},
+		refreshInterval: 50 * time.Millisecond,
+		ctx:             ctx,
+	}
+
+	go v.periodicReload()
+
+	// Wait for initial reload
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify paths were updated
+	v.mu.Lock()
+	currentPaths := v.paths
+	v.mu.Unlock()
+
+	assert.Equal(t, []string{"/path1"}, currentPaths)
+
+	// Change paths
+	paths = []string{"/path1", "/path2"}
+
+	// Wait for reload to pick up changes
+	time.Sleep(100 * time.Millisecond)
+
+	v.mu.Lock()
+	updatedPaths := v.paths
+	v.mu.Unlock()
+
+	assert.Equal(t, []string{"/path1", "/path2"}, updatedPaths)
+}
+
+func TestReloadCertPool(t *testing.T) {
+	tests := []struct {
+		name         string
+		pathProvider CAPathProvider
+		expectError  bool
+	}{
+		{
+			name:         "nil path provider",
+			pathProvider: nil,
+			expectError:  true,
+		},
+		{
+			name: "path provider returns error",
+			pathProvider: func() ([]string, error) {
+				return nil, assert.AnError
+			},
+			expectError: true,
+		},
+		{
+			name: "empty paths",
+			pathProvider: func() ([]string, error) {
+				return []string{}, nil
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid paths",
+			pathProvider: func() ([]string, error) {
+				return []string{"/invalid/path"}, nil
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			logger := logrus.New()
+			logger.SetLevel(logrus.ErrorLevel)
+
+			v := &verifier{
+				pathProvider:    tt.pathProvider,
+				log:             logger,
+				paths:           []string{},
+				refreshInterval: time.Minute,
+				ctx:             ctx,
+			}
+
+			err := v.reloadCertPool()
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	var callCount int
+	var mu sync.Mutex
+	pathProvider := func() ([]string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		callCount++
+		return []string{"/some/path"}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	v := &verifier{
+		pathProvider:    pathProvider,
+		log:             logger,
+		paths:           []string{},
+		refreshInterval: 50 * time.Millisecond,
+		ctx:             ctx,
+	}
+
+	go v.periodicReload()
+
+	// Wait for initial reload
+	time.Sleep(100 * time.Millisecond)
+
+	// Run multiple VerifyChain calls concurrently
+	const numGoroutines = 10
+	done := make(chan bool, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer func() { done <- true }()
+			for j := 0; j < 5; j++ {
+				err := v.VerifyChain([]byte("dummy"))
+				assert.Error(t, err) // Should error due to cert loading failure
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+
+	// Should have attempted at least some reloads
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+	assert.Greater(t, count, 0)
+}
+
+func TestPathSorting(t *testing.T) {
+	unsortedPaths := []string{"/path/z", "/path/a", "/path/m"}
+	pathProvider := func() ([]string, error) {
+		return unsortedPaths, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	v := &verifier{
+		pathProvider:    pathProvider,
+		log:             logger,
+		paths:           []string{},
+		refreshInterval: 50 * time.Millisecond,
+		ctx:             ctx,
+	}
+
+	go v.periodicReload()
+
+	// Wait for reload
+	time.Sleep(100 * time.Millisecond)
+
+	v.mu.Lock()
+	sortedPaths := v.paths
+	v.mu.Unlock()
+
+	// Paths should be sorted
+	expected := []string{"/path/a", "/path/m", "/path/z"}
+	assert.Equal(t, expected, sortedPaths)
+}

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -82,7 +83,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 	orgResolver := resolvers.BuildResolver(buildResolverOpts)
 	serviceHandler := service.WrapWithTracing(
-		service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}, orgResolver))
+		service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", tpm.NewDisabledCAVerifier(), orgResolver))
 
 	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, serviceHandler, s.k8sClient, kvStore, 1, 1, s.workerMetrics); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")

--- a/test/integration/alerts/exporter_test.go
+++ b/test/integration/alerts/exporter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -70,7 +71,7 @@ var _ = Describe("Alert Exporter", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		checkpointManager = alert_exporter.NewCheckpointManager(log, serviceHandler)
 		eventProcessor = alert_exporter.NewEventProcessor(log, serviceHandler)
 		alertSender = alert_exporter.NewAlertSender(log, cfg.Alertmanager.Hostname, cfg.Alertmanager.Port, cfg)

--- a/test/integration/periodic_checker/periodic_checker_test.go
+++ b/test/integration/periodic_checker/periodic_checker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/poll"
@@ -137,7 +138,7 @@ var _ = Describe("Periodic", func() {
 		// Setup worker client and service handler
 		workerClient = worker_client.NewWorkerClient(queuePublisher, log)
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 
 		channelManager, err = periodic.NewChannelManager(periodic.ChannelManagerConfig{
 			Log: log,

--- a/test/integration/rollout/device_selection/device_selection_test.go
+++ b/test/integration/rollout/device_selection/device_selection_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
@@ -347,7 +348,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 	})
 	AfterEach(func() {
 		store.DeleteTestDB(ctx, log, cfg, storeInst, dbName)

--- a/test/integration/rollout/disruption_budget/disruptions_budget_test.go
+++ b/test/integration/rollout/disruption_budget/disruptions_budget_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/rollout/disruption_budget"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
@@ -203,7 +204,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		capturedEvents = make([]api.Event, 0)
 	})
 	AfterEach(func() {

--- a/test/integration/service/service_suite_test.go
+++ b/test/integration/service/service_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -72,7 +73,7 @@ func (s *ServiceTestSuite) Setup() {
 	Expect(err).ToNot(HaveOccurred())
 
 	orgResolver := testutil.NewOrgResolver(s.cfg, s.Store.Organization(), s.Log)
-	s.Handler = service.NewServiceHandler(s.Store, s.workerClient, kvStore, s.caClient, s.Log, "", "", []string{}, orgResolver)
+	s.Handler = service.NewServiceHandler(s.Store, s.workerClient, kvStore, s.caClient, s.Log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 }
 
 // Teardown performs common cleanup for service tests

--- a/test/integration/tasks/device_disconnected_test.go
+++ b/test/integration/tasks/device_disconnected_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -49,7 +50,7 @@ var _ = Describe("DeviceDisconnected", func() {
 		workerClient = worker_client.NewMockWorkerClient(ctrl)
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		disconnectedTask = tasks.NewDeviceDisconnected(log, serviceHandler)
 	})
 

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -65,7 +66,7 @@ var _ = Describe("DeviceRender", func() {
 		kvStoreInst, err = kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 	})
 
 	AfterEach(func() {

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
@@ -79,7 +80,7 @@ var _ = Describe("FleetRollout", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 	})
 
 	AfterEach(func() {

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -58,7 +59,7 @@ var _ = Describe("FleetSelector", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		event := api.Event{
 			Reason: api.EventReasonResourceUpdated,
 			InvolvedObject: api.ObjectReference{

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -57,7 +58,7 @@ var _ = Describe("FleetValidate", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 
 		spec := api.RepositorySpec{}
 		err = spec.FromGenericRepoSpec(api.GenericRepoSpec{

--- a/test/integration/tasks/repo_update_test.go
+++ b/test/integration/tasks/repo_update_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -45,7 +46,7 @@ var _ = Describe("RepoUpdate", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 
 		// Create 2 git config items, each to a different repo
 		err = testutil.CreateRepositories(ctx, 2, storeInst, orgId)

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -88,7 +89,7 @@ var _ = Describe("RepoTester", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, stores.Organization(), log)
-		serviceHandler = service.NewServiceHandler(stores, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(stores, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		repotestr = tasks.NewRepoTester(log, serviceHandler)
 		repotestr.TypeSpecificRepoTester = &MockRepoTester{}
 	})

--- a/test/integration/tasks/resourcesync_test.go
+++ b/test/integration/tasks/resourcesync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
@@ -50,7 +51,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		orgResolver := testutil.NewOrgResolver(cfg, storeInst.Organization(), log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, orgResolver)
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", tpm.NewDisabledCAVerifier(), orgResolver)
 		resourceSync = tasks.NewResourceSync(serviceHandler, log, nil)
 
 		// Set up mock expectations for the publisher

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/flightctl/flightctl/internal/org/resolvers"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/queues"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -220,7 +221,7 @@ func NewTestApiServer(log logrus.FieldLogger, cfg *config.Config, store store.St
 		return nil, nil, fmt.Errorf("NewTLSListener: error creating TLS certs: %w", err)
 	}
 
-	return apiserver.New(log, cfg, store, ca, listener, queuesProvider, nil, orgResolver), listener, nil
+	return apiserver.New(log, cfg, store, ca, listener, queuesProvider, nil, tpm.NewDisabledCAVerifier(), orgResolver), listener, nil
 }
 
 // NewTestAgentServer creates a new test server and returns the server and the listener listening on localhost's next available port.
@@ -237,7 +238,7 @@ func NewTestAgentServer(ctx context.Context, log logrus.FieldLogger, cfg *config
 		return nil, nil, fmt.Errorf("NewTestAgentServer: error creating TLS certs: %w", err)
 	}
 
-	agentServer, err := agentserver.New(ctx, log, cfg, store, ca, listener, queuesProvider, tlsConfig, orgResolver)
+	agentServer, err := agentserver.New(ctx, log, cfg, store, ca, listener, queuesProvider, tlsConfig, tpm.NewDisabledCAVerifier(), orgResolver)
 	if err != nil {
 		_ = listener.Close()
 		return nil, nil, fmt.Errorf("NewTestAgentServer: error creating agent server: %w", err)


### PR DESCRIPTION
Unlike the agent, the api service doesn't have a mechanism for refreshing it's configuration. It generates/loads it's configuration on start up and then never again. The TPM cert paths are defined in the config file which currently requires a restart to pick up any new files. This PR changes the behavior so that paths in the config file can be updated and the service will refresh the cert pool without restarting the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Integrated TPM manufacturer CA verification across API, Agent, worker and service flows; supports disabled verifier for test/development.
  - Automatic, dynamic TPM CA certificate reloads on verification failure with throttling (no restart required).

- Documentation
  - Expanded TPM authentication guide with dynamic refresh, vendor CA notes, Kubernetes/standalone update steps, retry behavior, and rate-limiting guidance.

- Tests
  - Comprehensive verifier unit tests added; test suites updated to use the new disabled CA verifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->