### PR TITLE
NO-ISSUE: Change podman deployment kv image to pull from quay.io/sclorg

### DIFF
--- a/deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf
+++ b/deploy/podman/flightctl-kv/flightctl-kv-config/redis.conf
@@ -6,3 +6,6 @@ loglevel warning
 
 maxmemory 1gb
 maxmemory-policy allkeys-lru
+
+# Authentication - matches test password in test/test.mk
+requirepass adminpass

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -3,12 +3,11 @@ Description=Flight Control Key Value service
 
 [Container]
 ContainerName=flightctl-kv
-Image=docker.io/redis:7.4.1
+Image=quay.io/sclorg/redis-7-c9s:20250108
 Pull=missing
-Exec=/bin/sh -c 'redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
+Exec=/bin/sh -c 'redis-server /etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
 Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
-
+Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/etc/redis/redis.conf:ro,Z
 PublishPort=6379:6379
 
 [Service]

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -8,9 +8,9 @@ Image={{ .Kv.Image }}:{{ .Kv.Tag }}
 Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
-Exec=/bin/sh -c 'redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
+Exec=/bin/sh -c 'redis-server /etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
 Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
+Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/etc/redis/redis.conf:ro,Z
 
 [Service]
 Type=notify

--- a/deploy/podman/images.yaml
+++ b/deploy/podman/images.yaml
@@ -29,8 +29,8 @@ db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
-  image: docker.io/redis
-  tag: "7.4.1"
+  image: quay.io/sclorg/redis-7-c9s
+  tag: "20250108"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/deploy/podman/local-images.yaml
+++ b/deploy/podman/local-images.yaml
@@ -29,8 +29,8 @@ db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
-  image: docker.io/redis
-  tag: "7.4.1"
+  image: quay.io/sclorg/redis-7-c9s
+  tag: "20250108"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -35,7 +35,7 @@ oc image mirror quay.io/openshift/origin-cli:4.20.0 ${LOCAL_REGISTRY}/openshift/
 
 oc image mirror quay.io/sclorg/postgresql-16-c9s:20250214 ${LOCAL_REGISTRY}/sclorg/postgresql-16-c9s:20250214
 
-oc image mirror docker.io/redis:7.4.1 ${LOCAL_REGISTRY}/redis:7.4.1
+oc image mirror quay.io/sclorg/redis-7-c9s:20250108 ${LOCAL_REGISTRY}/sclorg/redis-7-c9s:20250108
 ```
 
 ## Configuring image repository mirroring
@@ -62,9 +62,6 @@ spec:
   - source: quay.io/openshift/origin-cli
     mirrors:
     - ${LOCAL_REGISTRY}/openshift/origin-cli
-  - source: docker.io/redis
-    mirrors:
-    - ${LOCAL_REGISTRY}/redis
 EOF
 ```
 

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -8,8 +8,8 @@ DB_SIZE_PARAMS=
 # IMAGE_PULL_SECRET_PATH=
 SQL_VERSION=${SQL_VERSION:-"latest"}
 SQL_IMAGE=${SQL_IMAGE:-"quay.io/sclorg/postgresql-16-c9s"}
-KV_VERSION=${KV_VERSION:-"7.4.1"}
-KV_IMAGE=${KV_IMAGE:-"docker.io/redis"}
+KV_VERSION=${KV_VERSION:-"20250108"}
+KV_IMAGE=${KV_IMAGE:-"quay.io/sclorg/redis-7-c9s"}
 
 source "${SCRIPT_DIR}"/functions
 IP=$(get_ext_ip)
@@ -44,8 +44,8 @@ while true; do
   esac
 done
 
-SQL_ARG="--set db.builtin.image.image=${SQL_IMAGE} --set db.builtin.image.tag=${SQL_VERSION}"
-KV_ARG="--set kv.image.image=${KV_IMAGE} --set kv.image.tag=${KV_VERSION}"
+SQL_ARG="--set db.builtin.image.image=${SQL_IMAGE} --set-string db.builtin.image.tag=${SQL_VERSION}"
+KV_ARG="--set kv.image.image=${KV_IMAGE} --set-string kv.image.tag=${KV_VERSION}"
 
 # helm expects the namespaces to exist, and creating namespaces
 # inside the helm charts is not recommended.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Redis image source and tag across deployments and manifests.
  * Changed Redis config mount target to the system path and made the mount read-only with SELinux labeling.
  * Adjusted container startup to reference the updated config path.
  * Secret environment variable for Redis remains unchanged (KV_PASSWORD).
* **Configuration**
  * Enabled password-based authentication in the Redis configuration.
* **Documentation**
  * Updated disconnected-install mirroring guidance to use the new Redis image.
* **Tests**
  * Updated deployment test script defaults and Helm argument behavior for the new image and tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->