### PR TITLE
EDM-2677: table now shows "" for non default

### DIFF
--- a/internal/cli/display/table.go
+++ b/internal/cli/display/table.go
@@ -423,7 +423,7 @@ func (f *TableFormatter) printAuthConfigProvidersTable(w *tabwriter.Writer, auth
 		issuer := NoneString
 		enabled := NoneString
 		name := NoneString
-		isDefault := NoneString
+		isDefault := ""
 		if ap.Metadata.Name != nil {
 			name = *ap.Metadata.Name
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Authentication provider table now shows an empty cell for non-default providers instead of placeholder text, creating a cleaner, less cluttered display.
  * The default provider continues to be highlighted distinctly, preserving clear identification while improving overall visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->