### PR TITLE
EDM-2300: Services must-gather script

### DIFF
--- a/packaging/must-gather/flightctl-services-must-gather
+++ b/packaging/must-gather/flightctl-services-must-gather
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Ensure script is run with sudo available
+if ! sudo -n true 2>/dev/null; then
+    echo "This script requires sudo privileges. Please run with a user that has sudo access."
+    exit 1
+fi
+
+echo "Warning: This operation could generate a very large file in the current directory."
+read -p "Do you have enough storage space? (y/n): " -n 1 -r
+echo ""
+
+# Check the user's response
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Operation canceled by the user."
+  exit 1
+fi
+
+echo "Beginning Must Gather Collection..."
+
+timestamp=$(date +"%Y%m%d-%H%M%S")
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+echo "# Collecting system information..."
+uname -a > "$temp_dir/uname-info.log" || true
+cat /etc/os-release > "$temp_dir/os-release.log" || true
+getenforce > "$temp_dir/selinux-status.log" || echo "SELinux not available" > "$temp_dir/selinux-status.log"
+sudo dnf list installed flightctl-services > "$temp_dir/services-version.log" || echo "Package not found or dnf not available" > "$temp_dir/services-version.log"
+
+echo "# Collecting systemd information..."
+sudo systemctl list-dependencies flightctl.target > "$temp_dir/target-list-dependencies.log" || echo "flightctl.target not found" > "$temp_dir/target-list-dependencies.log"
+sudo systemctl status 'flightctl*' > "$temp_dir/systemd-status.log" || echo "No flightctl services found" > "$temp_dir/systemd-status.log"
+sudo systemctl list-units 'flightctl*' > "$temp_dir/systemd-list-units.log" || echo "No flightctl units found" > "$temp_dir/systemd-list-units.log"
+
+echo "# Collecting journal logs..."
+for service in $(sudo systemctl list-units --no-legend 'flightctl*' 2>/dev/null |
+awk '{print $1}' || true); do
+    if [ -n "$service" ]; then
+        echo "## Collecting logs for $service..."
+        sudo journalctl -u "$service" --since "24 hours ago" --no-pager > "$temp_dir/${service}.log" || echo "Failed to collect logs for $service" > "$temp_dir/${service}.log"
+    fi
+done
+
+echo "# Collecting podman information..."
+sudo podman ps -a > "$temp_dir/podman-ps.log" || echo "podman ps failed" > "$temp_dir/podman-ps.log"
+sudo podman images -a > "$temp_dir/podman-images.log" || echo "podman images failed" > "$temp_dir/podman-images.log"
+sudo podman volume ls > "$temp_dir/podman-volumes.log" || echo "podman volume ls failed" > "$temp_dir/podman-volumes.log"
+sudo podman network ls > "$temp_dir/podman-networks.log" || echo "podman network ls failed" > "$temp_dir/podman-networks.log"
+sudo podman secret ls > "$temp_dir/podman-secrets.log" || echo "podman secret ls failed" > "$temp_dir/podman-secrets.log"
+if sudo podman network exists flightctl 2>/dev/null; then
+    sudo podman network inspect flightctl > "$temp_dir/podman-network-flightctl.log" || echo "Failed to inspect flightctl network" > "$temp_dir/podman-network-flightctl.log"
+else
+    echo "Network does not exist" > "$temp_dir/podman-network-flightctl.log"
+fi
+
+echo "# Collecting must-gather script itself..."
+cp "$0" "$temp_dir/flightctl-services-must-gather.txt"
+
+echo "# Creating must-gather archive..."
+filename="flightctl-services-must-gather-$timestamp.tgz"
+
+tar -czf "$filename" -C "$temp_dir" .
+rm -rf "$temp_dir"
+
+echo "$filename created successfully."

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -477,6 +477,9 @@ echo "Flightctl Observability Stack uninstalled."
     IMAGE_TAG=$(echo %{version} | tr '~' '-') \
     deploy/scripts/install.sh
 
+    # Copy services must gather script
+    cp packaging/must-gather/flightctl-services-must-gather %{buildroot}%{_bindir}
+
     # Copy sos report flightctl plugin
     mkdir -p %{buildroot}/usr/share/sosreport
     cp packaging/sosreport/sos/report/plugins/flightctl.py %{buildroot}/usr/share/sosreport
@@ -656,6 +659,9 @@ rm -rf /usr/share/sosreport
     # Files mounted to lib dir
     /usr/lib/systemd/system/flightctl.target
 
+    # Files mounted to bin dir
+    %attr(0755,root,root) %{_bindir}/flightctl-services-must-gather
+
 # Optional pre-upgrade database migration dry-run
 %pre services
 # $1 == 1 if it's an install
@@ -730,6 +736,8 @@ fi
 # If contexts were managed via policy, no cleanup is needed here.
 
 %changelog
+* Mon Oct 27 2025 Dakota Crowder <dcrowder@redhat.com> - 1.0
+- Add must-gather script for the services sub package
 * Wed Oct 8 2025 Ilya Skornyakov <iskornya@redhat.com> - 0.10.0
 - Add pre-upgrade database migration dry-run capability
 * Tue Jul 15 2025 Sam Batschelet <sbatsche@redhat.com> - 0.9.0-2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic must-gather utility that (with confirmation and elevated privileges) gathers system info, service and systemd state, recent service logs, and Podman data into a timestamped compressed archive.

* **Chores**
  * The diagnostic utility is packaged and installed as an executable in the services package and included in release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->