### PR TITLE
EDM-3117: fix imagebuild worker deployment

### DIFF
--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-scc.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-scc.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.imageBuilderWorker .Values.imageBuilderWorker.enabled }}
+{{- if eq (include "flightctl.enableOpenShiftExtensions" .) "true" }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: flightctl-imagebuilder-worker
+  labels:
+    flightctl.service: flightctl-imagebuilder-worker
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+  annotations:
+    description: "SecurityContextConstraints for flightctl-imagebuilder-worker. Allows privileged containers and hostPath volumes required for container-in-container builds."
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - SYS_ADMIN
+  - MKNOD
+  - SYS_CHROOT
+  - SETFCAP
+  - '*'
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfile: '*'
+volumes:
+  - '*'
+users:
+  - system:serviceaccount:{{ default .Release.Namespace .Values.global.internalNamespace }}:flightctl-imagebuilder-worker
+{{- end }}
+{{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift SecurityContextConstraints configuration to enable image builder worker functionality with support for container-in-container builds. When enabled via configuration, this provides the necessary permissions for the image builder worker component to operate within OpenShift environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->