### PR TITLE
EDM-2211: docs: clarify bootc image building dep

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -7,7 +7,7 @@ Flight Control is a service for declarative, GitOps-driven management of edge de
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `buildah`, `podman`, `podman-compose`, and `go-rpm-macros` (in case one needs to build RPM's)
+* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `buildah`, `podman`, `podman-compose`, `container-selinux` (>= 2.241) and `go-rpm-macros` (in case one needs to build RPM's)
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/docs/user/building-images.md
+++ b/docs/user/building-images.md
@@ -36,6 +36,7 @@ Before you start, ensure you have installed the following prerequisites:
 * `flightctl` CLI latest version ([installation guide](getting-started.md#installing-the-flight-control-cli))
 * `podman` version 5.0 or higher ([installation guide](https://podman.io/docs/installation))
 * `skopeo` version 1.14 or higher ([installation guide](https://github.com/containers/skopeo/blob/main/install.md))
+* `container-selinux` version 2.241 or higher (required by `bootc-image-builder`)
 
 ### Choosing an Enrollment Method
 


### PR DESCRIPTION
Error after failed BIB build

```
Error: OCI runtime error: crun: systemd failed to install eBPF device filter on cgroup.
```

This was tracked by upstream issue https://github.com/containers/container-selinux/issues/389
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added container-selinux (>= 2.241) to the prerequisites for building images.
  * Updated developer and user building guides to list the new dependency required by the image builder.
  * Clarified prerequisite versions to reduce setup issues and improve build reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->