### PR TITLE
EDM-2636: Systemd user client

### DIFF
--- a/internal/agent/client/systemd_test.go
+++ b/internal/agent/client/systemd_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestSystemdUserClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := []struct {
+		expectedArgs []any
+		run          func(m executer.Executer) error
+	}{
+		{
+			expectedArgs: []any{"--user", "restart", "testunit"},
+			run: func(m executer.Executer) error {
+				systemd := NewUserSystemd(m)
+				return systemd.Restart(t.Context(), "testunit")
+			},
+		},
+		{
+			expectedArgs: []any{"restart", "testunit"},
+			run: func(m executer.Executer) error {
+				systemd := NewSystemd(m)
+				return systemd.Restart(t.Context(), "testunit")
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		mockExec := executer.NewMockExecuter(ctrl)
+		mockExec.EXPECT().
+			ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", tt.expectedArgs...).
+			Return("", "", 0)
+
+		err := tt.run(mockExec)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
This adds an option to the systemd client to run with the --user flag which will be necessary when managing rootless quadlets.

Nothing uses it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-mode systemd support so the app can perform service operations in both user and system contexts.
  * Public API now exposes construction of user-mode systemd clients.

* **Behavioral Changes**
  * Reboot operations are now disallowed for user-mode instances.
  * Existing system-wide behavior remains backward compatible.

* **Tests**
  * Added tests verifying correct command construction and execution for user vs system modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->