### PR TITLE
EDM-2260: Graceful Shutdown and Signal Handling

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -180,7 +180,7 @@ func main() {
 	})
 
 	sigShutdown := make(chan os.Signal, 1)
-	signal.Notify(sigShutdown, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigShutdown, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		sig := <-sigShutdown
 		signal.Stop(sigShutdown)

--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -2,33 +2,46 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/alert_exporter"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
-	"github.com/flightctl/flightctl/internal/org/cache"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
+	"github.com/flightctl/flightctl/pkg/shutdown"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	ctx := context.Background()
-
 	log := log.InitLogs()
-	log.Println("Starting alert exporter")
+
+	if err := runCmd(log); err != nil {
+		log.Fatalf("Alert exporter error: %v", err)
+	}
+}
+
+func runCmd(log *logrus.Logger) error {
+	log.Info("Starting alert exporter")
+	defer log.Info("Alert exporter stopped")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
 
 	cfg, err := config.LoadOrGenerate(config.ConfigFile())
 	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
+		return fmt.Errorf("reading configuration: %w", err)
 	}
 	log.Printf("Using config: %s", cfg)
 
@@ -39,59 +52,129 @@ func main() {
 	log.SetLevel(logLvl)
 
 	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-alert-exporter")
-	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
-		}
-	}()
 
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 
-	log.Println("Initializing data store")
+	log.Info("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
-		log.Fatalf("initializing data store: %v", err)
+		return fmt.Errorf("initializing data store: %w", err)
 	}
 
 	store := store.NewStore(db, log.WithField("pkg", "store"))
-	defer store.Close()
 
 	processID := fmt.Sprintf("alert-exporter-%s-%s", util.GetHostname(), uuid.New().String())
 	queuesProvider, err := queues.NewRedisProvider(ctx, log, processID, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password, queues.DefaultRetryConfig())
 	if err != nil {
-		log.Fatalf("initializing queue provider: %v", err)
+		return fmt.Errorf("initializing queue provider: %w", err)
 	}
-	defer func() {
-		queuesProvider.Stop()
-		queuesProvider.Wait()
-	}()
 
 	kvStore, err := kvstore.NewKVStore(ctx, log, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password)
 	if err != nil {
-		log.Fatalf("initializing kv store: %v", err)
+		return fmt.Errorf("initializing kv store: %w", err)
 	}
-	defer kvStore.Close()
 
 	publisher, err := worker_client.QueuePublisher(ctx, queuesProvider)
 	if err != nil {
-		log.Fatalf("initializing task queue publisher: %v", err)
+		return fmt.Errorf("initializing task queue publisher: %w", err)
 	}
-	defer publisher.Close()
 	workerClient := worker_client.NewWorkerClient(publisher, log)
-
-	orgCache := cache.NewOrganizationTTL(cache.DefaultTTL)
-	go func() {
-		orgCache.Start(ctx)
-		log.Warn("Organization cache stopped unexpectedly")
-	}()
-	defer orgCache.Stop()
 
 	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(store, workerClient, kvStore, nil, log, "", "", []string{}))
 
 	server := alert_exporter.New(cfg, log)
-	if err := server.Run(ctx, serviceHandler); err != nil {
-		log.Fatalf("Error running server: %s", err)
+
+	// Channel to coordinate shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Cleanup function
+	cleanup := func(cleanupCtx context.Context) error {
+		log.Info("Starting cleanup...")
+
+		// Cancel ctx so any ctx-aware goroutines can react
+		cancel()
+
+		// Close resources
+		log.Info("Closing publisher")
+		publisher.Close()
+
+		log.Info("Closing KV store connections")
+		kvStore.Close()
+
+		log.Info("Closing database connections")
+		store.Close()
+
+		log.Info("Stopping queue provider")
+		queuesProvider.Stop()
+		queuesProvider.Wait()
+
+		// Shutdown tracer
+		if tracerShutdown != nil {
+			log.Info("Shutting down tracer")
+			if err := tracerShutdown(cleanupCtx); err != nil {
+				log.WithError(err).Error("Failed to shutdown tracer")
+			}
+		}
+
+		log.Info("Cleanup completed")
+		return nil
 	}
+
+	// Set up graceful shutdown
+	shutdown.GracefulShutdown(log, shutdownComplete, func(shutdownCtx context.Context) error {
+		// Run cleanup before process termination to avoid race condition
+		if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+			log.WithError(cleanupErr).Error("Failed to cleanup resources during signal shutdown")
+		}
+		return nil
+	})
+
+	// Start server in background
+	go func() {
+		log.Info("Starting alert exporter server")
+		err := server.Run(ctx, serviceHandler)
+
+		// Always signal main thread (nil for success, error for failure)
+		select {
+		case errCh <- err:
+		default:
+		}
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			cancel() // Cancel for both error AND success cases
+		}
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Alert exporter server error: %v", err)
+		}
+	}()
+
+	log.Info("Alert exporter server started, waiting for shutdown signal...")
+
+	// Wait for either error or shutdown completion
+	var serverErr error
+	select {
+	case err := <-errCh:
+		// Only treat real failures as errors, not context cancellation (normal shutdown)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Alert exporter failed: %v", err)
+			serverErr = err // Store error to return later
+
+			// Cleanup for real error path (signal-driven shutdown already handled cleanup in callback)
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cleanupCancel()
+			if cleanupErr := cleanup(cleanupCtx); cleanupErr != nil {
+				log.WithError(cleanupErr).Error("Failed to cleanup resources on error path")
+			}
+		}
+	case <-shutdownComplete:
+		// Graceful shutdown completed (cleanup already ran in signal callback)
+	}
+
+	log.Info("Alert exporter stopped, exiting...")
+	return serverErr
 }

