### PR TITLE
NO-ISSUE: proper login error when pam issuer's cookie expires

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -474,6 +474,7 @@ PAM
 alice
 bob
 charlie
+MaxAge
  - docs/user/installing/configuring-auth/auth-oauth2.md
 GitHub
 github.com

--- a/docs/user/installing/configuring-auth/auth-pam.md
+++ b/docs/user/installing/configuring-auth/auth-pam.md
@@ -87,6 +87,8 @@ auth:
     allowPublicClientWithoutPKCE: false                # SECURITY: Allow public clients without PKCE (not recommended)
     accessTokenExpiration: "1h"                         # Expiration duration for access tokens and ID tokens (default: "1h")
     refreshTokenExpiration: "168h"                     # Expiration duration for refresh tokens (default: "168h", equivalent to 7 days)
+    pendingSessionCookieMaxAge: "10m"                  # MaxAge duration for pending session cookies (default: "10m")
+    authenticatedSessionCookieMaxAge: "30m"            # MaxAge duration for authenticated session cookies (default: "30m")
 ```
 
 ### Configuration Parameters
@@ -103,6 +105,8 @@ auth:
 | `allowPublicClientWithoutPKCE` | Allow public clients to skip PKCE requirement. **Security Warning**: Only enable for testing | `false` |
 | `accessTokenExpiration` | Expiration duration for access tokens and ID tokens (e.g., `1h`, `30m`) | `1h` |
 | `refreshTokenExpiration` | Expiration duration for refresh tokens (e.g., `168h`, `720h`) | `168h` |
+| `pendingSessionCookieMaxAge` | MaxAge duration for pending session cookies (e.g., `10m`, `15m`) | `10m` |
+| `authenticatedSessionCookieMaxAge` | MaxAge duration for authenticated session cookies (e.g., `30m`, `1h`) | `30m` |
 
 ### Default Configuration
 
@@ -115,6 +119,8 @@ If the `pamOidcIssuer` section is present in the configuration file, the followi
 - **Redirect URIs**: Automatically configured based on the service's base UI URL or base URL
 - **Access Token Expiration**: Defaults to `1h`
 - **Refresh Token Expiration**: Defaults to `168h` (7 days)
+- **Pending Session Cookie MaxAge**: Defaults to `10m` (10 minutes)
+- **Authenticated Session Cookie MaxAge**: Defaults to `30m` (30 minutes)
 
 ### Security Note
 

--- a/internal/auth/oidc/pam/templates/login_form.html
+++ b/internal/auth/oidc/pam/templates/login_form.html
@@ -111,7 +111,19 @@
                     window.location.href = result.text;
                 } else {
                     // Failed login - show error message from server
-                    showError(result.text);
+                    // Try to parse as JSON first (OAuth2Error format), otherwise use plain text
+                    let errorMessage = result.text;
+                    try {
+                        const errorJson = JSON.parse(result.text);
+                        if (errorJson.error_description) {
+                            errorMessage = errorJson.error_description;
+                        } else if (errorJson.error) {
+                            errorMessage = errorJson.error;
+                        }
+                    } catch (e) {
+                        // Not JSON, use text as-is
+                    }
+                    showError(errorMessage);
                 }
             })
             .catch(error => {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,9 +157,6 @@ type PAMOIDCIssuer struct {
 	// AuthenticatedSessionCookieMaxAge is the MaxAge duration for authenticated session cookies
 	// Default: 30 minutes
 	AuthenticatedSessionCookieMaxAge util.Duration `json:"authenticatedSessionCookieMaxAge,omitempty"`
-	// CookieHttpOnly controls whether cookies are set with HttpOnly flag
-	// Default: true (nil means use default)
-	CookieHttpOnly *bool `json:"cookieHttpOnly,omitempty"`
 }
 
 type metricsConfig struct {
@@ -626,10 +623,6 @@ func applyPAMOIDCIssuerDefaults(c *Config) {
 	}
 	if c.Auth.PAMOIDCIssuer.AuthenticatedSessionCookieMaxAge == 0 {
 		c.Auth.PAMOIDCIssuer.AuthenticatedSessionCookieMaxAge = util.Duration(30 * time.Minute)
-	}
-	if c.Auth.PAMOIDCIssuer.CookieHttpOnly == nil {
-		httpOnly := true
-		c.Auth.PAMOIDCIssuer.CookieHttpOnly = &httpOnly
 	}
 }
 

--- a/internal/pam_issuer_server/handler.go
+++ b/internal/pam_issuer_server/handler.go
@@ -326,10 +326,17 @@ func (h *Handler) AuthLoginPost(w http.ResponseWriter, r *http.Request) {
 	h.log.Infof("Login request - username=%s", username)
 
 	// Validate required fields
-	if username == "" || password == "" || encryptedCookie == "" {
-		h.log.Warnf("Missing required fields - username=%v, hasPassword=%v, hasEncryptedCookie=%v",
-			username != "", password != "", encryptedCookie != "")
+	if username == "" || password == "" {
+		h.log.Warnf("Missing required fields - username=%v, hasPassword=%v",
+			username != "", password != "")
 		writeError(w, http.StatusBadRequest, "Missing required fields")
+		return
+	}
+
+	// If encrypted cookie is missing, return error
+	if encryptedCookie == "" {
+		h.log.Warnf("Missing encrypted cookie - login expired")
+		writeError(w, http.StatusBadRequest, "Your login session has expired. Please refresh the page and try again.")
 		return
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two PAM OIDC cookie settings: pendingSessionCookieMaxAge and authenticatedSessionCookieMaxAge.

* **Bug Fixes**
  * Improved login error messages to prefer parsed server error details.
  * Clarified session validation feedback with a specific message for expired login sessions.

* **Documentation**
  * Updated PAM-related docs and spelling dictionary entries.

* **Chores**
  * Removed the configurable HttpOnly setting and its defaulting for PAM OIDC cookies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->