### PR TITLE
EDM-2636: Executer user options

### DIFF
--- a/cmd/flightctl-agent/main.go
+++ b/cmd/flightctl-agent/main.go
@@ -122,7 +122,7 @@ func (s *systemInfoCmd) Execute() error {
 	reader := fileio.NewReader()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	exec := &executer.CommonExecuter{}
+	exec := executer.NewCommonExecuter()
 	info, err := systeminfo.Collect(ctx, s.log, exec, reader, nil, s.hardwareMapPath, systeminfo.WithAll())
 	if err != nil {
 		s.log.Fatalf("Error collecting system info: %v", err)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -124,7 +124,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		a.log.Infof("Using persisted CSR for enrollment")
 	}
 
-	executer := &executer.CommonExecuter{}
+	executer := executer.NewCommonExecuter()
 
 	// create enrollment client
 	enrollmentClient, err := newEnrollmentClient(a.config, a.log)

--- a/internal/agent/device/console/console_test.go
+++ b/internal/agent/device/console/console_test.go
@@ -57,7 +57,7 @@ type vars struct {
 
 func setupVars(t *testing.T) *vars {
 	ctrl := gomock.NewController(t)
-	executor := &executer.CommonExecuter{}
+	executor := executer.NewCommonExecuter()
 	logger := log.NewPrefixLogger("console")
 	mockGrpcClient := NewMockRouterServiceClient(ctrl)
 	mockStreamClient := NewMockRouterService_StreamClient(ctrl)

--- a/internal/agent/device/systeminfo/system_info_test.go
+++ b/internal/agent/device/systeminfo/system_info_test.go
@@ -20,7 +20,7 @@ import (
 func BenchmarkCollectInfo(b *testing.B) {
 	ctx := context.Background()
 	log := log.NewPrefixLogger("test")
-	exec := &executer.CommonExecuter{}
+	exec := executer.NewCommonExecuter()
 	reader := fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
 	hardwareMapPath := "/var/lib/flightctl/hardware_map.json"
 
@@ -154,7 +154,7 @@ func TestGetCustomInfoMap(t *testing.T) {
 			}
 
 			log := log.NewPrefixLogger("test")
-			exec := &executer.CommonExecuter{}
+			exec := executer.NewCommonExecuter()
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
@@ -497,7 +497,7 @@ func TestGetCustomInfoContextTimeout(t *testing.T) {
 			)
 			require.NoError(err)
 
-			exec := &executer.CommonExecuter{}
+			exec := executer.NewCommonExecuter()
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 

--- a/pkg/executer/executer_other.go
+++ b/pkg/executer/executer_other.go
@@ -9,15 +9,18 @@ import (
 	"os/exec"
 )
 
-func (e *CommonExecuter) CommandContext(ctx context.Context, command string, args ...string) *exec.Cmd {
+func (e *commonExecuter) CommandContext(ctx context.Context, command string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, command, args...)
 	return cmd
 }
 
-func (e *CommonExecuter) execute(ctx context.Context, cmd *exec.Cmd) (stdout string, stderr string, exitCode int) {
+func (e *commonExecuter) execute(ctx context.Context, cmd *exec.Cmd) (stdout string, stderr string, exitCode int) {
 	var stdoutBytes, stderrBytes bytes.Buffer
 	cmd.Stdout = &stdoutBytes
 	cmd.Stderr = &stderrBytes
+	if e.uid >= 0 {
+		panic("executing under a different user is only supported on Linux")
+	}
 
 	if err := cmd.Run(); err != nil {
 		// handle timeout error

--- a/pkg/executer/executer_test.go
+++ b/pkg/executer/executer_test.go
@@ -1,0 +1,28 @@
+package executer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuterUserHandling(t *testing.T) {
+	t.Run("running with no options", func(t *testing.T) {
+		e := NewCommonExecuter()
+		_, _, code := e.ExecuteWithContext(t.Context(), "env")
+		require.Equal(t, 0, code)
+	})
+
+	t.Run("setting homedir", func(t *testing.T) {
+		e := NewCommonExecuter(WithHomeDir("/tmp"))
+		out, _, code := e.ExecuteWithContext(t.Context(), "env")
+		require.Equal(t, 0, code)
+		require.Contains(t, out, "HOME=/tmp")
+	})
+
+	t.Run("running as user", func(t *testing.T) {
+		e := NewCommonExecuter(WithUIDAndGID(8484, 8484))
+		_, _, code := e.ExecuteWithContext(t.Context(), "env")
+		require.Equal(t, -1, code)
+	})
+}

--- a/pkg/executer/mock_executer.go
+++ b/pkg/executer/mock_executer.go
@@ -11,7 +11,6 @@ package executer
 
 import (
 	context "context"
-	os "os"
 	exec "os/exec"
 	reflect "reflect"
 
@@ -121,34 +120,4 @@ func (mr *MockExecuterMockRecorder) ExecuteWithContextFromDir(ctx, workingDir, c
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, workingDir, command, args}, env...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWithContextFromDir", reflect.TypeOf((*MockExecuter)(nil).ExecuteWithContextFromDir), varargs...)
-}
-
-// LookPath mocks base method.
-func (m *MockExecuter) LookPath(file string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LookPath", file)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LookPath indicates an expected call of LookPath.
-func (mr *MockExecuterMockRecorder) LookPath(file any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookPath", reflect.TypeOf((*MockExecuter)(nil).LookPath), file)
-}
-
-// TempFile mocks base method.
-func (m *MockExecuter) TempFile(dir, pattern string) (*os.File, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TempFile", dir, pattern)
-	ret0, _ := ret[0].(*os.File)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TempFile indicates an expected call of TempFile.
-func (mr *MockExecuterMockRecorder) TempFile(dir, pattern any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TempFile", reflect.TypeOf((*MockExecuter)(nil).TempFile), dir, pattern)
 }


### PR DESCRIPTION

This will be useful when we need to setup quadlets for a non-root
user.

It currently supports setting the uid/gid and homedir. More things can
be added if needed later (e.g. the USER envvar).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execute commands as a specified user (UID/GID) and set HOME on Linux

* **Refactor**
  * Executor initialization moved to a configurable constructor with functional options
  * Executor implementation made internal and public surface simplified (removed legacy helper methods)

* **Tests**
  * Added unit tests covering environment and user-handling behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->