### PR TITLE
EDM-3349: Avoid multi-user.target use for container apps

### DIFF
--- a/internal/agent/device/applications/provider/container.go
+++ b/internal/agent/device/applications/provider/container.go
@@ -249,7 +249,7 @@ func generateQuadlet(ctx context.Context, podman *client.Podman, rw fileio.ReadW
 
 	unit.Add("Service", "Restart", "on-failure").
 		Add("Service", "RestartSec", "60").
-		Add("Install", "WantedBy", "multi-user.target default.target")
+		Add("Install", "WantedBy", "default.target")
 
 	for _, vol := range lo.FromPtr(spec.Volumes) {
 		volType, err := vol.Type()

--- a/internal/agent/device/applications/provider/quadlet_test.go
+++ b/internal/agent/device/applications/provider/quadlet_test.go
@@ -756,7 +756,7 @@ Requires=db.service network.target
 Before=services.pod
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 
 [Container]
 Image=base.image
@@ -838,7 +838,7 @@ Image=vol-base.image
 					require.Contains(t, contentStr, "chronyd.service")
 					require.Contains(t, contentStr, "myapp-services.pod")
 					// Install section
-					require.Contains(t, contentStr, "multi-user.target")
+					require.Contains(t, contentStr, "default.target")
 					// Container section - all reference types
 					require.Contains(t, contentStr, "myapp-base.image")
 					require.Contains(t, contentStr, "myapp-app-net.network")
@@ -2050,7 +2050,7 @@ func TestGenerateQuadlet(t *testing.T) {
 				require.Contains(t, contentStr, "Restart=on-failure")
 				require.Contains(t, contentStr, "RestartSec=60")
 				require.Contains(t, contentStr, "[Install]")
-				require.Contains(t, contentStr, "WantedBy=multi-user.target default.target")
+				require.Contains(t, contentStr, "WantedBy=default.target")
 			},
 		},
 	}


### PR DESCRIPTION
Using default.target as the WantedBy target should be sufficient for normal server deployments.

It messes up rootless quadlet deployments to have multi-user.target since that only exists on root systemd instance. It should be safe to remove for both root and rootless quadlets though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated systemd unit configuration for container applications to streamline service dependencies by simplifying target bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->