### PR TITLE
EDM-2794: default to hostname, allow IP

### DIFF
--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -1,7 +1,9 @@
 global:
-  # The base domain for the deployment, from which the service FQDNs are derived.
-  # If provided, must be a fully qualified domain name (FQDN) like "example.com" or a hostname that resolves via DNS.
-  # If not provided, defaults to the system's hostname FQDN ('hostname -f').
+  # The base domain for the deployment. Set this to a fully qualified domain name (FQDN)
+  # that resolves via DNS to the host's IP address. For testing, you may use the system's
+  # hostame or IP address, but this is not recommended for production use.
+  # If left empty, defaults to the output of the `hostname` command and if that is not set
+  # (i.e. it returns localhost), then defaults to the default IP address of the host.
   baseDomain:
 
   # Certificate generation method - 'none' or 'builtin'

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -33,14 +33,8 @@ host_ips+=("127.0.0.1")
 # Validate the base domain from config, or default to hostname FQDN
 base_domain=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
 if [[ -z "$base_domain" ]]; then
-    base_domain="$hostname_fqdn"
-    echo "global.baseDomain not set, defaulting to system hostname FQDN ($base_domain)"
-fi
-
-# Validate as hostname or FQDN: lowercase alphanumerics and hyphens, final label must start with letter
-if ! [[ "$base_domain" =~ ^([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
-    echo "ERROR: global.baseDomain must be a valid hostname or FQDN (not an IP address)" 1>&2
-    exit 1
+    base_domain="$hostname_short"
+    echo "global.baseDomain not set, defaulting to system hostname ($base_domain)"
 fi
 
 # Build SAN arrays for each certificate type

--- a/docs/user/installing/installing-service-on-linux.md
+++ b/docs/user/installing/installing-service-on-linux.md
@@ -30,9 +30,9 @@ sudo dnf install -y flightctl-services
 
 Flight Control services can be configured through a central configuration file located at `/etc/flightctl/service-config.yaml`.
 
-To spin up services quickly for testing or development purposes, you can leave this file's defaults. This sets the base domain of the services to the host's fully qualified domain name (FQDN) (from `hostname -f`) and generates a self-signed certificate authority (CA) from which required certificates are issued.
-
 For a production environment, set the base domain (`global.baseDomain`) to your own fully qualified domain name (FQDN) and configure certificates from your own PKI (see [Custom Certificates](#custom-certificates)).
+
+To spin up services quickly for testing or development purposes, you may leave this file's defaults. This sets the base domain of the services to the host's `hostname` and generates a self-signed certificate authority (CA) from which required certificates are issued.
 
 You can then start the Flight Control services by running
 

--- a/internal/util/validation/standalone.go
+++ b/internal/util/validation/standalone.go
@@ -17,7 +17,7 @@ func ValidateStandaloneConfig(config *standalone.Config) []error {
 	allErrs := []error{}
 
 	baseDomain := config.Global.BaseDomain
-	allErrs = append(allErrs, ValidateHostnameOrFQDN(&baseDomain, "global.baseDomain")...)
+	allErrs = append(allErrs, ValidateIPOrHostnameOrFQDN(&baseDomain, "global.baseDomain")...)
 	allErrs = append(allErrs, validateAuthType(config.Global.Auth, "global.auth")...)
 
 	return allErrs


### PR DESCRIPTION
This PR updates the defaulting logic for `baseDomain` on RHEL from using `hostname -f` (which on too many systems returned `localhost`) to using `hostname` first and - if that returns `localhost`, too - use the default IP instead.

This PR also changes the input validation for the `baseDomain` so that it now accepts an IP address (again) or a hostname or FQDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hostname resolution now falls back to the machine's outbound IP when a hostname isn't usable, improving reliability on systems without proper DNS/hostname configuration.
  * Base domain validation and configuration now accept IP addresses as well as hostnames/FQDNs for greater setup flexibility.

* **Documentation**
  * Updated install and service guidance to reflect hostname vs. IP default behavior and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->