### PR TITLE
EDM-2732: cleanup flightctl-cert-generator job when succeeded (#2160)

### DIFF
--- a/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   generate-certificates.sh: |
 {{ .Files.Get "scripts/generate-certificates.sh" | nindent 4 }}
@@ -39,7 +39,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
   template:


### PR DESCRIPTION
(cherry picked from commit cd700c5065110754753a72fc758fad927c0339cd)