### PR TITLE
EDM-2670: Fix label indentation

### DIFF
--- a/deploy/helm/flightctl/templates/api/flightctl-api-route-agent.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-route-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- include "flightctl.standardLabels" . | nindent 4 }}
-  flightctl.service: flightctl-api
+    flightctl.service: flightctl-api
   name: flightctl-api-route-agent
   namespace: {{ .Release.Namespace }}
 spec:

--- a/deploy/helm/flightctl/templates/flightctl-mce-role.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-mce-role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: flightctl-device-registration
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
 rules:
   - verbs:
       - get
@@ -23,6 +25,8 @@ kind: RoleBinding
 metadata:
   name: managedcluster-import-controller-flightctl
   namespace: multicluster-engine
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reformatted deployment manifest metadata for consistent YAML indentation.
  * Added standard metadata labels to Kubernetes RBAC resources (ClusterRole and RoleBinding) to improve resource organization and identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->