### PR TITLE
[Backport] EDM-2253: Add hostname support to systeminfo and improve agent config

### DIFF
--- a/internal/agent/device/systeminfo/system_info.go
+++ b/internal/agent/device/systeminfo/system_info.go
@@ -457,6 +457,8 @@ func collectionOptsFromInfoKeys(infoKeys []string) ([]CollectOpt, error) {
 			opts = append(opts, withCollector(collectorKernel, collectKernelFunc))
 		case distroNameKey, distroVersionKey:
 			opts = append(opts, withCollector(collectorDistribution, collectDistributionFunc))
+		case hostnameKey, architectureKey:
+			// No specific collector needed - hostname and architecture are always collected
 		default:
 			errs = append(errs, fmt.Errorf("unknown key: %q", key))
 		}

--- a/internal/agent/device/systeminfo/system_info_test.go
+++ b/internal/agent/device/systeminfo/system_info_test.go
@@ -259,6 +259,20 @@ func TestGetCollectionOptsFromInfoKeys(t *testing.T) {
 			expectGPU: true,
 			expectErr: true,
 		},
+		{
+			name:      "hostname key should be supported",
+			infoKeys:  []string{hostnameKey},
+			expectErr: false, // Fixed: hostname is now properly supported
+		},
+		{
+			name:          "default system info with hostname key",
+			infoKeys:      config.DefaultSystemInfo, // This includes "hostname" which is now supported
+			expectErr:     false,                    // Fixed: default config now works properly
+			expectKernel:  true,                     // kernel is in default config
+			expectDistro:  true,                     // distro keys are in default config
+			expectSystem:  true,                     // product keys are in default config
+			expectNetwork: true,                     // network keys are in default config
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport for https://github.com/flightctl/flightctl/pull/1816

- Bug Fixes

  - Fixed handling of hostname and architecture information in system metadata collection to ensure these details are properly captured without errors.

- Tests

  - Added test coverage for hostname key support and default system information configuration validation.