--- a/cmd/flightctl-api/main.go
+++ b/cmd/flightctl-api/main.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	apiserver "github.com/flightctl/flightctl/internal/api_server"
@@ -24,34 +23,19 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
+	"github.com/flightctl/flightctl/pkg/shutdown"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
-//nolint:gocyclo
-func main() {
-	ctx := context.Background()
+// Helper functions for initialization
 
-	log := log.InitLogs()
-	log.Println("Starting API service")
-	defer log.Println("API service stopped")
-
-	cfg, err := config.LoadOrGenerate(config.ConfigFile())
-	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
-	}
-	log.Printf("Using config: %s", cfg)
-
-	logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
-	if err != nil {
-		logLvl = logrus.InfoLevel
-	}
-	log.SetLevel(logLvl)
-
+// initializeCertificates sets up CA and server certificates
+func initializeCertificates(ctx context.Context, cfg *config.Config, log *logrus.Logger) (*crypto.CAClient, *crypto.TLSCertificateConfig, error) {
 	ca, _, err := crypto.EnsureCA(cfg.CA)
 	if err != nil {
-		log.Fatalf("ensuring CA cert: %v", err)
+		return nil, nil, err
 	}
 
 	var serverCerts *crypto.TLSCertificateConfig
@@ -59,12 +43,15 @@ func main() {
 	// check for user-provided certificate files
 	if cfg.Service.SrvCertFile != "" || cfg.Service.SrvKeyFile != "" {
 		if canReadCertAndKey, err := crypto.CanReadCertAndKey(cfg.Service.SrvCertFile, cfg.Service.SrvKeyFile); !canReadCertAndKey {
-			log.Fatalf("cannot read provided server certificate or key: %v", err)
+			if err == nil {
+				err = fmt.Errorf("failed to read server certificate/key from %q and %q", cfg.Service.SrvCertFile, cfg.Service.SrvKeyFile)
+			}
+			return nil, nil, err
 		}
 
 		serverCerts, err = crypto.GetTLSCertificateConfig(cfg.Service.SrvCertFile, cfg.Service.SrvKeyFile)
 		if err != nil {
-			log.Fatalf("failed to load provided certificate: %v", err)
+			return nil, nil, err
 		}
 	} else {
 		srvCertFile := crypto.CertStorePath(cfg.Service.ServerCertName+".crt", cfg.Service.CertStore)
@@ -74,7 +61,7 @@ func main() {
 		if canReadCertAndKey, _ := crypto.CanReadCertAndKey(srvCertFile, srvKeyFile); canReadCertAndKey {
 			serverCerts, err = crypto.GetTLSCertificateConfig(srvCertFile, srvKeyFile)
 			if err != nil {
-				log.Fatalf("failed to load existing self-signed certificate: %v", err)
+				return nil, nil, err
 			}
 		} else {
 			// default to localhost if no alternative names are set
@@ -84,7 +71,7 @@ func main() {
 
 			serverCerts, err = ca.MakeAndWriteServerCertificate(ctx, srvCertFile, srvKeyFile, cfg.Service.AltNames, cfg.CA.ServerCertValidityDays)
 			if err != nil {
-				log.Fatalf("failed to create self-signed certificate: %v", err)
+				return nil, nil, err
 			}
 		}
 	}
@@ -101,138 +88,323 @@ func main() {
 		}
 	}
 
+	return ca, serverCerts, nil
+}
+
+// setupClientCertificates creates client certificates and config
+func setupClientCertificates(ctx context.Context, ca *crypto.CAClient, cfg *config.Config) error {
 	clientCertFile := crypto.CertStorePath(cfg.CA.ClientBootstrapCertName+".crt", cfg.Service.CertStore)
 	clientKeyFile := crypto.CertStorePath(cfg.CA.ClientBootstrapCertName+".key", cfg.Service.CertStore)
-	_, _, err = ca.EnsureClientCertificate(ctx, clientCertFile, clientKeyFile, cfg.CA.ClientBootstrapCommonName, cfg.CA.ClientBootstrapValidityDays)
+	_, _, err := ca.EnsureClientCertificate(ctx, clientCertFile, clientKeyFile, cfg.CA.ClientBootstrapCommonName, cfg.CA.ClientBootstrapValidityDays)
 	if err != nil {
-		log.Fatalf("ensuring bootstrap client cert: %v", err)
+		return err
 	}
 
 	// also write out a client config file
-
 	caPemBytes, err := ca.GetCABundle()
 	if err != nil {
-		log.Fatalf("loading CA certificate bundle: %v", err)
+		return err
 	}
 
 	err = client.WriteConfig(config.ClientConfigFile(), cfg.Service.BaseUrl, "", caPemBytes, nil)
 	if err != nil {
-		log.Fatalf("writing client config: %v", err)
+		return err
 	}
 
-	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-api")
-	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
-		}
-	}()
+	return nil
+}
 
