### PR TITLE
EMD-2207: Remove Docs and duplicate licenses from RPMs

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -64,7 +64,6 @@ jobs:
             docs/**
             .github/**
             examples/**
-            packaging/rpm/**
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -465,20 +465,6 @@ echo "Flightctl Observability Stack uninstalled."
 
     install -Dpm 0644 packaging/flightctl-services-install.conf %{buildroot}%{_sysconfdir}/flightctl/flightctl-services-install.conf
 
-    rm -f licenses.list
-
-    find . -type f -name LICENSE -or -name License | while read LICENSE_FILE; do
-        echo "%{_datadir}/licenses/%{NAME}/${LICENSE_FILE}" >> licenses.list
-    done
-    mkdir -vp "%{buildroot}%{_datadir}/licenses/%{NAME}"
-    cp LICENSE "%{buildroot}%{_datadir}/licenses/%{NAME}"
-
-    mkdir -vp "%{buildroot}%{_docdir}/%{NAME}"
-
-    for DOC in docs examples .markdownlint-cli2.yaml README.md; do
-        cp -vr "${DOC}" "%{buildroot}%{_docdir}/%{NAME}/${DOC}"
-    done
-
     # flightctl-services sub-package steps
     # Run the install script to move the quadlet files.
     #
@@ -577,7 +563,7 @@ fi
 # File listings
 # No %%files section for the main package, so it won't be built
 
-%files cli -f licenses.list
+%files cli
     %{_bindir}/flightctl
     %{_bindir}/flightctl-restore
     %license LICENSE
@@ -585,7 +571,7 @@ fi
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
     %{_datadir}/zsh/site-functions/_flightctl-completion
 
-%files agent -f licenses.list
+%files agent
     %license LICENSE
     %dir /etc/flightctl
     %{_bindir}/flightctl-agent
@@ -594,8 +580,6 @@ fi
     /usr/lib/systemd/system/flightctl-agent.service
     %{_sharedstatedir}/flightctl
     /usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
-    %{_docdir}/%{NAME}/*
-    %{_docdir}/%{NAME}/.markdownlint-cli2.yaml
     /usr/share/sosreport/flightctl.py
 
 %post agent


### PR DESCRIPTION
Excludes the docs from the Agent RPM and removes the duplicate LICENSES that are added to both the cli and agent.

CLI: 
Before: 
```
/usr/bin/flightctl
/usr/bin/flightctl-restore
/usr/lib/.build-id
/usr/lib/.build-id/97
/usr/lib/.build-id/97/fbe111e04ac83015f4fbecbe66ec946d50f13a
/usr/share/bash-completion/completions/flightctl-completion.bash
/usr/share/fish/vendor_completions.d/flightctl-completion.fish
/usr/share/licenses/flightctl-cli
/usr/share/licenses/flightctl-cli/LICENSE
/usr/share/licenses/flightctl/LICENSE
/usr/share/zsh/site-functions/_flightctl-completion
```

After:
```
/usr/bin/flightctl
/usr/bin/flightctl-restore
/usr/lib/.build-id
/usr/lib/.build-id/bb
/usr/lib/.build-id/bb/e33697055b5b0d4c656462d0b4b74ca3d127ed
/usr/lib/.build-id/e9
/usr/lib/.build-id/e9/3b6076fdb831af748bb08413b4ee6321955396
/usr/share/bash-completion/completions/flightctl-completion.bash
/usr/share/fish/vendor_completions.d/flightctl-completion.fish
/usr/share/licenses/flightctl-cli
/usr/share/licenses/flightctl-cli/LICENSE
/usr/share/zsh/site-functions/_flightctl-completion
```

Agent:

Before: 
```
/etc/flightctl
/usr/bin/flightctl-agent
/usr/bin/flightctl-must-gather
/usr/lib/.build-id
/usr/lib/.build-id/71
/usr/lib/.build-id/71/c745c5fff89be79c672ab3f15b5c3e1572e869
/usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml
/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
/usr/lib/systemd/system/flightctl-agent.service
/usr/share/doc/flightctl/.markdownlint-cli2.yaml
/usr/share/doc/flightctl/README.md
/usr/share/doc/flightctl/docs
/usr/share/doc/flightctl/docs/developer
/usr/share/doc/flightctl/docs/developer/README.md
/usr/share/doc/flightctl/docs/developer/architecture
/usr/share/doc/flightctl/docs/developer/architecture/alerts.md

.... elided
```

After:
```
rpm -qlp ./bin/rpm/flightctl-agent-1.0.0~main~49~g0571b629-1.20251008134745101009.main.49.g0571b629.el9.x86_64.rpm
/etc/flightctl
/usr/bin/flightctl-agent
/usr/bin/flightctl-must-gather
/usr/lib/.build-id
/usr/lib/.build-id/7d
/usr/lib/.build-id/7d/33f55987df7ba82eb07bbf11430ba0ded4bbd8
/usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml
/usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
/usr/lib/systemd/system/flightctl-agent.service
/usr/share/licenses/flightctl-agent
/usr/share/licenses/flightctl-agent/LICENSE
/usr/share/sosreport/flightctl.py
/var/lib/flightctl
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - RPM packages no longer include aggregated license list or bundled docs, reducing installed files.
  - Simplified package file listings for CLI and Agent to remove license-list references.
  - CI/workflow updated so packaging changes trigger downstream build and E2E steps.

- Documentation
  - Bundled docs and examples excluded from the agent package.

Impact: Smaller install footprint and CI now runs when packaging is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->