### PR TITLE
EDM-2265: fix E2E rollout tests beforeEach in OCP

### DIFF
--- a/test/e2e/rollout/rollout_suite_test.go
+++ b/test/e2e/rollout/rollout_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 const TIMEOUT = "5m"
 const POLLING = "125ms"
+const MEDIUMTIMEOUT = "10m"
 const LONGTIMEOUT = "15m"
 
 func TestRollout(t *testing.T) {

--- a/test/e2e/rollout/rollout_test.go
+++ b/test/e2e/rollout/rollout_test.go
@@ -657,6 +657,6 @@ func (tc *TestContext) verifyAllDevicesUpdated(expectedCount int) error {
 			}
 		}
 		return nil
-	}, "5m", "10s").Should(Succeed())
+	}, MEDIUMTIMEOUT, "10s").Should(Succeed())
 	return nil
 }

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -1420,10 +1420,12 @@ func (h *Harness) SetupVMFromPoolAndStartAgent(workerID int) error {
 	// Print agent files right after snapshot revert - should be empty/version 0
 	printAgentFilesForVM(testVM, "After Snapshot Revert")
 
-	// Stop the agent to ensure clean state
-	if _, err := testVM.RunSSH([]string{"sudo", "systemctl", "restart", "flightctl-agent"}, nil); err != nil {
-		return fmt.Errorf("failed to stop flightctl-agent: %w", err)
+	// Start the agent after snapshot revert
+	GinkgoWriter.Printf("🔄 Starting flightctl-agent after snapshot revert\n")
+	if _, err := testVM.RunSSH([]string{"sudo", "systemctl", "start", "flightctl-agent"}, nil); err != nil {
+		return fmt.Errorf("failed to start flightctl-agent: %w", err)
 	}
+	GinkgoWriter.Printf("✅ flightctl-agent started successfully after snapshot revert\n")
 
 	return nil
 }

--- a/test/harness/e2e/vm_pool.go
+++ b/test/harness/e2e/vm_pool.go
@@ -171,6 +171,15 @@ func (p *VMPool) createVMForWorker(workerID int) (vm.TestVMInterface, error) {
 	}
 
 	fmt.Printf("🔄 [VMPool] Worker %d: Creating pristine snapshot\n", workerID)
+
+	// Stop the agent before cleaning files to ensure it's not writing to /var/lib/flightctl
+	fmt.Printf("🔄 [VMPool] Worker %d: Stopping flightctl-agent before cleanup\n", workerID)
+	if _, err := newVM.RunSSH([]string{"sudo", "systemctl", "stop", "flightctl-agent"}, nil); err != nil {
+		// Log warning but don't fail - agent might not be running
+		fmt.Printf("⚠️  [VMPool] Worker %d: Warning - failed to stop flightctl-agent: %v (may not be running)\n", workerID, err)
+	}
+
+	// Clean up agent identity files in /var/lib/flightctl
 	_, err = newVM.RunSSH([]string{"sudo", "rm", "-rf", "/var/lib/flightctl/*"}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to clean state before taking pristine snapshot: %w", err)
@@ -190,6 +199,15 @@ func (p *VMPool) createVMForWorker(workerID int) (vm.TestVMInterface, error) {
 	// Print agent files right after snapshot is taken - current and desired should not exist
 	fmt.Printf("🔍 [VMPool] Worker %d: Printing agent files after snapshot creation:\n", workerID)
 	printAgentFilesForVM(newVM, "After Snapshot Creation")
+
+	// Restart the agent after snapshot creation
+	fmt.Printf("🔄 [VMPool] Worker %d: Restarting flightctl-agent after snapshot creation\n", workerID)
+	if _, err := newVM.RunSSH([]string{"sudo", "systemctl", "restart", "flightctl-agent"}, nil); err != nil {
+		// Log warning but don't fail - agent service might have issues but VM is still usable
+		fmt.Printf("⚠️  [VMPool] Worker %d: Warning - failed to restart flightctl-agent: %v\n", workerID, err)
+	} else {
+		fmt.Printf("✅ [VMPool] Worker %d: flightctl-agent restarted successfully after snapshot creation\n", workerID)
+	}
 
 	// VM stays running - no shutdown
 	fmt.Printf("✅ [VMPool] Worker %d: VM setup completed, VM is running\n", workerID)


### PR DESCRIPTION
Rollout tests in OCP are failing at BeforeEach step, when the snapshot is restored since the agent fails to send a new ER with error: "private key does not match public key".
In this PR I make sure: 

- the agent is shut down before removing the agent's files in /var/lib/flightctl and the snapshot is created
- the agent is restarted after the snapshot is restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved VM snapshot creation and management of the agent service during test harness setup for more reliable test runs and clearer logs.
  * Added a medium-length timeout and updated rollout tests to use it, adjusting wait time for device-update verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->