-	log.Println("Initializing data store")
+// initializeStores sets up database and KV store
+func initializeStores(ctx context.Context, cfg *config.Config, log *logrus.Logger) (store.Store, queues.Provider, kvstore.KVStore, error) {
+	log.Info("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
-		log.Fatalf("initializing data store: %v", err)
+		return nil, nil, nil, err
 	}
 
 	store := store.NewStore(db, log.WithField("pkg", "store"))
-	defer store.Close()
-
-	tlsConfig, agentTlsConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
-	if err != nil {
-		log.Fatalf("failed creating TLS config: %v", err)
-	}
-
-	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
 
 	processID := fmt.Sprintf("api-%s-%s", util.GetHostname(), uuid.New().String())
 	provider, err := queues.NewRedisProvider(ctx, log, processID, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password, queues.DefaultRetryConfig())
 	if err != nil {
-		log.Fatalf("failed connecting to Redis queue: %v", err)
+		return nil, nil, nil, err
 	}
 
 	kvStore, err := kvstore.NewKVStore(ctx, log, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password)
 	if err != nil {
-		log.Fatalf("creating kvstore: %v", err)
-	}
-	if err = rendered.Bus.Initialize(ctx, kvStore, provider, time.Duration(cfg.Service.RenderedWaitTimeout), log); err != nil {
-		log.Fatalf("creating rendered version manager: %v", err)
-	}
-	if err = rendered.Bus.Instance().Start(ctx); err != nil {
-		log.Fatalf("starting rendered version manager: %v", err)
+		return nil, nil, nil, err
 	}
 
+	if err = rendered.Bus.Initialize(ctx, kvStore, provider, time.Duration(cfg.Service.RenderedWaitTimeout), log); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return store, provider, kvStore, nil
+}
+
+// initializeMetricsCollectors sets up metrics collectors based on configuration
+func initializeMetricsCollectors(ctx context.Context, cfg *config.Config, store store.Store, log *logrus.Logger) []prometheus.Collector {
+	if cfg.Metrics == nil || !cfg.Metrics.Enabled {
+		return nil
+	}
+
+	var collectors []prometheus.Collector
+
+	if cfg.Metrics.DeviceCollector != nil && cfg.Metrics.DeviceCollector.Enabled {
+		collectors = append(collectors, domain.NewDeviceCollector(ctx, store, log, cfg))
+	}
+	if cfg.Metrics.FleetCollector != nil && cfg.Metrics.FleetCollector.Enabled {
+		collectors = append(collectors, domain.NewFleetCollector(ctx, store, log, cfg))
+	}
+	if cfg.Metrics.RepositoryCollector != nil && cfg.Metrics.RepositoryCollector.Enabled {
+		collectors = append(collectors, domain.NewRepositoryCollector(ctx, store, log, cfg))
+	}
+	if cfg.Metrics.ResourceSyncCollector != nil && cfg.Metrics.ResourceSyncCollector.Enabled {
+		collectors = append(collectors, domain.NewResourceSyncCollector(ctx, store, log, cfg))
+	}
+	if cfg.Metrics.SystemCollector != nil && cfg.Metrics.SystemCollector.Enabled {
+		if systemMetricsCollector := metrics.NewSystemCollector(ctx, cfg); systemMetricsCollector != nil {
+			collectors = append(collectors, systemMetricsCollector)
+		}
+	}
+	if cfg.Metrics.HttpCollector != nil && cfg.Metrics.HttpCollector.Enabled {
+		if httpMetricsCollector := metrics.NewHTTPMetricsCollector(ctx, cfg, "flightctl-api", log); httpMetricsCollector != nil {
+			collectors = append(collectors, httpMetricsCollector)
+		}
+	}
+
+	return collectors
+}
+
+// initializeServers creates API and agent servers
+func initializeServers(ctx context.Context, cfg *config.Config, store store.Store, ca *crypto.CAClient, provider queues.Provider, tlsConfig, agentTlsConfig *tls.Config, log *logrus.Logger) (*apiserver.Server, *agentserver.AgentServer, error) {
 	// create the agent service listener as tcp (combined HTTP+gRPC)
 	agentListener, err := net.Listen("tcp", cfg.Service.AgentEndpointAddress)
 	if err != nil {
-		log.Fatalf("creating listener: %s", err)
+		return nil, nil, err
 	}
 
 	agentServer, err := agentserver.New(ctx, log, cfg, store, ca, agentListener, provider, agentTlsConfig)
 	if err != nil {
-		log.Fatalf("initializing agent server: %v", err)
+		return nil, nil, err
 	}
 
+	// Create API server listener and server
+	listener, err := middleware.NewTLSListener(cfg.Service.Address, tlsConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	// we pass the grpc server for now, to let the console sessions to establish a connection in grpc
+	apiServer := apiserver.New(log, cfg, store, ca, listener, provider, agentServer.GetGRPCServer())
+
+	return apiServer, agentServer, nil
+}
+
+// startServers launches all servers in background goroutines
+func startServers(apiServer *apiserver.Server, agentServer *agentserver.AgentServer, collectors []prometheus.Collector, serverCtx context.Context, cancel context.CancelFunc, errCh chan error, log *logrus.Logger) {
+	// Start API server
 	go func() {
-		listener, err := middleware.NewTLSListener(cfg.Service.Address, tlsConfig)
-		if err != nil {
-			log.Fatalf("creating listener: %s", err)
+		log.Info("Starting API server")
+		err := apiServer.Run(serverCtx)
+
+		// Always signal main thread
+		select {
+		case errCh <- err:
+		default:
 		}
-		// we pass the grpc server for now, to let the console sessions to establish a connection in grpc
-		server := apiserver.New(log, cfg, store, ca, listener, provider, agentServer.GetGRPCServer())
-		if err := server.Run(ctx); err != nil {
-			log.Fatalf("Error running server: %s", err)
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			cancel() // Cancel for both error AND success cases
 		}
-		cancel()
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("API server error: %v", err)
+		}
 	}()
 
+	// Start Agent server
 	go func() {
-		if err := agentServer.Run(ctx); err != nil {
-			log.Fatalf("Error running server: %s", err)
+		log.Info("Starting Agent server (gRPC)")
+		err := agentServer.Run(serverCtx)
+
+		// Always signal main thread
+		select {
+		case errCh <- err:
+		default:
 		}
-		cancel()
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			cancel() // Cancel for both error AND success cases
+		}
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Agent server error: %v", err)
+		}
 	}()
 
-	if cfg.Metrics != nil && cfg.Metrics.Enabled {
-		var collectors []prometheus.Collector
-		if cfg.Metrics.DeviceCollector != nil && cfg.Metrics.DeviceCollector.Enabled {
-			collectors = append(collectors, domain.NewDeviceCollector(ctx, store, log, cfg))
-		}
-		if cfg.Metrics.FleetCollector != nil && cfg.Metrics.FleetCollector.Enabled {
-			collectors = append(collectors, domain.NewFleetCollector(ctx, store, log, cfg))
-		}
-		if cfg.Metrics.RepositoryCollector != nil && cfg.Metrics.RepositoryCollector.Enabled {
-			collectors = append(collectors, domain.NewRepositoryCollector(ctx, store, log, cfg))
-		}
-		if cfg.Metrics.ResourceSyncCollector != nil && cfg.Metrics.ResourceSyncCollector.Enabled {
-			collectors = append(collectors, domain.NewResourceSyncCollector(ctx, store, log, cfg))
-		}
-		if cfg.Metrics.SystemCollector != nil && cfg.Metrics.SystemCollector.Enabled {
-			if systemMetricsCollector := metrics.NewSystemCollector(ctx, cfg); systemMetricsCollector != nil {
-				collectors = append(collectors, systemMetricsCollector)
-				defer func() {
-					if err := systemMetricsCollector.Shutdown(); err != nil {
-						log.Errorf("Failed to shutdown system metrics collector: %v", err)
-					}
-				}()
-			}
-		}
-		if cfg.Metrics.HttpCollector != nil && cfg.Metrics.HttpCollector.Enabled {
-			if httpMetricsCollector := metrics.NewHTTPMetricsCollector(ctx, cfg, "flightctl-api", log); httpMetricsCollector != nil {
-				collectors = append(collectors, httpMetricsCollector)
-				defer func() {
-					if err := httpMetricsCollector.Shutdown(); err != nil {
-						log.Errorf("Failed to shutdown HTTP metrics collector: %v", err)
-					}
-				}()
-			}
-		}
-
+	// Start Metrics server if collectors are available
+	if len(collectors) > 0 {
 		go func() {
-			if err := tracing.RunMetricsServer(ctx, log, cfg.Metrics.Address, collectors...); err != nil {
-				log.Errorf("Error running metrics server: %s", err)
+			log.Info("Starting Metrics server")
+			metricsServer := metrics.NewMetricsServer(log, collectors...)
+			err := metricsServer.Run(serverCtx)
+
+			// Always signal main thread
+			select {
+			case errCh <- err:
+			default:
 			}
-			cancel()
+
+			// Always cancel unless it was already a context cancellation
+			if !errors.Is(err, context.Canceled) {
+				cancel() // Cancel for both error AND success cases
+			}
+
+			// Log errors for debugging
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Errorf("Metrics server error: %v", err)
+			}
 		}()
 	}
+}
 
-	<-ctx.Done()
+func main() {
+	log := log.InitLogs()
+
+	if err := runCmd(log); err != nil {
+		log.Fatalf("API service error: %v", err)
+	}
+}
+
+func runCmd(log *logrus.Logger) error {
+	log.Info("Starting API service")
+	defer log.Info("API service stopped")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+
+	cfg, err := config.LoadOrGenerate(config.ConfigFile())
+	if err != nil {
+		return err
+	}
+	log.Printf("Using config: %s", cfg)
+
+	logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
+	if err != nil {
+		logLvl = logrus.InfoLevel
+	}
+	log.SetLevel(logLvl)
+
+	// Initialize certificates
+	ca, serverCerts, err := initializeCertificates(ctx, cfg, log)
+	if err != nil {
+		return err
+	}
+
+	// Setup client certificates
+	err = setupClientCertificates(ctx, ca, cfg)
+	if err != nil {
+		return err
+	}
+
+	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-api")
+
+	// Initialize stores
+	store, provider, kvStore, err := initializeStores(ctx, cfg, log)
+	if err != nil {
+		return err
+	}
+
+	tlsConfig, agentTlsConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
+	if err != nil {
+		return err
+	}
+	if err = rendered.Bus.Instance().Start(ctx); err != nil {
+		return err
+	}
+
+	// Initialize servers
+	apiServer, agentServer, err := initializeServers(ctx, cfg, store, ca, provider, tlsConfig, agentTlsConfig, log)
+	if err != nil {
+		return err
+	}
+
+	// Start servers in background
+	serverCtx, serverCancel := context.WithCancel(ctx)
+	defer serverCancel()
+
+	// Set up cleanup function
+	cleanupFunc := func(cleanupCtx context.Context) {
+		log.Info("Starting cleanup...")
+
+		// Cancel main context to stop rendered bus and other background services
+		cancel()
+
+		// Stop queue provider
+		log.Info("Stopping queue provider")
+		provider.Stop()
+		provider.Wait()
+
+		// Close KV store
+		log.Info("Closing KV store connections")
+		kvStore.Close()
+
+		// Close database
+		log.Info("Closing database connections")
+		store.Close()
+
+		// Shutdown tracer
+		if tracerShutdown != nil {
+			log.Info("Shutting down tracer")
+			if err := tracerShutdown(cleanupCtx); err != nil {
+				log.WithError(err).Error("Failed to shutdown tracer")
+			}
+		}
+
+		log.Info("Cleanup completed")
+	}
+
+	// Initialize metrics collectors
+	collectors := initializeMetricsCollectors(ctx, cfg, store, log)
+
+	// Start all servers
+	startServers(apiServer, agentServer, collectors, serverCtx, cancel, errCh, log)
+
+	// Channel to coordinate shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Set up graceful shutdown
+	shutdown.GracefulShutdown(log, shutdownComplete, func(shutdownCtx context.Context) error {
+		// Stop servers first
+		serverCancel()
+		return nil
+	})
+
+	log.Info("All servers started, waiting for shutdown signal...")
+
+	// Wait for either error or shutdown completion
+	var serverErr error
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("API service failed: %v", err)
+			serverErr = err // Store error to return later
+		}
+	case <-shutdownComplete:
+		// Graceful shutdown completed
+	}
+
+	// Single cleanup call for ALL exit paths
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cleanupCancel()
+	cleanupFunc(cleanupCtx)
+
+	log.Info("API service stopped, exiting...")
+	return serverErr
 }

