### PR TITLE
EDM-2780: EDM-2784,EDM-2785,EDM-2787,EDM-2788 - doc changes

### DIFF
--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -15,12 +15,12 @@ Flight Control API server integrates with AAP Gateway by:
 
 Flight Control uses the following standard roles for authorization:
 
-- **Super Admin** - Unrestricted access to all resources and operations across all organizations
 - **`flightctl-admin`** - Full access to all resources within an organization
+  - **Note:** This role cannot be set directly. Users automatically receive this role when they are set as AAP super admin
 - **`flightctl-org-admin`** - Full access to all resources within a specific organization
 - **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories
 - **`flightctl-viewer`** - Read-only access to all resources
-- **`flightctl-installer`** - Read-only access to devices, fleets, repositories
+- **`flightctl-installer`** - Access to get and approve enrollmentrequests, and manage certificate signing requests
 
 ## Organization Mapping
 
@@ -55,11 +55,15 @@ auth:
   type: aap
   aap:
     apiUrl: https://aap-gateway.example.com
-    externalApiUrl: https://aap-gateway-external.example.com  # Optional
-    caCert: |
-      -----BEGIN CERTIFICATE-----
-      ...
-      -----END CERTIFICATE-----
+    authorizationUrl: https://aap-gateway.example.com/o/authorize/
+    tokenUrl: https://aap-gateway.example.com/o/token/
+    clientId: your-client-id
+    clientSecret: your-client-secret  # Optional
+    scopes:
+      - read
+      - write
+    displayName: "AAP Provider"  # Optional
+    enabled: true  # Optional, defaults to true
 ```
 
 ### Single Provider

--- a/docs/user/installing/configuring-auth/auth-kubernetes.md
+++ b/docs/user/installing/configuring-auth/auth-kubernetes.md
@@ -21,7 +21,9 @@ Flight Control provides the following standard ClusterRoles out-of-the-box:
 - **`flightctl-viewer-<namespace>`** - Read-only access to devices, fleets, resourcesyncs, organizations
 - **`flightctl-installer-<namespace>`** - Access to enrollmentrequests and certificate signing requests
 
-**Note:** ClusterRole names include a namespace suffix (e.g., `flightctl-admin-<namespace>`) to enable multi-release deployments in the same cluster. The `<namespace>` value matches your Helm release namespace. When creating RoleBindings, you must use the suffixed ClusterRole names.
+**Note:** ClusterRole names include a namespace suffix (e.g., `flightctl-admin-<namespace>`). The `<namespace>` value matches your Helm release namespace. When creating RoleBindings, you must use the suffixed ClusterRole names.
+
+**Note:** Flight Control automatically creates a service account named `flightctl-admin` with the `flightctl-admin-<namespace>` role; to use other role types, create your own service account and bind it to the desired ClusterRole.
 
 ## Configuration
 
@@ -51,7 +53,7 @@ If your cluster is OpenShift, use [OpenShift Authentication](auth-openshift.md) 
 
 ### ACM Deployments
 
-If deploying on ACM (by global.target: acm), the k8s auth values are automatically calculated.
+If deploying on ACM (Advanced Cluster Management), use [OpenShift Authentication](auth-openshift.md) instead of Kubernetes authentication.
 
 ## Limitations
 

--- a/docs/user/installing/configuring-auth/auth-oauth2.md
+++ b/docs/user/installing/configuring-auth/auth-oauth2.md
@@ -82,7 +82,7 @@ Flight Control currently recognizes the following roles with defined permissions
 - **`flightctl-org-admin`** - Full access to all resources within assigned organization
 - **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories
 - **`flightctl-viewer`** - Read-only access to devices, fleets, resourcesyncs, organizations
-- **`flightctl-installer`** - Access to devices, fleets, repositories (read-only)
+- **`flightctl-installer`** - Access to get and approve enrollmentrequests, and manage certificate signing requests
 
 **Note:** Other role names can be assigned via AuthProvider configuration but will not have permissions unless they match these recognized roles.
 

--- a/docs/user/installing/configuring-auth/auth-oidc.md
+++ b/docs/user/installing/configuring-auth/auth-oidc.md
@@ -87,7 +87,7 @@ Flight Control currently recognizes the following roles with defined permissions
 - **`flightctl-org-admin`** - Full access to all resources within assigned organization
 - **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories
 - **`flightctl-viewer`** - Read-only access to devices, fleets, resourcesyncs, organizations
-- **`flightctl-installer`** - Access to devices, fleets, repositories (read-only)
+- **`flightctl-installer`** - Access to get and approve enrollmentrequests, and manage certificate signing requests
 
 **Note:** Other role names can be assigned via AuthProvider configuration but will not have permissions unless they match these recognized roles.
 

--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -20,7 +20,9 @@ Flight Control provides the following standard ClusterRoles out-of-the-box:
 - **`flightctl-viewer-<namespace>`** - Read-only access to devices, fleets, resourcesyncs, organizations
 - **`flightctl-installer-<namespace>`** - Access to enrollmentrequests and certificate signing requests
 
-**Note:** ClusterRole names include a namespace suffix (e.g., `flightctl-admin-<namespace>`) to enable multi-release deployments in the same cluster. The `<namespace>` value matches your Helm release namespace. When creating RoleBindings, you must use the suffixed ClusterRole names.
+**Note:** ClusterRole names include a namespace suffix (e.g., `flightctl-admin-<namespace>`). The `<namespace>` value matches your Helm release namespace. When creating RoleBindings, you must use the suffixed ClusterRole names.
+
+**Note:** Flight Control automatically creates a service account named `flightctl-admin` with the `flightctl-admin-<namespace>` role; to use other role types, create your own service account and bind it to the desired ClusterRole.
 
 ## Organization Mapping
 

--- a/docs/user/installing/configuring-auth/auth-pam.md
+++ b/docs/user/installing/configuring-auth/auth-pam.md
@@ -85,6 +85,8 @@ auth:
       - "http://localhost:7777/callback"
     pamService: "flightctl"                            # PAM service name (default: "flightctl")
     allowPublicClientWithoutPKCE: false                # SECURITY: Allow public clients without PKCE (not recommended)
+    accessTokenExpiration: "1h"                         # Expiration duration for access tokens and ID tokens (default: "1h")
+    refreshTokenExpiration: "168h"                     # Expiration duration for refresh tokens (default: "168h", equivalent to 7 days)
 ```
 
 ### Configuration Parameters
