### PR TITLE
EDM-3258: EDM-3257,operator cant cancel fix

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-default-user-roles.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-default-user-roles.yaml
@@ -78,7 +78,7 @@ rules:
       - imageexports/download
   # Cancel operations for image builds/exports (PUT maps to update verb)
   - verbs:
-      - update
+      - create
     apiGroups:
       - flightctl.io
     resources:

--- a/docs/user/references/auth-resources.md
+++ b/docs/user/references/auth-resources.md
@@ -62,11 +62,11 @@ The table below contains the routes, names, resource names, and verbs for Flight
 |`GET /api/v1/imagebuilds/{name}`|`GetImageBuild`|`imagebuilds`|`get`|
 |`DELETE /api/v1/imagebuilds/{name}`|`DeleteImageBuild`|`imagebuilds`|`delete`|
 |`GET /api/v1/imagebuilds/{name}/log`|`GetImageBuildLog`|`imagebuilds/log`|`get`|
-|`PUT /api/v1/imagebuilds/{name}/cancel`|`CancelImageBuild`|`imagebuilds/cancel`|`update`|
+|`POST /api/v1/imagebuilds/{name}/cancel`|`CancelImageBuild`|`imagebuilds/cancel`|`create`|
 |`GET /api/v1/imageexports`|`ListImageExports`|`imageexports`|`list`|
 |`POST /api/v1/imageexports`|`CreateImageExport`|`imageexports`|`create`|
 |`GET /api/v1/imageexports/{name}`|`GetImageExport`|`imageexports`|`get`|
 |`DELETE /api/v1/imageexports/{name}`|`DeleteImageExport`|`imageexports`|`delete`|
 |`GET /api/v1/imageexports/{name}/log`|`GetImageExportLog`|`imageexports/log`|`get`|
-|`PUT /api/v1/imageexports/{name}/cancel`|`CancelImageExport`|`imageexports/cancel`|`update`|
+|`POST /api/v1/imageexports/{name}/cancel`|`CancelImageExport`|`imageexports/cancel`|`create`|
 |`GET /api/v1/imageexports/{name}/download`|`DownloadImageExport`|`imageexports/download`|`get`|

--- a/internal/auth/authz/static.go
+++ b/internal/auth/authz/static.go
@@ -33,9 +33,9 @@ var resourcePermissions = map[string]map[string][]string{
 		"resourcesyncs":         {"get", "list", "create", "update", "patch", "delete"},
 		"repositories":          {"get", "list", "create", "update", "patch", "delete"},
 		"imagebuilds":           {"get", "list", "create", "update", "patch", "delete"},
-		"imagebuilds/cancel":    {"update"},
+		"imagebuilds/cancel":    {"create"},
 		"imageexports":          {"get", "list", "create", "update", "patch", "delete"},
-		"imageexports/cancel":   {"update"},
+		"imageexports/cancel":   {"create"},
 		"imageexports/download": {"get"},
 		"*":                     {"get", "list"}, // Default read access for other resources
 	},

--- a/internal/auth/authz/static_test.go
+++ b/internal/auth/authz/static_test.go
@@ -129,7 +129,7 @@ func TestStaticAuthZ_CheckPermission(t *testing.T) {
 			name:     "operator can cancel imagebuilds",
 			roles:    []string{v1beta1.RoleOperator},
 			resource: "imagebuilds/cancel",
-			op:       "update",
+			op:       "create",
 			expected: true,
 		},
 		{
@@ -246,7 +246,7 @@ func TestStaticAuthZ_GetUserPermissions(t *testing.T) {
 				},
 				{
 					Resource:   "imagebuilds/cancel",
-					Operations: []string{"update"},
+					Operations: []string{"create"},
 				},
 				{
 					Resource:   "imageexports",
@@ -254,7 +254,7 @@ func TestStaticAuthZ_GetUserPermissions(t *testing.T) {
 				},
 				{
 					Resource:   "imageexports/cancel",
-					Operations: []string{"update"},
+					Operations: []string{"create"},
 				},
 				{
 					Resource:   "imageexports/download",

--- a/internal/cli/cancel.go
+++ b/internal/cli/cancel.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -118,21 +117,12 @@ func (o *CancelOptions) cancelImageBuild(ctx context.Context, name string) error
 		return fmt.Errorf("canceling imagebuild %s: %w", name, err)
 	}
 
-	if response.HTTPResponse != nil {
-		switch response.HTTPResponse.StatusCode {
-		case http.StatusOK:
-			fmt.Printf("ImageBuild cancellation requested: %s\n", name)
-			return nil
-		case http.StatusBadRequest:
-			return fmt.Errorf("cannot cancel imagebuild %s: %s", name, string(response.Body))
-		case http.StatusNotFound:
-			return fmt.Errorf("imagebuild not found: %s", name)
-		default:
-			return fmt.Errorf("failed to cancel imagebuild %s: %s", name, string(response.Body))
-		}
+	if err := validateImageBuilderResponse(response); err != nil {
+		return err
 	}
 
-	return fmt.Errorf("no response received")
+	fmt.Printf("ImageBuild cancellation requested: %s\n", name)
+	return nil
 }
 
 func (o *CancelOptions) cancelImageExport(ctx context.Context, name string) error {
@@ -146,19 +136,10 @@ func (o *CancelOptions) cancelImageExport(ctx context.Context, name string) erro
 		return fmt.Errorf("canceling imageexport %s: %w", name, err)
 	}
 
-	if response.HTTPResponse != nil {
-		switch response.HTTPResponse.StatusCode {
-		case http.StatusOK:
-			fmt.Printf("ImageExport cancellation requested: %s\n", name)
-			return nil
-		case http.StatusBadRequest:
-			return fmt.Errorf("cannot cancel imageexport %s: %s", name, string(response.Body))
-		case http.StatusNotFound:
-			return fmt.Errorf("imageexport not found: %s", name)
-		default:
-			return fmt.Errorf("failed to cancel imageexport %s: %s", name, string(response.Body))
-		}
+	if err := validateImageBuilderResponse(response); err != nil {
+		return err
 	}
 
-	return fmt.Errorf("no response received")
+	fmt.Printf("ImageExport cancellation requested: %s\n", name)
+	return nil
 }

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -133,9 +133,9 @@ func (o *LogsOptions) Run(ctx context.Context, args []string) error {
 	defer resp.Body.Close()
 
 	// Check response status
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to get logs: status %d, body: %s", resp.StatusCode, string(body))
+		return validateHttpResponse(body, resp.StatusCode, http.StatusOK)
 	}
 
 	// Handle streaming vs non-streaming


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Updated cancel operations for image builds and exports to use POST requests instead of PUT, aligning with create-like operation semantics.

* **Improvements**
  * Enhanced error handling and response validation consistency across CLI commands.

* **Documentation**
  * Updated API reference documentation to reflect the new cancel operation HTTP methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->