### PR TITLE
NO-ISSUE: Add documentation and checks to ensure correct version of podman for quadlets

### DIFF
--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -636,6 +636,9 @@ The following table shows the application runtimes and formats supported by Flig
 > Compose applications require `podman-compose` to be installed on the device.
 
 > [!NOTE]
+> `quadlet` and `container` applications require podman version 5.0 or above.
+
+> [!NOTE]
 > Image downloads adhere to the `pull-timeout` [configuration](../installing/installing-agent.md#agent-configuration).
 
 > [!TIP]

--- a/internal/agent/device/applications/provider/app_handler.go
+++ b/internal/agent/device/applications/provider/app_handler.go
@@ -40,12 +40,22 @@ type quadletHandler struct {
 	log            *log.PrefixLogger
 	volumeProvider volumeProvider
 	specVolumes    []v1beta1.ApplicationVolume
+	podman         *client.Podman
 }
 
 func (b *quadletHandler) Verify(ctx context.Context, path string) error {
 	if err := ensureDependenciesFromAppType([]string{"podman"}); err != nil {
 		return fmt.Errorf("ensuring dependencies: %w", err)
 	}
+
+	version, err := b.podman.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("podman version: %w", err)
+	}
+	if err := ensureMinQuadletPodmanVersion(version); err != nil {
+		return fmt.Errorf("quadlet app type: %w", err)
+	}
+
 	if err := ensureQuadlet(b.rw, path); err != nil {
 		return fmt.Errorf("ensuring quadlet: %w", err)
 	}
@@ -144,6 +154,15 @@ func (b *containerHandler) Verify(ctx context.Context, path string) error {
 	if err := ensureDependenciesFromAppType([]string{"podman"}); err != nil {
 		errs = append(errs, fmt.Errorf("ensuring dependencies: %w", err))
 	}
+
+	version, err := b.podman.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("podman version: %w", err)
+	}
+	if err := ensureMinQuadletPodmanVersion(version); err != nil {
+		return fmt.Errorf("container app type: %w", err)
+	}
+
 	for _, vol := range lo.FromPtr(b.spec.Volumes) {
 		volType, err := vol.Type()
 		if err != nil {

--- a/internal/agent/device/applications/provider/embedded.go
+++ b/internal/agent/device/applications/provider/embedded.go
@@ -19,7 +19,7 @@ type embeddedProvider struct {
 	handler    embeddedAppTypeHandler
 }
 
-func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter, l *log.PrefixLogger, bootTime string, installed bool) (embeddedAppTypeHandler, error) {
+func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter, l *log.PrefixLogger, podman *client.Podman, bootTime string, installed bool) (embeddedAppTypeHandler, error) {
 	switch appType {
 	case v1beta1.AppTypeQuadlet:
 		return &embeddedQuadletBehavior{
@@ -28,6 +28,7 @@ func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWrit
 			log:       l,
 			bootTime:  bootTime,
 			installed: installed,
+			podman:    podman,
 		}, nil
 	case v1beta1.AppTypeCompose:
 		return &embeddedComposeBehavior{
@@ -40,7 +41,7 @@ func newEmbeddedHandler(appType v1beta1.AppType, name string, rw fileio.ReadWrit
 }
 
 func newEmbedded(log *log.PrefixLogger, podman *client.Podman, readWriter fileio.ReadWriter, name string, appType v1beta1.AppType, bootTime string, installed bool) (Provider, error) {
-	handler, err := newEmbeddedHandler(appType, name, readWriter, log, bootTime, installed)
+	handler, err := newEmbeddedHandler(appType, name, readWriter, log, podman, bootTime, installed)
 	if err != nil {
 		return nil, fmt.Errorf("constructing embedded app handler: %w", err)
 	}

--- a/internal/agent/device/applications/provider/embedded_app_handler.go
+++ b/internal/agent/device/applications/provider/embedded_app_handler.go
@@ -33,12 +33,24 @@ type embeddedQuadletBehavior struct {
 	name      string
 	rw        fileio.ReadWriter
 	log       *log.PrefixLogger
+	podman    *client.Podman
 	bootTime  string
 	installed bool
 }
 
 func (e *embeddedQuadletBehavior) Verify(ctx context.Context) error {
-	return ensureQuadlet(e.rw, e.embeddedPath())
+	if err := ensureQuadlet(e.rw, e.embeddedPath()); err != nil {
+		return err
+	}
+
+	version, err := e.podman.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("podman version: %w", err)
+	}
+	if err := ensureMinQuadletPodmanVersion(version); err != nil {
+		return fmt.Errorf("quadlet app type: %w", err)
+	}
+	return nil
 }
 
 func (e *embeddedQuadletBehavior) Install(ctx context.Context) error {

--- a/internal/agent/device/applications/provider/embedded_test.go
+++ b/internal/agent/device/applications/provider/embedded_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // setupTestEnv creates a test environment with logger, podman mock, and readWriter
-func setupTestEnv(t *testing.T) (*log.PrefixLogger, *client.Podman, fileio.ReadWriter) {
+func setupTestEnv(t *testing.T) (*log.PrefixLogger, *client.Podman, fileio.ReadWriter, *executer.MockExecuter) {
 	log := log.NewPrefixLogger("test")
 	log.SetLevel(logrus.DebugLevel)
 
@@ -34,7 +34,7 @@ func setupTestEnv(t *testing.T) (*log.PrefixLogger, *client.Podman, fileio.ReadW
 	// Create the systemd unit directory for target file copying
 	require.NoError(t, rw.MkdirAll(lifecycle.QuadletTargetPath, fileio.DefaultDirectoryPermissions))
 
-	return log, podman, rw
+	return log, podman, rw, mockExec
 }
 
 // setupEmbeddedQuadletApp creates an embedded quadlet app directory with specified files
@@ -159,7 +159,7 @@ Network=app-net.network
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, podman, rw := setupTestEnv(t)
+			logger, podman, rw, _ := setupTestEnv(t)
 
 			// Setup embedded app
 			setupEmbeddedQuadletApp(t, rw, tt.appName, tt.files)
@@ -211,7 +211,7 @@ func TestEmbeddedProvider_Remove(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, podman, rw := setupTestEnv(t)
+			logger, podman, rw, _ := setupTestEnv(t)
 
 			// Setup embedded app (to ensure it exists)
 			setupEmbeddedQuadletApp(t, rw, tt.appName, map[string]string{"web.container": "[Container]\n"})
@@ -232,6 +232,89 @@ func TestEmbeddedProvider_Remove(t *testing.T) {
 			if tt.verifyFn != nil {
 				tt.verifyFn(t, rw, tt.appName)
 			}
+		})
+	}
+}
+
+func TestEmbeddedProvider_Verify(t *testing.T) {
+	tests := []struct {
+		name          string
+		appName       string
+		files         map[string]string
+		setupMocks    func(*executer.MockExecuter)
+		wantVerifyErr bool
+	}{
+		{
+			name:    "quadlet with valid podman version",
+			appName: "myapp",
+			files: map[string]string{
+				"web.container": `[Container]
+Image=quay.io/flightctl-tests/nginx:latest
+`,
+			},
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "podman", "--version").
+					Return("podman version 5.4.2", "", 0)
+			},
+			wantVerifyErr: false,
+		},
+		{
+			name:    "quadlet with podman version below minimum",
+			appName: "myapp",
+			files: map[string]string{
+				"web.container": `[Container]
+Image=quay.io/flightctl-tests/nginx:latest
+`,
+			},
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "podman", "--version").
+					Return("podman version 4.9.0", "", 0)
+			},
+			wantVerifyErr: true,
+		},
+		{
+			name:    "quadlet with podman version exactly at minimum",
+			appName: "myapp",
+			files: map[string]string{
+				"web.container": `[Container]
+Image=quay.io/flightctl-tests/nginx:latest
+`,
+			},
+			setupMocks: func(mockExec *executer.MockExecuter) {
+				mockExec.EXPECT().
+					ExecuteWithContext(gomock.Any(), "podman", "--version").
+					Return("podman version 5.0.0", "", 0)
+			},
+			wantVerifyErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, podman, rw, mockExec := setupTestEnv(t)
+
+			// Setup embedded app
+			setupEmbeddedQuadletApp(t, rw, tt.appName, tt.files)
+
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockExec)
+			}
+
+			// Create embedded provider
+			provider, err := newEmbedded(logger, podman, rw, tt.appName, v1beta1.AppTypeQuadlet, "2025-01-01T00:00:00Z", false)
+			require.NoError(t, err)
+
+			// Call Verify
+			ctx := context.Background()
+			err = provider.Verify(ctx)
+			if tt.wantVerifyErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "podman version")
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -326,7 +409,7 @@ func TestParseEmbeddedQuadlet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, podman, rw := setupTestEnv(t)
+			logger, podman, rw, _ := setupTestEnv(t)
 
 			// Setup all apps
 			for appName, files := range tt.apps {

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -39,6 +39,7 @@ func newImageHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter,
 			rw:          rw,
 			log:         l,
 			specVolumes: lo.FromPtr(provider.Volumes),
+			podman:      podman,
 		}
 		qb.volumeProvider = func() ([]*Volume, error) {
 			return extractQuadletVolumesFromDir(qb.ID(), rw, qb.AppPath())

--- a/internal/agent/device/applications/provider/inline.go
+++ b/internal/agent/device/applications/provider/inline.go
@@ -21,7 +21,7 @@ type inlineProvider struct {
 	handler    appTypeHandler
 }
 
-func newInlineHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter, spec *v1beta1.InlineApplicationProviderSpec, l *log.PrefixLogger, vm VolumeManager) (appTypeHandler, error) {
+func newInlineHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter, spec *v1beta1.InlineApplicationProviderSpec, l *log.PrefixLogger, vm VolumeManager, podman *client.Podman) (appTypeHandler, error) {
 	switch appType {
 	case v1beta1.AppTypeQuadlet:
 		qb := &quadletHandler{
@@ -29,6 +29,7 @@ func newInlineHandler(appType v1beta1.AppType, name string, rw fileio.ReadWriter
 			rw:          rw,
 			log:         l,
 			specVolumes: lo.FromPtr(spec.Volumes),
+			podman:      podman,
 		}
 		qb.volumeProvider = func() ([]*Volume, error) {
 			return extractQuadletVolumesFromSpec(qb.ID(), spec.Inline)
@@ -59,7 +60,7 @@ func newInline(log *log.PrefixLogger, podman *client.Podman, spec *v1beta1.Appli
 		return nil, err
 	}
 
-	handler, err := newInlineHandler(appType, appName, readWriter, &provider, log, volumeManager)
+	handler, err := newInlineHandler(appType, appName, readWriter, &provider, log, volumeManager, podman)
 	if err != nil {
 		return nil, fmt.Errorf("constructing inline app handler: %w", err)
 	}

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -848,3 +848,12 @@ func generateQuadlet(ctx context.Context, podman *client.Podman, rw fileio.ReadW
 	}
 	return nil
 }
+
+func ensureMinQuadletPodmanVersion(version *client.PodmanVersion) error {
+	// quadlet install utilizes dropins to add labels and environment files to the generated quadlets
+	// dropin support wasn't added until v5.0.0
+	if !version.GreaterOrEqual(5, 0) {
+		return fmt.Errorf("podman version 5.0 or higher required, got %d.%d", version.Major, version.Minor)
+	}
+	return nil
+}


### PR DESCRIPTION
Now outputs an error message like: 
```sh
applications: verify app provider: no retry: verifying image: podman version 5.0 or higher required for quadlet based applications, got 4.9
```
When an invalid version of podman is installed and attempting to use quadlet or container application types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified prerequisites: Podman 5.0+ is required for quadlet and container applications.

* **Improvements**
  * Runtime checks now validate Podman version and enforce the minimum Podman requirement for quadlet and container application deployment, preventing incompatible runtimes from proceeding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->