--- a/cmd/flightctl-periodic/main.go
+++ b/cmd/flightctl-periodic/main.go
@@ -2,24 +2,38 @@ package main
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	periodic "github.com/flightctl/flightctl/internal/periodic_checker"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/shutdown"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	ctx := context.Background()
-
 	log := log.InitLogs()
-	log.Println("Starting periodic")
+
+	if err := runCmd(log); err != nil {
+		log.Fatalf("Periodic service error: %v", err)
+	}
+}
+
+func runCmd(log *logrus.Logger) error {
+	log.Info("Starting periodic service")
+	defer log.Info("Periodic service stopped")
+
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	errCh := make(chan error, 1)
 
 	cfg, err := config.LoadOrGenerate(config.ConfigFile())
 	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
+		return err
 	}
 	log.Printf("Using config: %s", cfg)
 
@@ -30,23 +44,104 @@ func main() {
 	log.SetLevel(logLvl)
 
 	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-periodic")
-	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
-		}
-	}()
 
-	log.Println("Initializing data store")
+	log.Info("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
-		log.Fatalf("initializing data store: %v", err)
+		return err
 	}
 
 	store := store.NewStore(db, log.WithField("pkg", "store"))
-	defer store.Close()
 
 	server := periodic.New(cfg, log, store)
