### PR TITLE
NO-ISSUE: Close stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 1 * * *"  # Run daily
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-message: "This pull request has been inactive for 30 days and will be closed if no further activity occurs."
+          close-pr-message: "Closing this PR due to inactivity. Please reopen if needed."
+          exempt-pr-labels: "do-not-close"
+          operations-per-run: 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage inactive pull requests: PRs are marked stale after 30 days and closed after 7 more days of inactivity. Clear messages are posted when PRs become stale and when closed. PRs with the "do-not-close" label are exempt. The workflow runs daily and can also be triggered manually.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->