### PR TITLE
EDM-2536: separate device systemd status

### DIFF
--- a/test/e2e/agent/agent_suite_test.go
+++ b/test/e2e/agent/agent_suite_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -12,6 +13,8 @@ import (
 const TIMEOUT = "5m"
 const POLLING = "125ms"
 const LONGTIMEOUT = "10m"
+const TENMINTIMEOUT = 10 * time.Minute
+const TENSECTIMEOUT = 10 * time.Second
 
 // Define a type for messages.
 type Message string

--- a/test/e2e/agent/agent_systemd_status_test.go
+++ b/test/e2e/agent/agent_systemd_status_test.go
@@ -2,7 +2,6 @@ package agent_test
 
 import (
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -16,7 +15,8 @@ import (
 
 var _ = Describe("VM Agent behavior during updates", func() {
 	var (
-		deviceId string
+		deviceId       string
+		chronydService = "chronyd.service"
 	)
 
 	BeforeEach(func() {
@@ -217,7 +217,7 @@ var _ = Describe("VM Agent behavior during updates", func() {
 				desc := fmt.Sprintf("Updating to desired renderedVersion: %d", expectedVersion)
 				By(fmt.Sprintf("Waiting for update %d to be picked up", specVersion))
 				harness.WaitForDeviceContents(deviceId, desc, func(device *v1beta1.Device) bool {
-					return isDeviceUpdateObserved(device, expectedVersion)
+					return e2e.IsDeviceUpdateObserved(device, expectedVersion)
 				}, TIMEOUT)
 				currentVersion = expectedVersion
 			}
@@ -467,6 +467,201 @@ var _ = Describe("VM Agent behavior during updates", func() {
 			})).To(MatchError(ContainSubstring("must be unique")))
 
 		})
+		It("reports systemd services and applications based on device spec", Label("sanity", "86238"), func() {
+			harness := e2e.GetWorkerHarness()
+
+			By("enrolling a fresh device")
+			GinkgoWriter.Printf("Enrolled device %s\n", deviceId)
+
+			startVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("configuring device.spec.systemd.matchPatterns to track chronyd.service")
+			err = harness.UpdateSystemdMatchPatterns(deviceId, []string{chronydService})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(harness.WaitForDeviceNewRenderedVersion(deviceId, startVersion+1)).To(Succeed())
+
+			By("configuring device.spec.applications with a simple inline compose application")
+			composeContent := `
+version: "3.8"
+services:
+  sleep:
+    image: quay.io/flightctl-tests/alpine:v1
+    command: ["sleep", "infinity"]
+`
+			inlineApp := v1beta1.InlineApplicationProviderSpec{
+				Inline: []v1beta1.ApplicationContent{
+					{
+						Content: &composeContent,
+						Path:    "podman-compose.yaml",
+					},
+				},
+			}
+			err = harness.UpdateApplication(true, deviceId, "my-compose-app", inlineApp, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(harness.WaitForDeviceNewRenderedVersion(deviceId, startVersion+2)).To(Succeed())
+
+			By("waiting for device status to report applications and systemd sections")
+			Eventually(func() bool {
+				resp, err := harness.GetDeviceWithStatusSystem(deviceId)
+				if err != nil || resp == nil || resp.JSON200 == nil {
+					return false
+				}
+
+				dev := resp.JSON200
+				if dev.Status == nil {
+					return false
+				}
+
+				// Applications must be present and non-empty
+				if len(dev.Status.Applications) == 0 {
+					return false
+				}
+
+				// Systemd must be present and non-empty
+				if dev.Status.Systemd == nil || len(*dev.Status.Systemd) == 0 {
+					return false
+				}
+
+				return true
+			}, TENMINTIMEOUT, TENSECTIMEOUT).Should(BeTrue())
+
+			// Fetch a fresh copy after the Eventually, now that we know it's populated
+			resp, err := harness.GetDeviceWithStatusSystem(deviceId)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp).ToNot(BeNil())
+			Expect(resp.JSON200).ToNot(BeNil())
+			dev := resp.JSON200
+
+			Expect(dev.Status).ToNot(BeNil())
+			Expect(dev.Status.Applications).ToNot(BeNil())
+			Expect(len(dev.Status.Applications)).To(BeNumerically(">=", 1))
+			Expect(dev.Status.Systemd).ToNot(BeNil())
+			Expect(len(*dev.Status.Systemd)).To(BeNumerically(">=", 1))
+
+			var chronydSeen bool
+			for _, unit := range *dev.Status.Systemd {
+				if unit.Unit == chronydService {
+					chronydSeen = true
+					By("verifying chronyd.service is reported as active/loaded")
+					Expect(unit.ActiveState).To(Equal(v1beta1.SystemdActiveStateActive))
+					Expect(unit.LoadState).To(Equal(v1beta1.SystemdLoadStateLoaded))
+				}
+			}
+			Expect(chronydSeen).To(BeTrue(), "chronyd.service should be reported in status.systemd")
+
+			By("Scenario 2: failing tracked service degrades summary and exposes failed systemd unit")
+
+			// 1. Make sure we start from Online summary
+			Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).
+				WithArguments(deviceId).
+				Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+
+			// 2. Stop and mask the tracked service on the worker VM to prevent auto-restarts
+			_, err = harness.VM.RunSSH(
+				[]string{"sudo", "systemctl", "mask", "--now", "chronyd.service"},
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to mask/stop chronyd.service on device VM")
+
+			// 3. Confirm chronyd eventually reports a non-active state
+			waitForChronydState := func() v1beta1.SystemdActiveStateType {
+				resp, err := harness.GetDeviceWithStatusSystem(deviceId)
+				if err != nil || resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil || resp.JSON200.Status.Systemd == nil {
+					return v1beta1.SystemdActiveStateUnknown
+				}
+				for _, u := range *resp.JSON200.Status.Systemd {
+					if u.Unit == chronydService {
+						return u.ActiveState
+					}
+				}
+				return v1beta1.SystemdActiveStateUnknown
+			}
+
+			Eventually(waitForChronydState, LONGTIMEOUT, POLLING).
+				Should(BeElementOf(
+					[]v1beta1.SystemdActiveStateType{
+						v1beta1.SystemdActiveStateFailed,
+						v1beta1.SystemdActiveStateInactive,
+					}),
+					"chronyd.service should be reported as failed or inactive after stop",
+				)
+
+			// 4. Verify systemd status entry for chronyd shows failure or inactive state
+			unitStatus := harness.WaitForSystemdUnitStatus(deviceId, chronydService, LONGTIMEOUT, POLLING)
+			Expect(unitStatus.Unit).To(Equal(chronydService))
+			Expect(unitStatus.ActiveState).To(BeElementOf(
+				[]v1beta1.SystemdActiveStateType{
+					v1beta1.SystemdActiveStateFailed,
+					v1beta1.SystemdActiveStateInactive,
+				}),
+				"chronyd.service should appear in status.systemd as failed or inactive when the service is stopped")
+
+			// 5. Cleanup: restore chronyd so later scenarios start from healthy state
+			_, _ = harness.VM.RunSSH(
+				[]string{"sudo", "systemctl", "unmask", "chronyd.service"},
+				nil,
+			)
+			_, err = harness.VM.RunSSH(
+				[]string{"sudo", "systemctl", "start", "chronyd.service"},
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to restart chronyd.service on device VM")
+
+			// Track a deliberately failing systemd service
+			const failingServiceName = "edge-test-fail.service"
+
+			By("creating a dummy failing systemd unit on the device")
+			err = e2e.CreateFailingServiceOnDevice(harness, failingServiceName)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("updating matchPatterns to include chronyd.service and the failing service")
+			err = harness.UpdateSystemdMatchPatterns(deviceId, []string{chronydService, failingServiceName})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for device status.systemd to include the failing unit (with loaded or not-found state)")
+			failUnit := harness.WaitForSystemdUnitStatus(deviceId, failingServiceName, TENMINTIMEOUT, TENSECTIMEOUT)
+			Expect(failUnit.LoadState).To(Or(Equal(v1beta1.SystemdLoadStateLoaded), Equal(v1beta1.SystemdLoadStateNotFound)))
+			GinkgoWriter.Printf("Failing unit status: active=%s, sub=%s, load=%s\n",
+				string(failUnit.ActiveState), failUnit.SubState, string(failUnit.LoadState))
+
+			// Unmonitored failing service does not appear in systemd list
+			const untrackedService = "rsyslog.service"
+
+			By("stopping an untracked service on the device (rsyslog.service)")
+			err = e2e.StopServiceOnDevice(harness, untrackedService)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying rsyslog.service does not appear in status.systemd when it is not in matchPatterns")
+			Consistently(func() bool {
+				resp, err := harness.GetDeviceWithStatusSystem(deviceId)
+				if err != nil || resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil || resp.JSON200.Status.Systemd == nil {
+					return true // No systemd status means service is not tracked
+				}
+				for _, unit := range *resp.JSON200.Status.Systemd {
+					if unit.Unit == untrackedService {
+						return false
+					}
+				}
+				return true
+			}, 3*TENSECTIMEOUT, TENSECTIMEOUT).Should(BeTrue(), "untracked rsyslog.service should not appear in status.systemd")
+
+			By("cleaning up: removing applications and systemd from spec and restoring services")
+			err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+				device.Spec.Applications = nil
+				device.Spec.Systemd = nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = e2e.RestoreServiceOnDevice(harness, "chronyd.service")
+			Expect(err).NotTo(HaveOccurred())
+			// Clean up the failing test service (don't try to restart it)
+			err = e2e.RemoveSystemdService(harness, failingServiceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e.RestoreServiceOnDevice(harness, untrackedService)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 	})
 })
 
@@ -481,30 +676,6 @@ var flightDemosHttpRepoConfig = v1beta1.HttpConfigProviderSpec{
 		Suffix:     nil,
 	},
 	Name: "flightctl-demos-cfg",
-}
-
-// returns true if the device is updating or has already updated to the expected version
-func isDeviceUpdateObserved(device *v1beta1.Device, expectedVersion int) bool {
-	version, err := e2e.GetRenderedVersion(device)
-	if err != nil {
-		GinkgoWriter.Printf("Failed to parse rendered version '%s': %v\n", device.Status.Config.RenderedVersion, err)
-		return false
-	}
-	// The update has already applied
-	if version == expectedVersion {
-		return true
-	}
-	cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
-	if cond == nil {
-		return false
-	}
-	// send another update if we're in this state
-	validReasons := []v1beta1.UpdateState{
-		v1beta1.UpdateStatePreparing,
-		v1beta1.UpdateStateReadyToUpdate,
-		v1beta1.UpdateStateApplyingUpdate,
-	}
-	return slices.Contains(validReasons, v1beta1.UpdateState(cond.Reason))
 }
 
 func newInlineConfigVersion(version int) v1beta1.ConfigProviderSpec {

--- a/test/harness/e2e/harness_systemd.go
+++ b/test/harness/e2e/harness_systemd.go
@@ -1,0 +1,206 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+)
+
+func CreateFailingServiceOnDevice(h *Harness, serviceName string) error {
+	GinkgoWriter.Printf("creating failing systemd service %s on device VM\n", serviceName)
+
+	unitPath := fmt.Sprintf("/etc/systemd/system/%s", serviceName)
+	unitContents := `[Unit]
+Description=Edge test failing service
+
+[Service]
+Type=simple
+ExecStart=/bin/false
+Restart=no
+
+[Install]
+WantedBy=multi-user.target`
+
+	cmd := fmt.Sprintf(`set -euo pipefail
+sudo -n tee %s >/dev/null <<'EOF'
+%s
+EOF
+sudo -n systemctl daemon-reload
+sudo -n systemctl enable %s
+sudo -n systemctl start %s
+`, unitPath, unitContents, serviceName, serviceName)
+
+	const maxRetries = 5
+	var stdoutBuf *bytes.Buffer
+	var err error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		stdoutBuf, err = h.VM.RunSSH([]string{"bash", "-lc", cmd}, nil)
+		if err == nil {
+			break
+		}
+		outStr := ""
+		if stdoutBuf != nil {
+			outStr = stdoutBuf.String()
+		}
+		GinkgoWriter.Printf("attempt %d/%d: CreateFailingServiceOnDevice failed: %v\nstdout: %s\n", attempt, maxRetries, err, outStr)
+		time.Sleep(time.Duration(200*attempt) * time.Millisecond)
+	}
+	if err != nil {
+		outStr := ""
+		if stdoutBuf != nil {
+			outStr = stdoutBuf.String()
+		}
+		GinkgoWriter.Printf("CreateFailingServiceOnDevice final failure, stdout: %s\n", outStr)
+	}
+	return err
+}
+
+func StopServiceOnDevice(h *Harness, serviceName string) error {
+	GinkgoWriter.Printf("stopping service %s on device VM\n", serviceName)
+	stdoutBuf, err := h.VM.RunSSH([]string{"sudo", "systemctl", "stop", serviceName}, nil)
+	if err != nil {
+		outStr := ""
+		if stdoutBuf != nil {
+			outStr = stdoutBuf.String()
+		}
+		// Skip failure if the unit is not loaded/present on the VM
+		if strings.Contains(outStr, fmt.Sprintf("Unit %s not loaded", serviceName)) ||
+			strings.Contains(err.Error(), fmt.Sprintf("Unit %s not loaded", serviceName)) {
+			GinkgoWriter.Printf("systemctl stop %s skipped: unit not loaded\n", serviceName)
+			return nil
+		}
+		GinkgoWriter.Printf("systemctl stop stdout: %s\n", outStr)
+	}
+	return err
+}
+
+func RestoreServiceOnDevice(h *Harness, serviceName string) error {
+	GinkgoWriter.Printf("restoring service %s on device VM\n", serviceName)
+	stdoutBuf, err := h.VM.RunSSH([]string{"sudo", "systemctl", "restart", serviceName}, nil)
+	if err != nil {
+		outStr := ""
+		if stdoutBuf != nil {
+			outStr = stdoutBuf.String()
+		}
+		if strings.Contains(outStr, fmt.Sprintf("Unit %s not found", serviceName)) ||
+			strings.Contains(outStr, fmt.Sprintf("Unit %s not loaded", serviceName)) ||
+			strings.Contains(err.Error(), fmt.Sprintf("Unit %s not found", serviceName)) ||
+			strings.Contains(err.Error(), fmt.Sprintf("Unit %s not loaded", serviceName)) {
+			GinkgoWriter.Printf("systemctl restart %s skipped: unit not present\n", serviceName)
+			return nil
+		}
+		GinkgoWriter.Printf("systemctl restart %s failed: %v, stdout: %s\n", serviceName, err, outStr)
+	}
+	return err
+}
+
+// RemoveSystemdService disables and removes a systemd unit file on the device and reloads systemd.
+func RemoveSystemdService(h *Harness, serviceName string) error {
+	GinkgoWriter.Printf("removing systemd service %s on device VM\n", serviceName)
+	cmd := fmt.Sprintf(`set -euo pipefail
+sudo -n systemctl disable %s
+sudo -n rm -f /etc/systemd/system/%s
+sudo -n systemctl daemon-reload
+`, serviceName, serviceName)
+
+	_, err := h.VM.RunSSH([]string{"bash", "-lc", cmd}, nil)
+	return err
+}
+
+// UpdateSystemdMatchPatterns applies the given match patterns to device.spec.systemd.
+func (h *Harness) UpdateSystemdMatchPatterns(deviceID string, patterns []string) error {
+	device, err := h.GetDevice(deviceID)
+	if err != nil {
+		return err
+	}
+
+	var specCopy v1beta1.DeviceSpec
+	if device.Spec != nil {
+		specCopy = *device.Spec
+	}
+
+	mpCopy := append([]string(nil), patterns...)
+	specCopy.Systemd = &struct {
+		MatchPatterns *[]string `json:"matchPatterns,omitempty"`
+	}{
+		MatchPatterns: &mpCopy,
+	}
+
+	metadata := device.Metadata
+	if metadata.Name == nil {
+		metadata.Name = &deviceID
+	}
+	// Drop server-managed fields that would be disallowed on apply
+	metadata.ResourceVersion = nil
+	metadata.Generation = nil
+	metadata.CreationTimestamp = nil
+
+	deviceToApply := v1beta1.Device{
+		ApiVersion: v1beta1.DeviceAPIVersion,
+		Kind:       v1beta1.DeviceKind,
+		Metadata:   metadata,
+		Spec:       &specCopy,
+	}
+
+	deviceYAML, err := yaml.Marshal(deviceToApply)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.CLIWithStdin(string(deviceYAML), "apply", "-f", "-")
+	return err
+}
+
+// WaitForSystemdUnitsLen waits until status.systemd has the expected number of units.
+// Returns the final length for convenience.
+func (h *Harness) WaitForSystemdUnitsLen(deviceID string, expectedLen int, timeout, polling any) int {
+	length := -1
+
+	Eventually(func() int {
+		resp, err := h.GetDeviceWithStatusSystem(deviceID)
+		if err != nil || resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil {
+			length = -1
+			return length
+		}
+		if resp.JSON200.Status.Systemd == nil {
+			length = 0
+			return length
+		}
+		length = len(*resp.JSON200.Status.Systemd)
+		return length
+	}, timeout, polling).Should(Equal(expectedLen))
+
+	return length
+}
+
+// WaitForSystemdUnitStatus waits until the requested unit appears in status.systemd and returns it.
+// timeout and polling mirror Gomega Eventually args (string or time.Duration).
+func (h *Harness) WaitForSystemdUnitStatus(deviceID, unitName string, timeout, polling any) v1beta1.SystemdUnitStatus {
+	var unitStatus v1beta1.SystemdUnitStatus
+
+	Eventually(func() error {
+		resp, err := h.GetDeviceWithStatusSystem(deviceID)
+		if err != nil {
+			return err
+		}
+		if resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil || resp.JSON200.Status.Systemd == nil {
+			return fmt.Errorf("systemd status not populated yet")
+		}
+
+		for _, u := range *resp.JSON200.Status.Systemd {
+			if u.Unit == unitName {
+				unitStatus = u
+				return nil
+			}
+		}
+		return fmt.Errorf("%s not found in status.systemd", unitName)
+	}, timeout, polling).Should(Succeed())
+
+	return unitStatus
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end test harness for managing systemd services on devices (SSH-backed operations, retries, polling, lifecycle controls).
  * Added standardized longer e2e timeouts and a device-update observation helper.
  * New comprehensive scenario validating systemd service and application status reporting, dynamic pattern changes, failure simulation, masking/untracking, and cleanup.

Note: Testing infrastructure changes only; no direct impact on end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->