### PR TITLE
EDM-3376: Report Correct App Status on Container Start Failure

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -78,7 +78,7 @@ type ArtifactLayer struct {
 // It should be noted that the CLI represents events differently from libpod. (notably the time properties)
 // https://github.com/containers/podman/blob/main/cmd/podman/system/events.go#L81-L96
 type PodmanEvent struct {
-	ContainerExitCode int               `json:"ContainerExitCode,omitempty"`
+	ContainerExitCode *int              `json:"ContainerExitCode,omitempty"`
 	ID                string            `json:"ID"`
 	Image             string            `json:"Image"`
 	Name              string            `json:"Name"`

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/systemd"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
 )
 
 const (
@@ -519,7 +520,7 @@ func (m *PodmanMonitor) updateQuadletContainerStatus(ctx context.Context, app Ap
 	}
 
 	status := StatusType(event.Status)
-	if isFinishedStatus(status) && event.ContainerExitCode == 0 {
+	if isFinishedStatus(status) && lo.FromPtrOr(event.ContainerExitCode, -1) == 0 {
 		status = StatusExited
 	}
 	m.updateApplicationStatus(app, event, status, restartCount)

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -478,9 +478,7 @@ func createMockPodmanEvent(name string, username v1beta1.Username, service, stat
 			"io.podman.compose.version":               "1.0.6",
 		},
 	}
-	if exitCode != 0 {
-		event.ContainerExitCode = exitCode
-	}
+	event.ContainerExitCode = lo.ToPtr(exitCode)
 	return event
 }
 


### PR DESCRIPTION
Previously if a container died before being properly started (e.g. due to missing privileges) the container would be reported as Completed and the application seen as healthy.

Now a container that fails to start will be considered an error and the application unhealthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container exit code handling to accurately distinguish between absent exit codes and zero-value exit codes, enhancing container status monitoring precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->