### PR TITLE
EDM-2412: store: return 404 if checkpoint does not exist

### DIFF
--- a/internal/store/checkpoint.go
+++ b/internal/store/checkpoint.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -65,7 +66,7 @@ func (s *CheckpointStore) Get(ctx context.Context, consumer string, key string) 
 	result := s.getDB(ctx).Take(&checkpoint, "consumer = ? AND key = ?", consumer, key)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
+			return nil, flterrors.ErrResourceNotFound
 		}
 		return nil, result.Error
 	}


### PR DESCRIPTION
When we start up we get a request for a checkpoint that does not yet exist. Instead of returning an error (404) to the caller, we incorrectly return success (200) with empty data, 

ref. https://github.com/flightctl/flightctl/blob/bc3fab573b75ef766a974011c3af96822573cd1d/internal/service/common.go#L146
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to properly report when requested resources are not found, replacing silent nil returns with appropriate error responses for better API consistency and debuggability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->