### PR TITLE
EDM-2509: enforcing PKCE for public clients

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -402,3 +402,14 @@ SAN
  - docs/user/service-observability.md
 https
 http
+ - docs/user/pam-authentication.md
+OAuth2
+clientId
+clientSecret
+redirectUris
+URIs
+PKCE
+SSSD
+nsswitch.conf
+NSSwitch
+PAM

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ help:
 	@echo "    deploy-kv:       deploy only the key-value store as a container, for testing"
 	@echo "    deploy-quadlets: deploy the complete Flight Control service using Quadlets"
 	@echo "                     (includes proper startup ordering: DB -> KV -> other services)"
+	@echo "                     Supports AUTH=true and ORGS=true environment variables"
 	@echo "    clean:           clean up all containers and volumes"
 	@echo "    clean-all:       full cleanup including containers and bin directory"
 	@echo "    rebuild-containers: force rebuild all containers"

--- a/api/v1alpha1/pam-issuer/openapi.yaml
+++ b/api/v1alpha1/pam-issuer/openapi.yaml
@@ -68,6 +68,17 @@ paths:
           schema:
             type: string
           description: OAuth2 state parameter.
+        - name: code_challenge
+          in: query
+          schema:
+            type: string
+          description: PKCE code challenge.
+        - name: code_challenge_method
+          in: query
+          schema:
+            type: string
+            enum: [S256]
+          description: PKCE code challenge method (only S256 supported).
       responses:
         "200":
           description: Login form HTML (if user not authenticated)
@@ -329,6 +340,10 @@ components:
           type: string
           nullable: true
           description: OAuth2 scope.
+        code_verifier:
+          type: string
+          nullable: true
+          description: PKCE code verifier.
       description: OAuth2 token request
     TokenResponse:
       type: object
@@ -475,5 +490,11 @@ components:
           items:
             type: string
           description: Supported authentication methods.
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
+            enum: [S256]
+          description: Supported PKCE code challenge methods.
       description: OpenID Connect configuration
 

--- a/api/v1alpha1/pam-issuer/spec.gen.go
+++ b/api/v1alpha1/pam-issuer/spec.gen.go
@@ -177,6 +177,22 @@ func (siw *ServerInterfaceWrapper) AuthAuthorize(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// ------------- Optional query parameter "code_challenge" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "code_challenge", r.URL.Query(), &params.CodeChallenge)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "code_challenge", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "code_challenge_method" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "code_challenge_method", r.URL.Query(), &params.CodeChallengeMethod)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "code_challenge_method", Err: err})
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.AuthAuthorize(w, r, params)
 	}))
