### PR TITLE
EDM-2408: Move redis config for quadlets kv service to a .conf file t…

### DIFF
--- a/deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf
+++ b/deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf
@@ -1,0 +1,8 @@
+# Disable persistence
+save ""
+appendonly no
+
+loglevel warning
+
+maxmemory 1gb
+maxmemory-policy allkeys-lru

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -4,11 +4,9 @@ Description=Flight Control Key Value service
 [Container]
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
-Exec=/bin/sh -c 'mkdir -p /usr/local/etc/redis && echo "save \"\"" > /usr/local/etc/redis/redis.conf && echo "appendonly no" >> /usr/local/etc/redis/redis.conf && echo "loglevel $${REDIS_LOGLEVEL}" >> /usr/local/etc/redis/redis.conf && echo "maxmemory $${REDIS_MAXMEMORY}" >> /usr/local/etc/redis/redis.conf && echo "maxmemory-policy $${REDIS_MAXMEMORY_POLICY}" >> /usr/local/etc/redis/redis.conf && echo "requirepass $${KV_PASSWORD}" >> /usr/local/etc/redis/redis.conf && exec redis-server /usr/local/etc/redis/redis.conf'
+Exec=/bin/sh -c 'redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
 Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=REDIS_LOGLEVEL=warning
-Environment=REDIS_MAXMEMORY=1gb
-Environment=REDIS_MAXMEMORY_POLICY=allkeys-lru
+Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
 
 PublishPort=6379:6379
 

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -6,11 +6,9 @@ PartOf=flightctl.target
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
 Network=flightctl.network
-Exec=/bin/sh -c 'mkdir -p /usr/local/etc/redis && echo "save \"\"" > /usr/local/etc/redis/redis.conf && echo "appendonly no" >> /usr/local/etc/redis/redis.conf && echo "loglevel $${REDIS_LOGLEVEL}" >> /usr/local/etc/redis/redis.conf && echo "maxmemory $${REDIS_MAXMEMORY}" >> /usr/local/etc/redis/redis.conf && echo "maxmemory-policy $${REDIS_MAXMEMORY_POLICY}" >> /usr/local/etc/redis/redis.conf && echo "requirepass $${KV_PASSWORD}" >> /usr/local/etc/redis/redis.conf && exec redis-server /usr/local/etc/redis/redis.conf'
+Exec=/bin/sh -c 'redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
 Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=REDIS_LOGLEVEL=warning
-Environment=REDIS_MAXMEMORY=1gb
-Environment=REDIS_MAXMEMORY_POLICY=allkeys-lru
+Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
 
 [Service]
 Type=notify

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -610,6 +610,7 @@ rm -rf /usr/share/sosreport
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-api
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-alert-exporter
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db
+    %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-kv
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-alertmanager-proxy
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-ui
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-cli-artifacts
@@ -619,6 +620,7 @@ rm -rf /usr/share/sosreport
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-api/create_aap_application.sh
     %{_datadir}/flightctl/flightctl-alert-exporter/config.yaml
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db/enable-superuser.sh
+    %{_datadir}/flightctl/flightctl-kv/redis.conf
     %{_datadir}/flightctl/flightctl-ui/env.template
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-ui/init.sh
     %attr(0755,root,root) %{_datadir}/flightctl/init_utils.sh


### PR DESCRIPTION
…o prevent directory permissions issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified Redis container startup by externalizing configuration to a mountable config file and using the server CLI for password application.
  * Configured memory limits with automatic least-recently-used eviction.
  * Disabled persistence for key-value deployments.
  * Updated packaging to install the Redis configuration into the application data path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->