### PR TITLE
EDM-2855: remove E2E git server creation

### DIFF
--- a/test/test.mk
+++ b/test/test.mk
@@ -114,7 +114,7 @@ _run_template_migration:
     test/scripts/run_migration.sh \
 	'
 
-deploy-e2e-extras: bin/.ssh/id_rsa.pub bin/e2e-certs/ca.pem git-server-container
+deploy-e2e-extras: bin/.ssh/id_rsa.pub bin/e2e-certs/ca.pem
 	test/scripts/deploy_e2e_extras_with_helm.sh
 
 deploy-e2e-ocp-test-vm:
@@ -142,7 +142,7 @@ prepare-e2e-test: deploy-e2e-extras build-e2e-containers push-e2e-agent-images p
 	./test/scripts/prepare_cli.sh
 
 # Build E2E containers with Docker caching
-build-e2e-containers: git-server-container e2e-agent-images
+build-e2e-containers: e2e-agent-images
 	@echo "Building E2E containers with Docker caching..."
 
 # Ensure git-server container is built with proper caching


### PR DESCRIPTION
Removing the creation of this local git server E2E tool. This tool is not used in the E2E test, and it's creation is causing QE ci issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized E2E testing infrastructure by streamlining container build dependencies and reducing unnecessary prerequisites, improving overall build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->