### PR TITLE
EDM-3336: Remove sanity label from test 81737 (support multiple conso…

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -52,7 +52,7 @@ var _ = Describe("CLI - device console", func() {
 		cs.Close()
 	})
 
-	It("supports multiple simultaneous console sessions", Label("81737", "sanity", "agent"), func() {
+	It("supports multiple simultaneous console sessions", Label("81737", "agent"), func() {
 		// Get harness directly - no shared package-level variable
 		harness := e2e.GetWorkerHarness()
 


### PR DESCRIPTION
…le sessions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test labeling for console session testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->