### PR TITLE
EDM-3267: Improve application rollback and kube client configuration

### DIFF
--- a/internal/agent/client/kube.go
+++ b/internal/agent/client/kube.go
@@ -24,13 +24,21 @@ const (
 type KubernetesOption func(*kubernetesOptions)
 
 type kubernetesOptions struct {
-	binary string
+	binary         string
+	kubeconfigPath string
 }
 
 // WithBinary sets a specific kubectl/oc binary path instead of auto-discovering.
 func WithBinary(binary string) KubernetesOption {
 	return func(opts *kubernetesOptions) {
 		opts.binary = binary
+	}
+}
+
+// WithKubeconfigPath sets the kubeconfig path instead of auto-discovering.
+func WithKubeconfigPath(path string) KubernetesOption {
+	return func(opts *kubernetesOptions) {
+		opts.kubeconfigPath = path
 	}
 }
 
@@ -59,14 +67,20 @@ func WithKubeLabels(labels []string) KubeOption {
 
 // Kube provides a client for executing kubectl/oc CLI commands.
 type Kube struct {
-	exec       executer.Executer
-	log        *log.PrefixLogger
-	binary     string
-	readWriter fileio.ReadWriter
+	exec             executer.Executer
+	log              *log.PrefixLogger
+	readWriter       fileio.ReadWriter
+	commandAvailable func(string) bool
+
+	binary             string
+	kubeconfigPath     string
+	kubeconfigResolved bool
 }
 
-// NewKube creates a new Kube client. It auto-discovers kubectl or oc if no binary is specified.
-// Use IsAvailable to check if a kubernetes CLI binary was found.
+// NewKube creates a new Kube client with lazy initialization.
+// The kubernetes binary and kubeconfig are discovered on first use.
+// Use WithBinary option to set a specific binary path instead of auto-discovering.
+// Use WithKubeconfigPath option to set a specific kubeconfig path.
 func NewKube(
 	log *log.PrefixLogger,
 	exec executer.Executer,
@@ -78,151 +92,72 @@ func NewKube(
 		opt(options)
 	}
 
-	binary := options.binary
-	if binary == "" {
-		binary = discoverKubernetesBinary()
+	k := &Kube{
+		exec:               exec,
+		log:                log,
+		readWriter:         readWriter,
+		commandAvailable:   IsCommandAvailable,
+		binary:             options.binary,
+		kubeconfigPath:     options.kubeconfigPath,
+		kubeconfigResolved: options.kubeconfigPath != "",
 	}
-
-	return &Kube{
-		exec:       exec,
-		log:        log,
-		binary:     binary,
-		readWriter: readWriter,
-	}
+	return k
 }
 
-func discoverKubernetesBinary() string {
-	if IsCommandAvailable(kubectlCmd) {
+func (k *Kube) discoverBinary() string {
+	if k.commandAvailable(kubectlCmd) {
 		return kubectlCmd
 	}
-	if IsCommandAvailable(ocCmd) {
+	if k.commandAvailable(ocCmd) {
 		return ocCmd
 	}
 	return ""
 }
 
 // Binary returns the kubectl/oc binary path being used.
+// This triggers resolution if not already done.
+// Returns empty string if no kubernetes CLI binary is available.
 func (k *Kube) Binary() string {
+	_ = k.resolve()
 	return k.binary
 }
 
-// IsAvailable returns true if a kubernetes CLI binary (kubectl or oc) is available.
+// IsAvailable returns true if kubernetes is fully configured.
+// This attempts to resolve binary and kubeconfig if not already done.
 func (k *Kube) IsAvailable() bool {
-	return k.binary != ""
+	return k.resolve() == nil
 }
 
-// RefreshBinary re-runs binary discovery to find kubectl or oc.
-// This is a no-op if a binary is already set.
-// Returns true if a binary is available.
-func (k *Kube) RefreshBinary() bool {
-	if k.binary != "" {
-		return true
+// resolve attempts to discover binary and kubeconfig, caching the results.
+func (k *Kube) resolve() error {
+	if k.binary != "" && k.kubeconfigResolved {
+		return nil
 	}
-	k.binary = discoverKubernetesBinary()
-	return k.binary != ""
-}
 
-// WatchPodsCmd returns an exec.Cmd configured to watch pod events across all namespaces.
-// Use WithKubeLabels to filter pods by label selector.
-func (k *Kube) WatchPodsCmd(ctx context.Context, opts ...KubeOption) (*exec.Cmd, error) {
 	if k.binary == "" {
-		return nil, fmt.Errorf("kubernetes CLI binary not available")
+		k.binary = k.discoverBinary()
 	}
-
-	options := &kubeOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	args := []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"}
-
-	if len(options.labels) > 0 {
-		args = append(args, "-l", strings.Join(options.labels, ","))
-	}
-
-	if options.kubeconfigPath != "" {
-		args = append(args, "--kubeconfig", options.kubeconfigPath)
-	}
-
-	// #nosec G204 - binary is either hardcoded ("kubectl"/"oc") or explicitly configured, args are internally constructed
-	return exec.CommandContext(ctx, k.binary, args...), nil
-}
-
-// EnsureNamespace creates a namespace if it doesn't exist and applies any specified labels.
-func (k *Kube) EnsureNamespace(ctx context.Context, namespace string, opts ...KubeOption) error {
 	if k.binary == "" {
 		return fmt.Errorf("kubernetes CLI binary not available")
 	}
 
-	options := &kubeOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	exists, err := k.NamespaceExists(ctx, namespace, opts...)
-	if err != nil {
-		return fmt.Errorf("check namespace exists: %w", err)
-	}
-
-	if exists {
+	if k.kubeconfigResolved {
 		return nil
 	}
 
-	createArgs := []string{"create", "namespace", namespace}
-	if options.kubeconfigPath != "" {
-		createArgs = append(createArgs, "--kubeconfig", options.kubeconfigPath)
-	}
-	_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, k.binary, createArgs...)
-	if exitCode != 0 {
-		return fmt.Errorf("create namespace: %s", stderr)
+	path, err := k.resolveKubeconfig()
+	if err != nil {
+		return err
 	}
 
-	if len(options.labels) > 0 {
-		labelArgs := []string{"label", "namespace", namespace}
-		labelArgs = append(labelArgs, options.labels...)
-		labelArgs = append(labelArgs, "--overwrite")
-		if options.kubeconfigPath != "" {
-			labelArgs = append(labelArgs, "--kubeconfig", options.kubeconfigPath)
-		}
-		_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, k.binary, labelArgs...)
-		if exitCode != 0 {
-			return fmt.Errorf("label namespace: %s", stderr)
-		}
-	}
-
+	k.kubeconfigPath = path
+	k.kubeconfigResolved = true
+	k.log.Debugf("Kubernetes resolved: binary=%s kubeconfig=%s", k.binary, k.kubeconfigPath)
 	return nil
 }
 
-// NamespaceExists checks if a namespace exists in the cluster.
-func (k *Kube) NamespaceExists(ctx context.Context, namespace string, opts ...KubeOption) (bool, error) {
-	if k.binary == "" {
-		return false, fmt.Errorf("kubernetes CLI binary not available")
-	}
-
-	options := &kubeOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	args := []string{"get", "namespace", namespace}
-	if options.kubeconfigPath != "" {
-		args = append(args, "--kubeconfig", options.kubeconfigPath)
-	}
-
-	_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, k.binary, args...)
-	if exitCode == 0 {
-		return true, nil
-	}
-	if strings.Contains(stderr, "not found") {
-		return false, nil
-	}
-	return false, fmt.Errorf("get namespace: %s", stderr)
-}
-
-// ResolveKubeconfig finds a valid kubeconfig path by checking KUBECONFIG env,
-// microshift path, and the default ~/.kube/config location.
-// KUBECONFIG may contain multiple paths. The first existing path is returned.
-func (k *Kube) ResolveKubeconfig() (string, error) {
+// resolveKubeconfig finds a valid kubeconfig path.
+func (k *Kube) resolveKubeconfig() (string, error) {
 	var checkedPaths []string
 
 	if kubeconfigEnv := os.Getenv("KUBECONFIG"); kubeconfigEnv != "" {
@@ -237,7 +172,7 @@ func (k *Kube) ResolveKubeconfig() (string, error) {
 				return "", fmt.Errorf("check KUBECONFIG path: %w (checked: %s)", err, strings.Join(checkedPaths, ", "))
 			}
 			if exists {
-				return path, nil
+				return "", nil
 			}
 		}
 	}
@@ -268,7 +203,123 @@ func (k *Kube) ResolveKubeconfig() (string, error) {
 	return "", fmt.Errorf("no kubeconfig found, checked: %s", strings.Join(checkedPaths, ", "))
 }
 
+// WatchPodsCmd returns an exec.Cmd configured to watch pod events across all namespaces.
+// Use WithKubeLabels to filter pods by label selector.
+func (k *Kube) WatchPodsCmd(ctx context.Context, opts ...KubeOption) (*exec.Cmd, error) {
+	binary := k.Binary()
+
+	if binary == "" {
+		return nil, fmt.Errorf("kubernetes CLI binary not available")
+	}
+
+	options := &kubeOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	args := []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"}
+
+	if len(options.labels) > 0 {
+		args = append(args, "-l", strings.Join(options.labels, ","))
+	}
+
+	if options.kubeconfigPath != "" {
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	// #nosec G204 - binary is either hardcoded ("kubectl"/"oc") or explicitly configured, args are internally constructed
+	return exec.CommandContext(ctx, binary, args...), nil
+}
+
+// EnsureNamespace creates a namespace if it doesn't exist and applies any specified labels.
+func (k *Kube) EnsureNamespace(ctx context.Context, namespace string, opts ...KubeOption) error {
+	binary := k.Binary()
+
+	if binary == "" {
+		return fmt.Errorf("kubernetes CLI binary not available")
+	}
+
+	options := &kubeOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	exists, err := k.NamespaceExists(ctx, namespace, opts...)
+	if err != nil {
+		return fmt.Errorf("check namespace exists: %w", err)
+	}
+
+	if exists {
+		return nil
+	}
+
+	createArgs := []string{"create", "namespace", namespace}
+	if options.kubeconfigPath != "" {
+		createArgs = append(createArgs, "--kubeconfig", options.kubeconfigPath)
+	}
+	_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, binary, createArgs...)
+	if exitCode != 0 {
+		return fmt.Errorf("create namespace: %s", stderr)
+	}
+
+	if len(options.labels) > 0 {
+		labelArgs := []string{"label", "namespace", namespace}
+		labelArgs = append(labelArgs, options.labels...)
+		labelArgs = append(labelArgs, "--overwrite")
+		if options.kubeconfigPath != "" {
+			labelArgs = append(labelArgs, "--kubeconfig", options.kubeconfigPath)
+		}
+		_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, binary, labelArgs...)
+		if exitCode != 0 {
+			return fmt.Errorf("label namespace: %s", stderr)
+		}
+	}
+
+	return nil
+}
+
+// NamespaceExists checks if a namespace exists in the cluster.
+func (k *Kube) NamespaceExists(ctx context.Context, namespace string, opts ...KubeOption) (bool, error) {
+	binary := k.Binary()
+	if binary == "" {
+		return false, fmt.Errorf("kubernetes CLI binary not available")
+	}
+
+	options := &kubeOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	args := []string{"get", "namespace", namespace}
+	if options.kubeconfigPath != "" {
+		args = append(args, "--kubeconfig", options.kubeconfigPath)
+	}
+
+	_, stderr, exitCode := k.exec.ExecuteWithContext(ctx, binary, args...)
+	if exitCode == 0 {
+		return true, nil
+	}
+	if strings.Contains(stderr, "not found") {
+		return false, nil
+	}
+	return false, fmt.Errorf("get namespace: %s", stderr)
+}
+
+// ResolveKubeconfig resolves and returns the kubeconfig path.
+// This also ensures the binary is resolved.
+// The result is cached after the first successful resolution.
+func (k *Kube) ResolveKubeconfig() (string, error) {
+	if err := k.resolve(); err != nil {
+		return "", err
+	}
+	return k.kubeconfigPath, nil
+}
+
 // Kustomize runs kubectl kustomize on the specified directory and returns the output.
 func (k *Kube) Kustomize(ctx context.Context, dir string) (stdout, stderr string, exitCode int) {
-	return k.exec.ExecuteWithContext(ctx, k.binary, "kustomize", dir)
+	binary := k.Binary()
+	if binary == "" {
+		return "", "kubernetes CLI binary not available", 1
+	}
+	return k.exec.ExecuteWithContext(ctx, binary, "kustomize", dir)
 }

--- a/internal/agent/client/kube_test.go
+++ b/internal/agent/client/kube_test.go
@@ -12,81 +12,17 @@ import (
 )
 
 func TestNewKube_WithExplicitBinary(t *testing.T) {
-	require := require.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	logger := log.NewPrefixLogger("test")
-	mockExec := executer.NewMockExecuter(ctrl)
-	mockReadWriter := fileio.NewMockReadWriter(ctrl)
-
-	k8s := NewKube(logger, mockExec, mockReadWriter, WithBinary("kubectl"))
-	require.NotNil(k8s)
-	require.Equal("kubectl", k8s.Binary())
-	require.True(k8s.IsAvailable())
-
-	k8s = NewKube(logger, mockExec, mockReadWriter, WithBinary("oc"))
-	require.NotNil(k8s)
-	require.Equal("oc", k8s.Binary())
-	require.True(k8s.IsAvailable())
-}
-
-func TestKube_IsAvailable(t *testing.T) {
 	testCases := []struct {
-		name     string
-		binary   string
-		expected bool
+		name   string
+		binary string
 	}{
 		{
-			name:     "available when binary is set",
-			binary:   "kubectl",
-			expected: true,
+			name:   "kubectl binary",
+			binary: "kubectl",
 		},
 		{
-			name:     "not available when binary is empty",
-			binary:   "",
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			k8s := &Kube{binary: tc.binary}
-			require.Equal(t, tc.expected, k8s.IsAvailable())
-		})
-	}
-}
-
-func TestKube_WatchPodsCmd(t *testing.T) {
-	testCases := []struct {
-		name           string
-		binary         string
-		kubeconfigPath string
-		expectedArgs   []string
-	}{
-		{
-			name:           "kubectl without kubeconfig",
-			binary:         "kubectl",
-			kubeconfigPath: "",
-			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
-		},
-		{
-			name:           "kubectl with kubeconfig",
-			binary:         "kubectl",
-			kubeconfigPath: "/tmp/kubeconfig",
-			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/tmp/kubeconfig"},
-		},
-		{
-			name:           "oc without kubeconfig",
-			binary:         "oc",
-			kubeconfigPath: "",
-			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
-		},
-		{
-			name:           "oc with kubeconfig",
-			binary:         "oc",
-			kubeconfigPath: "/var/lib/microshift/resources/kubeadmin/kubeconfig",
-			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/var/lib/microshift/resources/kubeadmin/kubeconfig"},
+			name:   "oc binary",
+			binary: "oc",
 		},
 	}
 
@@ -100,13 +36,164 @@ func TestKube_WatchPodsCmd(t *testing.T) {
 			mockExec := executer.NewMockExecuter(ctrl)
 			mockReadWriter := fileio.NewMockReadWriter(ctrl)
 
-			k8s := NewKube(logger, mockExec, mockReadWriter, WithBinary(tc.binary))
+			k8s := NewKube(logger, mockExec, mockReadWriter,
+				WithBinary(tc.binary),
+				WithKubeconfigPath("/tmp/kubeconfig"),
+			)
+			require.NotNil(k8s)
+			require.Equal(tc.binary, k8s.Binary())
+			require.True(k8s.IsAvailable())
+		})
+	}
+}
 
-			var opts []KubeOption
-			if tc.kubeconfigPath != "" {
-				opts = append(opts, WithKubeKubeconfig(tc.kubeconfigPath))
+func TestKube_IsAvailable(t *testing.T) {
+	testCases := []struct {
+		name      string
+		binary    string
+		setupMock func(*fileio.MockReadWriter)
+		envSetup  func()
+		want      bool
+	}{
+		{
+			name:      "available when binary and kubeconfig are set",
+			binary:    "kubectl",
+			setupMock: func(mockRW *fileio.MockReadWriter) {},
+			envSetup:  func() {},
+			want:      true,
+		},
+		{
+			name:   "not available when kubeconfig resolution fails",
+			binary: "kubectl",
+			setupMock: func(mockRW *fileio.MockReadWriter) {
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(false, nil)
+				mockRW.EXPECT().PathExists("/nonexistent/.kube/config").Return(false, nil)
+			},
+			envSetup: func() {
+				t.Setenv("KUBECONFIG", "")
+				t.Setenv("HOME", "/nonexistent")
+			},
+			want: false,
+		},
+		{
+			name:      "not available when binary not found",
+			binary:    "",
+			setupMock: func(mockRW *fileio.MockReadWriter) {},
+			envSetup:  func() {},
+			want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			tc.setupMock(mockReadWriter)
+			tc.envSetup()
+
+			opts := []KubernetesOption{}
+			if tc.binary != "" {
+				opts = append(opts, WithBinary(tc.binary))
 			}
-			cmd, err := k8s.WatchPodsCmd(context.Background(), opts...)
+			if tc.want {
+				opts = append(opts, WithKubeconfigPath("/tmp/kubeconfig"))
+			}
+
+			k8s := NewKube(logger, mockExec, mockReadWriter, opts...)
+			if tc.binary == "" {
+				k8s.commandAvailable = func(string) bool { return false }
+			}
+
+			require.Equal(tc.want, k8s.IsAvailable())
+		})
+	}
+}
+
+func TestKube_WatchPodsCmd(t *testing.T) {
+	testCases := []struct {
+		name             string
+		binary           string
+		kubeconfigPath   string
+		commandAvailable func(string) bool
+		expectedArgs     []string
+		wantErr          bool
+		errContains      string
+	}{
+		{
+			name:           "kubectl without kubeconfig option",
+			binary:         "kubectl",
+			kubeconfigPath: "",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
+		},
+		{
+			name:           "kubectl with kubeconfig option",
+			binary:         "kubectl",
+			kubeconfigPath: "/tmp/kubeconfig",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/tmp/kubeconfig"},
+		},
+		{
+			name:           "oc without kubeconfig option",
+			binary:         "oc",
+			kubeconfigPath: "",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json"},
+		},
+		{
+			name:           "oc with kubeconfig option",
+			binary:         "oc",
+			kubeconfigPath: "/var/lib/microshift/resources/kubeadmin/kubeconfig",
+			expectedArgs:   []string{"get", "pods", "--watch", "--output-watch-events", "--all-namespaces", "-o", "json", "--kubeconfig", "/var/lib/microshift/resources/kubeadmin/kubeconfig"},
+		},
+		{
+			name:             "no binary available",
+			binary:           "",
+			commandAvailable: func(string) bool { return false },
+			wantErr:          true,
+			errContains:      "kubernetes CLI binary not available",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			logger := log.NewPrefixLogger("test")
+			mockExec := executer.NewMockExecuter(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			opts := []KubernetesOption{WithKubeconfigPath("/default/kubeconfig")}
+			if tc.binary != "" {
+				opts = append(opts, WithBinary(tc.binary))
+			}
+
+			k8s := NewKube(logger, mockExec, mockReadWriter, opts...)
+			if tc.commandAvailable != nil {
+				k8s.commandAvailable = tc.commandAvailable
+			}
+
+			var kubeOpts []KubeOption
+			if tc.kubeconfigPath != "" {
+				kubeOpts = append(kubeOpts, WithKubeKubeconfig(tc.kubeconfigPath))
+			}
+
+			cmd, err := k8s.WatchPodsCmd(context.Background(), kubeOpts...)
+
+			if tc.wantErr {
+				require.Error(err)
+				require.Nil(cmd)
+				if tc.errContains != "" {
+					require.Contains(err.Error(), tc.errContains)
+				}
+				return
+			}
+
 			require.NoError(err)
 			require.NotNil(cmd)
 			require.Equal(append([]string{tc.binary}, tc.expectedArgs...), cmd.Args)
@@ -114,26 +201,13 @@ func TestKube_WatchPodsCmd(t *testing.T) {
 	}
 }
 
-func TestKube_WatchPodsCmd_NoBinary(t *testing.T) {
-	require := require.New(t)
-
-	k8s := &Kube{
-		binary: "",
-	}
-
-	cmd, err := k8s.WatchPodsCmd(context.Background())
-	require.Error(err)
-	require.Nil(cmd)
-	require.Contains(err.Error(), "kubernetes CLI binary not available")
-}
-
 func TestKube_ResolveKubeconfig(t *testing.T) {
 	testCases := []struct {
 		name        string
 		setupMock   func(*fileio.MockReadWriter)
 		envSetup    func()
-		envCleanup  func()
 		wantPath    string
+		wantEmpty   bool
 		wantErr     bool
 		errContains string
 	}{
@@ -145,59 +219,51 @@ func TestKube_ResolveKubeconfig(t *testing.T) {
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "/custom/kubeconfig")
 			},
-			envCleanup: func() {},
-			wantPath:   "/custom/kubeconfig",
-			wantErr:    false,
+			wantEmpty: true,
 		},
 		{
 			name: "KUBECONFIG env var exists but file does not exist, fallback to microshift",
 			setupMock: func(mockRW *fileio.MockReadWriter) {
 				mockRW.EXPECT().PathExists("/custom/kubeconfig").Return(false, nil)
-				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(true, nil)
 			},
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "/custom/kubeconfig")
 			},
-			envCleanup: func() {},
-			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
-			wantErr:    false,
+			wantPath: microshiftKubeconfigPath,
 		},
 		{
 			name: "no KUBECONFIG env, microshift path exists",
 			setupMock: func(mockRW *fileio.MockReadWriter) {
-				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(true, nil)
 			},
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "")
 			},
-			envCleanup: func() {},
-			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
-			wantErr:    false,
+			wantPath: microshiftKubeconfigPath,
 		},
 		{
 			name: "no KUBECONFIG env, no microshift, default path exists",
 			setupMock: func(mockRW *fileio.MockReadWriter) {
-				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(false, nil)
 				mockRW.EXPECT().PathExists(gomock.Any()).Return(true, nil)
 			},
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "")
+				t.Setenv("HOME", "/home/testuser")
 			},
-			envCleanup: func() {},
-			wantPath:   "", // will match any path since HOME varies
-			wantErr:    false,
+			wantPath: "/home/testuser/.kube/config",
 		},
 		{
 			name: "no kubeconfig found anywhere",
 			setupMock: func(mockRW *fileio.MockReadWriter) {
-				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(false, nil)
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(false, nil)
 				mockRW.EXPECT().PathExists(gomock.Any()).Return(false, nil)
 			},
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "")
+				t.Setenv("HOME", "/nonexistent")
 			},
