### PR TITLE
EDM-2387: Allow flightctl_agent_t to get status of systemd services

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -175,6 +175,7 @@ allow flightctl_agent_t var_log_t:file { read open getattr };
 # Systemd service management
 systemd_manage_all_unit_files(flightctl_agent_t)
 systemd_start_all_unit_files(flightctl_agent_t)
+systemd_status_all_unit_files(flightctl_agent_t)
 systemd_reload_all_services(flightctl_agent_t)
 systemd_start_all_services(flightctl_agent_t)
 allow flightctl_agent_t init_t:system status;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded system-level permissions to allow the app to query and report service status, improving service management, monitoring, and diagnostics; reduces permission-related errors when checking services and enhances observability for troubleshooting and automated health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->