### PR TITLE
EDM-2535: [QE] Automate Quadlet Application Type Support

### DIFF
--- a/test/e2e/quadlets/README.md
+++ b/test/e2e/quadlets/README.md
@@ -1,0 +1,63 @@
+# Quadlets E2E Tests
+
+E2E tests for **Quadlets application type support** as defined in the Edge Management - application Test Plan, **section 4.2**.
+
+## Requirements
+
+- **Environment**: Quadlet tests require a **RHEL device** with FlightCtl deployed via **quadlets** (e.g. `make deploy-quadlets-vm`). Standard e2e VMs use a podman-compose agent and **do not support** quadlet applications.
+
+Quadlet tests use **inline** quadlet content (or OCI image provider for artifact tests) and a **plain public container image** (`quay.io/flightctl-tests/alpine:v1`, a minimal runtime) for the quadlet `Image=` field. They do **not** use the compose application bundle `sleep-app`, which contains a compose file and is for the compose application type.
+
+## Running
+
+Use the same pattern as other e2e env vars (`FLIGHTCTL_NS`, `KUBEADMIN_PASS`): **export** them before running make.
+
+```bash
+# With a quadlet-capable environment (e.g. RHEL VM from deploy-quadlets-vm)
+export FLIGHTCTL_NS=flightctl
+export KUBEADMIN_PASS=your-oc-password
+
+make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/quadlets
+```
+
+To run only the "Quadlet application lifecycle" context:
+
+```bash
+make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/quadlets GINKGO_FOCUS="Quadlet application lifecycle"
+```
+
+To run a single test by its `It` description:
+
+```bash
+make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/quadlets FLIGHTCTL_NS=flightctl-external \
+  GINKGO_FOCUS="verifies that a quadlets application can be deployed, updated and removed in an edge manager device"
+```
+
+**Troubleshooting:** If `make in-cluster-e2e-test` fails during `deploy-e2e-extras` with "image not present locally" and then "permission denied" when pulling (e.g. podman creating `/var/lib/containers/storage/libpod`), ensure podman/docker can pull images (e.g. run with appropriate permissions or pre-pull `quay.io/flightctl/e2eregistry:2`).
+
+Or, if the full e2e stack is already up and you have a quadlet VM enrolled:
+
+```bash
+make run-e2e-test GO_E2E_DIRS=test/e2e/quadlets
+```
+
+**Note:** Current e2e infrastructure does not yet provide quadlet VMs in the default pool. Run with `GO_E2E_DIRS=test/e2e/quadlets` when you have a quadlet-capable environment.
+
+## Test Plan Mapping (Section 4.2)
+
+| Test plan case | It description | Label / Polarion |
+|----------------|----------------|-------------------|
+| flightctl quadlets application lifecycle | verifies that a quadlets application can be deployed, updated and removed in an edge manager device | quadlets-lifecycle |
+| A complex application can be deployed to flightctl | verifies that a complex application including networks, volumes, pods, images, containers and envs can be deployed to an edge manager device | quadlets-complex |
+| Image provider can extract and deploy Quadlet files from OCI artifacts | verifies that we can create single or multiple files artifacts (also compressed) packaged in an image and install them in an EM device | quadlets-oci-artifacts |
+| Inline quadlets complex application with references ... survives a reboot | inline quadlets complex application with references can be deployed to an EM device and survives a reboot | 86280 (OCP-86280), sanity |
+| Validations in quadlets applications | verifies that there are validations and readable error messages in quadlets application files | quadlets-validations |
+| A quadlets app with crashed containers reports Degraded status | verifies that a crashing quadlets app is reported as Degraded | quadlets-degraded |
+
+Polarion IDs for the remaining cases are TBD by QE; update the `Label(...)` in each `It` when assigned.
+
+## References
+
+- Test plan: `t.pdf` section 4.2 (Quadlets applications type support)
+- E2E development guide: [test/e2e/README.md](../README.md)
+- Deploy quadlets VM: [test/scripts/deploy_quadlets_rhel.sh](../../scripts/deploy_quadlets_rhel.sh)

