### PR TITLE
EDM-2229: deploy/helm: fix doc links

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -201,7 +201,7 @@ db:
 - `verify-ca` - TLS/SSL required, verify server certificate against CA
 - `verify-full` - TLS/SSL required, verify certificate and hostname
 
-For complete TLS/SSL configuration details, see the [external database documentation](../../../user/external-database/).
+For complete TLS/SSL configuration details, see the [external database documentation](../../../docs/user/external-database.md).
 
 For more detailed configuration options, see the [Values](#values) section below.
 

--- a/deploy/helm/flightctl/README.md.gotmpl
+++ b/deploy/helm/flightctl/README.md.gotmpl
@@ -224,7 +224,7 @@ db:
 - `verify-ca` - TLS/SSL required, verify server certificate against CA
 - `verify-full` - TLS/SSL required, verify certificate and hostname
 
-For complete TLS/SSL configuration details, see the [external database documentation](../../../user/external-database/).
+For complete TLS/SSL configuration details, see the [external database documentation](../../../docs/user/external-database.md).
 {{ end }}
 
 For more detailed configuration options, see the [Values](#values) section below.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected TLS/SSL configuration links in the Helm chart README and README template to point to the canonical External Database documentation.
  * Replaced outdated local paths with direct docs references, ensuring access to complete, up-to-date guidance for configuring certificates with external databases.
  * Clarifies deployment steps and reduces confusion for users setting up secure database connections.
  * No functional changes to the chart or behavior; improvements are limited to documentation accuracy and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->