### PR TITLE
EDM-3131: Add Helm post-renderer for release label injection

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -273,6 +273,10 @@ rollouts
 reimplementing
 repurposed
 prefetch
+subcommand
+statefulsets
+daemonsets
+cronjobs
  - docs/user/references/api-resources.md
 namespacing
 approvedBy

--- a/internal/agent/client/kube.go
+++ b/internal/agent/client/kube.go
@@ -163,3 +163,8 @@ func (k *Kube) ResolveKubeconfig() (string, error) {
 
 	return "", fmt.Errorf("no kubeconfig found, checked: %s", strings.Join(checkedPaths, ", "))
 }
+
+// Kustomize runs kubectl kustomize on the specified directory and returns the output.
+func (k *Kube) Kustomize(ctx context.Context, dir string) (stdout, stderr string, exitCode int) {
+	return k.exec.ExecuteWithContext(ctx, k.binary, "kustomize", dir)
+}

--- a/internal/agent/device/applications/helm/docs.go
+++ b/internal/agent/device/applications/helm/docs.go
@@ -1,0 +1,4 @@
+// Package helm provides utilities for working with Helm charts and rendered manifests.
+// It includes functions for extracting container images from Kubernetes manifests
+// and injecting labels into resources for release tracking.
+package helm

--- a/internal/agent/device/applications/helm/images.go
+++ b/internal/agent/device/applications/helm/images.go
@@ -1,4 +1,4 @@
-package client
+package helm
 
 import (
 	"io"
@@ -49,6 +49,8 @@ type k8sContainer struct {
 }
 
 // ExtractImagesFromManifests parses Kubernetes manifests and returns all container image references.
+// It handles multi-document YAML and extracts images from Pods, Deployments, StatefulSets,
+// DaemonSets, ReplicaSets, Jobs, and CronJobs.
 func ExtractImagesFromManifests(manifests string) ([]string, error) {
 	imageSet := make(map[string]struct{})
 

--- a/internal/agent/device/applications/helm/images_test.go
+++ b/internal/agent/device/applications/helm/images_test.go
@@ -1,4 +1,4 @@
-package client
+package helm
 
 import (
 	"sort"
@@ -8,8 +8,6 @@ import (
 )
 
 func TestExtractImagesFromManifests(t *testing.T) {
-	require := require.New(t)
-
 	testCases := []struct {
 		name           string
 		manifests      string
@@ -258,6 +256,7 @@ spec:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
 			images, err := ExtractImagesFromManifests(tc.manifests)
 			require.NoError(err)
 

--- a/internal/agent/device/applications/helm/labeler.go
+++ b/internal/agent/device/applications/helm/labeler.go
@@ -1,0 +1,125 @@
+package helm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// AppLabelKey is the label key used to identify which application
+	// owns a Kubernetes resource. This enables querying all resources
+	// belonging to a specific application.
+	AppLabelKey = "agent.flightctl.io/app"
+
+	manifestsFileName     = "manifests.yaml"
+	kustomizationFileName = "kustomization.yaml"
+)
+
+// Labeler injects labels into Kubernetes manifests using kubectl kustomize.
+// It leverages kustomize's built-in label transformer which automatically
+// handles all Kubernetes resource types and their pod templates.
+type Labeler struct {
+	kube       *client.Kube
+	readWriter fileio.ReadWriter
+}
+
+// NewLabeler creates a new Labeler that uses kubectl kustomize to inject labels.
+func NewLabeler(kube *client.Kube, readWriter fileio.ReadWriter) *Labeler {
+	return &Labeler{
+		kube:       kube,
+		readWriter: readWriter,
+	}
+}
+
+// InjectLabels reads multi-document YAML from input, injects the provided labels
+// into each Kubernetes resource using kustomize, and writes the modified YAML to output.
+//
+// This function is designed to be used as a Helm post-renderer. Helm pipes
+// rendered templates through the post-renderer before applying them to the cluster.
+//
+// Labels are injected using kustomize's label transformer with:
+//   - includeSelectors: false (avoids modifying immutable selectors)
+//   - includeTemplates: true (ensures pods inherit labels from their controllers)
+//
+// This approach automatically handles all Kubernetes resource types including
+// Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, and any future types.
+func (l *Labeler) InjectLabels(ctx context.Context, input io.Reader, output io.Writer, labels map[string]string) error {
+	if !l.kube.IsAvailable() {
+		return fmt.Errorf("kubectl or oc not available")
+	}
+
+	tempDir, err := l.readWriter.MkdirTemp("kustomize-labels-*")
+	if err != nil {
+		return fmt.Errorf("create temp directory: %w", err)
+	}
+	defer func() { _ = l.readWriter.RemoveAll(tempDir) }()
+
+	manifestsPath := filepath.Join(tempDir, manifestsFileName)
+	kustomizationPath := filepath.Join(tempDir, kustomizationFileName)
+
+	manifests, err := io.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("read input manifests: %w", err)
+	}
+
+	if err := l.readWriter.WriteFile(manifestsPath, manifests, fileio.DefaultFilePermissions); err != nil {
+		return fmt.Errorf("write manifests file: %w", err)
+	}
+
+	kustomization := buildKustomization(labels)
+	kustomizationBytes, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return fmt.Errorf("marshal kustomization: %w", err)
+	}
+
+	if err := l.readWriter.WriteFile(kustomizationPath, kustomizationBytes, fileio.DefaultFilePermissions); err != nil {
+		return fmt.Errorf("write kustomization file: %w", err)
+	}
+
+	stdout, stderr, exitCode := l.kube.Kustomize(ctx, tempDir)
+	if exitCode != 0 {
+		return fmt.Errorf("kubectl kustomize failed (exit %d): %s", exitCode, stderr)
+	}
+
+	if _, err := output.Write([]byte(stdout)); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+
+	return nil
+}
+
+// kustomization represents the structure of a kustomization.yaml file.
+type kustomization struct {
+	APIVersion string        `yaml:"apiVersion"`
+	Kind       string        `yaml:"kind"`
+	Resources  []string      `yaml:"resources"`
+	Labels     []labelConfig `yaml:"labels"`
+}
+
+// labelConfig represents a label configuration in kustomization.yaml.
+type labelConfig struct {
+	Pairs            map[string]string `yaml:"pairs"`
+	IncludeSelectors bool              `yaml:"includeSelectors"`
+	IncludeTemplates bool              `yaml:"includeTemplates"`
+}
+
+func buildKustomization(labels map[string]string) kustomization {
+	return kustomization{
+		APIVersion: "kustomize.config.k8s.io/v1beta1",
+		Kind:       "Kustomization",
+		Resources:  []string{manifestsFileName},
+		Labels: []labelConfig{
+			{
+				Pairs:            labels,
+				IncludeSelectors: false,
+				IncludeTemplates: true,
+			},
+		},
+	}
+}

--- a/internal/agent/device/applications/helm/labeler_test.go
+++ b/internal/agent/device/applications/helm/labeler_test.go
@@ -1,0 +1,319 @@
+package helm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestLabelerInjectLabels(t *testing.T) {
+	const tempDir = "/tmp/kustomize-labels-test"
+
+	testCases := []struct {
+		name          string
+		input         string
+		labels        map[string]string
+		setupMocks    func(*executer.MockExecuter, *fileio.MockReadWriter, string) string
+		expected      []string
+		expectedCount int
+	}{
+		{
+			name: "simple pod with no existing labels",
+			input: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: nginx`,
+			labels: map[string]string{AppLabelKey: "my-app"},
+			setupMocks: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter, input string) string {
+				output := `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    agent.flightctl.io/app: my-app
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: nginx
+`
+				mockRW.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/manifests.yaml", []byte(input), fileio.DefaultFilePermissions).Return(nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).Return(output, "", 0)
+				mockRW.EXPECT().RemoveAll(tempDir).Return(nil)
+				return output
+			},
+			expected: []string{
+				"agent.flightctl.io/app: my-app",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "deployment with pod template",
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest`,
+			labels: map[string]string{AppLabelKey: "my-app"},
+			setupMocks: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter, input string) string {
+				output := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    agent.flightctl.io/app: my-app
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        agent.flightctl.io/app: my-app
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+`
+				mockRW.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/manifests.yaml", []byte(input), fileio.DefaultFilePermissions).Return(nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).Return(output, "", 0)
+				mockRW.EXPECT().RemoveAll(tempDir).Return(nil)
+				return output
+			},
+			expected: []string{
+				"agent.flightctl.io/app: my-app",
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "configmap only gets metadata labels",
+			input: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value`,
+			labels: map[string]string{AppLabelKey: "my-config"},
+			setupMocks: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter, input string) string {
+				output := `apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  labels:
+    agent.flightctl.io/app: my-config
+  name: test-config
+`
+				mockRW.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/manifests.yaml", []byte(input), fileio.DefaultFilePermissions).Return(nil)
+				mockRW.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).Return(output, "", 0)
+				mockRW.EXPECT().RemoveAll(tempDir).Return(nil)
+				return output
+			},
+			expected: []string{
+				"agent.flightctl.io/app: my-config",
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMocks(mockExec, mockReadWriter, tc.input)
+
+			kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+			labeler := NewLabeler(kubeClient, mockReadWriter)
+
+			var output bytes.Buffer
+			err := labeler.InjectLabels(context.Background(), strings.NewReader(tc.input), &output, tc.labels)
+			require.NoError(err)
+
+			result := output.String()
+			for _, exp := range tc.expected {
+				require.Contains(result, exp)
+				occurrences := strings.Count(result, exp)
+				require.Equal(tc.expectedCount, occurrences, "expected %d occurrences of label %q", tc.expectedCount, exp)
+			}
+		})
+	}
+}
+
+func TestLabelerInjectLabels_MkdirTempFails(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	mockReadWriter.EXPECT().MkdirTemp("kustomize-labels-*").Return("", fmt.Errorf("disk full"))
+
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	labeler := NewLabeler(kubeClient, mockReadWriter)
+
+	var output bytes.Buffer
+	err := labeler.InjectLabels(context.Background(), strings.NewReader("test"), &output, map[string]string{"key": "value"})
+	require.Error(err)
+	require.Contains(err.Error(), "create temp directory")
+}
+
+func TestLabelerInjectLabels_KustomizeFails(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	tempDir := "/tmp/kustomize-labels-test"
+	input := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: test"
+
+	mockReadWriter.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/manifests.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).
+		Return("", "error: invalid kustomization", 1)
+	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
+
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	labeler := NewLabeler(kubeClient, mockReadWriter)
+
+	var output bytes.Buffer
+	err := labeler.InjectLabels(context.Background(), strings.NewReader(input), &output, map[string]string{"key": "value"})
+	require.Error(err)
+	require.Contains(err.Error(), "kubectl kustomize failed")
+}
+
+func TestLabelerInjectLabels_EmptyInput(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	tempDir := "/tmp/kustomize-labels-test"
+
+	mockReadWriter.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/manifests.yaml", []byte(""), fileio.DefaultFilePermissions).Return(nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).
+		Return("", "", 0)
+	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
+
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	labeler := NewLabeler(kubeClient, mockReadWriter)
+
+	var output bytes.Buffer
+	err := labeler.InjectLabels(context.Background(), strings.NewReader(""), &output, map[string]string{"key": "value"})
+	require.NoError(err)
+	require.Empty(strings.TrimSpace(output.String()))
+}
+
+func TestLabelerInjectLabels_MultiDocument(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	tempDir := "/tmp/kustomize-labels-test"
+
+	input := `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config1
+data:
+  key: value1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config2
+data:
+  key: value2`
+
+	kustomizeOutput := `apiVersion: v1
+data:
+  key: value1
+kind: ConfigMap
+metadata:
+  labels:
+    agent.flightctl.io/app: multi-doc-test
+  name: config1
+---
+apiVersion: v1
+data:
+  key: value2
+kind: ConfigMap
+metadata:
+  labels:
+    agent.flightctl.io/app: multi-doc-test
+  name: config2
+`
+
+	mockReadWriter.EXPECT().MkdirTemp("kustomize-labels-*").Return(tempDir, nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/manifests.yaml", []byte(input), fileio.DefaultFilePermissions).Return(nil)
+	mockReadWriter.EXPECT().WriteFile(tempDir+"/kustomization.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", "kustomize", tempDir).
+		Return(kustomizeOutput, "", 0)
+	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
+
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	labeler := NewLabeler(kubeClient, mockReadWriter)
+
+	labels := map[string]string{AppLabelKey: "multi-doc-test"}
+
+	var output bytes.Buffer
+	err := labeler.InjectLabels(context.Background(), strings.NewReader(input), &output, labels)
+	require.NoError(err)
+
+	result := output.String()
+	occurrences := strings.Count(result, "agent.flightctl.io/app: multi-doc-test")
+	require.Equal(2, occurrences, "expected 2 label injections for 2 documents")
+}


### PR DESCRIPTION
Relying on helm application developers to correctly apply labels such that `app.kubernetes.io/instance`  or `app.kubernetes.io/name` labels are properly applied to deployed resources could result in some applications becoming unmonitorable. These labels are recommended by helm, but ultimately it's up to the developer to add them. Therefore, we need a reliable way to track the deployments. 

The agent will install and upgrade with a post-renderer argument to apply the `agent.flightctl.io/app` label. Post-Render requires a binary that accepts a yaml stream and outputs yaml. This utilizes `kubectl kustomize` to inject labels into resources that will be deployed, and can directly tied back to a specific application for monitoring purposes.

```yaml
  apiVersion: kustomize.config.k8s.io/v1beta1                                                                                                                            
  kind: Kustomization                                                                                                                                                    
  resources:                                                                                                                                                             
    - manifests.yaml                                                                                                                                                     
  labels:                                                                                                                                                                
    - pairs:                                                                                                                                                             
        agent.flightctl.io/app: my-app                                                                                                                                   
      includeSelectors: false                                                                                                                                            
      includeTemplates: true                                                                                                                                             
                                                                                                                                                                         
  Key settings:                                                                                                                                                          
  - includeSelectors: false - Avoids modifying immutable selectors (like spec.selector.matchLabels on Deployments)                                                       
  - includeTemplates: true - Ensures pods inherit labels from their controllers (adds labels to spec.template.metadata.labels)                                           
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI subcommand to inject application labels into Helm-rendered manifests via stdin/stdout
  * Helm post-renderer support applied to install/upgrade flows
  * Kustomize-based labeler to apply app labels across Kubernetes resources (including pod templates and CronJobs)

* **Documentation**
  * Added user docs and examples for the new CLI command and manifest label-injection workflow

* **Tests**
  * Added unit tests covering label injection and manifest image extraction behaviors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->