### PR TITLE
EDM-2261: Fix templating issue with inline application definitions

### DIFF
--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -747,7 +747,7 @@ func extractAppDataFromOCITarget(
 		}
 
 		// validate the compose spec
-		if errs := validation.ValidateComposeSpec(spec, false); len(errs) > 0 {
+		if errs := validation.ValidateComposeSpec(spec); len(errs) > 0 {
 			if rmErr := cleanupFn(); rmErr != nil {
 				return nil, fmt.Errorf("validating compose spec for app %s (%s): %w (cleanup failed: %v)", appName, imageRef, errors.Join(errs...), rmErr)
 			}
@@ -779,7 +779,7 @@ func extractAppDataFromOCITarget(
 		// validate all quadlets before extracting targets
 		var validationErrs []error
 		for quadletPath, quad := range spec {
-			if errs := validation.ValidateQuadletSpec(quad, quadletPath, false); len(errs) > 0 {
+			if errs := validation.ValidateQuadletSpec(quad, quadletPath); len(errs) > 0 {
 				validationErrs = append(validationErrs, errs...)
 			}
 		}
@@ -818,7 +818,7 @@ func ensureCompose(readWriter fileio.ReadWriter, appPath string) error {
 		return fmt.Errorf("parsing compose spec: %w", err)
 	}
 
-	if errs := validation.ValidateComposeSpec(spec, false); len(errs) > 0 {
+	if errs := validation.ValidateComposeSpec(spec); len(errs) > 0 {
 		return fmt.Errorf("validating compose spec: %w", errors.Join(errs...))
 	}
 
@@ -882,7 +882,7 @@ func ensureQuadlet(readWriter fileio.ReadWriter, appPath string) error {
 
 	var errs []error
 	for path, quad := range spec {
-		if e := validation.ValidateQuadletSpec(quad, path, false); len(e) > 0 {
+		if e := validation.ValidateQuadletSpec(quad, path); len(e) > 0 {
 			errs = append(errs, e...)
 		}
 	}

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -427,12 +427,3 @@ func asErrors(errs field.ErrorList) []error {
 	}
 	return agg.Errors()
 }
-
-// ValidateOCIReferenceStrict validates the supplied image depending on the source of the validation
-// If it's a fleet, template validation will occur, but for devices, strict reference checking is applied
-func ValidateOCIReferenceStrict(s *string, path string, fleetTemplate bool) []error {
-	if fleetTemplate {
-		return ValidateOciImageReferenceWithTemplates(s, path)
-	}
-	return ValidateOciImageReferenceStrict(s, path)
-}


### PR DESCRIPTION
Adds options to validate different application specs to overrwrite default image validation functions. This is necessary as from the services side, it's required to understand the difference between the templated and non-templated images. On the agent, the templating must be applied. 

Still applies the templating from https://github.com/flightctl/flightctl/pull/2277 but also allows 

```yaml
apiVersion: flightctl.io/v1beta1
kind: Fleet
metadata:
  name: templated-app-fleet
spec:
  selector:
    matchLabels:
      app: my-templated-app
  template:
    spec:
      applications:
        - name: my-app
          appType: container
          image: docker.io/library/nginx:latest
          ports:
            - "8081:80"
            - "8080:8080"
          resources:
            limits:
              cpu: "0.5"
              memory: "256m"
          volumes:
            - name: nginx-config
              mount:
                path: "/etc/nginx/conf.d"
              image:
                reference: quay.io/kkyrazis/quadlet-test/nginx-config-artifact:latest
            - name: nginx-html
              mount:
                path: "/usr/share/nginx/html"
              image:
                reference: quay.io/kkyrazis/quadlet-test/nginx-html-artifact-image:latest
            - name: nginx-logs
              mount:
                path: "/var/log/nginx"

        - name: my-app-2
          appType: quadlet
          image: "quay.io/kkyrazis/quadlet-test/quadlet-app-artifact:inline-app"
          envVars:
            LOG_MESSAGE: "Multi-file artifact (with .image ref)"
          volumes:
            - name: model-data
              image:
                reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
                pullPolicy: IfNotPresent

        - name: inline-app
          appType: quadlet
          envVars:
            LOG_MESSAGE: "Hello from FlightControl (Inline Ref)"
          inline:
            - path: app.container
              content: |
                [Unit]
                Description=Primary application container
                
                [Container]
                Image=quay.io/flightctl-tests/alpine:v3
                Exec=sh -c "echo 'Primary container started.' && echo 'LOG_MESSAGE:' $LOG_MESSAGE && sleep infinity"
                
                [Install]
                WantedBy=default.target
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated image-reference validation into a configurable validator used across Compose and Quadlet spec validation, unifying behavior and improving error aggregation when templates are involved.

* **Tests**
  * Added and updated test coverage for templated and custom-image-validation paths to ensure validation behavior remains correct.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->