### PR TITLE
EDM-2261: docs/user: add details on application fleet templating

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -878,10 +878,15 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 				allErrs = append(allErrs, fmt.Errorf("invalid image application provider: %w", err))
 				continue
 			}
+
 			if provider.Image == "" && app.Name == nil {
 				allErrs = append(allErrs, fmt.Errorf("image reference cannot be empty when application name is not provided"))
 			}
-			allErrs = append(allErrs, validation.ValidateOciImageReference(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName))...)
+			containsParams, paramErrs := validateParametersInString(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName), fleetTemplate)
+			allErrs = append(allErrs, paramErrs...)
+			if !containsParams {
+				allErrs = append(allErrs, validation.ValidateOciImageReference(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName))...)
+			}
 			volumes = provider.Volumes
 
 		case InlineApplicationProviderType:

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
@@ -817,4 +818,209 @@ func newTestApplication(require *require.Assertions, name string, appImage, volI
 	require.NoError(app.FromImageApplicationProviderSpec(provider))
 
 	return app
+}
+
+func TestValidateImageApplicationFleetTemplating(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name           string
+		image          string
+		fleetTemplate  bool
+		deviceName     string
+		deviceLabels   map[string]string
+		expectedOutput string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "valid image without template",
+			image:          "quay.io/flightctl/nginx:latest",
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{},
+			expectedOutput: "",
+		},
+		{
+			name:           "valid image with device name template",
+			image:          "quay.io/flightctl/app:{{ .metadata.name }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{},
+			expectedOutput: "quay.io/flightctl/app:device-1",
+		},
+		{
+			name:           "valid image with label template",
+			image:          "quay.io/flightctl/app:{{ .metadata.labels.version }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{"version": "v1.2.3"},
+			expectedOutput: "quay.io/flightctl/app:v1.2.3",
+		},
+		{
+			name:           "valid image with upper function",
+			image:          "quay.io/flightctl/app:{{ upper .metadata.labels.env }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{"env": "prod"},
+			expectedOutput: "quay.io/flightctl/app:PROD",
+		},
+		{
+			name:           "valid image with lower function",
+			image:          "quay.io/flightctl/app:{{ lower .metadata.name }}",
+			fleetTemplate:  true,
+			deviceName:     "DEVICE-1",
+			deviceLabels:   map[string]string{},
+			expectedOutput: "quay.io/flightctl/app:device-1",
+		},
+		{
+			name:           "valid image with replace function",
+			image:          "quay.io/flightctl/app:{{ replace \".\" \"-\" .metadata.name }}",
+			fleetTemplate:  true,
+			deviceName:     "device.1.test",
+			deviceLabels:   map[string]string{},
+			expectedOutput: "quay.io/flightctl/app:device-1-test",
+		},
+		{
+			name:           "valid image with pipeline",
+			image:          "quay.io/flightctl/app:{{ .metadata.labels.version | lower | replace \" \" \"-\" }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{"version": "V1 2 3"},
+			expectedOutput: "quay.io/flightctl/app:v1-2-3",
+		},
+		{
+			name:           "valid image with index function",
+			image:          "quay.io/flightctl/app:{{ index .metadata.labels \"app-version\" }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{"app-version": "2.0.0"},
+			expectedOutput: "quay.io/flightctl/app:2.0.0",
+		},
+		{
+			name:           "valid image with multiple templates",
+			image:          "quay.io/{{ .metadata.labels.registry }}/app:{{ .metadata.labels.version }}",
+			fleetTemplate:  true,
+			deviceName:     "device-1",
+			deviceLabels:   map[string]string{"registry": "myregistry", "version": "1.0.0"},
+			expectedOutput: "quay.io/myregistry/app:1.0.0",
+		},
+		{
+			name:          "invalid image with Go struct syntax",
+			image:         "quay.io/flightctl/app:{{ .Metadata.Name }}",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "cannot apply parameters, possibly because they access invalid fields",
+		},
+		{
+			name:          "invalid image with unsupported field",
+			image:         "quay.io/flightctl/app:{{ .metadata.annotations.version }}",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "cannot apply parameters, possibly because they access invalid fields",
+		},
+		{
+			name:          "invalid image with range control structure",
+			image:         "quay.io/flightctl/app:{{range .metadata.labels}}{{.}}{{end}}",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "unsupported elements",
+		},
+		{
+			name:          "invalid image with if control structure",
+			image:         "quay.io/flightctl/app:{{if .metadata.name}}latest{{else}}stable{{end}}",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "unsupported elements",
+		},
+		{
+			name:          "invalid image with unknown function",
+			image:         "quay.io/flightctl/app:{{ unknownfunc .metadata.name }}",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "function \"unknownfunc\" not defined",
+		},
+		{
+			name:          "invalid image with malformed template",
+			image:         "quay.io/flightctl/app:{{ .metadata.name",
+			fleetTemplate: true,
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "invalid parameter syntax",
+		},
+		{
+			name:          "invalid base image without template",
+			image:         "_invalid-image",
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "Invalid value",
+		},
+		{
+			name:          "template in non-fleet context should validate as normal OCI reference",
+			image:         "quay.io/flightctl/app:{{ .metadata.name }}",
+			deviceName:    "device-1",
+			deviceLabels:  map[string]string{},
+			wantErr:       true,
+			errContains:   "Invalid value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First, validate the application spec
+			app := ApplicationProviderSpec{
+				Name:    lo.ToPtr("test-app"),
+				AppType: lo.ToPtr(AppTypeCompose),
+			}
+
+			provider := ImageApplicationProviderSpec{
+				Image: tt.image,
+			}
+			require.NoError(app.FromImageApplicationProviderSpec(provider))
+
+			apps := []ApplicationProviderSpec{app}
+			errs := validateApplications(apps, tt.fleetTemplate)
+
+			if tt.wantErr {
+				require.NotEmpty(errs, "expected errors but got none")
+				found := false
+				for _, err := range errs {
+					if strings.Contains(err.Error(), tt.errContains) {
+						found = true
+						break
+					}
+				}
+				require.True(found, "expected error containing %q but got: %v", tt.errContains, errs)
+			} else {
+				require.Empty(errs, "expected no errors but got: %v", errs)
+
+				// If valid and a fleet template, test the actual template rendering
+				if tt.fleetTemplate && tt.expectedOutput != "" {
+					dev := &Device{
+						Metadata: ObjectMeta{
+							Name:   lo.ToPtr(tt.deviceName),
+							Labels: &tt.deviceLabels,
+						},
+					}
+
+					tmpl, err := template.New("test").Funcs(GetGoTemplateFuncMap()).Parse(tt.image)
+					require.NoError(err, "template should parse successfully")
+
+					output, err := ExecuteGoTemplateOnDevice(tmpl, dev)
+					require.NoError(err, "template should execute successfully")
+					require.Equal(tt.expectedOutput, output, "rendered template should match expected output")
+				}
+			}
+		})
+	}
 }

