### PR TITLE
EDM-2527: Automate alerting pipeline end-to-end

### DIFF
--- a/test/e2e/alertmanager_proxy/alertmanager_proxy_suite_test.go
+++ b/test/e2e/alertmanager_proxy/alertmanager_proxy_suite_test.go
@@ -1,0 +1,48 @@
+package alertmanagerproxy_test
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAlertmanagerProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Alertmanager Proxy E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = BeforeEach(func() {
+	workerID := GinkgoParallelProcess()
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	GinkgoWriter.Printf("[BeforeEach] Worker %d: Setting up test\n", workerID)
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	GinkgoWriter.Printf("[BeforeEach] Worker %d: Test setup completed\n", workerID)
+})
+
+var _ = AfterEach(func() {
+	workerID := GinkgoParallelProcess()
+	GinkgoWriter.Printf("[AfterEach] Worker %d: Cleaning up test resources\n", workerID)
+
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+
+	harness.SetTestContext(suiteCtx)
+
+	GinkgoWriter.Printf("[AfterEach] Worker %d: Test cleanup completed\n", workerID)
+})

--- a/test/e2e/alertmanager_proxy/alertmanager_proxy_test.go
+++ b/test/e2e/alertmanager_proxy/alertmanager_proxy_test.go
@@ -1,0 +1,317 @@
+package alertmanagerproxy_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	alertmanagerProxyServiceName = "flightctl-alertmanager-proxy"
+	alertmanagerProxyServicePort = 8443
+
+	proxyHealthPath   = "/health"
+	proxyStatusPath   = "/api/v2/status"
+	proxyAlertsPath   = "/api/v2/alerts"
+	proxyInvalidOrgID = "not-a-uuid"
+	healthBodyOK      = "OK"
+	applicationJSON   = "application/json"
+	statusKindField   = "\"kind\":\"Status\""
+	statusFailure     = "\"status\":\"Failure\""
+	authTokenErrMsg   = "failed to get auth token"
+	statusForbidden   = "Forbidden"
+	nonAdminUser      = "demouser1"
+	nonAdminPassword  = "demouser1"
+	authDisabledMsg   = "auth is disabled in this environment"
+	alertsLabelName   = "alertname"
+	alertsLabelOrgID  = "org_id"
+	alertsLabelRes    = "resource"
+
+	alertNameDeviceDisconnected = "DeviceDisconnected"
+	alertNameDeviceDiskWarning  = "DeviceDiskWarning"
+
+	prometheusServiceName = "flightctl-prometheus"
+	prometheusServicePort = 9090
+	prometheusQueryAlerts = `ALERTS{org_id="%s",alertname=~"%s|%s"}`
+	prometheusStatusOK    = "success"
+
+	uiServiceName         = "flightctl-ui"
+	uiServicePort         = 8080
+	uiConfigMapName       = "flightctl-ui"
+	uiConfigProxyJSONPath = "jsonpath={.data.FLIGHTCTL_ALERTMANAGER_PROXY}"
+	uiExpectedProxyHost   = "alertmanager-proxy"
+
+	httpClientTimeout = 10 * time.Second
+)
+
+var (
+	testHarness            *e2e.Harness
+	testRuntimeContext     string
+	defaultProxyNamespaces = []string{"flightctl-external", "flightctl", util.E2E_NAMESPACE}
+	defaultPromNamespaces  = []string{util.E2E_NAMESPACE, "flightctl", "flightctl-external"}
+	defaultUINamespaces    = []string{"flightctl-external", "flightctl", util.E2E_NAMESPACE}
+	defaultUWMNamespaces   = []string{"openshift-user-workload-monitoring"}
+	defaultOCPNamespace    = []string{"openshift-monitoring"}
+)
+
+type alertmanagerAlertResponse struct {
+	Labels map[string]string `json:"labels"`
+}
+
+var prometheusBackends = []e2e.ServiceAccessBackend{
+	{
+		ServiceName: prometheusServiceName,
+		Namespaces:  defaultPromNamespaces,
+		Port:        prometheusServicePort,
+		UseTLS:      false,
+		RequireAuth: false,
+	},
+	{
+		ServiceName: "prometheus-k8s",
+		Namespaces:  defaultOCPNamespace,
+		Port:        9091,
+		UseTLS:      true,
+		RequireAuth: true,
+	},
+	{
+		ServiceName: "prometheus-user-workload",
+		Namespaces:  defaultUWMNamespaces,
+		Port:        9091,
+		UseTLS:      true,
+		RequireAuth: true,
+	},
+}
+
+var _ = Describe("Alertmanager proxy", func() {
+	BeforeEach(func() {
+		testHarness = e2e.GetWorkerHarness()
+
+		ctxName, err := e2e.GetContext()
+		Expect(err).ToNot(HaveOccurred())
+		testRuntimeContext = ctxName
+		if ctxName != util.KIND && ctxName != util.OCP {
+			Skip(fmt.Sprintf("Kubernetes-backed test context required, got %q", ctxName))
+		}
+	})
+
+	It("Lets a user discover and query alerts through the proxy", Label("87773", "sanity"), func() {
+		By("Opening the alertmanager proxy endpoint")
+		baseURL, client, cleanup, err := testHarness.StartServiceAccess(alertmanagerProxyServiceName, defaultProxyNamespaces, alertmanagerProxyServicePort, true, httpClientTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to start proxy service access")
+		defer cleanup()
+
+		By("Verifying public health and status endpoints are reachable")
+		Eventually(testHarness.StatusCodePollerWithExpectedBody(client, baseURL, proxyHealthPath, "", healthBodyOK, http.StatusOK), util.TIMEOUT, util.POLLING).
+			Should(Equal(http.StatusOK), "expected /health to return %d with body %q", http.StatusOK, healthBodyOK)
+		Eventually(testHarness.JSONStatusCodePoller(client, baseURL, proxyStatusPath, "", applicationJSON, http.StatusOK), util.TIMEOUT, util.POLLING).
+			Should(Equal(http.StatusOK), "expected /api/v2/status to return %d with JSON content type", http.StatusOK)
+
+		By("Resolving the current organization context used by the logged-in user")
+		orgID, err := testHarness.GetOrganizationID()
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve organization id")
+		Expect(orgID).ToNot(BeEmpty(), "organization id should not be empty")
+
+		By("Ensuring an unauthenticated user cannot read alerts")
+		alertsPath := buildAlertsFilterPath(orgID, "", "")
+		noAuthStatusCode, noAuthBody, err := testHarness.HTTPGet(client, baseURL, alertsPath, "")
+		Expect(err).ToNot(HaveOccurred(), "unauthenticated alerts request failed for path %q", alertsPath)
+		Expect(noAuthStatusCode).To(Equal(http.StatusBadRequest), "expected unauthenticated /alerts to return %d", http.StatusBadRequest)
+		Expect(noAuthBody).ToNot(BeEmpty(), "unauthenticated /alerts response body should not be empty")
+		Expect(noAuthBody).To(ContainSubstring(statusKindField), "unauthenticated /alerts response should include status kind")
+		Expect(noAuthBody).To(ContainSubstring(statusFailure), "unauthenticated /alerts response should indicate failure")
+		Expect(noAuthBody).To(ContainSubstring(authTokenErrMsg), "unauthenticated /alerts response should mention missing auth token")
+
+		By("Authenticating and reading alerts for the same organization")
+		authMethod := login.LoginToAPIWithToken(testHarness)
+		if authMethod == login.AuthDisabled {
+			Skip(authDisabledMsg)
+		}
+		authOrgID, authToken, err := testHarness.ResolveOrganizationAndClientToken()
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve authenticated org/token context")
+		Expect(authOrgID).ToNot(BeEmpty(), "authenticated organization id should not be empty")
+		Expect(authToken).ToNot(BeEmpty(), "authenticated token should not be empty")
+
+		authAlertsPath := buildAlertsFilterPath(authOrgID, "", "")
+		withAuthStatusCode, withAuthBody, err := testHarness.HTTPGet(client, baseURL, authAlertsPath, authToken)
+		Expect(err).ToNot(HaveOccurred(), "authenticated alerts request failed for path %q", authAlertsPath)
+		Expect(withAuthStatusCode).To(Equal(http.StatusOK), "expected authenticated /alerts to return %d", http.StatusOK)
+		Expect(withAuthBody).ToNot(BeEmpty(), "authenticated /alerts response body should not be empty")
+		Expect(json.Valid([]byte(withAuthBody))).To(BeTrue(), "authenticated /alerts response body should be valid JSON")
+
+		By("Returning a clear validation error for malformed organization filters")
+		invalidPath := buildAlertsFilterPath(proxyInvalidOrgID, "", "")
+		statusCode, body, err := testHarness.HTTPGet(client, baseURL, invalidPath, authToken)
+		Expect(err).ToNot(HaveOccurred(), "malformed org_id request failed for path %q", invalidPath)
+		Expect(statusCode).To(Equal(http.StatusBadRequest), "expected malformed org_id request to return %d", http.StatusBadRequest)
+		Expect(body).ToNot(BeEmpty(), "malformed org_id response body should not be empty")
+		Expect(body).To(ContainSubstring("invalid org_id format in filter"), "malformed org_id response should describe invalid org_id")
+		Expect(body).To(ContainSubstring("invalid UUID length"), "malformed org_id response should include UUID length validation details")
+
+		By("Letting a user filter alerts by common alert categories")
+		for _, alertName := range []string{alertNameDeviceDisconnected, alertNameDeviceDiskWarning} {
+			filteredPath := buildAlertsFilterPath(authOrgID, alertName, "")
+			filterStatusCode, filterBody, err := testHarness.HTTPGet(client, baseURL, filteredPath, authToken)
+			Expect(err).ToNot(HaveOccurred(), "alert filter request failed for alertname=%q", alertName)
+			Expect(filterStatusCode).To(Equal(http.StatusOK), "expected alert filter request to return %d for alertname=%q", http.StatusOK, alertName)
+			Expect(filterBody).ToNot(BeEmpty(), "alert filter response should not be empty for alertname=%q", alertName)
+			Expect(json.Valid([]byte(filterBody))).To(BeTrue(), "alert filter response should be valid JSON for alertname=%q", alertName)
+
+			alerts, err := parseAlertsResponse(filterBody)
+			Expect(err).ToNot(HaveOccurred(), "failed to parse alert filter response for alertname=%q", alertName)
+			for _, alert := range alerts {
+				Expect(alert.Labels).ToNot(BeNil(), "alert labels should not be nil")
+				if name, ok := alert.Labels[alertsLabelName]; ok {
+					Expect(name).To(Equal(alertName), "alertname label mismatch")
+				}
+				if id, ok := alert.Labels[alertsLabelOrgID]; ok {
+					Expect(id).To(Equal(authOrgID), "org_id label mismatch")
+				}
+			}
+		}
+	})
+
+	It("denies authenticated user without alerts permission", Label("87776", "sanity"), func() {
+		if testRuntimeContext != util.OCP {
+			Skip("non-admin authz-denied flow currently validated on OCP context")
+		}
+
+		baseURL, client, cleanup, err := testHarness.StartServiceAccess(alertmanagerProxyServiceName, defaultProxyNamespaces, alertmanagerProxyServicePort, true, httpClientTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to start proxy service access")
+		defer cleanup()
+
+		defaultK8sContext, k8sAPIEndpoint, err := testHarness.ResolveClusterLoginContext(testHarness.Context)
+		if err != nil {
+			Skip(fmt.Sprintf("unable to resolve cluster login context for non-admin authz test: %v", err))
+		}
+
+		err = login.LoginAsNonAdmin(testHarness, nonAdminUser, nonAdminPassword, defaultK8sContext, k8sAPIEndpoint)
+		if err != nil {
+			Skip(fmt.Sprintf("unable to login as non-admin user %q for authz-denied test: %v", nonAdminUser, err))
+		}
+		defer func() {
+			restoreErr := restoreAdminLoginContext(testHarness, testHarness.Context, defaultK8sContext)
+			Expect(restoreErr).ToNot(HaveOccurred(), "failed to restore admin login context")
+		}()
+
+		orgID, err := testHarness.GetOrganizationID()
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve organization id")
+		Expect(orgID).ToNot(BeEmpty(), "organization id should not be empty")
+
+		token, err := testHarness.GetClientAccessToken()
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve non-admin token")
+		Expect(token).ToNot(BeEmpty(), "non-admin token should not be empty")
+
+		alertsPath := buildAlertsFilterPath(orgID, "", "")
+		statusCode, body, err := testHarness.HTTPGet(client, baseURL, alertsPath, token)
+		Expect(err).ToNot(HaveOccurred(), "non-admin alerts request failed")
+		Expect(statusCode).To(Equal(http.StatusForbidden), "expected non-admin alerts request to return %d", http.StatusForbidden)
+		Expect(body).ToNot(BeEmpty(), "forbidden response body should not be empty")
+		Expect(body).To(ContainSubstring(statusForbidden), "forbidden response should include %q", statusForbidden)
+	})
+
+	It("verifies Prometheus query path for common alert series", Label("87775"), func() {
+		orgID, err := testHarness.GetOrganizationID()
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve organization id")
+		Expect(orgID).ToNot(BeEmpty(), "organization id should not be empty")
+
+		promURL, _, promToken, cleanup, usedBackend, err := testHarness.StartFirstAvailableBackendAccess(prometheusBackends, httpClientTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to start prometheus backend access")
+		defer cleanup()
+		Expect(usedBackend.ServiceName).ToNot(BeEmpty(), "selected prometheus backend name should not be empty")
+		Expect(promURL).ToNot(BeEmpty(), "prometheus base URL should not be empty")
+
+		query := fmt.Sprintf(prometheusQueryAlerts, orgID, alertNameDeviceDisconnected, alertNameDeviceDiskWarning)
+		resp, err := testHarness.PromQueryWithToken(promURL, query, promToken)
+		Expect(err).ToNot(HaveOccurred(), "prometheus query failed for %q", query)
+		Expect(resp.Status).To(Equal(prometheusStatusOK), "expected prometheus query status %q", prometheusStatusOK)
+		Expect(resp.Data.Result).ToNot(BeNil(), "prometheus query should return a valid result array")
+	})
+
+	It("verifies UI visibility wiring for alertmanager-proxy", Label("87774"), func() {
+		uiNamespace, err := testHarness.ResolveServiceNamespace(uiServiceName, defaultUINamespaces)
+		if err != nil {
+			Skip(fmt.Sprintf("ui service unavailable for this environment: %v", err))
+		}
+		Expect(uiNamespace).ToNot(BeEmpty(), "resolved UI namespace should not be empty")
+
+		proxyURL, err := util.GetConfigMapDataByJSONPath(uiNamespace, uiConfigMapName, uiConfigProxyJSONPath)
+		Expect(err).ToNot(HaveOccurred(), "failed to resolve UI config map proxy URL")
+		Expect(strings.TrimSpace(proxyURL)).ToNot(BeEmpty(), "UI proxy URL should not be empty")
+		Expect(strings.ToLower(proxyURL)).To(ContainSubstring(uiExpectedProxyHost), "UI proxy URL should contain %q", uiExpectedProxyHost)
+
+		uiBaseURL, uiClient, cleanup, err := testHarness.StartServiceAccess(uiServiceName, defaultUINamespaces, uiServicePort, false, httpClientTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to start UI service access")
+		defer cleanup()
+
+		statusCode, body, contentType, err := testHarness.HTTPGetWithContentType(uiClient, uiBaseURL, "/", "")
+		Expect(err).ToNot(HaveOccurred(), "UI root request failed")
+		Expect(statusCode).To(BeElementOf(http.StatusOK, http.StatusBadRequest), "expected UI root status to be 200 or 400")
+		Expect(body).ToNot(BeEmpty(), "UI root response body should not be empty")
+		if contentType != "" {
+			Expect(contentType).To(
+				Or(
+					ContainSubstring("text/html"),
+					ContainSubstring(applicationJSON),
+					ContainSubstring("text/plain"),
+				),
+				"unexpected UI root content type %q",
+				contentType,
+			)
+		}
+	})
+})
+
+func buildAlertsFilterPath(orgID, alertName, resourceName string) string {
+	filters := url.Values{}
+	if orgID != "" {
+		filters.Add("filter", fmt.Sprintf("%s=%s", alertsLabelOrgID, orgID))
+	}
+	if alertName != "" {
+		filters.Add("filter", fmt.Sprintf("%s=%s", alertsLabelName, alertName))
+	}
+	if resourceName != "" {
+		filters.Add("filter", fmt.Sprintf("%s=%s", alertsLabelRes, resourceName))
+	}
+	return proxyAlertsPath + "?" + filters.Encode()
+}
+
+func parseAlertsResponse(body string) ([]alertmanagerAlertResponse, error) {
+	result := make([]alertmanagerAlertResponse, 0)
+	if body == "" {
+		return result, nil
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return nil, fmt.Errorf("failed to decode alerts response: %w", err)
+	}
+	return result, nil
+}
+
+func restoreAdminLoginContext(h *e2e.Harness, ctx context.Context, defaultK8sContext string) error {
+	if h == nil {
+		return fmt.Errorf("harness is nil")
+	}
+	if defaultK8sContext == "" {
+		return fmt.Errorf("default context is empty")
+	}
+
+	err := h.RestoreK8sContext(ctx, defaultK8sContext)
+	if err != nil {
+		return fmt.Errorf("failed to restore k8s context %q: %w", defaultK8sContext, err)
+	}
+
+	loginMethod := login.LoginToAPIWithToken(h)
+	if loginMethod == login.AuthDisabled {
+		return fmt.Errorf("auth is disabled while restoring admin login context")
+	}
+	return nil
+}

--- a/test/e2e/observability/observability_test.go
+++ b/test/e2e/observability/observability_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Device observability", func() {
 			harness := e2e.GetWorkerHarness()
 
 			By("verifying telemetry gateway configuration exports Prometheus metrics")
-			cfg, err := harness.GetConfigMapValue(telemetryGatewayNamespace, telemetryGatewayConfigMap, telemetryGatewayConfigPath)
+			cfg, err := util.GetConfigMapDataByJSONPath(telemetryGatewayNamespace, telemetryGatewayConfigMap, telemetryGatewayConfigPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).To(ContainSubstring("prometheus"))
 			Expect(cfg).To(ContainSubstring("listen"))

--- a/test/harness/e2e/harness_observability.go
+++ b/test/harness/e2e/harness_observability.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,20 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
-const promQueryEndpointPath = "/api/v1/query"
+const (
+	promQueryEndpointPath    = "/api/v1/query"
+	promBackendProbeQuery    = "1"
+	promBackendProbeTimeout  = 10 * time.Second
+	promBackendProbeInterval = 250 * time.Millisecond
+)
+
+type ServiceAccessBackend struct {
+	ServiceName string
+	Namespaces  []string
+	Port        int
+	UseTLS      bool
+	RequireAuth bool
+}
 
 // StartPortForwardWithCleanup starts port-forwarding and returns a cleanup function.
 func (h *Harness) StartPortForwardWithCleanup(namespace, target string, localPort, remotePort int) (func(), error) {
@@ -125,7 +139,19 @@ type PromQueryResponse struct {
 
 // PromQuery executes a Prometheus query against a base URL.
 func (h *Harness) PromQuery(baseURL, query string) (PromQueryResponse, error) {
+	return h.PromQueryWithToken(baseURL, query, "")
+}
+
+// PromQueryWithToken executes a Prometheus query against a base URL with optional bearer token.
+func (h *Harness) PromQueryWithToken(baseURL, query, bearerToken string) (PromQueryResponse, error) {
 	var parsed PromQueryResponse
+	if baseURL == "" {
+		return parsed, fmt.Errorf("baseURL cannot be empty")
+	}
+	if query == "" {
+		return parsed, fmt.Errorf("query cannot be empty")
+	}
+
 	client := &http.Client{Timeout: fiveSecondTimeout}
 	req, err := http.NewRequest(http.MethodGet, baseURL+promQueryEndpointPath, nil)
 	if err != nil {
@@ -134,6 +160,9 @@ func (h *Harness) PromQuery(baseURL, query string) (PromQueryResponse, error) {
 	q := req.URL.Query()
 	q.Set("query", query)
 	req.URL.RawQuery = q.Encode()
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -158,6 +187,86 @@ func (h *Harness) PromQuery(baseURL, query string) (PromQueryResponse, error) {
 	}
 
 	return parsed, nil
+}
+
+// HTTPGetWithContentType performs a GET request against baseURL+path with optional bearer token.
+func (h *Harness) HTTPGetWithContentType(client *http.Client, baseURL, path, bearerToken string) (int, string, string, error) {
+	if client == nil {
+		return 0, "", "", fmt.Errorf("http client is nil")
+	}
+	if baseURL == "" {
+		return 0, "", "", fmt.Errorf("base URL is empty")
+	}
+	if path == "" {
+		return 0, "", "", fmt.Errorf("request path is empty")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return 0, "", "", fmt.Errorf("failed to create GET request: %w", err)
+	}
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", "", fmt.Errorf("GET %s failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", "", fmt.Errorf("failed reading response body from %s: %w", path, err)
+	}
+
+	return resp.StatusCode, string(body), resp.Header.Get("Content-Type"), nil
+}
+
+// HTTPGet performs a GET request against baseURL+path with optional bearer token.
+func (h *Harness) HTTPGet(client *http.Client, baseURL, path, bearerToken string) (int, string, error) {
+	statusCode, body, _, err := h.HTTPGetWithContentType(client, baseURL, path, bearerToken)
+	return statusCode, body, err
+}
+
+// StatusCodePollerWithExpectedBody returns a poller that validates status code and exact body.
+func (h *Harness) StatusCodePollerWithExpectedBody(client *http.Client, baseURL, path, bearerToken, expectedBody string, expectedStatus int) func() int {
+	return func() int {
+		statusCode, body, err := h.HTTPGet(client, baseURL, path, bearerToken)
+		if err != nil {
+			return 0
+		}
+		if expectedBody != "" && body != expectedBody {
+			return 0
+		}
+		if expectedStatus == 0 {
+			return statusCode
+		}
+		if statusCode != expectedStatus {
+			return 0
+		}
+		return statusCode
+	}
+}
+
+// JSONStatusCodePoller returns a poller that validates status code and JSON body/content type.
+func (h *Harness) JSONStatusCodePoller(client *http.Client, baseURL, path, bearerToken, contentTypeMustContain string, expectedStatus int) func() int {
+	return func() int {
+		statusCode, body, contentType, err := h.HTTPGetWithContentType(client, baseURL, path, bearerToken)
+		if err != nil {
+			return 0
+		}
+		if expectedStatus != 0 && statusCode != expectedStatus {
+			return 0
+		}
+		if body == "" || !json.Valid([]byte(body)) {
+			return 0
+		}
+		if contentTypeMustContain != "" && !strings.Contains(contentType, contentTypeMustContain) {
+			return 0
+		}
+		return statusCode
+	}
 }
 
 // PromQueryResultCount returns a closure for polling the count of query results.
@@ -223,19 +332,6 @@ func labelsMatch(labels map[string]string, exact map[string]string, required []s
 	return true
 }
 
-// GetConfigMapValue returns a string value from a ConfigMap using a jsonpath selector.
-func (h *Harness) GetConfigMapValue(namespace, name, jsonPath string) (string, error) {
-	// #nosec G204 -- command args are fixed and controlled in test.
-	out, err := exec.Command("kubectl", "get", "configmap", name,
-		"-n", namespace,
-		"-o", jsonPath,
-	).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("kubectl get configmap: %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	return string(out), nil
-}
-
 // VerifyServiceExists verifies a Kubernetes service exists.
 func (h *Harness) VerifyServiceExists(namespace, name string) error {
 	// #nosec G204 -- command args are fixed and controlled in test.
@@ -244,6 +340,112 @@ func (h *Harness) VerifyServiceExists(namespace, name string) error {
 		return fmt.Errorf("kubectl get svc %s/%s: %w: %s", namespace, name, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// StartServiceAccess resolves, port-forwards and returns an HTTP client to a service.
+func (h *Harness) StartServiceAccess(serviceName string, namespaces []string, remotePort int, useTLS bool, timeout time.Duration) (string, *http.Client, func(), error) {
+	if h == nil {
+		return "", nil, nil, fmt.Errorf("harness is nil")
+	}
+	if serviceName == "" {
+		return "", nil, nil, fmt.Errorf("service name is empty")
+	}
+	if remotePort <= 0 {
+		return "", nil, nil, fmt.Errorf("invalid remote port: %d", remotePort)
+	}
+
+	namespace, err := h.ResolveServiceNamespace(serviceName, namespaces)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	localPort, err := h.GetFreeLocalPort()
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to allocate local port: %w", err)
+	}
+
+	target := "svc/" + serviceName
+	cleanup, err := h.StartPortForwardWithCleanup(namespace, target, localPort, remotePort)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to start port-forward for %s in namespace %s: %w", target, namespace, err)
+	}
+
+	scheme := "http"
+	transport := &http.Transport{}
+	if useTLS {
+		scheme = "https"
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 -- e2e test uses local ephemeral port-forward endpoint
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+	if timeout <= 0 {
+		timeout = fiveSecondTimeout
+	}
+	baseURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, localPort)
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+	return baseURL, client, cleanup, nil
+}
+
+// StartFirstAvailableBackendAccess starts access to the first available backend from a candidate list.
+// If a backend requires auth, an OpenShift token is returned.
+func (h *Harness) StartFirstAvailableBackendAccess(backends []ServiceAccessBackend, timeout time.Duration) (string, *http.Client, string, func(), ServiceAccessBackend, error) {
+	var selected ServiceAccessBackend
+	if h == nil {
+		return "", nil, "", nil, selected, fmt.Errorf("harness is nil")
+	}
+	if len(backends) == 0 {
+		return "", nil, "", nil, selected, fmt.Errorf("no backend candidates provided")
+	}
+
+	var lookupErrors []string
+	for _, backend := range backends {
+		baseURL, client, cleanup, err := h.StartServiceAccess(backend.ServiceName, backend.Namespaces, backend.Port, backend.UseTLS, timeout)
+		if err != nil {
+			lookupErrors = append(lookupErrors, fmt.Sprintf("%s: %v", backend.ServiceName, err))
+			continue
+		}
+
+		token := ""
+		if backend.RequireAuth {
+			token, err = h.GetOpenShiftToken()
+			if err != nil {
+				cleanup()
+				return "", nil, "", nil, selected, fmt.Errorf("failed to resolve OpenShift token for backend %s: %w", backend.ServiceName, err)
+			}
+		}
+
+		if err := h.waitForPrometheusBackendReady(baseURL, token); err != nil {
+			lookupErrors = append(lookupErrors, fmt.Sprintf("%s: %v", backend.ServiceName, err))
+			cleanup()
+			continue
+		}
+
+		return baseURL, client, token, cleanup, backend, nil
+	}
+
+	return "", nil, "", nil, selected, fmt.Errorf("unable to resolve backend from known candidates: %v", lookupErrors)
+}
+
+func (h *Harness) waitForPrometheusBackendReady(baseURL, bearerToken string) error {
+	if h == nil {
+		return fmt.Errorf("harness is nil")
+	}
+
+	deadline := time.Now().Add(promBackendProbeTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		_, lastErr = h.PromQueryWithToken(baseURL, promBackendProbeQuery, bearerToken)
+		if lastErr == nil {
+			return nil
+		}
+		time.Sleep(promBackendProbeInterval)
+	}
+
+	return fmt.Errorf("prometheus backend did not become ready within %s: %w", promBackendProbeTimeout, lastErr)
 }
 
 func parsePrometheusMetrics(body string) (map[string]*dto.MetricFamily, error) {

--- a/test/harness/e2e/harness_oc.go
+++ b/test/harness/e2e/harness_oc.go
@@ -65,3 +65,19 @@ func getSecretData(secretName, namespace, key string) (string, error) {
 
 	return strings.TrimSpace(string(output)), nil
 }
+
+// GetOpenShiftToken returns the current OpenShift bearer token from oc.
+func (h *Harness) GetOpenShiftToken() (string, error) {
+	if h == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	token, err := h.SH("oc", "whoami", "-t")
+	if err != nil {
+		return "", fmt.Errorf("failed to get openshift token from oc: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", fmt.Errorf("openshift token is empty")
+	}
+	return token, nil
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -86,6 +86,19 @@ func NewTestProvider(log logrus.FieldLogger) queues.Provider {
 	}
 }
 
+// GetConfigMapDataByJSONPath returns data from a ConfigMap using a jsonpath selector.
+func GetConfigMapDataByJSONPath(namespace, name, jsonPath string) (string, error) {
+	// #nosec G204 -- command args are fixed and controlled in test.
+	out, err := exec.Command("kubectl", "get", "configmap", name,
+		"-n", namespace,
+		"-o", jsonPath,
+	).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("kubectl get configmap: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
 func (t *testProvider) NewQueueProducer(_ context.Context, _ string) (queues.QueueProducer, error) {
 	return t, nil
 }


### PR DESCRIPTION
Tests for the alertmanager-proxy feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Alertmanager Proxy end-to-end tests covering health/status, auth flows (token/unauth/disabled), RBAC, alert filtering, Prometheus backend probes (TLS/auth variants), UI proxy behavior, malformed-filter/error cases, and per-test setup/teardown for isolated runs.
* **Chores**
  * Enhanced test harness and utilities: multi-backend service access with port-forwarding, token-aware HTTP/Prometheus checks, OpenShift token and context helpers, namespace resolution, and configmap JSON-path retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->