### PR TITLE
EDM-2604: Fix PAM issuer having the wrong redirect URI

### DIFF
--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
@@ -49,7 +49,7 @@ fi
 
 # Default redirect URI if not specified
 if [ -z "$PAM_OIDC_REDIRECT_URIS" ]; then
-  PAM_OIDC_REDIRECT_URIS="https://${BASE_DOMAIN}:443/auth/callback"
+  PAM_OIDC_REDIRECT_URIS="https://${BASE_DOMAIN}:443/callback"
 fi
 
 # Convert comma-separated list to YAML array format

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -528,7 +528,7 @@ func Load(cfgFile string) (*Config, error) {
 					base = c.Service.BaseUrl
 				}
 				if base != "" {
-					c.Auth.PAMOIDCIssuer.RedirectURIs = []string{strings.TrimSuffix(base, "/") + "/auth/callback"}
+					c.Auth.PAMOIDCIssuer.RedirectURIs = []string{strings.TrimSuffix(base, "/") + "/callback"}
 				}
 			}
 		}


### PR DESCRIPTION
The redirect URI for the flighctl UI is <ipURL>:PORT/callback
The PAM Issuer configuration had a mismatch, and used <ipURL>:PORT/auth/callback instead

When attempting to log in through the PAM issuer in the quadlets deployment, the API responded with the following error to the authorize request:
```
  
  {
    "apiVersion": "v1alpha1",
    "code": 400,
    "kind": "Status",
    "message": "invalid_request",
    "reason": "Error",
    "status": "Failure"
}
```

This PR attempts to fix the redirect URL for the UI. I'm not sure if additional redirect URIs are needed in cases where the UI may be disabled, so please check.

Finally, I made changes so that when "authorize" fails, it gives an indication of what caused the request being invalid. Currently it didn't log anything so I had to guess.

After the changes (using custom image for the UI deployment `quay.io/rh_ee_camadorg/fc-ui:auth-permissions-nov-18-1"`):
<img width="1741" height="1752" alt="pam-issuer-with-quadlets" src="https://github.com/user-attachments/assets/4250a7ec-f4ae-4578-84c7-1d06c3e1428f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling with context-aware validation feedback for authorization failures, including missing fields, redirect URI mismatches, PKCE validation issues, and state mismatches.
  * Improved security by masking sensitive data in error messages and logs.

* **Chores**
  * Updated default PAM OIDC redirect URI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->