### PR TITLE
EDM-2731: Allow cli-artifacts to be exposed by NodePorts

### DIFF
--- a/deploy/helm/flightctl/values.dev.yaml
+++ b/deploy/helm/flightctl/values.dev.yaml
@@ -66,6 +66,7 @@ dev:
     kv: 6379
     alertmanager: 9093
     alertmanagerProxy: 8443
+    cliArtifacts: 8090
     telemetryGatewayOtlp: 4317
     telemetryGatewayProm: 9464
     gitserver: 3222

--- a/deploy/helm/flightctl/values.nodeport.yaml
+++ b/deploy/helm/flightctl/values.nodeport.yaml
@@ -8,6 +8,7 @@ dev:
     kv: 6379
     alertmanager: 9093
     alertmanagerProxy: 8443
+    cliArtifacts: 8090
     telemetryGatewayOtlp: 4317
     telemetryGatewayProm: 9464
     gitserver: 3222


### PR DESCRIPTION
The cliArtifacts service was the only one that did not have nodePort mapping.
Unified so it behaves like the rest of the services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CLI artifacts port (8090) to the development environment configuration, exposing the CLI artifacts service.
  * Reorganized development node port mappings by relocating the registry entry to the end of the node ports block for clearer ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->