### PR TITLE
EDM-2261: Add templating for application images

### DIFF
--- a/api/v1beta1/validation.go
+++ b/api/v1beta1/validation.go
@@ -858,7 +858,7 @@ func (c ApplicationContent) Validate(index int, appValidator applicationValidato
 	allErrs = append(allErrs, validation.ValidateString(&decodedStr, contentPath, 0, maxInlineLength, nil, "")...)
 	_, paramErrs = validateParametersInString(&decodedStr, contentPath, fleetTemplate)
 	allErrs = append(allErrs, paramErrs...)
-	allErrs = append(allErrs, appValidator.ValidateContents(c.Path, decodedBytes)...)
+	allErrs = append(allErrs, appValidator.ValidateContents(c.Path, decodedBytes, fleetTemplate)...)
 
 	return allErrs
 }

--- a/api/v1beta1/validation_test.go
+++ b/api/v1beta1/validation_test.go
@@ -1793,7 +1793,7 @@ ExecStart=/usr/bin/myapp`,
 		t.Run(tt.name, func(t *testing.T) {
 			content := []byte(tt.content)
 			validator := quadletValidator{quadlets: make(map[string]*common.QuadletReferences)}
-			errs := validator.ValidateContents(tt.path, content)
+			errs := validator.ValidateContents(tt.path, content, false)
 
 			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
 			if tt.wantErrSubstr != "" && len(errs) > 0 {

--- a/docs/user/using/managing-fleets.md
+++ b/docs/user/using/managing-fleets.md
@@ -96,15 +96,21 @@ Here are some examples of what you can do with placeholders in device templates:
 
 * You can label devices by their deployment stage (say, `stage: testing` and `stage: production`) and then use the label with the key `stage` as placeholder when referencing the OS image to use (say, `quay.io/myorg/myimage:latest-{{ .metadata.labels.stage }}`) or when referencing a folder with configuration in a Git repository.
 * You can label devices by deployment site (say, `site: factory-berlin` and `site: factory-madrid`) and then use the label with the key `site` as parameter when referencing the secret with network access credentials in Kubernetes.
+* You can label devices by application version (say, `app-version: 1.2.3`) and then use the label to specify the container image for an application (say, `quay.io/myorg/myapp:{{ .metadata.labels.app-version }}` using the `index` function as `quay.io/myorg/myapp:{{ index .metadata.labels "app-version" }}`).
+* You can use the device name to create unique application configurations by templating the inline application content or path with `{{ .metadata.name }}`.
 
 The following fields in device templates support placeholders (including within values, unless otherwise noted):
 
-| Field | Placeholders supported in |
-| ----- | ------------------------- |
-| OS Image | repository name, image name, image tag |
-| Git Config Provider | targetRevision, path |
-| HTTP Config Provider | URL suffix, path |
-| Inline Config Provider | content, path |
+| Field                             | Placeholders supported in              |
+|-----------------------------------|----------------------------------------|
+| OS Image                          | repository name, image name, image tag |
+| Git Config Provider               | targetRevision, path                   |
+| HTTP Config Provider              | URL suffix, path                       |
+| Inline Config Provider            | content, path                          |
+| Image Application Provider        | image tag                              |
+| Inline Application Provider       | content, path                          |
+| Application Environment Variables | values                                 |
+| Application Volumes               | image tag                              |
 
 ### Using Kubernetes Secrets
 

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -747,7 +747,7 @@ func extractAppDataFromOCITarget(
 		}
 
 		// validate the compose spec
-		if errs := validation.ValidateComposeSpec(spec); len(errs) > 0 {
+		if errs := validation.ValidateComposeSpec(spec, false); len(errs) > 0 {
 			if rmErr := cleanupFn(); rmErr != nil {
 				return nil, fmt.Errorf("validating compose spec for app %s (%s): %w (cleanup failed: %v)", appName, imageRef, errors.Join(errs...), rmErr)
 			}
@@ -779,7 +779,7 @@ func extractAppDataFromOCITarget(
 		// validate all quadlets before extracting targets
 		var validationErrs []error
 		for quadletPath, quad := range spec {
-			if errs := validation.ValidateQuadletSpec(quad, quadletPath); len(errs) > 0 {
+			if errs := validation.ValidateQuadletSpec(quad, quadletPath, false); len(errs) > 0 {
 				validationErrs = append(validationErrs, errs...)
 			}
 		}
@@ -818,7 +818,7 @@ func ensureCompose(readWriter fileio.ReadWriter, appPath string) error {
 		return fmt.Errorf("parsing compose spec: %w", err)
 	}
 
-	if errs := validation.ValidateComposeSpec(spec); len(errs) > 0 {
+	if errs := validation.ValidateComposeSpec(spec, false); len(errs) > 0 {
 		return fmt.Errorf("validating compose spec: %w", errors.Join(errs...))
 	}
 
@@ -882,7 +882,7 @@ func ensureQuadlet(readWriter fileio.ReadWriter, appPath string) error {
 
 	var errs []error
 	for path, quad := range spec {
-		if e := validation.ValidateQuadletSpec(quad, path); len(e) > 0 {
+		if e := validation.ValidateQuadletSpec(quad, path, false); len(e) > 0 {
 			errs = append(errs, e...)
 		}
 	}

--- a/internal/util/validation/compose.go
+++ b/internal/util/validation/compose.go
@@ -57,8 +57,8 @@ func ValidateComposePaths(paths []string) error {
 	return nil
 }
 
-// ValidateComposeSpec verifies the ComposeSpec for common issues
-func ValidateComposeSpec(spec *common.ComposeSpec) []error {
+// ValidateComposeSpec verifies the ComposeSpec for common issues.
+func ValidateComposeSpec(spec *common.ComposeSpec, fleetTemplate bool) []error {
 	services := spec.Services
 	if len(services) == 0 {
 		return []error{fmt.Errorf("compose spec has no services")}
@@ -74,7 +74,7 @@ func ValidateComposeSpec(spec *common.ComposeSpec) []error {
 		if image == "" {
 			errs = append(errs, fmt.Errorf("service %s is missing an image", name))
 		}
-		if err := ValidateOciImageReferenceStrict(&image, "services."+name+".image"); err != nil {
+		if err := ValidateOCIReferenceStrict(&image, "services."+name+".image", fleetTemplate); err != nil {
 			errs = append(errs, err...)
 		}
 	}

--- a/internal/util/validation/quadlet_test.go
+++ b/internal/util/validation/quadlet_test.go
@@ -300,7 +300,7 @@ func TestValidateQuadletReferences(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidateQuadletSpec(tt.spec, tt.path)
+			errs := ValidateQuadletSpec(tt.spec, tt.path, false)
 			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
 			if tt.wantErrSubstr != "" && len(errs) > 0 {
 				require.Contains(errs[0].Error(), tt.wantErrSubstr)

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -427,3 +427,12 @@ func asErrors(errs field.ErrorList) []error {
 	}
 	return agg.Errors()
 }
+
+// ValidateOCIReferenceStrict validates the supplied image depending on the source of the validation
+// If it's a fleet, template validation will occur, but for devices, strict reference checking is applied
+func ValidateOCIReferenceStrict(s *string, path string, fleetTemplate bool) []error {
+	if fleetTemplate {
+		return ValidateOciImageReferenceWithTemplates(s, path)
+	}
+	return ValidateOciImageReferenceStrict(s, path)
+}


### PR DESCRIPTION
Adds more fleet templating for device applications

Given the following fleet
```yaml
apiVersion: flightctl.io/v1beta1
kind: Fleet
metadata:
  name: templated-app-fleet
