### PR TITLE
EDM-2339: Use non-IP-based rate limiting where possible

### DIFF
--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -32,16 +32,23 @@ db:
   sslrootcert: ""   # Path to SSL root certificate file (CA certificate)
 
 service:
+  # Trusted proxies that can set X-Forwarded-For/X-Real-IP headers
+  # This should include your load balancer and UI proxy IPs
+  trustedProxies:
+    - "10.0.0.0/8"    # Example: Internal network range
+    - "172.16.0.0/12" # Example: Docker/container network range
+    - "192.168.0.0/16" # Example: Private network range
   # Rate limiting configuration
   # Note: Only flightctl-api and flightctl-alertmanager-proxy services use rate limiting
   # Other services ignore this configuration
   rateLimit:
     enabled: true
+    # General API rate limiting
     requests: 300
-    window: 1m
+    window: "1m"
+    # Auth-specific rate limiting
     authRequests: 20
-    authWindow: 1h
-    trustedProxies: []
+    authWindow: "1h"
 
 observability:
   grafana:

--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -237,12 +237,12 @@ func (s *AgentServer) prepareHTTPHandler(serviceHandler service.Service) (http.H
 		if s.cfg.Service.RateLimit.Window > 0 {
 			window = time.Duration(s.cfg.Service.RateLimit.Window)
 		}
-		tlsmiddleware.InstallRateLimiter(router, tlsmiddleware.RateLimitOptions{
-			Requests:       requests,
-			Window:         window,
-			Message:        "Rate limit exceeded, please try again later",
-			TrustedProxies: []string{}, // No proxy headers for mTLS
-		})
+		// Use device identity rate limiter instead of IP-based
+		router.Use(tlsmiddleware.DeviceIdentityRateLimiter(
+			requests,
+			window,
+			"Rate limit exceeded, please try again later",
+		))
 	}
 
 	h := transport.NewAgentTransportHandler(serviceHandler, s.ca, s.log)

--- a/internal/api_server/middleware/middleware.go
+++ b/internal/api_server/middleware/middleware.go
@@ -58,7 +58,11 @@ func AddEventMetadataToCtx(next http.Handler) http.Handler {
 		if auth.GetConfiguredAuthType() != auth.AuthTypeNil {
 			identity, err := common.GetIdentity(ctx)
 			if err == nil && identity != nil {
-				userName = identity.GetUsername()
+				if username := identity.GetUsername(); username != "" {
+					userName = username
+				} else if uid := identity.GetUID(); uid != "" {
+					userName = uid
+				}
 			}
 		}
 		ctx = context.WithValue(ctx, consts.EventActorCtxKey, fmt.Sprintf("user:%s", userName))

--- a/internal/api_server/middleware/ratelimit.go
+++ b/internal/api_server/middleware/ratelimit.go
@@ -2,13 +2,15 @@ package middleware
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	api "github.com/flightctl/flightctl/api/v1alpha1"
+	"github.com/flightctl/flightctl/internal/auth/common"
+	"github.com/flightctl/flightctl/internal/crypto/signer"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/httprate"
 )
@@ -21,75 +23,118 @@ type RateLimitOptions struct {
 	TrustedProxies []string
 }
 
