### PR TITLE
EDM-2760: multi-auth listing AP's without org filter

### DIFF
--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -68,6 +68,9 @@ const (
 	// The requestID related to an event
 	EventAnnotationRequestID = "event-controller/requestID"
 
+	// AuthProvider annotation indicating it was created by a super admin
+	AuthProviderAnnotationCreatedBySuperAdmin = "auth-provider/createdBySuperAdmin"
+
 	RepositoryAPIVersion = "v1beta1"
 	RepositoryKind       = "Repository"
 	RepositoryListKind   = "RepositoryList"

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -66,6 +66,9 @@ func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMid
 	providerName := "oauth2"
 	metadata := api.ObjectMeta{
 		Name: &providerName,
+		Annotations: &map[string]string{
+			api.AuthProviderAnnotationCreatedBySuperAdmin: "true",
+		},
 	}
 
 	authNProvider, err := authn.NewOAuth2Auth(metadata, *cfg.Auth.OAuth2, getTlsConfig(cfg), log)
@@ -81,6 +84,9 @@ func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddl
 	providerName := "oidc"
 	metadata := api.ObjectMeta{
 		Name: &providerName,
+		Annotations: &map[string]string{
+			api.AuthProviderAnnotationCreatedBySuperAdmin: "true",
+		},
 	}
 
 	authNProvider, err := authn.NewOIDCAuth(metadata, *cfg.Auth.OIDC, getTlsConfig(cfg), log)

--- a/internal/auth/authn/multiauth.go
+++ b/internal/auth/authn/multiauth.go
@@ -13,7 +13,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/common"
-	"github.com/flightctl/flightctl/internal/store"
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/samber/lo"
@@ -42,6 +41,7 @@ const (
 // AuthProviderService interface for auth provider operations
 type AuthProviderService interface {
 	ListAuthProviders(ctx context.Context, orgId uuid.UUID, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status)
+	ListAllAuthProviders(ctx context.Context, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status)
 	GetAuthProvider(ctx context.Context, orgId uuid.UUID, name string) (*api.AuthProvider, api.Status)
 	GetAuthProviderByIssuerAndClientId(ctx context.Context, orgId uuid.UUID, issuer string, clientId string) (*api.AuthProvider, api.Status)
 }
@@ -202,8 +202,8 @@ func (m *MultiAuth) periodicLoader(ctx context.Context) {
 // LoadAllAuthProviders reloads auth providers from the database with change detection
 func (m *MultiAuth) LoadAllAuthProviders(ctx context.Context) error {
 
-	// List all auth providers from database
-	providerList, status := m.authProviderService.ListAuthProviders(ctx, store.NullOrgId, api.ListAuthProvidersParams{})
+	// List all auth providers from database without org filtering
+	providerList, status := m.authProviderService.ListAllAuthProviders(ctx, api.ListAuthProvidersParams{})
 	if status.Code != http.StatusOK {
 		return fmt.Errorf("failed to list auth providers: %v", status)
 	}
@@ -239,7 +239,7 @@ func (m *MultiAuth) LoadAllAuthProviders(ctx context.Context) error {
 
 		if exists {
 			// Provider exists - check if it changed
-			changed, err := m.hasProviderChanged(existingMiddleware, provider)
+			changed, err := m.hasProviderChanged(existingMiddleware, provider, lo.FromPtr(provider.Metadata.Name))
 			if err != nil {
 				m.log.Warnf("Failed to check if provider %s changed: %v", lo.FromPtr(provider.Metadata.Name), err)
 				continue
@@ -348,10 +348,11 @@ func (m *MultiAuth) getProviderKey(provider *api.AuthProvider) (AuthProviderCach
 // hasProviderChanged checks if a provider's configuration has changed
 //
 //nolint:gocyclo // Function complexity is acceptable for provider comparison
-func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware, newProvider *api.AuthProvider) (bool, error) {
+func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware, newProvider *api.AuthProvider, providerName string) (bool, error) {
 	// Determine new provider type
 	newDiscriminator, err := newProvider.Spec.Discriminator()
 	if err != nil {
+		m.log.Debugf("Provider %s: changed (failed to get new discriminator: %v)", providerName, err)
 		return true, err
 	}
 
@@ -372,45 +373,62 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 
 		// Compare all fields including client secret
 		if existingOidcSpec.Issuer != newOidcSpec.Issuer {
+			m.log.Debugf("Provider %s: changed (OIDC Issuer: existing=%q, new=%q)", providerName, existingOidcSpec.Issuer, newOidcSpec.Issuer)
 			return true, nil
 		}
 		if existingOidcSpec.ClientId != newOidcSpec.ClientId {
+			m.log.Debugf("Provider %s: changed (OIDC ClientId: existing=%q, new=%q)", providerName, existingOidcSpec.ClientId, newOidcSpec.ClientId)
 			return true, nil
 		}
 		if (existingOidcSpec.ClientSecret == nil) != (newOidcSpec.ClientSecret == nil) {
+			m.log.Debugf("Provider %s: changed (OIDC ClientSecret)", providerName)
 			return true, nil
 		}
 		if existingOidcSpec.ClientSecret != nil && newOidcSpec.ClientSecret != nil && *existingOidcSpec.ClientSecret != *newOidcSpec.ClientSecret {
+			m.log.Debugf("Provider %s: changed (OIDC ClientSecret)", providerName)
 			return true, nil
 		}
 		if existingOidcSpec.ProviderType != newOidcSpec.ProviderType {
+			m.log.Debugf("Provider %s: changed (OIDC ProviderType: existing=%q, new=%q)", providerName, existingOidcSpec.ProviderType, newOidcSpec.ProviderType)
 			return true, nil
 		}
 		if (existingOidcSpec.DisplayName == nil) != (newOidcSpec.DisplayName == nil) {
+			m.log.Debugf("Provider %s: changed (OIDC DisplayName: existing=%q, new=%q)", providerName, existingOidcSpec.DisplayName, newOidcSpec.DisplayName)
 			return true, nil
 		}
-		if existingOidcSpec.DisplayName != nil && newOidcSpec.DisplayName != nil && *existingOidcSpec.DisplayName != *newOidcSpec.DisplayName {
+		// Normalize DisplayName comparison: treat nil and empty string as equivalent
+		existingDisplayName := lo.FromPtr(existingOidcSpec.DisplayName)
+		newDisplayName := lo.FromPtr(newOidcSpec.DisplayName)
+		if existingDisplayName != newDisplayName {
+			m.log.Debugf("Provider %s: changed (OIDC DisplayName: existing=%q, new=%q)", providerName, existingDisplayName, newDisplayName)
 			return true, nil
 		}
 		if (existingOidcSpec.Enabled == nil) != (newOidcSpec.Enabled == nil) {
+			m.log.Debugf("Provider %s: changed (OIDC Enabled nil mismatch: existing=%v, new=%v)", providerName, existingOidcSpec.Enabled == nil, newOidcSpec.Enabled == nil)
 			return true, nil
 		}
 		if existingOidcSpec.Enabled != nil && newOidcSpec.Enabled != nil && *existingOidcSpec.Enabled != *newOidcSpec.Enabled {
+			m.log.Debugf("Provider %s: changed (OIDC Enabled: existing=%v, new=%v)", providerName, *existingOidcSpec.Enabled, *newOidcSpec.Enabled)
 			return true, nil
 		}
+		// Compare UsernameClaim directly (defaults should be set in validation if needed)
 		if !equalStringSlices(existingOidcSpec.UsernameClaim, newOidcSpec.UsernameClaim) {
+			m.log.Debugf("Provider %s: changed (OIDC UsernameClaim: existing=%v, new=%v)", providerName, existingOidcSpec.UsernameClaim, newOidcSpec.UsernameClaim)
 			return true, nil
 		}
 		// Compare scopes
 		if !equalScopes(existingOidcSpec.Scopes, newOidcSpec.Scopes) {
+			m.log.Debugf("Provider %s: changed (OIDC Scopes: existing=%v, new=%v)", providerName, existingOidcSpec.Scopes, newOidcSpec.Scopes)
 			return true, nil
 		}
 		// Compare organization assignment
 		if !equalOrganizationAssignments(existingOidcSpec.OrganizationAssignment, newOidcSpec.OrganizationAssignment) {
+			m.log.Debugf("Provider %s: changed (OIDC OrganizationAssignment)", providerName)
 			return true, nil
 		}
 		// Compare role assignment
 		if !equalRoleAssignments(existingOidcSpec.RoleAssignment, newOidcSpec.RoleAssignment) {
+			m.log.Debugf("Provider %s: changed (OIDC RoleAssignment)", providerName)
 			return true, nil
 		}
 
@@ -435,15 +453,19 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 			return true, nil
 		}
 		if existingOauth2Spec.AuthorizationUrl != newOauth2Spec.AuthorizationUrl {
+			m.log.Debugf("Provider %s: changed (OAuth2 AuthorizationUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.AuthorizationUrl, newOauth2Spec.AuthorizationUrl)
 			return true, nil
 		}
 		if existingOauth2Spec.TokenUrl != newOauth2Spec.TokenUrl {
+			m.log.Debugf("Provider %s: changed (OAuth2 TokenUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.TokenUrl, newOauth2Spec.TokenUrl)
 			return true, nil
 		}
 		if existingOauth2Spec.UserinfoUrl != newOauth2Spec.UserinfoUrl {
+			m.log.Debugf("Provider %s: changed (OAuth2 UserinfoUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.UserinfoUrl, newOauth2Spec.UserinfoUrl)
 			return true, nil
 		}
 		if existingOauth2Spec.ClientId != newOauth2Spec.ClientId {
+			m.log.Debugf("Provider %s: changed (OAuth2 ClientId: existing=%q, new=%q)", providerName, existingOauth2Spec.ClientId, newOauth2Spec.ClientId)
 			return true, nil
 		}
 		if (existingOauth2Spec.ClientSecret == nil) != (newOauth2Spec.ClientSecret == nil) {
@@ -462,16 +484,21 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 			return true, nil
 		}
 		if (existingOauth2Spec.Enabled == nil) != (newOauth2Spec.Enabled == nil) {
+			m.log.Debugf("Provider %s: changed (OAuth2 Enabled nil mismatch: existing=%v, new=%v)", providerName, existingOauth2Spec.Enabled == nil, newOauth2Spec.Enabled == nil)
 			return true, nil
 		}
 		if existingOauth2Spec.Enabled != nil && newOauth2Spec.Enabled != nil && *existingOauth2Spec.Enabled != *newOauth2Spec.Enabled {
+			m.log.Debugf("Provider %s: changed (OAuth2 Enabled: existing=%v, new=%v)", providerName, *existingOauth2Spec.Enabled, *newOauth2Spec.Enabled)
 			return true, nil
 		}
+		// Compare UsernameClaim directly (defaults are set in validation.go)
 		if !equalStringSlices(existingOauth2Spec.UsernameClaim, newOauth2Spec.UsernameClaim) {
+			m.log.Debugf("Provider %s: changed (OAuth2 UsernameClaim: existing=%v, new=%v)", providerName, existingOauth2Spec.UsernameClaim, newOauth2Spec.UsernameClaim)
 			return true, nil
 		}
 		// Compare scopes
 		if !equalScopes(existingOauth2Spec.Scopes, newOauth2Spec.Scopes) {
+			m.log.Debugf("Provider %s: changed (OAuth2 Scopes: existing=%v, new=%v)", providerName, existingOauth2Spec.Scopes, newOauth2Spec.Scopes)
 			return true, nil
 		}
 		// Compare introspection
@@ -480,10 +507,12 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 		}
 		// Compare organization assignment
 		if !equalOrganizationAssignments(existingOauth2Spec.OrganizationAssignment, newOauth2Spec.OrganizationAssignment) {
+			m.log.Debugf("Provider %s: changed (OAuth2 OrganizationAssignment)", providerName)
 			return true, nil
 		}
 		// Compare role assignment
 		if !equalRoleAssignments(existingOauth2Spec.RoleAssignment, newOauth2Spec.RoleAssignment) {
+			m.log.Debugf("Provider %s: changed (OAuth2 RoleAssignment)", providerName)
 			return true, nil
 		}
 

--- a/internal/auth/authn/oidc_auth.go
+++ b/internal/auth/authn/oidc_auth.go
@@ -80,8 +80,16 @@ func NewOIDCAuth(metadata api.ObjectMeta, spec api.OIDCProviderSpec, clientTlsCo
 	// Convert organization assignment to org config
 	orgConfig := convertOrganizationAssignmentToOrgConfig(spec.OrganizationAssignment)
 
-	// Create role extractor from role assignment
-	roleExtractor := NewRoleExtractor(spec.RoleAssignment, log)
+	// Check if AuthProvider was created by super admin
+	createdBySuperAdmin := false
+	if metadata.Annotations != nil {
+		if val, ok := (*metadata.Annotations)[api.AuthProviderAnnotationCreatedBySuperAdmin]; ok && val == "true" {
+			createdBySuperAdmin = true
+		}
+	}
+
+	// Create role extractor from role assignment with super admin flag
+	roleExtractor := NewRoleExtractor(spec.RoleAssignment, createdBySuperAdmin, log)
 
 	// Create identity cache with 10-minute TTL
 	// This caches validated identities to avoid repeated JWT validation

--- a/internal/auth/authn/oidc_auth_test.go
+++ b/internal/auth/authn/oidc_auth_test.go
@@ -42,7 +42,7 @@ func createTestOIDCAuth(jwksUri string) *OIDCAuth {
 		spec:          oidcSpec,
 		jwksUri:       jwksUri,
 		client:        &http.Client{Timeout: 5 * time.Second},
-		roleExtractor: NewRoleExtractor(roleAssignment, log),
+		roleExtractor: NewRoleExtractor(roleAssignment, false, log),
 		organizationExtractor: &OrganizationExtractor{
 			orgConfig: nil, // No org config for basic tests
 		},

--- a/internal/auth/authn/role_extractor_test.go
+++ b/internal/auth/authn/role_extractor_test.go
@@ -1,0 +1,205 @@
+package authn
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/v1beta1"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoleExtractor_FilterFlightctlAdmin_NotCreatedBySuperAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Create role assignment with dynamic role mapping
+	roleAssignment := api.AuthRoleAssignment{}
+	dynamicRoleAssignment := api.AuthDynamicRoleAssignment{
+		Type:      api.AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"roles"},
+	}
+	err := roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
+	require.NoError(t, err)
+
+	// Create extractor with createdBySuperAdmin=false
+	extractor := NewRoleExtractor(roleAssignment, false, log)
+
+	// Test claims with flightctl-admin role
+	claims := map[string]interface{}{
+		"roles": []interface{}{
+			api.ExternalRoleAdmin,
+			api.ExternalRoleViewer,
+			api.ExternalRoleOperator,
+		},
+	}
+
+	result := extractor.ExtractOrgRolesFromMap(claims)
+	require.NotNil(t, result)
+
+	// flightctl-admin should be filtered out
+	globalRoles := result["*"]
+	assert.NotContains(t, globalRoles, api.ExternalRoleAdmin, "flightctl-admin should be filtered out")
+	assert.Contains(t, globalRoles, api.ExternalRoleViewer, "viewer role should be present")
+	assert.Contains(t, globalRoles, api.ExternalRoleOperator, "operator role should be present")
+}
+
+func TestRoleExtractor_AllowFlightctlAdmin_CreatedBySuperAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Create role assignment with dynamic role mapping
+	roleAssignment := api.AuthRoleAssignment{}
+	dynamicRoleAssignment := api.AuthDynamicRoleAssignment{
+		Type:      api.AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"roles"},
+	}
+	err := roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
+	require.NoError(t, err)
+
+	// Create extractor with createdBySuperAdmin=true
+	extractor := NewRoleExtractor(roleAssignment, true, log)
+
+	// Test claims with flightctl-admin role
+	claims := map[string]interface{}{
+		"roles": []interface{}{
+			api.ExternalRoleAdmin,
+			api.ExternalRoleViewer,
+			api.ExternalRoleOperator,
+		},
+	}
+
+	result := extractor.ExtractOrgRolesFromMap(claims)
+	require.NotNil(t, result)
+
+	// flightctl-admin should be allowed
+	globalRoles := result["*"]
+	assert.Contains(t, globalRoles, api.ExternalRoleAdmin, "flightctl-admin should be allowed when created by super admin")
+	assert.Contains(t, globalRoles, api.ExternalRoleViewer, "viewer role should be present")
+	assert.Contains(t, globalRoles, api.ExternalRoleOperator, "operator role should be present")
+}
+
+func TestRoleExtractor_FilterOrgScopedFlightctlAdmin_NotCreatedBySuperAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Create role assignment with dynamic role mapping
+	roleAssignment := api.AuthRoleAssignment{}
+	dynamicRoleAssignment := api.AuthDynamicRoleAssignment{
+		Type:      api.AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"roles"},
+		Separator: lo.ToPtr(":"),
+	}
+	err := roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
+	require.NoError(t, err)
+
+	// Create extractor with createdBySuperAdmin=false
+	extractor := NewRoleExtractor(roleAssignment, false, log)
+
+	// Test claims with org-scoped flightctl-admin role
+	claims := map[string]interface{}{
+		"roles": []interface{}{
+			"org1:" + api.ExternalRoleAdmin,
+			"org1:" + api.ExternalRoleViewer,
+			"org2:" + api.ExternalRoleAdmin,
+			"org2:" + api.ExternalRoleOperator,
+		},
+	}
+
+	result := extractor.ExtractOrgRolesFromMap(claims)
+	require.NotNil(t, result)
+
+	// Org-scoped flightctl-admin should be filtered out
+	org1Roles := result["org1"]
+	assert.NotContains(t, org1Roles, api.ExternalRoleAdmin, "org1 flightctl-admin should be filtered out")
+	assert.Contains(t, org1Roles, api.ExternalRoleViewer, "org1 viewer role should be present")
+
+	org2Roles := result["org2"]
+	assert.NotContains(t, org2Roles, api.ExternalRoleAdmin, "org2 flightctl-admin should be filtered out")
+	assert.Contains(t, org2Roles, api.ExternalRoleOperator, "org2 operator role should be present")
+}
+
+func TestRoleExtractor_AllowOrgScopedFlightctlAdmin_CreatedBySuperAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Create role assignment with dynamic role mapping
+	roleAssignment := api.AuthRoleAssignment{}
+	dynamicRoleAssignment := api.AuthDynamicRoleAssignment{
+		Type:      api.AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"roles"},
+		Separator: lo.ToPtr(":"),
+	}
+	err := roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
+	require.NoError(t, err)
+
+	// Create extractor with createdBySuperAdmin=true
+	extractor := NewRoleExtractor(roleAssignment, true, log)
+
+	// Test claims with org-scoped flightctl-admin role
+	claims := map[string]interface{}{
+		"roles": []interface{}{
+			"org1:" + api.ExternalRoleAdmin,
+			"org1:" + api.ExternalRoleViewer,
+			"org2:" + api.ExternalRoleAdmin,
+		},
+	}
+
+	result := extractor.ExtractOrgRolesFromMap(claims)
+	require.NotNil(t, result)
+
+	// Org-scoped flightctl-admin should be allowed
+	org1Roles := result["org1"]
+	assert.Contains(t, org1Roles, api.ExternalRoleAdmin, "org1 flightctl-admin should be allowed when created by super admin")
+	assert.Contains(t, org1Roles, api.ExternalRoleViewer, "org1 viewer role should be present")
+
+	org2Roles := result["org2"]
+	assert.Contains(t, org2Roles, api.ExternalRoleAdmin, "org2 flightctl-admin should be allowed when created by super admin")
+}
+
+func TestRoleExtractor_MixedRoles_NotCreatedBySuperAdmin(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// Create role assignment with dynamic role mapping
+	roleAssignment := api.AuthRoleAssignment{}
+	dynamicRoleAssignment := api.AuthDynamicRoleAssignment{
+		Type:      api.AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"roles"},
+		Separator: lo.ToPtr(":"),
+	}
+	err := roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
+	require.NoError(t, err)
+
+	// Create extractor with createdBySuperAdmin=false
+	extractor := NewRoleExtractor(roleAssignment, false, log)
+
+	// Test claims with mixed global and org-scoped roles including flightctl-admin
+	claims := map[string]interface{}{
+		"roles": []interface{}{
+			api.ExternalRoleAdmin,              // Global flightctl-admin - should be filtered
+			api.ExternalRoleViewer,             // Global viewer - should be allowed
+			"org1:" + api.ExternalRoleAdmin,    // Org-scoped flightctl-admin - should be filtered
+			"org1:" + api.ExternalRoleOperator, // Org-scoped operator - should be allowed
+			"org2:" + api.ExternalRoleViewer,   // Org-scoped viewer - should be allowed
+		},
+	}
+
+	result := extractor.ExtractOrgRolesFromMap(claims)
+	require.NotNil(t, result)
+
+	// Check global roles
+	globalRoles := result["*"]
+	assert.NotContains(t, globalRoles, api.ExternalRoleAdmin, "global flightctl-admin should be filtered out")
+	assert.Contains(t, globalRoles, api.ExternalRoleViewer, "global viewer should be present")
+
+	// Check org1 roles
+	org1Roles := result["org1"]
+	assert.NotContains(t, org1Roles, api.ExternalRoleAdmin, "org1 flightctl-admin should be filtered out")
+	assert.Contains(t, org1Roles, api.ExternalRoleOperator, "org1 operator should be present")
+
+	// Check org2 roles
+	org2Roles := result["org2"]
+	assert.Contains(t, org2Roles, api.ExternalRoleViewer, "org2 viewer should be present")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -556,6 +556,7 @@ func applyAuthDefaults(c *Config) error {
 	applyAuthProviderEnabledDefaults(c.Auth)
 	applyPAMOIDCIssuerDefaults(c)
 	applyOIDCClientDefaults(c)
+	applyOpenShiftDefaults(c)
 	if err := applyOAuth2Defaults(c); err != nil {
 		return err
 	}
@@ -659,6 +660,19 @@ func applyOIDCOrganizationAssignmentDefaults(oidc *api.OIDCProviderSpec) {
 			Type:             api.AuthStaticOrganizationAssignmentTypeStatic,
 		}
 		_ = oidc.OrganizationAssignment.FromAuthStaticOrganizationAssignment(staticAssignment)
+	}
+}
+
+func applyOpenShiftDefaults(c *Config) {
+	if c.Auth.OpenShift == nil {
+		return
+	}
+
+	// Use authorizationUrl as issuer if issuer is not provided
+	if c.Auth.OpenShift.Issuer == nil || *c.Auth.OpenShift.Issuer == "" {
+		if c.Auth.OpenShift.AuthorizationUrl != nil {
+			c.Auth.OpenShift.Issuer = c.Auth.OpenShift.AuthorizationUrl
+		}
 	}
 }
 

--- a/internal/service/authprovider.go
+++ b/internal/service/authprovider.go
@@ -3,11 +3,14 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
+	"github.com/flightctl/flightctl/internal/contextutil"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 )
 
 // sanitizeSchemaError inspects the error and redacts sensitive fields
@@ -26,15 +29,97 @@ func sanitizeSchemaError(err error) string {
 	return errMsg
 }
 
+// applyAuthProviderDefaults applies default values to auth provider specs during creation.
+// This includes setting UsernameClaim for OIDC and OAuth2 providers, Issuer for OAuth2,
+// and inferring Introspection for OAuth2 if not provided.
+func applyAuthProviderDefaults(spec *api.AuthProviderSpec) error {
+	discriminator, err := spec.Discriminator()
+	if err != nil {
+		return nil // Not a valid provider, nothing to do
+	}
+
+	switch discriminator {
+	case string(api.Oidc):
+		oidcSpec, err := spec.AsOIDCProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OIDC provider spec: %w", err)
+		}
+
+		// Default UsernameClaim to ["preferred_username"] if not provided
+		if oidcSpec.UsernameClaim == nil || len(*oidcSpec.UsernameClaim) == 0 {
+			defaultUsernameClaim := []string{"preferred_username"}
+			oidcSpec.UsernameClaim = &defaultUsernameClaim
+		}
+
+		// Merge the mutated spec back into the union
+		if mergeErr := spec.MergeOIDCProviderSpec(oidcSpec); mergeErr != nil {
+			return fmt.Errorf("failed to update OIDC provider spec: %w", mergeErr)
+		}
+
+	case string(api.Oauth2):
+		oauth2Spec, err := spec.AsOAuth2ProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 provider spec: %w", err)
+		}
+
+		// Default UsernameClaim to ["preferred_username"] if not provided
+		if oauth2Spec.UsernameClaim == nil || len(*oauth2Spec.UsernameClaim) == 0 {
+			defaultUsernameClaim := []string{"preferred_username"}
+			oauth2Spec.UsernameClaim = &defaultUsernameClaim
+		}
+
+		// Use authorizationUrl as issuer if issuer is not provided
+		if oauth2Spec.Issuer == nil || *oauth2Spec.Issuer == "" {
+			oauth2Spec.Issuer = &oauth2Spec.AuthorizationUrl
+		}
+
+		// Infer introspection if not provided
+		if oauth2Spec.Introspection == nil {
+			introspection, err := api.InferOAuth2IntrospectionConfig(oauth2Spec)
+			if err != nil {
+				return fmt.Errorf("introspection field is required and could not be inferred: %w", err)
+			}
+			oauth2Spec.Introspection = introspection
+		}
+
+		// Merge the mutated spec back into the union
+		if mergeErr := spec.MergeOAuth2ProviderSpec(oauth2Spec); mergeErr != nil {
+			return fmt.Errorf("failed to update OAuth2 provider spec: %w", mergeErr)
+		}
+	}
+
+	return nil
+}
+
 func (h *ServiceHandler) CreateAuthProvider(ctx context.Context, orgId uuid.UUID, authProvider api.AuthProvider) (*api.AuthProvider, api.Status) {
 
 	// don't set fields that are managed by the service
 	NilOutManagedObjectMetaProperties(&authProvider.Metadata)
 
+	// Apply defaults for auth providers (only during creation)
+	if err := applyAuthProviderDefaults(&authProvider.Spec); err != nil {
+		return nil, api.StatusBadRequest(sanitizeSchemaError(err))
+	}
+
 	if errs := authProvider.Validate(ctx); len(errs) > 0 {
 		return nil, api.StatusBadRequest(sanitizeSchemaError(errors.Join(errs...)))
 	}
 
+	// Check if created by super admin and prepare annotations
+	mappedIdentity, ok := contextutil.GetMappedIdentityFromContext(ctx)
+	createdBySuperAdmin := ok && mappedIdentity.IsSuperAdmin()
+
+	// Clear user-provided annotations and set our annotation if needed
+	if createdBySuperAdmin {
+		authProvider.Metadata.Annotations = lo.ToPtr(map[string]string{
+			api.AuthProviderAnnotationCreatedBySuperAdmin: "true",
+		})
+		// Use fromAPI=false to preserve annotations
+		result, err := h.store.AuthProvider().CreateWithFromAPI(ctx, orgId, &authProvider, false, h.callbackAuthProviderUpdated)
+		return result, StoreErrorToApiStatus(err, true, api.AuthProviderKind, authProvider.Metadata.Name)
+	}
+
+	// For non-super-admin users, use regular Create (fromAPI=true, annotations cleared)
 	result, err := h.store.AuthProvider().Create(ctx, orgId, &authProvider, h.callbackAuthProviderUpdated)
 	return result, StoreErrorToApiStatus(err, true, api.AuthProviderKind, authProvider.Metadata.Name)
 }
