### PR TITLE
NO-ISSUE: delete cancels imagebuild/export

### DIFF
--- a/docs/user/using/managing-image-builds.md
+++ b/docs/user/using/managing-image-builds.md
@@ -130,6 +130,23 @@ This initiates a graceful cancellation of the build. The status will transition 
 > [!NOTE]
 > Only builds in `Pending`, `Building`, or `Pushing` status can be canceled. Builds that have already completed, failed, or been canceled cannot be canceled again.
 
+### Deleting an ImageBuild
+
+Delete an ImageBuild using the `delete` command:
+
+```console
+flightctl delete imagebuild/my-image-build
+```
+
+When deleting an ImageBuild:
+
+1. **Related ImageExports are deleted first**: Any ImageExport resources that reference this ImageBuild will be automatically deleted. Each related ImageExport will be canceled (if in progress) before deletion.
+2. **The ImageBuild is canceled if in progress**: If the ImageBuild is currently running (Pending, Building, or Pushing), it will be canceled and the delete operation will wait for the cancellation to complete.
+3. **The ImageBuild is deleted**: After all related resources are cleaned up, the ImageBuild itself is deleted.
+
+> [!NOTE]
+> Deleting an in-progress ImageBuild may take up to 30 seconds while waiting for the build to be canceled. If the cancellation does not complete within this timeout, the resource will still be deleted.
+
 ### Example: Early Binding ImageBuild
 
 ```yaml
@@ -274,6 +291,19 @@ This initiates a graceful cancellation of the export. The status will transition
 
 > [!NOTE]
 > Only exports in `Pending`, `Converting`, or `Pushing` status can be canceled. Exports that have already completed, failed, or been canceled cannot be canceled again.
+
+### Deleting an ImageExport
+
+Delete an ImageExport using the `delete` command:
+
+```console
+flightctl delete imageexport/my-image-export
+```
+
+If the ImageExport is currently in progress (Pending, Converting, or Pushing), the delete operation will automatically cancel the export first and wait for the cancellation to complete before deleting the resource. This ensures clean shutdown of any running export processes.
+
+> [!NOTE]
+> Deleting an in-progress ImageExport may take up to 30 seconds while waiting for the export to be canceled. If the cancellation does not complete within this timeout, the resource will still be deleted.
 
 ### Downloading the Exported Image
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ const (
 type Config struct {
 	Database            *dbConfig                  `json:"database,omitempty"`
 	Service             *svcConfig                 `json:"service,omitempty"`
-	ImageBuilderService *imageBuilderServiceConfig `json:"imageBuilderService,omitempty"`
+	ImageBuilderService *ImageBuilderServiceConfig `json:"imageBuilderService,omitempty"`
 	ImageBuilderWorker  *imageBuilderWorkerConfig  `json:"imageBuilderWorker,omitempty"`
 	KV                  *kvConfig                  `json:"kv,omitempty"`
 	Alertmanager        *alertmanagerConfig        `json:"alertmanager,omitempty"`
@@ -103,7 +103,7 @@ type HealthChecks struct {
 	ReadinessTimeout util.Duration `json:"readinessTimeout,omitempty"`
 }
 
-type imageBuilderServiceConfig struct {
+type ImageBuilderServiceConfig struct {
 	Address               string           `json:"address,omitempty"`
 	LogLevel              string           `json:"logLevel,omitempty"`
 	TLSCertFile           string           `json:"tlsCertFile,omitempty"`
@@ -118,6 +118,7 @@ type imageBuilderServiceConfig struct {
 	HttpMaxRequestSize    int              `json:"httpMaxRequestSize,omitempty"`
 	RateLimit             *RateLimitConfig `json:"rateLimit,omitempty"`
 	HealthChecks          *HealthChecks    `json:"healthChecks,omitempty"`
+	DeleteCancelTimeout   util.Duration    `json:"deleteCancelTimeout,omitempty"`
 }
 
 type imageBuilderWorkerConfig struct {
@@ -146,8 +147,8 @@ func NewDefaultImageBuilderWorkerConfig() *imageBuilderWorkerConfig {
 }
 
 // NewDefaultImageBuilderServiceConfig returns a default ImageBuilder service configuration
-func NewDefaultImageBuilderServiceConfig() *imageBuilderServiceConfig {
-	return &imageBuilderServiceConfig{
+func NewDefaultImageBuilderServiceConfig() *ImageBuilderServiceConfig {
+	return &ImageBuilderServiceConfig{
 		Address:               ":8445",
 		LogLevel:              "info",
 		HttpReadTimeout:       util.Duration(5 * time.Minute),
@@ -157,6 +158,7 @@ func NewDefaultImageBuilderServiceConfig() *imageBuilderServiceConfig {
 		HttpMaxNumHeaders:     32,
 		HttpMaxUrlLength:      2000,
 		HttpMaxRequestSize:    50 * 1024 * 1024, // 50MB
+		DeleteCancelTimeout:   util.Duration(30 * time.Second),
 		HealthChecks: &HealthChecks{
 			Enabled:          true,
 			ReadinessPath:    "/readyz",

--- a/internal/imagebuilder_api/server.go
+++ b/internal/imagebuilder_api/server.go
@@ -68,7 +68,7 @@ func New(
 		}
 	}
 
-	svc := service.NewService(ctx, imageBuilderStore, mainStore, queueProducer, kvStore, log)
+	svc := service.NewService(ctx, cfg, imageBuilderStore, mainStore, queueProducer, kvStore, log)
 	return &Server{
 		log:               log,
 		cfg:               cfg,

--- a/internal/imagebuilder_api/service/imageexport_test.go
+++ b/internal/imagebuilder_api/service/imageexport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,9 @@ import (
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	api "github.com/flightctl/flightctl/api/imagebuilder/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
@@ -26,7 +29,7 @@ func newTestImageExportService() (ImageExportService, *DummyImageExportStore, *D
 	imageExportStore := NewDummyImageExportStore()
 	imageBuildStore := NewDummyImageBuildStore()
 	repositoryStore := NewDummyRepositoryStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repositoryStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repositoryStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 	return svc, imageExportStore, imageBuildStore
 }
 
@@ -103,7 +106,7 @@ func TestCreateImageExport(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	imageExport := newValidImageExport("test-export")
 	result, status := svc.Create(ctx, orgId, imageExport)
@@ -128,7 +131,7 @@ func TestCreateImageExportDuplicate(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	imageExport := newValidImageExport("duplicate-test")
 
@@ -158,7 +161,7 @@ func TestCreateImageExportMissingFormats(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	imageExport := newValidImageExport("test")
 	imageExport.Spec.Format = ""
@@ -176,7 +179,7 @@ func TestCreateImageExportWithImageBuildRef(t *testing.T) {
 	// Set up repositories (destination only, source comes from ImageBuild)
 	repoStore := NewDummyRepositoryStore()
 	setupRepositoriesForImageExport(repoStore, ctx, orgId, false)
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// First create the ImageBuild that will be referenced
 	imageBuild := newValidImageBuild("my-build")
@@ -220,7 +223,7 @@ func TestGetImageExport(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create first
 	imageExport := newValidImageExport("get-test")
@@ -259,7 +262,7 @@ func TestListImageExports(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create multiple
 	for i := 0; i < 3; i++ {
@@ -290,7 +293,7 @@ func TestListImageExportsWithLimit(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create multiple
 	for i := 0; i < 5; i++ {
@@ -307,44 +310,312 @@ func TestListImageExportsWithLimit(t *testing.T) {
 	require.Len(result.Items, 2)
 }
 
-func TestDeleteImageExport(t *testing.T) {
+// Helper to create a short timeout config for delete tests
+func newShortTimeoutConfig() *config.ImageBuilderServiceConfig {
+	cfg := config.NewDefaultImageBuilderServiceConfig()
+	cfg.DeleteCancelTimeout = util.Duration(100 * time.Millisecond) // Very short timeout for testing
+	return cfg
+}
+
+// Helper to set up service with KVStore and short timeout for delete tests
+func setupDeleteTestService(ctx context.Context, orgId uuid.UUID, kvStore *DummyKVStore) (ImageExportService, *DummyImageExportStore, *DummyImageBuildStore) {
+	repoStore := NewDummyRepositoryStore()
+	setupRepositoriesForImageBuild(repoStore, ctx, orgId)
+	imageBuildStore := NewDummyImageBuildStore()
+	imageExportStore := NewDummyImageExportStore()
+
+	// Create the ImageBuild that will be referenced
+	imageBuild := newValidImageBuild("test-image-build")
+	_, _ = imageBuildStore.Create(ctx, orgId, &imageBuild)
+
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, kvStore, newShortTimeoutConfig(), log.InitLogs())
+	return svc, imageExportStore, imageBuildStore
+}
+
+// Helper to create an ImageExport with a specific status condition
+func createImageExportWithStatus(ctx context.Context, svc ImageExportService, imageExportStore *DummyImageExportStore, orgId uuid.UUID, name string, reason api.ImageExportConditionReason) *api.ImageExport {
+	imageExport := newValidImageExport(name)
+	created, _ := svc.Create(ctx, orgId, imageExport)
+
+	if created == nil {
+		return nil
+	}
+
+	// Initialize status if needed
+	if created.Status == nil {
+		created.Status = &api.ImageExportStatus{}
+	}
+	if created.Status.Conditions == nil {
+		created.Status.Conditions = &[]api.ImageExportCondition{}
+	}
+
+	// Set the appropriate status based on reason
+	conditionStatus := v1beta1.ConditionStatusFalse
+	if reason == api.ImageExportConditionReasonCompleted {
+		conditionStatus = v1beta1.ConditionStatusTrue
+	}
+
+	api.SetImageExportStatusCondition(created.Status.Conditions, api.ImageExportCondition{
+		Type:               api.ImageExportConditionTypeReady,
+		Status:             conditionStatus,
+		Reason:             string(reason),
+		Message:            "Test status",
+		LastTransitionTime: time.Now().UTC(),
+	})
+	updated, _ := svc.UpdateStatus(ctx, orgId, created)
+	return updated
+}
+
+func TestDeleteImageExport_Pending_CancelSuccess(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 	orgId := uuid.New()
 
-	// Set up repositories
-	repoStore := NewDummyRepositoryStore()
-	setupRepositoriesForImageBuild(repoStore, ctx, orgId)
-	imageBuildStore := NewDummyImageBuildStore()
+	kvStore := NewDummyKVStore()
+	svc, _, _ := setupDeleteTestService(ctx, orgId, kvStore)
 
-	// Create the ImageBuild that will be referenced
-	imageBuild := newValidImageBuild("test-image-build")
-	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
-	require.NoError(err)
-
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
-
-	// Create first
-	imageExport := newValidImageExport("delete-test")
+	// Create ImageExport (starts in Pending state)
+	imageExport := newValidImageExport("delete-pending-success")
 	_, status := svc.Create(ctx, orgId, imageExport)
 	require.Equal(int32(http.StatusCreated), statusCode(status))
 
-	// Delete it
-	deleted, status := svc.Delete(ctx, orgId, "delete-test")
+	// Simulate that the worker will send the canceled signal
+	canceledStreamKey := fmt.Sprintf("imageexport:canceled:%s:%s", orgId.String(), "delete-pending-success")
+	kvStore.SimulateCanceledSignal(canceledStreamKey)
+
+	// Delete it - should cancel first and wait for signal
+	deleted, status := svc.Delete(ctx, orgId, "delete-pending-success")
 	require.Equal(int32(http.StatusOK), statusCode(status))
 	require.NotNil(deleted)
-	require.Equal("delete-test", lo.FromPtr(deleted.Metadata.Name))
+	require.Equal("delete-pending-success", lo.FromPtr(deleted.Metadata.Name))
 
 	// Verify it's gone
-	_, status = svc.Get(ctx, orgId, "delete-test")
+	_, status = svc.Get(ctx, orgId, "delete-pending-success")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_Converting_CancelSuccess(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Converting state
+	created := createImageExportWithStatus(ctx, svc, imageExportStore, orgId, "delete-converting-success", api.ImageExportConditionReasonConverting)
+	require.NotNil(created)
+
+	// Simulate that the worker will send the canceled signal
+	canceledStreamKey := fmt.Sprintf("imageexport:canceled:%s:%s", orgId.String(), "delete-converting-success")
+	kvStore.SimulateCanceledSignal(canceledStreamKey)
+
+	// Delete it - should cancel first and wait for signal
+	deleted, status := svc.Delete(ctx, orgId, "delete-converting-success")
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-converting-success")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_Pushing_CancelSuccess(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Pushing state
+	created := createImageExportWithStatus(ctx, svc, imageExportStore, orgId, "delete-pushing-success", api.ImageExportConditionReasonPushing)
+	require.NotNil(created)
+
+	// Simulate that the worker will send the canceled signal
+	canceledStreamKey := fmt.Sprintf("imageexport:canceled:%s:%s", orgId.String(), "delete-pushing-success")
+	kvStore.SimulateCanceledSignal(canceledStreamKey)
+
+	// Delete it - should cancel first and wait for signal
+	deleted, status := svc.Delete(ctx, orgId, "delete-pushing-success")
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-pushing-success")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_CancelTimeout(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, _, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport (starts in Pending state - cancelable)
+	imageExport := newValidImageExport("delete-timeout")
+	_, status := svc.Create(ctx, orgId, imageExport)
+	require.Equal(int32(http.StatusCreated), statusCode(status))
+
+	// Do NOT simulate canceled signal - this will cause timeout
+
+	// Delete it - should cancel, timeout waiting, then delete anyway
+	start := time.Now()
+	deleted, status := svc.Delete(ctx, orgId, "delete-timeout")
+	elapsed := time.Since(start)
+
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+	require.Equal("delete-timeout", lo.FromPtr(deleted.Metadata.Name))
+
+	// Verify timeout happened (should take at least 100ms but not too long)
+	require.GreaterOrEqual(elapsed.Milliseconds(), int64(100), "Should have waited for timeout")
+	require.Less(elapsed.Milliseconds(), int64(500), "Should not wait too long")
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-timeout")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_Completed_NoCancelAttempt(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Completed state (not cancelable)
+	imageExport := newValidImageExport("delete-completed")
+	created, _ := svc.Create(ctx, orgId, imageExport)
+	require.NotNil(created)
+
+	// Initialize status if needed and set to Completed state
+	if created.Status == nil {
+		created.Status = &api.ImageExportStatus{}
+	}
+	if created.Status.Conditions == nil {
+		created.Status.Conditions = &[]api.ImageExportCondition{}
+	}
+	api.SetImageExportStatusCondition(created.Status.Conditions, api.ImageExportCondition{
+		Type:               api.ImageExportConditionTypeReady,
+		Status:             v1beta1.ConditionStatusTrue,
+		Reason:             string(api.ImageExportConditionReasonCompleted),
+		Message:            "Test completed",
+		LastTransitionTime: time.Now().UTC(),
+	})
+	_, _ = svc.UpdateStatus(ctx, orgId, created)
+
+	// Delete it - should NOT try to cancel (not cancelable)
+	start := time.Now()
+	deleted, status := svc.Delete(ctx, orgId, "delete-completed")
+	elapsed := time.Since(start)
+
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Should be fast (no cancel wait)
+	require.Less(elapsed.Milliseconds(), int64(50), "Should not wait for cancel on completed export")
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-completed")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+	_ = imageExportStore // suppress unused warning
+}
+
+func TestDeleteImageExport_Failed_NoCancelAttempt(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Failed state (not cancelable)
+	created := createImageExportWithStatus(ctx, svc, imageExportStore, orgId, "delete-failed", api.ImageExportConditionReasonFailed)
+	require.NotNil(created)
+
+	// Delete it - should NOT try to cancel (not cancelable)
+	start := time.Now()
+	deleted, status := svc.Delete(ctx, orgId, "delete-failed")
+	elapsed := time.Since(start)
+
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Should be fast (no cancel wait)
+	require.Less(elapsed.Milliseconds(), int64(50), "Should not wait for cancel on failed export")
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-failed")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_Canceled_NoCancelAttempt(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Canceled state (not cancelable)
+	created := createImageExportWithStatus(ctx, svc, imageExportStore, orgId, "delete-canceled", api.ImageExportConditionReasonCanceled)
+	require.NotNil(created)
+
+	// Delete it - should NOT try to cancel (already canceled)
+	start := time.Now()
+	deleted, status := svc.Delete(ctx, orgId, "delete-canceled")
+	elapsed := time.Since(start)
+
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Should be fast (no cancel wait)
+	require.Less(elapsed.Milliseconds(), int64(50), "Should not wait for cancel on already canceled export")
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-canceled")
+	require.Equal(int32(http.StatusNotFound), statusCode(status))
+}
+
+func TestDeleteImageExport_Canceling_NoCancelAttempt(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, imageExportStore, _ := setupDeleteTestService(ctx, orgId, kvStore)
+
+	// Create ImageExport and set to Canceling state (not cancelable - already canceling)
+	created := createImageExportWithStatus(ctx, svc, imageExportStore, orgId, "delete-canceling", api.ImageExportConditionReasonCanceling)
+	require.NotNil(created)
+
+	// Delete it - should NOT try to cancel (already canceling)
+	start := time.Now()
+	deleted, status := svc.Delete(ctx, orgId, "delete-canceling")
+	elapsed := time.Since(start)
+
+	require.Equal(int32(http.StatusOK), statusCode(status))
+	require.NotNil(deleted)
+
+	// Should be fast (no cancel wait)
+	require.Less(elapsed.Milliseconds(), int64(50), "Should not wait for cancel on already canceling export")
+
+	// Verify it's gone
+	_, status = svc.Get(ctx, orgId, "delete-canceling")
 	require.Equal(int32(http.StatusNotFound), statusCode(status))
 }
 
 func TestDeleteImageExportNotFound(t *testing.T) {
 	require := require.New(t)
-	svc, _, _ := newTestImageExportService()
 	ctx := context.Background()
 	orgId := uuid.New()
+
+	kvStore := NewDummyKVStore()
+	svc, _, _ := setupDeleteTestService(ctx, orgId, kvStore)
 
 	// Delete is idempotent - deleting non-existent resource returns success
 	deleted, status := svc.Delete(ctx, orgId, "nonexistent")
@@ -367,7 +638,7 @@ func TestUpdateImageExportStatus(t *testing.T) {
 	_, err := imageBuildStore.Create(ctx, orgId, &imageBuild)
 	require.NoError(err)
 
-	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(NewDummyImageExportStore(), imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create first
 	imageExport := newValidImageExport("status-test")
@@ -440,7 +711,7 @@ func TestDownloadImageExportNotReadyNoStatus(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport without status
 	imageExport := newValidImageExport("test-export")
@@ -463,7 +734,7 @@ func TestDownloadImageExportNotReadyNoConditions(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with status but no conditions
 	imageExport := newValidImageExport("test-export")
@@ -489,7 +760,7 @@ func TestDownloadImageExportNotReadyNoReadyCondition(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with status but no Ready condition
 	imageExport := newValidImageExport("test-export")
@@ -523,7 +794,7 @@ func TestDownloadImageExportNotReadyFalseStatus(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with Ready condition but status is False
 	imageExport := newValidImageExport("test-export")
@@ -560,7 +831,7 @@ func TestDownloadImageExportMissingManifestDigest(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with Ready condition but no manifest digest
 	imageExport := newValidImageExport("test-export")
@@ -595,7 +866,7 @@ func TestDownloadImageExportEmptyManifestDigest(t *testing.T) {
 	imageBuildStore := NewDummyImageBuildStore()
 	setupImageBuildForExport(imageBuildStore, ctx, orgId)
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with Ready condition but empty manifest digest
 	imageExport := newValidImageExport("test-export")
@@ -638,7 +909,7 @@ func TestDownloadImageExportDestinationRepositoryNotFound(t *testing.T) {
 	require.NoError(err)
 
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport that references ImageBuild with non-existent destination repository
 	imageExport := newReadyImageExport("test-export", "sha256:abc123")
@@ -666,7 +937,7 @@ func TestDownloadImageExportInvalidManifestDigest(t *testing.T) {
 	require.NoError(err)
 
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport with invalid manifest digest
 	imageExport := newReadyImageExport("test-export", "invalid-digest")
@@ -779,7 +1050,7 @@ func TestDownloadImageExportWithRedirect(t *testing.T) {
 	require.NoError(err)
 
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport
 	imageExport := newReadyImageExport("test-export", manifestDigest)
@@ -873,7 +1144,7 @@ func TestDownloadImageExportWithBlobReader(t *testing.T) {
 	require.NoError(err)
 
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport
 	imageExport := newReadyImageExport("test-export", manifestDigest)
@@ -975,7 +1246,7 @@ func TestDownloadImageExportManifestWrongLayerCount(t *testing.T) {
 	require.NoError(err)
 
 	imageExportStore := NewDummyImageExportStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repoStore, nil, nil, nil, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 
 	// Create ImageExport
 	imageExport := newReadyImageExport("test-export", manifestDigest)
@@ -998,7 +1269,7 @@ func newTestImageExportServiceWithKVStore() (ImageExportService, *DummyImageExpo
 	imageBuildStore := NewDummyImageBuildStore()
 	repositoryStore := NewDummyRepositoryStore()
 	kvStore := NewDummyKVStore()
-	svc := NewImageExportService(imageExportStore, imageBuildStore, repositoryStore, nil, nil, kvStore, log.InitLogs())
+	svc := NewImageExportService(imageExportStore, imageBuildStore, repositoryStore, nil, nil, kvStore, config.NewDefaultImageBuilderServiceConfig(), log.InitLogs())
 	return svc, imageExportStore, imageBuildStore
 }
 

--- a/internal/imagebuilder_worker/worker.go
+++ b/internal/imagebuilder_worker/worker.go
@@ -67,7 +67,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		w.log.WithError(err).Error("failed to create queue producer for service")
 		return err
 	}
-	imageBuilderService := imagebuilderapi.NewService(ctx, w.store, w.mainStore, queueProducer, w.kvStore, w.log)
+	imageBuilderService := imagebuilderapi.NewService(ctx, w.cfg, w.store, w.mainStore, queueProducer, w.kvStore, w.log)
 
 	// Launch queue consumers
 	if err := tasks.LaunchConsumers(ctx, w.queuesProvider, w.store, w.mainStore, w.kvStore, w.serviceHandler, imageBuilderService, w.cfg, w.log); err != nil {

--- a/test/integration/imagebuilder_worker/imagebuild_update_test.go
+++ b/test/integration/imagebuilder_worker/imagebuild_update_test.go
@@ -103,7 +103,7 @@ var _ = Describe("ImageBuild Update Integration Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create imagebuilder service
-		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, nil, log)
+		imageBuilderService = service.NewService(ctx, cfg, imageBuilderStore, mainStore, nil, nil, log)
 
 		// Setup mock queue producer to capture enqueued events
 		ctrl = gomock.NewController(GinkgoT())

--- a/test/integration/imagebuilder_worker/requeue_test.go
+++ b/test/integration/imagebuilder_worker/requeue_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Requeue Integration Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create imagebuilder service
-		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, nil, log)
+		imageBuilderService = service.NewService(ctx, cfg, imageBuilderStore, mainStore, nil, nil, log)
 
 		// Setup mock queue producer to capture enqueued events
 		ctrl = gomock.NewController(GinkgoT())

--- a/test/integration/imagebuilder_worker/status_updater_test.go
+++ b/test/integration/imagebuilder_worker/status_updater_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Status Updater Integration Tests", func() {
 		}
 
 		// Create imagebuilder service with kvStore
-		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, kvStoreInst, log)
+		imageBuilderService = service.NewService(ctx, cfg, imageBuilderStore, mainStore, nil, kvStoreInst, log)
 	})
 
 	AfterEach(func() {

--- a/test/integration/imagebuilder_worker/timeout_test.go
+++ b/test/integration/imagebuilder_worker/timeout_test.go
@@ -102,8 +102,11 @@ var _ = Describe("Timeout Check Integration Tests", func() {
 		kvStoreInst, kvErr = kvstore.NewKVStore(ctx, log, "localhost", 6379, domain.SecureString("adminpass"))
 		Expect(kvErr).ToNot(HaveOccurred())
 
+		// Create config with defaults
+		cfg = config.NewDefault()
+
 		// Create imagebuilder service
-		imageBuilderService = service.NewService(ctx, imageBuilderStore, mainStore, nil, kvStoreInst, log)
+		imageBuilderService = service.NewService(ctx, cfg, imageBuilderStore, mainStore, nil, kvStoreInst, log)
 
 		// Create consumer
 		consumer = tasks.NewConsumer(
@@ -113,7 +116,7 @@ var _ = Describe("Timeout Check Integration Tests", func() {
 			nil, // serviceHandler
 			imageBuilderService,
 			nil, // queueProducer
-			&config.Config{},
+			cfg,
 			log,
 		)
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable cancellation timeout (default 30s) for deletion flows; deletion will wait for cancellation completion before final removal.
  * Deletion now cascades to related export resources and signals cancellation completion to coordinate cleanup.

* **Documentation**
  * Added detailed deletion workflows and command examples for build and export resources, including cancellation and timeout notes.

* **Tests**
  * Expanded tests covering cancel, timeout, and cascade-delete scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->