### PR TITLE
EDM-2508: agent/device/application: prefetch image targets

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -218,6 +218,21 @@ func (p *Podman) ImageExists(ctx context.Context, image string) bool {
 	return exitCode == 0
 }
 
+// ImageDigest returns the digest of the specified image.
+// Returns empty string and error if the image does not exist or cannot be inspected.
+func (p *Podman) ImageDigest(ctx context.Context, image string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	args := []string{"image", "inspect", "--format", "{{.Digest}}", image}
+	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
+	if exitCode != 0 {
+		return "", fmt.Errorf("get image digest: %s: %w", image, errors.FromStderr(stderr, exitCode))
+	}
+	digest := strings.TrimSpace(stdout)
+	return digest, nil
+}
+
 // ArtifactExists returns true if the artifact exists in storage otherwise false.
 func (p *Podman) ArtifactExists(ctx context.Context, artifact string) bool {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)

--- a/internal/agent/device/applications/controller.go
+++ b/internal/agent/device/applications/controller.go
@@ -42,7 +42,6 @@ func (c *Controller) Sync(ctx context.Context, current, desired *v1alpha1.Device
 		c.podman,
 		c.readWriter,
 		current,
-		provider.WithVerify(),
 	)
 	if err != nil {
 		return fmt.Errorf("current app providers: %w", err)
@@ -54,7 +53,6 @@ func (c *Controller) Sync(ctx context.Context, current, desired *v1alpha1.Device
 		c.podman,
 		c.readWriter,
 		desired,
-		provider.WithVerify(),
 		provider.WithEmbedded(),
 	)
 	if err != nil {

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -525,4 +527,193 @@ func (m *mockDirEntry) Type() fs.FileMode {
 
 func (m *mockDirEntry) Info() (fs.FileInfo, error) {
 	return nil, nil
+}
+
+func TestCollectOCITargetsCache(t *testing.T) {
+	require := require.New(t)
+	log := log.NewPrefixLogger("test")
+	log.SetLevel(logrus.DebugLevel)
+
+	cache := provider.NewOCITargetCache()
+
+	// populate cache with nested targets for two applications
+	nestedTargets := []dependency.OCIPullTarget{
+		{Type: dependency.OCITypeImage, Reference: "quay.io/nested/image1:v1"},
+		{Type: dependency.OCITypeImage, Reference: "quay.io/nested/image2:v1"},
+	}
+
+	entry1 := provider.CacheEntry{
+		Name:     "app1",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/parent:v1", Digest: "sha256:digest1"},
+		Children: nestedTargets,
+	}
+	entry2 := provider.CacheEntry{
+		Name:     "app2",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/parent:v2", Digest: "sha256:digest2"},
+		Children: nestedTargets,
+	}
+
+	cache.Set(entry1)
+	cache.Set(entry2)
+
+	// verify cache retrieval
+	require.Equal(2, cache.Len())
+
+	cachedEntry1, found := cache.Get("app1")
+	require.True(found)
+	require.Len(cachedEntry1.Children, 2)
+	require.Equal("sha256:digest1", cachedEntry1.Parent.Digest)
+
+	cachedEntry2, found := cache.Get("app2")
+	require.True(found)
+	require.Len(cachedEntry2.Children, 2)
+	require.Equal("sha256:digest2", cachedEntry2.Parent.Digest)
+
+	// test GC removes unreferenced applications
+	cache.GC([]string{"app1"})
+	require.Equal(1, cache.Len())
+
+	_, found = cache.Get("app1")
+	require.True(found, "app1 should remain")
+
+	_, found = cache.Get("app2")
+	require.False(found, "app2 should be removed by GC")
+
+	// test clear
+	cache.Clear()
+	require.Equal(0, cache.Len())
+}
+
+func TestCollectOCITargetsErrorHandling(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	log := log.NewPrefixLogger("test")
+	log.SetLevel(logrus.DebugLevel)
+
+	testCases := []struct {
+		name          string
+		setupManager  func(*testing.T) *manager
+		expectError   bool
+		errorContains string
+		isRetryable   bool
+		expectRequeue bool
+	}{
+		{
+			name: "base image not available - returns base targets with Requeue=true",
+			setupManager: func(t *testing.T) *manager {
+				ctrl := gomock.NewController(t)
+				mockReadWriter := fileio.NewMockReadWriter(ctrl)
+				mockExec := executer.NewMockExecuter(ctrl)
+
+				mockExec.EXPECT().ExecuteWithContext(
+					gomock.Any(),
+					"podman",
+					[]string{"image", "exists", "quay.io/test/image:v1"},
+				).Return("", "", 1).AnyTimes() // exit code 1 = does not exist
+
+				mockPodmanClient := client.NewPodman(log, mockExec, mockReadWriter, testutil.NewPollConfig())
+				mockSystemdClient := client.NewSystemd(mockExec)
+				readWriter := fileio.NewReadWriter()
+				tmpDir := t.TempDir()
+				readWriter.SetRootdir(tmpDir)
+
+				return &manager{
+					readWriter:     readWriter,
+					podmanMonitor:  NewPodmanMonitor(log, mockPodmanClient, mockSystemdClient, "", mockReadWriter),
+					podmanClient:   mockPodmanClient,
+					systemdClient:  mockSystemdClient,
+					log:            log,
+					ociTargetCache: provider.NewOCITargetCache(),
+					appDataCache:   provider.NewAppDataCache(),
+				}
+			},
+			expectError:   false,
+			expectRequeue: true,
+		},
+		{
+			name: "hard failure during extraction - fails immediately",
+			setupManager: func(t *testing.T) *manager {
+				ctrl := gomock.NewController(t)
+				mockReadWriter := fileio.NewMockReadWriter(ctrl)
+				mockExec := executer.NewMockExecuter(ctrl)
+
+				mockExec.EXPECT().ExecuteWithContext(
+					gomock.Any(),
+					"podman",
+					[]string{"image", "exists", "quay.io/test/image:v1"},
+				).Return("", "", 0).AnyTimes() // exit code 0 = exists
+
+				// expect ImageDigest call (which will fail in this test)
+				mockExec.EXPECT().ExecuteWithContext(
+					gomock.Any(),
+					"podman",
+					[]string{"image", "inspect", "--format", "{{.Digest}}", "quay.io/test/image:v1"},
+				).Return("", "fatal error: disk full", 1).AnyTimes()
+
+				mockExec.EXPECT().ExecuteWithContext(
+					gomock.Any(),
+					"podman",
+					gomock.Any(),
+				).Return("", "fatal error: disk full", 1).AnyTimes()
+
+				mockPodmanClient := client.NewPodman(log, mockExec, mockReadWriter, testutil.NewPollConfig())
+				mockSystemdClient := client.NewSystemd(mockExec)
+				readWriter := fileio.NewReadWriter()
+				tmpDir := t.TempDir()
+				readWriter.SetRootdir(tmpDir)
+
+				return &manager{
+					readWriter:     readWriter,
+					podmanMonitor:  NewPodmanMonitor(log, mockPodmanClient, mockSystemdClient, "", mockReadWriter),
+					podmanClient:   mockPodmanClient,
+					systemdClient:  mockSystemdClient,
+					log:            log,
+					ociTargetCache: provider.NewOCITargetCache(),
+					appDataCache:   provider.NewAppDataCache(),
+				}
+			},
+			expectError:   true,
+			errorContains: "collecting nested OCI targets",
+			isRetryable:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := tc.setupManager(t)
+
+			providerSpec := v1alpha1.ApplicationProviderSpec{
+				Name:    lo.ToPtr("test-app"),
+				AppType: lo.ToPtr(v1alpha1.AppTypeCompose),
+			}
+			_ = providerSpec.FromImageApplicationProviderSpec(v1alpha1.ImageApplicationProviderSpec{
+				Image: "quay.io/test/image:v1",
+			})
+			spec := &v1alpha1.DeviceSpec{
+				Applications: &[]v1alpha1.ApplicationProviderSpec{providerSpec},
+			}
+
+			result, err := manager.CollectOCITargets(ctx, &v1alpha1.DeviceSpec{}, spec)
+
+			if tc.expectError {
+				require.Error(err)
+				require.Nil(result)
+				if tc.errorContains != "" {
+					require.Contains(err.Error(), tc.errorContains)
+				}
+				if tc.isRetryable {
+					require.True(errors.IsRetryable(err), "Error should be retryable, got: %v", err)
+				} else {
+					require.False(errors.IsRetryable(err), "Error should NOT be retryable, got: %v", err)
+				}
+			} else {
+				require.NoError(err)
+				require.NotNil(result)
+				if tc.expectRequeue {
+					require.True(result.Requeue, "Expected Requeue=true, got false")
+					require.NotEmpty(result.Targets, "Expected base targets to be returned")
+				}
+			}
+		})
+	}
 }

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -25,6 +25,7 @@ import (
 type MockMonitor struct {
 	ctrl     *gomock.Controller
 	recorder *MockMonitorMockRecorder
+	isgomock struct{}
 }
 
 // MockMonitorMockRecorder is the mock recorder for MockMonitor.
@@ -74,6 +75,7 @@ func (mr *MockMonitorMockRecorder) Status() *gomock.Call {
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
+	isgomock struct{}
 }
 
 // MockManagerMockRecorder is the mock recorder for MockManager.
@@ -122,10 +124,10 @@ func (mr *MockManagerMockRecorder) BeforeUpdate(ctx, desired any) *gomock.Call {
 }
 
 // CollectOCITargets mocks base method.
-func (m *MockManager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]dependency.OCIPullTarget, error) {
+func (m *MockManager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*dependency.OCICollection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollectOCITargets", ctx, current, desired)
-	ret0, _ := ret[0].([]dependency.OCIPullTarget)
+	ret0, _ := ret[0].(*dependency.OCICollection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -137,31 +139,31 @@ func (mr *MockManagerMockRecorder) CollectOCITargets(ctx, current, desired any) 
 }
 
 // Ensure mocks base method.
-func (m *MockManager) Ensure(ctx context.Context, provider provider.Provider) error {
+func (m *MockManager) Ensure(ctx context.Context, arg1 provider.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ensure", ctx, provider)
+	ret := m.ctrl.Call(m, "Ensure", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Ensure indicates an expected call of Ensure.
-func (mr *MockManagerMockRecorder) Ensure(ctx, provider any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Ensure(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), ctx, provider)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), ctx, arg1)
 }
 
 // Remove mocks base method.
-func (m *MockManager) Remove(ctx context.Context, provider provider.Provider) error {
+func (m *MockManager) Remove(ctx context.Context, arg1 provider.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Remove", ctx, provider)
+	ret := m.ctrl.Call(m, "Remove", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockManagerMockRecorder) Remove(ctx, provider any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Remove(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockManager)(nil).Remove), ctx, provider)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockManager)(nil).Remove), ctx, arg1)
 }
 
 // Shutdown mocks base method.
@@ -198,23 +200,24 @@ func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.C
 }
 
 // Update mocks base method.
