### PR TITLE
EDM-2286: Add correct selinux policy to custom-info directory

### DIFF
--- a/internal/agent/device/systeminfo/system_info.go
+++ b/internal/agent/device/systeminfo/system_info.go
@@ -533,7 +533,7 @@ func Collect(ctx context.Context, log *log.PrefixLogger, exec executer.Executer,
 	}
 
 	// custom info
-	if len(customKeys) > 0 {
+	if len(customKeys) > 0 || cfg.collectAllCustom {
 		customInfo, err := getCustomInfoMap(ctx, log, customKeys, reader, exec, opts...)
 		if err != nil {
 			if errors.IsContext(err) {

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -1,2 +1,3 @@
 /usr/bin/flightctl-agent                        --  gen_context(system_u:object_r:flightctl_agent_exec_t,s0)
 /var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)
+/usr/lib/flightctl/custom-info.d(/.*)?              gen_context(system_u:object_r:flightctl_agent_custom_info_exec_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -9,6 +9,7 @@ type flightctl_agent_t;
 type flightctl_agent_exec_t;
 type flightctl_agent_var_lib_t;
 type flightctl_agent_tmp_t;
+type flightctl_agent_custom_info_exec_t;
 
 # We generally use fedora when building images because of the packit tool, but unfortunately it
 # contains some newer types not yet available in centos stream. Defining them in one's own policy is
@@ -43,6 +44,8 @@ gen_require(`
 init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
 files_type(flightctl_agent_var_lib_t)
 files_tmp_file(flightctl_agent_tmp_t)
+files_type(flightctl_agent_custom_info_exec_t)
+
 
 ## Basic file access permissions  ##
 
@@ -96,6 +99,10 @@ allow flightctl_agent_t mail_spool_t:dir search;
 # TPM device access
 allow flightctl_agent_t tpm_device_t:chr_file { getattr open read write };
 allow flightctl_agent_t security_t:file { open read getattr };
+
+# /usr/lib/flightctl/custom-info.d execution
+allow flightctl_agent_t flightctl_agent_custom_info_exec_t:file { read getattr open execute execute_no_trans ioctl };
+allow flightctl_agent_t flightctl_agent_custom_info_exec_t:dir { read getattr search open };
 
 ## Process management & capabilities  ##
 


### PR DESCRIPTION
Using this branch: https://github.com/flightctl/flightctl/tree/system-info-fips-error as the basis for this test we see issues with being able to execute scripts for custom info.
```
level=warning msg="Failed to get custom info for key fips: fork/exec /usr/lib/flightctl/custom-info.d/fips: permission denied" file="device/systeminfo/system_info.go:767"
```

Example SELinux policy audit report: 
```
audit: type=1400 audit(1760370551.787:7): avc:  denied  { ioctl } for  pid=2091 comm="fips" path="/usr/lib/flightctl/custom-info.d/fips" dev="overlay" ino=57146 ioctlcmd=0x5401
```

Creating/applying the correct selinux policies resolves this issue and now get results like:
```
  systemInfo:
    elided...
    customInfo:
      fips: disabled
      uptime: 9m
      uptime2: 9m
```

Also, fixes an issue with the `flightctl-agent system-info` command not returning custom info ever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SELinux policy updated to recognize a custom-info directory and allow the agent to read and execute custom info components.
  * Agent now supports collecting all custom info when a "collect all" option is enabled.

* **Bug Fixes / Improvements**
  * Improved error handling and logging for custom info collection, including clearer handling of cancellation vs other errors and skipping collection when no keys are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->