spec:
  selector:
    matchLabels:
      app: my-templated-app
  template:
     spec:
       applications:
         - name: my-app
           appType: container
           image: docker.io/library/nginx:{{ .metadata.labels.container }}
           ports:
             - "8081:80"
             - "8080:8080"
           resources:
             limits:
               cpu: "0.5"
               memory: "256m"
           volumes:
             - name: nginx-config
               mount:
                 path: "/etc/nginx/conf.d"
               image:
                 reference: quay.io/kkyrazis/quadlet-test/nginx-config-artifact:latest
             - name: nginx-html
               mount:
                 path: "/usr/share/nginx/html"
               image:
                 reference: quay.io/kkyrazis/quadlet-test/nginx-html-artifact-image:latest
             - name: nginx-logs
               mount:
                 path: "/var/log/nginx"

         - name: my-app-2
           appType: quadlet
           image: "quay.io/kkyrazis/quadlet-test/quadlet-app-artifact:{{ .metadata.labels.quadlet }}"
           envVars:
             LOG_MESSAGE: "Multi-file artifact (with .image ref)"
           volumes:
             - name: model-data
               image:
                 reference: quay.io/kkyrazis/quadlet-test/model-artifact:{{ .metadata.labels.artifact}}
                 pullPolicy: IfNotPresent

         - name: inline-app
           appType: quadlet
           envVars:
             LOG_MESSAGE: "Hello from FlightControl (Inline Ref)"
           inline:
             - path: app.container
               content: |
                 [Unit]
                 Description=Primary application container
                 
                 [Container]
                 Image=quay.io/flightctl-tests/alpine:{{ .metadata.labels.inline }}
                 Exec=sh -c "echo 'Primary container started.' && echo 'LOG_MESSAGE:' $LOG_MESSAGE && sleep infinity"
                 
                 [Install]
                 WantedBy=default.target
