### PR TITLE
NO-ISSUE: Unset FLIGHTCTL_NS in deploy_e2e_extras.with_helm.sh

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -50,6 +50,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
+      FLIGHTCTL_NS: flightctl-external
     steps:
       # ========== PREPARE ENVIRONMENT ==========
       - name: Checkout

--- a/test/scripts/deploy_e2e_extras_with_helm.sh
+++ b/test/scripts/deploy_e2e_extras_with_helm.sh
@@ -37,8 +37,5 @@ insecure = true
 EOF
 fi
 
-# Set namespace for try_login to use correct service account
-export FLIGHTCTL_NS=flightctl-external
-
 # attempt login to flightctl
 try_login


### PR DESCRIPTION
This cause setups with a different NS than flightctl-external to break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E deployment script no longer explicitly sets a namespace before performing login, making namespace selection implicit — this may change which service account is used during login verification.
  * CI E2E job now supplies a default namespace via an environment variable to align the test environment with the script behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->