### PR TITLE
EDM-2402: Add opt out functionality for quadlet cert generation

### DIFF
--- a/deploy/podman/flightctl-certs-init.service
+++ b/deploy/podman/flightctl-certs-init.service
@@ -9,7 +9,7 @@ Type=oneshot
 RemainAfterExit=true
 Restart=on-failure
 RestartSec=5s
-ExecStart=/bin/bash -c 'BASE_DOMAIN=$(python3 /usr/share/flightctl/yaml_helpers.py extract .global.baseDomain /etc/flightctl/service-config.yaml); /usr/share/flightctl/generate-certificates.sh --cert-dir /etc/flightctl/pki --api-san "$BASE_DOMAIN"'
+ExecStart=/usr/share/flightctl/init_certs.sh
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -1,5 +1,9 @@
 global:
   baseDomain:
+  # Certificate generation method - 'none' or 'builtin'
+  # - none: Do not generate certificates. User must provide certs in /etc/flightctl/pki/ or the service will fail to start.
+  # - builtin: Generate required certificates using openssl (default)
+  generateCertificates: builtin
   auth:
     type: oidc # oidc, aap, oauth2, or none
     insecureSkipTlsVerify: true

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/flightctl/service-config.yaml"
+CERT_DIR="/etc/flightctl/pki"
+YAML_HELPER="/usr/share/flightctl/yaml_helpers.py"
+
+CERT_METHOD=$(python3 "$YAML_HELPER" extract .global.generateCertificates "$CONFIG_FILE")
+if [ "$CERT_METHOD" = "builtin" ]; then
+    echo "Certificate generation enabled - creating certificates using openssl"
+else
+    echo "Certificate generation disabled - skipping certificate creation"
+    exit 0
+fi
+
+# Generate certificates
+BASE_DOMAIN=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
+/usr/share/flightctl/generate-certificates.sh --cert-dir "$CERT_DIR" --api-san "$BASE_DOMAIN"

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -76,6 +76,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCopyFile, Source: "deploy/scripts/init_host.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "init_host.sh"), Template: false, Mode: ExecutableFileMode},
 		{Action: ActionCopyFile, Source: "deploy/scripts/secrets.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "secrets.sh"), Template: false, Mode: ExecutableFileMode},
 		{Action: ActionCopyFile, Source: "deploy/scripts/yaml_helpers.py", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "yaml_helpers.py"), Template: false, Mode: RegularFileMode},
+		{Action: ActionCopyFile, Source: "deploy/scripts/init_certs.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "init_certs.sh"), Template: false, Mode: ExecutableFileMode},
 
 		// Standalone binary
 		{Action: ActionCopyFile, Source: "bin/flightctl-standalone", Destination: filepath.Join(config.BinOutputDir, "flightctl-standalone"), Template: false, Mode: ExecutableFileMode},

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -687,6 +687,7 @@ rm -rf /usr/share/sosreport
 
     # Handle permissions for scripts setting host config
     %attr(0755,root,root) %{_datadir}/flightctl/init_host.sh
+    %attr(0755,root,root) %{_datadir}/flightctl/init_certs.sh
     %attr(0755,root,root) %{_datadir}/flightctl/secrets.sh
     %attr(0755,root,root) %{_datadir}/flightctl/yaml_helpers.py
     %attr(0755,root,root) %{_datadir}/flightctl/generate-certificates.sh


### PR DESCRIPTION
Mirrors [generateCertificates](https://github.com/flightctl/flightctl/blob/main/deploy/helm/flightctl/values.yaml#L15) flag available in the helm values.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control certificate generation (builtin or disabled).

* **Chores**
  * Certificate initialization now runs via a dedicated init script for clearer control flow.
  * Deployment and packaging updated to install and use the new initialization script.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->