### PR TITLE
EDM-3104: Add integration test for device management cert rotation

### DIFF
--- a/internal/agent/device/certmanager/manager.go
+++ b/internal/agent/device/certmanager/manager.go
@@ -3,6 +3,7 @@ package certmanager
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -152,7 +153,10 @@ func (a *AgentCertManager) Run(ctx context.Context) {
 		a.log.Errorf("Initial certificate sync failed: %v", err)
 	}
 
-	t := time.NewTicker(defaultSyncInterval)
+	interval := certManagerSyncInterval()
+	a.log.Debugf("Certificate manager sync interval: %s", interval)
+
+	t := time.NewTicker(interval)
 	defer t.Stop()
 
 	for {
@@ -165,4 +169,13 @@ func (a *AgentCertManager) Run(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func certManagerSyncInterval() time.Duration {
+	if v := os.Getenv("FLIGHTCTL_TEST_CERT_MANAGER_SYNC_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultSyncInterval
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test validating device management certificate rotation, on-disk renewal, TTL override behavior, and renewal metadata updates.

* **Chores**
  * Added environment-driven overrides for certificate expiry, renewal timing, and manager sync interval to support testing.
  * Expanded test helper to set and restore multiple environment variables atomically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->