### PR TITLE
EDM-2259: Fix draining workloads on shutdown

### DIFF
--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	"github.com/flightctl/flightctl/internal/agent/device/dependency"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
+	"github.com/flightctl/flightctl/internal/agent/shutdown"
 )
 
 const (
@@ -52,8 +53,8 @@ type Manager interface {
 	BeforeUpdate(ctx context.Context, desired *v1alpha1.DeviceSpec) error
 	// AfterUpdate is called after the application has been validated and is ready to be executed.
 	AfterUpdate(ctx context.Context) error
-	// Stop halts the application running on the device.
-	Stop(ctx context.Context) error
+	// Shutdown closes the manager according to the corresponding shutdown state
+	Shutdown(ctx context.Context, state shutdown.State) error
 
 	dependency.OCICollector
 	status.Exporter

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -17,6 +17,7 @@ import (
 	provider "github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	dependency "github.com/flightctl/flightctl/internal/agent/device/dependency"
 	status "github.com/flightctl/flightctl/internal/agent/device/status"
+	shutdown "github.com/flightctl/flightctl/internal/agent/shutdown"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -163,6 +164,20 @@ func (mr *MockManagerMockRecorder) Remove(ctx, provider any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockManager)(nil).Remove), ctx, provider)
 }
 
+// Shutdown mocks base method.
+func (m *MockManager) Shutdown(ctx context.Context, state shutdown.State) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown", ctx, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockManagerMockRecorder) Shutdown(ctx, state any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockManager)(nil).Shutdown), ctx, state)
+}
+
 // Status mocks base method.
 func (m *MockManager) Status(arg0 context.Context, arg1 *v1alpha1.DeviceStatus, arg2 ...status.CollectorOpt) error {
 	m.ctrl.T.Helper()
@@ -180,20 +195,6 @@ func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
-}
-
-// Stop mocks base method.
-func (m *MockManager) Stop(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stop", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockManagerMockRecorder) Stop(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockManager)(nil).Stop), ctx)
 }
 
 // Update mocks base method.

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -202,11 +202,14 @@ func (m *PodmanMonitor) stopMonitor() error {
 	return nil
 }
 
-func (m *PodmanMonitor) Stop(ctx context.Context) error {
-	if err := m.drain(ctx); err != nil {
-		return err
-	}
-	return nil
+// Stop stops the podman monitor without draining applications
+func (m *PodmanMonitor) Stop() error {
+	return m.stopMonitor()
+}
+
+// Drain stops and removes all applications, then stops the monitor
+func (m *PodmanMonitor) Drain(ctx context.Context) error {
+	return m.drain(ctx)
 }
 
 func (m *PodmanMonitor) getApps() []Application {

--- a/internal/agent/identity/identity.go
+++ b/internal/agent/identity/identity.go
@@ -90,8 +90,6 @@ type Provider interface {
 	WipeCredentials() error
 	// WipeCertificateOnly securely removes only the certificate (not keys or CSR)
 	WipeCertificateOnly() error
-	// Close cleans up any resources used by the provider
-	Close(ctx context.Context) error
 }
 
 // NewProvider creates an identity provider

--- a/internal/agent/identity/mock_identity.go
+++ b/internal/agent/identity/mock_identity.go
@@ -81,20 +81,6 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockProvider) Close(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockProviderMockRecorder) Close(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProvider)(nil).Close), ctx)
-}
-
 // CreateGRPCClient mocks base method.
 func (m *MockProvider) CreateGRPCClient(config *client0.Config) (grpc_v1.RouterServiceClient, error) {
 	m.ctrl.T.Helper()

--- a/internal/agent/identity/tpm.go
+++ b/internal/agent/identity/tpm.go
@@ -485,10 +485,3 @@ func (t *tpmProvider) WipeCertificateOnly() error {
 	t.log.Info("Successfully wiped certificate file")
 	return nil
 }
-
-func (t *tpmProvider) Close(ctx context.Context) error {
-	if t.client != nil {
-		return t.client.Close(ctx)
-	}
-	return nil
-}

--- a/internal/agent/shutdown/shutdown.go
+++ b/internal/agent/shutdown/shutdown.go
@@ -1,37 +1,91 @@
 package shutdown
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+	"unsafe"
 
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
 )
