### PR TITLE
EDM-3095: SELinux policy update

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -449,6 +449,7 @@ echo "Flight Control Observability Stack uninstalled."
 %install
     mkdir -p %{buildroot}/usr/bin
     mkdir -p %{buildroot}/etc/flightctl
+    mkdir -p %{buildroot}/etc/flightctl/hooks.d
     cp bin/flightctl %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
@@ -620,6 +621,8 @@ fi
 %files agent
     %license LICENSE
     %dir /etc/flightctl
+    %dir /etc/flightctl/hooks.d
+    %dir /usr/lib/flightctl/custom-info.d
     %{_bindir}/flightctl-agent
     %{_bindir}/flightctl-must-gather
     /usr/lib/flightctl/hooks.d/afterupdating/00-default.yaml

--- a/packaging/selinux/flightctl_agent.fc
+++ b/packaging/selinux/flightctl_agent.fc
@@ -2,3 +2,5 @@
 /var/lib/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_lib_t,s0)
 /var/log/flightctl(/.*)?                            gen_context(system_u:object_r:flightctl_agent_var_log_t,s0)
 /usr/lib/flightctl/custom-info.d(/.*)?              gen_context(system_u:object_r:flightctl_agent_custom_info_exec_t,s0)
+/etc/flightctl/hooks.d(/.*)?                        gen_context(system_u:object_r:flightctl_agent_hook_exec_t,s0)
+/usr/lib/flightctl/hooks.d(/.*)?                    gen_context(system_u:object_r:flightctl_agent_hook_exec_t,s0)

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -4,295 +4,70 @@ policy_module(flightctl_agent, 1.0.0)
 # https://pages.cs.wisc.edu/~matyas/selinux-policy/
 # https://access.redhat.com/articles/6999267
 
-
-type flightctl_agent_t;
+# The file context type for the agent executable binary
 type flightctl_agent_exec_t;
+application_executable_file(flightctl_agent_exec_t)
+
+# The file context type for agent files in /var/lib
 type flightctl_agent_var_lib_t;
