### PR TITLE
EDM-3263: when defaulting to HOST_FQDN -> lowercase it

### DIFF
--- a/cmd/flightctl-standalone/render_template.go
+++ b/cmd/flightctl-standalone/render_template.go
@@ -131,7 +131,8 @@ func (o *RenderTemplateOptions) getHostnameFQDN() (string, error) {
 	if err == nil && len(output) > 0 {
 		hostname := strings.TrimSpace(string(output))
 		if hostname != "" {
-			return hostname, nil
+			// Normalize to lowercase (DNS is case-insensitive per RFC 1123)
+			return strings.ToLower(hostname), nil
 		}
 	}
 
@@ -147,7 +148,8 @@ func (o *RenderTemplateOptions) getHostnameFQDN() (string, error) {
 		return "", fmt.Errorf("hostname command returned empty value")
 	}
 
-	return hostname, nil
+	// Normalize to lowercase (DNS is case-insensitive per RFC 1123)
+	return strings.ToLower(hostname), nil
 }
 
 func (o *RenderTemplateOptions) validateConfig(data map[string]interface{}) error {

--- a/deploy/podman/flightctl-api/flightctl-api-config/init.sh
+++ b/deploy/podman/flightctl-api/flightctl-api-config/init.sh
@@ -24,7 +24,8 @@ if [[ -z "$base_domain" ]]; then
     echo "ERROR: global.baseDomain is not set and HOST_FQDN is not available for defaulting" >&2
     exit 1
   fi
-  base_domain="${HOST_FQDN}"
+  # Normalize to lowercase (DNS is case-insensitive per RFC 1123)
+  base_domain="${HOST_FQDN,,}"
   echo "global.baseDomain not set, defaulting to host FQDN ($base_domain)"
 fi
 

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -33,7 +33,8 @@ host_ips+=("127.0.0.1")
 # Validate the base domain from config, or default to hostname FQDN
 base_domain=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
 if [[ -z "$base_domain" ]]; then
-    base_domain="$hostname_fqdn"
+    # Normalize to lowercase (DNS is case-insensitive per RFC 1123)
+    base_domain="${hostname_fqdn,,}"
     echo "global.baseDomain not set, defaulting to system hostname FQDN ($base_domain)"
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hostname and fully qualified domain name (FQDN) values are now consistently normalized to lowercase throughout the application to ensure proper DNS handling in compliance with DNS standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->