### PR TITLE
Update auth-openshift doc

### DIFF
--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -50,7 +50,7 @@ Flight Control uses RoleBindings from project namespaces to determine user permi
 3. For each project, Flight Control checks RoleBindings in the project namespace
 4. Permissions are mapped based on ClusterRoles bound to the user
 
-**Note:** Any role or organization configuration changes require users to log in again or wait approximately 5 minutes to receive updated assignments.
+**Note:** Any role or organization configuration changes require users to log in again (with a different token if you logged using an Openshift token) or wait approximately 5 minutes to receive updated assignments.
 
 ## Configuration
 


### PR DESCRIPTION
Add the need to use a different token after organizations changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenShift authentication guidance: when signing in with an OpenShift token, re-login may authenticate with a different/new token or you may need to wait ~5 minutes for the previous session to expire before re-authenticating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->