+
+const (
+	shutdownScheduledPath = "/run/systemd/shutdown/scheduled"
+	runlevelPath          = "/run/utmp"
+
+	// utmp record values
+	runlevelRecordType = 1 // utmp record type for runlevel changes
+	runLevelHalt       = '0'
+	runlevelReboot     = '6'
+)
+
+// UtmpRecord represents the structure of a utmp record
+type utmpRecord struct {
+	Type int32     // ut_type
+	Pid  int32     // ut_pid - for runlevel: encoded runlevel info
+	Line [32]byte  // ut_line
+	Id   [4]byte   // ut_id
+	User [32]byte  // ut_user
+	Host [256]byte // ut_host
+	Exit struct {  // ut_exit
+		Termination int16
+		Exit        int16
+	}
+	Session int32    // ut_session
+	Time    struct { // ut_tv
+		Sec  int32
+		Usec int32
+	}
+	AddrV6 [4]int32 // ut_addr_v6
+	Unused [20]byte // padding
+}
+
+// State indicates the context behind a shutdown
+type State struct {
+	// SystemShutdown indicates whether the shutdown was triggered by a system shutdown or some other mechanism.
+	SystemShutdown bool
+}
+
+// Callback is the callback that must be supplied for registering to receive shutdown notifications
+type Callback func(ctx context.Context, state State) error
 
 type Manager interface {
 	Run(context.Context)
 	Shutdown(context.Context)
-	Register(string, func(context.Context) error)
+	Register(string, Callback)
 }
 
 type manager struct {
-	once       sync.Once
-	registered map[string]func(context.Context) error
-	cancelFn   context.CancelFunc
-	timeout    time.Duration
-	log        *log.PrefixLogger
+	once          sync.Once
+	registered    map[string]Callback
+	cancelFn      context.CancelFunc
+	timeout       time.Duration
+	log           *log.PrefixLogger
+	systemdClient *client.Systemd
+	reader        fileio.Reader
 }
 
 // NewManager creates a new shutdown manager.
