### PR TITLE
EDM-3148: fix v7 image build in OCP

### DIFF
--- a/test/scripts/agent-images/flavors/cs10-bootc.conf
+++ b/test/scripts/agent-images/flavors/cs10-bootc.conf
@@ -1,6 +1,9 @@
 # Flavor configuration for cs10-bootc
 OS_ID=cs10-bootc
-EXCLUDE_VARIANTS="v7"
+# Only set EXCLUDE_VARIANTS if not already set (allows override from environment, including empty string)
+if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
+    EXCLUDE_VARIANTS="v7"
+fi
 
 # Build arguments for base image
 DEVICE_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10

--- a/test/scripts/agent-images/flavors/cs9-bootc.conf
+++ b/test/scripts/agent-images/flavors/cs9-bootc.conf
@@ -1,6 +1,9 @@
 # Flavor configuration for cs9-bootc
 OS_ID=cs9-bootc
-EXCLUDE_VARIANTS="v7"
+# Only set EXCLUDE_VARIANTS if not already set (allows override from environment, including empty string)
+if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
+    EXCLUDE_VARIANTS="v7"
+fi
 
 # Build arguments for base image
 DEVICE_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream9

--- a/test/scripts/agent-images/variants/v7/Containerfile
+++ b/test/scripts/agent-images/variants/v7/Containerfile
@@ -6,7 +6,8 @@ ARG BASE_IMAGE=quay.io/flightctl/flightctl-device:base
 
 FROM ${BASE_IMAGE}
 
-ADD --from=variant-context etc etc
+COPY --from=variant-context etc/yum.repos.d/flightctl.repo /etc/yum.repos.d/flightctl.repo
+COPY --from=variant-context etc/yum.repos.d/microshift.repo /etc/yum.repos.d/microshift.repo
 
 # Use BuildKit cache mounts for dnf package caching
 RUN --mount=type=cache,target=/var/cache/dnf \


### PR DESCRIPTION
v7 image was not built after refactoring in OCP+ACM causing the failure of microshift registration E2E test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable handling to preserve pre-existing values instead of unconditionally overriding them in build configurations.

* **Chores**
  * Enhanced container image build process by replacing broad file inclusion with explicit copying of specific repository files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->