### PR TITLE
EDM-2534: Make organizations not configurable in UI

### DIFF
--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
@@ -18,7 +18,6 @@ data:
   {{- end }}
   FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY: {{ .Values.ui.api.insecureSkipTlsVerify | quote }}
   IS_RHEM: {{ (eq .Chart.Name "redhat-rhem") | quote }}
-  ORGANIZATIONS_ENABLED: "true"
   AUTH_INSECURE_SKIP_VERIFY: {{ default ((.Values.global).auth).insecureSkipTlsVerify .Values.ui.auth.insecureSkipTlsVerify | quote }}
   BASE_UI_URL: {{ include "flightctl.getUIUrl" . }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
@@ -59,11 +59,6 @@ spec:
               configMapKeyRef:
                 name: flightctl-ui
                 key: FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY
-          - name: ORGANIZATIONS_ENABLED
-            valueFrom:
-              configMapKeyRef:
-                name: flightctl-ui
-                key: ORGANIZATIONS_ENABLED
           {{- if eq $enableMulticlusterExtensions "true" }}
           - name: TLS_KEY
             value: /app/serving-cert/tls.key


### PR DESCRIPTION
In the UI we're also removing the ability to make authorization and/or oganizations configurable.
See https://github.com/flightctl/flightctl-ui/pull/390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the ORGANIZATIONS_ENABLED configuration setting from the UI deployment setup, streamlining application initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->