### PR TITLE
EDM-2528: Add bash-completion as recommended RPM package

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -42,6 +42,7 @@ Requires: openssl
 # cli sub-package
 %package cli
 Summary: Flight Control CLI
+Recommends: bash-completion
 %description cli
 flightctl is the CLI for controlling the Flight Control service.
 


### PR DESCRIPTION
This is useful since that package is not installed by default in RHEL and is required to use our CLI autocomplete features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bash-completion as a recommended dependency for the CLI package to enhance shell integration and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->