### PR TITLE
EDM-2836: Separate UI and CLI artifacts certs

### DIFF
--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/init.sh
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-config/init.sh
@@ -21,27 +21,27 @@ sed '/^\s*listen\s*\[::\]:8090/d' "$NGINX_CONFIG_OUTPUT" > "${NGINX_CONFIG_OUTPU
 sed '/^\s*listen\s*8090 ssl/d' "$NGINX_CONFIG_OUTPUT" > "${NGINX_CONFIG_OUTPUT}.ipv6"
 
 # Wait for certificates
-wait_for_files "$CERTS_SOURCE_PATH/flightctl-api/server.crt" "$CERTS_SOURCE_PATH/flightctl-api/server.key"
+wait_for_files "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.crt" "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.key"
 
 # Handle server certificates
 #
 # The CLI artifacts container runs as user 1001 by default,
 # so we need to ensure that the server certificate and key files
 # can be read by this user.
-if [ -f "$CERTS_SOURCE_PATH/flightctl-api/server.crt" ]; then
-  cp "$CERTS_SOURCE_PATH/flightctl-api/server.crt" "$CERTS_DEST_PATH/server.crt"
+if [ -f "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.crt" ]; then
+  cp "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.crt" "$CERTS_DEST_PATH/server.crt"
   chown 1001:0 "$CERTS_DEST_PATH/server.crt"
   chmod 0440 "$CERTS_DEST_PATH/server.crt"
 else
-  echo "Error: Server certificate not found at $CERTS_SOURCE_PATH/flightctl-api/server.crt"
+  echo "Error: Server certificate not found at $CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.crt"
   exit 1
 fi
-if [ -f "$CERTS_SOURCE_PATH/flightctl-api/server.key" ]; then
-  cp "$CERTS_SOURCE_PATH/flightctl-api/server.key" "$CERTS_DEST_PATH/server.key"
+if [ -f "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.key" ]; then
+  cp "$CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.key" "$CERTS_DEST_PATH/server.key"
   chown 1001:0 "$CERTS_DEST_PATH/server.key"
   chmod 0440 "$CERTS_DEST_PATH/server.key"
 else
-  echo "Error: Server key not found at $CERTS_SOURCE_PATH/flightctl-api/server.key"
+  echo "Error: Server key not found at $CERTS_SOURCE_PATH/flightctl-cli-artifacts/server.key"
   exit 1
 fi
 

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Flight Control CLI Artifacts Certificates Initialization
 PartOf=flightctl.target
-After=flightctl-api.service flightctl-certs-init.service
-Wants=flightctl-api.service flightctl-certs-init.service
+After=flightctl-certs-init.service
+Wants=flightctl-certs-init.service
 
 [Container]
 Image=registry.access.redhat.com/ubi9/ubi-minimal:9.7-1763362218

--- a/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/init.sh
@@ -11,12 +11,11 @@ CERTS_SOURCE_PATH="/certs-source"
 CERTS_DEST_PATH="/certs-destination"
 
 # Wait for certificates
-wait_for_files "$CERTS_SOURCE_PATH/flightctl-api/server.crt" "$CERTS_SOURCE_PATH/flightctl-api/server.key"
+wait_for_files "$CERTS_SOURCE_PATH/flightctl-ui/server.crt" "$CERTS_SOURCE_PATH/flightctl-ui/server.key"
 
 # Copy certificates to destination path
-cp "$CERTS_SOURCE_PATH/flightctl-api/server.crt" "$CERTS_DEST_PATH/server.crt"
-cp "$CERTS_SOURCE_PATH/flightctl-api/server.key" "$CERTS_DEST_PATH/server.key"
-
+cp "$CERTS_SOURCE_PATH/flightctl-ui/server.crt" "$CERTS_DEST_PATH/server.crt"
+cp "$CERTS_SOURCE_PATH/flightctl-ui/server.key" "$CERTS_DEST_PATH/server.key"
 if [ -f "$CERTS_SOURCE_PATH/auth/ca.crt" ]; then
   echo "Using provided auth CA certificate"
   cp "$CERTS_SOURCE_PATH/auth/ca.crt" "$CERTS_DEST_PATH/ca_auth.crt"

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -96,6 +96,28 @@ pam_issuer_sans=(
 )
 pam_issuer_sans+=("${host_ips[@]}")
 
