### PR TITLE
EDM-2920: Add Pruning Configuration Support

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent/client"
@@ -16,6 +17,7 @@ import (
 	baseclient "github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/util"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
@@ -136,6 +138,9 @@ type Config struct {
 	// ProfilingEnabled turns on the loopback-only pprof server for local debugging.
 	ProfilingEnabled bool `json:"profiling-enabled,omitempty"`
 
+	// ImagePruning holds all image/artifact pruning-related configuration
+	ImagePruning ImagePruning `json:"image-pruning,omitempty"`
+
 	readWriter fileio.ReadWriter
 }
 
@@ -148,6 +153,12 @@ type TPM struct {
 	AuthEnabled bool `json:"auth-enabled,omitempty"`
 	// StorageFilePath specifies the file path for TPM key storage.
 	StorageFilePath string `json:"storage-file-path,omitempty"`
+}
+
+type ImagePruning struct {
+	// Enabled controls whether automatic pruning is enabled.
+	// Default: false
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // DefaultSystemInfo defines the list of system information keys that are included
@@ -188,6 +199,9 @@ func NewDefault() *Config {
 			StorageFilePath: filepath.Join(DefaultDataDir, DefaultTPMKeyFile),
 		},
 		AuditLog: *audit.NewDefaultAuditConfig(),
+		ImagePruning: ImagePruning{
+			Enabled: lo.ToPtr(false),
+		},
 	}
 
 	if value := os.Getenv(TestRootDirEnvKey); value != "" {
@@ -380,13 +394,21 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 		return err
 	}
 
+	// Sort entries lexically to ensure deterministic order
+	var yamlFiles []string
 	re := regexp.MustCompile(`^.*\.ya?ml$`)
 	for _, entry := range entries {
 		if entry.IsDir() || !re.MatchString(entry.Name()) {
 			continue
 		}
+		yamlFiles = append(yamlFiles, entry.Name())
+	}
+	sort.Strings(yamlFiles)
+
+	// Apply drop-ins in order (later files override earlier ones)
+	for _, filename := range yamlFiles {
 		overrideCfg := &Config{}
-		overridePath := filepath.Join(confSubdir, entry.Name())
+		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
 			return fmt.Errorf("reading override config %s: %w", overridePath, err)
@@ -425,6 +447,13 @@ func mergeConfigs(base, override *Config) {
 	// instrumentation
 	overrideIfNotEmpty(&base.MetricsEnabled, override.MetricsEnabled)
 	overrideIfNotEmpty(&base.ProfilingEnabled, override.ProfilingEnabled)
+
+	// pruning
+	// Always override pruning config from dropins when present.
+	// Since dropins are meant to override base config, we always apply the value.
+	// Note: This means a dropin without a pruning section won't change the base value,
+	// but a dropin with pruning.enabled: false will override to false.
+	overrideIfNotEmpty(&base.ImagePruning.Enabled, override.ImagePruning.Enabled)
 
 	for k, v := range override.DefaultLabels {
 		base.DefaultLabels[k] = v

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -62,4 +64,210 @@ func TestParseConfigFile_NoFile(t *testing.T) {
 
 	// Expect an error because the file does not exist
 	require.Error(err)
+}
+
+func TestLoadPruningFromConfig(t *testing.T) {
+	require := require.New(t)
+	tests := []struct {
+		name            string
+		setupFiles      func(t *testing.T, configDir string) string
+		expectedEnabled bool
+		wantErr         bool
+	}{
+		{
+			name: "no config files - uses default",
+			setupFiles: func(t *testing.T, configDir string) string {
+				configFile := filepath.Join(configDir, "config.yaml")
+				content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+`
+				require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+				return configFile
+			},
+			expectedEnabled: false, // Default from NewDefault() - nil pointer means disabled
+		},
+		{
+			name: "base config file enables pruning",
+			setupFiles: func(t *testing.T, configDir string) string {
+				configFile := filepath.Join(configDir, "config.yaml")
+				content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+image-pruning:
+  enabled: true
+`
+				require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+				return configFile
+			},
+			expectedEnabled: true,
+		},
+		{
+			name: "base config file disables pruning",
+			setupFiles: func(t *testing.T, configDir string) string {
+				configFile := filepath.Join(configDir, "config.yaml")
+				content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+image-pruning:
+  enabled: false
+`
+				require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+				return configFile
+			},
+			expectedEnabled: false,
+		},
+		{
+			name: "dropin overrides base config file",
+			setupFiles: func(t *testing.T, configDir string) string {
+				// Base file enables
+				configFile := filepath.Join(configDir, "config.yaml")
+				content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+image-pruning:
+  enabled: true
+`
+				require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+				// Dropin disables
+				dropinDir := filepath.Join(configDir, "conf.d")
+				require.NoError(os.MkdirAll(dropinDir, 0o755))
+				dropinPath := filepath.Join(dropinDir, "01-disable.yaml")
+				require.NoError(os.WriteFile(dropinPath, []byte("image-pruning:\n  enabled: false\n"), 0o600))
+				return configFile
+			},
+			expectedEnabled: false,
+		},
+		{
+			name: "multiple dropins - later overrides earlier",
+			setupFiles: func(t *testing.T, configDir string) string {
+				configFile := filepath.Join(configDir, "config.yaml")
+				content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+`
+				require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+				dropinDir := filepath.Join(configDir, "conf.d")
+				require.NoError(os.MkdirAll(dropinDir, 0o755))
+				// First dropin enables
+				require.NoError(os.WriteFile(filepath.Join(dropinDir, "01-enable.yaml"), []byte("image-pruning:\n  enabled: true\n"), 0o600))
+				// Second dropin disables (should win)
+				require.NoError(os.WriteFile(filepath.Join(dropinDir, "02-disable.yaml"), []byte("image-pruning:\n  enabled: false\n"), 0o600))
+				return configFile
+			},
+			expectedEnabled: false,
+		},
+		{
+			name: "invalid yaml in base config file",
+			setupFiles: func(t *testing.T, configDir string) string {
+				configFile := filepath.Join(configDir, "config.yaml")
+				require.NoError(os.WriteFile(configFile, []byte("invalid: yaml: content: [\n"), 0o600))
+				return configFile
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "etc", "flightctl")
+			dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+			// Create necessary directories
+			require.NoError(os.MkdirAll(configDir, 0o755))
+			require.NoError(os.MkdirAll(dataDir, 0o755))
+
+			cfg := NewDefault()
+			cfg.ConfigDir = configDir
+			cfg.DataDir = dataDir
+			cfg.readWriter = fileio.NewReadWriter()
+
+			configFile := tt.setupFiles(t, configDir)
+
+			err := cfg.LoadWithOverrides(configFile)
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+			if tt.expectedEnabled {
+				require.NotNil(cfg.ImagePruning.Enabled, "Enabled should not be nil when expected to be true")
+				require.True(*cfg.ImagePruning.Enabled, "Enabled should be true")
+			} else {
+				if cfg.ImagePruning.Enabled != nil {
+					require.False(*cfg.ImagePruning.Enabled, "Enabled should be false when not nil")
+				}
+			}
+		})
+	}
+}
+
+func TestLoadWithOverridesIncludesPruningFromConfD(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	// Create necessary directories
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter()
+
+	// Create base config file with pruning disabled
+	configFile := filepath.Join(configDir, "config.yaml")
+	content := `enrollment-service:
+  service:
+    server: https://enrollment.endpoint
+    certificate-authority-data: abcd
+  authentication:
+    client-certificate-data: efgh
+    client-key-data: ijkl
+status-update-interval: 0m10s
+image-pruning:
+  enabled: false
+`
+	require.NoError(os.WriteFile(configFile, []byte(content), 0o600))
+
+	// Create dropin in conf.d that enables pruning (should override config)
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+	dropinPath := filepath.Join(dropinDir, "enable.yaml")
+	require.NoError(os.WriteFile(dropinPath, []byte("image-pruning:\n  enabled: true\n"), 0o600))
+
+	// Load config with overrides
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err)
+	// Dropin should override config, so pruning should be enabled
+	require.NotNil(cfg.ImagePruning.Enabled, "Enabled should not be nil when dropin enables pruning")
+	require.True(*cfg.ImagePruning.Enabled, "pruning dropin should override config setting")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pruning configuration added: a configurable image-pruning setting is now supported and defaults to disabled.
  * Drop-in configuration files are applied in deterministic lexical order so overrides behave consistently.

* **Tests**
  * Added tests covering pruning loading, multiple drop-ins, override precedence, and handling of invalid drop-ins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->