### PR TITLE
EDM-2794: add missing TLS SANs, validate FQDN

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -264,6 +264,7 @@ v1.0.0
 P-256
 SHA-256
 config.yaml
+FQDN
  - docs/user/references/api-resources.md
 namespacing
 approvedBy

--- a/cmd/flightctl-standalone/render_template.go
+++ b/cmd/flightctl-standalone/render_template.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/flightctl/flightctl/internal/config/standalone"
@@ -41,22 +43,123 @@ func NewRenderTemplateCommand() *cobra.Command {
 }
 
 func (o *RenderTemplateOptions) Run() error {
-	if err := o.validateConfig(); err != nil {
-		return err
-	}
-
-	return template.Render(o.Config, o.InputFile, o.OutputFile)
-}
-
-func (o *RenderTemplateOptions) validateConfig() error {
+	// Read the config file
 	configData, err := os.ReadFile(o.Config)
 	if err != nil {
 		return fmt.Errorf("failed to read config file %s: %w", o.Config, err)
 	}
 
+	// Unmarshal into a map to preserve all fields
+	data := make(map[string]interface{})
+	if err := yaml.Unmarshal(configData, &data); err != nil {
+		return fmt.Errorf("failed to parse config YAML from %s: %w", o.Config, err)
+	}
+
+	// Apply defaults and completions to the config
+	if err := o.completeConfig(data); err != nil {
+		return err
+	}
+
+	// Validate the completed config
+	if err := o.validateConfig(data); err != nil {
+		return err
+	}
+
+	// Render template with the completed config data
+	return template.RenderWithData(data, o.InputFile, o.OutputFile)
+}
+
+func (o *RenderTemplateOptions) completeConfig(data map[string]interface{}) error {
+	// Navigate to global config
+	global, ok := data["global"].(map[string]interface{})
+	if !ok {
+		global = make(map[string]interface{})
+		data["global"] = global
+	}
+
+	// Default baseDomain if empty
+	baseDomain, _ := global["baseDomain"].(string)
+	if baseDomain == "" {
+		hostname, err := o.getHostnameFQDN()
+		if err != nil {
+			return fmt.Errorf("failed to get hostname for baseDomain default: %w", err)
+		}
+		global["baseDomain"] = hostname
+		fmt.Fprintf(os.Stderr, "global.baseDomain not set, defaulting to system hostname FQDN (%s)\n", hostname)
+	}
+
+	// Inject AAP OAuth client_id if file exists
+	auth, ok := global["auth"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	authType, _ := auth["type"].(string)
+	if authType != "aap" {
+		return nil
+	}
+
+	clientIDFile := "/etc/flightctl/pki/aap-client-id"
+	clientIDData, err := os.ReadFile(clientIDFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to read AAP client ID file %s: %w", clientIDFile, err)
+	}
+
+	clientID := strings.TrimSpace(string(clientIDData))
+	if clientID == "" {
+		return fmt.Errorf("AAP client ID file %s is empty", clientIDFile)
+	}
+
+	aap, ok := auth["aap"].(map[string]interface{})
+	if !ok {
+		aap = make(map[string]interface{})
+		auth["aap"] = aap
+	}
+	aap["clientId"] = clientID
+	fmt.Fprintf(os.Stderr, "Loaded AAP OAuth client_id from %s\n", clientIDFile)
+
+	return nil
+}
+
+func (o *RenderTemplateOptions) getHostnameFQDN() (string, error) {
+	// Try "hostname -f" first for FQDN
+	cmd := exec.Command("hostname", "-f")
+	output, err := cmd.Output()
+	if err == nil && len(output) > 0 {
+		hostname := strings.TrimSpace(string(output))
+		if hostname != "" {
+			return hostname, nil
+		}
+	}
+
+	// Fallback to "hostname" (short name)
+	cmd = exec.Command("hostname")
+	output, err = cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute hostname command: %w", err)
+	}
+
+	hostname := strings.TrimSpace(string(output))
+	if hostname == "" {
+		return "", fmt.Errorf("hostname command returned empty value")
+	}
+
+	return hostname, nil
+}
+
+func (o *RenderTemplateOptions) validateConfig(data map[string]interface{}) error {
+	// Marshal the map back to YAML and unmarshal to standalone.Config for validation
+	configData, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for validation: %w", err)
+	}
+
 	var config standalone.Config
 	if err := yaml.Unmarshal(configData, &config); err != nil {
-		return fmt.Errorf("failed to parse config YAML from %s: %w", o.Config, err)
+		return fmt.Errorf("failed to unmarshal config for validation: %w", err)
 	}
 
 	if errs := validation.ValidateStandaloneConfig(&config); len(errs) > 0 {

--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
@@ -12,8 +12,8 @@ Network=flightctl.network
 PublishPort=8443:8443
 EnvironmentFile=/etc/flightctl/flightctl-alertmanager-proxy/env
 Volume=/etc/flightctl/flightctl-alertmanager-proxy/config.yaml:/root/.flightctl/config.yaml:ro,z
-Volume=/etc/flightctl/pki/flightctl-api/server.crt:/root/.flightctl/certs/server.crt:ro,z
-Volume=/etc/flightctl/pki/flightctl-api/server.key:/root/.flightctl/certs/server.key:ro,z
+Volume=/etc/flightctl/pki/flightctl-alertmanager-proxy/server.crt:/root/.flightctl/certs/server.crt:ro,z
+Volume=/etc/flightctl/pki/flightctl-alertmanager-proxy/server.key:/root/.flightctl/certs/server.key:ro,z
 Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
 Environment=DB_USER=flightctl_app
 

--- a/deploy/podman/flightctl-api/flightctl-api-config/create_aap_application.sh
+++ b/deploy/podman/flightctl-api/flightctl-api-config/create_aap_application.sh
@@ -58,14 +58,16 @@ EOF
         exit 1
     fi
 
-    echo "Updating service config file with new client id: $client_id"
-    # Tempfile here is necessary because we cannot directly modify the mounted config file in place
-    tmpfile=$(mktemp)
-    trap 'rm -f "$tmpfile" "$oauth_output_file"' EXIT
-    if ! sed -E "s|^([[:space:]]*oAuthApplicationClientId:).*|\1 $client_id|" "$SERVICE_CONFIG_FILE" > "$tmpfile"; then
-        echo "Error: Failed to update config file" >&2
+    echo "Saving AAP OAuth client_id: $client_id"
+    # Write client_id to /certs that is mounted from /etc/flightctl/pki on the host
+    client_id_file="${CERTS_SOURCE_PATH}/aap-client-id"
+    if echo "$client_id" > "$client_id_file"; then
+        echo "AAP OAuth client_id saved to $client_id_file"
+    else
+        echo "Error: Failed to write client_id to $client_id_file" >&2
         exit 1
     fi
-    cat "$tmpfile" > "$SERVICE_CONFIG_FILE"
+
+    rm -f "$oauth_output_file"
     echo "OAuth Application created successfully"
 }

