### PR TITLE
Helm Application Type

### DIFF
--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -924,7 +924,7 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 		case AppTypeContainer:
 			allErrs = append(allErrs, validateContainerApplication(app, appName, fleetTemplate)...)
 		case AppTypeHelm:
-			allErrs = append(allErrs, validateHelmApplication(app, appName, fleetTemplate)...)
+			allErrs = append(allErrs, ValidateHelmApplication(app, appName, fleetTemplate)...)
 		case AppTypeCompose:
 			allErrs = append(allErrs, validateComposeApplication(app, appName, fleetTemplate)...)
 		case AppTypeQuadlet:
@@ -960,7 +960,7 @@ func validateContainerApplication(app ApplicationProviderSpec, appName string, f
 	return allErrs
 }
 
-func validateHelmApplication(app ApplicationProviderSpec, appName string, fleetTemplate bool) []error {
+func ValidateHelmApplication(app ApplicationProviderSpec, appName string, fleetTemplate bool) []error {
 	allErrs := []error{}
 	pathPrefix := fmt.Sprintf("spec.applications[%s]", appName)
 

--- a/internal/agent/client/helm.go
+++ b/internal/agent/client/helm.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -23,15 +25,25 @@ const (
 type HelmOption func(*helmOptions)
 
 type helmOptions struct {
-	namespace        string
-	valuesPaths      []string
-	kubeconfigPath   string
-	atomic           bool
-	createNamespace  bool
-	install          bool
-	timeout          time.Duration
-	postRendererPath string
-	postRendererArgs []string
+	namespace         string
+	valuesPaths       []string
+	kubeconfigPath    string
+	atomic            bool
+	rollbackOnFailure bool
+	createNamespace   bool
+	install           bool
+	timeout           time.Duration
+	postRendererPath  string
+	postRendererArgs  []string
+	ignoreNotFound    bool
+	helmEnv           map[string]string
+}
+
+// WithHelmEnv sets custom environment variables for this helm operation.
+func WithHelmEnv(env map[string]string) HelmOption {
+	return func(opts *helmOptions) {
+		opts.helmEnv = env
+	}
 }
 
 // WithNamespace sets the Kubernetes namespace for helm operations.
@@ -69,6 +81,14 @@ func WithAtomic() HelmOption {
 	}
 }
 
+// WithRollbackOnFailure enables the --rollback-on-failure flag for helm upgrade operations.
+// This is the Helm 4.x replacement for --atomic.
+func WithRollbackOnFailure() HelmOption {
+	return func(opts *helmOptions) {
+		opts.rollbackOnFailure = true
+	}
+}
+
 // WithCreateNamespace enables automatic namespace creation for helm operations.
 func WithCreateNamespace() HelmOption {
 	return func(opts *helmOptions) {
@@ -100,6 +120,13 @@ func WithPostRenderer(path string, args ...string) HelmOption {
 	}
 }
 
+// WithIgnoreNotFound treats "release not found" as a successful uninstall.
+func WithIgnoreNotFound() HelmOption {
+	return func(opts *helmOptions) {
+		opts.ignoreNotFound = true
+	}
+}
+
 // Helm provides a client for executing helm CLI commands.
 type Helm struct {
 	exec       executer.Executer
@@ -120,6 +147,19 @@ func NewHelm(log *log.PrefixLogger, exec executer.Executer, readWriter fileio.Re
 	}
 	h.cache = newHelmChartCache(h, chartsDir, readWriter, log)
 	return h
+}
+
+// helmEnv returns custom environment variables for helm commands.
+// It inherits the current environment and adds any custom helm-specific variables from options.
+func helmEnv(opts *helmOptions) []string {
+	if opts == nil || opts.helmEnv == nil {
+		return nil
+	}
+	env := os.Environ()
+	for k, v := range opts.helmEnv {
+		env = append(env, k+"="+v)
+	}
+	return env
 }
 
 // HelmVersion represents a parsed helm CLI version.
@@ -209,7 +249,8 @@ func (h *Helm) Pull(ctx context.Context, chartRef, destDir string, opts ...Clien
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	chartPath, version := SplitChartRef(chartRef)
+	normalizedRef := NormalizeChartRef(chartRef)
+	chartPath, version := SplitChartRef(normalizedRef)
 	args := []string{"pull", chartPath, "--untar", "--destination", destDir}
 	if version != "" {
 		args = append(args, "--version", version)
@@ -335,6 +376,10 @@ func (h *Helm) Install(ctx context.Context, releaseName, chartPath string, opts 
 		args = append(args, "--atomic")
 	}
 
+	if options.rollbackOnFailure {
+		args = append(args, "--rollback-on-failure")
+	}
+
 	if options.postRendererPath != "" {
 		args = append(args, "--post-renderer", options.postRendererPath)
 		for _, arg := range options.postRendererArgs {
@@ -405,6 +450,10 @@ func (h *Helm) Upgrade(ctx context.Context, releaseName, chartPath string, opts 
 		args = append(args, "--atomic")
 	}
 
+	if options.rollbackOnFailure {
+		args = append(args, "--rollback-on-failure")
+	}
+
 	if options.postRendererPath != "" {
 		args = append(args, "--post-renderer", options.postRendererPath)
 		for _, arg := range options.postRendererArgs {
@@ -412,7 +461,14 @@ func (h *Helm) Upgrade(ctx context.Context, releaseName, chartPath string, opts 
 		}
 	}
 
-	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	var stdout, stderr string
+	var exitCode int
+	if env := helmEnv(options); env != nil {
+		stdout, stderr, exitCode = h.exec.ExecuteWithContextFromDir(ctx, "", helmCmd, args, env...)
+	} else {
+		stdout, stderr, exitCode = h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	}
+	_ = stdout
 	if exitCode != 0 {
 		return fmt.Errorf("helm upgrade: %w", errors.FromStderr(stderr, exitCode))
 	}
@@ -450,6 +506,10 @@ func (h *Helm) Uninstall(ctx context.Context, releaseName string, opts ...HelmOp
 			return fmt.Errorf("kubeconfig does not exist: %s", options.kubeconfigPath)
 		}
 		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	if options.ignoreNotFound {
+		args = append(args, "--ignore-not-found")
 	}
 
 	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
@@ -500,6 +560,109 @@ func (h *Helm) Template(ctx context.Context, releaseName, chartPath string, opts
 	return stdout, nil
 }
 
+// Lint runs helm lint on a chart to validate its structure and templates.
+func (h *Helm) Lint(ctx context.Context, chartPath string, opts ...HelmOption) error {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"lint", chartPath}
+
+	for _, valuesPath := range options.valuesPaths {
+		exists, err := h.readWriter.PathExists(valuesPath)
+		if err != nil {
+			return fmt.Errorf("check values file path: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("values file does not exist: %s", valuesPath)
+		}
+		args = append(args, "--values", valuesPath)
+	}
+
+	_, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return fmt.Errorf("helm lint: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	return nil
+}
+
+// helmDryRunOutput represents the YAML output structure from helm dry-run.
+type helmDryRunOutput struct {
+	Manifest string `yaml:"manifest"`
+}
+
+// DryRun performs a helm upgrade --install --dry-run=server to validate
+// the chart against the Kubernetes API server without actually installing it.
+// Returns only the manifest (raw YAML) for compatibility with Template output.
+func (h *Helm) DryRun(ctx context.Context, releaseName, chartPath string, opts ...HelmOption) (string, error) {
+	options := &helmOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	timeout := h.timeout
+	if options.timeout > 0 {
+		timeout = options.timeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"upgrade", "--install", "--dry-run=server", "-o", "yaml", releaseName, chartPath}
+
+	if options.namespace != "" {
+		args = append(args, "--namespace", options.namespace)
+	}
+
+	if options.createNamespace {
+		args = append(args, "--create-namespace")
+	}
+
+	for _, valuesPath := range options.valuesPaths {
+		exists, err := h.readWriter.PathExists(valuesPath)
+		if err != nil {
+			return "", fmt.Errorf("check values file path: %w", err)
+		}
+		if !exists {
+			return "", fmt.Errorf("values file does not exist: %s", valuesPath)
+		}
+		args = append(args, "--values", valuesPath)
+	}
+
+	if options.kubeconfigPath != "" {
+		exists, err := h.readWriter.PathExists(options.kubeconfigPath)
+		if err != nil {
+			return "", fmt.Errorf("check kubeconfig path: %w", err)
+		}
+		if !exists {
+			return "", fmt.Errorf("kubeconfig does not exist: %s", options.kubeconfigPath)
+		}
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	stdout, stderr, exitCode := h.exec.ExecuteWithContext(ctx, helmCmd, args...)
+	if exitCode != 0 {
+		return "", fmt.Errorf("helm dry-run: %w", errors.FromStderr(stderr, exitCode))
+	}
+
+	var output helmDryRunOutput
+	if err := yaml.Unmarshal([]byte(stdout), &output); err != nil {
+		return "", fmt.Errorf("parse dry-run output: %w", err)
+	}
+
+	return output.Manifest, nil
+}
+
 // Resolve ensures a chart is pulled and its dependencies are updated.
 func (h *Helm) Resolve(ctx context.Context, chartRef string, opts ...ClientOption) error {
 	return h.cache.Pull(ctx, chartRef, opts...)
@@ -513,4 +676,10 @@ func (h *Helm) IsResolved(chartRef string) (bool, error) {
 // GetChartPath returns the local filesystem path for a cached chart.
 func (h *Helm) GetChartPath(chartRef string) string {
 	return h.cache.GetChartPath(chartRef)
+}
+
+// RemoveChart removes a cached helm chart by its reference.
+// The chart reference format is: oci://registry/chart:version or registry/chart:version
+func (h *Helm) RemoveChart(chartRef string) error {
+	return h.cache.RemoveChartByRef(chartRef)
 }

--- a/internal/agent/client/helm_cache.go
+++ b/internal/agent/client/helm_cache.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -78,6 +79,13 @@ func (c *helmChartCache) RemoveChart(chartDir string) error {
 		return fmt.Errorf("remove chart directory: %w", err)
 	}
 	return nil
+}
+
+// RemoveChartByRef removes a cached chart by its reference.
+// It resolves the chart path internally using the chart reference.
+func (c *helmChartCache) RemoveChartByRef(chartRef string) error {
+	chartDir := c.ChartDir(chartRef)
+	return c.RemoveChart(chartDir)
 }
 
 func (c *helmChartCache) EnsureChartsDir() error {
@@ -226,6 +234,16 @@ func SplitChartRef(chartRef string) (chartPath, version string) {
 	}
 
 	return chartRef, ""
+}
+
+// NormalizeChartRef ensures a chart reference has the oci:// scheme.
+// If no scheme is present, it assumes OCI and adds the prefix.
+func NormalizeChartRef(chartRef string) string {
+	parsed, err := url.Parse(chartRef)
+	if err != nil || parsed.Scheme == "" {
+		return "oci://" + chartRef
+	}
+	return chartRef
 }
 
 // SanitizeChartRef converts a chart reference into a filesystem-safe directory name.

--- a/internal/agent/client/kube_test.go
+++ b/internal/agent/client/kube_test.go
@@ -102,7 +102,11 @@ func TestKube_WatchPodsCmd(t *testing.T) {
 
 			k8s := NewKube(logger, mockExec, mockReadWriter, WithBinary(tc.binary))
 
-			cmd, err := k8s.WatchPodsCmd(context.Background(), tc.kubeconfigPath)
+			var opts []KubeOption
+			if tc.kubeconfigPath != "" {
+				opts = append(opts, WithKubeKubeconfig(tc.kubeconfigPath))
+			}
+			cmd, err := k8s.WatchPodsCmd(context.Background(), opts...)
 			require.NoError(err)
 			require.NotNil(cmd)
 			require.Equal(append([]string{tc.binary}, tc.expectedArgs...), cmd.Args)
@@ -117,7 +121,7 @@ func TestKube_WatchPodsCmd_NoBinary(t *testing.T) {
 		binary: "",
 	}
 
-	cmd, err := k8s.WatchPodsCmd(context.Background(), "")
+	cmd, err := k8s.WatchPodsCmd(context.Background())
 	require.Error(err)
 	require.Nil(cmd)
 	require.Contains(err.Error(), "kubernetes CLI binary not available")

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -3,9 +3,11 @@ package applications
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	"github.com/flightctl/flightctl/internal/agent/device/dependency"
 	"github.com/flightctl/flightctl/internal/agent/device/status"
@@ -77,10 +79,16 @@ type Application interface {
 	Path() string
 	// Workload returns a workload by name.
 	Workload(name string) (*Workload, bool)
+	// Workloads returns a copy of all workloads.
+	Workloads() []Workload
 	// AddWorkload adds a workload to the application.
 	AddWorkload(Workload *Workload)
 	// RemoveWorkload removes a workload from the application.
 	RemoveWorkload(name string) bool
+	// ClearWorkloads removes all workloads from the application.
+	ClearWorkloads()
+	// CopyWorkloadsFrom copies workloads from another application.
+	CopyWorkloadsFrom(other Application)
 	// IsEmbedded returns true if the application is embedded.
 	IsEmbedded() bool
 	// Volume is a volume manager.
@@ -89,6 +97,8 @@ type Application interface {
 	// the user. In the case there is no name provided it will be populated
 	// according to the rules of the application type.
 	Status() (*v1beta1.DeviceApplicationStatus, v1beta1.DeviceApplicationsSummaryStatus, error)
+	// ActionSpec returns the type-specific action configuration for this application.
+	ActionSpec() lifecycle.ActionSpec
 }
 
 // Workload represents an application workload tracked by a Monitor.
@@ -101,16 +111,17 @@ type Workload struct {
 }
 
 type application struct {
-	id        string
-	path      string
-	workloads []Workload
-	volume    provider.VolumeManager
-	status    *v1beta1.DeviceApplicationStatus
+	id         string
+	path       string
+	workloads  []Workload
+	volume     provider.VolumeManager
+	status     *v1beta1.DeviceApplicationStatus
+	actionSpec lifecycle.ActionSpec
 }
 
 // NewApplication creates a new application from an application provider.
-func NewApplication(provider provider.Provider) *application {
-	spec := provider.Spec()
+func NewApplication(p provider.Provider) *application {
+	spec := p.Spec()
 	return &application{
 		id:   spec.ID,
 		path: spec.Path,
@@ -123,6 +134,35 @@ func NewApplication(provider provider.Provider) *application {
 		},
 		volume: spec.Volume,
 	}
+}
+
+// NewHelmApplication creates a new application with Helm-specific configuration.
+func NewHelmApplication(p provider.Provider) *application {
+	spec := p.Spec()
+
+	var namespace string
+	var valuesFiles []string
+	var providerValuesPath string
+
+	if spec.HelmApp != nil {
+		if spec.HelmApp.Namespace != nil {
+			namespace = *spec.HelmApp.Namespace
+		}
+		if spec.HelmApp.ValuesFiles != nil {
+			valuesFiles = slices.Clone(*spec.HelmApp.ValuesFiles)
+		}
+		if spec.HelmApp.Values != nil && len(*spec.HelmApp.Values) > 0 {
+			providerValuesPath = provider.GetHelmProviderValuesPath(spec.Name)
+		}
+	}
+
+	app := NewApplication(p)
+	app.actionSpec = lifecycle.HelmSpec{
+		Namespace:          namespace,
+		ValuesFiles:        valuesFiles,
+		ProviderValuesPath: providerValuesPath,
+	}
+	return app
 }
 
 func (a *application) ID() string {
@@ -162,6 +202,24 @@ func (a *application) RemoveWorkload(name string) bool {
 		}
 	}
 	return false
+}
+
+func (a *application) Workloads() []Workload {
+	result := make([]Workload, len(a.workloads))
+	copy(result, a.workloads)
+	return result
+}
+
+func (a *application) ClearWorkloads() {
+	a.workloads = nil
+}
+
+func (a *application) CopyWorkloadsFrom(other Application) {
+	a.workloads = other.Workloads()
+}
+
+func (a *application) ActionSpec() lifecycle.ActionSpec {
+	return a.actionSpec
 }
 
 func (a *application) Path() string {

--- a/internal/agent/device/applications/helm/namespace.go
+++ b/internal/agent/device/applications/helm/namespace.go
@@ -1,0 +1,14 @@
+package helm
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+func AppNamespace(namespace *string, appName string) string {
+	if lo.FromPtr(namespace) != "" {
+		return *namespace
+	}
+	return fmt.Sprintf("%s-%s", "flightctl", appName)
+}

--- a/internal/agent/device/applications/helm/reference.go
+++ b/internal/agent/device/applications/helm/reference.go
@@ -1,0 +1,53 @@
+package helm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/agent/client"
+)
+
+const helmReleaseNameMaxLength = 53
+
+// SanitizeReleaseName combines a chart name and version into a valid Helm release name.
+// It lowercases the input, replaces invalid characters with hyphens,
+// removes consecutive hyphens, trims leading/trailing hyphens, and truncates to 53 characters.
+func SanitizeReleaseName(chartName string) (string, error) {
+	name, version, err := client.ParseChartRef(chartName)
+	if err != nil {
+		return "", fmt.Errorf("parsing chart reference: %w", err)
+	}
+	return sanitize(fmt.Sprintf("%s-%s", name, version)), nil
+}
+
+func sanitize(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	name = strings.ToLower(name)
+
+	var result strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			result.WriteRune(r)
+		} else {
+			result.WriteRune('-')
+		}
+	}
+
+	sanitized := result.String()
+
+	for strings.Contains(sanitized, "--") {
+		sanitized = strings.ReplaceAll(sanitized, "--", "-")
+	}
+
+	sanitized = strings.Trim(sanitized, "-")
+
+	if len(sanitized) > helmReleaseNameMaxLength {
+		sanitized = sanitized[:helmReleaseNameMaxLength]
+		sanitized = strings.TrimRight(sanitized, "-")
+	}
+
+	return sanitized
+}

--- a/internal/agent/device/applications/helm/reference_test.go
+++ b/internal/agent/device/applications/helm/reference_test.go
@@ -1,0 +1,78 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeReleaseName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		chartRef string
+		want     string
+	}{
+		{
+			name:     "simple chart and version",
+			chartRef: "registry.io/nginx:1.0.0",
+			want:     "nginx-1-0-0",
+		},
+		{
+			name:     "chart with hyphens",
+			chartRef: "registry.io/my-web-app:2.1.3",
+			want:     "my-web-app-2-1-3",
+		},
+		{
+			name:     "uppercase converted to lowercase",
+			chartRef: "registry.io/charts/my-chart:v1.2",
+			want:     "my-chart-v1-2",
+		},
+		{
+			name:     "version with rc suffix",
+			chartRef: "registry.io/app:1.0.0-rc1",
+			want:     "app-1-0-0-rc1",
+		},
+		{
+			name:     "digest version gets truncated",
+			chartRef: "registry.io/chart@sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+			want:     "chart-sha256-a3ed95caeb02ffe68cdd9fd84406680ae93d633c",
+		},
+		{
+			name:     "dots in chart name converted to hyphens",
+			chartRef: "registry.io/my.dotted.chart:1.0",
+			want:     "my-dotted-chart-1-0",
+		},
+		{
+			name:     "underscores in chart name converted to hyphens",
+			chartRef: "registry.io/my_chart_name:1.0.0",
+			want:     "my-chart-name-1-0-0",
+		},
+		{
+			name:     "long name truncated to 53 chars",
+			chartRef: "registry.io/a-very-long-chart-name-that-will-exceed-the-limit:1.0.0",
+			want:     "a-very-long-chart-name-that-will-exceed-the-limit-1-0",
+		},
+		{
+			name:     "trailing hyphens removed after truncation",
+			chartRef: "registry.io/chart-name-with-trailing:1-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0",
+			want:     "chart-name-with-trailing-1-0-0-0-0-0-0-0-0-0-0-0-0-0",
+		},
+		{
+			name:     "oci prefix is stripped",
+			chartRef: "oci://registry.io/charts/nginx:1.0.0",
+			want:     "nginx-1-0-0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			result, err := SanitizeReleaseName(tc.chartRef)
+
+			require.NoError(err)
+			require.Equal(tc.want, result)
+			require.LessOrEqual(len(result), helmReleaseNameMaxLength)
+		})
+	}
+}

--- a/internal/agent/device/applications/kubernetes_monitor.go
+++ b/internal/agent/device/applications/kubernetes_monitor.go
@@ -1,0 +1,362 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/helm"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	// pod phases
+	podPhasePending   = "Pending"
+	podPhaseRunning   = "Running"
+	podPhaseSucceeded = "Succeeded"
+	podPhaseFailed    = "Failed"
+
+	// container waiting reasons
+	containerReasonCrashLoopBackOff         = "CrashLoopBackOff"
+	containerReasonImagePullBackOff         = "ImagePullBackOff"
+	containerReasonCreateContainerConfigErr = "CreateContainerConfigError"
+	containerReasonCreateContainerErr       = "CreateContainerError"
+	containerReasonInvalidImageName         = "InvalidImageName"
+
+	// container terminated reasons
+	containerReasonOOMKilled = "OOMKilled"
+)
+
+// KubernetesMonitor monitors Kubernetes-based applications such as Helm releases.
+type KubernetesMonitor struct {
+	*monitor
+
+	k8sClient      *client.Kube
+	kubeconfigPath string
+	enabled        bool
+}
+
+// NewKubernetesMonitor creates a new KubernetesMonitor.
+func NewKubernetesMonitor(
+	log *log.PrefixLogger,
+	clients client.CLIClients,
+	rwFactory fileio.ReadWriterFactory,
+) *KubernetesMonitor {
+	k8sClient := clients.Kube()
+	if k8sClient == nil {
+		log.Info("Kubernetes based applications disabled: kubernetes client not available")
+		return &KubernetesMonitor{
+			monitor: newMonitor(log, "kubernetes"),
+			enabled: false,
+		}
+	}
+
+	kubeconfigPath, err := k8sClient.ResolveKubeconfig()
+	if err != nil {
+		log.Infof("Kubernetes based applications disabled: %v", err)
+		return &KubernetesMonitor{
+			monitor: newMonitor(log, "kubernetes"),
+			enabled: false,
+		}
+	}
+
+	m := newMonitor(log, "kubernetes",
+		handlerRegistration{
+			appType: v1beta1.AppTypeHelm,
+			handler: lifecycle.NewHelmHandler(log, clients, kubeconfigPath, lifecycle.OSExecutableResolver{}, rwFactory),
+		},
+	)
+
+	return &KubernetesMonitor{
+		monitor:        m,
+		k8sClient:      k8sClient,
+		kubeconfigPath: kubeconfigPath,
+		enabled:        true,
+	}
+}
+
+// IsEnabled returns true if kubernetes-based applications are supported.
+func (m *KubernetesMonitor) IsEnabled() bool {
+	return m.enabled
+}
+
+// Ensure adds an application to be monitored.
+func (m *KubernetesMonitor) Ensure(app Application) error {
+	if !m.enabled {
+		return errors.ErrKubernetesAppsDisabled
+	}
+	return m.monitor.Ensure(app)
+}
+
+// Remove removes an application from monitoring.
+func (m *KubernetesMonitor) Remove(app Application) error {
+	if !m.enabled {
+		return errors.ErrKubernetesAppsDisabled
+	}
+	return m.monitor.Remove(app)
+}
+
+// Update updates an existing application, preserving workloads from the old app.
+func (m *KubernetesMonitor) Update(app Application) error {
+	if !m.enabled {
+		return errors.ErrKubernetesAppsDisabled
+	}
+	return m.monitor.updateWithWorkloads(app)
+}
+
+// CreateCommand implements streamingMonitor interface.
+func (m *KubernetesMonitor) CreateCommand(ctx context.Context) (*exec.Cmd, error) {
+	return m.k8sClient.WatchPodsCmd(ctx,
+		client.WithKubeKubeconfig(m.kubeconfigPath),
+		client.WithKubeLabels([]string{helm.AppLabelKey}),
+	)
+}
+
+// Parser implements streamingMonitor interface.
+func (m *KubernetesMonitor) Parser() streamParser {
+	return jsonStreamParser{}
+}
+
+// HandleEvent implements streamingMonitor interface.
+func (m *KubernetesMonitor) HandleEvent(ctx context.Context, data []byte) {
+	m.handlePodEvent(ctx, data)
+}
+
+// OnRestart implements streamingMonitor interface.
+func (m *KubernetesMonitor) OnRestart() {
+	m.clearAllWorkloads()
+}
+
+func (m *KubernetesMonitor) startMonitor(ctx context.Context) error {
+	return m.startStreaming(ctx, m)
+}
+
+func (m *KubernetesMonitor) stopMonitor() error {
+	return m.stopStreaming()
+}
+
+// Stop stops the Kubernetes monitor.
+func (m *KubernetesMonitor) Stop() error {
+	return m.stopMonitor()
+}
+
+// Drain stops and removes all applications.
+func (m *KubernetesMonitor) Drain(ctx context.Context) error {
+	m.drainActions()
+
+	if err := m.drain(ctx); err != nil {
+		return err
+	}
+
+	return m.ExecuteActions(ctx)
+}
+
+// ExecuteActions executes all queued actions.
+func (m *KubernetesMonitor) ExecuteActions(ctx context.Context) error {
+	if _, err := m.executeActions(ctx, nil); err != nil {
+		return fmt.Errorf("execute kubernetes actions: %w", err)
+	}
+
+	if m.hasApps() {
+		if err := m.startMonitor(ctx); err != nil {
+			return fmt.Errorf("failed to start kubernetes monitor: %w", err)
+		}
+	} else {
+		if err := m.stopMonitor(); err != nil {
+			return fmt.Errorf("failed to stop kubernetes monitor: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type kubernetesWatchEvent struct {
+	Type   string        `json:"type"`
+	Object kubernetesPod `json:"object"`
+}
+
+type kubernetesPod struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name      string            `json:"name"`
+		Namespace string            `json:"namespace"`
+		UID       string            `json:"uid"`
+		Labels    map[string]string `json:"labels,omitempty"`
+	} `json:"metadata"`
+	Status kubernetesPodStatus `json:"status"`
+}
+
+type kubernetesPodStatus struct {
+	Phase             string                      `json:"phase"`
+	ContainerStatuses []kubernetesContainerStatus `json:"containerStatuses,omitempty"`
+}
+
+type kubernetesContainerStatus struct {
+	Name         string                       `json:"name"`
+	Ready        bool                         `json:"ready"`
+	RestartCount int                          `json:"restartCount"`
+	State        kubernetesContainerStateInfo `json:"state,omitempty"`
+}
+
+type kubernetesContainerStateInfo struct {
+	Waiting    *kubernetesContainerStateWaiting    `json:"waiting,omitempty"`
+	Running    *kubernetesContainerStateRunning    `json:"running,omitempty"`
+	Terminated *kubernetesContainerStateTerminated `json:"terminated,omitempty"`
+}
+
+type kubernetesContainerStateWaiting struct {
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type kubernetesContainerStateRunning struct {
+	StartedAt time.Time `json:"startedAt,omitempty"`
+}
+
+type kubernetesContainerStateTerminated struct {
+	ExitCode   int       `json:"exitCode"`
+	Reason     string    `json:"reason,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty"`
+}
+
+func (m *KubernetesMonitor) handlePodEvent(_ context.Context, data []byte) {
+	var event kubernetesWatchEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		m.log.Errorf("Failed to decode kubernetes watch event: %s %v", string(data), err)
+		return
+	}
+
+	pod := &event.Object
+	if pod.Kind != "Pod" {
+		m.log.Debugf("Ignoring non-pod event: %s", pod.Kind)
+		return
+	}
+
+	releaseID, ok := pod.Metadata.Labels[helm.AppLabelKey]
+	if !ok {
+		m.log.Debugf("Pod %s missing %s label, skipping", pod.Metadata.Name, helm.AppLabelKey)
+		return
+	}
+
+	m.mu.Lock()
+	app, ok := m.apps[releaseID]
+	m.mu.Unlock()
+	if !ok {
+		m.log.Debugf("Application not found for release: %s", releaseID)
+		return
+	}
+
+	switch event.Type {
+	case "DELETED":
+		m.removeWorkload(app, pod)
+	case "ADDED", "MODIFIED":
+		m.updatePodStatus(app, pod)
+	default:
+		m.log.Warnf("Unknown watch event type: %s", event.Type)
+	}
+}
+
+func (m *KubernetesMonitor) removeWorkload(app Application, pod *kubernetesPod) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if app.RemoveWorkload(pod.Metadata.Name) {
+		m.log.Debugf("Removed deleted pod: %s from app %s", pod.Metadata.Name, app.Name())
+	}
+}
+
+func (m *KubernetesMonitor) updatePodStatus(app Application, pod *kubernetesPod) {
+	status := m.mapPodPhaseToStatus(pod)
+	restarts := m.getPodRestartCount(pod)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	workload, exists := app.Workload(pod.Metadata.Name)
+	if exists {
+		workload.Status = status
+		if pod.Metadata.UID != workload.ID {
+			workload.ID = pod.Metadata.UID
+			workload.Restarts = restarts
+		} else if restarts > workload.Restarts {
+			workload.Restarts = restarts
+		}
+		return
+	}
+
+	m.log.Debugf("Adding pod: %s to app %s", pod.Metadata.Name, app.Name())
+	app.AddWorkload(&Workload{
+		ID:       pod.Metadata.UID,
+		Name:     pod.Metadata.Name,
+		Status:   status,
+		Restarts: restarts,
+	})
+}
+
+func (m *KubernetesMonitor) mapPodPhaseToStatus(pod *kubernetesPod) StatusType {
+	switch pod.Status.Phase {
+	case podPhasePending:
+		return StatusInit
+	case podPhaseRunning:
+		if m.hasContainerErrors(pod) {
+			return StatusDied
+		}
+		if m.allContainersReady(pod) {
+			return StatusRunning
+		}
+		return StatusInit
+	case podPhaseSucceeded:
+		return StatusExited
+	case podPhaseFailed:
+		return StatusDied
+	default:
+		return StatusInit
+	}
+}
+
+func (m *KubernetesMonitor) allContainersReady(pod *kubernetesPod) bool {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *KubernetesMonitor) hasContainerErrors(pod *kubernetesPod) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil {
+			switch cs.State.Waiting.Reason {
+			case containerReasonCrashLoopBackOff,
+				containerReasonImagePullBackOff,
+				containerReasonCreateContainerConfigErr,
+				containerReasonCreateContainerErr,
+				containerReasonInvalidImageName:
+				return true
+			}
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == containerReasonOOMKilled {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *KubernetesMonitor) getPodRestartCount(pod *kubernetesPod) int {
+	var total int
+	for _, cs := range pod.Status.ContainerStatuses {
+		total += cs.RestartCount
+	}
+	return total
+}

--- a/internal/agent/device/applications/lifecycle/helm.go
+++ b/internal/agent/device/applications/lifecycle/helm.go
@@ -1,0 +1,340 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/helm"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	flightctlManagedByLabel = "flightctl.io/managed-by=flightctl"
+	helmPostRendererPlugin  = "flightctl-postrenderer"
+)
+
+var _ ActionHandler = (*HelmHandler)(nil)
+
+// ExecutableResolver resolves the path to an executable binary.
+type ExecutableResolver interface {
+	Resolve() (string, error)
+}
+
+// OSExecutableResolver resolves the current process executable using os.Executable().
+type OSExecutableResolver struct{}
+
+func (r OSExecutableResolver) Resolve() (string, error) {
+	bin, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolving executable: %w", err)
+	}
+	if bin == "" {
+		return "", fmt.Errorf("executable not found")
+	}
+	return bin, nil
+}
+
+type HelmHandler struct {
+	clients            client.CLIClients
+	log                *log.PrefixLogger
+	kubeconfigPath     string
+	executableResolver ExecutableResolver
+	rwFactory          fileio.ReadWriterFactory
+}
+
+// helmVersionConfig holds version-specific configuration for helm operations.
+// This is necessary because Helm 3.x and 4.x have different approaches:
+//
+// Post-renderer differences:
+//   - Helm 3.x: Accepts a binary path via --post-renderer flag
+//   - Helm 4.x: Requires a plugin with type "postrenderer/v1" discovered via HELM_PLUGINS
+//
+// Atomic/rollback differences:
+//   - Helm 3.x: Uses --atomic flag for automatic rollback on failure
+//   - Helm 4.x: Renamed to --rollback-on-failure flag
+type helmVersionConfig struct {
+	optionFunc   func(appID string) client.HelmOption
+	extraOptions []client.HelmOption
+	cleanup      func()
+}
+
+func NewHelmHandler(log *log.PrefixLogger, clients client.CLIClients, kubeconfigPath string, resolver ExecutableResolver, rwFactory fileio.ReadWriterFactory) *HelmHandler {
+	return &HelmHandler{
+		clients:            clients,
+		log:                log,
+		kubeconfigPath:     kubeconfigPath,
+		executableResolver: resolver,
+		rwFactory:          rwFactory,
+	}
+}
+
+func (h *HelmHandler) Execute(ctx context.Context, actions Actions) error {
+	versionConfig, err := h.setupHelmVersionConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("setting up post-renderer: %w", err)
+	}
+	defer versionConfig.cleanup()
+
+	for _, action := range actions {
+		switch action.Type {
+		case ActionAdd:
+			if err := h.add(ctx, &action, versionConfig); err != nil {
+				return err
+			}
+		case ActionRemove:
+			if err := h.remove(ctx, &action); err != nil {
+				return err
+			}
+		case ActionUpdate:
+			if err := h.update(ctx, &action, versionConfig); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported action type: %s", action.Type)
+		}
+	}
+	return nil
+}
+
+func (h *HelmHandler) add(ctx context.Context, action *Action, versionConfig *helmVersionConfig) error {
+	releaseName := action.Name
+	chartPath := action.Path
+	helmSpec := h.getHelmSpec(action)
+	namespace := helmSpec.Namespace
+
+	h.log.Debugf("Installing helm release: %s namespace: %s chart: %s", releaseName, namespace, chartPath)
+
+	kubeOpts := []client.KubeOption{
+		client.WithKubeLabels([]string{flightctlManagedByLabel}),
+	}
+	if h.kubeconfigPath != "" {
+		kubeOpts = append(kubeOpts, client.WithKubeKubeconfig(h.kubeconfigPath))
+	}
+
+	if err := h.clients.Kube().EnsureNamespace(ctx, namespace, kubeOpts...); err != nil {
+		return fmt.Errorf("ensure namespace %s: %w", namespace, err)
+	}
+
+	opts := []client.HelmOption{
+		client.WithNamespace(namespace),
+		client.WithInstall(),
+		versionConfig.optionFunc(action.ID),
+	}
+	opts = append(opts, versionConfig.extraOptions...)
+	if h.kubeconfigPath != "" {
+		opts = append(opts, client.WithKubeconfig(h.kubeconfigPath))
+	}
+
+	valuesFiles := h.resolveValuesFiles(chartPath, helmSpec)
+	if len(valuesFiles) > 0 {
+		opts = append(opts, client.WithValuesFiles(valuesFiles))
+	}
+
+	if err := h.clients.Helm().Upgrade(ctx, releaseName, chartPath, opts...); err != nil {
+		return fmt.Errorf("helm upgrade --install %s: %w", releaseName, err)
+	}
+
+	h.log.Infof("Installed helm release: %s", releaseName)
+	return nil
+}
+
+func (h *HelmHandler) remove(ctx context.Context, action *Action) error {
+	releaseName := action.Name
+	helmSpec := h.getHelmSpec(action)
+	namespace := helmSpec.Namespace
+
+	h.log.Debugf("Uninstalling helm release: %s namespace: %s", releaseName, namespace)
+
+	opts := []client.HelmOption{
+		client.WithNamespace(namespace),
+		client.WithIgnoreNotFound(),
+	}
+	if h.kubeconfigPath != "" {
+		opts = append(opts, client.WithKubeconfig(h.kubeconfigPath))
+	}
+
+	if err := h.clients.Helm().Uninstall(ctx, releaseName, opts...); err != nil {
+		return fmt.Errorf("helm uninstall %s: %w", releaseName, err)
+	}
+
+	h.log.Infof("Uninstalled helm release: %s", releaseName)
+	return nil
+}
+
+func (h *HelmHandler) update(ctx context.Context, action *Action, versionConfig *helmVersionConfig) error {
+	releaseName := action.Name
+	chartPath := action.Path
+	helmSpec := h.getHelmSpec(action)
+	namespace := helmSpec.Namespace
+
+	h.log.Debugf("Upgrading helm release: %s namespace: %s chart: %s", releaseName, namespace, chartPath)
+
+	opts := []client.HelmOption{
+		client.WithNamespace(namespace),
+		client.WithInstall(),
+		versionConfig.optionFunc(action.ID),
+	}
+	opts = append(opts, versionConfig.extraOptions...)
+	if h.kubeconfigPath != "" {
+		opts = append(opts, client.WithKubeconfig(h.kubeconfigPath))
+	}
+
+	valuesFiles := h.resolveValuesFiles(chartPath, helmSpec)
+	if len(valuesFiles) > 0 {
+		opts = append(opts, client.WithValuesFiles(valuesFiles))
+	}
+
+	if err := h.clients.Helm().Upgrade(ctx, releaseName, chartPath, opts...); err != nil {
+		return fmt.Errorf("helm upgrade %s: %w", releaseName, err)
+	}
+
+	h.log.Infof("Upgraded helm release: %s", releaseName)
+	return nil
+}
+
+func (h *HelmHandler) getHelmSpec(action *Action) HelmSpec {
+	var spec HelmSpec
+	if s, ok := action.Spec.(HelmSpec); ok {
+		spec = s
+	}
+	spec.Namespace = helm.AppNamespace(&spec.Namespace, action.Name)
+	return spec
+}
+
+func (h *HelmHandler) resolveValuesFiles(chartPath string, helmSpec HelmSpec) []string {
+	var valuesFiles []string
+
+	for _, vf := range helmSpec.ValuesFiles {
+		absPath := filepath.Join(chartPath, vf)
+		valuesFiles = append(valuesFiles, absPath)
+	}
+
+	if helmSpec.ProviderValuesPath != "" {
+		valuesFiles = append(valuesFiles, helmSpec.ProviderValuesPath)
+	}
+
+	return valuesFiles
+}
+
+// setupHelmVersionConfig detects the installed Helm version and returns the
+// appropriate configuration for post-renderer and atomic/rollback behavior.
+func (h *HelmHandler) setupHelmVersionConfig(ctx context.Context) (*helmVersionConfig, error) {
+	version, err := h.clients.Helm().Version(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("detecting helm version: %w", err)
+	}
+
+	if !version.GreaterOrEqual(4, 0) {
+		// Helm 3.x: Pass binary path directly to --post-renderer flag.
+		// The flightctl-agent binary is invoked with "helm-render" subcommand.
+		bin, err := h.executableResolver.Resolve()
+		if err != nil {
+			return nil, fmt.Errorf("resolving executable: %w", err)
+		}
+		return &helmVersionConfig{
+			optionFunc: func(appID string) client.HelmOption {
+				return client.WithPostRenderer(bin, "helm-render", "--app", appID)
+			},
+			extraOptions: []client.HelmOption{
+				client.WithAtomic(),
+			},
+			cleanup: func() {},
+		}, nil
+	}
+
+	// Helm 4.x: Post-renderers must be plugins with type "postrenderer/v1".
+	// We create a temporary plugin directory with a plugin.yaml that wraps
+	// the flightctl-agent binary. The plugin is discovered via HELM_PLUGINS env var.
+	pluginsDir, cleanup, err := h.createPluginDir()
+	if err != nil {
+		return nil, fmt.Errorf("creating plugin directory: %w", err)
+	}
+
+	return &helmVersionConfig{
+		optionFunc: func(appID string) client.HelmOption {
+			// Pass plugin name instead of binary path - Helm discovers it via HELM_PLUGINS
+			return client.WithPostRenderer(helmPostRendererPlugin, "--app", appID)
+		},
+		extraOptions: []client.HelmOption{
+			client.WithHelmEnv(map[string]string{
+				"HELM_PLUGINS":    pluginsDir,
+				"HELM_CACHE_HOME": pluginsDir,
+			}),
+			client.WithRollbackOnFailure(),
+		},
+		cleanup: cleanup,
+	}, nil
+}
+
+// createPluginDir creates a temporary directory containing a Helm 4.x post-renderer plugin.
+//
+// Helm 4.x changed how post-renderers work - they must now be plugins rather than arbitrary
+// binaries. A plugin requires a plugin.yaml manifest with specific fields:
+//   - type: "postrenderer/v1" - identifies this as a post-renderer plugin
+//   - runtime: "subprocess" - tells Helm to execute a binary
+//   - runtimeConfig.platformCommand - specifies the binary and arguments to execute
+//
+// The plugin wraps the flightctl-agent binary, invoking it with the "helm-render" subcommand.
+// Helm discovers plugins via the HELM_PLUGINS environment variable, which we set to point
+// to this temporary directory.
+//
+// Returns the plugins directory path, a cleanup function to remove the directory, and any error.
+func (h *HelmHandler) createPluginDir() (string, func(), error) {
+	rw, err := h.rwFactory("")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating read writer: %w", err)
+	}
+
+	pluginsDir, err := rw.MkdirTemp("helm-plugins")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+
+	cleanup := func() {
+		if err := rw.RemoveAll(pluginsDir); err != nil {
+			h.log.Warnf("Failed to cleanup helm plugins directory %s: %v", pluginsDir, err)
+		}
+	}
+
+	// Plugin directory structure: HELM_PLUGINS/<plugin-name>/plugin.yaml
+	pluginDir := filepath.Join(pluginsDir, helmPostRendererPlugin)
+	if err := rw.MkdirAll(pluginDir, fileio.DefaultDirectoryPermissions); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("creating plugin directory: %w", err)
+	}
+
+	bin, err := h.executableResolver.Resolve()
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("resolving executable: %w", err)
+	}
+
+	// Create plugin.yaml manifest that wraps flightctl-agent with helm-render subcommand.
+	// The --app flag is passed via --post-renderer-args at runtime.
+	pluginYAML := fmt.Sprintf(`apiVersion: v1
+name: %s
+version: 1.0.0
+type: postrenderer/v1
+usage: "Post-renderer that injects flightctl app labels"
+description: "Wraps flightctl-agent helm-render to inject app labels into manifests"
+runtime: subprocess
+runtimeConfig:
+  platformCommand:
+    - command: %s
+      args:
+        - helm-render
+`, helmPostRendererPlugin, bin)
+
+	pluginPath := filepath.Join(pluginDir, "plugin.yaml")
+	if err := rw.WriteFile(pluginPath, []byte(pluginYAML), fileio.DefaultFilePermissions); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("writing plugin.yaml: %w", err)
+	}
+
+	h.log.Debugf("Created helm post-renderer plugin at %s", pluginPath)
+	return pluginsDir, cleanup, nil
+}

--- a/internal/agent/device/applications/lifecycle/helm_test.go
+++ b/internal/agent/device/applications/lifecycle/helm_test.go
@@ -1,0 +1,655 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/executer"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type testCLIClients struct {
+	helm *client.Helm
+	kube *client.Kube
+}
+
+func (t *testCLIClients) Podman() *client.Podman { return nil }
+func (t *testCLIClients) Skopeo() *client.Skopeo { return nil }
+func (t *testCLIClients) Kube() *client.Kube     { return t.kube }
+func (t *testCLIClients) Helm() *client.Helm     { return t.helm }
+func (t *testCLIClients) CRI() *client.CRI       { return nil }
+
+type testExecutableResolver struct {
+	path string
+}
+
+func (r testExecutableResolver) Resolve() (string, error) {
+	return r.path, nil
+}
+
+func TestHelmHandler_Execute_Add(t *testing.T) {
+	testCases := []struct {
+		name           string
+		action         *Action
+		kubeconfigPath string
+		setupMock      func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr        bool
+	}{
+		{
+			name: "success without kubeconfig",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"get", "namespace", "my-namespace",
+					}).Return("", "not found", 1),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"create", "namespace", "my-namespace",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"label", "namespace", "my-namespace",
+						"flightctl.io/managed-by=flightctl", "--overwrite",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+						"--install",
+						"--namespace", "my-namespace",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "my-namespace",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with kubeconfig",
+			action: &Action{
+				ID:   "prod-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{Namespace: "prod-namespace"},
+			},
+			kubeconfigPath: "/tmp/kubeconfig",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"get", "namespace", "prod-namespace", "--kubeconfig", "/tmp/kubeconfig",
+					}).Return("", "not found", 1),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"create", "namespace", "prod-namespace", "--kubeconfig", "/tmp/kubeconfig",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"label", "namespace", "prod-namespace",
+						"flightctl.io/managed-by=flightctl", "--overwrite", "--kubeconfig", "/tmp/kubeconfig",
+					}).Return("", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+						"--install",
+						"--namespace", "prod-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "prod-namespace",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with existing namespace",
+			action: &Action{
+				ID:   "existing-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{Namespace: "existing-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"get", "namespace", "existing-namespace",
+					}).Return("existing-namespace   Active   5d", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+						"--install",
+						"--namespace", "existing-namespace",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "existing-namespace",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with default namespace",
+			action: &Action{
+				ID:   "my-release",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"get", "namespace", "flightctl-my-release",
+					}).Return("", "not found", 1),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"create", "namespace", "flightctl-my-release",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"label", "namespace", "flightctl-my-release",
+						"flightctl.io/managed-by=flightctl", "--overwrite",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+						"--install",
+						"--namespace", "flightctl-my-release",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "my-release",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "error from helm upgrade --install",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"get", "namespace", "my-namespace",
+					}).Return("", "not found", 1),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"create", "namespace", "my-namespace",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+						"label", "namespace", "my-namespace",
+						"flightctl.io/managed-by=flightctl", "--overwrite",
+					}).Return("", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+						"--install",
+						"--namespace", "my-namespace",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "my-namespace",
+					}).Return("", "Error: chart not found", 1),
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "helm 4.x uses rollback-on-failure instead of atomic",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-1.0.0",
+				Type: ActionAdd,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().MkdirTemp("helm-plugins").Return("/tmp/helm-plugins-123", nil)
+				mockRW.EXPECT().MkdirAll("/tmp/helm-plugins-123/flightctl-postrenderer", fileio.DefaultDirectoryPermissions).Return(nil)
+				mockRW.EXPECT().WriteFile("/tmp/helm-plugins-123/flightctl-postrenderer/plugin.yaml", gomock.Any(), fileio.DefaultFilePermissions).Return(nil)
+				mockRW.EXPECT().RemoveAll("/tmp/helm-plugins-123").Return(nil)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+					"version", "--short",
+				}).Return("v4.0.0", "", 0)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+					"get", "namespace", "my-namespace",
+				}).Return("my-namespace   Active   5d", "", 0)
+				mockExec.EXPECT().ExecuteWithContextFromDir(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).DoAndReturn(func(ctx context.Context, dir, cmd string, args []string, env ...string) (string, string, int) {
+					require.Equal(t, "", dir)
+					require.Equal(t, "helm", cmd)
+					require.Contains(t, args, "--rollback-on-failure")
+					require.NotContains(t, args, "--atomic")
+					require.Contains(t, args, "--post-renderer")
+					require.Contains(t, args, "flightctl-postrenderer")
+					return "", "", 0
+				})
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+
+			clients := &testCLIClients{
+				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+			}
+			resolver := testExecutableResolver{path: "/test/flightctl"}
+			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
+				return mockReadWriter, nil
+			}
+			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			err := handler.Execute(context.Background(), []Action{*tc.action})
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmHandler_Execute_Remove(t *testing.T) {
+	testCases := []struct {
+		name           string
+		action         *Action
+		kubeconfigPath string
+		setupMock      func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr        bool
+	}{
+		{
+			name: "success without kubeconfig",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Type: ActionRemove,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"uninstall", "my-release",
+						"--namespace", "my-namespace",
+						"--ignore-not-found",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with kubeconfig",
+			action: &Action{
+				ID:   "prod-namespace",
+				Name: "my-release",
+				Type: ActionRemove,
+				Spec: HelmSpec{Namespace: "prod-namespace"},
+			},
+			kubeconfigPath: "/tmp/kubeconfig",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"uninstall", "my-release",
+						"--namespace", "prod-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
+						"--ignore-not-found",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "error from helm uninstall",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Type: ActionRemove,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"uninstall", "my-release",
+						"--namespace", "my-namespace",
+						"--ignore-not-found",
+					}).Return("", "Error: release not found", 1),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+
+			clients := &testCLIClients{
+				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+			}
+			resolver := testExecutableResolver{path: "/test/flightctl"}
+			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
+				return mockReadWriter, nil
+			}
+			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			err := handler.Execute(context.Background(), []Action{*tc.action})
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmHandler_Execute_Update(t *testing.T) {
+	testCases := []struct {
+		name           string
+		action         *Action
+		kubeconfigPath string
+		setupMock      func(*executer.MockExecuter, *fileio.MockReadWriter)
+		wantErr        bool
+	}{
+		{
+			name: "success without kubeconfig",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+				Type: ActionUpdate,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+						"--install",
+						"--namespace", "my-namespace",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "my-namespace",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with kubeconfig",
+			action: &Action{
+				ID:   "prod-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+				Type: ActionUpdate,
+				Spec: HelmSpec{Namespace: "prod-namespace"},
+			},
+			kubeconfigPath: "/tmp/kubeconfig",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+						"--install",
+						"--namespace", "prod-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "prod-namespace",
+					}).Return("", "", 0),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "error from helm upgrade",
+			action: &Action{
+				ID:   "my-namespace",
+				Name: "my-release",
+				Path: "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+				Type: ActionUpdate,
+				Spec: HelmSpec{Namespace: "my-namespace"},
+			},
+			kubeconfigPath: "",
+			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
+				gomock.InOrder(
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"version", "--short",
+					}).Return("v3.14.0", "", 0),
+					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-2.0.0",
+						"--install",
+						"--namespace", "my-namespace",
+						"--atomic",
+						"--post-renderer", "/test/flightctl",
+						"--post-renderer-args", "helm-render",
+						"--post-renderer-args", "--app",
+						"--post-renderer-args", "my-namespace",
+					}).Return("", "Error: chart not found", 1),
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockExec, mockReadWriter)
+
+			clients := &testCLIClients{
+				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+			}
+			resolver := testExecutableResolver{path: "/test/flightctl"}
+			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
+				return mockReadWriter, nil
+			}
+			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			err := handler.Execute(context.Background(), []Action{*tc.action})
+
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestHelmHandler_Execute_MultipleActions(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	gomock.InOrder(
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+			"version", "--short",
+		}).Return("v3.14.0", "", 0),
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+			"get", "namespace", "ns1",
+		}).Return("", "not found", 1),
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+			"create", "namespace", "ns1",
+		}).Return("", "", 0),
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+			"label", "namespace", "ns1",
+			"flightctl.io/managed-by=flightctl", "--overwrite",
+		}).Return("", "", 0),
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+			"upgrade", "app1", "/charts/app1",
+			"--install",
+			"--namespace", "ns1",
+			"--atomic",
+			"--post-renderer", "/test/flightctl",
+			"--post-renderer-args", "helm-render",
+			"--post-renderer-args", "--app",
+			"--post-renderer-args", "ns1",
+		}).Return("", "", 0),
+		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+			"upgrade", "app2", "/charts/app2",
+			"--install",
+			"--namespace", "ns2",
+			"--atomic",
+			"--post-renderer", "/test/flightctl",
+			"--post-renderer-args", "helm-render",
+			"--post-renderer-args", "--app",
+			"--post-renderer-args", "ns2",
+		}).Return("", "", 0),
+	)
+
+	clients := &testCLIClients{
+		helm: client.NewHelm(logger, mockExec, mockReadWriter, client.HelmChartsDir),
+		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+	}
+	resolver := testExecutableResolver{path: "/test/flightctl"}
+	rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
+		return mockReadWriter, nil
+	}
+	handler := NewHelmHandler(logger, clients, "", resolver, rwFactory)
+
+	actions := []Action{
+		{
+			ID:   "ns1",
+			Name: "app1",
+			Path: "/charts/app1",
+			Type: ActionAdd,
+			Spec: HelmSpec{Namespace: "ns1"},
+		},
+		{
+			ID:   "ns2",
+			Name: "app2",
+			Path: "/charts/app2",
+			Type: ActionUpdate,
+			Spec: HelmSpec{Namespace: "ns2"},
+		},
+	}
+
+	err := handler.Execute(context.Background(), actions)
+	require.NoError(err)
+}
+
+func TestHelmHandler_Execute_UnsupportedActionType(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := log.NewPrefixLogger("test")
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
+		"version", "--short",
+	}).Return("v3.14.0", "", 0)
+
+	clients := &testCLIClients{
+		helm: client.NewHelm(logger, mockExec, mockReadWriter, client.HelmChartsDir),
+		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+	}
+	resolver := testExecutableResolver{path: "/test/flightctl"}
+	rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
+		return mockReadWriter, nil
+	}
+	handler := NewHelmHandler(logger, clients, "", resolver, rwFactory)
+
+	action := Action{
+		ID:   "ns1",
+		Name: "app1",
+		Path: "/charts/app1",
+		Type: ActionType("unsupported"),
+	}
+
+	err := handler.Execute(context.Background(), []Action{action})
+	require.Error(err)
+	require.Contains(err.Error(), "unsupported action type")
+}

