### PR TITLE
EDM-2530: Flightctl version/tagging mismatch

### DIFF
--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -111,7 +111,7 @@ jobs:
         id: version-vars
         run: |
           set -euo pipefail
-          SOURCE_GIT_TAG=$(git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
+          SOURCE_GIT_TAG=$(./hack/current-version)
           if [ ! -d ".git" ]; then
             SOURCE_GIT_TREE_STATE=clean
           elif git diff --quiet; then


### PR DESCRIPTION
Currently, our GitHub action to get the current tag uses:

```bash
SOURCE_GIT_TAG=$(git describe --tags --exclude latest 2>/dev/null || echo "v0.0.0-unknown")
```

Unfortunately, `actions/checkout@v4` tweaks the tag of interest in a way that makes it a lightweight "commit" tag instead of an annotated tag, for example:

```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin \
    +f147e4121aecc7729d86de8ee1056faa19abab36:refs/tags/v0.10.0
```

The `git describe` command gives preference to annotated tags over lightweight tags, so the above change results in `git describe` returning the wrong tag &ndash; an unexpected version.

This change updates the workflow to use the existing `hack/current-version` script, whose behavior does not depend on whether or not the tag is annotated or lightweight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container image versioning in the automated build pipeline for more reliable tag generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->