### PR TITLE
NO-ISSUE: fix dirs not created for rpm

### DIFF
--- a/cmd/flightctl-standalone/render_quadlets.go
+++ b/cmd/flightctl-standalone/render_quadlets.go
@@ -33,6 +33,7 @@ func NewRenderQuadletsCommand() *cobra.Command {
 	cmd.Flags().StringVar(&config.QuadletFilesOutputDir, "quadlet-dir", config.QuadletFilesOutputDir, "Quadlet files output directory")
 	cmd.Flags().StringVar(&config.SystemdUnitOutputDir, "systemd-dir", config.SystemdUnitOutputDir, "Systemd unit output directory")
 	cmd.Flags().StringVar(&config.BinOutputDir, "bin-dir", config.BinOutputDir, "Binary output directory")
+	cmd.Flags().StringVar(&config.VarTmpOutputDir, "var-tmp-dir", config.VarTmpOutputDir, "Var tmp output directory for builds/exports")
 	cmd.Flags().StringSliceVar(&config.BinSourceDirs, "bin-source-dirs", []string{"bin"}, "Directories to search for binaries (searched in order)")
 	cmd.Flags().StringVar(&config.FlightctlServicesTagOverride, "flightctl-services-tag-override", "", "Override image tags for all FlightCtl services")
 	cmd.Flags().BoolVar(&config.FlightctlUiTagOverride, "flightctl-ui-tag-override", false, "Apply tag override to UI service")

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -110,7 +110,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-db-migrate"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-imagebuilder-api"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-imagebuilder-worker"), Mode: ExecutableFileMode},
-		{Action: ActionCreateEmptyDir, Destination: filepath.Join("/var/tmp/flightctl-builds"), Mode: ExecutableFileMode},
-		{Action: ActionCreateEmptyDir, Destination: filepath.Join("/var/tmp/flightctl-exports"), Mode: ExecutableFileMode},
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarTmpOutputDir, "flightctl-builds"), Mode: ExecutableFileMode},
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarTmpOutputDir, "flightctl-exports"), Mode: ExecutableFileMode},
 	}
 }

--- a/internal/quadlet/renderer/renderer.go
+++ b/internal/quadlet/renderer/renderer.go
@@ -46,6 +46,7 @@ type RendererConfig struct {
 	QuadletFilesOutputDir    string `mapstructure:"quadlet-dir"`
 	SystemdUnitOutputDir     string `mapstructure:"systemd-dir"`
 	BinOutputDir             string `mapstructure:"bin-dir"`
+	VarTmpOutputDir          string `mapstructure:"var-tmp-dir"`
 
 	// Source directories for binary search
 	BinSourceDirs []string `mapstructure:"bin-source-dirs"`
@@ -77,6 +78,7 @@ func NewRendererConfig() *RendererConfig {
 		QuadletFilesOutputDir:    "/usr/share/containers/systemd",
 		SystemdUnitOutputDir:     "/usr/lib/systemd/system",
 		BinOutputDir:             "/usr/bin",
+		VarTmpOutputDir:          "/var/tmp",
 	}
 }
 

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -502,7 +502,8 @@ echo "Flight Control Observability Stack uninstalled."
         --writeable-config-dir "%{buildroot}%{_sysconfdir}/flightctl" \
         --quadlet-dir "%{buildroot}%{_datadir}/containers/systemd" \
         --systemd-dir "%{buildroot}/usr/lib/systemd/system" \
-        --bin-dir "%{buildroot}/usr/bin"
+        --bin-dir "%{buildroot}/usr/bin" \
+        --var-tmp-dir "%{buildroot}%{_var}/tmp"
 
     # Copy services must gather script
     cp packaging/must-gather/flightctl-services-must-gather %{buildroot}%{_bindir}
@@ -693,6 +694,8 @@ rm -rf /usr/share/sosreport
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db-migrate
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-imagebuilder-api
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-imagebuilder-worker
+    %dir %attr(0755,root,root) %{_var}/tmp/flightctl-builds
+    %dir %attr(0755,root,root) %{_var}/tmp/flightctl-exports
     %{_datadir}/flightctl/flightctl-api/config.yaml.template
     %{_datadir}/flightctl/flightctl-api/env.template
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-api/init.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--var-tmp-dir` command-line flag to configure the temporary directory location used during quadlet rendering operations, with a default value of `/var/tmp`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->