### PR TITLE
EDM-3328: Document Pull Credential Requirements for Rootless Quadlets

### DIFF
--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -296,7 +296,7 @@ spec:
 If your device relies on containers from a private repository, [authentication credentials](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/index#configuring-container-pull-secrets_managing-users-groups-ssh-key-and-secrets-in-image-mode-for-rhel) (pull secrets) must be placed in the appropriate system paths.
 
 * **OS Image:** Uses `/etc/ostree/auth.json`
-* **Container Images:** Uses the system default for Podman, `/root/.config/containers/auth.json`
+* **Container Images:** Uses the system default for Podman, `~/.config/containers/auth.json`. You will need an `auth.json` file for each user that needs to pull from a private repo. When deploying `quadlet` or `container` apps, the `runAs` configuration determines which user needs the credentials.
 
 #### Auth File Format
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified container authentication docs: authentication is now per-user (user-specific config); each user needs an auth file and deployments use the effective user context to determine which credentials are applied for Podman container images and quadlet/container app deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->