### PR TITLE
EDM-2341: flightctl-userinfo-proxy container doesn't support the Memory setting

### DIFF
--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -60,11 +60,13 @@ observability:
       auth_url:
       token_url:
       api_url:
+      scopes:
 
       client_id:
 
-      local_admin_user:
-      local_admin_password:
+    local_admin_user:
+    local_admin_password:
+    root_url:
 
   prometheus:
     image:

--- a/docs/user/standalone-observability.md
+++ b/docs/user/standalone-observability.md
@@ -74,6 +74,10 @@ sudo systemctl enable flightctl-observability.target
 
 ```bash
 # When you change /etc/flightctl/service-config.yaml
+# First, ensure root is logged in to flightctl
+sudo flightctl login
+
+# Then regenerate configs
 sudo flightctl-render-observability      # Regenerate configs
 sudo systemctl restart flightctl-observability.target  # Apply changes
 ```
@@ -93,7 +97,7 @@ sudo systemctl restart flightctl-observability.target  # Apply changes
 
 **Two-step process:**
 
-1. **Config changes**: `sudo flightctl-render-observability` (renders templates)
+1. **Config changes**: `sudo flightctl login` then `sudo flightctl-render-observability` (renders templates)
 2. **Service management**: `sudo systemctl start/stop/restart flightctl-observability.target`
 
 ## Architecture
@@ -170,16 +174,18 @@ The observability services require the `flightctl` network from the core Flight 
 
 1. Install core Flight Control services (`flightctl-services`) to create the `flightctl` network
 2. Install observability services (`flightctl-telemetry-gateway` or `flightctl-observability`)
-3. Run `sudo flightctl-render-observability` to generate configuration files
-4. Start observability services with systemd targets
-5. Core services will automatically send telemetry to existing observability infrastructure
+3. Log in as root: `sudo flightctl login`
+4. Run `sudo flightctl-render-observability` to generate configuration files
+5. Start observability services with systemd targets
+6. Core services will automatically send telemetry to existing observability infrastructure
 
 ### Option 2: Simultaneous Installation
 
 1. Install both core services (`flightctl-services`) and observability services
-2. Run `sudo flightctl-render-observability` to generate configuration files
-3. Start observability services with systemd targets
-4. The `flightctl` network will be available for observability services
+2. Log in as root: `sudo flightctl login`
+3. Run `sudo flightctl-render-observability` to generate configuration files
+4. Start observability services with systemd targets
+5. The `flightctl` network will be available for observability services
 
 **Note**: The observability services will fail to start if the `flightctl` network is not available or if configuration files haven't been generated, so ensure the core services are installed first and configuration is rendered.
 
@@ -212,6 +218,10 @@ sudo dnf install flightctl-telemetry-gateway
 # 3. Configures systemd service (but does not start or enable it)
 
 # Generate configuration files from service-config.yaml:
+# First, ensure root is logged in to flightctl
+sudo flightctl login
+
+# Then render configuration templates
 sudo flightctl-render-observability
 
 # To start the telemetry gateway service:
@@ -271,6 +281,10 @@ sudo dnf install flightctl-observability
 # 3. Configures systemd services (but does not start or enable them)
 
 # Generate configuration files from service-config.yaml:
+# First, ensure root is logged in to flightctl
+sudo flightctl login
+
+# Then render configuration templates
 sudo flightctl-render-observability
 
 # To start all observability services:
@@ -326,7 +340,7 @@ observability:
       client_id: your-oauth-client-id
       auth_url: https://your-aap.com/o/authorize
       token_url: https://your-aap.com/o/token
-      api_url: http://flightctl-userinfo-proxy:8080
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo
       tls_skip_verify: false
       local_admin_user: admin
       local_admin_password: secure-password
@@ -471,11 +485,16 @@ observability:
       client_id: your-oauth-client-id
       auth_url: https://your-idp.com/o/authorize
       token_url: https://your-idp.com/o/token
