### PR TITLE
NO-ISSUE: Disable ResourceSync e2e

### DIFF
--- a/test/e2e/resourcesync/resourcesync_suite_test.go
+++ b/test/e2e/resourcesync/resourcesync_suite_test.go
@@ -3,54 +3,9 @@ package resourcesync_test
 import (
 	"testing"
 
-	"github.com/flightctl/flightctl/test/harness/e2e"
-	testutil "github.com/flightctl/flightctl/test/util"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 func TestResourcesync(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Resourcesync E2E Suite")
+	logrus.Info("Resourcesync E2E Suite is disabled")
 }
-
-var _ = BeforeSuite(func() {
-	// Setup VM and harness for this worker
-	_, _, err := e2e.SetupWorkerHarness()
-	Expect(err).ToNot(HaveOccurred())
-})
-
-var _ = BeforeEach(func() {
-	workerID := GinkgoParallelProcess()
-	harness := e2e.GetWorkerHarness()
-	suiteCtx := e2e.GetWorkerContext()
-
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
-
-	// Create test-specific context for proper tracing
-	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
-
-	// Set the test context in the harness
-	harness.SetTestContext(ctx)
-
-	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
-})
-
-var _ = AfterEach(func() {
-	workerID := GinkgoParallelProcess()
-	GinkgoWriter.Printf("🔄 [AfterEach] Worker %d: Cleaning up test resources\n", workerID)
-
-	// Get the harness and context directly - no shared variables needed
-	harness := e2e.GetWorkerHarness()
-	suiteCtx := e2e.GetWorkerContext()
-
-	// Clean up test resources BEFORE switching back to suite context
-	// This ensures we use the correct test ID for resource cleanup
-	err := harness.CleanUpAllTestResources()
-	Expect(err).ToNot(HaveOccurred())
-
-	// Now restore suite context for any remaining cleanup operations
-	harness.SetTestContext(suiteCtx)
-
-	GinkgoWriter.Printf("✅ [AfterEach] Worker %d: Test cleanup completed\n", workerID)
-})

--- a/test/e2e/resourcesync/resourcesync_test.go
+++ b/test/e2e/resourcesync/resourcesync_test.go
@@ -34,7 +34,7 @@ type testContext struct {
 	listParams       v1beta1.ListFleetsParams
 }
 
-var _ = Describe("ResourceSync success cases", func() {
+var _ = PDescribe("ResourceSync success cases", func() {
 	var tc *testContext
 
 	BeforeEach(func() {
@@ -138,7 +138,7 @@ var _ = Describe("ResourceSync success cases", func() {
 	})
 })
 
-var _ = Describe("ResourceSync Failure Cases", func() {
+var _ = PDescribe("ResourceSync Failure Cases", func() {
 	var tc *testContext
 
 	BeforeEach(func() {


### PR DESCRIPTION
Setup test steps for the ResourceSync e2e test is failing fairly consistently like so:
https://github.com/flightctl/flightctl/actions/runs/21437363127/job/61732700451#step:15:4774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled the resource synchronization end-to-end test suite
  * Updated test configuration to enable parallel execution for improved performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->