### PR TITLE
EDM-3317: Add shadow-utils dependency for agent

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -52,6 +52,8 @@ Summary: Flight Control management agent
 
 Requires: flightctl-selinux = %{version}
 Requires: jq
+# This provides the newuidmap binary used by podman when running rootless containers.
+Requires: shadow-utils
 # Pin the greenboot package to 0.15.z until the following issue is resolved:
 # https://github.com/fedora-iot/greenboot-rs/issues/141
 Requires: greenboot >= 0.15.0


### PR DESCRIPTION
This provides the newuidmap binary which podman needs when running rootless containers. This is likely already installed but on minimal installations it might be missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime dependency to ensure proper agent container functionality in rootless container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->