### PR TITLE
EDM-2465: Add upstream RHEL/CS-10 targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,28 +10,27 @@ packages:
     upstream_package_name: flightctl
     downstream_package_name: flightctl
     upstream_tag_template: v{version} # remove v from the start of the version tags (vx.y.z)->x.y.z
+    enable_net: True # this is necessary for go modules to download the sources
+    notifications:
+      failure_comment:
+        message: "/packit build"
 actions:
   get-current-version:
     - bash -c './hack/current-version --rpm | sed "s/^v//; s/-/~/g"'
 jobs:
   - job: copr_build
     trigger: pull_request
-    enable_net: True # this is necessary for go modules to download the sources
     targets:
       - fedora-43-x86_64
       - epel-9-aarch64
       - epel-10-aarch64
     module_hotfixes: true
-    notifications:
-      failure_comment:
-        message: "/packit build"
 
   - job: copr_build
     trigger: commit
     owner: "@redhat-et"
     project: flightctl-dev
     preserve_project: True
-    enable_net: True # this is necessary for go modules to download the sources
     targets:
       - fedora-42-aarch64
       - fedora-42-x86_64
@@ -41,9 +40,6 @@ jobs:
       - epel-9-x86_64
       - epel-10-aarch64
       - epel-10-x86_64
-    notifications:
-      failure_comment:
-        message: "/packit build"
 
 
   - job: copr_build
@@ -51,7 +47,6 @@ jobs:
     owner: "@redhat-et"
     project: flightctl
     preserve_project: True
-    enable_net: True # this is necessary for go modules to download the sources
     targets:
       - fedora-42-aarch64
       - fedora-42-x86_64
@@ -61,6 +56,3 @@ jobs:
       - epel-9-x86_64
       - epel-10-aarch64
       - epel-10-x86_64
-    notifications:
-      failure_comment:
-        message: "/packit build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI build targets to Fedora 43 and added EPEL 10 variants (x86_64, aarch64); removed legacy Fedora 41/Rawhide targets.
  * Switched the current-version action to use an RPM-oriented generator.
  * Added a package-level network enable flag for module fetching and enabled a failure-comment notification to trigger a rebuild command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->