### PR TITLE
EDM-3317/3306: Fix rootless issues in agent-vm

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -52,8 +52,6 @@ Summary: Flight Control management agent
 
 Requires: flightctl-selinux = %{version}
 Requires: jq
-# This provides the newuidmap binary used by podman when running rootless containers.
-Requires: shadow-utils
 # Pin the greenboot package to 0.15.z until the following issue is resolved:
 # https://github.com/fedora-iot/greenboot-rs/issues/141
 Requires: greenboot >= 0.15.0
@@ -464,13 +462,11 @@ rm -rf /usr/share/sosreport
 
 # We want a regular user to run applications with as there are several issues around system users
 # and running quadlet applications.
-id -u flightctl || useradd --home-dir /home/flightctl --create-home --user-group flightctl
-loginctl enable-linger flightctl || :
+id -u flightctl 2>/dev/null || useradd --home-dir /home/flightctl --create-home --user-group flightctl
+# This enables lingering for the user with a fallback when building in an env without an active systemd.
+loginctl enable-linger flightctl || (mkdir -p /var/lib/systemd/linger/ && touch /var/lib/systemd/linger/flightctl)
 mkdir -p /home/flightctl/{.config,.local}
 chown -R flightctl:flightctl /home/flightctl/{.config,.local}
-
-%postun agent
-loginctl disable-linger flightctl || :
 
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/flightctl_agent.pp.bz2

--- a/pkg/executer/executer_linux.go
+++ b/pkg/executer/executer_linux.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -22,10 +23,13 @@ func (e *commonExecuter) CommandContext(ctx context.Context, command string, arg
 	}
 
 	if e.uid >= 0 {
-		// When running as a different user, make sure the env is not inherited by setting it to a blank
-		// slice (if nil, it will be inherited).
+		// When running as a different user, make sure the env is not inherited (except for PATH).
 		if cmd.Env == nil {
 			cmd.Env = []string{}
+			// Preserve path if it exists for convenience when running commands that expect it set.
+			if path, ok := os.LookupEnv("PATH"); ok {
+				cmd.Env = append(cmd.Env, "PATH="+path)
+			}
 		}
 		if e.homeDir != "" {
 			// Forcefully override any existing HOME envvar if homeDir is set.


### PR DESCRIPTION
- Make lingering work even when installing the package in non-standard
  environments (e.g. image builder)
- Preserve PATH when executing as a different user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified packaging by removing an unnecessary dependency.
  * More robust agent installation: improved user-check logic and added lingering marker so services can run without an active session.
  * Preserve PATH when executing commands under a different user on Linux to maintain expected environment.
  * Adjusted uninstall behavior to avoid disabling lingering, preserving system configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->