### PR TITLE
EDM-3328: Non-root Pull Credential Handling

### DIFF
--- a/internal/agent/client/compose.go
+++ b/internal/agent/client/compose.go
@@ -15,7 +15,6 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/api/common"
-	"github.com/samber/lo"
 )
 
 const (
@@ -213,7 +212,7 @@ func ParseComposeFromSpec(contents []v1beta1.ApplicationContent) (*common.Compos
 			continue
 		}
 
-		contentBytes, err := fileio.DecodeContent(lo.FromPtr(c.Content), c.ContentEncoding)
+		contentBytes, err := c.ContentsDecoded()
 		if err != nil {
 			return nil, fmt.Errorf("decoding content %q: %w", filename, err)
 		}

--- a/internal/agent/client/quadlet.go
+++ b/internal/agent/client/quadlet.go
@@ -11,7 +11,6 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/flightctl/flightctl/internal/quadlet"
-	"github.com/samber/lo"
 )
 
 const (
@@ -101,7 +100,7 @@ func ParseQuadletReferencesFromSpec(contents []v1beta1.ApplicationContent) (map[
 			continue
 		}
 
-		contentBytes, err := fileio.DecodeContent(lo.FromPtr(c.Content), c.ContentEncoding)
+		contentBytes, err := c.ContentsDecoded()
 		if err != nil {
 			return nil, fmt.Errorf("decoding content %q: %w", filename, err)
 		}

--- a/internal/agent/device/applications/provider/compose.go
+++ b/internal/agent/device/applications/provider/compose.go
@@ -271,7 +271,7 @@ func (p *composeProvider) collectOCITargets(ctx context.Context, configProvider 
 			Type:         dependency.OCITypeAuto,
 			Reference:    p.imageRef,
 			PullPolicy:   v1beta1.PullIfNotPresent,
-			ClientOptsFn: containerPullOptions(configProvider),
+			ClientOptsFn: containerPullOptions(configProvider, p.spec.User),
 		})
 	} else {
 		composeSpec, err := client.ParseComposeFromSpec(p.inlineContent)
@@ -284,12 +284,12 @@ func (p *composeProvider) collectOCITargets(ctx context.Context, configProvider 
 					Type:         dependency.OCITypePodmanImage,
 					Reference:    svc.Image,
 					PullPolicy:   v1beta1.PullIfNotPresent,
-					ClientOptsFn: containerPullOptions(configProvider),
+					ClientOptsFn: containerPullOptions(configProvider, p.spec.User),
 				})
 			}
 		}
 	}
-	volTargets, err := extractVolumeTargets(p.spec.ComposeApp.Volumes, configProvider)
+	volTargets, err := extractVolumeTargets(p.spec.ComposeApp.Volumes, configProvider, p.spec.User)
 	if err != nil {
 		return nil, fmt.Errorf("extracting compose volume targets: %w", err)
 	}
@@ -301,7 +301,7 @@ func (p *composeProvider) extractNestedTargets(ctx context.Context, configProvid
 		return &AppData{}, nil
 	}
 
-	appData, err := extractAppDataFromOCITarget(ctx, p.podman, p.readWriter, p.spec.Name, p.imageRef, v1beta1.AppTypeCompose, configProvider)
+	appData, err := extractAppDataFromOCITarget(ctx, p.podman, p.readWriter, p.spec.Name, p.imageRef, v1beta1.AppTypeCompose, p.spec.User, configProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/device/applications/provider/container.go
+++ b/internal/agent/device/applications/provider/container.go
@@ -193,9 +193,9 @@ func (p *containerProvider) collectOCITargets(ctx context.Context, configProvide
 		Type:         dependency.OCITypePodmanImage,
 		Reference:    p.spec.ContainerApp.Image,
 		PullPolicy:   v1beta1.PullIfNotPresent,
-		ClientOptsFn: containerPullOptions(configProvider),
+		ClientOptsFn: containerPullOptions(configProvider, p.spec.User),
 	})
-	volTargets, err := extractVolumeTargets(p.spec.ContainerApp.Volumes, configProvider)
+	volTargets, err := extractVolumeTargets(p.spec.ContainerApp.Volumes, configProvider, p.spec.User)
 	if err != nil {
 		return nil, fmt.Errorf("extracting container volume targets: %w", err)
 	}

--- a/internal/agent/device/applications/provider/embedded_app_handler.go
+++ b/internal/agent/device/applications/provider/embedded_app_handler.go
@@ -130,7 +130,7 @@ func (e *embeddedQuadletBehavior) CollectOCITargets(_ context.Context, configPro
 	}
 	var targets []dependency.OCIPullTarget
 	for _, ref := range refs {
-		targets = append(targets, extractQuadletTargets(ref, configProvider)...)
+		targets = append(targets, extractQuadletTargets(ref, configProvider, v1beta1.CurrentProcessUsername)...)
 	}
 	return targets, nil
 }
@@ -188,7 +188,7 @@ func (e *embeddedComposeBehavior) CollectOCITargets(_ context.Context, configPro
 				Type:         dependency.OCITypePodmanImage,
 				Reference:    svc.Image,
 				PullPolicy:   v1beta1.PullIfNotPresent,
-				ClientOptsFn: containerPullOptions(configProvider),
+				ClientOptsFn: containerPullOptions(configProvider, v1beta1.CurrentProcessUsername),
 			})
 		}
 	}

