### PR TITLE
EDM-3074: Change renewal before expiration to 75%

### DIFF
--- a/internal/agent/device/certmanager/manager.go
+++ b/internal/agent/device/certmanager/manager.go
@@ -25,8 +25,8 @@ const (
 	certsBundleName       = "certs-config-yaml"
 	certsBundleConfigFile = "certs.yaml"
 
-	defaultSyncInterval = time.Hour
-	renewBeforeExpiry   = 30 * 24 * time.Hour
+	defaultSyncInterval         = time.Hour
+	renewBeforeExpiryPercentage = 75
 )
 
 type AgentCertManager struct {
@@ -101,7 +101,7 @@ func NewAgentCertManager(
 	managementBundle, err := pkgcertmanager.NewBundle(
 		managementBundleName,
 		pkgcertmanager.WithConfigProvider(
-			management.NewManagementConfigProvider(renewBeforeExpiry),
+			management.NewManagementConfigProvider(renewBeforeExpiryPercentage),
 		),
 		pkgcertmanager.WithProvisionerFactory(managementProvisionerFactory),
 		pkgcertmanager.WithStorageFactory(managementStorageFactory),

--- a/internal/agent/device/certmanager/provider/management/management.go
+++ b/internal/agent/device/certmanager/provider/management/management.go
@@ -36,11 +36,11 @@ const (
 // ---- ConfigProvider ----
 
 type managementConfigProvider struct {
-	renewBeforeExpiry time.Duration
+	renewBeforeExpiryPercentage int32
 }
 
-func NewManagementConfigProvider(renewBeforeExpiry time.Duration) *managementConfigProvider {
-	return &managementConfigProvider{renewBeforeExpiry: renewBeforeExpiry}
+func NewManagementConfigProvider(renewBeforeExpiryPercentage int32) *managementConfigProvider {
+	return &managementConfigProvider{renewBeforeExpiryPercentage: renewBeforeExpiryPercentage}
 }
 
 func (p *managementConfigProvider) Name() string { return configProviderName }
@@ -63,7 +63,7 @@ func (p *managementConfigProvider) GetCertificateConfigs() ([]certmanager.Certif
 
 	// Fall back to provider default only if neither override is set
 	if cfg.RenewBefore == nil && cfg.RenewBeforePercentage == nil {
-		cfg.RenewBefore = &p.renewBeforeExpiry
+		cfg.RenewBeforePercentage = &p.renewBeforeExpiryPercentage
 	}
 
 	return []certmanager.CertificateConfig{cfg}, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated certificate renewal mechanism from a fixed 30-day duration to a percentage-based approach (75% of certificate validity period), providing more flexible renewal timing across certificates with varying expiry dates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->