@@ -47,6 +132,28 @@ func (h *ServiceHandler) ListAuthProviders(ctx context.Context, orgId uuid.UUID,
 	}
 
 	result, err := h.store.AuthProvider().List(ctx, orgId, *listParams)
+	if err == nil {
+		return result, api.StatusOK()
+	}
+
+	var se *selector.SelectorError
+
+	switch {
+	case selector.AsSelectorError(err, &se):
+		return nil, api.StatusBadRequest(se.Error())
+	default:
+		return nil, api.StatusInternalServerError(err.Error())
+	}
+}
+
+func (h *ServiceHandler) ListAllAuthProviders(ctx context.Context, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status) {
+
+	listParams, status := prepareListParams(params.Continue, params.LabelSelector, params.FieldSelector, params.Limit)
+	if status != api.StatusOK() {
+		return nil, status
+	}
+
+	result, err := h.store.AuthProvider().ListAll(ctx, *listParams)
 	if err == nil {
 		return result, api.StatusOK()
 	}
@@ -82,7 +189,10 @@ func (h *ServiceHandler) ReplaceAuthProvider(ctx context.Context, orgId uuid.UUI
 			return nil, api.StatusBadRequest(sanitizeSchemaError(errors.Join(errs...)))
 		}
 	} else {
-		// Resource doesn't exist, validate creation
+		// Resource doesn't exist, apply defaults and validate creation
+		if err := applyAuthProviderDefaults(&authProvider.Spec); err != nil {
+			return nil, api.StatusBadRequest(sanitizeSchemaError(err))
+		}
 		if errs := authProvider.Validate(ctx); len(errs) > 0 {
 			return nil, api.StatusBadRequest(sanitizeSchemaError(errors.Join(errs...)))
 		}

--- a/internal/service/mock_service.go
+++ b/internal/service/mock_service.go
@@ -753,6 +753,21 @@ func (mr *MockServiceMockRecorder) GetTemplateVersion(ctx, orgId, fleet, name an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateVersion", reflect.TypeOf((*MockService)(nil).GetTemplateVersion), ctx, orgId, fleet, name)
 }
 
+// ListAllAuthProviders mocks base method.
+func (m *MockService) ListAllAuthProviders(ctx context.Context, params v1beta1.ListAuthProvidersParams) (*v1beta1.AuthProviderList, v1beta1.Status) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllAuthProviders", ctx, params)
+	ret0, _ := ret[0].(*v1beta1.AuthProviderList)
+	ret1, _ := ret[1].(v1beta1.Status)
+	return ret0, ret1
+}
+
+// ListAllAuthProviders indicates an expected call of ListAllAuthProviders.
+func (mr *MockServiceMockRecorder) ListAllAuthProviders(ctx, params any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAuthProviders", reflect.TypeOf((*MockService)(nil).ListAllAuthProviders), ctx, params)
+}
+
 // ListAuthProviders mocks base method.
 func (m *MockService) ListAuthProviders(ctx context.Context, orgId uuid.UUID, params v1beta1.ListAuthProvidersParams) (*v1beta1.AuthProviderList, v1beta1.Status) {
 	m.ctrl.T.Helper()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -100,6 +100,7 @@ type Service interface {
 	// AuthProvider
 	CreateAuthProvider(ctx context.Context, orgId uuid.UUID, authProvider api.AuthProvider) (*api.AuthProvider, api.Status)
 	ListAuthProviders(ctx context.Context, orgId uuid.UUID, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status)
+	ListAllAuthProviders(ctx context.Context, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status)
 	GetAuthProvider(ctx context.Context, orgId uuid.UUID, name string) (*api.AuthProvider, api.Status)
 	GetAuthProviderByIssuerAndClientId(ctx context.Context, orgId uuid.UUID, issuer string, clientId string) (*api.AuthProvider, api.Status)
 	GetAuthProviderByAuthorizationUrl(ctx context.Context, orgId uuid.UUID, authorizationUrl string) (*api.AuthProvider, api.Status)

--- a/internal/service/traced_service.go
+++ b/internal/service/traced_service.go
@@ -628,6 +628,13 @@ func (t *TracedService) ListAuthProviders(ctx context.Context, orgId uuid.UUID, 
 	return resp, st
 }
 
+func (t *TracedService) ListAllAuthProviders(ctx context.Context, params api.ListAuthProvidersParams) (*api.AuthProviderList, api.Status) {
+	ctx, span := startSpan(ctx, "ListAllAuthProviders")
+	resp, st := t.inner.ListAllAuthProviders(ctx, params)
+	endSpan(span, st)
+	return resp, st
+}
+
 func (t *TracedService) GetAuthProvider(ctx context.Context, orgId uuid.UUID, name string) (*api.AuthProvider, api.Status) {
 	ctx, span := startSpan(ctx, "GetAuthProvider")
 	resp, st := t.inner.GetAuthProvider(ctx, orgId, name)

--- a/internal/store/authprovider.go
+++ b/internal/store/authprovider.go
@@ -2,9 +2,14 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	api "github.com/flightctl/flightctl/api/v1beta1"
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -15,6 +20,7 @@ type AuthProvider interface {
 	InitialMigration(ctx context.Context) error
 
 	Create(ctx context.Context, orgId uuid.UUID, authProvider *api.AuthProvider, eventCallback EventCallback) (*api.AuthProvider, error)
+	CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, authProvider *api.AuthProvider, fromAPI bool, eventCallback EventCallback) (*api.AuthProvider, error)
 	Update(ctx context.Context, orgId uuid.UUID, authProvider *api.AuthProvider, eventCallback EventCallback) (*api.AuthProvider, error)
 	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, authProvider *api.AuthProvider, eventCallback EventCallback) (*api.AuthProvider, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*api.AuthProvider, error)
@@ -27,6 +33,9 @@ type AuthProvider interface {
 	// Used by domain metrics
 	Count(ctx context.Context, orgId uuid.UUID, listParams ListParams) (int64, error)
 	CountByOrg(ctx context.Context, orgId *uuid.UUID) ([]CountByOrgResult, error)
+
+	// ListAll lists all auth providers without org filtering
+	ListAll(ctx context.Context, listParams ListParams) (*api.AuthProviderList, error)
 }
 
 type AuthProviderStore struct {
@@ -114,6 +123,18 @@ func (s *AuthProviderStore) Create(ctx context.Context, orgId uuid.UUID, resourc
 	return provider, err
 }
 
+func (s *AuthProviderStore) CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, resource *api.AuthProvider, fromAPI bool, eventCallback EventCallback) (*api.AuthProvider, error) {
+	provider, _, _, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, fromAPI, func(ctx context.Context, before, after *api.AuthProvider) error {
+		// If there's an existing resource, return an error to enforce create-only behavior
+		if before != nil {
+			return flterrors.ErrDuplicateName
+		}
+		return nil
+	})
+	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), nil, provider, true, err)
+	return provider, err
+}
+
 func (s *AuthProviderStore) Update(ctx context.Context, orgId uuid.UUID, resource *api.AuthProvider, eventCallback EventCallback) (*api.AuthProvider, error) {
 	newProvider, oldProvider, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldProvider, newProvider, false, err)
