### PR TITLE
EDM-2255: added flightctl-restore to the rpm

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -431,9 +431,9 @@ echo "Flightctl Observability Stack uninstalled."
     SOURCE_GIT_COMMIT="%{?SOURCE_GIT_COMMIT:%{SOURCE_GIT_COMMIT}}%{!?SOURCE_GIT_COMMIT:%(echo %{version} | grep -o '[-~]g[0-9a-f]*' | sed 's/[-~]g//' || echo unknown)}" \
     SOURCE_GIT_TAG_NO_V="%{?SOURCE_GIT_TAG_NO_V:%{SOURCE_GIT_TAG_NO_V}}%{!?SOURCE_GIT_TAG_NO_V:%{version}}" \
     %if 0%{?rhel} == 9
-        %make_build build-cli build-agent
+        %make_build build-cli build-agent build-restore
     %else
-        DISABLE_FIPS="true" %make_build build-cli build-agent
+        DISABLE_FIPS="true" %make_build build-cli build-agent build-restore
     %endif
 
     # SELinux modules build
@@ -443,6 +443,7 @@ echo "Flightctl Observability Stack uninstalled."
     mkdir -p %{buildroot}/usr/bin
     mkdir -p %{buildroot}/etc/flightctl
     cp bin/flightctl %{buildroot}/usr/bin
+    cp bin/flightctl-restore %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/%{_sharedstatedir}/flightctl
     mkdir -p %{buildroot}/usr/lib/flightctl/custom-info.d
@@ -578,6 +579,7 @@ fi
 
 %files cli -f licenses.list
     %{_bindir}/flightctl
+    %{_bindir}/flightctl-restore
     %license LICENSE
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish


### PR DESCRIPTION
replacement for https://github.com/flightctl/flightctl/pull/1753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a new flightctl-restore command, installed as /usr/bin/flightctl-restore and included in the CLI package to support restore operations.

- Chores
  - Updated packaging to include the new restore utility in builds and installation.
  - Ensured compatibility across target platforms, including RHEL 9 and FIPS/non-FIPS variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->