### PR TITLE
EDM-2712: Mount ca bundle in api container and update docs

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -20,6 +20,7 @@ Volume=/etc/flightctl/pki/flightctl-api/server.crt:/root/.flightctl/certs/server
 Volume=/etc/flightctl/pki/flightctl-api/server.key:/root/.flightctl/certs/server.key:ro,z
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.crt:/root/.flightctl/certs/client-signer.crt:ro,z
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.key:/root/.flightctl/certs/client-signer.key:ro,z
+Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
 Volume=/etc/flightctl/flightctl-api/config.yaml:/root/.flightctl/config.yaml:ro,z
 
 Ulimit=nofile=300000:300000

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -37,9 +37,6 @@ global:
         - email
         - roles
       pamService: flightctl
-  organizations:
-    # Enable IdP-provided organizations support
-    enabled: false
 
 db:
   # external: Set to "enabled" to use external PostgreSQL database

--- a/docs/user/installing/configuring-auth/organizations.md
+++ b/docs/user/installing/configuring-auth/organizations.md
@@ -31,14 +31,6 @@ Multi-organization support requires a compatible identity provider. When enabled
 - Resources (devices, fleets, etc.) are scoped to specific organizations
 - Users can only access resources owned by their assigned organizations
 
-Organization support is enabled by setting a Helm configuration value (service-config value if using quadlets):
-
-```yaml
-global:
-  organizations:
-    enabled: true
-```
-
 > [!NOTE] Multi-organization deployments require a supported authentication provider (OIDC or AAP).
 
 ### Requirements for OIDC Organizations Integration


### PR DESCRIPTION
Addresses [EDM-2712](https://issues.redhat.com/browse/EDM-2712) - a failure to generate certificate requests due to being unable to load the ca bundle in quadlet deployments.

Also included is a configuration change (removing deprecated config) and a doc update for the new certs structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated docs with automated certificate generation, expanded PKI layout, guidance for custom/existing CAs, and auth-provider CA path.
  * Removed Helm example enabling organizations from documentation.

* **Bug Fixes / Ops**
  * API container now includes the CA bundle for runtime certificate verification.

* **Breaking Changes**
  * Multi-organization configuration option removed; review authentication setup if you relied on IdP-provided organizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->