### PR TITLE
EDM-3386: Default device alias during registration

### DIFF
--- a/api/core/v1beta1/consts.go
+++ b/api/core/v1beta1/consts.go
@@ -37,6 +37,8 @@ const (
 	// When this annotation is present, it means that the device has been selected for rollout in a batch
 	DeviceAnnotationSelectedForRollout = "fleet-controller/selectedForRollout"
 	DeviceAnnotationLastRolloutError   = "fleet-controller/lastRolloutError"
+	// EnrollmentRequestAnnotationDefaultAlias is set on enrollment requests with the computed default device alias (from defaultAliasKeys). On approval, this value is applied as metadata.labels["alias"] if alias is not set in approval labels.
+	EnrollmentRequestAnnotationDefaultAlias = "device-controller/defaultAlias"
 
 	// TODO: make configurable
 	// DeviceDisconnectedTimeout is the duration after which a device is considered to be not reporting and set to unknown status.

--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -81,7 +81,7 @@ func main() {
 	}()
 	defer orgCache.Stop()
 
-	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(store, workerClient, kvStore, nil, log, "", "", []string{}))
+	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(store, workerClient, kvStore, nil, log, "", "", []string{}, nil))
 
 	server := alert_exporter.New(cfg, log)
 	if err := server.Run(ctx, serviceHandler); err != nil {

--- a/cmd/flightctl-alertmanager-proxy/main.go
+++ b/cmd/flightctl-alertmanager-proxy/main.go
@@ -236,7 +236,7 @@ func main() {
 	defer orgCache.Stop()
 
 	// Create service handler for auth provider access
-	baseServiceHandler := service.NewServiceHandler(dataStore, nil, nil, nil, logger, "", "", nil)
+	baseServiceHandler := service.NewServiceHandler(dataStore, nil, nil, nil, logger, "", "", nil, nil)
 	serviceHandler := service.WrapWithTracing(baseServiceHandler)
 
 	// Initialize auth system

--- a/docs/user/installing/installing-service-on-linux-configuration.md
+++ b/docs/user/installing/installing-service-on-linux-configuration.md
@@ -16,6 +16,19 @@ Note - this is currently a subset of all configuration options.
 | --------- | ---- | :------: | ----------- |
 | `auth` | `AuthConfig` | | Authentication configuration for the Flight Control service. |
 | `organizations` | `OrganizationsConfig` | | Organization support configuration. Default: organizations disabled |
+| `defaultAliasKeys` | `[]string` | | Ordered list of keys used to compute a default device alias from enrollment request system info. When set, the first non-empty value from the device's `status.systemInfo` is used as the device alias when approving an enrollment request that does not specify an alias. Default: `["hostname"]`. Set to an empty list to disable. See [Default device alias](#default-device-alias). |
+
+### Default device alias
+
+When `defaultAliasKeys` is non-empty, the service computes a default alias for each enrollment request from the device's reported system information. On approval, if the approval does not set an alias label, the device's `metadata.labels["alias"]` is set to this computed value.
+
+Each key in `defaultAliasKeys` can be:
+
+- **Fixed fields:** `architecture`, `bootID`, `operatingSystem`, `agentVersion`
+- **Additional properties:** any key from system info (for example, `hostname`, `productSerial`, `kernel`)
+- **Custom info:** `customInfo.<key>` for a value from user-defined device scripts (the suffix after `customInfo.` must be a valid label-like token)
+
+Keys are evaluated in order; the first non-empty value is used. The result is sanitized for use as a Kubernetes label value (length and character rules). The default configuration uses `["hostname"]`. Set the list to empty to disable the default alias.
 
 ### Auth Configuration
 

--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -93,7 +93,7 @@ func (s *AgentServer) init(ctx context.Context) error {
 	workerClient := worker_client.NewWorkerClient(publisher, s.log)
 
 	s.serviceHandler = service.WrapWithTracing(
-		service.NewServiceHandler(s.store, workerClient, s.kvStore, s.ca, s.log, s.cfg.Service.AgentEndpointAddress, s.cfg.Service.BaseUIUrl, s.cfg.Service.TPMCAPaths))
+		service.NewServiceHandler(s.store, workerClient, s.kvStore, s.ca, s.log, s.cfg.Service.AgentEndpointAddress, s.cfg.Service.BaseUIUrl, s.cfg.Service.TPMCAPaths, s.cfg.Service.DefaultAliasKeys))
 
 	s.agentGrpcServer = NewAgentGrpcServer(s.log, s.cfg, s.serviceHandler)
 	return nil

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -153,7 +153,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// Create service handler and wrap with tracing
 	baseServiceHandler := service.NewServiceHandler(
-		s.store, workerClient, kvStore, s.ca, s.log, s.cfg.Service.BaseAgentEndpointUrl, s.cfg.Service.BaseUIUrl, s.cfg.Service.TPMCAPaths)
+		s.store, workerClient, kvStore, s.ca, s.log, s.cfg.Service.BaseAgentEndpointUrl, s.cfg.Service.BaseUIUrl, s.cfg.Service.TPMCAPaths, s.cfg.Service.DefaultAliasKeys)
 	serviceHandler := service.WrapWithTracing(baseServiceHandler)
 
 	// Initialize auth with traced service handler for OIDC provider access

--- a/internal/domain/consts.go
+++ b/internal/domain/consts.go
@@ -44,9 +44,10 @@ const DeviceQueryConsoleSessionMetadata = v1beta1.DeviceQueryConsoleSessionMetad
 // ========== EnrollmentRequest ==========
 
 const (
-	EnrollmentRequestAPIVersion = v1beta1.EnrollmentRequestAPIVersion
-	EnrollmentRequestKind       = v1beta1.EnrollmentRequestKind
-	EnrollmentRequestListKind   = v1beta1.EnrollmentRequestListKind
+	EnrollmentRequestAPIVersion               = v1beta1.EnrollmentRequestAPIVersion
+	EnrollmentRequestKind                     = v1beta1.EnrollmentRequestKind
+	EnrollmentRequestListKind                  = v1beta1.EnrollmentRequestListKind
+	EnrollmentRequestAnnotationDefaultAlias   = v1beta1.EnrollmentRequestAnnotationDefaultAlias
 )
 
 // ========== Fleet ==========

--- a/internal/imagebuilder_worker/worker.go
+++ b/internal/imagebuilder_worker/worker.go
@@ -42,7 +42,7 @@ func New(
 	ca *crypto.CAClient,
 ) *Worker {
 	// Create service handler for internal operations (enrollment credential generation)
-	serviceHandler := service.NewServiceHandler(mainStore, nil, kvStore, ca, log.WithField("component", "service"), cfg.Service.BaseAgentEndpointUrl, cfg.Service.BaseUIUrl, nil)
+	serviceHandler := service.NewServiceHandler(mainStore, nil, kvStore, ca, log.WithField("component", "service"), cfg.Service.BaseAgentEndpointUrl, cfg.Service.BaseUIUrl, nil, nil)
 
 	return &Worker{
 		cfg:            cfg,

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -85,7 +85,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}()
 	defer orgCache.Stop()
 
-	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}))
+	serviceHandler := service.WrapWithTracing(service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}, nil))
 
 	// Initialize the task executors
 	periodicTaskExecutors := InitializeTaskExecutors(s.log, serviceHandler, s.cfg, queuesProvider, workerClient, nil)

