### PR TITLE
EDM-2286: Add correct selinux policy to custom-info directory 

### DIFF
--- a/internal/agent/device/systeminfo/system_info.go
+++ b/internal/agent/device/systeminfo/system_info.go
@@ -533,7 +533,7 @@ func Collect(ctx context.Context, log *log.PrefixLogger, exec executer.Executer,
 	}
 
 	// custom info
-	if len(customKeys) > 0 {
+	if len(customKeys) > 0 || cfg.collectAllCustom {
 		customInfo, err := getCustomInfoMap(ctx, log, customKeys, reader, exec, opts...)
 		if err != nil {
 			if errors.IsContext(err) {

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -1,2 +1,3 @@
 /usr/bin/flightctl-agent                        --  gen_context(system_u:object_r:flightctl_agent_exec_t,s0)
 /var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)
+/usr/lib/flightctl/custom-info.d(/.*)?              gen_context(system_u:object_r:flightctl_agent_custom_info_exec_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -9,6 +9,7 @@ type flightctl_agent_t;
 type flightctl_agent_exec_t;
 type flightctl_agent_var_lib_t;
 type flightctl_agent_tmp_t;
+type flightctl_agent_custom_info_exec_t;
 
 # We generally use fedora when building images because of the packit tool, but unfortunately it
 # contains some newer types not yet available in centos stream. Defining them in one's own policy is
@@ -43,6 +44,8 @@ gen_require(`
 init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
 files_type(flightctl_agent_var_lib_t)
 files_tmp_file(flightctl_agent_tmp_t)
+files_type(flightctl_agent_custom_info_exec_t)
+
 
 ## Basic file access permissions  ##
 
@@ -96,6 +99,10 @@ allow flightctl_agent_t mail_spool_t:dir search;
 # TPM device access
 allow flightctl_agent_t tpm_device_t:chr_file { getattr open read write };
 allow flightctl_agent_t security_t:file { open read getattr };
+
+# /usr/lib/flightctl/custom-info.d execution
+allow flightctl_agent_t flightctl_agent_custom_info_exec_t:file { read getattr open execute execute_no_trans ioctl };
+allow flightctl_agent_t flightctl_agent_custom_info_exec_t:dir { read getattr search open };
 
 ## Process management & capabilities  ##
 


### PR DESCRIPTION
Backport of #1788 