### PR TITLE
EDM-2367: Separate last seen from device

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -82,6 +82,10 @@ func (m *MockDevice) GetWithoutServiceConditions(ctx context.Context, orgId uuid
 	return nil, nil
 }
 
+func (m *MockDevice) ListDisconnected(ctx context.Context, orgId uuid.UUID, listParams store.ListParams, cutoffTime time.Time) (*api.DeviceList, error) {
+	return nil, nil
+}
+
 func (m *MockDevice) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {
 	return nil, nil
 }

--- a/internal/service/common.go
+++ b/internal/service/common.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	MaxRecordsPerListRequest = 1000
+	MaxConcurrentAgents      = 15
 )
 
 func IsInternalRequest(ctx context.Context) bool {

--- a/internal/service/event_handler_test.go
+++ b/internal/service/event_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 )
 
 // MockKVStore implements kvstore.KVStore for testing
@@ -50,6 +51,7 @@ func serviceHandler() *ServiceHandler {
 		workerClient: &DummyWorkerClient{},
 		kvStore:      &MockKVStore{},
 		log:          logrus.New(),
+		agentGate:    semaphore.NewWeighted(MaxConcurrentAgents),
 	}
 }
 

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 )
 
 type ServiceHandler struct {
@@ -20,6 +21,7 @@ type ServiceHandler struct {
 	uiUrl         string
 	tpmCAPaths    []string
 	orgResolver   resolvers.Resolver
+	agentGate     *semaphore.Weighted
 }
 
 func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tpmCAPaths []string, orgResolver resolvers.Resolver) *ServiceHandler {
@@ -34,5 +36,6 @@ func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClien
 		uiUrl:         uiUrl,
 		tpmCAPaths:    tpmCAPaths,
 		orgResolver:   orgResolver,
+		agentGate:     semaphore.NewWeighted(MaxConcurrentAgents),
 	}
 }

--- a/internal/service/mock_service.go
+++ b/internal/service/mock_service.go
@@ -708,6 +708,21 @@ func (mr *MockServiceMockRecorder) ListDevicesByServiceCondition(ctx, conditionT
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDevicesByServiceCondition", reflect.TypeOf((*MockService)(nil).ListDevicesByServiceCondition), ctx, conditionType, conditionStatus, listParams)
 }
 
