### PR TITLE
Add skopeo to test-vm

### DIFF
--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -112,7 +112,7 @@ ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile
   # Install necessary packages
   sudo dnf install -y epel-release libvirt libvirt-client virt-install pam-devel swtpm wget \
                     make golang git \
-                    podman qemu-kvm sshpass
+                    podman qemu-kvm sshpass skopeo
   sudo dnf --enablerepo=crb install -y libvirt-devel
 
   # Install OpenShift client


### PR DESCRIPTION
Needed in order to discover the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * VM provisioning now installs skopeo in addition to existing packages (podman, qemu-kvm, sshpass), so skopeo is available on newly provisioned VMs.
  * No other provisioning logic or error handling was changed; this is an additive package update only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->