### PR TITLE
NO-ISSUE: add dependency to test vms

### DIFF
--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -110,7 +110,7 @@ echo "Executing commands in the VM..."
 ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${USER}@${VM_DEFAULT_IP} <<EOF
 
   # Install necessary packages
-  sudo dnf install -y epel-release libvirt libvirt-client virt-install swtpm \
+  sudo dnf install -y epel-release libvirt libvirt-client virt-install pam-devel swtpm \
                     make golang git \
                     podman qemu-kvm sshpass
   sudo dnf --enablerepo=crb install -y libvirt-devel

--- a/test/scripts/deploy_quadlets_rhel.sh
+++ b/test/scripts/deploy_quadlets_rhel.sh
@@ -105,7 +105,7 @@ ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile
   sudo dnf install -y \
   https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
   sudo dnf repolist
-  sudo dnf install -y libvirt libvirt-client virt-install swtpm \
+  sudo dnf install -y libvirt libvirt-client virt-install pam-devel swtpm \
                     make golang git \
                     podman qemu-kvm sshpass
   sudo dnf --enablerepo=crb install -y libvirt-devel


### PR DESCRIPTION
Adding pam-devel dependency to test vm to build flightctl client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pam-devel package to system dependencies in VM provisioning and deployment scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->