--- a/internal/agent/device/applications/lifecycle/lifecycle.go
+++ b/internal/agent/device/applications/lifecycle/lifecycle.go
@@ -26,6 +26,12 @@ type ActionHandler interface {
 	Execute(ctx context.Context, actions Actions) error
 }
 
+// ActionSpec is a marker interface for type-specific action configuration.
+// Only spec types defined in this package can implement this interface.
+type ActionSpec interface {
+	actionSpec()
+}
+
 type Action struct {
 	// ID of the application
 	ID string
@@ -45,7 +51,22 @@ type Action struct {
 	Embedded bool
 	// Volumes is a list of volume names related to this application
 	Volumes []Volume
+	// Spec holds type-specific configuration, discriminated by AppType.
+	Spec ActionSpec
 }
+
+// HelmSpec contains Helm-specific action configuration.
+type HelmSpec struct {
+	// Namespace is the Kubernetes namespace for the Helm release.
+	Namespace string
+	// ValuesFiles is a list of relative paths to values files within the chart.
+	ValuesFiles []string
+	// ProviderValuesPath is the absolute path to the provider-generated values file.
+	// This is set when the application spec contains inline Values.
+	ProviderValuesPath string
+}
+
+func (HelmSpec) actionSpec() {}
 
 type Actions []Action
 

--- a/internal/agent/device/applications/lifecycle/mock_lifecycle.go
+++ b/internal/agent/device/applications/lifecycle/mock_lifecycle.go
@@ -52,3 +52,38 @@ func (mr *MockActionHandlerMockRecorder) Execute(ctx, actions any) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockActionHandler)(nil).Execute), ctx, actions)
 }
