### PR TITLE
EDM-2776: Correct doc on permission to approve ERs

### DIFF
--- a/docs/user/references/auth-resources.md
+++ b/docs/user/references/auth-resources.md
@@ -29,7 +29,7 @@ The table below contains the routes, names, resource names, and verbs for Flight
 |`PATCH /api/v1/enrollmentrequests/{name}`|`PatchEnrollmentRequest`|`enrollmentrequests`|`patch`|
 |`DELETE /api/v1/enrollmentrequests/{name}`|`DeleteEnrollmentRequest`|`enrollmentrequests`|`delete`|
 |`GET /api/v1/enrollmentrequests/{name}/status`|`ReadEnrollmentRequestStatus`|`enrollmentrequests/status`|`get`|
-|`POST /api/v1/enrollmentrequests/{name}/approval`|`ApproveEnrollmentRequest`|`enrollmentrequests/approval`|`post`|
+|`PUT /api/v1/enrollmentrequests/{name}/approval`|`ApproveEnrollmentRequest`|`enrollmentrequests/approval`|`update`|
 |`PUT /api/v1/enrollmentrequests/{name}/status`|`ReplaceEnrollmentRequestStatus`|`enrollmentrequests/status`|`update`|
 |`POST /api/v1/fleets`|`CreateFleet`|`fleets`|`create`|
 |`GET /api/v1/fleets`|`ListFleets`|`fleets`|`list`|


### PR DESCRIPTION
The verb for approving Enrollment Requests is "PUT" and not "POST".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API docs for the enrollment approval endpoint to reflect the correct HTTP method (PUT instead of POST).
  * Clarified request examples and method listings so clients and integrations use PUT when approving enrollment requests.
  * No other API routes or request/response fields were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->