### PR TITLE
EDM-2968: Reload configuration upon configuration dropin files change

### DIFF
--- a/internal/agent/device/hook/actions.go
+++ b/internal/agent/device/hook/actions.go
@@ -154,6 +154,9 @@ func executeRunAction(ctx context.Context, exec executer.Executer, log *log.Pref
 	}
 	envVars := util.LabelMapToArray(action.EnvVars)
 
+	// Inject agent PID as environment variable for hooks to use
+	envVars = append(envVars, fmt.Sprintf("FLIGHTCTL_AGENT_PID=%d", os.Getpid()))
+
 	_, stderr, exitCode := exec.ExecuteWithContextFromDir(ctx, workDir, cmd, args, envVars...)
 	if exitCode != 0 {
 		log.Errorf("Running %q returned with exit code %d: %s", commandLine, exitCode, stderr)

--- a/internal/agent/device/hook/manager_test.go
+++ b/internal/agent/device/hook/manager_test.go
@@ -179,7 +179,7 @@ func expectExecCalls(mockExecuter *executer.MockExecuter, expectedCommands []com
 	if len(expectedCommands) > 0 {
 		calls := make([]any, len(expectedCommands))
 		for i, e := range expectedCommands {
-			calls[i] = mockExecuter.EXPECT().ExecuteWithContextFromDir(gomock.Any(), "", e.command, e.args).DoAndReturn(
+			calls[i] = mockExecuter.EXPECT().ExecuteWithContextFromDir(gomock.Any(), "", e.command, e.args, gomock.Any()).DoAndReturn(
 				func(ctx context.Context, workingDir, command string, args []string, env ...string) (string, string, int) {
 					return "", "", 0
 				}).Return("", "", 0).Times(1)

--- a/packaging/hooks.d/afterupdating/00-default.yaml
+++ b/packaging/hooks.d/afterupdating/00-default.yaml
@@ -10,3 +10,7 @@
   - path: /etc/firewalld/
     op: [created, updated, removed]
   run: firewall-cmd --reload
+- if:
+  - path: /etc/flightctl/conf.d/
+    op: [created, updated, removed]
+  run: /bin/sh -c 'kill -HUP ${FLIGHTCTL_AGENT_PID}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hooks now provide the agent PID to executed hook processes, and a post-update hook can signal the agent (SIGHUP) to reload configuration without restarting.
* **Tests**
  * Unit tests updated to account for the additional environment parameter passed to hook execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->