### PR TITLE
EDM-2266: Append org id param to console requests from cli and addres…

### DIFF
--- a/api/v1alpha1/consts.go
+++ b/api/v1alpha1/consts.go
@@ -89,6 +89,7 @@ const (
 	OrganizationAPIVersion = "v1alpha1"
 	OrganizationKind       = "Organization"
 	OrganizationListKind   = "OrganizationList"
+	OrganizationIDQueryKey = "org_id"
 
 	SystemKind           = "System"
 	SystemComponentDB    = "database"

--- a/internal/api_server/middleware/middleware.go
+++ b/internal/api_server/middleware/middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/auth"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/consts"
@@ -105,14 +106,14 @@ func AddOrgIDToCtx(resolver resolvers.Resolver, extractor OrgIDExtractor) func(h
 }
 
 func extractOrgIDFromRequestQuery(r *http.Request) (uuid.UUID, error) {
-	orgIDParam := r.URL.Query().Get("org_id")
+	orgIDParam := r.URL.Query().Get(api.OrganizationIDQueryKey)
 	if orgIDParam == "" {
 		return org.DefaultID, nil
 	}
 
 	parsedID, err := org.Parse(orgIDParam)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("invalid org_id parameter: %w", err)
+		return uuid.Nil, fmt.Errorf("invalid %s parameter: %w", api.OrganizationIDQueryKey, err)
 	}
 	return parsedID, nil
 }

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -181,6 +181,7 @@ func (o *ConsoleOptions) buildURL(baseURL, metadata string) (string, error) {
 	// Create query parameters
 	query := url.Values{}
 	query.Set(api.DeviceQueryConsoleSessionMetadata, metadata)
+	query.Set(api.OrganizationIDQueryKey, o.GetEffectiveOrganization())
 
 	// Encode the query parameters and attach them to the URL
 	u.RawQuery = query.Encode()

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -150,12 +150,14 @@ func removeSession(sessionID string) func(string) (string, error) {
 	}
 }
 
-func (m *ConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.UUID, deviceName, sessionMetadata string) (*ConsoleSession, error) {
+func (m *ConsoleSessionManager) StartSession(ctx context.Context, deviceName, sessionMetadata string) (*ConsoleSession, error) {
 	if sessionMetadata == "" {
 		m.log.Error("incompatible client: missing session metadata")
 		return nil, errors.New("incompatible client: missing session metadata")
 	}
 	m.log.Infof("Start session. Metadata %s", sessionMetadata)
+
+	orgId := getOrgIdFromContext(ctx)
 	session := &ConsoleSession{
 		OrgId:      orgId,
 		DeviceName: deviceName,

--- a/internal/service/enrollmentrequest.go
+++ b/internal/service/enrollmentrequest.go
@@ -17,7 +17,6 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service/common"
-	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/internal/util"
@@ -400,7 +399,7 @@ func (h *ServiceHandler) PatchEnrollmentRequest(ctx context.Context, name string
 func (h *ServiceHandler) DeleteEnrollmentRequest(ctx context.Context, name string) api.Status {
 	orgId := getOrgIdFromContext(ctx)
 
-	exists, err := h.deviceExists(ctx, name)
+	exists, err := h.deviceExists(ctx, orgId, name)
 	if err != nil {
 		return StoreErrorToApiStatus(err, false, api.DeviceKind, &name)
 	}
@@ -526,8 +525,8 @@ func (h *ServiceHandler) allowCreationOrUpdate(ctx context.Context, orgId uuid.U
 
 // deviceExists checks if a device with the given name exists in the store.
 // Error is returned if there is an error other than ErrResourceNotFound.
-func (h *ServiceHandler) deviceExists(ctx context.Context, name string) (bool, error) {
-	dev, err := h.store.Device().Get(ctx, store.NullOrgId, name)
+func (h *ServiceHandler) deviceExists(ctx context.Context, orgId uuid.UUID, name string) (bool, error) {
+	dev, err := h.store.Device().Get(ctx, orgId, name)
 	if errors.Is(err, flterrors.ErrResourceNotFound) {
 		return false, nil
 	}

--- a/internal/transport/console.go
+++ b/internal/transport/console.go
@@ -10,7 +10,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/flterrors"
-	"github.com/flightctl/flightctl/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 )
@@ -29,7 +28,6 @@ func (h *WebsocketHandler) injectProtocolsToMetadata(metadataStr string, protoco
 }
 
 func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Request) {
-	orgId := store.NullOrgId
 	deviceName := chi.URLParam(r, "name")
 
 	h.log.Infof("websocket console connection requested for device: %s", deviceName)
@@ -42,7 +40,7 @@ func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Re
 		http.Error(w, "protocols injection error", http.StatusInternalServerError)
 		return
 	}
-	consoleSession, err := h.consoleSessionManager.StartSession(r.Context(), orgId, deviceName, metadata)
+	consoleSession, err := h.consoleSessionManager.StartSession(r.Context(), deviceName, metadata)
 	// check for errors
 	if err != nil {
 		switch {


### PR DESCRIPTION
…s outdated const refs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Console URLs now include the organization identifier for organization-aware console sessions.
  - Requests can specify organization via a standardized query parameter for consistent routing.

- Bug Fixes
  - Device existence checks and enrollment request deletion now respect the selected organization, preventing cross-organization mismatches.

- Refactor
  - Console session startup now derives organization from context for more consistent behavior.
  - Middleware and transport updated to use the standardized organization query parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->