### PR TITLE
EDM-6163: Skip kind test

### DIFF
--- a/test/e2e/observability/observability_test.go
+++ b/test/e2e/observability/observability_test.go
@@ -23,15 +23,17 @@ const (
 )
 
 var _ = Describe("Device observability", func() {
+	BeforeEach(func() {
+		ctxStr, err := e2e.GetContext()
+		if err != nil || ctxStr != util.KIND {
+			Skip("KIND context required for telemetry gateway metrics")
+		}
+	})
+
 	Context("telemetry gateway metrics", func() {
 		It("should export device host metrics via the telemetry gateway", Label("85040"), func() {
 			// Get harness directly - no shared package-level variable
 			harness := e2e.GetWorkerHarness()
-
-			ctxStr, err := e2e.GetContext()
-			if err != nil || (ctxStr != util.KIND && ctxStr != util.OCP) {
-				Skip("Kubernetes context required for telemetry gateway metrics")
-			}
 
 			By("verifying telemetry gateway configuration exports Prometheus metrics")
 			cfg, err := harness.GetConfigMapValue(telemetryGatewayNamespace, telemetryGatewayConfigMap, telemetryGatewayConfigPath)


### PR DESCRIPTION
Test skipped as it is for kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite now requires a KIND Kubernetes environment and will skip runs in other contexts.
  * Removed previous in-test multi-environment validation; environment checks are centralized.
  * No changes to actual test steps or test behavior beyond environment enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->