### PR TITLE
EDM-2251: remove start condition for db-migrate

### DIFF
--- a/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
@@ -2,8 +2,7 @@
 Description=Flight Control Database Migration service
 PartOf=flightctl.target
 After=flightctl-db-wait.service flightctl-db-users-init.service
-Wants=flightctl-db-wait.service flightctl-db-users-init.service
-ConditionPathExists=/etc/flightctl/flightctl-api/config.yaml
+Wants=flightctl-db-wait.service flightctl-db-users-init.service 
 
 [Container]
 ContainerName=flightctl-db-migrate


### PR DESCRIPTION
Sometimes `config.yaml` isn’t ready _yet_, preventing the migration from starting 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified database migration startup behavior to improve initialization without requiring a specific configuration file path check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->