### PR TITLE
NO-ISSUE: downstream imagebuild with subscription

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -308,6 +308,9 @@ networkless
  builder-worker.container
  imageBuilderWorker
  bool
+ imagebuilder
+ repos
+ RHSM
  - docs/user/references/api-resources.md
 CertificateSigningRequest
 AuthConfig

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -331,7 +331,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | imageBuilderApi.image.image | string | `"quay.io/flightctl/flightctl-imagebuilder-api"` | ImageBuilder API container image |
 | imageBuilderApi.image.pullPolicy | string | `""` | Image pull policy for ImageBuilder API container |
 | imageBuilderApi.image.tag | string | `""` | ImageBuilder API image tag |
-| imageBuilderWorker | object | `{"defaultTTL":"168h","enabled":true,"image":{"image":"quay.io/flightctl/flightctl-imagebuilder-worker","pullPolicy":"","tag":""},"logLevel":"info","maxConcurrentBuilds":2,"privileged":true,"replicas":1,"resources":{}}` | ImageBuilder Worker Configuration |
+| imageBuilderWorker | object | `{"defaultTTL":"168h","enabled":true,"image":{"image":"quay.io/flightctl/flightctl-imagebuilder-worker","pullPolicy":"","tag":""},"logLevel":"info","maxConcurrentBuilds":2,"privileged":true,"replicas":1,"resources":{},"rhsmCaSecretName":"","rhsmSecretName":"","yumReposSecretName":""}` | ImageBuilder Worker Configuration |
 | imageBuilderWorker.defaultTTL | string | `"168h"` | Default TTL for image build resources |
 | imageBuilderWorker.enabled | bool | `true` | Enable imagebuilder worker service |
 | imageBuilderWorker.image.image | string | `"quay.io/flightctl/flightctl-imagebuilder-worker"` | ImageBuilder Worker container image |
@@ -342,6 +342,9 @@ For more detailed configuration options, see the [Values](#values) section below
 | imageBuilderWorker.privileged | bool | `true` | Enable privileged mode for container-in-container builds |
 | imageBuilderWorker.replicas | int | `1` | Number of worker replicas |
 | imageBuilderWorker.resources | object | `{}` | Resource requests and limits |
+| imageBuilderWorker.rhsmCaSecretName | string | `""` | Secret name containing RHSM CA certificates, mounted at /etc/rhsm/ca |
+| imageBuilderWorker.rhsmSecretName | string | `""` | Secret name containing RHEL subscription manager configuration, mounted at /etc/rhsm |
+| imageBuilderWorker.yumReposSecretName | string | `""` | Secret name containing yum repository configuration files, mounted at /etc/yum.repos.d |
 | kv | object | `{"fsGroup":"","image":{"image":"quay.io/sclorg/redis-7-c9s","pullPolicy":"","tag":"20250108"},"loglevel":"warning","maxmemory":"1gb","maxmemoryPolicy":"allkeys-lru","passwordSecretName":""}` | Key-Value Store Configuration |
 | kv.fsGroup | string | `""` | File system group ID for Redis pod security context |
 | kv.image.image | string | `"quay.io/sclorg/redis-7-c9s"` | Redis container image |

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
@@ -45,4 +45,10 @@ data:
         {{- if .Values.imageBuilderWorker.rpmRepoUrl }}
         rpmRepoUrl: {{ .Values.imageBuilderWorker.rpmRepoUrl | quote }}
         {{- end }}
+        {{- if kindIs "bool" .Values.imageBuilderWorker.rpmRepoAdd }}
+        rpmRepoAdd: {{ .Values.imageBuilderWorker.rpmRepoAdd }}
+        {{- end }}
+        {{- if .Values.imageBuilderWorker.rpmRepoEnable }}
+        rpmRepoEnable: {{ .Values.imageBuilderWorker.rpmRepoEnable | quote }}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
@@ -89,10 +89,25 @@ spec:
               name: host-modules
               readOnly: true
 
-            # 4. ENTITLEMENT: Optional RHEL entitlement certs for subscription-only repos
+            # 4. RHEL: Optional mounts for subscription-only repos
             {{- if .Values.imageBuilderWorker.entitlementCertsSecretName }}
             - mountPath: /etc/pki/entitlement
               name: entitlement-certs
+              readOnly: true
+            {{- end }}
+            {{- if .Values.imageBuilderWorker.yumReposSecretName }}
+            - mountPath: /etc/yum.repos.d
+              name: yum-repos
+              readOnly: true
+            {{- end }}
+            {{- if .Values.imageBuilderWorker.rhsmSecretName }}
+            - mountPath: /etc/rhsm
+              name: rhsm
+              readOnly: true
+            {{- end }}
+            {{- if .Values.imageBuilderWorker.rhsmCaSecretName }}
+            - mountPath: /etc/rhsm/ca
+              name: rhsm-ca
               readOnly: true
             {{- end }}
               
@@ -148,6 +163,21 @@ spec:
         - name: entitlement-certs
           secret:
             secretName: {{ .Values.imageBuilderWorker.entitlementCertsSecretName }}
+        {{- end }}
+        {{- if .Values.imageBuilderWorker.yumReposSecretName }}
+        - name: yum-repos
+          secret:
+            secretName: {{ .Values.imageBuilderWorker.yumReposSecretName }}
+        {{- end }}
+        {{- if .Values.imageBuilderWorker.rhsmSecretName }}
+        - name: rhsm
+          secret:
+            secretName: {{ .Values.imageBuilderWorker.rhsmSecretName }}
+        {{- end }}
+        {{- if .Values.imageBuilderWorker.rhsmCaSecretName }}
+        - name: rhsm-ca
+          secret:
+            secretName: {{ .Values.imageBuilderWorker.rhsmCaSecretName }}
         {{- end }}
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -539,8 +539,13 @@
         "logLevel": { "type": "string", "description": "Log level for ImageBuilder Worker" },
         "maxConcurrentBuilds": { "type": "integer", "description": "Maximum concurrent builds" },
         "defaultTTL": { "type": "string", "description": "Default TTL for build resources" },
-        "rpmRepoUrl": { "type": "string", "description": "RPM repository URL for flightctl-agent package" },
+        "rpmRepoUrl": { "type": "string", "description": "RPM repository URL to add via dnf config-manager --add-repo for flightctl-agent package" },
+        "rpmRepoAdd": { "type": "boolean", "description": "Whether to add the RPM repository via dnf config-manager --add-repo (defaults to true)" },
+        "rpmRepoEnable": { "type": "string", "description": "RPM repository name to enable via --enablerepo for flightctl-agent package installation" },
         "entitlementCertsSecretName": { "type": "string", "description": "Secret name containing RHEL entitlement certificates. On OpenShift, copy 'etc-pki-entitlement' from 'openshift-config-managed' namespace" },
+        "yumReposSecretName": { "type": "string", "description": "Secret name containing yum repository configuration files, mounted at /etc/yum.repos.d" },
+        "rhsmSecretName": { "type": "string", "description": "Secret name containing RHEL subscription manager configuration, mounted at /etc/rhsm" },
+        "rhsmCaSecretName": { "type": "string", "description": "Secret name containing RHSM CA certificates, mounted at /etc/rhsm/ca" },
         "privileged": { "type": "boolean", "description": "Enable privileged mode for container-in-container builds" },
         "resources": { "type": "object", "description": "Resource requests and limits" }
       }

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -329,6 +329,12 @@ imageBuilderWorker:
   defaultTTL: 168h
   # -- Enable privileged mode for container-in-container builds
   privileged: true
