### PR TITLE
EDM-3319: Return error 504 for connection timeout to console

### DIFF
--- a/internal/transport/v1beta1/console.go
+++ b/internal/transport/v1beta1/console.go
@@ -67,7 +67,7 @@ func (h *WebsocketHandler) HandleDeviceConsole(w http.ResponseWriter, r *http.Re
 		h.log.Errorf("timed out waiting for protocol for device: %s", deviceName)
 		http.Error(w,
 			fmt.Sprintf("timed out waiting for protocol for device: %s", deviceName),
-			http.StatusInternalServerError)
+			http.StatusGatewayTimeout)
 		return
 	}
 


### PR DESCRIPTION
Return status code 504 instead of 500 in the event of connection timeout when attempting to open a console session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status code returned when device protocol selection times out, now returns the appropriate gateway timeout response instead of internal server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->