### PR TITLE
EDM-2261: docs/user: add details on application fleet templating

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -881,7 +881,11 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 			if provider.Image == "" && app.Name == nil {
 				allErrs = append(allErrs, fmt.Errorf("image reference cannot be empty when application name is not provided"))
 			}
-			allErrs = append(allErrs, validation.ValidateOciImageReference(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName))...)
+			containsParams, paramErrs := validateParametersInString(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName), fleetTemplate)
+			allErrs = append(allErrs, paramErrs...)
+			if !containsParams {
+				allErrs = append(allErrs, validation.ValidateOciImageReference(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName))...)
+			}
 			volumes = provider.Volumes
 
 		case InlineApplicationProviderType:

--- a/docs/user/managing-fleets.md
+++ b/docs/user/managing-fleets.md
@@ -96,6 +96,8 @@ Here are some examples of what you can do with placeholders in device templates:
 
 * You can label devices by their deployment stage (say, `stage: testing` and `stage: production`) and then use the label with the key `stage` as placeholder when referencing the OS image to use (say, `quay.io/myorg/myimage:latest-{{ .metadata.labels.stage }}`) or when referencing a folder with configuration in a Git repository.
 * You can label devices by deployment site (say, `site: factory-berlin` and `site: factory-madrid`) and then use the label with the key `site` as parameter when referencing the secret with network access credentials in Kubernetes.
+* You can label devices by application version (say, `app-version: 1.2.3`) and then use the label to specify the container image for an application (say, `quay.io/myorg/myapp:{{ .metadata.labels.app-version }}` using the `index` function as `quay.io/myorg/myapp:{{ index .metadata.labels "app-version" }}`).
+* You can use the device name to create unique application configurations by templating the inline application content or path with `{{ .metadata.name }}`.
 
 The following fields in device templates support placeholders (including within values, unless otherwise noted):
 
@@ -105,6 +107,8 @@ The following fields in device templates support placeholders (including within 
 | Git Config Provider | targetRevision, path |
 | HTTP Config Provider | URL suffix, path |
 | Inline Config Provider | content, path |
+| Image Application Provider | image |
+| Inline Application Provider | content, path |
 
 ## Defining Rollout Policies
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added placeholder/template support in Image and Inline Application providers (image, content, and path fields).
- Bug Fixes / Validation
  - Improved validation to be parameter-aware: skip strict image-format checks when templates are present and validate rendered results.
- Documentation
  - Updated fleet management guide with examples for labels, device name, and template functions (upper, lower, replace, index); expanded placeholders table.
- Tests
  - Added unit tests covering valid/invalid templates, rendering behavior, and error scenarios for templated application references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->