### PR TITLE
NO-ISSUE: Add a troubleshooting section to auth-openshift

### DIFF
--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -154,6 +154,14 @@ flightctl get devices --org project-a
 flightctl get devices --org project-b
 ```
 
+## Troubleshooting
+
+**Error: no organizations found**  
+Make sure the user has a RoleBinding attached to the **view** role in at least one organization (namespace) and that the namespace has the right label.
+
+**403 error when performing actions on flightctl resources**  
+Make sure the user has a RoleBinding attached to a role with the right permission in the organization's namespace.
+
 ## Related Documentation
 
 - [Authentication Overview](overview.md) - Overview of all authentication methods


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting subsection to the OpenShift authentication docs covering two common errors: "no organizations found" and "403 when performing actions on flightctl resources." Provides clear, actionable guidance on ensuring appropriate role bindings/roles and correct namespace labeling and permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->