### PR TITLE
NO-ISSUE: *: use math/rand/v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ issues:
 linters:
   enable:
     - copyloopvar
+    - depguard
     - errcheck
     - gci
     - gocyclo
@@ -78,6 +79,13 @@ linters:
 linters-settings:
   enable:
     - shadow
+
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "^math/rand$"
+            desc: "Use math/rand/v2 instead"
 
   govet:
     settings:

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent/client"
@@ -142,8 +141,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		BaseDelay:    10 * time.Second,
 		Factor:       1.5,
 		MaxSteps:     a.config.PullRetrySteps,
-		JitterFactor: 0.1,                                             // jitterFactor (10% jitter to prevent thundering herd)
-		Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
+		JitterFactor: 0.1,
 	}
 
 	// create os client
@@ -425,12 +423,11 @@ func newEnrollmentClient(cfg *agent_config.Config, log *log.PrefixLogger) (clien
 	// Create infinite retry policy for enrollment requests using same config as management client
 	// but with infinite retries (MaxSteps: 0)
 	infiniteRetryConfig := poll.Config{
-		BaseDelay:    10 * time.Second,                                // baseDelay (same as management client)
-		Factor:       1.5,                                             // factor (same as management client)
-		MaxDelay:     1 * time.Minute,                                 // maxDelay (same as management client)
-		MaxSteps:     0,                                               // maxSteps (0 means infinite retries until context timeout)
-		JitterFactor: 0.1,                                             // jitterFactor (10% jitter to prevent thundering herd)
-		Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
+		BaseDelay:    10 * time.Second,
+		Factor:       1.5,
+		MaxDelay:     1 * time.Minute,
+		MaxSteps:     0,
+		JitterFactor: 0.1,
 	}
 
 	httpClient, err := client.NewFromConfig(&cfg.EnrollmentService.Config, log, client.WithHTTPRetry(infiniteRetryConfig))

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -2,7 +2,6 @@ package spec
 
 import (
 	"context"
-	"math/rand"
 	"time"
 
 	"github.com/flightctl/flightctl/api/v1alpha1"
@@ -28,13 +27,14 @@ const (
 )
 
 // defaultSpecPollConfig is the default poll configuration for the spec priority queue.
-var defaultSpecPollConfig = poll.Config{
-	BaseDelay:    30 * time.Second,
-	Factor:       1.5,
-	MaxDelay:     5 * time.Minute,
-	JitterFactor: 0.1,
-	Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
-}
+var defaultSpecPollConfig = func() poll.Config {
+	return poll.Config{
+		BaseDelay:    30 * time.Second,
+		Factor:       1.5,
+		MaxDelay:     5 * time.Minute,
+		JitterFactor: 0.1,
+	}
+}()
 
 // Watcher provides a way to watch for device spec updates.
 type Watcher interface {

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -3,7 +3,6 @@ package periodic
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/signal"
 	"sync"
@@ -129,7 +128,6 @@ func (s *Server) Run(ctx context.Context) error {
 			Factor:       3,
 			MaxDelay:     10 * time.Second,
 			JitterFactor: 0.1,
-			Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
 		},
 	}
 	periodicTaskPublisher, err := NewPeriodicTaskPublisher(publisherConfig)

--- a/test/integration/alerts/exporter_test.go
+++ b/test/integration/alerts/exporter_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"testing"
@@ -558,7 +558,7 @@ func createEvent(ctx context.Context, handler service.Service, reason api.EventR
 	ev := &api.Event{
 		Reason:         reason,
 		InvolvedObject: api.ObjectReference{Kind: kind, Name: name},
-		Metadata:       api.ObjectMeta{Name: lo.ToPtr(fmt.Sprintf("test-event-%d", rand.Int63()))}, //nolint:gosec
+		Metadata:       api.ObjectMeta{Name: lo.ToPtr(fmt.Sprintf("test-event-%d", rand.Int64()))}, //nolint:gosec
 	}
 	handler.CreateEvent(ctx, ev)
 }

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -264,7 +263,6 @@ func NewPollConfig() poll.Config {
 		Factor:       1.0,
 		MaxDelay:     1 * time.Millisecond,
 		JitterFactor: 0.1,
-		Rand:         rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
 	}
 }
 


### PR DESCRIPTION
This PR updates all usage of math/rand to math/rand/v2 which has many improvements and optimizations as described in this blog[1] by Russ Cox

[1] https://go.dev/blog/randv2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced legacy randomness implementation and added a linter rule enforcing the new RNG usage.
  * Changed config factory to return by value and improved defaults so RNG is safely auto-initialized when absent.

* **Tests**
  * Updated tests and helpers for the new RNG and added coverage verifying nil-RNG auto-initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->