-			envCleanup:  func() {},
-			wantPath:    "",
 			wantErr:     true,
 			errContains: "no kubeconfig found",
 		},
@@ -209,9 +275,7 @@ func TestKube_ResolveKubeconfig(t *testing.T) {
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig:/third/kubeconfig")
 			},
-			envCleanup: func() {},
-			wantPath:   "/first/kubeconfig",
-			wantErr:    false,
+			wantEmpty: true,
 		},
 		{
 			name: "KUBECONFIG with multiple paths - second exists",
@@ -222,23 +286,19 @@ func TestKube_ResolveKubeconfig(t *testing.T) {
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig:/third/kubeconfig")
 			},
-			envCleanup: func() {},
-			wantPath:   "/second/kubeconfig",
-			wantErr:    false,
+			wantEmpty: true,
 		},
 		{
 			name: "KUBECONFIG with multiple paths - none exist, fallback to microshift",
 			setupMock: func(mockRW *fileio.MockReadWriter) {
 				mockRW.EXPECT().PathExists("/first/kubeconfig").Return(false, nil)
 				mockRW.EXPECT().PathExists("/second/kubeconfig").Return(false, nil)
-				mockRW.EXPECT().PathExists("/var/lib/microshift/resources/kubeadmin/kubeconfig").Return(true, nil)
+				mockRW.EXPECT().PathExists(microshiftKubeconfigPath).Return(true, nil)
 			},
 			envSetup: func() {
 				t.Setenv("KUBECONFIG", "/first/kubeconfig:/second/kubeconfig")
 			},
-			envCleanup: func() {},
-			wantPath:   "/var/lib/microshift/resources/kubeadmin/kubeconfig",
-			wantErr:    false,
+			wantPath: microshiftKubeconfigPath,
 		},
 	}
 
