### PR TITLE
EDM-2638: documents token expiration / login command

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -36,6 +36,7 @@ Welcome to the Flight Control user documentation.
 
 **Using Flight Control** - How to manage individual and fleets of devices with Flight Control.
 
+* **[Using the CLI](using/cli/overview.md)** - How to use the Flight Control CLI
 * **[Provisioning Devices](using/provisioning-devices.md)** - How to provision a device with an OS image.
   * [Provisioning Physical Devices](using/provisioning-devices.md#provisioning-physical-devices)
   * [Provisioning on Red Hat OpenShift Virtualization](using/provisioning-devices.md#provisioning-on-red-hat-openshift-virtualization)
@@ -75,6 +76,7 @@ Welcome to the Flight Control user documentation.
 
 **References** - Useful references.
 
+* [CLI Commands](references/cli-commands.md)
 * [API Resources](references/api-resources.md)
 * [Authentication Resources](references/auth-resources.md)
 * [Device Status Definitions](references/device-api-statuses.md)

--- a/docs/user/installing/configuring-auth/auth-pam.md
+++ b/docs/user/installing/configuring-auth/auth-pam.md
@@ -114,6 +114,10 @@ If the `pamOidcIssuer` section is present in the configuration file, the followi
 
 The `allowPublicClientWithoutPKCE` parameter should remain `false` (default) in production environments. PKCE (Proof Key for Code Exchange) is required for public clients per OAuth 2.0 Security Best Current Practice. Only enable this setting for testing or backward compatibility with legacy clients.
 
+### Token Expiration
+
+JWT tokens issued by the PAM issuer have a fixed expiration time of **1 hour**. This expiration time is currently not configurable.
+
 ## User Management
 
 ### Adding Users to PAM Issuer

--- a/docs/user/installing/configuring-auth/overview.md
+++ b/docs/user/installing/configuring-auth/overview.md
@@ -49,6 +49,8 @@ Validates tokens via AAP Gateway API. Auto-maps AAP organizations to Flight Cont
 
 ## Managing Authentication Providers
 
+> **Note:** The examples below use the Flight Control CLI. See [Using the CLI](../../using/cli/overview.md) and [Logging in to the Service](../../using/cli/logging-in.md) for more information.
+
 Flight Control supports two types of authentication provider configuration:
 
 ### Dynamic Configuration (OIDC/OAuth2)

--- a/docs/user/installing/installing-cli.md
+++ b/docs/user/installing/installing-cli.md
@@ -73,3 +73,11 @@ flightctl version
 ```
 
 > Note: If you get a "command not found" error, ensure the binary is in your `PATH`.
+
+## Next Steps
+
+After installing the CLI, you'll need to authenticate to the Flight Control service:
+
+* [Using the CLI](../using/cli/overview.md) - CLI usage guide
+* [Logging in to the Service](../using/cli/logging-in.md) - How to authenticate to Flight Control
+* [Configuring Authentication](configuring-auth/overview.md) - Learn about authentication methods

--- a/docs/user/references/cli-commands.md
+++ b/docs/user/references/cli-commands.md
@@ -1,0 +1,61 @@
+# CLI Command Reference
+
+This document provides a reference for Flight Control CLI commands.
+
+For procedures and examples, see [Using the CLI](../using/cli/overview.md).
+
+## flightctl login
+
+Authenticate to a Flight Control service.
+
+### Synopsis
+
+```shell
+flightctl login <server_url> [flags]
+```
+
+### Arguments
+
+* `<server_url>` - URL of the Flight Control API server
+
+### Flags
+
+#### Token Authentication
+
+* `-t, --token <token>` - Bearer token for authentication
+
+#### Provider-Based Authentication
+
+* `--provider <name>` - Name of the authentication provider to use
+* `--show-providers` - List available authentication providers
+* `--auth-certificate-authority <path>` - Path to CA certificate file for the authentication server
+
+#### OAuth/OIDC Flow Flags
+
+* `--web` - Use OAuth/OIDC authorization code flow (opens browser)
+* `-u, --username <username>` - Username for OAuth/OIDC password flow
+* `-p, --password <password>` - Password for OAuth/OIDC password flow
+* `--callback-port <port>` - Port for OAuth/OIDC callback (default: 8080)
+
+#### TLS/Certificate Flags
+
+* `--certificate-authority <path>` - Path to CA certificate file for the API server
+* `-k, --insecure-skip-tls-verify` - Skip TLS certificate verification
+
+#### Other Flags
+
+* `-h, --help` - Display help
+
+### Configuration File
+
+* Default location: `~/.config/flightctl/client.yaml`
+
+### Exit Status
+
+* `0` - Success
+* Non-zero - Error
+
+## See Also
+
+* [Using the CLI](../using/cli/overview.md)
+* [Logging in to the Service](../using/cli/logging-in.md)

--- a/docs/user/using/cli/logging-in.md
+++ b/docs/user/using/cli/logging-in.md
@@ -1,0 +1,217 @@
+# Logging into the Flight Control Service Using the CLI
+
+This section explains how to authenticate to the Flight Control service using the `flightctl login` command. After successful login, your credentials are stored locally and used for all subsequent CLI operations.
+
+## Logging in with Web-Based Authentication
+
+Web-based authentication uses your browser to authenticate through the configured identity provider (OAuth2, OIDC, OpenShift, AAP, etc.). This is the recommended method for interactive use.
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* You have access to a web browser
+* You have user credentials for the configured identity provider
+* The OAuth/OIDC provider is configured to allow `http://localhost:8080/callback` as a redirect URL (or your custom callback port)
+
+**Procedure:**
+
+1. Log in to the Flight Control service:
+
+   ```shell
+   flightctl login https://flightctl.example.com --web
+   ```
+
+   A browser window opens automatically.
+
+2. Authenticate using your identity provider credentials in the browser.
+
+3. After successful authentication, the browser displays a success message and you can close the window.
+
+4. Verify successful login:
+
+   ```shell
+   flightctl get devices
+   ```
+
+   If authentication was successful, the command displays your devices or an empty list if no devices are enrolled yet.
+
+**Additional Options:**
+
+* To use a specific authentication provider when multiple providers are configured:
+
+  ```shell
+  flightctl login https://flightctl.example.com --web --provider=corporate-sso
+  ```
+
+  To see available providers, use `--show-providers` (see [Listing Available Authentication Providers](#listing-available-authentication-providers)).
+
+* To use a custom callback port:
+
+  ```shell
+  flightctl login https://flightctl.example.com --web --callback-port=9090
+  ```
+
+  Ensure the provider allows `http://localhost:9090/callback` as a redirect URL.
+
+* To specify a custom CA certificate for the API server:
+
+  ```shell
+  flightctl login https://flightctl.example.com --web --certificate-authority=/path/to/ca.crt
+  ```
+
+* To specify a custom CA certificate for the authentication server (when different from API server):
+
+  ```shell
+  flightctl login https://flightctl.example.com --web \
+    --certificate-authority=/path/to/api-ca.crt \
+    --auth-certificate-authority=/path/to/auth-ca.crt
+  ```
+
+## Logging in with a Token
+
+Token-based authentication is useful for automation, CI/CD pipelines, and non-interactive scenarios.
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* You have obtained a valid bearer token from your identity provider or administrator
+
+**Procedure:**
+
+1. Log in using your token:
+
+   ```shell
+   flightctl login https://flightctl.example.com --token=eyJhbGciOiJSUzI1NiIs...
+   ```
+
+2. Verify successful login:
+
+   ```shell
+   flightctl get devices
+   ```
+
+   If authentication was successful, the command displays your devices or an empty list if no devices are enrolled yet.
+
+**Additional Options:**
+
+* To specify a custom CA certificate:
+
+  ```shell
+  flightctl login https://flightctl.example.com --token=<your-token> --certificate-authority=/path/to/ca.crt
+  ```
+
+## Logging in with Username and Password
+
+Username and password authentication uses the OAuth/OIDC resource owner password credentials flow. This method is only available if your identity provider supports password flow.
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* Your identity provider supports the OAuth/OIDC password flow
+* You have a username and password for the identity provider
+
+**Procedure:**
+
+1. Log in with your credentials:
+
+   ```shell
+   flightctl login https://flightctl.example.com -u myuser -p mypassword
+   ```
+
+2. Verify successful login:
+
+   ```shell
+   flightctl get devices
+   ```
+
+   If authentication was successful, the command displays your devices or an empty list if no devices are enrolled yet.
+
+**Additional Options:**
+
+* To use a specific authentication provider when multiple providers are configured:
+
+  ```shell
+  flightctl login https://flightctl.example.com -u myuser -p mypassword --provider=corporate-sso
+  ```
+
+  To see available providers, use `--show-providers` (see [Listing Available Authentication Providers](#listing-available-authentication-providers)).
+
+* To specify a custom CA certificate:
+
+  ```shell
+  flightctl login https://flightctl.example.com -u myuser -p mypassword --certificate-authority=/path/to/ca.crt
+  ```
+
+## Listing Available Authentication Providers
+
+If multiple authentication providers are configured on the server, you can list them to see which providers are available and choose which one to use for authentication.
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* You have network access to the Flight Control API server
+
+**Procedure:**
+
+1. List available providers:
+
+   ```shell
+   flightctl login https://flightctl.example.com --show-providers
+   ```
+
+   The command displays a table of available authentication providers with their names and display names.
+
+2. Log in using a specific provider (replace `corporate-sso` with the provider name from the list):
+
+   ```shell
+   flightctl login https://flightctl.example.com --web --provider=corporate-sso
+   ```
+
+3. Verify successful login:
+
+   ```shell
+   flightctl get devices
+   ```
+
+   If authentication was successful, the command displays your devices or an empty list if no devices are enrolled yet.
+
+## Using Insecure Connections (Development Only)
+
+For development and testing environments with self-signed certificates, you can skip TLS certificate verification.
+
+> **Warning:** Never use this option in production environments. Skipping certificate verification makes your connection insecure and vulnerable to man-in-the-middle attacks.
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* You are working in a development or testing environment
+
+**Procedure:**
+
+1. Log in with TLS verification disabled:
+
+   ```shell
+   flightctl login https://flightctl.example.com --web --insecure-skip-tls-verify
+   ```
+
+2. Verify successful login:
+
+   ```shell
+   flightctl get devices
+   ```
+
+## Configuration File Location
+
+After successful login, your credentials are stored in the client configuration file:
+
+* **Default location:** `~/.config/flightctl/client.yaml`
+* **Contents:** Server URL, authentication tokens, TLS settings, selected organization
+
+To use a non-default configuration file location, use the `--config` flag with any `flightctl` command.
+
+## See Also
+
+* [CLI Command Reference](../../references/cli-commands.md) - Complete CLI command syntax and flags
+* [Configuring Authentication](../../installing/configuring-auth/overview.md) - Server-side authentication configuration
+* [Managing Devices](../managing-devices.md) - Working with devices after login
+* [Managing Fleets](../managing-fleets.md) - Working with fleets after login

--- a/docs/user/using/cli/overview.md
+++ b/docs/user/using/cli/overview.md
@@ -1,0 +1,146 @@
+# Using the Flight Control CLI
+
+The Flight Control CLI (`flightctl`) is a command-line tool for interacting with the Flight Control service. It provides commands for managing devices, fleets, repositories, and other resources.
+
+## Before You Begin
+
+**Prerequisites:**
+
+* You have installed the Flight Control CLI (see [Installing the CLI](../../installing/installing-cli.md))
+* You have credentials to access a Flight Control service
+
+## Authenticating to the Service
+
+Before running CLI commands, you must authenticate to the Flight Control service. See [Logging into the Flight Control Service](logging-in.md) for detailed authentication procedures.
+
+Quick start:
+
+```shell
+flightctl login https://flightctl.example.com --web
+```
+
+## Working with Resources
+
+### Viewing Resources
+
+To display resources, use the `get` command:
+
+```shell
+# Get all devices
+flightctl get devices
+
+# Get a specific device
+flightctl get device my-device
+
+# Get all fleets
+flightctl get fleets
+```
+
+For detailed information about managing devices and fleets, see:
+
+* [Managing Devices](../managing-devices.md)
+* [Managing Fleets](../managing-fleets.md)
+
+### Creating and Updating Resources
+
+To create or update resources from files, use the `apply` command:
+
+```shell
+# Apply a configuration from a file
+flightctl apply -f fleet.yaml
+
+# Apply all YAML files in a directory
+flightctl apply -f ./configurations/
+```
+
+### Deleting Resources
+
+To delete resources, use the `delete` command:
+
+```shell
+# Delete a specific fleet
+flightctl delete fleet my-fleet
+
+# Delete a device
+flightctl delete device my-device
+```
+
+### Editing Resources
+
+To edit a resource interactively, use the `edit` command:
+
+```shell
+# Edit a fleet configuration
+flightctl edit fleet my-fleet
+
+# Edit a device configuration
+flightctl edit device my-device
+```
+
+## Customizing Output
+
+### Output Formats
+
+Most commands support multiple output formats:
+
+```shell
+# Default table output (human-readable)
+flightctl get devices
+
+# JSON output
+flightctl get devices -o json
+
+# YAML output
+flightctl get devices -o yaml
+
+# Wide output with additional columns
+flightctl get devices -o wide
+```
+
+### Filtering with Selectors
+
+Filter resources using label selectors:
+
+```shell
+# Get devices with specific labels
+flightctl get devices --selector environment=production
+
+# Get devices matching multiple labels
+flightctl get devices --selector environment=production,region=us-west
+```
+
+See [Field Selectors](../field-selectors.md) for more information on filtering resources.
+
+## Using Global Flags
+
+The following flags are available for most commands:
+
+* `--config <path>` - Path to the config file (default: `~/.config/flightctl/client.yaml`)
+* `--server <url>` - Server URL (overrides config file)
+* `--token <token>` - Bearer token for authentication (overrides config file)
+* `--insecure-skip-tls-verify` - Skip TLS certificate verification (not recommended for production)
+* `-o, --output <format>` - Output format: `json`, `yaml`, `wide`, or `table`
+* `-h, --help` - Display help information
+* `-v, --verbose` - Enable verbose output
+
+## Getting Help
+
+To get help for any command, use the `--help` flag:
+
+```shell
+# General CLI help
+flightctl --help
+
+# Help for a specific command
+flightctl login --help
+flightctl get --help
+```
+
+For complete command syntax and flags, see the [CLI Command Reference](../../references/cli-commands.md).
+
+## Next Steps
+
+* [Logging in to the Service](logging-in.md) - Authenticate to Flight Control
+* [Managing Devices](../managing-devices.md) - Work with individual devices
+* [Managing Fleets](../managing-fleets.md) - Work with device fleets
+* [Troubleshooting](../troubleshooting.md) - Solve common issues


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI usage guide covering authentication, resource management, commands, and examples.
  * Added CLI command reference documenting login flags, arguments, and behaviors.
  * Added authentication guide with web-based, token, and username/password login methods.
  * Clarified JWT token expiration for PAM-issued tokens (1 hour, not configurable).
  * Enhanced installation guide with next-step links to CLI and auth documentation.
  * Improved site navigation with a new CLI section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->