-	if err := server.Run(ctx); err != nil {
-		log.Fatalf("Error running server: %s", err)
+
+	// Cleanup function to be called on both signal and error paths
+	cleanup := func(shutdownCtx context.Context) error {
+		log.Info("Starting cleanup...")
+
+		// Cancel server context to start graceful shutdown
+		log.Info("Stopping periodic server")
+		serverCancel()
+
+		// Give periodic tasks time to complete
+		log.Info("Waiting for periodic tasks to complete")
+		time.Sleep(2 * time.Second)
+
+		// Close database connections
+		log.Info("Closing database connections")
+		store.Close()
+
+		// Shutdown tracer
+		if tracerShutdown != nil {
+			log.Info("Shutting down tracer")
+			if err := tracerShutdown(shutdownCtx); err != nil {
+				log.WithError(err).Error("Failed to shutdown tracer")
+			}
+		}
+
+		log.Info("Cleanup completed")
+		return nil
 	}
+
+	// Start periodic server
+	go func() {
+		log.Info("Starting periodic server")
+		err := server.Run(serverCtx)
+
+		// Always signal main thread
+		select {
+		case errCh <- err:
+		default:
+		}
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			serverCancel() // Cancel for both error AND success cases
+		}
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Periodic server error: %v", err)
+		}
+	}()
+
+	// Channel to coordinate shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Set up graceful shutdown
+	shutdown.GracefulShutdown(log, shutdownComplete, func(shutdownCtx context.Context) error {
+		log.Info("Graceful shutdown signal received")
+
+		// Run cleanup before os.Exit
+		if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+			log.WithError(cleanupErr).Error("Failed to cleanup resources during signal shutdown")
+		}
+
+		return nil
+	})
+
+	log.Info("Periodic server started, waiting for shutdown signal...")
+
+	// Wait for either error or shutdown completion
+	var serverErr error
+	select {
+	case err := <-errCh:
+		// Only treat real failures as errors, not context cancellation (normal shutdown)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Periodic service failed: %v", err)
+			serverErr = err // Store error to return later
+
+			// Cleanup for error path only (signal path already cleaned up in callback)
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer shutdownCancel()
+			if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+				log.WithError(cleanupErr).Error("Failed to cleanup resources on error path")
+			}
+		}
+	case <-shutdownComplete:
+		// Graceful shutdown completed (cleanup already ran in signal callback)
+	}
+
+	log.Info("Periodic service stopped, exiting...")
+	return serverErr
 }

--- a/cmd/flightctl-restore/main.go
+++ b/cmd/flightctl-restore/main.go
@@ -66,8 +66,8 @@ func runRestore(ctx context.Context) error {
 	ctx = store.WithBypassSpanCheck(ctx)
 
 	log := log.InitLogs()
-	log.Println("Starting Flight Control restore preparation")
-	defer log.Println("Flight Control restore preparation completed")
+	log.Info("Starting Flight Control restore preparation")
+	defer log.Info("Flight Control restore preparation completed")
 
 	cfg, err := config.LoadOrGenerate(config.ConfigFile())
 	if err != nil {
@@ -88,7 +88,7 @@ func runRestore(ctx context.Context) error {
 		}
 	}()
 
-	log.Println("Initializing database connection for restore operations")
+	log.Info("Initializing database connection for restore operations")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
 		log.Fatalf("initializing database: %v", err)
@@ -101,14 +101,14 @@ func runRestore(ctx context.Context) error {
 		}
 	}()
 
-	log.Println("Initializing KV store connection for restore operations")
+	log.Info("Initializing KV store connection for restore operations")
 	kvStore, err := kvstore.NewKVStore(ctx, log, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password)
 	if err != nil {
 		log.Fatalf("initializing KV store: %v", err)
 	}
 	defer kvStore.Close()
 
-	log.Println("Creating store and service handler")
+	log.Info("Creating store and service handler")
 	storeInst := store.NewStore(db, log)
 
 	orgCache := cache.NewOrganizationTTL(cache.DefaultTTL)
@@ -120,11 +120,11 @@ func runRestore(ctx context.Context) error {
 
 	serviceHandler := service.NewServiceHandler(storeInst, nil, kvStore, nil, log, "", "", []string{})
 
-	log.Println("Running post-restoration device preparation")
+	log.Info("Running post-restoration device preparation")
 	if err := serviceHandler.PrepareDevicesAfterRestore(ctx); err != nil {
 		log.Fatalf("preparing devices after restore: %v", err)
 	}
 
-	log.Println("Post-restoration device preparation completed successfully")
+	log.Info("Post-restoration device preparation completed successfully")
 	return nil
 }

--- a/cmd/flightctl-telemetry-gateway/main.go
+++ b/cmd/flightctl-telemetry-gateway/main.go
@@ -2,26 +2,34 @@ package main
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"syscall"
+	"errors"
+	"sync"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	tg "github.com/flightctl/flightctl/internal/telemetry_gateway"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/shutdown"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	ctx := context.Background()
+
+	if err := runCmd(ctx); err != nil {
+		log.InitLogs().Fatalf("flightctl-telemetry-gateway: %v", err)
+	}
+}
+
+func runCmd(ctx context.Context) error {
 	log := log.InitLogs()
 
 	log.Info("Starting telemetry gateway")
+	defer log.Info("Telemetry gateway stopped")
 
 	cfg, err := config.LoadOrGenerate(config.ConfigFile())
 	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
+		return err
 	}
 	log.Printf("Using config: %s", cfg)
 