@@ -254,7 +314,6 @@ func TestKube_ResolveKubeconfig(t *testing.T) {
 
 			tc.setupMock(mockRW)
 			tc.envSetup()
-			defer tc.envCleanup()
 
 			k8s := NewKube(logger, mockExec, mockRW, WithBinary("kubectl"))
 
@@ -269,10 +328,10 @@ func TestKube_ResolveKubeconfig(t *testing.T) {
 			}
 
 			require.NoError(err)
-			if tc.wantPath != "" {
-				require.Equal(tc.wantPath, path)
+			if tc.wantEmpty {
+				require.Empty(path)
 			} else {
-				require.NotEmpty(path)
+				require.Equal(tc.wantPath, path)
 			}
 		})
 	}

--- a/internal/agent/device/applications/helm/labeler_test.go
+++ b/internal/agent/device/applications/helm/labeler_test.go
@@ -160,7 +160,7 @@ metadata:
 
 			tc.setupMocks(mockExec, mockReadWriter, tc.input)
 
-			kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+			kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp"))
 			labeler := NewLabeler(kubeClient, mockReadWriter)
 
 			var output bytes.Buffer
@@ -188,7 +188,7 @@ func TestLabelerInjectLabels_MkdirTempFails(t *testing.T) {
 
 	mockReadWriter.EXPECT().MkdirTemp("kustomize-labels-*").Return("", fmt.Errorf("disk full"))
 
-	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp"))
 	labeler := NewLabeler(kubeClient, mockReadWriter)
 
 	var output bytes.Buffer
@@ -216,7 +216,7 @@ func TestLabelerInjectLabels_KustomizeFails(t *testing.T) {
 		Return("", "error: invalid kustomization", 1)
 	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
 
-	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp"))
 	labeler := NewLabeler(kubeClient, mockReadWriter)
 
 	var output bytes.Buffer
@@ -243,7 +243,7 @@ func TestLabelerInjectLabels_EmptyInput(t *testing.T) {
 		Return("", "", 0)
 	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
 
-	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp"))
 	labeler := NewLabeler(kubeClient, mockReadWriter)
 
 	var output bytes.Buffer
@@ -304,7 +304,7 @@ metadata:
 		Return(kustomizeOutput, "", 0)
 	mockReadWriter.EXPECT().RemoveAll(tempDir).Return(nil)
 
-	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"))
+	kubeClient := client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp"))
 	labeler := NewLabeler(kubeClient, mockReadWriter)
 
 	labels := map[string]string{AppLabelKey: "multi-doc-test"}

--- a/internal/agent/device/applications/lifecycle/helm_test.go
+++ b/internal/agent/device/applications/lifecycle/helm_test.go
@@ -41,7 +41,7 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name: "success without kubeconfig",
+			name: "success with namespace creation",
 			action: &Action{
 				ID:   "my-namespace",
 				Name: "my-release",
@@ -49,26 +49,28 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 				Type: ActionAdd,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"get", "namespace", "my-namespace",
+						"get", "namespace", "my-namespace", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "not found", 1),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"create", "namespace", "my-namespace",
+						"create", "namespace", "my-namespace", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
 						"label", "namespace", "my-namespace",
-						"flightctl.io/managed-by=flightctl", "--overwrite",
+						"flightctl.io/managed-by=flightctl", "--overwrite", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
 						"--install",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -129,19 +131,21 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 				Type: ActionAdd,
 				Spec: HelmSpec{Namespace: "existing-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"get", "namespace", "existing-namespace",
+						"get", "namespace", "existing-namespace", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("existing-namespace   Active   5d", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
 						"--install",
 						"--namespace", "existing-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -161,26 +165,28 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 				Type: ActionAdd,
 				Spec: HelmSpec{},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"get", "namespace", "flightctl-my-release",
+						"get", "namespace", "flightctl-my-release", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "not found", 1),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"create", "namespace", "flightctl-my-release",
+						"create", "namespace", "flightctl-my-release", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
 						"label", "namespace", "flightctl-my-release",
-						"flightctl.io/managed-by=flightctl", "--overwrite",
+						"flightctl.io/managed-by=flightctl", "--overwrite", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
 						"--install",
 						"--namespace", "flightctl-my-release",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -200,26 +206,28 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 				Type: ActionAdd,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"get", "namespace", "my-namespace",
+						"get", "namespace", "my-namespace", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "not found", 1),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-						"create", "namespace", "my-namespace",
+						"create", "namespace", "my-namespace", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
 						"label", "namespace", "my-namespace",
-						"flightctl.io/managed-by=flightctl", "--overwrite",
+						"flightctl.io/managed-by=flightctl", "--overwrite", "--kubeconfig", "/tmp/kubeconfig",
 					}).Return("", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-1.0.0",
 						"--install",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -239,7 +247,7 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 				Type: ActionAdd,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				mockRW.EXPECT().MkdirTemp("helm-plugins").Return("/tmp/helm-plugins-123", nil)
 				mockRW.EXPECT().MkdirAll("/tmp/helm-plugins-123/flightctl-postrenderer", fileio.DefaultDirectoryPermissions).Return(nil)
@@ -249,8 +257,9 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 					"version", "--short",
 				}).Return("v4.0.0", "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-					"get", "namespace", "my-namespace",
+					"get", "namespace", "my-namespace", "--kubeconfig", "/tmp/kubeconfig",
 				}).Return("my-namespace   Active   5d", "", 0)
