### PR TITLE
NO-ISSUE: enable version support to test quadlets-vm

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -390,6 +390,16 @@ make deploy-quadlets-vm
 USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' VM_DISK_SIZE_INC=50 make deploy-quadlets-vm
 ```
 
+- Build and install from a specific git tag/version (builds inside VM):
+```bash
+GIT_VERSION="v1.0.0" USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' make deploy-quadlets-vm
+```
+
+- Install from brew build (downloads inside VM):
+```bash
+BREW_BUILD_URL="<brew-url>?taskID=<task-id>" USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' make deploy-quadlets-vm
+```
+
 **Access the VM:**
 After deployment, you'll get the VM IP address. SSH into it:
 ```bash

--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -110,7 +110,7 @@ echo "Executing commands in the VM..."
 ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${USER}@${VM_DEFAULT_IP} <<EOF
 
   # Install necessary packages
-  sudo dnf install -y epel-release libvirt libvirt-client virt-install pam-devel swtpm \
+  sudo dnf install -y epel-release libvirt libvirt-client virt-install pam-devel swtpm wget \
                     make golang git \
                     podman qemu-kvm sshpass
   sudo dnf --enablerepo=crb install -y libvirt-devel

--- a/test/scripts/deploy_quadlets_rhel.sh
+++ b/test/scripts/deploy_quadlets_rhel.sh
@@ -1,4 +1,28 @@
 #!/bin/bash
+#
+# Deploy FlightCtl Quadlets VM Script
+#
+# Creates a RHEL VM and installs FlightCtl services using systemd quadlets.
+# Supports installing from git version/branch, brew-build, or default COPR.
+#
+# Usage:
+#   # Default: Install from default COPR repository
+#   ./deploy_quadlets_rhel.sh
+#
+#   # Build and install from git tag/version
+#   GIT_VERSION="v1.0.0" ./deploy_quadlets_rhel.sh
+#
+#   # Install from brew build (downloads inside VM)
+#   BREW_BUILD_URL="<brew-url>?taskID=<task-id>" ./deploy_quadlets_rhel.sh
+#
+# Environment Variables:
+#   GIT_VERSION         - Git tag/version to clone and build from inside VM (e.g., "v1.0.0")
+#   BREW_BUILD_URL      - Full URL to brew build page (downloads inside VM)
+#   VM_NAME             - VM name (default: "quadlets-vm")
+#   VM_DISK_SIZE_INC    - Disk size increment in GB (default: 30)
+#   USER                - Username for VM access (default: current user)
+#   REDHAT_USER         - Red Hat account username
+#   REDHAT_PASSWORD     - Red Hat account password
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/functions
@@ -20,10 +44,29 @@ SSH_PRIVATE_KEY_PATH=${SSH_PRIVATE_KEY_PATH:-"/home/${USER}/.ssh/id_rsa"}
 SSH_PUBLIC_KEY_PATH=${SSH_PUBLIC_KEY_PATH:-"/home/${USER}/.ssh/id_rsa.pub"}
 USER_DATA_FILE="user-data.yaml"
 REMOTE_URL=${REMOTE_URL:-"https://github.com/flightctl/flightctl.git"}
-RPM_COPR="$(copr_repo)"
-RPM_COPR=${RPM_COPR:-"@redhat-et/flightctl-dev"}
-RPM_PACKAGE="flightctl-services"
-RPM_CLIENT="flightctl-cli"
+
+# Package installation configuration
+# Priority order (determined by environment variables):
+# 1. If GIT_VERSION is set, clone repo with that tag and build RPMs inside VM
+# 2. If BREW_BUILD_URL is set, download brew builds inside VM
+# 3. Otherwise, use default COPR repository
+
+if [[ -n "${GIT_VERSION:-}" ]]; then
+    echo "Using GIT_VERSION: ${GIT_VERSION} - will clone and build from source inside VM"
+    INSTALL_METHOD="git-build"
+elif [[ -n "${BREW_BUILD_URL:-}" ]]; then
+    echo "Using BREW_BUILD_URL: ${BREW_BUILD_URL} - will download brew builds inside VM"
+    INSTALL_METHOD="brew"
+else
+    echo "Using default COPR repository for package installation"
+    INSTALL_METHOD="default"
+    RPM_COPR="$(copr_repo)"
+    RPM_COPR=${RPM_COPR:-"@redhat-et/flightctl-dev"}
+    RPM_PACKAGE="flightctl-services"
+    RPM_CLIENT="flightctl-cli"
+    RPM_OBS="flightctl-observability"
+    RPM_TELEMETRY="flightctl-telemetry-gateway"
+fi
 
 # Generate user-data file
 echo "Generating user-data file..."
@@ -105,13 +148,161 @@ ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile
   sudo dnf install -y \
   https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
   sudo dnf repolist
-  sudo dnf install -y libvirt libvirt-client virt-install pam-devel swtpm \
-                    make golang git \
-                    podman qemu-kvm sshpass
+   sudo dnf install -y libvirt libvirt-client virt-install pam-devel swtpm wget \
+                     make golang git \
+                     podman qemu-kvm sshpass
   sudo dnf --enablerepo=crb install -y libvirt-devel
 
