### PR TITLE
EDM-2254: Fix directory drop in reference for db/kv

### DIFF
--- a/docs/user/restore.md
+++ b/docs/user/restore.md
@@ -312,8 +312,8 @@ echo "Database container file: $DB_CONTAINER_FILE"
 echo "KV store container file: $KV_CONTAINER_FILE"
 
 # Derive drop-in directories from source paths
-DB_DROPIN_DIR=$(dirname "$DB_CONTAINER_FILE").d
-KV_DROPIN_DIR=$(dirname "$KV_CONTAINER_FILE").d
+DB_DROPIN_DIR="${DB_CONTAINER_FILE}.d"
+KV_DROPIN_DIR="${KV_CONTAINER_FILE}.d"
 
 echo "Database drop-in directory: $DB_DROPIN_DIR"
 echo "KV store drop-in directory: $KV_DROPIN_DIR"
@@ -372,8 +372,8 @@ echo "Database container file: $DB_CONTAINER_FILE"
 echo "KV store container file: $KV_CONTAINER_FILE"
 
 # Derive drop-in directories from source paths
-DB_DROPIN_DIR=$(dirname "$DB_CONTAINER_FILE").d
-KV_DROPIN_DIR=$(dirname "$KV_CONTAINER_FILE").d
+DB_DROPIN_DIR="${DB_CONTAINER_FILE}.d"
+KV_DROPIN_DIR="${KV_CONTAINER_FILE}.d"
 
 echo "Database drop-in directory: $DB_DROPIN_DIR"
 echo "KV store drop-in directory: $KV_DROPIN_DIR"


### PR DESCRIPTION
Old behavior:
```
echo "Database drop-in directory: $DB_DROPIN_DIR"
echo "KV store drop-in directory: $KV_DROPIN_DIR"
Database drop-in directory: /usr/share/containers/systemd.d
KV store drop-in directory: /usr/share/containers/systemd.d
```

New behavior:
```
echo "Database drop-in directory: $DB_DROPIN_DIR"
echo "KV store drop-in directory: $KV_DROPIN_DIR"
Database drop-in directory: /usr/share/containers/systemd/flightctl-db.container.d
KV store drop-in directory: /usr/share/containers/systemd/flightctl-kv.container.d
```

Verified locally w/ quadlets install (not the full restore flow, but the drop in .conf files opening the ports appropriately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fixed drop-in directory resolution so drop-ins are created and detected at the intended locations next to their container files.

- Documentation
  - Updated restore instructions to reflect the revised drop-in directory locations and behavior for database and key-value components.

- Chores
  - Improved path-handling consistency to reduce confusion and align behavior with expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->