### PR TITLE
[Backport] EDM-1392: Fix bootc linting issue with tmpfiles.d configuration

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -600,6 +600,14 @@ fi
     /usr/share/sosreport/flightctl.py
 
 %post agent
+# Ensure /var/lib/flightctl exists immediately for environments where systemd-tmpfiles succeeds or via fallback
+# Try systemd-tmpfiles first, fall back to manual creation if it fails
+/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/flightctl.conf || {
+    mkdir -p /var/lib/flightctl && \
+    chown root:root /var/lib/flightctl && \
+    chmod 0755 /var/lib/flightctl
+}
+
 INSTALL_DIR="/usr/lib/python$(python3 --version | sed 's/^.* \(3[.][0-9]*\).*$/\1/')/site-packages/sos/report/plugins"
 mkdir -p $INSTALL_DIR
 cp /usr/share/sosreport/flightctl.py $INSTALL_DIR


### PR DESCRIPTION
Backports the fix for bootc linting failure where /var/lib/flightctl directory creation violated bootc filesystem guidelines.
https://github.com/flightctl/flightctl/pull/1540