### PR TITLE
EDM-2628: Add additional context to version command when config file …

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -34,6 +34,7 @@ const (
 
 	errReadingVersion = "Could not read server version"
 	errUnmarshalling  = "Could not unmarshal server response"
+	errNotLoggedIn    = "You must log in to view the server version. Please use the 'login' command to authenticate before proceeding"
 )
 
 func DefaultVersionOptions() *VersionOptions {
@@ -156,7 +157,14 @@ func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 
 	// Don't treat it as error if the server cannot be reached, just print the message.
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		if _, statErr := os.Stat(o.ConfigFilePath); os.IsNotExist(statErr) {
+			if o.Output == "" {
+				fmt.Printf("%s: %s\n", serviceVersionTitle, errReadingVersion)
+			}
+			fmt.Fprintf(os.Stderr, "%s\n", errNotLoggedIn)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
…is missing

(cherry picked from commit 4e19d4e6fa92415a5fbcbcb8951e469c62cd631a)