### PR TITLE
NO-ISSUE: added flightctl login --show-providers

### DIFF
--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -77,6 +77,7 @@ const (
 	AuthProviderListKind   = "AuthProviderList"
 
 	AuthConfigAPIVersion = "v1beta1"
+	AuthConfigKind       = "AuthConfig"
 
 	ResourceSyncAPIVersion = "v1beta1"
 	ResourceSyncKind       = "ResourceSync"

--- a/internal/cli/display/table.go
+++ b/internal/cli/display/table.go
@@ -76,6 +76,13 @@ func (f *TableFormatter) formatList(w *tabwriter.Writer, data interface{}, optio
 		return f.printEventsTable(w, data.(*apiclient.ListEventsResponse).JSON200.Items...)
 	case strings.EqualFold(options.Kind, api.AuthProviderKind):
 		return f.printAuthProvidersTable(w, data.(*apiclient.ListAuthProvidersResponse).JSON200.Items...)
+	case strings.EqualFold(options.Kind, api.AuthConfigKind):
+		// Special case for AuthConfig which contains providers
+		authConfig := data.(*api.AuthConfig)
+		if authConfig.Providers != nil && len(*authConfig.Providers) > 0 {
+			return f.printAuthConfigProvidersTable(w, authConfig)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown resource type %s", options.Kind)
 	}
@@ -396,6 +403,102 @@ func (f *TableFormatter) printEventsTable(w *tabwriter.Writer, events ...api.Eve
 			string(e.Type),
 			e.Message,
 		)
+	}
+	return nil
+}
+
+func (f *TableFormatter) printAuthConfigProvidersTable(w *tabwriter.Writer, authConfig *api.AuthConfig) error {
+	if authConfig == nil {
+		return fmt.Errorf("auth config is nil")
+	}
+
+	f.printHeaderRowLn(w, "NAME", "TYPE", "ISSUER", "ENABLED", "DEFAULT")
+
+	defaultProvider := ""
+	if authConfig.DefaultProvider != nil {
+		defaultProvider = *authConfig.DefaultProvider
+	}
+
+	for _, ap := range *authConfig.Providers {
+		issuer := NoneString
+		enabled := NoneString
+		name := NoneString
+		isDefault := NoneString
+		if ap.Metadata.Name != nil {
+			name = *ap.Metadata.Name
+		}
+
+		if name == defaultProvider {
+			isDefault = "*"
+		}
+
+		// Extract type from the discriminator
+		providerType, err := ap.Spec.Discriminator()
+		if err != nil {
+			return fmt.Errorf("failed to get discriminator for provider %s: %w", name, err)
+		}
+
+		// Extract issuer and enabled based on type
+		switch providerType {
+		case string(api.Oidc):
+			oidcSpec, err := ap.Spec.AsOIDCProviderSpec()
+			if err != nil {
+				return fmt.Errorf("failed to parse OIDC provider spec for %s: %w", name, err)
+			}
+			issuer = oidcSpec.Issuer
+			if oidcSpec.Enabled != nil {
+				enabled = util.BoolToStr(*oidcSpec.Enabled, "true", "false")
+			}
+		case string(api.Oauth2):
+			oauth2Spec, err := ap.Spec.AsOAuth2ProviderSpec()
+			if err != nil {
+				return fmt.Errorf("failed to parse OAuth2 provider spec for %s: %w", name, err)
+			}
+			if oauth2Spec.Issuer != nil {
+				issuer = *oauth2Spec.Issuer
+			}
+			if oauth2Spec.Enabled != nil {
+				enabled = util.BoolToStr(*oauth2Spec.Enabled, "true", "false")
+			}
+		case string(api.Openshift):
+			openshiftSpec, err := ap.Spec.AsOpenShiftProviderSpec()
+			if err != nil {
+				return fmt.Errorf("failed to parse OpenShift provider spec for %s: %w", name, err)
+			}
+			if openshiftSpec.Issuer != nil {
+				issuer = *openshiftSpec.Issuer
+			}
+			if openshiftSpec.Enabled != nil {
+				enabled = util.BoolToStr(*openshiftSpec.Enabled, "true", "false")
+			}
+		case string(api.Aap):
+			aapSpec, err := ap.Spec.AsAapProviderSpec()
+			if err != nil {
+				return fmt.Errorf("failed to parse AAP provider spec for %s: %w", name, err)
+			}
+			if aapSpec.Enabled != nil {
+				enabled = util.BoolToStr(*aapSpec.Enabled, "true", "false")
+			}
+			if aapSpec.ApiUrl != "" {
+				issuer = aapSpec.ApiUrl
+			}
+		case string(api.K8s):
+			k8sSpec, err := ap.Spec.AsK8sProviderSpec()
+			if err != nil {
+				return fmt.Errorf("failed to parse K8s provider spec for %s: %w", name, err)
+			}
+			if k8sSpec.Enabled != nil {
+				enabled = util.BoolToStr(*k8sSpec.Enabled, "true", "false")
+			}
+			if k8sSpec.ApiUrl != "" {
+				issuer = k8sSpec.ApiUrl
+			}
+		default:
+			issuer = NoneString
+			enabled = NoneString
+		}
+
+		f.printTableRowLn(w, name, providerType, issuer, enabled, isDefault)
 	}
 	return nil
 }


### PR DESCRIPTION
adds flightctl login --show-providers option:

this is different from what we already have today (flightctl get autheprovider/ap) since:

1. it should be allowed to be called before login
2. it returns only enabled auth providers
3. it returns static auth providers as well as dynamic providers

example:

```
 ./bin/flightctl login   -k https://10.100.102.70:3443 --show-providers
NAME		TYPE	ISSUER					ENABLED	DEFAULT
github-oauth2	oauth2	https://github.com			true	
oidc		oidc	https://10.100.102.70:8444/api/v1/auth	true	*

```

CLI structure was discussed with Avishay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--show-providers` to the login command to list available authentication providers with NAME, TYPE, ISSUER, ENABLED and DEFAULT indicators.
  * Provider display now supports OIDC, OAuth2, OpenShift, AAP and Kubernetes provider types and marks the default provider.

* **Chores**
  * Introduced a new exported auth config identifier to the public API surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->