### PR TITLE
EDM-2551: agent/selinux: enable listening on unreserved ports

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -141,6 +141,7 @@ dev_read_kmsg(flightctl_agent_t)
 # Network connections
 corenet_tcp_connect_all_ports(flightctl_agent_t)
 corenet_sendrecv_all_client_packets(flightctl_agent_t)
+corenet_tcp_bind_unreserved_ports(flightctl_agent_t)
 sysnet_dns_name_resolve(flightctl_agent_t)
 
 # Socket permissions


### PR DESCRIPTION
```
time="2025-11-12T01:32:50.435307Z" level=info msg="metrics server listening on http://127.0.0.1:15690/metrics/"
time="2025-11-12T01:32:50.440179Z" level=error msg="metrics server exited" file="agent/instrumentation/instrumentation.go:54"
```
<img width="1643" height="82" alt="image" src="https://github.com/user-attachments/assets/38e5155d-a9c4-41b2-9bb6-0a73f37d93a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system networking permissions to allow the agent to bind to additional unreserved TCP ports, improving connectivity and operational reliability.
  * This change reduces port-related failures for services that require ephemeral/unreserved port allocation and helps maintain stable network operations during dynamic connection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->