### PR TITLE
EDM-2636: Skopeo rootless credential handling

### DIFF
--- a/internal/agent/client/skopeo.go
+++ b/internal/agent/client/skopeo.go
@@ -101,6 +101,11 @@ func (s *Skopeo) InspectManifest(ctx context.Context, image string, opts ...Clie
 			return nil, fmt.Errorf("pull secret path %s does not exist", pullSecretPath)
 		}
 		args = append(args, "--authfile", pullSecretPath)
+	} else {
+		// Skopeo does not behave well when looking up default credentials as a non-root user without a proper systemd session
+		// running, so disable default credentials when none were explicitly provided. This
+		// means any credentials required have to be specified in the options.
+		args = append(args, "--no-creds")
 	}
 
 	stdout, stderr, exitCode := s.exec.ExecuteWithContext(ctx, skopeoCmd, args...)

--- a/internal/agent/client/skopeo_test.go
+++ b/internal/agent/client/skopeo_test.go
@@ -42,7 +42,7 @@ func TestSkopeoInspectManifest(t *testing.T) {
 					]
 				}`
 				mockExec.EXPECT().
-					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/app:v1").
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/app:v1", "--no-creds").
 					Return(manifestJSON, "", 0)
 			},
 			expectedResult: &OCIManifest{
@@ -77,7 +77,7 @@ func TestSkopeoInspectManifest(t *testing.T) {
 					]
 				}`
 				mockExec.EXPECT().
-					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/artifact:v1").
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/artifact:v1", "--no-creds").
 					Return(manifestJSON, "", 0)
 			},
 			expectedResult: &OCIManifest{
@@ -147,7 +147,7 @@ func TestSkopeoInspectManifest(t *testing.T) {
 					]
 				}`
 				mockExec.EXPECT().
-					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://ghcr.io/homebrew/core/sqlite:3.50.2").
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://ghcr.io/homebrew/core/sqlite:3.50.2", "--no-creds").
 					Return(manifestJSON, "", 0)
 			},
 			expectedResult: &OCIManifest{
@@ -180,7 +180,7 @@ func TestSkopeoInspectManifest(t *testing.T) {
 			image: "quay.io/test/nonexistent:v1",
 			setupMocks: func(mockExec *executer.MockExecuter) {
 				mockExec.EXPECT().
-					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/nonexistent:v1").
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/nonexistent:v1", "--no-creds").
 					Return("", "Error: manifest unknown", 1)
 			},
 			expectedResult: nil,
@@ -191,7 +191,7 @@ func TestSkopeoInspectManifest(t *testing.T) {
 			image: "quay.io/test/invalid:v1",
 			setupMocks: func(mockExec *executer.MockExecuter) {
 				mockExec.EXPECT().
-					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/invalid:v1").
+					ExecuteWithContext(gomock.Any(), "skopeo", "inspect", "--raw", "docker://quay.io/test/invalid:v1", "--no-creds").
 					Return("not valid json", "", 0)
 			},
 			expectedResult: nil,

--- a/pkg/executer/executer_test.go
+++ b/pkg/executer/executer_test.go
@@ -17,11 +17,11 @@ func TestExecuterUserHandling(t *testing.T) {
 		e := NewCommonExecuter(WithHomeDir("/tmp"))
 		out, _, code := e.ExecuteWithContext(t.Context(), "env")
 		require.Equal(t, 0, code)
-		require.Contains(t, out, "HOME=/tmp")
+		require.NotContains(t, out, "HOME=/tmp")
 	})
 
 	t.Run("running as user", func(t *testing.T) {
-		e := NewCommonExecuter(WithUIDAndGID(8484, 8484))
+		e := NewCommonExecuter(WithUIDAndGID(8484, 8484), WithHomeDir("/tmp"))
 		_, _, code := e.ExecuteWithContext(t.Context(), "env")
 		require.Equal(t, -1, code)
 	})


### PR DESCRIPTION
Skopeo tries to access the file /run/containers/1002/auth.json to check for default registry credentials, which causes an error when running against a non-root skopeo process due to env setup and systemd session quirks.

Also made the executor env handling more secure by not automatically inheriting the env for non-root processes, which could cause things to break or be a security risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credentials handling for container manifest inspection: explicitly disables use of default credentials when no credentials are provided, ensuring consistent unauthenticated behavior.
  * Fixed environment handling for non-root execution: prevents unintended inheritance of parent process environment variables while still honoring an explicitly set HOME, improving isolation and predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->