### PR TITLE
EDM-3028: greenboot-rs (0.16.x) fails to start in bootc container environments breaking OS rollback

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -52,6 +52,10 @@ Summary: Flight Control management agent
 
 Requires: flightctl-selinux = %{version}
 Requires: jq
+# Pin the greenboot package to 0.15.z until the following issue is resolved:
+# https://github.com/fedora-iot/greenboot-rs/issues/141
+Requires: greenboot >= 0.15.0
+Requires: greenboot < 0.16.0
 
 %description agent
 The flightctl-agent package provides the management agent for the Flight Control fleet management service.

--- a/test/scripts/agent-images/base/Containerfile
+++ b/test/scripts/agent-images/base/Containerfile
@@ -36,9 +36,16 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y python-dotenv
 
 # Base services and tooling that don't depend on our RPMs
+# NOTE: Pin to greenboot 0.15.x (shell greenboot) to avoid greenboot-rs (0.16.x) issues.
+# greenboot-rs has known problems:
+#   - Doesn't capture successful script output to journal (only failures)
+#   - Missing redboot-task-runner.service for pre-rollback diagnostics
+#   - Container compatibility issues (fedora-iot/greenboot-rs#132)
+# See: https://github.com/microshift-io/microshift/pull/176
+# See: https://github.com/fedora-iot/greenboot-rs/issues/141
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
-    dnf install -y greenboot greenboot-default-health-checks podman-compose && \
+    dnf install -y 'greenboot-0.15.*' 'greenboot-default-health-checks-0.15.*' podman-compose && \
     dnf install -y firewalld && \
     systemctl enable firewalld.service && \
     systemctl enable podman.service


### PR DESCRIPTION
## Problem

`greenboot-rs` (0.16.x) has several critical issues that affect `flightctl` deployments, particularly in `bootc` container environments:
1. **Startup Failure:** In environments where `/boot` is not a separate mount point (standard in many `bootc` images), `greenboot-rs` fails to start with: `Error: Failed to check boot mount state: Failed to read mount info`. This prevents health checks from ever running, effectively breaking OS rollback.
2. **Missing Output Capture:** Successful health check script output is discarded, making it difficult to debug or verify boot behavior.
3. **Missing Service:** The `redboot-task-runner.service` is missing, which prevents pre-rollback diagnostic scripts from capturing output to the journal.

## Root Cause

These issues are regressions or behavioral changes introduced in the migration from the shell-based `greenboot` (0.15.x) to the Rust-based `greenboot-rs` (0.16.x).

## Solution

Pin `greenboot` and `greenboot-default-health-checks` to version `0.15.x` (the stable shell-based implementation) until the upstream issues in `greenboot-rs` are resolved.
- Updated `packaging/rpm/flightctl.spec` to require `greenboot` >= 0.15.0 and < 0.16.0.
- Updated `test/scripts/agent-images/base/Containerfile` to explicitly install `greenboot-0.15.*` packages.

## Upstream References

* [fedora-iot/greenboot-rs#132](https://github.com/fedora-iot/greenboot-rs/issues/132) - bootc container compatibility issue
* [fedora-iot/greenboot-rs#141](https://github.com/fedora-iot/greenboot-rs/issues/141) - Script output not captured
* [microshift-io/microshift#176](https://github.com/microshift-io/microshift/pull/176) - MicroShift fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned greenboot dependency to version 0.15.x in the agent package
  * Updated container image base configuration to use versioned greenboot packages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->