### PR TITLE
EDM-2628: Add additional context to version command when config file …

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -34,6 +34,7 @@ const (
 
 	errReadingVersion = "Could not read server version"
 	errUnmarshalling  = "Could not unmarshal server response"
+	errNotLoggedIn    = "You must log in to view the server version. Please use the 'login' command to authenticate before proceeding"
 )
 
 func DefaultVersionOptions() *VersionOptions {
@@ -156,7 +157,14 @@ func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 
 	// Don't treat it as error if the server cannot be reached, just print the message.
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		if _, statErr := os.Stat(o.ConfigFilePath); os.IsNotExist(statErr) {
+			if o.Output == "" {
+				fmt.Printf("%s: %s\n", serviceVersionTitle, errReadingVersion)
+			}
+			fmt.Fprintf(os.Stderr, "%s\n", errNotLoggedIn)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, when a user was not logged in (e.g. no ~/.config/flightctl/client.yaml) a relatively unclear message was printed when the service version fetch failed.  This PR modifies the output in unstructured cases to print a login hint.

Previous usage:
```
$ flightctl version
Client Version: v1.0.0-main-611-gbecfe961-dirty
reading config: open /home/sserafin/.config/flightctl/client.yaml: no such file or directory
```

New usage (unstructured output)
```
$ flightctl version
Client Version: v1.0.0-main-611-gbecfe961-dirty
Server Version: Could not read server version
You must log in to view the server version. Please use the 'login' command to authenticate before proceeding

```
New usage (structured output)
```
$ flightctl version --output yaml
clientVersion:
  buildDate: "20251202"
  compiler: gc
  gitCommit: becfe961
  gitTreeState: dirty
  gitVersion: v1.0.0-main-611-gbecfe961
  goVersion: go1.24.6
  major: "1"
  minor: "0"
  patch: "0"
  platform: linux/amd64
You must log in to view the server version. Please use the 'login' command to authenticate before proceeding
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when the server version cannot be retrieved: if configuration is missing or the server is unreachable, users now receive a clear instruction to log in and a concise header indicating the read error.
  * Preserved existing success and formatted output behavior for version requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->