### PR TITLE
NO-ISSUE: fixed service config location

### DIFF
--- a/docs/user/installing/configuring-auth/auth-pam.md
+++ b/docs/user/installing/configuring-auth/auth-pam.md
@@ -65,7 +65,7 @@ There are no special prerequisites for using PAM authentication. The PAM issuer 
 
 ## Configuration
 
-The PAM issuer is configured in the Flight Control configuration file (typically `~/.flightctl/config.yaml` or `/etc/flightctl/config.yaml`). The configuration is located under the `auth.pamOidcIssuer` section.
+The PAM issuer is configured in the Flight Control configuration file (`/etc/flightctl/service-config.yaml`). The configuration is located under the `auth.pamOidcIssuer` section.
 
 ### Configuration Options
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PAM configuration reference to specify the service configuration location for PAM OIDC issuer settings (documentation clarified where to configure the issuer).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->