### PR TITLE
EDM-1057: Agent shows Online but stops updating after spec files are deleted

### DIFF
--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -151,6 +151,9 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 
 	desired, requeue, err := a.specManager.GetDesired(ctx)
 	if err != nil {
+		if a.recoverMissingSpec(err) {
+			return
+		}
 		a.log.Errorf("Failed to get desired spec: %v", err)
 		return
 	}
@@ -163,6 +166,9 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 
 	current, err := a.specManager.Read(spec.Current)
 	if err != nil {
+		if a.recoverMissingSpec(err) {
+			return
+		}
 		a.log.Errorf("Failed to get current spec: %v", err)
 		return
 	}
@@ -255,6 +261,20 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 			// Don't return error - pruning failures must not block reconciliation
 		}
 	}
+}
+
+// recoverMissingSpec checks if the error is due to a missing spec file and
+// attempts to recover by calling Ensure(). Returns true if recovery was
+// attempted, signaling the caller to return and let the next tick proceed.
+func (a *Agent) recoverMissingSpec(err error) bool {
+	if !errors.Is(err, errors.ErrMissingRenderedSpec) {
+		return false
+	}
+	a.log.Warnf("Spec file missing, recovering: %v", err)
+	if ensureErr := a.specManager.Ensure(); ensureErr != nil {
+		a.log.Errorf("Failed to recover spec files: %v", ensureErr)
+	}
+	return true
 }
 
 func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.Device, syncErr error, syncFn func(context.Context, *v1beta1.Device, *v1beta1.Device) error) error {

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -151,7 +151,7 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 
 	desired, requeue, err := a.specManager.GetDesired(ctx)
 	if err != nil {
-		if a.recoverMissingSpec(err) {
+		if a.handleMissingSpec(ctx, err) {
 			return
 		}
 		a.log.Errorf("Failed to get desired spec: %v", err)
@@ -166,7 +166,7 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 
 	current, err := a.specManager.Read(spec.Current)
 	if err != nil {
-		if a.recoverMissingSpec(err) {
+		if a.handleMissingSpec(ctx, err) {
 			return
 		}
 		a.log.Errorf("Failed to get current spec: %v", err)
@@ -263,17 +263,23 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 	}
 }
 
-// recoverMissingSpec checks if the error is due to a missing spec file and
-// attempts to recover by calling Ensure(). Returns true if recovery was
-// attempted, signaling the caller to return and let the next tick proceed.
-func (a *Agent) recoverMissingSpec(err error) bool {
+// handleMissingSpec checks if the error is due to a missing spec file. If so,
+// it pushes an error status to the server and terminates the process so that
+// systemd restarts the agent. On restart, Ensure() resets all specs to "0".
+func (a *Agent) handleMissingSpec(ctx context.Context, err error) bool {
 	if !errors.Is(err, errors.ErrMissingRenderedSpec) {
 		return false
 	}
-	a.log.Warnf("Spec file missing, recovering: %v", err)
-	if ensureErr := a.specManager.Ensure(); ensureErr != nil {
-		a.log.Errorf("Failed to recover spec files: %v", ensureErr)
+	msg := fmt.Sprintf("Spec file missing at runtime: %v", err)
+	a.log.Errorf("%s", msg)
+	_, updateErr := a.statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
+		Status: v1beta1.DeviceSummaryStatusError,
+		Info:   lo.ToPtr(msg),
+	}))
+	if updateErr != nil {
+		a.log.Warnf("Failed to push error status before exit: %v", updateErr)
 	}
+	a.log.Fatalf("Exiting due to missing spec file")
 	return true
 }
 

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -272,7 +272,9 @@ func (a *Agent) handleMissingSpec(ctx context.Context, err error) bool {
 	}
 	msg := fmt.Sprintf("Spec file missing at runtime: %v", err)
 	a.log.Errorf("%s", msg)
-	_, updateErr := a.statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
+	updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, updateErr := a.statusManager.Update(updateCtx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
 		Status: v1beta1.DeviceSummaryStatusError,
 		Info:   lo.ToPtr(msg),
 	}))

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -751,28 +751,28 @@ func TestOSRollback(t *testing.T) {
 	}
 }
 
