### PR TITLE
NO-ISSUE: Alertmanager-proxy can not access rolebindings

### DIFF
--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrole.yaml
@@ -12,4 +12,7 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["selfsubjectaccessreviews"]
     verbs: ["create"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["get", "list"]
 {{ end }}


### PR DESCRIPTION
The `flightctl-alertmanager-proxy` pod was showing errors when trying to retrieve the alerts.

This happened because the service did not have permissions to read the role bindings, and as a result, the user was considered as not being linked to any organization and resulted in an error 403.

```
2025/11/14 08:45:53 [flightctl-alertmanager-proxy-77cfdc7b65-l2m8s/8hGnDPgdjb-000389] "GET https://192.168.1.131:8443/api/v2/alerts?filter=org_id%3D00000000-0000-0000-0000-000000000000&org_id=00000000-0000-0000-0000-000000000000 HTTP/1.1" from 10.244.0.1:62938 - 403 93B in 1.688275ms
time="2025-11-14T08:45:53Z" level=warning msg="Failed to fetch RoleBindings" error="failed to list rolebindings in namespace flightctl-external: rolebindings.rbac.authorization.k8s.io is forbidden: User \"system:serviceaccount:flightctl-external:flightctl-alertmanager-proxy\" cannot list resource \"rolebindings\" in API group \"rbac.authorization.k8s.io\" in the namespace \"flightctl-external\""
time="2025-11-14T08:45:53Z" level=info msg="Extracted organizations and roles" organizations="[]" roles="[]" user="system:serviceaccount:flightctl-external:flightctl-user"
time="2025-11-14T08:45:53Z" level=info msg="Filtered roles after removing organizations" roles="[]" user="system:serviceaccount:flightctl-external:flightctl-user"
time="2025-11-14T08:45:53Z" level=info msg="K8s identity created" organizations="[]" roles="[]" uid=db51faed-49bb-425d-89e5-fb9092bf8486 user="system:serviceaccount:flightctl-external:flightctl-user"
```

There appear to be other unrelated errors in the pod, I haven't looked into these
```
time="2025-11-14T08:12:54Z" level=warning msg="Failed to reload auth providers: failed to list auth providers: {v1alpha1 500 Status missing tracing span in GORM context Internal Server Error Failure}" func="github.com/flightctl/flightctl/internal/auth/authn.(*MultiAuth).periodicLoader" file="/app/internal/auth/authn/multiauth.go:112"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cluster-level access permissions for the alerting system. This adjusts role access to include additional permissions for role bindings, improving permission alignment and reducing the risk of permission-related disruptions to alerting components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->