### PR TITLE
NO-ISSUE: github/workflows: disable external link checks

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -35,7 +35,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # Check all markdown files in docs directory
-          args: --verbose --no-progress --cache --max-cache-age 1d 'docs/**/*.md'
+          args: --verbose --no-progress --cache --max-cache-age 1d --offline 'docs/**/*.md'
           # Fail PRs with broken links, but not scheduled runs
           fail: ${{ github.event_name == 'pull_request' }}
           # Output format


### PR DESCRIPTION
the intention for the link checker was mostly internal. the external link check has some value but we are finding transient issues blocking developer progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation link-checking workflow to run in offline mode, allowing the process to operate without network connectivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->