### PR TITLE
NO-ISSUE: fix Publish Binaries workflow

### DIFF
--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -213,8 +213,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          OLD_RELEASE=$(gh release list --json 'tagName' --jq 'any(.[]; .tagName == "latest")')
-          if [ $OLD_RELEASE == 'true' ]; then
+          if gh release view latest >/dev/null 2>&1; then
             # if there is a release already we only update the binaries
             # otherwise a new release will trigger an rpm build from packit
             gh release upload latest --clobber release/*


### PR DESCRIPTION
The `gh` CLI lists only 30 releases by default, so the workflow failed to detect the `latest` release. This change fixes it by querying `latest` directly instead of listing and filtering releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the CLI binary release workflow with improved version detection and more efficient release handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->