-      api_url: http://flightctl-userinfo-proxy:8080  # Internal container communication
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo  # Internal container communication
+      scopes: read  # OAuth scopes to request
       tls_skip_verify: false  # Skip TLS verification for OAuth endpoints
-      local_admin_user: admin
-      local_admin_password: secure-password
     
+    # Local Admin Configuration (used when OAuth is disabled)
+    local_admin_user: admin
+    local_admin_password: secure-password
+    
+    # Server Configuration
+    root_url: http://localhost:3000  # Root URL for Grafana (used for OAuth redirects)
     protocol: http  # or https
     
     # HTTPS Configuration (Optional - only needed when protocol: https)
@@ -504,7 +523,7 @@ observability:
 
 1. **All configuration is in service-config.yaml**: No need to edit individual container files or environment variables
 2. **Automatic template generation**: The system automatically generates container configurations from your service-config.yaml
-3. **Hot configuration**: Use `sudo flightctl-render-observability` then restart services with systemd targets
+3. **Hot configuration**: Use `sudo flightctl login` then `sudo flightctl-render-observability` then restart services with systemd targets
 4. **Built-in validation**: The system automatically validates your configuration and provides clear error messages
 
 ## Configuration Management
@@ -518,6 +537,10 @@ Flight Control separates configuration management from service management for be
 **Render Configuration Templates**:
 
 ```bash
+# First, ensure root is logged in to flightctl
+sudo flightctl login
+
+# Then render configuration templates
 sudo flightctl-render-observability
 ```
 
@@ -564,6 +587,10 @@ These commands work whether you have the full observability stack, standalone Te
 2. **Render updated configuration**:
 
    ```bash
+   # Ensure root is logged in to flightctl
+   sudo flightctl login
+   
+   # Render configuration templates
    sudo flightctl-render-observability
    ```
 
@@ -607,7 +634,7 @@ observability:
       client_id: your-oauth-client-id
       auth_url: https://your-idp.com/o/authorize
       token_url: https://your-idp.com/o/token
-      api_url: http://flightctl-userinfo-proxy:8080  # Points to internal proxy
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo  # Points to internal proxy
       
   userinfo_proxy:
     upstream_url: https://your-aap-instance.com/api/gateway/v1/me/  # Your AAP instance's user API endpoint
@@ -711,10 +738,11 @@ observability:
 
 Even when installing only the Telemetry Gateway, you have access to the management commands:
 
+- `sudo flightctl login` - Log in as root to flightctl (required before rendering)
 - `sudo flightctl-render-observability` - Render configuration templates from `service-config.yaml`
 - `sudo systemctl start/stop/restart flightctl-telemetry-gateway.target` - Manage telemetry gateway service
 
-**Two-step process**: First render configuration with `flightctl-render-observability`, then manage services with systemd targets. This separation provides better control and follows systemd best practices.
+**Two-step process**: First log in with `sudo flightctl login`, then render configuration with `sudo flightctl-render-observability`, then manage services with systemd targets. This separation provides better control and follows systemd best practices.
 
 ### Standalone Stack Configuration (No OAuth)
 
@@ -727,8 +755,9 @@ observability:
     published_port: 3000
     oauth:
       enabled: false
-      local_admin_user: admin
-      local_admin_password: secure-password
+    
+    local_admin_user: admin
+    local_admin_password: secure-password
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -757,10 +786,12 @@ observability:
       client_id: flightctl-grafana-client
       auth_url: https://your-aap-instance.com/o/authorize
       token_url: https://your-aap-instance.com/o/token
-      api_url: http://flightctl-userinfo-proxy:8080
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo
+      scopes: read
       tls_skip_verify: false
-      local_admin_user: admin
-      local_admin_password: fallback-password
+    
+    local_admin_user: admin
+    local_admin_password: fallback-password
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -798,7 +829,8 @@ observability:
       client_id: flightctl-grafana-client
       auth_url: https://your-aap-instance.com/o/authorize
       token_url: https://your-aap-instance.com/o/token