--- a/internal/service/common/alias.go
+++ b/internal/service/common/alias.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/domain"
+)
+
+const (
+	// maxLabelValueLength is the maximum length for a Kubernetes label value.
+	maxLabelValueLength = 63
+)
+
+// labelValueRegex matches valid Kubernetes label value: [a-zA-Z0-9]([-a-zA-Z0-9_.]*[a-zA-Z0-9])?
+var labelValueRegex = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9_.]*[a-zA-Z0-9])?$`)
+
+const customInfoPrefix = "customInfo."
+
+// ComputeDefaultAlias returns the first non-empty value from systemInfo for the given keys, sanitized for use as a label value.
+// Keys can be: fixed DeviceSystemInfo fields (architecture, bootID, operatingSystem, agentVersion),
+// customInfo.<key> for CustomInfo[key], or any key for AdditionalProperties (e.g. hostname, productSerial).
+// Returns empty string if no non-empty value is found or the result would be invalid as a label value.
+func ComputeDefaultAlias(systemInfo domain.DeviceSystemInfo, keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		val := getSystemInfoValue(systemInfo, key)
+		val = strings.TrimSpace(val)
+		if val == "" {
+			continue
+		}
+		if out := sanitizeLabelValue(val); out != "" {
+			return out
+		}
+	}
+	return ""
+}
+
+// getSystemInfoValue returns the value for key from DeviceSystemInfo: fixed fields, customInfo.<key>, or additionalProperties.
+func getSystemInfoValue(systemInfo domain.DeviceSystemInfo, key string) string {
+	switch key {
+	case "architecture":
+		return systemInfo.Architecture
+	case "bootID":
+		return systemInfo.BootID
+	case "operatingSystem":
+		return systemInfo.OperatingSystem
+	case "agentVersion":
+		return systemInfo.AgentVersion
+	}
+	if strings.HasPrefix(key, customInfoPrefix) {
+		suffix := key[len(customInfoPrefix):]
+		if systemInfo.CustomInfo != nil {
+			if v, ok := (*systemInfo.CustomInfo)[suffix]; ok {
+				return v
+			}
+		}
+		return ""
+	}
+	val, _ := systemInfo.Get(key)
+	return val
+}
+
+// sanitizeLabelValue truncates and sanitizes s for use as a Kubernetes label value (max 63 chars, valid pattern).
+// Returns empty string if the result would be invalid.
+func sanitizeLabelValue(s string) string {
+	// Strip invalid characters: keep alphanumeric, '-', '_', '.'
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		}
+	}
+	s = b.String()
+	if len(s) > maxLabelValueLength {
+		s = s[:maxLabelValueLength]
+	}
+	s = strings.Trim(s, "-_.")
+	if s == "" || !labelValueRegex.MatchString(s) {
+		return ""
+	}
+	return s
+}

--- a/internal/service/common/alias_test.go
+++ b/internal/service/common/alias_test.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeDefaultAlias(t *testing.T) {
+	tests := []struct {
+		name      string
+		systemInfo domain.DeviceSystemInfo
+		keys      []string
+		want      string
+	}{
+		{
+			name:      "empty keys",
+			systemInfo: domain.DeviceSystemInfo{},
+			keys:      nil,
+			want:      "",
+		},
+		{
+			name:      "empty keys slice",
+			systemInfo: domain.DeviceSystemInfo{},
+			keys:      []string{},
+			want:      "",
+		},
+		{
+			name: "empty systemInfo",
+			systemInfo: domain.DeviceSystemInfo{},
+			keys:      []string{"hostname", "architecture"},
+			want:      "",
+		},
+		{
+			name: "hostname only from additionalProperties",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("hostname", "my-device-01")
+				return si
+			}(),
+			keys: []string{"hostname"},
+			want: "my-device-01",
+		},
+		{
+			name: "first non-empty wins - hostname then productSerial",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("hostname", "first")
+				si.Set("productSerial", "SN123")
+				return si
+			}(),
+			keys: []string{"hostname", "productSerial"},
+			want: "first",
+		},
+		{
+			name: "first non-empty wins - skip empty hostname",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("productSerial", "SN456")
+				return si
+			}(),
+			keys: []string{"hostname", "productSerial"},
+			want: "SN456",
+		},
+		{
+			name: "fixed field architecture",
+			systemInfo: domain.DeviceSystemInfo{
+				Architecture: "amd64",
+			},
+			keys: []string{"architecture"},
+			want: "amd64",
+		},
+		{
+			name: "fixed field operatingSystem",
+			systemInfo: domain.DeviceSystemInfo{
+				OperatingSystem: "Linux",
+			},
+			keys: []string{"operatingSystem"},
+			want: "Linux",
+		},
+		{
+			name: "fixed field bootID and agentVersion",
+			systemInfo: domain.DeviceSystemInfo{
+				BootID:       "boot-uuid",
+				AgentVersion: "1.2.3",
+			},
+			keys: []string{"bootID", "agentVersion"},
+			want: "boot-uuid",
+		},
+		{
+			name: "customInfo key",
+			systemInfo: func() domain.DeviceSystemInfo {
+				si := domain.DeviceSystemInfo{}
+				si.CustomInfo = &domain.CustomDeviceInfo{"mykey": "custom-value"}
+				return si
+			}(),
+			keys: []string{"customInfo.mykey"},
+			want: "custom-value",
+		},
+		{
+			name: "customInfo key with first non-empty",
+			systemInfo: func() domain.DeviceSystemInfo {
+				si := domain.DeviceSystemInfo{}
+				si.CustomInfo = &domain.CustomDeviceInfo{"alias": "from-custom"}
+				return si
+			}(),
+			keys: []string{"hostname", "customInfo.alias"},
+			want: "from-custom",
+		},
+		{
+			name: "sanitization strips invalid chars",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("hostname", "my@device#with$bad%chars")
+				return si
+			}(),
+			keys: []string{"hostname"},
+			want: "mydevicewithbadchars",
+		},
+		{
+			name: "sanitization truncates to 63 chars",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				long := ""
+				for i := 0; i < 80; i++ {
+					long += "a"
+				}
+				si.Set("hostname", long)
+				return si
+			}(),
+			keys: []string{"hostname"},
+			want: func() string {
+				s := ""
+				for i := 0; i < 63; i++ {
+					s += "a"
+				}
+				return s
+			}(),
+		},
+		{
+			name: "trimmed leading/trailing invalid results in empty",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("hostname", "---...")
+				return si
+			}(),
+			keys: []string{"hostname"},
+			want: "",
+		},
+		{
+			name: "whitespace trimmed from value",
+			systemInfo: func() domain.DeviceSystemInfo {
+				var si domain.DeviceSystemInfo
+				si.Set("hostname", "  good-host  ")
+				return si
+			}(),
+			keys: []string{"hostname"},
+			want: "good-host",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeDefaultAlias(tt.systemInfo, tt.keys)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestComputeDefaultAlias_SanitizeTruncate(t *testing.T) {
+	// 63 chars is max; 64+ gets truncated
+	var si domain.DeviceSystemInfo
+	long := ""
+	for i := 0; i < 70; i++ {
+		long += "b"
+	}
+	si.Set("hostname", long)
+	got := ComputeDefaultAlias(si, []string{"hostname"})
+	require.Len(t, got, 63)
+	assert.Equal(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", got)
+}
+
+func TestComputeDefaultAlias_EmptyAfterSanitize(t *testing.T) {
+	var si domain.DeviceSystemInfo
+	si.Set("hostname", "!!!@@@###")
+	got := ComputeDefaultAlias(si, []string{"hostname"})
+	assert.Empty(t, got)
+}
+
+func TestSanitizeLabelValue(t *testing.T) {
+	// Exported for testing only via ComputeDefaultAlias; test via public API
+	// Valid label values pass through
+	var si domain.DeviceSystemInfo
+	si.Set("x", "a1-b2_c3.d4")
+	got := ComputeDefaultAlias(si, []string{"x"})
+	assert.Equal(t, "a1-b2_c3.d4", got)
+}

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -10,30 +10,32 @@ import (
 )
 
 type ServiceHandler struct {
-	eventHandler  *EventHandler
-	store         store.Store
-	ca            *crypto.CAClient
-	log           logrus.FieldLogger
-	workerClient  worker_client.WorkerClient
-	kvStore       kvstore.KVStore
-	agentEndpoint string
-	uiUrl         string
-	tpmCAPaths    []string
-	agentGate     *semaphore.Weighted
+	eventHandler    *EventHandler
+	store           store.Store
+	ca              *crypto.CAClient
+	log             logrus.FieldLogger
+	workerClient    worker_client.WorkerClient
+	kvStore         kvstore.KVStore
+	agentEndpoint   string
+	uiUrl           string
+	tpmCAPaths      []string
+	agentGate       *semaphore.Weighted
+	defaultAliasKeys []string
 }
 
-func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tpmCAPaths []string) *ServiceHandler {
+func NewServiceHandler(store store.Store, workerClient worker_client.WorkerClient, kvStore kvstore.KVStore, ca *crypto.CAClient, log logrus.FieldLogger, agentEndpoint string, uiUrl string, tpmCAPaths []string, defaultAliasKeys []string) *ServiceHandler {
 	return &ServiceHandler{
-		eventHandler:  NewEventHandler(store, workerClient, log),
-		store:         store,
-		ca:            ca,
-		log:           log,
-		workerClient:  workerClient,
-		kvStore:       kvStore,
-		agentEndpoint: agentEndpoint,
-		uiUrl:         uiUrl,
-		tpmCAPaths:    tpmCAPaths,
-		agentGate:     semaphore.NewWeighted(MaxConcurrentAgents),
+		eventHandler:     NewEventHandler(store, workerClient, log),
+		store:            store,
+		ca:               ca,
+		log:              log,
+		workerClient:     workerClient,
+		kvStore:          kvStore,
+		agentEndpoint:    agentEndpoint,
+		uiUrl:            uiUrl,
+		tpmCAPaths:       tpmCAPaths,
+		agentGate:        semaphore.NewWeighted(MaxConcurrentAgents),
+		defaultAliasKeys: defaultAliasKeys,
 	}
 }
 

--- a/internal/tasks/device_connection_test.go
+++ b/internal/tasks/device_connection_test.go
@@ -52,7 +52,7 @@ func BenchmarkDeviceConnectionPoll(b *testing.B) {
 		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		require.NoError(err)
-		serviceHandler := service.NewServiceHandler(dbStore, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler := service.NewServiceHandler(dbStore, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 
 		devices := generateMockDevices(deviceCount)
 		err = batchCreateDevices(ctx, db, devices, deviceCount)

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -78,7 +78,7 @@ func (s *Server) Run(ctx context.Context) error {
 	defer orgCache.Stop()
 
 	serviceHandler := service.WrapWithTracing(
-		service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}))
+		service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}, nil))
 
 	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, serviceHandler, s.k8sClient, kvStore, 1, 1, s.workerMetrics); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -253,7 +253,7 @@ func NewTestHarness(ctx context.Context, testDirPath string, goRoutineErrorHandl
 		return nil, fmt.Errorf("NewTestHarness: failed to create queue publisher: %w", err)
 	}
 	workerClient := worker_client.NewWorkerClient(publisher, serverLog)
-	serviceHandler := service.NewServiceHandler(store, workerClient, kvStore, ca, serverLog, "", "", []string{})
+	serviceHandler := service.NewServiceHandler(store, workerClient, kvStore, ca, serverLog, "", "", []string{}, nil)
 
 	testHarness := &TestHarness{
 		agentConfig:           cfg,

--- a/test/integration/alerts/exporter_test.go
+++ b/test/integration/alerts/exporter_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Alert Exporter", func() {
 		mockProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 		checkpointManager = alert_exporter.NewCheckpointManager(log, serviceHandler)
 		eventProcessor = alert_exporter.NewEventProcessor(log, serviceHandler)
 		alertSender = alert_exporter.NewAlertSender(log, cfg.Alertmanager.Hostname, cfg.Alertmanager.Port, cfg)

--- a/test/integration/auth/auth_config_test.go
+++ b/test/integration/auth/auth_config_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Auth Config Integration Tests", func() {
 		ctx = context.WithValue(ctx, consts.MappedIdentityCtxKey, adminIdentity)
 
 		// Create service handler (it implements AuthProviderService interface)
-		serviceHandler = service.NewServiceHandler(testStore, nil, nil, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(testStore, nil, nil, nil, log, "", "", []string{}, nil)
 
 		// Create a config with static OIDC provider to test production initialization path
 		cfg := config.NewDefault(

--- a/test/integration/imagebuilder_worker/containerfile_test.go
+++ b/test/integration/imagebuilder_worker/containerfile_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Containerfile Generation", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create service handler for enrollment credential generation
-		serviceHandler = service.NewServiceHandler(mainStoreInst, nil, nil, caClient, log, "https://api.example.com", "https://ui.example.com", []string{})
+		serviceHandler = service.NewServiceHandler(mainStoreInst, nil, nil, caClient, log, "https://api.example.com", "https://ui.example.com", []string{}, nil)
 	})
 
 	AfterEach(func() {

--- a/test/integration/periodic_checker/periodic_checker_test.go
+++ b/test/integration/periodic_checker/periodic_checker_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Periodic", func() {
 
 		// Setup worker client and service handler
 		workerClient = worker_client.NewWorkerClient(queuePublisher, log)
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 
 		channelManager, err = periodic.NewChannelManager(periodic.ChannelManagerConfig{
 			Log: log,

--- a/test/integration/restore/restore_suite_test.go
+++ b/test/integration/restore/restore_suite_test.go
@@ -95,7 +95,7 @@ func (s *RestoreTestSuite) Setup() {
 	caClient, _, err := icrypto.EnsureCA(caCfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	s.Handler = service.NewServiceHandler(s.Store, workerClient, kvStore, caClient, s.Log, "", "", []string{})
+	s.Handler = service.NewServiceHandler(s.Store, workerClient, kvStore, caClient, s.Log, "", "", []string{}, nil)
 }
 
 // Teardown performs common cleanup for restore tests.

--- a/test/integration/rollout/device_selection/device_selection_test.go
+++ b/test/integration/rollout/device_selection/device_selection_test.go
@@ -346,7 +346,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 		publisher.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{}, nil)
 	})
 	AfterEach(func() {
 		store.DeleteTestDB(ctx, log, cfg, storeInst, dbName)

--- a/test/integration/rollout/disruption_budget/disruptions_budget_test.go
+++ b/test/integration/rollout/disruption_budget/disruptions_budget_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 
-		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, mockWorkerClient, kvStore, nil, log, "", "", []string{}, nil)
 		capturedEvents = make([]api.Event, 0)
 	})
 	AfterEach(func() {

--- a/test/integration/service/enrollmentrequest_default_alias_test.go
+++ b/test/integration/service/enrollmentrequest_default_alias_test.go
@@ -1,0 +1,179 @@
+package service_test
+
+import (
+	"context"
+	"net/http"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/identity"
+	"github.com/flightctl/flightctl/internal/org"
+	"github.com/flightctl/flightctl/internal/service"
+	"github.com/flightctl/flightctl/internal/store/model"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("EnrollmentRequest default alias", func() {
+	var suite *ServiceTestSuite
+
+	// handlerWithDefaultAliasKeys creates a handler with defaultAliasKeys set (e.g. []string{"hostname"}).
+	// Must be called after suite.Setup() so Store, kvStore, caClient, etc. are initialized.
+	handlerWithDefaultAliasKeys := func(keys []string) {
+		suite.Handler = service.NewServiceHandler(
+			suite.Store, suite.workerClient, suite.kvStore, suite.caClient, suite.Log,
+			"", "", []string{}, keys)
+	}
+
+	BeforeEach(func() {
+		suite = NewServiceTestSuite()
+		suite.Setup()
+	})
+
+	AfterEach(func() {
+		suite.Teardown()
+	})
+
+	Context("when defaultAliasKeys is configured", func() {
+		BeforeEach(func() {
+			handlerWithDefaultAliasKeys([]string{"hostname", "architecture"})
+		})
+
+		It("sets default-alias annotation on create when DeviceStatus.SystemInfo is present", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.DeviceStatus = &api.DeviceStatus{}
+			er.Spec.DeviceStatus.SystemInfo.Set("hostname", "my-edge-device")
+
+			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			created, status := suite.Handler.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+			Expect(created.Metadata.Annotations).ToNot(BeNil())
+			Expect(*created.Metadata.Annotations).To(HaveKeyWithValue(domain.EnrollmentRequestAnnotationDefaultAlias, "my-edge-device"))
+
+			retrieved, status := suite.Handler.GetEnrollmentRequest(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(*retrieved.Metadata.Annotations).To(HaveKeyWithValue(domain.EnrollmentRequestAnnotationDefaultAlias, "my-edge-device"))
+		})
+
+		It("updates default-alias annotation on replace when DeviceStatus.SystemInfo changes", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.DeviceStatus = &api.DeviceStatus{}
+			er.Spec.DeviceStatus.SystemInfo.Set("hostname", "original-host")
+
+			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			created, status := suite.Handler.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(*created.Metadata.Annotations).To(HaveKeyWithValue(domain.EnrollmentRequestAnnotationDefaultAlias, "original-host"))
+
+			replacement := *created
+			replacement.Spec.DeviceStatus.SystemInfo.Set("hostname", "updated-host")
+			replaced, status := suite.Handler.ReplaceEnrollmentRequest(suite.Ctx, suite.OrgID, erName, replacement)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(*replaced.Metadata.Annotations).To(HaveKeyWithValue(domain.EnrollmentRequestAnnotationDefaultAlias, "updated-host"))
+		})
+
+		It("applies default-alias annotation to device alias on approval when alias not in approval labels", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.DeviceStatus = &api.DeviceStatus{}
+			er.Spec.DeviceStatus.SystemInfo.Set("hostname", "approved-device-alias")
+
+			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			_, status := suite.Handler.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"env": "test"},
+			}
+
+			_, st := suite.Handler.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			device, status := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Metadata.Labels).ToNot(BeNil())
+			Expect(*device.Metadata.Labels).To(HaveKeyWithValue("alias", "approved-device-alias"))
+			Expect(*device.Metadata.Labels).To(HaveKeyWithValue("env", "test"))
+		})
+
+		It("keeps approval alias when alias is set in approval labels", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.DeviceStatus = &api.DeviceStatus{}
+			er.Spec.DeviceStatus.SystemInfo.Set("hostname", "from-systeminfo")
+
+			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			_, status := suite.Handler.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"alias": "explicit-alias", "env": "test"},
+			}
+
+			_, st := suite.Handler.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			device, status := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(*device.Metadata.Labels).To(HaveKeyWithValue("alias", "explicit-alias"))
+		})
+	})
+
+	Context("when defaultAliasKeys is nil/empty", func() {
+		It("does not set default-alias annotation and device has no alias when not in approval labels", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.DeviceStatus = &api.DeviceStatus{}
+			er.Spec.DeviceStatus.SystemInfo.Set("hostname", "no-default-config")
+
+			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			created, status := suite.Handler.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			if created.Metadata.Annotations != nil {
+				Expect(*created.Metadata.Annotations).ToNot(HaveKey(domain.EnrollmentRequestAnnotationDefaultAlias))
+			}
+
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"env": "test"},
+			}
+
+			_, st := suite.Handler.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			device, status := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			if device.Metadata.Labels != nil {
+				Expect(*device.Metadata.Labels).ToNot(HaveKey("alias"))
+			}
+		})
+	})
+})

--- a/test/integration/tasks/device_connection_test.go
+++ b/test/integration/tasks/device_connection_test.go
@@ -53,7 +53,7 @@ var _ = Describe("DeviceConnection", func() {
 		kvStore, err = kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		workerClient = worker_client.NewMockWorkerClient(ctrl)
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 		connectionTask = tasks.NewDeviceConnection(log, serviceHandler)
 	})
 

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -100,7 +100,7 @@ var _ = Describe("DeviceRender", func() {
 		var err error
 		kvStoreInst, err = kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{}, nil)
 
 		// Initialize queues provider and rendered.Bus for successful device rendering
 		// Only initialize once (singleton pattern), subsequent calls are no-ops

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -78,7 +78,7 @@ var _ = Describe("FleetRollout", func() {
 		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 	})
 
 	AfterEach(func() {

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -57,7 +57,7 @@ var _ = Describe("FleetSelector", func() {
 		workerClient = worker_client.NewWorkerClient(producer, log)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 		event := api.Event{
 			Reason: api.EventReasonResourceUpdated,
 			InvolvedObject: api.ObjectReference{

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -56,7 +56,7 @@ var _ = Describe("FleetValidate", func() {
 		workerClient = worker_client.NewWorkerClient(producer, log)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 
 		spec := api.RepositorySpec{}
 		err = spec.FromGitRepoSpec(api.GitRepoSpec{

--- a/test/integration/tasks/repo_update_test.go
+++ b/test/integration/tasks/repo_update_test.go
@@ -44,7 +44,7 @@ var _ = Describe("RepoUpdate", func() {
 		workerClient = worker_client.NewMockWorkerClient(ctrl)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 
 		// Create 2 git config items, each to a different repo
 		err = testutil.CreateRepositories(ctx, 2, storeInst, orgId)

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -119,7 +119,7 @@ var _ = Describe("RepoTester", func() {
 		workerClient := worker_client.NewWorkerClient(publisher, log)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(stores, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(stores, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 		repotestr = tasks.NewRepoTester(log, serviceHandler, func(repository *api.Repository) tasks.TypeSpecificRepoTester {
 			return &MockRepoTester{}
 		})

--- a/test/integration/tasks/resourcesync_test.go
+++ b/test/integration/tasks/resourcesync_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
-		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{}, nil)
 		resourceSync = tasks.NewResourceSync(serviceHandler, log, nil)
 
 		// Set up mock expectations for the publisher


### PR DESCRIPTION
- New server config option for the alias naming rule (ordered list of systemInfo keys).
- The default is to use hostname, then fall back to the current name (device fingerprint).
- Validate config at load and, where possible, when computing.
- On EnrollmentRequest create/replace/patch, compute default alias from er.Spec.DeviceStatus.SystemInfo and set a new annotation on the enrollment request.
- When creating the device from an approved enrollment request, if that annotation is set and alias is not already in approval labels, set the device label alias from the annotation.
- Unit tests for validation and alias computation; integration tests for ER create/replace and approval flow.
- Document the new config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic device alias generation from system information during enrollment. A new `defaultAliasKeys` configuration option allows customization of which system fields are used for alias computation. Default aliases are automatically applied to devices during enrollment approval when not explicitly provided.

* **Documentation**
  * Added configuration guide for the new default alias feature.

* **Tests**
  * Added test coverage for alias validation and enrollment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->