### PR TITLE
Fix for test VM Agent behavior status Device status tests 

### DIFF
--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -222,8 +222,6 @@ var _ = Describe("VM Agent behavior", func() {
 
 			By("should report the correct device status when trying to upgrade to a not existing image")
 			previousRenderedVersion := newRenderedVersion
-			nextGeneration, err := harness.PrepareNextDeviceGeneration(deviceId)
-			Expect(err).ToNot(HaveOccurred())
 			newRenderedVersion, err = harness.PrepareNextDeviceVersion(deviceId)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -236,9 +234,6 @@ var _ = Describe("VM Agent behavior", func() {
 				device.Spec.Os = &v1alpha1.DeviceOsSpec{Image: newImageReference}
 				GinkgoWriter.Printf("Updating %s to image %s\n", deviceId, device.Spec.Os.Image)
 			})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = harness.WaitForDeviceNewGeneration(deviceId, nextGeneration)
 			Expect(err).ToNot(HaveOccurred())
 
 			harness.WaitForDeviceContents(deviceId, fmt.Sprintf("Failed to update to renderedVersion: %s. Error", strconv.Itoa(newRenderedVersion)),


### PR DESCRIPTION
In case of use a non existing image WaitForDeviceContents panics. For now the check is removed. A follow up patch will add a better error for WaitForDeviceContents and UpdateDeviceWithRetries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end VM agent test to stop waiting for a new image generation and proceed directly with the device update, verifying displayed device version handling without synchronizing on generation availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->