### PR TITLE
EDM-1804: Add ability to generate Application Identities

### DIFF
--- a/internal/tpm/client_test.go
+++ b/internal/tpm/client_test.go
@@ -874,7 +874,10 @@ func TestClient_SimulatorIntegration(t *testing.T) {
 
 			rw := fileio.NewReadWriter(fileio.WithTestRootDir(t.TempDir()))
 
-			c, err := newClientWithConnection(sim, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+			connFactory := func() (io.ReadWriteCloser, error) {
+				return sim, nil
+			}
+			c, err := newClientWithConnection(connFactory, log.NewPrefixLogger("test"), rw, &agent_config.Config{
 				TPM: agent_config.TPM{
 					Enabled:         true,
 					DevicePath:      agent_config.DefaultTPMDevicePath,
@@ -896,7 +899,10 @@ func TestClient_SimulatorIntegration(t *testing.T) {
 			require.NoError(err)
 
 			// Create a new client with the same configuration
-			c2, err := newClientWithConnection(sim, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+			connFactory2 := func() (io.ReadWriteCloser, error) {
+				return sim, nil
+			}
+			c2, err := newClientWithConnection(connFactory2, log.NewPrefixLogger("test"), rw, &agent_config.Config{
 				TPM: agent_config.TPM{
 					Enabled:         true,
 					DevicePath:      agent_config.DefaultTPMDevicePath,
@@ -916,7 +922,10 @@ func TestClient_SimulatorIntegration(t *testing.T) {
 			require.NoError(err)
 
 			// Create a third client to verify Clear worked - TPM hierarchy reset and storage cleared
-			c3, err := newClientWithConnection(sim, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+			connFactory3 := func() (io.ReadWriteCloser, error) {
+				return sim, nil
+			}
+			c3, err := newClientWithConnection(connFactory3, log.NewPrefixLogger("test"), rw, &agent_config.Config{
 				TPM: agent_config.TPM{
 					Enabled:         true,
 					DevicePath:      agent_config.DefaultTPMDevicePath,
@@ -1348,7 +1357,10 @@ func TestSessionGenerateChallenge(t *testing.T) {
 
 			rw := fileio.NewReadWriter(fileio.WithTestRootDir(t.TempDir()))
 
-			c, err := newClientWithConnection(sim, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+			connFactory := func() (io.ReadWriteCloser, error) {
+				return sim, nil
+			}
+			c, err := newClientWithConnection(connFactory, log.NewPrefixLogger("test"), rw, &agent_config.Config{
 				TPM: agent_config.TPM{
 					Enabled:         true,
 					DevicePath:      agent_config.DefaultTPMDevicePath,
@@ -1405,7 +1417,10 @@ func TestCreateCredential(t *testing.T) {
 
 			rw := fileio.NewReadWriter(fileio.WithTestRootDir(t.TempDir()))
 
-			c, err := newClientWithConnection(sim, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+			connFactory := func() (io.ReadWriteCloser, error) {
+				return sim, nil
+			}
+			c, err := newClientWithConnection(connFactory, log.NewPrefixLogger("test"), rw, &agent_config.Config{
 				TPM: agent_config.TPM{
 					Enabled:         true,
 					DevicePath:      agent_config.DefaultTPMDevicePath,
@@ -1435,6 +1450,103 @@ func TestCreateCredential(t *testing.T) {
 
 			// Verify the secrets match
 			require.Equal(challenge.ExpectedSecret, actualSecret, "Decrypted secret should match the original secret")
+		})
+	}
+}
+
+type simConn struct {
+	sim *simulator.Simulator
+}
+
+func (s simConn) Read(p []byte) (n int, err error) {
+	return s.sim.Read(p)
+}
+
+func (s simConn) Write(p []byte) (n int, err error) {
+	return s.sim.Write(p)
+}
+
+func (s simConn) Close() error {
+	// no-op so that the sim doesn't close
+	return nil
+}
+
+func TestClient_CreateApplicationKeys(t *testing.T) {
+	testCases := []struct {
+		name            string
+		enableOwnership bool
+	}{
+		{
+			name:            "ownership disabled",
+			enableOwnership: false,
+		},
+		{
+			name:            "ownership enabled",
+			enableOwnership: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			sim, err := simulator.Get()
+			require.NoError(err)
+			defer sim.Close()
+
+			apps := []string{"app-1", "app-2"}
+
+			// Set up fake RSA endorsement key certificate in the simulator
+			err = setupFakeRSAEKCertificate(sim)
+			require.NoError(err)
+
+			rw := fileio.NewReadWriter(fileio.WithTestRootDir(t.TempDir()))
+
+			// Connection factory that properly manages the simulator connection
+			connFactory := func() (io.ReadWriteCloser, error) {
+				if err := sim.Reset(); err != nil {
+					return nil, err
+				}
+				return simConn{sim: sim}, nil
+			}
+
+			c, err := newClientWithConnection(connFactory, log.NewPrefixLogger("test"), rw, &agent_config.Config{
+				TPM: agent_config.TPM{
+					Enabled:         true,
+					DevicePath:      agent_config.DefaultTPMDevicePath,
+					StorageFilePath: agent_config.DefaultTPMKeyFile,
+					AuthEnabled:     tc.enableOwnership,
+				},
+			}, "test-model", "test-serial")
+			require.NoError(err)
+
+			for _, app := range apps {
+				// Call CreateApplicationKey
+				tcgCSR, exportedKey, err := c.CreateApplicationKey(app)
+				require.NoError(err, "CreateApplicationKey should succeed")
+
+				// Validate returned data
+				require.NotEmpty(tcgCSR, "TCG CSR should not be empty")
+				require.NotEmpty(exportedKey, "Exported key should not be empty")
+
+				// A second call shouldn't error
+				tcgCSR2, exportedKey2, err := c.CreateApplicationKey(app)
+				require.NoError(err, "CreateApplicationKey should succeed")
+
+				// similar but different
+				require.NotEqual(tcgCSR2, tcgCSR)
+				// same file should be generated
+				require.Equal(exportedKey2, exportedKey)
+
+				// Basic validation that TCG CSR is parseable
+				parsed, err := ParseTCGCSR(tcgCSR)
+				require.NoError(err, "TCG CSR should be parseable")
+				require.NotNil(parsed, "Parsed TCG CSR should not be nil")
+
+				// Test that we can clean up the application key
+				err = c.RemoveApplicationKey(app)
+				require.NoError(err, "RemoveApplicationKey should succeed")
+			}
 		})
 	}
 }

--- a/internal/tpm/device_id.go
+++ b/internal/tpm/device_id.go
@@ -1,0 +1,54 @@
+package tpm
+
+import (
+	"crypto"
+	"fmt"
+	"io"
+
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/transport"
+)
+
+type exportableDeviceID struct {
+	log          *log.PrefixLogger
+	parentHandle tpm2.TPMHandle
+	pub          tpm2.TPM2BPublic
+	priv         tpm2.TPM2BPrivate
+	loadedHandle tpm2.AuthHandle
+	conn         io.ReadWriteCloser
+}
+
+func (e *exportableDeviceID) Public() crypto.PublicKey {
+	pub, err := convertTPM2BPublicToPublicKey(&e.pub)
+	if err != nil {
+		e.log.Errorf("Failed to convert tpm blob to public key: %v", err)
+		return nil
+	}
+	return pub
+}
+
+func (e *exportableDeviceID) PublicBlob() []byte {
+	return tpm2.Marshal(e.pub)
+}
+
+func (e *exportableDeviceID) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return signWithKey(transport.FromReadWriter(e.conn), e.Handle(), digest)
+}
+
+func (e *exportableDeviceID) Close() error {
+	flushCmd := tpm2.FlushContext{FlushHandle: e.loadedHandle.Handle}
+	_, err := flushCmd.Execute(transport.FromReadWriter(e.conn))
+	if err != nil {
+		return fmt.Errorf("flushing device ID: %w", err)
+	}
+	return nil
+}
+
+func (e *exportableDeviceID) Handle() tpm2.AuthHandle {
+	return e.loadedHandle
+}
+
+func (e *exportableDeviceID) Export() ([]byte, error) {
+	return GenerateTPM2KeyFile(LoadableKey, e.parentHandle, e.pub, e.priv)
+}

--- a/internal/tpm/mock_tpm.go
+++ b/internal/tpm/mock_tpm.go
@@ -12,6 +12,7 @@ package tpm
 import (
 	context "context"
 	crypto "crypto"
+	io "io"
 	reflect "reflect"
 
 	tpm2 "github.com/google/go-tpm/tpm2"
@@ -67,6 +68,22 @@ func (m *MockClient) Close(ctx context.Context) error {
 func (mr *MockClientMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), ctx)
+}
+
+// CreateApplicationKey mocks base method.
+func (m *MockClient) CreateApplicationKey(name string) ([]byte, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateApplicationKey", name)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateApplicationKey indicates an expected call of CreateApplicationKey.
+func (mr *MockClientMockRecorder) CreateApplicationKey(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplicationKey", reflect.TypeOf((*MockClient)(nil).CreateApplicationKey), name)
 }
 
 // GetSigner mocks base method.
@@ -178,6 +195,34 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 	return m.recorder
 }
 
+// ClearApplicationKey mocks base method.
+func (m *MockStorage) ClearApplicationKey(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearApplicationKey", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearApplicationKey indicates an expected call of ClearApplicationKey.
+func (mr *MockStorageMockRecorder) ClearApplicationKey(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearApplicationKey", reflect.TypeOf((*MockStorage)(nil).ClearApplicationKey), arg0)
+}
+
+// ClearApplicationKeys mocks base method.
+func (m *MockStorage) ClearApplicationKeys() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearApplicationKeys")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearApplicationKeys indicates an expected call of ClearApplicationKeys.
+func (mr *MockStorageMockRecorder) ClearApplicationKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearApplicationKeys", reflect.TypeOf((*MockStorage)(nil).ClearApplicationKeys))
+}
+
 // ClearKey mocks base method.
 func (m *MockStorage) ClearKey(keyType KeyType) error {
 	m.ctrl.T.Helper()
@@ -220,6 +265,21 @@ func (mr *MockStorageMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStorage)(nil).Close))
 }
 
+// GetApplicationKey mocks base method.
+func (m *MockStorage) GetApplicationKey(arg0 string) (*AppKeyStoreData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationKey", arg0)
+	ret0, _ := ret[0].(*AppKeyStoreData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationKey indicates an expected call of GetApplicationKey.
+func (mr *MockStorageMockRecorder) GetApplicationKey(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationKey", reflect.TypeOf((*MockStorage)(nil).GetApplicationKey), arg0)
+}
+
 // GetKey mocks base method.
 func (m *MockStorage) GetKey(keyType KeyType) (*tpm2.TPM2BPublic, *tpm2.TPM2BPrivate, error) {
 	m.ctrl.T.Helper()
@@ -251,6 +311,20 @@ func (mr *MockStorageMockRecorder) GetPassword() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPassword", reflect.TypeOf((*MockStorage)(nil).GetPassword))
 }
 
+// StoreApplicationKey mocks base method.
+func (m *MockStorage) StoreApplicationKey(arg0 string, arg1 AppKeyStoreData) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreApplicationKey", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreApplicationKey indicates an expected call of StoreApplicationKey.
+func (mr *MockStorageMockRecorder) StoreApplicationKey(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreApplicationKey", reflect.TypeOf((*MockStorage)(nil).StoreApplicationKey), arg0, arg1)
+}
+
 // StoreKey mocks base method.
 func (m *MockStorage) StoreKey(keyType KeyType, public tpm2.TPM2BPublic, private tpm2.TPM2BPrivate) error {
 	m.ctrl.T.Helper()
@@ -279,6 +353,246 @@ func (mr *MockStorageMockRecorder) StorePassword(password any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorePassword", reflect.TypeOf((*MockStorage)(nil).StorePassword), password)
 }
 
+// MockCertifiable is a mock of Certifiable interface.
+type MockCertifiable struct {
+	ctrl     *gomock.Controller
+	recorder *MockCertifiableMockRecorder
+}
+
+// MockCertifiableMockRecorder is the mock recorder for MockCertifiable.
+type MockCertifiableMockRecorder struct {
+	mock *MockCertifiable
+}
+
+// NewMockCertifiable creates a new mock instance.
+func NewMockCertifiable(ctrl *gomock.Controller) *MockCertifiable {
+	mock := &MockCertifiable{ctrl: ctrl}
+	mock.recorder = &MockCertifiableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCertifiable) EXPECT() *MockCertifiableMockRecorder {
+	return m.recorder
+}
+
+// Handle mocks base method.
+func (m *MockCertifiable) Handle() tpm2.AuthHandle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Handle")
+	ret0, _ := ret[0].(tpm2.AuthHandle)
+	return ret0
+}
+
+// Handle indicates an expected call of Handle.
+func (mr *MockCertifiableMockRecorder) Handle() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockCertifiable)(nil).Handle))
+}
+
+// MockDeviceID is a mock of DeviceID interface.
+type MockDeviceID struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeviceIDMockRecorder
+}
+
+// MockDeviceIDMockRecorder is the mock recorder for MockDeviceID.
+type MockDeviceIDMockRecorder struct {
+	mock *MockDeviceID
+}
+
+// NewMockDeviceID creates a new mock instance.
+func NewMockDeviceID(ctrl *gomock.Controller) *MockDeviceID {
+	mock := &MockDeviceID{ctrl: ctrl}
+	mock.recorder = &MockDeviceIDMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDeviceID) EXPECT() *MockDeviceIDMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockDeviceID) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockDeviceIDMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDeviceID)(nil).Close))
+}
+
+// Handle mocks base method.
+func (m *MockDeviceID) Handle() tpm2.AuthHandle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Handle")
+	ret0, _ := ret[0].(tpm2.AuthHandle)
+	return ret0
+}
+
+// Handle indicates an expected call of Handle.
+func (mr *MockDeviceIDMockRecorder) Handle() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockDeviceID)(nil).Handle))
+}
+
+// Public mocks base method.
+func (m *MockDeviceID) Public() crypto.PublicKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Public")
+	ret0, _ := ret[0].(crypto.PublicKey)
+	return ret0
+}
+
+// Public indicates an expected call of Public.
+func (mr *MockDeviceIDMockRecorder) Public() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Public", reflect.TypeOf((*MockDeviceID)(nil).Public))
+}
+
+// PublicBlob mocks base method.
+func (m *MockDeviceID) PublicBlob() []byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublicBlob")
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+// PublicBlob indicates an expected call of PublicBlob.
+func (mr *MockDeviceIDMockRecorder) PublicBlob() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicBlob", reflect.TypeOf((*MockDeviceID)(nil).PublicBlob))
+}
+
+// Sign mocks base method.
+func (m *MockDeviceID) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sign", rand, digest, opts)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Sign indicates an expected call of Sign.
+func (mr *MockDeviceIDMockRecorder) Sign(rand, digest, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockDeviceID)(nil).Sign), rand, digest, opts)
+}
+
+// MockExportableDeviceID is a mock of ExportableDeviceID interface.
+type MockExportableDeviceID struct {
+	ctrl     *gomock.Controller
+	recorder *MockExportableDeviceIDMockRecorder
+}
+
+// MockExportableDeviceIDMockRecorder is the mock recorder for MockExportableDeviceID.
+type MockExportableDeviceIDMockRecorder struct {
+	mock *MockExportableDeviceID
+}
+
+// NewMockExportableDeviceID creates a new mock instance.
+func NewMockExportableDeviceID(ctrl *gomock.Controller) *MockExportableDeviceID {
+	mock := &MockExportableDeviceID{ctrl: ctrl}
+	mock.recorder = &MockExportableDeviceIDMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockExportableDeviceID) EXPECT() *MockExportableDeviceIDMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockExportableDeviceID) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockExportableDeviceIDMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockExportableDeviceID)(nil).Close))
+}
+
+// Export mocks base method.
+func (m *MockExportableDeviceID) Export() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Export")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Export indicates an expected call of Export.
+func (mr *MockExportableDeviceIDMockRecorder) Export() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockExportableDeviceID)(nil).Export))
+}
+
+// Handle mocks base method.
+func (m *MockExportableDeviceID) Handle() tpm2.AuthHandle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Handle")
+	ret0, _ := ret[0].(tpm2.AuthHandle)
+	return ret0
+}
+
+// Handle indicates an expected call of Handle.
+func (mr *MockExportableDeviceIDMockRecorder) Handle() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockExportableDeviceID)(nil).Handle))
+}
+
+// Public mocks base method.
+func (m *MockExportableDeviceID) Public() crypto.PublicKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Public")
+	ret0, _ := ret[0].(crypto.PublicKey)
+	return ret0
+}
+
+// Public indicates an expected call of Public.
+func (mr *MockExportableDeviceIDMockRecorder) Public() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Public", reflect.TypeOf((*MockExportableDeviceID)(nil).Public))
+}
+
+// PublicBlob mocks base method.
+func (m *MockExportableDeviceID) PublicBlob() []byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublicBlob")
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+// PublicBlob indicates an expected call of PublicBlob.
+func (mr *MockExportableDeviceIDMockRecorder) PublicBlob() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicBlob", reflect.TypeOf((*MockExportableDeviceID)(nil).PublicBlob))
+}
+
+// Sign mocks base method.
+func (m *MockExportableDeviceID) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sign", rand, digest, opts)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Sign indicates an expected call of Sign.
+func (mr *MockExportableDeviceIDMockRecorder) Sign(rand, digest, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockExportableDeviceID)(nil).Sign), rand, digest, opts)
+}
+
 // MockSession is a mock of Session interface.
 type MockSession struct {
 	ctrl     *gomock.Controller
@@ -300,6 +614,22 @@ func NewMockSession(ctrl *gomock.Controller) *MockSession {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSession) EXPECT() *MockSessionMockRecorder {
 	return m.recorder
+}
+
+// Certify mocks base method.
+func (m *MockSession) Certify(key Certifiable, qualifyingData []byte) ([]byte, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Certify", key, qualifyingData)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Certify indicates an expected call of Certify.
+func (mr *MockSessionMockRecorder) Certify(key, qualifyingData any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Certify", reflect.TypeOf((*MockSession)(nil).Certify), key, qualifyingData)
 }
 
 // CertifyKey mocks base method.
@@ -361,20 +691,6 @@ func (mr *MockSessionMockRecorder) CreateKey(keyType any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKey", reflect.TypeOf((*MockSession)(nil).CreateKey), keyType)
 }
 
-// FlushAllTransientHandles mocks base method.
-func (m *MockSession) FlushAllTransientHandles() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FlushAllTransientHandles")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// FlushAllTransientHandles indicates an expected call of FlushAllTransientHandles.
-func (mr *MockSessionMockRecorder) FlushAllTransientHandles() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAllTransientHandles", reflect.TypeOf((*MockSession)(nil).FlushAllTransientHandles))
-}
-
 // GenerateChallenge mocks base method.
 func (m *MockSession) GenerateChallenge(secret []byte) ([]byte, []byte, error) {
 	m.ctrl.T.Helper()
@@ -406,21 +722,6 @@ func (mr *MockSessionMockRecorder) GetEndorsementKeyCert() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEndorsementKeyCert", reflect.TypeOf((*MockSession)(nil).GetEndorsementKeyCert))
 }
 
-// GetHandle mocks base method.
-func (m *MockSession) GetHandle(keyType KeyType) (*tpm2.NamedHandle, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHandle", keyType)
-	ret0, _ := ret[0].(*tpm2.NamedHandle)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHandle indicates an expected call of GetHandle.
-func (mr *MockSessionMockRecorder) GetHandle(keyType any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHandle", reflect.TypeOf((*MockSession)(nil).GetHandle), keyType)
-}
-
 // GetPublicKey mocks base method.
 func (m *MockSession) GetPublicKey(keyType KeyType) (*tpm2.TPM2BPublic, error) {
 	m.ctrl.T.Helper()
@@ -436,6 +737,21 @@ func (mr *MockSessionMockRecorder) GetPublicKey(keyType any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicKey", reflect.TypeOf((*MockSession)(nil).GetPublicKey), keyType)
 }
 
+// LoadApplicationKey mocks base method.
+func (m *MockSession) LoadApplicationKey(appName string) (ExportableDeviceID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadApplicationKey", appName)
+	ret0, _ := ret[0].(ExportableDeviceID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadApplicationKey indicates an expected call of LoadApplicationKey.
+func (mr *MockSessionMockRecorder) LoadApplicationKey(appName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadApplicationKey", reflect.TypeOf((*MockSession)(nil).LoadApplicationKey), appName)
+}
+
 // LoadKey mocks base method.
 func (m *MockSession) LoadKey(keyType KeyType) (*tpm2.NamedHandle, error) {
 	m.ctrl.T.Helper()
@@ -449,6 +765,20 @@ func (m *MockSession) LoadKey(keyType KeyType) (*tpm2.NamedHandle, error) {
 func (mr *MockSessionMockRecorder) LoadKey(keyType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadKey", reflect.TypeOf((*MockSession)(nil).LoadKey), keyType)
+}
+
+// RemoveApplicationKey mocks base method.
+func (m *MockSession) RemoveApplicationKey(appName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveApplicationKey", appName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveApplicationKey indicates an expected call of RemoveApplicationKey.
+func (mr *MockSessionMockRecorder) RemoveApplicationKey(appName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveApplicationKey", reflect.TypeOf((*MockSession)(nil).RemoveApplicationKey), appName)
 }
 
 // Sign mocks base method.

--- a/internal/tpm/session.go
+++ b/internal/tpm/session.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
 	gotpmclient "github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm/tpm2"
@@ -21,37 +20,72 @@ const (
 	persistentHandleMax = tpm2.TPMHandle(0x81FFFFFF)
 	permanentHandleMin  = tpm2.TPMHandle(0x40000000)
 	permanentHandleMax  = tpm2.TPMHandle(0x4004FFFF)
-	nvReadChunkSize     = uint16(1024) // Maximum chunk size for NVRead operations
-	ekRSANVIndex        = gotpmclient.EKCertNVIndexRSA
-	ekECCNVIndex        = gotpmclient.EKCertNVIndexECC
+	// Table 11 of https://trustedcomputinggroup.org/wp-content/uploads/RegistryOfReservedTPM2HandlesAndLocalities_v1p1_pub.pdf
+	persistentHandleStart = tpm2.TPMHandle(0x81008000)
+	persistentHandleEnd   = tpm2.TPMHandle(0x8100FFFF)
+
+	nvReadChunkSize = uint16(1024) // Maximum chunk size for NVRead operations
+	ekRSANVIndex    = gotpmclient.EKCertNVIndexRSA
+	ekECCNVIndex    = gotpmclient.EKCertNVIndexECC
 )
 
 // tpmSession implements the Session interface
 type tpmSession struct {
-	conn        io.ReadWriteCloser
-	storage     Storage
-	log         *log.PrefixLogger
-	authEnabled bool
-	keyAlgo     KeyAlgorithm
+	conn             io.ReadWriteCloser
+	storage          Storage
+	log              *log.PrefixLogger
+	authEnabled      bool
+	shouldInitialize bool
+	keyAlgo          KeyAlgorithm
 
 	// Active handles
 	handles map[KeyType]*tpm2.NamedHandle
 }
 
+type SessionOption func(*tpmSession)
+
+// WithKeyAlgo sets the algorithm used for the session
+func WithKeyAlgo(keyAlgo KeyAlgorithm) SessionOption {
+	return func(s *tpmSession) {
+		s.keyAlgo = keyAlgo
+	}
+}
+
+// WithInitialization indicates that the session should initialize the device's main keys
+func WithInitialization() SessionOption {
+	return func(s *tpmSession) {
+		s.shouldInitialize = true
+	}
+}
+
+func WithAuth(authEnabled bool) SessionOption {
+	return func(s *tpmSession) {
+		s.authEnabled = authEnabled
+	}
+}
+
+func WithStorage(storage Storage) SessionOption {
+	return func(s *tpmSession) {
+		s.storage = storage
+	}
+}
+
 // NewSession creates a new TPM session
-func NewSession(conn io.ReadWriteCloser, rw fileio.ReadWriter, log *log.PrefixLogger, authEnabled bool, persistencePath string, keyAlgo KeyAlgorithm) (Session, error) {
+func NewSession(conn io.ReadWriteCloser, log *log.PrefixLogger, opts ...SessionOption) (Session, error) {
 	session := &tpmSession{
-		conn:        conn,
-		storage:     NewFileStorage(rw, persistencePath, log),
-		log:         log,
-		authEnabled: authEnabled,
-		keyAlgo:     keyAlgo,
-		handles:     make(map[KeyType]*tpm2.NamedHandle),
+		conn:    conn,
+		log:     log,
+		handles: make(map[KeyType]*tpm2.NamedHandle),
 	}
 
-	// initialize the session by ensuring SRK and setting up auth
-	if err := session.initialize(); err != nil {
-		return nil, fmt.Errorf("initializing TPM session: %w", err)
+	for _, option := range opts {
+		option(session)
+	}
+
+	if session.shouldInitialize {
+		if err := session.initialize(); err != nil {
+			return nil, fmt.Errorf("session initialization: %w", err)
+		}
 	}
 
 	return session, nil
@@ -121,6 +155,46 @@ func (s *tpmSession) CreateKey(keyType KeyType) (*tpm2.CreateResponse, error) {
 	return createRsp, nil
 }
 
+func (s *tpmSession) loadAppKey(appName string) (*exportableDeviceID, error) {
+	key, err := s.storage.GetApplicationKey(appName)
+	if err != nil {
+		return nil, fmt.Errorf("getting application key: %w", err)
+	}
+
+	pubCmd := tpm2.ReadPublic{ObjectHandle: key.ParentHandle}
+	pubRsp, err := pubCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, fmt.Errorf("reading parent: %x public info command: %w", key.ParentHandle, err)
+	}
+
+	loadCmd := tpm2.Load{
+		ParentHandle: tpm2.AuthHandle{
+			Handle: key.ParentHandle,
+			Name:   pubRsp.Name,
+			Auth:   tpm2.PasswordAuth(nil), // todo passwords
+		},
+		InPrivate: key.Private,
+		InPublic:  key.Public,
+	}
+	loadRsp, err := loadCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return nil, fmt.Errorf("loading app: %w", err)
+	}
+
+	return &exportableDeviceID{
+		log:          s.log,
+		parentHandle: key.ParentHandle,
+		pub:          key.Public,
+		priv:         key.Private,
+		loadedHandle: tpm2.AuthHandle{
+			Handle: loadRsp.ObjectHandle,
+			Name:   loadRsp.Name,
+			Auth:   tpm2.PasswordAuth(nil), // todo passwords
+		},
+		conn: s.conn,
+	}, nil
+}
+
 func (s *tpmSession) LoadKey(keyType KeyType) (*tpm2.NamedHandle, error) {
 	if handle, exists := s.handles[keyType]; exists {
 		s.log.Debugf("Key %s already loaded, handle=0x%x", keyType, handle.Handle)
@@ -188,31 +262,20 @@ func (s *tpmSession) flushKey(keyType KeyType) error {
 		return nil
 	}
 
-	if err := s.flushHandle(handle); err != nil {
+	if err := s.flushHandle(handle.Handle); err != nil {
 		return fmt.Errorf("flushing key %s: %w", keyType, err)
 	}
 	delete(s.handles, keyType)
 	return nil
 }
 
-func (s *tpmSession) CertifyKey(keyType KeyType, qualifyingData []byte) (certifyInfo, signature []byte, err error) {
-	// get target handle to certify
-	targetHandle, err := s.LoadKey(keyType)
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading target key: %w", err)
-	}
-
-	// determine the signing key based on what we're certifying
-	var signingHandle *tpm2.NamedHandle
-	// We don't create our keys with any auth. If that changes we need to update this
-	auth := tpm2.PasswordAuth(nil)
-
+func (s *tpmSession) certifyKey(handle tpm2.AuthHandle, qualifyingData []byte) ([]byte, []byte, error) {
 	// use LAK as the signing key for all certifications
 	lakHandle, err := s.LoadKey(LAK)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading LAK for certification: %w", err)
 	}
-	signingHandle = lakHandle
+	signingHandle := lakHandle
 
 	// create signature scheme
 	sigScheme := tpm2.TPMTSigScheme{
@@ -224,15 +287,11 @@ func (s *tpmSession) CertifyKey(keyType KeyType, qualifyingData []byte) (certify
 	}
 
 	cmd := tpm2.Certify{
-		ObjectHandle: tpm2.AuthHandle{
-			Handle: targetHandle.Handle,
-			Name:   targetHandle.Name,
-			Auth:   auth,
-		},
+		ObjectHandle: handle,
 		SignHandle: tpm2.AuthHandle{
 			Handle: signingHandle.Handle,
 			Name:   signingHandle.Name,
-			Auth:   auth,
+			Auth:   tpm2.PasswordAuth(nil),
 		},
 		QualifyingData: tpm2.TPM2BData{Buffer: qualifyingData},
 		InScheme:       sigScheme,
@@ -249,14 +308,40 @@ func (s *tpmSession) CertifyKey(keyType KeyType, qualifyingData []byte) (certify
 	return certifyInfoBytes, signatureBytes, nil
 }
 
+func (s *tpmSession) CertifyKey(keyType KeyType, qualifyingData []byte) (certifyInfo, signature []byte, err error) {
+	// get target handle to certify
+	targetHandle, err := s.LoadKey(keyType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading target key: %w", err)
+	}
+
+	return s.certifyKey(tpm2.AuthHandle{
+		Handle: targetHandle.Handle,
+		Name:   targetHandle.Name,
+		Auth:   tpm2.PasswordAuth(nil),
+	}, qualifyingData)
+}
+
+func (s *tpmSession) Certify(cert Certifiable, qualifyingData []byte) (certifyInfo, signature []byte, err error) {
+	return s.certifyKey(cert.Handle(), qualifyingData)
+}
+
 func (s *tpmSession) Sign(keyType KeyType, digest []byte) ([]byte, error) {
 	handle, err := s.LoadKey(keyType)
 	if err != nil {
 		return nil, fmt.Errorf("loading signing key: %w", err)
 	}
+	authHandel := tpm2.AuthHandle{
+		Handle: handle.Handle,
+		Name:   handle.Name,
+		Auth:   tpm2.PasswordAuth(nil),
+	}
+	return signWithKey(transport.FromReadWriter(s.conn), authHandel, digest)
+}
 
+func signWithKey(conn transport.TPM, handle tpm2.AuthHandle, digest []byte) ([]byte, error) {
 	cmd := tpm2.Sign{
-		KeyHandle: *handle,
+		KeyHandle: handle,
 		Digest: tpm2.TPM2BDigest{
 			Buffer: digest,
 		},
@@ -265,9 +350,9 @@ func (s *tpmSession) Sign(keyType KeyType, digest []byte) ([]byte, error) {
 		},
 	}
 
-	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
+	resp, err := cmd.Execute(conn)
 	if err != nil {
-		return nil, fmt.Errorf("sign command failed for %s (digest size: %d): %w", keyType, len(digest), err)
+		return nil, fmt.Errorf("sign command failed (digest size: %d): %w", len(digest), err)
 	}
 
 	// convert TPM signature to ASN.1 DER
@@ -413,7 +498,7 @@ func (s *tpmSession) flushKeys() []error {
 
 	// Flush all known handles
 	for keyType, handle := range s.handles {
-		if err := s.flushHandle(handle); err != nil {
+		if err := s.flushHandle(handle.Handle); err != nil {
 			errs = append(errs, fmt.Errorf("flushing %s: %w", keyType, err))
 		}
 		delete(s.handles, keyType)
@@ -430,6 +515,8 @@ func (s *tpmSession) clearStoredKeys() error {
 	for _, kt := range keyTypes {
 		_ = s.storage.ClearKey(kt)
 	}
+
+	_ = s.storage.ClearApplicationKeys()
 
 	return nil
 }
@@ -643,14 +730,9 @@ func (s *tpmSession) ensureSRK() (*tpm2.NamedHandle, error) {
 		password = nil
 	}
 
-	var template tpm2.TPMTPublic
-	switch s.keyAlgo {
-	case ECDSA:
-		template = tpm2.ECCSRKTemplate
-	case RSA:
-		template = tpm2.RSASRKTemplate
-	default:
-		return nil, fmt.Errorf("unsupported key algorithm: %s", s.keyAlgo)
+	template, err := StorageKeyTemplate(s.keyAlgo)
+	if err != nil {
+		return nil, err
 	}
 
 	cmd := tpm2.CreatePrimary{
@@ -710,7 +792,7 @@ func (s *tpmSession) ensureSRKIsLoaded() error {
 	// clear any cached child key handles since they're now invalid too
 	for keyType, handle := range s.handles {
 		if keyType != SRK {
-			_ = s.flushHandle(handle)
+			_ = s.flushHandle(handle.Handle)
 			delete(s.handles, keyType)
 		}
 	}
@@ -745,98 +827,24 @@ func (s *tpmSession) getKeyTemplate(keyType KeyType) (tpm2.TPMTPublic, error) {
 		return LDevIDTemplate(s.keyAlgo)
 	case LAK:
 		return AttestationKeyTemplate(s.keyAlgo)
+	case SRK:
+		return StorageKeyTemplate(s.keyAlgo)
 	default:
 		return tpm2.TPMTPublic{}, fmt.Errorf("unsupported key type: %s", keyType)
 	}
 }
 
-func (s *tpmSession) flushHandle(handle *tpm2.NamedHandle) error {
-	if handle == nil {
-		return nil
-	}
-
-	if handle.Handle < persistentHandleMin || handle.Handle > persistentHandleMax {
+func (s *tpmSession) flushHandle(handle tpm2.TPMHandle) error {
+	if handle >= transientHandleMin && handle <= transientHandleMax {
 		flushCmd := tpm2.FlushContext{
-			FlushHandle: handle.Handle,
+			FlushHandle: handle,
 		}
 
 		_, err := flushCmd.Execute(transport.FromReadWriter(s.conn))
 		if err != nil {
-			return fmt.Errorf("flushing context for handle 0x%x: %w", handle.Handle, err)
+			return fmt.Errorf("flushing context for handle 0x%x: %w", handle, err)
 		}
 	}
-	return nil
-}
-
-// FlushAllTransientHandles aggressively flushes all transient handles in the TPM
-// This helps clean up any handles that might have been created by go-tpm-tools or other libraries
-// It preserves handles that are actively tracked by this session
-func (s *tpmSession) FlushAllTransientHandles() error {
-	// Create a set of handles we want to preserve
-	preserveHandles := make(map[tpm2.TPMHandle]bool)
-	for _, handle := range s.handles {
-		if handle != nil {
-			preserveHandles[handle.Handle] = true
-		}
-	}
-
-	// get all loaded handles from the TPM
-	cmd := tpm2.GetCapability{
-		Capability:    tpm2.TPMCapHandles,
-		Property:      uint32(tpm2.TPMHTTransient) << 24, // transient handles start at 0x80000000
-		PropertyCount: 256,                               // maximum number of handles to retrieve
-	}
-
-	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
-	if err != nil {
-		// note: if we can't get capabilities, that's not necessarily an error
-		// the TPM might just not have any transient handles
-		s.log.Debugf("Could not get transient handles for cleanup: %v", err)
-		return nil
-	}
-
-	if resp.CapabilityData.Capability != tpm2.TPMCapHandles {
-		return nil
-	}
-
-	handles, err := resp.CapabilityData.Data.Handles()
-	if err != nil {
-		s.log.Debugf("Could not parse handle list: %v", err)
-		return nil
-	}
-
-	var flushErrors []error
-	flushedCount := 0
-	for _, handle := range handles.Handle {
-		// only flush transient handles (0x80000000 - 0x8FFFFFFF)
-		if handle >= transientHandleMin && handle <= transientHandleMax {
-			if preserveHandles[handle] {
-				s.log.Debugf("Preserving active session handle 0x%x", handle)
-				continue
-			}
-
-			flushCmd := tpm2.FlushContext{
-				FlushHandle: handle,
-			}
-
-			_, err := flushCmd.Execute(transport.FromReadWriter(s.conn))
-			if err != nil {
-				flushErrors = append(flushErrors, fmt.Errorf("flushing transient handle 0x%x: %w", handle, err))
-				continue
-			}
-			flushedCount++
-			s.log.Debugf("Flushed unused transient handle 0x%x", handle)
-		}
-	}
-
-	if flushedCount > 0 {
-		s.log.Debugf("Flushed %d unused transient handles", flushedCount)
-	}
-
-	if len(flushErrors) > 0 {
-		return fmt.Errorf("errors flushing transient handles: %v", flushErrors)
-	}
-
 	return nil
 }
 
@@ -946,7 +954,7 @@ func (s *tpmSession) GenerateChallenge(secret []byte) ([]byte, []byte, error) {
 		Handle: resp.ObjectHandle,
 		Name:   resp.Name,
 	}
-	defer func() { _ = s.flushHandle(ekHandle) }()
+	defer func() { _ = s.flushHandle(ekHandle.Handle) }()
 
 	lakHandle, err := s.LoadKey(LAK)
 	if err != nil {
@@ -1004,7 +1012,7 @@ func (s *tpmSession) SolveChallenge(credentialBlob, encryptedSecret []byte) ([]b
 		Handle: resp.ObjectHandle,
 		Name:   resp.Name,
 	}
-	defer func() { _ = s.flushHandle(ekHandle) }()
+	defer func() { _ = s.flushHandle(ekHandle.Handle) }()
 
 	lakHandle, err := s.LoadKey(LAK)
 	if err != nil {
@@ -1029,4 +1037,207 @@ func (s *tpmSession) SolveChallenge(credentialBlob, encryptedSecret []byte) ([]b
 	}
 
 	return activateResp.CertInfo.Buffer, nil
+}
+
+func (s *tpmSession) findAvailablePersistentHandle() (tpm2.TPMHandle, error) {
+	cmd := tpm2.GetCapability{
+		Capability:    tpm2.TPMCapHandles,
+		Property:      uint32(persistentHandleStart),
+		PropertyCount: uint32(persistentHandleEnd - persistentHandleStart + 1),
+	}
+	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return 0, fmt.Errorf("querying persistent handles: %w", err)
+	}
+
+	handles, err := resp.CapabilityData.Data.Handles()
+	if err != nil {
+		return 0, fmt.Errorf("parsing handle capability data: %w", err)
+	}
+
+	existingHandles := make(map[tpm2.TPMHandle]bool)
+	if handles != nil {
+		for _, handle := range handles.Handle {
+			if handle >= persistentHandleStart && handle <= persistentHandleEnd {
+				existingHandles[handle] = true
+			}
+		}
+	}
+
+	for handle := persistentHandleStart; handle <= persistentHandleEnd; handle++ {
+		if !existingHandles[handle] {
+			return handle, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no available persistent handles in range 0x%08X to 0x%08X", persistentHandleStart, persistentHandleEnd)
+}
+
+func (s *tpmSession) createNewAppIdentity(appName string) error {
+	// creating an app identity requires 2 slots for transient space. flush all loaded keys
+	// to create space
+	errs := s.flushKeys()
+	if len(errs) > 0 {
+		return fmt.Errorf("creating new app key: %s: %w", appName, errors.Join(errs...))
+	}
+
+	err := s.ensureSRKIsLoaded()
+	if err != nil {
+		return fmt.Errorf("ensuring SRK is loaded: %w", err)
+	}
+
+	template, err := StorageKeyTemplate(s.keyAlgo)
+	if err != nil {
+		return fmt.Errorf("storage app key template: %w", err)
+	}
+	// Create an individual storage key under the storage hierarchy for each application
+	// todo passwords
+	createCmd := tpm2.Create{
+		ParentHandle: s.handles[SRK],
+		InPublic:     tpm2.New2B(template),
+	}
+
+	createResp, err := createCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return fmt.Errorf("creating new app storage key: %w", err)
+	}
+
+	// Load the storage key so that it can be immediately evicted
+	loadCmd := tpm2.Load{
+		ParentHandle: s.handles[SRK],
+		InPrivate:    createResp.OutPrivate,
+		InPublic:     createResp.OutPublic,
+	}
+	loadRsp, err := loadCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return fmt.Errorf("loading app storage key: %w", err)
+	}
+
+	persistentHandle, err := s.findAvailablePersistentHandle()
+	if err != nil {
+		return fmt.Errorf("finding available persistent handle: %w", err)
+	}
+
+	ownerPass, err := s.getPassword()
+	if err != nil {
+		return fmt.Errorf("getting current password: %w", err)
+	}
+
+	evictCmd := tpm2.EvictControl{
+		Auth: tpm2.AuthHandle{
+			Handle: tpm2.TPMRHOwner,
+			Auth:   tpm2.PasswordAuth(ownerPass),
+		},
+		ObjectHandle: tpm2.NamedHandle{
+			Handle: loadRsp.ObjectHandle,
+			Name:   loadRsp.Name,
+		},
+		PersistentHandle: persistentHandle,
+	}
+	_, err = evictCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return fmt.Errorf("evicting app storage key: %w", err)
+	}
+
+	// teardown function to undo the persistence if any future step fails
+	clearPersistedKey := func(err error) error {
+		if clearErr := s.removePersistedKey(persistentHandle); clearErr != nil {
+			s.log.Errorf("Unable to roll back persisted key %x trying to create a new app identity: %s", persistentHandle, clearErr)
+			err = fmt.Errorf("removing persisted storage key: %w", clearErr)
+		}
+		return err
+	}
+
+	err = s.flushHandle(loadRsp.ObjectHandle)
+	if err != nil {
+		return clearPersistedKey(fmt.Errorf("flushing app storage key: %w", err))
+	}
+
+	// create the new identity under the handle that was just flushed
+	ldevTemplate, err := LDevIDTemplate(s.keyAlgo)
+	if err != nil {
+		return clearPersistedKey(fmt.Errorf("getting ldev template: %w", err))
+	}
+	createChildCmd := tpm2.Create{
+		ParentHandle: tpm2.AuthHandle{
+			Handle: persistentHandle,
+			Name:   loadRsp.Name,
+			Auth:   tpm2.PasswordAuth(nil), // todo need password
+		},
+		InPublic: tpm2.New2B(ldevTemplate),
+	}
+
+	createResp, err = createChildCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return clearPersistedKey(fmt.Errorf("creating new app identity key: %w", err))
+	}
+
+	err = s.storage.StoreApplicationKey(appName, AppKeyStoreData{
+		ParentHandle: persistentHandle,
+		Public:       createResp.OutPublic,
+		Private:      createResp.OutPrivate,
+	})
+	if err != nil {
+		return clearPersistedKey(fmt.Errorf("storing new app storage key: %w", err))
+	}
+	return nil
+}
+
+func (s *tpmSession) removePersistedKey(handle tpm2.TPMHandle) error {
+	pubCmd := tpm2.ReadPublic{ObjectHandle: handle}
+	pubRsp, err := pubCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return fmt.Errorf("reading public key: %w", err)
+	}
+
+	ownerPass, err := s.getPassword()
+	if err != nil {
+		return fmt.Errorf("getting current password: %w", err)
+	}
+
+	evictCmd := tpm2.EvictControl{
+		Auth:             tpm2.AuthHandle{Handle: tpm2.TPMRHOwner, Auth: tpm2.PasswordAuth(ownerPass)},
+		ObjectHandle:     tpm2.NamedHandle{Handle: handle, Name: pubRsp.Name},
+		PersistentHandle: handle,
+	}
+	_, err = evictCmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		return fmt.Errorf("evicting app storage key: %w", err)
+	}
+	return nil
+}
+
+func (s *tpmSession) LoadApplicationKey(appName string) (ExportableDeviceID, error) {
+	key, err := s.loadAppKey(appName)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			if err = s.createNewAppIdentity(appName); err != nil {
+				return nil, fmt.Errorf("creating new app identity: %w", err)
+			}
+			key, err = s.loadAppKey(appName)
+			if err != nil {
+				return nil, fmt.Errorf("loading new app identity: %w", err)
+			}
+			return key, nil
+		}
+		return nil, fmt.Errorf("loading key: %w", err)
+	}
+	return key, nil
+}
+func (s *tpmSession) RemoveApplicationKey(appName string) error {
+	handle, err := s.loadAppKey(appName)
+	if err != nil {
+		return fmt.Errorf("getting app: %w", err)
+	}
+	if err = handle.Close(); err != nil {
+		return fmt.Errorf("closing app handle: %w", err)
+	}
+	if err = s.removePersistedKey(handle.parentHandle); err != nil {
+		return fmt.Errorf("removing persisted key: %w", err)
+	}
+
+	if err = s.storage.ClearApplicationKey(appName); err != nil {
+		return fmt.Errorf("clearing app key: %w", err)
+	}
+	return nil
 }

--- a/internal/tpm/storage_test.go
+++ b/internal/tpm/storage_test.go
@@ -324,7 +324,7 @@ func TestFileStorageStoreKey(t *testing.T) {
 			setupTestData: func(t *testing.T, rw fileio.ReadWriter, storagePath string) {
 				// simulates a case where the file gets corrupted after write
 			},
-			wantErr: errors.New("validation failed for stored key ldevid"),
+			wantErr: errors.New("stored key ldevid"),
 		},
 	}
 

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -27,6 +27,8 @@ type Client interface {
 	Close(ctx context.Context) error
 	// VendorInfoCollector collects vendor information from the TPM
 	VendorInfoCollector(ctx context.Context) string
+	// CreateApplicationKey generates a TCG CSR IDEVID bundle and a TSS2 PEM encoded file for the specified application
+	CreateApplicationKey(name string) ([]byte, []byte, error)
 }
 
 const (
@@ -62,6 +64,14 @@ const (
 	RSA   KeyAlgorithm = "rsa"
 )
 
+type AppKeyStoreData struct {
+	ParentHandle tpm2.TPMHandle
+	ParentPass   []byte
+	Public       tpm2.TPM2BPublic
+	Private      tpm2.TPM2BPrivate
+	Pass         []byte
+}
+
 // Storage handles pure disk persistence of TPM data on disk
 type Storage interface {
 	// GetKey retrieves stored key data for the specified key type
@@ -71,6 +81,14 @@ type Storage interface {
 	StoreKey(keyType KeyType, public tpm2.TPM2BPublic, private tpm2.TPM2BPrivate) error
 	// ClearKey clears key data for the specified key type
 	ClearKey(keyType KeyType) error
+	// GetApplicationKey returns the AppKeyStoreData for a given application
+	GetApplicationKey(string) (*AppKeyStoreData, error)
+	// StoreApplicationKey stores the AppKeyStoreData for a given application
+	StoreApplicationKey(string, AppKeyStoreData) error
+	// ClearApplicationKey removes the stored info for the application
+	ClearApplicationKey(string) error
+	// ClearApplicationKeys removes all application keys
+	ClearApplicationKeys() error
 	// GetPassword retrieves the stored storage hierarchy password
 	GetPassword() ([]byte, error)
 	// StorePassword stores the storage hierarchy password
@@ -81,16 +99,43 @@ type Storage interface {
 	Close() error
 }
 
+// Certifiable defines an interface for keys that are certifiable
+type Certifiable interface {
+	// Handle returns the Handle of the Key to certify
+	Handle() tpm2.AuthHandle
+}
+
+// DeviceID defines an interface for Keys that represent an identity
+type DeviceID interface {
+	crypto.Signer
+	Certifiable
+	// Close flushes the key
+	Close() error
+	// PublicBlob returns the serialized TPM2Public portion of the key
+	PublicBlob() []byte
+}
+
+// ExportableDeviceID defines an interface for DeviceIDs that can be exported
+type ExportableDeviceID interface {
+	DeviceID
+	// Export generates a TSS2 PEM formatted file
+	Export() ([]byte, error)
+}
+
 // Session manages active TPM state and operations
 type Session interface {
-	// GetHandle returns the active handle for a key type
-	GetHandle(keyType KeyType) (*tpm2.NamedHandle, error)
 	// CreateKey creates a new key of the specified type
 	CreateKey(keyType KeyType) (*tpm2.CreateResponse, error)
 	// LoadKey loads a key into the TPM and returns its handle
 	LoadKey(keyType KeyType) (*tpm2.NamedHandle, error)
 	// CertifyKey certifies a key with the LAK
 	CertifyKey(keyType KeyType, qualifyingData []byte) (certifyInfo, signature []byte, err error)
+	// Certify certifies a key with the LAK
+	Certify(key Certifiable, qualifyingData []byte) (certifyInfo, signature []byte, err error)
+	// LoadApplicationKey creates or returns an already existing DeviceID
+	LoadApplicationKey(appName string) (ExportableDeviceID, error)
+	// RemoveApplicationKey removes the key for the specified application
+	RemoveApplicationKey(appName string) error
 	// Sign signs data with the specified key
 	Sign(keyType KeyType, digest []byte) ([]byte, error)
 	// GetPublicKey gets the public key for a key type
@@ -101,8 +146,6 @@ type Session interface {
 	GenerateChallenge(secret []byte) ([]byte, []byte, error)
 	// SolveChallenge decrypts the encryptedSecret to prove ownership of the credentials
 	SolveChallenge(credentialBlob, encryptedSecret []byte) ([]byte, error)
-	// FlushAllTransientHandles aggressively flushes all transient handles
-	FlushAllTransientHandles() error
 	// Clear performs a best-effort clear of the TPM, resetting keys and auth
 	Clear() error
 	// Close closes the session and flushes handles


### PR DESCRIPTION
Adds to ability to create Application Keys that are structured as defined in the following diagram. Due to the expected use of these requests, I've created the ability for multiple sessions to be created so that they can be used independently. The underlying shared storage was made thread safe. This will allow the device's primary identity to continue establishing tls sessions while the cert manager manages application keys. The entire operation is self contained so that all information that is relevant is generated, the TCG CSR and the TSS2 file, and then the session is closed.

<img width="2239" height="744" alt="image" src="https://github.com/user-attachments/assets/40a390e6-51d1-427d-82b2-7d99d5a53563" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create, load, remove per-application TPM keys; generate CSRs signed by per-key signers; exportable device identities; new client methods to manage application keys.

- **Refactor**
  - Lazy, option-driven TPM connection/session lifecycle with connection-factory support; session APIs extended for app-key flows; storage key template selection standardized; CSR generation extracted for reuse.

- **Chores**
  - File storage is concurrency-safe and persists per-application key data.

- **Tests**
  - Simulator-backed tests updated to use connection factories and exercise application-key lifecycle; mocks expanded for new app-key and device-ID APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->