### PR TITLE
EDM-2636: User-aware lifecycle handler + podman monitor

### DIFF
--- a/internal/agent/client/executer.go
+++ b/internal/agent/client/executer.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/userutil"
+)
+
+func ExecuterForUser(username v1beta1.Username) (executer.Executer, error) {
+	var execOpts []executer.ExecuterOption
+
+	if username != "" {
+		uid, gid, homeDir, err := userutil.LookupUser(username)
+		if err != nil {
+			return nil, err
+		}
+		execOpts = append(execOpts,
+			executer.WithHomeDir(homeDir),
+			executer.WithUIDAndGID(uid, gid),
+		)
+	}
+
+	return executer.NewCommonExecuter(execOpts...), nil
+}

--- a/internal/agent/device/applications/lifecycle/compose.go
+++ b/internal/agent/device/applications/lifecycle/compose.go
@@ -18,16 +18,16 @@ const (
 var _ ActionHandler = (*Compose)(nil)
 
 type Compose struct {
-	podman *client.Podman
-	writer fileio.Writer
-	log    *log.PrefixLogger
+	podmanFactory client.PodmanFactory
+	writerFactory fileio.ReadWriterFactory
+	log           *log.PrefixLogger
 }
 
-func NewCompose(log *log.PrefixLogger, writer fileio.Writer, podman *client.Podman) *Compose {
+func NewCompose(log *log.PrefixLogger, rwFactory fileio.ReadWriterFactory, podmanFactory client.PodmanFactory) *Compose {
 	return &Compose{
-		podman: podman,
-		writer: writer,
-		log:    log,
+		podmanFactory: podmanFactory,
+		writerFactory: rwFactory,
+		log:           log,
 	}
 }
 
@@ -36,12 +36,22 @@ func (c *Compose) add(ctx context.Context, action *Action) error {
 	projectName := action.ID
 	c.log.Debugf("Starting application: %s projectName: %s path: %s", appName, projectName, action.Path)
 
-	if err := c.ensurePodmanVolumes(ctx, action.Volumes, appName); err != nil {
+	podman, err := c.podmanFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating podman client: %w", err)
+	}
+
+	writer, err := c.writerFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating writer: %w", err)
+	}
+
+	if err := c.ensurePodmanVolumes(ctx, action.Volumes, appName, podman, writer); err != nil {
 		return fmt.Errorf("creating volumes: %w", err)
 	}
 
 	noRecreate := true
-	if err := c.podman.Compose().UpFromWorkDir(ctx, action.Path, projectName, noRecreate); err != nil {
+	if err := podman.Compose().UpFromWorkDir(ctx, action.Path, projectName, noRecreate); err != nil {
 		return err
 	}
 
@@ -53,8 +63,13 @@ func (c *Compose) remove(ctx context.Context, action *Action) error {
 	appName := action.Name
 	c.log.Debugf("Removing application: %s projectName: %s", appName, action.ID)
 
+	podman, err := c.podmanFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating podman client: %w", err)
+	}
+
 	var errs []error
-	if err := c.stopAndRemoveContainers(ctx, action); err != nil {
+	if err := c.stopAndRemoveContainers(ctx, action, podman); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -70,17 +85,27 @@ func (c *Compose) update(ctx context.Context, action *Action) error {
 	projectName := action.ID
 	c.log.Debugf("Updating application: %s projectName: %s path: %s", action.Name, projectName, action.Path)
 
-	if err := c.stopAndRemoveContainers(ctx, action); err != nil {
+	podman, err := c.podmanFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating podman client: %w", err)
+	}
+
+	writer, err := c.writerFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating writer: %w", err)
+	}
+
+	if err := c.stopAndRemoveContainers(ctx, action, podman); err != nil {
 		return err
 	}
 
-	if err := c.ensurePodmanVolumes(ctx, action.Volumes, projectName); err != nil {
+	if err := c.ensurePodmanVolumes(ctx, action.Volumes, projectName, podman, writer); err != nil {
 		return fmt.Errorf("creating volumes: %w", err)
 	}
 
 	// change to work dir and run `docker compose up -d`
 	noRecreate := true
-	if err := c.podman.Compose().UpFromWorkDir(ctx, action.Path, projectName, noRecreate); err != nil {
+	if err := podman.Compose().UpFromWorkDir(ctx, action.Path, projectName, noRecreate); err != nil {
 		return err
 	}
 
@@ -90,10 +115,10 @@ func (c *Compose) update(ctx context.Context, action *Action) error {
 }
 
 // stopAndRemoveContainers stops and removes all containers, pods, and networks created by the compose application.
-func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action) error {
+func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action, podman *client.Podman) error {
 	return cleanPodmanResources(
 		ctx,
-		c.podman,
+		podman,
 		[]string{
 			fmt.Sprintf("%s=%s", client.ComposeDockerProjectLabelKey, action.ID),
 		},
@@ -132,19 +157,19 @@ func cleanPodmanResources(ctx context.Context, podman *client.Podman, labels []s
 	return nil
 }
 
-func (c *Compose) Execute(ctx context.Context, actions ...*Action) error {
+func (c *Compose) Execute(ctx context.Context, actions Actions) error {
 	for _, action := range actions {
 		switch action.Type {
 		case ActionAdd:
-			if err := c.add(ctx, action); err != nil {
+			if err := c.add(ctx, &action); err != nil {
 				return err
 			}
 		case ActionRemove:
-			if err := c.remove(ctx, action); err != nil {
+			if err := c.remove(ctx, &action); err != nil {
 				return err
 			}
 		case ActionUpdate:
-			if err := c.update(ctx, action); err != nil {
+			if err := c.update(ctx, &action); err != nil {
 				return err
 			}
 		default:
@@ -159,6 +184,8 @@ func (c *Compose) ensurePodmanVolumes(
 	ctx context.Context,
 	volumes []Volume,
 	appID string,
+	podman *client.Podman,
+	writer fileio.Writer,
 ) error {
 	if len(volumes) == 0 {
 		return nil
@@ -167,7 +194,7 @@ func (c *Compose) ensurePodmanVolumes(
 	labels := []string{fmt.Sprintf("%s=%s", client.ComposeDockerProjectLabelKey, appID)}
 	// ensure the volume content is pulled and available
 	for _, volume := range volumes {
-		if err := c.ensurePodmanVolume(ctx, volume, labels); err != nil {
+		if err := c.ensurePodmanVolume(ctx, volume, labels, podman, writer); err != nil {
 			return fmt.Errorf("pulling image volume: %w", err)
 		}
 	}
@@ -179,19 +206,21 @@ func (c *Compose) ensurePodmanVolume(
 	ctx context.Context,
 	volume Volume,
 	labels []string,
+	podman *client.Podman,
+	writer fileio.Writer,
 ) error {
 	name := volume.ID
 	imageRef := volume.Reference
-	if c.podman.VolumeExists(ctx, name) {
+	if podman.VolumeExists(ctx, name) {
 		c.log.Tracef("Volume %q already exists, updating contents", name)
-		volumePath, err := c.podman.InspectVolumeMount(ctx, name)
+		volumePath, err := podman.InspectVolumeMount(ctx, name)
 		if err != nil {
 			return fmt.Errorf("inspect volume %q: %w", name, err)
 		}
-		if err := c.writer.RemoveContents(volumePath); err != nil {
+		if err := writer.RemoveContents(volumePath); err != nil {
 			return fmt.Errorf("removing volume content %q: %w", volumePath, err)
 		}
-		if _, err := c.podman.ExtractArtifact(ctx, imageRef, volumePath); err != nil {
+		if _, err := podman.ExtractArtifact(ctx, imageRef, volumePath); err != nil {
 			return fmt.Errorf("extract artifact: %w", err)
 		}
 		return nil
@@ -199,11 +228,11 @@ func (c *Compose) ensurePodmanVolume(
 
 	c.log.Infof("Creating volume %q from image %q", name, imageRef)
 
-	volumePath, err := c.podman.CreateVolume(ctx, name, labels)
+	volumePath, err := podman.CreateVolume(ctx, name, labels)
 	if err != nil {
 		return fmt.Errorf("creating volume %q: %w", name, err)
 	}
-	if _, err := c.podman.ExtractArtifact(ctx, imageRef, volumePath); err != nil {
+	if _, err := podman.ExtractArtifact(ctx, imageRef, volumePath); err != nil {
 		return fmt.Errorf("copy image contents: %w", err)
 	}
 

--- a/internal/agent/device/applications/lifecycle/mock_lifecycle.go
+++ b/internal/agent/device/applications/lifecycle/mock_lifecycle.go
@@ -40,20 +40,15 @@ func (m *MockActionHandler) EXPECT() *MockActionHandlerMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockActionHandler) Execute(ctx context.Context, actions ...*Action) error {
+func (m *MockActionHandler) Execute(ctx context.Context, actions Actions) error {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx}
-	for _, a := range actions {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Execute", varargs...)
+	ret := m.ctrl.Call(m, "Execute", ctx, actions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockActionHandlerMockRecorder) Execute(ctx any, actions ...any) *gomock.Call {
+func (mr *MockActionHandlerMockRecorder) Execute(ctx, actions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx}, actions...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockActionHandler)(nil).Execute), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockActionHandler)(nil).Execute), ctx, actions)
 }

--- a/internal/agent/device/applications/lifecycle/quadlet.go
+++ b/internal/agent/device/applications/lifecycle/quadlet.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,17 +27,17 @@ const (
 var _ ActionHandler = (*Quadlet)(nil)
 
 type Quadlet struct {
-	systemdManager systemd.Manager
-	podman         *client.Podman
-	rw             fileio.ReadWriter
+	systemdFactory systemd.ManagerFactory
+	podmanFactory  client.PodmanFactory
+	rwFactory      fileio.ReadWriterFactory
 	log            *log.PrefixLogger
 }
 
-func NewQuadlet(log *log.PrefixLogger, rw fileio.ReadWriter, systemdManager systemd.Manager, podman *client.Podman) *Quadlet {
+func NewQuadlet(log *log.PrefixLogger, rwFactory fileio.ReadWriterFactory, systemdFactory systemd.ManagerFactory, podmanFactory client.PodmanFactory) *Quadlet {
 	return &Quadlet{
-		systemdManager: systemdManager,
-		podman:         podman,
-		rw:             rw,
+		systemdFactory: systemdFactory,
+		podmanFactory:  podmanFactory,
+		rwFactory:      rwFactory,
 		log:            log,
 	}
 }
@@ -49,8 +50,8 @@ func isServiceLoaded(unitSet map[string]struct{}, service string) bool {
 	return exists
 }
 
-func (q *Quadlet) loadedUnits(ctx context.Context, services []string) (map[string]struct{}, error) {
-	units, err := q.systemdManager.ListUnitsByMatchPattern(ctx, services)
+func (q *Quadlet) loadedUnits(ctx context.Context, systemctl systemd.Manager, services []string) (map[string]struct{}, error) {
+	units, err := systemctl.ListUnitsByMatchPattern(ctx, services)
 	if err != nil {
 		return nil, fmt.Errorf("listing loaded units: %w", err)
 	}
@@ -64,7 +65,7 @@ func (q *Quadlet) loadedUnits(ctx context.Context, services []string) (map[strin
 	return unitSet, nil
 }
 
-func (q *Quadlet) add(ctx context.Context, action *Action) error {
+func (q *Quadlet) add(ctx context.Context, action Action, systemctl systemd.Manager) error {
 	appName := action.Name
 	q.log.Debugf("Starting quadlet application: %s path: %s", appName, action.Path)
 
@@ -78,12 +79,13 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 	if err != nil {
 		return fmt.Errorf("target name: %w", err)
 	}
-	services, err := q.systemdManager.ListDependencies(ctx, target)
+
+	services, err := systemctl.ListDependencies(ctx, target)
 	if err != nil {
 		return fmt.Errorf("listing dependencies: %w", err)
 	}
 
-	unitSet, err := q.loadedUnits(ctx, services)
+	unitSet, err := q.loadedUnits(ctx, systemctl, services)
 	if err != nil {
 		return fmt.Errorf("listing loading units: %w", err)
 	}
@@ -91,7 +93,7 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 	for _, service := range services {
 		if !isServiceLoaded(unitSet, service) {
 			err := fmt.Errorf("%s not loaded as a target", service)
-			generatorLogs, logsErr := q.systemdManager.Logs(ctx, client.WithLogTag("quadlet-generator"), client.WithLogSince(batchTime))
+			generatorLogs, logsErr := systemctl.Logs(ctx, client.WithLogTag("quadlet-generator"), client.WithLogSince(batchTime))
 			if logsErr != nil {
 				q.log.Errorf("Failed to fetch quadlet-generator logs: %v", logsErr)
 			}
@@ -106,7 +108,7 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 	requiresActionCleanup := true
 	defer func() {
 		if requiresActionCleanup {
-			if err := q.remove(ctx, action); err != nil {
+			if err := q.remove(ctx, action, systemctl); err != nil {
 				q.log.Errorf("Failed to remove quadlet application %s after failing to add it: %v", appName, err)
 			}
 		}
@@ -116,10 +118,10 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 		return fmt.Errorf("ensuring artifact volumes: %w", err)
 	}
 	q.log.Debugf("Starting quadlet: %s target: %s", appName, target)
-	if err := q.systemdManager.Start(ctx, target); err != nil {
+	if err := systemctl.Start(ctx, target); err != nil {
 		err = fmt.Errorf("starting target %s: %w", target, err)
 		for _, service := range services {
-			serviceLogs, serviceErr := q.systemdManager.Logs(ctx, client.WithLogUnit(service), client.WithLogSince(startTime))
+			serviceLogs, serviceErr := systemctl.Logs(ctx, client.WithLogUnit(service), client.WithLogSince(startTime))
 			if serviceErr != nil {
 				err = fmt.Errorf("gathering service %q logs: %w: %w", service, serviceErr, err)
 				continue
@@ -132,32 +134,33 @@ func (q *Quadlet) add(ctx context.Context, action *Action) error {
 		return err
 	}
 
-	q.systemdManager.AddExclusions(append(services, target)...)
+	systemctl.AddExclusions(append(services, target)...)
 
 	requiresActionCleanup = false
 	q.log.Infof("Started quadlet application: %s", appName)
 	return nil
 }
 
-func (q *Quadlet) remove(ctx context.Context, action *Action) error {
+func (q *Quadlet) remove(ctx context.Context, action Action, systemctl systemd.Manager) error {
 	appName := action.Name
 
 	target, err := targetName(action.ID)
 	if err != nil {
 		return fmt.Errorf("target name: %w", err)
 	}
-	services, err := q.systemdManager.ListDependencies(ctx, target)
+
+	services, err := systemctl.ListDependencies(ctx, target)
 	if err != nil {
 		return fmt.Errorf("listing dependencies: %w", err)
 	}
 
 	q.log.Debugf("Stopping quadlet: %s target: %s", appName, target)
 	// stopping the target will begin stopping the individual services, but it is not a synchronous operation.
-	if err := q.systemdManager.Stop(ctx, target); err != nil {
+	if err := systemctl.Stop(ctx, target); err != nil {
 		return fmt.Errorf("stopping target %s: %w", target, err)
 	}
 
-	unitSet, err := q.loadedUnits(ctx, services)
+	unitSet, err := q.loadedUnits(ctx, systemctl, services)
 	if err != nil {
 		return fmt.Errorf("listing loading units: %w", err)
 	}
@@ -169,21 +172,21 @@ func (q *Quadlet) remove(ctx context.Context, action *Action) error {
 		}
 		// stop and wait for all services to finish
 		q.log.Debugf("Stopping quadlet: %s services: %s", appName, strings.Join(servicesToStop, ", "))
-		if err := q.systemdManager.Stop(ctx, servicesToStop...); err != nil {
+		if err := systemctl.Stop(ctx, servicesToStop...); err != nil {
 			return fmt.Errorf("stopping services: %w", err)
 		}
 		q.log.Debugf("Resetting failed state for services: %q", strings.Join(servicesToStop, ", "))
 		// Reset all services so that properties such as restart counts are reset
-		if err := q.systemdManager.ResetFailed(ctx, servicesToStop...); err != nil {
+		if err := systemctl.ResetFailed(ctx, servicesToStop...); err != nil {
 			return fmt.Errorf("resetting failed: %w", err)
 		}
 	}
-	q.systemdManager.RemoveExclusions(append(services, target)...)
+	systemctl.RemoveExclusions(append(services, target)...)
 
 	return q.cleanResources(ctx, action)
 }
 
-func (q *Quadlet) cleanResources(ctx context.Context, action *Action) error {
+func (q *Quadlet) cleanResources(ctx context.Context, action Action) error {
 	q.log.Infof("Removed quadlet application: %s", action.Name)
 	// the labels applied to quadlets are only directly applied to that quadlet. They do not apply to
 	// any resources created indirectly. As an example, a container quadlet can create multiple volumes without referencing
@@ -196,8 +199,14 @@ func (q *Quadlet) cleanResources(ctx context.Context, action *Action) error {
 	filters := []string{
 		fmt.Sprintf("name=%s-*", action.ID),
 	}
+
+	podman, err := q.podmanFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating podman client: %w", err)
+	}
+
 	var errs []error
-	if err := cleanPodmanResources(ctx, q.podman, labels, filters); err != nil {
+	if err := cleanPodmanResources(ctx, podman, labels, filters); err != nil {
 		errs = append(errs, fmt.Errorf("cleaning podman resources: %w", err))
 	}
 	if len(errs) > 0 {
@@ -206,66 +215,64 @@ func (q *Quadlet) cleanResources(ctx context.Context, action *Action) error {
 	return nil
 }
 
-type quadletAfterReloadFn func(context.Context) error
+func (q *Quadlet) Execute(ctx context.Context, actions Actions) error {
+	for user, byType := range actions.ByUser() {
+		systemctl, err := q.systemdFactory(user)
+		if err != nil {
+			return fmt.Errorf("creating systemd client: %w", err)
+		}
 
-func (q *Quadlet) Execute(ctx context.Context, actions ...*Action) error {
-	if len(actions) == 0 {
-		return nil
-	}
-	afterReloadFns := make([]quadletAfterReloadFn, 0, len(actions))
-	for _, action := range actions {
-		switch action.Type {
-		// Add requires daemon reload to be called prior to performing any service starting
-		case ActionAdd:
-			afterReloadFns = append(afterReloadFns, func(ctx context.Context) error {
-				return q.add(ctx, action)
-			})
-		// Remove requires that stops are executed prior to calling daemon-reload
-		// but the entirety of its actions can happen prior to reload
-		case ActionRemove:
-			if err := q.remove(ctx, action); err != nil {
+		if len(byType.Unknown) > 0 {
+			return fmt.Errorf("unknown action type %s", byType.Unknown[0].Type)
+		}
+
+		for _, a := range slices.Concat(byType.Removes, byType.Updates) {
+			if err := q.remove(ctx, a, systemctl); err != nil {
 				return fmt.Errorf("removing: %w", err)
 			}
-		// Update behaves as the combination of Remove + Update
-		case ActionUpdate:
-			if err := q.remove(ctx, action); err != nil {
-				return fmt.Errorf("removing for update: %w", err)
-			}
-			afterReloadFns = append(afterReloadFns, func(ctx context.Context) error {
-				return q.add(ctx, action)
-			})
-		default:
-			return fmt.Errorf("unsupported action type: %s", action.Type)
 		}
-	}
-	if err := q.systemdManager.DaemonReload(ctx); err != nil {
-		return fmt.Errorf("daemon reload: %w", err)
+
+		if err := systemctl.DaemonReload(ctx); err != nil {
+			return fmt.Errorf("systemd daemon reload: %w", err)
+		}
+
+		// Add requires daemon reload to be called prior to performing any service starting
+		for _, a := range slices.Concat(byType.Adds, byType.Updates) {
+			if err := q.add(ctx, a, systemctl); err != nil {
+				return fmt.Errorf("adding: %w", err)
+			}
+		}
 	}
 
-	for _, afterReload := range afterReloadFns {
-		if err := afterReload(ctx); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
-func (q *Quadlet) ensureArtifactVolumes(ctx context.Context, action *Action) error {
+func (q *Quadlet) ensureArtifactVolumes(ctx context.Context, action Action) error {
 	if len(action.Volumes) == 0 {
 		return nil
 	}
+	podman, err := q.podmanFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating podman client: %w", err)
+	}
+
+	rw, err := q.rwFactory(action.User)
+	if err != nil {
+		return fmt.Errorf("creating read/writer: %w", err)
+	}
+
 	labels := []string{fmt.Sprintf("%s=%s", client.QuadletProjectLabelKey, action.ID)}
 	var artifactVolumes []string
 	cleanup := func(err error) error {
 		if len(artifactVolumes) > 0 {
-			if removeErr := q.podman.RemoveVolumes(ctx, artifactVolumes...); removeErr != nil {
+			if removeErr := podman.RemoveVolumes(ctx, artifactVolumes...); removeErr != nil {
 				err = fmt.Errorf("removing artifacts: %w: %w", removeErr, err)
 			}
 		}
 		return err
 	}
 	for _, volume := range action.Volumes {
-		if q.podman.ImageExists(ctx, volume.Reference) {
+		if podman.ImageExists(ctx, volume.Reference) {
 			q.log.Debugf("Skipping image-backed volume with reference %s", volume.Reference)
 			continue
 		}
@@ -273,25 +280,25 @@ func (q *Quadlet) ensureArtifactVolumes(ctx context.Context, action *Action) err
 		volumeName := volume.ID
 		volumePath := ""
 		var err error
-		if q.podman.VolumeExists(ctx, volumeName) {
+		if podman.VolumeExists(ctx, volumeName) {
 			q.log.Tracef("Volume %q already exists, updating contents", volumeName)
-			volumePath, err = q.podman.InspectVolumeMount(ctx, volumeName)
+			volumePath, err = podman.InspectVolumeMount(ctx, volumeName)
 			if err != nil {
 				return fmt.Errorf("inspect volume %q: %w", volumeName, err)
 			}
-			if err := q.rw.RemoveContents(volumePath); err != nil {
+			if err := rw.RemoveContents(volumePath); err != nil {
 				return fmt.Errorf("removing volume content %q: %w", volumePath, err)
 			}
 		} else {
 			q.log.Tracef("Creating volume %q", volumeName)
-			volumePath, err = q.podman.CreateVolume(ctx, volumeName, labels)
+			volumePath, err = podman.CreateVolume(ctx, volumeName, labels)
 			if err != nil {
 				return cleanup(fmt.Errorf("creating volume %q: %w", volumeName, err))
 			}
 			artifactVolumes = append(artifactVolumes, volumeName)
 		}
 
-		if _, err := q.podman.ExtractArtifact(ctx, volume.Reference, volumePath); err != nil {
+		if _, err := podman.ExtractArtifact(ctx, volume.Reference, volumePath); err != nil {
 			return cleanup(fmt.Errorf("extracting artifact to volume %q: %w", volumeName, err))
 		}
 

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -237,9 +237,21 @@ func TestManager(t *testing.T) {
 			currentProviders, err := provider.FromDeviceSpec(ctx, log, mockPodmanClient, readWriter, tc.current)
 			require.NoError(err)
 
+			var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+				return mockPodmanClient, nil
+			}
+			var systemdFactory systemd.ManagerFactory = func(user v1beta1.Username) (systemd.Manager, error) {
+				return mockSystemdMgr, nil
+			}
+			var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+				return readWriter, nil
+			}
+			var rwMockFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+				return mockReadWriter, nil
+			}
 			manager := &manager{
-				readWriter:    readWriter,
-				podmanMonitor: NewPodmanMonitor(log, mockPodmanClient, mockSystemdMgr, "", mockReadWriter),
+				rwFactory:     rwFactory,
+				podmanMonitor: NewPodmanMonitor(log, podmanFactory, systemdFactory, "", rwMockFactory),
 				log:           log,
 			}
 
@@ -321,9 +333,21 @@ func TestManagerRemoveApplication(t *testing.T) {
 		// Monitor stops during second AfterUpdate when no apps remain (no mock needed)
 	)
 
+	var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+		return mockPodmanClient, nil
+	}
+	var systemdFactory systemd.ManagerFactory = func(user v1beta1.Username) (systemd.Manager, error) {
+		return mockSystemdMgr, nil
+	}
+	var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+		return readWriter, nil
+	}
+	var rwMockFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+		return mockReadWriter, nil
+	}
 	manager := &manager{
-		readWriter:    readWriter,
-		podmanMonitor: NewPodmanMonitor(log, mockPodmanClient, mockSystemdMgr, "", mockReadWriter),
+		rwFactory:     rwFactory,
+		podmanMonitor: NewPodmanMonitor(log, podmanFactory, systemdFactory, "", rwMockFactory),
 		log:           log,
 	}
 
@@ -682,10 +706,23 @@ func TestCollectOCITargetsErrorHandling(t *testing.T) {
 					fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
 				)
 
+				var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+					return mockPodmanClient, nil
+				}
+				var systemdFactory systemd.ManagerFactory = func(user v1beta1.Username) (systemd.Manager, error) {
+					return mockSystemdMgr, nil
+				}
+
+				var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+					return readWriter, nil
+				}
+				var rwMockFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+					return mockReadWriter, nil
+				}
 				return &manager{
-					readWriter:     readWriter,
-					podmanMonitor:  NewPodmanMonitor(log, mockPodmanClient, mockSystemdMgr, "", mockReadWriter),
-					podmanClient:   mockPodmanClient,
+					rwFactory:      rwFactory,
+					podmanMonitor:  NewPodmanMonitor(log, podmanFactory, systemdFactory, "", rwMockFactory),
+					podmanFactory:  podmanFactory,
 					log:            log,
 					ociTargetCache: provider.NewOCITargetCache(),
 					appDataCache:   provider.NewAppDataCache(),
@@ -730,10 +767,22 @@ func TestCollectOCITargetsErrorHandling(t *testing.T) {
 					fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
 				)
 
+				var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+					return mockPodmanClient, nil
+				}
+				var systemdFactory systemd.ManagerFactory = func(user v1beta1.Username) (systemd.Manager, error) {
+					return mockSystemdMgr, nil
+				}
+				var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+					return readWriter, nil
+				}
+				var rwMockFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+					return mockReadWriter, nil
+				}
 				return &manager{
-					readWriter:     readWriter,
-					podmanMonitor:  NewPodmanMonitor(log, mockPodmanClient, mockSystemdMgr, "", mockReadWriter),
-					podmanClient:   mockPodmanClient,
+					rwFactory:      rwFactory,
+					podmanMonitor:  NewPodmanMonitor(log, podmanFactory, systemdFactory, "", rwMockFactory),
+					podmanFactory:  podmanFactory,
 					log:            log,
 					ociTargetCache: provider.NewOCITargetCache(),
 					appDataCache:   provider.NewAppDataCache(),

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -64,7 +64,7 @@ type ApplicationSpec struct {
 // before the base images are available locally.
 func CollectBaseOCITargets(
 	ctx context.Context,
-	readWriter fileio.ReadWriter,
+	rwFactory fileio.ReadWriterFactory,
 	spec *v1beta1.DeviceSpec,
 	configProvider client.PullConfigProvider,
 ) ([]dependency.OCIPullTarget, error) {
@@ -160,6 +160,10 @@ func CollectBaseOCITargets(
 		}
 	}
 
+	readWriter, err := rwFactory("")
+	if err != nil {
+		return nil, err
+	}
 	embeddedTargets, err := collectEmbeddedOCITargets(ctx, readWriter, configProvider)
 	if err != nil {
 		return nil, fmt.Errorf("collecting embedded OCI targets: %w", err)

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/pkg/userutil"
 )
 
 const (
@@ -69,6 +70,32 @@ type ReadWriter interface {
 type readWriter struct {
 	Reader
 	Writer
+}
+
+type ReadWriterFactory func(username v1beta1.Username) (ReadWriter, error)
+
+func NewReadWriterFactory(rootDir string) ReadWriterFactory {
+	return func(username v1beta1.Username) (ReadWriter, error) {
+		writerOptions := []WriterOption{
+			WithWriterRootDir(rootDir),
+		}
+
+		if username != "" {
+			uid, gid, _, err := userutil.LookupUser(username)
+			if err != nil {
+				return nil, err
+			}
+			writerOptions = append(writerOptions,
+				WithUID(uid),
+				WithGID(gid),
+			)
+		}
+
+		return NewReadWriter(
+			NewReader(WithReaderRootDir(rootDir)),
+			NewWriter(writerOptions...),
+		), nil
+	}
 }
 
 func NewReadWriter(reader Reader, writer Writer) ReadWriter {


### PR DESCRIPTION
This makes the compose and quadlet app lifecycle handlers mostly aware of users (though everything is still treated as root for now).

For the quadlets lifecycle handler, now that there are multiple systemd instances involved, we need to do all of the daemon reloading on a per-action basis instead of once for everything.

Also the podman monitor has the beginnings of user handling, but still needs more to fire up multiple event watchers for each user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions now include an owning user and are grouped per-user.
  * Per-user executer support enables operations to run with user-specific permissions.

* **Refactor**
  * Centralized file I/O via a root ReadWriter factory and wired client factories for consistent, safer access.
  * Lifecycle and container managers create per-action resources on demand for better isolation and error handling.

* **Tests**
  * Test suites updated to use factory-based dependency injection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->