### PR TITLE
EDM-2214: More than one flightctl-db-migration pod is created on timeout

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -267,14 +267,15 @@ For more detailed configuration options, see the [Values](#values) section below
 | db.type | string | `"pgsql"` | Database type (currently only 'pgsql' is supported) |
 | db.user | string | `"flightctl_app"` | Application database username |
 | db.userPassword | string | `""` | Application user password (leave empty for auto-generation) userPassword: Leave empty to auto-generate secure password, or set to use a specific password. |
-| dbSetup | object | `{"image":{"image":"quay.io/flightctl/flightctl-db-setup","pullPolicy":"","tag":""},"migration":{"activeDeadlineSeconds":600,"backoffLimit":3},"wait":{"sleep":2,"timeout":60}}` | Database Setup Configuration |
+| dbSetup | object | `{"image":{"image":"quay.io/flightctl/flightctl-db-setup","pullPolicy":"","tag":""},"migration":{"activeDeadlineSeconds":900,"backoffLimit":5},"wait":{"connectionTimeout":3,"sleep":2,"timeout":60}}` | Database Setup Configuration |
 | dbSetup.image.image | string | `"quay.io/flightctl/flightctl-db-setup"` | Database setup container image |
 | dbSetup.image.pullPolicy | string | `""` | Image pull policy for database setup container |
 | dbSetup.image.tag | string | `""` | Database setup image tag |
-| dbSetup.migration.activeDeadlineSeconds | int | `600` | Maximum runtime in seconds for the migration Job |
-| dbSetup.migration.backoffLimit | int | `3` | Number of retries for the migration Job on failure |
+| dbSetup.migration.activeDeadlineSeconds | int | `900` | Maximum runtime in seconds for the migration Job Extended timeout to account for external database latency |
+| dbSetup.migration.backoffLimit | int | `5` | Number of retries for the migration Job on failure Increased for external database scenarios which may be less reliable |
+| dbSetup.wait.connectionTimeout | int | `3` | Connection timeout for individual database connection attempts |
 | dbSetup.wait.sleep | int | `2` | Seconds to sleep between database connection attempts Default sleep interval between connection attempts |
-| dbSetup.wait.timeout | int | `60` | Seconds to wait for database readiness before failing Default timeout for database wait (can be overridden per deployment) |
+| dbSetup.wait.timeout | int | `60` | Seconds to wait for database readiness before failing Default timeout for database wait (can be overridden per deployment) Note: Migration jobs use longer timeouts (120s internal, 300s external) |
 | global.apiUrl | string | `""` | Alternative to global.auth.k8s.externalOpenShiftApiUrl with the same meaning, used by the multiclusterhub operator |
 | global.appCode | string | `""` | This is only related to deployment in Red Hat's PAAS. |
 | global.auth.aap.apiUrl | string | `""` | The URL of the AAP Gateway API endpoint |

--- a/deploy/helm/flightctl/templates/_db-migration-job.tpl
+++ b/deploy/helm/flightctl/templates/_db-migration-job.tpl
@@ -42,7 +42,8 @@ spec:
       serviceAccountName: flightctl-db-migration
       initContainers:
       {{- $userType := ternary "admin" "migration" (ne $ctx.Values.db.external "enabled") }}
-      {{- include "flightctl.databaseWaitInitContainer" (dict "context" $ctx "userType" $userType "timeout" 120 "sleep" 2) | nindent 6 }}
+      {{- $dbTimeout := ternary 300 120 (eq $ctx.Values.db.external "enabled") }}
+      {{- include "flightctl.databaseWaitInitContainer" (dict "context" $ctx "userType" $userType "timeout" $dbTimeout "sleep" 5) | nindent 6 }}
       {{- if ne $ctx.Values.db.external "enabled" }}
       {{- if not $isDryRun }}
       - name: setup-database-users

--- a/deploy/helm/flightctl/templates/flightctl-db-migration-job.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-db-migration-job.yaml
@@ -16,7 +16,7 @@
   "name" (printf "%s-dryrun" $baseName)
   "hooks" (list "pre-upgrade")
   "hookWeight" "-10"
-  "hookDeletePolicy" "before-hook-creation,hook-succeeded"
+  "hookDeletePolicy" "before-hook-creation,hook-succeeded,hook-failed"
   "isDryRun" true
 ) }}
 ---
@@ -28,14 +28,16 @@
   "name" $baseName
   "hooks" (list "pre-upgrade")
   "hookWeight" "10"
-  "hookDeletePolicy" "before-hook-creation,hook-succeeded"
+  "hookDeletePolicy" "before-hook-creation,hook-succeeded,hook-failed"
   "isDryRun" false
 ) }}
 {{- else if .Release.IsInstall }}
 {{- include "flightctl.dbMigrationJob" (dict
   "context" $root
   "name" $baseName
-  "hooks" (list)
+  "hooks" (list "post-install")
+  "hookWeight" "10"
+  "hookDeletePolicy" "before-hook-creation,hook-succeeded,hook-failed"
   "isDryRun" false
 ) }}
 {{- end }}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -337,15 +337,20 @@ dbSetup:
   wait:
     # -- Seconds to wait for database readiness before failing
     # Default timeout for database wait (can be overridden per deployment)
+    # Note: Migration jobs use longer timeouts (120s internal, 300s external)
     timeout: 60
     # -- Seconds to sleep between database connection attempts
     # Default sleep interval between connection attempts
     sleep: 2
+    # -- Connection timeout for individual database connection attempts
+    connectionTimeout: 3
   migration:
     # -- Number of retries for the migration Job on failure
-    backoffLimit: 3
+    # Increased for external database scenarios which may be less reliable
+    backoffLimit: 5
     # -- Maximum runtime in seconds for the migration Job
-    activeDeadlineSeconds: 600
+    # Extended timeout to account for external database latency
+    activeDeadlineSeconds: 900
 
 # -- Upgrade hooks
 upgradeHooks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable DB connection timeout for migration wait logic and introduced new global/Kubernetes external auth fields.
  - Introduced post-install hook and hook weight for initial installs to ensure migration runs at the right time.
- Bug Fixes
  - Improved migration reliability with dynamic timeouts, longer waits, increased backoff and active-deadline defaults, and longer sleep where applicable to reduce failures with slow/external databases.
  - Updated hook delete policies to include failed hooks, improving cleanup during dry-run, upgrade, and install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->