### PR TITLE
EDM-2230: Persist CSR Until enrollment

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -53,6 +53,8 @@ const (
 	GeneratedCertFile = "agent.crt"
 	// name of the agent's key file
 	KeyFile = "agent.key"
+	// CSRFile is the name of the persisted CSR file (temporary, deleted after enrollment)
+	CSRFile = "agent.csr"
 	// name of the enrollment certificate file
 	EnrollmentCertFile = "client-enrollment.crt"
 	// name of the enrollment key file

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -307,6 +307,15 @@ func (m *LifecycleManager) verifyEnrollment(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to store certificate: %w", err)
 	}
 
+	// Clear the persisted CSR once certificate is obtained
+	clientCSRPath := identity.GetCSRPath(m.dataDir)
+	if _, found, err := identity.LoadCSR(m.deviceReadWriter, clientCSRPath); err == nil && found {
+		m.log.Infof("Clearing persisted CSR after successful enrollment")
+		if err := identity.StoreCSR(m.deviceReadWriter, clientCSRPath, nil); err != nil {
+			m.log.Warnf("Failed to clear persisted CSR: %v", err)
+		}
+	}
+
 	return true, nil
 }
 

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -54,13 +54,13 @@ func generateTestCertificate(t *testing.T) string {
 func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 	tests := []struct {
 		name           string
-		setupMocks     func(*client.MockEnrollment, *identity.MockProvider)
+		setupMocks     func(*client.MockEnrollment, *identity.MockProvider, *fileio.MockReadWriter)
 		expectedResult bool
 		expectedError  string
 	}{
 		{
 			name: "identity proof required and succeeds",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -76,7 +76,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		},
 		{
 			name: "identity proof fails with ErrIdentityProofFailed",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -92,7 +92,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		},
 		{
 			name: "identity proof fails with other error",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -108,7 +108,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		},
 		{
 			name: "enrollment denied",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -127,7 +127,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		},
 		{
 			name: "enrollment failed",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -146,7 +146,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		},
 		{
 			name: "enrollment approved with certificate",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				certificate := generateTestCertificate(t)
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
@@ -160,13 +160,18 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 				}
 				mockEnrollment.EXPECT().GetEnrollmentRequest(gomock.Any(), "test-device").Return(enrollmentRequest, nil)
 				mockIdentity.EXPECT().StoreCertificate([]byte(certificate)).Return(nil)
+				// CSR cleanup now uses standalone functions (identity.LoadCSR/StoreCSR) with mockReadWriter
+				mockReadWriter.EXPECT().PathExists("certs/agent.csr").Return(true, nil)
+				mockReadWriter.EXPECT().ReadFile("certs/agent.csr").Return([]byte("test-csr"), nil)
+				mockReadWriter.EXPECT().PathExists("certs/agent.csr").Return(true, nil)
+				mockReadWriter.EXPECT().OverwriteAndWipe("certs/agent.csr").Return(nil)
 			},
 			expectedResult: true,
 			expectedError:  "",
 		},
 		{
 			name: "enrollment approved but no certificate yet",
-			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider) {
+			setupMocks: func(mockEnrollment *client.MockEnrollment, mockIdentity *identity.MockProvider, mockReadWriter *fileio.MockReadWriter) {
 				enrollmentRequest := &v1alpha1.EnrollmentRequest{
 					Status: &v1alpha1.EnrollmentRequestStatus{
 						Conditions: []v1alpha1.Condition{
@@ -204,7 +209,7 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 				log:              log.NewPrefixLogger("test"),
 			}
 
-			tt.setupMocks(mockEnrollment, mockIdentity)
+			tt.setupMocks(mockEnrollment, mockIdentity, mockReadWriter)
 
 			ctx := context.Background()
 			result, err := manager.verifyEnrollment(ctx)

--- a/internal/agent/identity/identity.go
+++ b/internal/agent/identity/identity.go
@@ -106,14 +106,15 @@ func NewProvider(
 
 	clientCertPath := config.ManagementService.GetClientCertificatePath()
 	clientKeyPath := config.ManagementService.GetClientKeyPath()
+	clientCSRPath := GetCSRPath(config.DataDir)
 
 	if tpmClient != nil {
 		log.Info("Using TPM-based identity provider")
-		return newTPMProvider(tpmClient, config, clientCertPath, rw, log)
+		return newTPMProvider(tpmClient, config, clientCertPath, clientCSRPath, rw, log)
 	}
 
 	log.Info("Using file-based identity provider")
-	return newFileProvider(clientKeyPath, clientCertPath, rw, log)
+	return newFileProvider(clientKeyPath, clientCertPath, clientCSRPath, rw, log)
 }
 
 // generateDeviceName creates a device name from a public key hash
@@ -123,4 +124,50 @@ func generateDeviceName(publicKey crypto.PublicKey) (string, error) {
 		return "", fmt.Errorf("failed to hash public key: %w", err)
 	}
 	return strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(publicKeyHash)), nil
+}
+
+// GetCSRPath returns the standard path where CSRs are stored
+func GetCSRPath(dataDir string) string {
+	return filepath.Join(dataDir, agent_config.DefaultCertsDirName, agent_config.CSRFile)
+}
+
+func StoreCSR(rw fileio.ReadWriter, csrPath string, csr []byte) error {
+	if csr == nil {
+		// Delete the CSR file if it exists
+		exists, err := rw.PathExists(csrPath)
+		if err != nil {
+			return fmt.Errorf("checking CSR existence: %w", err)
+		}
+		if exists {
+			if err := rw.OverwriteAndWipe(csrPath); err != nil {
+				return fmt.Errorf("deleting CSR file: %w", err)
+			}
+		}
+		return nil
+	}
+	return rw.WriteFile(csrPath, csr, 0600)
+}
+
+func LoadCSR(rw fileio.ReadWriter, csrPath string) ([]byte, bool, error) {
+	exists, err := rw.PathExists(csrPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("checking CSR existence: %w", err)
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	csr, err := rw.ReadFile(csrPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("reading CSR: %w", err)
+	}
+	return csr, true, nil
+}
+
+func hasCertificate(rw fileio.ReadWriter, certPath string, log *log.PrefixLogger) bool {
+	exists, err := rw.PathExists(certPath)
+	if err != nil {
+		log.Warnf("Failed to check certificate existence: %v", err)
+		return false
+	}
+	return exists
 }

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -1417,6 +1417,11 @@ func (h *Harness) SetupVMFromPoolAndStartAgent(workerID int) error {
 		return fmt.Errorf("failed to wait for SSH: %w", err)
 	}
 
+	// Clean any stale CSR from previous tests
+	_, err = testVM.RunSSH([]string{"sudo", "rm", "-f", "/var/lib/flightctl/certs/agent.csr"}, nil)
+	if err != nil {
+		logrus.Warnf("Failed to clean stale CSR: %v", err)
+	}
 	// Print agent files right after snapshot revert - should be empty/version 0
 	printAgentFilesForVM(testVM, "After Snapshot Revert")
 

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -780,6 +780,12 @@ func (h *Harness) SetupDeviceWithTPM(workerID int) error {
 		return fmt.Errorf("failed to stop agent: %w", err)
 	}
 
+	// Clean CSR from non-TPM agent start to avoid device ID mismatch
+	_, err = h.VM.RunSSH([]string{"sudo", "rm", "-f", "/var/lib/flightctl/certs/agent.csr"}, nil)
+	if err != nil {
+		logrus.Warnf("Failed to clean stale CSR: %v", err)
+	}
+
 	// 3. Wait for TPM hardware initialization
 	err = h.WaitForTPMInitialization()
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist and reuse the agent CSR across runs to avoid unnecessary regeneration; automatically clear stored CSR after successful enrollment.

* **Tests**
  * Expanded tests to cover CSR persistence, reuse, and post-enrollment cleanup flows.

* **Chores**
  * Added best-effort CSR cleanup during end-to-end and device setup steps (non-fatal if removal fails).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->