### PR TITLE
EDM-3123: Add CLI clients for helm, kube, and CRI operations for Helm Applications

### DIFF
--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -97,57 +97,107 @@ func IsComposeAvailable() bool {
 	return false
 }
 
-type PullSecret struct {
-	// Absolute path to the pull secret
+// PullConfig holds the path to a configuration file and a cleanup function for temporary files.
+type PullConfig struct {
+	// Path is the absolute path to the configuration file.
 	Path string
-	// Cleanup function for temporary files, or no-op
+	// Cleanup removes temporary files created for inline configurations.
 	Cleanup func()
 }
 
-// ResolvePullSecret returns the image pull secret path, preferring inline spec
-// auth then falling back to on disk.  Cleanup removes tmp files generated from
+// ConfigType identifies the type of configuration being resolved.
+type ConfigType string
+
+const (
+	// ConfigTypeContainerSecret is the configuration type for container registry pull secrets.
+	ConfigTypeContainerSecret ConfigType = "container-secret"
+	// ConfigTypeHelmRegistrySecret is the configuration type for Helm OCI registry secrets.
+	ConfigTypeHelmRegistrySecret ConfigType = "helm-registry-secret" //nolint:gosec
+	// ConfigTypeHelmRepoConfig is the configuration type for Helm repository configuration.
+	ConfigTypeHelmRepoConfig ConfigType = "helm-repo-config"
+	// ConfigTypeCRIConfig is the configuration type for CRI runtime configuration.
+	ConfigTypeCRIConfig ConfigType = "cri-config"
+)
+
+// PullConfigProvider provides access to configuration files by type.
+type PullConfigProvider interface {
+	// Get returns the PullConfig for the specified type, or nil if not available.
+	Get(configType ConfigType) *PullConfig
+	// Cleanup releases resources for all configurations.
+	Cleanup()
+}
+
+type pullConfigProvider struct {
+	configs map[ConfigType]*PullConfig
+}
+
+// NewPullConfigProvider creates a new PullConfigProvider with the given configurations.
+func NewPullConfigProvider(configs map[ConfigType]*PullConfig) PullConfigProvider {
+	return &pullConfigProvider{configs: configs}
+}
+
+func (p *pullConfigProvider) Get(configType ConfigType) *PullConfig {
+	if p == nil || p.configs == nil {
+		return nil
+	}
+	return p.configs[configType]
+}
+
+func (p *pullConfigProvider) Cleanup() {
+	if p == nil || p.configs == nil {
+		return
+	}
+	for _, config := range p.configs {
+		if config != nil && config.Cleanup != nil {
+			config.Cleanup()
+		}
+	}
+}
+
+// ResolvePullConfig returns the pull config path, preferring inline spec
+// then falling back to on disk. Cleanup removes tmp files generated from
 // inline spec if found and is otherwise a no-op.
-func ResolvePullSecret(
+func ResolvePullConfig(
 	log *log.PrefixLogger,
 	rw fileio.ReadWriter,
 	desired *v1beta1.DeviceSpec,
-	authPath string,
-) (*PullSecret, bool, error) {
-	specContent, found, err := authFromSpec(log, desired, authPath)
+	configPath string,
+) (*PullConfig, bool, error) {
+	specContent, found, err := authFromSpec(log, desired, configPath)
 	if err != nil {
 		return nil, false, err
 	}
 	if found {
-		exists, err := rw.PathExists(authPath)
+		exists, err := rw.PathExists(configPath)
 		if err != nil {
 			return nil, false, err
 		}
 		if exists {
-			diskContent, err := rw.ReadFile(authPath)
+			diskContent, err := rw.ReadFile(configPath)
 			if err != nil {
-				return nil, false, fmt.Errorf("reading existing auth file: %w", err)
+				return nil, false, fmt.Errorf("reading existing config file: %w", err)
 			}
 
 			if bytes.Equal(diskContent, specContent) {
-				log.Debugf("Using on-disk pull secret (identical to spec): %s", authPath)
-				return &PullSecret{Path: authPath, Cleanup: func() {}}, true, nil
+				log.Debugf("Using on-disk config (identical to spec): %s", configPath)
+				return &PullConfig{Path: configPath, Cleanup: func() {}}, true, nil
 			}
 		}
-		path, cleanup, err := fileio.WriteTmpFile(rw, "os_auth_", "auth.json", specContent, 0600)
+		path, cleanup, err := fileio.WriteTmpFile(rw, "config_", "config", specContent, 0600)
 		if err != nil {
-			return nil, false, fmt.Errorf("writing inline auth file: %w", err)
+			return nil, false, fmt.Errorf("writing inline config file: %w", err)
 		}
-		log.Debugf("Using inline auth from device spec")
-		return &PullSecret{Path: path, Cleanup: cleanup}, true, nil
+		log.Debugf("Using inline config from device spec")
+		return &PullConfig{Path: path, Cleanup: cleanup}, true, nil
 	}
 
-	exists, err := rw.PathExists(authPath)
+	exists, err := rw.PathExists(configPath)
 	if err != nil {
 		return nil, false, err
 	}
 	if exists {
-		log.Debugf("Using on-disk pull secret: %s", authPath)
-		return &PullSecret{Path: authPath, Cleanup: func() {}}, true, nil
+		log.Debugf("Using on-disk config: %s", configPath)
+		return &PullConfig{Path: configPath, Cleanup: func() {}}, true, nil
 	}
 
 	return nil, false, nil
@@ -192,8 +242,10 @@ func authFromSpec(log *log.PrefixLogger, device *v1beta1.DeviceSpec, authPath st
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	pullSecretPath string
-	timeout        time.Duration
+	pullSecretPath       string
+	repositoryConfigPath string
+	criConfigPath        string
+	timeout              time.Duration
 }
 
 // WithPullSecret sets the path to the pull secret. If unset uses the default
@@ -201,6 +253,22 @@ type clientOptions struct {
 func WithPullSecret(path string) ClientOption {
 	return func(opts *clientOptions) {
 		opts.pullSecretPath = path
+	}
+}
+
+// WithRepositoryConfig sets the path to the Helm repository configuration file.
+// This is used for authenticating with HTTP-based Helm chart repositories.
+func WithRepositoryConfig(path string) ClientOption {
+	return func(opts *clientOptions) {
+		opts.repositoryConfigPath = path
+	}
+}
+
+// WithCRIConfig sets the path to the crictl configuration file.
+// This is used for configuring the CRI runtime endpoint.
+func WithCRIConfig(path string) ClientOption {
+	return func(opts *clientOptions) {
+		opts.criConfigPath = path
 	}
 }
 

--- a/internal/agent/client/client_test.go
+++ b/internal/agent/client/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolvePullSecret(t *testing.T) {
+func TestResolvePullConfig(t *testing.T) {
 	require := require.New(t)
 
 	tests := []struct {
@@ -178,7 +178,7 @@ func TestResolvePullSecret(t *testing.T) {
 			}
 			log := log.NewPrefixLogger("test")
 
-			result, found, err := ResolvePullSecret(log, rw, tt.deviceSpec, tt.authPath)
+			result, found, err := ResolvePullConfig(log, rw, tt.deviceSpec, tt.authPath)
 			if tt.expectedError {
 				require.Error(err)
 				require.Nil(result)

--- a/internal/agent/client/cri.go
+++ b/internal/agent/client/cri.go
@@ -1,0 +1,307 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	crictlCmd         = "crictl"
+	defaultCRITimeout = 2 * time.Minute
+)
+
+// CRI provides a client for executing crictl CLI commands.
+type CRI struct {
+	exec       executer.Executer
+	log        *log.PrefixLogger
+	timeout    time.Duration
+	readWriter fileio.ReadWriter
+}
+
+// NewCRI creates a new CRI client for interacting with container runtimes via crictl.
+func NewCRI(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter) *CRI {
+	return &CRI{
+		log:        log,
+		exec:       exec,
+		timeout:    defaultCRITimeout,
+		readWriter: readWriter,
+	}
+}
+
+// Pull pulls an image using crictl with optional authentication.
+func (c *CRI) Pull(ctx context.Context, image string, opts ...ClientOption) (string, error) {
+	options := &clientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := c.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var args []string
+
+	if options.criConfigPath != "" {
+		exists, err := c.readWriter.PathExists(options.criConfigPath)
+		if err != nil {
+			return "", fmt.Errorf("check crictl config path: %w", err)
+		}
+		if !exists {
+			c.log.Errorf("CRI config path does not exist: %s", options.criConfigPath)
+		} else {
+			args = append(args, "--config", options.criConfigPath)
+		}
+	}
+
+	args = append(args, "pull")
+
+	// We use the CRICTL_AUTH environment variable instead of the --creds or --auth
+	// command-line flags for security: environment variables are not visible in the
+	// process list (ps), whereas command-line arguments expose credentials to any
+	// user who can list processes on the system.
+	//
+	// When setting cmd.Env in Go, the child process does NOT inherit the parent's
+	// environment - it only receives the explicitly provided variables. Therefore,
+	// we must include os.Environ() to preserve PATH and other necessary variables.
+	env := os.Environ()
+	if options.pullSecretPath != "" {
+		authString, err := c.getAuthStringForImage(image, options.pullSecretPath)
+		if err != nil {
+			return "", fmt.Errorf("get credentials for %s: %w", image, err)
+		}
+		if authString != "" {
+			env = append(env, fmt.Sprintf("CRICTL_AUTH=%s", authString))
+		}
+	}
+
+	args = append(args, image)
+
+	stdout, stderr, exitCode := c.exec.ExecuteWithContextFromDir(ctx, "", crictlCmd, args, env...)
+	if exitCode != 0 {
+		return "", fmt.Errorf("crictl pull: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return strings.TrimSpace(stdout), nil
+}
+
+// ImageExists checks if an image exists in the CRI runtime.
+func (c *CRI) ImageExists(ctx context.Context, image string, opts ...ClientOption) bool {
+	options := &clientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := c.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var args []string
+
+	if options.criConfigPath != "" {
+		exists, err := c.readWriter.PathExists(options.criConfigPath)
+		if err != nil {
+			c.log.Errorf("Failed to check CRI config path %s: %v", options.criConfigPath, err)
+			return false
+		}
+		if !exists {
+			c.log.Errorf("CRI config path does not exist: %s", options.criConfigPath)
+		} else {
+			args = append(args, "--config", options.criConfigPath)
+		}
+	}
+
+	args = append(args, "images", image)
+
+	stdout, _, exitCode := c.exec.ExecuteWithContext(ctx, crictlCmd, args...)
+	if exitCode != 0 {
+		return false
+	}
+
+	output := strings.TrimSpace(stdout)
+	lines := strings.Split(output, "\n")
+	return len(lines) > 1
+}
+
+// getAuthStringForImage retrieves the base64-encoded auth string for a specific image from an auth file.
+// This returns the auth string in the format expected by crictl --auth flag.
+func (c *CRI) getAuthStringForImage(image, authPath string) (string, error) {
+	config, exists, err := parseAuthFile(c.readWriter, authPath)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		c.log.Errorf("Pull secret path does not exist: %s", authPath)
+		return "", nil
+	}
+	if config == nil {
+		return "", nil
+	}
+
+	authString, _ := config.getAuthString(image)
+	return authString, nil
+}
+
+// The following types and functions implement Docker/containers auth.json parsing
+// and registry credential matching following podman's authentication logic.
+// This ensures compatibility with podman's credential resolution behavior,
+// including registry key normalization and hierarchical path matching.
+//
+// Reference: https://github.com/containers/podman/blob/main/pkg/auth/auth.go
+
+// dockerAuthConfig represents the structure of a Docker/containers auth.json file
+type dockerAuthConfig struct {
+	Auths map[string]authEntry `json:"auths"`
+}
+
+// authEntry represents a single registry authentication entry
+type authEntry struct {
+	Auth     string `json:"auth,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// parseAuthFile reads and parses a Docker/containers auth.json file.
+// Returns the config, whether the file exists, and any error.
+func parseAuthFile(rw fileio.ReadWriter, path string) (*dockerAuthConfig, bool, error) {
+	exists, err := rw.PathExists(path)
+	if err != nil {
+		return nil, false, fmt.Errorf("checking auth file path: %w", err)
+	}
+	if !exists {
+		return nil, false, nil
+	}
+
+	data, err := rw.ReadFile(path)
+	if err != nil {
+		return nil, true, fmt.Errorf("reading auth file: %w", err)
+	}
+
+	var rawConfig dockerAuthConfig
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		return nil, true, fmt.Errorf("parsing auth file: %w", err)
+	}
+
+	config := &dockerAuthConfig{
+		Auths: make(map[string]authEntry),
+	}
+	for key, entry := range rawConfig.Auths {
+		normalizedKey := normalizeAuthFileKey(key)
+		config.Auths[normalizedKey] = entry
+	}
+
+	return config, true, nil
+}
+
+// getAuthString returns the base64-encoded auth string for an image reference.
+// It follows the podman/containers registry matching rules, searching from
+// most specific to least specific:
+//   - registry.io/namespace/user/image
+//   - registry.io/namespace/user
+//   - registry.io/namespace
+//   - registry.io
+//
+// If the auth entry has an Auth field, it returns that directly (already base64 encoded).
+// If only Username/Password are available, it encodes them as base64(username:password).
+func (a *dockerAuthConfig) getAuthString(imageRef string) (string, bool) {
+	if a == nil || len(a.Auths) == 0 {
+		return "", false
+	}
+
+	ref := normalizeImageRef(imageRef)
+	paths := buildRegistryPaths(ref)
+
+	for _, path := range paths {
+		if entry, ok := a.Auths[path]; ok {
+			authString := getAuthStringFromEntry(entry)
+			if authString != "" {
+				return authString, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// normalizeImageRef removes the tag/digest and any scheme prefix from an image reference
+func normalizeImageRef(imageRef string) string {
+	ref := imageRef
+
+	if idx := strings.Index(ref, "://"); idx != -1 {
+		ref = ref[idx+3:]
+	}
+
+	named, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return ref
+	}
+
+	return reference.TrimNamed(named).Name()
+}
+
+// buildRegistryPaths generates all possible registry paths from most specific to least
+func buildRegistryPaths(ref string) []string {
+	parts := strings.Split(ref, "/")
+	if len(parts) == 0 {
+		return nil
+	}
+
+	var paths []string
+	for i := len(parts); i > 0; i-- {
+		paths = append(paths, strings.Join(parts[:i], "/"))
+	}
+
+	return paths
+}
+
+// getAuthStringFromEntry returns the base64-encoded auth string from an auth entry.
+// If the entry has an Auth field, it returns that directly.
+// If only Username/Password are available, it encodes them as base64(username:password).
+func getAuthStringFromEntry(entry authEntry) string {
+	if entry.Auth != "" {
+		return entry.Auth
+	}
+
+	if entry.Username != "" {
+		return base64.StdEncoding.EncodeToString(
+			[]byte(fmt.Sprintf("%s:%s", entry.Username, entry.Password)))
+	}
+
+	return ""
+}
+
+// normalizeAuthFileKey takes an auth file key and converts it into a canonical format.
+// This follows podman's normalization logic to ensure consistent matching with image references.
+func normalizeAuthFileKey(authFileKey string) string {
+	stripped := strings.TrimPrefix(authFileKey, "http://")
+	stripped = strings.TrimPrefix(stripped, "https://")
+
+	if stripped != authFileKey {
+		stripped, _, _ = strings.Cut(stripped, "/")
+	}
+
+	switch stripped {
+	case "registry-1.docker.io", "index.docker.io":
+		return "docker.io"
+	default:
+		return stripped
+	}
+}

--- a/internal/agent/client/cri_test.go
+++ b/internal/agent/client/cri_test.go
@@ -1,0 +1,175 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeImageRef(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "image with tag",
+			input:    "registry.io/namespace/user/image:tag",
+			expected: "registry.io/namespace/user/image",
+		},
+		{
+			name:     "image with digest",
+			input:    "registry.io/namespace/user/image@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expected: "registry.io/namespace/user/image",
+		},
+		{
+			name:     "image with oci scheme and tag",
+			input:    "oci://registry.example.com/charts/mychart:1.0.0",
+			expected: "registry.example.com/charts/mychart",
+		},
+		{
+			name:     "image with docker scheme",
+			input:    "docker://quay.io/myorg/myapp:v1",
+			expected: "quay.io/myorg/myapp",
+		},
+		{
+			name:     "localhost registry with port and tag",
+			input:    "localhost:5000/test-image:v1.0",
+			expected: "localhost:5000/test-image",
+		},
+		{
+			name:     "image without tag",
+			input:    "registry.io/namespace/image",
+			expected: "registry.io/namespace/image",
+		},
+		{
+			name:     "official docker hub image with tag",
+			input:    "nginx:latest",
+			expected: "docker.io/library/nginx",
+		},
+		{
+			name:     "user docker hub image",
+			input:    "user/nginx:latest",
+			expected: "docker.io/user/nginx",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := normalizeImageRef(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildRegistryPaths(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:  "full path with four levels",
+			input: "registry.io/namespace/user/image",
+			expected: []string{
+				"registry.io/namespace/user/image",
+				"registry.io/namespace/user",
+				"registry.io/namespace",
+				"registry.io",
+			},
+		},
+		{
+			name:  "short path with two levels",
+			input: "registry.io/image",
+			expected: []string{
+				"registry.io/image",
+				"registry.io",
+			},
+		},
+		{
+			name:  "single level",
+			input: "registry.io",
+			expected: []string{
+				"registry.io",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildRegistryPaths(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestNormalizeAuthFileKey(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "registry-1.docker.io normalizes to docker.io",
+			input:    "registry-1.docker.io",
+			expected: "docker.io",
+		},
+		{
+			name:     "index.docker.io normalizes to docker.io",
+			input:    "index.docker.io",
+			expected: "docker.io",
+		},
+		{
+			name:     "docker.io stays as docker.io",
+			input:    "docker.io",
+			expected: "docker.io",
+		},
+		{
+			name:     "https scheme stripped and path removed",
+			input:    "https://registry.io/v2/",
+			expected: "registry.io",
+		},
+		{
+			name:     "http scheme stripped and path removed",
+			input:    "http://registry.io/v2/",
+			expected: "registry.io",
+		},
+		{
+			name:     "https scheme stripped, no path",
+			input:    "https://registry.io",
+			expected: "registry.io",
+		},
+		{
+			name:     "plain registry name unchanged",
+			input:    "quay.io",
+			expected: "quay.io",
+		},
+		{
+			name:     "registry with namespace not affected by scheme stripping",
+			input:    "registry.io/namespace",
+			expected: "registry.io/namespace",
+		},
+		{
+			name:     "registry with namespace and scheme gets path stripped",
+			input:    "https://registry.io/namespace/image",
+			expected: "registry.io",
+		},
+		{
+			name:     "localhost with port",
+			input:    "localhost:5000",
+			expected: "localhost:5000",
+		},
+		{
+			name:     "localhost with port and https scheme",
+			input:    "https://localhost:5000/v2/",
+			expected: "localhost:5000",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := normalizeAuthFileKey(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/agent/client/dependencies.go
+++ b/internal/agent/client/dependencies.go
@@ -1,0 +1,75 @@
+package client
+
+// CLIClients provides access to CLI-based clients for container and Kubernetes operations.
+type CLIClients interface {
+	Podman() *Podman
+	Skopeo() *Skopeo
+	Kube() *Kube
+	Helm() *Helm
+	CRI() *CRI
+}
+
+type cliClients struct {
+	podman *Podman
+	skopeo *Skopeo
+	kube   *Kube
+	helm   *Helm
+	cri    *CRI
+}
+
+// CLIClientsOption is a functional option for configuring CLIClients.
+type CLIClientsOption func(*cliClients)
+
+// WithPodmanClient sets the Podman client.
+func WithPodmanClient(p *Podman) CLIClientsOption {
+	return func(c *cliClients) { c.podman = p }
+}
+
+// WithSkopeoClient sets the Skopeo client.
+func WithSkopeoClient(s *Skopeo) CLIClientsOption {
+	return func(c *cliClients) { c.skopeo = s }
+}
+
+// WithKubeClient sets the Kubernetes CLI client.
+func WithKubeClient(k *Kube) CLIClientsOption {
+	return func(c *cliClients) { c.kube = k }
+}
+
+// WithHelmClient sets the Helm client.
+func WithHelmClient(h *Helm) CLIClientsOption {
+	return func(c *cliClients) { c.helm = h }
+}
+
+// WithCRIClient sets the CRI client.
+func WithCRIClient(cri *CRI) CLIClientsOption {
+	return func(c *cliClients) { c.cri = cri }
+}
+
+// NewCLIClients creates a new CLIClients instance with the provided options.
+func NewCLIClients(opts ...CLIClientsOption) CLIClients {
+	c := &cliClients{}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *cliClients) Podman() *Podman {
+	return c.podman
+}
+
+func (c *cliClients) Skopeo() *Skopeo {
+	return c.skopeo
+}
+
+func (c *cliClients) Kube() *Kube {
+	return c.kube
+}
+
+func (c *cliClients) Helm() *Helm {
+	return c.helm
+}
+
+func (c *cliClients) CRI() *CRI {
+	return c.cri
+}

--- a/internal/agent/client/helm.go
+++ b/internal/agent/client/helm.go
@@ -1,0 +1,490 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	helmCmd            = "helm"
+	defaultHelmTimeout = 5 * time.Minute
+)
+
+// HelmOption is a functional option for configuring helm operations.
+type HelmOption func(*helmOptions)
+
+type helmOptions struct {
+	namespace       string
+	valuesPaths     []string
+	kubeconfigPath  string
+	atomic          bool
+	createNamespace bool
+	install         bool
+	timeout         time.Duration
+}
+
+// WithNamespace sets the Kubernetes namespace for helm operations.
+func WithNamespace(namespace string) HelmOption {
+	return func(opts *helmOptions) {
+		opts.namespace = namespace
+	}
+}
+
+// WithValuesFile sets a single values file path for helm operations.
+func WithValuesFile(path string) HelmOption {
+	return func(opts *helmOptions) {
+		opts.valuesPaths = []string{path}
+	}
+}
+
+// WithValuesFiles sets multiple values file paths for helm operations.
+func WithValuesFiles(paths []string) HelmOption {
+	return func(opts *helmOptions) {
+		opts.valuesPaths = paths
+	}
+}
+
+// WithKubeconfig sets the kubeconfig file path for helm operations.
+func WithKubeconfig(path string) HelmOption {
+	return func(opts *helmOptions) {
+		opts.kubeconfigPath = path
+	}
+}
+
+// WithAtomic enables atomic mode for helm install/upgrade operations.
+func WithAtomic() HelmOption {
+	return func(opts *helmOptions) {
+		opts.atomic = true
+	}
+}
+
+// WithCreateNamespace enables automatic namespace creation for helm operations.
+func WithCreateNamespace() HelmOption {
+	return func(opts *helmOptions) {
+		opts.createNamespace = true
+	}
+}
+
+// WithInstall enables the --install flag for helm upgrade operations.
+func WithInstall() HelmOption {
+	return func(opts *helmOptions) {
+		opts.install = true
+	}
+}
+
+// WithHelmTimeout sets a custom timeout for helm operations.
+func WithHelmTimeout(timeout time.Duration) HelmOption {
+	return func(opts *helmOptions) {
+		opts.timeout = timeout
+	}
+}
+
+// Helm provides a client for executing helm CLI commands.
+type Helm struct {
+	exec       executer.Executer
+	log        *log.PrefixLogger
+	timeout    time.Duration
+	readWriter fileio.ReadWriter
+	cache      *helmChartCache
+}
+
+// NewHelm creates a new Helm client with the specified logger, executor, and data directory.
+func NewHelm(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.ReadWriter, dataDir string) *Helm {
+	chartsDir := filepath.Join(dataDir, HelmChartsDir)
+	h := &Helm{
+		log:        log,
+		exec:       exec,
+		timeout:    defaultHelmTimeout,
+		readWriter: readWriter,
+	}
+	h.cache = newHelmChartCache(h, chartsDir, readWriter, log)
+	return h
+}
+
+// HelmVersion represents a parsed helm CLI version.
+type HelmVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// GreaterOrEqual returns true if this version is greater than or equal to the specified major.minor version.
+func (v HelmVersion) GreaterOrEqual(major, minor int) bool {
+	if v.Major > major {
+		return true
+	}
+	if v.Major == major && v.Minor >= minor {
+		return true
+	}
+	return false
+}
+
+// Version returns the installed helm CLI version.
+func (h *Helm) Version(ctx context.Context) (*HelmVersion, error) {
+	ctx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+
+	args := []string{"version", "--short"}
+	stdout, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return nil, fmt.Errorf("helm version: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return parseHelmVersion(stdout)
+}
+
+func parseHelmVersion(output string) (*HelmVersion, error) {
+	output = strings.TrimSpace(output)
+	output = strings.TrimPrefix(output, "v")
+
+	plusIdx := strings.Index(output, "+")
+	if plusIdx > 0 {
+		output = output[:plusIdx]
+	}
+
+	dashIdx := strings.Index(output, "-")
+	if dashIdx > 0 {
+		output = output[:dashIdx]
+	}
+
+	parts := strings.SplitN(output, ".", 3)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("unexpected helm version format: %q", output)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse helm major version: %w", err)
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("parse helm minor version: %w", err)
+	}
+
+	var patch int
+	if len(parts) >= 3 {
+		patch, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse helm patch version: %w", err)
+		}
+	}
+
+	return &HelmVersion{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// Pull downloads a helm chart from a registry to the specified destination directory.
+func (h *Helm) Pull(ctx context.Context, chartRef, destDir string, opts ...ClientOption) error {
+	options := &clientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	chartPath, version := SplitChartRef(chartRef)
+	args := []string{"pull", chartPath, "--untar", "--destination", destDir}
+	if version != "" {
+		args = append(args, "--version", version)
+	}
+
+	if options.pullSecretPath != "" {
+		exists, err := h.readWriter.PathExists(options.pullSecretPath)
+		if err != nil {
+			return fmt.Errorf("check registry config path: %w", err)
+		}
+		if !exists {
+			h.log.Errorf("Registry config path does not exist: %s", options.pullSecretPath)
+		} else {
+			args = append(args, "--registry-config", options.pullSecretPath)
+		}
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm pull: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// DependencyUpdate updates the dependencies for a chart at the specified path.
+func (h *Helm) DependencyUpdate(ctx context.Context, chartPath string, opts ...ClientOption) error {
+	options := &clientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"dependency", "update", chartPath}
+
+	if options.repositoryConfigPath != "" {
+		exists, err := h.readWriter.PathExists(options.repositoryConfigPath)
+		if err != nil {
+			return fmt.Errorf("check repository config path: %w", err)
+		}
+		if !exists {
+			h.log.Errorf("Repository config path does not exist: %s", options.repositoryConfigPath)
+		} else {
+			args = append(args, "--repository-config", options.repositoryConfigPath)
+		}
+	}
+
+	if options.pullSecretPath != "" {
+		exists, err := h.readWriter.PathExists(options.pullSecretPath)
+		if err != nil {
+			return fmt.Errorf("check registry config path: %w", err)
+		}
+		if !exists {
+			h.log.Errorf("Registry config path does not exist: %s", options.pullSecretPath)
+		} else {
+			args = append(args, "--registry-config", options.pullSecretPath)
+		}
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm dependency update: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// Install installs a helm chart as a release with the specified name.
+func (h *Helm) Install(ctx context.Context, releaseName, chartPath string, opts ...HelmOption) error {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"install", releaseName, chartPath}
+
+	if options.namespace != "" {
+		args = append(args, "--namespace", options.namespace)
+	}
+
+	if options.createNamespace {
+		args = append(args, "--create-namespace")
+	}
+
+	for _, valuesPath := range options.valuesPaths {
+		exists, err := h.readWriter.PathExists(valuesPath)
+		if err != nil {
+			return fmt.Errorf("check values file path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("values file does not exist: %s", valuesPath)
+		}
+		args = append(args, "--values", valuesPath)
+	}
+
+	if options.kubeconfigPath != "" {
+		exists, err := h.readWriter.PathExists(options.kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("check kubeconfig path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("kubeconfig does not exist: %s", options.kubeconfigPath)
+		}
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	if options.atomic {
+		args = append(args, "--atomic")
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm install: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// Upgrade upgrades an existing helm release to a new chart version.
+func (h *Helm) Upgrade(ctx context.Context, releaseName, chartPath string, opts ...HelmOption) error {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"upgrade", releaseName, chartPath}
+
+	if options.install {
+		args = append(args, "--install")
+	}
+
+	if options.namespace != "" {
+		args = append(args, "--namespace", options.namespace)
+	}
+
+	if options.createNamespace {
+		args = append(args, "--create-namespace")
+	}
+
+	for _, valuesPath := range options.valuesPaths {
+		exists, err := h.readWriter.PathExists(valuesPath)
+		if err != nil {
+			return fmt.Errorf("check values file path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("values file does not exist: %s", valuesPath)
+		}
+		args = append(args, "--values", valuesPath)
+	}
+
+	if options.kubeconfigPath != "" {
+		exists, err := h.readWriter.PathExists(options.kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("check kubeconfig path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("kubeconfig does not exist: %s", options.kubeconfigPath)
+		}
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	if options.atomic {
+		args = append(args, "--atomic")
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm upgrade: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// Uninstall removes a helm release from the cluster.
+func (h *Helm) Uninstall(ctx context.Context, releaseName string, opts ...HelmOption) error {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"uninstall", releaseName}
+
+	if options.namespace != "" {
+		args = append(args, "--namespace", options.namespace)
+	}
+
+	if options.kubeconfigPath != "" {
+		exists, err := h.readWriter.PathExists(options.kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("check kubeconfig path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("kubeconfig does not exist: %s", options.kubeconfigPath)
+		}
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm uninstall: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// Template renders a helm chart and returns the resulting Kubernetes manifests.
+func (h *Helm) Template(ctx context.Context, releaseName, chartPath string, opts ...HelmOption) (string, error) {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"template", releaseName, chartPath, "--skip-tests"}
+
+	if options.namespace != "" {
+		args = append(args, "--namespace", options.namespace)
+	}
+
+	for _, valuesPath := range options.valuesPaths {
+		exists, err := h.readWriter.PathExists(valuesPath)
+		if err != nil {
+			return "", fmt.Errorf("check values file path: %w", err)
+		}
+		if !exists {
+			return "", fmt.Errorf("values file does not exist: %s", valuesPath)
+		}
+		args = append(args, "--values", valuesPath)
+	}
+
+	stdout, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return "", fmt.Errorf("helm template: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return stdout, nil
+}
+
+// Resolve ensures a chart is pulled and its dependencies are updated.
+func (h *Helm) Resolve(ctx context.Context, chartRef string, opts ...ClientOption) error {
+	return h.cache.Pull(ctx, chartRef, opts...)
+}
+
+// IsResolved returns true if the chart has been fully resolved (pulled and dependencies updated).
+func (h *Helm) IsResolved(chartRef string) (bool, error) {
+	return h.cache.IsResolved(chartRef)
+}
+
+// GetChartPath returns the local filesystem path for a cached chart.
+func (h *Helm) GetChartPath(chartRef string) string {
+	return h.cache.GetChartPath(chartRef)
+}

--- a/internal/agent/client/helm_cache.go
+++ b/internal/agent/client/helm_cache.go
@@ -1,0 +1,238 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	chartReadyMarkerFile = ".flightctl-chart-ready"
+	chartYAMLFile        = "Chart.yaml"
+	// HelmChartsDir is the subdirectory within the data directory where helm charts are cached.
+	HelmChartsDir = "helm/charts"
+)
+
+type helmChartCache struct {
+	helm       *Helm
+	chartsDir  string
+	readWriter fileio.ReadWriter
+	log        *log.PrefixLogger
+}
+
+func newHelmChartCache(helm *Helm, chartsDir string, readWriter fileio.ReadWriter, log *log.PrefixLogger) *helmChartCache {
+	return &helmChartCache{
+		helm:       helm,
+		chartsDir:  chartsDir,
+		readWriter: readWriter,
+		log:        log,
+	}
+}
+
+func (c *helmChartCache) ChartDir(chartRef string) string {
+	return filepath.Join(c.chartsDir, SanitizeChartRef(chartRef))
+}
+
+func (c *helmChartCache) IsChartResolved(chartDir string) (bool, error) {
+	markerPath := filepath.Join(chartDir, chartReadyMarkerFile)
+	return c.readWriter.PathExists(markerPath, fileio.WithSkipContentCheck())
+}
+
+func (c *helmChartCache) MarkChartResolved(chartDir string) error {
+	markerPath := filepath.Join(chartDir, chartReadyMarkerFile)
+	return c.readWriter.WriteFile(markerPath, []byte{}, fileio.DefaultFilePermissions)
+}
+
+func (c *helmChartCache) ChartExists(chartDir string) (bool, error) {
+	exists, err := c.readWriter.PathExists(chartDir)
+	if err != nil {
+		return false, fmt.Errorf("check chart directory: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	chartYAMLPath := filepath.Join(chartDir, chartYAMLFile)
+	exists, err = c.readWriter.PathExists(chartYAMLPath)
+	if err != nil {
+		return false, fmt.Errorf("check Chart.yaml: %w", err)
+	}
+	return exists, nil
+}
+
+func (c *helmChartCache) RemoveChart(chartDir string) error {
+	exists, err := c.readWriter.PathExists(chartDir)
+	if err != nil {
+		return fmt.Errorf("check chart directory: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
+	if err := c.readWriter.RemoveAll(chartDir); err != nil {
+		return fmt.Errorf("remove chart directory: %w", err)
+	}
+	return nil
+}
+
+func (c *helmChartCache) EnsureChartsDir() error {
+	exists, err := c.readWriter.PathExists(c.chartsDir)
+	if err != nil {
+		return fmt.Errorf("check charts directory: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	if err := c.readWriter.MkdirAll(c.chartsDir, fileio.DefaultDirectoryPermissions); err != nil {
+		return fmt.Errorf("create charts directory: %w", err)
+	}
+	return nil
+}
+
+func (c *helmChartCache) ResolveChart(ctx context.Context, chartRef, chartDir string, opts ...ClientOption) error {
+	resolved, err := c.IsChartResolved(chartDir)
+	if err != nil {
+		return fmt.Errorf("check if chart resolved: %w", err)
+	}
+	if resolved {
+		return nil
+	}
+
+	chartExists, err := c.ChartExists(chartDir)
+	if err != nil {
+		return fmt.Errorf("check if chart exists: %w", err)
+	}
+
+	if !chartExists {
+		if err := c.RemoveChart(chartDir); err != nil {
+			return fmt.Errorf("remove stale chart directory: %w", err)
+		}
+
+		if err := c.EnsureChartsDir(); err != nil {
+			return err
+		}
+
+		if err := c.helm.Pull(ctx, chartRef, c.chartsDir, opts...); err != nil {
+			return fmt.Errorf("pull chart: %w", err)
+		}
+
+		chartName, _, err := ParseChartRef(chartRef)
+		if err != nil {
+			return fmt.Errorf("parse chart ref for rename: %w", err)
+		}
+		extractedDir := filepath.Join(c.chartsDir, chartName)
+		if extractedDir != chartDir {
+			if err := c.readWriter.Rename(extractedDir, chartDir); err != nil {
+				return fmt.Errorf("rename chart directory: %w", err)
+			}
+		}
+	}
+
+	if err := c.helm.DependencyUpdate(ctx, chartDir, opts...); err != nil {
+		return fmt.Errorf("update dependencies: %w", err)
+	}
+
+	if err := c.MarkChartResolved(chartDir); err != nil {
+		return fmt.Errorf("mark chart resolved: %w", err)
+	}
+
+	return nil
+}
+
+func (c *helmChartCache) Pull(ctx context.Context, chartRef string, opts ...ClientOption) error {
+	chartDir := c.ChartDir(chartRef)
+	return c.ResolveChart(ctx, chartRef, chartDir, opts...)
+}
+
+func (c *helmChartCache) IsResolved(chartRef string) (bool, error) {
+	chartDir := c.ChartDir(chartRef)
+	return c.IsChartResolved(chartDir)
+}
+
+func (c *helmChartCache) GetChartPath(chartRef string) string {
+	return c.ChartDir(chartRef)
+}
+
+// ChartRefType indicates whether a chart reference uses a tag or digest.
+type ChartRefType int
+
+const (
+	ChartRefTypeTag ChartRefType = iota
+	ChartRefTypeDigest
+)
+
+// ParseChartRef extracts the chart name and version/digest from a chart reference.
+// Supports both tag-based (oci://registry/chart:version) and digest-based (oci://registry/chart@sha256:...) references.
+func ParseChartRef(chartRef string) (name, version string, err error) {
+	ref := strings.TrimPrefix(chartRef, "oci://")
+
+	parsed, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", "", fmt.Errorf("parse chart reference: %w", err)
+	}
+
+	pathParts := strings.Split(reference.Path(parsed), "/")
+	name = pathParts[len(pathParts)-1]
+	if name == "" {
+		return "", "", fmt.Errorf("chart reference missing chart name: %s", chartRef)
+	}
+
+	if digested, ok := parsed.(reference.Digested); ok {
+		version = digested.Digest().String()
+	} else if tagged, ok := parsed.(reference.Tagged); ok {
+		version = tagged.Tag()
+	} else {
+		return "", "", fmt.Errorf("chart reference missing version tag or digest: %s", chartRef)
+	}
+
+	return name, version, nil
+}
+
+// SplitChartRef splits a chart reference into the chart path and version components.
+// For tag-based references (oci://registry/chart:version), returns (oci://registry/chart, version).
+// For digest-based references (oci://registry/chart@sha256:...), returns (chartRef, "") since
+// the digest must remain part of the URL for helm pull.
+func SplitChartRef(chartRef string) (chartPath, version string) {
+	ref := chartRef
+	hasOCIPrefix := strings.HasPrefix(ref, "oci://")
+	if hasOCIPrefix {
+		ref = strings.TrimPrefix(ref, "oci://")
+	}
+
+	parsed, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return chartRef, ""
+	}
+
+	if tagged, ok := parsed.(reference.Tagged); ok {
+		version = tagged.Tag()
+		trimmed := reference.TrimNamed(parsed)
+		if hasOCIPrefix {
+			chartPath = "oci://" + trimmed.String()
+		} else {
+			chartPath = trimmed.String()
+		}
+		return chartPath, version
+	}
+
+	if _, ok := parsed.(reference.Digested); ok {
+		return chartRef, ""
+	}
+
+	return chartRef, ""
+}
+
+// SanitizeChartRef converts a chart reference into a filesystem-safe directory name.
+func SanitizeChartRef(chartRef string) string {
+	ref := strings.TrimPrefix(chartRef, "oci://")
+	ref = strings.ReplaceAll(ref, "/", "_")
+	ref = strings.ReplaceAll(ref, ":", "_")
+	ref = strings.ReplaceAll(ref, "@", "_")
+	return ref
+}

--- a/internal/agent/client/helm_cache_test.go
+++ b/internal/agent/client/helm_cache_test.go
@@ -1,0 +1,656 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHelmChartCache_ChartDir(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartsDir string
+		chartRef  string
+		want      string
+	}{
+		{
+			name:      "OCI chart reference",
+			chartsDir: "/var/lib/flightctl/helm/charts",
+			chartRef:  "oci://registry.example.com/charts/myapp:1.0.0",
+			want:      "/var/lib/flightctl/helm/charts/registry.example.com_charts_myapp_1.0.0",
+		},
+		{
+			name:      "chart with complex path",
+			chartsDir: "/var/lib/flightctl/helm/charts",
+			chartRef:  "oci://quay.io/flightctl/my-web-app:2.1.3",
+			want:      "/var/lib/flightctl/helm/charts/quay.io_flightctl_my-web-app_2.1.3",
+		},
+		{
+			name:      "chart with prerelease version",
+			chartsDir: "/data/charts",
+			chartRef:  "oci://registry.io/webapp:1.0.0-rc1",
+			want:      "/data/charts/registry.io_webapp_1.0.0-rc1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			cache := newHelmChartCache(nil, tc.chartsDir, mockReadWriter, log)
+			got := cache.ChartDir(tc.chartRef)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHelmChartCache_IsChartResolved(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartDir  string
+		setupMock func(*fileio.MockReadWriter)
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:     "chart is resolved",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0/.flightctl-chart-ready", gomock.Any()).
+					Return(true, nil)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:     "chart is not resolved",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			cache := newHelmChartCache(nil, "/var/lib/flightctl/helm/charts", mockReadWriter, log)
+			got, err := cache.IsChartResolved(tc.chartDir)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestHelmChartCache_MarkChartResolved(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartDir  string
+		setupMock func(*fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name:     "success",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().WriteFile(
+					"/var/lib/flightctl/helm/charts/myapp-1.0.0/.flightctl-chart-ready",
+					[]byte{},
+					fileio.DefaultFilePermissions,
+				).Return(nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			cache := newHelmChartCache(nil, "/var/lib/flightctl/helm/charts", mockReadWriter, log)
+			err := cache.MarkChartResolved(tc.chartDir)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmChartCache_ChartExists(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartDir  string
+		setupMock func(*fileio.MockReadWriter)
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:     "chart exists with Chart.yaml",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(true, nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0/Chart.yaml").
+					Return(true, nil)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:     "directory exists but no Chart.yaml",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(true, nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0/Chart.yaml").
+					Return(false, nil)
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:     "directory does not exist",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(false, nil)
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			cache := newHelmChartCache(nil, "/var/lib/flightctl/helm/charts", mockReadWriter, log)
+			got, err := cache.ChartExists(tc.chartDir)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestHelmChartCache_RemoveChart(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartDir  string
+		setupMock func(*fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name:     "success - chart exists",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(true, nil)
+				mockRW.EXPECT().RemoveAll("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:     "success - chart does not exist",
+			chartDir: "/var/lib/flightctl/helm/charts/myapp-1.0.0",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts/myapp-1.0.0").
+					Return(false, nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			cache := newHelmChartCache(nil, "/var/lib/flightctl/helm/charts", mockReadWriter, log)
+			err := cache.RemoveChart(tc.chartDir)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmChartCache_EnsureChartsDir(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartsDir string
+		setupMock func(*fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name:      "directory already exists",
+			chartsDir: "/var/lib/flightctl/helm/charts",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(true, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "directory does not exist - creates it",
+			chartsDir: "/var/lib/flightctl/helm/charts",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(false, nil)
+				mockRW.EXPECT().MkdirAll("/var/lib/flightctl/helm/charts", fileio.DefaultDirectoryPermissions).
+					Return(nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			cache := newHelmChartCache(nil, tc.chartsDir, mockReadWriter, log)
+			err := cache.EnsureChartsDir()
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmChartCache_ResolveChart(t *testing.T) {
+	chartRef := "oci://registry.example.com/charts/myapp:1.0.0"
+	chartDir := "/var/lib/flightctl/helm/charts/registry.example.com_charts_myapp_1.0.0"
+
+	testCases := []struct {
+		name      string
+		setupMock func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name: "already resolved - returns immediately",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(true, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "chart exists but not resolved - runs dependency update only",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(true, nil)
+				mockRW.EXPECT().PathExists(chartDir+"/Chart.yaml").
+					Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", chartDir,
+				}).Return("", "", 0)
+				mockRW.EXPECT().WriteFile(
+					chartDir+"/.flightctl-chart-ready",
+					[]byte{},
+					fileio.DefaultFilePermissions,
+				).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "chart does not exist - pulls, renames, then updates dependencies",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/var/lib/flightctl/helm/charts",
+					"--version", "1.0.0",
+				}).Return("", "", 0)
+				mockRW.EXPECT().Rename(
+					"/var/lib/flightctl/helm/charts/myapp",
+					chartDir,
+				).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", chartDir,
+				}).Return("", "", 0)
+				mockRW.EXPECT().WriteFile(
+					chartDir+"/.flightctl-chart-ready",
+					[]byte{},
+					fileio.DefaultFilePermissions,
+				).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "chart does not exist and charts dir needs creation",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(false, nil)
+				mockRW.EXPECT().MkdirAll("/var/lib/flightctl/helm/charts", fileio.DefaultDirectoryPermissions).
+					Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/var/lib/flightctl/helm/charts",
+					"--version", "1.0.0",
+				}).Return("", "", 0)
+				mockRW.EXPECT().Rename(
+					"/var/lib/flightctl/helm/charts/myapp",
+					chartDir,
+				).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", chartDir,
+				}).Return("", "", 0)
+				mockRW.EXPECT().WriteFile(
+					chartDir+"/.flightctl-chart-ready",
+					[]byte{},
+					fileio.DefaultFilePermissions,
+				).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "pull fails - returns error",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/var/lib/flightctl/helm/charts",
+					"--version", "1.0.0",
+				}).Return("", "Error: chart not found", 1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "dependency update fails - returns error",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(true, nil)
+				mockRW.EXPECT().PathExists(chartDir+"/Chart.yaml").
+					Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", chartDir,
+				}).Return("", "Error: repository not found", 1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "stale chart dir exists without Chart.yaml - removes stale dir and re-pulls",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(chartDir+"/.flightctl-chart-ready", gomock.Any()).
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(true, nil)
+				mockRW.EXPECT().PathExists(chartDir+"/Chart.yaml").
+					Return(false, nil)
+				mockRW.EXPECT().PathExists(chartDir).
+					Return(true, nil)
+				mockRW.EXPECT().RemoveAll(chartDir).
+					Return(nil)
+				mockRW.EXPECT().PathExists("/var/lib/flightctl/helm/charts").
+					Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/var/lib/flightctl/helm/charts",
+					"--version", "1.0.0",
+				}).Return("", "", 0)
+				mockRW.EXPECT().Rename(
+					"/var/lib/flightctl/helm/charts/myapp",
+					chartDir,
+				).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", chartDir,
+				}).Return("", "", 0)
+				mockRW.EXPECT().WriteFile(
+					chartDir+"/.flightctl-chart-ready",
+					[]byte{},
+					fileio.DefaultFilePermissions,
+				).Return(nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			cache := newHelmChartCache(helm, "/var/lib/flightctl/helm/charts", mockReadWriter, log)
+			err := cache.ResolveChart(context.Background(), chartRef, chartDir)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestParseChartRef(t *testing.T) {
+	testCases := []struct {
+		name        string
+		chartRef    string
+		wantName    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "tag-based OCI reference",
+			chartRef:    "oci://registry.example.com/charts/myapp:1.0.0",
+			wantName:    "myapp",
+			wantVersion: "1.0.0",
+			wantErr:     false,
+		},
+		{
+			name:        "tag-based reference with complex path",
+			chartRef:    "oci://quay.io/flightctl/helm-charts/webapp:2.1.3",
+			wantName:    "webapp",
+			wantVersion: "2.1.3",
+			wantErr:     false,
+		},
+		{
+			name:        "digest-based OCI reference",
+			chartRef:    "oci://registry.example.com/charts/myapp@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantName:    "myapp",
+			wantVersion: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantErr:     false,
+		},
+		{
+			name:        "reference without version or digest",
+			chartRef:    "oci://registry.example.com/charts/myapp",
+			wantName:    "",
+			wantVersion: "",
+			wantErr:     true,
+		},
+		{
+			name:        "reference with both tag and digest",
+			chartRef:    "oci://registry.example.com/charts/myapp:1.0.0@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantName:    "myapp",
+			wantVersion: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			name, version, err := ParseChartRef(tc.chartRef)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tc.wantName, name)
+			require.Equal(tc.wantVersion, version)
+		})
+	}
+}
+
+func TestSplitChartRef(t *testing.T) {
+	testCases := []struct {
+		name        string
+		chartRef    string
+		wantPath    string
+		wantVersion string
+	}{
+		{
+			name:        "tag-based OCI reference",
+			chartRef:    "oci://registry.example.com/charts/myapp:1.0.0",
+			wantPath:    "oci://registry.example.com/charts/myapp",
+			wantVersion: "1.0.0",
+		},
+		{
+			name:        "digest-based OCI reference returns full ref with empty version",
+			chartRef:    "oci://registry.example.com/charts/myapp@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantPath:    "oci://registry.example.com/charts/myapp@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			wantVersion: "",
+		},
+		{
+			name:        "reference without version or digest",
+			chartRef:    "oci://registry.example.com/charts/myapp",
+			wantPath:    "oci://registry.example.com/charts/myapp",
+			wantVersion: "",
+		},
+		{
+			name:        "non-OCI reference with tag",
+			chartRef:    "registry.example.com/charts/myapp:1.0.0",
+			wantPath:    "registry.example.com/charts/myapp",
+			wantVersion: "1.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			path, version := SplitChartRef(tc.chartRef)
+
+			require.Equal(tc.wantPath, path)
+			require.Equal(tc.wantVersion, version)
+		})
+	}
+}
+
+func TestSanitizeChartRef(t *testing.T) {
+	testCases := []struct {
+		name     string
+		chartRef string
+		want     string
+	}{
+		{
+			name:     "tag-based OCI reference",
+			chartRef: "oci://registry.example.com/charts/myapp:1.0.0",
+			want:     "registry.example.com_charts_myapp_1.0.0",
+		},
+		{
+			name:     "digest-based OCI reference",
+			chartRef: "oci://registry.example.com/charts/myapp@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			want:     "registry.example.com_charts_myapp_sha256_a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			result := SanitizeChartRef(tc.chartRef)
+
+			require.Equal(tc.want, result)
+		})
+	}
+}

--- a/internal/agent/client/helm_images.go
+++ b/internal/agent/client/helm_images.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type k8sResource struct {
+	APIVersion string            `yaml:"apiVersion,omitempty"`
+	Kind       string            `yaml:"kind,omitempty"`
+	Metadata   k8sMetadata       `yaml:"metadata,omitempty"`
+	Spec       k8sPodSpecWrapper `yaml:"spec,omitempty"`
+}
+
+type k8sMetadata struct {
+	Name      string `yaml:"name,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
+type k8sPodSpecWrapper struct {
+	Template       *k8sPodTemplateSpec `yaml:"template,omitempty"`
+	JobTemplate    *k8sJobTemplateSpec `yaml:"jobTemplate,omitempty"`
+	Containers     []k8sContainer      `yaml:"containers,omitempty"`
+	InitContainers []k8sContainer      `yaml:"initContainers,omitempty"`
+}
+
+type k8sPodTemplateSpec struct {
+	Spec k8sPodSpec `yaml:"spec,omitempty"`
+}
+
+type k8sJobTemplateSpec struct {
+	Spec k8sJobSpec `yaml:"spec,omitempty"`
+}
+
+type k8sJobSpec struct {
+	Template k8sPodTemplateSpec `yaml:"template,omitempty"`
+}
+
+type k8sPodSpec struct {
+	Containers     []k8sContainer `yaml:"containers,omitempty"`
+	InitContainers []k8sContainer `yaml:"initContainers,omitempty"`
+}
+
+type k8sContainer struct {
+	Name  string `yaml:"name,omitempty"`
+	Image string `yaml:"image,omitempty"`
+}
+
+// ExtractImagesFromManifests parses Kubernetes manifests and returns all container image references.
+func ExtractImagesFromManifests(manifests string) ([]string, error) {
+	imageSet := make(map[string]struct{})
+
+	decoder := yaml.NewDecoder(strings.NewReader(manifests))
+	for {
+		var resource k8sResource
+		err := decoder.Decode(&resource)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			continue
+		}
+
+		images := extractImagesFromResource(&resource)
+		for _, img := range images {
+			if img != "" {
+				imageSet[img] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(imageSet))
+	for img := range imageSet {
+		result = append(result, img)
+	}
+	return result, nil
+}
+
+func extractImagesFromResource(resource *k8sResource) []string {
+	var images []string
+
+	switch resource.Kind {
+	case "Pod":
+		images = append(images, extractImagesFromContainers(resource.Spec.Containers)...)
+		images = append(images, extractImagesFromContainers(resource.Spec.InitContainers)...)
+
+	case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet":
+		if resource.Spec.Template != nil {
+			images = append(images, extractImagesFromContainers(resource.Spec.Template.Spec.Containers)...)
+			images = append(images, extractImagesFromContainers(resource.Spec.Template.Spec.InitContainers)...)
+		}
+
+	case "Job":
+		if resource.Spec.Template != nil {
+			images = append(images, extractImagesFromContainers(resource.Spec.Template.Spec.Containers)...)
+			images = append(images, extractImagesFromContainers(resource.Spec.Template.Spec.InitContainers)...)
+		}
+
+	case "CronJob":
+		if resource.Spec.JobTemplate != nil {
+			images = append(images, extractImagesFromContainers(resource.Spec.JobTemplate.Spec.Template.Spec.Containers)...)
+			images = append(images, extractImagesFromContainers(resource.Spec.JobTemplate.Spec.Template.Spec.InitContainers)...)
+		}
+	}
+
+	return images
+}
+
+func extractImagesFromContainers(containers []k8sContainer) []string {
+	images := make([]string, 0, len(containers))
+	for _, c := range containers {
+		if c.Image != "" {
+			images = append(images, c.Image)
+		}
+	}
+	return images
+}

--- a/internal/agent/client/helm_images_test.go
+++ b/internal/agent/client/helm_images_test.go
@@ -1,0 +1,269 @@
+package client
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractImagesFromManifests(t *testing.T) {
+	require := require.New(t)
+
+	testCases := []struct {
+		name           string
+		manifests      string
+		expectedImages []string
+	}{
+		{
+			name:           "empty manifest returns empty slice",
+			manifests:      "",
+			expectedImages: []string{},
+		},
+		{
+			name: "single Pod with containers",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: nginx:1.19
+  - name: sidecar
+    image: busybox:latest`,
+			expectedImages: []string{"nginx:1.19", "busybox:latest"},
+		},
+		{
+			name: "Pod with init containers and containers",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  initContainers:
+  - name: init
+    image: alpine:3.14
+  containers:
+  - name: app
+    image: nginx:1.19`,
+			expectedImages: []string{"alpine:3.14", "nginx:1.19"},
+		},
+		{
+			name: "Deployment with pod template",
+			manifests: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:v1.0.0
+      initContainers:
+      - name: init
+        image: init-image:latest`,
+			expectedImages: []string{"myapp:v1.0.0", "init-image:latest"},
+		},
+		{
+			name: "StatefulSet with pod template",
+			manifests: `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  template:
+    spec:
+      containers:
+      - name: db
+        image: postgres:13`,
+			expectedImages: []string{"postgres:13"},
+		},
+		{
+			name: "DaemonSet with pod template",
+			manifests: `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-daemonset
+spec:
+  template:
+    spec:
+      containers:
+      - name: agent
+        image: monitoring-agent:v2`,
+			expectedImages: []string{"monitoring-agent:v2"},
+		},
+		{
+			name: "ReplicaSet with pod template",
+			manifests: `apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: test-replicaset
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: webapp:v3`,
+			expectedImages: []string{"webapp:v3"},
+		},
+		{
+			name: "Job with pod template",
+			manifests: `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: worker
+        image: job-runner:latest`,
+			expectedImages: []string{"job-runner:latest"},
+		},
+		{
+			name: "CronJob with job template",
+			manifests: `apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: test-cronjob
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cron
+            image: cron-image:v1
+          initContainers:
+          - name: setup
+            image: setup-image:v1`,
+			expectedImages: []string{"cron-image:v1", "setup-image:v1"},
+		},
+		{
+			name: "multi-document YAML with multiple resources",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: app
+    image: app1:v1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment1
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: app2:v2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+spec:
+  ports:
+  - port: 80`,
+			expectedImages: []string{"app1:v1", "app2:v2"},
+		},
+		{
+			name: "deduplication of images",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: app1
+    image: nginx:1.19
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+spec:
+  containers:
+  - name: app2
+    image: nginx:1.19`,
+			expectedImages: []string{"nginx:1.19"},
+		},
+		{
+			name: "skips documents with missing kind",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+spec:
+  containers:
+  - name: app
+    image: valid-image:v1
+---
+apiVersion: v1
+metadata:
+  name: unknown-resource
+data:
+  key: value
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: another-pod
+spec:
+  containers:
+  - name: app
+    image: another-image:v2`,
+			expectedImages: []string{"valid-image:v1", "another-image:v2"},
+		},
+		{
+			name: "skips resources without images",
+			manifests: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque
+data:
+  password: cGFzc3dvcmQ=`,
+			expectedImages: []string{},
+		},
+		{
+			name: "handles containers with empty image",
+			manifests: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: ""
+  - name: valid
+    image: valid-image:v1`,
+			expectedImages: []string{"valid-image:v1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			images, err := ExtractImagesFromManifests(tc.manifests)
+			require.NoError(err)
+
+			sort.Strings(images)
+			sort.Strings(tc.expectedImages)
+			require.Equal(tc.expectedImages, images)
+		})
+	}
+}

--- a/internal/agent/client/helm_test.go
+++ b/internal/agent/client/helm_test.go
@@ -1,0 +1,826 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHelm_Version(t *testing.T) {
+	testCases := []struct {
+		name      string
+		setupMock func(*executer.MockExecuter)
+		want      *HelmVersion
+		wantErr   bool
+	}{
+		{
+			name: "success with standard version",
+			setupMock: func(mock *executer.MockExecuter) {
+				mock.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{"version", "--short"}).
+					Return("v3.14.0+gc4e7498\n", "", 0)
+			},
+			want:    &HelmVersion{Major: 3, Minor: 14, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name: "success with version without patch",
+			setupMock: func(mock *executer.MockExecuter) {
+				mock.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{"version", "--short"}).
+					Return("v3.8+g1234567\n", "", 0)
+			},
+			want:    &HelmVersion{Major: 3, Minor: 8, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name: "success with helm 4.x",
+			setupMock: func(mock *executer.MockExecuter) {
+				mock.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{"version", "--short"}).
+					Return("v4.0.0+gabcdef\n", "", 0)
+			},
+			want:    &HelmVersion{Major: 4, Minor: 0, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name: "error from helm command",
+			setupMock: func(mock *executer.MockExecuter) {
+				mock.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{"version", "--short"}).
+					Return("", "helm: command not found", 127)
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			readWriter := fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+			tc.setupMock(mockExec)
+			helm := NewHelm(log, mockExec, readWriter, "/var/lib/flightctl/helm/charts")
+			got, err := helm.Version(context.Background())
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestHelmVersion_GreaterOrEqual(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version HelmVersion
+		major   int
+		minor   int
+		want    bool
+	}{
+		{
+			name:    "equal version",
+			version: HelmVersion{Major: 3, Minor: 8, Patch: 0},
+			major:   3,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "greater minor version",
+			version: HelmVersion{Major: 3, Minor: 14, Patch: 0},
+			major:   3,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "greater major version",
+			version: HelmVersion{Major: 4, Minor: 0, Patch: 0},
+			major:   3,
+			minor:   8,
+			want:    true,
+		},
+		{
+			name:    "lesser minor version",
+			version: HelmVersion{Major: 3, Minor: 7, Patch: 0},
+			major:   3,
+			minor:   8,
+			want:    false,
+		},
+		{
+			name:    "lesser major version",
+			version: HelmVersion{Major: 2, Minor: 17, Patch: 0},
+			major:   3,
+			minor:   8,
+			want:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.version.GreaterOrEqual(tc.major, tc.minor)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseHelmVersion(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    *HelmVersion
+		wantErr bool
+	}{
+		{
+			name:    "standard version with build info",
+			input:   "v3.14.0+gc4e7498",
+			want:    &HelmVersion{Major: 3, Minor: 14, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name:    "version without v prefix",
+			input:   "3.14.2",
+			want:    &HelmVersion{Major: 3, Minor: 14, Patch: 2},
+			wantErr: false,
+		},
+		{
+			name:    "version with whitespace",
+			input:   "  v3.14.0+gc4e7498  \n",
+			want:    &HelmVersion{Major: 3, Minor: 14, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name:    "version without patch",
+			input:   "v3.8+g1234567",
+			want:    &HelmVersion{Major: 3, Minor: 8, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name:    "invalid version format",
+			input:   "invalid",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric major version",
+			input:   "vX.14.0",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "pre-release version with rc",
+			input:   "v3.14.0-rc.1",
+			want:    &HelmVersion{Major: 3, Minor: 14, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name:    "pre-release version with beta",
+			input:   "v4.0.0-beta.2",
+			want:    &HelmVersion{Major: 4, Minor: 0, Patch: 0},
+			wantErr: false,
+		},
+		{
+			name:    "pre-release version with alpha and build info",
+			input:   "v3.15.0-alpha.1+gc4e7498",
+			want:    &HelmVersion{Major: 3, Minor: 15, Patch: 0},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseHelmVersion(tc.input)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHelm_Pull(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartRef  string
+		destDir   string
+		opts      []ClientOption
+		setupMock func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name:     "success without auth",
+			chartRef: "oci://registry.example.com/charts/myapp:1.0.0",
+			destDir:  "/tmp/charts",
+			opts:     nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/tmp/charts",
+					"--version", "1.0.0",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:     "success with auth",
+			chartRef: "oci://registry.example.com/charts/myapp:1.0.0",
+			destDir:  "/tmp/charts",
+			opts:     []ClientOption{WithPullSecret("/path/to/auth.json")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/path/to/auth.json").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/tmp/charts",
+					"--version", "1.0.0",
+					"--registry-config", "/path/to/auth.json",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:     "error from helm pull",
+			chartRef: "oci://registry.example.com/charts/myapp:1.0.0",
+			destDir:  "/tmp/charts",
+			opts:     nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/tmp/charts",
+					"--version", "1.0.0",
+				}).Return("", "Error: chart not found", 1)
+			},
+			wantErr: true,
+		},
+		{
+			name:     "auth file not found continues without auth",
+			chartRef: "oci://registry.example.com/charts/myapp:1.0.0",
+			destDir:  "/tmp/charts",
+			opts:     []ClientOption{WithPullSecret("/path/to/auth.json")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/path/to/auth.json").Return(false, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"pull", "oci://registry.example.com/charts/myapp",
+					"--untar", "--destination", "/tmp/charts",
+					"--version", "1.0.0",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			err := helm.Pull(context.Background(), tc.chartRef, tc.destDir, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelm_DependencyUpdate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chartPath string
+		opts      []ClientOption
+		setupMock func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr   bool
+	}{
+		{
+			name:      "success without config",
+			chartPath: "/tmp/charts/myapp",
+			opts:      nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", "/tmp/charts/myapp",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "success with repository config",
+			chartPath: "/tmp/charts/myapp",
+			opts:      []ClientOption{WithRepositoryConfig("/path/to/repos.yaml")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/path/to/repos.yaml").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", "/tmp/charts/myapp",
+					"--repository-config", "/path/to/repos.yaml",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "success with both registry and repository config",
+			chartPath: "/tmp/charts/myapp",
+			opts: []ClientOption{
+				WithRepositoryConfig("/path/to/repos.yaml"),
+				WithPullSecret("/path/to/auth.json"),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/path/to/repos.yaml").Return(true, nil)
+				mockRW.EXPECT().PathExists("/path/to/auth.json").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", "/tmp/charts/myapp",
+					"--repository-config", "/path/to/repos.yaml",
+					"--registry-config", "/path/to/auth.json",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:      "error from helm dependency update",
+			chartPath: "/tmp/charts/myapp",
+			opts:      nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"dependency", "update", "/tmp/charts/myapp",
+				}).Return("", "Error: no repositories found", 1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			err := helm.DependencyUpdate(context.Background(), tc.chartPath, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelm_Install(t *testing.T) {
+	testCases := []struct {
+		name        string
+		releaseName string
+		chartPath   string
+		opts        []HelmOption
+		setupMock   func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr     bool
+	}{
+		{
+			name:        "success without options",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"install", "myapp", "/tmp/charts/myapp",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithNamespace("default")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"install", "myapp", "/tmp/charts/myapp",
+					"--namespace", "default",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with all options",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts: []HelmOption{
+				WithNamespace("production"),
+				WithCreateNamespace(),
+				WithValuesFile("/tmp/values.yaml"),
+				WithKubeconfig("/tmp/kubeconfig"),
+				WithAtomic(),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(true, nil)
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"install", "myapp", "/tmp/charts/myapp",
+					"--namespace", "production",
+					"--create-namespace",
+					"--values", "/tmp/values.yaml",
+					"--kubeconfig", "/tmp/kubeconfig",
+					"--atomic",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "error - values file not found",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithValuesFile("/tmp/values.yaml")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(false, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "error - kubeconfig not found",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithKubeconfig("/tmp/kubeconfig")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(false, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:        "error from helm install",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"install", "myapp", "/tmp/charts/myapp",
+				}).Return("", "Error: release already exists", 1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			err := helm.Install(context.Background(), tc.releaseName, tc.chartPath, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelm_Upgrade(t *testing.T) {
+	testCases := []struct {
+		name        string
+		releaseName string
+		chartPath   string
+		opts        []HelmOption
+		setupMock   func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr     bool
+	}{
+		{
+			name:        "success without options",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"upgrade", "myapp", "/tmp/charts/myapp",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace and values",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts: []HelmOption{
+				WithNamespace("production"),
+				WithValuesFile("/tmp/values.yaml"),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"upgrade", "myapp", "/tmp/charts/myapp",
+					"--namespace", "production",
+					"--values", "/tmp/values.yaml",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with all options",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts: []HelmOption{
+				WithNamespace("production"),
+				WithValuesFile("/tmp/values.yaml"),
+				WithKubeconfig("/tmp/kubeconfig"),
+				WithAtomic(),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(true, nil)
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"upgrade", "myapp", "/tmp/charts/myapp",
+					"--namespace", "production",
+					"--values", "/tmp/values.yaml",
+					"--kubeconfig", "/tmp/kubeconfig",
+					"--atomic",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "error from helm upgrade",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"upgrade", "myapp", "/tmp/charts/myapp",
+				}).Return("", "Error: release not found", 1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			err := helm.Upgrade(context.Background(), tc.releaseName, tc.chartPath, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelm_Template(t *testing.T) {
+	testCases := []struct {
+		name        string
+		releaseName string
+		chartPath   string
+		opts        []HelmOption
+		setupMock   func(*executer.MockExecuter, *fileio.MockReadWriter)
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "success without options",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"template", "myapp", "/tmp/charts/myapp", "--skip-tests",
+				}).Return("---\napiVersion: v1\nkind: ConfigMap\n", "", 0)
+			},
+			want:    "---\napiVersion: v1\nkind: ConfigMap\n",
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithNamespace("production")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"template", "myapp", "/tmp/charts/myapp", "--skip-tests",
+					"--namespace", "production",
+				}).Return("---\napiVersion: apps/v1\nkind: Deployment\n", "", 0)
+			},
+			want:    "---\napiVersion: apps/v1\nkind: Deployment\n",
+			wantErr: false,
+		},
+		{
+			name:        "success with values file",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithValuesFile("/tmp/values.yaml")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"template", "myapp", "/tmp/charts/myapp", "--skip-tests",
+					"--values", "/tmp/values.yaml",
+				}).Return("---\napiVersion: v1\nkind: Service\n", "", 0)
+			},
+			want:    "---\napiVersion: v1\nkind: Service\n",
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace and values",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts: []HelmOption{
+				WithNamespace("production"),
+				WithValuesFile("/tmp/values.yaml"),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"template", "myapp", "/tmp/charts/myapp", "--skip-tests",
+					"--namespace", "production",
+					"--values", "/tmp/values.yaml",
+				}).Return("---\napiVersion: apps/v1\nkind: StatefulSet\n", "", 0)
+			},
+			want:    "---\napiVersion: apps/v1\nkind: StatefulSet\n",
+			wantErr: false,
+		},
+		{
+			name:        "error - values file not found",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        []HelmOption{WithValuesFile("/tmp/values.yaml")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/values.yaml").Return(false, nil)
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:        "error from helm template",
+			releaseName: "myapp",
+			chartPath:   "/tmp/charts/myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"template", "myapp", "/tmp/charts/myapp", "--skip-tests",
+				}).Return("", "Error: chart not found", 1)
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			got, err := helm.Template(context.Background(), tc.releaseName, tc.chartPath, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				require.Empty(got)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestHelm_Uninstall(t *testing.T) {
+	testCases := []struct {
+		name        string
+		releaseName string
+		opts        []HelmOption
+		setupMock   func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr     bool
+	}{
+		{
+			name:        "success without options",
+			releaseName: "myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"uninstall", "myapp",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace",
+			releaseName: "myapp",
+			opts:        []HelmOption{WithNamespace("production")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"uninstall", "myapp",
+					"--namespace", "production",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with kubeconfig",
+			releaseName: "myapp",
+			opts:        []HelmOption{WithKubeconfig("/tmp/kubeconfig")},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"uninstall", "myapp",
+					"--kubeconfig", "/tmp/kubeconfig",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "success with namespace and kubeconfig",
+			releaseName: "myapp",
+			opts: []HelmOption{
+				WithNamespace("production"),
+				WithKubeconfig("/tmp/kubeconfig"),
+			},
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"uninstall", "myapp",
+					"--namespace", "production",
+					"--kubeconfig", "/tmp/kubeconfig",
+				}).Return("", "", 0)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "error from helm uninstall",
+			releaseName: "myapp",
+			opts:        nil,
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"uninstall", "myapp",
+				}).Return("", "Error: release not found", 1)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			log := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+			helm := NewHelm(log, mockExec, mockReadWriter, "/var/lib/flightctl/helm/charts")
+			err := helm.Uninstall(context.Background(), tc.releaseName, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}

--- a/internal/agent/client/kube.go
+++ b/internal/agent/client/kube.go
@@ -1,0 +1,165 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	kubectlCmd = "kubectl"
+	ocCmd      = "oc"
+
+	microshiftKubeconfigPath = "/var/lib/microshift/resources/kubeadmin/kubeconfig"
+)
+
+// KubernetesOption is a functional option for configuring the Kube client.
+type KubernetesOption func(*kubernetesOptions)
+
+type kubernetesOptions struct {
+	binary string
+}
+
+// WithBinary sets a specific kubectl/oc binary path instead of auto-discovering.
+func WithBinary(binary string) KubernetesOption {
+	return func(opts *kubernetesOptions) {
+		opts.binary = binary
+	}
+}
+
+// Kube provides a client for executing kubectl/oc CLI commands.
+type Kube struct {
+	exec       executer.Executer
+	log        *log.PrefixLogger
+	binary     string
+	readWriter fileio.ReadWriter
+}
+
+// NewKube creates a new Kube client. It auto-discovers kubectl or oc if no binary is specified.
+// Use IsAvailable to check if a kubernetes CLI binary was found.
+func NewKube(
+	log *log.PrefixLogger,
+	exec executer.Executer,
+	readWriter fileio.ReadWriter,
+	opts ...KubernetesOption,
+) *Kube {
+	options := &kubernetesOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	binary := options.binary
+	if binary == "" {
+		binary = discoverKubernetesBinary()
+	}
+
+	return &Kube{
+		exec:       exec,
+		log:        log,
+		binary:     binary,
+		readWriter: readWriter,
+	}
+}
+
+func discoverKubernetesBinary() string {
+	if IsCommandAvailable(kubectlCmd) {
+		return kubectlCmd
+	}
+	if IsCommandAvailable(ocCmd) {
+		return ocCmd
+	}
+	return ""
+}
+
+// Binary returns the kubectl/oc binary path being used.
+func (k *Kube) Binary() string {
+	return k.binary
+}
+
+// IsAvailable returns true if a kubernetes CLI binary (kubectl or oc) is available.
+func (k *Kube) IsAvailable() bool {
+	return k.binary != ""
+}
+
+// RefreshBinary re-runs binary discovery to find kubectl or oc.
+// This is a no-op if a binary is already set.
+// Returns true if a binary is available.
+func (k *Kube) RefreshBinary() bool {
+	if k.binary != "" {
+		return true
+	}
+	k.binary = discoverKubernetesBinary()
+	return k.binary != ""
+}
+
+// WatchPodsCmd returns an exec.Cmd configured to watch pod events across all namespaces.
+func (k *Kube) WatchPodsCmd(ctx context.Context, kubeconfigPath string) (*exec.Cmd, error) {
+	if k.binary == "" {
+		return nil, fmt.Errorf("kubernetes CLI binary not available")
+	}
+
+	args := []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"}
+
+	if kubeconfigPath != "" {
+		args = append(args, "--kubeconfig", kubeconfigPath)
+	}
+
+	// #nosec G204 - binary is either hardcoded ("kubectl"/"oc") or explicitly configured, args are internally constructed
+	return exec.CommandContext(ctx, k.binary, args...), nil
+}
+
+// ResolveKubeconfig finds a valid kubeconfig path by checking KUBECONFIG env,
+// microshift path, and the default ~/.kube/config location.
+// KUBECONFIG may contain multiple paths. The first existing path is returned.
+func (k *Kube) ResolveKubeconfig() (string, error) {
+	var checkedPaths []string
+
+	if kubeconfigEnv := os.Getenv("KUBECONFIG"); kubeconfigEnv != "" {
+		paths := filepath.SplitList(kubeconfigEnv)
+		for _, path := range paths {
+			if path == "" {
+				continue
+			}
+			checkedPaths = append(checkedPaths, fmt.Sprintf("%s (KUBECONFIG env)", path))
+			exists, err := k.readWriter.PathExists(path)
+			if err != nil {
+				return "", fmt.Errorf("check KUBECONFIG path: %w (checked: %s)", err, strings.Join(checkedPaths, ", "))
+			}
+			if exists {
+				return path, nil
+			}
+		}
+	}
+
+	checkedPaths = append(checkedPaths, microshiftKubeconfigPath)
+	exists, err := k.readWriter.PathExists(microshiftKubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("check microshift kubeconfig path: %w (checked: %s)", err, strings.Join(checkedPaths, ", "))
+	}
+	if exists {
+		return microshiftKubeconfigPath, nil
+	}
+
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		return "", fmt.Errorf("no kubeconfig found, checked: %s (HOME environment variable not set, cannot check default path)", strings.Join(checkedPaths, ", "))
+	}
+	defaultPath := filepath.Join(homeDir, ".kube", "config")
+	checkedPaths = append(checkedPaths, defaultPath)
+	exists, err = k.readWriter.PathExists(defaultPath)
+	if err != nil {
+		return "", fmt.Errorf("check default kubeconfig path: %w (checked: %s)", err, strings.Join(checkedPaths, ", "))
+	}
+	if exists {
+		return defaultPath, nil
+	}
+
+	return "", fmt.Errorf("no kubeconfig found, checked: %s", strings.Join(checkedPaths, ", "))
+}

--- a/internal/agent/client/kube_test.go
+++ b/internal/agent/client/kube_test.go
@@ -1,0 +1,275 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewKube_WithExplicitBinary(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	k8s := NewKube(logger, mockExec, mockReadWriter, WithBinary("kubectl"))
+	require.NotNil(k8s)
+	require.Equal("kubectl", k8s.Binary())
+	require.True(k8s.IsAvailable())
+
+	k8s = NewKube(logger, mockExec, mockReadWriter, WithBinary("oc"))
+	require.NotNil(k8s)
+	require.Equal("oc", k8s.Binary())
+	require.True(k8s.IsAvailable())
+}
+
+func TestKube_IsAvailable(t *testing.T) {
+	testCases := []struct {
+		name     string
+		binary   string
+		expected bool
+	}{
+		{
+			name:     "available when binary is set",
+			binary:   "kubectl",
+			expected: true,
+		},
+		{
+			name:     "not available when binary is empty",
+			binary:   "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8s := &Kube{binary: tc.binary}
+			require.Equal(t, tc.expected, k8s.IsAvailable())
+		})
+	}
+}
+
+func TestKube_WatchPodsCmd(t *testing.T) {
+	testCases := []struct {
+		name           string
+		binary         string
+		kubeconfigPath string
+		expectedArgs   []string
+	}{
+		{
+			name:           "kubectl without kubeconfig",
+			binary:         "kubectl",
+			kubeconfigPath: "",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
+		},
+		{
+			name:           "kubectl with kubeconfig",
+			binary:         "kubectl",
+			kubeconfigPath: "/tmp/kubeconfig",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/tmp/kubeconfig"},
+		},
+		{
+			name:           "oc without kubeconfig",
+			binary:         "oc",
+			kubeconfigPath: "",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
+		},
+		{
+			name:           "oc with kubeconfig",
+			binary:         "oc",
+			kubeconfigPath: "/var/lib/microshift/resources/kubeadmin/kubeconfig",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/var/lib/microshift/resources/kubeadmin/kubeconfig"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			k8s := NewKube(logger, mockExec, mockReadWriter, WithBinary(tc.binary))
+
+			cmd, err := k8s.WatchPodsCmd(context.Background(), tc.kubeconfigPath)
+			require.NoError(err)
+			require.NotNil(cmd)
+			require.Equal(append([]string{tc.binary}, tc.expectedArgs...), cmd.Args)
+		})
+	}
+}
+
+func TestKube_WatchPodsCmd_NoBinary(t *testing.T) {
+	require := require.New(t)
+
+	k8s := &Kube{
+		binary: "",
+	}
+
+	cmd, err := k8s.WatchPodsCmd(context.Background(), "")
+	require.Error(err)
+	require.Nil(cmd)
+	require.Contains(err.Error(), "kubernetes CLI binary not available")
+}
+
+func TestKube_ResolveKubeconfig(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setupMock   func(*fileio.MockReadWriter)
+		envSetup    func()
+		envCleanup  func()
+		wantPath    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "KUBECONFIG env var exists and file exists",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/custom/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "/custom/kubeconfig")
+			},
+			envCleanup: func() {},
+			wantPath:   "/custom/kubeconfig",
+			wantErr:    false,
+		},
+		{
+			name: "KUBECONFIG env var exists but file does not exist, fallback to microshift",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/custom/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "/custom/kubeconfig")
+			},
+			envCleanup: func() {},
+			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
+			wantErr:    false,
+		},
+		{
+			name: "no KUBECONFIG env, microshift path exists",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "")
+			},
+			envCleanup: func() {},
+			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
+			wantErr:    false,
+		},
+		{
+			name: "no KUBECONFIG env, no microshift, default path exists",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists(gomock.Any()).Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "")
+			},
+			envCleanup: func() {},
+			wantPath:   "", // will match any path since HOME varies
+			wantErr:    false,
+		},
+		{
+			name: "no kubeconfig found anywhere",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists(gomock.Any()).Return(false, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "")
+			},
+			envCleanup:  func() {},
+			wantPath:    "",
+			wantErr:     true,
+			errContains: "no kubeconfig found",
+		},
+		{
+			name: "KUBECONFIG with multiple paths - first exists",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/first/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig:/third/kubeconfig")
+			},
+			envCleanup: func() {},
+			wantPath:   "/first/kubeconfig",
+			wantErr:    false,
+		},
+		{
+			name: "KUBECONFIG with multiple paths - second exists",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/first/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists("/second/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig:/third/kubeconfig")
+			},
+			envCleanup: func() {},
+			wantPath:   "/second/kubeconfig",
+			wantErr:    false,
+		},
+		{
+			name: "KUBECONFIG with multiple paths - none exist, fallback to microshift",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists("/first/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists("/second/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig")
+			},
+			envCleanup: func() {},
+			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
+			wantErr:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockRW := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockRW)
+			tc.envSetup()
+			defer tc.envCleanup()
+
+			k8s := NewKube(logger, mockExec, mockRW, WithBinary("kubectl"))
+
+			path, err := k8s.ResolveKubeconfig()
+
+			if tc.wantErr {
+				require.Error(err)
+				if tc.errContains != "" {
+					require.Contains(err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			require.NoError(err)
+			if tc.wantPath != "" {
+				require.Equal(tc.wantPath, path)
+			} else {
+				require.NotEmpty(path)
+			}
+		})
+	}
+}

--- a/internal/agent/client/mock_client.go
+++ b/internal/agent/client/mock_client.go
@@ -309,3 +309,52 @@ func (mr *MockBootcMockRecorder) UsrOverlay(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UsrOverlay", reflect.TypeOf((*MockBootc)(nil).UsrOverlay), ctx)
 }
+
+// MockPullConfigProvider is a mock of PullConfigProvider interface.
+type MockPullConfigProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockPullConfigProviderMockRecorder
+}
+
+// MockPullConfigProviderMockRecorder is the mock recorder for MockPullConfigProvider.
+type MockPullConfigProviderMockRecorder struct {
+	mock *MockPullConfigProvider
+}
+
+// NewMockPullConfigProvider creates a new mock instance.
+func NewMockPullConfigProvider(ctrl *gomock.Controller) *MockPullConfigProvider {
+	mock := &MockPullConfigProvider{ctrl: ctrl}
+	mock.recorder = &MockPullConfigProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPullConfigProvider) EXPECT() *MockPullConfigProviderMockRecorder {
+	return m.recorder
+}
+
+// Cleanup mocks base method.
+func (m *MockPullConfigProvider) Cleanup() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Cleanup")
+}
+
+// Cleanup indicates an expected call of Cleanup.
+func (mr *MockPullConfigProviderMockRecorder) Cleanup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockPullConfigProvider)(nil).Cleanup))
+}
+
+// Get mocks base method.
+func (m *MockPullConfigProvider) Get(configType ConfigType) *PullConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", configType)
+	ret0, _ := ret[0].(*PullConfig)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockPullConfigProviderMockRecorder) Get(configType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPullConfigProvider)(nil).Get), configType)
+}

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -128,8 +128,8 @@ func (m *manager) BeforeUpdate(ctx context.Context, desired *v1beta1.DeviceSpec)
 	return m.verifyProviders(ctx, providers)
 }
 
