### PR TITLE
EDM-3026: first login in using the UI with quadlets leads to try again

### DIFF
--- a/internal/auth/oidc/pam/templates/login_form.html
+++ b/internal/auth/oidc/pam/templates/login_form.html
@@ -96,7 +96,8 @@
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                body: params
+                body: params,
+                credentials: 'same-origin'
             })
             .then(response => {
                 // Read the response text for both success and error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login requests now include same-origin credentials to ensure consistent session/cookie handling during authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->