### PR TITLE
EDM-2395: Add Inline Quadlet Spec Validation

### DIFF
--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -451,15 +451,24 @@ services:
   app:
     image: nginx:latest`
 
+	quadletContainerSpec := `[Container]
+Image=quay.io/podman/hello:latest
+PublishPort=8080:80`
+
+	quadletBuildSpec := `[Build]
+ContextDir=/tmp/build`
+
 	base64Content := base64.StdEncoding.EncodeToString([]byte(composeSpec))
 	tests := []struct {
 		name          string
+		appType       AppType
 		spec          InlineApplicationProviderSpec
 		fleetTemplate bool
 		expectErr     bool
 	}{
 		{
-			name: "valid plain content",
+			name:    "valid plain content",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{
@@ -472,7 +481,8 @@ services:
 			expectErr: false,
 		},
 		{
-			name: "duplicate path",
+			name:    "duplicate path",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "docker-compose.yaml", Content: lo.ToPtr("abc"), ContentEncoding: &plain},
@@ -482,7 +492,8 @@ services:
 			expectErr: true,
 		},
 		{
-			name: "invalid base64 content",
+			name:    "invalid base64 content",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "podman-compose.yaml", Content: lo.ToPtr(composeSpec), ContentEncoding: &base64Enc},
@@ -491,7 +502,8 @@ services:
 			expectErr: true,
 		},
 		{
-			name: "valid base64 content",
+			name:    "valid base64 content",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "podman-compose.yml", Content: &base64Content, ContentEncoding: &base64Enc},
@@ -500,7 +512,8 @@ services:
 			expectErr: false,
 		},
 		{
-			name: "unknown encoding",
+			name:    "unknown encoding",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "docker-compose.yaml", Content: lo.ToPtr(composeSpec), ContentEncoding: lo.ToPtr(EncodingType("unknown"))},
@@ -509,7 +522,8 @@ services:
 			expectErr: true,
 		},
 		{
-			name: "invalid compose path",
+			name:    "invalid compose path",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "invalid-compose.yaml", Content: lo.ToPtr(composeSpec), ContentEncoding: &plain},
@@ -518,7 +532,8 @@ services:
 			expectErr: true,
 		},
 		{
-			name: "invalid use of container_name",
+			name:    "invalid use of container_name",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "docker-compose.yaml", Content: lo.ToPtr(composeInvalidSpecContainerName), ContentEncoding: &plain},
@@ -527,10 +542,31 @@ services:
 			expectErr: true,
 		},
 		{
-			name: "invalid container short name",
+			name:    "invalid container short name",
+			appType: AppTypeCompose,
 			spec: InlineApplicationProviderSpec{
 				Inline: []ApplicationContent{
 					{Path: "docker-compose.yaml", Content: lo.ToPtr(composeInvalidSpecContainerShortname), ContentEncoding: &plain},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:    "valid quadlet container file",
+			appType: AppTypeQuadlet,
+			spec: InlineApplicationProviderSpec{
+				Inline: []ApplicationContent{
+					{Path: "app.container", Content: lo.ToPtr(quadletContainerSpec), ContentEncoding: &plain},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:    "unsupported quadlet build type",
+			appType: AppTypeQuadlet,
+			spec: InlineApplicationProviderSpec{
+				Inline: []ApplicationContent{
+					{Path: "app.build", Content: lo.ToPtr(quadletBuildSpec), ContentEncoding: &plain},
 				},
 			},
 			expectErr: true,
@@ -539,7 +575,7 @@ services:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := tt.spec.Validate(lo.ToPtr(AppTypeCompose), tt.fleetTemplate)
+			errs := tt.spec.Validate(lo.ToPtr(tt.appType), tt.fleetTemplate)
 			if tt.expectErr {
 				require.NotEmpty(t, errs, "expected errors but got none")
 			} else {
@@ -1108,4 +1144,128 @@ func createMemoryMonitor(t *testing.T) ResourceMonitor {
 		t.Fatalf("Failed to create Memory monitor: %v", err)
 	}
 	return monitor
+}
+
+func TestValidateApplicationContentQuadlet(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name          string
+		content       string
+		path          string
+		wantErrCount  int
+		wantErrSubstr string
+	}{
+		{
+			name: "valid container quadlet with OCI image",
+			content: `[Container]
+Image=quay.io/podman/hello:latest
+PublishPort=8080:80`,
+			path:         "test.container",
+			wantErrCount: 0,
+		},
+		{
+			name: "valid container quadlet with .image reference",
+			content: `[Container]
+Image=my-app.image
+PublishPort=8080:80`,
+			path:         "test.container",
+			wantErrCount: 0,
+		},
+		{
+			name: "valid volume quadlet",
+			content: `[Volume]
+Image=quay.io/containers/volume:latest`,
+			path:         "test.volume",
+			wantErrCount: 0,
+		},
+		{
+			name: "valid image quadlet",
+			content: `[Image]
+Image=quay.io/fedora/fedora:latest`,
+			path:         "test.image",
+			wantErrCount: 0,
+		},
+		{
+			name: "valid network quadlet",
+			content: `[Network]
+Subnet=10.0.0.0/24`,
+			path:         "test.network",
+			wantErrCount: 0,
+		},
+		{
+			name: "valid pod quadlet",
+			content: `[Pod]
+PodName=my-pod`,
+			path:         "test.pod",
+			wantErrCount: 0,
+		},
+		{
+			name: "invalid quadlet - parsing error (bad INI)",
+			content: `[Container
+Image=test`,
+			path:          "test.container",
+			wantErrCount:  1,
+			wantErrSubstr: "parse quadlet spec",
+		},
+		{
+			name: "invalid quadlet - .build reference",
+			content: `[Container]
+Image=my-app.build`,
+			path:          "test.container",
+			wantErrCount:  1,
+			wantErrSubstr: ".build quadlet types are unsupported",
+		},
+		{
+			name: "invalid quadlet - short OCI reference",
+			content: `[Container]
+Image=nginx:latest`,
+			path:          "test.container",
+			wantErrCount:  1,
+			wantErrSubstr: "container.image",
+		},
+		{
+			name: "invalid quadlet - image type missing Image key",
+			content: `[Image]
+Label=test`,
+			wantErrCount:  1,
+			path:          "test.image",
+			wantErrSubstr: ".image quadlet must have an Image key",
+		},
+		{
+			name: "invalid quadlet - unsupported Build type",
+			content: `[Build]
+ContextDir=/tmp/build`,
+			path:          "test.build",
+			wantErrCount:  1,
+			wantErrSubstr: "parse quadlet spec",
+		},
+		{
+			name: "non-quadlet systemd file",
+			content: `[Service]
+Type=simple
+ExecStart=/usr/bin/myapp`,
+			path:          "test.container",
+			wantErrCount:  1,
+			wantErrSubstr: "non quadlet type",
+		},
+		{
+			name:         "non-quadlet config file",
+			content:      `{"key": "val"}`,
+			path:         "conf.json",
+			wantErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := []byte(tt.content)
+			errs := ValidateApplicationContent(content, AppTypeQuadlet, tt.path)
+
+			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
+			if tt.wantErrSubstr != "" && len(errs) > 0 {
+				require.Contains(errs[0].Error(), tt.wantErrSubstr)
+			}
+		})
+	}
 }

--- a/internal/api/common/quadlet.go
+++ b/internal/api/common/quadlet.go
@@ -1,0 +1,125 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/quadlet"
+)
+
+// QuadletType represents the type of Quadlet unit file.
+type QuadletType string
+
+const (
+	QuadletTypeContainer QuadletType = "container"
+	QuadletTypeVolume    QuadletType = "volume"
+	QuadletTypeNetwork   QuadletType = "network"
+	QuadletTypeImage     QuadletType = "image"
+	QuadletTypePod       QuadletType = "pod"
+)
+
+var (
+	ErrUnsupportedQuadletType = fmt.Errorf("unsupported quadlet type")
+	ErrNonQuadletType         = fmt.Errorf("non quadlet type")
+)
+
+var (
+	SupportedQuadletExtensions = map[string]struct{}{
+		quadlet.ContainerExtension: {},
+		quadlet.VolumeExtension:    {},
+		quadlet.NetworkExtension:   {},
+		quadlet.ImageExtension:     {},
+		quadlet.PodExtension:       {},
+	}
+	UnsupportedQuadletExtensions = map[string]struct{}{
+		quadlet.BuildExtension:    {},
+		quadlet.ArtifactExtension: {},
+		quadlet.KubeExtension:     {},
+	}
+	UnsupportedQuadletSections = map[string]struct{}{
+		quadlet.BuildGroup:    {},
+		quadlet.ArtifactGroup: {},
+		quadlet.KubeGroup:     {},
+	}
+)
+
+// QuadletReferences represents a Quadlet unit file's parsed references.
+type QuadletReferences struct {
+	Type        QuadletType
+	Image       *string
+	MountImages []string
+}
+
+// ParseQuadletReferences parses unit file data into a QuadletReferences object
+func ParseQuadletReferences(data []byte) (*QuadletReferences, error) {
+	unit, err := quadlet.NewUnit(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing quadlet references: %w", err)
+	}
+
+	for group := range UnsupportedQuadletSections {
+		if unit.HasSection(group) {
+			return nil, fmt.Errorf("%w: type: %s", ErrUnsupportedQuadletType, group)
+		}
+	}
+
+	typeSections := map[string]QuadletType{
+		quadlet.ContainerGroup: QuadletTypeContainer,
+		quadlet.VolumeGroup:    QuadletTypeVolume,
+		quadlet.NetworkGroup:   QuadletTypeNetwork,
+		quadlet.ImageGroup:     QuadletTypeImage,
+		quadlet.PodGroup:       QuadletTypePod,
+	}
+
+	var detectedType QuadletType
+	var detectedSection string
+	foundCount := 0
+
+	for sectionName, quadletType := range typeSections {
+		if unit.HasSection(sectionName) {
+			detectedType = quadletType
+			detectedSection = sectionName
+			foundCount++
+		}
+	}
+
+	if foundCount == 0 {
+		return nil, ErrNonQuadletType
+	}
+
+	if foundCount > 1 {
+		return nil, fmt.Errorf("multiple quadlet type sections found")
+	}
+
+	spec := &QuadletReferences{
+		Type: detectedType,
+	}
+
+	image, err := unit.Lookup(detectedSection, quadlet.ImageKey)
+	if err != nil {
+		if !errors.Is(err, quadlet.ErrKeyNotFound) {
+			return nil, fmt.Errorf("finding image key: %w", err)
+		}
+	} else {
+		spec.Image = &image
+	}
+
+	mounts, err := unit.LookupAll(detectedSection, quadlet.MountKey)
+	if err != nil {
+		if !errors.Is(err, quadlet.ErrKeyNotFound) {
+			return nil, fmt.Errorf("finding mount key: %w", err)
+		}
+	} else {
+		for _, mount := range mounts {
+			mountImage, err := quadlet.MountImage(mount)
+			if err != nil {
+				return nil, fmt.Errorf("parsing mount image: %w", err)
+			}
+			if mountImage != "" {
+				spec.MountImages = append(spec.MountImages, mountImage)
+			}
+		}
+	}
+
+	return spec, nil
+}

--- a/internal/api/common/quadlet_test.go
+++ b/internal/api/common/quadlet_test.go
@@ -1,0 +1,258 @@
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQuadletSpec(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name            string
+		data            string
+		wantType        QuadletType
+		wantImage       *string
+		wantMountImages []string
+		wantErr         bool
+		wantErrType     error
+		wantErrSubstr   string
+	}{
+		// Valid parsing tests
+		{
+			name: "valid container with image",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+PublishPort=8080:80`,
+			wantType:  QuadletTypeContainer,
+			wantImage: lo.ToPtr("quay.io/podman/hello:latest"),
+		},
+		{
+			name: "valid container without image",
+			data: `[Container]
+PublishPort=8080:80`,
+			wantType:  QuadletTypeContainer,
+			wantImage: nil,
+		},
+		{
+			name: "valid volume with image",
+			data: `[Volume]
+Image=quay.io/containers/volume:latest`,
+			wantType:  QuadletTypeVolume,
+			wantImage: lo.ToPtr("quay.io/containers/volume:latest"),
+		},
+		{
+			name: "valid volume without image",
+			data: `[Volume]
+Device=/dev/sda1`,
+			wantType:  QuadletTypeVolume,
+			wantImage: nil,
+		},
+		{
+			name: "valid network",
+			data: `[Network]
+Subnet=10.0.0.0/24`,
+			wantType:  QuadletTypeNetwork,
+			wantImage: nil,
+		},
+		{
+			name: "valid image with image key",
+			data: `[Image]
+Image=quay.io/fedora/fedora:latest`,
+			wantType:  QuadletTypeImage,
+			wantImage: lo.ToPtr("quay.io/fedora/fedora:latest"),
+		},
+		{
+			name: "valid pod",
+			data: `[Pod]
+PodName=my-pod`,
+			wantType:  QuadletTypePod,
+			wantImage: nil,
+		},
+		{
+			name: "valid container with unit section",
+			data: `[Unit]
+Description=My container
+
+[Container]
+Image=quay.io/app/myapp:v1.0`,
+			wantType:  QuadletTypeContainer,
+			wantImage: lo.ToPtr("quay.io/app/myapp:v1.0"),
+		},
+		{
+			name:        "invalid INI format",
+			data:        `[Container\nImage=test`,
+			wantErr:     true,
+			wantErrType: nil,
+		},
+		{
+			name: "multiple type sections",
+			data: `[Container]
+Image=test
+
+[Volume]
+Device=/dev/sda1`,
+			wantErr:       true,
+			wantErrSubstr: "multiple quadlet type sections",
+		},
+		{
+			name: "unsupported type: Build",
+			data: `[Build]
+ContextDir=/tmp/build`,
+			wantErr:       true,
+			wantErrType:   ErrUnsupportedQuadletType,
+			wantErrSubstr: "Build",
+		},
+		{
+			name: "unsupported type: Kube",
+			data: `[Kube]
+Yaml=/path/to/kube.yaml`,
+			wantErr:       true,
+			wantErrType:   ErrUnsupportedQuadletType,
+			wantErrSubstr: "Kube",
+		},
+		{
+			name: "unsupported type: Artifact",
+			data: `[Artifact]
+Source=/path/to/artifact`,
+			wantErr:       true,
+			wantErrType:   ErrUnsupportedQuadletType,
+			wantErrSubstr: "Artifact",
+		},
+		{
+			name: "no recognized type section",
+			data: `[Unit]
+Description=Some unit`,
+			wantErr:     true,
+			wantErrType: ErrNonQuadletType,
+		},
+		{
+			name: "non-quadlet systemd file",
+			data: `[Service]
+Type=simple
+ExecStart=/usr/bin/myapp`,
+			wantErr:     true,
+			wantErrType: ErrNonQuadletType,
+		},
+		{
+			name: "container with build section",
+			data: `[Container]
+Image=test
+
+[Build]
+ContextDir=/tmp`,
+			wantErr:       true,
+			wantErrType:   ErrUnsupportedQuadletType,
+			wantErrSubstr: "Build",
+		},
+		{
+			name: "container with single image mount",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=image,source=quay.io/containers/data:v1,destination=/data`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: []string{"quay.io/containers/data:v1"},
+		},
+		{
+			name: "container with multiple image mounts",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=image,source=quay.io/containers/data:v1,destination=/data
+Mount=type=image,source=quay.io/containers/cache:latest,destination=/cache`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: []string{"quay.io/containers/data:v1", "quay.io/containers/cache:latest"},
+		},
+		{
+			name: "container with mixed mount types",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=image,source=quay.io/containers/data:v1,destination=/data
+Mount=type=volume,source=my-volume,destination=/vol`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: []string{"quay.io/containers/data:v1"},
+		},
+		{
+			name: "container with volume mount only",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=volume,source=my-volume,destination=/data`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: nil,
+		},
+		{
+			name: "container with mount but no type specified",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=source=my-volume,destination=/data`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: nil,
+		},
+		{
+			name: "container with Image and mount images",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=image,source=quay.io/containers/data:v1,destination=/data`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: []string{"quay.io/containers/data:v1"},
+		},
+		{
+			name: "container with multiple Mount keys referencing different images",
+			data: `[Container]
+Image=quay.io/app/myapp:v1.0
+Mount=type=image,source=quay.io/containers/db:v2,destination=/db
+Mount=type=image,source=quay.io/containers/cache:v3,destination=/cache
+Mount=type=volume,source=logs,destination=/logs`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/app/myapp:v1.0"),
+			wantMountImages: []string{"quay.io/containers/db:v2", "quay.io/containers/cache:v3"},
+		},
+		{
+			name: "container with image mount using src instead of source",
+			data: `[Container]
+Image=quay.io/podman/hello:latest
+Mount=type=image,src=quay.io/containers/data:v1,destination=/data`,
+			wantType:        QuadletTypeContainer,
+			wantImage:       lo.ToPtr("quay.io/podman/hello:latest"),
+			wantMountImages: []string{"quay.io/containers/data:v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := ParseQuadletReferences([]byte(tt.data))
+
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrType != nil {
+					require.True(errors.Is(err, tt.wantErrType), "expected error type %v, got %v", tt.wantErrType, err)
+				}
+				if tt.wantErrSubstr != "" {
+					require.Contains(err.Error(), tt.wantErrSubstr)
+				}
+				return
+			}
+
+			require.NoError(err)
+			require.NotNil(spec)
+			require.Equal(tt.wantType, spec.Type)
+
+			if tt.wantImage != nil {
+				require.NotNil(spec.Image)
+				require.Equal(*tt.wantImage, *spec.Image)
+			} else {
+				require.Nil(spec.Image)
+			}
+
+			require.Equal(tt.wantMountImages, spec.MountImages)
+		})
+	}
+}

