### PR TITLE
EDM-2696: Fix embedded quadlet app reconciliation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -357,6 +357,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		applicationsManager,
 		deviceReadWriter,
 		a.log,
+		systemInfoManager.BootTime(),
 	)
 
 	// create agent

--- a/internal/agent/device/applications/controller.go
+++ b/internal/agent/device/applications/controller.go
@@ -16,6 +16,7 @@ type Controller struct {
 	readWriter fileio.ReadWriter
 	manager    Manager
 	log        *log.PrefixLogger
+	bootTime   string
 }
 
 func NewController(
@@ -23,12 +24,14 @@ func NewController(
 	manager Manager,
 	readWriter fileio.ReadWriter,
 	log *log.PrefixLogger,
+	bootTime string,
 ) *Controller {
 	return &Controller{
 		log:        log,
 		manager:    manager,
 		podman:     podman,
 		readWriter: readWriter,
+		bootTime:   bootTime,
 	}
 }
 
@@ -42,6 +45,7 @@ func (c *Controller) Sync(ctx context.Context, current, desired *v1beta1.DeviceS
 		c.podman,
 		c.readWriter,
 		current,
+		provider.WithInstalledEmbedded(),
 	)
 	if err != nil {
 		return fmt.Errorf("current app providers: %w", err)
@@ -53,7 +57,7 @@ func (c *Controller) Sync(ctx context.Context, current, desired *v1beta1.DeviceS
 		c.podman,
 		c.readWriter,
 		desired,
-		provider.WithEmbedded(),
+		provider.WithEmbedded(c.bootTime),
 	)
 	if err != nil {
 		return fmt.Errorf("desired app providers: %w", err)

--- a/internal/agent/device/applications/controller_test.go
+++ b/internal/agent/device/applications/controller_test.go
@@ -499,7 +499,7 @@ func TestControllerSync(t *testing.T) {
 			mockAppManager := NewMockManager(ctrl)
 			podmanClient := client.NewPodman(log, mockExecuter, readWriter, util.NewPollConfig())
 
-			controller := NewController(podmanClient, mockAppManager, readWriter, log)
+			controller := NewController(podmanClient, mockAppManager, readWriter, log, "2025-01-01T00:00:00Z")
 
 			countainerMountDir := "/mount"
 			err = readWriter.MkdirAll(countainerMountDir, fileio.DefaultDirectoryPermissions)

--- a/internal/agent/device/applications/lifecycle/quadlet.go
+++ b/internal/agent/device/applications/lifecycle/quadlet.go
@@ -19,6 +19,8 @@ import (
 const (
 	QuadletAppPath         = "/etc/containers/systemd"
 	EmbeddedQuadletAppPath = "/usr/local/etc/containers/systemd"
+	QuadletTargetPath      = "/etc/systemd/system/"
+	QuadletTargetName      = "flightctl-quadlet-app.target"
 )
 
 var _ ActionHandler = (*Quadlet)(nil)
@@ -32,7 +34,6 @@ type Quadlet struct {
 }
 
 type actionCacheEntry struct {
-	services        []string
 	artifactVolumes []string
 }
 
@@ -44,28 +45,6 @@ func newActionCache() *actionCache {
 	return &actionCache{
 		cache: make(map[string]*actionCacheEntry),
 	}
-}
-
-func (a *actionCache) hasAction(actionID string) bool {
-	_, ok := a.cache[actionID]
-	return ok
-}
-
-func (a *actionCache) addServices(actionID string, services []string) {
-	entry, ok := a.cache[actionID]
-	if !ok {
-		entry = &actionCacheEntry{}
-		a.cache[actionID] = entry
-	}
-	entry.services = append(entry.services, services...)
-}
-
-func (a *actionCache) services(actionID string) []string {
-	entry, ok := a.cache[actionID]
-	if !ok {
-		return nil
-	}
-	return entry.services
 }
 
 func (a *actionCache) clearAction(actionID string) {
@@ -100,12 +79,26 @@ func NewQuadlet(log *log.PrefixLogger, rw fileio.ReadWriter, systemdManager syst
 }
 
 func isServiceLoaded(unitSet map[string]struct{}, service string) bool {
-	// report targets as loaded
 	if filepath.Ext(service) == ".target" {
 		return true
 	}
 	_, exists := unitSet[service]
 	return exists
+}
+
+func (q *Quadlet) loadedUnits(ctx context.Context, services []string) (map[string]struct{}, error) {
+	units, err := q.systemdManager.ListUnitsByMatchPattern(ctx, services)
+	if err != nil {
+		return nil, fmt.Errorf("listing loaded units: %w", err)
+	}
+
+	unitSet := make(map[string]struct{}, len(units))
+	for _, u := range units {
+		if u.LoadState == string(v1beta1.SystemdLoadStateLoaded) {
+			unitSet[u.Unit] = struct{}{}
+		}
+	}
+	return unitSet, nil
 }
 
 func (q *Quadlet) add(ctx context.Context, action *Action) error {
@@ -118,28 +111,18 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 	}
 	startTime := time.Now()
 
-	requiresActionCleanup := true
-	defer func() {
-		if requiresActionCleanup {
-			if err := q.cleanResources(ctx, action); err != nil {
-				q.log.Errorf("Failed to remove quadlet application %s after failing to add it: %v", appName, err)
-			}
-		}
-	}()
-
-	services, err := q.collectTargets(action.Path)
+	target, err := targetName(action.ID)
 	if err != nil {
-		return fmt.Errorf("collecting targets: %w", err)
+		return fmt.Errorf("target name: %w", err)
+	}
+	services, err := q.systemdManager.ListDependencies(ctx, target)
+	if err != nil {
+		return fmt.Errorf("listing dependencies: %w", err)
 	}
 
-	units, err := q.systemdManager.ListUnitsByMatchPattern(ctx, services)
+	unitSet, err := q.loadedUnits(ctx, services)
 	if err != nil {
-		return fmt.Errorf("listing loaded units: %w", err)
-	}
-
-	unitSet := make(map[string]struct{})
-	for _, u := range units {
-		unitSet[u.Unit] = struct{}{}
+		return fmt.Errorf("listing loading units: %w", err)
 	}
 
 	for _, service := range services {
@@ -157,30 +140,36 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 		}
 	}
 
+	requiresActionCleanup := true
+	defer func() {
+		if requiresActionCleanup {
+			if err := q.remove(ctx, action); err != nil {
+				q.log.Errorf("Failed to remove quadlet application %s after failing to add it: %v", appName, err)
+			}
+		}
+	}()
+
 	if err := q.ensureArtifactVolumes(ctx, action); err != nil {
 		return fmt.Errorf("ensuring artifact volumes: %w", err)
 	}
-
-	q.actionCache.addServices(action.ID, services)
-	if len(services) > 0 {
-		q.log.Debugf("Starting quadlet: %s services: %q", appName, strings.Join(services, ","))
-		if err := q.systemdManager.Start(ctx, services...); err != nil {
-			err = fmt.Errorf("starting units: %w", err)
-			for _, service := range services {
-				serviceLogs, serviceErr := q.systemdManager.Logs(ctx, client.WithLogUnit(service), client.WithLogSince(startTime))
-				if serviceErr != nil {
-					q.log.Errorf("Failed to gather service: %q logs: %v", service, serviceErr)
-					continue
-				}
-				if len(serviceLogs) > 0 {
-					q.log.Infof("Service: %q logs: %s", service, strings.Join(serviceLogs, "\n"))
-					err = fmt.Errorf("service: %q logs: %s: %w", service, strings.Join(serviceLogs, ","), err)
-				}
+	q.log.Debugf("Starting quadlet: %s target: %s", appName, target)
+	if err := q.systemdManager.Start(ctx, target); err != nil {
+		err = fmt.Errorf("starting target %s: %w", target, err)
+		for _, service := range services {
+			serviceLogs, serviceErr := q.systemdManager.Logs(ctx, client.WithLogUnit(service), client.WithLogSince(startTime))
+			if serviceErr != nil {
+				err = fmt.Errorf("gathering service %q logs: %w: %w", service, serviceErr, err)
+				continue
 			}
-			return err
+			if len(serviceLogs) > 0 {
+				q.log.Infof("Service: %q logs: %s", service, strings.Join(serviceLogs, "\n"))
+				err = fmt.Errorf("service: %q logs: %s: %w", service, strings.Join(serviceLogs, ","), err)
+			}
 		}
-		q.systemdManager.AddExclusions(services...)
+		return err
 	}
+
+	q.systemdManager.AddExclusions(append(services, target)...)
 
 	requiresActionCleanup = false
 	q.log.Infof("Started quadlet application: %s", appName)
@@ -189,33 +178,49 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 
 func (q *Quadlet) remove(ctx context.Context, action *Action) error {
 	appName := action.Name
-	if !q.actionCache.hasAction(action.ID) {
-		return nil
+
+	target, err := targetName(action.ID)
+	if err != nil {
+		return fmt.Errorf("target name: %w", err)
+	}
+	services, err := q.systemdManager.ListDependencies(ctx, target)
+	if err != nil {
+		return fmt.Errorf("listing dependencies: %w", err)
 	}
 
-	services := q.actionCache.services(action.ID)
-	if len(services) > 0 {
-		q.log.Debugf("Stopping quadlet: %s services: %q", appName, strings.Join(services, ","))
-		if err := q.systemdManager.Stop(ctx, services...); err != nil {
-			return fmt.Errorf("stopping units: %w", err)
-		}
-		failedServices := q.getFailedServices(ctx, services)
-		if len(failedServices) > 0 {
-			q.log.Debugf("Resetting failed state for services: %q", strings.Join(failedServices, ","))
-			if resetErr := q.systemdManager.ResetFailed(ctx, failedServices...); resetErr != nil {
-				q.log.Warnf("Failed to reset-failed for services %q: %v", strings.Join(failedServices, ","), resetErr)
-			}
-		}
-		q.systemdManager.RemoveExclusions(services...)
+	q.log.Debugf("Stopping quadlet: %s target: %s", appName, target)
+	// stopping the target will begin stopping the individual services, but it is not a synchronous operation.
+	if err := q.systemdManager.Stop(ctx, target); err != nil {
+		return fmt.Errorf("stopping target %s: %w", target, err)
 	}
+
+	unitSet, err := q.loadedUnits(ctx, services)
+	if err != nil {
+		return fmt.Errorf("listing loading units: %w", err)
+	}
+
+	if len(unitSet) > 0 {
+		servicesToStop := make([]string, 0, len(unitSet))
+		for service := range unitSet {
+			servicesToStop = append(servicesToStop, service)
+		}
+		// stop and wait for all services to finish
+		q.log.Debugf("Stopping quadlet: %s services: %s", appName, strings.Join(servicesToStop, ", "))
+		if err := q.systemdManager.Stop(ctx, servicesToStop...); err != nil {
+			return fmt.Errorf("stopping services: %w", err)
+		}
+		q.log.Debugf("Resetting failed state for services: %q", strings.Join(servicesToStop, ", "))
+		// Reset all services so that properties such as restart counts are reset
+		if err := q.systemdManager.ResetFailed(ctx, servicesToStop...); err != nil {
+			return fmt.Errorf("resetting failed: %w", err)
+		}
+	}
+	q.systemdManager.RemoveExclusions(append(services, target)...)
 
 	return q.cleanResources(ctx, action)
 }
 
 func (q *Quadlet) cleanResources(ctx context.Context, action *Action) error {
-	if !q.actionCache.hasAction(action.ID) {
-		return nil
-	}
 	defer q.actionCache.clearAction(action.ID)
 
 	q.log.Infof("Removed quadlet application: %s", action.Name)
@@ -310,97 +315,6 @@ func (q *Quadlet) Execute(ctx context.Context, actions ...*Action) error {
 	return nil
 }
 
-func (q *Quadlet) serviceName(file string, quadletSection string, defaultName string) (string, error) {
-	contents, err := q.rw.ReadFile(file)
-	if err != nil {
-		return "", fmt.Errorf("reading quadlet %s: %w", file, err)
-	}
-	unit, err := quadlet.NewUnit(contents)
-	if err != nil {
-		return "", fmt.Errorf("parsing quadlet %q: %w", file, err)
-	}
-
-	name, err := unit.Lookup(quadletSection, quadlet.ServiceNameKey)
-	if err != nil {
-		if errors.Is(err, quadlet.ErrKeyNotFound) {
-			return defaultName, nil
-		}
-		return "", fmt.Errorf("looking up %q: %w", quadletSection, err)
-	}
-	return name, nil
-}
-
-func (q *Quadlet) collectTargets(path string) ([]string, error) {
-	entries, err := q.rw.ReadDir(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading directory: %w", err)
-	}
-
-	var services []string
-	var targets []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-
-		filename := entry.Name()
-		ext := filepath.Ext(filename)
-		baseName := strings.TrimSuffix(filename, ext)
-
-		var sectionName string
-		var defaultName string
-		switch ext {
-		case quadlet.ContainerExtension:
-			sectionName = quadlet.ContainerGroup
-			defaultName = fmt.Sprintf("%s.service", baseName)
-		case quadlet.PodExtension:
-			sectionName = quadlet.PodGroup
-			defaultName = fmt.Sprintf("%s-pod.service", baseName)
-		case quadlet.VolumeExtension:
-			sectionName = quadlet.VolumeGroup
-			defaultName = fmt.Sprintf("%s-volume.service", baseName)
-		case quadlet.NetworkExtension:
-			sectionName = quadlet.NetworkGroup
-			defaultName = fmt.Sprintf("%s-network.service", baseName)
-		case quadlet.ImageExtension:
-			sectionName = quadlet.ImageGroup
-			defaultName = fmt.Sprintf("%s-image.service", baseName)
-		case ".target":
-			targets = append(targets, filename)
-			continue
-		default:
-			continue
-		}
-
-		serviceName, err := q.serviceName(filepath.Join(path, entry.Name()), sectionName, defaultName)
-		if err != nil {
-			return nil, fmt.Errorf("getting %s service name: %w", filename, err)
-		}
-
-		services = append(services, serviceName)
-	}
-
-	// ensure that targets are processed first and services are
-	// secondary.
-	return append(targets, services...), nil
-}
-
-func (q *Quadlet) getFailedServices(ctx context.Context, services []string) []string {
-	units, err := q.systemdManager.ListUnitsByMatchPattern(ctx, services)
-	if err != nil {
-		q.log.Warnf("Failed to list units to check for failed state: %v", err)
-		return nil
-	}
-
-	var failedServices []string
-	for _, u := range units {
-		if u.ActiveState == string(v1beta1.SystemdActiveStateFailed) {
-			failedServices = append(failedServices, u.Unit)
-		}
-	}
-	return failedServices
-}
-
 func (q *Quadlet) ensureArtifactVolumes(ctx context.Context, action *Action) error {
 	if len(action.Volumes) == 0 {
 		return nil
@@ -455,4 +369,11 @@ func (q *Quadlet) ensureArtifactVolumes(ctx context.Context, action *Action) err
 	}
 
 	return nil
+}
+
+func targetName(appID string) (string, error) {
+	if appID == "" {
+		return "", fmt.Errorf("empty appID")
+	}
+	return quadlet.NamespaceResource(appID, QuadletTargetName), nil
 }

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -29,6 +29,7 @@ type manager struct {
 	podmanClient  *client.Podman
 	readWriter    fileio.ReadWriter
 	log           *log.PrefixLogger
+	bootTime      string
 
 	// cache of extracted nested OCI targets
 	ociTargetCache *provider.OCITargetCache
@@ -50,6 +51,7 @@ func NewManager(
 		podmanMonitor:  NewPodmanMonitor(log, podmanClient, systemdManager, bootTime, readWriter),
 		podmanClient:   podmanClient,
 		log:            log,
+		bootTime:       bootTime,
 		ociTargetCache: provider.NewOCITargetCache(),
 		appDataCache:   provider.NewAppDataCache(),
 	}
@@ -114,7 +116,7 @@ func (m *manager) BeforeUpdate(ctx context.Context, desired *v1beta1.DeviceSpec)
 		m.podmanMonitor.client,
 		m.readWriter,
 		desired,
-		provider.WithEmbedded(),
+		provider.WithEmbedded(m.bootTime),
 		provider.WithAppDataCache(m.appDataCache),
 	)
 	if err != nil {

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -118,14 +118,16 @@ func TestManager(t *testing.T) {
 				{Content: quadlet1, Path: "test-app.container"},
 			}, v1beta1.AppTypeQuadlet),
 			setupMocks: func(mockExec *executer.MockExecuter, mockReadWriter *fileio.MockReadWriter, mockSystemdMgr *systemd.MockManager) {
-				// Set up quadlet file mocks
 				mockReadQuadletFiles(mockReadWriter, quadlet1)
+				appID := client.NewComposeID("quadlet-new")
+				target := appID + "-flightctl-quadlet-app.target"
+				services := []string{appID + "-test-app.service"}
 
 				gomock.InOrder(
-					// start new quadlet app
 					mockExecSystemdDaemonReload(mockSystemdMgr),
-					mockExecSystemdListUnitsWithResults(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdStart(mockSystemdMgr, "test-app.service"),
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockExecSystemdListUnitsWithResults(mockSystemdMgr, services...),
+					mockSystemdMgr.EXPECT().Start(gomock.Any(), target).Return(nil),
 					mockExecPodmanEvents(mockExec),
 				)
 			},
@@ -138,22 +140,27 @@ func TestManager(t *testing.T) {
 			}, v1beta1.AppTypeQuadlet),
 			desired: &v1beta1.DeviceSpec{},
 			setupMocks: func(mockExec *executer.MockExecuter, mockReadWriter *fileio.MockReadWriter, mockSystemdMgr *systemd.MockManager) {
-				// Set up quadlet file mocks
 				mockReadQuadletFiles(mockReadWriter, quadlet1)
+				appID := client.NewComposeID("quadlet-remove")
+				target := appID + "-flightctl-quadlet-app.target"
+				services := []string{appID + "-test-app.service"}
 
 				gomock.InOrder(
 					// start current quadlet app (first AfterUpdate)
 					mockExecSystemdDaemonReload(mockSystemdMgr),
-					mockExecSystemdListUnitsWithResults(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdStart(mockSystemdMgr, "test-app.service"),
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockExecSystemdListUnitsWithResults(mockSystemdMgr, services...),
+					mockSystemdMgr.EXPECT().Start(gomock.Any(), target).Return(nil),
 					mockExecPodmanEvents(mockExec),
 
 					// remove quadlet app (second AfterUpdate after syncProviders)
-					mockExecSystemdStop(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdListUnits(mockSystemdMgr, "test-app.service"),
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockSystemdMgr.EXPECT().Stop(gomock.Any(), target).Return(nil),
+					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return([]client.SystemDUnitListEntry{{Unit: services[0], LoadState: "loaded"}}, nil),
+					mockSystemdMgr.EXPECT().Stop(gomock.Any(), services[0]).Return(nil),
+					mockSystemdMgr.EXPECT().ResetFailed(gomock.Any(), services[0]).Return(nil),
 					mockExecSystemdDaemonReload(mockSystemdMgr),
 				)
-				// podman cleanup happens after systemd operations (not strictly ordered with above)
 				mockExecQuadletCleanup(mockExec, "quadlet-remove")
 			},
 		},
@@ -166,27 +173,33 @@ func TestManager(t *testing.T) {
 				{Content: quadlet2, Path: "test-app.container"},
 			}, v1beta1.AppTypeQuadlet),
 			setupMocks: func(mockExec *executer.MockExecuter, mockReadWriter *fileio.MockReadWriter, mockSystemdMgr *systemd.MockManager) {
-				// Set up quadlet file mocks - will return different content as needed
 				mockReadQuadletFiles(mockReadWriter, quadlet1)
 				mockReadQuadletFiles(mockReadWriter, quadlet2)
+				appID := client.NewComposeID("quadlet-update")
+				target := appID + "-flightctl-quadlet-app.target"
+				services := []string{appID + "-test-app.service"}
 
 				gomock.InOrder(
 					// start current quadlet app (first AfterUpdate)
 					mockExecSystemdDaemonReload(mockSystemdMgr),
-					mockExecSystemdListUnitsWithResults(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdStart(mockSystemdMgr, "test-app.service"),
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockExecSystemdListUnitsWithResults(mockSystemdMgr, services...),
+					mockSystemdMgr.EXPECT().Start(gomock.Any(), target).Return(nil),
 					mockExecPodmanEvents(mockExec),
 
-					// update: stop current quadlet app, then start updated (second AfterUpdate)
-					mockExecSystemdStop(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdListUnits(mockSystemdMgr, "test-app.service"),
+					// update: stop current quadlet app (remove phase)
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockSystemdMgr.EXPECT().Stop(gomock.Any(), target).Return(nil),
+					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return([]client.SystemDUnitListEntry{{Unit: services[0], LoadState: "loaded"}}, nil),
+					mockSystemdMgr.EXPECT().Stop(gomock.Any(), services[0]).Return(nil),
+					mockSystemdMgr.EXPECT().ResetFailed(gomock.Any(), services[0]).Return(nil),
 
-					// start updated quadlet app (monitor already running, no new podman events command)
+					// start updated quadlet app (add phase after daemon reload)
 					mockExecSystemdDaemonReload(mockSystemdMgr),
-					mockExecSystemdListUnitsWithResults(mockSystemdMgr, "test-app.service"),
-					mockExecSystemdStart(mockSystemdMgr, "test-app.service"),
+					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
+					mockExecSystemdListUnitsWithResults(mockSystemdMgr, services...),
+					mockSystemdMgr.EXPECT().Start(gomock.Any(), target).Return(nil),
 				)
-				// podman cleanup happens during the update (not strictly ordered with above)
 				mockExecQuadletCleanup(mockExec, "quadlet-update")
 			},
 			wantAppNames: []string{"quadlet-update"},
@@ -481,35 +494,17 @@ func mockExecSystemdDaemonReload(mockSystemdMgr *systemd.MockManager) *gomock.Ca
 	return mockSystemdMgr.EXPECT().DaemonReload(gomock.Any()).Return(nil)
 }
 
-func mockExecSystemdStart(mockSystemdMgr *systemd.MockManager, services ...string) *gomock.Call {
-	// Convert services to []any for gomock matcher
-	args := make([]any, len(services))
-	for i, s := range services {
-		args[i] = s
-	}
-	return mockSystemdMgr.EXPECT().Start(gomock.Any(), args...).Return(nil)
-}
-
-func mockExecSystemdStop(mockSystemdMgr *systemd.MockManager, services ...string) *gomock.Call {
-	// Convert services to []any for gomock matcher
-	args := make([]any, len(services))
-	for i, s := range services {
-		args[i] = s
-	}
-	return mockSystemdMgr.EXPECT().Stop(gomock.Any(), args...).Return(nil)
-}
-
-func mockExecSystemdListUnits(mockSystemdMgr *systemd.MockManager, services ...string) *gomock.Call {
-	units := []client.SystemDUnitListEntry{}
-	return mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return(units, nil)
-}
-
 func mockExecSystemdListUnitsWithResults(mockSystemdMgr *systemd.MockManager, services ...string) *gomock.Call {
 	units := make([]client.SystemDUnitListEntry, len(services))
 	for i, svc := range services {
-		units[i] = client.SystemDUnitListEntry{Unit: svc}
+		units[i] = client.SystemDUnitListEntry{Unit: svc, LoadState: "loaded"}
 	}
 	return mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return(units, nil)
+}
+
+func mockExecSystemdListDependencies(mockSystemdMgr *systemd.MockManager, appID string, services []string) *gomock.Call {
+	target := appID + "-flightctl-quadlet-app.target"
+	return mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), target).Return(services, nil)
 }
 
 func mockExecPodmanVolumeList(mockExec *executer.MockExecuter, name string) *gomock.Call {

--- a/internal/agent/device/applications/provider/embedded.go
+++ b/internal/agent/device/applications/provider/embedded.go
@@ -19,12 +19,15 @@ type embeddedProvider struct {
 	handler    embeddedAppTypeHandler
 }
 
-func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter) (embeddedAppTypeHandler, error) {
+func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter, l *log.PrefixLogger, bootTime string, installed bool) (embeddedAppTypeHandler, error) {
 	switch appType {
 	case v1beta1.AppTypeQuadlet:
 		return &embeddedQuadletBehavior{
-			name: name,
-			rw:   rw,
+			name:      name,
+			rw:        rw,
+			log:       l,
+			bootTime:  bootTime,
+			installed: installed,
 		}, nil
 	case v1beta1.AppTypeCompose:
 		return &embeddedComposeBehavior{
@@ -36,8 +39,8 @@ func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWrit
 	}
 }
 
-func newEmbedded(log *log.PrefixLogger, podman *client.Podman, readWriter fileio.ReadWriter, name string, appType v1beta1.AppType) (Provider, error) {
-	handler, err := newEmbeddedHandler(appType, name, readWriter)
+func newEmbedded(log *log.PrefixLogger, podman *client.Podman, readWriter fileio.ReadWriter, name string, appType v1beta1.AppType, bootTime string, installed bool) (Provider, error) {
+	handler, err := newEmbeddedHandler(appType, name, readWriter, log, bootTime, installed)
 	if err != nil {
 		return nil, fmt.Errorf("constructing embedded app handler: %w", err)
 	}
@@ -66,6 +69,7 @@ func newEmbedded(log *log.PrefixLogger, podman *client.Podman, readWriter fileio
 			EnvVars:  make(map[string]string),
 			Volume:   volumeManager,
 			Path:     handler.AppPath(),
+			bootTime: bootTime,
 		},
 	}, nil
 }

--- a/internal/agent/device/applications/provider/embedded_test.go
+++ b/internal/agent/device/applications/provider/embedded_test.go
@@ -31,6 +31,9 @@ func setupTestEnv(t *testing.T) (*log.PrefixLogger, *client.Podman, fileio.ReadW
 	rw.SetRootdir(tmpDir)
 	podman := client.NewPodman(log, mockExec, rw, util.NewPollConfig())
 
+	// Create the systemd unit directory for target file copying
+	require.NoError(t, rw.MkdirAll(lifecycle.QuadletTargetPath, fileio.DefaultDirectoryPermissions))
+
 	return log, podman, rw
 }
 
@@ -162,7 +165,7 @@ Network=app-net.network
 			setupEmbeddedQuadletApp(t, rw, tt.appName, tt.files)
 
 			// Create embedded provider
-			provider, err := newEmbedded(logger, podman, rw, tt.appName, v1beta1.AppTypeQuadlet)
+			provider, err := newEmbedded(logger, podman, rw, tt.appName, v1beta1.AppTypeQuadlet, "2025-01-01T00:00:00Z", false)
 			require.NoError(t, err)
 
 			// Call Install
@@ -217,7 +220,7 @@ func TestEmbeddedProvider_Remove(t *testing.T) {
 			setupRealQuadletApp(t, rw, tt.appName, tt.files)
 
 			// Create embedded provider
-			provider, err := newEmbedded(logger, podman, rw, tt.appName, v1beta1.AppTypeQuadlet)
+			provider, err := newEmbedded(logger, podman, rw, tt.appName, v1beta1.AppTypeQuadlet, "2025-01-01T00:00:00Z", false)
 			require.NoError(t, err)
 
 			// Call Remove
@@ -333,7 +336,7 @@ func TestParseEmbeddedQuadlet(t *testing.T) {
 			// Call parseEmbeddedQuadlet
 			var providers []Provider
 			ctx := context.Background()
-			err := parseEmbeddedQuadlet(ctx, logger, podman, rw, &providers)
+			err := parseEmbeddedQuadlet(ctx, logger, podman, rw, &providers, "2025-01-01T00:00:00Z")
 			require.NoError(t, err)
 
 			// Verify count

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -37,6 +37,7 @@ func newImageHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter,
 		qb := &quadletHandler{
 			name:        name,
 			rw:          rw,
+			log:         l,
 			specVolumes: lo.FromPtr(provider.Volumes),
 		}
 		qb.volumeProvider = func() ([]*Volume, error) {
@@ -55,6 +56,7 @@ func newImageHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter,
 		return &containerHandler{
 			name:   name,
 			rw:     rw,
+			log:    l,
 			podman: podman,
 			spec:   provider,
 		}, nil

--- a/internal/agent/device/applications/provider/inline.go
+++ b/internal/agent/device/applications/provider/inline.go
@@ -27,6 +27,7 @@ func newInlineHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter
 		qb := &quadletHandler{
 			name:        name,
 			rw:          rw,
+			log:         l,
 			specVolumes: lo.FromPtr(spec.Volumes),
 		}
 		qb.volumeProvider = func() ([]*Volume, error) {

--- a/internal/agent/device/applications/provider/quadlet_test.go
+++ b/internal/agent/device/applications/provider/quadlet_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -116,6 +117,159 @@ func TestPrefixQuadletReference(t *testing.T) {
 	}
 }
 
+func TestDefaultServiceName(t *testing.T) {
+	tests := []struct {
+		name        string
+		basename    string
+		ext         string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "container extension",
+			basename: "web",
+			ext:      ".container",
+			expected: "web.service",
+		},
+		{
+			name:     "pod extension",
+			basename: "services",
+			ext:      ".pod",
+			expected: "services-pod.service",
+		},
+		{
+			name:     "volume extension",
+			basename: "data",
+			ext:      ".volume",
+			expected: "data-volume.service",
+		},
+		{
+			name:     "network extension",
+			basename: "app-net",
+			ext:      ".network",
+			expected: "app-net-network.service",
+		},
+		{
+			name:     "image extension",
+			basename: "base",
+			ext:      ".image",
+			expected: "base-image.service",
+		},
+		{
+			name:        "unknown extension",
+			basename:    "foo",
+			ext:         ".unknown",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "empty extension",
+			basename:    "bar",
+			ext:         "",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := defaultServiceName(tt.basename, tt.ext)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetServiceName(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string][]byte
+		filePath    string
+		ext         string
+		defaultName string
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "non-pod quadlet returns default",
+			files: map[string][]byte{
+				"web.container": []byte(`[Container]
+Image=nginx:latest
+`),
+			},
+			filePath:    "web.container",
+			ext:         ".container",
+			defaultName: "web.service",
+			expected:    "web.service",
+		},
+		{
+			name: "pod without ServiceName returns default",
+			files: map[string][]byte{
+				"services.pod": []byte(`[Pod]
+PodName=my-pod
+Network=app-net
+`),
+			},
+			filePath:    "services.pod",
+			ext:         ".pod",
+			defaultName: "services-pod.service",
+			expected:    "services-pod.service",
+		},
+		{
+			name: "pod with ServiceName returns custom name",
+			files: map[string][]byte{
+				"services.pod": []byte(`[Pod]
+PodName=my-pod
+ServiceName=my-custom-service.service
+Network=app-net
+`),
+			},
+			filePath:    "services.pod",
+			ext:         ".pod",
+			defaultName: "services-pod.service",
+			expected:    "my-custom-service.service",
+		},
+		{
+			name: "volume quadlet returns default",
+			files: map[string][]byte{
+				"data.volume": []byte(`[Volume]
+`),
+			},
+			filePath:    "data.volume",
+			ext:         ".volume",
+			defaultName: "data-volume.service",
+			expected:    "data-volume.service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			rw := fileio.NewReadWriter()
+			rw.SetRootdir(tmpDir)
+
+			for filename, content := range tt.files {
+				err := rw.WriteFile(filename, content, fileio.DefaultFilePermissions)
+				require.NoError(t, err)
+			}
+
+			logger := log.NewPrefixLogger("test")
+			q := &quadletInstaller{readWriter: rw, logger: logger}
+			result, err := q.getServiceName(tt.filePath, tt.ext, tt.defaultName)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestUpdateSystemdReference(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -201,7 +355,8 @@ func TestUpdateSystemdReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateSystemdReference(tt.value, tt.appID, tt.quadletBasenames)
+			q := &quadletInstaller{appID: tt.appID}
+			result := q.updateSystemdReference(tt.value, tt.quadletBasenames)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -267,7 +422,8 @@ func TestUpdateSpaceSeparatedReferences(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateSpaceSeparatedReferences(tt.value, tt.appID, tt.quadletBasenames)
+			q := &quadletInstaller{appID: tt.appID}
+			result := q.updateSpaceSeparatedReferences(tt.value, tt.quadletBasenames)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -442,6 +598,7 @@ Image=nginx:latest
 			appID: "myapp",
 			expectedFiles: []string{
 				"myapp-web.container",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 			},
 			expectedDropIns: map[string]bool{
@@ -452,9 +609,18 @@ Image=nginx:latest
 					require.Contains(t, string(content), "[Container]")
 					require.Contains(t, string(content), "nginx:latest")
 				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "[Unit]")
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "After=myapp-web.service")
+				},
 				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
-					require.Contains(t, string(content), "[Container]")
-					require.Contains(t, string(content), "io.flightctl.quadlet.project=myapp")
+					contentStr := string(content)
+					require.Contains(t, contentStr, "[Unit]")
+					require.Contains(t, contentStr, "PartOf=myapp-flightctl-quadlet-app.target")
+					require.Contains(t, contentStr, "[Container]")
+					require.Contains(t, contentStr, "io.flightctl.quadlet.project=myapp")
 				},
 			},
 		},
@@ -476,6 +642,7 @@ Network=app-net.network
 				"myapp-web.container",
 				"myapp-data.volume",
 				"myapp-app-net.network",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 				"myapp-.volume.d/99-flightctl.conf",
 				"myapp-.network.d/99-flightctl.conf",
@@ -484,6 +651,12 @@ Network=app-net.network
 				"myapp-web.container": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-data.volume:/data")
 					require.Contains(t, string(content), "myapp-app-net.network")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-data-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-app-net-network.service")
 				},
 			},
 		},
@@ -498,13 +671,16 @@ Image=nginx:latest
 			appID: "myapp",
 			expectedFiles: []string{
 				"myapp-web.container",
+				"myapp-flightctl-quadlet-app.target",
 				".env",
 				"myapp-.container.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
-					require.Contains(t, string(content), "EnvironmentFile")
-					require.Contains(t, string(content), ".env")
+					contentStr := string(content)
+					require.Contains(t, contentStr, "PartOf=myapp-flightctl-quadlet-app.target")
+					require.Contains(t, contentStr, "EnvironmentFile")
+					require.Contains(t, contentStr, ".env")
 				},
 			},
 		},
@@ -525,10 +701,16 @@ Image=postgres:latest
 			expectedFiles: []string{
 				"myapp-web.container",
 				"myapp-db.container",
+				"myapp-flightctl-quadlet-app.target",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-web.container": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-db.container chronyd.service")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-db.service")
 				},
 			},
 		},
@@ -546,10 +728,16 @@ Volume=myapp-data.volume:/data
 			expectedFiles: []string{
 				"myapp-web.container",
 				"myapp-data.volume",
+				"myapp-flightctl-quadlet-app.target",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-web.container": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-data.volume:/data")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-data-volume.service")
 				},
 			},
 		},
@@ -627,10 +815,12 @@ Image=vol-base.image
 				"myapp-config.image",
 				"myapp-vol-base.image",
 				"myapp-app-net.network",
+				"myapp-flightctl-quadlet-app.target",
 				".env",
 				"myapp-.container.d/99-flightctl.conf",
 				"myapp-.pod.d/99-flightctl.conf",
 				"myapp-.volume.d/99-flightctl.conf",
+				"myapp-.image.d/99-flightctl.conf",
 				"myapp-.network.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
@@ -665,8 +855,25 @@ Image=vol-base.image
 				"myapp-cache-vol.volume": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-vol-base.image")
 				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-app.service")
+					require.Contains(t, contentStr, "Wants=myapp-db.service")
+					require.Contains(t, contentStr, "Wants=myapp-init.service")
+					require.Contains(t, contentStr, "Wants=myapp-services-pod.service")
+					require.Contains(t, contentStr, "Wants=myapp-data-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-logs-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-cache-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-shared-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-cache-vol-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-base-image.service")
+					require.Contains(t, contentStr, "Wants=myapp-config-image.service")
+					require.Contains(t, contentStr, "Wants=myapp-vol-base-image.service")
+					require.Contains(t, contentStr, "Wants=myapp-app-net-network.service")
+				},
 				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
 					contentStr := string(content)
