### PR TITLE
NO-ISSUE: Fix broken links in authentication docs

### DIFF
--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -100,7 +100,7 @@ flightctl get devices --org org-b
 
 ## Related Documentation
 
-- [Authentication Overview](authentication-overview.md) - Overview of all authentication methods
-- [API Resources](auth-resources.md) - Authorization reference and API endpoints
+- [Authentication Overview](overview.md) - Overview of all authentication methods
+- [API Resources](../../references/auth-resources.md) - Authorization reference and API endpoints
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [OIDC Authentication](oidc-auth.md) - For OIDC deployments
+- [OIDC Authentication](auth-oidc.md) - For OIDC deployments

--- a/docs/user/installing/configuring-auth/auth-kubernetes.md
+++ b/docs/user/installing/configuring-auth/auth-kubernetes.md
@@ -45,7 +45,7 @@ If you want to use a different cluster as auth authority, the following variable
 
 ### OpenShift Clusters
 
-If your cluster is OpenShift, use [OpenShift Authentication](openshift-auth.md) instead for better integration.
+If your cluster is OpenShift, use [OpenShift Authentication](auth-openshift.md) instead for better integration.
 
 ### ACM Deployments
 
@@ -64,7 +64,7 @@ If deploying on ACM (by global.target: acm), the k8s auth values are automatical
 - ✅ Integration with Kubernetes identity
 - ✅ Familiar with Kubernetes RBAC concepts
 
-**Note:** For OpenShift deployments, use [OpenShift authentication](openshift-auth.md) instead for better integration.
+**Note:** For OpenShift deployments, use [OpenShift authentication](auth-openshift.md) instead for better integration.
 
 ## Kubernetes RBAC Authorization
 
