### PR TITLE
Fix local UI deployment in kind cluster

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -266,7 +266,7 @@ Usage: {{- $authType := include "flightctl.getEffectiveAuthType" . }}
   {{- $scheme := (include "flightctl.getHttpScheme" . )}}
   {{- $exposeMethod := (include "flightctl.getServiceExposeMethod" . )}}
   {{- if eq $exposeMethod "nodePort" }}
-    {{- printf "%s://flightctl-alertmanager-proxy:8443" $scheme }}
+    {{- printf "https://flightctl-alertmanager-proxy:8443" }}
   {{- else if eq $exposeMethod "gateway" }}
     {{- if and (eq $scheme "http") (not (eq (int .Values.global.gateway.ports.http) 80))}}
       {{- printf "%s://alertmanager-proxy.%s:%v" $scheme $baseDomain .Values.global.gateway.ports.http }}

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -9,38 +9,41 @@ kubeadmConfigPatches:
 nodes:
 - role: control-plane
   extraPortMappings:
+  - containerPort: 3222 # local git server for E2E testing
+    hostPort: 3222
+    protocol: TCP  
   - containerPort: 3443 # flightctl API
     hostPort: 3443
     protocol: TCP
-  - containerPort: 8090 # flightctl CLI artifacts
-    hostPort: 8090
-    protocol: TCP
-  - containerPort: 7443 # flightctl agent endpoint API
-    hostPort: 7443
-    protocol: TCP
-  - containerPort: 5432 # postgresql DB
-    hostPort: 5432
-    protocol: TCP
-  - containerPort: 5000 # local registry for E2E testing
-    hostPort: 5000
-    protocol: TCP
-  - containerPort: 3222 # local git server for E2E testing
-    hostPort: 3222
-    protocol: TCP
-  - containerPort: 9090 # Prometheus server
-    hostPort: 9090
-    protocol: TCP
-  - containerPort: 8443 # alertmanager proxy
-    hostPort: 8443
-    protocol: TCP
+  - containerPort: 4317 # telemetry-gateway OTLP
+    hostPort: 4317
+    protocol: TCP    
   - containerPort: 4443 # gateway TLS
     hostPort: 4443
     protocol: TCP
   - containerPort: 4480 # gateway HTTP
     hostPort: 4480
     protocol: TCP
-  - containerPort: 4317 # telemetry-gateway OTLP
-    hostPort: 4317
+  - containerPort: 5000 # local registry for E2E testing
+    hostPort: 5000
+    protocol: TCP    
+  - containerPort: 5432 # postgresql DB
+    hostPort: 5432
+    protocol: TCP
+  - containerPort: 7443 # flightctl agent endpoint API
+    hostPort: 7443
+    protocol: TCP
+  - containerPort: 8090 # flightctl CLI artifacts
+    hostPort: 8090
+    protocol: TCP
+  - containerPort: 8443 # alertmanager proxy
+    hostPort: 8443
+    protocol: TCP
+  - containerPort: 9000 # flightctl UI
+    hostPort: 9000
+    protocol: TCP    
+  - containerPort: 9090 # Prometheus server
+    hostPort: 9090
     protocol: TCP
   - containerPort: 9464 # telemetry-gateway Prometheus
     hostPort: 9464


### PR DESCRIPTION
- UI port 9090 was not exposed
- In the UI, alerts were not visible. The alertmanager-proxy pod logs indicated that it was receiving a request on HTTP while the service is HTTPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced HTTPS for the Alertmanager proxy when exposed via nodePort.
  * Reconfigured local test cluster port mappings to add a local git server, telemetry/gateway endpoints, UI and registry ports, and restore the database and Prometheus ports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->