### PR TITLE
EDM-2675: adds db constraints for oidc/auth2 providers 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/goccy/go-yaml v1.18.0
+	github.com/jackc/pgx/v5 v5.5.5
 	github.com/mattbaird/jsonpatch v0.0.0-20240118010651-0ba75a80ca38
 	github.com/msteinert/pam/v2 v2.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.130.0
@@ -246,7 +247,6 @@ require (
 	github.com/ionos-cloud/sdk-go/v6 v6.3.4 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.5.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -45,6 +45,10 @@ var (
 	// authentication/authorization
 	ErrInvalidTokenClaims = errors.New("invalid token claims")
 	ErrMissingTokenClaims = errors.New("missing required token claims")
+
+	// authprovider
+	ErrDuplicateOIDCProvider   = errors.New("an OIDC auth provider with the same issuer and clientId already exists")
+	ErrDuplicateOAuth2Provider = errors.New("an OAuth2 auth provider with the same userinfoUrl and clientId already exists")
 )
 
 func IsClientAuthError(err error) bool {

--- a/internal/kvstore/kvstore.go
+++ b/internal/kvstore/kvstore.go
@@ -51,7 +51,7 @@ func NewKVStore(ctx context.Context, log logrus.FieldLogger, hostname string, po
 	if err := client.Ping(timeoutCtx).Err(); err != nil {
 		return nil, fmt.Errorf("failed to connect to KV store: %w", err)
 	}
-	log.Info("successfully connected to the KV store")
+	log.Debug("successfully connected to the KV store")
 
 	// Lua script to get the value if it exists, otherwise set and return it
 	luaScript := redis.NewScript(`

--- a/internal/service/common.go
+++ b/internal/service/common.go
@@ -123,6 +123,8 @@ var badRequestErrors = map[error]bool{
 var conflictErrors = map[error]bool{
 	flterrors.ErrUpdatingResourceWithOwnerNotAllowed: true,
 	flterrors.ErrDuplicateName:                       true,
+	flterrors.ErrDuplicateOIDCProvider:               true,
+	flterrors.ErrDuplicateOAuth2Provider:             true,
 	flterrors.ErrNoRowsUpdated:                       true,
 	flterrors.ErrResourceVersionConflict:             true,
 	flterrors.ErrResourceOwnerIsNil:                  true,

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -19,6 +19,12 @@ import (
 
 const retryIterations = 10
 
+// AuthProvider database constraint names
+const (
+	ConstraintAuthProviderOIDCUnique   = "idx_authproviders_oidc_unique"
+	ConstraintAuthProviderOAuth2Unique = "idx_authproviders_oauth2_unique"
+)
+
 type CreateOrUpdateMode string
 
 type EventCallbackCaller func(ctx context.Context, callbackEvent EventCallback, orgId uuid.UUID, name string, oldResource, newResource interface{}, created bool, err error)
@@ -29,6 +35,9 @@ func ErrorFromGormError(err error) error {
 	switch {
 	case err == nil:
 		return nil
+	case errors.Is(err, flterrors.ErrDuplicateOIDCProvider), errors.Is(err, flterrors.ErrDuplicateOAuth2Provider):
+		// Our custom dialector has already detected specific authprovider constraint violations
+		return err
 	case errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, gorm.ErrForeignKeyViolated):
 		return flterrors.ErrResourceNotFound
 	case errors.Is(err, gorm.ErrDuplicatedKey):

--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -172,7 +172,7 @@ func (s *GenericStore[P, M, A, AL]) createResource(ctx context.Context, resource
 	result := s.getDB(ctx).Create(resource)
 	if result.Error != nil {
 		err := ErrorFromGormError(result.Error)
-		return err == flterrors.ErrDuplicateName, err
+		return err == flterrors.ErrDuplicateName || err == flterrors.ErrDuplicateOIDCProvider || err == flterrors.ErrDuplicateOAuth2Provider, err
 	}
 	return false, nil
 }

--- a/test/integration/store/authprovider_test.go
+++ b/test/integration/store/authprovider_test.go
@@ -70,8 +70,8 @@ var _ = Describe("AuthProviderStore", func() {
 
 		oidcSpec := api.OIDCProviderSpec{
 			ProviderType:           api.Oidc,
-			Issuer:                 "https://accounts.google.com",
-			ClientId:               "test-client-id",
+			Issuer:                 fmt.Sprintf("https://issuer.example.com/%s", name), // Make issuer unique per provider
+			ClientId:               fmt.Sprintf("client-id-%s", name),                  // Make clientId unique per provider
 			ClientSecret:           lo.ToPtr("test-client-secret"),
 			Scopes:                 lo.ToPtr([]string{"openid", "profile", "email"}),
 			Enabled:                lo.ToPtr(true),
@@ -362,8 +362,8 @@ var _ = Describe("AuthProviderStore", func() {
 
 			oidcSpec := api.OIDCProviderSpec{
 				ProviderType:           api.Oidc,
-				Issuer:                 "https://accounts.google.com",
-				ClientId:               "test-client-id",
+				Issuer:                 "https://issuer.example.com/static-org-provider",
+				ClientId:               "client-id-static-org-provider",
 				ClientSecret:           lo.ToPtr("test-client-secret"),
 				Scopes:                 lo.ToPtr([]string{"openid", "profile", "email"}),
 				Enabled:                lo.ToPtr(true),
@@ -404,8 +404,8 @@ var _ = Describe("AuthProviderStore", func() {
 
 			oidcSpec := api.OIDCProviderSpec{
 				ProviderType:           api.Oidc,
-				Issuer:                 "https://accounts.google.com",
-				ClientId:               "test-client-id",
+				Issuer:                 "https://issuer.example.com/dynamic-org-provider",
+				ClientId:               "client-id-dynamic-org-provider",
 				ClientSecret:           lo.ToPtr("test-client-secret"),
 				Scopes:                 lo.ToPtr([]string{"openid", "profile", "email"}),
 				Enabled:                lo.ToPtr(true),
@@ -447,8 +447,8 @@ var _ = Describe("AuthProviderStore", func() {
 
 			oidcSpec := api.OIDCProviderSpec{
 				ProviderType:           api.Oidc,
-				Issuer:                 "https://accounts.google.com",
-				ClientId:               "test-client-id",
+				Issuer:                 "https://issuer.example.com/per-user-org-provider",
+				ClientId:               "client-id-per-user-org-provider",
 				ClientSecret:           lo.ToPtr("test-client-secret"),
 				Scopes:                 lo.ToPtr([]string{"openid", "profile", "email"}),
 				Enabled:                lo.ToPtr(true),


### PR DESCRIPTION
so we do not have same provider defined (issuer+clientid or userinfo+clientId)

the constraint is cross organization since auth providers are relevant before the authentication phase 

the PR adds support for proper psql error translation so we can extract the actual constraint that was in conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent creation of duplicate OIDC providers (same issuer + client ID).
  * Prevent creation of duplicate OAuth2 providers (same userinfo URL + client ID).
  * Uniqueness checks enforced across organizations.

* **Bug Fixes**
  * More precise conflict/error responses when auth-provider duplicates are detected.

* **Tests**
  * New integration tests covering duplicate detection for create, replace, and patch flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->