-      api_url: http://flightctl-userinfo-proxy:8080
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo
+      scopes: read
       tls_skip_verify: false
 
   prometheus:
@@ -844,10 +876,12 @@ observability:
       client_id: dev-grafana-client
       auth_url: https://dev-auth.local/o/authorize
       token_url: https://dev-auth.local/o/token
-      api_url: http://flightctl-userinfo-proxy:8080
+      api_url: http://flightctl-userinfo-proxy:8080/userinfo
+      scopes: read
       tls_skip_verify: true  # OK for development
-      local_admin_user: admin
-      local_admin_password: dev-password
+    
+    local_admin_user: admin
+    local_admin_password: dev-password
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -900,8 +934,9 @@ observability:
     published_port: 8080  # Use port 8080 instead of 3000
     oauth:
       enabled: false
-      local_admin_user: admin
-      local_admin_password: secure-password
+    
+    local_admin_user: admin
+    local_admin_password: secure-password
 
   prometheus:
     image: docker.io/prom/prometheus:latest
@@ -1006,9 +1041,16 @@ This section provides detailed documentation for every configuration variable av
 
 - **Type**: String (URL)
 - **Default**: Empty
-- **Description**: OAuth user info API endpoint. Grafana calls this to get user information. For AAP integration, use the UserInfo proxy: `http://flightctl-userinfo-proxy:8080`
+- **Description**: OAuth user info API endpoint. Grafana calls this to get user information. For AAP integration, use the UserInfo proxy: `http://flightctl-userinfo-proxy:8080/userinfo`
 - **Required**: When `oauth.enabled: true`
-- **Example**: `http://flightctl-userinfo-proxy:8080`
+- **Example**: `http://flightctl-userinfo-proxy:8080/userinfo`
+
+**`observability.grafana.oauth.scopes`**
+
+- **Type**: String
+- **Default**: `read`
+- **Description**: OAuth scopes to request from the identity provider. Specifies what permissions the OAuth application should request.
+- **Example**: `read`, `read write`, `openid profile email`
 
 **`observability.grafana.oauth.tls_skip_verify`**
 
@@ -1018,20 +1060,31 @@ This section provides detailed documentation for every configuration variable av
 - **Security**: Always use `false` in production
 - **Example**: `true` (development only)
 
-**`observability.grafana.oauth.local_admin_user`**
+#### Local Admin Configuration
+
+**`observability.grafana.local_admin_user`**
 
 - **Type**: String
 - **Default**: `admin`
-- **Description**: Username for local Grafana admin account. This account can be used as fallback when OAuth is unavailable.
+- **Description**: Username for local Grafana admin account. This account can be used as fallback when OAuth is unavailable or disabled.
 - **Example**: `admin`
 
-**`observability.grafana.oauth.local_admin_password`**
+**`observability.grafana.local_admin_password`**
 
 - **Type**: String
 - **Default**: `defaultadmin`
 - **Description**: Password for local Grafana admin account. Change this from the default for security.
 - **Security**: Use a strong password in production
 - **Example**: `secure-admin-password-123`
+
+#### Server Configuration
+
+**`observability.grafana.root_url`**
+
+- **Type**: String (URL)
+- **Default**: `http://localhost:3000`
+- **Description**: Root URL for Grafana. Used for OAuth redirects and asset loading. Should match the external URL where Grafana is accessible.
+- **Example**: `https://grafana.yourdomain.com`, `http://server-ip:3000`
 
 ### Prometheus Configuration Variables
 
@@ -1090,7 +1143,7 @@ telemetryGateway:
   listen:
     device: "0.0.0.0:4317"           # Address and port for device connections
   export:
-    prometheus: "flightctl-prometheus:9090"  # Prometheus export endpoint
+    prometheus: "0.0.0.0:9090"  # Prometheus export endpoint
   forward:
     endpoint: "external-collector.company.com:4317"  # External forwarding endpoint
     tls:

