### PR TITLE
EDM-2676: Fix telemetry gateway secrets

### DIFF
--- a/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
+++ b/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
@@ -62,9 +62,9 @@ spec:
           readOnly: true
           subPath: config.yaml
         - mountPath: /etc/telemetry-gateway/certs/ca.crt
-          name: ca-secret
+          name: ca-bundle
           readOnly: true
-          subPath: ca.crt
+          subPath: ca-bundle.crt
         - mountPath: /etc/telemetry-gateway/certs/server.crt
           name: telemetry-gateway-tls
           readOnly: true
@@ -79,9 +79,9 @@ spec:
       - configMap:
           name: flightctl-telemetry-gateway-config
         name: flightctl-telemetry-gateway-config
-      - name: ca-secret
-        secret:
-          secretName: flightctl-ca-secret
+      - name: ca-bundle
+        configMap:
+          name: flightctl-ca-bundle
       - name: telemetry-gateway-tls
         secret:
-          secretName: telemetry-gateway-tls
+          secretName: flightctl-telemetry-gateway-server-tls


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated telemetry gateway certificate handling: switched CA bundle mount from a secret to a configMap and updated the TLS secret reference used by the deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->