### PR TITLE
EDM-2932: Explicitly give console user passwordless sudo

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -317,6 +317,8 @@ echo "Flight Control Observability Stack uninstalled."
     mkdir -p %{buildroot}%{_sysusersdir}
     install -Dpm 0644 packaging/rpm/sysusers.d/flightctl.conf %{buildroot}%{_sysusersdir}/flightctl.conf
 
+    install -Dpm 0440 packaging/rpm/sudoers.d/flightctl %{buildroot}/etc/sudoers.d/flightctl
+
     # flightctl-services sub-package steps
     # Use the flightctl-standalone render quadlets command to generate quadlet files with the correct image tags.
     #
@@ -438,6 +440,7 @@ fi
     /usr/lib/systemd/system/flightctl-configure-greenboot.service
     /usr/share/sosreport/flightctl.py
     %{_sysusersdir}/flightctl.conf
+    /etc/sudoers.d/*
 
 %post agent
 # Enable the greenboot configuration service (runs before greenboot-healthcheck.service)

--- a/packaging/rpm/sudoers.d/flightctl
+++ b/packaging/rpm/sudoers.d/flightctl
@@ -1,0 +1,1 @@
+flightctl-console       ALL=(ALL)       NOPASSWD: ALL

--- a/packaging/rpm/sysusers.d/flightctl.conf
+++ b/packaging/rpm/sysusers.d/flightctl.conf
@@ -2,5 +2,3 @@ u flightctl-console - "Flightctl Agent Console User" /var/lib/flightctl  /bin/ba
 g flightctl-console -
 # Map the user to the group
 m flightctl-console flightctl-console
-# Give the flightctl-console user sudo access
-m flightctl-console wheel


### PR DESCRIPTION
Don't rely upon defaults or admin configuration.

Also *remove* the user from the wheel group since we are explicitly giving it sudo access now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated privilege escalation configuration so the flightctl-console user is granted passwordless sudo access via a dedicated sudoers entry.
  * Adjusted RPM packaging to include the new sudoers entry in agent installations, ensuring the configuration is deployed with the agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->