### PR TITLE
NO-ISSUE: Fix custom-info examples in agent-vm

### DIFF
--- a/test/e2e/agent/agent_system_info_test.go
+++ b/test/e2e/agent/agent_system_info_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Agent System Info", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(output.String()).To(ContainSubstring("siteName"))
-		Expect(output.String()).To(ContainSubstring("test"))
+		Expect(output.String()).To(ContainSubstring("emptyValue"))
 		Expect(output.String()).To(ContainSubstring("keyNotShown"))
 
 		By("Updating agent config with custom system info")
@@ -153,8 +153,8 @@ var _ = Describe("Agent System Info", func() {
 			}
 			return *sysInfo.CustomInfo
 		}, e2e.TIMEOUT, e2e.POLLING).Should(And(
-			HaveKey("siteName"),
-			HaveKey("test"), // Empty command should result in empty value
+			HaveKeyWithValue("siteName", "my site"),
+			HaveKeyWithValue("emptyValue", ""), // Empty command should result in empty value
 		), "Custom system info should be present with correct values")
 
 		By("Verifying unlisted custom scripts are not reported")
@@ -228,7 +228,7 @@ system-info: []
 	customSystemInfoConfig = `
 system-info-custom:
  - siteName
- - test
+ - emptyValue
 `
 )
 

--- a/test/scripts/agent-images/Containerfile-e2e-base.local
+++ b/test/scripts/agent-images/Containerfile-e2e-base.local
@@ -68,9 +68,9 @@ RUN mkdir -p /usr/lib/flightctl/custom-info.d && \
     chmod 755 /usr/lib/flightctl/custom-info.d
 
 # Add custom system info
-RUN echo '#!/bin/bash\necho "my site"' > /usr/lib/flightctl/custom-info.d/siteName && \
-    echo '#!/bin/bash\necho ""' > /usr/lib/flightctl/custom-info.d/test && \
-    echo '#!/bin/bash\necho "no-show"' > /usr/lib/flightctl/custom-info.d/keyNotShown && \
+RUN echo -e '#!/bin/bash\necho "my site"' > /usr/lib/flightctl/custom-info.d/siteName && \
+    echo -e '#!/bin/bash\necho ""' > /usr/lib/flightctl/custom-info.d/emptyValue && \
+    echo -e '#!/bin/bash\necho "no-show"' > /usr/lib/flightctl/custom-info.d/keyNotShown && \
     chmod 755 /usr/lib/flightctl/custom-info.d/*
 
 # Add the registry

--- a/test/scripts/agent-images/prepare_agent_config.sh
+++ b/test/scripts/agent-images/prepare_agent_config.sh
@@ -28,8 +28,12 @@ while true; do
   esac
 done
 
-# enforce the agent to fetch the spec and update status every 2 seconds to improve the E2E test speed
+# - Enforce the agent to fetch the spec and update status every 2 seconds to improve the E2E test speed
+# - Include the custom system info collectors that were defined in the container image
 cat <<EOF | tee -a  bin/agent/etc/flightctl/config.yaml
 spec-fetch-interval: $spec_fetch_interval
 status-update-interval: $status_update_interval
+system-info-custom:
+  - siteName
+  - emptyValue
 EOF


### PR DESCRIPTION
The PR fixes the "custom-info" examples that are part of "agent-vm" and configures them so that they are returned in the devices's custom-info. We should probably use better examples, but for now I kept the existing ones.

Issues:

1. Due to the missing -e, the shebang as interpreted as "/bin/bash\necho", which resulted in the errors below when running `flightctl-agent system-info`
```
time="2025-10-14T07:16:02.453436Z" level=warning msg="Failed to get custom info for key keyNotShown: fork/exec /usr/lib/flightctl/custom-info.d/keyNotShown: no such file or directory" file="device/systeminfo/system_info.go:767"
time="2025-10-14T07:16:02.453629Z" level=warning msg="Failed to get custom info for key siteName: fork/exec /usr/lib/flightctl/custom-info.d/siteName: no such file or directory" file="device/systeminfo/system_info.go:767"
time="2025-10-14T07:16:02.453758Z" level=warning msg="Failed to get custom info for key test: fork/exec /usr/lib/flightctl/custom-info.d/test: no such file or directory" file="device/systeminfo/system_info.go:767"
```

2. The custom-info collectors were later not added to the agent's config.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures newline characters in generated custom-info scripts are interpreted correctly, restoring expected multi-line formatting.

- **Tests**
  - Updated end-to-end tests and test assets to reflect new custom system info keys and expectations.
  - Renamed a sample custom-info asset for clearer intent.
  - Expanded the sample agent configuration to include custom collectors (siteName and emptyValue) without changing existing intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->