### PR TITLE
EDM-2344: Bug fix for config.yaml overwrite when using 'make deploy'

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -23,9 +23,9 @@ clean-cluster:
 	kind delete cluster
 
 ifndef SKIP_BUILD
-deploy: cluster build-containers build-cli deploy-helm prepare-agent-config
+deploy: cluster build-containers build-cli deploy-helm prepare-agent-config deploy-tpm-certs
 else
-deploy: cluster deploy-helm prepare-agent-config
+deploy: cluster deploy-helm prepare-agent-config deploy-tpm-certs
 	@echo "Skipping container and CLI builds (SKIP_BUILD is set)"
 endif
 
@@ -64,6 +64,31 @@ deploy-helm:
 
 prepare-agent-config:
 	TPM=$(TPM) test/scripts/agent-images/prepare_agent_config.sh --status-update-interval $(STATUS_UPDATE_INTERVAL) --spec-fetch-interval $(SPEC_FETCH_INTERVAL)
+
+deploy-tpm-certs:
+ifeq ($(TPM),enabled)
+	@echo "TPM is enabled - configuring TPM manufacturer CA certificates..."
+	@# Copy TPM manufacturer CA certificates to validate real hardware TPMs.
+	@mkdir -p bin/tpm-cas
+	@find tpm-manufacturer-certs -type f -name "*.pem" -exec cp {} bin/tpm-cas/ \;
+	@echo "Copied $$(ls bin/tpm-cas/*.pem 2>/dev/null | wc -l) TPM manufacturer CA certificates to bin/tpm-cas/"
+	@if ! compgen -G "bin/tpm-cas/*.pem" >/dev/null 2>&1; then \
+		echo "WARNING: No TPM manufacturer CA certificates found in tpm-manufacturer-certs/"; \
+		echo "         Hardware TPM enrollment may fail without manufacturer CAs."; \
+	fi
+	@echo ""
+	@# Create test swtpm CA (which will sign EK certs) for emulated TPM testing. These certificates must be
+	@# available to the server to validate TPM-based enrollment requests from the agent VM.
+	@echo "Creating test swtpm CA for emulated TPM testing..."
+	@test/scripts/create-test-swtpm-ca.sh bin/swtpm-ca
+	@cp bin/swtpm-ca/swtpm-localca-rootca-cert.pem bin/tpm-cas/
+	@cp bin/swtpm-ca/issuercert.pem bin/tpm-cas/swtpm-localca-issuer-cert.pem
+	@echo "✓ Added test swtpm CA certificates to deployment"
+	@echo ""
+	NAMESPACE=flightctl-external test/scripts/add-certs-to-deployment.sh bin/tpm-cas
+else
+	@echo "TPM is disabled - skipping TPM CA certificate configuration"
+endif
 
 deploy-db-helm: cluster
 	test/scripts/deploy_with_helm.sh --only-db

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -10,6 +10,10 @@ ifeq ($(SPEC_FETCH_INTERVAL),)
 	SPEC_FETCH_INTERVAL := 0m2s
 endif
 
+ifeq ($(TPM),)
+	TPM := disabled
+endif
+
 # Create kind cluster if it doesn't exist (idempotent)
 cluster: bin/e2e-certs/ca.pem
 	test/scripts/install_kind.sh
@@ -59,7 +63,7 @@ deploy-helm:
 	test/scripts/deploy_with_helm.sh --db-size $(DB_SIZE)
 
 prepare-agent-config:
-	test/scripts/agent-images/prepare_agent_config.sh --status-update-interval $(STATUS_UPDATE_INTERVAL) --spec-fetch-interval $(SPEC_FETCH_INTERVAL)
+	TPM=$(TPM) test/scripts/agent-images/prepare_agent_config.sh --status-update-interval $(STATUS_UPDATE_INTERVAL) --spec-fetch-interval $(SPEC_FETCH_INTERVAL)
 
 deploy-db-helm: cluster
 	test/scripts/deploy_with_helm.sh --only-db

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -5,6 +5,10 @@ APP_BUNDLE := $(ROOT_DIR)/bin/app-images-bundle.tar
 AGENT_BUNDLE_DIR := $(ROOT_DIR)/bin/agent-artifacts
 AGENT_BUNDLE := $(AGENT_BUNDLE_DIR)/agent-images-bundle-$(AGENT_OS_ID).tar
 
+ifeq ($(TPM),)
+	TPM := disabled
+endif
+
 bin/output/qcow2/disk.qcow2: $(E2E_AGENT_IMAGES_SENTINEL)
 
 # Build + bundle artifacts (no push)
@@ -44,7 +48,7 @@ push-e2e-agent-images: e2e-agent-images
 	$(ROOT_DIR)/test/scripts/agent-images/scripts/upload-quadlets.sh
 
 bin/.e2e-agent-certs:
-	./test/scripts/agent-images/prepare_agent_config.sh
+	TPM=$(TPM) ./test/scripts/agent-images/prepare_agent_config.sh
 	touch bin/.e2e-agent-certs
 
 .PHONY: e2e-agent-images

--- a/test/scripts/agent-images/prepare_agent_config.sh
+++ b/test/scripts/agent-images/prepare_agent_config.sh
@@ -39,3 +39,14 @@ system-info-custom:
   - siteName
   - emptyValue
 EOF
+
+# Add TPM configuration if enabled via environment variable
+if [ "${TPM:-disabled}" = "enabled" ]; then
+cat <<EOF | tee -a bin/agent/etc/flightctl/config.yaml
+tpm:
+  enabled: true
+  device-path: /dev/tpm0
+  auth-enabled: false
+  storage-file-path: /var/lib/flightctl/tpm-blob.yaml
+EOF
+fi

