### PR TITLE
EDM-3159: removed invalid part of the scc config

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -6,6 +6,34 @@ A helm chart for FlightControl
 
 **Homepage:** <https://github.com/flightctl/flightctl>
 
+## Prerequisites
+
+### Pod Security Standards
+
+The `flightctl-imagebuilder-worker` component requires elevated privileges to build OS images using osbuild/bootc. It needs:
+
+- Privileged container access
+- Host device access (`/dev`, `/sys`, `/lib/modules`)
+- Capabilities: `SYS_ADMIN`, `MKNOD`, `SYS_CHROOT`, `SETFCAP`
+
+If your namespace enforces the "restricted" Pod Security Standard, you will see warnings during deployment. To suppress these warnings, configure the namespace labels:
+
+```bash
+kubectl label namespace <namespace> \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+```
+
+On OpenShift clusters, the chart automatically creates a SecurityContextConstraints (SCC) that grants the required permissions to the `flightctl-imagebuilder-worker` service account.
+
+If you don't need image building capabilities, you can disable the imagebuilder-worker:
+
+```yaml
+imageBuilderWorker:
+  enabled: false
+```
+
 ## Installation
 
 ### Install Chart

--- a/deploy/helm/flightctl/README.md.gotmpl
+++ b/deploy/helm/flightctl/README.md.gotmpl
@@ -33,6 +33,34 @@
 {{- end }}
 {{ end }}
 
+## Prerequisites
+
+### Pod Security Standards
+
+The `flightctl-imagebuilder-worker` component requires elevated privileges to build OS images using osbuild/bootc. It needs:
+
+- Privileged container access
+- Host device access (`/dev`, `/sys`, `/lib/modules`)
+- Capabilities: `SYS_ADMIN`, `MKNOD`, `SYS_CHROOT`, `SETFCAP`
+
+If your namespace enforces the "restricted" Pod Security Standard, you will see warnings during deployment. To suppress these warnings, configure the namespace labels:
+
+```bash
+kubectl label namespace <namespace> \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged
+```
+
+On OpenShift clusters, the chart automatically creates a SecurityContextConstraints (SCC) that grants the required permissions to the `flightctl-imagebuilder-worker` service account.
+
+If you don't need image building capabilities, you can disable the imagebuilder-worker:
+
+```yaml
+imageBuilderWorker:
+  enabled: false
+```
+
 ## Installation
 
 ### Install Chart

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-scc.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-scc.yaml
@@ -32,7 +32,6 @@ runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: RunAsAny
-seccompProfile: '*'
 volumes:
   - '*'
 users:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed an explicit seccomp profile requirement so deployments can rely on standard/default seccomp behavior.

* **Documentation**
  * Added a Prerequisites section describing required privileges for the image builder worker (privileged access, host device access, capabilities), guidance to suppress pod security warnings, OpenShift SCC notes, and an option to disable the imagebuilder worker via configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->