### PR TITLE
EDM-2507: Add OCI auto detection

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -926,9 +926,6 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 			if provider.Image == "" && app.Name == nil {
 				allErrs = append(allErrs, fmt.Errorf("image reference cannot be empty when application name is not provided"))
 			}
-			if lo.FromPtr(app.AppType) == AppTypeQuadlet {
-				allErrs = append(allErrs, fmt.Errorf("image application provider does not support %q application type", AppTypeQuadlet))
-			}
 			allErrs = append(allErrs, validateOciImageReference(&provider.Image, fmt.Sprintf("spec.applications[%s].image", appName), fleetTemplate)...)
 			volumes = provider.Volumes
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -152,6 +152,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	// create podman client
 	podmanClient := client.NewPodman(a.log, executer, deviceReadWriter, pollBackoff)
 
+	// create skopeo client
+	skopeoClient := client.NewSkopeo(a.log, executer, deviceReadWriter)
+
 	// create systemd client
 	systemdClient := client.NewSystemd(executer)
 
@@ -247,7 +250,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	osManager := os.NewManager(a.log, osClient, deviceReadWriter, podmanClient)
 
 	// create prefetch manager
-	prefetchManager := dependency.NewPrefetchManager(a.log, podmanClient, deviceReadWriter, a.config.PullTimeout)
+	prefetchManager := dependency.NewPrefetchManager(a.log, podmanClient, skopeoClient, deviceReadWriter, a.config.PullTimeout)
 
 	// create status manager
 	statusManager := status.NewManager(

--- a/internal/agent/client/skopeo.go
+++ b/internal/agent/client/skopeo.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	skopeoCmd            = "skopeo"
+	defaultSkopeoTimeout = 2 * time.Minute
+)
+
+// OCIManifest represents the minimal OCI manifest structure needed for type detection
+type OCIManifest struct {
+	MediaType    string          `json:"mediaType"`
+	ArtifactType string          `json:"artifactType,omitempty"`
+	Config       *OCIDescriptor  `json:"config,omitempty"`
+	Manifests    json.RawMessage `json:"manifests,omitempty"`
+}
+
+// OCIDescriptor represents a content descriptor in an OCI manifest
+type OCIDescriptor struct {
+	MediaType string `json:"mediaType"`
+	Digest    string `json:"digest"`
+	Size      int64  `json:"size"`
+}
+
+type Skopeo struct {
+	exec       executer.Executer
+	log        *log.PrefixLogger
+	timeout    time.Duration
+	readWriter fileio.ReadWriter
+}
+
+func NewSkopeo(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter) *Skopeo {
+	return &Skopeo{
+		log:        log,
+		exec:       exec,
+		timeout:    defaultSkopeoTimeout,
+		readWriter: readWriter,
+	}
+}
+
+// InspectManifest inspects an OCI image or artifact and returns the deserialized manifest.
+// This is used to determine if a reference is an image or an artifact.
+func (s *Skopeo) InspectManifest(ctx context.Context, image string, opts ...ClientOption) (*OCIManifest, error) {
+	options := &clientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := s.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"inspect", "--raw", fmt.Sprintf("docker://%s", image)}
+
+	pullSecretPath := options.pullSecretPath
+	if pullSecretPath != "" {
+		exists, err := s.readWriter.PathExists(pullSecretPath)
+		if err != nil {
+			return nil, fmt.Errorf("check pull secret path: %w", err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("pull secret path %s does not exist", pullSecretPath)
+		}
+		args = append(args, "--authfile", pullSecretPath)
+	}
+
+	stdout, stderr, exitCode := s.exec.ExecuteWithContext(ctx, skopeoCmd, args...)
+	if exitCode != 0 {
+		return nil, fmt.Errorf("inspect manifest: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	var manifest OCIManifest
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &manifest); err != nil {
+		return nil, fmt.Errorf("parsing manifest JSON: %w", err)
+	}
+
+	return &manifest, nil
+}

--- a/internal/agent/client/skopeo_test.go
+++ b/internal/agent/client/skopeo_test.go
@@ -1,0 +1,249 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSkopeoInspectManifest(t *testing.T) {
+	tests := []struct {
+		name           string
+		image          string
+		setupMocks     func(*executer.MockExecuter)
+		expectedResult *OCIManifest
+		expectedError  bool
+	}{
+		{
+			name:  "inspect OCI image manifest",
+			image: "quay.io/test/app:v1",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				manifestJSON := `{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.oci.image.config.v1+json",
+						"digest": "sha256:abc123",
+						"size": 677
+					},
+					"layers": [
+						{
+							"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+							"digest": "sha256:def456",
+							"size": 195
+						}
+					]
+				}`
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/app:v1").
+					Return(manifestJSON, "", 0)
+			},
+			expectedResult: &OCIManifest{
+				MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Config: &OCIDescriptor{
+					MediaType: "application/vnd.oci.image.config.v1+json",
+					Digest:    "sha256:abc123",
+					Size:      677,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:  "inspect OCI artifact manifest",
+			image: "quay.io/test/artifact:v1",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				manifestJSON := `{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"artifactType": "application/vnd.example.artifact",
+					"config": {
+						"mediaType": "application/vnd.oci.empty.v1+json",
+						"digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+						"size": 2
+					},
+					"layers": [
+						{
+							"mediaType": "text/plain",
+							"digest": "sha256:xyz789",
+							"size": 20
+						}
+					]
+				}`
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/artifact:v1").
+					Return(manifestJSON, "", 0)
+			},
+			expectedResult: &OCIManifest{
+				MediaType:    "application/vnd.oci.image.manifest.v1+json",
+				ArtifactType: "application/vnd.example.artifact",
+				Config: &OCIDescriptor{
+					MediaType: "application/vnd.oci.empty.v1+json",
+					Digest:    "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+					Size:      2,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:  "inspect with authentication",
+			image: "private-registry.io/test/image:v1",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				manifestJSON := `{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.oci.image.config.v1+json",
+						"digest": "sha256:abc123",
+						"size": 500
+					}
+				}`
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://private-registry.io/test/image:v1", "--authfile", "/tmp/test-auth.json").
+					Return(manifestJSON, "", 0)
+			},
+			expectedResult: &OCIManifest{
+				MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Config: &OCIDescriptor{
+					MediaType: "application/vnd.oci.image.config.v1+json",
+					Digest:    "sha256:abc123",
+					Size:      500,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:  "inspect manifest index (multi-platform)",
+			image: "ghcr.io/homebrew/core/sqlite:3.50.2",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				manifestJSON := `{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.index.v1+json",
+					"manifests": [
+						{
+							"mediaType": "application/vnd.oci.image.manifest.v1+json",
+							"digest": "sha256:aaa111",
+							"size": 2567,
+							"platform": {
+								"architecture": "arm64",
+								"os": "linux"
+							}
+						},
+						{
+							"mediaType": "application/vnd.oci.image.manifest.v1+json",
+							"digest": "sha256:bbb222",
+							"size": 2572,
+							"platform": {
+								"architecture": "amd64",
+								"os": "linux"
+							}
+						}
+					]
+				}`
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://ghcr.io/homebrew/core/sqlite:3.50.2").
+					Return(manifestJSON, "", 0)
+			},
+			expectedResult: &OCIManifest{
+				MediaType: "application/vnd.oci.image.index.v1+json",
+				Manifests: json.RawMessage(`[
+						{
+							"mediaType": "application/vnd.oci.image.manifest.v1+json",
+							"digest": "sha256:aaa111",
+							"size": 2567,
+							"platform": {
+								"architecture": "arm64",
+								"os": "linux"
+							}
+						},
+						{
+							"mediaType": "application/vnd.oci.image.manifest.v1+json",
+							"digest": "sha256:bbb222",
+							"size": 2572,
+							"platform": {
+								"architecture": "amd64",
+								"os": "linux"
+							}
+						}
+					]`),
+			},
+			expectedError: false,
+		},
+		{
+			name:  "inspect fails with non-zero exit code",
+			image: "quay.io/test/nonexistent:v1",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/nonexistent:v1").
+					Return("", "Error: manifest unknown", 1)
+			},
+			expectedResult: nil,
+			expectedError:  true,
+		},
+		{
+			name:  "inspect returns invalid JSON",
+			image: "quay.io/test/invalid:v1",
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/invalid:v1").
+					Return("not valid json", "", 0)
+			},
+			expectedResult: nil,
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockExec := executer.NewMockExecuter(ctrl)
+			logger := log.NewPrefixLogger("test")
+			logger.SetLevel(logrus.ErrorLevel)
+
+			tt.setupMocks(mockExec)
+
+			readWriter := fileio.NewReadWriter()
+			skopeo := NewSkopeo(logger, mockExec, readWriter)
+
+			var opts []ClientOption
+			if tt.name == "inspect with authentication" {
+				tmpFile := "/tmp/test-auth.json"
+				_ = readWriter.WriteFile(tmpFile, []byte(`{"auths":{}}`), 0600)
+				defer func() { _ = readWriter.RemoveAll(tmpFile) }()
+				opts = append(opts, WithPullSecret(tmpFile))
+			}
+
+			ctx := context.Background()
+			result, err := skopeo.InspectManifest(ctx, tt.image, opts...)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, tt.expectedResult.MediaType, result.MediaType)
+				require.Equal(t, tt.expectedResult.ArtifactType, result.ArtifactType)
+
+				if tt.expectedResult.Config != nil {
+					require.NotNil(t, result.Config)
+					require.Equal(t, tt.expectedResult.Config.MediaType, result.Config.MediaType)
+					require.Equal(t, tt.expectedResult.Config.Digest, result.Config.Digest)
+					require.Equal(t, tt.expectedResult.Config.Size, result.Config.Size)
+				}
+
+				if len(tt.expectedResult.Manifests) > 0 {
+					require.NotEmpty(t, result.Manifests)
+				}
+			}
+		})
+	}
+}

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -87,7 +87,7 @@ func CollectBaseOCITargets(
 			// Add base image with PullIfNotPresent policy
 			policy := v1alpha1.PullIfNotPresent
 			targets = append(targets, dependency.OCIPullTarget{
-				Type:       dependency.OCITypeImage,
+				Type:       dependency.OCITypeAuto,
 				Reference:  imageSpec.Image,
 				PullPolicy: policy,
 				PullSecret: pullSecret,


### PR DESCRIPTION
Adds the ability for the dependency manager to auto detect the underlying OCI type and either pull the image or pull the artifact properly. Consumer's of these artifacts may need to check for the existence of the artifact or image to determine the real type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and classification of OCI image types (Image vs Artifact) during prefetch, improving handling of multi-platform and artifact images.
  * Improved image prefetch reliability by adding manifest inspection to the fetch flow.
  * Enabled Quadlet-type inline applications to be used with image-based providers.

* **Bug Fixes**
  * Removed restrictive validation that blocked Quadlet-type applications with image-based specs.

* **Tests**
  * Added tests for manifest inspection and OCI type detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->