### PR TITLE
EDM-2966: Capital Letters in hostname cause service startup failure

### DIFF
--- a/cmd/flightctl-standalone/render_template.go
+++ b/cmd/flightctl-standalone/render_template.go
@@ -91,6 +91,15 @@ func (o *RenderTemplateOptions) completeConfig(data map[string]interface{}) erro
 		fmt.Fprintf(os.Stderr, "global.baseDomain not set, defaulting to system hostname FQDN (%s)\n", hostname)
 	}
 
+	// Normalize baseDomain to lowercase (DNS is case-insensitive per RFC 1123).
+	// This covers both explicit values from service-config.yaml and hostname defaults.
+	baseDomain, _ = global["baseDomain"].(string)
+	normalized := strings.ToLower(baseDomain)
+	if normalized != baseDomain {
+		global["baseDomain"] = normalized
+		fmt.Fprintf(os.Stderr, "global.baseDomain normalized to lowercase: %s -> %s\n", baseDomain, normalized)
+	}
+
 	// Default UI forwarded-header settings.
 	ui, ok := global["ui"].(map[string]interface{})
 	if !ok {
@@ -162,6 +171,7 @@ func (o *RenderTemplateOptions) validateConfig(data map[string]interface{}) erro
 		return fmt.Errorf("failed to unmarshal config for validation: %w", err)
 	}
 
+	validation.NormalizeStandaloneConfig(&config)
 	if errs := validation.ValidateStandaloneConfig(&config); len(errs) > 0 {
 		errMsgs := make([]string, len(errs))
 		for i, err := range errs {

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -37,14 +37,19 @@ host_ips+=("127.0.0.1")
 # Validate the base domain from config, or default to hostname FQDN
 base_domain=$(python3 "$YAML_HELPER" extract .global.baseDomain "$CONFIG_FILE")
 if [[ -z "$base_domain" ]]; then
-    # Normalize to lowercase (DNS is case-insensitive per RFC 1123)
-    base_domain="${hostname_fqdn,,}"
+    base_domain="${hostname_fqdn}"
     echo "global.baseDomain not set, defaulting to system hostname FQDN ($base_domain)"
 fi
 
+# Normalize to lowercase (DNS is case-insensitive per RFC 1123)
+base_domain="${base_domain,,}"
+
 # Validate as hostname or FQDN: lowercase alphanumerics and hyphens, final label must start with letter
 if ! [[ "$base_domain" =~ ^([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
-    echo "ERROR: global.baseDomain must be a valid hostname or FQDN (not an IP address)" 1>&2
+    echo "ERROR: global.baseDomain '$base_domain' is not a valid hostname or FQDN." 1>&2
+    echo "  Hostnames must contain only lowercase letters, digits, and hyphens (e.g. 'example.com')." 1>&2
+    echo "  Fix: set a valid baseDomain in /etc/flightctl/service-config.yaml, or rename the host:" 1>&2
+    echo "    hostnamectl set-hostname <valid-hostname>" 1>&2
     exit 1
 fi
 

--- a/docs/user/installing/installing-service-on-linux.md
+++ b/docs/user/installing/installing-service-on-linux.md
@@ -2,6 +2,31 @@
 
 Containerized Flight Control services can be installed on a Fedora or RHEL host by running [Podman quadlet systemd units](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html).
 
+## Prerequisites
+
+The system hostname is used as the default `baseDomain` for Flight Control services. It must be a valid DNS name:
+
+- Only lowercase letters, digits, and hyphens (e.g. `my-host`, `flightctl.example.com`)
+- Must start and end with a letter or digit (not a hyphen)
+- Must not be an IP address
+
+> [!NOTE]
+> Uppercase letters in the hostname (e.g. `rhel9-GA`) are automatically normalized to lowercase. However, other invalid characters such as underscores will cause service startup failures.
+
+To check your hostname:
+
+```bash
+hostname -f
+```
+
+To rename a host with an invalid hostname:
+
+```bash
+sudo hostnamectl set-hostname <valid-hostname>
+```
+
+Alternatively, you can set `global.baseDomain` explicitly in `/etc/flightctl/service-config.yaml` to override the system hostname.
+
 ## Installing the RPM
 
 Services rpm files are hosted at [rpm.flightctl.io](https://rpm.flightctl.io/).  To install the latest release of flightctl-services enable the repo and install the rpm package.

--- a/internal/util/validation/standalone.go
+++ b/internal/util/validation/standalone.go
@@ -9,6 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// NormalizeStandaloneConfig canonicalizes config values in-place.
+// DNS names are case-insensitive per RFC 1123, so baseDomain is lowercased
+// to ensure consistent behavior across certificates, service URLs, and TLS verification.
+func NormalizeStandaloneConfig(config *standalone.Config) {
+	if config == nil {
+		return
+	}
+	config.Global.BaseDomain = strings.ToLower(config.Global.BaseDomain)
+}
+
+// ValidateStandaloneConfig validates the standalone service configuration.
+// Callers should call NormalizeStandaloneConfig first to canonicalize values.
 func ValidateStandaloneConfig(config *standalone.Config) []error {
 	if config == nil {
 		return []error{fmt.Errorf("config cannot be nil")}


### PR DESCRIPTION
## Problem

On RHEL systems with uppercase letters in the hostname (e.g. `rhel9-GA`), starting Flight Control services via `systemctl start flightctl.target` fails. The `flightctl-db-wait.service` exits with a validation error, causing all dependent services to stall:
```bash
global.baseDomain: Invalid value: "rhel9-GA": Invalid pattern
(regex used for validation is '(a-z0-9?\\.)a-z?')
```
This occurs when `baseDomain` is explicitly set with uppercase characters in `service-config.yaml`. The case where `baseDomain` is left blank (defaulting to hostname) was already normalized in `getHostnameFQDN()`.

## Root Cause

The `baseDomain` value is validated against a lowercase-only DNS regex, but normalization to lowercase was only applied in some code paths (e.g. when defaulting from hostname via `hostname -f`). When a user explicitly sets an uppercase `baseDomain` in `service-config.yaml`, it passes through to validation unnormalized and is rejected.

DNS hostnames are case-insensitive per RFC 1123, so uppercase letters are valid but need to be canonicalized to lowercase before validation and use in downstream contexts (certificate SANs, service URLs, TLS verification).

## Solution

- Added `NormalizeStandaloneConfig()` to canonicalize `baseDomain` to lowercase before validation, covering both explicit and hostname-defaulted values.
- Updated bash init scripts (`init_certs.sh`, `init.sh`) to normalize `baseDomain` unconditionally before the regex check, not only when defaulting from hostname.
- Improved error messages to include remediation hints (`hostnamectl set-hostname` or setting `baseDomain` in config).
- Added a "Prerequisites" section to the Linux installation docs documenting hostname requirements.
- Added unit tests for the normalization behavior and uppercase validation contract.