+					require.Contains(t, contentStr, "PartOf=myapp-flightctl-quadlet-app.target")
 					require.Contains(t, contentStr, "io.flightctl.quadlet.project=myapp")
 					require.Contains(t, contentStr, "EnvironmentFile")
 					require.Contains(t, contentStr, ".env")
@@ -689,6 +896,7 @@ Network=backend.network
 			expectedFiles: []string{
 				"myapp-web.container",
 				"myapp-backend.network",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-web.container.d/10-custom.conf",
 				"myapp-.container.d/99-flightctl.conf",
 				"myapp-.network.d/99-flightctl.conf",
@@ -696,6 +904,11 @@ Network=backend.network
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-web.container.d/10-custom.conf": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-backend.network")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-backend-network.service")
 				},
 			},
 		},
@@ -715,6 +928,7 @@ Volume=logs.volume:/logs
 			expectedFiles: []string{
 				"myapp-web.container",
 				"myapp-logs.volume",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/05-base.conf",
 				"myapp-.container.d/99-flightctl.conf",
 				"myapp-.volume.d/99-flightctl.conf",
@@ -722,6 +936,11 @@ Volume=logs.volume:/logs
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-.container.d/05-base.conf": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-logs.volume:/logs")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-logs-volume.service")
 				},
 			},
 		},
