### PR TITLE
EDM-2868: Make k8s1.32/ocp4.19 minimum

### DIFF
--- a/deploy/helm/flightctl/Chart.yaml
+++ b/deploy/helm/flightctl/Chart.yaml
@@ -11,4 +11,4 @@ annotations:
   charts.openshift.io/name: FlightControl
   charts.openshift.io/provider: FlightControl
   charts.openshift.io/supportURL: https://github.com/flightctl/flightctl
-kubeVersion: '>= 1.31.0-0'
+kubeVersion: '>= 1.32.0-0'

--- a/deploy/helm/flightctl/Chart.yaml.gotmpl
+++ b/deploy/helm/flightctl/Chart.yaml.gotmpl
@@ -11,4 +11,4 @@ annotations:
   charts.openshift.io/name: {{ .Annotations.Name }}
   charts.openshift.io/provider: {{ .Annotations.Provider }}
   charts.openshift.io/supportURL: {{ .Annotations.SupportURL }}
-kubeVersion: '>= 1.31.0-0'
+kubeVersion: '>= 1.32.0-0'

--- a/test/scripts/install_kind.sh
+++ b/test/scripts/install_kind.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-KIND_VERSION=0.25.0
+KIND_VERSION=0.26.0
 
 EXISTING_VERSION=$(kind version 2>&1 | awk '{print $2}' | sed 's/v//')
 


### PR DESCRIPTION
Due to FCTL UI plugin using PF6, the minimum OCP version is now 4.19
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum Kubernetes requirement for Helm deployments raised to 1.32.0-0; ensure cluster compatibility before upgrading or installing.

* **Tests**
  * Test tooling updated to use a newer kind version for local cluster testing; CI/local test environments may need the corresponding tool version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->