### PR TITLE
EDM-2368: CLI support for CRUD Auth providers

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -255,6 +255,13 @@ func applyFromReader(ctx context.Context, client *apiclient.ClientWithResponses,
 				httpResponse = response.HTTPResponse
 				message = string(response.Body)
 			}
+		case AuthProviderKind:
+			var response *apiclient.ReplaceAuthProviderResponse
+			response, err = client.ReplaceAuthProviderWithBodyWithResponse(ctx, resourceName, "application/json", bytes.NewReader(buf))
+			if response != nil {
+				httpResponse = response.HTTPResponse
+				message = string(response.Body)
+			}
 		default:
 			err = fmt.Errorf("%s: skipping resource of unknown kind %q: %v", filename, kind, resource)
 		}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -163,6 +163,8 @@ func (o *DeleteOptions) deleteOne(ctx context.Context, c *apiclient.ClientWithRe
 		response, err = c.DeleteResourceSyncWithResponse(ctx, name)
 	case CertificateSigningRequestKind:
 		response, err = c.DeleteCertificateSigningRequestWithResponse(ctx, name)
+	case AuthProviderKind:
+		response, err = c.DeleteAuthProviderWithResponse(ctx, name)
 	default:
 		return nil, fmt.Errorf("unsupported resource kind: %s", kind)
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -582,6 +582,14 @@ func (o *GetOptions) getResourceList(ctx context.Context, c *apiclient.ClientWit
 			Continue:      util.ToPtrWithNilDefault(o.Continue),
 		}
 		return c.ListEventsWithResponse(ctx, &params)
+	case AuthProviderKind:
+		params := api.ListAuthProvidersParams{
+			LabelSelector: util.ToPtrWithNilDefault(o.LabelSelector),
+			FieldSelector: util.ToPtrWithNilDefault(o.FieldSelector),
+			Limit:         util.ToPtrWithNilDefault(o.Limit),
+			Continue:      util.ToPtrWithNilDefault(o.Continue),
+		}
+		return c.ListAuthProvidersWithResponse(ctx, &params)
 	default:
 		return nil, fmt.Errorf("unsupported resource kind: %s", kind)
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -28,6 +28,7 @@ const (
 	DeviceKind                    ResourceKind = "device"
 	EnrollmentRequestKind         ResourceKind = "enrollmentrequest"
 	EventKind                     ResourceKind = "event"
+	AuthProviderKind              ResourceKind = "authprovider"
 	FleetKind                     ResourceKind = "fleet"
 	OrganizationKind              ResourceKind = "organization"
 	RepositoryKind                ResourceKind = "repository"
@@ -63,6 +64,7 @@ var (
 		DeviceKind:                    {},
 		EnrollmentRequestKind:         {},
 		EventKind:                     {},
+		AuthProviderKind:              {},
 		FleetKind:                     {},
 		OrganizationKind:              {},
 		RepositoryKind:                {},
@@ -77,6 +79,7 @@ var (
 		"devices":                    DeviceKind,
 		"enrollmentrequests":         EnrollmentRequestKind,
 		"events":                     EventKind,
+		"authproviders":              AuthProviderKind,
 		"fleets":                     FleetKind,
 		"organizations":              OrganizationKind,
 		"repositories":               RepositoryKind,
@@ -89,6 +92,7 @@ var (
 		DeviceKind:                    "devices",
 		EnrollmentRequestKind:         "enrollmentrequests",
 		EventKind:                     "events",
+		AuthProviderKind:              "authproviders",
 		FleetKind:                     "fleets",
 		OrganizationKind:              "organizations",
 		RepositoryKind:                "repositories",
@@ -101,6 +105,7 @@ var (
 		"dev":  DeviceKind,
 		"er":   EnrollmentRequestKind,
 		"ev":   EventKind,
+		"ap":   AuthProviderKind,
 		"flt":  FleetKind,
 		"org":  OrganizationKind,
 		"repo": RepositoryKind,
@@ -305,6 +310,8 @@ func GetSingleResource(ctx context.Context, c *apiclient.ClientWithResponses, ki
 		return c.GetResourceSyncWithResponse(ctx, name)
 	case CertificateSigningRequestKind:
 		return c.GetCertificateSigningRequestWithResponse(ctx, name)
+	case AuthProviderKind:
+		return c.GetAuthProviderWithResponse(ctx, name)
 	default:
 		return nil, fmt.Errorf("unsupported resource kind: %s", kind)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing Authentication Provider resources via the CLI
  * Users can now create, retrieve, delete, and list Authentication Providers using standard resource commands
  * Authentication Providers display in table format with NAME, TYPE, ISSUER, and CLIENT ID columns
  * Short alias "ap" available for Authentication Provider references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->