@@ -750,6 +969,7 @@ Volume=data.volume:/data
 				"myapp-foo-bar.container",
 				"myapp-foo-net.network",
 				"myapp-data.volume",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/01-global.conf",
 				"myapp-foo-.container.d/02-foo.conf",
 				"myapp-foo-bar.container.d/03-specific.conf",
@@ -767,6 +987,16 @@ Volume=data.volume:/data
 				},
 				"myapp-foo-bar.container.d/03-specific.conf": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "myapp-data.volume:/data")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-foo-bar.service")
+					require.Contains(t, contentStr, "Wants=myapp-foo-net-network.service")
+					require.Contains(t, contentStr, "Wants=myapp-data-volume.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "PartOf=myapp-flightctl-quadlet-app.target")
 				},
 			},
 		},
@@ -809,7 +1039,11 @@ Image=init:latest
 				"myapp-data.volume",
 				"myapp-logs.volume",
 				"myapp-cache.volume",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-app.container.d/10-config.conf",
+				"myapp-.container.d/99-flightctl.conf",
+				"myapp-.network.d/99-flightctl.conf",
+				"myapp-.volume.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
 				"myapp-app.container.d/10-config.conf": func(t *testing.T, content []byte) {
@@ -820,6 +1054,19 @@ Image=init:latest
 					require.Contains(t, contentStr, "myapp-data.volume:/data")
 					require.Contains(t, contentStr, "myapp-logs.volume:/logs")
 					require.Contains(t, contentStr, "source=myapp-cache.volume")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-app.service")
+					require.Contains(t, contentStr, "Wants=myapp-db.service")
+					require.Contains(t, contentStr, "Wants=myapp-init.service")
+					require.Contains(t, contentStr, "Wants=myapp-app-net-network.service")
+					require.Contains(t, contentStr, "Wants=myapp-data-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-logs-volume.service")
+					require.Contains(t, contentStr, "Wants=myapp-cache-volume.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
 				},
 			},
 		},
