### PR TITLE
[Backport] EDM-2720: Agent fails to start if version is missing (audit logger)

### DIFF
--- a/internal/agent/device/spec/audit/logger.go
+++ b/internal/agent/device/spec/audit/logger.go
@@ -43,7 +43,7 @@ func NewFileLogger(
 		return nil, fmt.Errorf("deviceID is required")
 	}
 	if agentVersion == "" {
-		return nil, fmt.Errorf("agentVersion is required")
+		agentVersion = "unknown"
 	}
 	if log == nil {
 		return nil, fmt.Errorf("logger is required")

--- a/internal/agent/device/spec/audit/logger_test.go
+++ b/internal/agent/device/spec/audit/logger_test.go
@@ -95,6 +95,27 @@ func TestNewFileLogger(t *testing.T) {
 	}
 }
 
+func TestNewFileLogger_EmptyAgentVersionUsesUnknown(t *testing.T) {
+	require := require.New(t)
+
+	// Create temp directory for test
+	tempDir := t.TempDir()
+	readWriter := fileio.NewReadWriter(fileio.WithTestRootDir(tempDir))
+
+	config := NewDefaultAuditConfig()
+	logger := log.NewPrefixLogger("test")
+
+	// Empty agentVersion should use "unknown" fallback instead of failing
+	auditLogger, err := NewFileLogger(config, readWriter, "test-device", "", logger)
+	require.NoError(err)
+	require.NotNil(auditLogger)
+	require.Equal("unknown", auditLogger.agentVersion)
+
+	defer func() {
+		_ = auditLogger.Close()
+	}()
+}
+
 func TestFileLogger_LogEventApply(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()


### PR DESCRIPTION
### Summary

Backport of #2123 to `release-1.0`.

### Problem

The agent fails to start when the `agentVersion` is empty (which can occur with certain RPM build configurations). The audit logger initialization throws a fatal error:
`level=fatal msg="running device agent: failed to create audit logger: agentVersion is required"`

### Solution

Use `"unknown"` as a fallback when `agentVersion` is empty instead of returning an error.

### Changes

- `internal/agent/device/spec/audit/logger.go`: Add fallback for empty `agentVersion`
- `internal/agent/device/spec/audit/logger_test.go`: Add test coverage for the fallback

### Original PR

- Main branch PR: #2123
- Original commit: 7ac440782f201a453d16313bf8a539014ae8c85f