--- a/deploy/podman/flightctl-api/flightctl-api-config/init.sh
+++ b/deploy/podman/flightctl-api/flightctl-api-config/init.sh
@@ -9,10 +9,28 @@ source "/config-source/create_aap_application.sh"
 
 # Define paths
 export SERVICE_CONFIG_FILE="/service-config.yaml"
+export CERTS_SOURCE_PATH="/certs"
 
 # Check if service config file exists
 if [ ! -f "$SERVICE_CONFIG_FILE" ]; then
   echo "Error: Service config file not found at $SERVICE_CONFIG_FILE"
+  exit 1
+fi
+
+# Validate the base domain from config, or default to host FQDN
+base_domain=$(extract_value "global.baseDomain" "$SERVICE_CONFIG_FILE")
+if [[ -z "$base_domain" ]]; then
+  if [[ -z "${HOST_FQDN:-}" ]]; then
+    echo "ERROR: global.baseDomain is not set and HOST_FQDN is not available for defaulting" >&2
+    exit 1
+  fi
+  base_domain="${HOST_FQDN}"
+  echo "global.baseDomain not set, defaulting to host FQDN ($base_domain)"
+fi
+
+# Validate as hostname or FQDN: lowercase alphanumerics and hyphens, final label must start with letter
+if ! [[ "$base_domain" =~ ^([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
+  echo "ERROR: global.baseDomain must be a valid hostname or FQDN (not an IP address)" 1>&2
   exit 1
 fi
 
@@ -23,14 +41,13 @@ INSECURE_SKIP_TLS_VERIFY=$(extract_value "global.auth.insecureSkipTlsVerify" "$S
 # Process auth settings based on auth type
 if [ "$AUTH_TYPE" == "aap" ]; then
   echo "Configuring AAP authentication"
-  BASE_DOMAIN=$(extract_value "global.baseDomain" "$SERVICE_CONFIG_FILE")
   AAP_API_URL=$(extract_value "global.auth.aap.apiUrl" "$SERVICE_CONFIG_FILE")
   AAP_OAUTH_TOKEN=$(extract_value "global.auth.aap.oAuthToken" "$SERVICE_CONFIG_FILE")
   AAP_CLIENT_ID=$(extract_value "global.auth.aap.oAuthApplicationClientId" "$SERVICE_CONFIG_FILE")
 
   # If client id is not set and we have an oauth token, create a new oauth application
   if [ -z "$AAP_CLIENT_ID" ] && [ -n "$AAP_OAUTH_TOKEN" ]; then
-    create_oauth_application "$AAP_OAUTH_TOKEN" "$BASE_DOMAIN" "$AAP_API_URL" "$INSECURE_SKIP_TLS_VERIFY"
+    create_oauth_application "$AAP_OAUTH_TOKEN" "$base_domain" "$AAP_API_URL" "$INSECURE_SKIP_TLS_VERIFY"
   fi
 fi
 

--- a/deploy/podman/flightctl-api/flightctl-api-init.container
+++ b/deploy/podman/flightctl-api/flightctl-api-init.container
@@ -10,6 +10,7 @@ Volume=/usr/share/flightctl/flightctl-api:/config-source:ro,z
 Volume=/usr/share/flightctl/init_utils.sh:/utils/init_utils.sh:ro,z
 Volume=/etc/flightctl/pki:/certs:rw,z
 Volume=/etc/flightctl/service-config.yaml:/service-config.yaml:ro,z
+EnvironmentFile=/run/flightctl/api_init_host.env
 Exec=/bin/sh /config-source/init.sh
 
 [Service]
@@ -17,6 +18,8 @@ Type=oneshot
 RemainAfterExit=true
 Restart=on-failure
 RestartSec=5s
+ExecStartPre=/usr/bin/mkdir -p /run/flightctl
+ExecStartPre=/bin/sh -c 'echo "HOST_FQDN=$(hostname -f || hostname)" > /run/flightctl/api_init_host.env'
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -1,8 +1,13 @@
 global:
+  # The base domain for the deployment, from which the service FQDNs are derived.
+  # If provided, must be a fully qualified domain name (FQDN) like "example.com" or a hostname that resolves via DNS.
+  # If not provided, defaults to the system's hostname FQDN ('hostname -f').
   baseDomain:
+
   # Certificate generation method - 'none' or 'builtin'
   # - none: Do not generate certificates. User must provide certs in /etc/flightctl/pki/ or the service will fail to start.
-  # - builtin: Generate required certificates using openssl (default)
+  # - builtin: Generate a self-signed CA cert in /etc/flightctl/pki/ca.{crt,key}, unless the user already provided that CA.
+  #            Generate the remaining certificates from the CA cert (default)
   generateCertificates: builtin
   auth:
     type: oidc # oidc, aap, oauth2, or none

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -13,6 +13,92 @@ else
     exit 0
 fi
 
+# Get system hostnames
+hostname_short=$(hostname)
+hostname_fqdn=$(hostname -f || hostname)
+
+# Get host IP addresses
+primary_ip=$(ip route get 1.1.1.1 2>/dev/null \
+    | awk '{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')
+
+host_ips=()
+if [ -n "$primary_ip" ]; then
+    host_ips+=("$primary_ip")
+else
+    # Fallback: Get all non-loopback IPs
+    mapfile -t host_ips < <(hostname -I 2>/dev/null | tr ' ' '\n' | awk 'NF' || true)
+fi
+host_ips+=("127.0.0.1")
+
+# Validate the base domain from config, or default to hostname FQDN
+base_domain=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
+if [[ -z "$base_domain" ]]; then
+    base_domain="$hostname_fqdn"
+    echo "global.baseDomain not set, defaulting to system hostname FQDN ($base_domain)"
+fi
+
+# Validate as hostname or FQDN: lowercase alphanumerics and hyphens, final label must start with letter
+if ! [[ "$base_domain" =~ ^([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
+    echo "ERROR: global.baseDomain must be a valid hostname or FQDN (not an IP address)" 1>&2
+    exit 1
+fi
+
+# Build SAN arrays for each certificate type
+# SANs include:
+#  * External DNS names (based on baseDomain)
+#  * System hostnames (short and FQDN)
+#  * Podman service names
+#  * Loopback address
+#  * All host IP addresses
+
+# API certificate SANs
+api_sans=(
+    "api.$base_domain"
+    "agent-api.$base_domain"
+    "$base_domain"
+    "$hostname_short"
+    "$hostname_fqdn"
+    "flightctl-api"
+    "localhost"
+)
+api_sans+=("${host_ips[@]}")
+
+# Telemetry certificate SANs
+telemetry_sans=(
+    "telemetry.$base_domain"
+    "$base_domain"
+    "$hostname_short"
+    "$hostname_fqdn"
+    "flightctl-telemetry-gateway"
+    "localhost"
+)
+telemetry_sans+=("${host_ips[@]}")
+
+# Alert Manager Proxy certificate SANs
+alertmanager_proxy_sans=(
+    "alertmanager-proxy.$base_domain"
+    "$base_domain"
+    "$hostname_short"
+    "$hostname_fqdn"
+    "flightctl-alertmanager-proxy"
+    "localhost"
+)
+alertmanager_proxy_sans+=("${host_ips[@]}")
+
+# Build the certificate generation command
+cert_gen_args=("--cert-dir" "$CERT_DIR")
+
+for san in "${api_sans[@]}"; do
+    cert_gen_args+=("--api-san" "$san")
+done
+
+for san in "${telemetry_sans[@]}"; do
+    cert_gen_args+=("--telemetry-san" "$san")
+done
+
+for san in "${alertmanager_proxy_sans[@]}"; do
+    cert_gen_args+=("--alertmanager-proxy-san" "$san")
+done
+
 # Generate certificates
-BASE_DOMAIN=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
-/usr/share/flightctl/generate-certificates.sh --cert-dir "$CERT_DIR" --api-san "$BASE_DOMAIN"
+/usr/share/flightctl/generate-certificates.sh "${cert_gen_args[@]}"

--- a/deploy/scripts/init_host.sh
+++ b/deploy/scripts/init_host.sh
@@ -5,28 +5,11 @@ set -eo pipefail
 # Load secret generation functions
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}"/secrets.sh
-source "${SCRIPT_DIR}"/init_utils.sh
-
-SERVICE_CONFIG_FILE="/etc/flightctl/service-config.yaml"
-
-write_default_base_domain() {
-    # Write base domain to the config file
-    base_domain="$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')"
-    echo "Setting base domain to: ${base_domain}"
-    sed -i "s/^\(\s*baseDomain\s*\):\s*.*$/\1: ${base_domain}/" "${SERVICE_CONFIG_FILE}"
-}
 
 main() {
     echo "Configuring Flight Control"
 
     ensure_secrets
-
-    base_domain=$(extract_value "baseDomain" "$SERVICE_CONFIG_FILE")
-    if [[ -z "$base_domain" ]]; then
-        write_default_base_domain
-    else
-        echo "Base domain already set to: $base_domain"
-    fi
 
     echo "Configuration complete"
 }

--- a/docs/user/installing/installing-service-on-linux.md
+++ b/docs/user/installing/installing-service-on-linux.md
@@ -28,53 +28,31 @@ sudo dnf config-manager addrepo --from-repofile=https://rpm.flightctl.io/flightc
 sudo dnf install -y flightctl-services
 ```
 
-### Installing a specific version
+Flight Control services can be configured through a central configuration file located at `/etc/flightctl/service-config.yaml`.
 
-Search for available versions:
+To spin up services quickly for testing or development purposes, you can leave this file's defaults. This sets the base domain of the services to the host's fully qualified domain name (FQDN) (from `hostname -f`) and generates a self-signed certificate authority (CA) from which required certificates are issued.
 
-```bash
-dnf list --showduplicates flightctl-services
-```
+For a production environment, set the base domain (`global.baseDomain`) to your own fully qualified domain name (FQDN) and configure certificates from your own PKI (see [Custom Certificates](#custom-certificates)).
 
-Install a specific version by appending the desired version to the package name:
-
-```bash
-sudo dnf install flightctl-services-1.0.0
-```
-
-## Quickstart
-
-To spin up services quickly for testing or development purposes, services can be started and spun up without authentication and with self-signed certificates.
-
-Services can be started by running a single .target file that specifies all required Flight Control services
+You can then start the Flight Control services by running
 
 ```bash
 sudo systemctl start flightctl.target
 ```
 
-Services can be monitored by checking systemd units
+Monitor that all `systemd` services come up correctly by running
 
 ```bash
 sudo systemctl list-units flightctl-*.service
 ```
 
-Or podman
+or by checking the running containers with
 
 ```bash
 sudo podman ps
 ```
 
-Once the UI service has spun up, find the automatically set baseDomain
-
-```bash
-grep baseDomain: /etc/flightctl/service-config.yaml
-```
-
-And visit the UI at https://<baseDomain>
-
-## Configuring Services
-
-Service configuration is largely managed by a file installed at `/etc/flightctl/service-config.yaml`.  The service config file is a unified location to update configuration that is then propagated to underlying services.
+Once the UI service has spun up, visit the UI at `https://BASE_DOMAIN` (where `BASE_DOMAIN` is what you configured in `global.baseDomain` or your hostname FQDN).
 
 ## Helpful Commands
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -20,6 +20,10 @@ func Render(inputFile string, templateFile string, outputFile string) error {
 		return fmt.Errorf("failed to parse YAML from %s: %w", inputFile, err)
 	}
 
+	return RenderWithData(data, templateFile, outputFile)
+}
+
+func RenderWithData(data interface{}, templateFile string, outputFile string) error {
 	tmpl, err := template.ParseFiles(templateFile)
 	if err != nil {
 		return fmt.Errorf("failed to parse template file %s: %w", templateFile, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded certificate SAN generation (multiple service types, hostnames, all IPs); rendering now auto-completes/validates config and supports rendering with provided data; OAuth client ID persisted to a file.

* **Bug Fixes**
  * Stricter hostname/FQDN validation with clear erroring and fallback to host FQDN when unset.

* **Configuration**
  * Added global.baseDomain and auth.insecureSkipTlsVerify; init captures HOST_FQDN at startup; updated volume bindings for alertproxy certs.

* **Tests**
  * Added comprehensive FQDN/hostname validation tests.

* **Documentation**
  * Consolidated installer guide and clarified base-domain and certificate guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->