+  # -- Secret name containing yum repository configuration files, mounted at /etc/yum.repos.d
+  yumReposSecretName: ""
+  # -- Secret name containing RHEL subscription manager configuration, mounted at /etc/rhsm
+  rhsmSecretName: ""
+  # -- Secret name containing RHSM CA certificates, mounted at /etc/rhsm/ca
+  rhsmCaSecretName: ""
   # -- Resource requests and limits
   resources: {}
 

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -329,6 +329,12 @@ imageBuilderWorker:
   defaultTTL: 168h
   # -- Enable privileged mode for container-in-container builds
   privileged: true
+  # -- Secret name containing yum repository configuration files, mounted at /etc/yum.repos.d
+  yumReposSecretName: ""
+  # -- Secret name containing RHEL subscription manager configuration, mounted at /etc/rhsm
+  rhsmSecretName: ""
+  # -- Secret name containing RHSM CA certificates, mounted at /etc/rhsm/ca
+  rhsmCaSecretName: ""
   # -- Resource requests and limits
   resources: {}
 

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
@@ -33,3 +33,9 @@ imageBuilderWorker:
   {{- if .imagebuilderWorker.rpmRepoUrl}}
   rpmRepoUrl: {{.imagebuilderWorker.rpmRepoUrl}}
   {{- end}}
+  {{- if or (eq (printf "%v" .imagebuilderWorker.rpmRepoAdd) "true") (eq (printf "%v" .imagebuilderWorker.rpmRepoAdd) "false")}}
+  rpmRepoAdd: {{.imagebuilderWorker.rpmRepoAdd}}
+  {{- end}}
+  {{- if .imagebuilderWorker.rpmRepoEnable}}
+  rpmRepoEnable: {{.imagebuilderWorker.rpmRepoEnable}}
+  {{- end}}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,8 @@ type imageBuilderWorkerConfig struct {
 	ImageBuilderTimeout      util.Duration `json:"imageBuilderTimeout,omitempty"`
 	TimeoutCheckTaskInterval util.Duration `json:"timeoutCheckTaskInterval,omitempty"`
 	RPMRepoURL               string        `json:"rpmRepoUrl,omitempty"`
+	RPMRepoAdd               *bool         `json:"rpmRepoAdd,omitempty"`
+	RPMRepoEnable            string        `json:"rpmRepoEnable,omitempty"`
 }
 
 // NewDefaultImageBuilderWorkerConfig returns a default ImageBuilder worker configuration

--- a/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
+++ b/internal/imagebuilder_worker/tasks/templates/Containerfile.tmpl
@@ -11,9 +11,13 @@ ARG USERNAME
 ARG AGENT_CONFIG_DEST_PATH=/etc/flightctl/config.yaml
 
 # Add Flight Control repository and install agent
-ARG RPM_REPO_URL
-RUN dnf -y config-manager --add-repo ${RPM_REPO_URL} && \
-    dnf install -y flightctl-agent && \
+ARG RPM_REPO_ADD
+ARG RPM_REPO_ADD_URL
+ARG RPM_REPO_ENABLE
+RUN if [ "${RPM_REPO_ADD}" = "true" ]; then \
+        dnf -y config-manager --add-repo ${RPM_REPO_ADD_URL}; \
+    fi && \
+    dnf install -y ${RPM_REPO_ENABLE:+--enablerepo=${RPM_REPO_ENABLE}} flightctl-agent && \
     dnf clean all
 
 # Enable Flight Control agent service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ImageBuilder Worker can mount RHEL/YUM secrets (yumReposSecretName, rhsmSecretName, rhsmCaSecretName) for subscription and repo files.
  * New RPM controls to optionally add and enable repositories: rpmRepoAdd (bool) and rpmRepoEnable (string).

* **Documentation**
  * Updated installation/configuration docs, Helm values, examples and README to cover secret-driven RHEL/YUM setup and rpmRepoAdd/rpmRepoEnable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->