### PR TITLE
NO-ISSUE: Update repo to rpm.flightctl.io

### DIFF
--- a/docs/developer/service-quadlets.md
+++ b/docs/developer/service-quadlets.md
@@ -237,7 +237,7 @@ sudo podman logs flightctl-api
 The service Quadlets are also available to install via an RPM.  Installation steps for the latest release:
 
 ```bash
-sudo dnf copr enable -y @redhat-et/flightctl
+sudo dnf config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo
 sudo dnf install -y flightctl-services
 sudo systemctl start flightctl.target
 sudo systemctl enable flightctl.target # To enable starting on reboot

--- a/docs/user/building-images.md
+++ b/docs/user/building-images.md
@@ -89,7 +89,7 @@ Create a file named `Containerfile` with the following content to build an OS im
 ```console
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent && \
     dnf -y clean all && \
     systemctl enable flightctl-agent.service
@@ -130,7 +130,7 @@ When using Flight Control with a RHEL 9 base image, you need to make a few chang
 ```console
 FROM registry.redhat.io/rhel9/rhel-bootc:9.5
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent && \
     dnf -y clean all && \
     systemctl enable flightctl-agent.service && \
@@ -247,7 +247,7 @@ Create a file named `Containerfile` with the following content to build an OS im
 ```console
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent && \
     dnf -y clean all && \
     systemctl enable flightctl-agent.service
@@ -322,7 +322,7 @@ Create a file named `Containerfile` with the following content to build an OS im
 ```console
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent && \
     dnf -y clean all && \
     systemctl enable flightctl-agent.service

--- a/docs/user/device-observability.md
+++ b/docs/user/device-observability.md
@@ -198,7 +198,7 @@ This shows a `bootc` based device image that installs flightctl-agent and OpenTe
 ```yaml
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent opentelemetry-collector && \
     dnf -y clean all && \
     systemctl enable flightctl-agent.service

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -289,7 +289,7 @@ $ cat Containerfile
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 
-RUN dnf -y copr enable @redhat-et/flightctl && \
+RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent; \
     dnf -y clean all; \
     systemctl enable flightctl-agent.service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated RPM installation steps to use the official repository via dnf config-manager --add-repo, replacing the COPR enablement.
  * Aligned installation examples across Getting Started, Building Images, and Device Observability to the new repo source.
  * Preserved install, cleanup, and service enablement commands while clarifying repository setup for RPM-based systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->