### PR TITLE
EDM-2195: helm: honor generateSecrets for all secrets

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -292,10 +292,11 @@ For more detailed configuration options, see the [Values](#values) section below
 | global.baseDomainTls.cert | string | `""` | Certificate for the base domain wildcard certificate, it should be valid for *.${baseDomain}. This certificate is only used for non mTLS endpoints, mTLS endpoints like agent-api, etc will use different certificates. |
 | global.baseDomainTls.key | string | `""` | Key for the base domain wildcard certificate. |
 | global.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
-| global.exposeServicesMethod | string | `"route"` | How the FCTL services should be exposed. Can be either nodePort or route |
+| global.exposeServicesMethod | string | `"route"` | How the Flight Control services should be exposed. Can be either nodePort or route |
 | global.gatewayClass | string | `""` | Gateway API class name for gateway exposure method |
 | global.gatewayPorts.http | int | `80` | HTTP port for Gateway API configuration |
 | global.gatewayPorts.tls | int | `443` | TLS port for Gateway API configuration |
+| global.generateSecrets | bool | `true` | Generate secrets when deploying Flight Control. This should be set to false if you want to provide your own secrets or when upgrading Flight Control to avoid overriding the existing secrets |
 | global.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for all containers |
 | global.imagePullSecretName | string | `""` | Name of the image pull secret for accessing private container registries |
 | global.internalNamespace | string | `""` | Namespace where internal components are deployed |

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
+{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pgadmin.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
+{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-db-pguser-keycloak.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
+{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
 {{ $password := include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-db-pguser-keycloak" "namespace" (default .Release.Namespace .Values.db.namespace) "key" "password" "context" $) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
+++ b/deploy/helm/flightctl/charts/keycloak/templates/keycloak-realm-secret.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin") }}
+{{ if and .Values.global.generateSecrets (and (eq (.Values.global).target "standalone") (eq (.Values.global.auth).type "builtin")) }}
 {{- $demoUserPassword := (include "keycloak.lookupOrGeneratePassword" (dict "secret" "keycloak-demouser-secret" "namespace" .Release.Namespace "key" "password" "context" $)) }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/flightctl/templates/flightctl-db-admin-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-admin-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.generateSecrets }}
 {{- $namespaces := list .Release.Namespace }}
 {{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
 {{- $namespaces = append $namespaces .Values.global.internalNamespace }}
@@ -36,4 +37,5 @@ data:
   # PostgreSQL superuser credentials for database initialization only
   masterUser: {{ $.Values.db.masterUser | b64enc }}
   masterPassword: {{ if $.Values.db.masterPassword }}{{ $.Values.db.masterPassword | b64enc }}{{ else }}{{ $masterPassword }}{{ end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-db-app-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-app-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.generateSecrets }}
 {{- $namespaces := list .Release.Namespace }}
 {{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
 {{- $namespaces = append $namespaces .Values.global.internalNamespace }}
@@ -35,4 +36,5 @@ type: Opaque
 data:
   user: {{ $.Values.db.user | b64enc }}
   userPassword: {{ if $.Values.db.userPassword }}{{ $.Values.db.userPassword | b64enc }}{{ else }}{{ $userPassword }}{{ end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-db-migration-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-migration-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.generateSecrets }}
 {{- $namespaces := list .Release.Namespace }}
 {{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
 {{- $namespaces = append $namespaces .Values.global.internalNamespace }}
@@ -33,4 +34,5 @@ data:
   # Migration user credentials for schema changes only
   migrationUser: {{ (default "flightctl_migrator" $.Values.db.migrationUser) | b64enc }}
   migrationPassword: {{ if $.Values.db.migrationPassword }}{{ $.Values.db.migrationPassword | b64enc }}{{ else }}{{ $migrationPassword }}{{ end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/flightctl-kv-secret.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-kv-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.generateSecrets }}
 {{- $namespaces := list .Release.Namespace }}
 {{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
 {{- $namespaces = append $namespaces .Values.global.internalNamespace }}
@@ -29,4 +30,5 @@ metadata:
 type: Opaque
 data:
   password: {{ if $.Values.kv.password }}{{ $.Values.kv.password | b64enc }}{{ else }}{{ $password }}{{ end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -60,7 +60,7 @@ global:
   clusterLevelSecretAccess: false
   # -- This is only related to deployment in Red Hat's PAAS.
   appCode: ""
-  # -- How the FCTL services should be exposed. Can be either nodePort or route
+  # -- How the Flight Control services should be exposed. Can be either nodePort or route
   exposeServicesMethod: "route" # route, nodePort, gateway
   # -- Gateway API class name for gateway exposure method
   gatewayClass: ""
@@ -86,6 +86,8 @@ global:
     tls: 443
     # -- HTTP port for Gateway API configuration
     http: 80
+  # -- Generate secrets when deploying Flight Control. This should be set to false if you want to provide your own secrets or when upgrading Flight Control to avoid overriding the existing secrets
+  generateSecrets: true
   # -- Image pull policy for all containers
   imagePullPolicy: IfNotPresent
   rbac:


### PR DESCRIPTION
This PR reverts the removal of globlal.generateSecrets. ACM today generates the resources for RHEM with 
```
helm template -f values.yaml -f values.acm.yaml --set global.generateSecrets=false .
```
the result is passwords we leaked into version control and would be applied globally.

- 
- https://github.com/flightctl/flightctl/commit/4b6d8e871496cefcb4c98634d2fbac5980095c99#diff-a189263f016ea14eddba975b4ca0c4f4de873653f3ae39e7353224b54c952a9d
- https://github.com/flightctl/flightctl/pull/1442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global generateSecrets (default: true) to control automatic secret creation during Flight Control deployment.
  * Secret generation for Flight Control and Keycloak components is now conditional on this setting to avoid overriding existing secrets on upgrades.

* **Documentation**
  * Clarified wording to reference "Flight Control" for service exposure.
  * Documented generateSecrets with guidance on supplying your own secrets or disabling generation during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->