+				mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil)
 				mockExec.EXPECT().ExecuteWithContextFromDir(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).DoAndReturn(func(ctx context.Context, dir, cmd string, args []string, env ...string) (string, string, int) {
@@ -260,6 +269,8 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 					require.NotContains(t, args, "--atomic")
 					require.Contains(t, args, "--post-renderer")
 					require.Contains(t, args, "flightctl-postrenderer")
+					require.Contains(t, args, "--kubeconfig")
+					require.Contains(t, args, "/tmp/kubeconfig")
 					return "", "", 0
 				})
 			},
@@ -279,15 +290,19 @@ func TestHelmHandler_Execute_Add(t *testing.T) {
 
 			tc.setupMock(mockExec, mockReadWriter)
 
+			kubeOpts := []client.KubernetesOption{client.WithBinary("kubectl")}
+			if tc.kubeconfigPath != "" {
+				kubeOpts = append(kubeOpts, client.WithKubeconfigPath(tc.kubeconfigPath))
+			}
 			clients := &testCLIClients{
 				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
-				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, kubeOpts...),
 			}
 			resolver := testExecutableResolver{path: "/test/flightctl"}
 			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
 				return mockReadWriter, nil
 			}
-			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			handler := NewHelmHandler(logger, clients, resolver, rwFactory)
 			err := handler.Execute(context.Background(), []Action{*tc.action})
 
 			if tc.wantErr {
@@ -308,22 +323,24 @@ func TestHelmHandler_Execute_Remove(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name: "success without kubeconfig",
+			name: "success with kubeconfig removes release",
 			action: &Action{
 				ID:   "my-namespace",
 				Name: "my-release",
 				Type: ActionRemove,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"uninstall", "my-release",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--ignore-not-found",
 					}).Return("", "", 0),
 				)