+
+// MockActionSpec is a mock of ActionSpec interface.
+type MockActionSpec struct {
+	ctrl     *gomock.Controller
+	recorder *MockActionSpecMockRecorder
+}
+
+// MockActionSpecMockRecorder is the mock recorder for MockActionSpec.
+type MockActionSpecMockRecorder struct {
+	mock *MockActionSpec
+}
+
+// NewMockActionSpec creates a new mock instance.
+func NewMockActionSpec(ctrl *gomock.Controller) *MockActionSpec {
+	mock := &MockActionSpec{ctrl: ctrl}
+	mock.recorder = &MockActionSpecMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockActionSpec) EXPECT() *MockActionSpecMockRecorder {
+	return m.recorder
+}
+
+// actionSpec mocks base method.
+func (m *MockActionSpec) actionSpec() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "actionSpec")
+}
+
+// actionSpec indicates an expected call of actionSpec.
+func (mr *MockActionSpecMockRecorder) actionSpec() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "actionSpec", reflect.TypeOf((*MockActionSpec)(nil).actionSpec))
+}

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -15,22 +15,25 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/systeminfo"
 	"github.com/flightctl/flightctl/internal/agent/shutdown"
 	"github.com/flightctl/flightctl/pkg/log"
-	"github.com/samber/lo"
 )
 
 const (
-	pullAuthPath = "/root/.config/containers/auth.json"
+	pullAuthPath       = "/root/.config/containers/auth.json"
+	helmRegistryConfig = "/root/.config/helm/registry/config.json"
+	helmRepoConfig     = "/root/.config/helm/repositories.yaml"
+	criConfigPath      = "/etc/crictl.yaml"
 )
 
 var _ Manager = (*manager)(nil)
 
 type manager struct {
-	podmanMonitor *PodmanMonitor
-	podmanFactory client.PodmanFactory
-	clients       client.CLIClients
-	rwFactory     fileio.ReadWriterFactory
-	log           *log.PrefixLogger
-	bootTime      string
+	podmanMonitor     *PodmanMonitor
+	kubernetesMonitor *KubernetesMonitor
+	clients           client.CLIClients
+	podmanFactory     client.PodmanFactory
+	rwFactory         fileio.ReadWriterFactory
+	log               *log.PrefixLogger
+	bootTime          string
 
 	// cache of extracted nested OCI targets
 	ociTargetCache *provider.OCITargetCache
@@ -49,14 +52,15 @@ func NewManager(
 ) Manager {
 	bootTime := systemInfo.BootTime()
 	return &manager{
-		rwFactory:      rwFactory,
-		podmanMonitor:  NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime, rwFactory),
-		podmanFactory:  podmanFactory,
-		clients:        clients,
-		log:            log,
-		bootTime:       bootTime,
-		ociTargetCache: provider.NewOCITargetCache(),
-		appDataCache:   provider.NewAppDataCache(),
+		rwFactory:         rwFactory,
+		podmanMonitor:     NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime, rwFactory),
+		kubernetesMonitor: NewKubernetesMonitor(log, clients, rwFactory),
+		podmanFactory:     podmanFactory,
+		clients:           clients,
+		log:               log,
+		bootTime:          bootTime,
+		ociTargetCache:    provider.NewOCITargetCache(),
+		appDataCache:      provider.NewAppDataCache(),
 	}
 }
 
