### PR TITLE
EDM-2358: fix lint cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,6 +48,18 @@ jobs:
           make tidy
           git diff --exit-code
 
+      - name: Cache golangci-lint volumes
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/containers/storage/volumes/golangci-lint-cache
+            ~/.local/share/containers/storage/volumes/go-build-cache
+            ~/.local/share/containers/storage/volumes/go-mod-cache
+          key: lint-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lint-cache-${{ runner.os }}-
+
       - name: Running Linter
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,12 @@ clean-quadlets:
 
 # Use custom golangci-lint container with libvirt support
 LINT_IMAGE := flightctl-lint:latest
-LINT_CONTAINER := podman run --rm -v $(GOBASE):/app:Z -w /app --user 0 $(LINT_IMAGE)
+LINT_CONTAINER := podman run --rm \
+	-v $(GOBASE):/app:Z \
+	-v golangci-lint-cache:/root/.cache/golangci-lint \
+	-v go-build-cache:/root/.cache/go-build \
+	-v go-mod-cache:/go/pkg/mod \
+	-w /app --user 0 $(LINT_IMAGE)
 
 .PHONY: tools lint-image
 tools:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved caching for lint and Go build artifacts in CI, reducing redundant work and speeding up lint and build-related steps.
  * Added persistent caches for local lint container runs to shorten iterative development feedback.
  * Faster feedback loop for developers through reduced repeated dependency and tool reprocessing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->