-func TestSyncRecoverMissingSpec(t *testing.T) {
+func TestSyncHandleMissingSpec(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	testCases := []struct {
 		name       string
-		setupMocks func(mockSpecManager *spec.MockManager)
+		setupMocks func(mockSpecManager *spec.MockManager, mockStatusManager *status.MockManager)
 	}{
 		{
-			name: "GetDesired returns ErrMissingRenderedSpec triggers recovery",
-			setupMocks: func(mockSpecManager *spec.MockManager) {
+			name: "GetDesired returns ErrMissingRenderedSpec triggers fatal exit",
+			setupMocks: func(mockSpecManager *spec.MockManager, mockStatusManager *status.MockManager) {
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(nil, false, errors.ErrMissingRenderedSpec)
-				mockSpecManager.EXPECT().Ensure().Return(nil)
+				mockStatusManager.EXPECT().Update(ctx, gomock.Any()).Return(nil, nil)
 			},
 		},
 		{
-			name: "Read current returns ErrMissingRenderedSpec triggers recovery",
-			setupMocks: func(mockSpecManager *spec.MockManager) {
+			name: "Read current returns ErrMissingRenderedSpec triggers fatal exit",
+			setupMocks: func(mockSpecManager *spec.MockManager, mockStatusManager *status.MockManager) {
 				desired := newVersionedDevice("1")
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil)
 				mockSpecManager.EXPECT().Read(spec.Current).Return(nil, errors.ErrMissingRenderedSpec)
-				mockSpecManager.EXPECT().Ensure().Return(nil)
+				mockStatusManager.EXPECT().Update(ctx, gomock.Any()).Return(nil, nil)
 			},
 		},
 	}
@@ -782,17 +782,24 @@ func TestSyncRecoverMissingSpec(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockSpecManager := spec.NewMockManager(ctrl)
-			tc.setupMocks(mockSpecManager)
+			mockStatusManager := status.NewMockManager(ctrl)
+			tc.setupMocks(mockSpecManager, mockStatusManager)
 
-			log := log.NewPrefixLogger("test")
-			log.SetLevel(logrus.DebugLevel)
+			logger := log.NewPrefixLogger("test")
+			logger.SetLevel(logrus.DebugLevel)
+
+			// Intercept log.Fatalf so os.Exit is not called during tests
+			fatalCalled := false
+			logger.ExitFunc = func(int) { fatalCalled = true }
 
 			agent := Agent{
-				log:         log,
-				specManager: mockSpecManager,
+				log:           logger,
+				specManager:   mockSpecManager,
+				statusManager: mockStatusManager,
 			}
 
 			agent.syncDeviceSpec(ctx)
+			require.True(t, fatalCalled, "expected log.Fatalf to be called")
 		})
 	}
 }

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -751,6 +751,52 @@ func TestOSRollback(t *testing.T) {
 	}
 }
 
