### PR TITLE
EDM-1332: Suppress bootc SELinux error

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -38,6 +38,7 @@ gen_require(`
     type usr_t;
     type node_t;
     type tpm_device_t, security_t;
+    type unconfined_service_t;
 
     attribute domain;
 ')
@@ -281,3 +282,9 @@ allow flightctl_agent_t rhsmcertd_log_t:dir write;
 allow flightctl_agent_t rhsmcertd_var_lib_t:dir { getattr search };
 allow flightctl_agent_t rhsmcertd_var_run_t:dir write;
 allow flightctl_agent_t usr_t:file write;
+
+# REMOVE this once https://github.com/bootc-dev/bootc/issues/1434 is fixed. We don't want to allow
+# it so as not to alter the behavior of bootc, but we can suppress the error as it has been
+# determined to be inoculous by the bootc maintainer.
+dontaudit unconfined_service_t self:capability2 mac_admin;
+


### PR DESCRIPTION
See https://github.com/bootc-dev/bootc/issues/1434 for the known issue on bootc's side. We don't want to allow it because it might alter the behavior of bootc in an unpredictable way, but we can suppress it in the avc logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal security policy to suppress specific audit log noise from unconfined services, improving log clarity.
  * Change is a temporary compatibility measure and may be reverted once the underlying platform issue is resolved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->