### PR TITLE
EDM-2288: remove yq dependency

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `buildah`, `podman`, `podman-compose`, `container-selinux` (>= 2.241) and `go-rpm-macros` (in case one needs to build RPM's)
+* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `buildah`, `podman`, `podman-compose`, `container-selinux` (>= 2.241), `go-rpm-macros` (in case one needs to build RPM's), `jq`, `python3`, and `python3-pyyaml` (or install PyYAML via pip)
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/docs/developer/service-quadlets.md
+++ b/docs/developer/service-quadlets.md
@@ -203,7 +203,7 @@ A basic API health check can be performed by calling `/readyz` via the API that 
 curl -fk https://localhost:3443/readyz && echo OK || echo FAIL
 
 # Using domain from config file
-DOMAIN="$(yq -r '.global.baseDomain // "localhost"' /etc/flightctl/service-config.yaml)"
+DOMAIN="$(python3 /usr/share/flightctl/yaml-to-json.py < /etc/flightctl/service-config.yaml | jq -r '.global.baseDomain // "localhost"')"
 curl -fk "https://${DOMAIN}:3443/readyz" && echo OK || echo FAIL
 ```
 

--- a/docs/user/device-observability.md
+++ b/docs/user/device-observability.md
@@ -84,8 +84,8 @@ Apply the CSR and approve it with flightctl:
 Extract the issued certificate and CA:
 
 ```bash
-./bin/flightctl get csr/svc-telemetry-gateway -o yaml | yq '.status.certificate' | base64 -d > ./certs/svc-telemetry-gateway.crt
-./bin/flightctl enrollmentconfig | yq '.enrollment-service.service.certificate-authority-data' | base64 -d > ./certs/ca.crt
+./bin/flightctl get csr/svc-telemetry-gateway -o yaml | python3 -c "import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))" | jq -r '.status.certificate' | base64 -d > ./certs/svc-telemetry-gateway.crt
+./bin/flightctl enrollmentconfig | python3 -c "import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))" | jq -r '."enrollment-service".service."certificate-authority-data"' | base64 -d > ./certs/ca.crt
 ```
 
 Resulting files:
@@ -270,9 +270,10 @@ RUN systemctl enable otelcol.service
 
 One way to extract the CA:
 
-```yaml
-flightctl enrollmentconfig \
-  | yq -r '.enrollment-service.service.certificate-authority-data' \
+```bash
+./bin/flightctl enrollmentconfig \
+  | python3 -c "import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))" \
+  | jq -r '."enrollment-service".service."certificate-authority-data"' \
   | base64 -d > /etc/otelcol/certs/ca.crt
 chmod 644 /etc/otelcol/certs/ca.crt
 ```

--- a/docs/user/standalone-observability.md
+++ b/docs/user/standalone-observability.md
@@ -422,7 +422,7 @@ observability:
             caFile: "/etc/telemetry-gateway/certs/ca.crt"
 ```
 
-**Note**: The `config` field contains the telemetry gateway configuration as a YAML object. The `flightctl-render-observability` script extracts this configuration using `yq` and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
+**Note**: The `config` field contains the telemetry gateway configuration as a YAML object. The `flightctl-render-observability` script extracts this configuration using Python and `jq`, and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
 
 ### UserInfo Proxy
 
@@ -705,7 +705,7 @@ observability:
           prometheus: "your-prometheus.company.com:9090"
 ```
 
-**Note**: The telemetry gateway configuration is provided as a YAML object in the `config` field. The `flightctl-render-observability` script extracts this configuration using `yq` and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
+**Note**: The telemetry gateway configuration is provided as a YAML object in the `config` field. The `flightctl-render-observability` script extracts this configuration using Python and `jq`, and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
 
 **Management Commands Available**:
 
@@ -1073,7 +1073,7 @@ The telemetry gateway uses a nested YAML object in the `config` field for its in
 
 - **Type**: YAML Object
 - **Default**: Empty
-- **Description**: Telemetry gateway configuration as a YAML object. The `flightctl-render-observability` script extracts this configuration using `yq` and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
+- **Description**: Telemetry gateway configuration as a YAML object. The `flightctl-render-observability` script extracts this configuration using Python and `jq`, and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
 - **Example**: See the sample configurations above for complete examples.
 
 **Configuration Structure**:

--- a/test/scripts/deploy_quadlets_rhel.sh
+++ b/test/scripts/deploy_quadlets_rhel.sh
@@ -109,8 +109,6 @@ ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile
                     make golang git \
                     podman qemu-kvm sshpass
   sudo dnf --enablerepo=crb install -y libvirt-devel
-  sudo curl -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq
-  sudo chmod +x /usr/local/bin/yq
 
   sudo dnf copr -y enable ${RPM_COPR}
   sudo dnf install -y ${RPM_PACKAGE} ${RPM_CLIENT}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples and notes to use Python + jq for parsing instead of yq across health checks, certificate extraction, and telemetry gateway configuration.
  * Clarified steps for extracting issued certificates, CA data, and rendering telemetry gateway config with the new tooling.
* **Tests**
  * Updated provisioning and certificate setup scripts to remove yq usage and rely on Python + jq.
* **Chores**
  * Expanded prerequisites to list jq, python3, and python3-pyyaml; removed runtime yq installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->