### PR TITLE
EDM-2828: Improve the error message when a user without an organization logs in

### DIFF
--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -156,7 +156,7 @@ flightctl get devices --org project-b
 
 ## Troubleshooting
 
-**Error: no organizations found**  
+**Error: "unable to log in to the application" / "You do not have access to any organizations"**  
 Make sure the user has a RoleBinding attached to the **view** role in at least one organization (namespace) and that the namespace has the right label.
 
 **403 error when performing actions on flightctl resources**  

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -531,7 +531,7 @@ func (o *LoginOptions) Run(ctx context.Context, args []string) error {
 	if response, err := c.ListOrganizationsWithResponse(ctx, &v1beta1.ListOrganizationsParams{}); err == nil && response.StatusCode() == http.StatusOK && response.JSON200 != nil {
 
 		if len(response.JSON200.Items) == 0 {
-			return fmt.Errorf("no organizations found")
+			return fmt.Errorf("unable to log in to the application\nYou do not have access to any organizations.\nPlease contact your administrator to be granted access to an organization")
 		}
 
 		org := response.JSON200.Items[0]


### PR DESCRIPTION
Improved the error message when a user without an organization logs in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error messaging when users have no accessible organizations. The message is now multi-line and more descriptive, clearly stating the inability to log in, that the user lacks organization access, and advising to contact an administrator to obtain access.

* **Documentation**
  * Updated OpenShift authentication troubleshooting guidance to reflect the new, clearer error wording and preserve existing steps for verifying role bindings and namespace labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->