@@ -363,15 +380,17 @@ func TestHelmHandler_Execute_Remove(t *testing.T) {
 				Type: ActionRemove,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"uninstall", "my-release",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--ignore-not-found",
 					}).Return("", "Error: release not found", 1),
 				)
@@ -392,15 +411,19 @@ func TestHelmHandler_Execute_Remove(t *testing.T) {
 
 			tc.setupMock(mockExec, mockReadWriter)
 
+			kubeOpts := []client.KubernetesOption{client.WithBinary("kubectl")}
+			if tc.kubeconfigPath != "" {
+				kubeOpts = append(kubeOpts, client.WithKubeconfigPath(tc.kubeconfigPath))
+			}
 			clients := &testCLIClients{
 				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
-				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, kubeOpts...),
 			}
 			resolver := testExecutableResolver{path: "/test/flightctl"}
 			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
 				return mockReadWriter, nil
 			}
-			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			handler := NewHelmHandler(logger, clients, resolver, rwFactory)
 			err := handler.Execute(context.Background(), []Action{*tc.action})
 
 			if tc.wantErr {
@@ -421,7 +444,7 @@ func TestHelmHandler_Execute_Update(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name: "success without kubeconfig",
+			name: "success with kubeconfig upgrades release",
 			action: &Action{
 				ID:   "my-namespace",
 				Name: "my-release",
@@ -429,16 +452,18 @@ func TestHelmHandler_Execute_Update(t *testing.T) {
 				Type: ActionUpdate,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-2.0.0",
 						"--install",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -489,16 +514,18 @@ func TestHelmHandler_Execute_Update(t *testing.T) {
 				Type: ActionUpdate,
 				Spec: HelmSpec{Namespace: "my-namespace"},
 			},
-			kubeconfigPath: "",
+			kubeconfigPath: "/tmp/kubeconfig",
 			setupMock: func(mockExec *executer.MockExecuter, mockRW *fileio.MockReadWriter) {
 				gomock.InOrder(
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"version", "--short",
 					}).Return("v3.14.0", "", 0),
+					mockRW.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 					mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 						"upgrade", "my-release", "/var/lib/flightctl/helm/charts/mychart-2.0.0",
 						"--install",
 						"--namespace", "my-namespace",
+						"--kubeconfig", "/tmp/kubeconfig",
 						"--atomic",
 						"--post-renderer", "/test/flightctl",
 						"--post-renderer-args", "helm-render",
@@ -523,15 +550,19 @@ func TestHelmHandler_Execute_Update(t *testing.T) {
 
 			tc.setupMock(mockExec, mockReadWriter)
 
+			kubeOpts := []client.KubernetesOption{client.WithBinary("kubectl")}
+			if tc.kubeconfigPath != "" {
+				kubeOpts = append(kubeOpts, client.WithKubeconfigPath(tc.kubeconfigPath))
+			}
 			clients := &testCLIClients{
 				helm: client.NewHelm(logger, mockExec, mockReadWriter, "/var/lib/flightctl"),
-				kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+				kube: client.NewKube(logger, mockExec, mockReadWriter, kubeOpts...),
 			}
 			resolver := testExecutableResolver{path: "/test/flightctl"}
 			rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
 				return mockReadWriter, nil
 			}
-			handler := NewHelmHandler(logger, clients, tc.kubeconfigPath, resolver, rwFactory)
+			handler := NewHelmHandler(logger, clients, resolver, rwFactory)
 			err := handler.Execute(context.Background(), []Action{*tc.action})
 
 			if tc.wantErr {
@@ -557,29 +588,33 @@ func TestHelmHandler_Execute_MultipleActions(t *testing.T) {
 			"version", "--short",
 		}).Return("v3.14.0", "", 0),
 		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-			"get", "namespace", "ns1",
+			"get", "namespace", "ns1", "--kubeconfig", "/tmp/kubeconfig",
 		}).Return("", "not found", 1),
 		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
-			"create", "namespace", "ns1",
+			"create", "namespace", "ns1", "--kubeconfig", "/tmp/kubeconfig",
 		}).Return("", "", 0),
 		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
 			"label", "namespace", "ns1",