@@ -71,6 +75,17 @@ func (m *manager) Ensure(ctx context.Context, provider provider.Provider) error 
 			return fmt.Errorf("installing application: %w", err)
 		}
 		return m.podmanMonitor.Ensure(ctx, NewApplication(provider))
+	case v1beta1.AppTypeHelm:
+		if !m.kubernetesMonitor.IsEnabled() {
+			return errors.ErrKubernetesAppsDisabled
+		}
+		if m.kubernetesMonitor.Has(provider.Spec().ID) {
+			return nil
+		}
+		if err := provider.Install(ctx); err != nil {
+			return fmt.Errorf("installing application: %w", err)
+		}
+		return m.kubernetesMonitor.Ensure(NewHelmApplication(provider))
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
@@ -84,6 +99,14 @@ func (m *manager) Remove(ctx context.Context, provider provider.Provider) error 
 			return fmt.Errorf("removing application: %w", err)
 		}
 		return m.podmanMonitor.QueueRemove(NewApplication(provider))
+	case v1beta1.AppTypeHelm:
+		if !m.kubernetesMonitor.IsEnabled() {
+			return errors.ErrKubernetesAppsDisabled
+		}
+		if err := provider.Remove(ctx); err != nil {
+			return fmt.Errorf("removing application: %w", err)
+		}
+		return m.kubernetesMonitor.Remove(NewHelmApplication(provider))
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
@@ -100,6 +123,17 @@ func (m *manager) Update(ctx context.Context, provider provider.Provider) error 
 			return fmt.Errorf("installing application: %w", err)
 		}
 		return m.podmanMonitor.QueueUpdate(NewApplication(provider))
+	case v1beta1.AppTypeHelm:
+		if !m.kubernetesMonitor.IsEnabled() {
+			return errors.ErrKubernetesAppsDisabled
+		}
+		if err := provider.Remove(ctx); err != nil {
+			return fmt.Errorf("removing application: %w", err)
+		}
+		if err := provider.Install(ctx); err != nil {
+			return fmt.Errorf("installing application: %w", err)
+		}
+		return m.kubernetesMonitor.Update(NewHelmApplication(provider))
 	default:
 		return fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
@@ -127,24 +161,55 @@ func (m *manager) BeforeUpdate(ctx context.Context, desired *v1beta1.DeviceSpec)
 		return fmt.Errorf("parsing apps: %w", err)
 	}
 
-	// the prefetch manager now handles scheduling internally via registered functions
-	// we only need to verify providers once images are ready
 	return m.verifyProviders(ctx, providers)
 }
 
