### PR TITLE
EDM-3228: Automatically mask bootc update.timer

### DIFF
--- a/docs/user/building/building-images.md
+++ b/docs/user/building/building-images.md
@@ -128,7 +128,7 @@ sudo podman build -t ${OCI_IMAGE_REPO}:${OCI_IMAGE_TAG} .
 
 #### Using RHEL base images
 
-When using Flight Control with a RHEL 9 base image, you need to make a few changes to the `Containerfile`, specifically you need to disable RHEL's default automatic updates and use a different command to enable the EPEL repository in case you need `podman-compose`:
+When using Flight Control with a RHEL 9 base image, you need to enable the EPEL repository in case you need `podman-compose`.
 
 ```console
 FROM registry.redhat.io/rhel9/rhel-bootc:9.5
@@ -136,8 +136,7 @@ FROM registry.redhat.io/rhel9/rhel-bootc:9.5
 RUN dnf -y config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
     dnf -y install flightctl-agent && \
     dnf -y clean all && \
-    systemctl enable flightctl-agent.service && \
-    systemctl mask bootc-fetch-apply-updates.timer
+    systemctl enable flightctl-agent.service
 
 # Optional: To enable podman-compose application support, uncomment below
 # RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \

--- a/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
+++ b/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
@@ -19,9 +19,6 @@ RUN dnf -y config-manager --add-repo ${RPM_REPO_URL} && \
 # Enable Flight Control agent service
 RUN systemctl enable flightctl-agent.service
 
-# Disable automatic bootc updates (flightctl manages updates)
-RUN systemctl mask bootc-fetch-apply-updates.timer || true
-
 # Install VM and cloud tools (needed for both early and late binding)
 # afterburn provides cloud metadata support, open-vm-tools for VMware guest tools
 RUN dnf install -y open-vm-tools && dnf clean all

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -467,7 +467,14 @@ loginctl enable-linger flightctl || :
 mkdir -p /home/flightctl/{.config,.local}
 chown -R flightctl:flightctl /home/flightctl/{.config,.local}
 
+# Disable bootc automatic updates on bootc systems (Flight Control manages updates)
+[ -f /usr/lib/systemd/system/bootc-fetch-apply-updates.timer ] && systemctl mask bootc-fetch-apply-updates.timer || true
+
 %postun agent
+# Restore bootc automatic-update timer only on full removal (not upgrade)
+if [ "$1" -eq 0 ]; then
+    [ -f /usr/lib/systemd/system/bootc-fetch-apply-updates.timer ] && systemctl unmask bootc-fetch-apply-updates.timer || true
+fi
 loginctl disable-linger flightctl || :
 
 %files selinux


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * RHEL 9 base image notes updated: enable EPEL for podman-compose, removed manual timer-masking instructions, and added a cleanup step for cached package data.

* **Improvements**
  * Installer now disables the system boot-update timer during install and restores it on full uninstall to simplify setup and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->