### PR TITLE
EDM-3160: Add imageBuilder configuration to UI deployments

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -280,6 +280,11 @@ Usage: {{- $authType := include "flightctl.getEffectiveAuthType" . }}
   {{- end }}
 {{- end }}
 
+
+{{- define "flightctl.getInternalImagebuilderApiUrl" }}
+  {{- print "https://flightctl-imagebuilder-api:8445"}}
+{{- end }}
+
 {{/*
 Generates a random alphanumeric password in the format xxxxx-xxxxx-xxxxx-xxxxx.
 */}}

--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
@@ -16,6 +16,9 @@ data:
   {{- if .Values.alertmanagerProxy.enabled }}
   FLIGHTCTL_ALERTMANAGER_PROXY: {{ include "flightctl.getAlertManagerProxyUrl" . }}
   {{- end }}
+  {{- if and .Values.imageBuilderApi .Values.imageBuilderApi.enabled }}
+  FLIGHTCTL_IMAGEBUILDER_SERVER: {{ include "flightctl.getInternalImagebuilderApiUrl" . }}
+  {{- end }}
   IS_RHEM: {{ (eq .Chart.Name "redhat-rhem") | quote }}
   AUTH_INSECURE_SKIP_VERIFY: {{ default ((.Values.global).auth).insecureSkipTlsVerify .Values.ui.auth.insecureSkipTlsVerify | quote }}
   BASE_UI_URL: {{ include "flightctl.getUIUrl" . }}

--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-deployment.yaml
@@ -55,6 +55,13 @@ spec:
                 name: flightctl-ui
                 key: FLIGHTCTL_ALERTMANAGER_PROXY
           {{- end }}
+          {{- if and .Values.imageBuilderApi .Values.imageBuilderApi.enabled }}
+          - name: FLIGHTCTL_IMAGEBUILDER_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: flightctl-ui
+                key: FLIGHTCTL_IMAGEBUILDER_SERVER
+          {{- end }}
           {{- if eq $enableMulticlusterExtensions "true" }}
           - name: TLS_KEY
             value: /app/serving-cert/tls.key

--- a/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
@@ -5,6 +5,7 @@ FLIGHTCTL_SERVER_EXTERNAL=https://{{.global.baseDomain}}:3443/
 FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY=true
 FLIGHTCTL_CLI_ARTIFACTS_SERVER=https://{{.global.baseDomain}}:8090
 FLIGHTCTL_ALERTMANAGER_PROXY=https://flightctl-alertmanager-proxy:8443
+FLIGHTCTL_IMAGEBUILDER_SERVER=https://{{.global.baseDomain}}:8445
 TLS_CERT=/app/certs/server.crt
 TLS_KEY=/app/certs/server.key
 AUTH_INSECURE_SKIP_VERIFY={{.global.auth.insecureSkipTlsVerify}}


### PR DESCRIPTION
The UI needs to receive the ImageBuilder API url.

Configuring the UI using the internal URL in OpenShift for now. This needs to be reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Image Builder API integration: UI and runtime can now be configured to use an internal image-builder server when enabled.
* **Chores**
  * Introduced configurable environment/value and ConfigMap entries to supply the image-builder server URL for deployments and local templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->