### PR TITLE
EDM-2848: flightctl-pam-issuer now mounts individual paths 

### DIFF
--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer.container
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer.container
@@ -15,13 +15,22 @@ Volume=/etc/flightctl/pki/flightctl-pam-issuer/server.crt:/root/.flightctl/certs
 Volume=/etc/flightctl/pki/flightctl-pam-issuer/server.key:/root/.flightctl/certs/server.key:ro,z
 Volume=/etc/flightctl/pki/flightctl-pam-issuer/token-signer.crt:/root/.flightctl/certs/client-signer.crt:ro,z
 Volume=/etc/flightctl/pki/flightctl-pam-issuer/token-signer.key:/root/.flightctl/certs/client-signer.key:ro,z
-Volume=flightctl-pam-issuer-etc:/etc:rw
+# User database files - persist local users created inside the container.
+# Other /etc files (PAM configs, nsswitch.conf, etc.) come from the container image
+# and are updated when the image is updated.
+Volume=/etc/flightctl/flightctl-pam-issuer/userdb/passwd:/etc/passwd:z
+Volume=/etc/flightctl/flightctl-pam-issuer/userdb/shadow:/etc/shadow:z
+Volume=/etc/flightctl/flightctl-pam-issuer/userdb/group:/etc/group:z
+Volume=/etc/flightctl/flightctl-pam-issuer/userdb/gshadow:/etc/gshadow:z
 Volume=/etc/flightctl/flightctl-pam-issuer/config.yaml:/root/.flightctl/config.yaml:ro,z
 
 [Service]
 Restart=always
 RestartSec=30
 
+# Migration from 1.0.0: Copy user database files from old /etc volume to new location.
+# TODO: Remove this ExecStartPre once 1.0.0 becomes unsupported.
+ExecStartPre=/usr/share/flightctl/flightctl-pam-issuer/migrate-userdb.sh
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-pam-issuer/config.yaml.template --output-file /etc/flightctl/flightctl-pam-issuer/config.yaml
 
 [Install]

--- a/deploy/podman/flightctl-pam-issuer/migrate-userdb.sh
+++ b/deploy/podman/flightctl-pam-issuer/migrate-userdb.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Migration from 1.0.0: Copy user database files from old /etc volume to new location.
+# TODO: Remove this migration script once 1.0.0 becomes unsupported.
+
+set -e
+
+USERDB_DIR=/etc/flightctl/flightctl-pam-issuer/userdb
+MIGRATION_MARKER="$USERDB_DIR/.migrated"
+
+# Skip if migration already completed
+if [ -f "$MIGRATION_MARKER" ]; then
+    exit 0
+fi
+
+OLD_VOL=$(podman volume inspect flightctl-pam-issuer-etc --format "{{.Mountpoint}}" 2>/dev/null || true)
+
+if [ -n "$OLD_VOL" ] && [ -f "$OLD_VOL/passwd" ]; then
+    for f in passwd shadow group gshadow; do
+        if [ -f "$OLD_VOL/$f" ] && { [ ! -f "$USERDB_DIR/$f" ] || [ ! -s "$USERDB_DIR/$f" ]; }; then
+            cp -p "$OLD_VOL/$f" "$USERDB_DIR/$f"
+            echo "Migrated $f from old volume"
+        fi
+    done
+fi
+
+# Mark migration as complete
+touch "$MIGRATION_MARKER"
+
+exit 0

--- a/docs/developer/pam-issuer-deployment.md
+++ b/docs/developer/pam-issuer-deployment.md
@@ -17,37 +17,24 @@ The following Quadlet files have been created:
 1. **flightctl-pam-issuer.container**
    - Quadlet container definition for systemd
    - Manages the PAM issuer container lifecycle
-   - Mounts configuration, certificates, and secrets
+   - Mounts configuration, certificates, and user database files
    - Publishes port 8444
-   - Depends on database, KV store, and init services
+   - Depends on certificate initialization service
 
-2. **flightctl-pam-issuer-init.container**
-   - Initialization container that templates configuration
-   - Runs once before the main container starts
-   - Processes `config.yaml.template` and `env.template`
-
-3. **flightctl-pam-issuer-config/config.yaml.template**
+2. **flightctl-pam-issuer-config/config.yaml.template**
    - Template for the PAM issuer configuration
    - Includes placeholders for:
-     - Database connection (hostname, port, name, user, SSL config)
-     - KV store connection
      - PAM OIDC issuer settings (address, issuer URL, client credentials, scopes, redirect URIs, PAM service)
 
