### PR TITLE
EDM-2786: Use auto instead of hardcoded ssl_ecdh_curve value

### DIFF
--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/nginx.conf
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/nginx.conf
@@ -23,7 +23,7 @@ http {
     default_type        application/octet-stream;
 
     ssl_protocols TLSv1.3;
-    ssl_ecdh_curve X25519:prime256v1:secp384r1;
+    ssl_ecdh_curve auto;
     ssl_prefer_server_ciphers off;
     ssl_stapling on;
     ssl_stapling_verify on;


### PR DESCRIPTION
Running cli-artifacts in a FIPS enabled RHEL environment results in a failure:


```
nginx: [emerg] SSL_CTX_set1_curves_list("X25519:prime256v1:secp384r1") failed
```

Verified changing to `auto` works in a FIPS enabled RHEL VM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TLS configuration to allow the server to automatically select the elliptic curve for connections rather than enforcing a specific curve, simplifying TLS negotiation and future-proofing compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->