### PR TITLE
EDM-3323: Element exceed the 64 chars limit

### DIFF
--- a/internal/agent/device/errors/structured.go
+++ b/internal/agent/device/errors/structured.go
@@ -17,6 +17,16 @@ type StructuredError struct {
 	Timestamp  time.Time
 }
 
+// truncateElement truncates an element value to 64 characters for use in structured error messages.
+// This ensures device status messages comply with API constraints while preserving the end of the path.
+func truncateElement(element string) string {
+	const maxLength = 64
+	if len(element) > maxLength {
+		return "..." + element[len(element)-maxLength:]
+	}
+	return element
+}
+
 // FormatError extracts phase and component from the error chain.
 func FormatError(err error) *StructuredError {
 	phase, rest := splitWrapped(err)
@@ -26,7 +36,7 @@ func FormatError(err error) *StructuredError {
 	return &StructuredError{
 		Phase:      phase,
 		Component:  component,
-		Element:    GetElement(err),
+		Element:    truncateElement(GetElement(err)),
 		StatusCode: statusCode,
 		Category:   inferCategory(statusCode),
 		Timestamp:  time.Now(),

--- a/internal/agent/device/errors/structured_test.go
+++ b/internal/agent/device/errors/structured_test.go
@@ -100,8 +100,8 @@ func TestGetElement(t *testing.T) {
 	}{
 		{
 			name:     "extracts element from direct wrap",
-			err:      fmt.Errorf("creating directory %w: %w", WithElement("/var/lib/myapp"), ErrPermissionDenied),
-			expected: "/var/lib/myapp",
+			err:      fmt.Errorf("creating directory %w: %w", WithElement("/var/lib/myapp/making/sure/the/string/is/longer/than/64/characters"), ErrPermissionDenied),
+			expected: "/var/lib/myapp/making/sure/the/string/is/longer/than/64/characters",
 		},
 		{
 			name:     "extracts element from nested chain",
@@ -151,6 +151,11 @@ func TestFormatErrorWithElement(t *testing.T) {
 			err: fmt.Errorf("%w: %w", ErrPhasePreparing,
 				fmt.Errorf("%w: %w", ErrComponentApplications, ErrNetwork)),
 			expectedElement: "",
+		},
+		{
+			name:            "truncates long element path in structured error",
+			err:             fmt.Errorf("creating directory %w: %w", WithElement("/var/lib/myapp/making/sure/the/string/is/longer/than/64/characters"), ErrPermissionDenied),
+			expectedElement: "..." + "ar/lib/myapp/making/sure/the/string/is/longer/than/64/characters",
 		},
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error element paths are now truncated in error messages so overly long paths display a shortened tail, preventing excessively long error strings.
* **Tests**
  * Unit tests updated to expect truncated element paths.
  * End-to-end test flow made delay-tolerant by waiting for the device to report ready/System info before asserting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->