--- a/test/e2e/quadlets/quadlets_suite_test.go
+++ b/test/e2e/quadlets/quadlets_suite_test.go
@@ -1,0 +1,71 @@
+package quadlets_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	defaultEventuallyTimeout         = 5 * time.Minute
+	defaultEventuallyPollingInterval = 250 * time.Millisecond
+)
+
+// Quadlet tests require a RHEL device with FlightCtl deployed via quadlets
+// (e.g. make deploy-quadlets-vm). Standard e2e VMs use podman-compose agent
+// and do not support quadlet applications.
+
+func TestQuadlets(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Quadlets E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	_, _, err := e2e.SetupWorkerHarness()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = BeforeEach(func() {
+	workerID := GinkgoParallelProcess()
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up quadlet test with VM from pool\n", workerID)
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	err := harness.SetupVMFromPoolAndStartAgent(workerID)
+	Expect(err).ToNot(HaveOccurred())
+
+	out, err := harness.VM.RunSSH([]string{"sudo", "systemctl", "is-active", "flightctl-agent"}, nil)
+	Expect(err).ToNot(HaveOccurred())
+	active := strings.TrimSpace(out.String())
+	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Quadlet test setup completed (flightctl-agent: %s)\n", workerID, active)
+	Expect(active).To(Equal("active"), "flightctl-agent should be active after setup")
+})
+
+var _ = AfterEach(func() {
+	workerID := GinkgoParallelProcess()
+	GinkgoWriter.Printf("🔄 [AfterEach] Worker %d: Cleaning up quadlet test resources\n", workerID)
+
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	harness.PrintAgentLogsIfFailed()
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+	harness.SetTestContext(suiteCtx)
+
+	GinkgoWriter.Printf("✅ [AfterEach] Worker %d: Quadlet test cleanup completed\n", workerID)
+})
+
+func init() {
+	SetDefaultEventuallyTimeout(defaultEventuallyTimeout)
+	SetDefaultEventuallyPollingInterval(defaultEventuallyPollingInterval)
+}

--- a/test/e2e/quadlets/quadlets_test.go
+++ b/test/e2e/quadlets/quadlets_test.go
@@ -1,0 +1,350 @@
+// Package quadlets_test implements e2e tests for Quadlets application type support
+// (Edge Management - application Test Plan, section 4.2).
+//
+// These tests require a RHEL device with FlightCtl
+// deployed via quadlets (e.g. make deploy-quadlets-vm). Standard e2e VMs are
+// not quadlet-capable. Polarion IDs for section 4.2 are TBD by QE; OCP-86280
+// is used for the inline complex app + reboot scenario.
+package quadlets_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// Time constants for reboot wait (aligned with harness VM SSH wait behavior).
+	rebootWaitInterval = 15 * time.Second
+	rebootMaxAttempts  = 5
+
+	// Quadlet app names used in tests.
+	quadletAppName              = "my-app"
+	quadletAppNameSecond        = "my-app-2"
+	quadletAppNameComplex       = "my-app-4"
+	quadletAppNameOCI           = "app-multi-file-artifact-with-image-ref"
+	quadletAppNameComplexInline = "complex-quadlet-inline-app"
+	quadletAppNameValidation    = "validation-test"
+	quadletAppNameCrash         = "crash-app"
+
+	quadletLabelProject   = "io.flightctl.quadlet.project"
+	quadletSystemdPath    = "/etc/containers/systemd"
+	quadletDropInFilename = "99-flightctl.conf"
+
+	expectedStatusBadRequest = 400
+)
+
+var _ = Describe("Quadlets application type support", Label("quadlets"), func() {
+	var harness *e2e.Harness
+	var deviceID string
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+		login.LoginToAPIWithToken(harness)
+		deviceID, _ = harness.EnrollAndWaitForOnlineStatus()
+	})
+
+	Context("Quadlet application lifecycle", func() {
+		// Test plan 4.2: flightctl quadlets application lifecycle
+		// Verifies deploy, update (with Volume/Network/Pod), and remove on an edge manager device.
+		It("verifies that a quadlets application can be deployed, updated and removed in an edge manager device", Label("86076", "sanity"), func() {
+			By("Adding inline quadlet app (Container only) to device")
+			registryImage := getQuadletTestImage(harness)
+			containerContent := getLifecycleInitialContainerContent(registryImage)
+			Expect(harness.UpdateDeviceWithQuadletInline(deviceID, quadletAppName, []string{"test.container"}, []string{containerContent})).ToNot(HaveOccurred())
+
+			By("Checking application status shows Running")
+			Expect(harness.WaitForApplicationStatus(deviceID, quadletAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+
+			By("Checking quadlet files and labels on device")
+			names, err := harness.RunPodmanPsContainerNames(false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(names).To(ContainSubstring(quadletAppName))
+			// quadletDropInFilename is created by the FlightCtl agent's quadlet installer (createQuadletDropIn in
+			// internal/agent/device/applications/provider/quadlet.go) under {appName}-.{type}.d/ when the app is applied.
+			confPath := fmt.Sprintf("%s/%s", quadletSystemdPath, quadletAppName)
+			_, err = harness.VM.RunSSH([]string{"sh", "-c", fmt.Sprintf("find %s -name %s -print | grep -q .", confPath, quadletDropInFilename)}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Updating app with Volume, Network, Pod")
+			volumeContent, networkContent, podContent, containerContentV2 := getQuadletVolumeNetworkPodUpdateContents(registryImage)
+			Expect(harness.UpdateDeviceWithQuadletInline(deviceID, quadletAppName,
+				[]string{"test.container", "test.volume", "test.network", "test.pod"},
+				[]string{containerContentV2, volumeContent, networkContent, podContent})).ToNot(HaveOccurred())
+
+			By("Checking status shows ready 2/2 and Running")
+			Expect(harness.WaitForApplicationStatus(deviceID, quadletAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+
+			By("Checking both containers are running")
+			names, err = harness.RunPodmanPsContainerNames(false)
+			Expect(err).ToNot(HaveOccurred())
+			allNames := strings.Fields(strings.TrimSpace(names))
+			quadletContainers := make([]string, 0, len(allNames))
+			for _, n := range allNames {
+				if strings.Contains(n, quadletAppName) {
+					quadletContainers = append(quadletContainers, n)
+				}
+			}
+			Expect(quadletContainers).To(HaveLen(2), "expected 2 running containers for app %q, got: %v", quadletAppName, quadletContainers)
+
+			By("Removing application from device config")
+			emptyApps := []v1beta1.ApplicationProviderSpec{}
+			Expect(harness.SetDeviceApplications(deviceID, &emptyApps)).ToNot(HaveOccurred())
+
+			By("Verifying resources are removed")
+			Eventually(func() bool {
+				names, err := harness.RunPodmanPsContainerNames(true)
+				if err != nil {
+					return false
+				}
+				return !strings.Contains(names, quadletAppName)
+			}, testutil.TIMEOUT, testutil.POLLING).Should(BeTrue(), "quadlet container %q should disappear from podman ps -a", quadletAppName)
+		})
+
+		// Test plan 4.2: A complex application can be deployed to flightctl
+		It("verifies that a complex application including networks, volumes, pods, images, containers and envs can be deployed to an edge manager device", Label("86279", "sanity"), func() {
+			By("Adding complex quadlet app with envVars, Container, Volume, Network, Pod")
+			imageRef := getQuadletTestImage(harness)
+			envVars, paths, contents := getComplexQuadletAppWithEnvsContents(imageRef)
+			Expect(harness.UpdateDeviceWithQuadletInlineAndEnvs(deviceID, quadletAppNameComplex, envVars, paths, contents)).ToNot(HaveOccurred())
+
+			By("Checking application folder, labels and .env on device")
+			appPath := quadletSystemdPath + "/" + quadletAppNameComplex
+			out, err := harness.VM.RunSSH([]string{"cat", appPath + "/.env"}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(ContainSubstring("FOO=FOOO"))
+			Expect(out.String()).To(ContainSubstring("SIMPLE=VALUE"))
+
+			By("Checking containers are running")
+			names, err := harness.RunPodmanPsContainerNames(false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(names).To(ContainSubstring(quadletAppNameComplex))
+
+			By("Removing configuration")
+			emptyApps := []v1beta1.ApplicationProviderSpec{}
+			Expect(harness.SetDeviceApplications(deviceID, &emptyApps)).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("Image provider and OCI artifacts", func() {
+		// Test plan 4.2: Image provider can extract and deploy Quadlet files from OCI artifacts
+		It("verifies that we can create single or multiple files artifacts (also compressed) packaged in an image and install them in an EM device", Label("86280", "sanity"), func() {
+			By("Adding quadlet app with image ref (multi-file artifact)")
+			appSpec, err := harness.QuadletImageAppSpec(quadletAppNameOCI,
+				"quay.io/flightctl-tests/quadlet-test/quadlet-app-artifact:with-image-ref",
+				map[string]string{"LOG_MESSAGE": "Multi-file artifact (with .image ref)"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(harness.SetDeviceApplications(deviceID, &[]v1beta1.ApplicationProviderSpec{appSpec})).ToNot(HaveOccurred())
+
+			By("Checking container status moves to Running and application folder is created")
+			Expect(harness.WaitForApplicationStatus(deviceID, quadletAppNameOCI, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+
+			By("Removing spec")
+			emptyApps := []v1beta1.ApplicationProviderSpec{}
+			Expect(harness.SetDeviceApplications(deviceID, &emptyApps)).ToNot(HaveOccurred())
+
+			By("Verifying applications were removed")
+			Eventually(func() bool {
+				names, err := harness.RunPodmanPsContainerNames(true)
+				if err != nil {
+					return false
+				}
+				return !strings.Contains(names, quadletAppNameOCI)
+			}, testutil.TIMEOUT, testutil.POLLING).Should(BeTrue(), "quadlet container %q should disappear from podman ps -a", quadletAppNameOCI)
+		})
+	})
+
+	Context("Inline quadlets with references and reboot", func() {
+		// Test plan 4.2: Inline quadlets complex application with references ... survives a reboot (OCP-86280).
+		It("inline quadlets complex application with references can be deployed to an EM device and survives a reboot", Label("86281", "sanity"), func() {
+			By("Adding inline quadlet app with refs (network, pod, container, volumes, worker-image.image)")
+			imageRef := getQuadletTestImage(harness)
+			envVars := map[string]string{"LOG_MESSAGE": "Hello from FlightControl (Inline Ref)"}
+			paths := []string{"app.network", "app.pod", "app.container", "data.volume", "sqlite.volume", "worker-image.image", "worker.container"}
+			contents := getComplexQuadletInlineContents(imageRef)
+			Expect(harness.UpdateDeviceWithQuadletInlineAndEnvs(deviceID, quadletAppNameComplexInline, envVars, paths, contents)).ToNot(HaveOccurred())
+
+			By("Checking application status and containers")
+			Expect(harness.WaitForApplicationStatus(deviceID, quadletAppNameComplexInline, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+
+			By("Rebooting VM")
+			Expect(harness.RebootVMAndWaitForSSH(rebootWaitInterval, rebootMaxAttempts)).ToNot(HaveOccurred())
+
+			By("Waiting for device to report application Running after reboot")
+			Expect(harness.WaitForApplicationStatus(deviceID, quadletAppNameComplexInline, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+
+			By("Removing config - no leftovers")
+			emptyApps := []v1beta1.ApplicationProviderSpec{}
+			Expect(harness.SetDeviceApplications(deviceID, &emptyApps)).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("Validations in quadlets applications", func() {
+		// Test plan 4.2: Validations in quadlets applications
+		It("verifies that there are validations and readable error messages in quadlets application files", Label("86352", "sanity"), func() {
+			By("Adding quadlet app with two volume files with the same VolumeName - update is rejected with 400")
+			apps, err := invalidQuadletSpecDuplicateVolumeName()
+			Expect(err).ToNot(HaveOccurred())
+			getResp, err := harness.Client.GetDeviceWithResponse(harness.Context, deviceID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.JSON200).ToNot(BeNil())
+			device := *getResp.JSON200
+			device.Spec.Applications = &apps
+
+			replaceResp, err := harness.Client.ReplaceDeviceWithResponse(harness.Context, deviceID, device)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(replaceResp.StatusCode()).To(Equal(expectedStatusBadRequest), "duplicate quadlet volume names should be rejected with 400")
+			Expect(string(replaceResp.Body)).ToNot(BeEmpty(), "error response should include a message")
+		})
+	})
+
+	Context("Quadlets app with crashed containers", func() {
+		// Test plan 4.2: A quadlets app with crashed containers reports Degraded status
+		It("verifies that a crashing quadlets app is reported as Degraded", Label("86353", "sanity"), func() {
+			By("Adding quadlet app with exit 1 container command")
+			imageRef := getQuadletTestImage(harness)
+			containerContent := getCrashAppContainerContent(imageRef)
+			Expect(harness.UpdateDeviceWithQuadletInline(deviceID, quadletAppNameCrash, []string{"test.container"}, []string{containerContent})).ToNot(HaveOccurred())
+
+			By("Checking application general status is Degraded (or Error)")
+			Expect(harness.WaitForApplicationSummaryDegradedOrError(deviceID, testutil.TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+		})
+	})
+})
+
+// Helpers (local to this package, no assertions inside)
+
+func getLifecycleInitialContainerContent(registryImage string) string {
+	return fmt.Sprintf(`[Container]
+Image=%s
+Exec=sleep infinity
+[Install]
+WantedBy=default.target
+`, registryImage)
+}
+
+func getQuadletVolumeNetworkPodUpdateContents(registryImage string) (volumeContent, networkContent, podContent, containerContent string) {
+	volumeContent = `[Volume]
+Driver=image
+Image=ghcr.io/homebrew/core/sqlite:3.50.2
+`
+	networkContent = `[Network]
+`
+	podContent = `[Pod]
+`
+	containerContent = fmt.Sprintf(`[Container]
+Image=%s
+Volume=test.volume:/mnt/volume
+Volume=name:/mnt/named-volume
+Exec=sh -c "echo 'Volume mounted.' && sleep infinity"
+[Install]
+WantedBy=default.target
+`, registryImage)
+	return volumeContent, networkContent, podContent, containerContent
+}
+
+func getComplexQuadletInlineContents(imageRef string) []string {
+	return []string{
+		"[Network]\nDriver=bridge\n",
+		"[Pod]\nNetwork=app.network\n",
+		fmt.Sprintf(`[Container]
+Image=%s
+Pod=app.pod
+Volume=model-data:/mnt/model:ro
+Exec=sh -c "echo 'Primary container started.' && sleep infinity"
+[Install]
+WantedBy=default.target
+`, imageRef),
+		"[Volume]\nDriver=local\n",
+		"[Volume]\nDriver=image\nImage=ghcr.io/homebrew/core/sqlite:3.50.2\n",
+		fmt.Sprintf("[Image]\nImage=%s\n", imageRef),
+		`[Container]
+Image=worker-image.image
+Pod=app.pod
+Volume=data.volume:/mnt/data
+Exec=sh -c "echo 'Worker started.' && sleep infinity"
+[Install]
+WantedBy=default.target
+`,
+	}
+}
+
+func getComplexQuadletAppWithEnvsContents(imageRef string) (envVars map[string]string, paths, contents []string) {
+	envVars = map[string]string{"FOO": "FOOO", "SIMPLE": "VALUE", "SOME_KEY": "default"}
+	paths = []string{"test.container", "test.volume", "test-name.volume", "test.network", "test.pod"}
+	contents = []string{
+		fmt.Sprintf(`[Container]
+Image=%s
+Network=test.network
+Pod=test.pod
+Volume=test.volume:/mnt/volume
+Volume=test-name.volume:/mnt/data
+Exec=sh -c "echo FOO: $FOO && sleep infinity"
+[Install]
+WantedBy=default.target
+`, imageRef),
+		`[Volume]
+Driver=image
+Image=ghcr.io/homebrew/core/sqlite:3.50.2
+`,
+		`[Volume]
+VolumeName=testdata
+Driver=local
+`,
+		`[Network]
+Driver=bridge
+DNS=1.1.1.1
+`,
+		`[Pod]
+Network=test.network
+`,
+	}
+	return envVars, paths, contents
+}
+
+func invalidQuadletSpecDuplicateVolumeName() ([]v1beta1.ApplicationProviderSpec, error) {
+	dupVolumeContent := `[Volume]
+VolumeName=testdata
+Driver=local
+`
+	inline := []v1beta1.ApplicationContent{
+		{Path: "test2.volume", Content: &dupVolumeContent},
+		{Path: "test-name.volume", Content: &dupVolumeContent},
+	}
+	appName := quadletAppNameValidation
+	quadletApp := v1beta1.QuadletApplication{
+		Name:    &appName,
+		AppType: v1beta1.AppTypeQuadlet,
+	}
+	if err := quadletApp.FromInlineApplicationProviderSpec(v1beta1.InlineApplicationProviderSpec{Inline: inline}); err != nil {
+		return nil, err
+	}
+	var appSpec v1beta1.ApplicationProviderSpec
+	if err := appSpec.FromQuadletApplication(quadletApp); err != nil {
+		return nil, err
+	}
+	return []v1beta1.ApplicationProviderSpec{appSpec}, nil
+}
+
+func getCrashAppContainerContent(imageRef string) string {
+	return fmt.Sprintf(`[Container]
+Image=%s
+Exec=sh -c "echo FOO && exit 1"
+[Install]
+WantedBy=default.target
+`, imageRef)
+}
+
+// getQuadletTestImage returns a plain container image for quadlet tests (not a compose/sleep-app bundle).
+// Uses a minimal runtime image (not an OS image); quadlet tests use inline quadlet content and
+// only need a simple container image for Image=.
+func getQuadletTestImage(harness *e2e.Harness) string {
+	return "quay.io/flightctl-tests/alpine:v1"
+}

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -1,0 +1,182 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/sirupsen/logrus"
+)
+
+// RunPodmanPsContainerNames runs podman ps (or podman ps -a) on the VM and returns container names.
+func (h *Harness) RunPodmanPsContainerNames(allContainers bool) (string, error) {
+	args := []string{"sudo", "podman", "ps", "--format", "{{.Names}}"}
+	if allContainers {
+		args = []string{"sudo", "podman", "ps", "-a", "--format", "{{.Names}}"}
+	}
+	out, err := h.VM.RunSSH(args, nil)
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// RebootVMAndWaitForSSH triggers a reboot on the VM and waits for SSH to become ready again.
+func (h *Harness) RebootVMAndWaitForSSH(waitInterval time.Duration, maxAttempts int) error {
+	_, _ = h.VM.RunSSH([]string{"sudo", "reboot"}, nil)
+	var sshErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		time.Sleep(waitInterval)
+		sshErr = h.VM.WaitForSSHToBeReady()
+		if sshErr == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("SSH did not become ready after reboot within %d attempts: %w", maxAttempts, sshErr)
+}
+
+// UpdateDeviceAndWaitForRenderedVersion updates the device with the given function and waits for the new rendered version.
+func (h *Harness) UpdateDeviceAndWaitForRenderedVersion(deviceID string, updateFunc func(*v1beta1.Device)) error {
+	newRenderedVersion, err := h.PrepareNextDeviceVersion(deviceID)
+	if err != nil {
+		return err
+	}
+	if err := h.UpdateDeviceWithRetries(deviceID, updateFunc); err != nil {
+		return err
+	}
+	return h.WaitForDeviceNewRenderedVersion(deviceID, newRenderedVersion)
+}
+
+// SetDeviceApplications sets device.Spec.Applications and waits for the new rendered version.
+func (h *Harness) SetDeviceApplications(deviceID string, apps *[]v1beta1.ApplicationProviderSpec) error {
+	return h.UpdateDeviceAndWaitForRenderedVersion(deviceID, func(device *v1beta1.Device) {
+		device.Spec.Applications = apps
+	})
+}
+
+// UpdateDeviceWithQuadletInline updates the device with an inline quadlet application (no env vars).
+func (h *Harness) UpdateDeviceWithQuadletInline(deviceID, appName string, paths, contents []string) error {
+	if len(paths) == 0 && len(contents) == 0 {
+		return h.SetDeviceApplications(deviceID, &[]v1beta1.ApplicationProviderSpec{})
+	}
+	inline := make([]v1beta1.ApplicationContent, len(paths))
+	for i := range paths {
+		c := ""
+		if i < len(contents) {
+			c = contents[i]
+		}
+		inline[i] = v1beta1.ApplicationContent{Path: paths[i], Content: &c}
+	}
+	quadletApp := v1beta1.QuadletApplication{
+		Name:    &appName,
+		AppType: v1beta1.AppTypeQuadlet,
+	}
+	if err := quadletApp.FromInlineApplicationProviderSpec(v1beta1.InlineApplicationProviderSpec{Inline: inline}); err != nil {
+		return err
+	}
+	var spec v1beta1.ApplicationProviderSpec
+	if err := spec.FromQuadletApplication(quadletApp); err != nil {
+		return err
+	}
+	return h.SetDeviceApplications(deviceID, &[]v1beta1.ApplicationProviderSpec{spec})
+}
+
+// UpdateDeviceWithQuadletInlineAndEnvs updates the device with an inline quadlet application and env vars.
+func (h *Harness) UpdateDeviceWithQuadletInlineAndEnvs(deviceID, appName string, envVars map[string]string, paths, contents []string) error {
+	inline := make([]v1beta1.ApplicationContent, len(paths))
+	for i := range paths {
+		c := ""
+		if i < len(contents) {
+			c = contents[i]
+		}
+		inline[i] = v1beta1.ApplicationContent{Path: paths[i], Content: &c}
+	}
+	quadletApp := v1beta1.QuadletApplication{
+		Name:    &appName,
+		AppType: v1beta1.AppTypeQuadlet,
+		EnvVars: &envVars,
+	}
+	if err := quadletApp.FromInlineApplicationProviderSpec(v1beta1.InlineApplicationProviderSpec{Inline: inline}); err != nil {
+		return err
+	}
+	var spec v1beta1.ApplicationProviderSpec
+	if err := spec.FromQuadletApplication(quadletApp); err != nil {
+		return err
+	}
+	return h.SetDeviceApplications(deviceID, &[]v1beta1.ApplicationProviderSpec{spec})
+}
+
+// QuadletImageAppSpec builds an ApplicationProviderSpec for a quadlet app from an image and env vars.
+func (h *Harness) QuadletImageAppSpec(name, image string, envVars map[string]string) (v1beta1.ApplicationProviderSpec, error) {
+	quadletApp := v1beta1.QuadletApplication{
+		Name:    &name,
+		AppType: v1beta1.AppTypeQuadlet,
+		EnvVars: &envVars,
+	}
+	if err := quadletApp.FromImageApplicationProviderSpec(v1beta1.ImageApplicationProviderSpec{Image: image}); err != nil {
+		return v1beta1.ApplicationProviderSpec{}, err
+	}
+	var spec v1beta1.ApplicationProviderSpec
+	if err := spec.FromQuadletApplication(quadletApp); err != nil {
+		return v1beta1.ApplicationProviderSpec{}, err
+	}
+	return spec, nil
+}
+
+func deviceHasApplicationWithStatus(device *v1beta1.Device, appName string, status v1beta1.ApplicationStatusType) bool {
+	if device == nil || device.Status == nil {
+		return false
+	}
+	for _, app := range device.Status.Applications {
+		if app.Name == appName && app.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func deviceApplicationsSummaryStatus(device *v1beta1.Device) string {
+	if device == nil || device.Status == nil {
+		return ""
+	}
+	return string(device.Status.ApplicationsSummary.Status)
+}
+
+// WaitForApplicationStatus polls until the device reports the given application with the given status, or timeout.
+func (h *Harness) WaitForApplicationStatus(deviceID, appName string, status v1beta1.ApplicationStatusType, timeout, polling time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := h.GetDeviceWithStatusSystem(deviceID)
+		if err != nil {
+			logrus.Debugf("WaitForApplicationStatus GetDeviceWithStatusSystem: %v", err)
+			time.Sleep(polling)
+			continue
+		}
+		if resp.JSON200 != nil && deviceHasApplicationWithStatus(resp.JSON200, appName, status) {
+			return nil
+		}
+		time.Sleep(polling)
+	}
+	return fmt.Errorf("timed out after %s waiting for application %s to have status %s", timeout, appName, status)
+}
+
+// WaitForApplicationSummaryDegradedOrError polls until the device's applications summary is Degraded or Error, or timeout.
+func (h *Harness) WaitForApplicationSummaryDegradedOrError(deviceID string, timeout, polling time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := h.GetDeviceWithStatusSystem(deviceID)
+		if err != nil {
+			logrus.Debugf("WaitForApplicationSummaryDegradedOrError GetDeviceWithStatusSystem: %v", err)
+			time.Sleep(polling)
+			continue
+		}
+		if resp.JSON200 != nil {
+			s := deviceApplicationsSummaryStatus(resp.JSON200)
+			if s == string(v1beta1.ApplicationsSummaryStatusDegraded) || s == string(v1beta1.ApplicationsSummaryStatusError) {
+				return nil
+			}
+		}
+		time.Sleep(polling)
+	}
+	return fmt.Errorf("timed out after %s waiting for applications summary to be Degraded or Error", timeout)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Quadlets end-to-end tests covering lifecycle, OCI/artifact scenarios, reboot resilience, error/invalid-spec cases, focused single-test runs, and test utilities for VM-based orchestration, agent lifecycle, application updates, status polling, and cleanup.

* **Documentation**
  * Added Quadlets E2E README with prerequisites, run instructions, test plan mapping, troubleshooting, and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->