### PR TITLE
EDM-2761: support edit for AP

### DIFF
--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -146,7 +146,7 @@ func (o *EditOptions) Validate(args []string) error {
 
 	// Check if resource type supports editing
 	switch kind {
-	case DeviceKind, FleetKind, RepositoryKind, CertificateSigningRequestKind:
+	case DeviceKind, FleetKind, RepositoryKind, CertificateSigningRequestKind, AuthProviderKind:
 		// These are supported for editing
 	default:
 		return errEditNotAllowed{kind}
@@ -484,6 +484,9 @@ func (o *EditOptions) executePatchOperation(ctx context.Context, client *apiclie
 		return o.extractResponseData(response, err)
 	case CertificateSigningRequestKind:
 		response, err := client.PatchCertificateSigningRequestWithBodyWithResponse(ctx, name, contentType, reader)
+		return o.extractResponseData(response, err)
+	case AuthProviderKind:
+		response, err := client.PatchAuthProviderWithBodyWithResponse(ctx, name, contentType, reader)
 		return o.extractResponseData(response, err)
 	case EnrollmentRequestKind:
 		response, err := client.PatchEnrollmentRequestWithBodyWithResponse(ctx, name, contentType, reader)


### PR DESCRIPTION
EDM-2761: support edit for AP
EDM-2762: updating client secret does not refresh cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AuthProvider resources can now be edited through the CLI command interface.

* **Bug Fixes**
  * Improved detection of authentication provider configuration changes for OIDC and OAuth2 providers with enhanced field-level comparison accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->