### PR TITLE
EDM-2692: Enable alerts in the UI quadlets deployment

### DIFF
--- a/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
@@ -4,6 +4,7 @@ FLIGHTCTL_SERVER=https://flightctl-api:3443/
 FLIGHTCTL_SERVER_EXTERNAL=https://{{.global.baseDomain}}:3443/
 FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY=true
 FLIGHTCTL_CLI_ARTIFACTS_SERVER=https://{{.global.baseDomain}}:8090
+FLIGHTCTL_ALERTMANAGER_PROXY=https://flightctl-alertmanager-proxy:8443
 TLS_CERT=/app/certs/server.crt
 TLS_KEY=/app/certs/server.key
 AUTH_INSECURE_SKIP_VERIFY={{.global.auth.insecureSkipTlsVerify}}


### PR DESCRIPTION
The UI was missing the setting that determines if Alerts are enabled in the UI.

In the quadlets deployment, the Alertmanager proxy is not optional, so we can add it unconditionally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to include alertmanager proxy settings for improved monitoring and alert management integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->