### PR TITLE
Make the token expire in 8 hours instead of 1

### DIFF
--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -131,7 +131,7 @@ LOGGED_IN=false
 # attempt to login, it could take some time for API to be stable
 for i in {1..60}; do
   if [ "$AUTH" ]; then
-    TOKEN=$(kubectl -n flightctl-external create token flightctl-admin --context kind-kind 2>/dev/null || true)
+    TOKEN=$(kubectl -n flightctl-external create token flightctl-admin --duration=8h --context kind-kind 2>/dev/null || true)
     if [ -n "$TOKEN" ] && ./bin/flightctl login -k https://api.${IP}.nip.io:${API_PORT} --token "$TOKEN"; then
       LOGGED_IN=true
       break


### PR DESCRIPTION
The current token expires in 1h so we keep needing to renew it too frequently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment scripts updated to enforce a maximum token validity of 8 hours for issued tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->