-4. **flightctl-pam-issuer-config/env.template**
-   - Environment variable template
-   - Sets HOME=/root
-
-5. **flightctl-pam-issuer-config/init.sh**
-   - Initialization script executed by the init container
-   - Extracts values from `/etc/flightctl/service-config.yaml`
-   - Templates configuration files with actual values
-   - Handles both internal and external database configurations
-   - Converts comma-separated lists to YAML arrays
-
-6. **pam-flightctl**
+3. **pam-flightctl**
    - PAM service configuration file
    - Copied to `/etc/pam.d/flightctl` in the container
    - Configures PAM authentication modules
+
+4. **migrate-userdb.sh**
+   - Migration script for upgrading from 1.0.0
+   - Copies user database files from old `/etc` volume to new location
+   - Runs once and creates a marker file to skip subsequent runs
 
 ## Service Configuration
 

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -24,6 +24,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		// PAM Issuer service
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer.container", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-pam-issuer.container"), Template: true, Mode: RegularFileMode},
 		{Action: ActionCopyDir, Source: "deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "flightctl-pam-issuer/"), Template: false, Mode: RegularFileMode},
+		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-pam-issuer/migrate-userdb.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "flightctl-pam-issuer/migrate-userdb.sh"), Template: false, Mode: ExecutableFileMode},
 
 		// Database service
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-db/flightctl-db.container", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-db.container"), Template: true, Mode: RegularFileMode},
@@ -146,5 +147,13 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-grafana", "certs"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarLibOutputDir, "grafana"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarLibOutputDir, "prometheus"), Mode: ExecutableFileMode},
+
+		// PAM Issuer user database files - persist local users created inside the container
+		// Other /etc files (PAM configs, nsswitch.conf, etc.) come from the container image
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-pam-issuer", "userdb"), Mode: ExecutableFileMode},
+		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-pam-issuer", "userdb", "passwd"), Mode: RegularFileMode},
+		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-pam-issuer", "userdb", "shadow"), Mode: ShadowFileMode},
+		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-pam-issuer", "userdb", "group"), Mode: RegularFileMode},
+		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-pam-issuer", "userdb", "gshadow"), Mode: ShadowFileMode},
 	}
 }

--- a/internal/quadlet/renderer/renderer.go
+++ b/internal/quadlet/renderer/renderer.go
@@ -24,6 +24,7 @@ const (
 const (
 	RegularFileMode    os.FileMode = 0644 // Regular files
 	ExecutableFileMode os.FileMode = 0755 // Executable files and directories
+	ShadowFileMode     os.FileMode = 0600 // Shadow files (password hashes) - root only
 )
 
 type InstallAction struct {

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -488,6 +488,12 @@ loginctl disable-linger flightctl || :
     %dir %{_sysconfdir}/flightctl/flightctl-alertmanager-proxy
     %dir %{_sysconfdir}/flightctl/flightctl-api
     %dir %{_sysconfdir}/flightctl/flightctl-cli-artifacts
+    %dir %{_sysconfdir}/flightctl/flightctl-pam-issuer
+    %dir %{_sysconfdir}/flightctl/flightctl-pam-issuer/userdb
+    %config(noreplace) %{_sysconfdir}/flightctl/flightctl-pam-issuer/userdb/group
+    %attr(0600,root,root) %config(noreplace) %{_sysconfdir}/flightctl/flightctl-pam-issuer/userdb/gshadow
+    %config(noreplace) %{_sysconfdir}/flightctl/flightctl-pam-issuer/userdb/passwd
+    %attr(0600,root,root) %config(noreplace) %{_sysconfdir}/flightctl/flightctl-pam-issuer/userdb/shadow
     %dir %{_sysconfdir}/flightctl/flightctl-db-migrate
     %dir %{_sysconfdir}/flightctl/flightctl-imagebuilder-api
     %dir %{_sysconfdir}/flightctl/flightctl-imagebuilder-worker
@@ -536,6 +542,7 @@ loginctl disable-linger flightctl || :
     %{_datadir}/flightctl/flightctl-alertmanager/alertmanager.yml
     %{_datadir}/flightctl/flightctl-alertmanager-proxy/env.template
     %{_datadir}/flightctl/flightctl-pam-issuer/config.yaml.template
+    %attr(0755,root,root) %{_datadir}/flightctl/flightctl-pam-issuer/migrate-userdb.sh
     %{_datadir}/flightctl/flightctl-alertmanager-proxy/config.yaml.template
     %{_datadir}/flightctl/flightctl-alert-exporter/config.yaml.template
     %{_datadir}/flightctl/flightctl-periodic/config.yaml.template


### PR DESCRIPTION
additionally there is a migration script from old format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PAM issuer now mounts individual read-only user database files and runs an automated one-time migration on upgrade.
  * Service install metadata added so the unit can be enabled by the platform target.

* **Documentation**
  * Deployment docs updated to reflect new mounts, migration workflow, and removal of the separate init unit.

* **Chores**
  * Packaging and deployment updated to include userdb persistence and the migration helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->