@@ -78,7 +78,7 @@ Flight Control uses [Kubernetes RBAC authorization](https://kubernetes.io/docs/r
 
 ## API Endpoints
 
-API endpoints are documented in [Authentication resources](auth-resources.md). The resources and verbs in this document should be used for creating API objects **Role** or **ClusterRole**.
+API endpoints are documented in [Authentication resources](../../references/auth-resources.md). The resources and verbs in this document should be used for creating API objects **Role** or **ClusterRole**.
 
 ## Login
 
@@ -129,7 +129,7 @@ flightctl login https://flightctl.example.com --token=$TOKEN
 
 ## Related Documentation
 
-- [Authentication Overview](authentication-overview.md) - Overview of all authentication methods
-- [API Resources](auth-resources.md) - Authorization reference and API endpoints
+- [Authentication Overview](overview.md) - Overview of all authentication methods
+- [API Resources](../../references/auth-resources.md) - Authorization reference and API endpoints
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [OpenShift Authentication](openshift-auth.md) - For OpenShift deployments
+- [OpenShift Authentication](auth-openshift.md) - For OpenShift deployments

--- a/docs/user/installing/configuring-auth/auth-oauth2.md
+++ b/docs/user/installing/configuring-auth/auth-oauth2.md
@@ -17,7 +17,7 @@ Use OAuth2 authentication when:
 
 - ✅ Your provider supports OAuth2 but not OIDC
 
-**Note:** If your provider supports OIDC, use [OIDC authentication](oidc-auth.md) instead as it provides better standardization.
+**Note:** If your provider supports OIDC, use [OIDC authentication](auth-oidc.md) instead as it provides better standardization.
 
 ## Organization and Role Mapping
 
@@ -275,7 +275,7 @@ The CLI will open a browser for authentication. Users select their OAuth2 provid
 
 ## Related Documentation
 
-- [Authentication Overview](authentication-overview.md) - Overview of all authentication methods
-- [OIDC Authentication](oidc-auth.md) - Preferred authentication method
+- [Authentication Overview](overview.md) - Overview of all authentication methods
+- [OIDC Authentication](auth-oidc.md) - Preferred authentication method
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [API Resources](auth-resources.md) - Authorization reference
+- [API Resources](../../references/auth-resources.md) - Authorization reference

--- a/docs/user/installing/configuring-auth/auth-oidc.md
+++ b/docs/user/installing/configuring-auth/auth-oidc.md
@@ -22,7 +22,7 @@ Flight Control works with any OIDC-compliant provider, including:
 - Auth0
 - And any other OIDC-compliant provider
 
-For standalone deployments, [PAM Issuer](pam-authentication.md) is bundled as a default OIDC provider.
+For standalone deployments, [PAM Issuer](auth-pam.md) is bundled as a default OIDC provider.
 
 ## Organization and Role Mapping
 
@@ -279,8 +279,8 @@ The CLI will open a browser for authentication. Users select their OIDC provider
 
 ## Related Documentation
 
-- [Authentication Overview](authentication-overview.md) - Overview of all authentication methods
-- [OAuth2 Authentication](oauth2-auth.md) - Alternative for non-OIDC providers
-- [PAM Issuer](pam-authentication.md) - Bundled OIDC provider for Linux Deployment
+- [Authentication Overview](overview.md) - Overview of all authentication methods
+- [OAuth2 Authentication](auth-oauth2.md) - Alternative for non-OIDC providers
+- [PAM Issuer](auth-pam.md) - Bundled OIDC provider for Linux Deployment
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [API Resources](auth-resources.md) - Authorization reference
+- [API Resources](../../references/auth-resources.md) - Authorization reference

--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -178,7 +178,7 @@ flightctl get devices --org project-b
 
 ## Related Documentation
 
-- [Authentication Overview](authentication-overview.md) - Overview of all authentication methods
-- [API Resources](auth-resources.md) - Authorization reference and API endpoints
+- [Authentication Overview](overview.md) - Overview of all authentication methods
+- [API Resources](../../references/auth-resources.md) - Authorization reference and API endpoints
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [Kubernetes Authentication](kubernetes-auth.md) - For Kubernetes deployments
+- [Kubernetes Authentication](auth-kubernetes.md) - For Kubernetes deployments

--- a/docs/user/installing/configuring-auth/overview.md
+++ b/docs/user/installing/configuring-auth/overview.md
@@ -10,7 +10,7 @@ Flight Control automatically configures authentication based on your deployment 
 |------------------------|----------------------|-------------|
 | **AAP (Ansible Automation Platform)** | AAP Gateway | Integrates with AAP Gateway for authentication and authorization |
 | **OpenShift** | OpenShift OAuth | Uses OpenShift's OAuth server for authentication |
-| **Standalone (Quadlet/Podman)** | OIDC | Flight Control API server uses OIDC authentication. [PAM Issuer](pam-authentication.md) (bundled OIDC provider) is deployed by default |
+| **Standalone (Quadlet/Podman)** | OIDC | Flight Control API server uses OIDC authentication. [PAM Issuer](auth-pam.md) (bundled OIDC provider) is deployed by default |
 | **Kubernetes (non-OpenShift)** | Kubernetes RBAC | Uses Kubernetes service accounts and RBAC for authentication |
 
 ### Supported Authentication Methods
@@ -21,31 +21,31 @@ Flight Control API server supports the following authentication methods:
 
 Standard OpenID Connect protocol. Works with any OIDC-compliant provider (Azure AD, Okta, Keycloak, Google, etc.). Supports dynamic provider configuration, flexible organization and role mapping, and multiple simultaneous providers.
 
-→ [OIDC Authentication Documentation](oidc-auth.md)
+→ [OIDC Authentication Documentation](auth-oidc.md)
 
 #### 2. OAuth2
 
 Generic OAuth2 protocol for providers that don't fully support OIDC. Supports dynamic provider configuration and flexible organization and role mapping.
 
-→ [OAuth2 Authentication Documentation](oauth2-auth.md)
+→ [OAuth2 Authentication Documentation](auth-oauth2.md)
 
 #### 3. Kubernetes
 
 Validates Kubernetes service account tokens via TokenReview API. Maps to RoleBindings in the namespace where Flight Control is deployed. All users assigned to `default` organization.
 
-→ [Kubernetes Authentication Documentation](kubernetes-auth.md)
+→ [Kubernetes Authentication Documentation](auth-kubernetes.md)
 
 #### 4. OpenShift
 
 Integrates with OpenShift OAuth server. Auto-maps OpenShift projects to Flight Control organizations and uses RoleBindings from project namespaces.
 
-→ [OpenShift Authentication Documentation](openshift-auth.md)
+→ [OpenShift Authentication Documentation](auth-openshift.md)
 
 #### 5. AAP (Ansible Automation Platform)
 
 Validates tokens via AAP Gateway API. Auto-maps AAP organizations to Flight Control organizations. Restricted to AAP super admins only.
 
-→ [AAP Authentication Documentation](aap-auth.md)
+→ [AAP Authentication Documentation](auth-aap.md)
 
 ## Managing Authentication Providers
 
@@ -124,11 +124,11 @@ For detailed configuration examples, see the specific authentication method docu
 
 ## Related Documentation
 
-- [OIDC Authentication](oidc-auth.md) - OIDC provider setup and configuration
-- [OAuth2 Authentication](oauth2-auth.md) - OAuth2 provider setup
-- [Kubernetes Authentication](kubernetes-auth.md) - Kubernetes RBAC integration
-- [OpenShift Authentication](openshift-auth.md) - OpenShift OAuth integration
-- [AAP Authentication](aap-auth.md) - AAP Gateway integration
-- [PAM Issuer](pam-authentication.md) - Bundled OIDC provider for Linux Deployment
+- [OIDC Authentication](auth-oidc.md) - OIDC provider setup and configuration
+- [OAuth2 Authentication](auth-oauth2.md) - OAuth2 provider setup
+- [Kubernetes Authentication](auth-kubernetes.md) - Kubernetes RBAC integration
+- [OpenShift Authentication](auth-openshift.md) - OpenShift OAuth integration
+- [AAP Authentication](auth-aap.md) - AAP Gateway integration
+- [PAM Issuer](auth-pam.md) - Bundled OIDC provider for Linux Deployment
 - [Organizations](organizations.md) - Multi-tenancy configuration
-- [API Resources](auth-resources.md) - Authorization reference
+- [API Resources](../../references/auth-resources.md) - Authorization reference


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication docs: multiple links now point to renamed/auth-prefixed pages for OIDC, OAuth2, Kubernetes, OpenShift, AAP, and PAM.
  * Fixed Related Documentation and API Resources links to the new references location.
  * Improved wording and clarified standalone deployment guidance for default OIDC/PAM provider selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->