### PR TITLE
EDM-3365: Skip quadlet actions during system shutdown drain

### DIFF
--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -166,7 +166,7 @@ func (m *PodmanMonitor) drain(ctx context.Context) error {
 		}
 	}
 
-	if err := m.ExecuteActions(ctx); err != nil {
+	if err := m.executeActions(ctx, true); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -285,7 +285,12 @@ func normalizeActionAppType(appType v1beta1.AppType) v1beta1.AppType {
 	return appType
 }
 
+// ExecuteActions executes all queued actions.
 func (m *PodmanMonitor) ExecuteActions(ctx context.Context) error {
+	return m.executeActions(ctx, false)
+}
+
+func (m *PodmanMonitor) executeActions(ctx context.Context, systemShutdown bool) error {
 	ctx = m.addBatchTimeToCtx(ctx)
 	actions := m.drainActions()
 
@@ -293,6 +298,12 @@ func (m *PodmanMonitor) ExecuteActions(ctx context.Context) error {
 	for i := range actions {
 		action := actions[i]
 		appType := normalizeActionAppType(action.AppType)
+
+		if systemShutdown && appType == v1beta1.AppTypeQuadlet {
+			m.log.Debugf("System shutdown: skipping quadlet action for %s", action.Name)
+			continue
+		}
+
 		_, ok := m.handlers[appType]
 		if !ok {
 			return fmt.Errorf("%w: no action handler registered: %s", errors.ErrUnsupportedAppType, action.AppType)

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -795,6 +795,89 @@ func TestPodmanMonitorHandlerSelection(t *testing.T) {
 	require.Equal(0, len(quadletActions), "Quadlet handler should not be called")
 }
 
+func TestPodmanMonitorDrainSkipsQuadletActions(t *testing.T) {
+	require := require.New(t)
+
+	ctx := context.Background()
+	log := log.NewPrefixLogger("test")
+	log.SetLevel(logrus.DebugLevel)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockPodmanClient := client.NewPodman(log, mockExec, mockReadWriter, util.NewPollConfig())
+
+	tempDir := t.TempDir()
+	readWriter := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+
+	mockExec.EXPECT().CommandContext(gomock.Any(), "podman", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			now := time.Now().UnixNano()
+			return exec.CommandContext(ctx, "echo", fmt.Sprintf(`{"timeNano": %d}`, now)) //nolint:gosec
+		}).AnyTimes()
+
+	var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+		return mockPodmanClient, nil
+	}
+	var systemdFactory systemd.ManagerFactory = func(user v1beta1.Username) (systemd.Manager, error) {
+		return systemd.NewMockManager(ctrl), nil
+	}
+	var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+		return readWriter, nil
+	}
+	podmanMonitor := NewPodmanMonitor(log, podmanFactory, systemdFactory, "", rwFactory)
+
+	mockComposeHandler := lifecycle.NewMockActionHandler(ctrl)
+	mockQuadletHandler := lifecycle.NewMockActionHandler(ctrl)
+
+	var composeActions []lifecycle.Action
+	var quadletActions []lifecycle.Action
+
+	mockComposeHandler.EXPECT().Execute(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, action lifecycle.Actions) error {
+			composeActions = append(composeActions, action...)
+			return nil
+		}).AnyTimes()
+	mockQuadletHandler.EXPECT().Execute(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, action lifecycle.Actions) error {
+			quadletActions = append(quadletActions, action...)
+			return nil
+		}).AnyTimes()
+
+	podmanMonitor.handlers[v1beta1.AppTypeCompose] = mockComposeHandler
+	podmanMonitor.handlers[v1beta1.AppTypeQuadlet] = mockQuadletHandler
+
+	composeApp := createTestApplicationWithType(require, "compose-app", v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, v1beta1.AppTypeCompose)
+	quadletApp := createTestApplicationWithType(require, "quadlet-app", v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, v1beta1.AppTypeQuadlet)
+	containerApp := createTestApplicationWithType(require, "container-app", v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, v1beta1.AppTypeContainer)
+
+	err := podmanMonitor.Ensure(t.Context(), composeApp)
+	require.NoError(err)
+	err = podmanMonitor.Ensure(t.Context(), quadletApp)
+	require.NoError(err)
+	err = podmanMonitor.Ensure(t.Context(), containerApp)
+	require.NoError(err)
+
+	err = podmanMonitor.ExecuteActions(ctx)
+	require.NoError(err)
+
+	require.Equal(1, len(composeActions), "Compose handler should be called once for add")
+	require.Equal(2, len(quadletActions), "Quadlet handler should be called twice for add (quadlet + container)")
+
+	composeActions = nil
+	quadletActions = nil
+
+	err = podmanMonitor.Drain(ctx)
+	require.NoError(err)
+
+	require.Equal(1, len(composeActions), "Compose handler should be called once for remove during drain")
+	require.Equal(0, len(quadletActions), "Quadlet handler should NOT be called during drain (system shutdown)")
+}
+
 func TestPodmanMonitorStatusAggregation(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
When a system shutdown is pending, systemd calls (list-dependencies, .etc) report errors. Since shutting down will stop the applications anyway, we skip those actions and just kill any monitors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved system shutdown and drain operations with enhanced action management for better stability and controlled execution flow.
  * Refined action execution logic with improved state and monitor lifecycle management.

* **Tests**
  * Added comprehensive test coverage for system drain and shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->