-func (m *manager) resolvePullSecret(desired *v1beta1.DeviceSpec) (*client.PullSecret, error) {
-	secret, found, err := client.ResolvePullSecret(m.log, m.readWriter, desired, pullAuthPath)
+func (m *manager) resolvePullSecret(desired *v1beta1.DeviceSpec) (*client.PullConfig, error) {
+	secret, found, err := client.ResolvePullConfig(m.log, m.readWriter, desired, pullAuthPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolving pull secret: %w", err)
 	}
@@ -237,7 +237,7 @@ func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1bet
 func (m *manager) collectNestedTargets(
 	ctx context.Context,
 	desired *v1beta1.DeviceSpec,
-	secret *client.PullSecret,
+	secret *client.PullConfig,
 ) ([]dependency.OCIPullTarget, bool, []string, error) {
 	var allNestedTargets []dependency.OCIPullTarget
 	var activeAppNames []string
@@ -335,7 +335,7 @@ func (m *manager) extractNestedTargetsForImage(
 	ctx context.Context,
 	appSpec v1beta1.ApplicationProviderSpec,
 	imageSpec *v1beta1.ImageApplicationProviderSpec,
-	secret *client.PullSecret,
+	secret *client.PullConfig,
 ) (*provider.AppData, error) {
 	return provider.ExtractNestedTargetsFromImage(
 		ctx,

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -486,7 +486,7 @@ func (m *mockProvider) Spec() *provider.ApplicationSpec {
 	}
 }
 
-func (m *mockProvider) OCITargets(ctx context.Context, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func (m *mockProvider) OCITargets(ctx context.Context, pullSecret *client.PullConfig) ([]dependency.OCIPullTarget, error) {
 	return nil, nil
 }
 

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -66,7 +66,7 @@ func CollectBaseOCITargets(
 	ctx context.Context,
 	readWriter fileio.ReadWriter,
 	spec *v1beta1.DeviceSpec,
-	pullSecret *client.PullSecret,
+	pullSecret *client.PullConfig,
 ) ([]dependency.OCIPullTarget, error) {
 	if spec.Applications == nil {
 		return nil, nil
@@ -170,7 +170,7 @@ func CollectBaseOCITargets(
 }
 
 // collectEmbeddedOCITargets discovers embedded applications and extracts their OCI targets
-func collectEmbeddedOCITargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func collectEmbeddedOCITargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullConfig) ([]dependency.OCIPullTarget, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -194,7 +194,7 @@ func collectEmbeddedOCITargets(ctx context.Context, readWriter fileio.ReadWriter
 	return targets, nil
 }
 
-func collectEmbeddedComposeTargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func collectEmbeddedComposeTargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullConfig) ([]dependency.OCIPullTarget, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -256,7 +256,7 @@ func collectEmbeddedComposeTargets(ctx context.Context, readWriter fileio.ReadWr
 	return targets, nil
 }
 
-func collectEmbeddedQuadletTargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func collectEmbeddedQuadletTargets(ctx context.Context, readWriter fileio.ReadWriter, pullSecret *client.PullConfig) ([]dependency.OCIPullTarget, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -320,7 +320,7 @@ func ExtractNestedTargetsFromImage(
 	readWriter fileio.ReadWriter,
 	appSpec *v1beta1.ApplicationProviderSpec,
 	imageSpec *v1beta1.ImageApplicationProviderSpec,
-	pullSecret *client.PullSecret,
+	pullSecret *client.PullConfig,
 ) (*AppData, error) {
 	// Resolve canonical app name
 	appName, err := ResolveImageAppName(appSpec)
@@ -698,7 +698,7 @@ func extractAppDataFromOCITarget(
 	appName string,
 	imageRef string,
 	appType v1beta1.AppType,
-	pullSecret *client.PullSecret,
+	pullSecret *client.PullConfig,
 ) (*AppData, error) {
 	tmpAppPath, err := readWriter.MkdirTemp("app_temp")
 	if err != nil {
@@ -951,7 +951,7 @@ func validateEnvVars(envVars map[string]string) error {
 	return nil
 }
 
-func extractQuadletTargets(quad *common.QuadletReferences, pullSecret *client.PullSecret) []dependency.OCIPullTarget {
+func extractQuadletTargets(quad *common.QuadletReferences, pullSecret *client.PullConfig) []dependency.OCIPullTarget {
 	var targets []dependency.OCIPullTarget
 	if quad.Image != nil && !quadlet.IsImageReference(*quad.Image) {
 		targets = append(targets, dependency.OCIPullTarget{
@@ -974,7 +974,7 @@ func extractQuadletTargets(quad *common.QuadletReferences, pullSecret *client.Pu
 	return targets
 }
 
-func extractVolumeTargets(vols *[]v1beta1.ApplicationVolume, pullSecret *client.PullSecret) ([]dependency.OCIPullTarget, error) {
+func extractVolumeTargets(vols *[]v1beta1.ApplicationVolume, pullSecret *client.PullConfig) ([]dependency.OCIPullTarget, error) {
 	var targets []dependency.OCIPullTarget
 	if vols == nil {
 		return targets, nil

--- a/internal/agent/device/applications/provider/provider_test.go
+++ b/internal/agent/device/applications/provider/provider_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestExtractQuadletTargets(t *testing.T) {
-	testPullSecret := &client.PullSecret{
+	testPullSecret := &client.PullConfig{
 		Path:    "/tmp/test-pull-secret",
 		Cleanup: func() {},
 	}
@@ -20,7 +20,7 @@ func TestExtractQuadletTargets(t *testing.T) {
 	tests := []struct {
 		name           string
 		quad           *common.QuadletReferences
-		pullSecret     *client.PullSecret
+		pullSecret     *client.PullConfig
 		expectedCount  int
 		expectedRefs   []string
 		expectedType   dependency.OCIType

--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -74,7 +74,7 @@ type OCIPullTarget struct {
 	Reference  string
 	Digest     string
 	PullPolicy v1beta1.ImagePullPolicy
-	PullSecret *client.PullSecret
+	PullSecret *client.PullConfig
 }
 
 // OCICollection represents the result of collecting OCI targets

--- a/internal/agent/device/dependency/dependency_test.go
+++ b/internal/agent/device/dependency/dependency_test.go
@@ -857,7 +857,7 @@ func TestPullSecretCleanup(t *testing.T) {
 	var cleanupCalls []string
 
 	// create multiple pull secrets to test comprehensive cleanup
-	appPullSecret := &client.PullSecret{
+	appPullSecret := &client.PullConfig{
 		Path: "/tmp/app-auth.json",
 		Cleanup: func() {
 			cleanupCalls = append(cleanupCalls, "app-auth-cleanup")

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -33,6 +33,8 @@ type Writer interface {
 	RemoveFile(file string) error
 	// RemoveAll removes the file or directory at the given path
 	RemoveAll(path string) error
+	// Rename renames (moves) oldpath to newpath
+	Rename(oldpath, newpath string) error
 	// RemoveContents removes all files and subdirectories within the given path,
 	// but leaves the directory itself intact. It is a no-op if the path does not exist.
 	RemoveContents(path string) error

--- a/internal/agent/device/fileio/mock_fileio.go
+++ b/internal/agent/device/fileio/mock_fileio.go
@@ -284,6 +284,20 @@ func (mr *MockWriterMockRecorder) RemoveFile(file any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFile", reflect.TypeOf((*MockWriter)(nil).RemoveFile), file)
 }
 
+// Rename mocks base method.
+func (m *MockWriter) Rename(oldpath, newpath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rename", oldpath, newpath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Rename indicates an expected call of Rename.
+func (mr *MockWriterMockRecorder) Rename(oldpath, newpath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockWriter)(nil).Rename), oldpath, newpath)
+}
+
 // WriteFile mocks base method.
 func (m *MockWriter) WriteFile(name string, data []byte, perm fs.FileMode, opts ...FileOption) error {
 	m.ctrl.T.Helper()
@@ -623,6 +637,20 @@ func (m *MockReadWriter) RemoveFile(file string) error {
 func (mr *MockReadWriterMockRecorder) RemoveFile(file any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFile", reflect.TypeOf((*MockReadWriter)(nil).RemoveFile), file)
+}
+
+// Rename mocks base method.
+func (m *MockReadWriter) Rename(oldpath, newpath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rename", oldpath, newpath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Rename indicates an expected call of Rename.
+func (mr *MockReadWriterMockRecorder) Rename(oldpath, newpath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockReadWriter)(nil).Rename), oldpath, newpath)
 }
 
 // WriteFile mocks base method.

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -170,6 +170,10 @@ func (w *writer) RemoveAll(path string) error {
 	return nil
 }
 
+func (w *writer) Rename(oldpath, newpath string) error {
+	return os.Rename(filepath.Join(w.rootDir, oldpath), filepath.Join(w.rootDir, newpath))
+}
+
 func (w *writer) RemoveContents(path string) error {
 	fullPath := filepath.Join(w.rootDir, path)
 	entries, err := os.ReadDir(fullPath)

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -112,7 +112,7 @@ func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1bet
 	}
 
 	// resolve pull secret for authentication
-	secret, found, err := client.ResolvePullSecret(m.log, m.readWriter, desired, authPath)
+	secret, found, err := client.ResolvePullConfig(m.log, m.readWriter, desired, authPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolving pull secret: %w", err)
 	}


### PR DESCRIPTION
Adds required infrastructure for helm applications:
1. `helm` client  - for pulling, installing, upgrading and removing charts
2. `kubectl` client - for watching events
3. `crictl` client - for pulling images.

Adds a helm_cache to cache OCI packages.

Changes `PullSecret` into `PullConfig` to indicate that other configuration values can be provided (crictl.yaml).

Created a `CLIClients` struct for passing around cli clients. It's becoming to unwieldy to pass down Podman, Skopeo, Kubectl, Crictl and whatever else may come in the future everywhere. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRI client for pulling/checking images, full Helm client with chart caching and install/upgrade/template/uninstall, Kubernetes helper with kubeconfig discovery, manifest image extractor, unified CLI-clients wrapper.
  * New PullConfig abstraction with options to configure repository and CRI config paths.
  * File rename support in device file I/O.

* **Bug Fixes / Improvements**
  * Consistent "config" terminology, improved resolution and cleanup behavior, added client configuration options, expanded unit tests and mocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->