-func (m *manager) resolvePullSecret(desired *v1beta1.DeviceSpec) (*client.PullConfig, error) {
+func (m *manager) resolvePullConfigs(desired *v1beta1.DeviceSpec) (client.PullConfigProvider, error) {
 	rootRW, err := m.rwFactory("")
 	if err != nil {
 		return nil, err
 	}
-	secret, found, err := client.ResolvePullConfig(m.log, rootRW, desired, pullAuthPath)
+	configs := make(map[client.ConfigType]*client.PullConfig)
+
+	containerConfig, found, err := client.ResolvePullConfig(m.log, rootRW, desired, pullAuthPath)
 	if err != nil {
-		return nil, fmt.Errorf("resolving pull secret: %w", err)
+		return nil, fmt.Errorf("resolving container auth config: %w", err)
 	}
-	if !found {
-		return nil, nil
+	if found {
+		configs[client.ConfigTypeContainerSecret] = containerConfig
 	}
-	return secret, nil
+
+	helmRegistryCfg, found, err := client.ResolvePullConfig(m.log, rootRW, desired, helmRegistryConfig)
+	if err != nil {
+		return nil, fmt.Errorf("resolving helm registry config: %w", err)
+	}
+	if found {
+		configs[client.ConfigTypeHelmRegistrySecret] = helmRegistryCfg
+	} else if containerConfig != nil {
+		// Avoid double cleaning
+		configs[client.ConfigTypeHelmRegistrySecret] = &client.PullConfig{
+			Path:    containerConfig.Path,
+			Cleanup: nil,
+		}
+	}
+
+	helmRepoCfg, found, err := client.ResolvePullConfig(m.log, rootRW, desired, helmRepoConfig)
+	if err != nil {
+		return nil, fmt.Errorf("resolving helm repository config: %w", err)
+	}
+	if found {
+		configs[client.ConfigTypeHelmRepoConfig] = helmRepoCfg
+	}
+
+	criConfig, found, err := client.ResolvePullConfig(m.log, rootRW, desired, criConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving CRI config: %w", err)
+	}
+	if found {
+		configs[client.ConfigTypeCRIConfig] = criConfig
+	}
+
+	return client.NewPullConfigProvider(configs), nil
 }
 
 func (m *manager) verifyProviders(ctx context.Context, providers []provider.Provider) error {
@@ -157,14 +222,16 @@ func (m *manager) verifyProviders(ctx context.Context, providers []provider.Prov
 }
 
 func (m *manager) AfterUpdate(ctx context.Context) error {
-	// cleanup extraction cache from this sync cycle
 	defer m.clearAppDataCache()
 
-	// execute actions for applications using the podman runtime - this includes
-	// compose and quadlets
 	if err := m.podmanMonitor.ExecuteActions(ctx); err != nil {
-		return fmt.Errorf("error executing actions: %w", err)
+		return fmt.Errorf("error executing podman actions: %w", err)
 	}
+
+	if err := m.kubernetesMonitor.ExecuteActions(ctx); err != nil {
+		return fmt.Errorf("error executing kubernetes actions: %w", err)
+	}
+
 	return nil
 }
 
@@ -178,25 +245,95 @@ func (m *manager) clearAppDataCache() {
 }
 
 func (m *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, opts ...status.CollectorOpt) error {
-	applicationsStatus, applicationSummary, err := m.podmanMonitor.Status()
+	var allResults []AppStatusResult
+
+	podmanResults, err := m.podmanMonitor.Status()
 	if err != nil {
 		return err
 	}
+	allResults = append(allResults, podmanResults...)
 
-	status.ApplicationsSummary.Status = applicationSummary.Status
-	status.ApplicationsSummary.Info = applicationSummary.Info
-	status.Applications = applicationsStatus
+	k8sResults, err := m.kubernetesMonitor.Status()
+	if err != nil {
+		return err
+	}
+	allResults = append(allResults, k8sResults...)
+
+	statuses, summary := aggregateAppStatuses(allResults)
+	status.ApplicationsSummary = summary
+	status.Applications = statuses
 	return nil
 }
 
+func aggregateAppStatuses(results []AppStatusResult) ([]v1beta1.DeviceApplicationStatus, v1beta1.DeviceApplicationsSummaryStatus) {
+	if len(results) == 0 {
+		return []v1beta1.DeviceApplicationStatus{}, v1beta1.DeviceApplicationsSummaryStatus{
+			Status: v1beta1.ApplicationsSummaryStatusNoApplications,
+		}
+	}
+
+	statuses := make([]v1beta1.DeviceApplicationStatus, 0, len(results))
+	var overallStatus v1beta1.ApplicationsSummaryStatusType
+	var erroredApps []string
+	var degradedApps []string
+
+	for _, result := range results {
+		statuses = append(statuses, result.Status)
+
+		switch result.Summary.Status {
+		case v1beta1.ApplicationsSummaryStatusError:
+			erroredApps = append(erroredApps, fmt.Sprintf("%s is in status %s", result.Status.Name, result.Summary.Status))
+			overallStatus = v1beta1.ApplicationsSummaryStatusError
+		case v1beta1.ApplicationsSummaryStatusDegraded:
+			degradedApps = append(degradedApps, fmt.Sprintf("%s is in status %s", result.Status.Name, result.Summary.Status))
+			if overallStatus != v1beta1.ApplicationsSummaryStatusError {
+				overallStatus = v1beta1.ApplicationsSummaryStatusDegraded
+			}
+		case v1beta1.ApplicationsSummaryStatusUnknown:
+			degradedApps = append(degradedApps, fmt.Sprintf("Not started: %s", result.Status.Name))
+			if overallStatus != v1beta1.ApplicationsSummaryStatusError {
+				overallStatus = v1beta1.ApplicationsSummaryStatusDegraded
+			}
+		case v1beta1.ApplicationsSummaryStatusHealthy:
+			if overallStatus != v1beta1.ApplicationsSummaryStatusError &&
+				overallStatus != v1beta1.ApplicationsSummaryStatusDegraded {
+				overallStatus = v1beta1.ApplicationsSummaryStatusHealthy
+			}
+		}
+	}
+
+	summary := v1beta1.DeviceApplicationsSummaryStatus{Status: overallStatus}
+	if len(erroredApps) > 0 || len(degradedApps) > 0 {
+		summary.Info = buildAppSummaryInfo(erroredApps, degradedApps, maxAppSummaryInfoLength)
+	}
+	return statuses, summary
+}
+
 func (m *manager) Shutdown(ctx context.Context, state shutdown.State) error {
+	var errs []error
+
 	if state.SystemShutdown {
 		m.log.Info("System shutdown detected - draining applications")
-		return m.podmanMonitor.Drain(ctx)
+		if err := m.podmanMonitor.Drain(ctx); err != nil {
+			errs = append(errs, err)
+		}
+		if err := m.kubernetesMonitor.Drain(ctx); err != nil {
+			errs = append(errs, err)
+		}
 	} else {
-		m.log.Debug("Agent restart detected - stopping monitor")
-		return m.podmanMonitor.Stop()
+		m.log.Debug("Agent restart detected - stopping monitors")
+		if err := m.podmanMonitor.Stop(); err != nil {
+			errs = append(errs, err)
+		}
+		if err := m.kubernetesMonitor.Stop(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
 // CollectOCITargets implements two-phase collection:
@@ -213,18 +350,10 @@ func (m *manager) CollectOCITargets(ctx context.Context, current, desired *v1bet
 		return &dependency.OCICollection{}, nil
 	}
 
-	// resolve pull secret
-	secret, err := m.resolvePullSecret(desired)
+	configProvider, err := m.resolvePullConfigs(desired)
 	if err != nil {
-		return nil, fmt.Errorf("resolving pull secret: %w", err)
+		return nil, fmt.Errorf("resolving pull secrets: %w", err)
 	}
-
-	// create config provider from pull secret
-	configs := make(map[client.ConfigType]*client.PullConfig)
-	if secret != nil {
-		configs[client.ConfigTypeContainerSecret] = secret
-	}
-	configProvider := client.NewPullConfigProvider(configs)
 
 	baseTargets, err := provider.CollectBaseOCITargets(ctx, m.rwFactory, desired, configProvider)
 	if err != nil {
@@ -259,103 +388,150 @@ func (m *manager) collectNestedTargets(
 	needsRequeue := false
 
 	for _, appSpec := range *desired.Applications {
-		appName, err := appSpec.GetName()
+		appName, err := provider.ResolveImageAppName(&appSpec)
 		if err != nil {
-			return nil, false, nil, fmt.Errorf("getting app name: %w", err)
+			return nil, false, nil, fmt.Errorf("resolving app name: %w", err)
 		}
-		resolvedName := lo.FromPtr(appName)
-		activeAppNames = append(activeAppNames, resolvedName)
-
+		activeAppNames = append(activeAppNames, appName)
 		needsExtraction, err := provider.AppNeedsNestedExtraction(&appSpec)
 		if err != nil {
-			return nil, false, nil, fmt.Errorf("checking nested extraction for app %s: %w", resolvedName, err)
+			return nil, false, nil, fmt.Errorf("checking nested extraction for app %s: %w", appName, err)
 		}
 		if !needsExtraction {
 			continue
 		}
 
-		imageRef, err := provider.ResolveImageRef(&appSpec)
-		if err != nil {
-			return nil, false, nil, fmt.Errorf("resolving image ref for app %s: %w", resolvedName, err)
-		}
-
 		targetUser, err := provider.ResolveUser(&appSpec)
 		if err != nil {
-			return nil, false, nil, fmt.Errorf("resolving app user for app %s: %w", resolvedName, err)
+			return nil, false, nil, fmt.Errorf("resolving user %q: %w", appSpec, err)
 		}
 
-		var digest string
-		var ociType dependency.OCIType
-		var exists bool
-
-		podman, err := m.podmanFactory(targetUser)
+		targets, requeue, err := m.collectNestedTargetsForApp(ctx, appSpec, configProvider)
 		if err != nil {
-			return nil, false, nil, fmt.Errorf("creating podman client: %w", err)
+			return nil, false, nil, fmt.Errorf("collecting nested targets for %s: %w", appName, err)
 		}
 
-		// Check if it's an image first (most common case)
-		if podman.ImageExists(ctx, imageRef) {
-			ociType = dependency.OCITypePodmanImage
-			exists = true
-			digest, err = podman.ImageDigest(ctx, imageRef)
-			if err != nil {
-				return nil, false, nil, fmt.Errorf("getting image digest for %s: %w", imageRef, err)
-			}
-		} else if podman.ArtifactExists(ctx, imageRef) {
-			ociType = dependency.OCITypePodmanArtifact
-			exists = true
-			digest, err = podman.ArtifactDigest(ctx, imageRef)
-			if err != nil {
-				return nil, false, nil, fmt.Errorf("getting artifact digest for %s: %w", imageRef, err)
-			}
-		}
-
-		if !exists {
-			m.log.Debugf("Reference %s for app %s not available yet, skipping nested extraction", imageRef, resolvedName)
+		if requeue {
 			needsRequeue = true
-			continue
 		}
-
-		if cachedEntry, found := m.ociTargetCache.Get(resolvedName); found {
-			if cachedEntry.Parent.Digest == digest {
-				// cache hit - parent digest matches
-				m.log.Debugf("Using cached nested targets for app %s (digest: %s)", resolvedName, digest)
-				allNestedTargets = allNestedTargets.Add(cachedEntry.Owner, cachedEntry.Children...)
-				continue
-			}
-			m.log.Debugf("Cache invalidated for app %s - digest changed from %s to %s", resolvedName, cachedEntry.Parent.Digest, digest)
-		}
-
-		appData, err := m.extractNestedTargetsForImage(ctx, &appSpec, configProvider)
-		if err != nil {
-			return nil, false, nil, fmt.Errorf("extracting nested targets for app %s: %w", resolvedName, err)
-		}
-
-		m.appDataCache[resolvedName] = appData
-
-		cacheEntry := provider.CacheEntry{
-			Name:  resolvedName,
-			Owner: appData.Owner,
-			Parent: dependency.OCIPullTarget{
-				Type:      ociType,
-				Reference: imageRef,
-				Digest:    digest,
-			},
-			Children: appData.Targets,
-		}
-		m.ociTargetCache.Set(cacheEntry)
-		m.log.Debugf("Cached %d nested targets for app %s (type: %s, digest: %s)", len(appData.Targets), resolvedName, ociType, digest)
-
-		allNestedTargets = allNestedTargets.Add(appData.Owner, appData.Targets...)
+		allNestedTargets = allNestedTargets.Add(targetUser, targets...)
 	}
 
 	return allNestedTargets, needsRequeue, activeAppNames, nil
 }
 
+// collectNestedTargetsForApp extracts nested OCI targets from a single image-based application.
+func (m *manager) collectNestedTargetsForApp(
+	ctx context.Context,
+	appSpec v1beta1.ApplicationProviderSpec,
+	configProvider client.PullConfigProvider,
+) ([]dependency.OCIPullTarget, bool, error) {
+	appName, err := provider.ResolveImageAppName(&appSpec)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolving app name: %w", err)
+	}
+
+	ref, err := provider.ResolveImageRef(&appSpec)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolving image ref: %w", err)
+	}
+
+	appType, err := appSpec.GetAppType()
+	if err != nil {
+		return nil, false, fmt.Errorf("getting app type: %w", err)
+	}
+
+	user, err := provider.ResolveUser(&appSpec)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolving user %q: %w", appSpec, err)
+	}
+
+	available, ociType, digest, err := m.isParentAvailable(ctx, appType, ref, user)
+	if err != nil {
+		return nil, false, fmt.Errorf("checking parent availability: %w", err)
+	}
+	if !available {
+		m.log.Debugf("Reference %s for app %s not available yet, skipping nested extraction", ref, appName)
+		return nil, true, nil
+	}
+
+	if cachedEntry, found := m.ociTargetCache.Get(appName); found {
+		if m.isCacheValid(cachedEntry, ref, digest) {
+			m.log.Debugf("Using cached nested targets for app %s", appName)
+			return cachedEntry.Children, false, nil
+		}
+		m.log.Debugf("Cache invalidated for app %s", appName)
+	}
+
+	appData, err := m.extractNestedTargetsForImage(ctx, appSpec, configProvider)
+	if err != nil {
+		return nil, false, fmt.Errorf("extracting nested targets for app %s: %w", appName, err)
+	}
+
+	m.appDataCache[appName] = appData
+
+	m.ociTargetCache.Set(provider.CacheEntry{
+		Name: appName,
+		Parent: dependency.OCIPullTarget{
+			Type:      ociType,
+			Reference: ref,
+			Digest:    digest,
+		},
+		Children: appData.Targets,
+	})
+	m.log.Debugf("Cached %d nested targets for app %s (type: %s)", len(appData.Targets), appName, ociType)
+
+	return appData.Targets, false, nil
+}
+
+// isParentAvailable checks if the parent OCI target is available locally.
+func (m *manager) isParentAvailable(ctx context.Context, appType v1beta1.AppType, ref string, user v1beta1.Username) (bool, dependency.OCIType, string, error) {
+	switch appType {
+	case v1beta1.AppTypeHelm:
+		resolved, err := m.clients.Helm().IsResolved(ref)
+		if err != nil {
+			return false, "", "", fmt.Errorf("check chart resolved: %w", err)
+		}
+		return resolved, dependency.OCITypeHelmChart, "", nil
+	default:
+		podman, err := m.podmanFactory(user)
+		if err != nil {
+			return false, "", "", fmt.Errorf("creating podman client: %w", err)
+		}
+
+		if podman.ImageExists(ctx, ref) {
+			digest, err := podman.ImageDigest(ctx, ref)
+			if err != nil {
+				return false, "", "", fmt.Errorf("getting image digest: %w", err)
+			}
+			return true, dependency.OCITypePodmanImage, digest, nil
+		}
+		if podman.ArtifactExists(ctx, ref) {
+			digest, err := podman.ArtifactDigest(ctx, ref)
+			if err != nil {
+				return false, "", "", fmt.Errorf("getting artifact digest: %w", err)
+			}
+			return true, dependency.OCITypePodmanArtifact, digest, nil
+		}
+		return false, "", "", nil
+	}
+}
+
+// isCacheValid checks if a cache entry is still valid for the given reference and digest.
+func (m *manager) isCacheValid(entry provider.CacheEntry, ref, digest string) bool {
+	if entry.Parent.Reference != ref {
+		return false
+	}
+	if digest != "" && entry.Parent.Digest != digest {
+		return false
+	}
+	return true
+}
+
 // extractNestedTargetsForImage extracts nested OCI targets from a single image-based application.
 func (m *manager) extractNestedTargetsForImage(
 	ctx context.Context,
-	appSpec *v1beta1.ApplicationProviderSpec,
+	appSpec v1beta1.ApplicationProviderSpec,
 	configProvider client.PullConfigProvider,
 ) (*provider.AppData, error) {
 	return provider.ExtractNestedTargetsFromImage(
@@ -364,7 +540,7 @@ func (m *manager) extractNestedTargetsForImage(
 		m.podmanFactory,
 		m.clients,
 		m.rwFactory,
-		appSpec,
+		&appSpec,
 		configProvider,
 	)
 }

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -253,11 +253,13 @@ func TestManager(t *testing.T) {
 			currentProviders, err := provider.FromDeviceSpec(ctx, log, podmanFactory, nil, rwFactory, tc.current)
 			require.NoError(err)
 
+			cliClients := client.NewCLIClients()
 			manager := &manager{
-				rwFactory:     rwFactory,
-				podmanMonitor: NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime.Format(time.RFC3339), rwMockFactory),
-				clients:       client.NewCLIClients(),
-				log:           log,
+				rwFactory:         rwFactory,
+				podmanMonitor:     NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime.Format(time.RFC3339), rwMockFactory),
+				kubernetesMonitor: NewKubernetesMonitor(log, cliClients, rwFactory),
+				clients:           cliClients,
+				log:               log,
 			}
 
 			// ensure the current applications are installed
@@ -352,11 +354,12 @@ func TestManagerRemoveApplication(t *testing.T) {
 	var rwMockFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
 		return mockReadWriter, nil
 	}
+	cliClients := client.NewCLIClients()
 	manager := &manager{
-		rwFactory:     rwFactory,
-		podmanMonitor: NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime.Format(time.RFC3339), rwMockFactory),
-		clients:       client.NewCLIClients(),
-		log:           log,
+		rwFactory:         rwFactory,
+		podmanMonitor:     NewPodmanMonitor(log, podmanFactory, systemdFactory, bootTime.Format(time.RFC3339), rwMockFactory),
+		kubernetesMonitor: NewKubernetesMonitor(log, cliClients, rwFactory),
+		log:               log,
 	}
 
 	// Ensure current applications

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	lifecycle "github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
 	provider "github.com/flightctl/flightctl/internal/agent/device/applications/provider"
 	dependency "github.com/flightctl/flightctl/internal/agent/device/dependency"
 	status "github.com/flightctl/flightctl/internal/agent/device/status"
@@ -234,6 +235,20 @@ func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 	return m.recorder
 }
 
+// ActionSpec mocks base method.
+func (m *MockApplication) ActionSpec() lifecycle.ActionSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ActionSpec")
+	ret0, _ := ret[0].(lifecycle.ActionSpec)
+	return ret0
+}
+
+// ActionSpec indicates an expected call of ActionSpec.
+func (mr *MockApplicationMockRecorder) ActionSpec() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionSpec", reflect.TypeOf((*MockApplication)(nil).ActionSpec))
+}
+
 // AddWorkload mocks base method.
 func (m *MockApplication) AddWorkload(Workload *Workload) {
 	m.ctrl.T.Helper()
@@ -258,6 +273,30 @@ func (m *MockApplication) AppType() v1beta1.AppType {
 func (mr *MockApplicationMockRecorder) AppType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppType", reflect.TypeOf((*MockApplication)(nil).AppType))
+}
+
+// ClearWorkloads mocks base method.
+func (m *MockApplication) ClearWorkloads() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearWorkloads")
+}
+
+// ClearWorkloads indicates an expected call of ClearWorkloads.
+func (mr *MockApplicationMockRecorder) ClearWorkloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearWorkloads", reflect.TypeOf((*MockApplication)(nil).ClearWorkloads))
+}
+
+// CopyWorkloadsFrom mocks base method.
+func (m *MockApplication) CopyWorkloadsFrom(other Application) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CopyWorkloadsFrom", other)
+}
+
+// CopyWorkloadsFrom indicates an expected call of CopyWorkloadsFrom.
+func (mr *MockApplicationMockRecorder) CopyWorkloadsFrom(other any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyWorkloadsFrom", reflect.TypeOf((*MockApplication)(nil).CopyWorkloadsFrom), other)
 }
 
 // ID mocks base method.
@@ -387,4 +426,18 @@ func (m *MockApplication) Workload(name string) (*Workload, bool) {
 func (mr *MockApplicationMockRecorder) Workload(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Workload", reflect.TypeOf((*MockApplication)(nil).Workload), name)
+}
+
+// Workloads mocks base method.
+func (m *MockApplication) Workloads() []Workload {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Workloads")
+	ret0, _ := ret[0].([]Workload)
+	return ret0
+}
+
+// Workloads indicates an expected call of Workloads.
+func (mr *MockApplicationMockRecorder) Workloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Workloads", reflect.TypeOf((*MockApplication)(nil).Workloads))
 }