@@ -449,50 +465,52 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+QabY/btvmvEOyAJYBfLtd1GPxp7jVBnTSNcXaWD72DQUuPZeYoUiUp+9zi/vvwkJQs",
-	"2ZTPLpIO2z7dWXz4vL9Lv9NE5YWSIK2ho9+pSdaQM/fv20/vZrdgCiUN4O8UTKJ5YbmSdETfzj78TD7B",
-	"kryDHZmBpT1aaFWAthzc9QfYub/cQu7+aR8zkR0jHYtMaW7X+YD2qN0VQEfUWM1lRp96NNGb4yuvhcD/",
-	"E5KUegNEshzIi5XS5PUNQRZ6BAbZoEfu6LR//d3f7+jLKO6IhLezMYFHrxuPEp8gzjiKB54eI0HtTH6I",
-	"w9tdHB4hozdknMlcpaUozTk8ljFTIs3SxEk+RjR+Qx77iVI65ZLZtrbjVHdRJLtLkDzVT9TyMySW7h8w",
-	"rdkuDvGhADn54UbJFc9KzTztQ1Y8ELlRUkJiSdKCPvRqVtq10vw3d7oAmRaKSxvx5CYcqeDibi0Yz83C",
-	"lEWhtIWIE82qI+JhEU0dVkf42mrp0UwzaRf49Ewi7oLzwgsp8XRh1QPIheGZ5DJbMJEtNkyU51IO9wir",
-	"8sClDBhTgo6YePLDDfGHURN83j6YRal5JM19ejc7bT4dUuQlGq7u/BElm0SdTcfDXoi/dOFziTjhCuEp",
-	"SMtXHHREMJBlTke/0KJcCp5gYDGut9wAve89z5X3q+54m+P5aUO1USwwkhc52LVKzxQTb6CAiQ/qcPcy",
-	"7ZYGNJcrdUKUjwb0RK7UKWliyW5mmS1NRAD3nHBDGNFgSy2Ji0mCKTdhQhhi18ySVMm/2gpC2TVo4pE7",
-	"EQ/SYMH/BdpE8+l4OglnJIUVl4D4gWz8M+eV2GMQtSJ2zQ3RUGgwIK1Xq1oRJgPlAZmBxovErFUpUkzO",
-	"G9DIZaIyyX+rsRlilSMjmAVjCZcWtGTCi9ojTKYkZzuiwXlqKRsYfIYakPdKA0HjjMja2sKMhsOM28HD",
-	"P8yAq2Gi8ryU3O6GiZJW82VplTbDFDYghoZnfaaTNbeQ2FLDkBW875iVKJQZ5Ok3GowqdeLD4rgKqBRi",
-	"zpdlYND5fpzPp5VxENZZz+nPOPv2yBXhKyKVJQacy6yUzpmlI8ql/fZ6TxNVk4H2LYuM9Sxcpt5dPHvB",
-	"XWo74SNU9e3r2ZxUUnlevNn2oGZvQdQ+lysIXK+0yh2Wysvdj0Rw7LZMucy5Rdf4tQRj0bgDcsMkSrcE",
-	"UhYps5AOyESSG5aDuGEGvrr9XErro8riFszBGJZFjDgm6zJnsq+BpWwpgDSOfRRAMGIdExhrLhw6Sg4z",
-	"0cgjOUvWXEInqe16d0AADc2l4+GOvmFclBruaOBnQCaBIe8C3BDIC4s4QLufUjmNo6chMrZhXCDhARmT",
-	"W8cm9iwai4LBuHZuHIR1brwsMfOAcZ6rNqA1T4HweAo3p1Nc0OVeeeSDBKJWI3JHZ2WSgDF3lCjdlPSr",
-	"u40pIOkzmfaDSqPJHB2dayw/vzRza4jQWvCQJmoP2DvdfaQguJp460Mo0hNhi3pNXFWsAu0oz/t4XMQm",
-	"m3A/RKyfcWQpnPXpyOoSor2uw2cg0WCfw+mhyAvljplwKc+3DwHEjwqnqfboVnMLH6TYeYDOZNvu2esk",
-	"22753WPXIZ8l8L757pR2324jxqpN0rDSYNa+oaY9esxFtG8qmDFbpSP2moYTr8Xqhyf+AoOvNJBiKnDN",
-	"8kqo7R/Vbpv145HVHwfPQ25aFy5QrmtvO/XqTs/Cg02ZZDnEezG3UviiSjuM+IaTnIjjrk3MQSAHsKOO",
-	"zaW/LpsEHB7Io4qvSbRWuvO6O3WB03150bp5ElHjKI7vseAazILLznkAIXw4W55jlsekotoVvNEPPeO5",
-	"gTvddOATo0Y86j1nh+H+PTANOhLSsU6/mhBO+AS6Yz1IdDoF5IyLyHIGHxOWphpMvNdxFxcbcIU97cLg",
-	"z8O4dFT+lkoJYPKEW70+7U/xkH1TCuHWgNE7SmdMhixq4vFOWjCXjXeFhhVoDemiO6dMKxhSwcSbPCWg",
-	"i0N3dvFYHxsvDgf3s2ZNRAdJqbndzXD68nwunQtjiOx/valmkLef5rR3tFuZE+/3IXm1B2xsexx29BUf",
-	"HjUn2Kg5c+KVa6Tncu/Rhu4mFPrWw49a0BHFXm24eTXEo2F17nsrF94RqKoW+7VKI4DouEqczqbEP+5R",
-	"tVoJLmHh8+pR7QuPe1QVILHHOtxF+gLnonbFsZocEgoHzR6c1q5zCOwfV+mpU76mwb16nzyHkzTw9ewO",
-	"9ciQresRyoMtCNF/kGorh14Z/cM9bMVSi5EnZBaFd82qkpZ57iq7WGD5P1eCZ2ubWDHgilZpg87XQN64",
-	"E2TbaiXIHFhOe7R0/FWzQOv206EPT8fv+0uGTYBLuQcrIgN6wxPfPbRpDe7k3A3vAaLQasNTMMTXmGEM",
-	"W2lw8jY7YyEn0/F78mIqyixzc964DfpepaUA83Jwh6oTPIFQJoLw44IlayDXg6sjebfb7YC544HS2TDc",
-	"NcOfJjevf5697l8PrgZrmwvnSNw6rzzQI/LmBJh6qTQZTye0RzfVyohuXjFRrNmryrVYwemIfju4Grxy",
-	"m0G7duF1mY+MfqcZPO+cKTcJDpq71oKtHhonaRgFYi8P9utex9/11VXleOBXeawoRDDC8HMY0v2GCv/7",
-	"i4YVHdFvhvuXbsOwvxrGyDn3vuBthQtdlhk3RrZj8B7POnJep+JCVxh9l3E8G4WRSahtXKHjRpItmGY5",
-	"WNDIa2ef1diSu2qHh7+WoHf7MG6t32mzr/ad9175VasVRmif7GIN1zmTboyV/bB8io1zyWlIuUYTf7yd",
-	"dAvvYdy7i1NE612gBzyXh3qEihGvitPlomErCKR2gU4CCHaSwP2z8Wjh0Q5dumoF4iGiozD7SWXcDac5",
-	"+XH+/ifygq98EcWhrxFakL7EHPbt1XVs0A0WtOogUAqWAVGaLFnygKfecxDR375gRgkvBCLSfc/SeuXj",
-	"iL76E4h+lHXGSZHqd3+KqJPqRYBxe2g/Wl6WKD9vH0xnjjz8DoK8ePvp3exlO036dm/DBE/rre5xfsSL",
-	"X7PCtD7oiKjq6JOOi7QkMGI61dSIp5ZmoiWmu4Q4NGeWj//HfP1fl1j/QznvlGP3aKFiC/OpVm6cEnsJ",
-	"3HsqYzoj2gk7VW6xHmh/r9LdCWkf+9vtto/I+6UWILFZSdvin9jQn1wHR14jNbwxBuD9JHbS3G6c3m3W",
-	"kA1mjpec7Vv1HrnhgRdW2DrJbLldEwPOSP/jBfZgBlwxLrDSXpLE68VnPARaq+ajQaBBm8m0Xki7jUc8",
-	"PuZhoXJebFymp9bbLxT0wjC7APezzvslq3j7bUDEDebtFwFf2OefJX92nj30verTmO5xtLXUbrmfBqs5",
-	"bLjMfJfe2IfFPa9C8zX7raM1fawpPuD2S2eLs3hoNeaN5a7rrZpr3V/usTPotqi76z73cFf9YmlIG5fi",
-	"GSW67qqN5jbdoXU5oPl0//TvAAAA//9wcu+xwiwAAA==",
+	"H4sIAAAAAAAC/+RaW4/bNvb/KgT7B/4TwJfJdFMs/LTudII6aRojdjYPncCgpWOZGYpUScqOW8x3XxyS",
+	"kiWb8tjdJAvsPiUjkufG37nSf9JE5YWSIK2hoz+pSdaQM/ffVx9ez96BKZQ0gH+nYBLNC8uVpCP6avb2",
+	"V/IBluQ17MgMLO3RQqsCtOXgjj/Azv3LLeTuP+1lJrJjomORKc3tOh/QHrW7AuiIGqu5zOhjjyZ6c3zk",
+	"Tgj8f0KSUm+ASJYDuVopTe5uCYrQIzDIBj1yT6f9mxc/3NNnUdoRDd/NxgQ+e9t4kvgFacZJPPD0mAha",
+	"Z/JTfL/dxffjzugJGRcyV2kpSnOOjGXsKpFnaeIsP0csfks+9xOldMols21rx7nuokR2lxB5rL+o5SdI",
+	"LN1/YFqzXXzH2wLk5KdbJVc8KzXzvA9F8ZvIrZISEkuS1u5DVLPSrpXmf7jVBci0UFzaCJKb+0i1Lw5r",
+	"wXhuFqYsCqUtREA0q5aI34tkarc6otc2S48mKoVFsmZCgMxgkYNdq/RMftPXt3cECZCaAAkEWkKALHM6",
+	"+o3Obl78QD/2nhYq00zaBX49UxJ3wLnGherzdGHVA8iF4ZnkMlswkS02TJTncg7nCKuC06UCGFOCjuBu",
+	"8tMt8YtRXHzaPphFqXkk9n54PTuNKR3i9iUWrs78FSObRJ3Nx++9kH7pfPoSdcIRwlOQlq846IhiFW6L",
+	"cil4gt7OuN5yA2eB2OOqOwjMcf30RbVJLDC8XOaheAIVTHykiTnnk3qUBjSXK3VClfcG9ESu1CltYhF4",
+	"ZpktTUQB951wQxjRYEstifNJgnkgYUIYYtfMklTJ/7fVDmXXoIkn7lQ8iM0F/ydoEw3y4+kkrJEUVlwC",
+	"0gey8d8cKrHwIWpF7JoboqHQYEBab1a1IkwGzgMyA40HiVmrUqSYMTagUcpEZZL/UVMzxCrHRjALxhIu",
+	"LWjJhFe1R5hMSc52RINDaikbFHyEGpA3SgPByxmRtbWFGQ2HGbeDh7+bAVfDROV5KbndDRMlrebL0ipt",
+	"hilsQAwNz/pMJ2tuIbGlhiEreN8JK1EpM8jT7zQYVerEu8VxalIpxMCXZWAQfD/P59PqclyWwNtz9jPu",
+	"fnvkmvAVkcoSAw4yK6VzZumIcmm/v9nzRNNkoH0dJWOFFJeph4sXL8Clvif8hKZ+dzebk0orL4u/tv1W",
+	"s79BtD6XKwhSr7TKHZUK5e6PRHAsAU25zLlFaPxegrF4uQNyyyRqtwRSFimzkA7IRJJbloO4ZQa++v25",
+	"kNZHk8VvMAdjWBa5xDFZlzmTfQ0sZUsBpLHsvQDCJdY+gb7m3KEj5TAT9TySs2TNJXSy2q53Bwzworl0",
+	"MtzTl4yLUsM9DfIMyCQI5CHADYG8sEgDtPtTKmdxRBoSYxvGBTIekDF558TEQkpjUjDo1w7GQVkH42WJ",
+	"kQeMQ67agNY8BcLjIdycDnHBlnvjkbcSiFqNyD2dlUkCxtxTonRT068OG1NA0mcy7QeTRoM5Ap1rTD+/",
+	"NWNr8NBa8RAmagTsQfcxkhBcTnznXShSE2HdfENcVqwc7SjOe39cxNqtcD54rG+8ZCnc7dOR1SVEC3BH",
+	"z0CiwT5F0+8iV8otM+FCni8fwhbfv5zm2qNbzS28lWLnN3QG23YjUQfZdh/iPrsK+TyFsSPYgHOASGG6",
+	"L/qrPWdR3Zf0nTbcF/FIsSq+NKw0mLUv02mPHusWrcYKZsxW6QgKpmHF3031h2d+hS5dGkgxwLgSfCXU",
+	"9q/eWVv04+7cLwc8ozStAxdcmSuaO+3qVs+ig6WeZDnEKzw3PfmiRjuMIw2QnIgOXUOng/AQth3VgS6o",
+	"dt1JoOE3eVLxiZDWSnced6vOSboPL1onTxJqLMXpfS64BrPgsrPLwB0+SFieY+7AUKXadUGjynoCuUE6",
+	"3QTwiQYm7vVeskN3/xGYBh1x6Vj/UPUdJzCBcKzbk05QQM64iMyh8DNhaarBxCsod7CKlmkXBb8emrCj",
+	"pLpUSgCTJ2B1dxpPcZd9WQrhJp7RM0pnTIYoauL+Tlp7LmsaCw0r0BrSRXdMmVZ7SLUnXjoqAV0SurWL",
+	"hwWxpuVwHHBWB4vkICk1t7sZ9nRezqWDMLrI/q+XVWfz6sOc9o4mNnPicR+CV7ttx2LKUUesePeoJcHy",
+	"z10nHrlBfi72Hg0jb0P50Pr4Xgs6olgBDjfPh7g0rNZ9xebcO7KrysV+WNNwIDquAqe7U+I/96harQSX",
+	"sPBx9Sj3hc89qgqQWLkdjl19gnNeu+KYTQ4ZhYVmZU9r6Bxu9p+r8NSpX/PCvXkfvYSTNMj15Lj46CJb",
+	"xyOcB1sQov8g1VYOvTH6hyPnSqSWII8oLCrvSmAlLfPSVfdigeX/WAmerW1ixYArWoUNOl8DeelWUGyr",
+	"lSBzYDnt0dLJV3UYrdOPhxiejt/0lwyLABdyDwZPBvSGJ756aPMa3Mu5GwmEHYVWG56CIT7HDGPUSoP9",
+	"vNkZCzmZjt+Qq6kos8x1j+P21jcqLQWYZ4N7NJ3gCYQ0EZQfFyxZA7kZXB/pu91uB8wtD5TOhuGsGf4y",
+	"ub37dXbXvxlcD9Y2Fw5I3DpUHtgRZXMKTL1WmoynE9qjm2oQRTfPmSjW7HkFLVZwOqLfD64Hz9280a6d",
+	"e12GkdGfNIOnwZlyk2D7umuN7epWdJKGBiP2TrIfIjv5bq6vK+CBHxCyohDhEoafQuvv5174v//TsKIj",
+	"+t1w/744DFOxYYydg/cFDzPOdVlmXHPa9sGPuNYR8zoNF6rC6LPNcccVGjGhtnGDjhtBtmCa5WBBo6yd",
+	"dVZj9u6yHS7+XoLe7d24NdSnzbraV95741elVmjMfbCLFVzn9M8xUfYt+CkxzmWnIeUar/j9u0m38n6P",
+	"exE5xbSeMPqN58pQt1Ax5lVyulw1LAWB1BDoZIDbLmMQeZrrvK3WC+C/zSY8MpArJcWOzG5e/EDqp4pn",
+	"58kQ3jhoDLQdb4iPH5+MSBY+26EL2K1QdEjoKND8ojLu2vOc/Dx/8wu54itfRmDb2wgukD7DKP799U2s",
+	"1Q8YtuogVBQsA6I0WbLkAVe97yChv33BmBoeWiLa/cjSepTmmD7/Bkzfyzrmpsj1xTdRdVI9sBg33/fN",
+	"9WWp4tP2wXRmicMfvZCrVx9ez561E4UveDdM8LSelh9nCDz4NXNs69c7EVMd/X7nIisJ9JhOMzX8qWWZ",
+	"aJLtTqKOzJkJ9H8xY32p1PLNAut/KOadAnaPFir2EDHVyjWUYq+Be/8zptOjnbJT5R4sAu8fVbo7oe3n",
+	"/na77SPxfqkFSMyRaVv9Ey8fJwfikee5BhpjGzxOYivN+c7p6W69syHM8Zi3faqepDcQeGGGrYPMlts1",
+	"MeAu6b88wR50wSvGBWbaS4J4PfqNu0Br2H7UCjV4M5nWI3k384n7xzyMlM7zjcvs1HpVREUvdLMLaD8J",
+	"3i+ZxdvvIREYzNtPIV8Y80+yPzvOHmKv+slRd0PeGuu34KfBag4bLjNfpTcmgnHkVWS+Zr119FARK4oP",
+	"pP3S0eIsGVqFeWO87Wqr5mD7t49YGXTfqDvrfkbjjvrR2pA2DsUjSnTgV1+am/WH0uWA5+PHx38FAAD/",
+	"/6FgTOyvLgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1alpha1/pam-issuer/types.gen.go
+++ b/api/v1alpha1/pam-issuer/types.gen.go
@@ -7,6 +7,11 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for OpenIDConfigurationCodeChallengeMethodsSupported.
+const (
+	OpenIDConfigurationCodeChallengeMethodsSupportedS256 OpenIDConfigurationCodeChallengeMethodsSupported = "S256"
+)
+
 // Defines values for OpenIDConfigurationSubjectTypesSupported.
 const (
 	Pairwise OpenIDConfigurationSubjectTypesSupported = "pairwise"
@@ -28,6 +33,11 @@ const (
 const (
 	Code  AuthAuthorizeParamsResponseType = "code"
 	Token AuthAuthorizeParamsResponseType = "token"
+)
+
+// Defines values for AuthAuthorizeParamsCodeChallengeMethod.
+const (
+	AuthAuthorizeParamsCodeChallengeMethodS256 AuthAuthorizeParamsCodeChallengeMethod = "S256"
 )
 
 // JWKSResponse JSON Web Key Set
@@ -70,6 +80,9 @@ type OpenIDConfiguration struct {
 	// ClaimsSupported Supported claims.
 	ClaimsSupported *[]string `json:"claims_supported,omitempty"`
 
+	// CodeChallengeMethodsSupported Supported PKCE code challenge methods.
+	CodeChallengeMethodsSupported *[]OpenIDConfigurationCodeChallengeMethodsSupported `json:"code_challenge_methods_supported,omitempty"`
+
 	// GrantTypesSupported Supported grant types.
 	GrantTypesSupported *[]string `json:"grant_types_supported,omitempty"`
 
@@ -100,6 +113,9 @@ type OpenIDConfiguration struct {
 	// UserinfoEndpoint UserInfo endpoint.
 	UserinfoEndpoint *string `json:"userinfo_endpoint,omitempty"`
 }
+
+// OpenIDConfigurationCodeChallengeMethodsSupported defines model for OpenIDConfiguration.CodeChallengeMethodsSupported.
+type OpenIDConfigurationCodeChallengeMethodsSupported string
 
 // OpenIDConfigurationSubjectTypesSupported defines model for OpenIDConfiguration.SubjectTypesSupported.
 type OpenIDConfigurationSubjectTypesSupported string
@@ -135,6 +151,9 @@ type TokenRequest struct {
 
 	// Code Authorization code for authorization_code grant.
 	Code *string `json:"code"`
+
+	// CodeVerifier PKCE code verifier.
+	CodeVerifier *string `json:"code_verifier"`
 
 	// GrantType OAuth2 grant type.
 	GrantType TokenRequestGrantType `json:"grant_type"`
@@ -222,10 +241,19 @@ type AuthAuthorizeParams struct {
 
 	// State OAuth2 state parameter.
 	State *string `form:"state,omitempty" json:"state,omitempty"`
+
+	// CodeChallenge PKCE code challenge.
+	CodeChallenge *string `form:"code_challenge,omitempty" json:"code_challenge,omitempty"`
+
+	// CodeChallengeMethod PKCE code challenge method (only S256 supported).
+	CodeChallengeMethod *AuthAuthorizeParamsCodeChallengeMethod `form:"code_challenge_method,omitempty" json:"code_challenge_method,omitempty"`
 }
 
 // AuthAuthorizeParamsResponseType defines parameters for AuthAuthorize.
 type AuthAuthorizeParamsResponseType string
+
+// AuthAuthorizeParamsCodeChallengeMethod defines parameters for AuthAuthorize.
+type AuthAuthorizeParamsCodeChallengeMethod string
 
 // AuthLoginParams defines parameters for AuthLogin.
 type AuthLoginParams struct {

--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -33,8 +33,16 @@ auth:
   aap:
     apiUrl: {{AAP_API_URL}}
     externalApiUrl: {{AAP_EXTERNAL_API_URL}}
-  {{elseif OIDC}}
+  {{endif AAP}}
+  {{if OIDC}}
   oidc:
-    oidcAuthority: {{OIDC_URL}}
-    externalOidcAuthority: {{OIDC_EXTERNAL_URL}}
-  {{endif}}
+    oidcAuthority: {{OIDC_ISSUER}}
+    externalOidcAuthority: {{OIDC_EXTERNAL_AUTHORITY}}
+    clientId: {{OIDC_CLIENT_ID}}
+    enabled: {{OIDC_ENABLED}}
+    usernameClaim: {{OIDC_USERNAME_CLAIM}}
+    roleClaim: {{OIDC_ROLE_CLAIM}}
+    organizationAssignment:
+      type: {{OIDC_ORG_ASSIGNMENT_TYPE}}
+      organizationName: {{OIDC_ORG_NAME}}
+  {{endif OIDC}}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -2,7 +2,7 @@ global:
   baseDomain:
   auth:
     type: none # aap, oidc, builtin (legacy, translates to oidc with PAM), or none
-    insecureSkipTlsVerify: false
+    insecureSkipTlsVerify: true
     aap:
       apiUrl:
       externalApiUrl:

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -6,6 +6,25 @@ set -eo pipefail
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/shared.sh
 
+# Function to configure auth and organizations in service-config.yaml
+configure_service_config() {
+    local service_config="${CONFIG_WRITEABLE_DIR}/service-config.yaml"
+    
+    # Configure authentication if AUTH environment variable is set
+    if [ -n "$AUTH" ] && [ "$AUTH" != "false" ] && [ "$AUTH" != "FALSE" ]; then
+        echo "Enabling authentication (OIDC with PAM issuer)..."
+        # Set auth type to oidc (PAM issuer is enabled by default in service-config.yaml)
+        sed -i '/^  auth:/,/^  [^ ]/ { s/type: none.*/type: oidc/ }' "$service_config"
+    fi
+    
+    # Configure organizations if ORGS environment variable is set
+    if [ -n "$ORGS" ] && [ "$ORGS" != "false" ] && [ "$ORGS" != "FALSE" ]; then
+        echo "Enabling organizations support..."
+        # Find the organizations section and change enabled to true
+        sed -i '/^  organizations:/,/^  [^ ]/ { s/enabled: false/enabled: true/ }' "$service_config"
+    fi
+}
+
 # Function to switch container images from quay.io to locally built ones for development
 switch_to_local_images() {
     echo "Switching container images to locally built ones for development..."
@@ -29,6 +48,9 @@ if ! deploy/scripts/install.sh; then
     echo "Error: Installation failed"
     exit 1
 fi
+
+# Configure service-config.yaml based on environment variables (AUTH and ORGS)
+configure_service_config
 
 # Switch to locally built container images for development
 switch_to_local_images

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -47,6 +47,23 @@ To deploy with IdP provided organizations configured:
 AUTH=true ORGS=true make deploy
 ```
 
+### Deployment using Quadlets
+
+The service can also be deployed using systemd Quadlets (Podman containers managed by systemd):
+```
+make deploy-quadlets
+```
+
+To deploy with auth enabled (uses OIDC with PAM issuer):
+```
+AUTH=true make deploy-quadlets
+```
+
+To deploy with organizations support enabled:
+```
+AUTH=true ORGS=true make deploy-quadlets
+```
+
 Note it stores its generated CA cert, server cert, and client-bootstrap cert in `$HOME/.flightctl/certs`
 and the client configuration in `$HOME/.flightctl/client.yaml`.
 

--- a/docs/developer/pam-issuer-architecture.md
+++ b/docs/developer/pam-issuer-architecture.md
@@ -302,3 +302,4 @@ go test ./test/integration/...
 **Solution**:
 - Don't build `flightctl-pam-issuer` on non-Linux
 - Only build `flightctl-api` (no PAM dependency)
+

--- a/docs/developer/service-quadlets.md
+++ b/docs/developer/service-quadlets.md
@@ -181,12 +181,70 @@ This unified approach provides:
 - **Reduced complexity** by eliminating duplicate container variants
 - **Proven security model** following the same pattern used by internal database mode
 
+### Deployment-time Configuration
+
+The `deploy-quadlets` target supports environment variables to configure authentication and organization features during deployment:
+
+#### AUTH Environment Variable
+
+Setting `AUTH=true` enables authentication by modifying the `service-config.yaml` during deployment:
+
+```bash
+AUTH=true make deploy-quadlets
+```
+
+This changes:
+```yaml
+global:
+  auth:
+    type: none    # Changes to: type: oidc
+```
+
+This enables OIDC authentication with the PAM issuer service (which is enabled by default in the service-config.yaml), which:
+- Deploys the `flightctl-pam-issuer` service on port 8444
+- Configures the API to use OIDC authentication with the PAM issuer as the identity provider
+- Enables PAM-based user authentication (validates against system users)
+
+#### ORGS Environment Variable
+
+Setting `ORGS=true` enables organization support by modifying the `service-config.yaml` during deployment:
+
+```bash
+AUTH=true ORGS=true make deploy-quadlets
+```
+
+This changes:
+```yaml
+global:
+  organizations:
+    enabled: false    # Changes to: enabled: true
+```
+
+When organizations are enabled, the system:
+- Allows IdP-provided organization assignments via OIDC claims
+- Supports multi-tenant deployments with organization-based resource isolation
+- Requires AUTH to be enabled (organizations work in conjunction with authentication)
+
+These environment variables modify `/etc/flightctl/service-config.yaml` after installation, before the init containers process the configuration templates.
+
 ## Local Deployment
 
 Deploy all services:
 
 ```bash
 make deploy-quadlets
+```
+
+Deploy with authentication enabled (uses OIDC with PAM issuer):
+
+```bash
+AUTH=true make deploy-quadlets
+```
+
+Deploy with organizations support enabled:
+
+```bash
+AUTH=true ORGS=true make deploy-quadlets
 ```
 
 Deploy individual services:

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -47,6 +47,7 @@ Welcome to the Flight Control user documentation.
 * Installing and Configuring the Flight Control Service and UI
   * [Configuring External PostgreSQL Database](external-database.md)
   * [Configuring Flight Control to use k8s auth](kubernetes-auth.md)
+  * [PAM Authentication](pam-authentication.md)
   * [TPM Device Authentication](tpm-authentication.md)
 * [Installing the Flight Control CLI](install-cli.md)
 * Using the Flight Control CLI

--- a/docs/user/pam-authentication.md
+++ b/docs/user/pam-authentication.md
@@ -1,0 +1,160 @@
+# PAM Authentication
+
+This document describes how to use PAM authentication with Flight Control.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [User Management](#user-management)
+  - [Adding Users to PAM Issuer](#adding-users-to-pam-issuer)
+  - [Using Host System Users (Advanced)](#using-host-system-users-advanced)
+- [Security Considerations](#security-considerations)
+
+## Overview
+
+The PAM issuer is an OpenID Connect (OIDC) implementation that Flight Control provides out of the box for standalone and Quadlet deployments. It enables user authentication using Linux PAM (Pluggable Authentication Modules), allowing administrators to authenticate users with standard Linux user credentials.
+
+The PAM issuer runs as a separate service (`flightctl-pam-issuer`) and provides OIDC-compliant authentication endpoints that integrate with the main Flight Control API server.
+
+## Prerequisites
+
+There are no special prerequisites for using PAM authentication. The PAM issuer service is included in Quadlet and standalone Flight Control deployments.
+
+## Configuration
+
+The PAM issuer is configured in the Flight Control configuration file (typically `~/.flightctl/config.yaml` or `/etc/flightctl/config.yaml`). The configuration is located under the `auth.pamOidcIssuer` section.
+
+### Configuration Options
+
+```yaml
+auth:
+  pamOidcIssuer:
+    address: ":8444"                                    # Listen address for the PAM issuer service
+    issuer: "https://localhost:8444/api/v1/auth"       # Base URL for the OIDC issuer
+    clientId: "flightctl-client"                       # OAuth2 client ID
+    clientSecret: ""                                    # OAuth2 client secret (empty for public clients)
+    scopes:                                             # Supported OAuth2 scopes
+      - "openid"
+      - "profile"
+      - "email"
+      - "roles"
+    redirectUris:                                       # Allowed redirect URIs for OAuth2 flows
+      - "http://localhost:7777/callback"
+    pamService: "flightctl"                            # PAM service name (default: "flightctl")
+    allowPublicClientWithoutPKCE: false                # SECURITY: Allow public clients without PKCE (not recommended)
+```
+
+### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `address` | Listen address for the PAM issuer service | `:8444` |
+| `issuer` | Base URL for the OIDC issuer. Must match where `.well-known/openid-configuration` is served | Service base URL |
+| `clientId` | OAuth2 client ID for authentication | `flightctl-client` |
+| `clientSecret` | OAuth2 client secret. Leave empty for public clients (CLI) | Empty |
+| `scopes` | OAuth2 scopes supported by the issuer | `["openid", "profile", "email", "roles"]` |
+| `redirectUris` | Allowed redirect URIs for OAuth2 authorization code flow | Based on service base URL |
+| `pamService` | PAM service name to use for authentication (must match `/etc/pam.d/<name>`) | `flightctl` |
+| `allowPublicClientWithoutPKCE` | Allow public clients to skip PKCE requirement. **Security Warning**: Only enable for testing | `false` |
+
+### Default Configuration
+
+If the `pamOidcIssuer` section is present in the configuration file, the following defaults are automatically applied:
+
+- **PAM Service**: Defaults to `"flightctl"`
+- **Issuer URL**: Defaults to the service's base URL if not specified
+- **Client ID**: Defaults to `"flightctl-client"`
+- **Scopes**: Defaults to `["openid", "profile", "email", "roles"]`
+- **Redirect URIs**: Automatically configured based on the service's base UI URL or base URL
+
+### Security Note
+
+The `allowPublicClientWithoutPKCE` parameter should remain `false` (default) in production environments. PKCE (Proof Key for Code Exchange) is required for public clients per OAuth 2.0 Security Best Current Practice. Only enable this setting for testing or backward compatibility with legacy clients.
+
+## User Management
+
+### Adding Users to PAM Issuer
+
+For security reasons, the PAM issuer manages its own users within its container. This isolation ensures that authentication credentials are contained within the PAM issuer service and do not affect the host system.
+
+To add a user to the PAM issuer:
+
+1. **Create a new user:**
+
+```bash
+sudo podman exec flightctl-pam-issuer adduser <USER>
+```
+
+1. **Set the user's password:**
+
+```bash
+sudo podman exec flightctl-pam-issuer passwd <USER>
+```
+
+**Example:**
+
+```bash
+# Add user 'alice'
+sudo podman exec flightctl-pam-issuer adduser alice
+
+# Set password for 'alice'
+sudo podman exec flightctl-pam-issuer passwd alice
+```
+
+You will be prompted to enter and confirm the password.
+
+### Using Host System Users (Advanced)
+
+If you prefer to use your host system's existing users instead of managing users within the PAM issuer container, you can configure System Security Services Daemon (SSSD) integration.
+
+**Requirements:**
+
+1. **Mount the SSSD pipe** - The SSSD communication pipe must be mounted from the host into the PAM issuer container. Add the following line to the `[Container]` section of the `/etc/containers/systemd/flightctl-pam-issuer.container` file:
+
+```text
+Volume=/var/lib/sss/pipes:/var/lib/sss/pipes:rw
+```
+
+1. **Configure the host SSSD service** - Ensure that your host's SSSD configuration (`/etc/sssd/sssd.conf`) and NSSwitch (`/etc/nsswitch.conf`) include the `files` provider. This allows PAM to authenticate against both local user files and SSSD-managed users.
+
+1. **Configure the container NSSwitch** - The PAM issuer container's `/etc/nsswitch.conf` must also include the `files` provider.
+
+Example `/etc/nsswitch.conf` configuration (both host and container):
+
+```text
+passwd:     files sss
+shadow:     files sss
+group:      files sss
+```
+
+Consult your system's SSSD documentation for detailed configuration steps specific to your environment.
+
+## Security Considerations
+
+### User Isolation
+
+By default, the PAM issuer maintains its own user database within the container. This provides:
+
+- **Isolation**: Authentication credentials are separate from the host system
+- **Security**: Compromised PAM issuer credentials do not affect host system access
+- **Portability**: User management is self-contained within the service
+
+### Password Management
+
+- Use strong passwords for all PAM issuer users
+- Regularly rotate passwords following your organization's security policies
+- Consider implementing password complexity requirements through PAM configuration
+
+### Access Control
+
+- Only grant PAM issuer access to users who require Flight Control administrative capabilities
+- Review user access regularly and remove accounts that are no longer needed
+- Monitor authentication logs for suspicious activity
+
+## Additional Resources
+
+For technical details about the PAM issuer architecture and deployment configurations, see the developer documentation:
+
+- [PAM Issuer Architecture](../developer/pam-issuer-architecture.md)
+- [PAM Issuer Deployment Guide](../developer/pam-issuer-deployment.md)

--- a/internal/auth/issuer/pam/oidc_issuer.go
+++ b/internal/auth/issuer/pam/oidc_issuer.go
@@ -37,7 +37,7 @@ type OIDCIssuer interface {
 	Authorize(ctx context.Context, req *pamapi.AuthAuthorizeParams) (*AuthorizeResponse, error)
 
 	// Login handles the login form submission
-	Login(ctx context.Context, username, password, clientID, redirectURI, state string) (*LoginResult, error)
+	Login(ctx context.Context, username, password, clientID, redirectURI, state, codeChallenge, codeChallengeMethod string) (*LoginResult, error)
 
 	// Discovery and Configuration
 	GetOpenIDConfiguration() (*pamapi.OpenIDConfiguration, error)

--- a/internal/auth/issuer/pam/pam_issuer_test.go
+++ b/internal/auth/issuer/pam/pam_issuer_test.go
@@ -1,0 +1,589 @@
+//go:build linux
+
+package pam
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"os/user"
+	"testing"
+	"time"
+
+	pamapi "github.com/flightctl/flightctl/api/v1alpha1/pam-issuer"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/config/ca"
+	fccrypto "github.com/flightctl/flightctl/internal/crypto"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+// MockAuthenticator is a mock implementation of the Authenticator interface for testing
+type MockAuthenticator struct {
+	authenticateFunc  func(username, password string) error
+	lookupUserFunc    func(username string) (*user.User, error)
+	getUserGroupsFunc func(systemUser *user.User) ([]string, error)
+}
+
+func (m *MockAuthenticator) Authenticate(username, password string) error {
+	if m.authenticateFunc != nil {
+		return m.authenticateFunc(username, password)
+	}
+	return nil
+}
+
+func (m *MockAuthenticator) LookupUser(username string) (*user.User, error) {
+	if m.lookupUserFunc != nil {
+		return m.lookupUserFunc(username)
+	}
+	return &user.User{
+		Username: username,
+		Uid:      "1000",
+		Gid:      "1000",
+		Name:     "Test User",
+		HomeDir:  "/home/" + username,
+	}, nil
+}
+
+func (m *MockAuthenticator) GetUserGroups(systemUser *user.User) ([]string, error) {
+	if m.getUserGroupsFunc != nil {
+		return m.getUserGroupsFunc(systemUser)
+	}
+	return []string{"flightctl-admin"}, nil
+}
+
+func (m *MockAuthenticator) Close() error {
+	return nil
+}
+
+// Helper function to generate PKCE challenge from verifier
+func generatePKCEChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func TestPAMIssuer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PAM Issuer Unit Test Suite")
+}
+
+var _ = Describe("PAM Issuer Unit Tests", func() {
+	var (
+		ctx          context.Context
+		mockAuth     *MockAuthenticator
+		testProvider *PAMOIDCProvider
+		caClient     *fccrypto.CAClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockAuth = &MockAuthenticator{}
+
+		// Create test CA client
+		cfg := ca.NewDefault(GinkgoT().TempDir())
+		var err error
+		caClient, _, err = fccrypto.EnsureCA(cfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if testProvider != nil {
+			testProvider.Close()
+		}
+	})
+
+	Context("PKCE Authorization Flow Scenarios", func() {
+		Context("Scenario 1: Public client with PKCE (required)", func() {
+			BeforeEach(func() {
+				config := &config.PAMOIDCIssuer{
+					Issuer:       "https://test.example.com",
+					Scopes:       []string{"openid", "profile", "email"},
+					ClientID:     "public-client",
+					ClientSecret: "", // No secret = public client
+					RedirectURIs: []string{"https://example.com/callback"},
+					PAMService:   "other",
+				}
+
+				var err error
+				testProvider, err = NewPAMOIDCProviderWithAuthenticator(caClient, config, mockAuth)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should accept authorization request with valid PKCE", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:            "public-client",
+					RedirectUri:         "https://example.com/callback",
+					ResponseType:        pamapi.Code,
+					State:               lo.ToPtr("test-state"),
+					CodeChallenge:       lo.ToPtr(codeChallenge),
+					CodeChallengeMethod: lo.ToPtr(pamapi.AuthAuthorizeParamsCodeChallengeMethodS256),
+				}
+
+				authResp, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(authResp).ToNot(BeNil())
+				Expect(authResp.Type).To(Equal(AuthorizeResponseTypeHTML))
+			})
+
+			It("should reject authorization request without PKCE", func() {
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:     "public-client",
+					RedirectUri:  "https://example.com/callback",
+					ResponseType: pamapi.Code,
+					State:        lo.ToPtr("test-state"),
+				}
+
+				_, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid_request"))
+			})
+
+			It("should reject authorization request with code_challenge but no method", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:      "public-client",
+					RedirectUri:   "https://example.com/callback",
+					ResponseType:  pamapi.Code,
+					State:         lo.ToPtr("test-state"),
+					CodeChallenge: lo.ToPtr(codeChallenge),
+				}
+
+				_, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid_request"))
+			})
+
+			It("should verify PKCE correctly at token endpoint", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "public-client",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("public-client"),
+					CodeVerifier: lo.ToPtr(codeVerifier),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).To(BeNil())
+				Expect(response.AccessToken).ToNot(BeNil())
+			})
+
+			It("should reject token request with wrong PKCE verifier", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "public-client",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("public-client"),
+					CodeVerifier: lo.ToPtr("wrong-verifier"),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_grant"))
+			})
+
+			It("should reject token request with missing PKCE verifier", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "public-client",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType: pamapi.AuthorizationCode,
+					Code:      lo.ToPtr(authCode),
+					ClientId:  lo.ToPtr("public-client"),
+					// No CodeVerifier provided
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_grant"))
+			})
+		})
+
+		Context("Scenario 2: Public client without PKCE (explicitly allowed by config)", func() {
+			BeforeEach(func() {
+				config := &config.PAMOIDCIssuer{
+					Issuer:                       "https://test.example.com",
+					Scopes:                       []string{"openid", "profile", "email"},
+					ClientID:                     "public-client-no-pkce",
+					ClientSecret:                 "", // No secret = public client
+					RedirectURIs:                 []string{"https://example.com/callback"},
+					PAMService:                   "other",
+					AllowPublicClientWithoutPKCE: true,
+				}
+
+				var err error
+				testProvider, err = NewPAMOIDCProviderWithAuthenticator(caClient, config, mockAuth)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should accept authorization request without PKCE when allowed", func() {
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:     "public-client-no-pkce",
+					RedirectUri:  "https://example.com/callback",
+					ResponseType: pamapi.Code,
+					State:        lo.ToPtr("test-state"),
+				}
+
+				authResp, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(authResp).ToNot(BeNil())
+				Expect(authResp.Type).To(Equal(AuthorizeResponseTypeHTML))
+			})
+
+			It("should still accept authorization request with PKCE", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:            "public-client-no-pkce",
+					RedirectUri:         "https://example.com/callback",
+					ResponseType:        pamapi.Code,
+					State:               lo.ToPtr("test-state"),
+					CodeChallenge:       lo.ToPtr(codeChallenge),
+					CodeChallengeMethod: lo.ToPtr(pamapi.AuthAuthorizeParamsCodeChallengeMethodS256),
+				}
+
+				authResp, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(authResp).ToNot(BeNil())
+				Expect(authResp.Type).To(Equal(AuthorizeResponseTypeHTML))
+			})
+		})
+
+		Context("Scenario 3: Confidential client without PKCE (secret-based auth)", func() {
+			BeforeEach(func() {
+				config := &config.PAMOIDCIssuer{
+					Issuer:       "https://test.example.com",
+					Scopes:       []string{"openid", "profile", "email"},
+					ClientID:     "confidential-client",
+					ClientSecret: "super-secret-value",
+					RedirectURIs: []string{"https://example.com/callback"},
+					PAMService:   "other",
+				}
+
+				var err error
+				testProvider, err = NewPAMOIDCProviderWithAuthenticator(caClient, config, mockAuth)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should accept authorization request without PKCE", func() {
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:     "confidential-client",
+					RedirectUri:  "https://example.com/callback",
+					ResponseType: pamapi.Code,
+					State:        lo.ToPtr("test-state"),
+				}
+
+				authResp, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(authResp).ToNot(BeNil())
+				Expect(authResp.Type).To(Equal(AuthorizeResponseTypeHTML))
+			})
+
+			It("should require client secret at token endpoint", func() {
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:        authCode,
+					ClientID:    "confidential-client",
+					RedirectURI: "https://example.com/callback",
+					Scope:       "openid profile",
+					State:       "test-state",
+					Username:    "testuser",
+					ExpiresAt:   time.Now().Add(10 * time.Minute),
+					CreatedAt:   time.Now(),
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client"),
+					ClientSecret: lo.ToPtr("super-secret-value"),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).To(BeNil())
+				Expect(response.AccessToken).ToNot(BeNil())
+			})
+
+			It("should reject token request with wrong client secret", func() {
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:        authCode,
+					ClientID:    "confidential-client",
+					RedirectURI: "https://example.com/callback",
+					Scope:       "openid profile",
+					State:       "test-state",
+					Username:    "testuser",
+					ExpiresAt:   time.Now().Add(10 * time.Minute),
+					CreatedAt:   time.Now(),
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client"),
+					ClientSecret: lo.ToPtr("wrong-secret"),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_client"))
+			})
+
+			It("should reject token request without client secret", func() {
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:        authCode,
+					ClientID:    "confidential-client",
+					RedirectURI: "https://example.com/callback",
+					Scope:       "openid profile",
+					State:       "test-state",
+					Username:    "testuser",
+					ExpiresAt:   time.Now().Add(10 * time.Minute),
+					CreatedAt:   time.Now(),
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType: pamapi.AuthorizationCode,
+					Code:      lo.ToPtr(authCode),
+					ClientId:  lo.ToPtr("confidential-client"),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_client"))
+			})
+		})
+
+		Context("Scenario 4: Confidential client with PKCE (extra security)", func() {
+			BeforeEach(func() {
+				config := &config.PAMOIDCIssuer{
+					Issuer:       "https://test.example.com",
+					Scopes:       []string{"openid", "profile", "email"},
+					ClientID:     "confidential-client-pkce",
+					ClientSecret: "super-secret-value",
+					RedirectURIs: []string{"https://example.com/callback"},
+					PAMService:   "other",
+				}
+
+				var err error
+				testProvider, err = NewPAMOIDCProviderWithAuthenticator(caClient, config, mockAuth)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should accept authorization request with PKCE", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authParams := &pamapi.AuthAuthorizeParams{
+					ClientId:            "confidential-client-pkce",
+					RedirectUri:         "https://example.com/callback",
+					ResponseType:        pamapi.Code,
+					State:               lo.ToPtr("test-state"),
+					CodeChallenge:       lo.ToPtr(codeChallenge),
+					CodeChallengeMethod: lo.ToPtr(pamapi.AuthAuthorizeParamsCodeChallengeMethodS256),
+				}
+
+				authResp, err := testProvider.Authorize(ctx, authParams)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(authResp).ToNot(BeNil())
+				Expect(authResp.Type).To(Equal(AuthorizeResponseTypeHTML))
+			})
+
+			It("should require both client secret and PKCE verifier at token endpoint", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "confidential-client-pkce",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client-pkce"),
+					ClientSecret: lo.ToPtr("super-secret-value"),
+					CodeVerifier: lo.ToPtr(codeVerifier),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).To(BeNil())
+				Expect(response.AccessToken).ToNot(BeNil())
+			})
+
+			It("should reject token request with correct secret but wrong PKCE verifier", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "confidential-client-pkce",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client-pkce"),
+					ClientSecret: lo.ToPtr("super-secret-value"),
+					CodeVerifier: lo.ToPtr("wrong-verifier"),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_grant"))
+			})
+
+			It("should reject token request with correct PKCE but wrong secret", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "confidential-client-pkce",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client-pkce"),
+					ClientSecret: lo.ToPtr("wrong-secret"),
+					CodeVerifier: lo.ToPtr(codeVerifier),
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_client"))
+			})
+
+			It("should reject token request with missing PKCE verifier when challenge was provided", func() {
+				codeVerifier := "test-verifier-with-sufficient-entropy-for-pkce"
+				codeChallenge := generatePKCEChallenge(codeVerifier)
+
+				authCode := "test-auth-code"
+				codeData := &AuthorizationCodeData{
+					Code:                authCode,
+					ClientID:            "confidential-client-pkce",
+					RedirectURI:         "https://example.com/callback",
+					Scope:               "openid profile",
+					State:               "test-state",
+					Username:            "testuser",
+					ExpiresAt:           time.Now().Add(10 * time.Minute),
+					CreatedAt:           time.Now(),
+					CodeChallenge:       codeChallenge,
+					CodeChallengeMethod: pamapi.AuthAuthorizeParamsCodeChallengeMethodS256,
+				}
+				testProvider.codeStore.StoreCode(codeData)
+
+				tokenReq := &pamapi.TokenRequest{
+					GrantType:    pamapi.AuthorizationCode,
+					Code:         lo.ToPtr(authCode),
+					ClientId:     lo.ToPtr("confidential-client-pkce"),
+					ClientSecret: lo.ToPtr("super-secret-value"),
+					// Missing CodeVerifier
+				}
+
+				response, err := testProvider.Token(ctx, tokenReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.Error).ToNot(BeNil())
+				Expect(*response.Error).To(Equal("invalid_grant"))
+			})
+		})
+	})
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,10 @@ type PAMOIDCIssuer struct {
 	RedirectURIs []string `json:"redirectUris,omitempty"`
 	// PAMService is the PAM service name to use for authentication (default: "flightctl")
 	PAMService string `json:"pamService" validate:"required"`
+	// AllowPublicClientWithoutPKCE allows public clients (no client secret) to skip PKCE
+	// SECURITY WARNING: This should only be enabled for testing or backward compatibility
+	// Default: false (PKCE required for public clients per OAuth 2.0 Security BCP)
+	AllowPublicClientWithoutPKCE bool `json:"allowPublicClientWithoutPKCE,omitempty"`
 }
 
 type metricsConfig struct {

--- a/test/integration/auth/pam_issuer_test.go
+++ b/test/integration/auth/pam_issuer_test.go
@@ -66,6 +66,12 @@ var _ = Describe("PAM Issuer Integration Tests", func() {
 			Expect(*config.ResponseTypesSupported).To(ContainElement("code"))
 			Expect(config.GrantTypesSupported).ToNot(BeNil())
 			Expect(*config.GrantTypesSupported).To(ContainElements("authorization_code", "refresh_token"))
+			// Verify PKCE support is advertised (only S256, not plain)
+			Expect(config.CodeChallengeMethodsSupported).ToNot(BeNil())
+			Expect(*config.CodeChallengeMethodsSupported).To(ContainElement(
+				pamapi.OpenIDConfigurationCodeChallengeMethodsSupportedS256,
+			))
+			Expect(*config.CodeChallengeMethodsSupported).To(HaveLen(1))
 		})
 
 		It("should provide JWKS endpoint", func() {


### PR DESCRIPTION
1. adds PKCE enforcment for flightctl-pam-issuer 
2. add docs 
3. adds auth=true and orgs=true mode for make deploy-quadlets 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PKCE (S256) support added to OAuth2/OIDC flows (authorize, login and token exchanges) and advertised in OpenID configuration
  * Quadlets (Podman/systemd) deployment supports AUTH and ORGS environment modes to enable OIDC/PAM and organizations

* **Documentation**
  * New PAM authentication user guide and updated developer Quadlets deployment docs with AUTH/ORGS examples and PKCE guidance

* **Other**
  * Make help text updated to document AUTH/ORGS deploy options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->