--- a/docs/user/managing-fleets.md
+++ b/docs/user/managing-fleets.md
@@ -96,6 +96,8 @@ Here are some examples of what you can do with placeholders in device templates:
 
 * You can label devices by their deployment stage (say, `stage: testing` and `stage: production`) and then use the label with the key `stage` as placeholder when referencing the OS image to use (say, `quay.io/myorg/myimage:latest-{{ .metadata.labels.stage }}`) or when referencing a folder with configuration in a Git repository.
 * You can label devices by deployment site (say, `site: factory-berlin` and `site: factory-madrid`) and then use the label with the key `site` as parameter when referencing the secret with network access credentials in Kubernetes.
+* You can label devices by application version (say, `app-version: 1.2.3`) and then use the label to specify the container image for an application (say, `quay.io/myorg/myapp:{{ .metadata.labels.app-version }}` using the `index` function as `quay.io/myorg/myapp:{{ index .metadata.labels "app-version" }}`).
+* You can use the device name to create unique application configurations by templating the inline application content or path with `{{ .metadata.name }}`.
 
 The following fields in device templates support placeholders (including within values, unless otherwise noted):
 
@@ -105,6 +107,8 @@ The following fields in device templates support placeholders (including within 
 | Git Config Provider | targetRevision, path |
 | HTTP Config Provider | URL suffix, path |
 | Inline Config Provider | content, path |
+| Image Application Provider | image |
+| Inline Application Provider | content, path |
 
 ## Defining Rollout Policies
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support templated placeholders in Image Application Provider image fields for fleets (e.g., device name, labels, index, upper/lower/replace).
* Bug Fixes
  * Validation defers OCI image checks when templates are present to avoid false errors.
  * Clear error when image is empty and application name is missing.
* Documentation
  * Added examples for placeholder-based image tags (e.g., app-version label, device name).
  * Documented placeholder support for Image and Inline Application Providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->