### PR TITLE
NO-ISSUE: Remove UI mapping - needs a solution for embedded UI

### DIFF
--- a/deploy/kind.yaml
+++ b/deploy/kind.yaml
@@ -15,9 +15,6 @@ nodes:
   - containerPort: 7443 # flightctl agent endpoint API
     hostPort: 7443
     protocol: TCP
-  - containerPort: 9000 # ui
-    hostPort: 9000
-    protocol: TCP
   - containerPort: 8090 # cli artifacts
     hostPort: 8090
     protocol: TCP


### PR DESCRIPTION
Exposing the UI port in `kind.yaml` was preventing some users to work with the independent UI even if they had the embedded UI disabled.

We'll need to find a solution to make the embedded UI work properly, but we can do it later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed UI port exposure from cluster configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->