### PR TITLE
EDM-2193: Address Postgress Race Condition CVE

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.6'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24.6
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-alert-exporter
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alert-exporter-container" \

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-alertmanager-proxy
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-alertmanager-proxy-container" \

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-api
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-api-container" \

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as builder
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/Containerfile.db-setup
+++ b/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/Containerfile.lint
+++ b/Containerfile.lint
@@ -1,4 +1,4 @@
-FROM docker.io/golangci/golangci-lint:v1.61.0
+FROM docker.io/golangci/golangci-lint:v1.64.8
 
 # Install libvirt and TPM development packages
 USER root

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-periodic
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-periodic-container" \

--- a/Containerfile.telemetry-gateway
+++ b/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-telemetry-gateway
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-telemetry-gateway-container" \

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-userinfo-proxy
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-userinfo-proxy-container" \

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-worker
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-worker-container" \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.9
+toolchain go1.24.6
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/hack/Containerfile.ci_rpm_builder
+++ b/hack/Containerfile.ci_rpm_builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805
 
 USER 0
 

--- a/hack/build_flightctl-base.sh
+++ b/hack/build_flightctl-base.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE_TAG=9.6-1752500771
+IMAGE_TAG=9.6-1762316544
 
 container=$(buildah from registry.redhat.io/ubi9-micro:$IMAGE_TAG)
 

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.9
+toolchain go1.24.6
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,8 @@
 module github.com/flightctl/flightctl/tools
 
-go 1.23
+go 1.24.0
+
+toolchain go1.24.6
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2


### PR DESCRIPTION
Cherry pick of  [PR](https://github.com/flightctl/flightctl/pull/1921) resolves the security issue by upgrading to Go 1.24.6, which includes the official patch for CVE-2025-47907 (database/sql race condition during query cancellation).