--- a/internal/agent/device/applications/provider/provider_test.go
+++ b/internal/agent/device/applications/provider/provider_test.go
@@ -231,7 +231,7 @@ func TestExtractQuadletTargets(t *testing.T) {
 			mockResolver := dependency.NewMockPullConfigResolver(ctrl)
 			tt.setupMocks(mockResolver)
 
-			targets := extractQuadletTargets(tt.quad, mockResolver)
+			targets := extractQuadletTargets(tt.quad, mockResolver, v1beta1.CurrentProcessUsername)
 
 			require.Equal(tt.expectedCount, len(targets), "unexpected number of targets")
 

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -331,7 +331,7 @@ func (p *quadletProvider) collectOCITargets(ctx context.Context, configProvider 
 			Type:         dependency.OCITypeAuto,
 			Reference:    p.imageRef,
 			PullPolicy:   v1beta1.PullIfNotPresent,
-			ClientOptsFn: containerPullOptions(configProvider),
+			ClientOptsFn: containerPullOptions(configProvider, p.spec.User),
 		})
 	} else {
 		quadletSpec, err := client.ParseQuadletReferencesFromSpec(p.inlineContent)
@@ -339,10 +339,10 @@ func (p *quadletProvider) collectOCITargets(ctx context.Context, configProvider 
 			return nil, fmt.Errorf("parsing quadlet spec: %w", err)
 		}
 		for _, quad := range quadletSpec {
-			targets = targets.Add(p.spec.User, extractQuadletTargets(quad, configProvider)...)
+			targets = targets.Add(p.spec.User, extractQuadletTargets(quad, configProvider, p.spec.User)...)
 		}
 	}
-	volTargets, err := extractVolumeTargets(p.spec.QuadletApp.Volumes, configProvider)
+	volTargets, err := extractVolumeTargets(p.spec.QuadletApp.Volumes, configProvider, p.spec.User)
 	if err != nil {
 		return nil, fmt.Errorf("extracting quadlet volume targets: %w", err)
 	}
@@ -354,7 +354,7 @@ func (p *quadletProvider) extractNestedTargets(ctx context.Context, configProvid
 		return &AppData{}, nil
 	}
 
-	appData, err := extractAppDataFromOCITarget(ctx, p.podman, p.readWriter, p.spec.Name, p.imageRef, v1beta1.AppTypeQuadlet, configProvider)
+	appData, err := extractAppDataFromOCITarget(ctx, p.podman, p.readWriter, p.spec.Name, p.imageRef, v1beta1.AppTypeQuadlet, p.spec.User, configProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/device/applications/provider/utils.go
+++ b/internal/agent/device/applications/provider/utils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/pkg/log"
-	"github.com/samber/lo"
 )
 
 const (
@@ -166,7 +165,7 @@ func writeInlineContentToPath(rw fileio.ReadWriter, appPath string, contents []v
 		return fmt.Errorf("creating directory: %w", err)
 	}
 	for _, content := range contents {
-		contentBytes, err := fileio.DecodeContent(lo.FromPtr(content.Content), content.ContentEncoding)
+		contentBytes, err := content.ContentsDecoded()
 		if err != nil {
 			return fmt.Errorf("decoding application content: %w", err)
 		}

--- a/internal/agent/device/dependency/pull_config_test.go
+++ b/internal/agent/device/dependency/pull_config_test.go
@@ -331,9 +331,16 @@ func TestPullConfigResolver_AuthFromSpec(t *testing.T) {
 			resolver := NewPullConfigResolver(testLog, rwFactory).(*pullConfigResolver)
 			resolver.BeforeUpdate(tt.deviceSpec)
 
-			auth, found := resolver.authFromSpec(tt.deviceSpec, tt.authPath)
-			require.Equal(tt.expectedFound, found)
-			require.Equal(tt.expectedAuth, string(auth))
+			authFile := resolver.authFromSpec(tt.deviceSpec, tt.authPath)
+			t.Logf("authFile: %v", authFile)
+			if tt.expectedFound {
+				require.NotNil(authFile)
+				auth, err := authFile.ContentsDecoded()
+				require.NoError(err)
+				require.Equal(tt.expectedAuth, string(auth))
+			} else {
+				require.Nil(authFile)
+			}
 		})
 	}
 }

--- a/internal/agent/device/fileio/managed_file.go
+++ b/internal/agent/device/fileio/managed_file.go
@@ -55,7 +55,7 @@ func (m *managedFile) decodeFile() error {
 	if m.contents != nil {
 		return nil
 	}
-	contents, err := DecodeContent(m.file.Content, m.file.ContentEncoding)
+	contents, err := m.file.ContentsDecoded()
 	if err != nil {
 		return err
 	}

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"io/fs"
@@ -621,26 +620,6 @@ func lookupGID(group string) (int, error) {
 	}
 	gid, _ := strconv.Atoi(osGroup.Gid)
 	return gid, nil
-}
-
-// DecodeContents decodes the content based on the encoding type and returns the
-// decoded content as a byte slice.
-func DecodeContent(content string, encoding *v1beta1.EncodingType) ([]byte,
-	error) {
-	if encoding == nil || *encoding == "plain" {
-		return []byte(content), nil
-	}
-
-	switch *encoding {
-	case "base64":
-		decoded, err := base64.StdEncoding.DecodeString(content)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode base64 content: %w", err)
-		}
-		return decoded, nil
-	default:
-		return nil, fmt.Errorf("unsupported content encoding: %q", *encoding)
-	}
 }
 
 // WriteTmpFile writes the given content to a temporary file with the specified name prefix.


### PR DESCRIPTION
Instead of hardcoding /root/.config/containers/auth.json, dynamically derive the expected auth.json path based on the user that owns the application whose images are being pulled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized content decoding for consistent handling of inline and embedded content.
  * Container image pulls and volume handling are now user-aware, applying per-user authentication and access paths.
  * Internal decoding and auth flows simplified, reducing duplicate logic and improving maintainability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->