### PR TITLE
EDM-2757: Add quadlet file cross referencing validation

### DIFF
--- a/api/v1beta1/application_validation.go
+++ b/api/v1beta1/application_validation.go
@@ -1,0 +1,76 @@
+package v1beta1
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/flightctl/flightctl/internal/api/common"
+	"github.com/flightctl/flightctl/internal/quadlet"
+	"github.com/flightctl/flightctl/internal/util/validation"
+)
+
+type applicationValidator interface {
+	// ValidateContents returns any errors for the supplied individual contents. It is expected for a caller
+	// to validate the contents before validating the application so that the validator can build state.
+	ValidateContents(path string, contents []byte) []error
+	// Validate returns any errors for the application evaluated as a whole.
+	Validate() []error
+}
+
+type composeValidator struct {
+	paths map[string]struct{}
+}
+
+func (c *composeValidator) ValidateContents(path string, content []byte) []error {
+	c.paths[path] = struct{}{}
+	composeSpec, err := common.ParseComposeSpec(content)
+	if err != nil {
+		return []error{fmt.Errorf("parse compose spec: %w", err)}
+	}
+	return validation.ValidateComposeSpec(composeSpec)
+}
+func (c *composeValidator) Validate() []error {
+	if err := validation.ValidateComposePaths(slices.Collect(maps.Keys(c.paths))); err != nil {
+		return []error{fmt.Errorf("spec.applications[].inline[].path: %w", err)}
+	}
+	return nil
+}
+
+type quadletValidator struct {
+	quadlets map[string]*common.QuadletReferences
+}
+
+func (q *quadletValidator) ValidateContents(path string, content []byte) []error {
+	// Quadlet apps can come with misc files, so only validate that the quadlet files are defined correctly
+	if quadlet.IsQuadletFile(path) {
+		quadletSpec, err := common.ParseQuadletReferences(content)
+		if err != nil {
+			return []error{fmt.Errorf("parse quadlet spec %q: %w", path, err)}
+		}
+		q.quadlets[path] = quadletSpec
+		return validation.ValidateQuadletSpec(quadletSpec, path)
+	}
+	return nil
+}
+
+func (q *quadletValidator) Validate() []error {
+	var errs []error
+	if err := validation.ValidateQuadletPaths(slices.Collect(maps.Keys(q.quadlets))); err != nil {
+		errs = append(errs, fmt.Errorf("spec.applications[].inline[].path: %w", err))
+	}
+	errs = append(errs, validation.ValidateQuadletCrossReferences(q.quadlets)...)
+	return errs
+}
+
+type unknownAppTypeValidator struct {
+	appType AppType
+}
+
+func (u *unknownAppTypeValidator) ValidateContents(path string, content []byte) []error {
+	return nil
+}
+
+func (u *unknownAppTypeValidator) Validate() []error {
+	return []error{fmt.Errorf("unsupported application type: %s", u.appType)}
+}

--- a/api/v1beta1/validation_test.go
+++ b/api/v1beta1/validation_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/robfig/cron/v3"
@@ -1706,7 +1707,8 @@ ExecStart=/usr/bin/myapp`,
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			content := []byte(tt.content)
-			errs := ValidateApplicationContent(content, AppTypeQuadlet, tt.path)
+			validator := quadletValidator{quadlets: make(map[string]*common.QuadletReferences)}
+			errs := validator.ValidateContents(tt.path, content)
 
 			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
 			if tt.wantErrSubstr != "" && len(errs) > 0 {

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -814,6 +814,8 @@ func ensureQuadlet(readWriter fileio.ReadWriter, appPath string) error {
 		}
 	}
 
+	errs = append(errs, validation.ValidateQuadletCrossReferences(spec)...)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("validating quadlets spec: %w", errors.Join(errs...))
 	}

--- a/internal/quadlet/quadlet.go
+++ b/internal/quadlet/quadlet.go
@@ -179,13 +179,12 @@ func MountType(mount string) (string, error) {
 	return "volume", nil
 }
 
-// MountImage parses the Image from a mount if it exists
-func MountImage(mount string) (string, error) {
-	mountType, err := MountType(mount)
+func mountValue(mount string, mountType string) (string, error) {
+	t, err := MountType(mount)
 	if err != nil {
 		return "", err
 	}
-	if mountType != "image" {
+	if t != mountType {
 		return "", nil
 	}
 
@@ -208,14 +207,34 @@ func MountImage(mount string) (string, error) {
 	return "", nil
 }
 
+// MountImage parses the Image from a mount if it exists
+func MountImage(mount string) (string, error) {
+	return mountValue(mount, "image")
+}
+
+// MountVolume parses the Volume from a mount if it exists
+func MountVolume(mount string) (string, error) {
+	return mountValue(mount, "volume")
+}
+
 // IsImageReference returns true if the given string ends with the image quadlet extension.
 func IsImageReference(image string) bool {
-	return strings.HasSuffix(image, ImageExtension)
+	return IsQuadletReference(image, ImageExtension)
 }
 
 // IsBuildReference returns true if the given string ends with the build quadlet extension.
 func IsBuildReference(ref string) bool {
-	return strings.HasSuffix(ref, BuildExtension)
+	return IsQuadletReference(ref, BuildExtension)
+}
+
+// IsVolumeReference returns true if the given string ends with the volume quadlet extension.
+func IsVolumeReference(ref string) bool {
+	return IsQuadletReference(ref, VolumeExtension)
+}
+
+// IsQuadletReference returns true if the given reference matches the expected quadlet extension
+func IsQuadletReference(ref, expected string) bool {
+	return strings.HasSuffix(ref, expected)
 }
 
 // IsQuadletFile returns true if the given file path has a recognized quadlet extension.


### PR DESCRIPTION
Adds validation to ensure applications that have quadlets that reference other quadlets are all defined within their application.
The following spec will now produce an error like: 
```"apiVersion":"v1beta1","code":400,"kind":"Status","message":"quadlet file \"app.pod\" references \"app.network\" which is not defined in the application\nquadlet file \"app.container\" references \"app.network\" which is not defined in the application","reason":"Bad Request","status":"Failure"```
```yaml
      inline:
        - path: app.pod
          content: |
            [Pod]
            Network=app.network
        - path: app.container
          content: |
            [Unit]
            Description=Primary application container
            
            [Container]
            Image=quay.io/flightctl-tests/alpine:v1
            Network=app.network
            Pod=app.pod
            
            [Install]
            WantedBy=default.target
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter quadlet cross-reference validation: ensures images, volumes, networks and pods referenced in quadlets are defined within the application.
  * Expanded parsing of mount and volume references for more accurate validation.
  * Unified application validation flow that validates compose- and quadlet-based packages consistently.

* **Tests**
  * Expanded test coverage for quadlet references, mounts and cross-reference error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->