### PR TITLE
EDM-2736: Add note on restrictions of perUser orgAssignment

### DIFF
--- a/docs/user/installing/configuring-auth/auth-oauth2.md
+++ b/docs/user/installing/configuring-auth/auth-oauth2.md
@@ -35,8 +35,11 @@ Configure how users are assigned to organizations via `organizationAssignment` i
   - `organizationNamePrefix`: Optional prefix for organization names
   - `organizationNameSuffix`: Optional suffix for organization names
 - **Per User** (`type: perUser`): Creates a separate organization for each user
+
   - `organizationNamePrefix`: Prefix for user-specific org name (default: `"user-org-"`)
   - `organizationNameSuffix`: Optional suffix for org name
+
+  **Important:** When choosing `organizationAssignment=perUser`, it's recommended to use `roleAssignment=static` with the `flightctl-org-admin` role. Since each user manages their own organization, `flightctl-org-admin` provides the appropriate permissions for managing organization resources. See below for details on role assignment.
 
 ### Role Assignment
 
@@ -311,14 +314,14 @@ spec:
   roleAssignment:
     type: static
     roles:
-      - flightctl-operator
+      - flightctl-org-admin
 EOF
 ```
 
 This configuration will:
 
 - Create a separate organization for each user (e.g., `user-org-alice`, `user-org-bob`)
-- Assign all users the `flightctl-operator` role in their personal organization
+- Assign all users the `flightctl-org-admin` role in their personal organization, giving them full administrative access to manage their organization's resources
 
 **Example with GitHub OAuth2:**
 

--- a/docs/user/installing/configuring-auth/auth-oidc.md
+++ b/docs/user/installing/configuring-auth/auth-oidc.md
@@ -40,8 +40,11 @@ Configure how users are assigned to organizations via `organizationAssignment` i
   - `organizationNamePrefix`: Optional prefix for organization names
   - `organizationNameSuffix`: Optional suffix for organization names
 - **Per User** (`type: perUser`): Creates a separate organization for each user
+
   - `organizationNamePrefix`: Prefix for user-specific org name (default: `"user-org-"`)
   - `organizationNameSuffix`: Optional suffix for org name
+
+  **Important:** When choosing `organizationAssignment=perUser`, it's recommended to use `roleAssignment=static` with the `flightctl-org-admin` role. Since each user manages their own organization, `flightctl-org-admin` provides the appropriate permissions for managing organization resources. See below for details on role assignment.
 
 ### Role Assignment
 
@@ -209,14 +212,14 @@ spec:
   roleAssignment:
     type: static
     roles:
-      - flightctl-operator
+      - flightctl-org-admin
 EOF
 ```
 
 This configuration will:
 
 - Create a separate organization for each user (e.g., `user-org-alice`, `user-org-bob`)
-- Assign all users the `flightctl-operator` role in their personal organization
+- Assign all users the `flightctl-org-admin` role in their personal organization, giving them full administrative access to manage their organization's resources
 
 **Example with simple (non-nested) claim paths:**
 


### PR DESCRIPTION
Clarify that when defining `perUser` orgAssignment, the auth provider `roleAssignment` should be `flightctl-org-admin` or `flightctl-admin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Per User organizationAssignment now recommends using static roleAssignment with the admin role.
  * Updated Per User examples to assign the admin role instead of operator.
  * Added guidance for organizationNamePrefix (default "user-org-") and organizationNameSuffix and noted Per User creates separate user-specific organizations.
  * Minor formatting and clarity edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->