### PR TITLE
EDM-2723: agent/status: ensure timeout

### DIFF
--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -33,6 +33,20 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 > The `/etc/flightctl/conf.d/` drop-in directory supports only a subset of the agent configuration. Currently supported keys include:
 > `log-level`, `system-info`, `system-info-custom`, and `system-info-timeout`.
 
+## Communication Timeouts
+
+The agent uses the following internal timeouts when communicating with the Flight Control service:
+
+| Operation | Timeout | Description |
+| --------- | ------- | ----------- |
+| Spec fetch (long-poll) | 4 minutes | The agent uses long-polling to fetch device specification updates. The server holds the connection open until a new specification is available or the timeout expires. |
+| Status update | 60 seconds | Timeout for pushing device status updates to the service. If the update times out, the agent retries on the next status sync interval. |
+
+These timeouts are not configurable. The spec fetch timeout is intentionally long to support efficient long-polling, while the status update timeout is shorter to ensure timely retries within the configured `status-update-interval`.
+
+> [!NOTE]
+> If a status update fails (including timeout), the agent preserves the pending status and automatically retries on the next sync cycle. This ensures status updates are eventually delivered even during transient network issues.
+
 ## Built-in system info collectors
 
 The agent has a set of built-in collectors for system information. You can see the information collected by these collectors using the following command:

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -93,7 +93,7 @@ func TestSync(t *testing.T) {
 					mockResourceManager.EXPECT().BeforeUpdate(ctx, desired.Spec).Return(nil),
 					mockSpecManager.EXPECT().CheckPolicy(ctx, policy.Download, desired.Version()).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 					mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()),
 					mockSpecManager.EXPECT().IsOSUpdate().Return(false),
 					mockPrefetchManager.EXPECT().BeforeUpdate(ctx, current.Spec, desired.Spec).Return(nil),
@@ -101,9 +101,9 @@ func TestSync(t *testing.T) {
 					mockHookManager.EXPECT().OnBeforeUpdating(ctx, current.Spec, desired.Spec).Return(nil),
 					mockSpecManager.EXPECT().CheckPolicy(ctx, policy.Update, desired.Version()).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 					mockHookManager.EXPECT().Sync(current.Spec, desired.Spec).Return(nil),
 					mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil),
 					mockLifecycleManager.EXPECT().Sync(ctx, current.Spec, desired.Spec).Return(nil),
@@ -115,7 +115,7 @@ func TestSync(t *testing.T) {
 					//
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
 					mockSpecManager.EXPECT().SetUpgradeFailed(desired.Version()).Return(nil),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 					mockSpecManager.EXPECT().Rollback(ctx).Return(nil),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
 					mockHookManager.EXPECT().Sync(desired.Spec, current.Spec).Return(nil),
@@ -126,7 +126,7 @@ func TestSync(t *testing.T) {
 					mockHookManager.EXPECT().OnAfterUpdating(ctx, desired.Spec, current.Spec, false).Return(nil),
 					mockAppManager.EXPECT().AfterUpdate(ctx).Return(nil),
 					mockPrefetchManager.EXPECT().Cleanup(),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 					//
 					// resync steady state current 0 desired 0
 					//
@@ -262,7 +262,7 @@ func TestRollbackDevice(t *testing.T) {
 				mockManagementClient *client.MockManagement,
 			) {
 				gomock.InOrder(
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 				)
 			},
 		},
@@ -276,7 +276,7 @@ func TestRollbackDevice(t *testing.T) {
 				mockManagementClient *client.MockManagement,
 			) {
 				gomock.InOrder(
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 				)
 			},
 		},
@@ -291,7 +291,7 @@ func TestRollbackDevice(t *testing.T) {
 			) {
 				gomock.InOrder(
 					// mockSystemInfoManager.EXPECT().BootID().Return("boot-id"),
-					mockManagementClient.EXPECT().UpdateDeviceStatus(ctx, deviceName, gomock.Any()).Return(nil),
+					mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil),
 				)
 			},
 			wantSyncErr: errors.New("sync error"),


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent communication timeouts: 4-minute spec fetch (long-poll) and 60-second status update timeout; describes retry and preservation behavior.

* **Bug Fixes**
  * Improved status update reliability with enforced timeouts, clearer retry behavior on failures, and preservation of pending status between sync cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->