### PR TITLE
Remove flightctl-admin from AAP auth docs

### DIFF
--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -16,7 +16,6 @@ Flight Control API server integrates with AAP Gateway by:
 Flight Control uses the following standard roles for authorization:
 
 - **Super Admin** - Unrestricted access to all resources and operations across all organizations
-- **`flightctl-admin`** - Full access to all resources within an organization
 - **`flightctl-org-admin`** - Full access to all resources within a specific organization
 - **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories
 - **`flightctl-viewer`** - Read-only access to all resources


### PR DESCRIPTION
There is not flightctl-admin role when using AAP, Only superadmin and flightctl-org-admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the "flightctl-admin" role from the list of standard roles for AAP authentication configuration; remaining roles unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->