### PR TITLE
EDM-2854: Add ttlSecondsAfterFinished to completed jobs in helm

### DIFF
--- a/deploy/helm/flightctl/templates/db/_db-migration-job.tpl
+++ b/deploy/helm/flightctl/templates/db/_db-migration-job.tpl
@@ -36,6 +36,9 @@ spec:
   {{- if gt ($ctx.Values.dbSetup.migration.activeDeadlineSeconds | int) 0 }}
   activeDeadlineSeconds: {{ $ctx.Values.dbSetup.migration.activeDeadlineSeconds | int }}
   {{- end }}
+  {{- if gt ($ctx.Values.dbSetup.migration.ttlSecondsAfterFinished | int) 0 }}
+  ttlSecondsAfterFinished: {{ $ctx.Values.dbSetup.migration.ttlSecondsAfterFinished | int }}
+  {{- end }}
   completions: 1
   parallelism: 1
   template:

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -577,7 +577,8 @@
           "additionalProperties": false,
           "properties": {
             "backoffLimit": { "type": "integer", "description": "Number of retries for the migration Job on failure" },
-            "activeDeadlineSeconds": { "type": "integer", "description": "Maximum runtime in seconds for the migration Job (0 = no deadline)" }
+            "activeDeadlineSeconds": { "type": "integer", "description": "Maximum runtime in seconds for the migration Job (0 = no deadline)" },
+            "ttlSecondsAfterFinished": { "type": "integer", "description": "TTL in seconds for completed/failed migration Jobs before automatic deletion (0 = no TTL)" }
           }
         }
       }

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -359,6 +359,8 @@ dbSetup:
     backoffLimit: 2147483647
     # -- Maximum runtime in seconds for the migration Job (0 = no deadline)
     activeDeadlineSeconds: 0
+    # -- TTL in seconds for completed/failed migration Jobs before automatic deletion (0 = no TTL)
+    ttlSecondsAfterFinished: 0
 
 # -- Upgrade hooks
 upgradeHooks:


### PR DESCRIPTION
Make sure there are no leftovers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Time To Live (TTL) configuration for database migration jobs, enabling automatic cleanup of finished jobs after a configurable duration (disabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->