### PR TITLE
EDM-2967: Obtain Ingress cert on OpenShift env

### DIFF
--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-certs-secret.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-certs-secret.yaml
@@ -1,4 +1,6 @@
-{{ if and .Values.ui.enabled (or ((.Values.global).auth).caCert .Values.ui.auth.caCert) }}
+{{ if .Values.ui.enabled }}
+{{ $caCrt := default (include "flightctl.getAuthCaCrt" .) .Values.ui.auth.caCert }}
+{{ if $caCrt }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,5 +11,6 @@ metadata:
     flightctl.service: flightctl-ui
 type: Opaque
 stringData:
-  ca_auth.crt: {{ default ((.Values.global).auth).caCert .Values.ui.auth.caCert | quote }}
+  ca_auth.crt: {{ $caCrt | quote }}
+{{ end }}
 {{ end }}

--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
@@ -1,5 +1,6 @@
 {{ if .Values.ui.enabled }}
 {{ $enableMulticlusterExtensions := (include "flightctl.enableMulticlusterExtensions" .)}}
+{{ $caCrt := default (include "flightctl.getAuthCaCrt" .) .Values.ui.auth.caCert }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,7 +92,7 @@ spec:
             - mountPath: /app/certs/ca.crt
               name: ca-bundle
               subPath: ca-bundle.crt
-            {{- if or ((.Values.global).auth).caCert .Values.ui.auth.caCert }}
+            {{- if $caCrt }}
             - mountPath: /app/certs/ca_auth.crt
               name: flightctl-ui-certs
               subPath: ca_auth.crt
@@ -105,7 +106,7 @@ spec:
         - name: ca-bundle
           secret:
             secretName: flightctl-ca-bundle
-        {{- if or ((.Values.global).auth).caCert .Values.ui.auth.caCert }}
+        {{- if $caCrt }}
         - name: flightctl-ui-certs
           secret:
             secretName: flightctl-ui-certs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CA certificate resolution that automatically falls back to OpenShift's default ingress certificate when no explicit certificate is configured, reducing manual setup requirements.

* **Chores**
  * Centralized CA certificate handling across authentication and UI deployment templates for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->