+func TestSyncRecoverMissingSpec(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testCases := []struct {
+		name       string
+		setupMocks func(mockSpecManager *spec.MockManager)
+	}{
+		{
+			name: "GetDesired returns ErrMissingRenderedSpec triggers recovery",
+			setupMocks: func(mockSpecManager *spec.MockManager) {
+				mockSpecManager.EXPECT().GetDesired(ctx).Return(nil, false, errors.ErrMissingRenderedSpec)
+				mockSpecManager.EXPECT().Ensure().Return(nil)
+			},
+		},
+		{
+			name: "Read current returns ErrMissingRenderedSpec triggers recovery",
+			setupMocks: func(mockSpecManager *spec.MockManager) {
+				desired := newVersionedDevice("1")
+				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil)
+				mockSpecManager.EXPECT().Read(spec.Current).Return(nil, errors.ErrMissingRenderedSpec)
+				mockSpecManager.EXPECT().Ensure().Return(nil)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockSpecManager := spec.NewMockManager(ctrl)
+			tc.setupMocks(mockSpecManager)
+
+			log := log.NewPrefixLogger("test")
+			log.SetLevel(logrus.DebugLevel)
+
+			agent := Agent{
+				log:         log,
+				specManager: mockSpecManager,
+			}
+
+			agent.syncDeviceSpec(ctx)
+		})
+	}
+}
+
 func newVersionedDevice(version string) *v1beta1.Device {
 	device := &v1beta1.Device{
 		Metadata: v1beta1.ObjectMeta{

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -755,6 +755,21 @@ func TestSyncHandleMissingSpec(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	expectErrorStatus := func(mockStatusManager *status.MockManager) {
+		mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, fns ...status.UpdateStatusFn) (*v1beta1.DeviceStatus, error) {
+				ds := &v1beta1.DeviceStatus{}
+				for _, fn := range fns {
+					require.NoError(t, fn(ds))
+				}
+				require.Equal(t, v1beta1.DeviceSummaryStatusError, ds.Summary.Status)
+				require.NotNil(t, ds.Summary.Info)
+				require.Contains(t, *ds.Summary.Info, "missing")
+				return nil, nil
+			},
+		)
+	}
+
 	testCases := []struct {
 		name       string
 		setupMocks func(mockSpecManager *spec.MockManager, mockStatusManager *status.MockManager)
@@ -763,7 +778,7 @@ func TestSyncHandleMissingSpec(t *testing.T) {
 			name: "GetDesired returns ErrMissingRenderedSpec triggers fatal exit",
 			setupMocks: func(mockSpecManager *spec.MockManager, mockStatusManager *status.MockManager) {
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(nil, false, errors.ErrMissingRenderedSpec)
-				mockStatusManager.EXPECT().Update(ctx, gomock.Any()).Return(nil, nil)
+				expectErrorStatus(mockStatusManager)
 			},
 		},
 		{
@@ -772,7 +787,7 @@ func TestSyncHandleMissingSpec(t *testing.T) {
 				desired := newVersionedDevice("1")
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil)
 				mockSpecManager.EXPECT().Read(spec.Current).Return(nil, errors.ErrMissingRenderedSpec)
-				mockStatusManager.EXPECT().Update(ctx, gomock.Any()).Return(nil, nil)
+				expectErrorStatus(mockStatusManager)
 			},
 		},
 	}

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -136,32 +136,43 @@ func (s *manager) Ensure() error {
 		}
 	}
 