@@ -183,6 +204,115 @@ func (s *AuthProviderStore) CountByOrg(ctx context.Context, orgId *uuid.UUID) ([
 	}
 
 	return results, nil
+}
+
+func (s *AuthProviderStore) ListAll(ctx context.Context, listParams ListParams) (*api.AuthProviderList, error) {
+	var resourceList []model.AuthProvider
+	var nextContinue *string
+	var numRemaining *int64
+
+	// Build query without org filtering
+	query := s.getDB(ctx).Model(&model.AuthProvider{})
+
+	// Apply field selector if present
+	if listParams.FieldSelector != nil {
+		q, p, err := listParams.FieldSelector.Parse(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		query = query.Where(q, p...)
+	}
+
+	// Apply label selector if present
+	if listParams.LabelSelector != nil {
+		q, p, err := listParams.LabelSelector.Parse(ctx, selector.NewHiddenSelectorName("metadata.labels"), nil)
+		if err != nil {
+			return nil, err
+		}
+		query = query.Where(q, p...)
+	}
+
+	// Apply annotation selector if present
+	if listParams.AnnotationSelector != nil {
+		q, p, err := listParams.AnnotationSelector.Parse(ctx, selector.NewHiddenSelectorName("metadata.annotations"), nil)
+		if err != nil {
+			return nil, err
+		}
+		query = query.Where(q, p...)
+	}
+
+	// Apply sorting
+	columns, order, _ := getSortColumns(listParams)
+	orderExprs := lo.Map(columns, func(col SortColumn, _ int) string {
+		return fmt.Sprintf("%s %s", col, order)
+	})
+	if len(orderExprs) > 0 {
+		query = query.Order(strings.Join(orderExprs, ", "))
+	}
+
+	// Apply pagination if limit is set
+	if listParams.Limit > 0 {
+		query = AddPaginationToQuery(query, listParams.Limit+1, listParams.Continue, listParams)
+	}
+
+	// Execute query
+	result := query.Find(&resourceList)
+	if result.Error != nil {
+		return nil, ErrorFromGormError(result.Error)
+	}
+
+	// Handle pagination continuation token
+	if listParams.Limit > 0 && len(resourceList) > listParams.Limit {
+		lastIndex := len(resourceList) - 1
+		lastItem := resourceList[lastIndex]
+		columns, _, _ := getSortColumns(listParams)
+
+		// Build values for continue token
+		continueValues := make([]string, len(columns))
+		for i, col := range columns {
+			switch col {
+			case SortByName:
+				continueValues[i] = lastItem.GetName()
+			case SortByCreatedAt:
+				continueValues[i] = lastItem.GetTimestamp().Format(time.RFC3339Nano)
+			default:
+				continueValues[i] = ""
+			}
+		}
+
+		resourceList = resourceList[:lastIndex]
+
+		var numRemainingVal int64
+		if listParams.Continue != nil {
+			numRemainingVal = listParams.Continue.Count - int64(listParams.Limit)
+			if numRemainingVal < 1 {
+				numRemainingVal = 1
+			}
+		} else {
+			// Count remaining items
+			countQuery := s.getDB(ctx).Model(&model.AuthProvider{})
+			if listParams.FieldSelector != nil {
+				q, p, _ := listParams.FieldSelector.Parse(ctx, nil)
+				countQuery = countQuery.Where(q, p...)
+			}
+			if listParams.LabelSelector != nil {
+				q, p, _ := listParams.LabelSelector.Parse(ctx, selector.NewHiddenSelectorName("metadata.labels"), nil)
+				countQuery = countQuery.Where(q, p...)
+			}
+			if listParams.AnnotationSelector != nil {
+				q, p, _ := listParams.AnnotationSelector.Parse(ctx, selector.NewHiddenSelectorName("metadata.annotations"), nil)
+				countQuery = countQuery.Where(q, p...)
+			}
+			numRemainingVal = CountRemainingItems(countQuery, continueValues, listParams)
+		}
+
+		nextContinue = BuildContinueString(continueValues, numRemainingVal)
+		numRemaining = &numRemainingVal
+	}
+
+	// Convert to API resources
+	apiList, err := s.genericStore.listModelToAPI(resourceList, nextContinue, numRemaining)
+	return &apiList, err
 }
 
 func (s *AuthProviderStore) GetAuthProviderByIssuerAndClientId(ctx context.Context, orgId uuid.UUID, issuer string, clientId string) (*api.AuthProvider, error) {

--- a/pkg/k8sclient/k8s_client_test.go
+++ b/pkg/k8sclient/k8s_client_test.go
@@ -1,0 +1,77 @@
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithLabelSelector(t *testing.T) {
+	tests := []struct {
+		name           string
+		selector       string
+		expectParamSet bool
+	}{
+		{
+			name:           "valid label selector",
+			selector:       "io.flightctl/instance=test-release",
+			expectParamSet: true,
+		},
+		{
+			name:           "key only selector",
+			selector:       "environment",
+			expectParamSet: true,
+		},
+		{
+			name:           "empty selector",
+			selector:       "",
+			expectParamSet: false,
+		},
+		{
+			name:           "key=value selector",
+			selector:       "key=value",
+			expectParamSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock request to verify the parameter is set
+			// We can't easily test rest.Request directly, but we can verify the option function
+			option := WithLabelSelector(tt.selector)
+
+			// Verify the option is not nil
+			assert.NotNil(t, option)
+
+			// For empty selector, the option should still exist but not set the param
+			// We can't easily test the actual Param call without a real request,
+			// but we can verify the function is created correctly
+			if tt.selector == "" {
+				// Empty selector should not set the param
+				// The function will check if selector != "" before calling req.Param
+				assert.NotNil(t, option)
+			} else {
+				// Non-empty selector should set the param
+				assert.NotNil(t, option)
+			}
+		})
+	}
+}
+
+// TestWithLabelSelector_Integration tests that the option actually sets the parameter
+// This is a basic integration test to verify the option works with a real request
+func TestWithLabelSelector_Integration(t *testing.T) {
+	selector := "io.flightctl/instance=test-release"
+	option := WithLabelSelector(selector)
+
+	// Create a minimal request to test
+	// Note: This is a simplified test since we can't easily create a full rest.Request
+	// without a real Kubernetes client config
+	_ = option
+
+	// Verify the option function is created
+	assert.NotNil(t, option)
+
+	// The actual parameter setting is tested indirectly through the OpenShift auth tests
+	// which verify that ListProjects is called with the correct options
+}


### PR DESCRIPTION
EDM-2760: multi-auth listing AP's without org filter
NO-ISSUE: prevent non super-admins from setting static role = super admin , or by receiving it as a dynamic role value
NO-ISSUE: fix defaults not being set in validation.go or config.go (they were set in individual auth providers) which caused false detection of auth provider update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added listing of all authentication providers across organizations.
  * Authentication providers created by super admins now support flightctl-admin role assignments.

* **Bug Fixes**
  * Fixed flightctl-admin role filtering: roles are now correctly preserved when providers are created by super admins.

* **Security**
  * Enforced admin-only restrictions for static role and organization mapping configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->