### PR TITLE
NO-ISSUE: adding fields to pam issuer template

### DIFF
--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
@@ -31,3 +31,6 @@ auth:
       - http://localhost:8080/callback
 {{- end}}
     pamService: {{if .global.auth.pamOidcIssuer.pamService}}{{.global.auth.pamOidcIssuer.pamService}}{{else}}flightctl{{end}}
+    allowPublicClientWithoutPKCE: {{if .global.auth.pamOidcIssuer.allowPublicClientWithoutPKCE}}{{.global.auth.pamOidcIssuer.allowPublicClientWithoutPKCE}}{{else}}false{{end}}
+    accessTokenExpiration: {{if .global.auth.pamOidcIssuer.accessTokenExpiration}}{{.global.auth.pamOidcIssuer.accessTokenExpiration}}{{else}}1h{{end}}
+    refreshTokenExpiration: {{if .global.auth.pamOidcIssuer.refreshTokenExpiration}}{{.global.auth.pamOidcIssuer.refreshTokenExpiration}}{{else}}168h{{end}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three PAM OIDC issuer configuration options:
    * allowPublicClientWithoutPKCE — defaults to false
    * accessTokenExpiration — defaults to 1 hour
    * refreshTokenExpiration — defaults to 168 hours
  * Each option supports conditional templating with automatic fallback to the specified defaults

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->