--- a/internal/agent/device/applications/monitor.go
+++ b/internal/agent/device/applications/monitor.go
@@ -1,0 +1,505 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	stderrs "errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/provider"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+const (
+	stopMonitorWaitDuration = 5 * time.Second
+	maxAppSummaryInfoLength = 256
+	restartDelay            = 5 * time.Second
+)
+
+// streamingMonitor defines the interface for monitors that stream events from external processes.
+// Implementations provide the command factory and event handling logic.
+type streamingMonitor interface {
+	CreateCommand(ctx context.Context) (*exec.Cmd, error)
+	Parser() streamParser
+	HandleEvent(ctx context.Context, data []byte)
+	OnRestart()
+}
+
+type streamParser interface {
+	parse(ctx context.Context, r io.Reader, handler func([]byte)) error
+}
+
+type jsonStreamParser struct{}
+
+func (jsonStreamParser) parse(ctx context.Context, r io.Reader, handler func([]byte)) error {
+	decoder := json.NewDecoder(r)
+	for {
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return err
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			handler(raw)
+		}
+	}
+}
+
+type handlerRegistration struct {
+	appType v1beta1.AppType
+	handler lifecycle.ActionHandler
+}
+
+// AppStatusResult holds the status result for a single application.
+type AppStatusResult struct {
+	Status  v1beta1.DeviceApplicationStatus
+	Summary v1beta1.DeviceApplicationsSummaryStatus
+}
+
+// monitor provides shared functionality for application monitors.
+type monitor struct {
+	mu                sync.Mutex
+	cmd               *exec.Cmd
+	cancelFn          context.CancelFunc
+	running           bool
+	listenerCloseChan chan struct{}
+
+	apps     map[string]Application
+	actions  []lifecycle.Action
+	handlers map[v1beta1.AppType]lifecycle.ActionHandler
+
+	log  *log.PrefixLogger
+	name string
+}
+
+func newMonitor(log *log.PrefixLogger, name string, registrations ...handlerRegistration) *monitor {
+	handlers := make(map[v1beta1.AppType]lifecycle.ActionHandler, len(registrations))
+	for _, reg := range registrations {
+		handlers[reg.appType] = reg.handler
+	}
+	return &monitor{
+		apps:     make(map[string]Application),
+		handlers: handlers,
+		log:      log,
+		name:     name,
+	}
+}
+
+func (m *monitor) hasApps() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.apps) > 0
+}
+
+func (m *monitor) Has(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.apps[id]
+	return ok
+}
+
+func (m *monitor) getApps() []Application {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	apps := make([]Application, 0, len(m.apps))
+	for _, app := range m.apps {
+		apps = append(apps, app)
+	}
+	return apps
+}
+
+func (m *monitor) drainActions() []lifecycle.Action {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	actions := make([]lifecycle.Action, len(m.actions))
+	copy(actions, m.actions)
+	m.actions = nil
+	return actions
+}
+
+func (m *monitor) Ensure(app Application) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	appID := app.ID()
+	if _, ok := m.apps[appID]; ok {
+		return nil
+	}
+	m.apps[appID] = app
+
+	action := lifecycle.Action{
+		AppType:  app.AppType(),
+		Type:     lifecycle.ActionAdd,
+		Name:     app.Name(),
+		ID:       appID,
+		Path:     app.Path(),
+		Embedded: app.IsEmbedded(),
+		Volumes:  provider.ToLifecycleVolumes(app.Volume().List()),
+		Spec:     app.ActionSpec(),
+	}
+
+	m.actions = append(m.actions, action)
+	return nil
+}
+
+func (m *monitor) canRemoveApp(app Application) bool {
+	_, ok := m.apps[app.ID()]
+	return ok || app.IsEmbedded()
+}
+
+func (m *monitor) Remove(app Application) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	appID := app.ID()
+	if !m.canRemoveApp(app) {
+		m.log.Errorf("%s application not found: %s", m.name, app.Name())
+		return nil
+	}
+
+	delete(m.apps, appID)
+
+	action := lifecycle.Action{
+		AppType: app.AppType(),
+		Type:    lifecycle.ActionRemove,
+		Name:    app.Name(),
+		ID:      appID,
+		Volumes: provider.ToLifecycleVolumes(app.Volume().List()),
+		Spec:    app.ActionSpec(),
+	}
+
+	m.actions = append(m.actions, action)
+	return nil
+}
+
+func (m *monitor) Update(app Application) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	appID := app.ID()
+	if _, ok := m.apps[appID]; !ok {
+		return errors.ErrAppNotFound
+	}
+
+	m.apps[appID] = app
+
+	action := lifecycle.Action{
+		AppType: app.AppType(),
+		Type:    lifecycle.ActionUpdate,
+		Name:    app.Name(),
+		ID:      appID,
+		Path:    app.Path(),
+		Volumes: provider.ToLifecycleVolumes(app.Volume().List()),
+		Spec:    app.ActionSpec(),
+	}
+
+	m.actions = append(m.actions, action)
+	return nil
+}
+
+func (m *monitor) updateWithWorkloads(app Application) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	appID := app.ID()
+	oldApp, ok := m.apps[appID]
+	if !ok {
+		return errors.ErrAppNotFound
+	}
+
+	app.CopyWorkloadsFrom(oldApp)
+	m.apps[appID] = app
+
+	action := lifecycle.Action{
+		AppType: app.AppType(),
+		Type:    lifecycle.ActionUpdate,
+		Name:    app.Name(),
+		ID:      appID,
+		Path:    app.Path(),
+		Volumes: provider.ToLifecycleVolumes(app.Volume().List()),
+		Spec:    app.ActionSpec(),
+	}
+
+	m.actions = append(m.actions, action)
+	return nil
+}
+
+func (m *monitor) clearAllWorkloads() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, app := range m.apps {
+		app.ClearWorkloads()
+	}
+}
+
+func (m *monitor) drain(ctx context.Context) error {
+	var errs []error
+
+	apps := m.getApps()
+	m.log.Infof("Draining %d applications", len(apps))
+	for _, app := range apps {
+		if err := m.Remove(app); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (m *monitor) startStreaming(ctx context.Context, mon streamingMonitor) error {
+	m.mu.Lock()
+	if m.running {
+		m.log.Debugf("%s monitor is already running", m.name)
+		m.mu.Unlock()
+		return nil
+	}
+
+	m.log.Infof("Starting %s monitor", m.name)
+	ctx, cancelFn := context.WithCancel(ctx)
+
+	listenerChannel := make(chan struct{})
+	m.cancelFn = cancelFn
+	m.running = true
+	m.listenerCloseChan = listenerChannel
+	m.mu.Unlock()
+
+	go func() {
+		defer close(listenerChannel)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			mon.OnRestart()
+
+			cmd, err := mon.CreateCommand(ctx)
+			if err != nil {
+				m.log.Errorf("Failed to create %s command: %v", m.name, err)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(restartDelay):
+				}
+				continue
+			}
+
+			err = m.runStreamingLoop(ctx, cmd, mon.Parser(), mon.HandleEvent)
+			if errors.IsContext(err) {
+				return
+			}
+
+			if err != nil {
+				m.log.Errorf("%s monitor error: %v, restarting...", m.name, err)
+			} else {
+				m.log.Debugf("%s monitor stream closed, restarting...", m.name)
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(restartDelay):
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (m *monitor) runStreamingLoop(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	parser streamParser,
+	handler func(ctx context.Context, data []byte),
+) error {
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+
+	m.mu.Lock()
+	m.cmd = cmd
+	m.mu.Unlock()
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	m.listenForEvents(ctx, stdoutPipe, parser, handler)
+
+	if err := cmd.Wait(); err != nil && !isExpectedShutdownError(err) {
+		return fmt.Errorf("command exited with error: %w", err)
+	}
+
+	return nil
+}
+
+func (m *monitor) listenForEvents(ctx context.Context, stdoutPipe io.ReadCloser, parser streamParser, handler func(ctx context.Context, data []byte)) {
+	defer m.log.Debugf("Done listening for %s events", m.name)
+
+	wrappedHandler := func(data []byte) {
+		m.log.Debugf("Received %s event: %s", m.name, string(data))
+		handler(ctx, data)
+	}
+
+	if err := parser.parse(ctx, stdoutPipe, wrappedHandler); err != nil && !errors.IsContext(err) {
+		m.log.Errorf("Error reading %s events: %v", m.name, err)
+	}
+}
+
+func (m *monitor) stopStreaming() error {
+	m.mu.Lock()
+	if !m.running {
+		m.log.Debugf("%s monitor is already stopped", m.name)
+		m.mu.Unlock()
+		return nil
+	}
+	cancelFn := m.cancelFn
+	cmd := m.cmd
+	listenerChan := m.listenerCloseChan
+	m.cmd = nil
+	m.cancelFn = nil
+	m.running = false
+	m.listenerCloseChan = nil
+	m.mu.Unlock()
+
+	m.log.Infof("Stopping %s monitor", m.name)
+
+	if cmd != nil && cmd.Process != nil {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			m.log.Debugf("Failed to send SIGTERM to %s monitor (process may have exited): %v", m.name, err)
+		}
+	}
+
+	cancelFn()
+
+	if !waitForChannelWithTimeout(listenerChan, stopMonitorWaitDuration) {
+		m.log.Warnf("Timeout waiting for %s monitor to shutdown", m.name)
+	}
+
+	m.log.Infof("%s monitor stopped", m.name)
+	return nil
+}
+
+// executeActions executes queued actions grouped by app type.
+// The normalizeAppType function allows mapping app types (e.g., Container -> Quadlet).
+// Returns the drained actions for any post-processing by the caller.
+func (m *monitor) executeActions(ctx context.Context, normalizeAppType func(v1beta1.AppType) v1beta1.AppType) ([]lifecycle.Action, error) {
+	actions := m.drainActions()
+
+	groupedActions := make(map[v1beta1.AppType][]lifecycle.Action)
+	for i := range actions {
+		action := actions[i]
+		appType := action.AppType
+		if normalizeAppType != nil {
+			appType = normalizeAppType(appType)
+		}
+		if _, ok := m.handlers[appType]; !ok {
+			return actions, fmt.Errorf("%w: no action handler registered: %s", errors.ErrUnsupportedAppType, action.AppType)
+		}
+		groupedActions[appType] = append(groupedActions[appType], action)
+	}
+
+	for appType, typeActions := range groupedActions {
+		if err := m.handlers[appType].Execute(ctx, typeActions); err != nil {
+			return actions, err
+		}
+	}
+
+	return actions, nil
+}
+
+// Status returns the status of all monitored applications.
+func (m *monitor) Status() ([]AppStatusResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var errs []error
+	results := make([]AppStatusResult, 0, len(m.apps))
+
+	for _, app := range m.apps {
+		appStatus, appSummary, err := app.Status()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		results = append(results, AppStatusResult{
+			Status:  *appStatus,
+			Summary: appSummary,
+		})
+	}
+
+	if len(errs) > 0 {
+		return results, errors.Join(errs...)
+	}
+
+	return results, nil
+}
+
+func waitForChannelWithTimeout(c <-chan struct{}, dur time.Duration) bool {
+	timer := time.NewTimer(dur)
+	defer timer.Stop()
+	select {
+	case <-c:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func isExpectedShutdownError(err error) bool {
+	if errors.IsContext(err) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if stderrs.As(err, &exitErr) {
+		if status, ok := exitErr.ProcessState.Sys().(syscall.WaitStatus); ok {
+			if status.ExitStatus() == 1 {
+				return true
+			}
+			if status.Signaled() {
+				signal := status.Signal()
+				return signal == syscall.SIGKILL || signal == syscall.SIGTERM
+			}
+		}
+	}
+	return false
+}
+
+func buildAppSummaryInfo(erroredApps, degradedApps []string, maxLen int) *string {
+	if len(erroredApps) == 0 && len(degradedApps) == 0 {
+		return nil
+	}
+
+	info := strings.Join(append(erroredApps, degradedApps...), ", ")
+	if len(info) > maxLen {
+		info = fmt.Sprintf("%s...", info[:maxLen-3])
+	}
+	return &info
+}

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -972,8 +972,10 @@ func TestPodmanMonitorStatusAggregation(t *testing.T) {
 				}
 			}
 
-			statuses, summary, err := podmanMonitor.Status()
+			results, err := podmanMonitor.Status()
 			require.NoError(err)
+
+			statuses, summary := aggregateAppStatuses(results)
 
 			require.Equal(tc.expectedStatus, summary.Status,
 				"expected summary status %s but got %s", tc.expectedStatus, summary.Status)

--- a/internal/agent/device/applications/provider/helm.go
+++ b/internal/agent/device/applications/provider/helm.go
@@ -1,0 +1,330 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/helm"
+	"github.com/flightctl/flightctl/internal/agent/device/errors"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	helmValuesPath     = "/var/lib/flightctl/helm/values"
+	helmValuesFileName = "flightctl-values.yaml"
+)
+
+// GetHelmProviderValuesPath returns the absolute path to the provider-generated values file
+// for a given application name.
+func GetHelmProviderValuesPath(appName string) string {
+	return filepath.Join(helmValuesPath, appName, helmValuesFileName)
+}
+
+type helmProvider struct {
+	log       *log.PrefixLogger
+	clients   client.CLIClients
+	rw        fileio.ReadWriter
+	spec      *ApplicationSpec
+	namespace string
+}
+
+func newHelmProvider(
+	ctx context.Context,
+	log *log.PrefixLogger,
+	clients client.CLIClients,
+	apiSpec *v1beta1.ApplicationProviderSpec,
+	rwFactory fileio.ReadWriterFactory,
+	cfg *parseConfig,
+) (*helmProvider, error) {
+	helmApp, err := (*apiSpec).AsHelmApplication()
+	if err != nil {
+		return nil, fmt.Errorf("getting helm application: %w", err)
+	}
+
+	appName := lo.FromPtr(helmApp.Name)
+	if appName == "" {
+		appName, err = helm.SanitizeReleaseName(helmApp.Image)
+		if err != nil {
+			return nil, fmt.Errorf("creating release name: %w", err)
+		}
+	}
+
+	namespace := helm.AppNamespace(helmApp.Namespace, appName)
+
+	chartPath := clients.Helm().GetChartPath(helmApp.Image)
+
+	volumeManager, err := NewVolumeManager(log, appName, v1beta1.AppTypeHelm, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rw, err := rwFactory(v1beta1.CurrentProcessUsername)
+	if err != nil {
+		return nil, fmt.Errorf("creating read/writer: %w", err)
+	}
+
+	return &helmProvider{
+		log:       log,
+		clients:   clients,
+		rw:        rw,
+		namespace: namespace,
+		spec: &ApplicationSpec{
+			Name:    appName,
+			ID:      fmt.Sprintf("%s_%s", namespace, appName),
+			AppType: v1beta1.AppTypeHelm,
+			Path:    chartPath,
+			HelmApp: &helmApp,
+			Volume:  volumeManager,
+		},
+	}, nil
+}
+
+func (p *helmProvider) chartRef() string {
+	return p.spec.HelmApp.Image
+}
+
+func (p *helmProvider) values() map[string]interface{} {
+	return lo.FromPtr(p.spec.HelmApp.Values)
+}
+
+func (p *helmProvider) valuesFiles() []string {
+	return lo.FromPtr(p.spec.HelmApp.ValuesFiles)
+}
+
+func (p *helmProvider) valuesDir() string {
+	return filepath.Join(helmValuesPath, p.spec.Name)
+}
+
+func (p *helmProvider) Verify(ctx context.Context) error {
+	var apiSpec v1beta1.ApplicationProviderSpec
+	err := apiSpec.FromHelmApplication(*p.spec.HelmApp)
+	if err != nil {
+		return fmt.Errorf("validating application spec: %w", err)
+	}
+	if errs := v1beta1.ValidateHelmApplication(apiSpec, p.spec.Name, false); len(errs) > 0 {
+		return fmt.Errorf("validating helm application: %w", errors.Join(errs...))
+	}
+
+	if err := ensureDependenciesFromAppType([]string{"helm"}); err != nil {
+		return fmt.Errorf("%w: ensuring dependencies: %w", errors.ErrNoRetry, err)
+	}
+
+	if p.clients.Kube().Binary() == "" {
+		return fmt.Errorf("kubectl or oc not installed for app %s", p.spec.Name)
+	}
+
+	version, err := p.clients.Helm().Version(ctx)
+	if err != nil {
+		return fmt.Errorf("helm version: %w", err)
+	}
+	if !version.GreaterOrEqual(3, 8) {
+		return fmt.Errorf("helm version >= 3.8 required for OCI support, found %d.%d.%d", version.Major, version.Minor, version.Patch)
+	}
+
+	resolved, err := p.clients.Helm().IsResolved(p.chartRef())
+	if err != nil {
+		return fmt.Errorf("check chart resolved: %w", err)
+	}
+	if !resolved {
+		return fmt.Errorf("chart %s not resolved", p.chartRef())
+	}
+
+	kubeconfigPath, err := p.clients.Kube().ResolveKubeconfig()
+	if err != nil {
+		p.log.Warnf("Cluster not available for Helm app %s: %v (will retry)", p.spec.Name, err)
+		return fmt.Errorf("resolve kubeconfig: %w: %w", err, errors.ErrRetryable)
+	}
+
+	chartPath := p.spec.Path
+	valuesPaths, cleanup, err := resolveHelmValues(p.spec.Name, chartPath, p.valuesFiles(), p.spec.HelmApp.Values, "", p.rw)
+	if err != nil {
+		return fmt.Errorf("resolving values: %w", err)
+	}
+	defer cleanup()
+
+	var lintOpts []client.HelmOption
+	if len(valuesPaths) > 0 {
+		lintOpts = append(lintOpts, client.WithValuesFiles(valuesPaths))
+	}
+
+	if err := p.clients.Helm().Lint(ctx, chartPath, lintOpts...); err != nil {
+		return fmt.Errorf("helm lint failed: %w", err)
+	}
+
+	dryRunOpts := []client.HelmOption{
+		client.WithKubeconfig(kubeconfigPath),
+		client.WithNamespace(p.namespace),
+		client.WithCreateNamespace(),
+	}
+	if len(valuesPaths) > 0 {
+		dryRunOpts = append(dryRunOpts, client.WithValuesFiles(valuesPaths))
+	}
+
+	if _, err := p.clients.Helm().DryRun(ctx, p.spec.Name, chartPath, dryRunOpts...); err != nil {
+		if errors.Is(err, errors.ErrNetwork) || errors.IsTimeoutError(err) {
+			p.log.Warnf("Cluster not reachable for Helm dry-run of %s: %v (will retry)", p.spec.Name, err)
+			return fmt.Errorf("helm dry-run validation failed: %w: %w", err, errors.ErrRetryable)
+		}
+		return fmt.Errorf("helm dry-run validation failed: %w", err)
+	}
+
+	return nil
+}
+
+func (p *helmProvider) Install(ctx context.Context) error {
+	values := p.values()
+	if len(values) == 0 {
+		return nil
+	}
+
+	valuesDir := p.valuesDir()
+	if err := p.rw.MkdirAll(valuesDir, fileio.DefaultDirectoryPermissions); err != nil {
+		return fmt.Errorf("create values directory: %w", err)
+	}
+
+	if err := writeFlightctlHelmValues(ctx, &values, valuesDir, p.rw); err != nil {
+		return fmt.Errorf("write helm values file: %w", err)
+	}
+
+	return nil
+}
+
+func (p *helmProvider) Remove(ctx context.Context) error {
+	valuesDir := p.valuesDir()
+	exists, err := p.rw.PathExists(valuesDir)
+	if err != nil {
+		return fmt.Errorf("check values directory: %w", err)
+	}
+	if exists {
+		if err := p.rw.RemoveAll(valuesDir); err != nil {
+			return fmt.Errorf("remove values directory: %w", err)
+		}
+	}
+	return nil
+}
+
+func (p *helmProvider) Name() string {
+	return p.spec.Name
+}
+
+func (p *helmProvider) ID() string {
+	return p.spec.ID
+}
+
+func (p *helmProvider) Spec() *ApplicationSpec {
+	return p.spec
+}
+
+func writeFlightctlHelmValues(_ context.Context, values *map[string]any, dir string, rw fileio.ReadWriter) error {
+	if values != nil && len(*values) > 0 {
+		data, err := yaml.Marshal(values)
+		if err != nil {
+			return fmt.Errorf("marshal values: %w", err)
+		}
+		if err := rw.WriteFile(filepath.Join(dir, helmValuesFileName), data, fileio.DefaultFilePermissions); err != nil {
+			return fmt.Errorf("write flightctl values: %w", err)
+		}
+	}
+	return nil
+}
+
+// resolveHelmValues resolves values files to absolute paths and writes inline values.
+// It validates that chart-relative values files exist in the chart directory.
+// If tempPath is provided, inline values are written there; otherwise a temp directory is created.
+// Returns the list of absolute values file paths, a cleanup function (may be nil), and any error.
+func resolveHelmValues(
+	appName string,
+	chartPath string,
+	valuesFiles []string,
+	values *map[string]interface{},
+	tempPath string,
+	rw fileio.ReadWriter,
+) ([]string, func(), error) {
+	var paths []string
+
+	absChartPath, err := filepath.Abs(filepath.Clean(chartPath))
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve chart path: %w", err)
+	}
+
+	for _, vf := range valuesFiles {
+		if filepath.IsAbs(vf) {
+			return nil, nil, fmt.Errorf("values file path must be relative: %s", vf)
+		}
+
+		absJoined, err := filepath.Abs(filepath.Join(absChartPath, filepath.Clean(vf)))
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolve values file path %s: %w", vf, err)
+		}
+
+		rel, err := filepath.Rel(absChartPath, absJoined)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, nil, fmt.Errorf("values file path escapes chart directory: %s", vf)
+		}
+
+		exists, err := rw.PathExists(absJoined)
+		if err != nil {
+			return nil, nil, fmt.Errorf("check values file %s: %w", vf, err)
+		}
+		if !exists {
+			return nil, nil, fmt.Errorf("values file not found in chart: %s", vf)
+		}
+		paths = append(paths, absJoined)
+	}
+
+	cleanupFn := func() {}
+	if values != nil && len(*values) > 0 {
+		if tempPath != "" {
+			valuesPath := filepath.Join(tempPath, helmValuesFileName)
+			valuesData, err := yaml.Marshal(values)
+			if err != nil {
+				return nil, nil, fmt.Errorf("marshal inline values: %w", err)
+			}
+			if err := rw.WriteFile(valuesPath, valuesData, fileio.DefaultFilePermissions); err != nil {
+				return nil, nil, fmt.Errorf("write inline values: %w", err)
+			}
+			paths = append(paths, valuesPath)
+		} else {
+			valuesPath, cleanup, err := writeHelmValuesTemp(rw, appName, *values)
+			if err != nil {
+				return nil, nil, fmt.Errorf("write inline values: %w", err)
+			}
+			cleanupFn = cleanup
+			paths = append(paths, valuesPath)
+		}
+	}
+
+	return paths, cleanupFn, nil
+}
+
+// writeHelmValuesTemp writes Helm values to a temporary file for use with helm dry-run.
+func writeHelmValuesTemp(rw fileio.ReadWriter, appName string, values map[string]interface{}) (string, func(), error) {
+	valuesData, err := yaml.Marshal(values)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal values: %w", err)
+	}
+
+	tmpDir, err := rw.MkdirTemp("helm_values")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	valuesPath := filepath.Join(tmpDir, appName+"-values.yaml")
+	if err := rw.WriteFile(valuesPath, valuesData, fileio.DefaultFilePermissions); err != nil {
+		_ = rw.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("write values file: %w", err)
+	}
+
+	cleanup := func() {
+		_ = rw.RemoveAll(tmpDir)
+	}
+
+	return valuesPath, cleanup, nil
+}

