### PR TITLE
EDM-3349: Fix truncated unit names in list-dependencies output

### DIFF
--- a/internal/agent/client/systemd.go
+++ b/internal/agent/client/systemd.go
@@ -227,12 +227,13 @@ func (s *Systemd) ShowByMatchPattern(ctx context.Context, matchPatterns []string
 }
 
 // ListDependencies returns the list of units that the specified unit depends on.
-// Uses `systemctl list-dependencies --plain` to get a flat list of dependencies.
+// Uses `systemctl list-dependencies --plain --full` to get a flat list of dependencies.
+// The --full flag prevents systemd from truncating long unit names.
 func (s *Systemd) ListDependencies(ctx context.Context, unit string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultSystemctlTimeout)
 	defer cancel()
 
-	command, args := s.createArgs("list-dependencies", "--plain", "--no-pager", unit)
+	command, args := s.createArgs("list-dependencies", "--plain", "--no-pager", "--full", unit)
 	stdout, stderr, exitCode := s.exec.ExecuteWithContext(ctx, command, args...)
 	if exitCode != 0 {
 		return nil, fmt.Errorf("list-dependencies for %s: %w", unit, errors.FromStderr(stderr, exitCode))


### PR DESCRIPTION
When using the rootless user flightctl, the name of the systemd unit exceeded the length of what was output via `systemd list-dependencies` and would result in something like `my-unit-flightctl-12341.serv...` which would cause cascading failures. `--full` fixes that. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Systemd dependency information no longer truncates long unit names. Extended dependency listings now display the complete names of dependencies, improving visibility and preventing information loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->