```

with the following device:
```yaml
apiVersion: flightctl.io/v1beta1
kind: Device
metadata:
  name: hogagh4qdu3qiaq08ucm85ittqputdnv03kto9jjeg4jvhgb6p7g
  labels:
    app: my-templated-app
    container: alpine
    quadlet: with-image-ref
    artifact: latest
    inline: v1
```

the following spec gets rendered:

```yaml
apiVersion: flightctl.io/v1beta1
kind: Device
metadata:
  annotations:
    device-controller/renderedSpecHash: 2ce4e7d8566ee45be33e2460d05718ae25f76606a1345e974247c33d38ca88c7
    device-controller/renderedVersion: "4"
    fleet-controller/renderedTemplateVersion: templated-app-fleet-5
    fleet-controller/templateVersion: templated-app-fleet-5
  creationTimestamp: "2025-12-19T18:37:19.760997Z"
  generation: 4
  labels:
    app: my-templated-app
    artifact: latest
    container: alpine
    inline: v1
    quadlet: with-image-ref
  name: hogagh4qdu3qiaq08ucm85ittqputdnv03kto9jjeg4jvhgb6p7g
  owner: Fleet/templated-app-fleet
  resourceVersion: "45"
spec:
  applications:
    - appType: container
      image: docker.io/library/nginx:alpine
      name: my-app
      ports:
        - 8081:80
        - 8080:8080
      resources:
        limits:
          cpu: "0.5"
          memory: 256m
      volumes:
        - image:
            pullPolicy: IfNotPresent
            reference: quay.io/kkyrazis/quadlet-test/nginx-config-artifact:latest
          mount:
            path: /etc/nginx/conf.d
          name: nginx-config
          reclaimPolicy: Retain
        - image:
            pullPolicy: IfNotPresent
            reference: quay.io/kkyrazis/quadlet-test/nginx-html-artifact-image:latest
          mount:
            path: /usr/share/nginx/html
          name: nginx-html
          reclaimPolicy: Retain
        - mount:
            path: /var/log/nginx
          name: nginx-logs
          reclaimPolicy: Retain
    - appType: quadlet
      envVars:
        LOG_MESSAGE: Multi-file artifact (with .image ref)
      image: quay.io/kkyrazis/quadlet-test/quadlet-app-artifact:with-image-ref
      name: my-app-2
      volumes:
        - image:
            pullPolicy: IfNotPresent
            reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
          name: model-data
          reclaimPolicy: Retain
    - appType: quadlet
      envVars:
        LOG_MESSAGE: Hello from FlightControl (Inline Ref)
      inline:
        - content: |
            [Unit]
            Description=Primary application container

            [Container]
            Image=quay.io/flightctl-tests/alpine:v1
            Exec=sh -c "echo 'Primary container started.' && echo 'LOG_MESSAGE:' $LOG_MESSAGE && sleep infinity"

            [Install]
            WantedBy=default.target
          path: app.container
      name: inline-app
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templating expanded: device labels, device names, app-version and env vars can template image references, inline app content, and per-volume settings.
  * Parameter substitution added for image-based and inline applications, with per-volume error reporting and per-app error aggregation.

* **Documentation**
  * Updated placeholders table with entries for image application provider, inline application provider, application env vars, and application volumes.

* **Validation**
  * Image-reference validation now allows template expressions when validating fleet templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->