### PR TITLE
EDM-2092: Cleanup resources left after tests

### DIFF
--- a/test/scripts/e2e_cleanup.sh
+++ b/test/scripts/e2e_cleanup.sh
@@ -27,19 +27,19 @@ echo "🔍 [Cleanup] Found ${#flightctl_vms[@]} flightctl e2e VMs: ${flightctl_v
 # Clean up each VM
 for vm_name in "${flightctl_vms[@]}"; do
     echo "🔄 [Cleanup] Cleaning up VM: $vm_name"
-    
+
     # 1. Delete pristine snapshot (ignore errors)
     echo "🔄 [Cleanup] Deleting pristine snapshot for $vm_name"
     if ! virsh snapshot-delete "$vm_name" "pristine" --metadata 2>/dev/null; then
         echo "⚠️  [Cleanup] Failed to delete pristine snapshot for $vm_name (may not exist)"
     fi
-    
+
     # 2. Destroy the VM if it's running (ignore errors)
     echo "🔄 [Cleanup] Destroying VM: $vm_name"
     if ! virsh destroy "$vm_name" 2>/dev/null; then
         echo "⚠️  [Cleanup] Failed to destroy $vm_name (may not be running)"
     fi
-    
+
     # 3. Undefine the domain (try multiple approaches)
     echo "🔄 [Cleanup] Undefining domain: $vm_name"
     if virsh undefine "$vm_name" 2>/dev/null; then

--- a/test/scripts/run_e2e_tests.sh
+++ b/test/scripts/run_e2e_tests.sh
@@ -148,5 +148,13 @@ if ! test/scripts/e2e_cleanup.sh; then
 fi
 echo "✅ [Test Execution] Cleanup completed"
 
+# Step 3b: Re-run the same cluster resource cleanup as startup
+echo "🔄 [Test Execution] Step 3b: Running post-test resource cleanup (same logic as e2e_startup.sh)..."
+if ! test/scripts/e2e_startup.sh; then
+    echo "⚠️  [Test Execution] Post-test resource cleanup failed, but continuing to report test result..."
+else
+    echo "✅ [Test Execution] Post-test resource cleanup completed successfully"
+fi
+
 # Exit with the test exit code
 exit $TEST_EXIT_CODE


### PR DESCRIPTION
Cleanup for ERS without labels as advised by @asafbennatan .
Currently running e2e tests leaves out only ERS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a post-test cleanup step that re-runs cluster resource cleanup after main cleanup, logs success or non-fatal failures, and does not alter the test exit outcome.

* **Chores**
  * Minor formatting and whitespace adjustments in test cleanup scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->