### PR TITLE
NO-ISSUE: LastSeen CLI use "never" not "none"

### DIFF
--- a/internal/cli/display/table.go
+++ b/internal/cli/display/table.go
@@ -165,7 +165,7 @@ func (f *TableFormatter) printDevicesSummaryTable(w *tabwriter.Writer, summary *
 func (f *TableFormatter) printDevicesLastSeenTable(w *tabwriter.Writer, lastSeen *api.DeviceLastSeen) error {
 	f.printHeaderRowLn(w, "LAST SEEN", "TIME AGO")
 	if lastSeen == nil {
-		f.printTableRowLn(w, NoneString, NoneString)
+		f.printTableRowLn(w, "<never>", "<never>")
 	} else {
 		f.printTableRowLn(w, lastSeen.LastSeen.Format(time.RFC3339), humanize.Time(lastSeen.LastSeen))
 	}


### PR DESCRIPTION
Show <never> instead of <none> for device last seen when no timestamp exists.