### PR TITLE
EDM-2246: Ensure alertmanager-proxy tag is updated from :latest when …

### DIFF
--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -24,12 +24,10 @@ export SYSTEMD_UNIT_OUTPUT_DIR
 # Tags for dev builds on the main branch look like: 0.6.0-main-119-gf75bcff
 get_services_for_tag() {
     local image_tag="$1"
-    local services=()
+    local services=("api" "periodic" "worker" "alert-exporter" "cli-artifacts" "alertmanager-proxy")
 
-    if [[ "$image_tag" =~ -main- ]]; then
-        services+=("api" "periodic" "worker" "alert-exporter" "cli-artifacts")
-    else
-        services+=("api" "periodic" "worker" "alert-exporter" "ui" "cli-artifacts")
+    if [[ ! "$image_tag" =~ -main- ]]; then
+        services+=("ui")
     fi
 
     echo "${services[@]}"


### PR DESCRIPTION
…installing rpm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment script to broaden default service updates, now including additional services (e.g., alerting proxy) by default.
  * Adjusted tag-based behavior: UI updates are now applied only for non-main image tags; main-tag deployments no longer implicitly include UI.
  * Aligns which service images are updated across tags for more predictable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->