-// InstallRateLimiter installs RealIP + custom rate limiter.
-func InstallRateLimiter(r chi.Router, opts RateLimitOptions) {
+// getClientIPFromRequest extracts the client IP from the request's RemoteAddr
+// Returns the IP portion, falling back to the full RemoteAddr if parsing fails
+func getClientIPFromRequest(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// IPRateLimiter creates an IP-based rate limiter.
+// This is the traditional rate limiter that works by client IP address.
+// Note: Should be used with TrustedRealIP middleware for proper proxy handling
+func IPRateLimiter(requests int, window time.Duration, message string) func(http.Handler) http.Handler {
+	limiter := httprate.Limit(
+		requests,
+		window,
+		httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+			// Use the client IP as the key
+			// Note: r.RemoteAddr will be the real IP if TrustedRealIP middleware is used
+			return getClientIPFromRequest(r), nil
+		}),
+		httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", strconv.Itoa(int(window.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    http.StatusTooManyRequests,
+				"message": message,
+				"reason":  "TooManyRequests",
+			}); err != nil {
+				// If JSON encoding fails, we can't do much more
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return limiter
+}
+
+// InstallIPRateLimiter installs RealIP + IP-based rate limiter.
+// This is a convenience function that applies both TrustedRealIP and IPRateLimiter.
+// Note: This function is deprecated. Use TrustedRealIP + IPRateLimiter directly instead.
+func InstallIPRateLimiter(r chi.Router, opts RateLimitOptions) {
 	// 1) Only trust X-Forwarded-For/X-Real-IP when the immediate peer is in one of these CIDRs
 	if len(opts.TrustedProxies) > 0 {
 		r.Use(TrustedRealIP(opts.TrustedProxies))
 	}
-
-	// 2) Build a limiter: N req per window, keyed by client IP
-	limiter := httprate.Limit(
-		opts.Requests, // e.g. 60
-		opts.Window,   // e.g. time.Minute
-		httprate.WithKeyFuncs( // bucket by r.RemoteAddr (after RealIP)
-			httprate.KeyByIP,
-		),
-		httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
-			// build your API status
-			status := api.Status{
-				Code:    http.StatusTooManyRequests,
-				Message: opts.Message,
-				Reason:  "TooManyRequests",
-			}
-
-			// emit headers + JSON
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Retry-After", strconv.Itoa(int(opts.Window.Seconds())))
-			w.WriteHeader(http.StatusTooManyRequests)
-			_ = json.NewEncoder(w).Encode(status)
-		}),
-	)
-
-	// 3) Register it for all routes (user + agent routers)
-	r.Use(limiter)
+	// 2) Apply IP-based rate limiting
+	r.Use(IPRateLimiter(opts.Requests, opts.Window, opts.Message))
 }
 
