### PR TITLE
NO-ISSUE: Fix packit version selection

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,7 +16,7 @@ packages:
         message: "/packit build"
 actions:
   get-current-version:
-    - bash -c '(git describe --tags --match "v*-main" || git describe --tags) | sed "s/^v//; s/-/~/g"'
+    - bash -c 'git describe --first-parent --tags --match "v*" | sed "s/^v//; s/-/~/g"'
 jobs:
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
Fixes problem that the way the current version is obtained in  the `.packit.yaml` may pick tags from a different branch than the current and so get the wrong version.