### PR TITLE
EDM-2607: proper support for AP enabled flag

### DIFF
--- a/internal/auth/authn/aapgateway.go
+++ b/internal/auth/authn/aapgateway.go
@@ -66,6 +66,10 @@ func NewAapGatewayAuth(metadata api.ObjectMeta, spec api.AapProviderSpec, client
 	return &authN, nil
 }
 
+func (a AapGatewayAuth) IsEnabled() bool {
+	return a.spec.Enabled != nil && *a.spec.Enabled
+}
+
 func (a AapGatewayAuth) loadUserInfo(ctx context.Context, token string) (*AAPIdentity, error) {
 	item := a.cache.Get(token)
 	if item != nil {

--- a/internal/auth/authn/k8s.go
+++ b/internal/auth/authn/k8s.go
@@ -39,6 +39,10 @@ func NewK8sAuthN(metadata api.ObjectMeta, spec api.K8sProviderSpec, k8sClient k8
 	return authN, nil
 }
 
+func (o K8sAuthN) IsEnabled() bool {
+	return o.spec.Enabled != nil && *o.spec.Enabled
+}
+
 func (o K8sAuthN) loadTokenReview(ctx context.Context, token string) (*k8sAuthenticationV1.TokenReview, error) {
 	item := o.cache.Get(token)
 	if item != nil {

--- a/internal/auth/authn/multiauth_test.go
+++ b/internal/auth/authn/multiauth_test.go
@@ -32,13 +32,18 @@ func createTestJWT(issuer, subject, audience string) string {
 
 // MockAuthNMiddleware is a mock implementation of AuthNMiddleware for testing
 type MockAuthNMiddleware struct {
-	issuer string
-	valid  bool
+	issuer  string
+	valid   bool
+	enabled bool // whether the provider is enabled
 }
 
 func (m *MockAuthNMiddleware) GetAuthToken(r *http.Request) (string, error) {
 	// Return a proper JWT token for testing
 	return createTestJWT(m.issuer, "testuser", "test-client"), nil
+}
+
+func (m *MockAuthNMiddleware) IsEnabled() bool {
+	return m.enabled
 }
 
 func (m *MockAuthNMiddleware) ValidateToken(ctx context.Context, token string) error {
@@ -100,6 +105,7 @@ func (m *MockAuthNMiddleware) GetAuthConfig() *api.AuthConfig {
 		ClientId:     "test-client",
 		ClientSecret: lo.ToPtr("test-secret"),
 		ProviderType: api.OIDCProviderSpecProviderType("oidc"),
+		Enabled:      lo.ToPtr(m.enabled),
 	}
 
 	provider := api.AuthProvider{
@@ -126,14 +132,14 @@ func TestMultiAuth_ValidateToken(t *testing.T) {
 	multiAuth := NewMultiAuth(nil, nil, log)
 
 	// Add mock static methods
-	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true}
-	invalidMethod := &MockAuthNMiddleware{issuer: "https://invalid-issuer.com", valid: false}
+	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true, enabled: true}
+	invalidMethod := &MockAuthNMiddleware{issuer: "https://invalid-issuer.com", valid: false, enabled: true}
 
 	multiAuth.AddStaticProvider("https://valid-issuer.com:test-client", validMethod)
 	multiAuth.AddStaticProvider("https://invalid-issuer.com:test-client", invalidMethod)
 
 	// Add mock AAP provider
-	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true}
+	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("aap", aapMethod)
 
 	tests := []struct {
@@ -194,7 +200,7 @@ func TestMultiAuth_ValidateToken_NoAAP(t *testing.T) {
 	multiAuth := NewMultiAuth(nil, nil, log)
 
 	// Add mock static methods only (no AAP method)
-	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true}
+	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("https://valid-issuer.com:test-client", validMethod)
 
 	tests := []struct {
@@ -242,11 +248,11 @@ func TestMultiAuth_GetIdentity(t *testing.T) {
 	multiAuth := NewMultiAuth(nil, nil, log)
 
 	// Add mock static method
-	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true}
+	validMethod := &MockAuthNMiddleware{issuer: "https://valid-issuer.com", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("https://valid-issuer.com:test-client", validMethod)
 
 	// Add mock AAP method
-	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true}
+	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("aap", aapMethod)
 
 	tests := []struct {
@@ -310,7 +316,7 @@ func TestMultiAuth_GetAuthConfig(t *testing.T) {
 	assert.Nil(t, config.DefaultProvider)
 
 	// Add first static method
-	mockMethod1 := &MockAuthNMiddleware{issuer: "https://test-issuer-1.com", valid: true}
+	mockMethod1 := &MockAuthNMiddleware{issuer: "https://test-issuer-1.com", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("https://test-issuer-1.com", mockMethod1)
 
 	config = multiAuth.GetAuthConfig()
@@ -324,7 +330,7 @@ func TestMultiAuth_GetAuthConfig(t *testing.T) {
 	assert.Equal(t, "https://test-issuer-1.com", *(*config.Providers)[0].Metadata.Name)
 
 	// Add second static method
-	mockMethod2 := &MockAuthNMiddleware{issuer: "https://test-issuer-2.com", valid: true}
+	mockMethod2 := &MockAuthNMiddleware{issuer: "https://test-issuer-2.com", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("https://test-issuer-2.com", mockMethod2)
 
 	config = multiAuth.GetAuthConfig()
@@ -346,14 +352,14 @@ func TestMultiAuth_HasMethods(t *testing.T) {
 	assert.Equal(t, 0, len(multiAuth.staticProviders))
 
 	// Add static provider
-	mockMethod := &MockAuthNMiddleware{issuer: "https://test-issuer.com", valid: true}
+	mockMethod := &MockAuthNMiddleware{issuer: "https://test-issuer.com", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("https://test-issuer.com", mockMethod)
 	assert.Equal(t, 1, len(multiAuth.staticProviders))
 	_, hasAAP := multiAuth.staticProviders["aap"]
 	assert.False(t, hasAAP)
 
 	// Add AAP provider
-	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true}
+	aapMethod := &MockAuthNMiddleware{issuer: "aap", valid: true, enabled: true}
 	multiAuth.AddStaticProvider("aap", aapMethod)
 	assert.Equal(t, 2, len(multiAuth.staticProviders))
 	_, hasAAP = multiAuth.staticProviders["aap"]
@@ -413,4 +419,186 @@ func TestExtractIssuerFromToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiAuth_GetAuthConfig_EnabledFlag(t *testing.T) {
+	log := logrus.New()
+	multiAuth := NewMultiAuth(nil, nil, log)
+
+	// Add enabled provider
+	enabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://enabled-issuer.com",
+		valid:   true,
+		enabled: true,
+	}
+	multiAuth.AddStaticProvider("https://enabled-issuer.com:test-client", enabledProvider)
+
+	// Add disabled provider
+	disabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer.com:test-client", disabledProvider)
+
+	// Get auth config
+	config := multiAuth.GetAuthConfig()
+	require.NotNil(t, config)
+	require.NotNil(t, config.Providers)
+
+	// Only enabled provider should be in the config
+	assert.Len(t, *config.Providers, 1, "Only enabled providers should be in auth config")
+	assert.Equal(t, "https://enabled-issuer.com", *(*config.Providers)[0].Metadata.Name)
+
+	// Verify the enabled provider has enabled=true
+	oidcSpec, err := (*config.Providers)[0].Spec.AsOIDCProviderSpec()
+	require.NoError(t, err)
+	require.NotNil(t, oidcSpec.Enabled)
+	assert.True(t, *oidcSpec.Enabled)
+}
+
+func TestMultiAuth_GetAuthConfig_AllDisabled(t *testing.T) {
+	log := logrus.New()
+	multiAuth := NewMultiAuth(nil, nil, log)
+
+	// Add only disabled providers
+	disabledProvider1 := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer-1.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer-1.com:test-client", disabledProvider1)
+
+	disabledProvider2 := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer-2.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer-2.com:test-client", disabledProvider2)
+
+	// Get auth config
+	config := multiAuth.GetAuthConfig()
+	require.NotNil(t, config)
+	require.NotNil(t, config.Providers)
+
+	// No providers should be in the config since all are disabled
+	assert.Len(t, *config.Providers, 0, "No providers should be in auth config when all are disabled")
+	assert.Nil(t, config.DefaultProvider, "Default provider should be nil when all providers are disabled")
+}
+
+func TestMultiAuth_GetAuthConfig_MultipleEnabledProviders(t *testing.T) {
+	log := logrus.New()
+	multiAuth := NewMultiAuth(nil, nil, log)
+
+	// Add multiple enabled providers
+	for i := 1; i <= 3; i++ {
+		provider := &MockAuthNMiddleware{
+			issuer:  "https://enabled-issuer-" + string(rune('0'+i)) + ".com",
+			valid:   true,
+			enabled: true,
+		}
+		multiAuth.AddStaticProvider("https://enabled-issuer-"+string(rune('0'+i))+".com:test-client", provider)
+	}
+
+	// Add one disabled provider in the middle
+	disabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer.com:test-client", disabledProvider)
+
+	// Get auth config
+	config := multiAuth.GetAuthConfig()
+	require.NotNil(t, config)
+	require.NotNil(t, config.Providers)
+
+	// Only enabled providers should be in the config
+	assert.Len(t, *config.Providers, 3, "Only enabled providers should be in auth config")
+
+	// Verify none of the providers is the disabled one
+	for _, provider := range *config.Providers {
+		assert.NotEqual(t, "https://disabled-issuer.com", *provider.Metadata.Name)
+	}
+}
+
+func TestMultiAuth_ValidateToken_DisabledProvider(t *testing.T) {
+	log := logrus.New()
+	multiAuth := NewMultiAuth(nil, nil, log)
+
+	// Add enabled provider
+	enabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://enabled-issuer.com",
+		valid:   true,
+		enabled: true,
+	}
+	multiAuth.AddStaticProvider("https://enabled-issuer.com:test-client", enabledProvider)
+
+	// Add disabled provider
+	disabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer.com:test-client", disabledProvider)
+
+	ctx := context.Background()
+
+	// Token from enabled provider should validate successfully
+	enabledToken := createTestJWT("https://enabled-issuer.com", "user123", "test-client")
+	err := multiAuth.ValidateToken(ctx, enabledToken)
+	assert.NoError(t, err, "Token from enabled provider should validate successfully")
+
+	// Token from disabled provider should fail validation
+	disabledToken := createTestJWT("https://disabled-issuer.com", "user123", "test-client")
+	err = multiAuth.ValidateToken(ctx, disabledToken)
+	assert.Error(t, err, "Token from disabled provider should fail validation")
+	assert.Contains(t, err.Error(), "no enabled OIDC provider found", "Error should indicate no enabled provider found")
+}
+
+func TestMultiAuth_GetPossibleProviders_EnabledFlag(t *testing.T) {
+	log := logrus.New()
+	multiAuth := NewMultiAuth(nil, nil, log)
+
+	// Add enabled OIDC provider
+	enabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://enabled-issuer.com",
+		valid:   true,
+		enabled: true,
+	}
+	multiAuth.AddStaticProvider("https://enabled-issuer.com:test-client", enabledProvider)
+
+	// Add disabled OIDC provider
+	disabledProvider := &MockAuthNMiddleware{
+		issuer:  "https://disabled-issuer.com",
+		valid:   true,
+		enabled: false,
+	}
+	multiAuth.AddStaticProvider("https://disabled-issuer.com:test-client", disabledProvider)
+
+	// Add enabled AAP provider (opaque tokens)
+	enabledAAPProvider := &MockAuthNMiddleware{
+		issuer:  "aap",
+		valid:   true,
+		enabled: true,
+	}
+	multiAuth.AddStaticProvider("aap", enabledAAPProvider)
+
+	// Test with JWT token from enabled provider
+	enabledToken := createTestJWT("https://enabled-issuer.com", "user123", "test-client")
+	providers, _, err := multiAuth.getPossibleProviders(enabledToken)
+	assert.NoError(t, err)
+	assert.Len(t, providers, 1, "Should return only the enabled provider")
+
+	// Test with JWT token from disabled provider
+	disabledToken := createTestJWT("https://disabled-issuer.com", "user123", "test-client")
+	_, _, err = multiAuth.getPossibleProviders(disabledToken)
+	assert.Error(t, err, "Should fail to find enabled provider for disabled issuer")
+	assert.Contains(t, err.Error(), "no enabled OIDC provider found")
+
+	// Test with opaque token (should return all enabled providers since issuer is unknown)
+	opaqueToken := "opaque-token-string" // #nosec G101 -- This is a test token, not a credential
+	providers, _, err = multiAuth.getPossibleProviders(opaqueToken)
+	assert.NoError(t, err)
+	assert.Len(t, providers, 2, "Should return all enabled providers for opaque token (enabled OIDC + enabled AAP)")
 }

--- a/internal/auth/authn/oauth2_auth.go
+++ b/internal/auth/authn/oauth2_auth.go
@@ -75,6 +75,10 @@ func NewOAuth2Auth(metadata api.ObjectMeta, spec api.OAuth2ProviderSpec, tlsConf
 	}, nil
 }
 
+func (o *OAuth2Auth) IsEnabled() bool {
+	return o.spec.Enabled != nil && *o.spec.Enabled
+}
+
 // GetOAuth2Spec returns the internal OAuth2 spec with client secret intact (for internal use only)
 func (o *OAuth2Auth) GetOAuth2Spec() api.OAuth2ProviderSpec {
 	return o.spec

--- a/internal/auth/authn/oidc_auth.go
+++ b/internal/auth/authn/oidc_auth.go
@@ -94,6 +94,10 @@ func NewOIDCAuth(metadata api.ObjectMeta, spec api.OIDCProviderSpec, clientTlsCo
 	return oidcAuth, nil
 }
 
+func (o *OIDCAuth) IsEnabled() bool {
+	return o.spec.Enabled != nil && *o.spec.Enabled
+}
+
 // ensureDiscovery performs lazy OIDC discovery on first use
 // This is called automatically before validating tokens
 func (o *OIDCAuth) ensureDiscovery(ctx context.Context) error {

--- a/internal/auth/authn/openshift_auth.go
+++ b/internal/auth/authn/openshift_auth.go
@@ -68,6 +68,10 @@ func NewOpenShiftAuth(metadata api.ObjectMeta, spec api.OpenShiftProviderSpec, k
 	return auth, nil
 }
 
+func (o *OpenShiftAuth) IsEnabled() bool {
+	return o.spec.Enabled != nil && *o.spec.Enabled
+}
+
 // hashToken creates a SHA256 hash of the token for cache key
 func hashToken(token string) string {
 	hash := sha256.Sum256([]byte(token))

--- a/internal/auth/common/common.go
+++ b/internal/auth/common/common.go
@@ -51,6 +51,7 @@ type AuthNMiddleware interface {
 	ValidateToken(ctx context.Context, token string) error
 	GetIdentity(ctx context.Context, token string) (Identity, error)
 	GetAuthConfig() *v1alpha1.AuthConfig
+	IsEnabled() bool
 }
 
 type BaseIdentity struct {

--- a/internal/auth/common/common_mock.go
+++ b/internal/auth/common/common_mock.go
@@ -143,6 +143,15 @@ func (m *MockAuthNMiddleware) GetAuthConfig() *v1alpha1.AuthConfig {
 	return ret0
 }
 
+// IsEnabled mocks base method.
+func (m *MockAuthNMiddleware) IsEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabled indicates an expected call of IsEnabled.
 // GetAuthConfig indicates an expected call of GetAuthConfig.
 func (mr *MockAuthNMiddlewareMockRecorder) GetAuthConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/internal/auth/nil_auth.go
+++ b/internal/auth/nil_auth.go
@@ -28,6 +28,10 @@ func (NilAuth) GetUserPermissions(_ context.Context) (*api.PermissionList, error
 	}, nil
 }
 
+func (NilAuth) IsEnabled() bool {
+	return true
+}
+
 func (NilAuth) ValidateToken(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -302,10 +302,12 @@ func WithK8sAuth(apiUrl, rbacNs string) ConfigOption {
 				DynamicProviderCacheTTL: util.Duration(5 * time.Second),
 			}
 		}
+		enabled := true
 		c.Auth.K8s = &api.K8sProviderSpec{
 			ApiUrl:       apiUrl,
 			RbacNs:       &rbacNs,
 			ProviderType: api.K8s,
+			Enabled:      &enabled,
 		}
 	}
 }
@@ -317,10 +319,12 @@ func WithAAPAuth(apiUrl, externalApiUrl string) ConfigOption {
 				DynamicProviderCacheTTL: util.Duration(5 * time.Second),
 			}
 		}
+		enabled := true
 		c.Auth.AAP = &api.AapProviderSpec{
 			ApiUrl:         apiUrl,
 			ExternalApiUrl: &externalApiUrl,
 			ProviderType:   "aap",
+			Enabled:        &enabled,
 		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers now expose an enabled/disabled state and the auth config reflects provider Enabled flags.

* **Bug Fixes**
  * Auth config and token resolution consider only enabled providers.
  * Kubernetes and AAP providers are explicitly enabled by default when configured.
  * Auth config ordering is deterministic and no longer produces unintended defaults for fully disabled setups.
  * Provider listing API returns both enabled and disabled providers as expected.

* **Tests**
  * Test coverage updated to validate enabled/disabled provider behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->