### PR TITLE
Merge pull request #1740 from DakCrowder/bugfix/edm-2246/rpm-fix

### DIFF
--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -24,12 +24,10 @@ export SYSTEMD_UNIT_OUTPUT_DIR
 # Tags for dev builds on the main branch look like: 0.6.0-main-119-gf75bcff
 get_services_for_tag() {
     local image_tag="$1"
-    local services=()
+    local services=("api" "periodic" "worker" "alert-exporter" "cli-artifacts" "alertmanager-proxy")
 
-    if [[ "$image_tag" =~ -main- ]]; then
-        services+=("api" "periodic" "worker" "cli-artifacts")
-    else
-        services+=("api" "periodic" "worker" "ui" "cli-artifacts")
+    if [[ ! "$image_tag" =~ -main- ]]; then
+        services+=("ui")
     fi
 
     echo "${services[@]}"


### PR DESCRIPTION
Adds alertmanager-proxy and alert-exporter to list of services to ensure the :latest tag on the related quay container urls are overwritten for installed rpm files