### PR TITLE
EDM-2875: lifecycle - requeue , timeout , imagebuild update

### DIFF
--- a/internal/imagebuilder_api/store/imageexport.go
+++ b/internal/imagebuilder_api/store/imageexport.go
@@ -3,8 +3,10 @@ package store
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
 	api "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	flightctlstore "github.com/flightctl/flightctl/internal/store"
@@ -62,6 +64,23 @@ func (s *imageExportStore) Create(ctx context.Context, orgId uuid.UUID, imageExp
 	// Set initial Generation and ResourceVersion on create (matching GenericStore pattern)
 	m.Generation = lo.ToPtr(int64(1))
 	m.ResourceVersion = lo.ToPtr(int64(1))
+
+	// Set initial status with Ready=False, Reason=Pending if status is nil or empty
+	if m.Status == nil || m.Status.Data.Conditions == nil || len(*m.Status.Data.Conditions) == 0 {
+		now := time.Now().UTC()
+		initialStatus := api.ImageExportStatus{
+			Conditions: &[]api.ImageExportCondition{
+				{
+					Type:               api.ImageExportConditionTypeReady,
+					Status:             v1beta1.ConditionStatusFalse,
+					Reason:             string(api.ImageExportConditionReasonPending),
+					Message:            "ImageExport created, waiting to be processed",
+					LastTransitionTime: now,
+				},
+			},
+		}
+		m.Status = model.MakeJSONField(initialStatus)
+	}
 
 	db := getDB(ctx, s.db)
 	result := db.WithContext(ctx).Create(m)
@@ -195,17 +214,37 @@ func (s *imageExportStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, im
 		return nil, flterrors.ErrResourceIsNil
 	}
 
-	// Update status and return updated row in single query
+	// Parse resource_version from input for optimistic locking
+	var resourceVersion *int64
+	if imageExport.Metadata.ResourceVersion != nil {
+		rv, err := strconv.ParseInt(lo.FromPtr(imageExport.Metadata.ResourceVersion), 10, 64)
+		if err != nil {
+			return nil, flterrors.ErrIllegalResourceVersionFormat
+		}
+		resourceVersion = &rv
+	}
+
+	// Update with optional resource_version check for optimistic locking
+	// If resourceVersion is nil, skip optimistic locking (no resource_version in WHERE clause)
+	// Always increment resource_version regardless
 	var updated []ImageExport
-	result := s.db.WithContext(ctx).Model(&updated).
+	query := getDB(ctx, s.db).WithContext(ctx).Model(&updated).
 		Clauses(clause.Returning{}).
-		Where("org_id = ? AND name = ?", orgId, *imageExport.Metadata.Name).
-		Update("status", model.MakeJSONField(*imageExport.Status))
+		Where("org_id = ? AND name = ?", orgId, *imageExport.Metadata.Name)
+
+	if resourceVersion != nil {
+		query = query.Where("resource_version = ?", lo.FromPtr(resourceVersion))
+	}
+
+	result := query.Updates(map[string]interface{}{
+		"status":           model.MakeJSONField(*imageExport.Status),
+		"resource_version": gorm.Expr("resource_version + 1"),
+	})
 	if result.Error != nil {
 		return nil, flightctlstore.ErrorFromGormError(result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return nil, flterrors.ErrResourceNotFound
+		return nil, flterrors.ErrNoRowsUpdated
 	}
 
 	return updated[0].ToApiResource()

--- a/internal/imagebuilder_worker/tasks/imagebuild_update.go
+++ b/internal/imagebuilder_worker/tasks/imagebuild_update.go
@@ -1,0 +1,126 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/flightctl/flightctl/internal/service/common"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+// HandleImageBuildUpdate handles ImageBuild ResourceUpdated events
+// If the ImageBuild is completed, it requeues related ImageExports that haven't started yet
+// This method is public to allow testing with mocked services
+func (c *Consumer) HandleImageBuildUpdate(ctx context.Context, eventWithOrgId worker_client.EventWithOrgId, log logrus.FieldLogger) error {
+	event := eventWithOrgId.Event
+	orgID := eventWithOrgId.OrgId
+	imageBuildName := event.InvolvedObject.Name
+
+	log = log.WithField("imageBuild", imageBuildName).WithField("orgId", orgID)
+	log.Info("Handling ImageBuild update event")
+
+	// Load the ImageBuild resource
+	imageBuild, status := c.imageBuilderService.ImageBuild().Get(ctx, orgID, imageBuildName, false)
+	if imageBuild == nil || !imagebuilderapi.IsStatusOK(status) {
+		return fmt.Errorf("failed to load ImageBuild %q: %v", imageBuildName, status)
+	}
+
+	// Check if ImageBuild is completed
+	if imageBuild.Status == nil || imageBuild.Status.Conditions == nil {
+		log.Debug("ImageBuild has no status or conditions, skipping requeue of ImageExports")
+		return nil
+	}
+
+	readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*imageBuild.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+	if readyCondition == nil ||
+		readyCondition.Status != api.ConditionStatusTrue ||
+		readyCondition.Reason != string(apiimagebuilder.ImageBuildConditionReasonCompleted) {
+		log.Debug("ImageBuild is not completed, skipping requeue of ImageExports")
+		return nil
+	}
+
+	log.Info("ImageBuild is completed, checking for related ImageExports to requeue")
+
+	// Find ImageExports that reference this ImageBuild
+	// Use field selector to filter at database level by imageBuildRef
+	fieldSelectorStr := fmt.Sprintf("spec.source.imageBuildRef = %s", imageBuildName)
+	imageExports, status := c.imageBuilderService.ImageExport().List(ctx, orgID, apiimagebuilder.ListImageExportsParams{
+		FieldSelector: &fieldSelectorStr,
+	})
+	if !imagebuilderapi.IsStatusOK(status) {
+		return fmt.Errorf("failed to list ImageExports for ImageBuild %q: %v", imageBuildName, status)
+	}
+	if imageExports == nil || len(imageExports.Items) == 0 {
+		log.Debug("No ImageExports found for this ImageBuild")
+		return nil
+	}
+
+	// Filter for ImageExports that need requeueing:
+	// - Have Pending reason, OR
+	// - Don't have a Ready condition at all (not started yet)
+	requeuedCount := 0
+	for _, imageExport := range imageExports.Items {
+		// Check if this ImageExport needs requeueing
+		shouldRequeue := false
+		if imageExport.Status == nil || imageExport.Status.Conditions == nil {
+			// No status or conditions - needs requeueing
+			shouldRequeue = true
+		} else {
+			// Look for Ready condition
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*imageExport.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			if readyCondition == nil {
+				// No Ready condition - needs requeueing
+				shouldRequeue = true
+			} else if readyCondition.Reason == string(apiimagebuilder.ImageExportConditionReasonPending) {
+				// Has Pending reason - needs requeueing
+				shouldRequeue = true
+			}
+			// Skip if already Completed, Failed, or Converting
+		}
+
+		if !shouldRequeue {
+			continue
+		}
+		exportName := lo.FromPtr(imageExport.Metadata.Name)
+		if exportName == "" {
+			log.Warn("ImageExport has empty name, skipping")
+			continue
+		}
+
+		requeueEvent := common.GetResourceCreatedOrUpdatedSuccessEvent(
+			ctx,
+			true,
+			api.ResourceKind(string(apiimagebuilder.ResourceKindImageExport)),
+			exportName,
+			nil,
+			log,
+			nil,
+		)
+		if requeueEvent == nil {
+			log.WithField("imageExport", exportName).Warn("Failed to create requeue event")
+			continue
+		}
+
+		// Enqueue the event
+		if err := c.enqueueEvent(ctx, orgID, requeueEvent, log); err != nil {
+			log.WithError(err).WithField("imageExport", exportName).Error("Failed to requeue ImageExport")
+			continue
+		}
+
+		log.WithField("imageExport", exportName).Info("Requeued ImageExport due to ImageBuild completion")
+		requeuedCount++
+	}
+
+	if requeuedCount > 0 {
+		log.WithField("requeuedCount", requeuedCount).Info("Requeued ImageExports due to ImageBuild completion")
+	} else {
+		log.Debug("No ImageExports needed requeueing")
+	}
+
+	return nil
+}

--- a/internal/imagebuilder_worker/tasks/requeue.go
+++ b/internal/imagebuilder_worker/tasks/requeue.go
@@ -1,0 +1,312 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/flightctl/flightctl/internal/service/common"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+// RunRequeueOnStartup runs the requeue task once on startup
+// This method is public to allow testing with mocked services
+func (c *Consumer) RunRequeueOnStartup(ctx context.Context) {
+	c.log.Debug("Running requeue task on startup")
+	c.executeRequeue(ctx)
+	c.log.Debug("Startup requeue task completed")
+}
+
+// executeRequeue performs the requeue check and requeues tasks as needed
+func (c *Consumer) executeRequeue(ctx context.Context) {
+	log := c.log.WithField("task", "requeue")
+	log.Debug("Starting periodic requeue task")
+
+	// List all organizations
+	orgs, err := c.mainStore.Organization().List(ctx, store.ListParams{})
+	if err != nil {
+		log.WithError(err).Error("Failed to list organizations")
+		return
+	}
+
+	totalRequeued := 0
+	totalFailed := 0
+	for _, org := range orgs {
+		requeued, failed, err := c.requeueForOrg(ctx, org.ID, log)
+		if err != nil {
+			log.WithError(err).WithField("orgId", org.ID).Error("Failed to requeue tasks for organization")
+			continue
+		}
+		totalRequeued += requeued
+		totalFailed += failed
+	}
+
+	if totalRequeued > 0 || totalFailed > 0 {
+		log.WithField("requeued", totalRequeued).WithField("movedToFail", totalFailed).Info("Periodic requeue task completed")
+	} else {
+		log.Debug("Periodic requeue task completed - no tasks requeued or moved to fail")
+	}
+}
+
+// requeueForOrg checks and requeues imagebuild and imageexport tasks for a specific organization
+// Only requeues resources that are in Pending state (haven't started processing)
+// For resources that have started processing but aren't Completed/Failed, marks them as Failed
+// Returns the number of resources requeued and the number moved to fail
+func (c *Consumer) requeueForOrg(ctx context.Context, orgID uuid.UUID, log logrus.FieldLogger) (int, int, error) {
+	requeuedCount := 0
+	failedCount := 0
+
+	// Get all ImageBuilds that are not completed or failed
+	// Use field selector to exclude Completed and Failed statuses
+	fieldSelectorStr := "status.conditions.ready.reason notin (Completed, Failed)"
+	imageBuilds, status := c.imageBuilderService.ImageBuild().List(ctx, orgID, apiimagebuilder.ListImageBuildsParams{
+		FieldSelector: &fieldSelectorStr,
+	})
+	if !imagebuilderapi.IsStatusOK(status) {
+		return requeuedCount, failedCount, fmt.Errorf("failed to list imagebuilds: %v", status)
+	}
+	if imageBuilds == nil {
+		return requeuedCount, failedCount, fmt.Errorf("imageBuilds list is nil")
+	}
+
+	for _, imageBuild := range imageBuilds.Items {
+		if c.shouldRequeueImageBuild(&imageBuild) {
+			// Only requeue if Pending (hasn't started processing)
+			if err := c.requeueImageBuild(ctx, orgID, &imageBuild, log); err != nil {
+				log.WithError(err).WithField("imageBuild", lo.FromPtr(imageBuild.Metadata.Name)).Error("Failed to requeue imageBuild")
+				continue
+			}
+			requeuedCount++
+		} else {
+			// Has started processing but isn't Completed/Failed - mark as Failed
+			if err := c.markImageBuildAsFailed(ctx, orgID, &imageBuild, log); err != nil {
+				log.WithError(err).WithField("imageBuild", lo.FromPtr(imageBuild.Metadata.Name)).Error("Failed to mark imageBuild as failed")
+				continue
+			}
+			failedCount++
+		}
+	}
+
+	// Get all ImageExports that are not completed or failed
+	imageExports, status := c.imageBuilderService.ImageExport().List(ctx, orgID, apiimagebuilder.ListImageExportsParams{
+		FieldSelector: &fieldSelectorStr,
+	})
+	if !imagebuilderapi.IsStatusOK(status) {
+		return requeuedCount, failedCount, fmt.Errorf("failed to list imageexports: %v", status)
+	}
+	if imageExports == nil {
+		return requeuedCount, failedCount, fmt.Errorf("imageExports list is nil")
+	}
+
+	for _, imageExport := range imageExports.Items {
+		if c.shouldRequeueImageExport(&imageExport) {
+			// Only requeue if Pending (hasn't started processing)
+			if err := c.requeueImageExport(ctx, orgID, &imageExport, log); err != nil {
+				log.WithError(err).WithField("imageExport", lo.FromPtr(imageExport.Metadata.Name)).Error("Failed to requeue imageExport")
+				continue
+			}
+			requeuedCount++
+		} else {
+			// Has started processing but isn't Completed/Failed - mark as Failed
+			if err := c.markImageExportAsFailed(ctx, orgID, &imageExport, log); err != nil {
+				log.WithError(err).WithField("imageExport", lo.FromPtr(imageExport.Metadata.Name)).Error("Failed to mark imageExport as failed")
+				continue
+			}
+			failedCount++
+		}
+	}
+
+	return requeuedCount, failedCount, nil
+}
+
+// shouldRequeueImageBuild checks if an ImageBuild should be requeued
+// Returns true only if the resource is in Pending state (hasn't started processing)
+// Returns false if it has started processing (Building, Pushing) or is in a terminal state
+// Note: Field selector guarantees status.conditions.ready.reason exists
+func (c *Consumer) shouldRequeueImageBuild(imageBuild *apiimagebuilder.ImageBuild) bool {
+	// Find Ready condition - field selector guarantees it exists
+	readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*imageBuild.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+	if readyCondition == nil {
+		// Should not reach here due to field selector, but defensive return
+		return false
+	}
+	// Only requeue if Pending
+	return readyCondition.Reason == string(apiimagebuilder.ImageBuildConditionReasonPending)
+}
+
+// shouldRequeueImageExport checks if an ImageExport should be requeued
+// Returns true only if the resource is in Pending state (hasn't started processing)
+// Returns false if it has started processing (Converting, Pushing) or is in a terminal state
+// Note: Field selector guarantees status.conditions.ready.reason exists
+func (c *Consumer) shouldRequeueImageExport(imageExport *apiimagebuilder.ImageExport) bool {
+	// Find Ready condition - field selector guarantees it exists
+	readyCondition := apiimagebuilder.FindImageExportStatusCondition(*imageExport.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+	if readyCondition == nil {
+		// Should not reach here due to field selector, but defensive return
+		return false
+	}
+	// Only requeue if Pending
+	return readyCondition.Reason == string(apiimagebuilder.ImageExportConditionReasonPending)
+}
+
+// requeueImageBuild requeues an ImageBuild by creating and enqueueing a ResourceCreated event
+func (c *Consumer) requeueImageBuild(ctx context.Context, orgID uuid.UUID, imageBuild *apiimagebuilder.ImageBuild, log logrus.FieldLogger) error {
+	name := lo.FromPtr(imageBuild.Metadata.Name)
+	if name == "" {
+		return fmt.Errorf("imageBuild name is empty")
+	}
+
+	// Create ResourceCreated event
+	event := common.GetResourceCreatedOrUpdatedSuccessEvent(
+		ctx,
+		true,
+		api.ResourceKind(string(apiimagebuilder.ResourceKindImageBuild)),
+		name,
+		nil,
+		log,
+		nil,
+	)
+	if event == nil {
+		return fmt.Errorf("failed to create event")
+	}
+
+	// Enqueue the event
+	return c.enqueueRequeueEvent(ctx, orgID, event, log)
+}
+
+// requeueImageExport requeues an ImageExport by creating and enqueueing a ResourceCreated event
+func (c *Consumer) requeueImageExport(ctx context.Context, orgID uuid.UUID, imageExport *apiimagebuilder.ImageExport, log logrus.FieldLogger) error {
+	name := lo.FromPtr(imageExport.Metadata.Name)
+	if name == "" {
+		return fmt.Errorf("imageExport name is empty")
+	}
+
+	// Create ResourceCreated event
+	event := common.GetResourceCreatedOrUpdatedSuccessEvent(
+		ctx,
+		true,
+		api.ResourceKind(string(apiimagebuilder.ResourceKindImageExport)),
+		name,
+		nil,
+		log,
+		nil,
+	)
+	if event == nil {
+		return fmt.Errorf("failed to create event")
+	}
+
+	// Enqueue the event
+	return c.enqueueRequeueEvent(ctx, orgID, event, log)
+}
+
+// enqueueRequeueEvent enqueues an event to the imagebuild queue
+func (c *Consumer) enqueueRequeueEvent(ctx context.Context, orgID uuid.UUID, event *api.Event, log logrus.FieldLogger) error {
+	// Create EventWithOrgId structure for the queue
+	eventWithOrgId := worker_client.EventWithOrgId{
+		OrgId: orgID,
+		Event: *event,
+	}
+
+	payload, err := json.Marshal(eventWithOrgId)
+	if err != nil {
+		return fmt.Errorf("failed to marshal event: %w", err)
+	}
+
+	// Use creation timestamp if available, otherwise use current time
+	var timestamp int64
+	if event.Metadata.CreationTimestamp != nil {
+		timestamp = event.Metadata.CreationTimestamp.UnixMicro()
+	} else {
+		timestamp = time.Now().UnixMicro()
+	}
+
+	if err := c.queueProducer.Enqueue(ctx, payload, timestamp); err != nil {
+		return fmt.Errorf("failed to enqueue event: %w", err)
+	}
+
+	log.WithField("orgId", orgID).
+		WithField("kind", event.InvolvedObject.Kind).
+		WithField("name", event.InvolvedObject.Name).
+		Debug("Requeued task")
+	return nil
+}
+
+// markImageBuildAsFailed marks an ImageBuild as Failed because it was in a non-terminal state on startup
+func (c *Consumer) markImageBuildAsFailed(ctx context.Context, orgID uuid.UUID, imageBuild *apiimagebuilder.ImageBuild, log logrus.FieldLogger) error {
+	name := lo.FromPtr(imageBuild.Metadata.Name)
+	if name == "" {
+		return fmt.Errorf("imageBuild name is empty")
+	}
+
+	// Update status to Failed
+	now := time.Now().UTC()
+	failedCondition := apiimagebuilder.ImageBuildCondition{
+		Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+		Status:             api.ConditionStatusFalse,
+		Reason:             string(apiimagebuilder.ImageBuildConditionReasonFailed),
+		Message:            "Operation was in progress on startup and could not be resumed",
+		LastTransitionTime: now,
+	}
+
+	// Status and Conditions are guaranteed to exist due to field selector filtering
+	apiimagebuilder.SetImageBuildStatusCondition(imageBuild.Status.Conditions, failedCondition)
+
+	// Update status - if resource changed, optimistic locking will cause this to fail, which is fine
+	_, err := c.imageBuilderService.ImageBuild().UpdateStatus(ctx, orgID, imageBuild)
+	if err != nil {
+		// If update failed due to resource version mismatch, that's fine - resource was updated by another process
+		if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			log.WithField("imageBuild", name).Debug("ImageBuild was updated by another process, skipping failed mark")
+			return nil
+		}
+		return fmt.Errorf("failed to update ImageBuild status: %w", err)
+	}
+
+	log.WithField("imageBuild", name).Info("Marked ImageBuild as failed (was in progress on startup)")
+	return nil
+}
+
+// markImageExportAsFailed marks an ImageExport as Failed because it was in a non-terminal state on startup
+func (c *Consumer) markImageExportAsFailed(ctx context.Context, orgID uuid.UUID, imageExport *apiimagebuilder.ImageExport, log logrus.FieldLogger) error {
+	name := lo.FromPtr(imageExport.Metadata.Name)
+	if name == "" {
+		return fmt.Errorf("imageExport name is empty")
+	}
+
+	// Update status to Failed
+	now := time.Now().UTC()
+	failedCondition := apiimagebuilder.ImageExportCondition{
+		Type:               apiimagebuilder.ImageExportConditionTypeReady,
+		Status:             api.ConditionStatusFalse,
+		Reason:             string(apiimagebuilder.ImageExportConditionReasonFailed),
+		Message:            "Operation was in progress on startup and could not be resumed",
+		LastTransitionTime: now,
+	}
+
+	// Status and Conditions are guaranteed to exist due to field selector filtering
+	apiimagebuilder.SetImageExportStatusCondition(imageExport.Status.Conditions, failedCondition)
+
+	// Update status - if resource changed, optimistic locking will cause this to fail, which is fine
+	_, err := c.imageBuilderService.ImageExport().UpdateStatus(ctx, orgID, imageExport)
+	if err != nil {
+		// If update failed due to resource version mismatch, that's fine - resource was updated by another process
+		if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			log.WithField("imageExport", name).Debug("ImageExport was updated by another process, skipping failed mark")
+			return nil
+		}
+		return fmt.Errorf("failed to update ImageExport status: %w", err)
+	}
+
+	log.WithField("imageExport", name).Info("Marked ImageExport as failed (was in progress on startup)")
+	return nil
+}

--- a/internal/imagebuilder_worker/tasks/timeout.go
+++ b/internal/imagebuilder_worker/tasks/timeout.go
@@ -1,0 +1,151 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+// CheckAndMarkTimeoutsForOrg checks for timed-out image builds and exports in a specific organization
+// This method is public to allow testing with mocked services
+// Returns the number of resources moved to fail
+func (c *Consumer) CheckAndMarkTimeoutsForOrg(ctx context.Context, orgID uuid.UUID, timeoutDuration time.Duration, log logrus.FieldLogger) (int, error) {
+	log.Debug("Starting timeout check for organization")
+	defer log.Debug("Timeout check for organization completed")
+
+	// Calculate threshold timestamp
+	threshold := time.Now().UTC().Add(-timeoutDuration)
+	thresholdStr := threshold.Format(time.RFC3339)
+
+	failedCount := 0
+
+	// Build field selector to find resources that:
+	// 1. Are not in terminal states (Completed, Failed, Pending)
+	// 2. Have lastSeen older than threshold
+	fieldSelectorStr := fmt.Sprintf("status.conditions.ready.reason notin (Completed, Failed, Pending),status.lastSeen<%s", thresholdStr)
+
+	// Check ImageBuilds
+	imageBuilds, status := c.imageBuilderService.ImageBuild().List(ctx, orgID, apiimagebuilder.ListImageBuildsParams{
+		FieldSelector: &fieldSelectorStr,
+	})
+	if !imagebuilderapi.IsStatusOK(status) {
+		log.WithError(fmt.Errorf("status: %v", status)).Error("Failed to list imagebuilds for timeout check")
+	} else if imageBuilds != nil {
+		for _, imageBuild := range imageBuilds.Items {
+			updated, err := c.markImageBuildAsTimedOut(ctx, orgID, &imageBuild, timeoutDuration, log)
+			if err != nil {
+				log.WithError(err).WithField("imageBuild", lo.FromPtr(imageBuild.Metadata.Name)).Error("Failed to mark imageBuild as timed out")
+				failedCount++
+				continue
+			}
+			if updated {
+				failedCount++
+			}
+		}
+	}
+
+	// Check ImageExports
+	imageExports, status := c.imageBuilderService.ImageExport().List(ctx, orgID, apiimagebuilder.ListImageExportsParams{
+		FieldSelector: &fieldSelectorStr,
+	})
+	if !imagebuilderapi.IsStatusOK(status) {
+		log.WithError(fmt.Errorf("status: %v", status)).Error("Failed to list imageexports for timeout check")
+	} else if imageExports != nil {
+		for _, imageExport := range imageExports.Items {
+			updated, err := c.markImageExportAsTimedOut(ctx, orgID, &imageExport, timeoutDuration, log)
+			if err != nil {
+				log.WithError(err).WithField("imageExport", lo.FromPtr(imageExport.Metadata.Name)).Error("Failed to mark imageExport as timed out")
+				failedCount++
+				continue
+			}
+			if updated {
+				failedCount++
+			}
+		}
+	}
+
+	return failedCount, nil
+}
+
+// markImageBuildAsTimedOut marks an ImageBuild as Failed due to timeout
+// Returns (updated, error) where updated indicates whether a DB row was actually updated
+func (c *Consumer) markImageBuildAsTimedOut(ctx context.Context, orgID uuid.UUID, imageBuild *apiimagebuilder.ImageBuild, timeoutDuration time.Duration, log logrus.FieldLogger) (bool, error) {
+	name := lo.FromPtr(imageBuild.Metadata.Name)
+	if name == "" {
+		return false, fmt.Errorf("imageBuild name is empty")
+	}
+
+	// Update status to Failed
+	now := time.Now().UTC()
+	failedCondition := apiimagebuilder.ImageBuildCondition{
+		Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+		Status:             v1beta1.ConditionStatusFalse,
+		Reason:             string(apiimagebuilder.ImageBuildConditionReasonFailed),
+		Message:            fmt.Sprintf("Operation timed out: last seen more than %v ago", timeoutDuration),
+		LastTransitionTime: now,
+	}
+
+	// Set the Failed condition using the helper function
+	// Status and Conditions are guaranteed to exist due to field selector filtering
+	apiimagebuilder.SetImageBuildStatusCondition(imageBuild.Status.Conditions, failedCondition)
+
+	// Update status - if resource changed, optimistic locking will cause this to fail, which is fine
+	_, err := c.imageBuilderService.ImageBuild().UpdateStatus(ctx, orgID, imageBuild)
+	if err != nil {
+		// If update failed due to resource version mismatch, that's fine - resource was updated by another process
+		if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			log.WithField("imageBuild", name).Debug("ImageBuild was updated by another process, skipping timeout mark")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to update ImageBuild status: %w", err)
+	}
+
+	log.WithField("imageBuild", name).Info("Marked ImageBuild as timed out")
+	return true, nil
+}
+
+// markImageExportAsTimedOut marks an ImageExport as Failed due to timeout
+// Returns (updated, error) where updated indicates whether a DB row was actually updated
+func (c *Consumer) markImageExportAsTimedOut(ctx context.Context, orgID uuid.UUID, imageExport *apiimagebuilder.ImageExport, timeoutDuration time.Duration, log logrus.FieldLogger) (bool, error) {
+	name := lo.FromPtr(imageExport.Metadata.Name)
+	if name == "" {
+		return false, fmt.Errorf("imageExport name is empty")
+	}
+
+	// Update status to Failed
+	now := time.Now().UTC()
+	failedCondition := apiimagebuilder.ImageExportCondition{
+		Type:               apiimagebuilder.ImageExportConditionTypeReady,
+		Status:             v1beta1.ConditionStatusFalse,
+		Reason:             string(apiimagebuilder.ImageExportConditionReasonFailed),
+		Message:            fmt.Sprintf("Operation timed out: last seen more than %v ago", timeoutDuration),
+		LastTransitionTime: now,
+	}
+
+	// Set the Failed condition using the helper function
+	// Status and Conditions are guaranteed to exist due to field selector filtering
+	apiimagebuilder.SetImageExportStatusCondition(imageExport.Status.Conditions, failedCondition)
+
+	// Update status - if resource changed, optimistic locking will cause this to fail, which is fine
+	_, err := c.imageBuilderService.ImageExport().UpdateStatus(ctx, orgID, imageExport)
+	if err != nil {
+		// If update failed due to resource version mismatch, that's fine - resource was updated by another process
+		if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			log.WithField("imageExport", name).Debug("ImageExport was updated by another process, skipping timeout mark")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to update ImageExport status: %w", err)
+	}
+
+	log.WithField("imageExport", name).Info("Marked ImageExport as timed out")
+	return true, nil
+}

--- a/internal/imagebuilder_worker/tasks/timeout_test.go
+++ b/internal/imagebuilder_worker/tasks/timeout_test.go
@@ -1,0 +1,416 @@
+package tasks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockImageBuilderService is a mock implementation of imagebuilderapi.Service for testing
+type mockImageBuilderService struct {
+	imageBuilds    []*apiimagebuilder.ImageBuild
+	imageExports   []*apiimagebuilder.ImageExport
+	updatedBuilds  map[string]*apiimagebuilder.ImageBuild  // tracks which builds were updated
+	updatedExports map[string]*apiimagebuilder.ImageExport // tracks which exports were updated
+}
+
+func newMockImageBuilderService() *mockImageBuilderService {
+	return &mockImageBuilderService{
+		imageBuilds:    make([]*apiimagebuilder.ImageBuild, 0),
+		imageExports:   make([]*apiimagebuilder.ImageExport, 0),
+		updatedBuilds:  make(map[string]*apiimagebuilder.ImageBuild),
+		updatedExports: make(map[string]*apiimagebuilder.ImageExport),
+	}
+}
+
+func (m *mockImageBuilderService) ImageBuild() imagebuilderapi.ImageBuildService {
+	return &mockImageBuildService{parent: m}
+}
+
+func (m *mockImageBuilderService) ImageExport() imagebuilderapi.ImageExportService {
+	return &mockImageExportService{parent: m}
+}
+
+type mockImageBuildService struct {
+	parent *mockImageBuilderService
+}
+
+func (m *mockImageBuildService) Create(ctx context.Context, orgId uuid.UUID, imageBuild apiimagebuilder.ImageBuild) (*apiimagebuilder.ImageBuild, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+func (m *mockImageBuildService) Get(ctx context.Context, orgId uuid.UUID, name string, withExports bool) (*apiimagebuilder.ImageBuild, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+func (m *mockImageBuildService) List(ctx context.Context, orgId uuid.UUID, params apiimagebuilder.ListImageBuildsParams) (*apiimagebuilder.ImageBuildList, v1beta1.Status) {
+	// Filter based on field selector - simulate the actual field selector behavior
+	var filtered []apiimagebuilder.ImageBuild
+	var threshold time.Time
+
+	// Parse threshold from field selector if present
+	// Format: "status.conditions.ready.reason not in (Completed, Failed, Pending),status.lastSeen<{timestamp}"
+	if params.FieldSelector != nil {
+		parts := strings.Split(*params.FieldSelector, ",")
+		for _, part := range parts {
+			if strings.HasPrefix(part, "status.lastSeen<") {
+				thresholdStr := strings.TrimPrefix(part, "status.lastSeen<")
+				parsed, err := time.Parse(time.RFC3339, thresholdStr)
+				if err == nil {
+					threshold = parsed
+				}
+			}
+		}
+	}
+
+	for _, ib := range m.parent.imageBuilds {
+		if ib.Status == nil || ib.Status.Conditions == nil {
+			continue
+		}
+
+		readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*ib.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+		if readyCondition == nil {
+			continue
+		}
+
+		reason := readyCondition.Reason
+		// Exclude Completed, Failed, Pending (as per field selector)
+		if reason == string(apiimagebuilder.ImageBuildConditionReasonCompleted) ||
+			reason == string(apiimagebuilder.ImageBuildConditionReasonFailed) ||
+			reason == string(apiimagebuilder.ImageBuildConditionReasonPending) {
+			continue
+		}
+
+		// If field selector is provided, check lastSeen against threshold
+		if params.FieldSelector != nil {
+			if ib.Status.LastSeen == nil {
+				continue
+			}
+			if !ib.Status.LastSeen.Before(threshold) {
+				continue // lastSeen is not older than threshold
+			}
+		}
+
+		filtered = append(filtered, *ib)
+	}
+
+	return &apiimagebuilder.ImageBuildList{Items: filtered}, v1beta1.StatusOK()
+}
+
+func (m *mockImageBuildService) UpdateStatus(ctx context.Context, orgId uuid.UUID, imageBuild *apiimagebuilder.ImageBuild) (*apiimagebuilder.ImageBuild, error) {
+	name := lo.FromPtr(imageBuild.Metadata.Name)
+	m.parent.updatedBuilds[name] = imageBuild
+	return imageBuild, nil
+}
+
+func (m *mockImageBuildService) UpdateLastSeen(ctx context.Context, orgId uuid.UUID, name string, timestamp time.Time) error {
+	return nil
+}
+
+func (m *mockImageBuildService) Delete(ctx context.Context, orgId uuid.UUID, name string) (*apiimagebuilder.ImageBuild, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+type mockImageExportService struct {
+	parent *mockImageBuilderService
+}
+
+func (m *mockImageExportService) Create(ctx context.Context, orgId uuid.UUID, imageExport apiimagebuilder.ImageExport) (*apiimagebuilder.ImageExport, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+func (m *mockImageExportService) Get(ctx context.Context, orgId uuid.UUID, name string) (*apiimagebuilder.ImageExport, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+func (m *mockImageExportService) List(ctx context.Context, orgId uuid.UUID, params apiimagebuilder.ListImageExportsParams) (*apiimagebuilder.ImageExportList, v1beta1.Status) {
+	// Filter based on field selector - simulate the actual field selector behavior
+	var filtered []apiimagebuilder.ImageExport
+	var threshold time.Time
+
+	// Parse threshold from field selector if present
+	if params.FieldSelector != nil {
+		parts := strings.Split(*params.FieldSelector, ",")
+		for _, part := range parts {
+			if strings.HasPrefix(part, "status.lastSeen<") {
+				thresholdStr := strings.TrimPrefix(part, "status.lastSeen<")
+				parsed, err := time.Parse(time.RFC3339, thresholdStr)
+				if err == nil {
+					threshold = parsed
+				}
+			}
+		}
+	}
+
+	for _, ie := range m.parent.imageExports {
+		if ie.Status == nil || ie.Status.Conditions == nil {
+			continue
+		}
+
+		readyCondition := apiimagebuilder.FindImageExportStatusCondition(*ie.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+		if readyCondition == nil {
+			continue
+		}
+
+		reason := readyCondition.Reason
+		// Exclude Completed, Failed, Pending (as per field selector)
+		if reason == string(apiimagebuilder.ImageExportConditionReasonCompleted) ||
+			reason == string(apiimagebuilder.ImageExportConditionReasonFailed) ||
+			reason == string(apiimagebuilder.ImageExportConditionReasonPending) {
+			continue
+		}
+
+		// If field selector is provided, check lastSeen against threshold
+		if params.FieldSelector != nil {
+			if ie.Status.LastSeen == nil {
+				continue
+			}
+			if !ie.Status.LastSeen.Before(threshold) {
+				continue // lastSeen is not older than threshold
+			}
+		}
+
+		filtered = append(filtered, *ie)
+	}
+
+	return &apiimagebuilder.ImageExportList{Items: filtered}, v1beta1.StatusOK()
+}
+
+func (m *mockImageExportService) UpdateStatus(ctx context.Context, orgId uuid.UUID, imageExport *apiimagebuilder.ImageExport) (*apiimagebuilder.ImageExport, error) {
+	name := lo.FromPtr(imageExport.Metadata.Name)
+	m.parent.updatedExports[name] = imageExport
+	return imageExport, nil
+}
+
+func (m *mockImageExportService) UpdateLastSeen(ctx context.Context, orgId uuid.UUID, name string, timestamp time.Time) error {
+	return nil
+}
+
+func (m *mockImageExportService) Delete(ctx context.Context, orgId uuid.UUID, name string) (*apiimagebuilder.ImageExport, v1beta1.Status) {
+	return nil, v1beta1.StatusOK()
+}
+
+func createTestImageBuild(name string, reason apiimagebuilder.ImageBuildConditionReason, lastSeen time.Time) *apiimagebuilder.ImageBuild {
+	now := time.Now().UTC()
+	conditions := []apiimagebuilder.ImageBuildCondition{
+		{
+			Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+			Status:             v1beta1.ConditionStatusFalse,
+			Reason:             string(reason),
+			Message:            "test",
+			LastTransitionTime: now,
+		},
+	}
+
+	return &apiimagebuilder.ImageBuild{
+		ApiVersion: apiimagebuilder.ImageBuildAPIVersion,
+		Kind:       string(apiimagebuilder.ResourceKindImageBuild),
+		Metadata: v1beta1.ObjectMeta{
+			Name: lo.ToPtr(name),
+		},
+		Status: &apiimagebuilder.ImageBuildStatus{
+			Conditions: &conditions,
+			LastSeen:   &lastSeen,
+		},
+	}
+}
+
+func createTestImageExport(name string, reason apiimagebuilder.ImageExportConditionReason, lastSeen time.Time) *apiimagebuilder.ImageExport {
+	now := time.Now().UTC()
+	conditions := []apiimagebuilder.ImageExportCondition{
+		{
+			Type:               apiimagebuilder.ImageExportConditionTypeReady,
+			Status:             v1beta1.ConditionStatusFalse,
+			Reason:             string(reason),
+			Message:            "test",
+			LastTransitionTime: now,
+		},
+	}
+
+	return &apiimagebuilder.ImageExport{
+		ApiVersion: apiimagebuilder.ImageExportAPIVersion,
+		Kind:       string(apiimagebuilder.ResourceKindImageExport),
+		Metadata: v1beta1.ObjectMeta{
+			Name: lo.ToPtr(name),
+		},
+		Status: &apiimagebuilder.ImageExportStatus{
+			Conditions: &conditions,
+			LastSeen:   &lastSeen,
+		},
+	}
+}
+
+func TestCheckAndMarkTimeoutsForOrg(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	timeoutDuration := 5 * time.Minute
+	logger := logrus.NewEntry(logrus.New())
+
+	tests := []struct {
+		name                   string
+		setupBuilds            []*apiimagebuilder.ImageBuild
+		setupExports           []*apiimagebuilder.ImageExport
+		timeoutDuration        time.Duration
+		expectedUpdatedBuilds  []string
+		expectedUpdatedExports []string
+	}{
+		{
+			name: "marks timed-out Building ImageBuild as Failed",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-1", apiimagebuilder.ImageBuildConditionReasonBuilding, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{"build-1"},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name:        "marks timed-out Converting ImageExport as Failed",
+			setupBuilds: []*apiimagebuilder.ImageBuild{},
+			setupExports: []*apiimagebuilder.ImageExport{
+				createTestImageExport("export-1", apiimagebuilder.ImageExportConditionReasonConverting, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{},
+			expectedUpdatedExports: []string{"export-1"},
+		},
+		{
+			name: "marks timed-out Pushing ImageBuild as Failed",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-2", apiimagebuilder.ImageBuildConditionReasonPushing, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{"build-2"},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name: "does not mark recent Building ImageBuild",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-3", apiimagebuilder.ImageBuildConditionReasonBuilding, time.Now().UTC().Add(-1*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name: "does not mark Pending ImageBuild (excluded by field selector)",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-4", apiimagebuilder.ImageBuildConditionReasonPending, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name: "does not mark Completed ImageBuild (excluded by field selector)",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-5", apiimagebuilder.ImageBuildConditionReasonCompleted, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name: "does not mark Failed ImageBuild (excluded by field selector)",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-6", apiimagebuilder.ImageBuildConditionReasonFailed, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports:           []*apiimagebuilder.ImageExport{},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{},
+			expectedUpdatedExports: []string{},
+		},
+		{
+			name: "marks multiple timed-out resources",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-7", apiimagebuilder.ImageBuildConditionReasonBuilding, time.Now().UTC().Add(-10*time.Minute)),
+				createTestImageBuild("build-8", apiimagebuilder.ImageBuildConditionReasonPushing, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			setupExports: []*apiimagebuilder.ImageExport{
+				createTestImageExport("export-2", apiimagebuilder.ImageExportConditionReasonConverting, time.Now().UTC().Add(-10*time.Minute)),
+				createTestImageExport("export-3", apiimagebuilder.ImageExportConditionReasonPushing, time.Now().UTC().Add(-10*time.Minute)),
+			},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{"build-7", "build-8"},
+			expectedUpdatedExports: []string{"export-2", "export-3"},
+		},
+		{
+			name: "handles mix of timed-out and recent resources",
+			setupBuilds: []*apiimagebuilder.ImageBuild{
+				createTestImageBuild("build-9", apiimagebuilder.ImageBuildConditionReasonBuilding, time.Now().UTC().Add(-10*time.Minute)),
+				createTestImageBuild("build-10", apiimagebuilder.ImageBuildConditionReasonBuilding, time.Now().UTC().Add(-1*time.Minute)),
+			},
+			setupExports: []*apiimagebuilder.ImageExport{
+				createTestImageExport("export-4", apiimagebuilder.ImageExportConditionReasonConverting, time.Now().UTC().Add(-10*time.Minute)),
+				createTestImageExport("export-5", apiimagebuilder.ImageExportConditionReasonConverting, time.Now().UTC().Add(-1*time.Minute)),
+			},
+			timeoutDuration:        timeoutDuration,
+			expectedUpdatedBuilds:  []string{"build-9"},
+			expectedUpdatedExports: []string{"export-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			mockService := newMockImageBuilderService()
+			mockService.imageBuilds = tt.setupBuilds
+			mockService.imageExports = tt.setupExports
+
+			consumer := &Consumer{
+				imageBuilderService: mockService,
+				cfg:                 &config.Config{},
+				log:                 logger,
+			}
+
+			// Execute
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, tt.timeoutDuration, logger)
+			require.NoError(t, err)
+			expectedFailedCount := len(tt.expectedUpdatedBuilds) + len(tt.expectedUpdatedExports)
+			assert.Equal(t, expectedFailedCount, failedCount, "failed count should match expected")
+
+			// Verify updated builds
+			assert.Equal(t, len(tt.expectedUpdatedBuilds), len(mockService.updatedBuilds), "number of updated builds should match")
+			for _, expectedName := range tt.expectedUpdatedBuilds {
+				updated, ok := mockService.updatedBuilds[expectedName]
+				require.True(t, ok, "build %s should have been updated", expectedName)
+
+				// Verify it was marked as Failed
+				readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+				require.NotNil(t, readyCondition, "build %s should have Ready condition", expectedName)
+				assert.Equal(t, string(apiimagebuilder.ImageBuildConditionReasonFailed), readyCondition.Reason, "build %s should be marked as Failed", expectedName)
+				assert.Equal(t, v1beta1.ConditionStatusFalse, readyCondition.Status, "build %s should have Status False", expectedName)
+				assert.Contains(t, readyCondition.Message, "timed out", "build %s should have timeout message", expectedName)
+			}
+
+			// Verify updated exports
+			assert.Equal(t, len(tt.expectedUpdatedExports), len(mockService.updatedExports), "number of updated exports should match")
+			for _, expectedName := range tt.expectedUpdatedExports {
+				updated, ok := mockService.updatedExports[expectedName]
+				require.True(t, ok, "export %s should have been updated", expectedName)
+
+				// Verify it was marked as Failed
+				readyCondition := apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+				require.NotNil(t, readyCondition, "export %s should have Ready condition", expectedName)
+				assert.Equal(t, string(apiimagebuilder.ImageExportConditionReasonFailed), readyCondition.Reason, "export %s should be marked as Failed", expectedName)
+				assert.Equal(t, v1beta1.ConditionStatusFalse, readyCondition.Status, "export %s should have Status False", expectedName)
+				assert.Contains(t, readyCondition.Message, "timed out", "export %s should have timeout message", expectedName)
+			}
+		})
+	}
+}

--- a/internal/imagebuilder_worker/worker.go
+++ b/internal/imagebuilder_worker/worker.go
@@ -7,7 +7,9 @@ import (
 	"syscall"
 
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/crypto"
+	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
 	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
 	"github.com/flightctl/flightctl/internal/imagebuilder_worker/tasks"
 	"github.com/flightctl/flightctl/internal/kvstore"
@@ -59,8 +61,16 @@ func (w *Worker) Run(ctx context.Context) error {
 	w.log.Println("Initializing ImageBuilder Worker")
 	w.log.Printf("Starting with maxConcurrentBuilds: %d", w.cfg.ImageBuilderWorker.MaxConcurrentBuilds)
 
+	// Create imagebuilder service
+	queueProducer, err := w.queuesProvider.NewQueueProducer(ctx, consts.ImageBuildTaskQueue)
+	if err != nil {
+		w.log.WithError(err).Error("failed to create queue producer for service")
+		return err
+	}
+	imageBuilderService := imagebuilderapi.NewService(ctx, w.store, w.mainStore, queueProducer, w.log)
+
 	// Launch queue consumers
-	if err := tasks.LaunchConsumers(ctx, w.queuesProvider, w.store, w.mainStore, w.kvStore, w.serviceHandler, w.cfg, w.log); err != nil {
+	if err := tasks.LaunchConsumers(ctx, w.queuesProvider, w.store, w.mainStore, w.kvStore, w.serviceHandler, imageBuilderService, w.cfg, w.log); err != nil {
 		w.log.WithError(err).Error("failed to launch consumers")
 		return err
 	}

--- a/test/integration/imagebuilder_store/imagebuild_test.go
+++ b/test/integration/imagebuilder_store/imagebuild_test.go
@@ -523,7 +523,7 @@ var _ = Describe("ImageBuildStore", func() {
 
 			_, err := storeInst.ImageBuild().UpdateStatus(ctx, orgId, imageBuild)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+			Expect(err).To(MatchError(flterrors.ErrNoRowsUpdated))
 		})
 	})
 

--- a/test/integration/imagebuilder_store/imageexport_test.go
+++ b/test/integration/imagebuilder_store/imageexport_test.go
@@ -572,7 +572,7 @@ var _ = Describe("ImageExportStore", func() {
 
 			_, err := storeInst.ImageExport().UpdateStatus(ctx, orgId, imageExport)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+			Expect(err).To(MatchError(flterrors.ErrNoRowsUpdated))
 		})
 	})
 

--- a/test/integration/imagebuilder_worker/containerfile_test.go
+++ b/test/integration/imagebuilder_worker/containerfile_test.go
@@ -32,9 +32,9 @@ var (
 	suiteCtx context.Context
 )
 
-func TestContainerfileGeneration(t *testing.T) {
+func TestImageBuilderWorker(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Containerfile Generation Suite")
+	RunSpecs(t, "ImageBuilder Worker Integration Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/test/integration/imagebuilder_worker/imagebuild_update_test.go
+++ b/test/integration/imagebuilder_worker/imagebuild_update_test.go
@@ -1,0 +1,505 @@
+package imagebuilder_worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
+	"github.com/flightctl/flightctl/internal/imagebuilder_worker/tasks"
+	flightctlstore "github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/testutil"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutilpkg "github.com/flightctl/flightctl/test/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+// TestImageBuildUpdateSuite is kept for compatibility but RunSpecs is handled by the package-level suite
+func TestImageBuildUpdateSuite(t *testing.T) {
+	// RunSpecs is called in containerfile_test.go for the entire package
+}
+
+var _ = Describe("ImageBuild Update Integration Tests", func() {
+	var (
+		log                 *logrus.Logger
+		ctx                 context.Context
+		orgID               uuid.UUID
+		mainStore           flightctlstore.Store
+		imageBuilderStore   imagebuilderstore.Store
+		imageBuilderService service.Service
+		consumer            *tasks.Consumer
+		cfg                 *config.Config
+		dbName              string
+		db                  *gorm.DB
+		ctrl                *gomock.Controller
+		mockQueueProducer   *queues.MockQueueProducer
+		enqueuedEvents      []EnqueuedEvent
+		testID              string
+		testRepoName        string
+		sourceRepoName      string
+		outputRepoName      string
+	)
+
+	BeforeEach(func() {
+		ctx = testutilpkg.StartSpecTracerForGinkgo(suiteCtx)
+		log = flightlog.InitLogs()
+
+		// Extract test ID from context
+		testID = ctx.Value(testutilpkg.TestIDKey).(string)
+		testRepoName = fmt.Sprintf("test-repo-%s", testID)
+		sourceRepoName = fmt.Sprintf("source-repo-%s", testID)
+		outputRepoName = fmt.Sprintf("output-repo-%s", testID)
+
+		// Use main store's PrepareDBForUnitTests which includes organizations table
+		mainStore, cfg, dbName, db = flightctlstore.PrepareDBForUnitTests(ctx, log)
+
+		// Create imagebuilder store on the same db connection
+		imageBuilderStore = imagebuilderstore.NewStore(db, log.WithField("pkg", "imagebuilder-store"))
+
+		// Run imagebuilder-specific migrations only for local strategy
+		strategy := os.Getenv("FLIGHTCTL_TEST_DB_STRATEGY")
+		if strategy != testutil.StrategyTemplate {
+			err := imageBuilderStore.RunMigrations(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Create test organization (required for foreign key constraint)
+		orgID = uuid.New()
+		err := testutilpkg.CreateTestOrganization(ctx, mainStore, orgID)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create required repositories for ImageBuild/ImageExport tests with unique test-id-based names
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, testRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, sourceRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Create output-repo with ReadWrite access mode (required for ImageExport destination)
+		outputRepo, err := createOCIRepository(ctx, mainStore.Repository(), orgID, outputRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Update output-repo to have ReadWrite access mode
+		ociSpec, err := outputRepo.Spec.AsOciRepoSpec()
+		Expect(err).ToNot(HaveOccurred())
+		ociSpec.AccessMode = lo.ToPtr(v1beta1.ReadWrite)
+		err = outputRepo.Spec.FromOciRepoSpec(ociSpec)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = mainStore.Repository().Update(ctx, orgID, outputRepo, flightctlstore.EventCallback(func(context.Context, v1beta1.ResourceKind, uuid.UUID, string, interface{}, interface{}, bool, error) {
+		}))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create imagebuilder service
+		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, log)
+
+		// Setup mock queue producer to capture enqueued events
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer = queues.NewMockQueueProducer(ctrl)
+		enqueuedEvents = make([]EnqueuedEvent, 0)
+
+		// Capture enqueued events
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, payload []byte, timestamp int64) error {
+				var eventWithOrgId worker_client.EventWithOrgId
+				if err := json.Unmarshal(payload, &eventWithOrgId); err == nil {
+					enqueuedEvents = append(enqueuedEvents, EnqueuedEvent{
+						OrgID:   eventWithOrgId.OrgId,
+						Event:   eventWithOrgId.Event,
+						Payload: payload,
+					})
+				}
+				return nil
+			}).
+			AnyTimes()
+
+		// Create consumer
+		consumer = tasks.NewConsumer(
+			imageBuilderStore,
+			mainStore,
+			nil, // kvStore
+			nil, // serviceHandler
+			imageBuilderService,
+			mockQueueProducer,
+			&config.Config{},
+			log,
+		)
+	})
+
+	AfterEach(func() {
+		flightctlstore.DeleteTestDB(ctx, log, cfg, mainStore, dbName)
+		ctrl.Finish()
+	})
+
+	// Helper function to create an ImageBuild with specific status
+	createImageBuildWithStatus := func(name string, reason apiimagebuilder.ImageBuildConditionReason) *apiimagebuilder.ImageBuild {
+		imageBuild := &apiimagebuilder.ImageBuild{
+			ApiVersion: apiimagebuilder.ImageBuildAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageBuild),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageBuildSpec{
+				Source: apiimagebuilder.ImageBuildSource{
+					Repository: testRepoName,
+					ImageName:  "test-image",
+					ImageTag:   "v1.0.0",
+				},
+				Destination: apiimagebuilder.ImageBuildDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageBuild().Create(ctx, orgID, *imageBuild)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status
+		toUpdate, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition
+		now := time.Now().UTC()
+		statusValue := v1beta1.ConditionStatusFalse
+		if reason == apiimagebuilder.ImageBuildConditionReasonCompleted {
+			statusValue = v1beta1.ConditionStatusTrue
+		}
+		conditions := []apiimagebuilder.ImageBuildCondition{
+			{
+				Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+				Status:             statusValue,
+				Reason:             string(reason),
+				Message:            "test",
+				LastTransitionTime: now,
+			},
+		}
+		toUpdate.Status = &apiimagebuilder.ImageBuildStatus{
+			Conditions: &conditions,
+		}
+
+		// Update status
+		_, err := imageBuilderService.ImageBuild().UpdateStatus(ctx, orgID, toUpdate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	// Helper function to create an ImageExport with specific status that references an ImageBuild
+	createImageExportWithImageBuildRef := func(name string, imageBuildName string, reason apiimagebuilder.ImageExportConditionReason) *apiimagebuilder.ImageExport {
+		source := apiimagebuilder.ImageExportSource{}
+		err := source.FromImageBuildRefSource(apiimagebuilder.ImageBuildRefSource{
+			Type:          apiimagebuilder.ImageBuildRefSourceTypeImageBuild,
+			ImageBuildRef: imageBuildName,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		imageExport := &apiimagebuilder.ImageExport{
+			ApiVersion: apiimagebuilder.ImageExportAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageExport),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageExportSpec{
+				Source: source,
+				Destination: apiimagebuilder.ImageExportDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+				Format: apiimagebuilder.ExportFormatTypeQCOW2,
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageExport().Create(ctx, orgID, *imageExport)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status if needed
+		toUpdate, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition if reason is provided
+		if reason != "" {
+			now := time.Now().UTC()
+			statusValue := v1beta1.ConditionStatusFalse
+			if reason == apiimagebuilder.ImageExportConditionReasonCompleted {
+				statusValue = v1beta1.ConditionStatusTrue
+			}
+			conditions := []apiimagebuilder.ImageExportCondition{
+				{
+					Type:               apiimagebuilder.ImageExportConditionTypeReady,
+					Status:             statusValue,
+					Reason:             string(reason),
+					Message:            "test",
+					LastTransitionTime: now,
+				},
+			}
+			toUpdate.Status = &apiimagebuilder.ImageExportStatus{
+				Conditions: &conditions,
+			}
+
+			// Update status
+			_, err = imageBuilderService.ImageExport().UpdateStatus(ctx, orgID, toUpdate)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	// Helper function to create a ResourceUpdated event for an ImageBuild
+	createImageBuildUpdateEvent := func(imageBuildName string) worker_client.EventWithOrgId {
+		event := domain.GetBaseEvent(
+			ctx,
+			domain.ResourceKind(string(apiimagebuilder.ResourceKindImageBuild)),
+			imageBuildName,
+			domain.EventReasonResourceUpdated,
+			"ImageBuild status was updated successfully.",
+			nil,
+		)
+		return worker_client.EventWithOrgId{
+			OrgId: orgID,
+			Event: *event,
+		}
+	}
+
+	Context("ImageBuild Update Handler", func() {
+		It("should requeue Pending ImageExports when ImageBuild completes", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-1"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create ImageExports that reference this ImageBuild
+			createImageExportWithImageBuildRef("pending-export-1", imageBuildName, apiimagebuilder.ImageExportConditionReasonPending)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that the Pending ImageExport was requeued
+			Expect(len(enqueuedEvents)).To(Equal(1))
+			event := enqueuedEvents[0]
+			Expect(event.OrgID).To(Equal(orgID))
+			Expect(event.Event.InvolvedObject.Kind).To(Equal(string(apiimagebuilder.ResourceKindImageExport)))
+			Expect(event.Event.InvolvedObject.Name).To(Equal("pending-export-1"))
+			Expect(event.Event.Reason).To(Equal(domain.EventReasonResourceCreated))
+		})
+
+		It("should requeue ImageExports with no Ready condition when ImageBuild completes", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-2"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create ImageExport with no status (no Ready condition)
+			createImageExportWithImageBuildRef("no-status-export-1", imageBuildName, "")
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that the ImageExport was requeued
+			Expect(len(enqueuedEvents)).To(Equal(1))
+			event := enqueuedEvents[0]
+			Expect(event.Event.InvolvedObject.Name).To(Equal("no-status-export-1"))
+		})
+
+		It("should not requeue Converting ImageExports when ImageBuild completes", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-3"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create ImageExport that is already Converting
+			createImageExportWithImageBuildRef("converting-export-1", imageBuildName, apiimagebuilder.ImageExportConditionReasonConverting)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+
+		It("should not requeue Completed ImageExports when ImageBuild completes", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-4"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create ImageExport that is already Completed
+			createImageExportWithImageBuildRef("completed-export-1", imageBuildName, apiimagebuilder.ImageExportConditionReasonCompleted)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+
+		It("should not requeue Failed ImageExports when ImageBuild completes", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-5"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create ImageExport that is already Failed
+			createImageExportWithImageBuildRef("failed-export-1", imageBuildName, apiimagebuilder.ImageExportConditionReasonFailed)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+
+		It("should not requeue ImageExports when ImageBuild is not completed", func() {
+			// Create a Building ImageBuild (not completed)
+			imageBuildName := "building-build-1"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonBuilding)
+
+			// Create ImageExport that references this ImageBuild
+			createImageExportWithImageBuildRef("pending-export-2", imageBuildName, apiimagebuilder.ImageExportConditionReasonPending)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued (ImageBuild is not completed)
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+
+		It("should handle multiple ImageExports correctly", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-6"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Create multiple ImageExports with different states
+			createImageExportWithImageBuildRef("pending-export-3", imageBuildName, apiimagebuilder.ImageExportConditionReasonPending)
+			createImageExportWithImageBuildRef("no-status-export-2", imageBuildName, "")
+			createImageExportWithImageBuildRef("converting-export-2", imageBuildName, apiimagebuilder.ImageExportConditionReasonConverting)
+			createImageExportWithImageBuildRef("completed-export-2", imageBuildName, apiimagebuilder.ImageExportConditionReasonCompleted)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that only Pending and no-status ImageExports were requeued
+			Expect(len(enqueuedEvents)).To(Equal(2))
+
+			// Check that pending-export-3 and no-status-export-2 were requeued
+			requeuedNames := make(map[string]bool)
+			for _, event := range enqueuedEvents {
+				requeuedNames[event.Event.InvolvedObject.Name] = true
+			}
+			Expect(requeuedNames["pending-export-3"]).To(BeTrue())
+			Expect(requeuedNames["no-status-export-2"]).To(BeTrue())
+			Expect(requeuedNames["converting-export-2"]).To(BeFalse())
+			Expect(requeuedNames["completed-export-2"]).To(BeFalse())
+		})
+
+		It("should handle ImageBuild with no status gracefully", func() {
+			// Create an ImageBuild with no status
+			imageBuildName := "no-status-build-1"
+			imageBuild := &apiimagebuilder.ImageBuild{
+				ApiVersion: apiimagebuilder.ImageBuildAPIVersion,
+				Kind:       string(apiimagebuilder.ResourceKindImageBuild),
+				Metadata: v1beta1.ObjectMeta{
+					Name: lo.ToPtr(imageBuildName),
+				},
+				Spec: apiimagebuilder.ImageBuildSpec{
+					Source: apiimagebuilder.ImageBuildSource{
+						Repository: testRepoName,
+						ImageName:  "test-image",
+						ImageTag:   "v1.0.0",
+					},
+					Destination: apiimagebuilder.ImageBuildDestination{
+						Repository: outputRepoName,
+						ImageName:  "output-image",
+						Tag:        "v1.0.0",
+					},
+				},
+			}
+
+			_, status := imageBuilderService.ImageBuild().Create(ctx, orgID, *imageBuild)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			// Create ImageExport that references this ImageBuild
+			createImageExportWithImageBuildRef("pending-export-4", imageBuildName, apiimagebuilder.ImageExportConditionReasonPending)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued (ImageBuild has no status)
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+
+		It("should handle ImageBuild with no ImageExports gracefully", func() {
+			// Create a completed ImageBuild
+			imageBuildName := "completed-build-7"
+			createImageBuildWithStatus(imageBuildName, apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Create and handle the update event
+			eventWithOrgId := createImageBuildUpdateEvent(imageBuildName)
+			err := consumer.HandleImageBuildUpdate(ctx, eventWithOrgId, log)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that nothing was requeued (no ImageExports reference this ImageBuild)
+			Expect(len(enqueuedEvents)).To(Equal(0))
+		})
+	})
+})

--- a/test/integration/imagebuilder_worker/requeue_test.go
+++ b/test/integration/imagebuilder_worker/requeue_test.go
@@ -1,0 +1,486 @@
+package imagebuilder_worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
+	"github.com/flightctl/flightctl/internal/imagebuilder_worker/tasks"
+	flightctlstore "github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/testutil"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutilpkg "github.com/flightctl/flightctl/test/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+// TestRequeueSuite is kept for compatibility but RunSpecs is handled by the package-level suite
+func TestRequeueSuite(t *testing.T) {
+	// RunSpecs is called in containerfile_test.go for the entire package
+}
+
+var _ = Describe("Requeue Integration Tests", func() {
+	var (
+		log                 *logrus.Logger
+		ctx                 context.Context
+		orgID               uuid.UUID
+		mainStore           flightctlstore.Store
+		imageBuilderStore   imagebuilderstore.Store
+		imageBuilderService service.Service
+		consumer            *tasks.Consumer
+		cfg                 *config.Config
+		dbName              string
+		db                  *gorm.DB
+		ctrl                *gomock.Controller
+		mockQueueProducer   *queues.MockQueueProducer
+		enqueuedEvents      []EnqueuedEvent
+		testID              string
+		testRepoName        string
+		sourceRepoName      string
+		outputRepoName      string
+	)
+
+	BeforeEach(func() {
+		ctx = testutilpkg.StartSpecTracerForGinkgo(suiteCtx)
+		log = flightlog.InitLogs()
+
+		// Extract test ID from context
+		testID = ctx.Value(testutilpkg.TestIDKey).(string)
+		testRepoName = fmt.Sprintf("test-repo-%s", testID)
+		sourceRepoName = fmt.Sprintf("source-repo-%s", testID)
+		outputRepoName = fmt.Sprintf("output-repo-%s", testID)
+
+		// Use main store's PrepareDBForUnitTests which includes organizations table
+		mainStore, cfg, dbName, db = flightctlstore.PrepareDBForUnitTests(ctx, log)
+
+		// Create imagebuilder store on the same db connection
+		imageBuilderStore = imagebuilderstore.NewStore(db, log.WithField("pkg", "imagebuilder-store"))
+
+		// Run imagebuilder-specific migrations only for local strategy
+		strategy := os.Getenv("FLIGHTCTL_TEST_DB_STRATEGY")
+		if strategy != testutil.StrategyTemplate {
+			err := imageBuilderStore.RunMigrations(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Create test organization (required for foreign key constraint)
+		orgID = uuid.New()
+		err := testutilpkg.CreateTestOrganization(ctx, mainStore, orgID)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create required repositories for ImageBuild/ImageExport tests with unique test-id-based names
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, testRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, sourceRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Create output-repo with ReadWrite access mode (required for ImageExport destination)
+		outputRepo, err := createOCIRepository(ctx, mainStore.Repository(), orgID, outputRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Update output-repo to have ReadWrite access mode
+		ociSpec, err := outputRepo.Spec.AsOciRepoSpec()
+		Expect(err).ToNot(HaveOccurred())
+		ociSpec.AccessMode = lo.ToPtr(v1beta1.ReadWrite)
+		err = outputRepo.Spec.FromOciRepoSpec(ociSpec)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = mainStore.Repository().Update(ctx, orgID, outputRepo, flightctlstore.EventCallback(func(context.Context, v1beta1.ResourceKind, uuid.UUID, string, interface{}, interface{}, bool, error) {
+		}))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create imagebuilder service
+		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, log)
+
+		// Setup mock queue producer to capture enqueued events
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer = queues.NewMockQueueProducer(ctrl)
+		enqueuedEvents = make([]EnqueuedEvent, 0)
+
+		// Capture enqueued events
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, payload []byte, timestamp int64) error {
+				var eventWithOrgId worker_client.EventWithOrgId
+				if err := json.Unmarshal(payload, &eventWithOrgId); err == nil {
+					enqueuedEvents = append(enqueuedEvents, EnqueuedEvent{
+						OrgID:   eventWithOrgId.OrgId,
+						Event:   eventWithOrgId.Event,
+						Payload: payload,
+					})
+				}
+				return nil
+			}).
+			AnyTimes()
+
+		// Create consumer
+		consumer = tasks.NewConsumer(
+			imageBuilderStore,
+			mainStore,
+			nil, // kvStore
+			nil, // serviceHandler
+			imageBuilderService,
+			mockQueueProducer,
+			&config.Config{},
+			log,
+		)
+	})
+
+	AfterEach(func() {
+		flightctlstore.DeleteTestDB(ctx, log, cfg, mainStore, dbName)
+		ctrl.Finish()
+	})
+
+	// Helper function to create an ImageBuild with specific status
+	createImageBuildWithStatus := func(name string, reason apiimagebuilder.ImageBuildConditionReason) *apiimagebuilder.ImageBuild {
+		imageBuild := &apiimagebuilder.ImageBuild{
+			ApiVersion: apiimagebuilder.ImageBuildAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageBuild),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageBuildSpec{
+				Source: apiimagebuilder.ImageBuildSource{
+					Repository: testRepoName,
+					ImageName:  "test-image",
+					ImageTag:   "v1.0.0",
+				},
+				Destination: apiimagebuilder.ImageBuildDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageBuild().Create(ctx, orgID, *imageBuild)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status
+		toUpdate, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition
+		now := time.Now().UTC()
+		conditions := []apiimagebuilder.ImageBuildCondition{
+			{
+				Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+				Status:             v1beta1.ConditionStatusFalse,
+				Reason:             string(reason),
+				Message:            "test",
+				LastTransitionTime: now,
+			},
+		}
+		toUpdate.Status = &apiimagebuilder.ImageBuildStatus{
+			Conditions: &conditions,
+		}
+
+		// Update status
+		_, err := imageBuilderService.ImageBuild().UpdateStatus(ctx, orgID, toUpdate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	// Helper function to create an ImageExport with specific status
+	createImageExportWithStatus := func(name string, reason apiimagebuilder.ImageExportConditionReason) *apiimagebuilder.ImageExport {
+		source := apiimagebuilder.ImageExportSource{}
+		err := source.FromImageReferenceSource(apiimagebuilder.ImageReferenceSource{
+			Type:       apiimagebuilder.ImageReference,
+			Repository: sourceRepoName,
+			ImageName:  "source-image",
+			ImageTag:   "v1.0.0",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		imageExport := &apiimagebuilder.ImageExport{
+			ApiVersion: apiimagebuilder.ImageExportAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageExport),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageExportSpec{
+				Source: source,
+				Destination: apiimagebuilder.ImageExportDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+				Format: apiimagebuilder.ExportFormatTypeQCOW2,
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageExport().Create(ctx, orgID, *imageExport)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status
+		toUpdate, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition
+		now := time.Now().UTC()
+		conditions := []apiimagebuilder.ImageExportCondition{
+			{
+				Type:               apiimagebuilder.ImageExportConditionTypeReady,
+				Status:             v1beta1.ConditionStatusFalse,
+				Reason:             string(reason),
+				Message:            "test",
+				LastTransitionTime: now,
+			},
+		}
+		toUpdate.Status = &apiimagebuilder.ImageExportStatus{
+			Conditions: &conditions,
+		}
+
+		// Update status
+		_, err = imageBuilderService.ImageExport().UpdateStatus(ctx, orgID, toUpdate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	Context("Requeue on Startup", func() {
+		It("should requeue Pending ImageBuilds", func() {
+			// Create a Pending ImageBuild
+			createImageBuildWithStatus("pending-build-1", apiimagebuilder.ImageBuildConditionReasonPending)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that the ImageBuild was requeued
+			Expect(len(enqueuedEvents)).To(Equal(1))
+			event := enqueuedEvents[0]
+			Expect(event.OrgID).To(Equal(orgID))
+			Expect(event.Event.InvolvedObject.Kind).To(Equal(string(apiimagebuilder.ResourceKindImageBuild)))
+			Expect(event.Event.InvolvedObject.Name).To(Equal("pending-build-1"))
+			Expect(event.Event.Reason).To(Equal(v1beta1.EventReasonResourceCreated))
+		})
+
+		It("should mark non-Pending, non-terminal ImageBuilds as Failed", func() {
+			// Create a Building ImageBuild (started processing)
+			createImageBuildWithStatus("building-build-1", apiimagebuilder.ImageBuildConditionReasonBuilding)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageBuild was marked as Failed
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "building-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+			Expect(readyCondition.Message).To(ContainSubstring("was in progress on startup"))
+		})
+
+		It("should not requeue Completed ImageBuilds", func() {
+			// Create a Completed ImageBuild
+			createImageBuildWithStatus("completed-build-1", apiimagebuilder.ImageBuildConditionReasonCompleted)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageBuild status is unchanged
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "completed-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonCompleted)))
+		})
+
+		It("should not requeue Failed ImageBuilds", func() {
+			// Create a Failed ImageBuild
+			createImageBuildWithStatus("failed-build-1", apiimagebuilder.ImageBuildConditionReasonFailed)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageBuild status is unchanged
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "failed-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+		})
+
+		It("should requeue Pending ImageExports", func() {
+			// Create a Pending ImageExport
+			createImageExportWithStatus("pending-export-1", apiimagebuilder.ImageExportConditionReasonPending)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that the ImageExport was requeued
+			Expect(len(enqueuedEvents)).To(Equal(1))
+			event := enqueuedEvents[0]
+			Expect(event.OrgID).To(Equal(orgID))
+			Expect(event.Event.InvolvedObject.Kind).To(Equal(string(apiimagebuilder.ResourceKindImageExport)))
+			Expect(event.Event.InvolvedObject.Name).To(Equal("pending-export-1"))
+			Expect(event.Event.Reason).To(Equal(v1beta1.EventReasonResourceCreated))
+		})
+
+		It("should mark non-Pending, non-terminal ImageExports as Failed", func() {
+			// Create a Converting ImageExport (started processing)
+			createImageExportWithStatus("converting-export-1", apiimagebuilder.ImageExportConditionReasonConverting)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageExport was marked as Failed
+			updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, "converting-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonFailed)))
+			Expect(readyCondition.Message).To(ContainSubstring("was in progress on startup"))
+		})
+
+		It("should handle mix of resources correctly", func() {
+			// Create resources with different states
+			createImageBuildWithStatus("pending-build-2", apiimagebuilder.ImageBuildConditionReasonPending)
+			createImageBuildWithStatus("building-build-2", apiimagebuilder.ImageBuildConditionReasonBuilding)
+			createImageBuildWithStatus("completed-build-2", apiimagebuilder.ImageBuildConditionReasonCompleted)
+			createImageExportWithStatus("pending-export-2", apiimagebuilder.ImageExportConditionReasonPending)
+			createImageExportWithStatus("converting-export-2", apiimagebuilder.ImageExportConditionReasonConverting)
+			createImageExportWithStatus("completed-export-2", apiimagebuilder.ImageExportConditionReasonCompleted)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that only Pending resources were requeued
+			Expect(len(enqueuedEvents)).To(Equal(2))
+
+			// Check that pending-build-2 and pending-export-2 were requeued
+			requeuedNames := make(map[string]bool)
+			for _, event := range enqueuedEvents {
+				requeuedNames[event.Event.InvolvedObject.Name] = true
+			}
+			Expect(requeuedNames["pending-build-2"]).To(BeTrue())
+			Expect(requeuedNames["pending-export-2"]).To(BeTrue())
+
+			// Verify building-build-2 was marked as Failed
+			build, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "building-build-2", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*build.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+
+			// Verify completed-build-2 was not changed
+			build, status = imageBuilderService.ImageBuild().Get(ctx, orgID, "completed-build-2", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition = apiimagebuilder.FindImageBuildStatusCondition(*build.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonCompleted)))
+
+			// Verify converting-export-2 was marked as Failed
+			export, status := imageBuilderService.ImageExport().Get(ctx, orgID, "converting-export-2")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition2 := apiimagebuilder.FindImageExportStatusCondition(*export.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition2.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonFailed)))
+
+			// Verify completed-export-2 was not changed
+			export, status = imageBuilderService.ImageExport().Get(ctx, orgID, "completed-export-2")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition2 = apiimagebuilder.FindImageExportStatusCondition(*export.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition2.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonCompleted)))
+		})
+
+		It("should mark Pushing ImageBuild as Failed", func() {
+			// Create a Pushing ImageBuild (started processing)
+			createImageBuildWithStatus("pushing-build-1", apiimagebuilder.ImageBuildConditionReasonPushing)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageBuild was marked as Failed
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "pushing-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+		})
+
+		It("should mark Pushing ImageExport as Failed", func() {
+			// Create a Pushing ImageExport (started processing)
+			createImageExportWithStatus("pushing-export-1", apiimagebuilder.ImageExportConditionReasonPushing)
+
+			// Clear enqueued events
+			enqueuedEvents = make([]EnqueuedEvent, 0)
+
+			// Run requeue task
+			consumer.RunRequeueOnStartup(ctx)
+
+			// Verify that nothing was requeued
+			Expect(len(enqueuedEvents)).To(Equal(0))
+
+			// Verify that the ImageExport was marked as Failed
+			updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, "pushing-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonFailed)))
+		})
+	})
+})
+
+// EnqueuedEvent represents an event that was enqueued during testing
+type EnqueuedEvent struct {
+	OrgID   uuid.UUID
+	Event   v1beta1.Event
+	Payload []byte
+}

--- a/test/integration/imagebuilder_worker/timeout_test.go
+++ b/test/integration/imagebuilder_worker/timeout_test.go
@@ -1,0 +1,452 @@
+package imagebuilder_worker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiimagebuilder "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
+	"github.com/flightctl/flightctl/internal/imagebuilder_worker/tasks"
+	flightctlstore "github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/testutil"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	testutilpkg "github.com/flightctl/flightctl/test/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// TestTimeoutSuite is kept for compatibility but RunSpecs is handled by the package-level suite
+func TestTimeoutSuite(t *testing.T) {
+	// RunSpecs is called in containerfile_test.go for the entire package
+}
+
+var _ = Describe("Timeout Check Integration Tests", func() {
+	var (
+		log                 *logrus.Logger
+		ctx                 context.Context
+		orgID               uuid.UUID
+		mainStore           flightctlstore.Store
+		imageBuilderStore   imagebuilderstore.Store
+		imageBuilderService service.Service
+		consumer            *tasks.Consumer
+		cfg                 *config.Config
+		dbName              string
+		db                  *gorm.DB
+		testID              string
+		testRepoName        string
+		sourceRepoName      string
+		outputRepoName      string
+	)
+
+	BeforeEach(func() {
+		ctx = testutilpkg.StartSpecTracerForGinkgo(suiteCtx)
+		log = flightlog.InitLogs()
+
+		// Extract test ID from context
+		testID = ctx.Value(testutilpkg.TestIDKey).(string)
+		testRepoName = fmt.Sprintf("test-repo-%s", testID)
+		sourceRepoName = fmt.Sprintf("source-repo-%s", testID)
+		outputRepoName = fmt.Sprintf("output-repo-%s", testID)
+
+		// Use main store's PrepareDBForUnitTests which includes organizations table
+		mainStore, cfg, dbName, db = flightctlstore.PrepareDBForUnitTests(ctx, log)
+
+		// Create imagebuilder store on the same db connection
+		imageBuilderStore = imagebuilderstore.NewStore(db, log.WithField("pkg", "imagebuilder-store"))
+
+		// Run imagebuilder-specific migrations only for local strategy
+		strategy := os.Getenv("FLIGHTCTL_TEST_DB_STRATEGY")
+		if strategy != testutil.StrategyTemplate {
+			err := imageBuilderStore.RunMigrations(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Create test organization (required for foreign key constraint)
+		orgID = uuid.New()
+		err := testutilpkg.CreateTestOrganization(ctx, mainStore, orgID)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create required repositories for ImageBuild/ImageExport tests with unique test-id-based names
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, testRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = createOCIRepository(ctx, mainStore.Repository(), orgID, sourceRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Create output-repo with ReadWrite access mode (required for ImageExport destination)
+		outputRepo, err := createOCIRepository(ctx, mainStore.Repository(), orgID, outputRepoName, "quay.io", nil)
+		Expect(err).ToNot(HaveOccurred())
+		// Update output-repo to have ReadWrite access mode
+		ociSpec, err := outputRepo.Spec.AsOciRepoSpec()
+		Expect(err).ToNot(HaveOccurred())
+		ociSpec.AccessMode = lo.ToPtr(v1beta1.ReadWrite)
+		err = outputRepo.Spec.FromOciRepoSpec(ociSpec)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = mainStore.Repository().Update(ctx, orgID, outputRepo, flightctlstore.EventCallback(func(context.Context, v1beta1.ResourceKind, uuid.UUID, string, interface{}, interface{}, bool, error) {
+		}))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create imagebuilder service
+		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, log)
+
+		// Create consumer
+		consumer = tasks.NewConsumer(
+			imageBuilderStore,
+			mainStore,
+			nil, // kvStore
+			nil, // serviceHandler
+			imageBuilderService,
+			nil, // queueProducer
+			&config.Config{},
+			log,
+		)
+	})
+
+	AfterEach(func() {
+		flightctlstore.DeleteTestDB(ctx, log, cfg, mainStore, dbName)
+	})
+
+	// Helper function to create an ImageBuild with specific status
+	createImageBuildWithStatus := func(name string, reason apiimagebuilder.ImageBuildConditionReason, lastSeen time.Time) *apiimagebuilder.ImageBuild {
+		imageBuild := &apiimagebuilder.ImageBuild{
+			ApiVersion: apiimagebuilder.ImageBuildAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageBuild),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageBuildSpec{
+				Source: apiimagebuilder.ImageBuildSource{
+					Repository: testRepoName,
+					ImageName:  "test-image",
+					ImageTag:   "v1.0.0",
+				},
+				Destination: apiimagebuilder.ImageBuildDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageBuild().Create(ctx, orgID, *imageBuild)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status
+		toUpdate, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition
+		now := time.Now().UTC()
+		conditions := []apiimagebuilder.ImageBuildCondition{
+			{
+				Type:               apiimagebuilder.ImageBuildConditionTypeReady,
+				Status:             v1beta1.ConditionStatusFalse,
+				Reason:             string(reason),
+				Message:            "test",
+				LastTransitionTime: now,
+			},
+		}
+		toUpdate.Status = &apiimagebuilder.ImageBuildStatus{
+			Conditions: &conditions,
+			LastSeen:   &lastSeen,
+		}
+
+		// Update status
+		_, err := imageBuilderService.ImageBuild().UpdateStatus(ctx, orgID, toUpdate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update lastSeen separately
+		err = imageBuilderStore.ImageBuild().UpdateLastSeen(ctx, orgID, name, lastSeen)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, name, false)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	// Helper function to create an ImageExport with specific status
+	createImageExportWithStatus := func(name string, reason apiimagebuilder.ImageExportConditionReason, lastSeen time.Time) *apiimagebuilder.ImageExport {
+		source := apiimagebuilder.ImageExportSource{}
+		err := source.FromImageReferenceSource(apiimagebuilder.ImageReferenceSource{
+			Type:       apiimagebuilder.ImageReference,
+			Repository: sourceRepoName,
+			ImageName:  "source-image",
+			ImageTag:   "v1.0.0",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		imageExport := &apiimagebuilder.ImageExport{
+			ApiVersion: apiimagebuilder.ImageExportAPIVersion,
+			Kind:       string(apiimagebuilder.ResourceKindImageExport),
+			Metadata: v1beta1.ObjectMeta{
+				Name: lo.ToPtr(name),
+			},
+			Spec: apiimagebuilder.ImageExportSpec{
+				Source: source,
+				Destination: apiimagebuilder.ImageExportDestination{
+					Repository: outputRepoName,
+					ImageName:  "output-image",
+					Tag:        "v1.0.0",
+				},
+				Format: apiimagebuilder.ExportFormatTypeQCOW2,
+			},
+		}
+
+		// Create the resource (status will be set to Pending by default)
+		_, status := imageBuilderService.ImageExport().Create(ctx, orgID, *imageExport)
+		Expect(status.Code).To(Equal(int32(201)))
+
+		// Get the created resource to update its status
+		toUpdate, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+
+		// Set the desired condition
+		now := time.Now().UTC()
+		conditions := []apiimagebuilder.ImageExportCondition{
+			{
+				Type:               apiimagebuilder.ImageExportConditionTypeReady,
+				Status:             v1beta1.ConditionStatusFalse,
+				Reason:             string(reason),
+				Message:            "test",
+				LastTransitionTime: now,
+			},
+		}
+		toUpdate.Status = &apiimagebuilder.ImageExportStatus{
+			Conditions: &conditions,
+			LastSeen:   &lastSeen,
+		}
+
+		// Update status
+		_, err = imageBuilderService.ImageExport().UpdateStatus(ctx, orgID, toUpdate)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Update lastSeen separately
+		err = imageBuilderStore.ImageExport().UpdateLastSeen(ctx, orgID, name, lastSeen)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the final resource
+		updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, name)
+		Expect(status.Code).To(Equal(int32(200)))
+		return updated
+	}
+
+	Context("Timeout Check for ImageBuilds", func() {
+		It("should mark timed-out Building ImageBuild as Failed", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+
+			// Create an ImageBuild in Building state with old lastSeen
+			createImageBuildWithStatus("timeout-build-1", apiimagebuilder.ImageBuildConditionReasonBuilding, oldLastSeen)
+
+			// Verify initial state
+			build, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "timeout-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*build.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonBuilding)))
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(1))
+
+			// Verify it was marked as Failed
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "timeout-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition = apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+			Expect(readyCondition.Message).To(ContainSubstring("timed out"))
+		})
+
+		It("should not mark recent Building ImageBuild", func() {
+			timeoutDuration := 5 * time.Minute
+			recentLastSeen := time.Now().UTC().Add(-1 * time.Minute)
+
+			// Create an ImageBuild in Building state with recent lastSeen
+			createImageBuildWithStatus("recent-build-1", apiimagebuilder.ImageBuildConditionReasonBuilding, recentLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(0))
+
+			// Verify it was NOT marked as Failed
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "recent-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonBuilding)))
+		})
+
+		It("should not mark Pending ImageBuild (excluded by field selector)", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+
+			// Create an ImageBuild in Pending state with old lastSeen
+			createImageBuildWithStatus("pending-build-1", apiimagebuilder.ImageBuildConditionReasonPending, oldLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(0))
+
+			// Verify it was NOT marked as Failed (Pending is excluded)
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "pending-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonPending)))
+		})
+
+		It("should mark timed-out Pushing ImageBuild as Failed", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+
+			// Create an ImageBuild in Pushing state with old lastSeen
+			createImageBuildWithStatus("pushing-build-1", apiimagebuilder.ImageBuildConditionReasonPushing, oldLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(1))
+
+			// Verify it was marked as Failed
+			updated, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "pushing-build-1", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+		})
+	})
+
+	Context("Timeout Check for ImageExports", func() {
+		It("should mark timed-out Converting ImageExport as Failed", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+
+			// Create an ImageExport in Converting state with old lastSeen
+			createImageExportWithStatus("timeout-export-1", apiimagebuilder.ImageExportConditionReasonConverting, oldLastSeen)
+
+			// Verify initial state
+			export, status := imageBuilderService.ImageExport().Get(ctx, orgID, "timeout-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*export.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonConverting)))
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(1))
+
+			// Verify it was marked as Failed
+			updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, "timeout-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition = apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonFailed)))
+			Expect(readyCondition.Message).To(ContainSubstring("timed out"))
+		})
+
+		It("should not mark recent Converting ImageExport", func() {
+			timeoutDuration := 5 * time.Minute
+			recentLastSeen := time.Now().UTC().Add(-1 * time.Minute)
+
+			// Create an ImageExport in Converting state with recent lastSeen
+			createImageExportWithStatus("recent-export-1", apiimagebuilder.ImageExportConditionReasonConverting, recentLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(0))
+
+			// Verify it was NOT marked as Failed
+			updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, "recent-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonConverting)))
+		})
+
+		It("should not mark Pending ImageExport (excluded by field selector)", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+
+			// Create an ImageExport in Pending state with old lastSeen
+			createImageExportWithStatus("pending-export-1", apiimagebuilder.ImageExportConditionReasonPending, oldLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(0))
+
+			// Verify it was NOT marked as Failed (Pending is excluded)
+			updated, status := imageBuilderService.ImageExport().Get(ctx, orgID, "pending-export-1")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageExportStatusCondition(*updated.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition).ToNot(BeNil())
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonPending)))
+		})
+	})
+
+	Context("Timeout Check with Multiple Resources", func() {
+		It("should mark multiple timed-out resources correctly", func() {
+			timeoutDuration := 5 * time.Minute
+			oldLastSeen := time.Now().UTC().Add(-10 * time.Minute)
+			recentLastSeen := time.Now().UTC().Add(-1 * time.Minute)
+
+			// Create multiple resources with different states
+			createImageBuildWithStatus("timeout-build-2", apiimagebuilder.ImageBuildConditionReasonBuilding, oldLastSeen)
+			createImageBuildWithStatus("recent-build-2", apiimagebuilder.ImageBuildConditionReasonBuilding, recentLastSeen)
+			createImageBuildWithStatus("pending-build-2", apiimagebuilder.ImageBuildConditionReasonPending, oldLastSeen)
+			createImageExportWithStatus("timeout-export-2", apiimagebuilder.ImageExportConditionReasonConverting, oldLastSeen)
+			createImageExportWithStatus("recent-export-2", apiimagebuilder.ImageExportConditionReasonConverting, recentLastSeen)
+
+			// Run timeout check
+			failedCount, err := consumer.CheckAndMarkTimeoutsForOrg(ctx, orgID, timeoutDuration, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failedCount).To(Equal(2))
+
+			// Verify timeout-build-2 was marked as Failed
+			build1, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "timeout-build-2", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition := apiimagebuilder.FindImageBuildStatusCondition(*build1.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonFailed)))
+
+			// Verify recent-build-2 was NOT marked as Failed
+			build2, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "recent-build-2", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition = apiimagebuilder.FindImageBuildStatusCondition(*build2.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonBuilding)))
+
+			// Verify pending-build-2 was NOT marked as Failed
+			build3, status := imageBuilderService.ImageBuild().Get(ctx, orgID, "pending-build-2", false)
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition = apiimagebuilder.FindImageBuildStatusCondition(*build3.Status.Conditions, apiimagebuilder.ImageBuildConditionTypeReady)
+			Expect(readyCondition.Reason).To(Equal(string(apiimagebuilder.ImageBuildConditionReasonPending)))
+
+			// Verify timeout-export-2 was marked as Failed
+			export1, status := imageBuilderService.ImageExport().Get(ctx, orgID, "timeout-export-2")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition2 := apiimagebuilder.FindImageExportStatusCondition(*export1.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition2.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonFailed)))
+
+			// Verify recent-export-2 was NOT marked as Failed
+			export2, status := imageBuilderService.ImageExport().Get(ctx, orgID, "recent-export-2")
+			Expect(status.Code).To(Equal(int32(200)))
+			readyCondition2 = apiimagebuilder.FindImageExportStatusCondition(*export2.Status.Conditions, apiimagebuilder.ImageExportConditionTypeReady)
+			Expect(readyCondition2.Reason).To(Equal(string(apiimagebuilder.ImageExportConditionReasonConverting)))
+		})
+	})
+})


### PR DESCRIPTION
on startup - inprogress tasks -> fail , non started tasks -> re-enqueued
periodically check for lastSeen , if threshold passed -> move to fail
handle imagebuild status update when ready=true -> fire imageexport re-enqueue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable image-builder timeouts, startup requeue, and periodic timeout checks.

* **Improvements**
  * Status-change events are emitted and enqueued without blocking processing.
  * Optimistic/versioned status updates for stronger consistency.
  * Field-selector support for status-based queries.
  * Worker now handles resource-update events, triggering requeueing or fail/timeout transitions.

* **Tests**
  * Expanded unit and integration suites covering requeue, update, timeout, and event flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->