### PR TITLE
EDM-2739: added validation for oauth2/oidc with static role assignment - only known external roles are allowed

### DIFF
--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -117,6 +117,8 @@ const (
 	RoleInstaller = "installer" // Limited access for device installation
 )
 
+var KnownExternalRoles = []string{ExternalRoleAdmin, ExternalRoleOrgAdmin, ExternalRoleOperator, ExternalRoleViewer, ExternalRoleInstaller}
+
 type UpdateState string
 
 const (

--- a/api/v1beta1/validation.go
+++ b/api/v1beta1/validation.go
@@ -1735,6 +1735,9 @@ func (a AuthStaticRoleAssignment) Validate(ctx context.Context) []error {
 		if role == "" {
 			allErrs = append(allErrs, fmt.Errorf("role at index %d cannot be empty", i))
 		}
+		if !slices.Contains(KnownExternalRoles, role) {
+			allErrs = append(allErrs, fmt.Errorf("role at index %d is not a valid role: %s", i, role))
+		}
 	}
 
 	return allErrs

--- a/api/v1beta1/validation_test.go
+++ b/api/v1beta1/validation_test.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"context"
 	"encoding/base64"
 	"strings"
 	"testing"
@@ -1706,6 +1707,105 @@ ExecStart=/usr/bin/myapp`,
 			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
 			if tt.wantErrSubstr != "" && len(errs) > 0 {
 				require.Contains(errs[0].Error(), tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestAuthStaticRoleAssignment_Validate(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		assignment AuthStaticRoleAssignment
+		wantErrs   int
+		errSubstrs []string
+	}{
+		{
+			name: "empty roles list",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{},
+			},
+			wantErrs:   1,
+			errSubstrs: []string{"at least one role is required"},
+		},
+		{
+			name: "invalid custom role",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, ExternalRoleViewer, "custom-role"},
+			},
+			wantErrs:   1,
+			errSubstrs: []string{"is not a valid role"},
+		},
+		{
+			name: "valid known roles",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, ExternalRoleViewer, ExternalRoleOperator},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "invalid role",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, "invalid-role"},
+			},
+			wantErrs:   1,
+			errSubstrs: []string{"is not a valid role"},
+		},
+		{
+			name: "empty role string",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, ""},
+			},
+			wantErrs:   2,
+			errSubstrs: []string{"cannot be empty", "is not a valid role"},
+		},
+		{
+			name: "all known external roles",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, ExternalRoleOrgAdmin, ExternalRoleOperator, ExternalRoleViewer, ExternalRoleInstaller},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "multiple invalid roles",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{"invalid-role-1", "invalid-role-2"},
+			},
+			wantErrs:   2,
+			errSubstrs: []string{"is not a valid role", "is not a valid role"},
+		},
+		{
+			name: "mix of valid and invalid roles",
+			assignment: AuthStaticRoleAssignment{
+				Type:  AuthStaticRoleAssignmentTypeStatic,
+				Roles: []string{ExternalRoleAdmin, "invalid-role", ExternalRoleViewer},
+			},
+			wantErrs:   1,
+			errSubstrs: []string{"is not a valid role"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.assignment.Validate(ctx)
+			require.Len(errs, tt.wantErrs, "expected %d errors, got %d: %v", tt.wantErrs, len(errs), errs)
+
+			if len(tt.errSubstrs) > 0 {
+				require.Equal(len(tt.errSubstrs), len(errs), "number of error substrings (%d) must match number of actual errors (%d)", len(tt.errSubstrs), len(errs))
+				for i, substr := range tt.errSubstrs {
+					if i < len(errs) {
+						require.Contains(errs[i].Error(), substr, "error at index %d should contain %q", i, substr)
+					}
+				}
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -710,13 +711,104 @@ func Validate(cfg *Config) error {
 			return fmt.Errorf("readinessPath and livenessPath must not be identical")
 		}
 	}
+
+	// Validate OIDC and OAuth2 provider role assignments
+	if cfg.Auth != nil {
+		if cfg.Auth.OIDC != nil {
+			if err := validateAuthProviderRoleAssignment(cfg.Auth.OIDC.RoleAssignment, string(api.Oidc)); err != nil {
+				return err
+			}
+		}
+		if cfg.Auth.OAuth2 != nil {
+			if err := validateAuthProviderRoleAssignment(cfg.Auth.OAuth2.RoleAssignment, string(api.Oauth2)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateAuthProviderRoleAssignment(roleAssignment api.AuthRoleAssignment, providerType string) error {
+	discriminator, err := roleAssignment.Discriminator()
+	if err != nil {
+		// No role assignment configured, which is valid
+		return nil
+	}
+
+	if discriminator != string(api.AuthStaticRoleAssignmentTypeStatic) {
+		// Only validate static role assignments
+		return nil
+	}
+
+	staticAssignment, err := roleAssignment.AsAuthStaticRoleAssignment()
+	if err != nil {
+		return fmt.Errorf("%s provider: invalid static role assignment: %w", providerType, err)
+	}
+
+	// Validate that all roles are in KnownExternalRoles
+	for i, role := range staticAssignment.Roles {
+		if role == "" {
+			return fmt.Errorf("%s provider: role at index %d cannot be empty", providerType, i)
+		}
+		if !slices.Contains(api.KnownExternalRoles, role) {
+			return fmt.Errorf("%s provider: role at index %d is not a valid role: %s (must be one of: %v)", providerType, i, role, api.KnownExternalRoles)
+		}
+	}
+
 	return nil
 }
 
 func (cfg *Config) String() string {
-	contents, err := json.Marshal(cfg)
+	// Create a sanitized copy to avoid mutating the original config
+	sanitized := cfg.sanitizeForLogging()
+	contents, err := json.Marshal(sanitized)
 	if err != nil {
 		return "<error>"
 	}
 	return string(contents)
+}
+
+// sanitizeForLogging creates a copy of the config with sensitive fields redacted
+func (cfg *Config) sanitizeForLogging() *Config {
+	if cfg == nil {
+		return nil
+	}
+
+	// Create a deep copy by marshaling and unmarshaling
+	// This is safe because SecureString already handles redaction in MarshalJSON
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return cfg
+	}
+
+	var sanitized Config
+	if err := json.Unmarshal(cfgJSON, &sanitized); err != nil {
+		return cfg
+	}
+
+	// Redact client secrets in all auth providers
+	if sanitized.Auth != nil {
+		if sanitized.Auth.OIDC != nil && sanitized.Auth.OIDC.ClientSecret != nil {
+			redacted := "[REDACTED]"
+			sanitized.Auth.OIDC.ClientSecret = &redacted
+		}
+		if sanitized.Auth.OAuth2 != nil && sanitized.Auth.OAuth2.ClientSecret != nil {
+			redacted := "[REDACTED]"
+			sanitized.Auth.OAuth2.ClientSecret = &redacted
+		}
+		if sanitized.Auth.OpenShift != nil && sanitized.Auth.OpenShift.ClientSecret != nil {
+			redacted := "[REDACTED]"
+			sanitized.Auth.OpenShift.ClientSecret = &redacted
+		}
+		if sanitized.Auth.AAP != nil && sanitized.Auth.AAP.ClientSecret != nil {
+			redacted := "[REDACTED]"
+			sanitized.Auth.AAP.ClientSecret = &redacted
+		}
+		if sanitized.Auth.PAMOIDCIssuer != nil && sanitized.Auth.PAMOIDCIssuer.ClientSecret != "" {
+			sanitized.Auth.PAMOIDCIssuer.ClientSecret = "[REDACTED]"
+		}
+	}
+
+	return &sanitized
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,9 @@ package config
 import (
 	"strings"
 	"testing"
+
+	api "github.com/flightctl/flightctl/api/v1beta1"
+	"github.com/samber/lo"
 )
 
 func TestConfig_String_ObfuscatesSensitiveData(t *testing.T) {
@@ -48,5 +51,155 @@ func TestConfig_String_ObfuscatesSensitiveData(t *testing.T) {
 	}
 	if !strings.Contains(result, "testuser") {
 		t.Error("Non-sensitive username should be preserved")
+	}
+}
+
+func TestConfig_String_RedactsAuthClientSecrets(t *testing.T) {
+	oidcSecret := "oidc-secret-123"
+	oauth2Secret := "oauth2-secret-456" //nolint:gosec // G101: These are test values, not real credentials
+	openshiftSecret := "openshift-secret-789"
+	aapSecret := "aap-secret-abc"
+	pamSecret := "pam-secret-xyz"
+
+	cfg := &Config{
+		Auth: &authConfig{
+			OIDC: &api.OIDCProviderSpec{
+				ProviderType: api.Oidc,
+				Issuer:       "https://example.com",
+				ClientId:     "test-client-id",
+				ClientSecret: &oidcSecret,
+			},
+			OAuth2: &api.OAuth2ProviderSpec{
+				ProviderType:     api.Oauth2,
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				UserinfoUrl:      "https://example.com/userinfo",
+				ClientId:         "test-client-id",
+				ClientSecret:     &oauth2Secret,
+			},
+			OpenShift: &api.OpenShiftProviderSpec{
+				ProviderType:           api.Openshift,
+				ClusterControlPlaneUrl: lo.ToPtr("https://api.example.com"),
+				AuthorizationUrl:       lo.ToPtr("https://example.com/auth"),
+				ClientId:               lo.ToPtr("test-client-id"),
+				ClientSecret:           &openshiftSecret,
+			},
+			AAP: &api.AapProviderSpec{
+				ProviderType:     api.Aap,
+				ApiUrl:           "https://aap.example.com",
+				AuthorizationUrl: "https://aap.example.com/auth",
+				ClientId:         "test-client-id",
+				ClientSecret:     &aapSecret,
+			},
+			PAMOIDCIssuer: &PAMOIDCIssuer{
+				Issuer:       "https://pam.example.com",
+				ClientID:     "pam-client-id",
+				ClientSecret: pamSecret,
+				PAMService:   "flightctl",
+			},
+		},
+	}
+
+	result := cfg.String()
+
+	// Verify all client secrets are redacted
+	if strings.Contains(result, oidcSecret) {
+		t.Error("OIDC client secret should be redacted")
+	}
+	if strings.Contains(result, oauth2Secret) {
+		t.Error("OAuth2 client secret should be redacted")
+	}
+	if strings.Contains(result, openshiftSecret) {
+		t.Error("OpenShift client secret should be redacted")
+	}
+	if strings.Contains(result, aapSecret) {
+		t.Error("AAP client secret should be redacted")
+	}
+	if strings.Contains(result, pamSecret) {
+		t.Error("PAM OIDC issuer client secret should be redacted")
+	}
+
+	// Verify redaction markers are present
+	if !strings.Contains(result, "[REDACTED]") {
+		t.Error("String() should contain [REDACTED] markers")
+	}
+
+	// Verify non-sensitive data is preserved
+	if !strings.Contains(result, "test-client-id") {
+		t.Error("Non-sensitive client ID should be preserved")
+	}
+	if !strings.Contains(result, "https://example.com") {
+		t.Error("Non-sensitive issuer URL should be preserved")
+	}
+}
+
+func TestConfig_String_DoesNotMutateOriginal(t *testing.T) {
+	oidcSecret := "original-secret"
+	cfg := &Config{
+		Auth: &authConfig{
+			OIDC: &api.OIDCProviderSpec{
+				ProviderType: api.Oidc,
+				Issuer:       "https://example.com",
+				ClientId:     "test-client-id",
+				ClientSecret: &oidcSecret,
+			},
+		},
+	}
+
+	// Call String() multiple times
+	_ = cfg.String()
+	_ = cfg.String()
+
+	// Verify original config is not mutated
+	if cfg.Auth.OIDC.ClientSecret == nil {
+		t.Fatal("Original client secret pointer should not be nil")
+	}
+	if *cfg.Auth.OIDC.ClientSecret != oidcSecret {
+		t.Errorf("Original client secret should not be mutated, got: %s, want: %s", *cfg.Auth.OIDC.ClientSecret, oidcSecret)
+	}
+}
+
+func TestConfig_String_HandlesNilAuthConfig(t *testing.T) {
+	cfg := &Config{
+		Database: &dbConfig{
+			Type:     "pgsql",
+			Hostname: "localhost",
+		},
+		Auth: nil,
+	}
+
+	result := cfg.String()
+
+	// Should not panic and should still produce valid JSON
+	if !strings.Contains(result, "localhost") {
+		t.Error("Should handle nil auth config gracefully")
+	}
+}
+
+func TestConfig_String_HandlesNilClientSecrets(t *testing.T) {
+	cfg := &Config{
+		Auth: &authConfig{
+			OIDC: &api.OIDCProviderSpec{
+				ProviderType: api.Oidc,
+				Issuer:       "https://example.com",
+				ClientId:     "test-client-id",
+				ClientSecret: nil, // No secret configured
+			},
+			OAuth2: &api.OAuth2ProviderSpec{
+				ProviderType:     api.Oauth2,
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				UserinfoUrl:      "https://example.com/userinfo",
+				ClientId:         "test-client-id",
+				ClientSecret:     nil, // No secret configured
+			},
+		},
+	}
+
+	result := cfg.String()
+
+	// Should not panic with nil secrets
+	if !strings.Contains(result, "test-client-id") {
+		t.Error("Should handle nil client secrets gracefully")
 	}
 }

--- a/test/integration/service/authprovider_test.go
+++ b/test/integration/service/authprovider_test.go
@@ -294,7 +294,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -337,7 +337,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -532,7 +532,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -577,7 +577,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -621,7 +621,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -666,7 +666,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -778,7 +778,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -887,7 +887,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1065,7 +1065,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1124,7 +1124,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1184,7 +1184,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1250,7 +1250,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1327,7 +1327,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1377,7 +1377,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -1434,7 +1434,7 @@ var _ = Describe("AuthProvider Service Integration Tests", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/integration/store/authprovider_test.go
+++ b/test/integration/store/authprovider_test.go
@@ -63,7 +63,7 @@ var _ = Describe("AuthProviderStore", func() {
 		roleAssignment := api.AuthRoleAssignment{}
 		staticRoleAssignment := api.AuthStaticRoleAssignment{
 			Type:  api.AuthStaticRoleAssignmentTypeStatic,
-			Roles: []string{"viewer"},
+			Roles: []string{api.ExternalRoleViewer},
 		}
 		err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 		Expect(err).ToNot(HaveOccurred())
@@ -355,7 +355,7 @@ var _ = Describe("AuthProviderStore", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -397,7 +397,7 @@ var _ = Describe("AuthProviderStore", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())
@@ -440,7 +440,7 @@ var _ = Describe("AuthProviderStore", func() {
 			roleAssignment := api.AuthRoleAssignment{}
 			staticRoleAssignment := api.AuthStaticRoleAssignment{
 				Type:  api.AuthStaticRoleAssignmentTypeStatic,
-				Roles: []string{"viewer"},
+				Roles: []string{api.ExternalRoleViewer},
 			}
 			err = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -306,7 +306,7 @@ func ReturnTestAuthProvider(orgId uuid.UUID, name string, issuer string, labels 
 	roleAssignment := api.AuthRoleAssignment{}
 	staticRoleAssignment := api.AuthStaticRoleAssignment{
 		Type:  api.AuthStaticRoleAssignmentTypeStatic,
-		Roles: []string{"viewer"},
+		Roles: []string{api.ExternalRoleViewer},
 	}
 	if err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment); err != nil {
 		panic(fmt.Sprintf("failed to create role assignment: %v", err))
@@ -436,7 +436,7 @@ func CreateTestAuthProviderWithDynamicOrg(ctx context.Context, authStore store.A
 	roleAssignment := api.AuthRoleAssignment{}
 	staticRoleAssignment := api.AuthStaticRoleAssignment{
 		Type:  api.AuthStaticRoleAssignmentTypeStatic,
-		Roles: []string{"viewer"},
+		Roles: []string{api.ExternalRoleViewer},
 	}
 	if err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment); err != nil {
 		log.Fatalf("failed to create role assignment: %v", err)
@@ -487,7 +487,7 @@ func CreateTestAuthProviderWithPerUserOrg(ctx context.Context, authStore store.A
 	roleAssignment := api.AuthRoleAssignment{}
 	staticRoleAssignment := api.AuthStaticRoleAssignment{
 		Type:  api.AuthStaticRoleAssignmentTypeStatic,
-		Roles: []string{"viewer"},
+		Roles: []string{api.ExternalRoleViewer},
 	}
 	if err := roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment); err != nil {
 		log.Fatalf("failed to create role assignment: %v", err)


### PR DESCRIPTION
added validation for oauth2/oidc with static role assignment - only known external roles are allowed
EDM-2606: additionally redacting client secrets from config log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a canonical list of known external roles.

* **Bug Fixes**
  * Tightened role validation for external (OIDC/OAuth2) assignments to reject unknown roles.
  * Configuration logging now redacts authentication client secrets and does not mutate the live config.

* **Tests**
  * Added and expanded tests covering role validation and redaction/handling of authentication secrets; updated tests to use the canonical role constant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->