### PR TITLE
NO-ISSUE: Add CodeRabbit local configuration for automated PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,6 @@
 reviews:
   auto_review:
-    # Set to true to ensure CodeRabbit reviews PRs even if they are in 'Draft' status.
-    # Bots often create PRs as drafts first, which CodeRabbit ignores by default.
+    # Draft PRs are excluded from automatic reviews.
     drafts: false
 
     # Ensure this list does NOT contain your bot's username.
@@ -13,7 +12,7 @@ reviews:
 
     # If your bot uses specific keywords in the title (like "WIP" or "Experimental"),
     # ensure they are not listed here, as this will cause CodeRabbit to skip the review.
-    ignore_title_keywords:
+    ignore_title_keywords: []
 
     # Ensure automatic reviews are globally enabled for the repository.
     enabled: true


### PR DESCRIPTION
CodeRabbit allows configuration in several levels. The lowest level is the repository level by using a file placed on the root folder.
The following file should force:
1. Disable draft PRs from review.
2. Exclude packit-as-a-service from reviews.
3. Enabled by default for the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automatic repository review behavior.
  * Configured drafts handling so draft PRs are subject to review.
  * Excluded the bot account "packit-as-a-service" from automatic reviews.
  * Left title keyword ignore list empty (no title keywords are excluded by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->