### PR TITLE
NO-ISSUE: repo url + entitlements support

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -292,6 +292,16 @@ containerd
 prefetching
 prefetches
 networkless
+ - docs/user/installing/configuring-imagebuilder.md
+ entitlement
+ uncomment
+ volume
+ builder-worker
+ ImageBuilder
+ air-gapped
+ builder-worker.container
+ imageBuilderWorker
+ bool
  - docs/user/references/api-resources.md
 namespacing
 approvedBy

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -27,6 +27,8 @@ kubectl label namespace <namespace> \
 
 On OpenShift clusters, the chart automatically creates a SecurityContextConstraints (SCC) that grants the required permissions to the `flightctl-imagebuilder-worker` service account.
 
+For additional ImageBuilder Worker configuration options (custom RPM repositories, RHEL entitlement certificates), see the [ImageBuilder configuration documentation](../../../docs/user/installing/configuring-imagebuilder.md).
+
 If you don't need image building capabilities, you can disable the imagebuilder-worker:
 
 ```yaml

--- a/deploy/helm/flightctl/README.md.gotmpl
+++ b/deploy/helm/flightctl/README.md.gotmpl
@@ -54,6 +54,8 @@ kubectl label namespace <namespace> \
 
 On OpenShift clusters, the chart automatically creates a SecurityContextConstraints (SCC) that grants the required permissions to the `flightctl-imagebuilder-worker` service account.
 
+For additional ImageBuilder Worker configuration options (custom RPM repositories, RHEL entitlement certificates), see the [ImageBuilder configuration documentation](../../../docs/user/installing/configuring-imagebuilder.md).
+
 If you don't need image building capabilities, you can disable the imagebuilder-worker:
 
 ```yaml

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
@@ -42,4 +42,7 @@ data:
         logLevel: {{ default "info" .Values.imageBuilderWorker.logLevel }}
         maxConcurrentBuilds: {{ default 2 .Values.imageBuilderWorker.maxConcurrentBuilds }}
         defaultTTL: {{ default "168h" .Values.imageBuilderWorker.defaultTTL }}
+        {{- if .Values.imageBuilderWorker.rpmRepoUrl }}
+        rpmRepoUrl: {{ .Values.imageBuilderWorker.rpmRepoUrl | quote }}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
@@ -88,6 +88,13 @@ spec:
             - mountPath: /lib/modules
               name: host-modules
               readOnly: true
+
+            # 4. ENTITLEMENT: Optional RHEL entitlement certs for subscription-only repos
+            {{- if .Values.imageBuilderWorker.entitlementCertsSecretName }}
+            - mountPath: /etc/pki/entitlement
+              name: entitlement-certs
+              readOnly: true
+            {{- end }}
               
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
           {{- with .Values.imageBuilderWorker.resources }}
@@ -137,5 +144,10 @@ spec:
           hostPath:
             path: /lib/modules
             type: Directory
+        {{- if .Values.imageBuilderWorker.entitlementCertsSecretName }}
+        - name: entitlement-certs
+          secret:
+            secretName: {{ .Values.imageBuilderWorker.entitlementCertsSecretName }}
+        {{- end }}
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -539,6 +539,8 @@
         "logLevel": { "type": "string", "description": "Log level for ImageBuilder Worker" },
         "maxConcurrentBuilds": { "type": "integer", "description": "Maximum concurrent builds" },
         "defaultTTL": { "type": "string", "description": "Default TTL for build resources" },
+        "rpmRepoUrl": { "type": "string", "description": "RPM repository URL for flightctl-agent package" },
+        "entitlementCertsSecretName": { "type": "string", "description": "Secret name containing RHEL entitlement certificates. On OpenShift, copy 'etc-pki-entitlement' from 'openshift-config-managed' namespace" },
         "privileged": { "type": "boolean", "description": "Enable privileged mode for container-in-container builds" },
         "resources": { "type": "object", "description": "Resource requests and limits" }
       }

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
@@ -30,3 +30,6 @@ imageBuilderWorker:
   logLevel: {{if .imagebuilderWorker.logLevel}}{{.imagebuilderWorker.logLevel}}{{else}}info{{end}}
   maxConcurrentBuilds: {{if .imagebuilderWorker.maxConcurrentBuilds}}{{.imagebuilderWorker.maxConcurrentBuilds}}{{else}}2{{end}}
   defaultTTL: {{if .imagebuilderWorker.defaultTTL}}{{.imagebuilderWorker.defaultTTL}}{{else}}168h{{end}}
+  {{- if .imagebuilderWorker.rpmRepoUrl}}
+  rpmRepoUrl: {{.imagebuilderWorker.rpmRepoUrl}}
+  {{- end}}

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
@@ -22,6 +22,9 @@ Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Volume=/var/tmp/flightctl-builds:/var/tmp/flightctl-builds:rw,z
 Volume=/var/tmp/flightctl-exports:/var/tmp/flightctl-exports:rw,z
 Volume=flightctl-worker-storage:/var/lib/containers
