### PR TITLE
EDM-2553: flightctl-api of the latest flightctl-services tries to pull an image with tag 1.0.0

### DIFF
--- a/hack/current-version
+++ b/hack/current-version
@@ -13,12 +13,21 @@ if [[ -z "$tag" ]]; then
   tag=$(git describe --tags --exclude latest 2>/dev/null || echo -n "v0.0.0-unknown")
 fi
 
-# For RPM packaging (when called from packit), remove branch info and git commit hash
-# since COPR will add its own branch and commit information, preventing duplication
+# For RPM packaging (when called from packit), remove git commit hash but preserve main branch info
+# since COPR will add its own commit information, preventing duplication
 if [[ "${PACKIT_BUILD:-}" == "1" ]] || [[ "$1" == "--rpm" ]]; then
-  # Remove everything after the base version (e.g., "-main-211-g1234567") from the tag
-  # This leaves only the base version like "v1.0.0" and lets COPR handle the rest
-  tag=$(echo "$tag" | sed 's/-.*$//')
+  # For main branch builds, preserve the "-main" part but remove commit details
+  # Examples:
+  #   v1.0.0-main-211-g1234567 -> v1.0.0-main
+  #   v1.0.0-feature-123-g5678abc -> v1.0.0 (non-main branches get stripped completely)
+  #   v1.0.0 -> v1.0.0 (release tags stay as-is)
+  if [[ "$tag" =~ -main ]]; then
+    # Keep base version and "-main" but remove commit details
+    tag=$(echo "$tag" | sed 's/-main.*$/-main/')
+  else
+    # Remove everything after the base version for non-main branches
+    tag=$(echo "$tag" | sed 's/-.*$//')
+  fi
 fi
 
 echo -n "$tag"


### PR DESCRIPTION
This is the side effect of removing parts in [EDM-2269](https://issues.redhat.com/browse/EDM-2269) . The `-main` have to be kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version tagging in RPM packaging to differentiate main-branch builds from feature-branch builds with distinct version suffix handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->