@@ -846,6 +1093,7 @@ WantedBy=multi-user.target
 				"myapp-web.container",
 				"myapp-db.container",
 				"myapp-app-services.target",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
@@ -857,6 +1105,14 @@ WantedBy=multi-user.target
 					// External system targets should NOT be namespaced
 					require.Contains(t, contentStr, "network.target")
 					require.Contains(t, contentStr, "multi-user.target")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-db.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
 				},
 			},
 		},
@@ -883,6 +1139,7 @@ WantedBy=multi-user.target
 			expectedFiles: []string{
 				"myapp-web.container",
 				"myapp-app-services.target",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
@@ -896,6 +1153,13 @@ WantedBy=multi-user.target
 					contentStr := string(content)
 					// System target should NOT be namespaced
 					require.Contains(t, contentStr, "WantedBy=multi-user.target")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
 				},
 			},
 		},
@@ -929,6 +1193,7 @@ VolumeName=app-cache
 				"myapp-db.container",
 				"myapp-backend.network",
 				"myapp-cache.volume",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 				"myapp-.network.d/99-flightctl.conf",
 				"myapp-.volume.d/99-flightctl.conf",
@@ -954,6 +1219,16 @@ VolumeName=app-cache
 				"myapp-cache.volume": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "VolumeName=myapp-app-cache")
 				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-db.service")
