### PR TITLE
EDM-2651: Ensure MCE has permissions to create repo/get devices

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-mce-role.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-mce-role.yaml
@@ -1,0 +1,34 @@
+{{- if eq (include "flightctl.enableMulticlusterExtensions" .) "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flightctl-device-registration
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - flightctl.io
+    resources:
+      - devices
+  - verbs:
+      - create
+    apiGroups:
+      - flightctl.io
+    resources:
+      - repositories
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managedcluster-import-controller-flightctl
+  namespace: multicluster-engine
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flightctl-device-registration
+subjects:
+  - kind: ServiceAccount
+    name: managedcluster-import-controller-v2
+    namespace: multicluster-engine
+{{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multicluster extensions, enabling device registration capabilities across multiple clusters when the feature is enabled in your configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->