### PR TITLE
EDM-2702: fixed aap public oauth2 client

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -36,7 +36,7 @@ auth:
     apiUrl: {{.global.auth.aap.apiUrl}}
     issuer: {{.global.auth.aap.issuer}}
     clientId: {{.global.auth.aap.clientId}}
-    clientSecret: {{.global.auth.aap.clientSecret}}
+    clientSecret: {{if .global.auth.aap.clientSecret}}{{.global.auth.aap.clientSecret}}{{end}}
     authorizationUrl: {{.global.auth.aap.authorizationUrl}}
     tokenUrl: {{.global.auth.aap.tokenUrl}}
     enabled: {{if .global.auth.aap.enabled}}{{.global.auth.aap.enabled}}{{else}}true{{end}}
@@ -55,11 +55,11 @@ auth:
     {{if .global.auth.pamOidcIssuer.enabled}}
     issuer: {{if .global.auth.pamOidcIssuer.issuer}}{{.global.auth.pamOidcIssuer.issuer}}{{else}}https://{{.global.baseDomain}}:8444/api/v1/auth{{end}}
     clientId: {{if .global.auth.pamOidcIssuer.clientId}}{{.global.auth.pamOidcIssuer.clientId}}{{else}}flightctl-client{{end}}
-    clientSecret: {{.global.auth.pamOidcIssuer.clientSecret}}
+    clientSecret: {{if .global.auth.pamOidcIssuer.clientSecret}}{{.global.auth.pamOidcIssuer.clientSecret}}{{end}}
     {{else}}
     issuer: {{.global.auth.oidc.issuer}}
     clientId: {{.global.auth.oidc.clientId}}
-    clientSecret: {{.global.auth.oidc.clientSecret}}
+    clientSecret: {{if .global.auth.oidc.clientSecret}}{{.global.auth.oidc.clientSecret}}{{end}}
     
     {{end}}
     usernameClaim:

--- a/internal/service/auth_token_proxy.go
+++ b/internal/service/auth_token_proxy.go
@@ -212,7 +212,7 @@ func (p *AuthTokenProxy) findProviderForToken(ctx context.Context, providerName 
 			Issuer:        aapSpec.ApiUrl,
 			TokenEndpoint: tokenUrl,
 			ClientId:      aapSpec.ClientId,
-			UseBasicAuth:  true, // AAP requires Basic Auth for client credentials
+			UseBasicAuth:  aapSpec.ClientSecret != nil && *aapSpec.ClientSecret != "", // AAP requires Basic Auth for client credentials
 		}, aapSpec.ClientId, clientSecret, api.StatusOK()
 
 	default:
@@ -335,11 +335,8 @@ func (p *AuthTokenProxy) proxyTokenRequest(ctx context.Context, providerConfig *
 	req.Header.Set("Accept", "application/json, application/x-www-form-urlencoded")
 
 	// For providers using Basic Auth (like AAP), set the Authorization header
+	// Only use Basic Auth if UseBasicAuth is true
 	if providerConfig.UseBasicAuth {
-		if clientSecret == "" {
-			p.authN.GetLogger().Errorf("Token proxy: provider requires Basic Auth but client_secret is not configured")
-			return nil, fmt.Errorf("provider requires Basic Auth but client_secret is not configured")
-		}
 		req.SetBasicAuth(clientId, clientSecret)
 		p.authN.GetLogger().Debugf("Token proxy: using Basic Auth with client_id=%s", clientId)
 	}


### PR DESCRIPTION
fixes template to set proper empty values for clientSecret if these were not provided , 
additionally makes sure to proxy exchange without the basic auth if its a public client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client secret fields for authentication providers are now only included when values are provided, preventing empty entries in generated configurations.
  * Token request behavior for basic authentication has been tightened: activation is now tied to credential presence and missing secrets no longer cause runtime errors during token proxying.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->