+					require.Contains(t, contentStr, "Wants=myapp-backend-network.service")
+					require.Contains(t, contentStr, "Wants=myapp-cache-volume.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
+				},
 			},
 		},
 		{
@@ -977,6 +1252,7 @@ Network=none
 				"myapp-web.container",
 				"myapp-app.container",
 				"myapp-test.container",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.container.d/99-flightctl.conf",
 			},
 			checkFileContents: map[string]func(*testing.T, []byte){
@@ -991,6 +1267,15 @@ Network=none
 				"myapp-test.container": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "Network=none")
 					require.NotContains(t, string(content), "myapp-none")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-web.service")
+					require.Contains(t, contentStr, "Wants=myapp-app.service")
+					require.Contains(t, contentStr, "Wants=myapp-test.service")
+				},
+				"myapp-.container.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
 				},
 			},
 		},
@@ -1010,6 +1295,7 @@ NetworkName=application-network
 			expectedFiles: []string{
 				"myapp-services.pod",
 				"myapp-app-net.network",
+				"myapp-flightctl-quadlet-app.target",
 				"myapp-.pod.d/99-flightctl.conf",
 				"myapp-.network.d/99-flightctl.conf",
 			},
@@ -1023,6 +1309,46 @@ NetworkName=application-network
 				"myapp-app-net.network": func(t *testing.T, content []byte) {
 					require.Contains(t, string(content), "NetworkName=myapp-application-network")
 				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-services-pod.service")
+					require.Contains(t, contentStr, "Wants=myapp-app-net-network.service")
+				},
+				"myapp-.pod.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					require.Contains(t, string(content), "PartOf=myapp-flightctl-quadlet-app.target")
+				},
+			},
+		},
+		{
+			name: "pod with custom ServiceName",
+			files: map[string][]byte{
+				"services.pod": []byte(`[Pod]
+PodName=app-services-pod
+ServiceName=my-custom-service.service
+Network=app-net
+`),
+				"app-net.network": []byte(`[Network]
+`),
+			},
+			appID: "myapp",
+			expectedFiles: []string{
+				"myapp-services.pod",
+				"myapp-app-net.network",
+				"myapp-flightctl-quadlet-app.target",
+				"myapp-.pod.d/99-flightctl.conf",
+				"myapp-.network.d/99-flightctl.conf",
+			},
+			checkFileContents: map[string]func(*testing.T, []byte){
+				"myapp-services.pod": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "ServiceName=myapp-my-custom-service.service")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-my-custom-service.service")
+					require.Contains(t, contentStr, "After=myapp-my-custom-service.service")
+					require.Contains(t, contentStr, "Wants=myapp-app-net-network.service")
+				},
 			},
 		},
 	}
