### PR TITLE
Use port 9001 for embedded UI

### DIFF
--- a/deploy/helm/flightctl/values.dev.yaml
+++ b/deploy/helm/flightctl/values.dev.yaml
@@ -55,13 +55,12 @@ telemetryGateway:
     image: localhost/flightctl-telemetry-gateway
     tag: latest
 
-
 dev:
   exposeServicesMethod: "nodePort"
   nodePorts:
     api: 3443
     agent: 7443
-    ui: 9000
+    ui: 9001
     db: 5432
     kv: 6379
     alertmanager: 9093

--- a/deploy/helm/flightctl/values.nodeport.yaml
+++ b/deploy/helm/flightctl/values.nodeport.yaml
@@ -3,7 +3,7 @@ dev:
   nodePorts:
     api: 3443
     agent: 7443
-    ui: 9000
+    ui: 9001
     db: 5432
     kv: 6379
     alertmanager: 9093

--- a/deploy/kind.yaml
+++ b/deploy/kind.yaml
@@ -15,8 +15,8 @@ nodes:
   - containerPort: 7443 # flightctl agent endpoint API
     hostPort: 7443
     protocol: TCP
-  - containerPort: 9000 # ui
-    hostPort: 9000
+  - containerPort: 9001 # ui
+    hostPort: 9001
     protocol: TCP
   - containerPort: 8090 # cli artifacts
     hostPort: 8090

--- a/docs/user/installing/preparing-installation-on-linux.md
+++ b/docs/user/installing/preparing-installation-on-linux.md
@@ -35,7 +35,7 @@ graph TB
             API[API Server<br/>:3443 - User API<br/>:7443 - Agent API<br/>:15690 - Metrics<br/>:15691 - DB Metrics]
             WORKER[Worker Processes<br/>Background Tasks]
             PERIODIC[Periodic Tasks<br/>Scheduled Jobs]
-            UI[Web UI<br/>:8080/:9000]
+            UI[Web UI<br/>:8080/:9001]
             CLI_ARTIFACTS[CLI Artifacts<br/>:8090]
         end
 
@@ -67,7 +67,7 @@ graph TB
     %% User Communication Flow
     USERS -.->|"HTTPS<br/>Port 443"| LB_USER
     LB_USER --> API
-    USERS -.->|"HTTP/HTTPS<br/>Port 9000"| UI
+    USERS -.->|"HTTP/HTTPS<br/>Port 9001"| UI
     USERS -.->|"HTTP/HTTPS<br/>Port 8090"| CLI_ARTIFACTS
     USERS -.->|"HTTPS<br/>Port 8444"| AUTH
 
@@ -150,7 +150,7 @@ graph TB
 ### Web User Interface
 
 - **Port 8080** (TCP) - **HTTP/HTTPS** - Web UI (exposed via reverse proxy)
-- **Port 9000** (TCP) - **HTTP** - Web UI (development/nodePort deployments)
+- **Port 9001** (TCP) - **HTTP** - Web UI (development/nodePort deployments)
 
 ### Authentication Services
 
@@ -223,7 +223,7 @@ ACCEPT tcp port 7443 from any (agents can be on any network)
 
 ```text
 ACCEPT tcp port 3443 from trusted networks/users
-ACCEPT tcp port 9000 from trusted networks/users (UI - nodePort deployments)
+ACCEPT tcp port 9001 from trusted networks/users (UI - nodePort deployments)
 ACCEPT tcp port 8090 from trusted networks/users (CLI artifacts)
 ```
 
@@ -437,7 +437,7 @@ telnet api.flightctl.example.com 3443
 
 ### Development Environment
 
-- Uses NodePort services (ports 3443, 7443, 9000, 8444)
+- Uses NodePort services (ports 3443, 7443, 9001, 8444)
 - May expose internal services for debugging
 - Less restrictive firewall rules
 
@@ -460,7 +460,7 @@ telnet api.flightctl.example.com 3443
 | API Server | 3443  | HTTPS | External | Main API endpoint |
 | API Server | 7443  | HTTPS/mTLS | External | Agent endpoint |
 | Web UI | 8080  | HTTP/HTTPS | External | Web interface |
-| Web UI | 9000  | HTTP | External | Development UI |
+| Web UI | 9001  | HTTP | External | Development UI |
 | PostgreSQL | 5432  | TCP | Internal | Database |
 | Redis | 6379  | TCP | Internal | Key-value store |
 | Internal OIDC | 8444  | HTTPS | External | Authentication |

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -114,7 +114,7 @@ function get_endpoint_host() {
             echo "agent-api.${IP}.nip.io:7443"
             ;;
         flightctl-ui)
-            echo "ui.${IP}.nip.io:9000"
+            echo "ui.${IP}.nip.io:9001"
             ;;
         *)
             echo "Unable to find endpoint for ${name}" >&2

--- a/test/scripts/kind_cluster.yaml
+++ b/test/scripts/kind_cluster.yaml
@@ -39,8 +39,8 @@ nodes:
   - containerPort: 8443 # alertmanager proxy
     hostPort: 8443
     protocol: TCP
-  - containerPort: 9000 # flightctl UI
-    hostPort: 9000
+  - containerPort: 9001 # flightctl UI
+    hostPort: 9001
     protocol: TCP    
   - containerPort: 9090 # Prometheus server
     hostPort: 9090


### PR DESCRIPTION
As suggested in https://github.com/flightctl/flightctl/pull/2242, we can just expose the embedded UI in another port than the one used by  the flighctl-ui repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Web UI service/node port from 9000 to 9001 across deployment manifests, development configs, and test environment mappings.

* **Documentation**
  * Updated installation guide and related diagrams, examples, and firewall notes to reflect the UI port change (9001).

* **Tests**
  * Adjusted test scripts and cluster test mappings to use the new UI port (9001).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->