### PR TITLE
EDM-3103: Document agent management certificate rotation

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,6 +5,7 @@ config:
   no-blanks-blockquote: false # to allow two block quotes after another
   no-duplicate-heading: false # to allow common sections like "Further References"
   table-column-style: false # to allow inconsistent table column styles
+  ul-style: false # to allow mixed unordered list markers (-, *, +)
 
 # Ignore files referenced by .gitignore (only valid at root)
 gitignore: true

--- a/.spelling
+++ b/.spelling
@@ -482,6 +482,7 @@ SSL
 PL/pgSQL
 PL
 pgSQL
+PromQL
 values.yaml
 values.dev.yaml
 CN

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -19,7 +19,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 | `spec-fetch-interval`    | `Duration` | | **Deprecated**: This parameter is no longer used. The agent now uses long-polling to receive specification updates immediately when available. |
 | `status-update-interval` | `Duration` | | Interval in which the agent reports its device status under normal conditions. The agent immediately sends status reports on major events related to the health of the system and application workloads as well as on the progress during a system update. Default: `60s` |
 | `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. Default: `{}` |
-| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault"]` |
+| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
 | `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
 | `system-info-timeout`    | `Duration` | | The timeout for collecting system info. Default: `2m`. Maximum: `2m` |
 | `pull-timeout`           | `Duration` | | The timeout for pulling a single OCI target. Default: `10m` |
@@ -112,6 +112,21 @@ status:
     distroName: Red Hat Enterprise Linux
     distroVersion: 9.5 (Plow)
 ```
+
+## Managed system info collectors
+
+These system info fields are populated internally by the `flightctl-agent`.
+They reflect the agent lifecycle state and are updated only when the underlying state changes
+(for example, certificate rotation or TPM initialization).
+
+| System Info Key          | Description                                                              |
+|--------------------------|--------------------------------------------------------------------------|
+| `managementCertSerial`   | Serial number of the active device management certificate                |
+| `managementCertNotAfter` | Expiration time (`NotAfter`) of the active device management certificate |
+| `tpmVendorInfo`          | TPM vendor information derived from the device’s TPM manufacturer data   |
+
+> [!NOTE]
+> These managed system info fields follow the same configuration and reporting semantics as built-in system information collectors, and can be included or excluded from device status reporting via the `system-info` configuration parameter.
 
 ## Custom system info collectors
 

