### PR TITLE
NO-ISSUE: fix pam issuer callback

### DIFF
--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/init.sh
@@ -49,7 +49,7 @@ fi
 
 # Default redirect URI if not specified
 if [ -z "$PAM_OIDC_REDIRECT_URIS" ]; then
-  PAM_OIDC_REDIRECT_URIS="https://${BASE_DOMAIN}:443/auth/callback"
+  PAM_OIDC_REDIRECT_URIS="https://${BASE_DOMAIN}:443/callback"
 fi
 
 # Convert comma-separated list to YAML array format


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default PAM OIDC authentication callback path — the default redirect now uses /callback instead of /auth/callback.
  * Updated the default redirect URI to match the new callback path; this change only affects the default value and does not alter any other behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->