### PR TITLE
NO-ISSUE: Add link to configuring auth after installing service on Linux

### DIFF
--- a/docs/user/installing/installing-service-on-linux.md
+++ b/docs/user/installing/installing-service-on-linux.md
@@ -52,7 +52,13 @@ or by checking the running containers with
 sudo podman ps
 ```
 
-Once the UI service has spun up, visit the UI at `https://BASE_DOMAIN` (where `BASE_DOMAIN` is what you configured in `global.baseDomain` or your hostname FQDN).
+## Configure Authentication
+
+Before accessing Flight Control (via the UI or CLI), you need to configure authentication for the service. By default, the deployment includes an OIDC provider called [PAM Issuer](configuring-auth/auth-pam.md).
+
+See the [Authentication Overview](configuring-auth/overview.md) for detailed information about available authentication methods and how to configure them for your deployment.
+
+Once authentication is configured, you can access the UI at `https://BASE_DOMAIN` (where `BASE_DOMAIN` is what you configured in `global.baseDomain` or your hostname FQDN).
 
 ## Helpful Commands
 


### PR DESCRIPTION
The current documentation makes it look like the user can immediately use the service / UI after installing it, but given there is no default user, that is not the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to reflect that authentication configuration is now required before accessing the Flight Control UI or CLI.
  * Added authentication setup section with details on the default OIDC provider.
  * Reorganized installation flow to present authentication configuration before UI access instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->