### PR TITLE
EDM-2786: Use auto instead of hardcoded ssl_ecdh_curve value

### DIFF
--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/nginx.conf
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/nginx.conf
@@ -23,7 +23,7 @@ http {
     default_type        application/octet-stream;
 
     ssl_protocols TLSv1.3;
-    ssl_ecdh_curve X25519:prime256v1:secp384r1;
+    ssl_ecdh_curve auto;
     ssl_prefer_server_ciphers off;
     ssl_stapling on;
     ssl_stapling_verify on;


### PR DESCRIPTION
(cherry picked from commit 1b5c23b224e32a9522e25832f82f5a3e851b3ee9)