### PR TITLE
EDM-3262: fixed cancel not working properly for pending states

### DIFF
--- a/internal/imagebuilder_api/service/imagebuild_test.go
+++ b/internal/imagebuilder_api/service/imagebuild_test.go
@@ -1038,10 +1038,10 @@ func TestCancelImageBuild_Pending(t *testing.T) {
 	require.NotNil(result.Status)
 	require.NotNil(result.Status.Conditions)
 
-	// Verify status is Canceling
+	// Verify status is Canceled (Pending resources go directly to Canceled, no active processing to stop)
 	readyCondition := api.FindImageBuildStatusCondition(*result.Status.Conditions, api.ImageBuildConditionTypeReady)
 	require.NotNil(readyCondition)
-	require.Equal(string(api.ImageBuildConditionReasonCanceling), readyCondition.Reason)
+	require.Equal(string(api.ImageBuildConditionReasonCanceled), readyCondition.Reason)
 }
 
 func TestCancelImageBuild_Building(t *testing.T) {
@@ -1272,8 +1272,8 @@ func TestCancelImageBuild_NoStatus(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(result)
 
-	// Verify status is Canceling
+	// Verify status is Canceled (no status = Pending, which goes directly to Canceled)
 	readyCondition := api.FindImageBuildStatusCondition(*result.Status.Conditions, api.ImageBuildConditionTypeReady)
 	require.NotNil(readyCondition)
-	require.Equal(string(api.ImageBuildConditionReasonCanceling), readyCondition.Reason)
+	require.Equal(string(api.ImageBuildConditionReasonCanceled), readyCondition.Reason)
 }

--- a/internal/imagebuilder_api/service/imageexport_test.go
+++ b/internal/imagebuilder_api/service/imageexport_test.go
@@ -1307,10 +1307,10 @@ func TestCancelImageExport_Pending(t *testing.T) {
 	require.NotNil(result.Status)
 	require.NotNil(result.Status.Conditions)
 
-	// Verify status is Canceling
+	// Verify status is Canceled (Pending resources go directly to Canceled, no active processing to stop)
 	readyCondition := api.FindImageExportStatusCondition(*result.Status.Conditions, api.ImageExportConditionTypeReady)
 	require.NotNil(readyCondition)
-	require.Equal(string(api.ImageExportConditionReasonCanceling), readyCondition.Reason)
+	require.Equal(string(api.ImageExportConditionReasonCanceled), readyCondition.Reason)
 }
 
 func TestCancelImageExport_Converting(t *testing.T) {
@@ -1514,8 +1514,8 @@ func TestCancelImageExport_NoStatus(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(result)
 
-	// Verify status is Canceling
+	// Verify status is Canceled (no status = Pending, which goes directly to Canceled)
 	readyCondition := api.FindImageExportStatusCondition(*result.Status.Conditions, api.ImageExportConditionTypeReady)
 	require.NotNil(readyCondition)
-	require.Equal(string(api.ImageExportConditionReasonCanceling), readyCondition.Reason)
+	require.Equal(string(api.ImageExportConditionReasonCanceled), readyCondition.Reason)
 }


### PR DESCRIPTION
moving pending state ib/ie directly to cancel state - relying on db optimistic locking with resource_version to avoid race conditions between api and worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable cancellation with retry-on-conflict and clearer cancel vs canceling transitions
  * Pending/no-status resources now cancel immediately; in-progress items transition to canceling and complete properly
  * Improved cleanup and signaling so cancellation events are emitted and removed predictably

* **Tests**
  * Updated tests to expect immediate cancellation for pending/no-status cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->