### PR TITLE
EDM-28114: Read db wait config from templated service config

### DIFF
--- a/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
@@ -14,7 +14,6 @@ Environment=DB_MIGRATION_USER=flightctl_migrator
 Secret=flightctl-postgresql-migrator-password,type=env,target=DB_PASSWORD
 Secret=flightctl-postgresql-migrator-password,type=env,target=DB_MIGRATION_PASSWORD
 Volume=/etc/flightctl/flightctl-db-migrate/config.yaml:/root/.flightctl/config.yaml:ro,z
-Volume=/etc/flightctl/service-config.yaml:/etc/flightctl/service-config.yaml:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Exec=/usr/local/bin/flightctl-db-migrate
 
@@ -24,8 +23,6 @@ RemainAfterExit=yes
 Restart=on-failure
 RestartSec=30
 TimeoutStartSec=10m
-
-ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-db-migrate/config.yaml.template --output-file /etc/flightctl/flightctl-db-migrate/config.yaml
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
@@ -32,9 +32,7 @@ Type=oneshot
 RemainAfterExit=yes
 Restart=on-failure
 RestartSec=5
-ExecCondition=/bin/bash -c 'test "$(python3 /usr/share/flightctl/yaml_helpers.py extract ".db.external" /etc/flightctl/service-config.yaml --default "disabled")" != "enabled"'
+ExecCondition=/bin/bash -c 'test "$(python3 /usr/share/flightctl/yaml_helpers.py extract ".db.type" /etc/flightctl/service-config.yaml --default "builtin")" != "external"'
 
 [Install]
 WantedBy=flightctl.target
-
-

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-wait.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-wait.container
@@ -9,9 +9,10 @@ Image={{ .DbSetup.Image }}:{{ .DbSetup.Tag }}
 Network=flightctl.network
 AutoUpdate=none
 Environment=DB_USER=flightctl_app
-Environment=SERVICE_CONFIG_PATH=/etc/flightctl/service-config.yaml
+Environment=SERVICE_CONFIG_PATH=/etc/flightctl/db-config.yaml
 Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Volume=/etc/flightctl/service-config.yaml:/etc/flightctl/service-config.yaml:ro,z
+Volume=/etc/flightctl/flightctl-db-migrate/config.yaml:/etc/flightctl/db-config.yaml:ro,z
+Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Exec=/app/deploy/scripts/wait-for-database.sh --timeout=60 --sleep=1
 
 [Service]
@@ -19,8 +20,7 @@ Type=oneshot
 RemainAfterExit=yes
 Restart=on-failure
 RestartSec=1
+ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-db-migrate/config.yaml.template --output-file /etc/flightctl/flightctl-db-migrate/config.yaml
 
 [Install]
 WantedBy=flightctl.target
-
-

--- a/docs/user/installing/configuring-external-database.md
+++ b/docs/user/installing/configuring-external-database.md
@@ -272,16 +272,15 @@ Edit `/etc/flightctl/service-config.yaml` and add or update the `db:` section:
 
 ```yaml
 db:
-  external: "enabled"
-  hostname: "your-postgres-hostname.example.com"
-  port: 5432
-  name: flightctl
-  user: flightctl_app
-  migrationUser: flightctl_migrator
+  type: "external"
+  external:
+    hostname: "your-postgres-hostname.example.com"
+    port: 5432
+    name: flightctl
   # Note: Passwords are managed through Podman secrets, not YAML config
 ```
 
-**Note**: The `service-config.yaml` file is always required for quadlet deployments (for baseDomain, auth settings, etc.). For internal database deployments, the `db:` section can be omitted entirely or set to `external: "disabled"`. **Passwords are never stored in YAML files** - they are managed through Podman secrets for security.
+**Note**: The `service-config.yaml` file is always required for quadlet deployments (for baseDomain, auth settings, etc.). For internal database deployments, the `db:` section can be omitted entirely (defaults to `type: "builtin"`). **Passwords are never stored in YAML files** - they are managed through Podman secrets for security.
 
 #### 2. Set up secrets
 
@@ -298,7 +297,7 @@ After RPM installation, configure and deploy Flight Control with external databa
 ```bash
 # 1. Configure external database connection
 sudo vi /etc/flightctl/service-config.yaml
-# Set: external: "enabled" and your database connection details
+# Set: type: "external" and configure the external: block with your database details
 
 # 2. Disable internal database services (they conflict with external database)
 sudo systemctl mask flightctl-db.service flightctl-db-users-init.service
@@ -395,7 +394,7 @@ sudo systemctl status flightctl-db-migrate.service
 
    **Common Causes**:
    - **Network connectivity**: Verify firewall rules and network routing to external database
-   - **Authentication**: Check usernames and passwords in service-config.yaml
+   - **Authentication**: Check Podman secrets and usernames in service-config.yaml
    - **SSL configuration**: Verify SSL certificates and connection parameters
    - **Database permissions**: Ensure migration user has sufficient privileges
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * DB config moved to an explicit type-based schema (builtin/external) with updated defaults and standardized service startup conditions and rendering steps.

* **Documentation**
  * External database guide and deployment instructions updated to show the new schema and secret-based authentication workflow.

* **Chores**
  * Replaced fragile shell YAML parsing with a Python-backed reader, added validation and warnings, and adjusted how config and certificates are sourced at startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->