### PR TITLE
EDM-2689: Fix systemd unit in status when spec empty

### DIFF
--- a/internal/agent/device/systemd/systemd.go
+++ b/internal/agent/device/systemd/systemd.go
@@ -127,6 +127,7 @@ func (m *manager) normalizeActiveStateValue(val v1beta1.SystemdActiveStateType) 
 
 func (m *manager) Status(ctx context.Context, device *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
 	if len(m.patterns) == 0 {
+		device.Systemd = nil
 		return nil
 	}
 


### PR DESCRIPTION
Clear `device.status.systemd` when user removes systemd monitoring from spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device status handling to correctly reflect system state when no patterns are configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->