### PR TITLE
NO-ISSUE: fix ER certificate is missing the org ID extension

### DIFF
--- a/internal/service/enrollment_credential.go
+++ b/internal/service/enrollment_credential.go
@@ -82,7 +82,9 @@ func (h *ServiceHandler) GenerateEnrollmentCredential(ctx context.Context, orgId
 
 	// Submit CSR through the service with internal request context
 	// This ensures the Owner field is preserved (not nil'd out)
+	// Also add orgId to context so WithOrgIDExtension can inject it into the certificate
 	internalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, true)
+	internalCtx = util.WithOrganizationID(internalCtx, orgId)
 	result, status := h.CreateCertificateSigningRequest(internalCtx, orgId, csrResource)
 	if status.Code != 201 && status.Code != 200 {
 		return nil, status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Organization ID is now properly embedded in enrollment credentials during the credential generation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->