### PR TITLE
NO-ISSUE: Only lint diagrams in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,7 @@ lint-docs: .output/stamps/lint-docs
 .PHONY: lint-diagrams
 lint-diagrams:
 	@echo "Verifying Excalidraw diagrams have scene embedded"
-	@for d in $$(find . -type d); do \
+	@for d in $$(find ./docs -type d); do \
 		for f in $$(find $$d -maxdepth 1 -type f -iname '*.svg'); do \
 			if [ -f "$$d/.excalidraw-ignore" ] && $$(basename "$$f" | grep -q --basic-regexp --file=$$d/.excalidraw-ignore); then continue ; fi ; \
 			if ! grep -q "excalidraw+json" $$f; then \


### PR DESCRIPTION
Addresses failure in lint-docs due to svg not being excluded - https://github.com/flightctl/flightctl/actions/runs/21910142027/job/63261373949?pr=2429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an internal Excalidraw ignore configuration to exclude a specific asset from design files, reducing clutter in diagram exports and simplifying design maintenance. No changes to features, UI, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->