@@ -32,25 +40,94 @@ func main() {
 	log.SetLevel(logLvl)
 
 	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-telemetry-gateway")
-	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
-		}
-	}()
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Handle graceful shutdown
-	sigShutdown := make(chan os.Signal, 1)
-	signal.Notify(sigShutdown, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
-	go func() {
-		<-sigShutdown
-		log.Info("Shutdown signal received")
+	// Use sync.Once to ensure tracer shutdown runs only once
+	var shutdownOnce sync.Once
+
+	// Tracer shutdown function with defensive guard
+	shutdownTracer := func(shutdownCtx context.Context) {
+		shutdownOnce.Do(func() {
+			if tracerShutdown != nil {
+				if err := tracerShutdown(shutdownCtx); err != nil {
+					log.WithError(err).Error("Failed to shutdown tracer")
+				}
+			}
+		})
+	}
+
+	errCh := make(chan error, 1)
+
+	// Cleanup function to be called on both signal and error paths
+	cleanup := func(cleanupCtx context.Context) error {
+		log.Info("Starting cleanup...")
+
+		// Cancel context to stop telemetry gateway
 		cancel()
+
+		// Flush tracer (idempotent via sync.Once)
+		shutdownTracer(cleanupCtx)
+
+		log.Info("Cleanup completed")
+		return nil
+	}
+
+	// Start telemetry gateway in background
+	go func() {
+		log.Info("Starting telemetry gateway")
+		err := tg.Run(ctx, cfg)
+
+		// Always signal main thread
+		select {
+		case errCh <- err:
+		default:
+		}
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			cancel() // Cancel for both error AND success cases
+		}
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Telemetry gateway error: %v", err)
+		}
 	}()
 
-	if err := tg.Run(ctx, cfg); err != nil {
-		log.Fatalf("failed to create telemetry gateway: %v", err)
+	// Channel to coordinate shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Set up graceful shutdown
+	shutdown.GracefulShutdown(log, shutdownComplete, func(shutdownCtx context.Context) error {
+		// Run cleanup for signal-driven shutdown (includes tracer flush)
+		if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+			log.WithError(cleanupErr).Error("Failed to cleanup resources during signal shutdown")
+		}
+		return nil
+	})
+
+	log.Info("Telemetry gateway started, waiting for shutdown signal...")
+
+	// Wait for either error or shutdown completion
+	var serverErr error
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Telemetry gateway failed: %v", err)
+			serverErr = err // Store error to return later
+		}
+		// Cleanup for error path (signal path already cleaned up in callback)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), shutdown.DefaultGracefulShutdownTimeout)
+		defer cleanupCancel()
+		if cleanupErr := cleanup(cleanupCtx); cleanupErr != nil {
+			log.WithError(cleanupErr).Error("Failed to cleanup resources on error path")
+		}
+	case <-shutdownComplete:
+		// Graceful shutdown completed (cleanup already ran in signal callback)
 	}
+
+	log.Info("Telemetry gateway stopped, exiting...")
+	return serverErr
 }

--- a/cmd/flightctl-worker/main.go
+++ b/cmd/flightctl-worker/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/consts"
@@ -18,21 +17,32 @@ import (
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/queues"
+	"github.com/flightctl/flightctl/pkg/shutdown"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	ctx := context.Background()
-
 	log := log.InitLogs()
-	log.Println("Starting worker service")
-	defer log.Println("Worker service stopped")
+
+	if err := runCmd(log); err != nil {
+		log.Fatalf("Worker service error: %v", err)
+	}
+}
+
+func runCmd(log *logrus.Logger) error {
+	log.Info("Starting worker service")
+	defer log.Info("Worker service stopped")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
 
 	cfg, err := config.LoadOrGenerate(config.ConfigFile())
 	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
+		return err
 	}
 	log.Printf("Using config: %s", cfg)
 
@@ -43,22 +53,15 @@ func main() {
 	log.SetLevel(logLvl)
 
 	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-worker")
-	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
-		}
-	}()
 
-	log.Println("Initializing data store")
+	log.Info("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
-		log.Fatalf("initializing data store: %v", err)
+		return err
 	}
 
 	store := store.NewStore(db, log.WithField("pkg", "store"))
-	defer store.Close()
 
-	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
 	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-worker")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-worker")
