### PR TITLE
EDM-3136: token refresh is now initilized on its own and does not cause issues where multiple instance are used

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,11 @@ func NewClient(server string, opts ...ClientOption) (*apiclient.ClientWithRespon
 	for _, opt := range opts {
 		opt(config)
 	}
-	return internalclient.NewFromConfig(config, "")
+	c, err := internalclient.NewFromConfig(config, "")
+	if err != nil {
+		return nil, err
+	}
+	return c.ClientWithResponses, nil
 }
 
 // GetDevice fetches a device by name.

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -162,8 +162,11 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serviceClient.Start(ctx)
+	defer serviceClient.Stop()
+
 	// Create simulator fleet configuration
-	if err := createSimulatorFleet(ctx, serviceClient, log); err != nil {
+	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
 		log.Warnf("Failed to create simulator fleet: %v", err)
 	}
 
@@ -199,7 +202,7 @@ func main() {
 		agents:          agents,
 		agentFolders:    agentsFolders,
 		log:             log,
-		serviceClient:   serviceClient,
+		serviceClient:   serviceClient.ClientWithResponses,
 		formattedLabels: formattedLables,
 		sem:             sem,
 		jitterDuration:  jitterDuration,

--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -99,6 +99,8 @@ func (o *ApproveOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	kind, name, err := parseAndValidateKindNameFromArgsSingle(args)
 	if err != nil {

--- a/internal/cli/certificate.go
+++ b/internal/cli/certificate.go
@@ -176,8 +176,10 @@ func (o *CertificateOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
-	csrName, err := o.submitCsrWithRetries(ctx, c, priv)
+	csrName, err := o.submitCsrWithRetries(ctx, c.ClientWithResponses, priv)
 	if err != nil {
 		return err
 	}
@@ -192,7 +194,7 @@ func (o *CertificateOptions) Run(ctx context.Context, args []string) error {
 	var currentCsr *api.CertificateSigningRequest
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		fmt.Fprint(os.Stderr, ".")
-		currentCsr, err = getCsr(csrName, c, ctx)
+		currentCsr, err = getCsr(csrName, c.ClientWithResponses, ctx)
 		if err != nil {
 			return false, fmt.Errorf("reading CSR %q: %w", ctx.Value("name"), err)
 		}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
-	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -157,7 +157,7 @@ func (o *CompletionOptions) Validate(args []string) error {
 
 type ClientBuilderOptions interface {
 	Complete(cmd *cobra.Command, args []string) error
-	BuildClient() (*apiclient.ClientWithResponses, error)
+	BuildClient() (*client.Client, error)
 }
 
 type KindNameAutocomplete struct {
@@ -222,6 +222,8 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 	}
 	c, err := o.BuildClient()
 	if err == nil {
+		c.Start(context.Background())
+		defer c.Stop()
 		switch kind {
 		case DeviceKind:
 			resp, err := c.ListDevicesWithResponse(context.Background(), &api.ListDevicesParams{})

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,7 @@ func makeDeviceListResponse(t *testing.T, numItems int) *http.Response {
 
 type fakeClientOptions struct {
 	responses      []*http.Response
-	client         *apiclient.ClientWithResponses
+	client         *client.Client
 	fakeHTTPClient *fakeHTTPClient
 	t              *testing.T
 }
@@ -61,9 +62,13 @@ func (fo *fakeClientOptions) Complete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (fo *fakeClientOptions) BuildClient() (*apiclient.ClientWithResponses, error) {
+func (fo *fakeClientOptions) BuildClient() (*client.Client, error) {
 	if fo.client == nil {
-		fo.client, fo.fakeHTTPClient = newTestClient(fo.t, fo.responses...)
+		var apiClient *apiclient.ClientWithResponses
+		apiClient, fo.fakeHTTPClient = newTestClient(fo.t, fo.responses...)
+		fo.client = &client.Client{
+			ClientWithResponses: apiClient,
+		}
 	}
 	return fo.client, nil
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -168,6 +168,8 @@ func (o *ConfigOptions) getOrganizationDisplayName(ctx context.Context, organiza
 	if err != nil {
 		return "", fmt.Errorf("failed to create API client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	field := fmt.Sprintf("metadata.name=%s", organizationId)
 	params := api.ListOrganizationsParams{FieldSelector: &field}

--- a/internal/cli/decommission.go
+++ b/internal/cli/decommission.go
@@ -103,6 +103,8 @@ func (o *DecommissionOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	_, name, err := parseAndValidateKindNameFromArgsSingle(args)
 	if err != nil {

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
-	imagebuilderclient "github.com/flightctl/flightctl/internal/api/imagebuilder/client"
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -113,9 +113,11 @@ func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	if len(args) == 1 {
-		response, err := o.deleteOne(ctx, c, kind, name)
+		response, err := o.deleteOne(ctx, c.ClientWithResponses, kind, name)
 		if err != nil {
 			return err
 		}
@@ -128,7 +130,7 @@ func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
 
 	names := args[1:]
 
-	return o.deleteMultiple(ctx, c, kind, names)
+	return o.deleteMultiple(ctx, c.ClientWithResponses, kind, names)
 }
 
 func (o *DeleteOptions) runImageBuildDelete(ctx context.Context, args []string, kind ResourceKind, name string) error {
@@ -136,6 +138,8 @@ func (o *DeleteOptions) runImageBuildDelete(ctx context.Context, args []string, 
 	if err != nil {
 		return fmt.Errorf("creating imagebuilder client: %w", err)
 	}
+	ibClient.Start(ctx)
+	defer ibClient.Stop()
 
 	if len(args) == 1 {
 		response, err := ibClient.DeleteImageBuildWithResponse(ctx, name)
@@ -153,7 +157,7 @@ func (o *DeleteOptions) runImageBuildDelete(ctx context.Context, args []string, 
 	return o.deleteMultipleImageBuilds(ctx, ibClient, kind, names)
 }
 
-func (o *DeleteOptions) deleteMultipleImageBuilds(ctx context.Context, c *imagebuilderclient.ClientWithResponses, kind ResourceKind, names []string) error {
+func (o *DeleteOptions) deleteMultipleImageBuilds(ctx context.Context, c *client.ImageBuilderClient, kind ResourceKind, names []string) error {
 	var errorCount int
 
 	for _, name := range names {
@@ -180,6 +184,8 @@ func (o *DeleteOptions) runImageExportDelete(ctx context.Context, args []string,
 	if err != nil {
 		return fmt.Errorf("creating imagebuilder client: %w", err)
 	}
+	ibClient.Start(ctx)
+	defer ibClient.Stop()
 
 	if len(args) == 1 {
 		response, err := ibClient.DeleteImageExportWithResponse(ctx, name)
@@ -197,7 +203,7 @@ func (o *DeleteOptions) runImageExportDelete(ctx context.Context, args []string,
 	return o.deleteMultipleImageExports(ctx, ibClient, kind, names)
 }
 
-func (o *DeleteOptions) deleteMultipleImageExports(ctx context.Context, c *imagebuilderclient.ClientWithResponses, kind ResourceKind, names []string) error {
+func (o *DeleteOptions) deleteMultipleImageExports(ctx context.Context, c *client.ImageBuilderClient, kind ResourceKind, names []string) error {
 	var errorCount int
 
 	for _, name := range names {

--- a/internal/cli/deny.go
+++ b/internal/cli/deny.go
@@ -88,6 +88,8 @@ func (o *DenyOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	kind, name, err := parseAndValidateKindNameFromArgsSingle(args)
 	if err != nil {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -165,6 +165,8 @@ func (o *EditOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	clientWithResponses.Start(ctx)
+	defer clientWithResponses.Stop()
 
 	kind, name, err := parseAndValidateKindName(args[0])
 	if err != nil {
@@ -182,9 +184,9 @@ func (o *EditOptions) Run(ctx context.Context, args []string) error {
 
 	switch kind {
 	case TemplateVersionKind:
-		originalResource, err = GetTemplateVersion(fetchCtx, clientWithResponses, o.FleetName, name)
+		originalResource, err = GetTemplateVersion(fetchCtx, clientWithResponses.ClientWithResponses, o.FleetName, name)
 	default:
-		originalResource, err = GetSingleResource(fetchCtx, clientWithResponses, kind, name)
+		originalResource, err = GetSingleResource(fetchCtx, clientWithResponses.ClientWithResponses, kind, name)
 	}
 	fetchCancel()
 	if err != nil {
@@ -205,7 +207,7 @@ func (o *EditOptions) Run(ctx context.Context, args []string) error {
 
 	// Apply the changes
 	applyCtx, applyCancel := o.WithTimeout(ctx)
-	err = o.applyChanges(applyCtx, clientWithResponses, editedContent, kind, name, originalResource)
+	err = o.applyChanges(applyCtx, clientWithResponses.ClientWithResponses, editedContent, kind, name, originalResource)
 	applyCancel()
 	if err != nil {
 		// Save the edited content to a temporary file for recovery

--- a/internal/cli/enrollmentconfig.go
+++ b/internal/cli/enrollmentconfig.go
@@ -79,6 +79,8 @@ func (o *EnrollmentConfigOptions) Run(ctx context.Context, args []string) error 
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	params := &api.GetEnrollmentConfigParams{}
 	if len(args) > 0 {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -451,6 +451,8 @@ func (o *LoginOptions) validateTokenWithServer(ctx context.Context, token string
 				o.enableInsecure()
 				c, cerr := client.NewFromConfig(o.clientConfig, o.ConfigFilePath, client.WithUserAgentHeader("flightctl-cli"))
 				if cerr == nil {
+					c.Start(ctx)
+					defer c.Stop()
 					res, err = c.AuthValidateWithResponse(ctx, &v1beta1.AuthValidateParams{Authorization: &headerVal})
 				}
 			}

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -145,6 +145,8 @@ func (o *ResumeOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
+	c.Start(ctx)
+	defer c.Stop()
 
 	// Handle single device case
 	_, name, err := parseAndValidateKindNameFromArgsOptionalSingle(args)
@@ -153,10 +155,10 @@ func (o *ResumeOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(name) == 0 {
-		return o.runBulkResume(ctx, c)
+		return o.runBulkResume(ctx, c.ClientWithResponses)
 	}
 
-	return o.runSingleResume(ctx, c, name)
+	return o.runSingleResume(ctx, c.ClientWithResponses, name)
 }
 
 func (o *ResumeOptions) runSingleResume(ctx context.Context, c *apiclient.ClientWithResponses, name string) error {

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -118,6 +118,8 @@ func (o *VersionOptions) Run(ctx context.Context, args []string) error {
 	var serverVersion *api.Version
 	c, err := o.BuildClient()
 	if err == nil {
+		c.Start(ctx)
+		defer c.Stop()
 		var response *apiclient.GetVersionResponse
 		response, err = c.GetVersionWithResponse(ctx)
 		serverVersion, err = o.processResponse(response, err)


### PR DESCRIPTION
Adding a bit of context as to why this was required - > QE were trying to test RBAC but they discovered that they are not able to reliabliy use differetn login tokens (representing different users and different permissions) -> the refresher structure was the root cause -> this PR fixes it
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI and tools now automatically start/stop API and image-builder clients.
  * Token refresher available via client wrappers to manage auth tokens during runtime.

* **Refactor**
  * Unified client wrappers with Start/Stop lifecycle used across CLI, console, completion, simulator, and tests.
  * Fetching and apply flows updated to use the new client surface for consistent behavior and cleanup.

* **Tests**
  * Test harnesses updated to use and clean up the client lifecycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->