+# Optional: Mount RHEL entitlement certs for subscription-only repos (auto-detected if present).
+# On RHEL hosts with active subscription, uncomment to use host entitlements:
+# Volume=/etc/pki/entitlement:/etc/pki/entitlement:ro,z
 PodmanArgs=--privileged
 
 [Service]

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -20,6 +20,7 @@ Welcome to the Flight Control user documentation.
   * Configuring the Flight Control Service
     * [Configuring Authentication and Authorization](installing/configuring-auth/overview.md)
     * [Configuring an External PostgreSQL Database](installing/configuring-external-database.md)
+    * [Configuring the ImageBuilder Worker](installing/configuring-imagebuilder.md)
     * [Configuring Device Attestation](installing/configuring-device-attestation.md)
     * [Configuring Rate Limits on API Requests](installing/configuring-rate-limiting.md)
 

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -1,0 +1,202 @@
+# Configuring ImageBuilder Worker
+
+The Flight Control ImageBuilder Worker builds OS images for devices. This document covers configuration options for customizing the image build process.
+
+## Prerequisites
+
+- Flight Control deployed with ImageBuilder Worker enabled (`imageBuilderWorker.enabled: true`, which is the default)
+- For RHEL subscription content: RHEL entitlement certificates
+
+## RPM Repository Configuration
+
+The ImageBuilder Worker installs the `flightctl-agent` package during image builds. By default, it uses the public Flight Control RPM repository.
+
+### Default Repository
+
+The default repository URL is:
+
+```text
+https://rpm.flightctl.io/flightctl-epel.repo
+```
+
+### Using a Custom Repository
+
+To use a custom RPM repository (e.g., an internal mirror, air-gapped environment, or Red Hat subscription repo), configure the `rpmRepoUrl` setting.
+
+#### Kubernetes (Helm)
+
+```yaml
+imageBuilderWorker:
+  rpmRepoUrl: "https://your-internal-mirror.example.com/flightctl.repo"
+```
+
+#### Podman Quadlet
+
+Edit `/etc/flightctl/service-config.yaml`:
+
+```yaml
+imagebuilderWorker:
+  rpmRepoUrl: "https://your-internal-mirror.example.com/flightctl.repo"
+```
+
+## RHEL Entitlement Certificates
+
+If your image builds need to access RHEL subscription-only repositories (e.g., when using RHEL base images or Red Hat packages), you need to provide entitlement certificates.
+
+The ImageBuilder Worker automatically detects entitlement certificates mounted at `/etc/pki/entitlement` and makes them available during builds.
+
+### Kubernetes (Helm)
+
+#### On OpenShift
+
+OpenShift clusters with RHEL entitlements have certificates available in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace.
+
+##### Step 1: Copy the entitlement secret to your namespace
+
+```bash
+# Get the current namespace
+NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
+
+# Copy the secret
+kubectl get secret etc-pki-entitlement -n openshift-config-managed -o yaml | \
+  sed "s/namespace: openshift-config-managed/namespace: ${NAMESPACE}/" | \
+  kubectl apply -f -
+```
+
+##### Step 2: Configure the Helm chart
+
+```yaml
+imageBuilderWorker:
+  entitlementCertsSecretName: "etc-pki-entitlement"
+```
+
+#### On Other Kubernetes Distributions
+
+##### Step 1: Create a secret from your entitlement certificates
+
+```bash
+# From a RHEL host with active subscription
+kubectl create secret generic rhel-entitlement \
+  --from-file=/etc/pki/entitlement/
+```
+
+Or create the secret from individual certificate files:
+
+```bash
+kubectl create secret generic rhel-entitlement \
+  --from-file=entitlement.pem=/path/to/entitlement.pem \
+  --from-file=entitlement-key.pem=/path/to/entitlement-key.pem
+```
+
+##### Step 2: Configure the Helm chart
+
+```yaml
+imageBuilderWorker:
+  entitlementCertsSecretName: "rhel-entitlement"
+```
+
+### Podman Quadlet
+
+On RHEL hosts with an active subscription, the entitlement certificates are already available at `/etc/pki/entitlement`.
+
+#### Step 1: Enable the volume mount
+
+Edit `/etc/flightctl/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container` and uncomment the entitlement volume line:
+
+```ini
+[Container]
+# ... other settings ...
+Volume=/etc/pki/entitlement:/etc/pki/entitlement:ro,z
+```
+
+#### Step 2: Restart the service
+
+```bash
+sudo systemctl restart flightctl-imagebuilder-worker.service
+```
+
+## Configuration Reference
+
+### Kubernetes (Helm) Values
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `imageBuilderWorker.enabled` | bool | `true` | Enable ImageBuilder Worker service |
+| `imageBuilderWorker.rpmRepoUrl` | string | `""` | Custom RPM repository URL for flightctl-agent package. If empty, uses the default public repository. |
+| `imageBuilderWorker.entitlementCertsSecretName` | string | `""` | Kubernetes secret containing RHEL entitlement certificates. The secret contents are mounted at `/etc/pki/entitlement`. |
+| `imageBuilderWorker.logLevel` | string | `"info"` | Log level for the worker |
+| `imageBuilderWorker.maxConcurrentBuilds` | int | `2` | Maximum number of concurrent image builds |
+| `imageBuilderWorker.defaultTTL` | string | `"168h"` | Default time-to-live for build resources |
+| `imageBuilderWorker.privileged` | bool | `true` | Run container in privileged mode (required for image builds) |
+
+### Podman Quadlet Configuration
+
+Edit `/etc/flightctl/service-config.yaml`:
+
+```yaml
+imagebuilderWorker:
+  logLevel: info
+  maxConcurrentBuilds: 2
+  defaultTTL: 168h
+  rpmRepoUrl: ""  # Custom RPM repository URL (optional)
+```
+
+## Troubleshooting
+
+### Build Fails with "Package not found" Error
+
+**Problem**: Image build fails because `flightctl-agent` package cannot be found.
+
+**Solution**:
+
+1. Verify the RPM repository URL is accessible from the build environment
+2. Check if you need to configure a custom repository URL
+3. Ensure network connectivity to the repository
+
+### Build Fails with "Subscription required" Error
+
+**Problem**: Image build fails when accessing RHEL subscription content.
+
+**Solution**:
+
+1. Verify entitlement certificates are properly configured
+2. On Kubernetes: Check that the secret exists and contains valid certificates
+
+   ```bash
+   kubectl get secret <entitlement-secret-name> -o yaml
+   ```
+
+3. On Podman: Verify the host has an active RHEL subscription
+
+   ```bash
+   sudo subscription-manager status
+   ```
+
+### Entitlement Certificates Not Working
+
+**Problem**: Entitlement certificates are configured but builds still fail.
+
+**Diagnosis**:
+
+1. Check ImageBuilder Worker logs:
+
+   ```bash
+   # Kubernetes
+   kubectl logs deployment/flightctl-imagebuilder-worker
+
+   # Podman
+   sudo journalctl -u flightctl-imagebuilder-worker.service
+   ```
+
+2. Verify the certificate files are valid:
+
+   ```bash
+   # Check certificate expiration
+   openssl x509 -in /etc/pki/entitlement/*.pem -noout -dates
+   ```
+
+**Common Causes**:
+
+- Expired entitlement certificates
+- Incorrect secret format (certificates must be PEM encoded)
+- Missing certificate key file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type imageBuilderWorkerConfig struct {
 	LastSeenUpdateInterval   util.Duration `json:"lastSeenUpdateInterval,omitempty"`
 	ImageBuilderTimeout      util.Duration `json:"imageBuilderTimeout,omitempty"`
 	TimeoutCheckTaskInterval util.Duration `json:"timeoutCheckTaskInterval,omitempty"`
+	RPMRepoURL               string        `json:"rpmRepoUrl,omitempty"`
 }
 
 // NewDefaultImageBuilderWorkerConfig returns a default ImageBuilder worker configuration