-  sudo dnf copr -y enable ${RPM_COPR}
-  sudo dnf install -y ${RPM_PACKAGE} ${RPM_CLIENT}
+  # Install build dependencies for git-build method
+  if [[ "${INSTALL_METHOD}" == "git-build" ]]; then
+    echo "Installing build dependencies for RPM building..."
+    sudo dnf install -y packit rpm-build go-rpm-macros openssl-devel selinux-policy selinux-policy-devel
+  fi
+
+  # Build or download FlightCtl packages based on installation method
+  if [[ "${INSTALL_METHOD}" == "git-build" ]]; then
+    echo "Building FlightCtl packages from git version ${GIT_VERSION}..."
+    BUILD_DIR="${USER_HOME}"
+    cd \${BUILD_DIR}
+
+    # Clone repository with the specified tag
+    echo "Cloning flightctl repository with tag ${GIT_VERSION}..."
+    echo "Repository will be cloned to: \${BUILD_DIR}/flightctl"
+    git clone --depth 1 --branch "${GIT_VERSION}" "${REMOTE_URL}" flightctl || {
+      echo "ERROR: Failed to clone repository with tag ${GIT_VERSION}"
+      exit 1
+    }
+
+    echo "Repository cloned successfully to: \${BUILD_DIR}/flightctl"
+
+    # Change to the flightctl repository directory before building
+    cd \${BUILD_DIR}/flightctl
+    echo "Current directory: \$(pwd)"
+
+    # Build RPMs
+    echo "Building RPMs..."
+    make rpm || {
+      echo "ERROR: Failed to build RPMs"
+      exit 1
+    }
+
+    # Verify RPMs were built
+    if ! ls bin/rpm/flightctl-*.rpm >/dev/null 2>&1; then
+      echo "ERROR: No RPMs found in bin/rpm after build"
+      exit 1
+    fi
+
+    echo "Successfully built RPMs:"
+    ls -lh bin/rpm/flightctl-*.rpm
+
+    # Install service RPMs (exclude agent, selinux, debug, src)
+    cd bin/rpm
+    echo "Installing FlightCtl packages from built RPMs in: \$(pwd)"
+    # Filter out unwanted packages before installing
+    INSTALL_RPMS=""
+    for rpm in flightctl-*.rpm; do
+      if [[ ! "\${rpm}" =~ (agent|selinux|debug|\.src\.rpm) ]]; then
+        if [[ -f "\${rpm}" ]]; then
+          INSTALL_RPMS="\${INSTALL_RPMS} \${rpm}"
+        fi
+      fi
+    done
+
+    if [[ -z "\${INSTALL_RPMS}" ]]; then
+      echo "ERROR: No service RPMs found to install (all were filtered out)"
+      echo "Available RPMs:"
+      ls -lh flightctl-*.rpm 2>/dev/null || echo "No RPMs found"
+      exit 1
+    fi
+
+    echo "Installing RPMs: \${INSTALL_RPMS}"
+    # Install each RPM individually to handle missing packages gracefully
+    INSTALL_FAILED=0
+    for rpm in \${INSTALL_RPMS}; do
+      if [[ -f "\${rpm}" ]]; then
+        echo "Installing \${rpm}..."
+        if sudo dnf install -y "\${rpm}"; then
+          echo "Successfully installed \${rpm}"
+        else
+          echo "WARNING: Failed to install \${rpm} (may not be available in this version)"
+          INSTALL_FAILED=1
+        fi
+      fi
+    done
+
+    # Check if at least the core services package was installed
+    if ! rpm -q flightctl-services >/dev/null 2>&1; then
+      echo "ERROR: flightctl-services package was not installed, which is required"
+      exit 1
+    fi
+
+    if [[ \${INSTALL_FAILED} -eq 1 ]]; then
+      echo "WARNING: Some packages failed to install (may not be available in version ${GIT_VERSION})"
+      echo "Installed packages:"
+      rpm -qa | grep flightctl || echo "No flightctl packages found"
+    fi
+    cd -
+
+  elif [[ "${INSTALL_METHOD}" == "brew" ]]; then
+    echo "Downloading FlightCtl packages from brew build: ${BREW_BUILD_URL}"
+
+    # Login to Red Hat registry for container image access
+    echo "Logging in to registry.redhat.io..."
+    sudo podman login registry.redhat.io --username $REDHAT_USER --password $REDHAT_PASSWORD || {
+      echo "WARNING: Failed to login to registry.redhat.io (container images may not be available)"
+    }
+
+    BREW_TMP_DIR="${USER_HOME}/brew-rpms"
+    mkdir -p \${BREW_TMP_DIR}
+    cd \${BREW_TMP_DIR}
+
+    # Fetch brew page and extract RPM URLs
+    brew_page=\$(curl -k -s "${BREW_BUILD_URL}")
+    if [ \$? -ne 0 ]; then
+      echo "ERROR: Failed to fetch brew page from URL: ${BREW_BUILD_URL}"
+      exit 1
+    fi
+
+    # Extract RPM URLs (use sed as fallback if grep -P not available)
+    rpm_urls=\$(echo "\${brew_page}" | grep -oP 'https://[^"]+\.rpm' 2>/dev/null || echo "\${brew_page}" | grep -o 'https://[^"]*\.rpm')
+    if [[ -z "\${rpm_urls}" ]]; then
+      echo "ERROR: No RPM URLs found in brew page"
+      exit 1
+    fi
+
+    # Download required RPMs
+    echo "Downloading RPMs from brew..."
+    while IFS= read -r url; do
+      [[ -z "\$url" ]] && continue
+      filename=\$(basename "\$url")
+      # Download service packages we need (exclude agent, selinux, debug, src)
+      if [[ "\${filename}" =~ ^flightctl-(services|observability|telemetry-gateway)- ]] || \
+         ([[ "\${filename}" =~ ^flightctl- ]] && \
+          [[ ! "\${filename}" =~ (agent|selinux|debug|\.src\.rpm) ]]); then
+        echo "Downloading \${filename}..."
+        wget --no-check-certificate -O "\${filename}" "\$url" || exit 1
+      fi
+    done <<< "\${rpm_urls}"
+
+    # Install downloaded RPMs
+    if ls flightctl-*.rpm >/dev/null 2>&1; then
+      echo "Installing FlightCtl packages from brew RPMs..."
+      sudo dnf install -y flightctl-*.rpm || {
+        echo "ERROR: Failed to install brew RPMs"
+        exit 1
+      }
+    else
+      echo "ERROR: No FlightCtl RPMs found in brew build"
+      exit 1
+    fi
+
+    cd - > /dev/null
+
+  else
+    echo "Installing FlightCtl packages from COPR: ${RPM_COPR}"
+    sudo dnf copr -y enable ${RPM_COPR}
+    sudo dnf install -y ${RPM_PACKAGE} ${RPM_CLIENT} ${RPM_OBS} ${RPM_TELEMETRY}
+  fi
 
   # Install OpenShift client
   echo "Installing OpenShift client..."

