### PR TITLE
EDM-2266: CLI handle Multiple Org Selection

### DIFF
--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const testOrganizationID = "00000000-0000-0000-0000-000000000000"
+
 func TestEditOptions_Validate(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -89,7 +91,7 @@ func TestEditOptions_Validate(t *testing.T) {
 			// Mock the config file path to avoid login requirement
 			tempDir := t.TempDir()
 			configPath := filepath.Join(tempDir, "client.yaml")
-			writeTestConfig(t, configPath, "test-org")
+			writeTestConfig(t, configPath, testOrganizationID)
 			opts.ConfigFilePath = configPath
 
 			err := opts.Validate(tc.args)
@@ -492,7 +494,7 @@ func TestEditOptions_Run_ArgumentHandling(t *testing.T) {
 			// Mock the config file path to avoid login requirement
 			tempDir := t.TempDir()
 			configPath := filepath.Join(tempDir, "client.yaml")
-			writeTestConfig(t, configPath, "test-org")
+			writeTestConfig(t, configPath, testOrganizationID)
 			opts.ConfigFilePath = configPath
 
 			// We can't easily test the full Run method without mocking the client,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login now auto-selects and persists a single organization when present and shows a list when multiple organizations exist.

* **Improvements**
  * Client setup and login respect the server-side organizations flag.
  * Configuration is parsed earlier to surface errors sooner.
  * Validation can be configured to skip the organization requirement for applicable commands.
  * Clearer messages and warnings when an organization is required or cannot be fetched.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->