### PR TITLE
NO-ISSUE: minor - fix broken link in docs

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -260,7 +260,7 @@ The CLI uses the host's certificate authority (CA) pool to verify the Flight Con
 
 ## Building a Bootable Container Image including the Flight Control Agent
 
-Next, we will use [Podman](https://github.com/containers/podman) to build a [bootable container image (bootc)](https://containers.github.io/bootc/) that includes the Flight Control Agent binary and configuration. The configuration contains the connection details and credentials required by the agent to discover the service and send an enrollment request to the service.
+Next, we will use [Podman](https://github.com/containers/podman) to build a [bootable container image (bootc)](https://bootc-dev.github.io/bootc/) that includes the Flight Control Agent binary and configuration. The configuration contains the connection details and credentials required by the agent to discover the service and send an enrollment request to the service.
 
 Retrieve the agent configuration with enrollment credentials by running:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bootc image documentation link to a new reference site to ensure users access the latest guidance.
  * Clarified the “Building a Bootable Container Image including the Flight Control Agent” section by correcting the hyperlink used when retrieving agent configuration with enrollment credentials.
  * Improved reliability of getting-started guidance by aligning references with current sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->