### PR TITLE
NO-ISSUE: prepare merge groups

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -63,7 +64,7 @@ jobs:
           FLIGHTCTL_TEST_DB_STRATEGY: template
 
       - name: Detect baseline for compatibility testing
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         id: detect_baseline
         env:
           GH_TOKEN: ${{ github.token }}
@@ -82,8 +83,13 @@ jobs:
             BASELINE_REF="${LATEST_RELEASE_TAG}"
             echo "Using latest release as baseline: ${BASELINE_REF}"
           else
-            BASELINE_REF="${{ github.event.pull_request.base.sha }}"
-            echo "Failed to detect latest release, falling back to PR base: ${BASELINE_REF}"
+            # Use the appropriate base depending on event type
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              BASELINE_REF="${{ github.event.pull_request.base.sha }}"
+            else
+              BASELINE_REF="${{ github.event.merge_group.base_sha }}"
+            fi
+            echo "Failed to detect latest release, falling back to base: ${BASELINE_REF}"
           fi
           echo ""
           echo "================================================"
@@ -93,7 +99,7 @@ jobs:
           echo "baseline_ref=${BASELINE_REF}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout baseline branch
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         uses: actions/checkout@v4
         with:
           repository: flightctl/flightctl

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 jobs:
   lint-docs:

--- a/.github/workflows/lint-openapi.yaml
+++ b/.github/workflows/lint-openapi.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 jobs:
   lint-openapi:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -13,6 +13,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -8,6 +8,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
 
 jobs:
   setup:
@@ -190,7 +191,7 @@ jobs:
 
   publish:
     name: Publish Binaries
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     needs: verify
     permissions:

--- a/.github/workflows/rpmlint.yaml
+++ b/.github/workflows/rpmlint.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
this prepares the CI for when we want to enable merge groups 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to support GitHub's merge-group trigger across testing, linting, publishing, and release pipelines.
  * Ensures pull-request merge-group events are handled consistently (including baseline selection and checkout) so grouped PRs run the same checks as individual PRs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->