### PR TITLE
EDM-2277: Add note on RHEL base image requirements

### DIFF
--- a/docs/user/building-images.md
+++ b/docs/user/building-images.md
@@ -146,11 +146,15 @@ RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.rep
 ADD config.yaml /etc/flightctl/
 ```
 
-You also need to log in to the Red Hat registry before building your image:
-
-```console
-sudo podman login registry.redhat.io
-```
+> [!IMPORTANT]
+> To build RHEL-based bootc images, the build host itself must be a registered RHEL or Fedora system
+> that has access to Red Hat content through subscription-manager.
+>
+> You also need to log in to the Red Hat registry before building your image:
+>
+> ```console
+> sudo podman login registry.redhat.io
+> ```
 
 ### Signing and Publishing the OS Image (bootc)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added an IMPORTANT notice clarifying prerequisites for building RHEL-based bootc images: the build host must be a registered RHEL or Fedora system with subscription-manager access to Red Hat content.
  - Moved the Red Hat registry login command into the admonition for greater visibility while leaving the command itself unchanged.
  - Applied the same clarification in both the main bootc section and the RHEL base image subsection to reduce confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->