### PR TITLE
NO-ISSUE: fix aap config

### DIFF
--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-config/init.sh
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-config/init.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # Extract database configuration
-DB_EXTERNAL=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*external:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
+DB_EXTERNAL=$(extract_value "db.external" "$SERVICE_CONFIG_FILE")
 if [ "$DB_EXTERNAL" == "enabled" ]; then
   echo "External database - password will come from Podman secret"
 else

--- a/deploy/podman/flightctl-api/flightctl-api-config/init.sh
+++ b/deploy/podman/flightctl-api/flightctl-api-config/init.sh
@@ -29,19 +29,19 @@ SRV_CERT_FILE=""
 SRV_KEY_FILE=""
 
 # Extract database configuration
-DB_EXTERNAL=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*external:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
+DB_EXTERNAL=$(extract_value "db.external" "$SERVICE_CONFIG_FILE")
 if [ "$DB_EXTERNAL" == "enabled" ]; then
   echo "Configuring external database connection"
-  DB_HOSTNAME=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*hostname:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
-  DB_PORT=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*port:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -1)
-  DB_NAME=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*name:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
-  DB_USER=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*user:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
+  DB_HOSTNAME=$(extract_value "db.hostname" "$SERVICE_CONFIG_FILE")
+  DB_PORT=$(extract_value "db.port" "$SERVICE_CONFIG_FILE")
+  DB_NAME=$(extract_value "db.name" "$SERVICE_CONFIG_FILE")
+  DB_USER=$(extract_value "db.user" "$SERVICE_CONFIG_FILE")
 
   # Extract SSL configuration for external database
