### PR TITLE
NO-ISSUE: Bug fix where CLI overrides 365 day ecert default

### DIFF
--- a/docs/user/references/certificate-architecture.md
+++ b/docs/user/references/certificate-architecture.md
@@ -23,7 +23,7 @@ For TPM attestation certificates, see [Configuring Device Attestation](../instal
 | [API Server](../../../internal/crypto/signer/signer_server_svc.go) | API TLS                  | 2 years  | Root CA                  |
 | [Telemetry Gateway](../../../internal/crypto/signer/signer_server_svc.go)             | Metrics TLS              | 2 years  | Root CA                  |
 | [Alertmanager Proxy](../../../internal/crypto/signer/signer_server_svc.go)            | Alerts TLS               | 2 years  | Root CA                  |
-| [Device Enrollment](../../../internal/crypto/signer/signer_device_enrollment.go)                    | Device enrollment        | 7 days   | Client-Signer CA         |
+| [Device Enrollment](../../../internal/crypto/signer/signer_device_enrollment.go)                    | Device enrollment        | 1 year   | Client-Signer CA         |
 | [Device Management](../../../internal/crypto/signer/signer_device_management.go)             | Device operations        | 1 year   | Client-Signer CA         |
 | [Device Services](../../../internal/crypto/signer/signer_device_svc_client.go)    | Device services    | 1 year   | Client-Signer CA |
 | PAM Issuer Token Signer CA *  | Signs JWT tokens         | 10 years | Root CA                  |

--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -56,7 +56,7 @@ func DefaultCertificateOptions() *CertificateOptions {
 	return &CertificateOptions{
 		GlobalOptions: DefaultGlobalOptions(),
 		Name:          "",
-		Expiration:    "7d",
+		Expiration:    "365d",
 		Output:        "embedded",
 		OutputDir:     ".",
 		EncryptKey:    false,

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -15,8 +15,6 @@ import (
 	"github.com/samber/lo"
 )
 
-const DefaultEnrollmentCertExpirySeconds int32 = 60 * 60 * 24 * 7 // 7 days
-
 // nowFunc allows overriding for unit tests
 var nowFunc = time.Now
 


### PR DESCRIPTION
This PR:
- Updates a CLI default from 7 days to 365 days for consistency
- Updates docs to reflect this change
- Removes dead code incorrect validity default from `internal/service`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended device enrollment certificate validity period from 7 days to 1 year, reducing the frequency of certificate renewal requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->