### PR TITLE
NO-ISSUE: Increase agent-vm default RAM to 2048 MiB

### DIFF
--- a/deploy/agent-vm.mk
+++ b/deploy/agent-vm.mk
@@ -1,5 +1,5 @@
 VMNAME ?= flightctl-device-default
-VMRAM ?= 512
+VMRAM ?= 2048
 VMCPUS ?= 1
 VMDISK = /var/lib/libvirt/images/$(VMNAME).qcow2
 VMDISKSIZE_DEFAULT := 10G

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -85,7 +85,7 @@ The agent-vm target accepts multiple parameters:
 
 - VMNAME: the name of the VM to create (default: flightctl-device-default)
 - VMCPUS: the number of CPUs to allocate to the VM (default: 1)
-- VMRAM: the amount of memory to allocate to the VM (default: 512)
+- VMRAM: the amount of memory in MiB to allocate to the VM (default: 2048)
 - VMDISKSIZE: the disk size for the VM (default: 10G)
 - VMWAIT: the amount of minutes to wait on the console during first boot (default: 0)
 


### PR DESCRIPTION
## Problem

`make agent-vm` boots the VM with 512 MiB of RAM, which is below the `osinfo-db` recommended minimum of 1536 MiB for `fedora-eln`. As the bootc image has grown over time (greenboot, TPM, SELinux, updated systemd/kernel), 512 MiB is no longer sufficient for the VM to reliably complete boot, it memory-thrashes and fails to obtain a DHCP lease, preventing the agent from enrolling.

Every developer running `make agent-vm` without explicitly passing `VMRAM=` will hit this.

## Root Cause

The 512 MiB default was set when `agent-vm.mk` was first created (March 2024) and was never updated. `virt-install --os-variant fedora-eln` has always emitted:
```
WARNING Requested memory 512 MiB is less than the recommended 1536 MiB for OS fedora-eln
```
This warning was ignored. With a smaller image it used to barely squeeze through, but as the image grew the margin evaporated.

## Solution

Bump `VMRAM` default from 512 to 2048 MiB — above the `osinfo-db` recommended minimum for `fedora-eln`. This eliminates the `virt-install` warning and ensures reliable VM boot out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased default agent VM memory allocation from 512 MiB to 2048 MiB to improve performance and stability.

* **Documentation**
  * Updated developer documentation to specify VM memory values in MiB and reflect the new default allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->