### PR TITLE
EDM-2269: Upstream flightctl services rpm version is incorrect (remove branch info)

### DIFF
--- a/hack/current-version
+++ b/hack/current-version
@@ -13,11 +13,12 @@ if [[ -z "$tag" ]]; then
   tag=$(git describe --tags --exclude latest 2>/dev/null || echo -n "v0.0.0-unknown")
 fi
 
-# For RPM packaging (when called from packit), remove the git commit hash suffix
-# since COPR will add its own commit hash, preventing duplication
+# For RPM packaging (when called from packit), remove branch info and git commit hash
+# since COPR will add its own branch and commit information, preventing duplication
 if [[ "${PACKIT_BUILD:-}" == "1" ]] || [[ "$1" == "--rpm" ]]; then
-  # Remove the git commit hash part (e.g., "-g1234567") from the tag
-  tag=$(echo "$tag" | sed 's/-g[0-9a-f]*$//')
+  # Remove everything after the base version (e.g., "-main-211-g1234567") from the tag
+  # This leaves only the base version like "v1.0.0" and lets COPR handle the rest
+  tag=$(echo "$tag" | sed 's/-.*$//')
 fi
 
 echo -n "$tag"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved version tag processing to strip all suffixes after the base version so build outputs display the clean base version (e.g., v1.0.0). Packaging systems will continue to reattach branch/commit metadata, resulting in more consistent version display and artifacts during RPM/build flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->