### PR TITLE
EDM-2419: fixed meter collector to have a single label

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -317,3 +317,79 @@ func TestDeviceCollectorWithOrgFilter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
 }
+
+func TestDeviceCollectorWithEmptyResults(t *testing.T) {
+	// Test the new behavior where empty results emit a default metric
+	mockStore := &MockStore{results: []store.CountByOrgAndStatusResult{}} // Empty results
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create collector
+	config := config.NewDefault()
+	config.Metrics.DeviceCollector.GroupByFleet = true
+	collector := NewDeviceCollector(ctx, mockStore, log, config)
+
+	// Wait a bit for the collector to start and collect metrics
+	time.Sleep(10 * time.Millisecond)
+
+	// Test that metrics are collected even with empty results
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	// Collect metrics
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	// Verify that we got metrics even with empty results
+	// Should have 3 default metrics (one for each gauge: summary, application, update)
+	assert.GreaterOrEqual(t, len(metrics), 3, "Expected at least 3 metrics (one default per gauge) even with empty results")
+
+	t.Logf("Collected %d metrics with empty results", len(metrics))
+}
+
+func TestDeviceCollectorUpdateDeviceMetricsWithEmptyResults(t *testing.T) {
+	// Test the updateDeviceMetrics method directly with empty results
+	mockStore := &MockStore{results: []store.CountByOrgAndStatusResult{}} // Empty results
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create collector
+	config := config.NewDefault()
+	config.Metrics.DeviceCollector.GroupByFleet = true
+	collector := NewDeviceCollector(ctx, mockStore, log, config)
+
+	// Call updateDeviceMetrics directly
+	collector.updateDeviceMetrics()
+
+	// Test that metrics are collected even with empty results
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	// Collect metrics
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	// Verify that we got metrics even with empty results
+	// Should have 3 default metrics (one for each gauge: summary, application, update)
+	assert.GreaterOrEqual(t, len(metrics), 3, "Expected at least 3 metrics (one default per gauge) even with empty results")
+
+	t.Logf("Direct updateDeviceMetrics call with empty results collected %d metrics", len(metrics))
+}

--- a/internal/instrumentation/metrics/domain/fleet.go
+++ b/internal/instrumentation/metrics/domain/fleet.go
@@ -96,16 +96,22 @@ func (c *FleetCollector) updateFleetMetrics() {
 
 	// Update total fleets metric
 	c.totalFleetsGauge.Reset()
-	for _, result := range statusCounts {
-		orgIdLabel := result.OrgID
-		if orgIdLabel == "" {
-			orgIdLabel = "unknown"
+
+	if len(statusCounts) == 0 {
+		// Always emit at least one metric to indicate "no fleets" rather than "metric absent"
+		c.totalFleetsGauge.WithLabelValues("unknown", "none").Set(0)
+	} else {
+		for _, result := range statusCounts {
+			orgIdLabel := result.OrgID
+			if orgIdLabel == "" {
+				orgIdLabel = "unknown"
+			}
+			status := result.Status
+			if status == "" {
+				status = "none"
+			}
+			c.totalFleetsGauge.WithLabelValues(orgIdLabel, status).Set(float64(result.Count))
 		}
-		status := result.Status
-		if status == "" {
-			status = "none"
-		}
-		c.totalFleetsGauge.WithLabelValues(orgIdLabel, status).Set(float64(result.Count))
 	}
 
 	c.log.WithFields(logrus.Fields{

--- a/internal/instrumentation/metrics/domain/repository.go
+++ b/internal/instrumentation/metrics/domain/repository.go
@@ -96,12 +96,18 @@ func (c *RepositoryCollector) updateRepositoryMetrics() {
 
 	// Update repositories metric
 	c.repositoriesGauge.Reset()
-	for _, result := range repoCounts {
-		orgIdLabel := result.OrgID
-		if orgIdLabel == "" {
-			orgIdLabel = "unknown"
+
+	if len(repoCounts) == 0 {
+		// Always emit at least one metric to indicate "no repositories" rather than "metric absent"
+		c.repositoriesGauge.WithLabelValues("unknown").Set(0)
+	} else {
+		for _, result := range repoCounts {
+			orgIdLabel := result.OrgID
+			if orgIdLabel == "" {
+				orgIdLabel = "unknown"
+			}
+			c.repositoriesGauge.WithLabelValues(orgIdLabel).Set(float64(result.Count))
 		}
-		c.repositoriesGauge.WithLabelValues(orgIdLabel).Set(float64(result.Count))
 	}
 
 	c.log.WithFields(logrus.Fields{

--- a/internal/instrumentation/metrics/domain/resourcesync.go
+++ b/internal/instrumentation/metrics/domain/resourcesync.go
@@ -97,16 +97,22 @@ func (c *ResourceSyncCollector) updateResourceSyncMetrics() {
 
 	// Update resource syncs metric
 	c.resourceSyncsGauge.Reset()
-	for _, result := range resourceSyncCounts {
-		orgIdLabel := result.OrgID
-		if orgIdLabel == "" {
-			orgIdLabel = "unknown"
+
+	if len(resourceSyncCounts) == 0 {
+		// Always emit at least one metric to indicate "no resource syncs" rather than "metric absent"
+		c.resourceSyncsGauge.WithLabelValues("unknown", "none").Set(0)
+	} else {
+		for _, result := range resourceSyncCounts {
+			orgIdLabel := result.OrgID
+			if orgIdLabel == "" {
+				orgIdLabel = "unknown"
+			}
+			status := result.Status
+			if status == "" {
+				status = "none"
+			}
+			c.resourceSyncsGauge.WithLabelValues(orgIdLabel, status).Set(float64(result.Count))
 		}
-		status := result.Status
-		if status == "" {
-			status = "none"
-		}
-		c.resourceSyncsGauge.WithLabelValues(orgIdLabel, status).Set(float64(result.Count))
 	}
 
 	c.log.WithFields(logrus.Fields{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collectors now always emit default zero-value metrics when underlying data is empty, ensuring no missing metrics and more reliable observability across devices, fleets, repositories, and resource syncs.
  * Metric updates are applied consistently in a single consolidated pass to ensure accurate, up-to-date counts.

* **Tests**
  * Added tests verifying collectors emit metrics even when stores return empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->