### PR TITLE
Updated init container quadlet files 

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-init.container
+++ b/deploy/podman/flightctl-api/flightctl-api-init.container
@@ -21,6 +21,8 @@ Restart=on-failure
 RestartSec=5s
 ExecStartPre=/usr/bin/mkdir -p /run/flightctl
 ExecStartPre=/bin/sh -c 'echo "HOST_FQDN=$(hostname -f || hostname)" > /run/flightctl/api_init_host.env'
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-certs-init.service
+++ b/deploy/podman/flightctl-certs-init.service
@@ -10,6 +10,8 @@ RemainAfterExit=true
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/share/flightctl/init_certs.sh
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts-init.container
@@ -21,6 +21,8 @@ Type=oneshot
 RemainAfterExit=true
 Restart=on-failure
 RestartSec=5s
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
@@ -34,6 +34,8 @@ RemainAfterExit=yes
 Restart=on-failure
 RestartSec=5
 ExecCondition=/bin/bash -c 'test "$(python3 /usr/share/flightctl/yaml_helpers.py extract ".db.type" /etc/flightctl/service-config.yaml --default "builtin")" != "external"'
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-ui/flightctl-ui-init.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui-init.container
@@ -20,6 +20,8 @@ RemainAfterExit=true
 TimeoutStartSec=5s
 Restart=on-failure
 RestartSec=5s
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=flightctl.target


### PR DESCRIPTION
Updated init container quadlet files to ensure everything in standardoutput and standarderror shows up in journal. This helps with troubleshooting init issues. Since the container is removed automatically there is no way other than relying on journal to ensure initialization steps completed successfully 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced service logging: multiple init services now route standard output and error to the systemd journal, enabling centralized log collection and improved visibility for troubleshooting and monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->