### PR TITLE
EDM-2350-v2: Fix documentation to reference correct telemetery gateway export listen port (9464) for prometheus

### DIFF
--- a/docs/user/standalone-observability.md
+++ b/docs/user/standalone-observability.md
@@ -245,7 +245,7 @@ observability:
     config:
       telemetryGateway:
         export:
-          prometheus: "your-prometheus.company.com:9090"
+          prometheus: 0.0.0.0:9464
         forward:
           endpoint: "your-otel-collector.company.com:4317"
           tls:
@@ -729,7 +729,7 @@ observability:
           tls:
             insecureSkipTlsVerify: false
         export:
-          prometheus: "your-prometheus.company.com:9090"
+          prometheus: 0.0.0.0:9464
 ```
 
 **Note**: The telemetry gateway configuration is provided as a YAML object in the `config` field. The `flightctl-render-observability` script extracts this configuration using Python and `PyYAML`, and writes it to `/etc/flightctl/telemetry-gateway/config.yaml`.
@@ -918,7 +918,7 @@ observability:
           tls:
             insecureSkipTlsVerify: false
         export:
-          prometheus: "your-prometheus.company.com:9090"
+          prometheus: 0.0.0.0:9464
 ```
 
 **Note**: The telemetry gateway automatically configures itself based on the `observability.telemetry_gateway.config.telemetryGateway` section in `service-config.yaml`. No manual OpenTelemetry configuration files are needed.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated standalone observability configuration documentation for Prometheus telemetry gateway endpoints to reflect internal address configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->