### PR TITLE
NO-ISSUE: Use selected org when creating new devices with agent-vm

### DIFF
--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -196,7 +196,7 @@ build_qcow2_image() {
                     quay.io/centos-bootc/bootc-image-builder:latest \
                     build \
                     --type qcow2 \
-                    --local "${REGISTRY_ADDRESS}/flightctl-device:base"
+                    "${REGISTRY_ADDRESS}/flightctl-device:base"
     if is_acm_installed; then
         sudo qemu-img resize "$(pwd)"/bin/output/qcow2/disk.qcow2 +5G # increasing disk size for microshift registration to acm test only
     fi

--- a/test/scripts/agent-images/prepare_agent_config.sh
+++ b/test/scripts/agent-images/prepare_agent_config.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -e -x -o pipefail
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "${SCRIPT_DIR}"/../functions
+
 mkdir -p bin/agent/etc/flightctl/certs
 
 echo Requesting enrollment enrollment certificate/key and config for agent =====
 
-org_id=$(./bin/flightctl get organizations | awk 'NR==2 {print $1}')
-./bin/flightctl config set-organization "$org_id"
+ensure_organization_set
 
 # remove any previous CSR with the same name in case it existed
 ./bin/flightctl delete csr/client-enrollment || true

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -150,8 +150,7 @@ if [[ "${LOGGED_IN}" == "false" ]]; then
   exit 1
 fi
 
-org_id=$(./bin/flightctl get organizations | awk 'NR==2 {print $1}')
-./bin/flightctl config set-organization "$org_id"
+ensure_organization_set
 
 # Setup telemetry gateway certificates (non-blocking)
 if ! "${SCRIPT_DIR}"/setup_telemetry_gateway_certs.sh \

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -297,3 +297,31 @@ download_brew_rpms() {
     cd - > /dev/null
     return 0
 }
+
+# Function to ensure an organization is selected in the CLI context
+# If no organization is currently set, it will automatically select the first available one
+function ensure_organization_set() {
+    local output
+    output=$(./bin/flightctl config current-organization 2>/dev/null)
+    
+    local current_org=""
+    if [ -n "$output" ]; then
+        # Output can be "organization-id (<optional>display-name)", or a message to the user
+        # If the output contains a UUID, then an organization is set
+        local first_field=$(echo "$output" | awk '{print $1}')
+        if [[ "$first_field" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            current_org="$first_field"
+        fi
+    fi
+
+    if [ -z "$current_org" ]; then
+        echo "No organization currently set, selecting first available organization"
+        local org_id
+        org_id=$(./bin/flightctl get organizations | awk 'NR==2 {print $1}')
+        ./bin/flightctl config set-organization "$org_id"
+        echo "Set organization to: $org_id"
+    else
+        echo "Organization already set to: $current_org"
+    fi
+    return 0
+}


### PR DESCRIPTION
When running `agent-vm`, the script would associate the device with first organization from the list. Now the script will check if an organization was already selected and won't overwrite it.

Note: Supported by Cursor AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for telemetry certificate setup so deployment logs a warning and continues if setup fails.
  * Improved certificate enrollment flow and removal of stale enrollment requests to avoid failures; enrollment output is now incorporated into agent config.

* **Chores**
  * Unified organization initialization across deployment scripts with automatic detection and assignment.
  * Agent image build updated to reference non-local base images.

* **New Features**
  * Agent configuration supports long-form CLI options for interval settings and a help flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->