+// ListDisconnectedDevices mocks base method.
+func (m *MockService) ListDisconnectedDevices(ctx context.Context, params v1alpha1.ListDevicesParams, cutoffTime time.Time) (*v1alpha1.DeviceList, v1alpha1.Status) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDisconnectedDevices", ctx, params, cutoffTime)
+	ret0, _ := ret[0].(*v1alpha1.DeviceList)
+	ret1, _ := ret[1].(v1alpha1.Status)
+	return ret0, ret1
+}
+
+// ListDisconnectedDevices indicates an expected call of ListDisconnectedDevices.
+func (mr *MockServiceMockRecorder) ListDisconnectedDevices(ctx, params, cutoffTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDisconnectedDevices", reflect.TypeOf((*MockService)(nil).ListDisconnectedDevices), ctx, params, cutoffTime)
+}
+
 // ListDisruptionBudgetFleets mocks base method.
 func (m *MockService) ListDisruptionBudgetFleets(ctx context.Context) (*v1alpha1.FleetList, v1alpha1.Status) {
 	m.ctrl.T.Helper()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -50,6 +50,7 @@ type Service interface {
 	UpdateServiceSideDeviceStatus(ctx context.Context, device api.Device) bool
 	SetOutOfDate(ctx context.Context, owner string) error
 	UpdateServerSideDeviceStatus(ctx context.Context, name string) error
+	ListDisconnectedDevices(ctx context.Context, params api.ListDevicesParams, cutoffTime time.Time) (*api.DeviceList, api.Status)
 
 	// EnrollmentConfig
 	GetEnrollmentConfig(ctx context.Context, params api.GetEnrollmentConfigParams) (*api.EnrollmentConfig, api.Status)

--- a/internal/service/teststore_framework_test.go
+++ b/internal/service/teststore_framework_test.go
@@ -158,6 +158,10 @@ func (s *DummyDevice) Get(ctx context.Context, orgId uuid.UUID, name string) (*a
 	return nil, flterrors.ErrResourceNotFound
 }
 
+func (s *DummyDevice) GetWithoutServiceConditions(ctx context.Context, orgId uuid.UUID, name string) (*api.Device, error) {
+	return s.Get(ctx, orgId, name)
+}
+
 func (s *DummyDevice) Update(ctx context.Context, orgId uuid.UUID, device *api.Device, fieldsToUnset []string, fromAPI bool, validationCallback store.DeviceStoreValidationCallback, callbackEvent store.EventCallback) (*api.Device, error) {
 	for i, dev := range *s.devices {
 		if *device.Metadata.Name == *dev.Metadata.Name {

--- a/internal/service/traced_service.go
+++ b/internal/service/traced_service.go
@@ -114,6 +114,13 @@ func (t *TracedService) ListDevices(ctx context.Context, params api.ListDevicesP
 	return resp, st
 }
 
+func (t *TracedService) ListDisconnectedDevices(ctx context.Context, params api.ListDevicesParams, cutoffTime time.Time) (*api.DeviceList, api.Status) {
+	ctx, span := startSpan(ctx, "ListDisconnectedDevices")
+	resp, st := t.inner.ListDisconnectedDevices(ctx, params, cutoffTime)
+	endSpan(span, st)
+	return resp, st
+}
+
 func (t *TracedService) ListDevicesByServiceCondition(ctx context.Context, conditionType string, conditionStatus string, listParams store.ListParams) (*api.DeviceList, api.Status) {
 	ctx, span := startSpan(ctx, "ListDevicesByServiceCondition")
 	resp, st := t.inner.ListDevicesByServiceCondition(ctx, conditionType, conditionStatus, listParams)

--- a/test/integration/service/service_suite_test.go
+++ b/test/integration/service/service_suite_test.go
@@ -96,7 +96,7 @@ func NewServiceTestSuite() *ServiceTestSuite {
 // SetDeviceLastSeen sets the lastSeen timestamp for a device directly in the database
 func (s *ServiceTestSuite) SetDeviceLastSeen(deviceName string, lastSeen time.Time) error {
 	orgId := store.NullOrgId
-	result := s.db.WithContext(s.Ctx).Model(&model.Device{}).Where("org_id = ? AND name = ?", orgId, deviceName).Updates(map[string]interface{}{
+	result := s.db.WithContext(s.Ctx).Model(&model.DeviceTimestamp{}).Where("org_id = ? AND name = ?", orgId, deviceName).Updates(map[string]interface{}{
 		"last_seen": lastSeen,
 	})
 	return result.Error

--- a/test/integration/tasks/device_disconnected_test.go
+++ b/test/integration/tasks/device_disconnected_test.go
@@ -61,7 +61,7 @@ var _ = Describe("DeviceDisconnected", func() {
 
 	// Helper function to set device lastSeen directly in the database
 	setDeviceLastSeen := func(deviceName string, lastSeen time.Time) error {
-		result := db.WithContext(ctx).Model(&model.Device{}).Where("org_id = ? AND name = ?", orgId, deviceName).Updates(map[string]interface{}{
+		result := db.WithContext(ctx).Model(&model.DeviceTimestamp{}).Where("org_id = ? AND name = ?", orgId, deviceName).Updates(map[string]interface{}{
 			"last_seen": lastSeen,
 		})
 		return result.Error


### PR DESCRIPTION
Reduce contention on devices table by moving the last_seen column to a different table.
Before the change API requests graph response time for 100K devices was very unstable:

<img width="720" height="284" alt="image_720" src="https://github.com/user-attachments/assets/e9b00260-7ecc-4c90-bb8f-5aaf603967cd" />

After the change API requests response time became stable and relatively smooth:

<img width="719" height="157" alt="image_720" src="https://github.com/user-attachments/assets/c9902d6c-7f85-4c60-acf2-b9bfb07646d2" />


EDM-2372: Protect database from bursts of API requests originating from devices

In case there is a burst of API requests originating from devices that cause many SQL operations to be executed concurrently, the handling of all database requests become very slow. To solve it, the number of concurrent database requests originating from devices should be limited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List disconnected devices by cutoff time.
  * Retrieve device last-seen timestamp.

* **Improvements**
  * Agent concurrency gating to coordinate agent-driven operations.
  * Last-seen moved to dedicated timestamp storage for more reliable tracking and pagination.

* **Tests / Migrations**
  * Tests updated to use last-seen APIs.
  * Database migration and backfill added to support timestamp storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->