### PR TITLE
NO-ISSUE: Allow overriding binary search dirs

### DIFF
--- a/cmd/flightctl-standalone/render_quadlets.go
+++ b/cmd/flightctl-standalone/render_quadlets.go
@@ -33,6 +33,7 @@ func NewRenderQuadletsCommand() *cobra.Command {
 	cmd.Flags().StringVar(&config.QuadletFilesOutputDir, "quadlet-dir", config.QuadletFilesOutputDir, "Quadlet files output directory")
 	cmd.Flags().StringVar(&config.SystemdUnitOutputDir, "systemd-dir", config.SystemdUnitOutputDir, "Systemd unit output directory")
 	cmd.Flags().StringVar(&config.BinOutputDir, "bin-dir", config.BinOutputDir, "Binary output directory")
+	cmd.Flags().StringSliceVar(&config.BinSourceDirs, "bin-source-dirs", []string{"bin"}, "Directories to search for binaries (searched in order)")
 	cmd.Flags().StringVar(&config.FlightctlServicesTagOverride, "flightctl-services-tag-override", "", "Override image tags for all FlightCtl services")
 	cmd.Flags().BoolVar(&config.FlightctlUiTagOverride, "flightctl-ui-tag-override", false, "Apply tag override to UI service")
 

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -83,7 +83,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCopyFile, Source: "deploy/scripts/init_certs.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "init_certs.sh"), Template: false, Mode: ExecutableFileMode},
 
 		// Standalone binary
-		{Action: ActionCopyFile, Source: "bin/flightctl-standalone", Destination: filepath.Join(config.BinOutputDir, "flightctl-standalone"), Template: false, Mode: ExecutableFileMode},
+		{Action: ActionCopyBinary, Source: "flightctl-standalone", Destination: filepath.Join(config.BinOutputDir, "flightctl-standalone"), Template: false, Mode: ExecutableFileMode},
 
 		// Empty files
 		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "ssh", "known_hosts"), Mode: RegularFileMode},


### PR DESCRIPTION
The downstream build doesn't necessarily put binaries in the local bin directory. I worked around this by simply putting the binary in the expected location. This PR allows for adding directories for searching for binaries defaulting to `bin` to preserve the current behavior.

Usage:
```sh
flightctl-standalone render quadlets --config deploy/podman/images.yaml --bin-source-dirs some_dir,/path/to/somewhere
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag (--bin-source-dirs) to specify multiple directories for binary lookup and control search order.
  * Installer now locates and copies binaries from those configured source directories and logs resolved source→destination mappings.

* **Tests**
  * Added tests for binary resolution across multiple directories, fallback behavior, and error cases when binaries are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->