### PR TITLE
EDM-2409: Add internal ctx key to alert exporter service

### DIFF
--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -48,6 +48,7 @@ func main() {
 
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-alert-exporter")
+	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)


### PR DESCRIPTION
Addresses [EDM-2409](https://issues.redhat.com/browse/EDM-2409) - regression to the alert-exporter.

Effectively what is happening is there is a ListOrganizations call in the exporter.  It requires a context key to be set to bypass user-specific checks and return all orgs for internal calls that is currently not being set in the exporter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure improvement to support request context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->