-// TrustedRealIP only rewrites RemoteAddr when the immediate peer is in one of your LB CIDRs
-func TrustedRealIP(trustedCIDRs []string) func(http.Handler) http.Handler {
-	// parse CIDRs once
-	var nets []*net.IPNet
-	for _, cidr := range trustedCIDRs {
-		if _, n, err := net.ParseCIDR(cidr); err == nil {
-			nets = append(nets, n)
+// TrustedRealIP middleware extracts the real client IP from trusted proxy headers.
+// It only trusts X-Forwarded-For, X-Real-IP, and True-Client-IP headers when the
+// immediate peer (r.RemoteAddr) is in the trustedProxies list.
+// If the peer is not trusted, headers are silently ignored and r.RemoteAddr is used.
+func TrustedRealIP(trustedProxies []string) func(http.Handler) http.Handler {
+	// Pre-parse trusted proxy CIDRs and literal IPs once at middleware construction time
+	// This avoids parsing on every request, keeping the hot path allocation-free
+	var trustedNets []*net.IPNet
+	for _, entry := range trustedProxies {
+		s := strings.TrimSpace(entry)
+		if s == "" {
+			continue
+		}
+		if strings.Contains(s, "/") {
+			if _, n, err := net.ParseCIDR(s); err == nil {
+				trustedNets = append(trustedNets, n)
+			}
+			continue
+		}
+		if ip := net.ParseIP(s); ip != nil {
+			// Convert literal IP to a single-host network
+			if ip.To4() != nil {
+				trustedNets = append(trustedNets, &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)})
+			} else {
+				trustedNets = append(trustedNets, &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)})
+			}
 		}
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// extract peer IP
-			host, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err == nil {
-				peerIP := net.ParseIP(host)
-
-				// check if peer is trusted
-				isTrusted := false
-				for _, n := range nets {
-					if n.Contains(peerIP) {
-						isTrusted = true
-						break
-					}
-				}
-
-				if isTrusted {
-					// only trust and process headers from trusted peers
-					// Follow chi middleware order: True-Client-IP -> X-Real-IP -> X-Forwarded-For
-					if tci := r.Header.Get("True-Client-IP"); tci != "" {
-						r.RemoteAddr = tci
-					} else if xr := r.Header.Get("X-Real-IP"); xr != "" {
-						r.RemoteAddr = xr
-					} else if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-						r.RemoteAddr = strings.TrimSpace(strings.Split(xff, ",")[0])
+			// Check if the immediate peer is trusted
+			if len(trustedNets) > 0 {
+				host := getClientIPFromRequest(r)
+				if peerIP := net.ParseIP(host); peerIP != nil {
+					for _, trustedNet := range trustedNets {
+						if trustedNet.Contains(peerIP) {
+							// Peer is trusted, extract real IP from headers
+							// Priority: True-Client-IP > X-Real-IP > X-Forwarded-For
+							if tc := strings.TrimSpace(r.Header.Get("True-Client-IP")); tc != "" {
+								if ip := net.ParseIP(tc); ip != nil {
+									r.RemoteAddr = ip.String()
+									break
+								}
+							}
+							if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
+								if ip := net.ParseIP(xr); ip != nil {
+									r.RemoteAddr = ip.String()
+									break
+								}
+							}
+							if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+								first := strings.TrimSpace(strings.Split(xff, ",")[0])
+								if ip := net.ParseIP(first); ip != nil {
+									r.RemoteAddr = ip.String()
+									break
+								}
+							}
+							break
+						}
 					}
 				}
 				// silent ignore: untrusted headers are simply ignored, no logging or blocking
@@ -97,4 +142,93 @@ func TrustedRealIP(trustedCIDRs []string) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// UserIdentityRateLimiter creates a rate limiter keyed by user identity (username/UID) from authenticated context
+// This is used for authenticated endpoints where we know the user identity
+// Note: Should be used after authentication middleware
+func UserIdentityRateLimiter(requests int, window time.Duration, message string) func(http.Handler) http.Handler {
+	limiter := httprate.Limit(
+		requests,
+		window,
+		httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+			// Extract user identity from context
+			ctx := r.Context()
+			identity, err := common.GetIdentity(ctx)
+			if err != nil {
+				// Fallback to IP if no identity available
+				return getClientIPFromRequest(r), nil
+			}
+
+			// Use username or UID as the key
+			if username := identity.GetUsername(); username != "" {
+				return fmt.Sprintf("user:%s", username), nil
+			}
+			if uid := identity.GetUID(); uid != "" {
+				return fmt.Sprintf("uid:%s", uid), nil
+			}
+
+			// Fallback to IP if no username/UID
+			return getClientIPFromRequest(r), nil
+		}),
+		httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", strconv.Itoa(int(window.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    http.StatusTooManyRequests,
+				"message": message,
+				"reason":  "TooManyRequests",
+			}); err != nil {
+				// If JSON encoding fails, we can't do much more
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return limiter
+}
+
+// DeviceIdentityRateLimiter creates a rate limiter keyed by device fingerprint from mTLS certificate
+// This is used for agent endpoints where devices authenticate via mTLS
+// Note: Should be used after TLS middleware that extracts the peer certificate
+func DeviceIdentityRateLimiter(requests int, window time.Duration, message string) func(http.Handler) http.Handler {
+	limiter := httprate.Limit(
+		requests,
+		window,
+		httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+			// Extract device fingerprint from TLS peer certificate
+			ctx := r.Context()
+			peerCertificate, err := signer.PeerCertificateFromCtx(ctx)
+			if err != nil {
+				// Fallback to IP if no certificate available
+				return getClientIPFromRequest(r), nil
+			}
+
+			// Extract device fingerprint from certificate
+			fingerprint, err := signer.GetDeviceFingerprintExtension(peerCertificate)
+			if err != nil {
+				// Fallback to IP if no fingerprint available
+				return getClientIPFromRequest(r), nil
+			}
+
+			// Use device fingerprint as the key
+			return fmt.Sprintf("device:%s", fingerprint), nil
+		}),
+		httprate.WithLimitHandler(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", strconv.Itoa(int(window.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			if err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    http.StatusTooManyRequests,
+				"message": message,
+				"reason":  "TooManyRequests",
+			}); err != nil {
+				// If JSON encoding fails, we can't do much more
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return limiter
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,9 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_String_ObfuscatesSensitiveData(t *testing.T) {
@@ -49,4 +52,113 @@ func TestConfig_String_ObfuscatesSensitiveData(t *testing.T) {
 	if !strings.Contains(result, "testuser") {
 		t.Error("Non-sensitive username should be preserved")
 	}
+}
+
+func TestValidateTrustedProxies(t *testing.T) {
+	t.Run("ValidCIDRs", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"192.168.1.0/24",
+			"10.0.0.0/8",
+			"2001:db8::/32",
+		}
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ValidIPs", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"192.168.1.100",
+			"10.0.0.1",
+			"2001:db8::1",
+			"::1",
+		}
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("MixedValidEntries", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"192.168.1.0/24",
+			"10.0.0.1",
+			"2001:db8::/32",
+			"::1",
+		}
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("EmptyEntries", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"",
+			"   ",
+			"192.168.1.100",
+			"\t",
+			"10.0.0.1",
+		}
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("SingleInvalidEntry", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"192.168.1.100",
+			"invalid-ip",
+			"10.0.0.1",
+		}
+
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid TrustedProxies entry: invalid-ip")
+		assert.Contains(t, err.Error(), "must be a valid CIDR block or IP address")
+	})
+
+	t.Run("MultipleInvalidEntries", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{
+			"192.168.1.100",
+			"invalid-ip",
+			"not-a-cidr",
+			"10.0.0.1",
+			"bad-format",
+		}
+
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid TrustedProxies entries:")
+		assert.Contains(t, err.Error(), "invalid-ip, not-a-cidr, bad-format")
+		assert.Contains(t, err.Error(), "must be valid CIDR blocks or IP addresses")
+	})
+
+	t.Run("NoTrustedProxies", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = []string{}
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("NilTrustedProxies", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service.TrustedProxies = nil
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("NilService", func(t *testing.T) {
+		cfg := NewDefault()
+		cfg.Service = nil
+
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
When Flight Control is deployed behind the OpenShift router, all incoming requests appear to originate from the HAProxy IP address rather than the actual client IP. This occurs because the router is configured in TLS passthrough mode, meaning it cannot inspect or modify HTTP headers and therefore does not inject X-Forwarded-For or X-Real-IP.

As a result, the rate limiter, which currently keys requests by source IP, treats all traffic as a single source, effectively disabling per-client rate limiting and potentially leading to unintended throttling.

We now use non-IP-based rate limiting where possible:
1. For authenticated endpoints, we now use identity-based limiting, falling back to IP-based where not available.
2. For agent endpoints, we use device fingerprint-based limiting, again falling back to IP-based where not available.
3. We still use IP-based rate limiting for pre-authentication endpoints (auth/validate).

In addition, we apply trusted proxy handling globally for consistent real IP detection, so that the correct IP is shown in logs and other contexts. We also moved the trusted proxy configuration from rate limit config to service config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced rate limiting now supports user-identity and device-identity strategies in addition to IP-based limits
  * Improved handling of authenticated user requests with automatic fallback mechanisms

* **Improvements**
  * Trusted proxies configuration is now configurable at the service level for better reverse proxy support
  * Better client IP detection for proxied traffic scenarios

* **Documentation**
  * Updated rate limiting guidance with per-endpoint strategies
  * Added OpenShift TLS passthrough considerations and recommendations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->