### PR TITLE
NO-ISSUE: agent/device: remove stop and unnecessary locking

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -336,9 +336,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		a.log,
 	)
 
-	// register agent with shutdown manager
-	shutdownManager.Register("agent", agent.Stop)
-
 	// register reloader with reload manager
 	reloadManager.Register(agent.ReloadConfig)
 	reloadManager.Register(systemInfoManager.ReloadConfig)

--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -265,7 +265,11 @@ func (m *prefetchManager) pull(ctx context.Context, target string, task *prefetc
 func (m *prefetchManager) setResult(image string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	task := m.tasks[image]
+	task, ok := m.tasks[image]
+	if !ok {
+		m.log.Debugf("Task for %s no longer exists, skipping result update", image)
+		return
+	}
 	task.err = err
 	task.done = true
 }


### PR DESCRIPTION
The [shutdown manager cancels the main context](https://github.com/flightctl/flightctl/blob/3f84eefc1aed5bb872f470900d4a70043646ac50/internal/agent/shutdown/shutdown.go#L48) during shutdown. So registering the Stop with the shutdown manager created an unnecessary need for a mutex on the cancelFn that was only ever fired by that manager.  This PR also fixes a potential panic trying to read a task that has already been cleaned up.

This fix was [proposed here](https://github.com/flightctl/flightctl/pull/1652/files#r2364508520) but I have not had time yet to stabalize that PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent lifecycle adjusted so it no longer binds into the global shutdown manager; explicit agent stop path removed.
* **Bug Fixes**
  * Prefetch/dependency handling now guards against updating tasks that no longer exist to avoid race issues.
* **Tests**
  * Added a test ensuring task cleanup prevents later updates from resurrecting or modifying cleared tasks.
* **Chores**
  * Internal cleanup of synchronization and cancellable-context handling; no user-facing feature changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->