-			"flightctl.io/managed-by=flightctl", "--overwrite",
+			"flightctl.io/managed-by=flightctl", "--overwrite", "--kubeconfig", "/tmp/kubeconfig",
 		}).Return("", "", 0),
+		mockReadWriter.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 			"upgrade", "app1", "/charts/app1",
 			"--install",
 			"--namespace", "ns1",
+			"--kubeconfig", "/tmp/kubeconfig",
 			"--atomic",
 			"--post-renderer", "/test/flightctl",
 			"--post-renderer-args", "helm-render",
 			"--post-renderer-args", "--app",
 			"--post-renderer-args", "ns1",
 		}).Return("", "", 0),
+		mockReadWriter.EXPECT().PathExists("/tmp/kubeconfig").Return(true, nil),
 		mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{
 			"upgrade", "app2", "/charts/app2",
 			"--install",
 			"--namespace", "ns2",
+			"--kubeconfig", "/tmp/kubeconfig",
 			"--atomic",
 			"--post-renderer", "/test/flightctl",
 			"--post-renderer-args", "helm-render",
@@ -590,13 +625,13 @@ func TestHelmHandler_Execute_MultipleActions(t *testing.T) {
 
 	clients := &testCLIClients{
 		helm: client.NewHelm(logger, mockExec, mockReadWriter, client.HelmChartsDir),
-		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp/kubeconfig")),
 	}
 	resolver := testExecutableResolver{path: "/test/flightctl"}
 	rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
 		return mockReadWriter, nil
 	}
-	handler := NewHelmHandler(logger, clients, "", resolver, rwFactory)
+	handler := NewHelmHandler(logger, clients, resolver, rwFactory)
 
 	actions := []Action{
 		{
@@ -634,13 +669,13 @@ func TestHelmHandler_Execute_UnsupportedActionType(t *testing.T) {
 
 	clients := &testCLIClients{
 		helm: client.NewHelm(logger, mockExec, mockReadWriter, client.HelmChartsDir),
-		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl")),
+		kube: client.NewKube(logger, mockExec, mockReadWriter, client.WithBinary("kubectl"), client.WithKubeconfigPath("/tmp/kubeconfig")),
 	}
 	resolver := testExecutableResolver{path: "/test/flightctl"}
 	rwFactory := func(_ v1beta1.Username) (fileio.ReadWriter, error) {
 		return mockReadWriter, nil
 	}
-	handler := NewHelmHandler(logger, clients, "", resolver, rwFactory)
+	handler := NewHelmHandler(logger, clients, resolver, rwFactory)
 
 	action := Action{
 		ID:   "ns1",

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -101,7 +101,8 @@ func (m *manager) Remove(ctx context.Context, provider provider.Provider) error 
 		return m.podmanMonitor.QueueRemove(NewApplication(provider))
 	case v1beta1.AppTypeHelm:
 		if !m.kubernetesMonitor.IsEnabled() {
-			return errors.ErrKubernetesAppsDisabled
+			m.log.Debugf("Skipping removal of Helm app %s: Kubernetes not available", provider.Name())
+			return nil
 		}
 		if err := provider.Remove(ctx); err != nil {
 			return fmt.Errorf("removing application: %w", err)

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -365,9 +365,7 @@ func (m *PodmanMonitor) ExecuteActions(ctx context.Context) error {
 func (m *PodmanMonitor) drainActions() []lifecycle.Action {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	actions := make([]lifecycle.Action, len(m.actions))
-	copy(actions, m.actions)
-	// reset actions to ensure we don't execute the same actions again
+	actions := reduceActions(m.actions)
 	m.actions = nil
 	return actions
 }

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -3,9 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -959,13 +962,20 @@ func GetDiff(
 		currentProviders[provider.ID()] = provider
 	}
 
-	for id, provider := range currentProviders {
+	currentIDs := slices.Collect(maps.Keys(currentProviders))
+	desiredIDs := slices.Collect(maps.Keys(desiredProviders))
+
+	sort.Strings(currentIDs)
+	sort.Strings(desiredIDs)
+
+	for _, id := range currentIDs {
 		if _, exists := desiredProviders[id]; !exists {
-			diff.Removed = append(diff.Removed, provider)
+			diff.Removed = append(diff.Removed, currentProviders[id])
 		}
 	}
 
-	for id, desiredProvider := range desiredProviders {
+	for _, id := range desiredIDs {
+		desiredProvider := desiredProviders[id]
 		if currentProvider, exists := currentProviders[id]; !exists {
 			diff.Ensure = append(diff.Ensure, desiredProvider)
 		} else {


### PR DESCRIPTION
Fixes a few bugs:
1. Kube config / binary resolution is now lazily loaded rather than immediately on agent startup. Depending on the order of operations, sometimes the microshift kubeconfig wouldn't exist yet.
2. Depending on ordering, applications could be installed and fail to uninstall on rollback. (app1 installs, app2 fails to install and triggers a rollback, on rollback app2 is attempted to remove but that also fails. App1 never experiences the remove command)

Adds some behavior so that applications that are added and then immediately removed (from rollback) no longer attempt to add themselves first. When ExecuteActions runs, only the last action for an application is run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand detection of kubectl/oc with a new option to supply a kubeconfig path and runtime kubeconfig resolution.

* **Bug Fixes**
  * Continue syncing providers on individual errors and report aggregated failures.
  * Helm removals safely skip when Kubernetes is unavailable.

* **Performance**
  * Deterministic ordering and deduplication of application actions to avoid redundant work.

* **Tests**
  * Expanded table-driven tests for kubeconfig/binary resolution, action reduction, provider sync, and helm flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->