-	// Create missing files with appropriate reason
+	// Check if any individual file is missing
+	anyMissing := false
 	for _, specType := range []Type{Current, Desired, Rollback} {
 		exists, err := s.exists(specType)
 		if err != nil {
 			return err
 		}
-
 		if !exists {
+			anyMissing = true
+		}
+	}
+
+	// If any file is missing, reset ALL files to version "0".
+	// This ensures the agent never tries to reason about partial state.
+	if anyMissing {
+		for _, specType := range []Type{Current, Desired, Rollback} {
 			var reason audit.Reason
 			if allMissing {
-				// First startup - all files created during bootstrap
 				reason = audit.ReasonBootstrap
 				s.log.Infof("First startup: creating %s spec file", specType)
 			} else {
-				// File corruption recovery - use appropriate reason
 				if specType == Rollback {
 					reason = audit.ReasonInitialization
 				} else {
 					reason = audit.ReasonRecovery
 				}
-				s.log.Warnf("Spec file does not exist %s. Resetting state to empty...", specType)
+				s.log.Warnf("Spec file missing, resetting all specs to empty...")
 			}
 
 			if err := s.write(context.TODO(), specType, newVersionedDevice("0"), reason); err != nil {
 				return err
 			}
+		}
+
+		// Reset publisher version so the next poll fetches the latest spec.
+		if !allMissing {
+			s.publisher.ResetVersion("0")
 		}
 	}
 

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -123,8 +123,9 @@ func (s *manager) Ensure() error {
 	// Check and recreate missing spec files.
 	// Distinguishes between first startup (bootstrap) and recovery from corruption.
 
-	// Determine if this is first startup by checking if ALL files are missing
+	// Single pass to determine allMissing and anyMissing
 	allMissing := true
+	anyMissing := false
 	for _, specType := range []Type{Current, Desired, Rollback} {
 		exists, err := s.exists(specType)
 		if err != nil {
@@ -132,18 +133,7 @@ func (s *manager) Ensure() error {
 		}
 		if exists {
 			allMissing = false
-			break
-		}
-	}
-
-	// Check if any individual file is missing
-	anyMissing := false
-	for _, specType := range []Type{Current, Desired, Rollback} {
-		exists, err := s.exists(specType)
-		if err != nil {
-			return err
-		}
-		if !exists {
+		} else {
 			anyMissing = true
 		}
 	}

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -151,6 +151,9 @@ func (s *manager) Ensure() error {
 	// If any file is missing, reset ALL files to version "0".
 	// This ensures the agent never tries to reason about partial state.
 	if anyMissing {
+		if !allMissing {
+			s.log.Warnf("Spec file missing, resetting all specs to empty...")
+		}
 		for _, specType := range []Type{Current, Desired, Rollback} {
 			var reason audit.Reason
 			if allMissing {
@@ -162,7 +165,6 @@ func (s *manager) Ensure() error {
 				} else {
 					reason = audit.ReasonRecovery
 				}
-				s.log.Warnf("Spec file missing, resetting all specs to empty...")
 			}
 
 			if err := s.write(context.TODO(), specType, newVersionedDevice("0"), reason); err != nil {

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -53,6 +53,7 @@ type Publisher interface {
 	Watch() Watcher
 	SetClient(client.Management)
 	SetOnConflictPausedInvalidator(LastStatusInvalidator)
+	ResetVersion(version string)
 }
 
 type publisher struct {
@@ -81,6 +82,12 @@ func newPublisher(deviceName string,
 		deviceNotFoundHandler: deviceNotFoundHandler,
 		log:                   log,
 	}
+}
+
+func (n *publisher) ResetVersion(version string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.lastKnownVersion = version
 }
 
 func (n *publisher) getRenderedFromManagementAPIWithRetry(

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -212,16 +212,17 @@ func TestEnsure(t *testing.T) {
 			cache:            newCache(log),
 		}
 
-		// First loop: check all 3 files for allMissing detection (all return false)
+		// allMissing loop: all 3 files missing (allMissing=true)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(false, nil)
-		// Second loop: check current file, find it missing, attempt write and fail
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(false, nil)
+		// anyMissing loop: all 3 files missing (anyMissing=true)
+		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(false, nil)
+		// write loop: attempt to write first file and fail
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(fileErr)
 		err := s.Ensure()
 		require.ErrorIs(err, errors.ErrWritingRenderedSpec)
 	})
 
-	t.Run("files are written when they don't exist", func(t *testing.T) {
+	t.Run("one file missing resets all specs to zero", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -234,20 +235,25 @@ func TestEnsure(t *testing.T) {
 			deviceReadWriter: mockReadWriter,
 			queue:            mockPriorityQueue,
 			cache:            newCache(log),
+			publisher:        newPublisher("test", poll.NewConfig(time.Second, 1.5), "1", nil, log),
 		}
 
-		// First loop: check first file, it exists, break early
+		// allMissing loop: first file exists, break early (allMissing=false)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
-		// Second loop: check all 3 files
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)  // current exists
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)  // desired exists
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(false, nil) // rollback missing
-		// Write the missing file
-		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		// anyMissing loop: current exists, desired exists, rollback missing
+		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
+		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
+		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(false, nil)
+		// write loop: all 3 files reset to "0"
+		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Times(3).Return(nil)
 		mockReadWriter.EXPECT().ReadFile(gomock.Any()).Return([]byte(`{}`), nil).Times(3)
 		mockPriorityQueue.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)
 		err := s.Ensure()
 		require.NoError(err)
+
+		// publisher version should be reset to "0" during recovery
+		pub := s.publisher.(*publisher)
+		require.Equal("0", pub.lastKnownVersion)
 	})
 
 	t.Run("no files are written when they all exist", func(t *testing.T) {
@@ -265,9 +271,9 @@ func TestEnsure(t *testing.T) {
 			cache:            newCache(log),
 		}
 
-		// First loop: check all 3 files for allMissing detection - all exist, break early
+		// allMissing loop: first file exists, break early (allMissing=false)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
-		// Second loop: check each file before potentially creating - all exist
+		// anyMissing loop: all 3 files exist (anyMissing=false, no writes)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(true, nil)
 		mockReadWriter.EXPECT().ReadFile(gomock.Any()).Return([]byte(`{}`), nil).Times(3)
 		mockPriorityQueue.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -212,9 +212,7 @@ func TestEnsure(t *testing.T) {
 			cache:            newCache(log),
 		}
 
-		// allMissing loop: all 3 files missing (allMissing=true)
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(false, nil)
-		// anyMissing loop: all 3 files missing (anyMissing=true)
+		// single loop: all 3 files missing (allMissing=true, anyMissing=true)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(false, nil)
 		// write loop: attempt to write first file and fail
 		mockReadWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(fileErr)
@@ -238,9 +236,7 @@ func TestEnsure(t *testing.T) {
 			publisher:        newPublisher("test", poll.NewConfig(time.Second, 1.5), "1", nil, log),
 		}
 
-		// allMissing loop: first file exists, break early (allMissing=false)
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
-		// anyMissing loop: current exists, desired exists, rollback missing
+		// single loop: current exists, desired exists, rollback missing (allMissing=false, anyMissing=true)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(false, nil)
@@ -271,9 +267,7 @@ func TestEnsure(t *testing.T) {
 			cache:            newCache(log),
 		}
 
-		// allMissing loop: first file exists, break early (allMissing=false)
-		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(1).Return(true, nil)
-		// anyMissing loop: all 3 files exist (anyMissing=false, no writes)
+		// single loop: all 3 files exist (allMissing=false, anyMissing=false)
 		mockReadWriter.EXPECT().PathExists(gomock.Any()).Times(3).Return(true, nil)
 		mockReadWriter.EXPECT().ReadFile(gomock.Any()).Return([]byte(`{}`), nil).Times(3)
 		mockPriorityQueue.EXPECT().Add(gomock.Any(), gomock.Any()).Times(1)


### PR DESCRIPTION
## Problem

When `/var/lib/flightctl` is deleted while the agent is running, the device gets stuck. It stays `Online` but stops applying updates. The reconciliation loop silently fails on every tick with `ErrMissingRenderedSpec` from `GetDesired()` or `Read(Current)`, logs the error, and returns indefinitely. Only an agent restart recovers the device.

## Root Cause

`syncDeviceSpec()` in `device.go` treats `ErrMissingRenderedSpec` as a generic error: it logs and returns without any recovery action. The existing `Ensure()` method in the spec manager already knows how to detect and recreate missing spec files (with proper logging and auditing), but it is only called during bootstrap. Never during the runtime reconciliation loop.

## Solution

When a spec file goes missing at runtime, the agent pushes an error status to the server and exits non-zero, letting systemd restart it.
On restart, `Ensure()` detects the missing file(s) and resets ALL spec files to version "0" - the agent does not try to reason about partial state. The publisher then fetches the latest spec from the server and
reconciles from scratch.

Key changes:
- `handleMissingSpec()` in `syncDeviceSpec()` pushes `DeviceSummaryStatusError` and calls `log.Fatalf()`
- `Ensure()` resets all three spec files when any single file is missing (not just the missing one)
- `ResetVersion()` on the publisher aligns the in-memory version after the on-disk reset so the next poll fetches the latest spec
- Audit trail entries use `reason: "recovery"` (or `"bootstrap"` on first startup)