### PR TITLE
EDM-2250: Treat graceful HTTP shutdown correctly in metrics server (#…

### DIFF
--- a/internal/instrumentation/instrumentation.go
+++ b/internal/instrumentation/instrumentation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
@@ -81,7 +80,7 @@ func (m *MetricsServer) Run(ctx context.Context) error {
 		_ = srv.Shutdown(ctxTimeout)
 	}()
 
-	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, net.ErrClosed) {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 


### PR DESCRIPTION
…1888)

Replace net.ErrClosed with http.ErrServerClosed when handling ListenAndServe()