### PR TITLE
EDM-2158: Cleanup DB users and permissions

### DIFF
--- a/deploy/podman/flightctl-db/flightctl-db-config/enable-superuser.sh
+++ b/deploy/podman/flightctl-db/flightctl-db-config/enable-superuser.sh
@@ -86,6 +86,10 @@ _psql -U "$DB_ADMIN_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA p
 _psql -U "$DB_ADMIN_USER" -d "$DB_NAME" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO \"$DB_APP_USER\";"
 
 # Create function to grant permissions on existing tables (for post-migration)
+# Note: This function is also defined in setup_database_users.sql for Helm deployments.
+# The duplication is intentional to support different deployment paths:
+# - This script: Podman/standalone deployments (runs as admin at DB startup)
+# - setup_database_users.sql: Helm/Kubernetes deployments (runs via migration job)
 cat << EOF | _psql -U "$DB_ADMIN_USER" -d "$DB_NAME"
 CREATE OR REPLACE FUNCTION grant_app_permissions_on_existing_tables()
 RETURNS void AS \$function\$

--- a/deploy/scripts/migration-setup.sh
+++ b/deploy/scripts/migration-setup.sh
@@ -19,7 +19,10 @@ echo "Granting privileges to migration user..."
 PGPASSWORD="$DB_ADMIN_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" -c "
 GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$DB_MIGRATION_USER\";
 GRANT USAGE, CREATE ON SCHEMA public TO \"$DB_MIGRATION_USER\";
-GRANT CREATE ON DATABASE \"$DB_NAME\" TO \"$DB_MIGRATION_USER\";"
+GRANT CREATE ON DATABASE \"$DB_NAME\" TO \"$DB_MIGRATION_USER\";
+-- Grant data-plane permissions WITH GRANT OPTION for external DB support
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"$DB_MIGRATION_USER\" WITH GRANT OPTION;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$DB_MIGRATION_USER\" WITH GRANT OPTION;"
 
 echo "Migration user setup completed. Running database migration..."
 /usr/local/bin/flightctl-db-migrate

--- a/deploy/scripts/setup_database_users.sql
+++ b/deploy/scripts/setup_database_users.sql
@@ -30,24 +30,30 @@ GRANT CONNECT ON DATABASE "${DB_NAME}" TO "${DB_APP_USER}";
 GRANT USAGE ON SCHEMA public TO "${DB_MIGRATION_USER}";
 GRANT USAGE ON SCHEMA public TO "${DB_APP_USER}";
 
--- Grant migration user minimum required privileges for schema migrations
+-- Grant migration user privileges for schema migrations
 -- Following the principle of least privilege, these are the specific privileges needed:
 -- 1. CREATE on schema - for creating tables, indexes, sequences, functions, and triggers
 -- 2. CREATE on database - for creating additional schemas if needed
--- Note: Migration user does NOT get data-plane permissions (SELECT, INSERT, UPDATE, DELETE)
--- for security reasons - migrations should only modify schema structure, not data
 GRANT CREATE ON SCHEMA public TO "${DB_MIGRATION_USER}";
 GRANT CREATE ON DATABASE "${DB_NAME}" TO "${DB_MIGRATION_USER}";
 
--- Grant additional privileges needed for schema operations only
--- Migration user should NOT have data-plane permissions (SELECT, INSERT, UPDATE, DELETE)
--- for security reasons - migrations only modify schema, not data
+-- Grant additional privileges needed for schema and post-migration operations
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${DB_MIGRATION_USER}";
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "${DB_MIGRATION_USER}";
 
--- Grant migration user additional privileges for schema modifications
--- The CREATE privilege on schema allows creating, altering, and dropping tables, indexes, etc.
--- No additional ALTER/DROP privileges needed - these are handled by CREATE on schema
+-- Grant migration user data-plane permissions WITH GRANT OPTION
+-- This allows the migrator to grant these permissions to the application user
+-- after running migrations, enabling support for external databases without admin access
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public
+    TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public
+    TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+
+-- Ensure future tables also get WITH GRANT OPTION for migrator
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
 
 -- Grant application user limited privileges for data operations
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${DB_APP_USER}";


### PR DESCRIPTION
## Summary

- Add `WITH GRANT OPTION` permissions to `flightctl_migrator` user, allowing it to grant data-plane permissions to `flightctl_app` after migrations
- This enables external database support where admin/superuser access may not be available
- Update related scripts for consistency and add documentation about intentional code duplication

## Test plan

- [x] Verified locally with PostgreSQL container
- [x] Confirmed migrator can grant permissions on admin-owned tables
- [x] Confirmed app user can read/write after migrator grants access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database permission configuration across deployment scripts to ensure proper access controls for data operations during initialization and for future schema changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->