### PR TITLE
EDM-3162: CI fix for should show events for application workload validation

### DIFF
--- a/test/e2e/cli/cli_events_test.go
+++ b/test/e2e/cli/cli_events_test.go
@@ -379,9 +379,11 @@ var _ = Describe("cli events operation", func() {
 
 			By("Updating device with non-existing app image")
 
+			GinkgoWriter.Printf("Starting update to add invalid application for %s\n", deviceName)
+
 			// Apply the invalid application configuration
 
-			err = harness.UpdateDevice(deviceName, func(device *v1beta1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceName, func(device *v1beta1.Device) {
 				imageName := "quay.io/rh_ee_camadorg/oci-app-ko:latest"
 				// Create the application spec with the invalid image
 				var applicationConfig = v1beta1.ImageApplicationProviderSpec{
@@ -398,6 +400,7 @@ var _ = Describe("cli events operation", func() {
 				GinkgoWriter.Printf("Updating %s with application\n", deviceName)
 			})
 			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Finished update to add invalid application for %s\n", deviceName)
 
 			By("Checking that the application error event is shown")
 			Eventually(func() string {
@@ -409,13 +412,15 @@ var _ = Describe("cli events operation", func() {
 			}, "2m", "5s").Should(Not(BeEmpty()), "Expected application error event to be shown")
 
 			By("Fixing the application by using valid image or removing it")
+			GinkgoWriter.Printf("Starting update to remove applications for %s\n", deviceName)
 			// Remove the application to fix the issue
-			err = harness.UpdateDevice(deviceName, func(device *v1beta1.Device) {
+			err = harness.UpdateDeviceWithRetries(deviceName, func(device *v1beta1.Device) {
 				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{}
 				GinkgoWriter.Printf("Updating %s removing applications\n", deviceName)
 			})
 
 			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Finished update to remove applications for %s\n", deviceName)
 
 			By("Checking that 'No application workloads' success event is shown")
 			Eventually(func() string {


### PR DESCRIPTION
Fix for CI failure:
https://issues.redhat.com/browse/EDM-3162
Added retries for the device updates to avoid immediate failure in the second update.
Added minor logging for future debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Device update operations now include retry logic to improve reliability when adding or removing applications
  * Enhanced diagnostic logging added to CLI event tests for better troubleshooting and debugging support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->