--- a/test/test.mk
+++ b/test/test.mk
@@ -5,7 +5,6 @@ GO_TESTING_FLAGS= -count=1 -race $(GO_BUILD_FLAGS)
 
 GO_UNITTEST_DIRS 		= ./internal/... ./api/... ./pkg/...
 GO_INTEGRATIONTEST_DIRS ?= ./test/integration/...
-TEST_DIR ?= 
 GO_E2E_DIRS 			= ./test/e2e/...
 
 GO_UNITTEST_FLAGS 		 = $(GO_TESTING_FLAGS) $(GO_UNITTEST_DIRS)        -coverprofile=$(REPORTS)/unit-coverage.out
@@ -122,7 +121,7 @@ deploy-e2e-ocp-test-vm:
 	sudo --preserve-env=VM_DISK_SIZE_INC test/scripts/create_vm_libvirt.sh ${KUBECONFIG_PATH}
 
 deploy-quadlets-vm:
-	sudo --preserve-env=VM_DISK_SIZE_INC --preserve-env=USER --preserve-env=REDHAT_USER --preserve-env=REDHAT_PASSWORD test/scripts/deploy_quadlets_rhel.sh
+	sudo --preserve-env=VM_DISK_SIZE_INC --preserve-env=USER --preserve-env=REDHAT_USER --preserve-env=REDHAT_PASSWORD --preserve-env=GIT_VERSION --preserve-env=BREW_BUILD_URL test/scripts/deploy_quadlets_rhel.sh
 
 clean-quadlets-vm:
 	@echo "Cleaning up quadlets-vm..."


### PR DESCRIPTION
Enabling version support for testing in rhel quadlets-vm.

**From latest main copr builds**
```bash
export USER="your-username"
export REDHAT_USER="your-email@redhat.com"
export REDHAT_PASSWORD="your-password"
make deploy-quadlets-vm
```

**Optional configuration:**
- Set custom disk size increment (default is 30G):
```bash
USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' VM_DISK_SIZE_INC=50 make deploy-quadlets-vm
```

- Build and install from a specific git tag/version (builds inside VM):
```bash
GIT_VERSION="v1.0.0" USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' make deploy-quadlets-vm
```

- Install from brew build (downloads inside VM):
```bash
BREW_BUILD_URL="https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=12345678" USER=redhat-user REDHAT_USER=redhat-user@redhat.com REDHAT_PASSWORD='your-password' make deploy-quadlets-vm
```

**Access the VM:**
After deployment, you'll get the VM IP address. SSH into it:
```bash
ssh ${USER}@${VM_IP}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple VM deployment install methods: choose git-build by tag, brew-build by URL, or default COPR-style via environment, with improved in-VM install validation and error handling.

* **Documentation**
  * Deployment docs show separate install-option examples and in-VM status/check guidance.

* **Chores**
  * VM provisioning ensures download tooling is available and deployment preserves GIT_VERSION and BREW_BUILD_URL; removed TEST_DIR Makefile variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->