-  DB_SSL_MODE=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*sslmode:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
-  DB_SSL_CERT=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*sslcert:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
-  DB_SSL_KEY=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*sslkey:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
-  DB_SSL_ROOT_CERT=$(sed -n '/^db:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n 's/^[[:space:]]*sslrootcert:[[:space:]]*[\"'"'"']*\([^\"'"'"'[:space:]]*\)[\"'"'"']*.*/\1/p' | head -1)
+  DB_SSL_MODE=$(extract_value "db.sslmode" "$SERVICE_CONFIG_FILE")
+  DB_SSL_CERT=$(extract_value "db.sslcert" "$SERVICE_CONFIG_FILE")
+  DB_SSL_KEY=$(extract_value "db.sslkey" "$SERVICE_CONFIG_FILE")
+  DB_SSL_ROOT_CERT=$(extract_value "db.sslrootcert" "$SERVICE_CONFIG_FILE")
 
   # Build SSL configuration block
   DB_SSL_CONFIG=""
@@ -117,11 +117,11 @@ FLIGHTCTL_DISABLE_AUTH=""
 
 
 # Extract rate limit values from service-config.yaml
-RATE_LIMIT_ENABLED=$(sed -n '/^service:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*rateLimit:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*enabled:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
-RATE_LIMIT_REQUESTS=$(sed -n '/^service:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*rateLimit:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*requests:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
-RATE_LIMIT_WINDOW=$(sed -n '/^service:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*rateLimit:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*window:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
-RATE_LIMIT_AUTH_REQUESTS=$(sed -n '/^service:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*rateLimit:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*authRequests:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
-RATE_LIMIT_AUTH_WINDOW=$(sed -n '/^service:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*rateLimit:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*authWindow:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
+RATE_LIMIT_ENABLED=$(extract_value "service.rateLimit.enabled" "$SERVICE_CONFIG_FILE")
+RATE_LIMIT_REQUESTS=$(extract_value "service.rateLimit.requests" "$SERVICE_CONFIG_FILE")
+RATE_LIMIT_WINDOW=$(extract_value "service.rateLimit.window" "$SERVICE_CONFIG_FILE")
+RATE_LIMIT_AUTH_REQUESTS=$(extract_value "service.rateLimit.authRequests" "$SERVICE_CONFIG_FILE")
+RATE_LIMIT_AUTH_WINDOW=$(extract_value "service.rateLimit.authWindow" "$SERVICE_CONFIG_FILE")
 
 # Set defaults if not configured
 RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
@@ -131,7 +131,7 @@ RATE_LIMIT_AUTH_REQUESTS=${RATE_LIMIT_AUTH_REQUESTS:-20}
 RATE_LIMIT_AUTH_WINDOW=${RATE_LIMIT_AUTH_WINDOW:-1h}
 
 # Extract organizations enabled value (defaults to false if not configured)
-ORGANIZATIONS_ENABLED=$(sed -n '/^global:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*organizations:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*enabled:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
+ORGANIZATIONS_ENABLED=$(extract_value "global.organizations.enabled" "$SERVICE_CONFIG_FILE")
 ORGANIZATIONS_ENABLED=${ORGANIZATIONS_ENABLED:-false}
 
 # Verify required values were found
@@ -145,10 +145,10 @@ AUTH_SED_CMDS=()
 # Process auth settings based on auth type
 if [ "$AUTH_TYPE" == "aap" ]; then
   echo "Configuring AAP authentication"
-  AAP_API_URL=$(extract_value "apiUrl" "$SERVICE_CONFIG_FILE")
-  AAP_EXTERNAL_API_URL=$(extract_value "externalApiUrl" "$SERVICE_CONFIG_FILE")
-  AAP_OAUTH_TOKEN=$(extract_value "oAuthToken" "$SERVICE_CONFIG_FILE")
-  AAP_CLIENT_ID=$(extract_value "oAuthApplicationClientId" "$SERVICE_CONFIG_FILE")
+  AAP_API_URL=$(extract_value "global.auth.aap.apiUrl" "$SERVICE_CONFIG_FILE")
+  AAP_EXTERNAL_API_URL=$(extract_value "global.auth.aap.externalApiUrl" "$SERVICE_CONFIG_FILE")
+  AAP_OAUTH_TOKEN=$(extract_value "global.auth.aap.oAuthToken" "$SERVICE_CONFIG_FILE")
+  AAP_CLIENT_ID=$(extract_value "global.auth.aap.oAuthApplicationClientId" "$SERVICE_CONFIG_FILE")
 
   AUTH_SED_CMDS=(
     -e "/{{if AAP}}/d"

--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
@@ -31,12 +31,12 @@ if [ -z "$BASE_DOMAIN" ]; then
 fi
 
 # Extract PAM OIDC Issuer configuration
-PAM_OIDC_ISSUER=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "issuer:" | head -1 | sed 's/.*issuer:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//' | sed 's/#.*$//')
-PAM_OIDC_CLIENT_ID=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "clientId:" | head -1 | sed 's/.*clientId:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//')
-PAM_OIDC_CLIENT_SECRET=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "clientSecret:" | head -1 | sed 's/.*clientSecret:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//')
-PAM_OIDC_SCOPES=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "scopes:" | head -1 | sed 's/.*scopes:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//')
-PAM_OIDC_REDIRECT_URIS=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "redirectUris:" | head -1 | sed 's/.*redirectUris:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//')
-PAM_OIDC_SERVICE=$(grep -A 20 "pamOidcIssuer:" "$SERVICE_CONFIG_FILE" | grep "pamService:" | head -1 | sed 's/.*pamService:[[:space:]]*\(.*\)/\1/' | sed 's/[[:space:]]*$//')
+PAM_OIDC_ISSUER=$(extract_value "global.auth.pamOidcIssuer.issuer" "$SERVICE_CONFIG_FILE")
+PAM_OIDC_CLIENT_ID=$(extract_value "global.auth.pamOidcIssuer.clientId" "$SERVICE_CONFIG_FILE")
+PAM_OIDC_CLIENT_SECRET=$(extract_value "global.auth.pamOidcIssuer.clientSecret" "$SERVICE_CONFIG_FILE")
+PAM_OIDC_SCOPES=$(extract_value "global.auth.pamOidcIssuer.scopes" "$SERVICE_CONFIG_FILE")
+PAM_OIDC_REDIRECT_URIS=$(extract_value "global.auth.pamOidcIssuer.redirectUris" "$SERVICE_CONFIG_FILE")
+PAM_OIDC_SERVICE=$(extract_value "global.auth.pamOidcIssuer.pamService" "$SERVICE_CONFIG_FILE")
 
 # Set defaults
 PAM_OIDC_CLIENT_ID=${PAM_OIDC_CLIENT_ID:-flightctl-client}

--- a/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
@@ -39,7 +39,7 @@ AUTH_CLIENT_ID=""
 AUTH_URL=""
 
 # Extract organizations enabled value (defaults to false if not configured)
-ORGANIZATIONS_ENABLED=$(sed -n '/^global:/,/^[^[:space:]]/p' "$SERVICE_CONFIG_FILE" | sed -n '/^[[:space:]]*organizations:/,/^[^[:space:]]/p' | sed -n '/^[[:space:]]*enabled:[[:space:]]*\([^[:space:]]*\).*/s//\1/p' | head -1)
+ORGANIZATIONS_ENABLED=$(extract_value "global.organizations.enabled" "$SERVICE_CONFIG_FILE")
 ORGANIZATIONS_ENABLED=${ORGANIZATIONS_ENABLED:-false}
 
 # Verify required values were found

--- a/test/integration/auth/auth_config_test.go
+++ b/test/integration/auth/auth_config_test.go
@@ -553,9 +553,9 @@ var _ = Describe("Auth Config Integration Tests", func() {
 			// Verify dynamic provider exists
 			Expect(dynamicProvider).ToNot(BeNil(), "Dynamic provider should be in config")
 
-			// Default provider should be set to the static provider name
+			// Default provider should be set to the first provider alphabetically
 			Expect(config.DefaultProvider).ToNot(BeNil())
-			Expect(*config.DefaultProvider).To(Equal("oidc"), "Default provider should be oidc")
+			Expect(*config.DefaultProvider).To(Equal("dynamic-test"), "Default provider should be dynamic-test (alphabetically first)")
 		})
 	})
 })


### PR DESCRIPTION
switch to use extract_value function instead of sed/greps

fixes multi-auth unit test that will fail sporadically since default auth provider is not taken after sorting 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration parsing across deployment init scripts to a unified extractor for more consistent behavior.
  * Simplified PAM and AAP auth config handling and added sensible defaults for PAM service/client IDs.
* **Behavior Change**
  * Rate limiting now enabled by default (requests=300, window=1m; authRequests=20, authWindow=1h).
  * Default authentication provider selection now follows the alphabetically first available provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->