### PR TITLE
EDM-2352: improve e2e BeforeEach stability

### DIFF
--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -13,6 +13,7 @@ VM_CPUS=8                  # Number of CPUs
 VM_DISK_SIZE_INC=${VM_DISK_SIZE_INC:-30} # Disk size increment
 NETWORK_NAME="$(get_ocp_nodes_network)"   # Network name
 NETWORK_NAME=${NETWORK_NAME:-baremetal-0}
+DEFAULT_NETWORK_NAME="default"
 echo "ocp_network name is: ${NETWORK_NAME}"
 echo "Disk size increment: ${VM_DISK_SIZE_INC}G"
 ISO_URL="https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-9-latest.x86_64.qcow2"
@@ -67,6 +68,10 @@ echo "Resizing image ${DISK_PATH}..."
 qemu-img resize ${DISK_PATH} +${VM_DISK_SIZE_INC}G && \
 qemu-img info --output=json "${DISK_PATH}"
 
+# Restart default network
+sudo virsh net-destroy ${DEFAULT_NETWORK_NAME}
+sudo virsh net-start ${DEFAULT_NETWORK_NAME}
+
 # Create the VM
 echo "Creating virtual machine ${VM_NAME}..."
 virt-install \
@@ -75,7 +80,7 @@ virt-install \
   --vcpus $VM_CPUS \
   --disk path=$DISK_PATH,format=qcow2 \
   --os-variant centos-stream9  \
-  --network network="default" \
+  --network network=$DEFAULT_NETWORK_NAME \
   --network network=$NETWORK_NAME,model=virtio \
   --import \
   --cpu host-model \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced VM snapshot revert workflow in tests with retry attempts, backoff and improved logging to increase reliability.
  * Disabled a flaky console/tuning end-to-end test to stabilize the test suite.

* **Chores**
  * Made VM setup network name configurable in test scripts instead of using a hardcoded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->