@@ -66,7 +69,7 @@ func main() {
 	processID := fmt.Sprintf("worker-%s-%s", util.GetHostname(), uuid.New().String())
 	provider, err := queues.NewRedisProvider(ctx, log, processID, cfg.KV.Hostname, cfg.KV.Port, cfg.KV.Password, queues.DefaultRetryConfig())
 	if err != nil {
-		log.Fatalf("failed connecting to Redis queue: %v", err)
+		return err
 	}
 
 	k8sClient, err := k8sclient.NewK8SClient()
@@ -91,18 +94,116 @@ func main() {
 		}
 
 		if len(collectors) > 0 {
+			// Start metrics server in background
 			go func() {
-				if err := tracing.RunMetricsServer(ctx, log, cfg.Metrics.Address, collectors...); err != nil {
-					log.Errorf("Error running metrics server: %s", err)
+				log.Info("Starting metrics server")
+				metricsServer := metrics.NewMetricsServer(log, collectors...)
+				err := metricsServer.Run(ctx)
+
+				// Always signal main thread
+				select {
+				case errCh <- err:
+				default:
 				}
-				cancel()
+
+				// Always cancel unless it was already a context cancellation
+				if !errors.Is(err, context.Canceled) {
+					cancel() // Cancel for both error AND success cases
+				}
+
+				// Log errors for debugging
+				if err != nil && !errors.Is(err, context.Canceled) {
+					log.Errorf("Metrics server error: %v", err)
+				}
 			}()
 		}
 	}
 
 	server := workerserver.New(cfg, log, store, provider, k8sClient, workerCollector)
-	if err := server.Run(ctx); err != nil {
-		log.Fatalf("Error running server: %s", err)
+
+	// Start worker server
+	go func() {
+		log.Info("Starting worker server")
+		err := server.Run(ctx)
+
+		// Always signal main thread
+		select {
+		case errCh <- err:
+		default:
+		}
+
+		// Always cancel unless it was already a context cancellation
+		if !errors.Is(err, context.Canceled) {
+			cancel() // Cancel for both error AND success cases
+		}
+
+		// Log errors for debugging
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Worker server error: %v", err)
+		}
+	}()
+
+	// Channel to coordinate shutdown completion
+	shutdownComplete := make(chan struct{})
+
+	// Cleanup function
+	cleanup := func(cleanupCtx context.Context) error {
+		log.Info("Starting cleanup...")
+
+		// Cancel ctx so any ctx-aware goroutines can react
+		cancel()
+
+		// Stop queue provider
+		log.Info("Stopping queue provider")
+		provider.Stop()
+		provider.Wait()
+
+		// Close database
+		log.Info("Closing database connections")
+		store.Close()
+
+		// Shutdown tracer
+		if tracerShutdown != nil {
+			log.Info("Shutting down tracer")
+			if err := tracerShutdown(cleanupCtx); err != nil {
+				log.WithError(err).Error("Failed to shutdown tracer")
+			}
+		}
+
+		log.Info("Cleanup completed")
+		return nil
 	}
-	cancel()
+
+	// Set up graceful shutdown
+	shutdown.GracefulShutdown(log, shutdownComplete, func(shutdownCtx context.Context) error {
+		// Run cleanup before process termination to avoid race condition
+		if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+			log.WithError(cleanupErr).Error("Failed to cleanup resources during signal shutdown")
+		}
+		return nil
+	})
+
+	log.Info("Worker server started, waiting for shutdown signal...")
+
+	// Wait for either error or shutdown completion
+	var serverErr error
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Worker failed: %v", err)
+			serverErr = err // Store error to return later
+
+			// Cleanup only for real error path; signal/cancellation path is handled in the callback
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cleanupCancel()
+			if cleanupErr := cleanup(cleanupCtx); cleanupErr != nil {
+				log.WithError(cleanupErr).Error("Failed to cleanup resources on error path")
+			}
+		}
+	case <-shutdownComplete:
+		// Graceful shutdown completed (cleanup already ran in signal callback)
+	}
+
+	log.Info("Worker stopped, exiting...")
+	return serverErr
 }

--- a/docs/developer/architecture/service-observability.md
+++ b/docs/developer/architecture/service-observability.md
@@ -26,11 +26,17 @@ A tracer is the component responsible for creating spans. Each service or compon
 
 ## Tracer Initialization
 
-All services should call `InitTracer()` during startup to configure the global OpenTelemetry tracer:
+All services should call `tracing.InitTracer()` during startup to configure the global OpenTelemetry tracer:
 
 ```go
-shutdown := InitTracer(log, cfg, "flightctl-api")
-defer shutdown(ctx)
+import "github.com/flightctl/flightctl/internal/instrumentation/tracing"
+
+tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-api")
+defer func() {
+    if err := tracerShutdown(ctx); err != nil {
+        log.WithError(err).Error("Failed to shutdown tracer")
+    }
+}()
 ```
 
 This function:
