### PR TITLE
EDM-2729: helm: fix nil ui port

### DIFF
--- a/deploy/helm/flightctl/values.dev.yaml
+++ b/deploy/helm/flightctl/values.dev.yaml
@@ -61,6 +61,7 @@ dev:
   nodePorts:
     api: 3443
     agent: 7443
+    ui: 9000
     db: 5432
     kv: 6379
     alertmanager: 9093

--- a/deploy/helm/flightctl/values.nodeport.yaml
+++ b/deploy/helm/flightctl/values.nodeport.yaml
@@ -3,6 +3,7 @@ dev:
   nodePorts:
     api: 3443
     agent: 7443
+    ui: 9000
     db: 5432
     kv: 6379
     alertmanager: 9093


### PR DESCRIPTION
```
http://192.168.1.42.nip.io:<nil>/enroll/45v9fcecfr2sq20s2g54gj8492rstvrg89d3psl435u50cd7fv7
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development environment updated to expose the UI service on port 9000, adding it to the set of development node ports and making the UI reachable on that port during local/dev runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->