### PR TITLE
EDM-3265: build cs9 microshift image only if the repo is accessible

### DIFF
--- a/test/harness/e2e/vm/domain-template.xml
+++ b/test/harness/e2e/vm/domain-template.xml
@@ -1,6 +1,6 @@
 <domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>{{.Name}}</name>
-  <memory unit="MiB">512</memory>
+  <memory unit="MiB">2048</memory>
   <memoryBacking>
     <source type="memfd"/>
     <access mode="shared"/>

--- a/test/scripts/agent-images/flavors/cs10-bootc.conf
+++ b/test/scripts/agent-images/flavors/cs10-bootc.conf
@@ -1,11 +1,5 @@
 # Flavor configuration for cs10-bootc
 OS_ID=cs10-bootc
-# Only set EXCLUDE_VARIANTS if not already set (allows override from environment, including empty string)
-if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
-    EXCLUDE_VARIANTS="v7"
-fi
-
-# Build arguments for base image
 DEVICE_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10
 ENABLE_CRB=1
 EPEL_NEXT=0

--- a/test/scripts/agent-images/flavors/cs9-bootc.conf
+++ b/test/scripts/agent-images/flavors/cs9-bootc.conf
@@ -1,11 +1,5 @@
 # Flavor configuration for cs9-bootc
 OS_ID=cs9-bootc
-# Only set EXCLUDE_VARIANTS if not already set (allows override from environment, including empty string)
-if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
-    EXCLUDE_VARIANTS="v7"
-fi
-
-# Build arguments for base image
 DEVICE_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream9
 ENABLE_CRB=0
 EPEL_NEXT=1

--- a/test/scripts/agent-images/scripts/build.sh
+++ b/test/scripts/agent-images/scripts/build.sh
@@ -132,7 +132,9 @@ if [ -n "${EXCLUDE_VARIANTS:-}" ]; then
     [ $skip -eq 0 ] && tmp="${tmp} ${v}"
   done
   variants_list="$(echo "${tmp}" | xargs -n999 echo)"
+  echo "  EXCLUDE_VARIANTS: ${EXCLUDE_VARIANTS}"
 fi
+echo "  Variants to build: ${variants_list:-none}"
 
   if [ "${BUILD_BASE}" = "true" ]; then
     echo -e "\033[32m[${OS_ID}] Building base ${base_img_canonical}\033[m"

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -221,6 +221,12 @@ function is_acm_installed() {
   fi
 }
 
+# Function to check if RHOCP repo is accessible (required for v7/MicroShift)
+function has_rhocp_access() {
+    local url="https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.15/os/repodata/repomd.xml"
+    curl -sf --connect-timeout 5 --max-time 10 -o /dev/null "$url" 2>/dev/null
+}
+
 # Function to get the ocp nodes network name
 function get_ocp_nodes_network() {
   ip=$(/usr/local/bin/oc get node -owide --no-headers | tail -n 1 | awk '{print $6}') || return 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased VM memory allocation for test environments from 512 MiB to 2048 MiB.
  * Enhanced test infrastructure with improved auto-detection logic for variant builds based on system accessibility.
  * Added detailed logging output for better visibility into test build configuration and variant selection.
  * Updated test configuration handling to remove hardcoded defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->