@@ -143,6 +144,7 @@ func NewDefaultImageBuilderWorkerConfig() *imageBuilderWorkerConfig {
 		LastSeenUpdateInterval:   util.Duration(30 * time.Second),
 		ImageBuilderTimeout:      util.Duration(3 * time.Minute),
 		TimeoutCheckTaskInterval: util.Duration(1 * time.Minute),
+		RPMRepoURL:               "https://rpm.flightctl.io/flightctl-epel.repo",
 	}
 }
 

--- a/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
+++ b/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
@@ -11,7 +11,8 @@ ARG USERNAME
 ARG AGENT_CONFIG_DEST_PATH=/etc/flightctl/config.yaml
 
 # Add Flight Control repository and install agent
-RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
+ARG RPM_REPO_URL
+RUN dnf -y config-manager --add-repo ${RPM_REPO_URL} && \
     dnf install -y flightctl-agent && \
     dnf clean all
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Configuring the ImageBuilder Worker" guide covering prerequisites, RPM repo and entitlement certificate setup for Helm and Podman, examples, and troubleshooting.
  * Added cross-references and README updates to surface ImageBuilder configuration.

* **New Features**
  * Configurable RPM repository URL for the ImageBuilder Worker (default provided).
  * Optional RHEL entitlement certificate mounting to support subscription-only repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->