@@ -113,4 +119,137 @@ func (t *TracedService) ListCertificateSigningRequests(ctx context.Context, p ap
 - Reduces boilerplate in service logic
 - Standardizes status and error reporting
 - Keeps all span logic consistent and easy to audit
+
+---
+
+## Graceful Shutdown Integration
+
+All FlightCtl services implement standardized graceful shutdown that works seamlessly with OpenTelemetry tracing. The shutdown process ensures spans are properly flushed before service termination.
+
+### Standard Shutdown Pattern
+
+All services follow this pattern for coordinated shutdown:
+
+```go
+func main() {
+    startTime := time.Now()
+    ctx := context.Background()
+
+    log := log.InitLogs()
+    log.Info("Starting service")
+    defer func() {
+        log.WithField("uptime", time.Since(startTime)).Info("Service stopped")
+    }()
+
+    // Initialize tracer with shutdown function
+    tracerShutdown := tracing.InitTracer(log, cfg, "service-name")
+    defer func() {
+        if err := tracerShutdown(ctx); err != nil {
+            log.WithError(err).Error("Failed to shutdown tracer")
+        }
+    }()
+
+    // Set up signal handling for graceful shutdown
+    ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+    defer cancel()
+
+    // Start services in goroutines...
+
+    // Wait for shutdown signal or error
+    select {
+    case <-ctx.Done():
+        log.Info("Shutdown signal received, initiating graceful shutdown")
+    case err := <-serverErrors:
+        log.Errorf("Server error received: %v", err)
+        cancel()
+    }
+
+    // Coordinated shutdown with timeout
+    const shutdownTimeout = 30 * time.Second
+    log.Infof("Starting coordinated shutdown (timeout: %v)", shutdownTimeout)
+
+    shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+    defer shutdownCancel()
+
+    // Shutdown servers and resources in order
+    if err := server.Shutdown(shutdownCtx); err != nil {
+        log.Errorf("Server shutdown error: %v", err)
+    }
+
+    // Stop queue providers
+    provider.Stop()
+    provider.Wait()
+
+    // Close database connections
+    store.Close()
+
+    // Close other resources
+    kvStore.Close()
+
+    // Tracer shutdown is handled by defer earlier, ensuring it completes
+    // within timeout. The defer ensures spans are flushed even if shutdown
+    // logic encounters errors.
+
+    log.Info("Graceful shutdown completed")
+}
+```
+
+### Shutdown Signal Handling
+
+**Supported Signals:**
+- `SIGINT` (Ctrl+C) - Interactive shutdown
+- `SIGTERM` - Graceful termination (default for `kubectl delete pod`)
+- `SIGQUIT` - Quit with core dump
+
+**Note:** `SIGHUP` is reserved for configuration reloading and is not handled by the graceful shutdown system.
+
+**Signal Processing:**
+- Uses `signal.NotifyContext()` for cross-platform compatibility
+- 30-second timeout for graceful shutdown operations
+- Tracer shutdown happens automatically via defer before timeout
+
+### Shutdown Observability
+
+**Structured Logging:**
+
+```go
+// Service startup
+log.WithField("version", version).Info("Starting service")
+
+// Shutdown initiated
+log.Info("Shutdown signal received, initiating graceful shutdown")
+
+// Shutdown completed
+log.WithField("uptime", time.Since(startTime)).Info("Service stopped")
+```
+
+**Tracing Integration:**
+- Active spans are completed before shutdown
+- Tracer flush occurs during shutdown sequence
+- No spans are lost during graceful termination
+
+### Error Handling During Shutdown
+
+Services handle shutdown errors gracefully:
+
+```go
+// Example: Coordinated server shutdown
+go func() {
+    if err := server.Run(ctx); err != nil {
+        log.Errorf("Server error: %v", err)
+        serverErrors <- err  // Signal main thread, don't exit immediately
+    }
+}()
+
+// Main thread coordinates shutdown
+select {
+case <-ctx.Done():
+    // Signal-based shutdown
+case err := <-serverErrors:
+    // Error-based shutdown - still allows tracer cleanup
+    log.Errorf("Initiating shutdown due to error: %v", err)
+}
+```
+
+This ensures that even during error conditions, OpenTelemetry spans are properly flushed and observability data is preserved.
 

--- a/internal/agent/AGENTS.md
+++ b/internal/agent/AGENTS.md
@@ -29,8 +29,9 @@ The agent reconciles `Device.Spec` from control plane, reports resource usage, m
 
 ### Threading & Lifecycle
 - Primarily single-threaded (async requires strong justification)
-- **Graceful Termination** (`agent/shutdown`): Clean shutdown with in-flight completion
-- **Configuration Reload** (`agent/reload`): Runtime updates without restart
+- **Graceful shutdown** (`agent/shutdown`): Phase-based termination with component priorities
+- **Configuration reload** (`agent/reload`): Runtime updates without restart
+- **Signal handling**: Standard signals (`SIGINT`, `SIGHUP`, `SIGTERM`)
 
 ## Testing Standards
 - Use `testify/require`: `require := require.New(t)`

--- a/internal/alert_exporter/server.go
+++ b/internal/alert_exporter/server.go
@@ -6,9 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/config"
@@ -52,18 +49,6 @@ func (s *Server) Run(ctx context.Context, serviceHandler service.Service) error 
 	go s.updateUptimeMetric(ctx)
 
 	alertExporter := NewAlertExporter(s.log, serviceHandler, s.cfg)
-
-	// Handle shutdown gracefully
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-	go func() {
-		sig := <-sigCh
-		logger.WithFields(logrus.Fields{
-			"signal": sig.String(),
-		}).Info("Received shutdown signal, initiating graceful shutdown")
-		cancel()
-	}()
 
 	backoff := time.Second
 	maxBackoff := time.Minute

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,0 +1,59 @@
+package shutdown
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultGracefulShutdownTimeout = 30 * time.Second
+)
+
+// defaultShutdownFunc is the default no-op shutdown function used when nil is passed
+var defaultShutdownFunc = func(context.Context) error { return nil }
+
+// GracefulShutdown sets up graceful shutdown handling for a service.
+// It listens for SIGINT, SIGTERM, and SIGQUIT signals and calls the provided shutdown function.
+// The shutdownComplete channel is closed when shutdown signal is received.
+// If shutdownFunc is nil, it uses default behavior (just closes the channel).
+// The shutdown function receives a context with timeout and must respect context cancellation
+// to ensure timely completion. If the shutdown function returns an error, it is logged but
+// the channel is still closed and process exit handling is left to the caller.
+func GracefulShutdown(log *logrus.Logger, shutdownComplete chan struct{}, shutdownFunc func(context.Context) error) {
+	GracefulShutdownWithTimeout(log, shutdownComplete, shutdownFunc, DefaultGracefulShutdownTimeout)
+}
+
+// GracefulShutdownWithTimeout sets up graceful shutdown handling with a custom timeout.
+func GracefulShutdownWithTimeout(log *logrus.Logger, shutdownComplete chan struct{}, shutdownFunc func(context.Context) error, timeout time.Duration) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+
+	go func() {
+		sig := <-signals
+		log.Infof("Received signal %s, initiating graceful shutdown", sig.String())
+
+		// If no custom shutdown function provided, use default behavior
+		if shutdownFunc == nil {
+			shutdownFunc = defaultShutdownFunc
+		}
+
+		log.Info("Graceful shutdown signal received")
+
+		// Create timeout context for cleanup
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		// Execute shutdown function
+		if err := shutdownFunc(ctx); err != nil {
+			log.WithError(err).Error("Graceful shutdown function failed")
+		}
+
+		// Signal shutdown completion
+		close(shutdownComplete)
+	}()
+}


### PR DESCRIPTION
this PR replaces https://github.com/flightctl/flightctl/pull/1893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Multiple services reorganized into modular startup flows (background servers, context-driven lifecycles) with runCmd-style orchestration and unified error propagation.
  * Per-service inline signal handling consolidated or removed in favor of coordinated shutdown wiring.

* **New Features**
  * Added a shared graceful-shutdown utility with default timeout and coordinated cleanup signaling.
  * User info proxy exposes upstream response/user types for API use.

* **Documentation**
  * Observability docs updated to standardize tracer init/shutdown and graceful-shutdown pattern.

* **Bug Fixes / Quality**
  * Startup logging normalized; shutdown paths made more robust and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->