### PR TITLE
NO-ISSUE: fixes shutdown manager returns before all background processes shutdown

### DIFF
--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -249,9 +249,14 @@ func (m *prefetchManager) Run(ctx context.Context) {
 	m.log.Debug("Prefetch manager started")
 	defer m.log.Debug("Prefetch manager stopped")
 
-	go m.worker(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.worker(ctx)
+	}()
 
-	<-ctx.Done()
+	wg.Wait()
 }
 
 func (m *prefetchManager) worker(ctx context.Context) {

--- a/internal/agent/shutdown/shutdown.go
+++ b/internal/agent/shutdown/shutdown.go
@@ -98,7 +98,10 @@ func (m *manager) Run(ctx context.Context) {
 		signal.Stop(signals)
 		close(signals)
 	}()
+
+	done := make(chan struct{})
 	go func(ctx context.Context) {
+		defer close(done)
 		select {
 		case s := <-signals:
 			m.log.Infof("Agent received shutdown signal: %s", s)
@@ -110,7 +113,7 @@ func (m *manager) Run(ctx context.Context) {
 		}
 	}(ctx)
 
-	<-ctx.Done()
+	<-done
 }
 
 func (m *manager) Shutdown(ctx context.Context) {


### PR DESCRIPTION
was found as part of [this](https://github.com/flightctl/flightctl/actions/runs/22176717749/attempts/1) flaky  **integration** test:


seems like the shutdown manager was not waiting for all background processes to complete  , in test env this resulted in a race condition . 

in production this could result in incomplete shutdown behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved concurrent task management and lifecycle handling across agent services for cleaner startup/shutdown and synchronized background tasks.
  * Enhanced graceful shutdown procedures to ensure background work is cancelled and awaited before exit.
  * Strengthened session and worker synchronization to prevent premature termination.

* **New Features**
  * Enrollment attempts now use a resilient retry policy.
  * TPM is explicitly skipped when disabled to avoid errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->