-func (m *MockManager) Update(ctx context.Context, provider provider.Provider) error {
+func (m *MockManager) Update(ctx context.Context, arg1 provider.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, provider)
+	ret := m.ctrl.Call(m, "Update", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockManagerMockRecorder) Update(ctx, provider any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Update(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), ctx, provider)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockManager)(nil).Update), ctx, arg1)
 }
 
 // MockApplication is a mock of Application interface.
 type MockApplication struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationMockRecorder
+	isgomock struct{}
 }
 
 // MockApplicationMockRecorder is the mock recorder for MockApplication.

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -476,7 +476,7 @@ func (m *mockProvider) Spec() *provider.ApplicationSpec {
 	}
 }
 
-func (m *mockProvider) OCITargets(pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func (m *mockProvider) OCITargets(ctx context.Context, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
 	return nil, nil
 }
 

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
 	"github.com/flightctl/flightctl/internal/agent/client"
-	"github.com/flightctl/flightctl/internal/agent/device/dependency"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -23,9 +22,12 @@ type imageProvider struct {
 	readWriter fileio.ReadWriter
 	log        *log.PrefixLogger
 	spec       *ApplicationSpec
+
+	// AppData stores the extracted app data from OCITargets to reuse in Verify
+	AppData *AppData
 }
 
-func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.ApplicationProviderSpec, readWriter fileio.ReadWriter) (*imageProvider, error) {
+func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.ApplicationProviderSpec, readWriter fileio.ReadWriter, appType v1alpha1.AppType) (*imageProvider, error) {
 	provider, err := spec.AsImageApplicationProviderSpec()
 	if err != nil {
 		return nil, fmt.Errorf("getting provider spec:%w", err)
@@ -37,7 +39,7 @@ func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.Appli
 		appName = provider.Image
 	}
 	embedded := false
-	path, err := pathFromAppType(v1alpha1.AppTypeCompose, appName, embedded)
+	path, err := pathFromAppType(appType, appName, embedded)
 	if err != nil {
 		return nil, fmt.Errorf("getting app path: %w", err)
 	}
@@ -53,7 +55,7 @@ func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.Appli
 		readWriter: readWriter,
 		spec: &ApplicationSpec{
 			Name:          appName,
-			AppType:       lo.FromPtr(spec.AppType),
+			AppType:       appType,
 			Path:          path,
 			EnvVars:       lo.FromPtr(spec.EnvVars),
 			Embedded:      embedded,
@@ -63,42 +65,12 @@ func newImage(log *log.PrefixLogger, podman *client.Podman, spec *v1alpha1.Appli
 	}, nil
 }
 
-func (p *imageProvider) OCITargets(pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
-	policy := v1alpha1.PullIfNotPresent
-	var targets []dependency.OCIPullTarget
-	targets = append(targets, dependency.OCIPullTarget{
-		Type:       dependency.OCITypeImage,
-		Reference:  p.spec.ImageProvider.Image,
-		PullPolicy: policy,
-		PullSecret: pullSecret,
-	})
-
-	// volume artifacts
-	volTargets, err := extractVolumeTargets(p.spec.ImageProvider.Volumes, pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("parsing volume targets: %w", err)
-	}
-	targets = append(targets, volTargets...)
-
-	return targets, nil
-}
-
 func (p *imageProvider) Verify(ctx context.Context) error {
 	if err := validateEnvVars(p.spec.EnvVars); err != nil {
 		return fmt.Errorf("%w: validating env vars: %w", errors.ErrInvalidSpec, err)
 	}
 
-	// type declared in the spec overrides the type from the image
-	image := p.spec.ImageProvider.Image
-	if p.spec.AppType == "" {
-		appType, err := typeFromImage(ctx, p.podman, image)
-		if err != nil {
-			return fmt.Errorf("getting app type: %w", err)
-		}
-		p.spec.AppType = appType
-	}
-
-	if p.spec.AppType != v1alpha1.AppTypeCompose {
+	if p.spec.AppType != v1alpha1.AppTypeCompose && p.spec.AppType != v1alpha1.AppTypeQuadlet {
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, p.spec.AppType)
 	}
 
@@ -110,36 +82,52 @@ func (p *imageProvider) Verify(ctx context.Context) error {
 		return fmt.Errorf("%w: ensuring volume dependencies: %w", errors.ErrNoRetry, err)
 	}
 
-	// create a temporary directory to copy the image contents
-	tmpAppPath, err := p.readWriter.MkdirTemp("app_temp")
-	if err != nil {
-		return fmt.Errorf("creating tmp dir: %w", err)
-	}
+	var tmpAppPath string
+	var shouldCleanup bool
 
-	cleanup := func() {
-		if err := p.readWriter.RemoveAll(tmpAppPath); err != nil {
-			p.log.Errorf("Cleaning up temporary directory %q: %v", tmpAppPath, err)
+	if p.AppData != nil {
+		tmpAppPath = p.AppData.TmpPath
+		shouldCleanup = true
+	} else {
+		// no cache, extract the image contents
+		var err error
+		tmpAppPath, err = p.readWriter.MkdirTemp("app_temp")
+		if err != nil {
+			return fmt.Errorf("creating tmp dir: %w", err)
+		}
+		shouldCleanup = true
+
+		// copy image contents to a tmp directory for further processing
+		if err := p.podman.CopyContainerData(ctx, p.spec.ImageProvider.Image, tmpAppPath); err != nil {
+			if rmErr := p.readWriter.RemoveAll(tmpAppPath); rmErr != nil {
+				p.log.Warnf("Failed to cleanup temporary directory %q: %v", tmpAppPath, rmErr)
+			}
+			return fmt.Errorf("copy image contents: %w", err)
 		}
 	}
-	defer cleanup()
 
-	// copy image contents to a tmp directory for further processing
-	if err := p.podman.CopyContainerData(ctx, image, tmpAppPath); err != nil {
-		return fmt.Errorf("copy image contents: %w", err)
-	}
+	defer func() {
+		if shouldCleanup && tmpAppPath != "" {
+			if err := p.readWriter.RemoveAll(tmpAppPath); err != nil {
+				p.log.Warnf("Failed to cleanup temporary directory %q: %v", tmpAppPath, err)
+			}
+			p.AppData = nil
+		}
+	}()
 
 	switch p.spec.AppType {
 	case v1alpha1.AppTypeCompose:
 		p.spec.ID = client.NewComposeID(p.spec.Name)
-		path, err := pathFromAppType(p.spec.AppType, p.spec.Name, p.spec.Embedded)
-		if err != nil {
-			return fmt.Errorf("getting app path: %w", err)
-		}
-		p.spec.Path = path
 
 		// ensure the compose application content in tmp dir is valid
 		if err := ensureCompose(p.readWriter, tmpAppPath); err != nil {
 			return fmt.Errorf("ensuring compose: %w", err)
+		}
+	case v1alpha1.AppTypeQuadlet:
+		p.spec.ID = client.NewComposeID(p.spec.Name)
+
+		if err := ensureQuadlet(p.readWriter, tmpAppPath); err != nil {
+			return fmt.Errorf("ensuring quadlet: %w", err)
 		}
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, p.spec.AppType)
@@ -149,6 +137,15 @@ func (p *imageProvider) Verify(ctx context.Context) error {
 }
 
 func (p *imageProvider) Install(ctx context.Context) error {
+	// cleanup any cached extracted path from OCITargets since Install will extract to final location
+	if p.AppData != nil {
+		p.log.Debugf("Cleaning up cached app data before Install")
+		if cleanupErr := p.AppData.Cleanup(); cleanupErr != nil {
+			p.log.Warnf("Failed to cleanup cached app data: %v", cleanupErr)
+		}
+		p.AppData = nil
+	}
+
 	if p.spec.ImageProvider == nil {
 		return fmt.Errorf("image application spec is nil")
 	}
@@ -161,14 +158,32 @@ func (p *imageProvider) Install(ctx context.Context) error {
 		return fmt.Errorf("writing env file: %w", err)
 	}
 
-	if err := writeComposeOverride(p.log, p.spec.Path, p.spec.Volume, p.readWriter, client.ComposeOverrideFilename); err != nil {
-		return fmt.Errorf("writing override file %w", err)
+	switch p.spec.AppType {
+	case v1alpha1.AppTypeCompose:
+		if err := writeComposeOverride(p.log, p.spec.Path, p.spec.Volume, p.readWriter, client.ComposeOverrideFilename); err != nil {
+			return fmt.Errorf("writing override file %w", err)
+		}
+	case v1alpha1.AppTypeQuadlet:
+		if err := installQuadlet(p.readWriter, p.spec.Path, p.spec.ID); err != nil {
+			return fmt.Errorf("installing quadlet: %w", err)
+		}
+	default:
+		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, p.spec.AppType)
 	}
 
 	return nil
 }
 
 func (p *imageProvider) Remove(ctx context.Context) error {
+	// cleanup any cached extracted path
+	if p.AppData != nil {
+		p.log.Debugf("Cleaning up cached app data before Remove")
+		if cleanupErr := p.AppData.Cleanup(); cleanupErr != nil {
+			p.log.Warnf("Failed to cleanup cached app data: %v", cleanupErr)
+		}
+		p.AppData = nil
+	}
+
 	if err := p.readWriter.RemoveAll(p.spec.Path); err != nil {
 		return fmt.Errorf("removing application: %w", err)
 	}

--- a/internal/agent/device/applications/provider/image_cache.go
+++ b/internal/agent/device/applications/provider/image_cache.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
+)
+
+// CacheEntry represents cached nested targets extracted from image-based applications.
+type CacheEntry struct {
+	Name string
+	// Parent is the parent image from which child OCI targets were extracted.
+	Parent dependency.OCIPullTarget
+	// Children are OCI targets extracted from parent image.
+	Children []dependency.OCIPullTarget
+}
+
+// OCITargetCache caches child OCI targets extracted from parents.
+type OCITargetCache struct {
+	entries map[string]CacheEntry
+}
+
+// NewOCITargetCache creates a new cache instance
+func NewOCITargetCache() *OCITargetCache {
+	return &OCITargetCache{
+		entries: make(map[string]CacheEntry),
+	}
+}
+
+// Get retrieves cached nested targets for the given entity name.
+// Returns the entry and true if found, empty entry and false otherwise.
+func (c *OCITargetCache) Get(name string) (CacheEntry, bool) {
+	entry, found := c.entries[name]
+	return entry, found
+}
+
+// Set stores a cache entry.
+func (c *OCITargetCache) Set(entry CacheEntry) {
+	c.entries[entry.Name] = entry
+}
+
+// GC removes cache entries for entities not in the activeNames list.
+// This prevents unbounded cache growth as entities are added/removed.
+func (c *OCITargetCache) GC(activeNames []string) {
+	// build set of active names for O(1) lookup
+	active := make(map[string]struct{}, len(activeNames))
+	for _, name := range activeNames {
+		active[name] = struct{}{}
+	}
+
+	// remove entries not in active set
+	for name := range c.entries {
+		if _, isActive := active[name]; !isActive {
+			delete(c.entries, name)
+		}
+	}
+}
+
+// Len returns the number of entries in the cache
+func (c *OCITargetCache) Len() int {
+	return len(c.entries)
+}
+
+// Clear removes all entries from the cache
+func (c *OCITargetCache) Clear() {
+	c.entries = make(map[string]CacheEntry)
+}

--- a/internal/agent/device/applications/provider/image_cache_test.go
+++ b/internal/agent/device/applications/provider/image_cache_test.go
@@ -1,0 +1,224 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNestedTargetCacheGetSet(t *testing.T) {
+	require := require.New(t)
+	cache := NewOCITargetCache()
+
+	require.Equal(0, cache.Len())
+
+	entry, found := cache.Get("myapp")
+	require.False(found)
+	require.Empty(entry.Name)
+
+	imageBasedEntry := CacheEntry{
+		Name: "image-app",
+		Parent: dependency.OCIPullTarget{
+			Type:      dependency.OCITypeImage,
+			Reference: "quay.io/myapp:v1",
+			Digest:    "sha256:abc123",
+		},
+		Children: []dependency.OCIPullTarget{
+			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"},
+			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+		},
+	}
+	cache.Set(imageBasedEntry)
+	require.Equal(1, cache.Len())
+
+	entry, found = cache.Get("image-app")
+	require.True(found)
+	require.Equal("image-app", entry.Name)
+	require.Equal("sha256:abc123", entry.Parent.Digest)
+	require.Len(entry.Children, 2)
+}
+
+func TestNestedTargetCacheGC(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupCache     func(*OCITargetCache)
+		activeNames    []string
+		expectedLen    int
+		expectedRemain []string
+	}{
+		{
+			name: "GC removes unreferenced applications",
+			setupCache: func(c *OCITargetCache) {
+				c.Set(CacheEntry{
+					Name:     "active1",
+					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:aaa"},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"}},
+				})
+				c.Set(CacheEntry{
+					Name:     "active2",
+					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:bbb"},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"}},
+				})
+				c.Set(CacheEntry{
+					Name:     "stale1",
+					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app3:v1", Digest: "sha256:ccc"},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/nginx:alpine"}},
+				})
+			},
+			activeNames:    []string{"active1", "active2"},
+			expectedLen:    2,
+			expectedRemain: []string{"active1", "active2"},
+		},
+		{
+			name: "GC with empty active list clears all",
+			setupCache: func(c *OCITargetCache) {
+				c.Set(CacheEntry{
+					Name:   "app1",
+					Parent: dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:aaa"},
+				})
+				c.Set(CacheEntry{
+					Name:   "app2",
+					Parent: dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:bbb"},
+				})
+			},
+			activeNames:    []string{},
+			expectedLen:    0,
+			expectedRemain: []string{},
+		},
+		{
+			name: "GC preserves all active applications",
+			setupCache: func(c *OCITargetCache) {
+				c.Set(CacheEntry{
+					Name:   "app1",
+					Parent: dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:aaa"},
+				})
+				c.Set(CacheEntry{
+					Name:   "app2",
+					Parent: dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:bbb"},
+				})
+			},
+			activeNames:    []string{"app1", "app2"},
+			expectedLen:    2,
+			expectedRemain: []string{"app1", "app2"},
+		},
+		{
+			name: "GC on empty cache is safe",
+			setupCache: func(c *OCITargetCache) {
+				// empty cache
+			},
+			activeNames:    []string{"app1"},
+			expectedLen:    0,
+			expectedRemain: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			cache := NewOCITargetCache()
+			tc.setupCache(cache)
+
+			cache.GC(tc.activeNames)
+
+			require.Equal(tc.expectedLen, cache.Len())
+			for _, name := range tc.expectedRemain {
+				_, found := cache.Get(name)
+				require.True(found, "expected app %s to remain after GC", name)
+			}
+		})
+	}
+}
+
+func TestNestedTargetCacheClear(t *testing.T) {
+	require := require.New(t)
+	cache := NewOCITargetCache()
+
+	cache.Set(CacheEntry{
+		Name:     "image-app1",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:abc"},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"}},
+	})
+	cache.Set(CacheEntry{
+		Name:     "image-app2",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:def"},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/nginx:alpine"}},
+	})
+	require.Equal(2, cache.Len())
+
+	cache.Clear()
+	require.Equal(0, cache.Len())
+
+	_, found := cache.Get("image-app1")
+	require.False(found)
+	_, found = cache.Get("image-app2")
+	require.False(found)
+}
+
+func TestNestedTargetCacheOverwriteEntry(t *testing.T) {
+	require := require.New(t)
+	cache := NewOCITargetCache()
+
+	initialEntry := CacheEntry{
+		Name:     "myapp",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:old"},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:6"}},
+	}
+	cache.Set(initialEntry)
+
+	entry, found := cache.Get("myapp")
+	require.True(found)
+	require.Equal("sha256:old", entry.Parent.Digest)
+	require.Len(entry.Children, 1)
+
+	updatedEntry := CacheEntry{
+		Name:   "myapp",
+		Parent: dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:new"},
+		Children: []dependency.OCIPullTarget{
+			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:7"},
+			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+		},
+	}
+	cache.Set(updatedEntry)
+
+	entry, found = cache.Get("myapp")
+	require.True(found)
+	require.Equal("sha256:new", entry.Parent.Digest)
+	require.Len(entry.Children, 2)
+	require.Equal(1, cache.Len()) // still only one entry
+}
+
+func TestNestedTargetCacheInvalidation(t *testing.T) {
+	require := require.New(t)
+	cache := NewOCITargetCache()
+
+	// Cache entry for image-based app with old digest
+	cache.Set(CacheEntry{
+		Name:     "myapp",
+		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:old"},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:6"}},
+	})
+
+	entry, found := cache.Get("myapp")
+	require.True(found)
+	require.NotNil(entry.Parent)
+
+	// Simulate parent image digest change (new version pulled)
+	currentDigest := "sha256:new"
+	require.NotEqual(entry.Parent.Digest, currentDigest, "should detect digest change for cache invalidation")
+
+	// Update cache with new digest and children (simulating re-extraction after invalidation)
+	cache.Set(CacheEntry{
+		Name:   "myapp",
+		Parent: dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:new"},
+		Children: []dependency.OCIPullTarget{
+			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:7"},
+			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+		},
+	})
+
+	entry, found = cache.Get("myapp")
+	require.True(found)
+	require.Equal("sha256:new", entry.Parent.Digest)
+	require.Len(entry.Children, 2)
+}

