### PR TITLE
EDM-2228: Installation fails when using an external database with sslmode verify-ca

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -195,11 +195,13 @@ db:
 
 **TLS/SSL Modes:**
 - `disable` - No TLS/SSL (not recommended for production)
+- `allow` - TLS/SSL if available, otherwise plain connection
+- `prefer` - TLS/SSL preferred, fallback to plain connection
 - `require` - TLS/SSL required, no certificate verification
 - `verify-ca` - TLS/SSL required, verify server certificate against CA
 - `verify-full` - TLS/SSL required, verify certificate and hostname
 
-For complete TLS/SSL configuration details, see the [external database documentation](https://docs.flightctl.io/user/external-database/).
+For complete TLS/SSL configuration details, see the [external database documentation](../../../user/external-database/).
 
 For more detailed configuration options, see the [Values](#values) section below.
 

--- a/deploy/helm/flightctl/README.md.gotmpl
+++ b/deploy/helm/flightctl/README.md.gotmpl
@@ -218,11 +218,13 @@ db:
 
 **TLS/SSL Modes:**
 - `disable` - No TLS/SSL (not recommended for production)
+- `allow` - TLS/SSL if available, otherwise plain connection
+- `prefer` - TLS/SSL preferred, fallback to plain connection
 - `require` - TLS/SSL required, no certificate verification
 - `verify-ca` - TLS/SSL required, verify server certificate against CA
 - `verify-full` - TLS/SSL required, verify certificate and hostname
 
-For complete TLS/SSL configuration details, see the [external database documentation](https://docs.flightctl.io/user/external-database/).
+For complete TLS/SSL configuration details, see the [external database documentation](../../../user/external-database/).
 {{ end }}
 
 For more detailed configuration options, see the [Values](#values) section below.

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -268,6 +268,8 @@ Parameters:
   - name: DB_SSL_ROOT_CERT
     value: "{{ $context.Values.db.sslrootcert }}"
   {{- end }}
+  volumeMounts:
+  {{- include "flightctl.dbSslVolumeMounts" $context | nindent 2 }}
 {{- end }}
 
 {{- /*

--- a/deploy/helm/flightctl/templates/flightctl-alert-exporter-deployment.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-alert-exporter-deployment.yaml
@@ -46,6 +46,22 @@ spec:
                 secretKeyRef:
                   name: flightctl-db-app-secret
                   key: user
+            {{- if .Values.db.sslmode }}
+            - name: DB_SSL_MODE
+              value: "{{ .Values.db.sslmode }}"
+            {{- end }}
+            {{- if .Values.db.sslcert }}
+            - name: DB_SSL_CERT
+              value: "{{ .Values.db.sslcert }}"
+            {{- end }}
+            {{- if .Values.db.sslkey }}
+            - name: DB_SSL_KEY
+              value: "{{ .Values.db.sslkey }}"
+            {{- end }}
+            {{- if .Values.db.sslrootcert }}
+            - name: DB_SSL_ROOT_CERT
+              value: "{{ .Values.db.sslrootcert }}"
+            {{- end }}
             {{- if .Values.alertExporter.env }}
             {{- range $key, $value := .Values.alertExporter.env }}
             - name: {{ $key }}
@@ -56,6 +72,7 @@ spec:
             - mountPath: /root/.flightctl
               name: flightctl-alert-exporter-config
               readOnly: true
+            {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /health
@@ -77,4 +94,5 @@ spec:
         - name: flightctl-alert-exporter-config
           configMap:
             name: flightctl-alert-exporter-config
+        {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional DB TLS modes ("allow", "prefer") and support for supplying DB certificates/keys/root so components can use TLS when available.

- **Documentation**
  - Clarified external database guide: Helm auto-detects existing DB secrets, shows explicit namespace and Helm ownership metadata, and documents sslrootcert usage.
  - Switched external-database link to a relative path and streamlined TLS/SSL configuration wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->