### PR TITLE
EDM-1659: Restore flightctl-base

### DIFF
--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
      microdnf install ca-certificates --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alert-exporter-container" \

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -37,13 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-alert-exporter
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-     microdnf install ca-certificates --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alert-exporter-container" \
@@ -53,5 +47,4 @@ LABEL \
   name="flightctl-alert-exporter" \
   summary="Flight Control Edge management service, alert exporter"
 COPY --from=build /app/bin/flightctl-alert-exporter .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-alert-exporter

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -37,13 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-alertmanager-proxy
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-    microdnf install ca-certificates --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alertmanager-proxy-container" \
@@ -53,6 +47,5 @@ LABEL \
   name="flightctl-alertmanager-proxy" \
   summary="Flight Control Edge management service, alertmanager proxy"
 COPY --from=build /app/bin/flightctl-alertmanager-proxy .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 EXPOSE 8443
 CMD ./flightctl-alertmanager-proxy

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     microdnf install ca-certificates --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alertmanager-proxy-container" \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     dnf install ca-certificates tzdata --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-api-container" \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -36,13 +36,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-api
 
-FROM registry.access.redhat.com/ubi9/ubi as certs
-# Use BuildKit cache mounts for dnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-    dnf install ca-certificates tzdata --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-api-container" \
@@ -52,7 +46,5 @@ LABEL \
   name="flightctl-api" \
   summary="Flight Control Edge management API server"
 COPY --from=build /app/bin/flightctl-api .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
-COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 
 CMD ./flightctl-api

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-multiarch-clis
 
-FROM registry.access.redhat.com/ubi9/ubi as certs
+FROM registry.access.redhat.com/ubi9/ubi
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
      microdnf install ca-certificates --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-periodic-container" \

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -37,13 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-periodic
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-     microdnf install ca-certificates --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-periodic-container" \
@@ -53,5 +47,4 @@ LABEL \
   name="flightctl-periodic" \
   summary="Flight Control Edge management service, periodic job worker"
 COPY --from=build /app/bin/flightctl-periodic .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-periodic

--- a/Containerfile.telemetry-gateway
+++ b/Containerfile.telemetry-gateway
@@ -37,13 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-telemetry-gateway
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-    microdnf install ca-certificates --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-telemetry-gateway-container" \
@@ -53,5 +47,4 @@ LABEL \
   name="flightctl-telemetry-gateway" \
   summary="Flight Control Edge management service, telemetry gateway"
 COPY --from=build /app/bin/flightctl-telemetry-gateway .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-telemetry-gateway

--- a/Containerfile.telemetry-gateway
+++ b/Containerfile.telemetry-gateway
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     microdnf install ca-certificates --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-telemetry-gateway-container" \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -37,12 +37,6 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-userinfo-proxy
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-     microdnf install ca-certificates --nodocs -y
-
 FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /app
 LABEL \
@@ -53,7 +47,6 @@ LABEL \
   name="flightctl-userinfo-proxy" \
   summary="Flight Control UserInfo proxy for Grafana authentication"
 COPY --from=build /app/bin/flightctl-userinfo-proxy .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 
 EXPOSE 8080
 

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     microdnf install ca-certificates --nodocs -y
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-worker-container" \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -37,13 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-worker
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal as certs
-# Use BuildKit cache mounts for microdnf package caching
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=cache,target=/var/lib/dnf \
-    microdnf install ca-certificates --nodocs -y
-
-FROM quay.io/flightctl/flightctl-base:9.6-1752500771
+FROM quay.io/flightctl/flightctl-base:9.6-1758714456
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-worker-container" \
@@ -53,5 +47,4 @@ LABEL \
   name="flightctl-worker" \
   summary="Flight Control Edge management service, async job worker"
 COPY --from=build /app/bin/flightctl-worker .
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 CMD ./flightctl-worker

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ ifeq ($(DEBUG),true)
 	LD_FLAGS :=
 	GC_FLAGS := -gcflags "all=-N -l"
 else
-	# strip everything we can
-	LD_FLAGS := -w -s
+	# strip debug info, but keep symbols
+	LD_FLAGS := -w
 	GC_FLAGS :=
 endif
 


### PR DESCRIPTION
Switch app images back to `quay.io/flightctl/flightctl-base:9.6-1752500771`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized container base images across services to a single maintained base.
  - Removed redundant certificate build stages and CA-bundle injection from images.
  - Enriched container metadata/labels for clearer identification in registries and Kubernetes.
  - Adjusted build flags to preserve symbol information (no change to runtime behavior).
  - No functional changes to runtime commands; deployment compatibility preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->