### PR TITLE
NO-ISSUE: Consolidate api org setting middleware

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -235,9 +235,8 @@ func (s *AgentServer) prepareHTTPHandler(ctx context.Context, serviceHandler ser
 	}()
 	identityMappingMiddleware := fcmiddleware.NewIdentityMappingMiddleware(identityMapper, s.log)
 
-	// Create organization extraction and validation middlewares once
-	extractOrgMiddleware := fcmiddleware.ExtractOrgIDToCtx(fcmiddleware.CertOrgIDExtractor, s.log)
-	validateOrgMiddleware := fcmiddleware.ValidateOrgMembership(s.log)
+	// Create organization extraction and validation middleware once
+	orgMiddleware := fcmiddleware.ExtractAndValidateOrg(fcmiddleware.CertOrgIDExtractor, s.log)
 
 	// Create authentication routing middleware once
 	authRoutingMiddleware := func(next http.Handler) http.Handler {
@@ -268,8 +267,7 @@ func (s *AgentServer) prepareHTTPHandler(ctx context.Context, serviceHandler ser
 	authMiddlewares := []func(http.Handler) http.Handler{
 		authRoutingMiddleware,
 		identityMappingMiddleware.MapIdentityToDB,
-		extractOrgMiddleware,
-		validateOrgMiddleware,
+		orgMiddleware,
 	}
 
 	// request size limits should come before logging to prevent DoS attacks from filling logs

--- a/internal/api_server/middleware/middleware.go
+++ b/internal/api_server/middleware/middleware.go
@@ -10,6 +10,8 @@ import (
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/contextutil"
 	"github.com/flightctl/flightctl/internal/crypto/signer"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/reqid"
@@ -77,7 +79,9 @@ func UserAgentLogger(logger logrus.FieldLogger) func(http.Handler) http.Handler 
 }
 
 // OrgIDExtractor extracts an organization ID from an HTTP request.
-type OrgIDExtractor func(context.Context, *http.Request) (uuid.UUID, error)
+// Returns (orgID, present, error) where present is true if the org ID was
+// explicitly specified in the request.
+type OrgIDExtractor func(context.Context, *http.Request) (uuid.UUID, bool, error)
 
 // QueryOrgIDExtractor is the default extractor that reads the org_id from the query string.
 var QueryOrgIDExtractor OrgIDExtractor = extractOrgIDFromRequestQuery
@@ -85,44 +89,11 @@ var QueryOrgIDExtractor OrgIDExtractor = extractOrgIDFromRequestQuery
 // CertOrgIDExtractor reads the org_id from the client certificate.
 var CertOrgIDExtractor OrgIDExtractor = extractOrgIDFromRequestCert
 
-// ExtractOrgIDToCtx extracts organization ID using the supplied extractor and sets it in the request context.
-// This middleware only extracts and sets the org ID - it does not validate membership.
-func ExtractOrgIDToCtx(extractor OrgIDExtractor, logger logrus.FieldLogger) func(http.Handler) http.Handler {
+// ExtractAndValidateOrg extracts organization ID using the supplied extractor, validates
+// membership, and sets it in the request context.
+func ExtractAndValidateOrg(extractor OrgIDExtractor, logger logrus.FieldLogger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			reqLogger := log.WithReqIDFromCtx(ctx, logger)
-
-			orgID, err := extractor(ctx, r)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			// Log the extracted organization ID
-			reqLogger.Debugf("ExtractOrgIDToCtx: extracted orgID=%s from request", orgID.String())
-
-			// If no organization ID was found, use the user's first organization
-			if orgID == uuid.Nil {
-				mappedIdentity, ok := contextutil.GetMappedIdentityFromContext(ctx)
-				if ok && len(mappedIdentity.GetOrganizations()) > 0 {
-					orgID = mappedIdentity.GetOrganizations()[0].ID
-					reqLogger.Debugf("ExtractOrgIDToCtx: extracted orgID=%s from mapped identity", orgID.String())
-				}
-			}
-
-			// Set org ID in context and proceed
-			ctx = util.WithOrganizationID(ctx, orgID)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
-}
-
-// ValidateOrgMembership validates that the user is a member of the organization in the context.
-// This middleware only validates membership - it does not extract the org ID.
-func ValidateOrgMembership(logger logrus.FieldLogger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip validation for public auth endpoints
 			if authcommon.IsPublicAuthEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
@@ -131,72 +102,97 @@ func ValidateOrgMembership(logger logrus.FieldLogger) func(http.Handler) http.Ha
 			ctx := r.Context()
 			reqLogger := log.WithReqIDFromCtx(ctx, logger)
 
-			// Get organization ID from context
-			orgID, ok := util.GetOrgIdFromContext(ctx)
-			if !ok {
-				http.Error(w, "No organization ID found in context", http.StatusForbidden)
-				return
-			}
-			// Log the organization ID being validated
-			reqLogger.Debugf("ValidateOrgMembership: validating access to orgID=%s", orgID.String())
-
-			// Get mapped identity from context (set by identity mapping middleware)
 			mappedIdentity, ok := contextutil.GetMappedIdentityFromContext(ctx)
 			if !ok {
-				http.Error(w, "No mapped identity found in context", http.StatusInternalServerError)
-				return
-			}
-			// Check if the user is a member of the organization and log organizations
-			isMember := false
-			userOrgIDs := make([]string, len(mappedIdentity.GetOrganizations()))
-			for i, org := range mappedIdentity.GetOrganizations() {
-				userOrgIDs[i] = fmt.Sprintf("%s(%s)", org.ExternalID, org.ID.String())
-				if org.ID == orgID {
-					isMember = true
-				}
-			}
-			reqLogger.Debugf("ValidateOrgMembership: user organizations=%v, isMember=%v", userOrgIDs, isMember)
-
-			if !isMember {
-				http.Error(w, fmt.Sprintf("Access denied to organization: %s (user organizations: %v)", orgID, userOrgIDs), http.StatusForbidden)
+				http.Error(w, flterrors.ErrNoMappedIdentity.Error(), http.StatusInternalServerError)
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			orgID, err := resolveOrgID(ctx, r, extractor, mappedIdentity)
+			if err != nil {
+				reqLogger.Debugf("ExtractAndValidateOrg: error resolving org: %v", err)
+				http.Error(w, err.Error(), statusForOrgError(err))
+				return
+			}
+
+			reqLogger.Debugf("ExtractAndValidateOrg: resolved orgID=%s", orgID.String())
+			ctx = util.WithOrganizationID(ctx, orgID)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
-func extractOrgIDFromRequestQuery(ctx context.Context, r *http.Request) (uuid.UUID, error) {
+// resolveOrgID extracts an org ID from the request or infers it from the user's orgs.
+// If explicitly provided, validates the user is a member.
+func resolveOrgID(ctx context.Context, r *http.Request, extractor OrgIDExtractor, mappedIdentity *identity.MappedIdentity) (uuid.UUID, error) {
+	orgID, present, err := extractor(ctx, r)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	userOrgs := mappedIdentity.GetOrganizations()
+	if present {
+		for _, org := range userOrgs {
+			if org.ID == orgID {
+				return orgID, nil
+			}
+		}
+		return uuid.Nil, flterrors.ErrNotOrgMember
+	}
+
+	// No org ID provided from the extrctor
+	// If the user only has access to one org, return that org ID
+	// If the user has no orgs or multiple orgs without one specified, return an error
+	switch len(userOrgs) {
+	case 1:
+		return userOrgs[0].ID, nil
+	case 0:
+		return uuid.Nil, flterrors.ErrNoOrganizations
+	default:
+		return uuid.Nil, flterrors.ErrAmbiguousOrganization
+	}
+}
+
+func statusForOrgError(err error) int {
+	switch err {
+	case flterrors.ErrNoOrganizations, flterrors.ErrNotOrgMember:
+		return http.StatusForbidden
+	case flterrors.ErrAmbiguousOrganization, flterrors.ErrInvalidOrgID:
+		return http.StatusBadRequest
+	}
+	return http.StatusBadRequest
+}
+
+func extractOrgIDFromRequestQuery(ctx context.Context, r *http.Request) (uuid.UUID, bool, error) {
 	orgIDParam := r.URL.Query().Get(api.OrganizationIDQueryKey)
 	if orgIDParam == "" {
-		return uuid.Nil, nil
+		return uuid.Nil, false, nil
 	}
 
 	parsedID, err := uuid.Parse(orgIDParam)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("invalid %s parameter: %w", api.OrganizationIDQueryKey, err)
+		return uuid.Nil, false, flterrors.ErrInvalidOrgID
 	}
-	return parsedID, nil
+	return parsedID, true, nil
 }
 
 // extractOrgIDFromRequestCert extracts organization ID from the client certificate.
-// Returns the nil UUID if no organization ID is found in the certificate or if the
-// certificate doesn't contain an org ID extension.
-func extractOrgIDFromRequestCert(ctx context.Context, r *http.Request) (uuid.UUID, error) {
+// Returns (orgID, true, nil) if an org ID is found in the certificate.
+// Returns (uuid.Nil, false, error) if no certificate is found or has no org ID extension.
+func extractOrgIDFromRequestCert(ctx context.Context, r *http.Request) (uuid.UUID, bool, error) {
 	peerCertificate, err := signer.PeerCertificateFromCtx(ctx)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("failed to extract peer certificate from context: %w", err)
+		return uuid.Nil, false, fmt.Errorf("failed to extract peer certificate from context: %w", err)
 	}
 
 	orgID, present, err := signer.GetOrgIDExtensionFromCert(peerCertificate)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("failed to extract organization ID from certificate: %w", err)
+		return uuid.Nil, false, fmt.Errorf("failed to extract organization ID from certificate: %w", err)
 	}
 	if !present {
-		return uuid.Nil, fmt.Errorf("no organization ID found in certificate")
+		return uuid.Nil, false, fmt.Errorf("no organization ID found in certificate")
 	}
-	return orgID, nil
+	return orgID, true, nil
 }
 
 // SecurityHeaders adds security headers to all HTTP responses.

--- a/internal/api_server/middleware/middleware_test.go
+++ b/internal/api_server/middleware/middleware_test.go
@@ -12,10 +12,13 @@ import (
 
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/crypto/signer"
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/flightctl/flightctl/internal/org"
 	orgmodel "github.com/flightctl/flightctl/internal/org/model"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,34 +43,129 @@ func contextWithCert(cert *x509.Certificate) context.Context {
 }
 
 // -----------------------------------------------------------------------------
-// Tests for the query extractor.
+// Tests for ExtractAndValidateOrg middleware.
 // -----------------------------------------------------------------------------
-func TestExtractOrgIDFromRequestQuery(t *testing.T) {
-	validID := uuid.New()
+func TestExtractAndValidateOrg(t *testing.T) {
+	orgID := uuid.New()
+	orgID2 := uuid.New()
 
 	cases := []struct {
-		name     string
-		rawQuery string
-		wantID   uuid.UUID
-		wantErr  bool
+		name               string
+		rawQuery           string
+		userOrgs           []*orgmodel.Organization
+		hasMappedIdentity  bool
+		wantMiddlewareErr  error
+		wantMiddlewareCode int
+		wantContextID      uuid.UUID
 	}{
-		{"no param returns default", "", org.DefaultID, false},
-		{"empty param returns default", "org_id=", org.DefaultID, false},
-		{"valid id", fmt.Sprintf("org_id=%s", validID), validID, false},
-		{"invalid uuid", "org_id=not-a-uuid", uuid.Nil, true},
+		{
+			name:               "no param with zero orgs returns no organizations error",
+			rawQuery:           "",
+			userOrgs:           []*orgmodel.Organization{},
+			hasMappedIdentity:  true,
+			wantMiddlewareErr:  flterrors.ErrNoOrganizations,
+			wantMiddlewareCode: http.StatusForbidden,
+		},
+		{
+			name:              "no param with single org uses that org",
+			rawQuery:          "",
+			userOrgs:          []*orgmodel.Organization{{ID: orgID, ExternalID: "user-org"}},
+			hasMappedIdentity: true,
+			wantContextID:     orgID,
+		},
+		{
+			name:     "no param with multiple orgs returns ambiguous error",
+			rawQuery: "",
+			userOrgs: []*orgmodel.Organization{
+				{ID: orgID, ExternalID: "user-org-1"},
+				{ID: orgID2, ExternalID: "user-org-2"},
+			},
+			hasMappedIdentity:  true,
+			wantMiddlewareErr:  flterrors.ErrAmbiguousOrganization,
+			wantMiddlewareCode: http.StatusBadRequest,
+		},
+		{
+			name:     "explicit org_id with multiple orgs succeeds",
+			rawQuery: fmt.Sprintf("org_id=%s", orgID),
+			userOrgs: []*orgmodel.Organization{
+				{ID: orgID, ExternalID: "user-org-1"},
+				{ID: orgID2, ExternalID: "user-org-2"},
+			},
+			hasMappedIdentity: true,
+			wantContextID:     orgID,
+		},
+		{
+			name:               "no mapped identity returns internal server error",
+			rawQuery:           "org_id=",
+			userOrgs:           nil,
+			hasMappedIdentity:  false,
+			wantMiddlewareErr:  flterrors.ErrNoMappedIdentity,
+			wantMiddlewareCode: http.StatusInternalServerError,
+		},
+		{
+			name:               "explicit org_id with empty user orgs returns forbidden",
+			rawQuery:           fmt.Sprintf("org_id=%s", orgID),
+			userOrgs:           []*orgmodel.Organization{},
+			hasMappedIdentity:  true,
+			wantMiddlewareErr:  flterrors.ErrNotOrgMember,
+			wantMiddlewareCode: http.StatusForbidden,
+		},
+		{
+			name:               "explicit org_id for org not in user orgs returns forbidden",
+			rawQuery:           fmt.Sprintf("org_id=%s", orgID2),
+			userOrgs:           []*orgmodel.Organization{{ID: orgID, ExternalID: "user-org"}},
+			hasMappedIdentity:  true,
+			wantMiddlewareErr:  flterrors.ErrNotOrgMember,
+			wantMiddlewareCode: http.StatusForbidden,
+		},
+		{
+			name:               "invalid uuid",
+			rawQuery:           "org_id=not-a-uuid",
+			userOrgs:           []*orgmodel.Organization{},
+			hasMappedIdentity:  true,
+			wantMiddlewareErr:  flterrors.ErrInvalidOrgID,
+			wantMiddlewareCode: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, "/?"+tc.rawQuery, nil)
-			got, err := extractOrgIDFromRequestQuery(context.Background(), r)
-			if tc.wantErr {
-				assert.Error(t, err)
-				assert.Equal(t, uuid.Nil, got)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.wantID, got)
+
+			ctx := r.Context()
+			if tc.hasMappedIdentity {
+				mappedIdentity := identity.NewMappedIdentity(
+					"test-user", "test-uid", tc.userOrgs,
+					map[string][]string{}, false,
+					identity.NewIssuer("test", "test-issuer"),
+				)
+				ctx = context.WithValue(ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+				r = r.WithContext(ctx)
 			}
+
+			var capturedOrgID uuid.UUID
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedOrgID, _ = util.GetOrgIdFromContext(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			logger := logrus.New()
+			logger.SetLevel(logrus.DebugLevel)
+			middleware := ExtractAndValidateOrg(QueryOrgIDExtractor, logger)
+
+			rr := httptest.NewRecorder()
+			middleware(testHandler).ServeHTTP(rr, r)
+
+			if tc.wantMiddlewareErr != nil {
+				assert.Equal(t, tc.wantMiddlewareCode, rr.Code)
+				assert.Contains(t, rr.Body.String(), tc.wantMiddlewareErr.Error(),
+					"expected response body to contain %q", tc.wantMiddlewareErr)
+				return
+			}
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tc.wantContextID, capturedOrgID,
+				"expected context org ID %s but got %s", tc.wantContextID, capturedOrgID)
 		})
 	}
 }
@@ -93,28 +191,32 @@ func TestExtractOrgIDFromRequestCert(t *testing.T) {
 	}
 
 	cases := []struct {
-		name    string
-		ctx     context.Context
-		wantID  uuid.UUID
-		wantErr bool
+		name        string
+		ctx         context.Context
+		wantID      uuid.UUID
+		wantPresent bool
+		wantErr     bool
 	}{
-		{"no certificate", context.Background(), uuid.Nil, true},
-		{"cert without extension", contextWithCert(&x509.Certificate{}), uuid.Nil, true},
-		{"cert with valid extension", contextWithCertAndOrg(createCertWithOrgID(validID), orgEntity), validID, false},
+		{"no certificate", context.Background(), uuid.Nil, false, true},
+		{"cert without extension", contextWithCert(&x509.Certificate{}), uuid.Nil, false, true},
+		{"cert with valid extension", contextWithCertAndOrg(createCertWithOrgID(validID), orgEntity), validID, true, false},
+		{"cert with default org id", contextWithCertAndOrg(createCertWithOrgID(org.DefaultID), orgEntity), org.DefaultID, true, false},
 		{"cert with invalid uuid", contextWithCert(func() *x509.Certificate {
 			encoded, _ := asn1.Marshal("not-a-uuid")
 			return &x509.Certificate{ExtraExtensions: []pkix.Extension{{Id: signer.OIDOrgID, Value: encoded}}}
-		}()), uuid.Nil, true},
+		}()), uuid.Nil, false, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(tc.ctx)
-			got, err := extractOrgIDFromRequestCert(tc.ctx, r)
+			got, present, err := extractOrgIDFromRequestCert(tc.ctx, r)
 			if tc.wantErr {
 				assert.Error(t, err)
+				assert.False(t, present)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tc.wantPresent, present)
 			}
 			assert.Equal(t, tc.wantID, got)
 		})

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -210,16 +210,14 @@ func (s *Server) Run(ctx context.Context) error {
 	}()
 	identityMappingMiddleware := fcmiddleware.NewIdentityMappingMiddleware(identityMapper, s.log)
 
-	// Create organization extraction and validation middlewares once
-	extractOrgMiddleware := fcmiddleware.ExtractOrgIDToCtx(fcmiddleware.QueryOrgIDExtractor, s.log)
-	validateOrgMiddleware := fcmiddleware.ValidateOrgMembership(s.log)
+	// Create organization extraction and validation middleware once
+	orgMiddleware := fcmiddleware.ExtractAndValidateOrg(fcmiddleware.QueryOrgIDExtractor, s.log)
 	userAgentMiddleware := fcmiddleware.UserAgentLogger(s.log)
 
 	authMiddewares := []func(http.Handler) http.Handler{
 		auth.CreateAuthNMiddleware(s.authN, s.log),
 		identityMappingMiddleware.MapIdentityToDB,
-		extractOrgMiddleware,
-		validateOrgMiddleware,
+		orgMiddleware,
 		auth.CreateAuthZMiddleware(s.authZ, s.log),
 	}
 

--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -43,8 +43,13 @@ var (
 	ErrExtensionNotFound = errors.New("certificate extension not found")
 
 	// authentication/authorization
-	ErrInvalidTokenClaims = errors.New("invalid token claims")
-	ErrMissingTokenClaims = errors.New("missing required token claims")
+	ErrInvalidTokenClaims    = errors.New("invalid token claims")
+	ErrMissingTokenClaims    = errors.New("missing required token claims")
+	ErrNoMappedIdentity      = errors.New("unable to get mapped identity from context")
+	ErrNoOrganizations       = errors.New("user belongs to no organizations")
+	ErrAmbiguousOrganization = errors.New("user belongs to multiple organizations but no organization specified")
+	ErrInvalidOrgID          = errors.New("invalid organization ID format")
+	ErrNotOrgMember          = errors.New("access denied to organization")
 
 	// authprovider
 	ErrDuplicateOIDCProvider   = errors.New("an OIDC auth provider with the same issuer and clientId already exists")

--- a/internal/service/auth_token_proxy.go
+++ b/internal/service/auth_token_proxy.go
@@ -16,7 +16,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/authn"
-	"github.com/google/uuid"
 )
 
 // cacheEntry holds a cached token endpoint with its expiration time
@@ -77,7 +76,7 @@ func NewAuthTokenProxy(authN *authn.MultiAuth) *AuthTokenProxy {
 
 // ProxyTokenRequest handles OAuth2 token exchange requests
 // Returns TokenResponse and HTTP status code (200 for success, 400 for errors per OAuth2 spec)
-func (p *AuthTokenProxy) ProxyTokenRequest(ctx context.Context, orgId uuid.UUID, providerName string, tokenReq *api.TokenRequest) (*api.TokenResponse, int) {
+func (p *AuthTokenProxy) ProxyTokenRequest(ctx context.Context, providerName string, tokenReq *api.TokenRequest) (*api.TokenResponse, int) {
 	// Validate grant type
 	if tokenReq.GrantType != api.AuthorizationCode && tokenReq.GrantType != api.RefreshToken {
 		return createErrorTokenResponse("unsupported_grant_type", "Only authorization_code and refresh_token grant types are supported"), http.StatusBadRequest

--- a/internal/transport/auth_token.go
+++ b/internal/transport/auth_token.go
@@ -1,14 +1,11 @@
 package transport
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
-	"github.com/flightctl/flightctl/internal/util"
-	"github.com/google/uuid"
 )
 
 // AuthToken handles OAuth2 token exchange requests
@@ -64,22 +61,13 @@ func (h *TransportHandler) AuthToken(w http.ResponseWriter, r *http.Request, pro
 	}
 
 	// Call auth token proxy to process the token request
-	orgId := getOrgIdFromContext(r.Context())
-	tokenResp, httpStatus := h.authTokenProxy.ProxyTokenRequest(r.Context(), orgId, providername, &tokenReq)
+	tokenResp, httpStatus := h.authTokenProxy.ProxyTokenRequest(r.Context(), providername, &tokenReq)
 
 	// OAuth2 token endpoint returns 200 for success, 400 for all errors
 	// Token response includes error fields for error cases
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
 	_ = json.NewEncoder(w).Encode(tokenResp)
-}
-
-// getOrgIdFromContext extracts the organization ID from the context
-func getOrgIdFromContext(ctx context.Context) uuid.UUID {
-	if orgId, ok := util.GetOrgIdFromContext(ctx); ok {
-		return orgId
-	}
-	return uuid.Nil
 }
 
 // createTokenErrorResponse creates an OAuth2 error response


### PR DESCRIPTION
We have a `orgID == uuid.Nil` conditoinal in the current api middleware.  This conditional evaluates to true when orgID is the default org ID since they are both "00000000-0000-0000-0000-000000000000", which can result in a situation where:

- A user passes the default org id as the org_id param
- We then might attempt to set the org id in context from the .GetOrganizations() call, which _could_ be a **different** organization than the default.

When taking a pass through the middleware it became simpler to just refactor the two extract and validate middlewares into one (they were always coupled).

Initial conditional problem raised by @ori-amizur a couple of days ago


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better automatic organization detection from certificates/identity when org is omitted.
  * Token exchange no longer requires providing an explicit org ID.

* **Bug Fixes**
  * More precise HTTP statuses and error responses for missing, ambiguous, invalid, or non-member organization cases.
  * Improved validation to reject conflicting or malformed organization identifiers.

* **Refactor**
  * Organization extraction and validation combined into a single middleware for simpler request flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->