-type flightctl_agent_var_log_t;
-type flightctl_agent_tmp_t;
-type flightctl_agent_custom_info_exec_t;
-
-# We generally use fedora when building images because of the packit tool, but unfortunately it
-# contains some newer types not yet available in centos stream. Defining them in one's own policy is
-# the recommended workaround, see https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Backwards_compatibility.
-ifndef(`cgroup_type', `
-  attribute cgroup_type;
-')
-
-gen_require(`
-    type install_t, install_exec_t;
-    type hostname_t, hostname_exec_t;
-    type kernel_t, sysfs_t, ptmx_t, devpts_t, unlabeled_t, nsfs_t;
-    type etc_t, hostname_etc_t, tmp_t, home_root_t, root_t, fs_t, admin_home_t;
-    type container_var_lib_t, container_runtime_t, container_file_t, container_ro_file_t, container_var_run_t;
-    type var_t, var_run_t, device_t, var_log_t, install_var_run_t;
-    type sysctl_t, sysctl_irq_t;
-    type systemd_unit_file_t, systemd_logind_t, systemd_userdbd_runtime_t;
-    type tmpfs_t, cgroup_t;
-    type shadow_t, systemd_passwd_var_run_t, syslogd_var_run_t;
-    type proc_t, init_t, mail_spool_t;
-    type firewalld_t, firewalld_etc_rw_t;
-    type devlog_t;
-    type sshd_key_t, sshd_unit_file_t;
-    type rhsmcertd_config_t, rhsmcertd_log_t, rhsmcertd_var_run_t, rhsmcertd_var_lib_t;
-    type usr_t;
-    type node_t;
-    type tpm_device_t, security_t;
-    type unconfined_service_t;
-
-    attribute domain;
-')
-
-init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
 files_type(flightctl_agent_var_lib_t)
-files_type(flightctl_agent_var_log_t)
+
+# The file context type for agent files in /var/log
+type flightctl_agent_var_log_t;
+logging_log_file(flightctl_agent_var_log_t)
+
+# The file context type for any temporary agent files.
+type flightctl_agent_tmp_t;
 files_tmp_file(flightctl_agent_tmp_t)
-files_type(flightctl_agent_custom_info_exec_t)
 
+# The primary agent process domain
+type flightctl_agent_t;
+init_daemon_domain(flightctl_agent_t, flightctl_agent_exec_t)
+domain_type(flightctl_agent_t)
+# The agent itself should run as an unconfined domain because of how many things it needs access to.
+# This is done by other top-level system services, such as cron, virtd, xserver, etc. and seems
+# appropriate given the massive surface area of control for the agent and the previous constant
+# expansion of this policy when we attempted to explicitly list out the permissions one by one.
+unconfined_domain(flightctl_agent_t)
+role system_r types flightctl_agent_t;
 
-## Basic file access permissions  ##
-
-# System directories
-files_read_etc_files(flightctl_agent_t)
-files_read_etc_runtime_files(flightctl_agent_t)
-files_read_usr_files(flightctl_agent_t)
-files_read_boot_files(flightctl_agent_t)
-files_read_generic_pids(flightctl_agent_t)
-files_read_var_lib_files(flightctl_agent_t)
-files_manage_var_files(flightctl_agent_t)
-files_manage_var_dirs(flightctl_agent_t)
-
-# /etc management
-manage_dirs_pattern(flightctl_agent_t, etc_t, etc_t)
-manage_files_pattern(flightctl_agent_t, etc_t, etc_t)
-manage_lnk_files_pattern(flightctl_agent_t, etc_t, etc_t)
-
-manage_files_pattern(flightctl_agent_t, hostname_etc_t, etc_t)
-manage_lnk_files_pattern(flightctl_agent_t, hostname_etc_t, etc_t)
-
-manage_dirs_pattern(flightctl_agent_t, bin_t, bin_t)
-manage_files_pattern(flightctl_agent_t, bin_t, bin_t)
-manage_lnk_files_pattern(flightctl_agent_t, bin_t, bin_t)
-
-manage_dirs_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
-manage_files_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
-manage_lnk_files_pattern(flightctl_agent_t, firewalld_etc_rw_t, firewalld_etc_rw_t)
-
-# /var/lib/flightctl management
-manage_dirs_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
-manage_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
-manage_lnk_files_pattern(flightctl_agent_t, flightctl_agent_var_lib_t, flightctl_agent_var_lib_t)
-files_var_lib_filetrans(flightctl_agent_t, flightctl_agent_var_lib_t, dir, "flightctl")
-
-# /var/log/flightctl management
-manage_dirs_pattern(flightctl_agent_t, flightctl_agent_var_log_t, flightctl_agent_var_log_t)
-manage_files_pattern(flightctl_agent_t, flightctl_agent_var_log_t, flightctl_agent_var_log_t)
-manage_lnk_files_pattern(flightctl_agent_t, flightctl_agent_var_log_t, flightctl_agent_var_log_t)
-logging_log_filetrans(flightctl_agent_t, flightctl_agent_var_log_t, dir, "flightctl")
-
-# /tmp management
-files_tmp_filetrans(flightctl_agent_t, flightctl_agent_tmp_t, { file dir })
-manage_dirs_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
-manage_files_pattern(flightctl_agent_t, tmp_t, flightctl_agent_tmp_t)
-
-# Admin home (root) directory access
-userdom_manage_admin_dirs(flightctl_agent_t)
-userdom_manage_admin_files(flightctl_agent_t)
-userdom_search_admin_dir(flightctl_agent_t)
-allow flightctl_agent_t home_root_t:lnk_file read;
-
-# User home directory access
-userdom_search_user_home_dirs(flightctl_agent_t)
-userdom_manage_user_home_content(flightctl_agent_t)
-
-# System directory access
-allow flightctl_agent_t mail_spool_t:dir search;
-
-# TPM device access
-allow flightctl_agent_t tpm_device_t:chr_file { getattr open read write };
-allow flightctl_agent_t security_t:file { open read getattr };
-
-# /usr/lib/flightctl/custom-info.d execution
-allow flightctl_agent_t flightctl_agent_custom_info_exec_t:file { read getattr open execute execute_no_trans ioctl };
-allow flightctl_agent_t flightctl_agent_custom_info_exec_t:dir { read getattr search open };
-
-## Process management & capabilities  ##
-
-# Basic process capabilities
-allow flightctl_agent_t self:capability { dac_override chown setuid setgid sys_admin audit_write sys_resource dac_read_search sys_chroot mknod };
+# This is for some reason excluded by the unconfined_domain macro so add it back.
 allow flightctl_agent_t self:capability2 { mac_admin mac_override };
-allow flightctl_agent_t self:process { fork signal sigchld execmem setfscreate getsched setsched setpgid setcap setrlimit };
 
-# Process information access
-allow flightctl_agent_t domain:dir getattr;
+# Custom info hook domain
+type flightctl_agent_custom_info_t;
+domain_type(flightctl_agent_custom_info_t)
+role system_r types flightctl_agent_custom_info_t;
+type flightctl_agent_custom_info_exec_t;
+application_executable_file(flightctl_agent_custom_info_exec_t)
+# Execute custom info scripts in their own domain flightctl_agent_custom_info_t and make it
+# unconfined until further refinement is possible.
+domtrans_pattern(flightctl_agent_t, flightctl_agent_custom_info_exec_t, flightctl_agent_custom_info_t)
+allow flightctl_agent_t flightctl_agent_custom_info_exec_t:file entrypoint;
+unconfined_domain(flightctl_agent_custom_info_t)
+# This allows custom info scripts to use any executable file type since we cannot predict ahead of
+# time what it would need.
+allow flightctl_agent_custom_info_t file_type:file entrypoint;
 
-# Executable access
-corecmd_exec_all_executables(flightctl_agent_t)
-domtrans_pattern(flightctl_agent_t, install_exec_t, install_t)
-domtrans_pattern(flightctl_agent_t, hostname_exec_t, hostname_t)
-
-## System information access  ##
-
-# Kernel and system state
-kernel_read_system_state(flightctl_agent_t)
-kernel_read_network_state(flightctl_agent_t)
-kernel_read_all_proc(flightctl_agent_t)
-kernel_read_all_sysctls(flightctl_agent_t)
-kernel_request_load_module(flightctl_agent_t)
-init_read_state(flightctl_agent_t)
-init_mmap_read_var_lib_files(flightctl_agent_t)
-init_read_var_lib_files(flightctl_agent_t)
-init_search_var_lib_dirs(flightctl_agent_t)
-
-# Device information
-dev_read_sysfs(flightctl_agent_t)
-dev_read_kmsg(flightctl_agent_t)
-
-## Networking permissions  ##
-
-# Network connections
-corenet_tcp_connect_all_ports(flightctl_agent_t)
-corenet_sendrecv_all_client_packets(flightctl_agent_t)
-corenet_tcp_bind_unreserved_ports(flightctl_agent_t)
-sysnet_dns_name_resolve(flightctl_agent_t)
-
-# Socket permissions
-allow flightctl_agent_t self:{ tcp_socket udp_socket netlink_route_socket } { create bind connect read write getattr setattr lock append sendto recvfrom listen accept };
-allow flightctl_agent_t self:unix_dgram_socket { create connect read write getattr };
-allow flightctl_agent_t kernel_t:unix_dgram_socket sendto;
-allow flightctl_agent_t kernel_t:unix_stream_socket connectto;
-
-# Netlink audit socket for namespace operations
-allow flightctl_agent_t self:netlink_audit_socket { create bind connect read write getattr setattr lock append sendto recvfrom nlmsg_relay };
-
-## System services access  ##
-
-# Authentication and user management
-auth_read_passwd(flightctl_agent_t)
-auth_read_shadow(flightctl_agent_t)
-init_read_utmp(flightctl_agent_t)
-allow flightctl_agent_t systemd_passwd_var_run_t:dir { search open read watch };
-allow flightctl_agent_t systemd_passwd_var_run_t:file { open read };
-
-# Localization and logging
-miscfiles_read_localization(flightctl_agent_t)
-logging_read_all_logs(flightctl_agent_t)
-logging_send_audit_msgs(flightctl_agent_t)
-allow flightctl_agent_t devlog_t:lnk_file read;
-allow flightctl_agent_t devlog_t:sock_file write;
-
-# Journal access permissions
-allow flightctl_agent_t syslogd_var_run_t:dir { read search };
-# Read-only access to /var/log for journal/syslog reading
-allow flightctl_agent_t var_log_t:dir { read watch search };
-allow flightctl_agent_t var_log_t:file { read open getattr };
-
-# Systemd service management
-systemd_manage_all_unit_files(flightctl_agent_t)
-systemd_start_all_unit_files(flightctl_agent_t)
-systemd_status_all_unit_files(flightctl_agent_t)
-systemd_reload_all_services(flightctl_agent_t)
-systemd_start_all_services(flightctl_agent_t)
-systemd_stop_systemd_services(flightctl_agent_t)
-allow flightctl_agent_t init_t:system { status stop start };
-
-# sshd config/service permissions
-manage_files_pattern(flightctl_agent_t, sshd_key_t, sshd_key_t)
-manage_dirs_pattern(flightctl_agent_t, sshd_key_t, sshd_key_t)
-manage_lnk_files_pattern(flightctl_agent_t, sshd_key_t, sshd_key_t)
-ssh_systemctl(flightctl_agent_t)
-
-# SystemD user database access
-allow flightctl_agent_t systemd_userdbd_runtime_t:dir read;
-allow flightctl_agent_t systemd_userdbd_runtime_t:sock_file write;
-
-
-# D-Bus system bus access
-dbus_system_bus_client(flightctl_agent_t)
-optional_policy(`
-    systemd_dbus_chat_hostnamed(flightctl_agent_t)
-')
-# This is necessary to run the hook that calls firewall-cmd --reload
-allow flightctl_agent_t systemd_logind_t:dbus send_msg;
-allow flightctl_agent_t firewalld_t:dbus send_msg;
-
-## Container runtime support  ##
-
-# Container storage and runtime
-container_read_share_files(flightctl_agent_t)
-container_manage_files(flightctl_agent_t)
-container_runtime_domtrans(flightctl_agent_t)
-admin_pattern(flightctl_agent_t, container_var_lib_t, container_var_lib_t)
-
-# Container storage overlay access
-allow flightctl_agent_t container_file_t:dir { open read getattr search write remove_name };
-allow flightctl_agent_t container_file_t:file { unlink open read getattr create write };
-allow flightctl_agent_t container_file_t:lnk_file { read getattr };
-
-# Container read-only storage access
-allow flightctl_agent_t container_ro_file_t:dir { open read getattr search write rmdir };
-allow flightctl_agent_t container_ro_file_t:file { open read getattr write };
-
-# Container runtime storage access
-allow flightctl_agent_t container_var_run_t:dir { read getattr write search remove_name rmdir };
-allow flightctl_agent_t container_var_run_t:file { read open getattr unlink };
-
-# install var run file management
-manage_files_pattern(flightctl_agent_t, install_var_run_t, install_var_run_t)
-manage_dirs_pattern(flightctl_agent_t, install_var_run_t, install_var_run_t)
-manage_lnk_files_pattern(flightctl_agent_t, install_var_run_t, install_var_run_t)
-
-# CGroup access for container management
-allow flightctl_agent_t cgroup_t:dir search;
-
-# Container runtime process interaction
-allow flightctl_agent_t { install_t hostname_t container_runtime_t }:fd use;
-allow { install_t hostname_t container_runtime_t } flightctl_agent_t:fd use;
-allow flightctl_agent_t { install_t hostname_t container_runtime_t }:process { sigchld signal sigkill sigstop signull };
-
-# Container runtime transitions
-allow flightctl_agent_t container_runtime_t:process2 { nnp_transition nosuid_transition };
-allow flightctl_agent_t install_t:process2 { nnp_transition nosuid_transition };
-
-## Console & terminal access  ##
-
-# Terminal and PTY access for console sessions
-term_use_all_terms(flightctl_agent_t)
-allow flightctl_agent_t ptmx_t:chr_file { create read write open ioctl getattr setattr };
-allow flightctl_agent_t devpts_t:chr_file { create read write append open getattr ioctl setattr };
-allow flightctl_agent_t devpts_t:filesystem associate;
-allow flightctl_agent_t nsfs_t:file getattr;
-allow flightctl_agent_t unlabeled_t:dir search;
-
-## Filesystem & mount operations  ##
-
-# Filesystem mount operations
-fs_mount_all_fs(flightctl_agent_t)
-fs_remount_all_fs(flightctl_agent_t)
-fs_unmount_all_fs(flightctl_agent_t)
-fs_getattr_all_fs(flightctl_agent_t)
-
-# Mount-on permissions for key directories (bind mounts)
-allow flightctl_agent_t { root_t etc_t var_t tmp_t device_t var_run_t sysfs_t admin_home_t }:dir mounton;
-allow flightctl_agent_t proc_t:dir { mounton write };
-
-# Tmpfs directory creation and mount-on permissions
-allow flightctl_agent_t tmpfs_t:dir { create write add_name mounton };
-
-# Special filesystem access for namespace operations
-allow flightctl_agent_t sysctl_t:file { mounton write };
-allow flightctl_agent_t sysctl_irq_t:dir { write mounton };
-  
-# This allows installation of dnf packages
-allow flightctl_agent_t node_t:tcp_socket node_bind;
-allow flightctl_agent_t rhsmcertd_config_t:dir search;
-allow flightctl_agent_t rhsmcertd_log_t:dir write;
-allow flightctl_agent_t rhsmcertd_var_lib_t:dir { getattr search };
-allow flightctl_agent_t rhsmcertd_var_run_t:dir write;
-allow flightctl_agent_t usr_t:file write;
+# Agent hook domain
+type flightctl_agent_hook_t;
+domain_type(flightctl_agent_hook_t)
+role system_r types flightctl_agent_hook_t;
+type flightctl_agent_hook_exec_t;
+application_executable_file(flightctl_agent_hook_exec_t)
+# Execute hook scripts in their own domain flightctl_agent_hook_t. Make it unconfined for now as it
+# needs a lot of power.
+domtrans_pattern(flightctl_agent_t, flightctl_agent_hook_exec_t, flightctl_agent_hook_t)
+allow flightctl_agent_t flightctl_agent_hook_exec_t:file entrypoint;
+unconfined_domain(flightctl_agent_hook_t)
+# This allows hook scripts to use any executable file type since we cannot predict ahead of
+# time what it would need.
+allow flightctl_agent_hook_t file_type:file entrypoint;
 
 # REMOVE this once https://github.com/bootc-dev/bootc/issues/1434 is fixed. We don't want to allow
 # it so as not to alter the behavior of bootc, but we can suppress the error as it has been
 # determined to be inoculous by the bootc maintainer.
+gen_require(`
+  type unconfined_service_t;
+')
 dontaudit unconfined_service_t self:capability2 mac_admin;
-


### PR DESCRIPTION
- Make flightctl_agent_t an unconfined domain
- Add separate domains/file contexts for hooks and custom info scripts. These initially will be run as unconfined as well given how flexible they need to be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent package installation to create and declare new directories for hooks and custom-info configurations.
  * Updated security policies to properly govern file access and execution within the new hook and custom-info directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->