### PR TITLE
EDM-2565: Update services must gather params

### DIFF
--- a/packaging/must-gather/flightctl-services-must-gather
+++ b/packaging/must-gather/flightctl-services-must-gather
@@ -2,6 +2,39 @@
 
 set -euo pipefail
 
+JOURNAL_SINCE="24 hours ago"
+NON_INTERACTIVE=false
+
+usage() {
+  echo "Usage: $0 [--since <value>] [-y]"
+  echo ""
+  echo "  --since <value>   Time passed to journalctl --since (default: \"24 hours ago\")"
+  echo "  -y                Non-interactive mode, skip confirmation prompt"
+  echo "  -h, --help        Show this help message"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since)
+      JOURNAL_SINCE="$2"
+      shift 2
+      ;;
+    -y)
+      NON_INTERACTIVE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
 # Ensure script is run with sudo available
 if ! sudo -n true 2>/dev/null; then
     echo "This script requires sudo privileges. Please run with a user that has sudo access."
@@ -9,13 +42,18 @@ if ! sudo -n true 2>/dev/null; then
 fi
 
 echo "Warning: This operation could generate a very large file in the current directory."
-read -p "Do you have enough storage space? (y/n): " -n 1 -r
-echo ""
 
-# Check the user's response
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-  echo "Operation canceled by the user."
-  exit 1
+if [[ "$NON_INTERACTIVE" == false ]]; then
+  read -p "Do you have enough storage space? (y/n): " -n 1 -r
+  echo ""
+
+  # Check the user's response
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Operation canceled by the user."
+    exit 1
+  fi
+else
+  echo "Running in non-interactive mode, skipping confirmation..."
 fi
 
 echo "Beginning Must Gather Collection..."
@@ -35,12 +73,12 @@ sudo systemctl list-dependencies flightctl.target > "$temp_dir/target-list-depen
 sudo systemctl status 'flightctl*' > "$temp_dir/systemd-status.log" || echo "No flightctl services found" > "$temp_dir/systemd-status.log"
 sudo systemctl list-units 'flightctl*' > "$temp_dir/systemd-list-units.log" || echo "No flightctl units found" > "$temp_dir/systemd-list-units.log"
 
-echo "# Collecting journal logs..."
-for service in $(sudo systemctl list-units --no-legend 'flightctl*' 2>/dev/null |
+echo "# Collecting journal logs since: $JOURNAL_SINCE..."
+for service in $(sudo systemctl list-units --no-legend --plain 'flightctl*' 2>/dev/null |
 awk '{print $1}' || true); do
     if [ -n "$service" ]; then
         echo "## Collecting logs for $service..."
-        sudo journalctl -u "$service" --since "24 hours ago" --no-pager > "$temp_dir/${service}.log" || echo "Failed to collect logs for $service" > "$temp_dir/${service}.log"
+        sudo journalctl -u "$service" --since "$JOURNAL_SINCE" --no-pager > "$temp_dir/${service}.log" || echo "Failed to collect logs for $service" > "$temp_dir/${service}.log"
     fi
 done
 


### PR DESCRIPTION
Addresses:

- [EDM-2563](https://issues.redhat.com/browse/EDM-2563) empty log file included in must-gather
- [EDM-2565](https://issues.redhat.com/browse/EDM-2565) add --since arg
- [EDM-2566](https://issues.redhat.com/browse/EDM-2566) add -y non interactive mode to auto-confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable time window for log collection via `JOURNAL_SINCE` variable (default: 24 hours ago)
  * Added non-interactive mode for automated log gathering
  * Added new CLI options: `--since`, `-y`, `-h/--help` with usage information
  * Improved log collection parsing and display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->