### PR TITLE
EDM-2252: Enhance and document quadlet uninstall + cleanup steps

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -205,6 +205,7 @@ localhost
 copr
 repo
 rpm
+rpms
 podman
 Quickstart
 https

--- a/cmd/flightctl-standalone/cleanup.go
+++ b/cmd/flightctl-standalone/cleanup.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/quadlet"
+	"github.com/flightctl/flightctl/internal/quadlet/renderer"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/spf13/cobra"
+)
+
+const (
+	// Timeout for waiting for containers to be removed by systemd
+	containerRemoveTimeout = 60 * time.Second
+	// Polling interval for checking container status
+	containerPollInterval = 2 * time.Second
+)
+
+type CleanupOptions struct {
+	AcceptPrompt bool
+}
+
+func NewCleanupCommand() *cobra.Command {
+	opts := &CleanupOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Clean up Flight Control services and artifacts",
+		Long: `Stop and disable Flight Control services, then remove all associated
+podman artifacts (containers, images, volumes, networks, secrets).
+
+This operation is destructive - use with caution.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.AcceptPrompt, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func (o *CleanupOptions) Run() error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("cleanup requires root privileges, please run with sudo")
+	}
+
+	if !o.AcceptPrompt {
+		if !confirmCleanup() {
+			fmt.Println("Cleanup cancelled.")
+			return nil
+		}
+	}
+
+	fmt.Println("Starting Flight Control cleanup...")
+
+	exec := &executer.CommonExecuter{}
+	podmanClient := podman.NewClient(exec)
+	ctx := context.Background()
+
+	if err := stopServices(ctx, exec); err != nil {
+		fmt.Printf("Warning: Failed to stop services: %v\n", err)
+	}
+
+	if err := disableTarget(ctx, exec); err != nil {
+		fmt.Printf("Warning: Failed to disable target: %v\n", err)
+	}
+
+	if err := waitForContainersToRemove(ctx, podmanClient); err != nil {
+		fmt.Printf("Warning: Failed waiting for containers to stop: %v\n", err)
+	}
+
+	if err := removeImages(ctx, podmanClient); err != nil {
+		fmt.Printf("Warning: Failed to remove images: %v\n", err)
+	}
+
+	if err := removeVolumes(ctx, podmanClient); err != nil {
+		fmt.Printf("Warning: Failed to remove volumes: %v\n", err)
+	}
+
+	if err := removeSecrets(ctx, podmanClient); err != nil {
+		fmt.Printf("Warning: Failed to remove secrets: %v\n", err)
+	}
+
+	if err := removeNetwork(ctx, podmanClient); err != nil {
+		fmt.Printf("Warning: Failed to remove network: %v\n", err)
+	}
+
+	fmt.Println("Cleanup completed.")
+	return nil
+}
+
+func confirmCleanup() bool {
+	fmt.Println("WARNING: This will remove all Flight Control services and data.")
+	fmt.Println("This operation cannot be undone.")
+	fmt.Print("Are you sure you want to continue? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
+}
+
+func stopServices(ctx context.Context, exec executer.Executer) error {
+	fmt.Println("Stopping Flight Control services...")
+
+	_, stdout, exitCode := exec.ExecuteWithContext(ctx, "systemctl", "stop", renderer.SystemdTargetName)
+	if exitCode != 0 {
+		return fmt.Errorf("systemctl stop %s: %s\n", renderer.SystemdTargetName, stdout)
+	}
+
+	fmt.Println("Services stopped")
+	return nil
+}
+
+func disableTarget(ctx context.Context, exec executer.Executer) error {
+	fmt.Println("Disabling Flight Control target...")
+
+	_, stdout, exitCode := exec.ExecuteWithContext(ctx, "systemctl", "disable", renderer.SystemdTargetName)
+	if exitCode != 0 {
+		return fmt.Errorf("systemctl disable %s: %s\n", renderer.SystemdTargetName, stdout)
+	}
+
+	fmt.Println("Target disabled")
+	return nil
+}
+
+func waitForContainersToRemove(ctx context.Context, client *podman.Client) error {
+	fmt.Println("Waiting for Flight Control containers to be removed...")
+
+	deadline := time.Now().Add(containerRemoveTimeout)
+	for {
+		containers, err := client.ListContainers(ctx, podman.ListContainersOptions{
+			All:    true,
+			Filter: "name=flightctl-",
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list containers: %w", err)
+		}
+
+		if len(containers) == 0 {
+			fmt.Println("All containers removed")
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for containers to be removed: %v", containers)
+		}
+
+		time.Sleep(containerPollInterval)
+	}
+}
+
+func removeImages(ctx context.Context, client *podman.Client) error {
+	fmt.Println("Removing Flight Control images...")
+
+	// Find all .container files in the quadlet directory
+	pattern := filepath.Join(renderer.DefaultQuadletDir, "flightctl*.container")
+	containerFiles, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("failed to glob container files: %w", err)
+	}
+
+	// Track unique images to avoid duplicate removal attempts
+	imageSet := make(map[string]struct{})
+
+	for _, containerFile := range containerFiles {
+		content, err := os.ReadFile(containerFile)
+		if err != nil {
+			fmt.Printf("Warning: Failed to read container file %s: %v\n", containerFile, err)
+			continue
+		}
+
+		unit, err := quadlet.NewUnit(content)
+		if err != nil {
+			fmt.Printf("Warning: Failed to parse container file %s: %v\n", containerFile, err)
+			continue
+		}
+
+		image, err := unit.GetImage()
+		if err != nil {
+			continue
+		}
+
+		imageSet[image] = struct{}{}
+	}
+
+	// Remove each unique image using the podman client
+	for image := range imageSet {
+		fmt.Printf("Removing image: %s\n", image)
+		err := client.RemoveImage(ctx, image)
+		if err != nil {
+			if errors.Is(err, podman.ErrImageDoesNotExist) {
+				continue
+			}
+			fmt.Printf("Warning: Failed to remove image %s (may be in use): %v\n", image, err)
+		}
+	}
+
+	return nil
+}
+
+func removeVolumes(ctx context.Context, client *podman.Client) error {
+	fmt.Println("Removing Flight Control volumes...")
+
+	for _, volume := range renderer.KnownVolumes {
+		fmt.Printf("Removing volume: %s\n", volume)
+		err := client.RemoveVolume(ctx, volume)
+		if err != nil {
+			if errors.Is(err, podman.ErrVolumeDoesNotExist) {
+				continue
+			}
+			fmt.Printf("Warning: Failed to remove volume %s: %v\n", volume, err)
+		}
+	}
+
+	return nil
+}
+
+func removeNetwork(ctx context.Context, client *podman.Client) error {
+	fmt.Println("Removing Flight Control network...")
+
+	fmt.Printf("Removing network: %s\n", renderer.PodmanNetworkName)
+	err := client.RemoveNetwork(ctx, renderer.PodmanNetworkName)
+	if err != nil {
+		if errors.Is(err, podman.ErrNetworkDoesNotExist) {
+			return nil
+		}
+		fmt.Printf("Warning: Failed to remove network %s: %v\n", renderer.PodmanNetworkName, err)
+		return err
+	}
+
+	return nil
+}
+
+func removeSecrets(ctx context.Context, client *podman.Client) error {
+	fmt.Println("Removing Flight Control secrets...")
+
+	for _, secret := range renderer.KnownSecrets {
+		fmt.Printf("Removing secret: %s\n", secret)
+		err := client.RemoveSecret(ctx, secret, podman.RemoveSecretOptions{
+			Ignore: true,
+		})
+		if err != nil {
+			fmt.Printf("Warning: Failed to remove secret %s: %v\n", secret, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/flightctl-standalone/main.go
+++ b/cmd/flightctl-standalone/main.go
@@ -27,6 +27,7 @@ func NewStandaloneCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewRenderCommand())
+	cmd.AddCommand(NewCleanupCommand())
 
 	return cmd
 }

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -16,6 +16,7 @@ Welcome to the Flight Control user documentation.
     * [Installing with Ansible Automation Platform](installing/installing-service-on-kubernetes.md#installing-with-ansible-automation-platform)
 
   * **[Installing the Flight Control Service on Linux](installing/installing-service-on-linux.md)**
+    * **[Uninstalling on Linux](installing/uninstalling-service-on-linux.md)
 
   * Configuring the Flight Control Service
     * [Configuring Authentication and Authorization](installing/configuring-auth/overview.md)

--- a/docs/user/installing/uninstalling-service-on-linux.md
+++ b/docs/user/installing/uninstalling-service-on-linux.md
@@ -1,0 +1,34 @@
+# Uninstalling on Linux
+
+Before you uninstall Flight Control services, remove all data and podman artifacts using the cleanup script.
+
+## Uninstalling Flight Control from an RPM package
+
+### Prerequisites
+
+You are logged in as an administrator with root (sudo) access.
+
+### Procedure
+
+1. Clean all data and podman artifacts by running the following command:
+
+   ```bash
+   sudo /usr/bin/flightctl-standalone cleanup
+   ```
+
+   This script performs the following clean up actions:
+
+   - Stops and disables `flightctl.target`
+   - Remove Flight Control owned podman containers, images, volumes, secrets, and networks
+
+2. Remove installed RPMs
+
+   ```bash
+   sudo dnf remove "flightctl-*"
+   ```
+
+3. Remove leftover configuration
+
+   ```bash
+   sudo rm -f /etc/flightctl
+   ```

--- a/internal/quadlet/renderer/renderer.go
+++ b/internal/quadlet/renderer/renderer.go
@@ -71,11 +71,11 @@ type RendererConfig struct {
 
 func NewRendererConfig() *RendererConfig {
 	return &RendererConfig{
-		ReadOnlyConfigOutputDir:  "/usr/share/flightctl",
-		WriteableConfigOutputDir: "/etc/flightctl",
-		QuadletFilesOutputDir:    "/usr/share/containers/systemd",
-		SystemdUnitOutputDir:     "/usr/lib/systemd/system",
-		BinOutputDir:             "/usr/bin",
+		ReadOnlyConfigOutputDir:  DefaultReadOnlyConfigDir,
+		WriteableConfigOutputDir: DefaultWriteableConfigDir,
+		QuadletFilesOutputDir:    DefaultQuadletDir,
+		SystemdUnitOutputDir:     DefaultSystemdUnitDir,
+		BinOutputDir:             DefaultBinDir,
 	}
 }
 

--- a/internal/quadlet/renderer/utils.go
+++ b/internal/quadlet/renderer/utils.go
@@ -1,0 +1,33 @@
+package renderer
+
+const (
+	// Default installation paths
+	DefaultQuadletDir         = "/usr/share/containers/systemd"
+	DefaultReadOnlyConfigDir  = "/usr/share/flightctl"
+	DefaultWriteableConfigDir = "/etc/flightctl"
+	DefaultSystemdUnitDir     = "/usr/lib/systemd/system"
+	DefaultBinDir             = "/usr/bin"
+
+	// Systemd target and network names
+	SystemdTargetName = "flightctl.target"
+	PodmanNetworkName = "flightctl"
+)
+
+// KnownVolumes lists volume names created by the standalone installation
+var KnownVolumes = []string{
+	"flightctl-db",
+	"flightctl-kv",
+	"flightctl-alertmanager",
+	"flightctl-ui-certs",
+	"flightctl-cli-artifacts-certs",
+	"flightctl-pam-issuer-etc",
+}
+
+// KnownSecrets lists secret names created by the standalone installation
+var KnownSecrets = []string{
+	"flightctl-postgresql-password",
+	"flightctl-postgresql-master-password",
+	"flightctl-postgresql-user-password",
+	"flightctl-postgresql-migrator-password",
+	"flightctl-kv-password",
+}

--- a/internal/quadlet/unit.go
+++ b/internal/quadlet/unit.go
@@ -167,3 +167,7 @@ func (u *Unit) Add(section string, key string, value string) *Unit {
 	})
 	return u
 }
+
+func (u *Unit) GetImage() (string, error) {
+	return u.Lookup(ContainerGroup, ImageKey)
+}

--- a/pkg/podman/client.go
+++ b/pkg/podman/client.go
@@ -1,0 +1,19 @@
+package podman
+
+import (
+	"github.com/flightctl/flightctl/pkg/executer"
+)
+
+const (
+	podmanCmd = "podman"
+)
+
+type Client struct {
+	exec executer.Executer
+}
+
+func NewClient(exec executer.Executer) *Client {
+	return &Client{
+		exec: exec,
+	}
+}

--- a/pkg/podman/container.go
+++ b/pkg/podman/container.go
@@ -1,0 +1,36 @@
+package podman
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type ListContainersOptions struct {
+	All    bool
+	Filter string
+}
+
+type Container struct {
+	ID string `json:"ID"`
+}
+
+func (c *Client) ListContainers(ctx context.Context, options ListContainersOptions) ([]Container, error) {
+	cmdArgs := []string{"ps", "--format", "json"}
+	if options.All {
+		cmdArgs = append(cmdArgs, "-a")
+	}
+	if options.Filter != "" {
+		cmdArgs = append(cmdArgs, "--filter", options.Filter)
+	}
+
+	stdout, stderr, exitCode := c.exec.ExecuteWithContext(ctx, podmanCmd, cmdArgs...)
+	if exitCode != 0 {
+		return nil, wrapPodmanError(ErrListContainers, stderr)
+	}
+	var containers []Container
+	err := json.Unmarshal([]byte(stdout), &containers)
+	if err != nil {
+		return nil, wrapPodmanError(ErrUnmarshalContainers, err.Error())
+	}
+	return containers, nil
+}

--- a/pkg/podman/container_test.go
+++ b/pkg/podman/container_test.go
@@ -1,0 +1,120 @@
+package podman_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestListContainers_Options(t *testing.T) {
+	testCases := []struct {
+		name                string
+		options             podman.ListContainersOptions
+		expectedExecCommand []string
+	}{
+		{
+			name:                "no options",
+			options:             podman.ListContainersOptions{},
+			expectedExecCommand: []string{"ps", "--format", "json"},
+		},
+		{
+			name:                "all containers",
+			options:             podman.ListContainersOptions{All: true},
+			expectedExecCommand: []string{"ps", "--format", "json", "-a"},
+		},
+		{
+			name:                "filtered containers",
+			options:             podman.ListContainersOptions{Filter: "name=flightctl-"},
+			expectedExecCommand: []string{"ps", "--format", "json", "--filter", "name=flightctl-"},
+		},
+		{
+			name:                "all and filtered containers",
+			options:             podman.ListContainersOptions{All: true, Filter: "name=flightctl-"},
+			expectedExecCommand: []string{"ps", "--format", "json", "-a", "--filter", "name=flightctl-"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", tc.expectedExecCommand).Return("[]", "", 0)
+			client := podman.NewClient(mockExec)
+			_, err := client.ListContainers(context.Background(), tc.options)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestListContainers_ExecCommandCalls(t *testing.T) {
+	testData, err := os.ReadFile("testdata/ps_result.json")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		options        podman.ListContainersOptions
+		execReturn     ExecReturn
+		expectedError  error
+		expextedResult []podman.Container
+	}{
+		{
+			name:           "success with no containers",
+			options:        podman.ListContainersOptions{},
+			execReturn:     NewExecReturn("[]", "", 0),
+			expectedError:  nil,
+			expextedResult: []podman.Container{},
+		},
+		{
+			name:          "success with multiple containers",
+			options:       podman.ListContainersOptions{},
+			execReturn:    NewExecReturn(string(testData), "", 0),
+			expectedError: nil,
+			expextedResult: []podman.Container{
+				{
+					ID: "300a734d0a3d66cfee538e3ad79a7cb8ec0e1807e1851a1e11140628b5f40c42",
+				},
+				{
+					ID: "a40112b4ab01f7671e9ad9e214cb1af2e4d338c17523e3445e7573607e0a38a8",
+				},
+			},
+		},
+		{
+			name:           "failure from exec command",
+			options:        podman.ListContainersOptions{},
+			execReturn:     NewExecReturn("", "error", 1),
+			expectedError:  podman.ErrListContainers,
+			expextedResult: []podman.Container{},
+		},
+		{
+			name:           "failure from unmarshal",
+			options:        podman.ListContainersOptions{},
+			execReturn:     NewExecReturn("invalid json", "", 0),
+			expectedError:  podman.ErrUnmarshalContainers,
+			expextedResult: []podman.Container{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", gomock.Any()).Return(tc.execReturn.stdout, tc.execReturn.stderr, tc.execReturn.exitCode)
+			client := podman.NewClient(mockExec)
+			containers, err := client.ListContainers(context.Background(), tc.options)
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expextedResult, containers)
+			}
+		})
+	}
+}

--- a/pkg/podman/errors.go
+++ b/pkg/podman/errors.go
@@ -1,0 +1,36 @@
+package podman
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	// Containers
+	ErrListContainers      = errors.New("list containers failed")
+	ErrUnmarshalContainers = errors.New("unmarshal containers failed")
+
+	// Images
+	ErrRemoveImage       = errors.New("remove image failed")
+	ErrImageDoesNotExist = errors.New("image does not exist")
+
+	// Volumes
+	ErrRemoveVolume       = errors.New("remove volume failed")
+	ErrVolumeDoesNotExist = errors.New("volume does not exist")
+
+	// Networks
+	ErrRemoveNetwork       = errors.New("remove network failed")
+	ErrNetworkDoesNotExist = errors.New("network does not exist")
+
+	// Secrets
+	ErrRemoveSecret = errors.New("remove secret failed")
+)
+
+func wrapPodmanError(err error, stderr string) error {
+	return fmt.Errorf(
+		"%w: %s",
+		err,
+		strings.TrimSpace(stderr),
+	)
+}

--- a/pkg/podman/image.go
+++ b/pkg/podman/image.go
@@ -1,0 +1,17 @@
+package podman
+
+import (
+	"context"
+)
+
+func (c *Client) RemoveImage(ctx context.Context, image string) error {
+	cmdArgs := []string{"rmi", image}
+	_, stderr, exitCode := c.exec.ExecuteWithContext(ctx, podmanCmd, cmdArgs...)
+	if exitCode != 0 {
+		if exitCode == 1 {
+			return ErrImageDoesNotExist
+		}
+		return wrapPodmanError(ErrRemoveImage, stderr)
+	}
+	return nil
+}

--- a/pkg/podman/image_test.go
+++ b/pkg/podman/image_test.go
@@ -1,0 +1,53 @@
+package podman_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRemoveImage(t *testing.T) {
+	testCases := []struct {
+		name           string
+		execReturn     ExecReturn
+		expectedReturn error
+	}{
+		{
+			name:           "success",
+			execReturn:     NewExecReturn("", "", 0),
+			expectedReturn: nil,
+		},
+		{
+			name:           "image does not exist",
+			execReturn:     NewExecReturn("", "error: no such image", 1),
+			expectedReturn: podman.ErrImageDoesNotExist,
+		},
+		{
+			name:           "error from exec command",
+			execReturn:     NewExecReturn("", "error", 125),
+			expectedReturn: podman.ErrRemoveImage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "rmi", "quay.io/example/app:v1.0").Return(tc.execReturn.stdout, tc.execReturn.stderr, tc.execReturn.exitCode)
+			client := podman.NewClient(mockExec)
+			err := client.RemoveImage(context.Background(), "quay.io/example/app:v1.0")
+
+			if tc.expectedReturn != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedReturn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/podman/network.go
+++ b/pkg/podman/network.go
@@ -1,0 +1,17 @@
+package podman
+
+import (
+	"context"
+)
+
+func (c *Client) RemoveNetwork(ctx context.Context, network string) error {
+	cmdArgs := []string{"network", "rm", network}
+	_, stderr, exitCode := c.exec.ExecuteWithContext(ctx, podmanCmd, cmdArgs...)
+	if exitCode != 0 {
+		if exitCode == 1 {
+			return ErrNetworkDoesNotExist
+		}
+		return wrapPodmanError(ErrRemoveNetwork, stderr)
+	}
+	return nil
+}

--- a/pkg/podman/network_test.go
+++ b/pkg/podman/network_test.go
@@ -1,0 +1,53 @@
+package podman_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRemoveNetwork(t *testing.T) {
+	testCases := []struct {
+		name           string
+		execReturn     ExecReturn
+		expectedReturn error
+	}{
+		{
+			name:           "success",
+			execReturn:     NewExecReturn("", "", 0),
+			expectedReturn: nil,
+		},
+		{
+			name:           "network does not exist",
+			execReturn:     NewExecReturn("", "error: no such network", 1),
+			expectedReturn: podman.ErrNetworkDoesNotExist,
+		},
+		{
+			name:           "error from exec command",
+			execReturn:     NewExecReturn("", "error", 125),
+			expectedReturn: podman.ErrRemoveNetwork,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "network", "rm", "flightctl").Return(tc.execReturn.stdout, tc.execReturn.stderr, tc.execReturn.exitCode)
+			client := podman.NewClient(mockExec)
+			err := client.RemoveNetwork(context.Background(), "flightctl")
+
+			if tc.expectedReturn != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedReturn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/podman/secret.go
+++ b/pkg/podman/secret.go
@@ -1,0 +1,22 @@
+package podman
+
+import (
+	"context"
+)
+
+type RemoveSecretOptions struct {
+	Ignore bool
+}
+
+func (c *Client) RemoveSecret(ctx context.Context, secret string, options RemoveSecretOptions) error {
+	cmdArgs := []string{"secret", "rm", secret}
+	if options.Ignore {
+		cmdArgs = append(cmdArgs, "--ignore")
+	}
+
+	_, stderr, exitCode := c.exec.ExecuteWithContext(ctx, podmanCmd, cmdArgs...)
+	if exitCode != 0 {
+		return wrapPodmanError(ErrRemoveSecret, stderr)
+	}
+	return nil
+}

--- a/pkg/podman/secret_test.go
+++ b/pkg/podman/secret_test.go
@@ -1,0 +1,50 @@
+package podman_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRemoveSecret(t *testing.T) {
+	testCases := []struct {
+		name           string
+		execReturn     ExecReturn
+		expectedReturn error
+	}{
+		{
+			name:           "success",
+			execReturn:     NewExecReturn("", "", 0),
+			expectedReturn: nil,
+		},
+		{
+			name:           "error from exec command",
+			execReturn:     NewExecReturn("", "error", 125),
+			expectedReturn: podman.ErrRemoveSecret,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "secret", "rm", "db-password").Return(tc.execReturn.stdout, tc.execReturn.stderr, tc.execReturn.exitCode)
+			client := podman.NewClient(mockExec)
+			err := client.RemoveSecret(context.Background(), "db-password", podman.RemoveSecretOptions{
+				Ignore: false,
+			})
+
+			if tc.expectedReturn != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedReturn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/podman/testdata/ps_result.json
+++ b/pkg/podman/testdata/ps_result.json
@@ -1,0 +1,133 @@
+[
+  {
+    "AutoRemove": true,
+    "Command": [
+      "/bin/sh",
+      "-c",
+      "./flightctl-api"
+    ],
+    "CreatedAt": "2 minutes ago",
+    "CIDFile": "/run/flightctl-api.cid",
+    "Exited": false,
+    "ExitedAt": -62135596800,
+    "ExitCode": 0,
+    "ExposedPorts": null,
+    "Id": "300a734d0a3d66cfee538e3ad79a7cb8ec0e1807e1851a1e11140628b5f40c42",
+    "Image": "localhost/flightctl-api:latest",
+    "ImageID": "acc675ede1b98d6398facad9c7258d3d99cf11a0326f4e7460e9155ed176ef1e",
+    "IsInfra": false,
+    "Labels": {
+      "PODMAN_SYSTEMD_UNIT": "flightctl-api.service",
+      "architecture": "x86_64",
+      "build-date": "2025-11-12T16:39:14Z",
+      "com.redhat.component": "flightctl-api-container",
+      "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
+      "cpe": "cpe:/a:redhat:enterprise_linux:9::appstream",
+      "description": "Flight Control Edge management API server",
+      "distribution-scope": "public",
+      "io.buildah.version": "1.40.1",
+      "io.k8s.description": "Flight Control Edge management API server",
+      "io.k8s.display-name": "Flight Control API Server",
+      "io.openshift.expose-services": "",
+      "maintainer": "Red Hat, Inc.",
+      "name": "flightctl-api",
+      "org.opencontainers.image.revision": "6c67d821194848bd86e453329d99c88c8a1d792d",
+      "release": "1762965531",
+      "summary": "Flight Control Edge management API server",
+      "url": "https://catalog.redhat.com/en/search?searchType=containers",
+      "vcs-ref": "6c67d821194848bd86e453329d99c88c8a1d792d",
+      "vcs-type": "git",
+      "vendor": "Red Hat, Inc.",
+      "version": "9.7"
+    },
+    "Mounts": [
+      "/root/.flightctl/certs/db",
+      "/root/.flightctl/certs/server.crt",
+      "/root/.flightctl/certs/server.key",
+      "/root/.flightctl/certs/client-signer.crt",
+      "/root/.flightctl/certs/client-signer.key",
+      "/root/.flightctl/certs/ca-bundle.crt",
+      "/root/.flightctl/config.yaml"
+    ],
+    "Names": [
+      "flightctl-api"
+    ],
+    "Namespaces": {},
+    "Networks": [
+      "flightctl"
+    ],
+    "Pid": 434123,
+    "Pod": "",
+    "PodName": "",
+    "Ports": [
+      {
+        "host_ip": "",
+        "container_port": 3443,
+        "host_port": 3443,
+        "range": 1,
+        "protocol": "tcp"
+      },
+      {
+        "host_ip": "",
+        "container_port": 7443,
+        "host_port": 7443,
+        "range": 1,
+        "protocol": "tcp"
+      }
+    ],
+    "Restarts": 0,
+    "Size": null,
+    "StartedAt": 1767888462,
+    "State": "running",
+    "Status": "Up 2 minutes",
+    "Created": 1767888462
+  },
+  {
+    "AutoRemove": true,
+    "Command": [
+      "--config.file=/usr/local/etc/alertmanager/alertmanager.yml",
+      "--storage.path=/var/lib/alertmanager"
+    ],
+    "CreatedAt": "2 minutes ago",
+    "CIDFile": "/run/flightctl-alertmanager.cid",
+    "Exited": false,
+    "ExitedAt": -62135596800,
+    "ExitCode": 0,
+    "ExposedPorts": {
+      "9093": [
+        "tcp"
+      ]
+    },
+    "Id": "a40112b4ab01f7671e9ad9e214cb1af2e4d338c17523e3445e7573607e0a38a8",
+    "Image": "quay.io/prometheus/alertmanager:v0.28.1",
+    "ImageID": "91c01b3cec9b5b3071454a5bf13814e64127ed1601b9afd3b932559945fc9a5e",
+    "IsInfra": false,
+    "Labels": {
+      "PODMAN_SYSTEMD_UNIT": "flightctl-alertmanager.service",
+      "maintainer": "The Prometheus Authors <prometheus-developers@googlegroups.com>",
+      "org.opencontainers.image.source": "https://github.com/prometheus/alertmanager"
+    },
+    "Mounts": [
+      "/usr/local/etc/alertmanager/alertmanager.yml",
+      "/alertmanager",
+      "/var/lib/alertmanager"
+    ],
+    "Names": [
+      "flightctl-alertmanager"
+    ],
+    "Namespaces": {},
+    "Networks": [
+      "flightctl"
+    ],
+    "Pid": 434274,
+    "Pod": "",
+    "PodName": "",
+    "Ports": null,
+    "Restarts": 0,
+    "Size": null,
+    "StartedAt": 1767888463,
+    "State": "running",
+    "Status": "Up 2 minutes",
+    "Created": 1767888462
+  }
+]

--- a/pkg/podman/testutil_test.go
+++ b/pkg/podman/testutil_test.go
@@ -1,0 +1,15 @@
+package podman_test
+
+type ExecReturn struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func NewExecReturn(stdout string, stderr string, exitCode int) ExecReturn {
+	return ExecReturn{
+		stdout:   stdout,
+		stderr:   stderr,
+		exitCode: exitCode,
+	}
+}

--- a/pkg/podman/volume.go
+++ b/pkg/podman/volume.go
@@ -1,0 +1,17 @@
+package podman
+
+import (
+	"context"
+)
+
+func (c *Client) RemoveVolume(ctx context.Context, volume string) error {
+	cmdArgs := []string{"volume", "rm", volume}
+	_, stderr, exitCode := c.exec.ExecuteWithContext(ctx, podmanCmd, cmdArgs...)
+	if exitCode != 0 {
+		if exitCode == 1 {
+			return ErrVolumeDoesNotExist
+		}
+		return wrapPodmanError(ErrRemoveVolume, stderr)
+	}
+	return nil
+}

--- a/pkg/podman/volume_test.go
+++ b/pkg/podman/volume_test.go
@@ -1,0 +1,53 @@
+package podman_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/podman"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRemoveVolume(t *testing.T) {
+	testCases := []struct {
+		name           string
+		execReturn     ExecReturn
+		expectedReturn error
+	}{
+		{
+			name:           "success",
+			execReturn:     NewExecReturn("", "", 0),
+			expectedReturn: nil,
+		},
+		{
+			name:           "volume does not exist",
+			execReturn:     NewExecReturn("", "error: no such volume", 1),
+			expectedReturn: podman.ErrVolumeDoesNotExist,
+		},
+		{
+			name:           "error from exec command",
+			execReturn:     NewExecReturn("", "error", 125),
+			expectedReturn: podman.ErrRemoveVolume,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "volume", "rm", "flightctl").Return(tc.execReturn.stdout, tc.execReturn.stderr, tc.execReturn.exitCode)
+			client := podman.NewClient(mockExec)
+			err := client.RemoveVolume(context.Background(), "flightctl")
+
+			if tc.expectedReturn != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedReturn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add cleanup script to purge podman related data and artifacts on uninstall
- Update documentation for uninstalling and removing data for the standalone installation on linux
- Breaks out a /pkg/podman intended to be a thin wrapper around podman cli calls
  - No agent client usage has been ported yet