### PR TITLE
EDM-3335: Improve user lookup failure error messaging

### DIFF
--- a/internal/agent/client/executer.go
+++ b/internal/agent/client/executer.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/userutil"
@@ -12,7 +14,7 @@ func ExecuterForUser(username v1beta1.Username) (executer.Executer, error) {
 	if !username.IsCurrentProcessUser() {
 		uid, gid, homeDir, err := userutil.LookupUser(username)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to lookup user %s: %w", username, err)
 		}
 		execOpts = append(execOpts,
 			executer.WithHomeDir(homeDir),

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -1140,7 +1140,7 @@ func quadletAppPath(appName string, user v1beta1.Username) (string, error) {
 	} else {
 		_, _, homeDir, err := userutil.LookupUser(user)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to lookup user %s: %w", user, err)
 		}
 		return filepath.Join(homeDir, ".config/containers/systemd", appName), nil
 	}

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -1,6 +1,7 @@
 package fileio
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 
@@ -83,7 +84,7 @@ func NewReadWriterFactory(rootDir string) ReadWriterFactory {
 		if !username.IsCurrentProcessUser() {
 			uid, gid, _, err := userutil.LookupUser(username)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to lookup user %s: %w", username, err)
 			}
 			writerOptions = append(writerOptions,
 				WithUID(uid),


### PR DESCRIPTION
This is a slight improvement. Unfortunately it will first occur during prefetch before provider validation but this should make it very clear that the main error is that the user does not exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for user lookup failures to provide additional diagnostic context.
  * Improved permission handling for file operations by properly including group ID information alongside user ID settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->