### PR TITLE
EDM-3127: Add Helm OCI chart prefetching support

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -157,6 +157,22 @@ func (a *Agent) Run(ctx context.Context) error {
 	// create skopeo client
 	skopeoClient := client.NewSkopeo(a.log, executer, deviceReadWriter)
 
+	// create kube client
+	kubeClient := client.NewKube(a.log, executer, deviceReadWriter)
+
+	// create helm client
+	helmClient := client.NewHelm(a.log, executer, deviceReadWriter, a.config.DataDir)
+
+	// create CRI client
+	criClient := client.NewCRI(a.log, executer, deviceReadWriter)
+
+	// create CLI clients
+	cliClients := client.NewCLIClients(
+		client.WithKubeClient(kubeClient),
+		client.WithHelmClient(helmClient),
+		client.WithCRIClient(criClient),
+	)
+
 	// create systemd client
 	systemdClient := client.NewSystemd(executer)
 
@@ -255,8 +271,10 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	// create prefetch manager
 	prefetchManager := dependency.NewPrefetchManager(
-		a.log, podmanClient,
+		a.log,
+		podmanClient,
 		skopeoClient,
+		cliClients,
 		deviceReadWriter,
 		a.config.PullTimeout,
 		resourceManager,

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -593,8 +593,8 @@ func TestCollectOCITargetsCache(t *testing.T) {
 
 	// populate cache with nested targets for two applications
 	nestedTargets := []dependency.OCIPullTarget{
-		{Type: dependency.OCITypeImage, Reference: "quay.io/nested/image1:v1"},
-		{Type: dependency.OCITypeImage, Reference: "quay.io/nested/image2:v1"},
+		{Type: dependency.OCITypePodmanImage, Reference: "quay.io/nested/image1:v1"},
+		{Type: dependency.OCITypePodmanImage, Reference: "quay.io/nested/image2:v1"},
 	}
 
 	entry1 := provider.CacheEntry{

--- a/internal/agent/device/applications/provider/image.go
+++ b/internal/agent/device/applications/provider/image.go
@@ -116,7 +116,7 @@ func (p *imageProvider) extractOCIContents(ctx context.Context, ociType dependen
 			p.log.Warnf("Failed to cleanup directory %q: %v", path, err)
 		}
 	}
-	if ociType == dependency.OCITypeArtifact {
+	if ociType == dependency.OCITypePodmanArtifact {
 		if err := extractAndProcessArtifact(ctx, p.podman, p.log, p.spec.ImageProvider.Image, path, p.readWriter); err != nil {
 			clean()
 			return fmt.Errorf("extract artifact contents: %w", err)
@@ -266,7 +266,7 @@ func typeFromImage(ctx context.Context, podman *client.Podman, image string) (v1
 	var appTypeValue string
 	var ok bool
 
-	if ociType == dependency.OCITypeArtifact {
+	if ociType == dependency.OCITypePodmanArtifact {
 		// For artifacts, check annotations
 		artifactInfo, err := podman.InspectArtifactAnnotations(ctx, image)
 		if err != nil {
@@ -297,12 +297,12 @@ func typeFromImage(ctx context.Context, podman *client.Podman, image string) (v1
 func detectOCIType(ctx context.Context, podman *client.Podman, imageRef string) (dependency.OCIType, error) {
 	// Check if it exists as an image first (most common case)
 	if podman.ImageExists(ctx, imageRef) {
-		return dependency.OCITypeImage, nil
+		return dependency.OCITypePodmanImage, nil
 	}
 
 	// Check if it exists as an artifact
 	if podman.ArtifactExists(ctx, imageRef) {
-		return dependency.OCITypeArtifact, nil
+		return dependency.OCITypePodmanArtifact, nil
 	}
 
 	// Reference doesn't exist locally - this shouldn't happen after prefetch

--- a/internal/agent/device/applications/provider/image_cache_test.go
+++ b/internal/agent/device/applications/provider/image_cache_test.go
@@ -20,13 +20,13 @@ func TestNestedTargetCacheGetSet(t *testing.T) {
 	imageBasedEntry := CacheEntry{
 		Name: "image-app",
 		Parent: dependency.OCIPullTarget{
-			Type:      dependency.OCITypeImage,
+			Type:      dependency.OCITypePodmanImage,
 			Reference: "quay.io/myapp:v1",
 			Digest:    "sha256:abc123",
 		},
 		Children: []dependency.OCIPullTarget{
-			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"},
-			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:latest"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/postgres:16"},
 		},
 	}
 	cache.Set(imageBasedEntry)
@@ -53,17 +53,17 @@ func TestNestedTargetCacheGC(t *testing.T) {
 				c.Set(CacheEntry{
 					Name:     "active1",
 					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:aaa"},
-					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"}},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:latest"}},
 				})
 				c.Set(CacheEntry{
 					Name:     "active2",
 					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:bbb"},
-					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"}},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/postgres:16"}},
 				})
 				c.Set(CacheEntry{
 					Name:     "stale1",
 					Parent:   dependency.OCIPullTarget{Reference: "quay.io/app3:v1", Digest: "sha256:ccc"},
-					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/nginx:alpine"}},
+					Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/nginx:alpine"}},
 				})
 			},
 			activeNames:    []string{"active1", "active2"},
@@ -137,12 +137,12 @@ func TestNestedTargetCacheClear(t *testing.T) {
 	cache.Set(CacheEntry{
 		Name:     "image-app1",
 		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app1:v1", Digest: "sha256:abc"},
-		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:latest"}},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:latest"}},
 	})
 	cache.Set(CacheEntry{
 		Name:     "image-app2",
 		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app2:v1", Digest: "sha256:def"},
-		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/nginx:alpine"}},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/nginx:alpine"}},
 	})
 	require.Equal(2, cache.Len())
 
@@ -162,7 +162,7 @@ func TestNestedTargetCacheOverwriteEntry(t *testing.T) {
 	initialEntry := CacheEntry{
 		Name:     "myapp",
 		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:old"},
-		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:6"}},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:6"}},
 	}
 	cache.Set(initialEntry)
 
@@ -175,8 +175,8 @@ func TestNestedTargetCacheOverwriteEntry(t *testing.T) {
 		Name:   "myapp",
 		Parent: dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:new"},
 		Children: []dependency.OCIPullTarget{
-			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:7"},
-			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:7"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/postgres:16"},
 		},
 	}
 	cache.Set(updatedEntry)
@@ -196,7 +196,7 @@ func TestNestedTargetCacheInvalidation(t *testing.T) {
 	cache.Set(CacheEntry{
 		Name:     "myapp",
 		Parent:   dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:old"},
-		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypeImage, Reference: "quay.io/redis:6"}},
+		Children: []dependency.OCIPullTarget{{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:6"}},
 	})
 
 	entry, found := cache.Get("myapp")
@@ -212,8 +212,8 @@ func TestNestedTargetCacheInvalidation(t *testing.T) {
 		Name:   "myapp",
 		Parent: dependency.OCIPullTarget{Reference: "quay.io/app:v1", Digest: "sha256:new"},
 		Children: []dependency.OCIPullTarget{
-			{Type: dependency.OCITypeImage, Reference: "quay.io/redis:7"},
-			{Type: dependency.OCITypeImage, Reference: "quay.io/postgres:16"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/redis:7"},
+			{Type: dependency.OCITypePodmanImage, Reference: "quay.io/postgres:16"},
 		},
 	})
 


### PR DESCRIPTION
Wires up the dependency to manager to handle CRI vs podman based images and to handle pull configs properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart dependency support.
  * Broader runtime support: Podman and CRI images are detected and handled.
  * Per-target pull/configuration support for fetching container artifacts.

* **Refactor**
  * Centralized CLI client handling for image/chart operations.
  * Reworked pull/config flow to use a provider abstraction and wired into prefetch/pull logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->