### PR TITLE
NO-ISSUE: improve E2E os upgrade stability

### DIFF
--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -362,7 +362,7 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, _, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, util.DeviceTags.V9)
 			Expect(err).ToNot(HaveOccurred())
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+			err = harness.WaitForDeviceNewRenderedVersionWithReboot(deviceId, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Reload the flight agent")

--- a/test/e2e/observability/observability_test.go
+++ b/test/e2e/observability/observability_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Device observability", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, _, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, util.DeviceTags.V10)
 			Expect(err).ToNot(HaveOccurred())
-			err = harness.WaitForDeviceNewRenderedVersion(deviceId, nextRenderedVersion)
+			err = harness.WaitForDeviceNewRenderedVersionWithReboot(deviceId, nextRenderedVersion)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for otelcol to be running on the device")


### PR DESCRIPTION
Improving E2E test os upgrade stability with WaitForDeviceNewRenderedVersionWithReboot function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to validate device behavior during reboot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->