--- a/internal/quadlet/quadlet.go
+++ b/internal/quadlet/quadlet.go
@@ -1,0 +1,179 @@
+package quadlet
+
+import (
+	"encoding/csv"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const (
+	// ContainerExtension is the file extension for container quadlet files.
+	ContainerExtension = ".container"
+	// VolumeExtension is the file extension for volume quadlet files.
+	VolumeExtension = ".volume"
+	// NetworkExtension is the file extension for network quadlet files.
+	NetworkExtension = ".network"
+	// ImageExtension is the file extension for image quadlet files.
+	ImageExtension = ".image"
+	// PodExtension is the file extension for pod quadlet files.
+	PodExtension = ".pod"
+	// BuildExtension is the file extension for build quadlet files.
+	BuildExtension = ".build"
+	// ArtifactExtension is the file extension for artifact quadlet files.
+	ArtifactExtension = ".artifact"
+	// KubeExtension is the file extension for kube quadlet files.
+	KubeExtension = ".kube"
+
+	// ContainerGroup is the section name for container specifications in quadlet files.
+	ContainerGroup = "Container"
+	// VolumeGroup is the section name for volume specifications in quadlet files.
+	VolumeGroup = "Volume"
+	// NetworkGroup is the section name for network specifications in quadlet files.
+	NetworkGroup = "Network"
+	// ImageGroup is the section name for image specifications in quadlet files.
+	ImageGroup = "Image"
+	// PodGroup is the section name for pod specifications in quadlet files.
+	PodGroup = "Pod"
+	// BuildGroup is the section name for build specifications in quadlet files.
+	BuildGroup = "Build"
+	// ArtifactGroup is the section name for artifact specifications in quadlet files.
+	ArtifactGroup = "Artifact"
+	// KubeGroup is the section name for kube specifications in quadlet files.
+	KubeGroup = "Kube"
+
+	// ImageKey is the key name for image references in quadlet unit sections.
+	ImageKey = "Image"
+	// MountKey is the key name for mount specifications in quadlet unit sections.
+	MountKey = "Mount"
+)
+
+// see https://github.com/containers/podman/blob/main/pkg/systemd/parser/unitfile.go#L942
+func templateParts(filename string) (string, string, bool) {
+	ext := filepath.Ext(filename)
+	basename := strings.TrimSuffix(filename, ext)
+	parts := strings.SplitN(basename, "@", 2)
+	if len(parts) < 2 {
+		return parts[0], "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// DropinDirectories returns the paths in which to search for drop-in conf files for the specified file
+// in order of most specific path to least.
+// see https://github.com/containers/podman/blob/main/pkg/systemd/parser/unitfile.go#L952
+func DropinDirectories(quadlet string) []string {
+	unitName, instanceName, isTemplate := templateParts(quadlet)
+
+	ext := filepath.Ext(quadlet)
+	dropinExt := ext + ".d"
+
+	var dropinPaths []string
+
+	topLevelDropIn := strings.TrimPrefix(dropinExt, ".")
+	dropinPaths = append(dropinPaths, topLevelDropIn)
+
+	truncatedParts := strings.Split(unitName, "-")
+	if len(truncatedParts) > 1 {
+		truncatedParts = truncatedParts[:len(truncatedParts)-1]
+		for i := range truncatedParts {
+			truncatedUnitPath := strings.Join(truncatedParts[:i+1], "-") + "-"
+			dropinPaths = append(dropinPaths, truncatedUnitPath+dropinExt)
+			if isTemplate {
+				truncatedTemplatePath := truncatedUnitPath + "@"
+				dropinPaths = append(dropinPaths, truncatedTemplatePath+dropinExt)
+			}
+		}
+	}
+	if instanceName != "" {
+		dropinPaths = append(dropinPaths, unitName+"@"+dropinExt)
+	}
+	dropinPaths = append(dropinPaths, quadlet+".d")
+	// reverse the list so that drop-ins are parsed in order of most specific to least
+	slices.Reverse(dropinPaths)
+	return dropinPaths
+}
+
+func MountParts(mount string) ([]string, error) {
+	records, err := csv.NewReader(strings.NewReader(mount)).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) != 1 {
+		return nil, fmt.Errorf("invalid mount format")
+	}
+	return records[0], nil
+}
+
+// MountType returns the type (volume, image, .etc) associated with the mount
+// see https://github.com/containers/podman/blob/main/pkg/specgenutilexternal/mount.go
+func MountType(mount string) (string, error) {
+	parts, err := MountParts(mount)
+	if err != nil {
+		return "", err
+	}
+	for _, s := range parts {
+		kv := strings.Split(s, "=")
+		if len(kv) == 2 && strings.TrimSpace(kv[0]) == "type" {
+			return strings.TrimSpace(kv[1]), nil
+		}
+	}
+	return "volume", nil
+}
+
+// MountImage parses the Image from a mount if it exists
+func MountImage(mount string) (string, error) {
+	mountType, err := MountType(mount)
+	if err != nil {
+		return "", err
+	}
+	if mountType != "image" {
+		return "", nil
+	}
+
+	parts, err := MountParts(mount)
+	if err != nil {
+		return "", err
+	}
+
+	for _, part := range parts {
+		key, image, hasVal := strings.Cut(part, "=")
+		key = strings.TrimSpace(key)
+		image = strings.TrimSpace(image)
+		if key == "source" || key == "src" {
+			if !hasVal {
+				return "", fmt.Errorf("mount source invalid")
+			}
+			return image, nil
+		}
+	}
+	return "", nil
+}
+
+// IsImageReference returns true if the given string ends with the image quadlet extension.
+func IsImageReference(image string) bool {
+	return strings.HasSuffix(image, ImageExtension)
+}
+
+// IsBuildReference returns true if the given string ends with the build quadlet extension.
+func IsBuildReference(ref string) bool {
+	return strings.HasSuffix(ref, BuildExtension)
+}
+
+var quadlets = map[string]struct{}{
+	ContainerExtension: {},
+	VolumeExtension:    {},
+	NetworkExtension:   {},
+	PodExtension:       {},
+	ImageExtension:     {},
+	KubeExtension:      {},
+	ArtifactExtension:  {},
+	BuildExtension:     {},
+}
+
+// IsQuadletFile returns true if the given file path has a recognized quadlet extension.
+func IsQuadletFile(quadlet string) bool {
+	_, ok := quadlets[filepath.Ext(quadlet)]
+	return ok
+}

--- a/internal/quadlet/unit.go
+++ b/internal/quadlet/unit.go
@@ -1,0 +1,105 @@
+package quadlet
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/coreos/go-systemd/v22/unit"
+)
+
+// ErrKeyNotFound is returned when a requested key is not found in a unit section.
+var ErrKeyNotFound = errors.New("key not found")
+
+// ErrSectionNotFound is returned when a requested section is not found in a unit file.
+var ErrSectionNotFound = errors.New("section not found")
+
+// Unit represents a systemd unit file with sections and key-value entries.
+type Unit struct {
+	sections []*unit.UnitSection
+}
+
+// NewUnitFromReader creates a new Unit by deserializing systemd unit file data from a reader.
+func NewUnitFromReader(reader io.Reader) (*Unit, error) {
+	u := &Unit{}
+	sec, err := unit.DeserializeSections(reader)
+	if err != nil {
+		return nil, fmt.Errorf("deserializing sections :%w", err)
+	}
+	u.sections = sec
+	return u, nil
+}
+
+// NewUnit creates a new Unit by deserializing systemd unit file data from a byte slice.
+func NewUnit(b []byte) (*Unit, error) {
+	return NewUnitFromReader(bytes.NewReader(b))
+}
+
+// Merge merges another Unit into this Unit, combining sections and entries.
+func (u *Unit) Merge(o *Unit) {
+	for _, section := range o.sections {
+		sec := u.findSection(section.Section)
+		if sec == nil {
+			u.sections = append(u.sections, section)
+		} else {
+			sec.Entries = append(sec.Entries, section.Entries...)
+		}
+	}
+}
+
+// Lookup finds the last value for a given key in the specified section.
+// Returns ErrSectionNotFound if the section doesn't exist, or ErrKeyNotFound if the key doesn't exist.
+func (u *Unit) Lookup(section string, key string) (string, error) {
+	sec := u.findSection(section)
+	if sec == nil {
+		return "", ErrSectionNotFound
+	}
+	for i := len(sec.Entries) - 1; i >= 0; i-- {
+		entry := sec.Entries[i]
+		if entry.Name == key {
+			return entry.Value, nil
+		}
+	}
+	return "", ErrKeyNotFound
+}
+
+// LookupAll finds all values for a given key in the specified section.
+// Returns ErrSectionNotFound if the section doesn't exist.
+func (u *Unit) LookupAll(section string, key string) ([]string, error) {
+	sec := u.findSection(section)
+	if sec == nil {
+		return nil, ErrSectionNotFound
+	}
+
+	var values []string
+	for _, entry := range sec.Entries {
+		if entry.Name == key {
+			values = append(values, entry.Value)
+		}
+	}
+	return values, nil
+}
+
+// Write serializes the Unit back to systemd unit file format and returns the byte representation.
+func (u *Unit) Write() ([]byte, error) {
+	contents, err := io.ReadAll(unit.SerializeSections(u.sections))
+	if err != nil {
+		return nil, fmt.Errorf("serialzing sections: %w", err)
+	}
+	return contents, nil
+}
+
+// HasSection returns true if the Unit contains the specified section.
+func (u *Unit) HasSection(section string) bool {
+	return u.findSection(section) != nil
+}
+
+func (u *Unit) findSection(name string) *unit.UnitSection {
+	for _, section := range u.sections {
+		if section.Section == name {
+			return section
+		}
+	}
+	return nil
+}

--- a/internal/util/validation/quadlet.go
+++ b/internal/util/validation/quadlet.go
@@ -1,0 +1,124 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/internal/api/common"
+	"github.com/flightctl/flightctl/internal/quadlet"
+)
+
+func validateContainerImage(image string, path string) error {
+	if quadlet.IsBuildReference(image) {
+		return fmt.Errorf(".build quadlet types are unsupported: %s", image)
+	}
+	if !quadlet.IsImageReference(image) {
+		return errors.Join(ValidateOciImageReferenceStrict(&image, path)...)
+	}
+	return nil
+}
+
+// ValidateQuadletSpec verifies the QuadletSpec for common issues
+func ValidateQuadletSpec(spec *common.QuadletReferences, path string) []error {
+	var errs []error
+
+	typeToExtension := map[common.QuadletType]string{
+		common.QuadletTypeContainer: quadlet.ContainerExtension,
+		common.QuadletTypeVolume:    quadlet.VolumeExtension,
+		common.QuadletTypeNetwork:   quadlet.NetworkExtension,
+		common.QuadletTypeImage:     quadlet.ImageExtension,
+		common.QuadletTypePod:       quadlet.PodExtension,
+	}
+
+	if expectedExt, ok := typeToExtension[spec.Type]; !ok {
+		errs = append(errs, fmt.Errorf("invalid quadlet type: %s", spec.Type))
+	} else {
+		actualExt := filepath.Ext(path)
+		if expectedExt != actualExt {
+			errs = append(errs, fmt.Errorf("quadlet type %q does not match file extension %q (expected %q)", spec.Type, actualExt, expectedExt))
+		}
+	}
+
+	switch spec.Type {
+	case common.QuadletTypeContainer:
+		if spec.Image == nil {
+			errs = append(errs, fmt.Errorf(".container quadlet must have an Image key"))
+		} else {
+			if err := validateContainerImage(*spec.Image, "container.image"); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		for _, mountImage := range spec.MountImages {
+			if err := validateContainerImage(mountImage, "container.mount.image"); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+	case common.QuadletTypeVolume:
+		if spec.Image != nil {
+			image := *spec.Image
+			if !quadlet.IsImageReference(image) {
+				if err := ValidateOciImageReferenceStrict(spec.Image, "volume.image"); err != nil {
+					errs = append(errs, err...)
+				}
+			}
+		}
+
+	case common.QuadletTypeImage:
+		if spec.Image == nil {
+			errs = append(errs, fmt.Errorf(".image quadlet must have an Image key"))
+		} else {
+			if err := ValidateOciImageReferenceStrict(spec.Image, "image.image"); err != nil {
+				errs = append(errs, err...)
+			}
+		}
+
+	case common.QuadletTypeNetwork, common.QuadletTypePod:
+		// no validation required
+
+	default:
+		errs = append(errs, fmt.Errorf("%w: %q", common.ErrUnsupportedQuadletType, spec.Type))
+	}
+
+	return errs
+}
+
+// ValidateQuadletPaths validates a list of paths for inline quadlet applications
+func ValidateQuadletPaths(paths []string) error {
+	var errs []error
+
+	if len(paths) == 0 {
+		return fmt.Errorf("no paths provided")
+	}
+
+	foundSupported := false
+
+	for _, path := range paths {
+		ext := filepath.Ext(path)
+
+		if _, ok := common.SupportedQuadletExtensions[ext]; ok {
+			if !isAtRoot(path) {
+				errs = append(errs, fmt.Errorf("quadlet file must be at root level: %q", path))
+			}
+			foundSupported = true
+			continue
+		}
+
+		if _, ok := common.UnsupportedQuadletExtensions[ext]; ok {
+			errs = append(errs, fmt.Errorf("unsupported quadlet type %q in path: %s", ext, path))
+			continue
+		}
+	}
+
+	if !foundSupported {
+		errs = append(errs, fmt.Errorf("no supported quadlet types supplied"))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}

--- a/internal/util/validation/quadlet_test.go
+++ b/internal/util/validation/quadlet_test.go
@@ -1,0 +1,427 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/api/common"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateQuadletReferences(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name          string
+		path          string
+		spec          *common.QuadletReferences
+		wantErrCount  int
+		wantErrSubstr string
+	}{
+		{
+			name: "container with no image",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: nil,
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "must have an Image key",
+		},
+		{
+			name: "container with valid OCI reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: lo.ToPtr("quay.io/podman/hello:latest"),
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with .image reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: lo.ToPtr("my-app.image"),
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with .build reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: lo.ToPtr("my-app.build"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: ".build quadlet types are unsupported",
+		},
+		{
+			name: "container with invalid OCI reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: lo.ToPtr("nginx:latest"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "container.image",
+		},
+		{
+			name: "volume with no image",
+			path: "data.volume",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeVolume,
+				Image: nil,
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "volume with valid OCI reference",
+			path: "data.volume",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeVolume,
+				Image: lo.ToPtr("quay.io/containers/volume:latest"),
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "volume with .image reference",
+			path: "data.volume",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeVolume,
+				Image: lo.ToPtr("my-volume.image"),
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "volume with invalid OCI reference",
+			path: "data.volume",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeVolume,
+				Image: lo.ToPtr("alpine:3.18"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "volume.image",
+		},
+		{
+			name: "image with valid OCI reference",
+			path: "myimage.image",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeImage,
+				Image: lo.ToPtr("quay.io/fedora/fedora:latest"),
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "image with no image",
+			path: "myimage.image",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeImage,
+				Image: nil,
+			},
+			wantErrCount:  1,
+			wantErrSubstr: ".image quadlet must have an Image key",
+		},
+		{
+			name: "image with invalid OCI reference",
+			path: "myimage.image",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeImage,
+				Image: lo.ToPtr("busybox"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "image.image",
+		},
+		{
+			name: "image with .image reference",
+			path: "myimage.image",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeImage,
+				Image: lo.ToPtr("another.image"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "image.image",
+		},
+		{
+			name: "network with no image",
+			path: "net.network",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeNetwork,
+				Image: nil,
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "pod with no image",
+			path: "mypod.pod",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypePod,
+				Image: nil,
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with valid OCI mount image",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"quay.io/containers/data:v1"},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with valid .image mount reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"my-data.image"},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with .build mount reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"my-app.build"},
+			},
+			wantErrCount:  1,
+			wantErrSubstr: ".build quadlet types are unsupported",
+		},
+		{
+			name: "container with invalid OCI mount reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"alpine:latest"},
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "container.mount.image",
+		},
+		{
+			name: "container with multiple valid mount images",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"quay.io/containers/data:v1", "data.image", "quay.io/example/cache:latest"},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "container with multiple mount images (some invalid)",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"quay.io/containers/data:v1", "alpine:latest"},
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "container.mount.image",
+		},
+		{
+			name: "container with no Image but valid mount images",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       nil,
+				MountImages: []string{"quay.io/containers/data:v1"},
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "must have an Image key",
+		},
+		{
+			name: "container with valid Image but .build mount reference",
+			path: "app.container",
+			spec: &common.QuadletReferences{
+				Type:        common.QuadletTypeContainer,
+				Image:       lo.ToPtr("quay.io/podman/hello:latest"),
+				MountImages: []string{"build.build"},
+			},
+			wantErrCount:  1,
+			wantErrSubstr: ".build quadlet types are unsupported",
+		},
+		{
+			name: "container type with volume extension",
+			path: "app.volume",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeContainer,
+				Image: lo.ToPtr("quay.io/podman/hello:latest"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "does not match file extension",
+		},
+		{
+			name: "volume type with container extension",
+			path: "data.container",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeVolume,
+				Image: lo.ToPtr("quay.io/containers/volume:latest"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "does not match file extension",
+		},
+		{
+			name: "image type with network extension",
+			path: "myimage.network",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeImage,
+				Image: lo.ToPtr("quay.io/fedora/fedora:latest"),
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "does not match file extension",
+		},
+		{
+			name: "network type with pod extension",
+			path: "net.pod",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypeNetwork,
+				Image: nil,
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "does not match file extension",
+		},
+		{
+			name: "pod type with image extension",
+			path: "mypod.image",
+			spec: &common.QuadletReferences{
+				Type:  common.QuadletTypePod,
+				Image: nil,
+			},
+			wantErrCount:  1,
+			wantErrSubstr: "does not match file extension",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateQuadletSpec(tt.spec, tt.path)
+			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
+			if tt.wantErrSubstr != "" && len(errs) > 0 {
+				require.Contains(errs[0].Error(), tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateQuadletPaths(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name          string
+		paths         []string
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		// Valid cases
+		{
+			name:    "single container file",
+			paths:   []string{"app.container"},
+			wantErr: false,
+		},
+		{
+			name:    "single volume file",
+			paths:   []string{"data.volume"},
+			wantErr: false,
+		},
+		{
+			name:    "multiple valid types",
+			paths:   []string{"app.container", "data.volume"},
+			wantErr: false,
+		},
+		{
+			name:    "all supported types",
+			paths:   []string{"app.container", "data.volume", "net.network", "img.image", "mypod.pod"},
+			wantErr: false,
+		},
+		{
+			name:    "mix of supported quadlet and non-quadlet files",
+			paths:   []string{"app.container", "config.yaml", "README.txt"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown extensions mixed with valid quadlet",
+			paths:   []string{"app.container", "script.sh", "data.conf"},
+			wantErr: false,
+		},
+		{
+			name:    "nested non-quadlet files with root quadlet",
+			paths:   []string{"app.container", "config/settings.yaml", "scripts/deploy.sh"},
+			wantErr: false,
+		},
+
+		// Invalid cases
+		{
+			name:          "empty paths slice",
+			paths:         []string{},
+			wantErr:       true,
+			wantErrSubstr: "no paths provided",
+		},
+		{
+			name:          "contains build file - unsupported",
+			paths:         []string{"app.build"},
+			wantErr:       true,
+			wantErrSubstr: "unsupported quadlet type \".build\"",
+		},
+		{
+			name:          "contains artifact file - unsupported",
+			paths:         []string{"app.artifact"},
+			wantErr:       true,
+			wantErrSubstr: "unsupported quadlet type \".artifact\"",
+		},
+		{
+			name:          "contains kube file - unsupported",
+			paths:         []string{"app.kube"},
+			wantErr:       true,
+			wantErrSubstr: "unsupported quadlet type \".kube\"",
+		},
+		{
+			name:          "mix of valid and unsupported",
+			paths:         []string{"app.container", "build.build"},
+			wantErr:       true,
+			wantErrSubstr: "unsupported quadlet type \".build\"",
+		},
+		{
+			name:          "only non-quadlet files - no supported types",
+			paths:         []string{"config.txt", "data.yaml"},
+			wantErr:       true,
+			wantErrSubstr: "no supported quadlet",
+		},
+		{
+			name:          "only build file - both unsupported and no valid types",
+			paths:         []string{"app.build"},
+			wantErr:       true,
+			wantErrSubstr: "unsupported quadlet type \".build\"",
+		},
+		{
+			name:          "nested quadlet file - must be at root",
+			paths:         []string{"config/app.container"},
+			wantErr:       true,
+			wantErrSubstr: "quadlet file must be at root level",
+		},
+		{
+			name:          "mix of root and nested quadlet files",
+			paths:         []string{"app.container", "subdir/data.volume"},
+			wantErr:       true,
+			wantErrSubstr: "quadlet file must be at root level",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateQuadletPaths(tt.paths)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrSubstr != "" {
+					require.Contains(err.Error(), tt.wantErrSubstr)
+				}
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}


### PR DESCRIPTION
Adds Validation for Inline Quadlet Application's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-user support for Quadlet applications: detection, parsing, and validation of quadlet files and references.

* **Improvements**
  * Application validation now supports both Compose and Quadlet types with improved path-aware checks and clearer errors.
  * Stronger mount and image reference handling and explicit constraints for Quadlet volume definitions.

* **Tests**
  * Expanded validation test coverage for Quadlet parsing, paths, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->