+# UI certificate SANs
+ui_sans=(
+    "ui.$base_domain"
+    "$base_domain"
+    "$hostname_short"
+    "$hostname_fqdn"
+    "flightctl-ui"
+    "localhost"
+)
+ui_sans+=("${host_ips[@]}")
+
+# CLI Artifacts certificate SANs
+cli_artifacts_sans=(
+    "cli-artifacts.$base_domain"
+    "$base_domain"
+    "$hostname_short"
+    "$hostname_fqdn"
+    "flightctl-cli-artifacts"
+    "localhost"
+)
+cli_artifacts_sans+=("${host_ips[@]}")
+
 # Build the certificate generation command
 cert_gen_args=("--cert-dir" "$CERT_DIR")
 
@@ -113,6 +135,14 @@ done
 
 for san in "${pam_issuer_sans[@]}"; do
     cert_gen_args+=("--pam-issuer-san" "$san")
+done
+
+for san in "${ui_sans[@]}"; do
+    cert_gen_args+=("--ui-san" "$san")
+done
+
+for san in "${cli_artifacts_sans[@]}"; do
+    cert_gen_args+=("--cli-artifacts-san" "$san")
 done
 
 # Generate certificates

--- a/docs/user/references/certificate-architecture.md
+++ b/docs/user/references/certificate-architecture.md
@@ -26,6 +26,8 @@ For TPM attestation certificates, see [Configuring Device Attestation](../instal
 | [Device Enrollment](../../../internal/crypto/signer/signer_device_enrollment.go)                    | Device enrollment        | 1 year   | Client-Signer CA         |
 | [Device Management](../../../internal/crypto/signer/signer_device_management.go)             | Device operations        | 1 year   | Client-Signer CA         |
 | [Device Services](../../../internal/crypto/signer/signer_device_svc_client.go)    | Device services    | 1 year   | Client-Signer CA |
+| UI Server *                   | UI TLS                   | 2 years  | Root CA                  |
+| CLI Artifacts Server *        | CLI Artifacts TLS        | 2 years  | Root CA                  |
 | PAM Issuer Token Signer CA *  | Signs JWT tokens         | 10 years | Root CA                  |
 | PAM Issuer Server *           | PAM Issuer TLS           | 2 years  | Root CA                  |
 
@@ -57,6 +59,10 @@ Generation controlled by `global.generateCertificates` in Helm `values.yaml`: `a
 | `/etc/flightctl/pki/flightctl-api/client-signer.key`    | Client-Signer CA key            |
 | `/etc/flightctl/pki/flightctl-api/server.crt`           | API server cert                 |
 | `/etc/flightctl/pki/flightctl-api/server.key`           | API server key                  |
+| `/etc/flightctl/pki/flightctl-ui/server.crt`            | UI server cert                  |
+| `/etc/flightctl/pki/flightctl-ui/server.key`            | UI server key                   |
+| `/etc/flightctl/pki/flightctl-cli-artifacts/server.crt` | CLI Artifacts server cert       |
+| `/etc/flightctl/pki/flightctl-cli-artifacts/server.key` | CLI Artifacts server key        |
 | `/etc/flightctl/pki/flightctl-pam-issuer/token-signer.crt` | PAM Issuer Token Signer CA   |
 | `/etc/flightctl/pki/flightctl-pam-issuer/token-signer.key` | PAM Issuer Token Signer CA key |
 | `/etc/flightctl/pki/flightctl-pam-issuer/server.crt`   | PAM Issuer server cert          |


### PR DESCRIPTION
Generates additional certs for `flightctl-ui` and `flightctl-cli-artifacts` services when on RHEL, so they no longer use the `flightctl-api`'s certs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS certificates now generated and installed for UI and CLI Artifacts services, signed by the Root CA with 2-year validity
  * CLI options to provide custom SANs for UI and CLI Artifacts (domains, hostnames, IPs)
  * Certificate generation progress updated to a 10-step status including UI and CLI certificate steps

* **Documentation**
  * Certificate architecture updated with new entries and filesystem locations for UI and CLI Artifacts TLS assets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->