### PR TITLE
EDM-2272: device/application/podman: ensure pods are cleaned up on removal

### DIFF
--- a/internal/agent/device/applications/lifecycle/compose.go
+++ b/internal/agent/device/applications/lifecycle/compose.go
@@ -95,7 +95,7 @@ func (c *Compose) update(ctx context.Context, action *Action) error {
 	return nil
 }
 
-// stopAndRemoveContainers stops and removes all containers and networks created by the compose application.
+// stopAndRemoveContainers stops and removes all containers, pods, and networks created by the compose application.
 func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action) error {
 	var errs []error
 
@@ -107,10 +107,18 @@ func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action) e
 		errs = append(errs, err)
 	}
 
+	pods, err := c.podman.ListPods(ctx, labels)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
 	if err := c.podman.StopContainers(ctx, labels); err != nil {
 		errs = append(errs, err)
 	}
 	if err := c.podman.RemoveContainer(ctx, labels); err != nil {
+		errs = append(errs, err)
+	}
+	if err := c.podman.RemovePods(ctx, pods...); err != nil {
 		errs = append(errs, err)
 	}
 	if err := c.podman.RemoveNetworks(ctx, networks...); err != nil {


### PR DESCRIPTION
Manually tested 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Podman pod listing and removal added to application shutdown to clean up pods alongside containers and networks.
  - Support for removing multiple Podman pods with per-operation timeouts.

- Bug Fixes
  - Reduces orphaned Podman pods and leftover resources after stopping apps.
  - Improves reliability of cleanup with aggregated error reporting.

- Tests
  - Added test helpers to simulate Podman pod listing and removal in lifecycle tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->