### PR TITLE
EDM-2550: disable agent metrics handler by default

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -66,7 +66,7 @@ const (
 	// TestRootDirEnvKey is the environment variable key used to set the file system root when testing.
 	TestRootDirEnvKey = "FLIGHTCTL_TEST_ROOT_DIR"
 	// DefaultMetricsEnabled controls whether Prometheus metrics are enabled by default.
-	DefaultMetricsEnabled = true
+	DefaultMetricsEnabled = false
 	// DefaultProfilingEnabled controls whether runtime profiling (pprof) is enabled by default.
 	DefaultProfilingEnabled = false
 )


### PR DESCRIPTION
metrics should be opt-in and disabled by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Metrics collection is disabled by default. Enable metrics explicitly in your configuration to restore telemetry and monitoring.
  * Existing deployments that relied on default-enabled metrics will stop sending data until updated; no other runtime behavior, APIs, or error handling are affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->