--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -35,8 +35,15 @@ const (
 type OCIPullTarget struct {
 	Type       OCIType
 	Reference  string
+	Digest     string 
 	PullPolicy v1alpha1.ImagePullPolicy
 	PullSecret *client.PullSecret
+}
+
+// OCICollection represents the result of collecting OCI targets
+type OCICollection struct {
+	Targets []OCIPullTarget
+	Requeue bool // true if collection is incomplete and should be retried
 }
 
 // PrefetchStatus provides the current status of prefetch operations
@@ -61,8 +68,8 @@ type PrefetchManager interface {
 
 // OCICollector interface for components that can collect OCI targets
 type OCICollector interface {
-	// CollectOCITargets returns a function that collects and processes OCI targets
-	CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error)
+	// CollectOCITargets collects OCI targets and indicates if requeue is needed
+	CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error)
 }
 
 type prefetchManager struct {
@@ -163,25 +170,35 @@ func (m *prefetchManager) isTargetsChanged(seenTargets map[string]struct{}) bool
 func (m *prefetchManager) BeforeUpdate(ctx context.Context, current, desired *v1alpha1.DeviceSpec) error {
 	m.log.Debug("Collecting OCI targets from all dependency sources")
 
-	// collect all OCI targets from registered functions
 	var allTargets []OCIPullTarget
+	var requeueNeeded bool
 	m.mu.Lock()
 	collectors := slices.Clone(m.collectors)
 	m.mu.Unlock()
 
 	for i, collector := range collectors {
-		targets, err := collector.CollectOCITargets(ctx, current, desired)
+		result, err := collector.CollectOCITargets(ctx, current, desired)
 		if err != nil {
 			return fmt.Errorf("prefetch collector %d failed: %w", i, err)
 		}
-		allTargets = append(allTargets, targets...)
+		allTargets = append(allTargets, result.Targets...)
+		if result.Requeue {
+			requeueNeeded = true
+		}
 	}
 
-	seenTargets := make(map[string]struct{}, len(allTargets))
+	seenTargets := make(map[string]struct{})
+	newTargets := make([]OCIPullTarget, 0)
 	for _, target := range allTargets {
-		seenTargets[target.Reference] = struct{}{}
+		if _, seen := seenTargets[target.Reference]; !seen {
+			newTargets = append(newTargets, target)
+			seenTargets[target.Reference] = struct{}{}
+		}
 	}
 
+	m.log.Debugf("Collected %d unique OCI targets", len(seenTargets))
+
+	// clean up stale prefetch tasks if targets have changed
 	m.mu.Lock()
 	if m.isTargetsChanged(seenTargets) {
 		m.log.Debug("OCI targets changed, cleaning up stale prefetch tasks")
@@ -189,14 +206,24 @@ func (m *prefetchManager) BeforeUpdate(ctx context.Context, current, desired *v1
 	}
 	m.mu.Unlock()
 
-	if len(allTargets) > 0 {
-		m.log.Debugf("Scheduling %d total OCI targets for prefetching", len(allTargets))
-		if err := m.Schedule(ctx, allTargets); err != nil {
+	if len(newTargets) > 0 {
+		m.log.Debugf("Scheduling %d new targets for prefetch", len(newTargets))
+		if err := m.Schedule(ctx, newTargets); err != nil {
 			return fmt.Errorf("scheduling prefetch targets: %w", err)
 		}
 	}
 
-	return m.checkReady(ctx)
+	if err := m.checkReady(ctx); err != nil {
+		return err
+	}
+
+	// collector requested a requeue, return retryable error to trigger another iteration
+	if requeueNeeded {
+		m.log.Debug("Requeue requested by collector, will retry after current targets are fetched")
+		return errors.ErrPrefetchNotReady
+	}
+
+	return nil
 }
 
 func (m *prefetchManager) checkReady(ctx context.Context) error {
@@ -222,6 +249,7 @@ func (m *prefetchManager) checkReady(ctx context.Context) error {
 	}
 
 	if len(pending) > 0 {
+		// ensure retry
 		return fmt.Errorf("%w: %v", errors.ErrPrefetchNotReady, pending)
 	}
 	return nil

--- a/internal/agent/device/dependency/dependency_test.go
+++ b/internal/agent/device/dependency/dependency_test.go
@@ -231,8 +231,8 @@ func TestEnsureScheduled(t *testing.T) {
 			manager := NewPrefetchManager(log, podman, rw, timeout)
 
 			// register a collector that returns the test targets
-			manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
-				return tt.targets, nil
+			manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
+				return &OCICollection{Targets: tt.targets}, nil
 			}))
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -370,8 +370,8 @@ func TestStatus(t *testing.T) {
 		},
 	}
 
-	manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
-		return targets, nil
+	manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
+		return &OCICollection{Targets: targets}, nil
 	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -393,7 +393,7 @@ func TestStatus(t *testing.T) {
 func TestBeforeUpdate(t *testing.T) {
 	tests := []struct {
 		name       string
-		collectors []func() ([]OCIPullTarget, error)
+		collectors []func() (*OCICollection, error)
 		setupMocks func(*executer.MockExecuter)
 		wantErr    error
 	}{
@@ -405,9 +405,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "empty device specs with registered collectors",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{}, nil
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -416,9 +416,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "single collector with missing images",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testImageV1,
@@ -429,7 +429,7 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  testImageV2,
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -444,9 +444,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "single collector with all images present",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testImageV1,
@@ -457,7 +457,7 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  testImageV2,
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -471,9 +471,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "single collector with mixed image availability",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testImageV1,
@@ -484,7 +484,7 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  testImageV2,
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -499,10 +499,10 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "multiple collectors with different image sets",
-			collectors: []func() ([]OCIPullTarget, error){
+			collectors: []func() (*OCICollection, error){
 				// app collector
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testImageV1,
@@ -513,17 +513,17 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  testImageV2,
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 				// os collector
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testOSImage,
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -540,8 +540,8 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "collector returns error",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
 					return nil, fmt.Errorf("failed to collect OCI targets")
 				},
 			},
@@ -552,15 +552,15 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "artifact target with missing image",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeArtifact,
 							Reference:  "quay.io/test/artifact:latest",
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -572,15 +572,15 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "artifact target with existing artifact",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeArtifact,
 							Reference:  "quay.io/test/existing-artifact:latest",
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -591,9 +591,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "mixed image and artifact targets with some missing",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  "quay.io/test/existing-image:latest",
@@ -604,7 +604,7 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  "quay.io/test/missing-artifact:latest",
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -619,9 +619,9 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "mixed image and artifact targets all existing",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  "quay.io/test/existing-image:latest",
@@ -632,7 +632,7 @@ func TestBeforeUpdate(t *testing.T) {
 							Reference:  "quay.io/test/existing-artifact:latest",
 							PullPolicy: v1alpha1.PullIfNotPresent,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -646,15 +646,15 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "pull always policy with existing artifact",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeArtifact,
 							Reference:  "quay.io/test/always-artifact:latest",
 							PullPolicy: v1alpha1.PullAlways,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -665,15 +665,15 @@ func TestBeforeUpdate(t *testing.T) {
 		},
 		{
 			name: "pull always policy with existing image",
-			collectors: []func() ([]OCIPullTarget, error){
-				func() ([]OCIPullTarget, error) {
-					return []OCIPullTarget{
+			collectors: []func() (*OCICollection, error){
+				func() (*OCICollection, error) {
+					return &OCICollection{Targets: []OCIPullTarget{
 						{
 							Type:       OCITypeImage,
 							Reference:  testImageV1,
 							PullPolicy: v1alpha1.PullAlways,
 						},
-					}, nil
+					}}, nil
 				},
 			},
 			setupMocks: func(mockExec *executer.MockExecuter) {
@@ -705,7 +705,7 @@ func TestBeforeUpdate(t *testing.T) {
 
 			// Register collectors
 			for _, collector := range tt.collectors {
-				manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
+				manager.RegisterOCICollector(newTestOCICollector(func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
 					return collector()
 				}))
 			}
@@ -833,15 +833,15 @@ func TestPullSecretCleanup(t *testing.T) {
 	}
 
 	// simulate a collector that would be called by applications manager
-	appCollector := func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
-		return []OCIPullTarget{
+	appCollector := func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
+		return &OCICollection{Targets: []OCIPullTarget{
 			{
 				Type:       OCITypeImage,
 				Reference:  "registry.example.com/app:latest",
 				PullPolicy: v1alpha1.PullIfNotPresent,
 				PullSecret: appPullSecret,
 			},
-		}, nil
+		}}, nil
 	}
 
 	// register the collector
@@ -886,14 +886,14 @@ type taskState struct {
 
 // testOCICollector is a test helper that implements OCICollector interface
 type testOCICollector struct {
-	collectFn func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error)
+	collectFn func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error)
 }
 
-func (t *testOCICollector) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
+func (t *testOCICollector) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
 	return t.collectFn(ctx, current, desired)
 }
 
-func newTestOCICollector(fn func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error)) OCICollector {
+func newTestOCICollector(fn func(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error)) OCICollector {
 	return &testOCICollector{collectFn: fn}
 }
 

--- a/internal/agent/device/dependency/mock_dependency.go
+++ b/internal/agent/device/dependency/mock_dependency.go
@@ -116,10 +116,10 @@ func (m *MockOCICollector) EXPECT() *MockOCICollectorMockRecorder {
 }
 
 // CollectOCITargets mocks base method.
-func (m *MockOCICollector) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]OCIPullTarget, error) {
+func (m *MockOCICollector) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*OCICollection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollectOCITargets", ctx, current, desired)
-	ret0, _ := ret[0].([]OCIPullTarget)
+	ret0, _ := ret[0].(*OCICollection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -88,7 +88,8 @@ var (
 	ErrInvalidPolicyType      = errors.New("invalid policy type")
 
 	// prefetch
-	ErrPrefetchNotReady = errors.New("oci prefetch not ready")
+	ErrPrefetchNotReady     = errors.New("oci prefetch not ready")
+	ErrOCICollectorNotReady = errors.New("oci target collector not ready")
 
 	// bootc
 	ErrBootcStatusInvalidJSON = errors.New("bootc status did not return valid JSON")
@@ -112,7 +113,7 @@ func IsRetryable(err error) bool {
 		return true
 	case errors.Is(err, ErrDownloadPolicyNotReady), errors.Is(err, ErrUpdatePolicyNotReady):
 		return true
-	case errors.Is(err, ErrPrefetchNotReady):
+	case errors.Is(err, ErrPrefetchNotReady), errors.Is(err, ErrOCICollectorNotReady):
 		return true
 	case errors.Is(err, ErrNoContent):
 		// no content is a retryable error it means the server does not have a

--- a/internal/agent/device/os/mock_os.go
+++ b/internal/agent/device/os/mock_os.go
@@ -137,10 +137,10 @@ func (mr *MockManagerMockRecorder) BeforeUpdate(ctx, current, desired any) *gomo
 }
 
 // CollectOCITargets mocks base method.
-func (m *MockManager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]dependency.OCIPullTarget, error) {
+func (m *MockManager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*dependency.OCICollection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollectOCITargets", ctx, current, desired)
-	ret0, _ := ret[0].([]dependency.OCIPullTarget)
+	ret0, _ := ret[0].(*dependency.OCICollection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -77,10 +77,10 @@ func (m *manager) BeforeUpdate(ctx context.Context, current, desired *v1alpha1.D
 	return nil
 }
 
-func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) ([]dependency.OCIPullTarget, error) {
+func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1alpha1.DeviceSpec) (*dependency.OCICollection, error) {
 	if desired.Os == nil {
 		m.log.Debug("No OS spec to collect OCI targets from")
-		return nil, nil
+		return &dependency.OCICollection{}, nil
 	}
 
 	osImage := desired.Os.Image
@@ -97,12 +97,12 @@ func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1alp
 	if isDesiredImageRunning {
 		// desired OS image is already booted, no need to pull it
 		m.log.Debugf("Desired OS image is currently booted: %s", osImage)
-		return nil, nil
+		return &dependency.OCICollection{}, nil
 	}
 
 	if m.podmanClient.ImageExists(ctx, osImage) {
 		m.log.Debugf("OS image already exists in container storage: %s", osImage)
-		return nil, nil
+		return &dependency.OCICollection{}, nil
 	}
 
 	target := dependency.OCIPullTarget{
@@ -121,7 +121,7 @@ func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1alp
 	}
 
 	m.log.Debugf("Collected 1 OCI target from OS spec: %s", osImage)
-	return []dependency.OCIPullTarget{target}, nil
+	return &dependency.OCICollection{Targets: []dependency.OCIPullTarget{target}}, nil
 }
 
 func (m *manager) AfterUpdate(ctx context.Context, desired *v1alpha1.DeviceSpec) error {


### PR DESCRIPTION
This PR adds the ability for the prefetch manager to prefetch dependencies for both embedded and image based applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Quadlet application type support alongside Compose.

* **Improvements**
  * More reliable multi-application handling with an upfront inspect-then-mount/unmount flow.
  * Two-phase OCI target collection with per-image nested-target caching to avoid redundant work.
  * Improved prefetch scheduling with readiness/requeue semantics for more robust dependency discovery and retries.

* **Tests**
  * Expanded tests for multi-app flows, caching behavior, and error/retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->