--- a/packaging/observability/flightctl-render-observability
+++ b/packaging/observability/flightctl-render-observability
@@ -141,9 +141,8 @@ setup_telemetry_gateway_certs() {
         # Run the certificate setup script
         if ! /etc/flightctl/scripts/setup_telemetry_gateway_certs.sh --mode "$mode" \
         --sans "$sans" --force-rotate  ; then
-            log "WARNING" "Certificate setup failed, but continuing with configuration rendering"
-            log "INFO" "You can run the certificate setup manually later:"
-            log "INFO" "  sudo /etc/flightctl/scripts/setup_telemetry_gateway_certs.sh --mode $mode"
+            log "ERROR" "Certificate setup failed, aborting configuration rendering"
+            exit 1
         else
             log "INFO" "Telemetry-gateway certificates setup completed successfully"
         fi

--- a/packaging/observability/flightctl-telemetry-gateway.container.template
+++ b/packaging/observability/flightctl-telemetry-gateway.container.template
@@ -1,5 +1,5 @@
 [Unit]
-Description=FlightCtl OpenTelemetry Collector
+Description=FlightCtl Telemetry Gateway
 After=flightctl-network.service
 Wants=flightctl-network.service
 PartOf=flightctl-telemetry-gateway.target flightctl-observability.target

--- a/packaging/observability/flightctl-telemetry-gateway.target
+++ b/packaging/observability/flightctl-telemetry-gateway.target
@@ -1,5 +1,5 @@
 [Unit]
-Description=FlightCtl OpenTelemetry Collector Target
+Description=FlightCtl Telemetry Gateway Target
 Documentation=https://docs.flightctl.io/user/standalone-observability/
 Wants=flightctl-network.service flightctl-telemetry-gateway.service
 After=flightctl-network.service flightctl-telemetry-gateway.service

--- a/packaging/observability/flightctl-userinfo-proxy.container.template
+++ b/packaging/observability/flightctl-userinfo-proxy.container.template
@@ -21,9 +21,6 @@ Environment=USERINFO_SKIP_TLS_VERIFY=${USERINFO_SKIP_TLS_VERIFY}
 # Security
 User=1001:1001
 
-# Resource limits
-Memory=64m
-
 [Service]
 Restart=on-failure
 RestartSec=10

--- a/packaging/observability/grafana.ini.template
+++ b/packaging/observability/grafana.ini.template
@@ -2,6 +2,7 @@
 [server]
 http_port = 3000
 # http_addr = 0.0.0.0 # Default
+root_url = ${GRAFANA_ROOT_URL}
 
 # HTTPS Configuration
 protocol = ${GRAFANA_PROTOCOL}
@@ -50,7 +51,7 @@ client_id = ${GRAFANA_OAUTH_CLIENT_ID}
 auth_url = ${GRAFANA_OAUTH_AUTH_URL}
 token_url = ${GRAFANA_OAUTH_TOKEN_URL}
 api_url = ${GRAFANA_OAUTH_API_URL}
-scopes = read
+scopes = ${GRAFANA_OAUTH_SCOPES}
 role_attribute_path = contains(roles[*], 'grafana-admin') && 'Admin', contains(roles[*], 'grafana-editor') && 'Editor', true && 'Viewer'
 tls_skip_verify_insecure = ${GRAFANA_TLS_SKIP_VERIFY}
 

--- a/packaging/observability/observability.defs
+++ b/packaging/observability/observability.defs
@@ -6,8 +6,11 @@ GRAFANA_OAUTH_CLIENT_ID        | .observability.grafana.oauth.client_id         
 GRAFANA_OAUTH_AUTH_URL         | .observability.grafana.oauth.auth_url                      |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
 GRAFANA_OAUTH_TOKEN_URL        | .observability.grafana.oauth.token_url                     |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
 GRAFANA_OAUTH_API_URL          | .observability.grafana.oauth.api_url                       |                                              | grafana.ini.template                          | /etc/grafana/grafana.ini
-GRAFANA_LOCAL_ADMIN_USER       | .observability.grafana.oauth.local_admin_user              | admin                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
-GRAFANA_LOCAL_ADMIN_PASSWORD   | .observability.grafana.oauth.local_admin_password          | defaultadmin                                 | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_OAUTH_SCOPES           | .observability.grafana.oauth.scopes                        | read                                         | grafana.ini.template                          | /etc/grafana/grafana.ini
+
+GRAFANA_LOCAL_ADMIN_USER       | .observability.grafana.local_admin_user                    | admin                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_LOCAL_ADMIN_PASSWORD   | .observability.grafana.local_admin_password                | defaultadmin                                 | grafana.ini.template                          | /etc/grafana/grafana.ini
+GRAFANA_ROOT_URL               | .observability.grafana.root_url                            | http://localhost:3000                        | grafana.ini.template                          | /etc/grafana/grafana.ini
 
 GRAFANA_TLS_SKIP_VERIFY        | .observability.grafana.oauth.tls_skip_verify               | false                                        | grafana.ini.template                          | /etc/grafana/grafana.ini
 GRAFANA_PROTOCOL               | .observability.grafana.protocol                            | http                                         | grafana.ini.template                          | /etc/grafana/grafana.ini
@@ -19,7 +22,7 @@ GRAFANA_PUBLISHED_PORT         | .observability.grafana.published_port          
 
 PROMETHEUS_IMAGE               | .observability.prometheus.image                            | docker.io/prom/prometheus:latest             | flightctl-prometheus.container.template       | /etc/containers/systemd/flightctl-prometheus.container
 
-USERINFO_PROXY_IMAGE           | .observability.userinfo_proxy.image                       | flightctl/userinfo-proxy:latest              | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
-USERINFO_UPSTREAM_URL          | .observability.userinfo_proxy.upstream_url                |                                              | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
-USERINFO_SKIP_TLS_VERIFY       | .observability.userinfo_proxy.skip_tls_verify             | false                                        | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+USERINFO_PROXY_IMAGE           | .observability.userinfo_proxy.image                        | quay.io/flightctl/flightctl-userinfo-proxy:latest | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+USERINFO_UPSTREAM_URL          | .observability.userinfo_proxy.upstream_url                 |                                              | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
+USERINFO_SKIP_TLS_VERIFY       | .observability.userinfo_proxy.skip_tls_verify              | false                                        | flightctl-userinfo-proxy.container.template   | /etc/containers/systemd/flightctl-userinfo-proxy.container
 

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -112,12 +112,12 @@ Requires:       selinux-policy-targeted
 %description observability
 This package provides the complete FlightCtl Observability Stack, including
 Prometheus for metric storage, Grafana for visualization, and
-OpenTelemetry Collector for metric collection. All components run in Podman containers
+Telemetry Gateway for metric collection. All components run in Podman containers
 managed by systemd and can be installed independently without requiring core FlightCtl
 services to be running. This package automatically includes the flightctl-telemetry-gateway package.
 
 %files telemetry-gateway
-# OpenTelemetry Collector specific files
+# Telemetry Gateway specific files
 /opt/flightctl-observability/templates/flightctl-telemetry-gateway.container.template
 /opt/flightctl-observability/templates/flightctl-telemetry-gateway-config.yaml.template
 
@@ -128,7 +128,7 @@ services to be running. This package automatically includes the flightctl-teleme
 /etc/flightctl/definitions/telemetry-gateway.defs
 
 # Configuration management script - needed for standalone telemetry-gateway deployment
-/usr/local/bin/flightctl-render-observability
+/usr/bin/flightctl-render-observability
 
 # Note: Uses flightctl network from flightctl-services package
 
@@ -170,7 +170,7 @@ services to be running. This package automatically includes the flightctl-teleme
 %ghost /etc/containers/systemd/flightctl-userinfo-proxy.container
 
 # Configuration management script
-/usr/local/bin/flightctl-render-observability
+/usr/bin/flightctl-render-observability
 
 # Systemd target for full observability stack
 /usr/lib/systemd/system/flightctl-observability.target
@@ -192,13 +192,13 @@ services to be running. This package automatically includes the flightctl-teleme
 
 %pre telemetry-gateway
 # This script runs BEFORE the files are installed onto the system.
-echo "Preparing to install FlightCtl OpenTelemetry Collector..."
+echo "Preparing to install FlightCtl Telemetry Gateway..."
 echo "Note: OpenTelemetry collector can be installed independently of other FlightCtl services."
 
 
 %post telemetry-gateway
 # This script runs AFTER the files have been installed onto the system.
-echo "Running post-install actions for FlightCtl OpenTelemetry Collector..."
+echo "Running post-install actions for FlightCtl Telemetry Gateway..."
 
 # Create necessary directories on the host if they don't already exist.
 /usr/bin/mkdir -p /opt/flightctl-observability/templates
@@ -207,13 +207,11 @@ echo "Running post-install actions for FlightCtl OpenTelemetry Collector..."
 
 # Apply persistent SELinux contexts for volumes and configuration files.
 /usr/sbin/semanage fcontext -a -t container_file_t "/opt/flightctl-observability/templates(/.*)?" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -a -t container_file_t "/usr/local/bin/flightctl-render-observability" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -a -t container_file_t "/usr/local/bin/" >/dev/null 2>&1 || :
+/usr/sbin/semanage fcontext -a -t container_file_t "/usr/bin/flightctl-render-observability" >/dev/null 2>&1 || :
 
 # Restore file contexts based on the new rules (and default rules)
 /usr/sbin/restorecon -RvF /opt/flightctl-observability/templates >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/flightctl-render-observability >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/ >/dev/null 2>&1 || :
+/usr/sbin/restorecon -RvF /usr/bin/flightctl-render-observability >/dev/null 2>&1 || :
 
 # Enable specific SELinux boolean if needed
 /usr/sbin/setsebool -P container_manage_cgroup on >/dev/null 2>&1 || :
@@ -237,14 +235,14 @@ fi
 echo "Reloading systemd daemon..."
 /usr/bin/systemctl daemon-reload
 
-echo "FlightCtl OpenTelemetry Collector installed. Service is configured but not started."
+echo "FlightCtl Telemetry Gateway installed. Service is configured but not started."
 echo "To render config: sudo flightctl-render-observability"
 echo "To start services: sudo systemctl start flightctl-telemetry-gateway.target"
 echo "For automatic startup: sudo systemctl enable flightctl-telemetry-gateway.target"
 
 
 %preun telemetry-gateway
-echo "Running pre-uninstall actions for FlightCtl OpenTelemetry Collector..."
+echo "Running pre-uninstall actions for FlightCtl Telemetry Gateway..."
 # Stop and disable the target and services
 /usr/bin/systemctl stop flightctl-telemetry-gateway.target >/dev/null 2>&1 || :
 /usr/bin/systemctl disable flightctl-telemetry-gateway.target >/dev/null 2>&1 || :
@@ -253,7 +251,7 @@ echo "Running pre-uninstall actions for FlightCtl OpenTelemetry Collector..."
 
 
 %postun telemetry-gateway
-echo "Running post-uninstall actions for FlightCtl OpenTelemetry Collector..."
+echo "Running post-uninstall actions for FlightCtl Telemetry Gateway..."
 # Clean up Podman container
 /usr/bin/podman rm -f flightctl-telemetry-gateway >/dev/null 2>&1 || :
 
@@ -271,16 +269,15 @@ fi
 
 # Remove SELinux fcontext rules added by this package
 /usr/sbin/semanage fcontext -d -t container_file_t "/opt/flightctl-observability/templates(/.*)?" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -d -t container_file_t "/usr/local/bin/flightctl-render-observability" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -d -t container_file_t "/usr/local/bin/" >/dev/null 2>&1 || :
+/usr/sbin/semanage fcontext -d -t container_file_t "/usr/bin/flightctl-render-observability" >/dev/null 2>&1 || :
+/usr/sbin/semanage fcontext -d -t container_file_t "/usr/bin/" >/dev/null 2>&1 || :
 
 # Restore default SELinux contexts for affected directories
 /usr/sbin/restorecon -RvF /opt/flightctl-observability/templates >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/flightctl-render-observability >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/ >/dev/null 2>&1 || :
+/usr/sbin/restorecon -RvF /usr/bin/flightctl-render-observability >/dev/null 2>&1 || :
 
 /usr/bin/systemctl daemon-reload
-echo "FlightCtl OpenTelemetry Collector uninstalled."
+echo "FlightCtl Telemetry Gateway uninstalled."
 
 
 %pre observability
@@ -299,7 +296,7 @@ echo "Running post-install actions for Flightctl Observability Stack..."
 /usr/bin/mkdir -p /etc/grafana/provisioning/dashboards /etc/grafana/provisioning/dashboards/flightctl
 /usr/bin/mkdir -p /etc/grafana/certs
 /usr/bin/mkdir -p /etc/flightctl /opt/flightctl-observability/templates
-/usr/bin/mkdir -p /usr/local/bin /usr/lib/systemd/system
+/usr/bin/mkdir -p /usr/bin /usr/lib/systemd/system
 /usr/bin/mkdir -p /etc/flightctl/scripts
 /usr/bin/mkdir -p /etc/flightctl/definitions
 
@@ -316,8 +313,7 @@ chown 472:472 /var/lib/grafana
 /usr/sbin/semanage fcontext -a -t container_file_t "/etc/grafana/certs(/.*)?" >/dev/null 2>&1 || :
 
 /usr/sbin/semanage fcontext -a -t container_file_t "/opt/flightctl-observability/templates(/.*)?" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -a -t container_file_t "/usr/local/bin/flightctl-render-observability" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -a -t container_file_t "/usr/local/bin/" >/dev/null 2>&1 || :
+/usr/sbin/semanage fcontext -a -t container_file_t "/usr/bin/flightctl-render-observability" >/dev/null 2>&1 || :
 
 # Restore file contexts based on the new rules (and default rules)
 /usr/sbin/restorecon -RvF /etc/prometheus >/dev/null 2>&1 || :
@@ -326,8 +322,7 @@ chown 472:472 /var/lib/grafana
 /usr/sbin/restorecon -RvF /var/lib/grafana >/dev/null 2>&1 || :
 /usr/sbin/restorecon -RvF /etc/grafana/certs >/dev/null 2>&1 || :
 /usr/sbin/restorecon -RvF /opt/flightctl-observability/templates >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/flightctl-render-observability >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/ >/dev/null 2>&1 || :
+/usr/sbin/restorecon -RvF /usr/bin/flightctl-render-observability >/dev/null 2>&1 || :
 
 # Enable specific SELinux boolean if needed
 /usr/sbin/setsebool -P container_manage_cgroup on >/dev/null 2>&1 || :
@@ -395,8 +390,7 @@ echo "Running post-uninstall actions for Flightctl Observability Stack..."
 /usr/sbin/semanage fcontext -d -t container_file_t "/var/lib/prometheus(/.*)?" >/dev/null 2>&1 || :
 
 /usr/sbin/semanage fcontext -d -t container_file_t "/opt/flightctl-observability/templates(/.*)?" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -d -t container_file_t "/usr/local/bin/flightctl-render-observability" >/dev/null 2>&1 || :
-/usr/sbin/semanage fcontext -d -t container_file_t "/usr/local/bin/" >/dev/null 2>&1 || :
+/usr/sbin/semanage fcontext -d -t container_file_t "/usr/bin/flightctl-render-observability" >/dev/null 2>&1 || :
 
 
 # Restore default SELinux contexts for affected directories
@@ -406,8 +400,7 @@ echo "Running post-uninstall actions for Flightctl Observability Stack..."
 /usr/sbin/restorecon -RvF /etc/prometheus >/dev/null 2>&1 || :
 /usr/sbin/restorecon -RvF /var/lib/prometheus >/dev/null 2>&1 || :
 /usr/sbin/restorecon -RvF /opt/flightctl-observability/templates >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/flightctl-render-observability >/dev/null 2>&1 || :
-/usr/sbin/restorecon -RvF /usr/local/bin/ >/dev/null 2>&1 || :
+/usr/sbin/restorecon -RvF /usr/bin/flightctl-render-observability >/dev/null 2>&1 || :
 
 
 /usr/bin/systemctl daemon-reload
@@ -501,7 +494,7 @@ echo "Flightctl Observability Stack uninstalled."
      mkdir -p %{buildroot}/var/lib/prometheus
      mkdir -p %{buildroot}/var/lib/grafana # For Grafana's data
      mkdir -p %{buildroot}/opt/flightctl-observability/templates # Staging for template files processed in %post
-     mkdir -p %{buildroot}/usr/local/bin # For the reloader script
+     mkdir -p %{buildroot}/usr/bin # For the reloader script
      mkdir -p %{buildroot}/usr/lib/systemd/system # For systemd units
 
      # Install pre-upgrade helper script to libexec
@@ -529,7 +522,7 @@ echo "Flightctl Observability Stack uninstalled."
      install -m 0755 test/scripts/setup_telemetry_gateway_certs.sh %{buildroot}/etc/flightctl/scripts
      install -m 0755 test/scripts/functions %{buildroot}/etc/flightctl/scripts
 
-     install -m 0755 packaging/observability/flightctl-render-observability %{buildroot}/usr/local/bin/
+     install -m 0755 packaging/observability/flightctl-render-observability %{buildroot}/usr/bin/
      install -m 0644 packaging/observability/observability.defs %{buildroot}/etc/flightctl/definitions/
      install -m 0644 packaging/observability/telemetry-gateway.defs %{buildroot}/etc/flightctl/definitions/
 

--- a/test/scripts/setup_telemetry_gateway_certs.sh
+++ b/test/scripts/setup_telemetry_gateway_certs.sh
@@ -112,6 +112,12 @@ if [[ ! -f "${YAML_HELPERS_PATH}" ]]; then
   exit 1
 fi
 
+# Test flightctl CLI login to server
+if ! flightctl version | grep 'Server Version:' >/dev/null 2>&1; then
+  echo "ERROR: flightctl CLI cannot connect to server. Please ensure you are logged in with 'flightctl login'."
+  exit 1
+fi
+
 # Mode-specific dependencies and setup
 if [[ "${MODE}" == "kubernetes" ]]; then
   need kubectl


### PR DESCRIPTION


Remove the setting from the container file

EDM-2323: In quadlets observability doc is not explained how to configure login using a different auth provider than AAP (e.g keycloak)

Added scopes grafana configuration variable to adapt for different identity providers.

EDM-2336: In service-config.yaml is missing the possibility to set grafana root_url

Added configuration variable

EDM-2285: flightctl-render-observability is installed to /usr/local/bin/flightctl-render-observability and is not seen by root

Changed the location of the script to /usr/bin

EDM-2287: setup_telemetry_gateway_certs.sh reports "not logged in" even when user is authenticated to flightctl

Added documentation that user must log in as root before running "sudo flightctl-render-observability"

EDM-2340: [documentation] flightctl-infoproxy image is wrong in quadlets observability doc, and AAP urls are missing the final part

Modified documentation

EDM-2337: 500 when I run sudo flightctl-render-observability and login token is expired

Tried to anticipate that such a problem can happen by running "flightctl version"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grafana root URL, configurable OAuth scopes, and local admin credential fields.
  * Require login before rendering observability configs.

* **Bug Fixes**
  * Certificate setup now fails fast with error logging and proper exit codes.
  * Added CLI connectivity validation during setup.

* **Chores**
  * Renamed observability components to Telemetry Gateway terminology.
  * Updated userinfo proxy image and removed container memory limits.

* **Documentation**
  * Updated docs to reflect login-before-render flow and new config fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->