### PR TITLE
EDM-2709: Address race condition in services startup

### DIFF
--- a/deploy/podman/flightctl-certs-init.service
+++ b/deploy/podman/flightctl-certs-init.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Flight Control Certificates Initialization
 PartOf=flightctl.target
+# The db service initializes configuration (.global.baseDomain) this service relies on
+After=flightctl-db.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Currently a race can occur when the global.baseDomain has not been written but the pam issuer service config is templated (which relies on this value).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted service startup order so certificate initialization runs after the database service.
  * Added an inline comment clarifying reliance on the database configuration for certificate setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->