### PR TITLE
EDM-2295: Clean up quadlet podman resources

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -376,6 +376,41 @@ func (p *Podman) CreateVolume(ctx context.Context, name string, labels []string)
 	return mountpoint, nil
 }
 
+type podmanVolume struct {
+	Name string `json:"Name"`
+}
+
+func (p *Podman) ListVolumes(ctx context.Context, labels []string, filters []string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	args := []string{
+		"volume",
+		"ls",
+		"--format",
+		"json",
+	}
+	args = applyFilters(args, labels, filters)
+	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
+	if exitCode != 0 {
+		return nil, fmt.Errorf("list volumes: %w", errors.FromStderr(stderr, exitCode))
+	}
+	var podVols []podmanVolume
+	err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &podVols)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal volumes: %w", err)
+	}
+	volumesSeen := make(map[string]struct{})
+	volumes := make([]string, 0, len(podVols))
+	for _, volume := range podVols {
+		if _, ok := volumesSeen[volume.Name]; !ok {
+			volumesSeen[volume.Name] = struct{}{}
+			volumes = append(volumes, volume.Name)
+		}
+	}
+	return volumes, nil
+}
+
 func (p *Podman) VolumeExists(ctx context.Context, name string) bool {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
@@ -385,17 +420,25 @@ func (p *Podman) VolumeExists(ctx context.Context, name string) bool {
 	return exitCode == 0
 }
 
-func (p *Podman) InspectVolumeMount(ctx context.Context, name string) (string, error) {
+func (p *Podman) inspectVolumeProperty(ctx context.Context, name string, property string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 
-	args := []string{"volume", "inspect", name, "--format", "{{.Mountpoint}}"}
+	args := []string{"volume", "inspect", name, "--format", property}
 	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
 	if exitCode != 0 {
-		return "", fmt.Errorf("inspect volume mountpoint: %w", errors.FromStderr(stderr, exitCode))
+		return "", fmt.Errorf("inspect volume property %s: %w", property, errors.FromStderr(stderr, exitCode))
 	}
 
 	return strings.TrimSpace(stdout), nil
+}
+
+func (p *Podman) InspectVolumeDriver(ctx context.Context, name string) (string, error) {
+	return p.inspectVolumeProperty(ctx, name, "{{.Driver}}")
+}
+
+func (p *Podman) InspectVolumeMount(ctx context.Context, name string) (string, error) {
+	return p.inspectVolumeProperty(ctx, name, "{{.Mountpoint}}")
 }
 
 func (p *Podman) RemoveVolumes(ctx context.Context, volumes ...string) error {
@@ -412,7 +455,18 @@ func (p *Podman) RemoveVolumes(ctx context.Context, volumes ...string) error {
 	return nil
 }
 
-func (p *Podman) ListNetworks(ctx context.Context, labels []string) ([]string, error) {
+func applyFilters(args, labels, filters []string) []string {
+	for _, label := range labels {
+		args = append(args, "--filter", fmt.Sprintf("label=%s", label))
+	}
+
+	for _, filter := range filters {
+		args = append(args, "--filter", filter)
+	}
+	return args
+}
+
+func (p *Podman) ListNetworks(ctx context.Context, labels []string, filters []string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 
@@ -422,13 +476,11 @@ func (p *Podman) ListNetworks(ctx context.Context, labels []string) ([]string, e
 		"--format",
 		"{{.Network.ID}}",
 	}
-	for _, label := range labels {
-		args = append(args, "--filter", fmt.Sprintf("label=%s", label))
-	}
+	args = applyFilters(args, labels, filters)
 
 	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
 	if exitCode != 0 {
-		return nil, fmt.Errorf("list containers: %w", errors.FromStderr(stderr, exitCode))
+		return nil, fmt.Errorf("list networks: %w", errors.FromStderr(stderr, exitCode))
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
@@ -477,9 +529,7 @@ func (p *Podman) ListPods(ctx context.Context, labels []string) ([]string, error
 		"--format",
 		"{{.Pod}}",
 	}
-	for _, label := range labels {
-		args = append(args, "--filter", fmt.Sprintf("label=%s", label))
-	}
+	args = applyFilters(args, labels, []string{})
 
 	stdout, stderr, exitCode := p.exec.ExecuteWithContext(ctx, podmanCmd, args...)
 	if exitCode != 0 {

--- a/internal/agent/device/applications/lifecycle/compose.go
+++ b/internal/agent/device/applications/lifecycle/compose.go
@@ -97,31 +97,38 @@ func (c *Compose) update(ctx context.Context, action *Action) error {
 
 // stopAndRemoveContainers stops and removes all containers, pods, and networks created by the compose application.
 func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action) error {
+	return cleanPodmanResources(
+		ctx,
+		c.podman,
+		[]string{
+			fmt.Sprintf("%s=%s", client.ComposeDockerProjectLabelKey, action.ID),
+		},
+		[]string{},
+	)
+}
+
+func cleanPodmanResources(ctx context.Context, podman *client.Podman, labels []string, filters []string) error {
 	var errs []error
-
-	// project name is derived from the application ID
-	projectName := action.ID
-	labels := []string{fmt.Sprintf("%s=%s", client.ComposeDockerProjectLabelKey, projectName)}
-	networks, err := c.podman.ListNetworks(ctx, labels)
+	networks, err := podman.ListNetworks(ctx, labels, filters)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	pods, err := c.podman.ListPods(ctx, labels)
+	pods, err := podman.ListPods(ctx, labels)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	if err := c.podman.StopContainers(ctx, labels); err != nil {
+	if err := podman.StopContainers(ctx, labels); err != nil {
 		errs = append(errs, err)
 	}
-	if err := c.podman.RemoveContainer(ctx, labels); err != nil {
+	if err := podman.RemoveContainer(ctx, labels); err != nil {
 		errs = append(errs, err)
 	}
-	if err := c.podman.RemovePods(ctx, pods...); err != nil {
+	if err := podman.RemovePods(ctx, pods...); err != nil {
 		errs = append(errs, err)
 	}
-	if err := c.podman.RemoveNetworks(ctx, networks...); err != nil {
+	if err := podman.RemoveNetworks(ctx, networks...); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -150,9 +150,11 @@ func TestManager(t *testing.T) {
 					mockExecSystemdStop(mockExec, "test-app.service"),
 					mockExecSystemdListUnits(mockExec, "test-app.service"),
 					mockExecSystemdDaemonReload(mockExec),
-
-					// no podman events mock needed since no apps remain after removal
 				)
+				// podman cleanup happens after systemd operations (not strictly ordered with above)
+				mockExecQuadletCleanup(mockExec, "quadlet-remove")
+
+				// no podman events mock needed since no apps remain after removal
 			},
 		},
 		{
@@ -183,6 +185,8 @@ func TestManager(t *testing.T) {
 					mockExecSystemdStart(mockExec, "test-app.service"),
 					mockExecPodmanEvents(mockExec),
 				)
+				// podman cleanup happens during the update (not strictly ordered with above)
+				mockExecQuadletCleanup(mockExec, "quadlet-update")
 			},
 			wantAppNames: []string{"quadlet-update"},
 		},
@@ -496,6 +500,65 @@ func mockExecSystemdListUnits(mockExec *executer.MockExecuter, services ...strin
 		"/usr/bin/systemctl",
 		args,
 	).Return("[]", "", 0)
+}
+
+func mockExecPodmanVolumeList(mockExec *executer.MockExecuter, name string) *gomock.Call {
+	id := client.NewComposeID(name)
+	return mockExec.
+		EXPECT().
+		ExecuteWithContext(
+			gomock.Any(),
+			"podman",
+			[]string{
+				"volume", "ls",
+				"--format", "json",
+				"--filter", "label=io.flightctl.quadlet.project=" + id,
+				"--filter", "name=" + id + "-*",
+			},
+		).
+		Return("[]", "", 0)
+}
+
+func mockExecQuadletPodmanNetworkList(mockExec *executer.MockExecuter, name string) *gomock.Call {
+	id := client.NewComposeID(name)
+	return mockExec.
+		EXPECT().
+		ExecuteWithContext(
+			gomock.Any(),
+			"podman",
+			[]string{
+				"network", "ls",
+				"--format", "{{.Network.ID}}",
+				"--filter", "label=io.flightctl.quadlet.project=" + id,
+				"--filter", "name=" + id + "-*",
+			},
+		).
+		Return("", "", 0)
+}
+
+func mockExecQuadletPodmanPodList(mockExec *executer.MockExecuter, name string) *gomock.Call {
+	id := client.NewComposeID(name)
+	return mockExec.
+		EXPECT().
+		ExecuteWithContext(
+			gomock.Any(),
+			"podman",
+			[]string{
+				"ps", "-a",
+				"--format", "{{.Pod}}",
+				"--filter", "label=io.flightctl.quadlet.project=" + id,
+			},
+		).
+		Return("", "", 0)
+}
+
+func mockExecQuadletCleanup(mockExec *executer.MockExecuter, name string) {
+	id := client.NewComposeID(name)
+	mockExecQuadletPodmanNetworkList(mockExec, name)
+	mockExecQuadletPodmanPodList(mockExec, name)
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"stop", "--filter", "label=io.flightctl.quadlet.project=" + id}).Return("", "", 0)
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", []string{"rm", "--filter", "label=io.flightctl.quadlet.project=" + id}).Return("", "", 0)
+	mockExecPodmanVolumeList(mockExec, name)
 }
 
 func mockReadQuadletFiles(mockReadWriter *fileio.MockReadWriter, quadletContent string) {

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -62,7 +62,7 @@ func NewPodmanMonitor(
 		client: podman,
 		handlers: map[v1alpha1.AppType]lifecycle.ActionHandler{
 			v1alpha1.AppTypeCompose: lifecycle.NewCompose(log, rw, podman),
-			v1alpha1.AppTypeQuadlet: lifecycle.NewQuadlet(log, rw, systemd),
+			v1alpha1.AppTypeQuadlet: lifecycle.NewQuadlet(log, rw, systemd, podman),
 		},
 		apps:          make(map[string]Application),
 		lastEventTime: bootTime,

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -269,8 +269,13 @@ func createQuadletDropIn(readWriter fileio.ReadWriter, dirPath, appID, extension
 	sectionName := quadlet.Extensions[extension]
 
 	unit := quadlet.NewEmptyUnit()
-	// add label for tracking quadlet events by app id
-	unit.Add(sectionName, quadlet.LabelKey, fmt.Sprintf("%s=%s", client.QuadletProjectLabelKey, appID))
+	// Pod quadlets don't have first class support for the LabelKey until v5.6
+	if extension == quadlet.PodExtension {
+		unit.Add(sectionName, quadlet.PodmanArgsKey, fmt.Sprintf("--label=%s=%s", client.QuadletProjectLabelKey, appID))
+	} else {
+		// add label for tracking quadlet events by app id
+		unit.Add(sectionName, quadlet.LabelKey, fmt.Sprintf("%s=%s", client.QuadletProjectLabelKey, appID))
+	}
 
 	// Only containers support environment files
 	if hasEnvFile && extension == quadlet.ContainerExtension {

--- a/internal/quadlet/quadlet.go
+++ b/internal/quadlet/quadlet.go
@@ -65,6 +65,10 @@ const (
 	PodNameKey = "PodName"
 	// NetworkNameKey is the key name for specifying a custom network name in the [Network] section.
 	NetworkNameKey = "NetworkName"
+	// PodmanArgsKey is the key name for specifying arbitrary arguments to podman
+	PodmanArgsKey = "PodmanArgs"
+	// ServiceNameKey is the key name for overriding the default service name
+	ServiceNameKey = "ServiceName"
 )
 
 // Sections maps quadlet section names to their corresponding file extensions.


### PR DESCRIPTION
* Adds behavior similar to compose that to clean up resources that may be left behind by podman when quadlets are removed. 
* Adds the ability to specify other filters for Podman calls to get networks or volumes
* Removes image based volumes from quadlet applications 
* Fixes bug with [Pod] labels.

Note:
Quadlets can be defined as:
```ini
#test.container
[Container]
...
Volume=name:/mnt/path
Volume=test.volume:/mnt/path2


#test.volume
[Volume]
Driver=image
Image=<>
```

get installed as:
```ini
#my-app-123-test.container
[Container]
...
Volume=my-app-123-name:/mnt/path #named volume is namespaced
Volume=my-app-123-test.volume:/mnt/path2 #quadlet reference is namespaced
Label=project=my-app-123 #tracking label is added.


#my-app-123-test.volume
[Volume]
Driver=image
Image=<>
Label=project=my-app-123 #tracking label is added.
```

Any resources (networks, volumes) that are created directly from a [Container] do **NOT** have the project label applied to them. To account for this, we allow filtering based on the project label OR the namespacing ID.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader Quadlet support for volumes, networks, pods, images and containers
  * Volume listing with label/filter support and volume driver/mount inspection
  * Pod-specific labeling support for Quadlets

* **Bug Fixes**
  * Improved Quadlet service name resolution with safer fallbacks
  * More reliable error messages during resource cleanup

* **Improvements**
  * Centralized Podman-backed resource cleanup with aggregated error reporting
  * Tests extended to cover Podman cleanup scenarios and argument matching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->