### PR TITLE
NO-ISSUE: fixed additional auth types on K8 being overriden by K8's Authz

### DIFF
--- a/cmd/flightctl-alertmanager-proxy/main.go
+++ b/cmd/flightctl-alertmanager-proxy/main.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/flightctl/flightctl/internal/api_server/middleware"
 	"github.com/flightctl/flightctl/internal/auth"
-	"github.com/flightctl/flightctl/internal/auth/authn"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
@@ -102,7 +101,7 @@ func (p *AlertmanagerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // - /health and /api/v2/status: skip auth (just continue)
 // - all other endpoints: full auth chain (auth -> identity mapping -> org extract -> org validate -> authZ)
 func createConditionalAuthMiddleware(
-	authN common.AuthNMiddleware,
+	authN common.MultiAuthNMiddleware,
 	authZ auth.AuthZMiddleware,
 	identityMappingMiddleware *middleware.IdentityMappingMiddleware,
 	extractOrgMiddleware func(http.Handler) http.Handler,
@@ -251,15 +250,13 @@ func main() {
 		logger.Fatalf("Failed to initialize auth: %v", err)
 	}
 
-	// Start auth provider loader if MultiAuth is configured (not NilAuth)
-	if multiAuth, ok := authN.(*authn.MultiAuth); ok {
-		go func() {
-			if err := multiAuth.Start(ctx); err != nil {
-				logger.Errorf("Failed to start auth provider loader: %v", err)
-			}
-			cancel() // Trigger coordinated shutdown if auth loader exits
-		}()
-	}
+	// Start auth provider loader
+	go func() {
+		if err := authN.Start(ctx); err != nil {
+			logger.Errorf("Failed to start auth provider loader: %v", err)
+		}
+		cancel() // Trigger coordinated shutdown if auth loader exits
+	}()
 
 	authZ, err := auth.InitMultiAuthZ(cfg, logger)
 	if err != nil {

--- a/internal/auth/authn/oauth2_auth.go
+++ b/internal/auth/authn/oauth2_auth.go
@@ -69,7 +69,7 @@ func NewOAuth2Auth(metadata api.ObjectMeta, spec api.OAuth2ProviderSpec, tlsConf
 	orgConfig := convertOrganizationAssignmentToOrgConfig(spec.OrganizationAssignment)
 
 	// Create role extractor from role assignment
-	roleExtractor := NewRoleExtractor(spec.RoleAssignment)
+	roleExtractor := NewRoleExtractor(spec.RoleAssignment, log)
 
 	// Create stateless organization extractor
 	organizationExtractor := NewOrganizationExtractor(orgConfig)

--- a/internal/auth/authn/oidc_auth.go
+++ b/internal/auth/authn/oidc_auth.go
@@ -81,7 +81,7 @@ func NewOIDCAuth(metadata api.ObjectMeta, spec api.OIDCProviderSpec, clientTlsCo
 	orgConfig := convertOrganizationAssignmentToOrgConfig(spec.OrganizationAssignment)
 
 	// Create role extractor from role assignment
-	roleExtractor := NewRoleExtractor(spec.RoleAssignment)
+	roleExtractor := NewRoleExtractor(spec.RoleAssignment, log)
 
 	// Create identity cache with 10-minute TTL
 	// This caches validated identities to avoid repeated JWT validation

--- a/internal/auth/authn/oidc_auth_test.go
+++ b/internal/auth/authn/oidc_auth_test.go
@@ -42,7 +42,7 @@ func createTestOIDCAuth(jwksUri string) *OIDCAuth {
 		spec:          oidcSpec,
 		jwksUri:       jwksUri,
 		client:        &http.Client{Timeout: 5 * time.Second},
-		roleExtractor: NewRoleExtractor(roleAssignment),
+		roleExtractor: NewRoleExtractor(roleAssignment, log),
 		organizationExtractor: &OrganizationExtractor{
 			orgConfig: nil, // No org config for basic tests
 		},

--- a/internal/auth/authn/openshift_auth.go
+++ b/internal/auth/authn/openshift_auth.go
@@ -218,6 +218,18 @@ func (o *OpenShiftAuth) GetIdentity(ctx context.Context, token string) (common.I
 		}
 	}
 
+	// Check if user is in system:cluster-admins group and grant global admin role
+	for _, group := range review.Status.User.Groups {
+		if group == "system:cluster-admins" {
+			if orgRoles["*"] == nil {
+				orgRoles["*"] = []string{}
+			}
+			orgRoles["*"] = append(orgRoles["*"], api.ExternalRoleAdmin)
+			o.log.WithField("user", username).Debug("User is in system:cluster-admins, granting global admin role")
+			break
+		}
+	}
+
 	o.log.WithFields(logrus.Fields{
 		"user":     username,
 		"orgRoles": orgRoles,
@@ -227,7 +239,7 @@ func (o *OpenShiftAuth) GetIdentity(ctx context.Context, token string) (common.I
 	reportedOrganizations, isSuperAdmin := common.BuildReportedOrganizations(projects, orgRoles, false)
 
 	// Create issuer with OpenShift cluster information
-	issuer := identity.NewIssuer(identity.AuthTypeOAuth2, *o.spec.Issuer)
+	issuer := identity.NewIssuer(identity.AuthTypeOpenShift, *o.spec.Issuer)
 
 	o.log.WithFields(logrus.Fields{
 		"user":          username,

--- a/internal/auth/authn/role_extractor.go
+++ b/internal/auth/authn/role_extractor.go
@@ -5,17 +5,20 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
+	"github.com/sirupsen/logrus"
 )
 
 // RoleExtractor handles role extraction from claims based on role assignment configuration
 type RoleExtractor struct {
 	roleAssignment api.AuthRoleAssignment
+	log            logrus.FieldLogger
 }
 
 // NewRoleExtractor creates a new role extractor with the given role assignment
-func NewRoleExtractor(roleAssignment api.AuthRoleAssignment) *RoleExtractor {
+func NewRoleExtractor(roleAssignment api.AuthRoleAssignment, log logrus.FieldLogger) *RoleExtractor {
 	return &RoleExtractor{
 		roleAssignment: roleAssignment,
+		log:            log,
 	}
 }
 
@@ -44,6 +47,7 @@ func (r *RoleExtractor) ExtractRolesFromMap(claims map[string]interface{}) []str
 func (r *RoleExtractor) ExtractOrgRolesFromMap(claims map[string]interface{}) map[string][]string {
 	discriminator, err := r.roleAssignment.Discriminator()
 	if err != nil {
+		r.log.Errorf("RoleExtractor: failed to get discriminator: %v", err)
 		return nil
 	}
 
@@ -53,6 +57,7 @@ func (r *RoleExtractor) ExtractOrgRolesFromMap(claims map[string]interface{}) ma
 	case string(api.AuthDynamicRoleAssignmentTypeDynamic):
 		return r.extractDynamicOrgRolesFromMap(claims)
 	default:
+		r.log.Warnf("RoleExtractor: unknown discriminator: %s", discriminator)
 		return nil
 	}
 }
@@ -73,11 +78,13 @@ func (r *RoleExtractor) extractStaticOrgRoles() map[string][]string {
 func (r *RoleExtractor) extractDynamicOrgRolesFromMap(claims map[string]interface{}) map[string][]string {
 	dynamicRoleAssignment, err := r.roleAssignment.AsAuthDynamicRoleAssignment()
 	if err != nil {
+		r.log.Errorf("RoleExtractor: failed to get dynamic role assignment: %v", err)
 		return nil
 	}
 
 	claimPath := dynamicRoleAssignment.ClaimPath
 	if len(claimPath) == 0 {
+		r.log.Warnf("RoleExtractor: claimPath is empty")
 		return nil
 	}
 
@@ -90,12 +97,16 @@ func (r *RoleExtractor) extractDynamicOrgRolesFromMap(claims map[string]interfac
 	// Navigate to the claim value
 	current := claims
 	for i, part := range claimPath {
+		r.log.Debugf("RoleExtractor: navigating claimPath[%d]=%s, current keys: %v", i, part, getMapKeys(current))
 		if i == len(claimPath)-1 {
 			// Last part - extract the roles array
 			if value, exists := current[part]; exists {
 				if roles, ok := value.([]interface{}); ok {
 					return r.parseRolesWithSeparator(roles, separator)
 				}
+				r.log.Warnf("RoleExtractor: claim value is not an array: %T", value)
+			} else {
+				r.log.Warnf("RoleExtractor: claim path[%d]=%s does not exist in current map", i, part)
 			}
 			return nil
 		}
@@ -104,15 +115,27 @@ func (r *RoleExtractor) extractDynamicOrgRolesFromMap(claims map[string]interfac
 		if next, exists := current[part]; exists {
 			if nextMap, ok := next.(map[string]interface{}); ok {
 				current = nextMap
+				r.log.Debugf("RoleExtractor: navigated to nested map at path[%d]=%s", i, part)
 			} else {
+				r.log.Warnf("RoleExtractor: path[%d]=%s exists but is not a map: %T", i, part, next)
 				return nil
 			}
 		} else {
+			r.log.Warnf("RoleExtractor: path[%d]=%s does not exist", i, part)
 			return nil
 		}
 	}
 
 	return nil
+}
+
+// getMapKeys is a helper to get keys from a map for logging
+func getMapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 // parseRolesWithSeparator parses role strings and separates org-scoped from global roles

--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/sirupsen/logrus"
@@ -142,95 +143,129 @@ func (m *MultiAuthZ) CheckPermission(ctx context.Context, resource string, op st
 	// Get identity from context
 	identityVal := ctx.Value(consts.IdentityCtxKey)
 	if identityVal == nil {
-		m.log.Debug("No identity in context, using static authZ")
-		return m.getStaticAuthZ().CheckPermission(ctx, resource, op)
+		m.log.Warn("No identity in context, returning 403")
+		return false, nil
 	}
 
 	ident, ok := identityVal.(common.Identity)
 	if !ok {
-		m.log.Warnf("Identity in context has incorrect type: %T", identityVal)
-		return m.getStaticAuthZ().CheckPermission(ctx, resource, op)
+		m.log.Warnf("Identity in context has incorrect type: %T, returning 403", identityVal)
+		return false, nil
 	}
 
 	// Check issuer type
 	issuer := ident.GetIssuer()
 	if issuer == nil {
-		m.log.Debug("Identity has no issuer, using static authZ")
+		m.log.Warn("Identity has no issuer, returning 403")
+		return false, nil
+	}
+
+	m.log.Debugf("CheckPermission: identity type=%T, issuer type=%s, issuer=%s", ident, issuer.Type, issuer.String())
+
+	// Route based on issuer type to avoid type collision
+	switch issuer.Type {
+	case identity.AuthTypeOpenShift:
+		return m.checkPermissionOpenShift(ctx, ident, resource, op)
+	case identity.AuthTypeK8s:
+		return m.checkPermissionK8s(ctx, ident, resource, op)
+	default:
+		// For OIDC, OAuth2, AAP and all other issuer types, use static authZ
+		m.log.Debugf("Using static authZ for issuer type=%s (%s)", issuer.Type, issuer.String())
 		return m.getStaticAuthZ().CheckPermission(ctx, resource, op)
 	}
+}
 
-	// Check if this is an OpenShift identity
-	if openshiftIdent, ok := ident.(*common.OpenShiftIdentity); ok && m.openshiftAuthZCache != nil {
-		m.log.Debugf("Using OpenShift authZ for identity from issuer: %s", issuer.String())
+// checkPermissionOpenShift handles permission checks for OpenShift identities
+func (m *MultiAuthZ) checkPermissionOpenShift(ctx context.Context, ident common.Identity, resource string, op string) (bool, error) {
+	issuer := ident.GetIssuer()
+	m.log.Infof("Using OpenShift authZ for issuer: %s", issuer.String())
 
-		// Get token from context
-		tokenVal := ctx.Value(consts.TokenCtxKey)
-		if tokenVal == nil {
-			m.log.Warn("OpenShift identity but no token in context")
-			return false, nil
-		}
-		token, ok := tokenVal.(string)
-		if !ok {
-			m.log.Warnf("OpenShift token in context has incorrect type: %T", tokenVal)
-			return false, nil
-		}
-
-		// Get control plane URL from identity
-		controlPlaneUrl := openshiftIdent.GetControlPlaneUrl()
-		if controlPlaneUrl == "" {
-			m.log.Warn("OpenShift identity has no control plane URL")
-			return false, nil
-		}
-
-		// Get or create openshiftAuthZ for this control plane
-		openshiftAuthZ, err := m.getOpenShiftAuthZ(controlPlaneUrl)
-		if err != nil {
-			m.log.WithError(err).Errorf("Failed to initialize OpenShift authZ for %s", controlPlaneUrl)
-			return false, err
-		}
-
-		return openshiftAuthZ.CheckPermission(ctx, token, resource, op)
+	if m.openshiftAuthZCache == nil {
+		m.log.Warn("OpenShift issuer but OpenShift authZ not configured, returning 403")
+		return false, nil
 	}
 
-	// Check if this is a K8s identity
-	if k8sIdent, ok := ident.(*common.K8sIdentity); ok && m.k8sAuthZCache != nil {
-		m.log.Debugf("Using K8s authZ for identity from issuer: %s", issuer.String())
-
-		// Get token from context
-		tokenVal := ctx.Value(consts.TokenCtxKey)
-		if tokenVal == nil {
-			m.log.Warn("K8s identity but no token in context")
-			return false, nil
-		}
-		token, ok := tokenVal.(string)
-		if !ok {
-			m.log.Warnf("K8s token in context has incorrect type: %T", tokenVal)
-			return false, nil
-		}
-
-		// Get control plane URL from identity
-		controlPlaneUrl := k8sIdent.GetControlPlaneUrl()
-		if controlPlaneUrl == "" {
-			m.log.Warn("K8s identity has no control plane URL")
-			return false, nil
-		}
-
-		// Get rbac namespace from identity
-		rbacNs := k8sIdent.GetRbacNs()
-
-		// Get or create k8sAuthZ for this control plane
-		k8sAuthZ, err := m.getK8sAuthZ(controlPlaneUrl, rbacNs)
-		if err != nil {
-			m.log.WithError(err).Errorf("Failed to initialize k8s authZ for %s", controlPlaneUrl)
-			return false, err
-		}
-
-		return k8sAuthZ.CheckPermission(ctx, token, resource, op)
+	openshiftIdent, ok := ident.(*common.OpenShiftIdentity)
+	if !ok {
+		m.log.Errorf("Issuer type is OpenShift but identity type is %T, returning 403", ident)
+		return false, nil
 	}
 
-	// For all other issuer types, use static authZ
-	m.log.Debugf("Using static authZ for identity from issuer: %s", issuer.String())
-	return m.getStaticAuthZ().CheckPermission(ctx, resource, op)
+	// Get token from context
+	tokenVal := ctx.Value(consts.TokenCtxKey)
+	if tokenVal == nil {
+		m.log.Warn("OpenShift identity but no token in context, returning 403")
+		return false, nil
+	}
+	token, ok := tokenVal.(string)
+	if !ok {
+		m.log.Warnf("OpenShift token in context has incorrect type: %T, returning 403", tokenVal)
+		return false, nil
+	}
+
+	// Get control plane URL from identity
+	controlPlaneUrl := openshiftIdent.GetControlPlaneUrl()
+	if controlPlaneUrl == "" {
+		m.log.Warn("OpenShift identity has no control plane URL, returning 403")
+		return false, nil
+	}
+
+	// Get or create openshiftAuthZ for this control plane
+	openshiftAuthZ, err := m.getOpenShiftAuthZ(controlPlaneUrl)
+	if err != nil {
+		m.log.WithError(err).Errorf("Failed to initialize OpenShift authZ for %s", controlPlaneUrl)
+		return false, err
+	}
+
+	return openshiftAuthZ.CheckPermission(ctx, token, resource, op)
+}
+
+// checkPermissionK8s handles permission checks for K8s identities
+func (m *MultiAuthZ) checkPermissionK8s(ctx context.Context, ident common.Identity, resource string, op string) (bool, error) {
+	issuer := ident.GetIssuer()
+	m.log.Infof("Using K8s authZ for issuer: %s", issuer.String())
+
+	if m.k8sAuthZCache == nil {
+		m.log.Warn("K8s issuer but K8s authZ not configured, returning 403")
+		return false, nil
+	}
+
+	k8sIdent, ok := ident.(*common.K8sIdentity)
+	if !ok {
+		m.log.Errorf("Issuer type is K8s but identity type is %T, returning 403", ident)
+		return false, nil
+	}
+
+	// Get token from context
+	tokenVal := ctx.Value(consts.TokenCtxKey)
+	if tokenVal == nil {
+		m.log.Warn("K8s identity but no token in context, returning 403")
+		return false, nil
+	}
+	token, ok := tokenVal.(string)
+	if !ok {
+		m.log.Warnf("K8s token in context has incorrect type: %T, returning 403", tokenVal)
+		return false, nil
+	}
+
+	// Get control plane URL from identity
+	controlPlaneUrl := k8sIdent.GetControlPlaneUrl()
+	if controlPlaneUrl == "" {
+		m.log.Warn("K8s identity has no control plane URL, returning 403")
+		return false, nil
+	}
+
+	// Get rbac namespace from identity
+	rbacNs := k8sIdent.GetRbacNs()
+
+	// Get or create k8sAuthZ for this control plane
+	k8sAuthZ, err := m.getK8sAuthZ(controlPlaneUrl, rbacNs)
+	if err != nil {
+		m.log.WithError(err).Errorf("Failed to initialize k8s authZ for %s", controlPlaneUrl)
+		return false, err
+	}
+
+	return k8sAuthZ.CheckPermission(ctx, token, resource, op)
 }
 
 // GetUserPermissions gets all permissions for the user based on the identity's issuer type
@@ -238,95 +273,129 @@ func (m *MultiAuthZ) GetUserPermissions(ctx context.Context) (*api.PermissionLis
 	// Get identity from context
 	identityVal := ctx.Value(consts.IdentityCtxKey)
 	if identityVal == nil {
-		m.log.Debug("No identity in context, using static authZ")
-		return m.getStaticAuthZ().GetUserPermissions(ctx)
+		m.log.Warn("No identity in context, returning forbidden")
+		return nil, fmt.Errorf("no identity in context")
 	}
 
 	ident, ok := identityVal.(common.Identity)
 	if !ok {
-		m.log.Warnf("Identity in context has incorrect type: %T", identityVal)
-		return m.getStaticAuthZ().GetUserPermissions(ctx)
+		m.log.Warnf("Identity in context has incorrect type: %T, returning forbidden", identityVal)
+		return nil, fmt.Errorf("identity has incorrect type")
 	}
 
 	// Check issuer type
 	issuer := ident.GetIssuer()
 	if issuer == nil {
-		m.log.Debug("Identity has no issuer, using static authZ")
+		m.log.Warn("Identity has no issuer, returning forbidden")
+		return nil, fmt.Errorf("identity has no issuer")
+	}
+
+	m.log.Debugf("GetUserPermissions: identity type=%T, issuer type=%s, issuer=%s", ident, issuer.Type, issuer.String())
+
+	// Route based on issuer type to avoid type collision
+	switch issuer.Type {
+	case identity.AuthTypeOpenShift:
+		return m.getUserPermissionsOpenShift(ctx, ident)
+	case identity.AuthTypeK8s:
+		return m.getUserPermissionsK8s(ctx, ident)
+	default:
+		// For OIDC, OAuth2, AAP and all other issuer types, use static authZ
+		m.log.Infof("Using static authZ for issuer type=%s (%s)", issuer.Type, issuer.String())
 		return m.getStaticAuthZ().GetUserPermissions(ctx)
 	}
+}
 
-	// Check if this is an OpenShift identity
-	if openshiftIdent, ok := ident.(*common.OpenShiftIdentity); ok && m.openshiftAuthZCache != nil {
-		m.log.Debugf("Using OpenShift authZ for identity from issuer: %s", issuer.String())
+// getUserPermissionsOpenShift handles getting user permissions for OpenShift identities
+func (m *MultiAuthZ) getUserPermissionsOpenShift(ctx context.Context, ident common.Identity) (*api.PermissionList, error) {
+	issuer := ident.GetIssuer()
+	m.log.Infof("Using OpenShift authZ for issuer: %s", issuer.String())
 
-		// Get token from context
-		tokenVal := ctx.Value(consts.TokenCtxKey)
-		if tokenVal == nil {
-			m.log.Warn("OpenShift identity but no token in context")
-			return nil, fmt.Errorf("no OpenShift token in context")
-		}
-		token, ok := tokenVal.(string)
-		if !ok {
-			m.log.Warnf("OpenShift token in context has incorrect type: %T", tokenVal)
-			return nil, fmt.Errorf("OpenShift token has incorrect type")
-		}
-
-		// Get control plane URL from identity
-		controlPlaneUrl := openshiftIdent.GetControlPlaneUrl()
-		if controlPlaneUrl == "" {
-			m.log.Warn("OpenShift identity has no control plane URL")
-			return nil, fmt.Errorf("OpenShift identity has no control plane URL")
-		}
-
-		// Get or create openshiftAuthZ for this control plane
-		openshiftAuthZ, err := m.getOpenShiftAuthZ(controlPlaneUrl)
-		if err != nil {
-			m.log.WithError(err).Errorf("Failed to initialize OpenShift authZ for %s", controlPlaneUrl)
-			return nil, err
-		}
-
-		return openshiftAuthZ.GetUserPermissions(ctx, token)
+	if m.openshiftAuthZCache == nil {
+		m.log.Warn("OpenShift issuer but OpenShift authZ not configured")
+		return nil, fmt.Errorf("OpenShift authZ not configured")
 	}
 
-	// Check if this is a K8s identity
-	if k8sIdent, ok := ident.(*common.K8sIdentity); ok && m.k8sAuthZCache != nil {
-		m.log.Debugf("Using K8s authZ for identity from issuer: %s", issuer.String())
-
-		// Get token from context
-		tokenVal := ctx.Value(consts.TokenCtxKey)
-		if tokenVal == nil {
-			m.log.Warn("K8s identity but no token in context")
-			return nil, fmt.Errorf("no k8s token in context")
-		}
-		token, ok := tokenVal.(string)
-		if !ok {
-			m.log.Warnf("K8s token in context has incorrect type: %T", tokenVal)
-			return nil, fmt.Errorf("k8s token has incorrect type")
-		}
-
-		// Get control plane URL from identity
-		controlPlaneUrl := k8sIdent.GetControlPlaneUrl()
-		if controlPlaneUrl == "" {
-			m.log.Warn("K8s identity has no control plane URL")
-			return nil, fmt.Errorf("K8s identity has no control plane URL")
-		}
-
-		// Get rbac namespace from identity
-		rbacNs := k8sIdent.GetRbacNs()
-
-		// Get or create k8sAuthZ for this control plane
-		k8sAuthZ, err := m.getK8sAuthZ(controlPlaneUrl, rbacNs)
-		if err != nil {
-			m.log.WithError(err).Errorf("Failed to initialize k8s authZ for %s", controlPlaneUrl)
-			return nil, err
-		}
-
-		return k8sAuthZ.GetUserPermissions(ctx, token)
+	openshiftIdent, ok := ident.(*common.OpenShiftIdentity)
+	if !ok {
+		m.log.Errorf("Issuer type is OpenShift but identity type is %T", ident)
+		return nil, fmt.Errorf("identity type mismatch")
 	}
 
-	// For all other issuer types, use static authZ
-	m.log.Debugf("Using static authZ for identity from issuer: %s", issuer.String())
-	return m.getStaticAuthZ().GetUserPermissions(ctx)
+	// Get token from context
+	tokenVal := ctx.Value(consts.TokenCtxKey)
+	if tokenVal == nil {
+		m.log.Warn("OpenShift identity but no token in context")
+		return nil, fmt.Errorf("no OpenShift token in context")
+	}
+	token, ok := tokenVal.(string)
+	if !ok {
+		m.log.Warnf("OpenShift token in context has incorrect type: %T", tokenVal)
+		return nil, fmt.Errorf("OpenShift token has incorrect type")
+	}
+
+	// Get control plane URL from identity
+	controlPlaneUrl := openshiftIdent.GetControlPlaneUrl()
+	if controlPlaneUrl == "" {
+		m.log.Warn("OpenShift identity has no control plane URL")
+		return nil, fmt.Errorf("OpenShift identity has no control plane URL")
+	}
+
+	// Get or create openshiftAuthZ for this control plane
+	openshiftAuthZ, err := m.getOpenShiftAuthZ(controlPlaneUrl)
+	if err != nil {
+		m.log.WithError(err).Errorf("Failed to initialize OpenShift authZ for %s", controlPlaneUrl)
+		return nil, err
+	}
+
+	return openshiftAuthZ.GetUserPermissions(ctx, token)
+}
+
+// getUserPermissionsK8s handles getting user permissions for K8s identities
+func (m *MultiAuthZ) getUserPermissionsK8s(ctx context.Context, ident common.Identity) (*api.PermissionList, error) {
+	issuer := ident.GetIssuer()
+	m.log.Infof("Using K8s authZ for issuer: %s", issuer.String())
+
+	if m.k8sAuthZCache == nil {
+		m.log.Warn("K8s issuer but K8s authZ not configured")
+		return nil, fmt.Errorf("K8s authZ not configured")
+	}
+
+	k8sIdent, ok := ident.(*common.K8sIdentity)
+	if !ok {
+		m.log.Errorf("Issuer type is K8s but identity type is %T", ident)
+		return nil, fmt.Errorf("identity type mismatch")
+	}
+
+	// Get token from context
+	tokenVal := ctx.Value(consts.TokenCtxKey)
+	if tokenVal == nil {
+		m.log.Warn("K8s identity but no token in context")
+		return nil, fmt.Errorf("no k8s token in context")
+	}
+	token, ok := tokenVal.(string)
+	if !ok {
+		m.log.Warnf("K8s token in context has incorrect type: %T", tokenVal)
+		return nil, fmt.Errorf("k8s token has incorrect type")
+	}
+
+	// Get control plane URL from identity
+	controlPlaneUrl := k8sIdent.GetControlPlaneUrl()
+	if controlPlaneUrl == "" {
+		m.log.Warn("K8s identity has no control plane URL")
+		return nil, fmt.Errorf("K8s identity has no control plane URL")
+	}
+
+	// Get rbac namespace from identity
+	rbacNs := k8sIdent.GetRbacNs()
+
+	// Get or create k8sAuthZ for this control plane
+	k8sAuthZ, err := m.getK8sAuthZ(controlPlaneUrl, rbacNs)
+	if err != nil {
+		m.log.WithError(err).Errorf("Failed to initialize k8s authZ for %s", controlPlaneUrl)
+		return nil, err
+	}
+
+	return k8sAuthZ.GetUserPermissions(ctx, token)
 }
 
 // InitMultiAuthZ initializes authorization with support for multiple methods

--- a/internal/auth/common/common.go
+++ b/internal/auth/common/common.go
@@ -53,6 +53,10 @@ type AuthNMiddleware interface {
 	GetAuthConfig() *v1beta1.AuthConfig
 	IsEnabled() bool
 }
+type MultiAuthNMiddleware interface {
+	AuthNMiddleware
+	ValidateTokenAndGetProvider(ctx context.Context, token string) (AuthNMiddleware, error)
+}
 
 type BaseIdentity struct {
 	username      string

--- a/internal/auth/common/common_mock.go
+++ b/internal/auth/common/common_mock.go
@@ -14,7 +14,7 @@ import (
 	http "net/http"
 	reflect "reflect"
 
-	api "github.com/flightctl/flightctl/api/v1beta1"
+	v1beta1 "github.com/flightctl/flightctl/api/v1beta1"
 	identity "github.com/flightctl/flightctl/internal/identity"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -70,20 +70,6 @@ func (mr *MockIdentityMockRecorder) GetOrganizations() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizations", reflect.TypeOf((*MockIdentity)(nil).GetOrganizations))
 }
 
-// GetRoles mocks base method.
-func (m *MockIdentity) GetRoles() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRoles")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetRoles indicates an expected call of GetRoles.
-func (mr *MockIdentityMockRecorder) GetRoles() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoles", reflect.TypeOf((*MockIdentity)(nil).GetRoles))
-}
-
 // GetUID mocks base method.
 func (m *MockIdentity) GetUID() string {
 	m.ctrl.T.Helper()
@@ -112,6 +98,151 @@ func (mr *MockIdentityMockRecorder) GetUsername() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsername", reflect.TypeOf((*MockIdentity)(nil).GetUsername))
 }
 
+// IsSuperAdmin mocks base method.
+func (m *MockIdentity) IsSuperAdmin() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSuperAdmin")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSuperAdmin indicates an expected call of IsSuperAdmin.
+func (mr *MockIdentityMockRecorder) IsSuperAdmin() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSuperAdmin", reflect.TypeOf((*MockIdentity)(nil).IsSuperAdmin))
+}
+
+// SetSuperAdmin mocks base method.
+func (m *MockIdentity) SetSuperAdmin(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSuperAdmin", arg0)
+}
+
+// SetSuperAdmin indicates an expected call of SetSuperAdmin.
+func (mr *MockIdentityMockRecorder) SetSuperAdmin(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSuperAdmin", reflect.TypeOf((*MockIdentity)(nil).SetSuperAdmin), arg0)
+}
+
+// MockK8sIdentityProvider is a mock of K8sIdentityProvider interface.
+type MockK8sIdentityProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockK8sIdentityProviderMockRecorder
+}
+
+// MockK8sIdentityProviderMockRecorder is the mock recorder for MockK8sIdentityProvider.
+type MockK8sIdentityProviderMockRecorder struct {
+	mock *MockK8sIdentityProvider
+}
+
+// NewMockK8sIdentityProvider creates a new mock instance.
+func NewMockK8sIdentityProvider(ctrl *gomock.Controller) *MockK8sIdentityProvider {
+	mock := &MockK8sIdentityProvider{ctrl: ctrl}
+	mock.recorder = &MockK8sIdentityProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockK8sIdentityProvider) EXPECT() *MockK8sIdentityProviderMockRecorder {
+	return m.recorder
+}
+
+// GetControlPlaneUrl mocks base method.
+func (m *MockK8sIdentityProvider) GetControlPlaneUrl() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControlPlaneUrl")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetControlPlaneUrl indicates an expected call of GetControlPlaneUrl.
+func (mr *MockK8sIdentityProviderMockRecorder) GetControlPlaneUrl() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneUrl", reflect.TypeOf((*MockK8sIdentityProvider)(nil).GetControlPlaneUrl))
+}
+
+// GetIssuer mocks base method.
+func (m *MockK8sIdentityProvider) GetIssuer() *identity.Issuer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssuer")
+	ret0, _ := ret[0].(*identity.Issuer)
+	return ret0
+}
+
+// GetIssuer indicates an expected call of GetIssuer.
+func (mr *MockK8sIdentityProviderMockRecorder) GetIssuer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssuer", reflect.TypeOf((*MockK8sIdentityProvider)(nil).GetIssuer))
+}
+
+// GetOrganizations mocks base method.
+func (m *MockK8sIdentityProvider) GetOrganizations() []ReportedOrganization {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrganizations")
+	ret0, _ := ret[0].([]ReportedOrganization)
+	return ret0
+}
+
+// GetOrganizations indicates an expected call of GetOrganizations.
+func (mr *MockK8sIdentityProviderMockRecorder) GetOrganizations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizations", reflect.TypeOf((*MockK8sIdentityProvider)(nil).GetOrganizations))
+}
+
+// GetUID mocks base method.
+func (m *MockK8sIdentityProvider) GetUID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetUID indicates an expected call of GetUID.
+func (mr *MockK8sIdentityProviderMockRecorder) GetUID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUID", reflect.TypeOf((*MockK8sIdentityProvider)(nil).GetUID))
+}
+
+// GetUsername mocks base method.
+func (m *MockK8sIdentityProvider) GetUsername() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsername")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetUsername indicates an expected call of GetUsername.
+func (mr *MockK8sIdentityProviderMockRecorder) GetUsername() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsername", reflect.TypeOf((*MockK8sIdentityProvider)(nil).GetUsername))
+}
+
+// IsSuperAdmin mocks base method.
+func (m *MockK8sIdentityProvider) IsSuperAdmin() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSuperAdmin")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSuperAdmin indicates an expected call of IsSuperAdmin.
+func (mr *MockK8sIdentityProviderMockRecorder) IsSuperAdmin() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSuperAdmin", reflect.TypeOf((*MockK8sIdentityProvider)(nil).IsSuperAdmin))
+}
+
+// SetSuperAdmin mocks base method.
+func (m *MockK8sIdentityProvider) SetSuperAdmin(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSuperAdmin", arg0)
+}
+
+// SetSuperAdmin indicates an expected call of SetSuperAdmin.
+func (mr *MockK8sIdentityProviderMockRecorder) SetSuperAdmin(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSuperAdmin", reflect.TypeOf((*MockK8sIdentityProvider)(nil).SetSuperAdmin), arg0)
+}
+
 // MockAuthNMiddleware is a mock of AuthNMiddleware interface.
 type MockAuthNMiddleware struct {
 	ctrl     *gomock.Controller
@@ -136,22 +267,13 @@ func (m *MockAuthNMiddleware) EXPECT() *MockAuthNMiddlewareMockRecorder {
 }
 
 // GetAuthConfig mocks base method.
-func (m *MockAuthNMiddleware) GetAuthConfig() *api.AuthConfig {
+func (m *MockAuthNMiddleware) GetAuthConfig() *v1beta1.AuthConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthConfig")
-	ret0, _ := ret[0].(*api.AuthConfig)
+	ret0, _ := ret[0].(*v1beta1.AuthConfig)
 	return ret0
 }
 
-// IsEnabled mocks base method.
-func (m *MockAuthNMiddleware) IsEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsEnabled indicates an expected call of IsEnabled.
 // GetAuthConfig indicates an expected call of GetAuthConfig.
 func (mr *MockAuthNMiddlewareMockRecorder) GetAuthConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
@@ -188,6 +310,20 @@ func (mr *MockAuthNMiddlewareMockRecorder) GetIdentity(ctx, token any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentity", reflect.TypeOf((*MockAuthNMiddleware)(nil).GetIdentity), ctx, token)
 }
 
+// IsEnabled mocks base method.
+func (m *MockAuthNMiddleware) IsEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabled indicates an expected call of IsEnabled.
+func (mr *MockAuthNMiddlewareMockRecorder) IsEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockAuthNMiddleware)(nil).IsEnabled))
+}
+
 // ValidateToken mocks base method.
 func (m *MockAuthNMiddleware) ValidateToken(ctx context.Context, token string) error {
 	m.ctrl.T.Helper()
@@ -200,4 +336,114 @@ func (m *MockAuthNMiddleware) ValidateToken(ctx context.Context, token string) e
 func (mr *MockAuthNMiddlewareMockRecorder) ValidateToken(ctx, token any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateToken", reflect.TypeOf((*MockAuthNMiddleware)(nil).ValidateToken), ctx, token)
+}
+
+// MockMultiAuthNMiddleware is a mock of MultiAuthNMiddleware interface.
+type MockMultiAuthNMiddleware struct {
+	ctrl     *gomock.Controller
+	recorder *MockMultiAuthNMiddlewareMockRecorder
+}
+
+// MockMultiAuthNMiddlewareMockRecorder is the mock recorder for MockMultiAuthNMiddleware.
+type MockMultiAuthNMiddlewareMockRecorder struct {
+	mock *MockMultiAuthNMiddleware
+}
+
+// NewMockMultiAuthNMiddleware creates a new mock instance.
+func NewMockMultiAuthNMiddleware(ctrl *gomock.Controller) *MockMultiAuthNMiddleware {
+	mock := &MockMultiAuthNMiddleware{ctrl: ctrl}
+	mock.recorder = &MockMultiAuthNMiddlewareMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMultiAuthNMiddleware) EXPECT() *MockMultiAuthNMiddlewareMockRecorder {
+	return m.recorder
+}
+
+// GetAuthConfig mocks base method.
+func (m *MockMultiAuthNMiddleware) GetAuthConfig() *v1beta1.AuthConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthConfig")
+	ret0, _ := ret[0].(*v1beta1.AuthConfig)
+	return ret0
+}
+
+// GetAuthConfig indicates an expected call of GetAuthConfig.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) GetAuthConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthConfig", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).GetAuthConfig))
+}
+
+// GetAuthToken mocks base method.
+func (m *MockMultiAuthNMiddleware) GetAuthToken(r *http.Request) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthToken", r)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuthToken indicates an expected call of GetAuthToken.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) GetAuthToken(r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthToken", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).GetAuthToken), r)
+}
+
+// GetIdentity mocks base method.
+func (m *MockMultiAuthNMiddleware) GetIdentity(ctx context.Context, token string) (Identity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIdentity", ctx, token)
+	ret0, _ := ret[0].(Identity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIdentity indicates an expected call of GetIdentity.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) GetIdentity(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentity", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).GetIdentity), ctx, token)
+}
+
+// IsEnabled mocks base method.
+func (m *MockMultiAuthNMiddleware) IsEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEnabled indicates an expected call of IsEnabled.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) IsEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).IsEnabled))
+}
+
+// ValidateToken mocks base method.
+func (m *MockMultiAuthNMiddleware) ValidateToken(ctx context.Context, token string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateToken", ctx, token)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateToken indicates an expected call of ValidateToken.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) ValidateToken(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateToken", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).ValidateToken), ctx, token)
+}
+
+// ValidateTokenAndGetProvider mocks base method.
+func (m *MockMultiAuthNMiddleware) ValidateTokenAndGetProvider(ctx context.Context, token string) (AuthNMiddleware, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateTokenAndGetProvider", ctx, token)
+	ret0, _ := ret[0].(AuthNMiddleware)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateTokenAndGetProvider indicates an expected call of ValidateTokenAndGetProvider.
+func (mr *MockMultiAuthNMiddlewareMockRecorder) ValidateTokenAndGetProvider(ctx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateTokenAndGetProvider", reflect.TypeOf((*MockMultiAuthNMiddleware)(nil).ValidateTokenAndGetProvider), ctx, token)
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -51,7 +51,7 @@ func stringToAction(s string) action {
 	return action(s)
 }
 
-func CreateAuthNMiddleware(authN common.AuthNMiddleware, log logrus.FieldLogger) func(http.Handler) http.Handler {
+func CreateAuthNMiddleware(multiAuth common.MultiAuthNMiddleware, log logrus.FieldLogger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			// Skip authentication for public auth endpoints
@@ -59,22 +59,25 @@ func CreateAuthNMiddleware(authN common.AuthNMiddleware, log logrus.FieldLogger)
 				next.ServeHTTP(w, r)
 				return
 			}
-			authToken, err := authN.GetAuthToken(r)
+			authToken, err := multiAuth.GetAuthToken(r)
 			if err != nil {
 				log.WithError(err).Error("failed to get auth token")
 				writeResponse(w, api.StatusBadRequest("failed to get auth token"), log)
 				return
 			}
 			log.Debugf("Auth middleware: got auth token (length: %d)", len(authToken))
-			err = authN.ValidateToken(r.Context(), authToken)
+
+			// Use ValidateTokenAndGetProvider to ensure the same provider validates and creates identity
+			provider, err := multiAuth.ValidateTokenAndGetProvider(r.Context(), authToken)
 			if err != nil {
 				log.WithError(err).Error("failed to validate token")
 				writeResponse(w, api.StatusUnauthorized("failed to validate token"), log)
 				return
 			}
-			log.Debugf("Auth middleware: token validated successfully")
+			log.Debugf("Auth middleware: token validated successfully by provider")
+
 			ctx := context.WithValue(r.Context(), consts.TokenCtxKey, authToken)
-			identity, err := authN.GetIdentity(ctx, authToken)
+			identity, err := provider.GetIdentity(ctx, authToken)
 			if err != nil {
 				log.WithError(err).Error("failed to get identity")
 			} else {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -18,7 +18,7 @@ func createAuthZMiddleware(authZ AuthZMiddleware) http.Handler {
 	}))
 }
 
-func createAuthNMiddleware(authN common.AuthNMiddleware) http.Handler {
+func createAuthNMiddleware(authN common.MultiAuthNMiddleware) http.Handler {
 	return CreateAuthNMiddleware(authN, logrus.New())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -260,22 +260,24 @@ func TestAuthN(t *testing.T) {
 
 	for _, r := range authNRequests {
 		for _, tc := range testCases {
-			authNMock := common.NewMockAuthNMiddleware(ctrl)
+			authNMock := common.NewMockMultiAuthNMiddleware(ctrl)
 
 			if r.shouldSkipCheck || !tc.withToken {
-				authNMock.EXPECT().ValidateToken(gomock.Any(), gomock.Any()).Times(0)
+				authNMock.EXPECT().ValidateTokenAndGetProvider(gomock.Any(), gomock.Any()).Times(0)
 				if r.shouldSkipCheck {
 					authNMock.EXPECT().GetAuthToken(gomock.Any()).Times(0)
 				} else {
 					authNMock.EXPECT().GetAuthToken(gomock.Any()).Times(1).Return("", fmt.Errorf("err"))
 				}
 			} else {
-				authNMock.EXPECT().ValidateToken(gomock.Any(), gomock.Any()).Return(tc.tokenErr).Times(1)
 				authNMock.EXPECT().GetAuthToken(gomock.Any()).Times(1).Return("token", nil)
 				if tc.tokenErr != nil {
-					authNMock.EXPECT().GetIdentity(gomock.Any(), gomock.Any()).Times(0)
+					authNMock.EXPECT().ValidateTokenAndGetProvider(gomock.Any(), gomock.Any()).Return(nil, tc.tokenErr).Times(1)
 				} else {
-					authNMock.EXPECT().GetIdentity(gomock.Any(), "token").Return(&common.BaseIdentity{}, tc.identityErr).Times(1)
+					// Return a mock provider that will be used to get identity
+					providerMock := common.NewMockAuthNMiddleware(ctrl)
+					providerMock.EXPECT().GetIdentity(gomock.Any(), "token").Return(&common.BaseIdentity{}, tc.identityErr).Times(1)
+					authNMock.EXPECT().ValidateTokenAndGetProvider(gomock.Any(), gomock.Any()).Return(providerMock, nil).Times(1)
 				}
 			}
 			authNMiddleware := createAuthNMiddleware(authNMock)

--- a/internal/identity/issuer.go
+++ b/internal/identity/issuer.go
@@ -1,10 +1,11 @@
 package identity
 
 const (
-	AuthTypeK8s    = "k8s"
-	AuthTypeOIDC   = "OIDC"
-	AuthTypeOAuth2 = "OAuth2"
-	AuthTypeAAP    = "AAPGateway"
+	AuthTypeK8s       = "k8s"
+	AuthTypeOIDC      = "OIDC"
+	AuthTypeOAuth2    = "OAuth2"
+	AuthTypeAAP       = "AAPGateway"
+	AuthTypeOpenShift = "openshift"
 )
 
 // Issuer represents the source that produced an identity
@@ -50,4 +51,9 @@ func (i *Issuer) IsK8s() bool {
 // IsOAuth2 returns true if this is an OAuth2 issuer
 func (i *Issuer) IsOAuth2() bool {
 	return i.Type == AuthTypeOAuth2
+}
+
+// IsOpenShift returns true if this is an OpenShift issuer
+func (i *Issuer) IsOpenShift() bool {
+	return i.Type == AuthTypeOpenShift
 }

--- a/test/integration/auth/auth_config_test.go
+++ b/test/integration/auth/auth_config_test.go
@@ -68,9 +68,7 @@ var _ = Describe("Auth Config Integration Tests", func() {
 		authN, err := auth.InitMultiAuth(cfg, log, serviceHandler)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(authN).ToNot(BeNil(), "Expected auth instance")
-		var ok bool
-		multiAuth, ok = authN.(*authn.MultiAuth)
-		Expect(ok).To(BeTrue(), "Expected MultiAuth instance when auth is configured")
+		multiAuth = authN
 	})
 
 	AfterEach(func() {
@@ -124,8 +122,7 @@ var _ = Describe("Auth Config Integration Tests", func() {
 			authN, err := auth.InitMultiAuth(cfg, log, serviceHandler)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(authN).ToNot(BeNil())
-			multiAuthWithAll, ok := authN.(*authn.MultiAuth)
-			Expect(ok).To(BeTrue(), "Expected MultiAuth instance when auth is configured")
+			multiAuthWithAll := authN
 
 			// Get auth config via service handler
 			authConfig := multiAuthWithAll.GetAuthConfig()


### PR DESCRIPTION
makes sure we are getting the user identity with the auth that was used to validate the token ,
re-adds kubeadmin support for openshift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Multi-provider authentication with provider-aware token validation and identity resolution
  - Issuer-specific authorization paths for OpenShift and Kubernetes, including OpenShift group-based admin grants

* **Improvements**
  - Token responses parsed for JSON and form-encoded formats; Accept header added
  - Redacted token logging and more detailed role-extraction diagnostics
  - Per-provider validation timeouts and provider-driven identity propagation

* **Chores**
  - Graceful handling when auth is disabled (returns a no-op/dummy provider)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->