### PR TITLE
EDM-2232: Explicitly set device fields unset by ApplyJSONPatch

### DIFF
--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -436,6 +436,14 @@ func (h *ServiceHandler) PatchDevice(ctx context.Context, name string, patch api
 		return nil, api.StatusBadRequest(err.Error())
 	}
 
+	// Status.LastSeen and Status.SystemInfo.AdditionalProperties are not marshaled into newObj by ApplyJSONPatch
+	// and will always be set to nil as they have "-" json tags and will not be copied into newObj.  For now, set the fields manually
+	// so later validation passes
+	if currentObj.Status != nil {
+		newObj.Status.LastSeen = currentObj.Status.LastSeen
+		newObj.Status.SystemInfo.AdditionalProperties = currentObj.Status.SystemInfo.AdditionalProperties
+	}
+
 	if errs := newObj.Validate(); len(errs) > 0 {
 		return nil, api.StatusBadRequest(errors.Join(errs...).Error())
 	}


### PR DESCRIPTION
TLDR; Device PATCH operations fail for devices with a LastSeen value

Device PATCH operations were sometimes failing like so when trying to edit labels for an onboarded device:

```bash
flightctl edit device/n8q1764dk6t39c1vkmnn4o061bos2miq0bd1n6afbbm0193i74eg
Your changes have been saved to: /tmp/flightctl-edit-failed-device-n8q1764dk6t39c1vkmnn4o061bos2miq0bd1n6afbbm0193i74eg-591206639.yaml
You can apply these changes later using: flightctl apply -f /tmp/flightctl-edit-failed-device-n8q1764dk6t39c1vkmnn4o061bos2miq0bd1n6afbbm0193i74eg-591206639.yaml
Error: applying changes: server returned status: 400 Bad Request
Error details: {"apiVersion":"v1alpha1","code":400,"kind":"Status","message":"status is immutable","reason":"Bad Request","status":"Failure"}
```

This was a result of [this validation check failing](https://github.com/flightctl/flightctl/blob/main/api/v1alpha1/validation.go#L1165) despite the status not being directly modified.  Further investigation revealed that the LastSeen property was not being serialized as it was recently changed to have a ["-" json tag](https://github.com/flightctl/flightctl/blob/main/api/v1alpha1/types.gen.go#L890) so the ApplyJSONPatch function would effectively "un-set" the data and a comparison between the device fetched from the database and the result of ApplyJSONPatch would then fail.

This solution is a bit of a hack and something more holistic would be good to prevent this same type of thing in the future for other non-serialized fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device patching now preserves "Last Seen" and additional system info so status data is not lost during updates.
  * Validation during device updates improved to avoid false failures and ensure immutability checks remain consistent.
  * Metadata and system info handling during patches made more reliable, producing steadier and more predictable device status after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->