--- a/docs/user/references/certificate-architecture.md
+++ b/docs/user/references/certificate-architecture.md
@@ -25,6 +25,7 @@ For TPM attestation certificates, see [Configuring Device Attestation](../instal
 | [Alertmanager Proxy](../../../internal/crypto/signer/signer_server_svc.go)            | Alerts TLS               | 2 years  | Root CA                  |
 | [Device Enrollment](../../../internal/crypto/signer/signer_device_enrollment.go)                    | Device enrollment        | 1 year   | Client-Signer CA         |
 | [Device Management](../../../internal/crypto/signer/signer_device_management.go)             | Device operations        | 1 year   | Client-Signer CA         |
+| [Device Management Renewal](../../../internal/crypto/signer/signer_device_management_renewal.go)             | Device operations        | 1 year   | Client-Signer CA         |
 | [Device Services](../../../internal/crypto/signer/signer_device_svc_client.go)    | Device services    | 1 year   | Client-Signer CA |
 | UI Server *                   | UI TLS                   | 2 years  | Root CA                  |
 | CLI Artifacts Server *        | CLI Artifacts TLS        | 2 years  | Root CA                  |
@@ -119,8 +120,25 @@ flightctl certificate request --signer=enrollment --expiration=30d --output=embe
 
 ## Certificate Rotation
 
+### Agent-managed Certificates
+
+The `flightctl-agent` automatically manages and rotates a subset of certificates used for device operation and communication.
+
+#### Device Management Certificate
+
+The device management certificate is **automatically rotated** by the `flightctl-agent` before expiration.
+
+- Rotation is handled internally by the agent.
+- A new certificate is issued using the `Device Management Renewal` signer.
+- Rotation occurs based on the configured renewal policy and does **not** require re-enrollment.
+- Rotation events are reflected in device status via managed system info fields: `managementCertSerial`, `managementCertNotAfter`.
+
+#### Device Services Certificates
+
+Certificates used for device services and issued using the `Device Services` signer are also agent-managed and **automatically rotated** by the `flightctl-agent` before expiration.
+
 > [!IMPORTANT]
-> Certificates are **not** automatically rotated. Administrators must track expiration dates and manually renew certificates or re-enroll devices before they expire.
+> Other Certificates are **not** automatically rotated. Administrators must track expiration dates and manually renew certificates before they expire.
 
 ## Backup and Recovery
 

--- a/docs/user/references/security-guidelines.md
+++ b/docs/user/references/security-guidelines.md
@@ -88,10 +88,13 @@ Devices authenticate using X.509 client certificates:
 
 #### Certificate Management
 
-- **Enrollment Certificates**: Used only for initial enrollment (configurable validity)
-- **Management Certificates**: Device-specific certificates for ongoing operations
-- **Hardware Protection**: Private keys are protected by TPM when available
-- **Automatic Rotation**: Certificates are currently *NOT* rotated
+- **Enrollment Certificates**: Used only for initial enrollment (configurable validity).
+- **Management Certificates**: Device-specific certificates used by the agent for ongoing
+  communication with the Flight Control service.
+- **Hardware Protection**: Private keys are protected by TPM when available.
+- **Automatic Rotation**: The device **management certificate** is automatically renewed
+  by the agent before expiration. Rotation is handled internally by the agent
+  and does not require re-enrollment or administrator action.
 
 ### Authorization
 
@@ -245,10 +248,13 @@ Devices authenticate using X.509 client certificates:
 
 #### Certificate Management
 
-- **Enrollment Certificates**: Used only for initial enrollment (configurable validity)
-- **Management Certificates**: Device-specific certificates for ongoing operations
-- **Hardware Protection**: Private keys are protected by TPM when available
-- **Automatic Rotation**: Certificates are currently *NOT* rotated
+- **Enrollment Certificates**: Used only for initial enrollment (configurable validity).
+- **Management Certificates**: Device-specific certificates used by the agent for ongoing
+  communication with the Flight Control service.
+- **Hardware Protection**: Private keys are protected by TPM when available.
+- **Automatic Rotation**: The device **management certificate** is automatically renewed
+  by the agent before expiration. Rotation is handled internally by the agent
+  and does not require re-enrollment or administrator action.
 
 ### Authorization
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -6,6 +6,11 @@ The first time the Flight Control Agent runs, it generates a cryptographic key p
 
 When the device is not yet enrolled, the agent performs service discovery to find its Flight Control Service instance. It then establishes a secure, mTLS-protected network connection to the Service using the X.509 enrollment certificate it has been provided with during image building or device provisioning. Next, it submits an Enrollment Request to the service that includes a description of the device's hardware and operating system as well as an X.509 Certificate Signing Request (CSR) including its cryptographic identity to obtain its initial management certificate. At this point, the device is not yet considered trusted and therefore remains quarantined in a "device lobby" until its Enrollment Request has been approved or denied by an authorized user (e.g. a administrator, an installer persona, or an auto-approver process).
 
+> [!NOTE]
+> The device **management certificate** is automatically renewed by the `flightctl-agent`
+> **before it expires**, once it reaches approximately **75% of its lifetime**.
+> Renewal happens proactively to avoid service disruption and does not require user action.
+
 ### Enrolling using the Web UI
 
 ### Enrolling using the CLI
@@ -318,7 +323,8 @@ However, there are scenarios where this is impractical, for example, when config
 
 Conceptually, this set of configuration files can be thought of as an additional, dynamic layer on top of the OS image's layers. The Flight Control Agent applies updates to this layer transactionally, ensuring that either all files have been successfully updated in the file system or have been returned to their pre-update state. Further, if the user updates both a devices OS and configuration set at the same time, the Flight Control Agent will first update the OS, then apply the specified configuration set on top.
 
-> [!Important] After the Flight Control Agent has updated the configuration on disk, this configuration still needs to be *activated*. That means, running services need to reload the new configuration into memory for it to become effective. If the update involves a reboot, services will be restarted by systemd in the right order with the new configuration automatically. If the update does not involve a reboot, many services can detect changes to their configuration files and automatically reload them. When a service does not support this, you [use Device Lifecycle Hooks](managing-devices.md#using-device-lifecycle-hooks) to specify rules like "if configuration file X has changed, run command Y". Also refer to this section for the set of default rules that the Flight Control Agent applies.
+> [!Important]
+> After the Flight Control Agent has updated the configuration on disk, this configuration still needs to be *activated*. That means, running services need to reload the new configuration into memory for it to become effective. If the update involves a reboot, services will be restarted by systemd in the right order with the new configuration automatically. If the update does not involve a reboot, many services can detect changes to their configuration files and automatically reload them. When a service does not support this, you [use Device Lifecycle Hooks](managing-devices.md#using-device-lifecycle-hooks) to specify rules like "if configuration file X has changed, run command Y". Also refer to this section for the set of default rules that the Flight Control Agent applies.
 
 Users can specify a list of configurations sets, in which case the Flight Control Agent applies the sets in sequence and on top of each other, such that in case of conflict the "last one wins".
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for automatic device management certificate renewal (behavior and monitoring), new management-certificate metrics with PromQL examples, updates to certificate architecture and security guidance, and documentation of managed system-info collectors plus their default fields.
* **Chores**
  * Minor editorial and tooling config updates (markdown linting and spelling).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->