@@ -1032,6 +1358,10 @@ NetworkName=application-network
 			tmpDir := t.TempDir()
 			rw := fileio.NewReadWriter()
 			rw.SetRootdir(tmpDir)
+
+			// Create the systemd unit directory for target file copying
+			err := rw.MkdirAll(lifecycle.QuadletTargetPath, fileio.DefaultDirectoryPermissions)
+			require.NoError(t, err)
 
 			for filename, content := range tt.files {
 				// Create parent directory if file is in a subdirectory
@@ -1044,7 +1374,8 @@ NetworkName=application-network
 				require.NoError(t, err)
 			}
 
-			err := installQuadlet(rw, "/", tt.appID)
+			logger := log.NewPrefixLogger("test")
+			err = installQuadlet(rw, logger, "/", tt.appID)
 			require.NoError(t, err)
 
 			for _, expectedFile := range tt.expectedFiles {
@@ -1057,7 +1388,7 @@ NetworkName=application-network
 				}
 			}
 
-			err = installQuadlet(rw, "/", tt.appID)
+			err = installQuadlet(rw, logger, "/", tt.appID)
 			require.NoError(t, err, "second call to installQuadlet should succeed (idempotency)")
 
 			for _, expectedFile := range tt.expectedFiles {

--- a/internal/agent/device/applications/provider/volume.go
+++ b/internal/agent/device/applications/provider/volume.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/flightctl/flightctl/api/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/client"
@@ -305,7 +306,7 @@ func extractQuadletVolumes(appID string, quadlets map[string]*common.QuadletRefe
 		if quad.Type != common.QuadletTypeVolume || quad.Image == nil {
 			continue
 		}
-
+		name = strings.TrimPrefix(name, fmt.Sprintf("%s-", appID))
 		volumes = append(volumes, &Volume{
 			Name:      name,
 			ID:        quadlet.VolumeName(quad.Name, quadlet.NamespaceResource(appID, name)),

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -203,7 +203,7 @@ func TestSync(t *testing.T) {
 			podmanClient := client.NewPodman(log, mockExec, readWriter, testutil.NewPollConfig())
 			mockWatcher := spec.NewMockWatcher(ctrl)
 			consoleManager := console.NewManager(mockRouterService, deviceName, mockExec, mockWatcher, log)
-			appController := applications.NewController(podmanClient, mockAppManager, readWriter, log)
+			appController := applications.NewController(podmanClient, mockAppManager, readWriter, log, "2025-01-01T00:00:00Z")
 			statusManager := status.NewManager(deviceName, log)
 			statusManager.SetClient(mockManagementClient)
 			configController := config.NewController(readWriter, log)

--- a/internal/agent/device/systemd/mock_systemd.go
+++ b/internal/agent/device/systemd/mock_systemd.go
@@ -86,6 +86,21 @@ func (mr *MockManagerMockRecorder) EnsurePatterns(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsurePatterns", reflect.TypeOf((*MockManager)(nil).EnsurePatterns), arg0)
 }
 
+// ListDependencies mocks base method.
+func (m *MockManager) ListDependencies(ctx context.Context, unit string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDependencies", ctx, unit)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDependencies indicates an expected call of ListDependencies.
+func (mr *MockManagerMockRecorder) ListDependencies(ctx, unit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDependencies", reflect.TypeOf((*MockManager)(nil).ListDependencies), ctx, unit)
+}
+
 // ListUnitsByMatchPattern mocks base method.
 func (m *MockManager) ListUnitsByMatchPattern(ctx context.Context, matchPatterns []string) ([]client.SystemDUnitListEntry, error) {
 	m.ctrl.T.Helper()

--- a/internal/agent/device/systemd/systemd.go
+++ b/internal/agent/device/systemd/systemd.go
@@ -33,6 +33,8 @@ type Manager interface {
 	ResetFailed(ctx context.Context, units ...string) error
 	// ListUnitsByMatchPattern lists systemd units matching the provided patterns.
 	ListUnitsByMatchPattern(ctx context.Context, matchPatterns []string) ([]client.SystemDUnitListEntry, error)
+	// ListDependencies returns the list of units that the specified unit depends on.
+	ListDependencies(ctx context.Context, unit string) ([]string, error)
 	// Logs returns the logs based on the specified options
 	Logs(ctx context.Context, options ...client.LogOptions) ([]string, error)
 	status.Exporter
@@ -95,6 +97,10 @@ func (m *manager) ResetFailed(ctx context.Context, units ...string) error {
 
 func (m *manager) ListUnitsByMatchPattern(ctx context.Context, matchPatterns []string) ([]client.SystemDUnitListEntry, error) {
 	return m.client.ListUnitsByMatchPattern(ctx, matchPatterns)
+}
+
+func (m *manager) ListDependencies(ctx context.Context, unit string) ([]string, error) {
+	return m.client.ListDependencies(ctx, unit)
 }
 
 func (m *manager) Logs(ctx context.Context, options ...client.LogOptions) ([]string, error) {


### PR DESCRIPTION
Embedded compose applications exist only within the image that supplies them. Therefore, whenever a new OS image is deployed and application reconciliation occurs, enqueuing an `Add` to the application manager to effectively `podman compose up -d` is always appropriate. If updating to a new image, the old embedded application won't be added (as it doesn't exist) and therefore won't start. With quadlet's this is not the case.

Quadlets must be namespaced and as such, require moving the embedded quadlets into `/etc/containers/systemd/<app-name>`  This means that lifecycle of embedded applications can exist outside the scope of their image and must support natural `add`, `remove`, or `updates`.

To solve these issues the following was done:

* Instead of requiring the `lifecycle` handler to discover which applications to start/stop (by reading the installation directory), the act of installing a quadlet now generates an `<app-id>-flightctl.target` unit and marks all quadlets as PartOf the target.
* The `lifecycle` handler now calls `systemctl start <app-id>-flightctl.target`
* The `lifecycle` handler now calls `systemctl stop <app-id>-flightctl.target` (unfortunately this isn't synchronous)
*  The `lifecycle` handler now calls `systemctl list-dependencies <app-id>-flightctl.target` to determine the current state of the application and stops all of those services.
*  Embedded quadlet applications are installed with a marker file (`.flightctl-embedded`) containing the system's boot time in their application directory.
* When applications are synced, the `current` spec now includes searching for installed quadlets. (desired still scans for requested quadlets) Embedded quadlets have an unexported `boottime` added to their spec so that proper spec diffing can occur. If an embedded quadlet is installed and it's no longer in the image, it will be removed naturally. If the installed quadlet has a different installed boottime from current, an update will occur. In the steady state, embedded boottimes will match and `ensure` will be called. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover and manage pre-installed embedded apps and their boot-time metadata.
  * Resolve and operate app dependencies via consolidated target units for more reliable lifecycle operations.
  * Expose dependency listing for systemd units to improve orchestration.

* **Refactor**
  * Thread device boot time through provisioning and embedded app handling.
  * Centralized installer flow and added structured logging for embedded/quadlet installs.

* **Bug Fixes**
  * Improved removal, cleanup and error propagation for app add/remove/update flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->