### PR TITLE
EDM-2799: added offline access scope to get refresh token, fixed extr…

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -82,6 +82,7 @@ auth:
       - profile
       - email
       - roles
+      - offline_access
 {{- end}}
     organizationAssignment:
       type: {{if .global.auth.oidc.organizationAssignment.type}}{{.global.auth.oidc.organizationAssignment.type}}{{else}}static{{end}}

--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
@@ -20,6 +20,7 @@ auth:
       - profile
       - email
       - roles
+      - offline_access
 {{- end}}
     redirectUris:
 {{- if .global.auth.pamOidcIssuer.redirectUris}}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -45,6 +45,7 @@ global:
         - profile
         - email
         - roles
+        - offline_access
       pamService: flightctl
 
 db:

--- a/internal/cli/login/oauth.go
+++ b/internal/cli/login/oauth.go
@@ -202,8 +202,11 @@ func oauth2RefreshTokenFlow(refreshToken string, getClient GetClientFunc) (AuthI
 		return ret, fmt.Errorf("failed to parse token expiration: %w", err)
 	}
 
+	idTokenString := getIdToken(accessData.ResponseData)
+
 	ret.AccessToken = accessData.AccessToken
 	ret.RefreshToken = accessData.RefreshToken // May be empty if not returned
+	ret.IdToken = idTokenString
 	ret.ExpiresIn = expiresIn
 
 	return ret, nil


### PR DESCRIPTION
fixed refresh token not being asked for by offline_access , this is now the default of pam oidc issuer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default OpenID Connect scopes now include offline_access when no custom scopes are provided, enabling long-lived/non-interactive access.

* **Bug Fixes**
  * OAuth token refresh flow now captures and returns the id_token from refresh responses, improving session continuity and token handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->