### PR TITLE
EDM-2396: Fix build source tag detection

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -42,7 +42,7 @@ jobs:
             echo "image_tags,helm_tag=${image_tags[@]}"
 
           else
-            version=$(git describe --long --tags --exclude latest)
+            version=$(./hack/current-version)
             # image tags should not have the leading v, and we tag rcs with ~rc1..rcX for rpm version ordering
             version=$(echo "${version#v}" | sed 's/~/-/g')
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,7 @@ packages:
     upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
 actions:
   get-current-version:
-    - bash -c '(git describe --tags --match "v[0-9]*" 2>/dev/null || echo "v0.0.0-unknown") | sed "s/^v//; s/-/~/g"'
+    - bash -c './hack/current-version | sed "s/^v//; s/-/~/g"'
 jobs:
   - job: copr_build
     trigger: pull_request

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ GOARCH := $(shell go env GOARCH)
 
 VERBOSE ?= false
 
-SOURCE_GIT_TAG ?=$(shell git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
+SOURCE_GIT_TAG ?=$(shell ./hack/current-version)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')

--- a/hack/current-version
+++ b/hack/current-version
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Prefer proper release tags pointing at this exact commit first, prioritizing the highest version
+# tag. If there is no tag at this commit, then fallback to 'git describe' which will construct a
+# "human-readable" artificial tag.
+tag=$(git -c "versionsort.suffix=-rc" tag --points-at HEAD --sort version:refname | tail -n 1 2>/dev/null)
+
+if [[ -z "$tag" ]]; then
+  tag=$(git describe --tags --exclude latest 2>/dev/null || echo -n "v0.0.0-unknown")
+fi
+
+echo -n "$tag"


### PR DESCRIPTION
If there is one or more tags at the current commit, use the highest tag (as determined by git's tag version sorting with suffix specified).

If there is no tag at the HEAD commit, use 'git describe' to generate an artificial tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build/version detection: tag resolution now prefers an exact tag at HEAD and falls back to the previous describe-based method when none found.
  * Unified version sourcing across build, CI and packaging steps to produce more consistent version strings for non-tag builds and published images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->