### PR TITLE
EDM-2783: agent/device/applications: ensure terminated containers

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -264,6 +264,7 @@ v1.0.0
 P-256
 SHA-256
 config.yaml
+backoff
  - docs/user/references/api-resources.md
 namespacing
 approvedBy

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -624,6 +624,10 @@ The following table shows the application runtimes and formats supported by Flig
 
 ### Runtime: **Podman**
 
+### Application Self-Healing
+
+The Flight Control agent automatically monitors application workloads and restarts containers that have unexpectedly stopped, died, or been removed. When stopped workloads are detected during the agent's reconciliation loop, a restart action is queued. The agent uses exponential backoff between restart attempts to avoid overwhelming the system during persistent failures.
+
 | Specification                                                                                                      | Format            | Source / Delivery              |
 |--------------------------------------------------------------------------------------------------------------------|-------------------|--------------------------------|
 | Compose specification (via [`podman-compose`](https://github.com/containers/podman-compose))                       | OCI Image         | OCI registry                   |

--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -24,6 +24,7 @@ import (
 const (
 	ComposeOverrideFilename      = "99-compose-flightctl-agent.override.yaml"
 	ComposeDockerProjectLabelKey = "com.docker.compose.project"
+	ComposeDockerServiceLabelKey = "com.docker.compose.service"
 	defaultPodmanTimeout         = 10 * time.Minute
 )
 

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -25,9 +25,19 @@ const (
 
 // PodmanInspect represents the overall structure of podman inspect output
 type PodmanInspect struct {
-	Restarts int                   `json:"RestartCount"`
-	State    PodmanContainerState  `json:"State"`
-	Config   PodmanContainerConfig `json:"Config"`
+	Restarts   int                   `json:"RestartCount"`
+	State      PodmanContainerState  `json:"State"`
+	Config     PodmanContainerConfig `json:"Config"`
+	HostConfig PodmanHostConfig      `json:"HostConfig"`
+}
+
+type PodmanHostConfig struct {
+	RestartPolicy PodmanRestartPolicy `json:"RestartPolicy"`
+}
+
+type PodmanRestartPolicy struct {
+	Name              string `json:"Name"`
+	MaximumRetryCount int    `json:"MaximumRetryCount"`
 }
 
 // ContainerState represents the container state part of the podman inspect output

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -374,3 +374,17 @@ func (mr *MockApplicationMockRecorder) Workload(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Workload", reflect.TypeOf((*MockApplication)(nil).Workload), name)
 }
+
+// Workloads mocks base method.
+func (m *MockApplication) Workloads() []Workload {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Workloads")
+	ret0, _ := ret[0].([]Workload)
+	return ret0
+}
+
+// Workloads indicates an expected call of Workloads.
+func (mr *MockApplicationMockRecorder) Workloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Workloads", reflect.TypeOf((*MockApplication)(nil).Workloads))
+}

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -191,10 +191,8 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 
 	// Update if new version is greater, or if either version is empty/invalid
 	if newVersionInt > lastVersionInt {
-		n.log.Infof("Version updated from '%s' to '%s'", n.lastKnownVersion, newVersion)
+		n.log.Debugf("New spec version received: %s -> %s", n.lastKnownVersion, newVersion)
 		n.lastKnownVersion = newVersion
-	} else {
-		n.log.Debugf("Version not updated (new: %d, last: %d), keeping: '%s'", newVersionInt, lastVersionInt, n.lastKnownVersion)
 	}
 
 	// notify all watchers of the new device spec

--- a/internal/api/common/common.go
+++ b/internal/api/common/common.go
@@ -17,6 +17,7 @@ type ComposeService struct {
 	Image         string   `json:"image"`
 	ContainerName string   `json:"container_name,omitempty"`
 	Volumes       []string `json:"volumes,omitempty"`
+	Restart       string   `json:"restart,omitempty"`
 }
 type ComposeVolume struct {
 	External bool `json:"external,omitempty"`


### PR DESCRIPTION
The agent now automatically detects and restarts application containers that have unexpectedly stopped, died, or been removed. This enables self-healing for managed applications without manual intervention.
  
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications now surface per-service restart policies; workloads include service identity and restart metadata; runtime inspection exposes host config/restart-policy info and compose service label.

* **Bug Fixes**
  * Reconcile/ensure detects stopped workloads and queues restarts during reconciliation; install flow now triggers post-install checks to enable self‑healing.

* **Tests**
  * Added suites validating stopped-workload detection and restart/reconciliation behavior.

* **Documentation**
  * Added "Application Self‑Healing" guidance.

* **Chores**
  * Reduced device version-change log verbosity; updated spelling dictionary.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->