### PR TITLE
NO-ISSUE: fixed recurring device name during e2e

### DIFF
--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -48,6 +48,7 @@ var _ = BeforeEach(func() {
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"fmt"
 	"io"
 	"net"
@@ -678,6 +679,11 @@ func (h *Harness) TestEnrollmentApproval(labels ...map[string]string) *v1beta1.E
 }
 
 func (h *Harness) CleanUpAllTestResources() error {
+	if h.VM != nil {
+		if err := h.StopFlightCtlAgent(); err != nil {
+			logrus.Warnf("Failed to stop agent before cleanup: %v", err)
+		}
+	}
 	return h.CleanUpTestResources(util.ResourceTypes[:]...)
 }
 
@@ -1552,6 +1558,18 @@ func (h *Harness) SetupVMFromPool(workerID int) error {
 	// Wait for SSH to be ready
 	if err := testVM.WaitForSSHToBeReady(); err != nil {
 		return fmt.Errorf("failed to wait for SSH: %w", err)
+	}
+
+	// Reseed the VM's entropy pool with host-generated random bytes.
+	// After a snapshot revert the kernel CSPRNG state is identical to the
+	// snapshot, which can cause the agent to generate the same private key
+	// (and therefore the same device name) across different test runs.
+	entropy := make([]byte, 512)
+	if _, err := cryptorand.Read(entropy); err != nil {
+		return fmt.Errorf("failed to generate entropy on host: %w", err)
+	}
+	if _, err := testVM.RunSSH([]string{"sudo", "dd", "of=/dev/urandom", "bs=512", "count=1"}, bytes.NewBuffer(entropy)); err != nil {
+		logrus.Warnf("Failed to reseed VM entropy: %v", err)
 	}
 
 	// Clean any stale CSR from previous tests

--- a/test/harness/e2e/vm_pool.go
+++ b/test/harness/e2e/vm_pool.go
@@ -200,16 +200,9 @@ func (p *VMPool) createVMForWorker(workerID int) (vm.TestVMInterface, error) {
 	fmt.Printf("🔍 [VMPool] Worker %d: Printing agent files after snapshot creation:\n", workerID)
 	printAgentFilesForVM(newVM, "After Snapshot Creation")
 
-	// Restart the agent after snapshot creation
-	fmt.Printf("🔄 [VMPool] Worker %d: Restarting flightctl-agent after snapshot creation\n", workerID)
-	if _, err := newVM.RunSSH([]string{"sudo", "systemctl", "restart", "flightctl-agent"}, nil); err != nil {
-		// Log warning but don't fail - agent service might have issues but VM is still usable
-		fmt.Printf("⚠️  [VMPool] Worker %d: Warning - failed to restart flightctl-agent: %v\n", workerID, err)
-	} else {
-		fmt.Printf("✅ [VMPool] Worker %d: flightctl-agent restarted successfully after snapshot creation\n", workerID)
-	}
-
 	// VM stays running - no shutdown
+	// The agent is intentionally left stopped; the first test to use this VM
+	// will revert to the pristine snapshot and start the agent itself.
 	fmt.Printf("✅ [VMPool] Worker %d: VM setup completed, VM is running\n", workerID)
 	return newVM, nil
 }


### PR DESCRIPTION
1. prevent unnecessary flightctl agent restart right after vm creation which causes an orphaned ER
2. manually reseeds /udev/random since this could result in the same private key provided across vm restores (since vm is restored to the exact same state )
3. makes sure to stop flightctl-agent before cleaning up test resources to avoid ER created right after cleanup and before snapshot is reverted 

this should solve the reported issue where sometimes an enrolled device was in an AwaitingReconnection state / ConflictPaused State ( this is because we got the same device name as the original one created on VM creation / the same name as a device that had a chance to recreate its ER after resource deletion)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced VM entropy initialization during test setup to improve randomness consistency
  * Improved flightctl-agent lifecycle management in test cleanup procedures for better resource handling
  * Refined VM snapshot recovery process to ensure proper initialization state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->