-func NewManager(log *log.PrefixLogger, timeout time.Duration, cancelFn context.CancelFunc) Manager {
+func NewManager(
+	log *log.PrefixLogger,
+	systemdClient *client.Systemd,
+	reader fileio.Reader,
+	timeout time.Duration,
+	cancelFn context.CancelFunc) Manager {
 	return &manager{
-		registered: make(map[string]func(context.Context) error),
-		timeout:    timeout,
-		cancelFn:   cancelFn,
-		log:        log,
+		registered:    make(map[string]Callback),
+		timeout:       timeout,
+		cancelFn:      cancelFn,
+		log:           log,
+		systemdClient: systemdClient,
+		reader:        reader,
 	}
 }
 
@@ -40,17 +94,19 @@ func (m *manager) Run(ctx context.Context) {
 	// handle teardown
 	signals := make(chan os.Signal, 2)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(signals)
+		close(signals)
+	}()
 	go func(ctx context.Context) {
 		select {
 		case s := <-signals:
 			m.log.Infof("Agent received shutdown signal: %s", s)
 			m.Shutdown(ctx)
 			m.cancelFn()
-			close(signals)
 		case <-ctx.Done():
 			m.log.Infof("Context has been cancelled, shutting down.")
 			m.Shutdown(ctx)
-			close(signals)
 		}
 	}(ctx)
 
@@ -60,13 +116,16 @@ func (m *manager) Run(ctx context.Context) {
 func (m *manager) Shutdown(ctx context.Context) {
 	// ensure multiple calls to Shutdown are idempotent
 	m.once.Do(func() {
+		state := State{
+			SystemShutdown: m.isSystemShutdown(ctx),
+		}
 		now := time.Now()
 		// give the agent time to shutdown gracefully
 		ctx, cancel := context.WithTimeout(ctx, m.timeout)
 		defer cancel()
 		for name, fn := range m.registered {
 			m.log.Infof("Shutting down: %s", name)
-			if err := fn(ctx); err != nil {
+			if err := fn(ctx, state); err != nil {
 				m.log.Errorf("Error shutting down: %s", err)
 			}
 		}
@@ -74,10 +133,101 @@ func (m *manager) Shutdown(ctx context.Context) {
 	})
 }
 
-func (m *manager) Register(name string, fn func(context.Context) error) {
+func (m *manager) Register(name string, fn Callback) {
 	if _, ok := m.registered[name]; ok {
 		m.log.Warnf("Shutdown function %s already registered", name)
 		return
 	}
 	m.registered[name] = fn
+}
+
+// IsSystemShutdown checks if the system is shutting down or rebooting
+// by checking systemd targets and runlevels
+func (m *manager) isSystemShutdown(ctx context.Context) bool {
+	return m.isShuttingDownViaSystemd(ctx) || m.isShuttingDownViaRunlevel()
+}
+
+func (m *manager) isShuttingDownViaSystemd(ctx context.Context) bool {
+	exists, err := m.reader.PathExists(shutdownScheduledPath)
+	if err != nil {
+		m.log.Errorf("Error checking if %s exists: %v", shutdownScheduledPath, err)
+	} else if exists {
+		m.log.Debug("System shutdown detected via scheduled file")
+		return true
+	}
+
+	shutdownJobs, err := m.systemdClient.ListJobs(ctx)
+	if err != nil {
+		m.log.Errorf("Failed to list systemd jobs: %v", err)
+		return false
+	}
+
+	// check if any shutdown-related jobs are starting
+	shutdownTargets := map[string]struct{}{
+		"shutdown.target": {},
+		"reboot.target":   {},
+		"poweroff.target": {},
+		"halt.target":     {},
+	}
+
+	for _, job := range shutdownJobs {
+		if _, isShutdownTarget := shutdownTargets[job.Unit]; isShutdownTarget && job.JobType == "start" {
+			m.log.Debugf("System shutdown detected: %s job is %s", job.Unit, job.State)
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseUtmpRecords parses binary utmp data into structured records
+func parseUtmpRecords(data []byte, logger *log.PrefixLogger) []utmpRecord {
+	var records []utmpRecord
+	recordSize := unsafe.Sizeof(utmpRecord{})
+	logger.Debugf("Parsing runlevel records. Record size: %d", recordSize)
+	for offset := 0; offset < len(data); offset += int(recordSize) {
+		if offset+int(recordSize) > len(data) {
+			break
+		}
+
+		var record utmpRecord
+		reader := bytes.NewReader(data[offset : offset+int(recordSize)])
+		if err := binary.Read(reader, binary.NativeEndian, &record); err != nil {
+			logger.Debugf("Error parsing utmp record at offset %d: %v", offset, err)
+			continue // skip malformed records
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func (m *manager) isShuttingDownViaRunlevel() bool {
+	utmpBytes, err := m.reader.ReadFile(runlevelPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m.log.Debugf("Run level not found at %s; skipping run level detection", runlevelPath)
+		} else {
+			m.log.Errorf("Failed to read %s file: %v", runlevelPath, err)
+		}
+		return false
+	}
+
+	records := parseUtmpRecords(utmpBytes, m.log)
+
+	// utmp is an append only log. Parse the records in reverse to find the most recent run level entry
+	for i := len(records) - 1; i >= 0; i-- {
+		record := records[i]
+		if record.Type == runlevelRecordType {
+			// run_level records use the pid to indicate the level. The pid represents the character, not the numerical
+			// value ('0', not 0)
+			runLevel := byte(record.Pid)
+			if runLevel == runlevelReboot || runLevel == runLevelHalt {
+				m.log.Debugf("System shutdown detected: level %c", runLevel)
+				return true
+			}
+			break
+		}
+	}
+
+	return false
 }

--- a/internal/agent/shutdown/shutdown_test.go
+++ b/internal/agent/shutdown/shutdown_test.go
@@ -1,0 +1,282 @@
+package shutdown
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestParseUtmpRecords(t *testing.T) {
+	t.Skip("Test disabled to avoid reading from actual run level path")
+	reader := fileio.NewReadWriter()
+	testData, err := reader.ReadFile(runlevelPath)
+	require.Nil(t, err)
+	l := log.NewPrefixLogger("test")
+	records := parseUtmpRecords(testData, l)
+	require.Nil(t, err)
+	require.NotEmpty(t, records)
+
+	var record *utmpRecord
+	for _, rec := range records {
+		if rec.Type == runlevelRecordType {
+			record = &rec
+			break
+		}
+	}
+
+	require.NotNil(t, record, "run level expected")
+}
+
+func TestIsShuttingDownViaRunlevelWithTestData(t *testing.T) {
+	tmpDir := t.TempDir()
+	rw := fileio.NewReadWriter()
+	rw.SetRootdir(tmpDir)
+	testLogger := log.NewPrefixLogger("test")
+
+	// Write test data to a file
+	err := rw.WriteFile(runlevelPath, createRunlevelTestData('6'), 0600)
+	require.Nil(t, err)
+
+	// Create manager instance
+	mgr := &manager{
+		log:    testLogger,
+		reader: rw,
+	}
+
+	result := mgr.isShuttingDownViaRunlevel()
+	require.True(t, result)
+}
+
+func TestIsShuttingDownViaSystemd(t *testing.T) {
+	testCases := []struct {
+		name                string
+		scheduledFileExists bool
+		scheduledFileError  error
+		systemctlOutput     string
+		systemctlError      error
+		systemctlExitCode   int
+		expectedResult      bool
+	}{
+		{
+			name:                "scheduled file exists",
+			scheduledFileExists: true,
+			expectedResult:      true,
+		},
+		{
+			name:                "shutdown.target job running",
+			scheduledFileExists: false,
+			systemctlOutput:     "123 shutdown.target start running\n",
+			systemctlExitCode:   0,
+			expectedResult:      true,
+		},
+		{
+			name:                "reboot.target job running",
+			scheduledFileExists: false,
+			systemctlOutput:     "456 reboot.target start waiting\n",
+			systemctlExitCode:   0,
+			expectedResult:      true,
+		},
+		{
+			name:                "poweroff.target job running",
+			scheduledFileExists: false,
+			systemctlOutput:     "789 poweroff.target start running\n",
+			systemctlExitCode:   0,
+			expectedResult:      true,
+		},
+		{
+			name:                "halt.target job running",
+			scheduledFileExists: false,
+			systemctlOutput:     "101 halt.target start waiting\n",
+			systemctlExitCode:   0,
+			expectedResult:      true,
+		},
+		{
+			name:                "no scheduled file, no jobs",
+			scheduledFileExists: false,
+			systemctlOutput:     "",
+			systemctlExitCode:   0,
+			expectedResult:      false,
+		},
+		{
+			name:                "shutdown job wrong type",
+			scheduledFileExists: false,
+			systemctlOutput:     "123 shutdown.target stop running\n",
+			systemctlExitCode:   0,
+			expectedResult:      false,
+		},
+		{
+			name:                "non-shutdown jobs only",
+			scheduledFileExists: false,
+			systemctlOutput:     "234 sshd.service start running\n567 nginx.service restart waiting\n",
+			systemctlExitCode:   0,
+			expectedResult:      false,
+		},
+		{
+			name:                "failed to list jobs",
+			scheduledFileExists: false,
+			systemctlError:      nil,
+			systemctlExitCode:   1,
+			expectedResult:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			testLogger := log.NewPrefixLogger("test")
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+			mockExec := executer.NewMockExecuter(ctrl)
+			systemdClient := client.NewSystemd(mockExec)
+
+			// Setup file existence mock
+			mockReadWriter.EXPECT().PathExists(shutdownScheduledPath).Return(tc.scheduledFileExists, tc.scheduledFileError)
+
+			// Setup systemctl mock only if scheduled file doesn't exist
+			if !tc.scheduledFileExists && tc.scheduledFileError == nil {
+				mockExec.EXPECT().ExecuteWithContext(
+					gomock.Any(),
+					"/usr/bin/systemctl",
+					[]string{"list-jobs", "--no-pager", "--no-legend"},
+				).Return(tc.systemctlOutput, "", tc.systemctlExitCode)
+			}
+
+			// Create manager instance
+			mgr := &manager{
+				log:           testLogger,
+				systemdClient: systemdClient,
+				reader:        mockReadWriter,
+			}
+
+			result := mgr.isShuttingDownViaSystemd(ctx)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestIsSystemShutdown(t *testing.T) {
+	testCases := []struct {
+		name                string
+		scheduledFileExists bool
+		systemctlOutput     string
+		systemctlExitCode   int
+		utmpData            []byte
+		expectedResult      bool
+	}{
+		{
+			name:                "systemd reboot job running",
+			scheduledFileExists: false,
+			systemctlOutput:     "123 reboot.target start running\n",
+			systemctlExitCode:   0,
+			expectedResult:      true,
+		},
+		{
+			name:                "runlevel 6 detected",
+			scheduledFileExists: false,
+			systemctlOutput:     "",
+			systemctlExitCode:   0,
+			utmpData:            createRunlevelTestData('6'),
+			expectedResult:      true,
+		},
+		{
+			name:                "runlevel 0 detected",
+			scheduledFileExists: false,
+			systemctlOutput:     "",
+			systemctlExitCode:   0,
+			utmpData:            createRunlevelTestData('0'),
+			expectedResult:      true,
+		},
+		{
+			name:                "no shutdown detected",
+			scheduledFileExists: false,
+			systemctlOutput:     "",
+			systemctlExitCode:   0,
+			utmpData:            createRunlevelTestData('5'),
+			expectedResult:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			testLogger := log.NewPrefixLogger("test")
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockExec := executer.NewMockExecuter(ctrl)
+			systemdClient := client.NewSystemd(mockExec)
+
+			// Setup file system
+			tmpDir := t.TempDir()
+			rw := fileio.NewReadWriter()
+			rw.SetRootdir(tmpDir)
+
+			// Write utmp test data
+			if tc.utmpData != nil {
+				err := rw.WriteFile(runlevelPath, tc.utmpData, 0600)
+				require.Nil(t, err)
+			}
+
+			// Mock systemctl list-jobs call
+			mockExec.EXPECT().ExecuteWithContext(
+				gomock.Any(),
+				"/usr/bin/systemctl",
+				[]string{"list-jobs", "--no-pager", "--no-legend"},
+			).Return(tc.systemctlOutput, "", tc.systemctlExitCode)
+
+			// Create manager instance
+			mgr := &manager{
+				log:           testLogger,
+				systemdClient: systemdClient,
+				reader:        rw,
+			}
+
+			result := mgr.isSystemShutdown(ctx)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestIsSystemShutdownScheduledFile(t *testing.T) {
+	ctx := context.Background()
+	testLogger := log.NewPrefixLogger("test")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockExec := executer.NewMockExecuter(ctrl)
+	systemdClient := client.NewSystemd(mockExec)
+
+	// Setup file system
+	tmpDir := t.TempDir()
+	rw := fileio.NewReadWriter()
+	rw.SetRootdir(tmpDir)
+
+	err := rw.WriteFile(shutdownScheduledPath, []byte{0x00}, 0600)
+	require.Nil(t, err)
+
+	// Create manager instance
+	mgr := &manager{
+		log:           testLogger,
+		systemdClient: systemdClient,
+		reader:        rw,
+	}
+
+	result := mgr.isSystemShutdown(ctx)
+	require.True(t, result)
+}
+
+// Helper function to create test utmp data with specific runlevel
+func createRunlevelTestData(runlevel byte) []byte {
+	data := make([]byte, 384)
+	data[0] = 0x01     // Type = RUN_LVL
+	data[4] = runlevel // Pid = runlevel character
+	return data
+}

--- a/internal/tpm/client.go
+++ b/internal/tpm/client.go
@@ -346,7 +346,7 @@ func (c *client) Clear() error {
 }
 
 // Close closes the TPM session.
-func (c *client) Close(ctx context.Context) error {
+func (c *client) Close() error {
 	if c.session != nil {
 		return c.session.Close()
 	}

--- a/internal/tpm/client_test.go
+++ b/internal/tpm/client_test.go
@@ -322,7 +322,7 @@ func TestClient_Close(t *testing.T) {
 				log:     logger,
 			}
 
-			err := c.Close(context.Background())
+			err := c.Close()
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/internal/tpm/mock_tpm.go
+++ b/internal/tpm/mock_tpm.go
@@ -57,17 +57,17 @@ func (mr *MockClientMockRecorder) Clear() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockClient) Close(ctx context.Context) error {
+func (m *MockClient) Close() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", ctx)
+	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockClientMockRecorder) Close(ctx any) *gomock.Call {
+func (mr *MockClientMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
 }
 
 // CreateApplicationKey mocks base method.

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -24,7 +24,7 @@ type Client interface {
 	// Clear clears any stored TPM data
 	Clear() error
 	// Close closes the TPM session
-	Close(ctx context.Context) error
+	Close() error
 	// VendorInfoCollector collects vendor information from the TPM
 	VendorInfoCollector(ctx context.Context) string
 	// CreateApplicationKey generates a TCG CSR IDEVID bundle and a TSS2 PEM encoded file for the specified application


### PR DESCRIPTION
Derived from #1652

Adds logic to the shutdown manager to determine if the agent is stopping as a result of a system shutdown. If it's a system shutdown, the application manager will attempt to drain the running applications. If it's just a simple stop of the flightctl-agent service, it will simply stop the monitor that is running and leave the applications running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - State-aware shutdown: agent detects OS shutdown/reboot (systemd/runlevel) and adapts shutdown callbacks.
  - Applications now support state-aware shutdown to drain or stop services based on system state.
  - Systemd job visibility added for better coordination with system services.

- Bug Fixes
  - Reduced hangs during shutdown/restart.
  - Improved TPM shutdown handling and streamlined identity shutdown flow.

- Tests
  - Comprehensive unit tests for shutdown detection and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->