--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrAppDependency          = errors.New("failed to resolve application dependency")
 	ErrUnsupportedAppProvider = errors.New("unsupported application provider")
 	ErrAppLabel               = errors.New("required label not found")
+	ErrKubernetesAppsDisabled = errors.New("kubernetes applications disabled")
 
 	// compose
 	ErrNoComposeFile     = errors.New("no valid compose file found")

--- a/internal/agent/device/image_pruning/manager.go
+++ b/internal/agent/device/image_pruning/manager.go
@@ -29,6 +29,14 @@ const (
 	ReferencesFileName = "image-artifact-references.json"
 )
 
+// RefType constants for tracking what pulled each image
+const (
+	RefTypePodman   = "podman"   // Container images for podman apps (compose, quadlet, container)
+	RefTypeCRI      = "cri"      // Container images for Kubernetes/Helm workloads
+	RefTypeArtifact = "artifact" // OCI artifacts (volumes, etc.)
+	RefTypeHelm     = "helm"     // Helm charts (stored in helm cache, not image storage)
+)
+
 // Manager provides the public API for managing image pruning operations.
 type Manager interface {
 	// Prune removes unused container images and OCI artifacts after successful spec reconciliation.
@@ -121,41 +129,52 @@ func (m *manager) Prune(ctx context.Context) error {
 		return nil
 	}
 
-	totalEligible := len(eligible.Images) + len(eligible.Artifacts)
+	totalEligible := len(eligible.Images) + len(eligible.Artifacts) + len(eligible.CRI) + len(eligible.Helm)
 
-	var removedImages int
-	var removedImageRefs []ImageRef
-	var removedArtifacts int
-	var removedArtifactRefs []ImageRef
+	var allRemovedRefs []ImageRef
 
 	if totalEligible > 0 {
-		m.log.Infof("Starting pruning of %d eligible images and %d eligible artifacts", len(eligible.Images), len(eligible.Artifacts))
+		m.log.Infof("Starting pruning of %d podman images, %d artifacts, %d CRI images, %d helm charts",
+			len(eligible.Images), len(eligible.Artifacts), len(eligible.CRI), len(eligible.Helm))
 
-		// Remove eligible images and artifacts separately, tracking which ones were successfully removed
-		var err error
-		removedImages, removedImageRefs, err = m.removeEligibleImages(ctx, eligible.Images)
+		// Remove eligible items by type, tracking which ones were successfully removed
+		removedImages, removedImageRefs, err := m.removeEligibleImages(ctx, eligible.Images)
 		if err != nil {
-			m.log.Warnf("Error during image removal: %v", err)
-			// Continue with artifact removal even if image removal failed
+			m.log.Warnf("Error during podman image removal: %v", err)
 		}
+		allRemovedRefs = append(allRemovedRefs, removedImageRefs...)
 
-		removedArtifacts, removedArtifactRefs, err = m.removeEligibleArtifacts(ctx, eligible.Artifacts)
+		removedArtifacts, removedArtifactRefs, err := m.removeEligibleArtifacts(ctx, eligible.Artifacts)
 		if err != nil {
 			m.log.Warnf("Error during artifact removal: %v", err)
-			// Continue with validation even if some removals failed
 		}
+		allRemovedRefs = append(allRemovedRefs, removedArtifactRefs...)
 
-		m.log.Infof("Pruning complete: removed %d of %d eligible images, %d of %d eligible artifacts", removedImages, len(eligible.Images), removedArtifacts, len(eligible.Artifacts))
+		removedCRI, removedCRIRefs, err := m.removeEligibleCRIImages(ctx, eligible.CRI)
+		if err != nil {
+			m.log.Warnf("Error during CRI image removal: %v", err)
+		}
+		allRemovedRefs = append(allRemovedRefs, removedCRIRefs...)
+
+		removedHelm, removedHelmRefs, err := m.removeEligibleHelmCharts(eligible.Helm)
+		if err != nil {
+			m.log.Warnf("Error during helm chart removal: %v", err)
+		}
+		allRemovedRefs = append(allRemovedRefs, removedHelmRefs...)
+
+		m.log.Infof("Pruning complete: removed %d/%d podman images, %d/%d artifacts, %d/%d CRI images, %d/%d helm charts",
+			removedImages, len(eligible.Images),
+			removedArtifacts, len(eligible.Artifacts),
+			removedCRI, len(eligible.CRI),
+			removedHelm, len(eligible.Helm))
 	} else {
 		m.log.Debug("No images or artifacts eligible for pruning")
 	}
 
 	// Remove successfully pruned items from the references file
-	// This ensures the accumulated file only contains items that still exist or haven't been pruned yet
-	if len(removedImageRefs) > 0 || len(removedArtifactRefs) > 0 {
-		if err := m.removePrunedReferencesFromFile(removedImageRefs, removedArtifactRefs); err != nil {
+	if len(allRemovedRefs) > 0 {
+		if err := m.removePrunedReferencesFromFile(allRemovedRefs, nil); err != nil {
 			m.log.Warnf("Failed to remove pruned references from file: %v", err)
-			// Don't block reconciliation on file update errors
 		}
 	}
 
@@ -221,8 +240,9 @@ func (m *manager) getImageReferencesFromSpecs(ctx context.Context, device *v1bet
 	images = append(images, specRefs...)
 
 	// Extract OS image (not included in extractReferencesFromSpec)
+	// OS images are pulled via podman
 	if device.Spec.Os != nil && device.Spec.Os.Image != "" {
-		images = append(images, ImageRef{Image: device.Spec.Os.Image})
+		images = append(images, ImageRef{Image: device.Spec.Os.Image, Type: RefTypePodman})
 	}
 
 	// Extract nested targets from image-based applications
@@ -245,9 +265,11 @@ type ImageArtifactReferences struct {
 	References []ImageRef `json:"references"` // Single list of all references (no categorization)
 }
 
+// ImageRef represents a reference to an image, artifact, or helm chart with its source type.
 type ImageRef struct {
 	Image string           `json:"image"`
 	Owner v1beta1.Username `json:"owner"`
+	Type  string           `json:"type"` // One of RefType* constants
 }
 
 // setOwnerOnRefs sets the owner on all ImageRefs in the slice.
@@ -382,17 +404,20 @@ func (m *manager) removePrunedReferencesFromFile(removedImages []ImageRef, remov
 	return nil
 }
 
-// EligibleItems holds separate lists of eligible images and artifacts for pruning.
+// EligibleItems holds lists of eligible items for pruning, organized by type.
 type EligibleItems struct {
-	Images    []ImageRef
-	Artifacts []ImageRef
+	Images    []ImageRef // Podman images eligible for removal
+	Artifacts []ImageRef // Podman artifacts eligible for removal
+	CRI       []ImageRef // CRI images eligible for removal
+	Helm      []ImageRef // Helm charts eligible for removal
 }
 
-// determineEligibleImages determines which images and artifacts are eligible for pruning.
+// determineEligibleImages determines which images, artifacts, and charts are eligible for pruning.
 // It only prunes items that were previously referenced (according to the references file)
 // but are no longer referenced in the current specs.
-// OS images are included and can be pruned if they lose their references.
-// Returns separate lists for images and artifacts.
+// An item is only eligible when ALL reference types have been released (e.g., if an image
+// is referenced by both podman and CRI, it's only eligible when both references are dropped).
+// Returns separate lists by type for appropriate cleanup.
 func (m *manager) determineEligibleImages(ctx context.Context) (*EligibleItems, error) {
 	m.log.Debug("Determining eligible images and artifacts for pruning")
 
@@ -404,12 +429,12 @@ func (m *manager) determineEligibleImages(ctx context.Context) (*EligibleItems, 
 		return &EligibleItems{
 			Images:    []ImageRef{},
 			Artifacts: []ImageRef{},
+			CRI:       []ImageRef{},
+			Helm:      []ImageRef{},
 		}, nil
 	}
 
 	// Get current required references from specs (includes application images, OS images, and artifacts)
-	// Note: We don't need to list all images/artifacts upfront anymore.
-	// Categorization happens per-reference during pruning when we check existence.
 	var currentRequiredRefs []ImageRef
 
 	// Process both current and desired specs in a loop
@@ -450,48 +475,113 @@ func (m *manager) determineEligibleImages(ctx context.Context) (*EligibleItems, 
 		currentRequiredRefs = append(currentRequiredRefs, specRefs...)
 	}
 
-	currentRequiredRefs = lo.Uniq(currentRequiredRefs)
+	// Build a set of current references keyed by (Image, Type)
+	currentRefSet := make(map[string]struct{})
+	for _, ref := range currentRequiredRefs {
+		key := refKey(ref.Image, ref.Type)
+		currentRefSet[key] = struct{}{}
+	}
 
-	// Get previous references (single list, no categorization)
+	// Build a set of images that still have at least one reference
+	imagesWithRefs := make(map[string]struct{})
+	for _, ref := range currentRequiredRefs {
+		imagesWithRefs[ref.Image] = struct{}{}
+	}
+
+	// Get previous references
 	previousReferences := previousRefs.References
 
 	// Find references that were previously recorded but are no longer in current specs
-	eligibleReferences := lo.Without(lo.Uniq(previousReferences), currentRequiredRefs...)
-
-	// Categorize eligible references during pruning (when we can check existence)
-	// Only include references that we successfully categorize
-	var eligibleImages []ImageRef
-	var eligibleArtifacts []ImageRef
-
-	for _, ref := range eligibleReferences {
-		podmanClient, err := m.podmanClientFactory(ref.Owner)
-		if err != nil {
-			return nil, fmt.Errorf("constructing podman client: %w", err)
+	// A reference is eligible if its (Image, Type) tuple is not in current refs
+	var eligibleRefs []ImageRef
+	for _, ref := range previousReferences {
+		key := refKey(ref.Image, ref.Type)
+		if _, exists := currentRefSet[key]; !exists {
+			// This specific (Image, Type) reference has been dropped
+			// But we only want to delete if ALL references to this image are gone
+			if _, hasOtherRef := imagesWithRefs[ref.Image]; !hasOtherRef {
+				eligibleRefs = append(eligibleRefs, ref)
+			}
 		}
-		// Check if it exists as an image
-		if podmanClient.ImageExists(ctx, ref.Image) {
-			eligibleImages = append(eligibleImages, ref)
-			continue
-		}
-		// Check if it exists as an artifact
-		if podmanClient.ArtifactExists(ctx, ref.Image) {
-			eligibleArtifacts = append(eligibleArtifacts, ref)
-			continue
-		}
-		// If it doesn't exist as either, skip it (can't prune what doesn't exist)
-		// We don't remove it from the references file as it might be currently being downloaded
-		m.log.Debugf("Skipping reference %s - doesn't exist as image or artifact (might be downloading)", ref)
 	}
 
-	if len(eligibleImages) == 0 && len(eligibleArtifacts) == 0 {
+	eligibleRefs = lo.Uniq(eligibleRefs)
+
+	// Categorize eligible references by type and verify existence
+	var eligibleImages []ImageRef
+	var eligibleArtifacts []ImageRef
+	var eligibleCRI []ImageRef
+	var eligibleHelm []ImageRef
+
+	for _, ref := range eligibleRefs {
+		switch ref.Type {
+		case RefTypePodman:
+			podmanClient, err := m.podmanClientFactory(ref.Owner)
+			if err != nil {
+				return nil, fmt.Errorf("constructing podman client: %w", err)
+			}
+			// Image providers can reference either images or artifacts - check both
+			if podmanClient.ImageExists(ctx, ref.Image) {
+				eligibleImages = append(eligibleImages, ref)
+			} else if podmanClient.ArtifactExists(ctx, ref.Image) {
+				eligibleArtifacts = append(eligibleArtifacts, ref)
+			} else {
+				m.log.Debugf("Skipping podman reference %s - doesn't exist as image or artifact", ref.Image)
+			}
+
+		case RefTypeCRI:
+			if m.clients.CRI().ImageExists(ctx, ref.Image) {
+				eligibleCRI = append(eligibleCRI, ref)
+			} else {
+				m.log.Debugf("Skipping CRI reference %s - doesn't exist", ref.Image)
+			}
+
+		case RefTypeArtifact:
+			podmanClient, err := m.podmanClientFactory(ref.Owner)
+			if err != nil {
+				return nil, fmt.Errorf("constructing podman client: %w", err)
+			}
+			if podmanClient.ArtifactExists(ctx, ref.Image) {
+				eligibleArtifacts = append(eligibleArtifacts, ref)
+			} else {
+				m.log.Debugf("Skipping artifact reference %s - doesn't exist", ref.Image)
+			}
+
+		case RefTypeHelm:
+			resolved, err := m.clients.Helm().IsResolved(ref.Image)
+			if err != nil {
+				m.log.Debugf("Skipping helm reference %s - error checking: %v", ref.Image, err)
+				continue
+			}
+			if resolved {
+				eligibleHelm = append(eligibleHelm, ref)
+			} else {
+				m.log.Debugf("Skipping helm reference %s - chart not found", ref.Image)
+			}
+
+		default:
+			m.log.Debugf("Skipping reference %s - unknown type: %s", ref.Image, ref.Type)
+		}
+	}
+
+	totalEligible := len(eligibleImages) + len(eligibleArtifacts) + len(eligibleCRI) + len(eligibleHelm)
+	if totalEligible == 0 {
 		m.log.Debug("No previously referenced items have lost their references - nothing to prune")
 	} else {
-		m.log.Debugf("Found %d eligible images and %d eligible artifacts for pruning (previously referenced but no longer)", len(eligibleImages), len(eligibleArtifacts))
+		m.log.Debugf("Found eligible for pruning: %d images, %d artifacts, %d CRI images, %d helm charts",
+			len(eligibleImages), len(eligibleArtifacts), len(eligibleCRI), len(eligibleHelm))
 	}
 	return &EligibleItems{
 		Images:    eligibleImages,
 		Artifacts: eligibleArtifacts,
+		CRI:       eligibleCRI,
+		Helm:      eligibleHelm,
 	}, nil
+}
+
+// refKey creates a unique key for an (Image, Type) tuple.
+func refKey(image, refType string) string {
+	return image + "|" + refType
 }
 
 // extractReferencesFromSpec extracts all image and artifact reference strings from a device spec.
@@ -547,7 +637,7 @@ func (m *manager) extractReferencesFromApplication(_ context.Context, appSpec *v
 		if err != nil {
 			return nil, fmt.Errorf("getting container application: %w", err)
 		}
-		refs = append(refs, ImageRef{Image: containerApp.Image, Owner: owner})
+		refs = append(refs, ImageRef{Image: containerApp.Image, Owner: owner, Type: RefTypePodman})
 		if containerApp.Volumes != nil {
 			volRefs, err := m.extractVolumeReferences(*containerApp.Volumes)
 			if err != nil {
@@ -571,7 +661,7 @@ func (m *manager) extractReferencesFromApplication(_ context.Context, appSpec *v
 			if err != nil {
 				return nil, fmt.Errorf("getting compose image spec: %w", err)
 			}
-			refs = append(refs, ImageRef{Image: imageSpec.Image, Owner: owner})
+			refs = append(refs, ImageRef{Image: imageSpec.Image, Owner: owner, Type: RefTypePodman})
 		} else {
 			inlineSpec, err := composeApp.AsInlineApplicationProviderSpec()
 			if err != nil {
@@ -607,7 +697,7 @@ func (m *manager) extractReferencesFromApplication(_ context.Context, appSpec *v
 			if err != nil {
 				return nil, fmt.Errorf("getting quadlet image spec: %w", err)
 			}
-			refs = append(refs, ImageRef{Image: imageSpec.Image, Owner: owner})
+			refs = append(refs, ImageRef{Image: imageSpec.Image, Owner: owner, Type: RefTypePodman})
 		} else {
 			inlineSpec, err := quadletApp.AsInlineApplicationProviderSpec()
 			if err != nil {
@@ -629,6 +719,13 @@ func (m *manager) extractReferencesFromApplication(_ context.Context, appSpec *v
 			refs = append(refs, volRefs...)
 		}
 
+	case v1beta1.AppTypeHelm:
+		helmApp, err := (*appSpec).AsHelmApplication()
+		if err != nil {
+			return nil, fmt.Errorf("getting helm application: %w", err)
+		}
+		refs = append(refs, ImageRef{Image: helmApp.Image, Owner: owner, Type: RefTypeHelm})
+
 	default:
 		return nil, fmt.Errorf("%w: %s", errors.ErrUnsupportedAppType, appType)
 	}
@@ -646,7 +743,7 @@ func (m *manager) extractComposeReferences(contents []v1beta1.ApplicationContent
 	var refs []ImageRef
 	for _, svc := range spec.Services {
 		if svc.Image != "" {
-			refs = append(refs, ImageRef{Image: svc.Image})
+			refs = append(refs, ImageRef{Image: svc.Image, Type: RefTypePodman})
 		}
 	}
 
@@ -660,13 +757,13 @@ func (m *manager) extractImagesFromQuadletReferences(quadlets map[string]*common
 	for _, quad := range quadlets {
 		// Extract images from service/container quadlets (only if it's an OCI image, not a quadlet file reference)
 		if quad.Image != nil && !quadlet.IsImageReference(*quad.Image) {
-			refs = append(refs, ImageRef{Image: *quad.Image})
+			refs = append(refs, ImageRef{Image: *quad.Image, Type: RefTypePodman})
 		}
 
 		// Extract mount images (only if they're OCI images, not quadlet file references)
 		for _, mountImage := range quad.MountImages {
 			if !quadlet.IsImageReference(mountImage) {
-				refs = append(refs, ImageRef{Image: mountImage})
+				refs = append(refs, ImageRef{Image: mountImage, Type: RefTypePodman})
 			}
 		}
 	}
@@ -686,6 +783,7 @@ func (m *manager) extractQuadletReferences(contents []v1beta1.ApplicationContent
 }
 
 // extractVolumeReferences extracts image/artifact reference strings from application volumes.
+// ImageVolume types are artifacts, ImageMountVolume types could be images or artifacts (use auto-detect).
 func (m *manager) extractVolumeReferences(volumes []v1beta1.ApplicationVolume) ([]ImageRef, error) {
 	var refs []ImageRef
 
@@ -701,14 +799,15 @@ func (m *manager) extractVolumeReferences(volumes []v1beta1.ApplicationVolume) (
 			if err != nil {
 				return nil, fmt.Errorf("getting image volume provider spec: %w", err)
 			}
-			refs = append(refs, ImageRef{Image: provider.Image.Reference})
+			refs = append(refs, ImageRef{Image: provider.Image.Reference, Type: RefTypeArtifact})
 
 		case v1beta1.ImageMountApplicationVolumeProviderType:
 			provider, err := vol.AsImageMountVolumeProviderSpec()
 			if err != nil {
 				return nil, fmt.Errorf("getting image mount volume provider spec: %w", err)
 			}
-			refs = append(refs, ImageRef{Image: provider.Image.Reference})
+			// ImageMount volumes could be images or artifacts - type is determined at pruning time
+			refs = append(refs, ImageRef{Image: provider.Image.Reference, Type: RefTypePodman})
 
 		case v1beta1.MountApplicationVolumeProviderType:
 			// Mount volumes don't have images
@@ -801,7 +900,7 @@ func (m *manager) extractEmbeddedComposeReferences(ctx context.Context) ([]Image
 		// Extract images from services
 		for _, svc := range spec.Services {
 			if svc.Image != "" {
-				refs = append(refs, ImageRef{Image: svc.Image})
+				refs = append(refs, ImageRef{Image: svc.Image, Type: RefTypePodman})
 			}
 		}
 	}
@@ -887,17 +986,27 @@ func (m *manager) extractNestedTargetsFromSpec(ctx context.Context, device *v1be
 			continue
 		}
 
-		podmanClient, err := m.podmanClientFactory(user)
+		appType, err := appSpec.GetAppType()
 		if err != nil {
-			m.log.Errorf("Skipping app %s: failed to create podman client: %v", appName, err)
+			m.log.Debugf("Skipping app %s: failed to get app type: %v", appName, err)
 			continue
 		}
 
-		// Check if the image/artifact exists locally (required for extraction)
-		exists := podmanClient.ImageExists(ctx, imageName) || podmanClient.ArtifactExists(ctx, imageName)
+		// Check if the image/artifact/chart exists locally (required for extraction)
+		var exists bool
+		if appType == v1beta1.AppTypeHelm {
+			exists, _ = m.clients.Helm().IsResolved(imageName)
+		} else {
+			podmanClient, err := m.podmanClientFactory(user)
+			if err != nil {
+				m.log.Errorf("Skipping app %s: failed to create podman client: %v", appName, err)
+				continue
+			}
+			exists = podmanClient.ImageExists(ctx, imageName) || podmanClient.ArtifactExists(ctx, imageName)
+		}
 		if !exists {
-			// Image not available locally - skip nested extraction (best-effort for pruning)
-			m.log.Debugf("Skipping nested extraction for app %s: image %s not available locally", appName, imageName)
+			// Image/chart not available locally - skip nested extraction (best-effort for pruning)
+			m.log.Debugf("Skipping nested extraction for app %s: %s not available locally", appName, imageName)
 			continue
 		}
 
@@ -914,7 +1023,7 @@ func (m *manager) extractNestedTargetsFromSpec(ctx context.Context, device *v1be
 		)
 		if err != nil {
 			// Log warning but continue - nested extraction is best-effort for pruning
-			m.log.Debugf("Failed to extract nested targets from app %s (image %s): %v", appName, imageName, err)
+			m.log.Debugf("Failed to extract nested targets from app %s (%s): %v", appName, imageName, err)
 			continue
 		}
 
@@ -922,10 +1031,17 @@ func (m *manager) extractNestedTargetsFromSpec(ctx context.Context, device *v1be
 			continue
 		}
 
+		// Determine the type for nested references based on app type
+		// Helm apps use CRI for workload images, other apps use podman
+		nestedRefType := RefTypePodman
+		if appType == v1beta1.AppTypeHelm {
+			nestedRefType = RefTypeCRI
+		}
+
 		// Collect reference strings from extracted targets
 		for _, target := range appData.Targets {
 			if target.Reference != "" {
-				allReferences = append(allReferences, ImageRef{Image: target.Reference, Owner: user})
+				allReferences = append(allReferences, ImageRef{Image: target.Reference, Owner: user, Type: nestedRefType})
 			}
 		}
 
@@ -974,17 +1090,8 @@ func (m *manager) validateCapability(ctx context.Context) error {
 			return fmt.Errorf("extracting current images for validation: %w", err)
 		}
 		currentImages = append(currentImages, specRefs...)
-		// Add OS image if present (will be validated separately below)
 		for _, img := range currentImages {
-			podmanClient, err := m.podmanClientFactory(img.Owner)
-			if err != nil {
-				return fmt.Errorf("constructing podman client: %w", err)
-			}
-
-			exists := podmanClient.ImageExists(ctx, img.Image)
-			if !exists {
-				exists = podmanClient.ArtifactExists(ctx, img.Image)
-			}
+			exists := m.checkRefExists(ctx, img)
 			if !exists {
 				missingImages = append(missingImages, img)
 				m.log.Warnf("Current application image missing after pruning: %s", img)
@@ -1012,15 +1119,7 @@ func (m *manager) validateCapability(ctx context.Context) error {
 		}
 		desiredImages = append(desiredImages, specRefs...)
 		for _, ref := range desiredImages {
-			podmanClient, err := m.podmanClientFactory(ref.Owner)
-			if err != nil {
-				return fmt.Errorf("constructing podman client: %w", err)
-			}
-
-			exists := podmanClient.ImageExists(ctx, ref.Image)
-			if !exists {
-				exists = podmanClient.ArtifactExists(ctx, ref.Image)
-			}
+			exists := m.checkRefExists(ctx, ref)
 			if !exists {
 				missingImages = append(missingImages, ref)
 				m.log.Warnf("Desired application image missing after pruning: %s", ref)
@@ -1044,6 +1143,30 @@ func (m *manager) validateCapability(ctx context.Context) error {
 
 	m.log.Debug("Capability validated successfully")
 	return nil
+}
+
+func (m *manager) checkRefExists(ctx context.Context, ref ImageRef) bool {
+	switch ref.Type {
+	case RefTypeHelm:
+		exists, _ := m.clients.Helm().IsResolved(ref.Image)
+		return exists
+	case RefTypeCRI:
+		return m.clients.CRI().ImageExists(ctx, ref.Image)
+	case RefTypeArtifact:
+		podmanClient, err := m.podmanClientFactory(ref.Owner)
+		if err != nil {
+			m.log.Errorf("Failed to construct podman client for artifact check: %v", err)
+			return false
+		}
+		return podmanClient.ArtifactExists(ctx, ref.Image)
+	default:
+		podmanClient, err := m.podmanClientFactory(ref.Owner)
+		if err != nil {
+			m.log.Errorf("Failed to construct podman client for image check: %v", err)
+			return false
+		}
+		return podmanClient.ImageExists(ctx, ref.Image) || podmanClient.ArtifactExists(ctx, ref.Image)
+	}
 }
 
 // removeEligibleImages removes the list of eligible images from Podman storage.
@@ -1123,6 +1246,85 @@ func (m *manager) removeEligibleArtifacts(ctx context.Context, eligibleArtifacts
 	// Log summary if there were any failures
 	if len(removalErrors) > 0 {
 		m.log.Warnf("Artifact pruning completed with %d failures out of %d attempts", len(removalErrors), len(eligibleArtifacts))
+	}
+
+	return removedCount, removedRefs, nil
+}
+
+// removeEligibleCRIImages removes the list of eligible CRI images.
+// It returns the count of successfully removed images, the list of successfully removed image references, and any error encountered.
+// Errors during individual removals are logged but don't stop the process.
+func (m *manager) removeEligibleCRIImages(ctx context.Context, eligibleImages []ImageRef) (int, []ImageRef, error) {
+	var removedCount int
+	var removedRefs []ImageRef
+	var removalErrors []error
+
+	criClient := m.clients.CRI()
+
+	for _, ref := range eligibleImages {
+		if criClient.ImageExists(ctx, ref.Image) {
+			if err := criClient.RemoveImage(ctx, ref.Image); err != nil {
+				m.log.Warnf("Failed to remove CRI image %s: %v", ref.Image, err)
+				removalErrors = append(removalErrors, fmt.Errorf("failed to remove CRI image %s: %w", ref.Image, err))
+				continue
+			}
+			removedCount++
+			m.log.Debugf("Removed CRI image: %s", ref.Image)
+		}
+		removedRefs = append(removedRefs, ref)
+	}
+
+	// Return error only if all removals failed
+	if len(removalErrors) == len(eligibleImages) && len(eligibleImages) > 0 {
+		return removedCount, removedRefs, fmt.Errorf("all CRI image removals failed: %d errors", len(removalErrors))
+	}
+
+	// Log summary if there were any failures
+	if len(removalErrors) > 0 {
+		m.log.Warnf("CRI image pruning completed with %d failures out of %d attempts", len(removalErrors), len(eligibleImages))
+	}
+
+	return removedCount, removedRefs, nil
+}
+
+// removeEligibleHelmCharts removes the list of eligible Helm charts from the cache.
+// It returns the count of successfully removed charts, the list of successfully removed chart references, and any error encountered.
+// Errors during individual removals are logged but don't stop the process.
+func (m *manager) removeEligibleHelmCharts(eligibleCharts []ImageRef) (int, []ImageRef, error) {
+	var removedCount int
+	var removedRefs []ImageRef
+	var removalErrors []error
+
+	helmClient := m.clients.Helm()
+
+	for _, ref := range eligibleCharts {
+		resolved, err := helmClient.IsResolved(ref.Image)
+		if err != nil {
+			m.log.Warnf("Failed to check Helm chart %s: %v", ref.Image, err)
+			removalErrors = append(removalErrors, fmt.Errorf("failed to check helm chart %s: %w", ref.Image, err))
+			continue
+		}
+
+		if resolved {
+			if err := helmClient.RemoveChart(ref.Image); err != nil {
+				m.log.Warnf("Failed to remove Helm chart %s: %v", ref.Image, err)
+				removalErrors = append(removalErrors, fmt.Errorf("failed to remove helm chart %s: %w", ref.Image, err))
+				continue
+			}
+			removedCount++
+			m.log.Debugf("Removed Helm chart: %s", ref.Image)
+		}
+		removedRefs = append(removedRefs, ref)
+	}
+
+	// Return error only if all removals failed
+	if len(removalErrors) == len(eligibleCharts) && len(eligibleCharts) > 0 {
+		return removedCount, removedRefs, fmt.Errorf("all Helm chart removals failed: %d errors", len(removalErrors))
+	}
+
+	// Log summary if there were any failures
+	if len(removalErrors) > 0 {
+		m.log.Warnf("Helm chart pruning completed with %d failures out of %d attempts", len(removalErrors), len(eligibleCharts))
 	}
 
 	return removedCount, removedRefs, nil


### PR DESCRIPTION
Combines the PRs: 

https://github.com/flightctl/flightctl/pull/2428
https://github.com/flightctl/flightctl/pull/2416
https://github.com/flightctl/flightctl/pull/2417

and contains all logic required for the helm application type.

```yaml
    status:
      applications:
        - appType: quadlet
          embedded: false
          name: complex-quadlet-inline-app
          ready: 3/3
          restarts: 0
          status: Running
          volumes:
            - name: model-data
              reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
            - name: sqlite.volume
              reference: ghcr.io/homebrew/core/sqlite:3.50.2
        - appType: container
          embedded: false
          name: nginx-multi-port-server
          ready: 1/1
          restarts: 0
          status: Running
          volumes:
            - name: nginx-config
              reference: quay.io/kkyrazis/quadlet-test/nginx-config-artifact:latest
            - name: nginx-html
              reference: quay.io/kkyrazis/quadlet-test/nginx-html-artifact-image:latest
        - appType: quadlet
          embedded: false
          name: app-multi-file-artifact-with-image-ref
          ready: 3/3
          restarts: 0
          status: Running
          volumes:
            - name: model-data
              reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
            - name: sqlite.volume
              reference: ghcr.io/homebrew/core/sqlite:3.50.2
        - appType: quadlet
          embedded: false
          name: app-tar-gz-artifact-with-image-ref
          ready: 3/3
          restarts: 0
          status: Running
          volumes:
            - name: model-data
              reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
            - name: sqlite.volume
              reference: ghcr.io/homebrew/core/sqlite:3.50.2
        - appType: quadlet
          embedded: false
          name: app-container-image-with-image-ref
          ready: 3/3
          restarts: 0
          status: Running
          volumes:
            - name: model-data
              reference: quay.io/kkyrazis/quadlet-test/model-artifact:latest
            - name: sqlite.volume
              reference: ghcr.io/homebrew/core/sqlite:3.50.2
        - appType: helm
          embedded: false
          name: test
          ready: 1/1
          restarts: 0
          status: Running
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Helm lifecycle support (install/upgrade/remove) with dry-run, linting, release name sanitization, chart cache management, and provider values handling
  * Kubernetes monitoring for Helm-based apps with namespace management
  * Per-operation CRI image removal and extended kube options
  * Image pruning extended to CRI and Helm chart types

* **Bug Fixes & Improvements**
  * Improved status reporting and aggregation across monitors
  * Retry/rollback and ignore-not-found enhancements for deployments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->