@@ -100,7 +102,7 @@ auth:
 | `pamService` | PAM service name to use for authentication (must match `/etc/pam.d/<name>`) | `flightctl` |
 | `allowPublicClientWithoutPKCE` | Allow public clients to skip PKCE requirement. **Security Warning**: Only enable for testing | `false` |
 | `accessTokenExpiration` | Expiration duration for access tokens and ID tokens (e.g., `1h`, `30m`) | `1h` |
-| `refreshTokenExpiration` | Expiration duration for refresh tokens (e.g., `7d`, `168h`) | `7d` |
+| `refreshTokenExpiration` | Expiration duration for refresh tokens (e.g., `168h`, `720h`) | `168h` |
 
 ### Default Configuration
 
@@ -112,7 +114,7 @@ If the `pamOidcIssuer` section is present in the configuration file, the followi
 - **Scopes**: Defaults to `["openid", "profile", "email", "roles"]`
 - **Redirect URIs**: Automatically configured based on the service's base UI URL or base URL
 - **Access Token Expiration**: Defaults to `1h`
-- **Refresh Token Expiration**: Defaults to `7d`
+- **Refresh Token Expiration**: Defaults to `168h` (7 days)
 
 ### Security Note
 
@@ -120,7 +122,7 @@ The `allowPublicClientWithoutPKCE` parameter should remain `false` (default) in 
 
 ### Token Expiration
 
-Token expiration times are configurable via `accessTokenExpiration` and `refreshTokenExpiration` parameters. By default, access tokens and ID tokens expire after **1 hour**, and refresh tokens expire after **7 days**.
+Token expiration times are configurable via `accessTokenExpiration` and `refreshTokenExpiration` parameters. By default, access tokens and ID tokens expire after **1 hour**, and refresh tokens expire after **168 hours (7 days)**.
 
 ## User Management
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * AAP auth docs now describe OAuth-style endpoints and client credentials.
  * Clarified Super Admin is auto-assigned when a user is designated AAP super admin.
  * Updated flightctl-installer role to allow approving enrollment requests and managing CSRs across auth guides.
  * PAM auth docs add token lifetime settings and default refresh token 168h (examples updated).
  * Clarified ClusterRole naming/RoleBinding guidance, auto-created flightctl-admin service account, and ACM recommendation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->