### PR TITLE
EDM-3128: Helm App Docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -286,6 +286,12 @@ imagebuilds
 imagebuild
 imageexport
 imageexports
+kubeconfig
+CRI
+containerd
+prefetching
+prefetches
+networkless
  - docs/user/references/api-resources.md
 namespacing
 approvedBy


### PR DESCRIPTION
Adds documentation for helm applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added extensive Helm/Kubernetes runtime docs: Helm application definitions and examples, prerequisites and tool notes (helm, kubectl/oc, crictl), kubeconfig discovery and auth configuration, CRI considerations, deployment/update workflows, image prefetching behavior and caveats, and updated image/artifact pruning to include Helm charts and related scenarios; formatting consistency improvements.

* **Chores**
  * Expanded spelling configuration to recognize additional terms: kubeconfig, CRI, containerd, prefetching, prefetches, networkless.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->