### PR TITLE
NO-ISSUE: Allow image builder in make deploy without sudo

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -18,10 +18,19 @@ cluster: bin/e2e-certs/ca.pem
 clean-cluster:
 	kind delete cluster
 
+# Warn if deploy is run with sudo (kind-based deploy doesn't need sudo)
+check-sudo-warning:
+	@if [ "$$(id -u)" = "0" ] && [ -n "$$SUDO_USER" ]; then \
+		echo "WARNING: Running 'make deploy' with sudo is not recommended."; \
+		echo "The kind-based deployment does not require sudo."; \
+		echo "Container builds will use your user's podman to avoid permission issues."; \
+		echo ""; \
+	fi
+
 ifndef SKIP_BUILD
-deploy: cluster build-containers build-cli deploy-helm prepare-agent-config
+deploy: check-sudo-warning cluster build-containers build-cli deploy-helm prepare-agent-config
 else
-deploy: cluster deploy-helm prepare-agent-config
+deploy: check-sudo-warning cluster deploy-helm prepare-agent-config
 	@echo "Skipping container and CLI builds (SKIP_BUILD is set)"
 endif
 


### PR DESCRIPTION
Changes the scripts so that image builder works even when deployed with `make deploy` (without sudo permissions).

Prevents having to switch between two `kind` contexts / configurations for `client.yaml` etc when wanting to use ImageBuilder or the other base components of flightctl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container build and cleanup commands now run through a sudo-aware wrapper so builds invoked as root use the original invoking user's container runtime.
  * Deployment now runs a preflight warning when invoked with sudo to discourage unnecessary root use and clarify build behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->