### PR TITLE
EDM-2932: Separate user for console sessions

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -379,6 +379,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	consoleManager := console.NewManager(
 		grpcClient,
 		deviceName,
+		console.ConsoleUser,
 		rootExecuter,
 		specManager.Watch(),
 		a.log,

--- a/internal/agent/device/console/console_test.go
+++ b/internal/agent/device/console/console_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os/user"
 	"strings"
 	"sync"
 	"testing"
@@ -76,6 +77,7 @@ func setupVars(t *testing.T) *vars {
 		controller: NewManager(
 			mockGrpcClient,
 			"mydevice",
+			lo.Must(user.Current()).Username,
 			executor,
 			mockWatcher,
 			logger),
@@ -207,9 +209,10 @@ func TestConsole(t *testing.T) {
 		sessionID := uuid.New().String()
 		consoleDef := deviceConsole(sessionID, sessionMetadata(t, "xterm", nil,
 			&v1beta1.DeviceCommand{
-				Command: "exit",
+				Command: "/bin/bash",
 				Args: []string{
-					"11",
+					"-c",
+					`exit 11`,
 				}},
 			false))
 
@@ -258,12 +261,10 @@ func TestConsole(t *testing.T) {
 		v := setupVars(t)
 		sessionID := uuid.New().String()
 		consoleDef := deviceConsole(sessionID, sessionMetadata(t, "xterm", nil, &v1beta1.DeviceCommand{
-			Command: "echo",
-			Args: []string{"stdout",
-				";",
-				"echo",
-				"stderr",
-				">&2",
+			Command: "/bin/bash",
+			Args: []string{
+				"-c",
+				`echo stdout; echo stderr >&2`,
 			},
 		}, false))
 

--- a/internal/agent/device/console/manager.go
+++ b/internal/agent/device/console/manager.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	cleanupDuration = 5 * time.Minute
+	ConsoleUser     = "flightctl-console"
 )
 
 type Manager struct {
@@ -27,6 +28,7 @@ type Manager struct {
 	log        *log.PrefixLogger
 	deviceName string
 	watcher    spec.Watcher
+	user       string
 
 	activeSessions   []*session
 	inactiveSessions []*session
@@ -42,6 +44,7 @@ type TerminalSize struct {
 func NewManager(
 	grpcClient grpc_v1.RouterServiceClient,
 	deviceName string,
+	user string,
 	executor executer.Executer,
 	watcher spec.Watcher,
 	log *log.PrefixLogger,
@@ -49,6 +52,7 @@ func NewManager(
 	return &Manager{
 		grpcClient: grpcClient,
 		deviceName: deviceName,
+		user:       user,
 		executor:   executor,
 		watcher:    watcher,
 		log:        log,
@@ -120,6 +124,7 @@ func (c *Manager) start(ctx context.Context, dc v1beta1.DeviceConsole) {
 		id:       dc.SessionID,
 		executor: c.executor,
 		log:      c.log,
+		user:     c.user,
 	}
 	if !c.add(s) {
 		return

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -192,7 +192,7 @@ func TestSync(t *testing.T) {
 			var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
 				return readWriter, nil
 			}
-			consoleManager := console.NewManager(mockRouterService, deviceName, mockExec, mockWatcher, log)
+			consoleManager := console.NewManager(mockRouterService, deviceName, "root", mockExec, mockWatcher, log)
 			appController := applications.NewController(podmanFactory, nil, mockAppManager, rwFactory, log, "2025-01-01T00:00:00Z")
 			statusManager := status.NewManager(deviceName, log)
 			statusManager.SetClient(mockManagementClient)

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -58,6 +58,7 @@ Requires: shadow-utils
 # https://github.com/fedora-iot/greenboot-rs/issues/141
 Requires: greenboot >= 0.15.0
 Requires: greenboot < 0.16.0
+Requires: sudo
 
 %description agent
 The flightctl-agent package provides the management agent for the Flight Control fleet management service.
@@ -315,6 +316,9 @@ echo "Flight Control Observability Stack uninstalled."
 
     install -Dpm 0644 packaging/flightctl-services-install.conf %{buildroot}%{_sysconfdir}/flightctl/flightctl-services-install.conf
 
+    mkdir -p %{buildroot}%{_sysusersdir}
+    install -Dpm 0644 packaging/rpm/sysusers.d/flightctl.conf %{buildroot}%{_sysusersdir}/flightctl.conf
+
     # flightctl-services sub-package steps
     # Use the flightctl-standalone render quadlets command to generate quadlet files with the correct image tags.
     #
@@ -435,6 +439,7 @@ fi
     /usr/libexec/flightctl/configure-greenboot.sh
     /usr/lib/systemd/system/flightctl-configure-greenboot.service
     /usr/share/sosreport/flightctl.py
+    %{_sysusersdir}/flightctl.conf
 
 %post agent
 # Enable the greenboot configuration service (runs before greenboot-healthcheck.service)

--- a/packaging/rpm/sysusers.d/flightctl.conf
+++ b/packaging/rpm/sysusers.d/flightctl.conf
@@ -1,0 +1,6 @@
+u flightctl-console - "Flightctl Agent Console User" /var/lib/flightctl  /bin/bash
+g flightctl-console -
+# Map the user to the group
+m flightctl-console flightctl-console
+# Give the flightctl-console user sudo access
+m flightctl-console wheel

--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -12,13 +12,6 @@ type flightctl_agent_var_log_t;
 type flightctl_agent_tmp_t;
 type flightctl_agent_custom_info_exec_t;
 
-# We generally use fedora when building images because of the packit tool, but unfortunately it
-# contains some newer types not yet available in centos stream. Defining them in one's own policy is
-# the recommended workaround, see https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Backwards_compatibility.
-ifndef(`cgroup_type', `
-  attribute cgroup_type;
-')
-
 gen_require(`
     type install_t, install_exec_t;
     type hostname_t, hostname_exec_t;
@@ -31,6 +24,7 @@ gen_require(`
     type firewalld_t;
     type node_t;
     type unconfined_t, unconfined_service_t;
+    type shell_exec_t;
     type tpm_device_t;
 
     attribute domain;
@@ -51,8 +45,9 @@ files_read_all_chr_files(flightctl_agent_t)
 
 domtrans_pattern(flightctl_agent_t, install_exec_t, install_t)
 domtrans_pattern(flightctl_agent_t, hostname_exec_t, hostname_t)
+# Allow the agent to transition to unconfined for shell sessions (e.g. the console)
+domtrans_pattern(flightctl_agent_t, shell_exec_t, unconfined_t)
 container_runtime_domtrans(flightctl_agent_t)
-
 
 # Allow the agent to run subprocesses as unconfined_t only for that subprocess. This allows us to
 # run things like the 'sos' binary which requires a ton of privileges without having to give them
@@ -71,6 +66,8 @@ allow flightctl_agent_t self:capability { dac_override chown fowner fsetid kill 
 allow flightctl_agent_t self:capability2 { mac_admin mac_override };
 allow flightctl_agent_t self:cap_userns { kill };
 allow flightctl_agent_t self:process { fork signal sigchld execmem setfscreate getsched setsched setpgid setcap setrlimit };
+# Allow the agent to write kernel keys
+allow flightctl_agent_t self:key write;
 
 
 ## System information access  ##

--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -37,13 +37,18 @@ var _ = Describe("CLI - device console", func() {
 		deviceID, _ = harness.EnrollAndWaitForOnlineStatus()
 	})
 
+	AfterEach(func() {
+		harness := e2e.GetWorkerHarness()
+		harness.PrintAgentLogsIfFailed()
+	})
+
 	It("connects to a device and executes a simple command", Label("80483", "sanity", "agent"), func() {
 		// Get harness directly - no shared package-level variable
 		harness := e2e.GetWorkerHarness()
 
 		cs := harness.NewConsoleSession(deviceID)
 		cs.MustSend("pwd")
-		cs.MustExpect("/root")
+		cs.MustExpect("/var/lib/flightctl")
 		cs.Close()
 	})
 
@@ -55,14 +60,14 @@ var _ = Describe("CLI - device console", func() {
 		cs2 := harness.NewConsoleSession(deviceID)
 
 		cs2.MustSend("pwd")
-		cs2.MustExpect("/root")
+		cs2.MustExpect("/var/lib/flightctl")
 
-		cs1.MustSend("echo Session1 > /var/home/user/file.txt")
-		cs2.MustSend("cat /var/home/user/file.txt")
+		cs1.MustSend("echo Session1 > /tmp/file.txt")
+		cs2.MustSend("cat /tmp/file.txt")
 		cs2.MustExpect("Session1")
 
-		cs2.MustSend("echo Session2 >> /var/home/user/file.txt")
-		cs1.MustSend("cat /var/home/user/file.txt")
+		cs2.MustSend("echo Session2 >> /tmp/file.txt")
+		cs1.MustSend("cat /tmp/file.txt")
 		cs1.MustExpect("(?s).*Session1.*Session2.*")
 
 		cs1.Close()
@@ -115,68 +120,6 @@ var _ = Describe("CLI - device console", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(out).To(ContainSubstring("not found"))
 	})
-
-	// Commenting since this feature is deprecated
-	// It("allows tuning spec-fetch-interval", Label("82538"), func() {
-	// 	// Get harness directly - no shared package-level variable
-	// 	harness := e2e.GetWorkerHarness()
-
-	// 	const (
-	// 		cfgFile              = "/etc/flightctl/config.yaml"
-	// 		specFetchKey         = "spec-fetch-interval"
-	// 		specFetchIntervalSec = 20
-	// 		rootPwd              = "user"
-	// 	)
-
-	// 	sendAsRoot := func(cs *e2e.ConsoleSession, cmd string) {
-	// 		cs.MustSend(fmt.Sprintf("echo '%s' | sudo -S %s", rootPwd, cmd))
-	// 	}
-
-	// 	cs := harness.NewConsoleSession(deviceID)
-
-	// 	// show current config & ensure the key is present
-	// 	sendAsRoot(cs, "cat "+cfgFile)
-	// 	cs.MustExpect(specFetchKey)
-
-	// 	// patch config
-	// 	sedExpr := fmt.Sprintf("sed -i -E 's/%s: .+m.+s/%s: 0m%ds/g' %s && cat %s", specFetchKey, specFetchKey,
-	// 		specFetchIntervalSec, cfgFile, cfgFile)
-	// 	sendAsRoot(cs, sedExpr)
-	// 	cs.MustExpect(fmt.Sprintf("%s: 0m%ds", specFetchKey, specFetchIntervalSec))
-	// 	sendAsRoot(cs, fmt.Sprintf("sh -c \"echo 'log-level: debug' >> %s\" && cat %s", cfgFile, cfgFile))
-	// 	cs.MustExpect("log-level: debug")
-
-	// 	sendAsRoot(cs, "systemctl restart flightctl-agent")
-	// 	cs.Close()
-
-	// 	By("waiting for publisher logs with the new interval")
-	// 	// Wait for the target log messages to appear
-	// 	opts := vm.JournalOpts{
-	// 		Unit:     "flightctl-agent",
-	// 		Since:    logLookbackDuration,
-	// 		LastBoot: true,
-	// 	}
-	// 	util.EventuallySlow(harness.VM.JournalLogs).
-	// 		WithArguments(opts).
-	// 		Should(And(
-	// 			ContainSubstring("No new template version from management service"),
-	// 			ContainSubstring("publisher.go"),
-	// 		))
-
-	// 	// Now validate the timing intervals
-	// 	logPattern := regexp.MustCompile(`.*time="([^"]+).*No new template version from management service.*publisher\.go.*"`)
-	// 	expectedInterval := time.Duration(specFetchIntervalSec) * time.Second
-	// 	Eventually(func() bool {
-	// 		logs, err := harness.VM.JournalLogs(vm.JournalOpts{
-	// 			Unit:     "flightctl-agent",
-	// 			Since:    logLookbackDuration,
-	// 			LastBoot: true,
-	// 		})
-	// 		Expect(err).ToNot(HaveOccurred())
-
-	// 		return validateTimestampIntervals(logs, logPattern, expectedInterval)
-	// 	}, 2*time.Minute, 10*time.Second).Should(BeTrue())
-	// })
 
 	It("recovers from image pull network disruption", Label("82541"), func() {
 		// Get harness directly - no shared package-level variable

--- a/test/harness/e2e/harness_console.go
+++ b/test/harness/e2e/harness_console.go
@@ -25,7 +25,7 @@ func (h *Harness) NewConsoleSession(deviceID string) *ConsoleSession {
 
 	// Trigger prompt and wait for it.
 	cs.MustSend("")
-	cs.MustExpect(".*root@.*#")
+	cs.MustExpect(`.*flightctl-console@.*\$`)
 
 	return cs
 }


### PR DESCRIPTION
The user that will be used for console sessions is right now hardcoded
to a 'flightctl-console' user by default. This default user is created
upon RPM installation (if it doesn't exist) and is added to the 'wheel'
supplimental group so that it gets passwordless sudo access.

The SELinux domain for the console shell is transitioned to the normal `unconfined_t` domain which is used by normal shell users so that things are more consistent with a normal shell session (e.g. via ssh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable console user for shell sessions (default "console"); interactive shells run as that user and use its home (/var/lib/flightctl).

* **Chores**
  * Added sudo as a runtime dependency and automated system-user provisioning via sysusers.
  * Updated SELinux policy to allow required shell transitions and permissions for console sessions.

* **Tests**
  * Updated tests for new user, home dir, prompt and file paths; added failure log dumping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->