--- a/test/scripts/agent-images/prepare_agent_config.sh
+++ b/test/scripts/agent-images/prepare_agent_config.sh
@@ -17,14 +17,16 @@ ensure_organization_set
 
 status_update_interval=0m2s
 spec_fetch_interval=0m2s
+tpm="${TPM:-disabled}"
 # Use external getopt for long options
-options=$(getopt -o h --long status-update-interval:,spec-fetch-interval:,help -n "$0" -- "$@")
+options=$(getopt -o h --long status-update-interval:,spec-fetch-interval:,tpm:,help -n "$0" -- "$@")
 eval set -- "$options"
 while true; do
   case "$1" in
-  -h|--help) echo "Usage: $0 --status-update-interval=0m2s"; exit 1 ;;
+  -h|--help) echo "Usage: $0 --status-update-interval=0m2s --tpm=enabled"; exit 1 ;;
   --status-update-interval) status_update_interval=$2; shift 2 ;;
   --spec-fetch-interval) spec_fetch_interval=$2; shift 2 ;;
+  --tpm) tpm=$2; shift 2 ;;
   --) shift; break ;;
   *) echo "Invalid option: $1" >&2; exit 1 ;;
   esac
@@ -40,8 +42,8 @@ system-info-custom:
   - emptyValue
 EOF
 
-# Add TPM configuration if enabled via environment variable
-if [ "${TPM:-disabled}" = "enabled" ]; then
+# Add TPM configuration if enabled via environment variable or command line flag
+if [ "$tpm" = "enabled" ]; then
 cat <<EOF | tee -a bin/agent/etc/flightctl/config.yaml
 tpm:
   enabled: true

--- a/test/scripts/create-test-swtpm-ca.sh
+++ b/test/scripts/create-test-swtpm-ca.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script creates a test swtpm-localca CA for use with emulated TPMs.
+# The CA is used to sign TPM Endorsement Key (EK) certificates.
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <output-directory>"
+    echo "  output-directory: Directory where CA files will be created"
+    exit 1
+fi
+
+OUTPUT_DIR="$1"
+
+echo "Creating test swtpm CA in ${OUTPUT_DIR}..."
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+# Check if CA already exists
+if [ -f "${OUTPUT_DIR}/signkey.pem" ] && [ -f "${OUTPUT_DIR}/issuercert.pem" ] && [ -f "${OUTPUT_DIR}/swtpm-localca-rootca-cert.pem" ]; then
+    echo "✓ Test swtpm CA already exists in ${OUTPUT_DIR}"
+    exit 0
+fi
+
+# Create temporary directory for CA generation
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+# Generate root CA private key
+openssl ecparam -name secp384r1 -genkey -noout -out "${TEMP_DIR}/rootca-key.pem"
+
+# Generate root CA certificate
+openssl req -new -x509 -days 3650 -key "${TEMP_DIR}/rootca-key.pem" \
+    -out "${OUTPUT_DIR}/swtpm-localca-rootca-cert.pem" \
+    -subj "/CN=swtpm-localca-rootca" \
+    -sha384
+
+# Generate intermediate CA private key
+openssl ecparam -name secp384r1 -genkey -noout -out "${OUTPUT_DIR}/signkey.pem"
+
+# Generate intermediate CA certificate signing request
+openssl req -new -key "${OUTPUT_DIR}/signkey.pem" \
+    -out "${TEMP_DIR}/intermediate.csr" \
+    -subj "/CN=swtpm-localca" \
+    -sha384
+
+# Sign intermediate CA certificate with root CA
+openssl x509 -req -in "${TEMP_DIR}/intermediate.csr" \
+    -CA "${OUTPUT_DIR}/swtpm-localca-rootca-cert.pem" \
+    -CAkey "${TEMP_DIR}/rootca-key.pem" \
+    -CAcreateserial \
+    -out "${OUTPUT_DIR}/issuercert.pem" \
+    -days 3650 \
+    -sha384 \
+    -extensions v3_ca \
+    -extfile <(cat <<EOF
+[v3_ca]
+basicConstraints = CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+EOF
+)
+
+# Initialize certificate serial number file
+echo "01" > "${OUTPUT_DIR}/certserial"
+
+echo "✓ Test swtpm CA created successfully:"
+echo "  - Root CA: ${OUTPUT_DIR}/swtpm-localca-rootca-cert.pem"
+echo "  - Intermediate CA: ${OUTPUT_DIR}/issuercert.pem"
+echo "  - Signing key: ${OUTPUT_DIR}/signkey.pem"
+echo "  - Serial file: ${OUTPUT_DIR}/certserial"


### PR DESCRIPTION
The issue (as described in [EDM-2344](https://issues.redhat.com/browse/EDM-2344)) is that manual updates to `config.yaml` are wiped when running `make deploy`. Since TPM options are not enabled for `make deploy`, it's not possible to use `make deploy` to bring up a TPM-enabled agent test VM.

Note: I used this issue as my AI Goal for Emerging Tech with Claude Code, as is noted on each commit. Let me know if there are any concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TPM support added to agent configuration (disabled by default, opt-in).
  * Deployment now runs a TPM certificate preparation step, including generation and installation of a test TPM CA and adding certs to deployments when TPM is enabled.

* **Chores**
  * Build/deploy scripts and VM provisioning flows updated to propagate TPM state and handle installation/cleanup of test CA artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->