### PR TITLE
EDM-3392: imagebuild/export to respect ca.cert

### DIFF
--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -466,13 +466,13 @@ func (s *imageExportService) Download(ctx context.Context, orgId uuid.UUID, name
 	}
 
 	// Setup repository reference and authentication
-	repoRef, scheme, registryHostname, err := s.setupRepositoryReference(ctx, &ociSpec, imageBuild.Spec.Destination.ImageName)
+	repoRef, scheme, registryHostname, err := s.setupRepositoryReference(ctx, &ociSpec, imageBuild.Spec.Destination.ImageName, log)
 	if err != nil {
 		return nil, err
 	}
 
 	// Fetch and parse manifest
-	manifest, err := s.fetchAndParseManifest(ctx, repoRef, manifestDigestStr)
+	manifest, err := s.fetchAndParseManifest(ctx, repoRef, manifestDigestStr, log)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (s *imageExportService) Download(ctx context.Context, orgId uuid.UUID, name
 	log.WithFields(logrus.Fields{"blobURL": blobURLStr, "layerDigest": layerDigestStr}).Debug("Constructed blob URL")
 
 	// Create HTTP client with TLS configuration
-	httpClient, err := s.createBlobFetchHTTPClient(&ociSpec)
+	httpClient, err := s.createHTTPClient(&ociSpec)
 	if err != nil {
 		log.WithError(err).Error("Failed to create HTTP client")
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
@@ -519,7 +519,7 @@ func (s *imageExportService) Download(ctx context.Context, orgId uuid.UUID, name
 	}
 
 	// Add authentication if available
-	if err := s.addAuthenticationToRequest(ctx, getReq, httpClient, scheme, registryHostname, imageBuild.Spec.Destination.ImageName, &ociSpec); err != nil {
+	if err := s.addAuthenticationToRequest(ctx, getReq, httpClient, scheme, registryHostname, imageBuild.Spec.Destination.ImageName, &ociSpec, log); err != nil {
 		return nil, err
 	}
 
@@ -531,11 +531,11 @@ func (s *imageExportService) Download(ctx context.Context, orgId uuid.UUID, name
 
 	log.WithFields(logrus.Fields{"blobURL": blobURLStr, "statusCode": getResp.StatusCode}).Debug("Received GET response")
 
-	return s.handleBlobResponse(getResp, blobURLStr)
+	return s.handleBlobResponse(getResp, blobURLStr, log)
 }
 
 // setupRepositoryReference creates a repository reference and configures authentication
-func (s *imageExportService) setupRepositoryReference(ctx context.Context, ociSpec *coredomain.OciRepoSpec, imageName string) (*remote.Repository, string, string, error) {
+func (s *imageExportService) setupRepositoryReference(ctx context.Context, ociSpec *coredomain.OciRepoSpec, imageName string, log logrus.FieldLogger) (*remote.Repository, string, string, error) {
 	scheme := "https"
 	if ociSpec.Scheme != nil {
 		scheme = string(*ociSpec.Scheme)
@@ -543,83 +543,99 @@ func (s *imageExportService) setupRepositoryReference(ctx context.Context, ociSp
 	registryHostname := ociSpec.Registry
 	destRef := fmt.Sprintf("%s/%s", registryHostname, imageName)
 
-	s.log.WithFields(logrus.Fields{
+	log.WithFields(logrus.Fields{
 		"destRef": destRef, "scheme": scheme, "registryHostname": registryHostname,
 		"imageName": imageName,
 	}).Debug("Creating repository reference")
 
 	repoRef, err := remote.NewRepository(destRef)
 	if err != nil {
-		s.log.WithError(err).WithField("destRef", destRef).Error("Failed to create repository reference")
+		log.WithError(err).WithField("destRef", destRef).Error("Failed to create repository reference")
 		return nil, "", "", fmt.Errorf("failed to create repository reference: %w", err)
 	}
 
-	// Create client with TLS configuration and optional authentication
-	repoRef.Client, err = s.createRepositoryClient(ociSpec, registryHostname)
+	// Configure auth client with TLS settings and credentials
+	authClient := &auth.Client{}
+
+	tlsConfig, err := createTLSConfig(ociSpec)
 	if err != nil {
-		s.log.WithError(err).Error("Failed to create repository client")
-		return nil, "", "", fmt.Errorf("failed to create repository client: %w", err)
+		return nil, "", "", fmt.Errorf("failed to create TLS config for repository: %w", err)
 	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	authClient.Client = &http.Client{Transport: transport}
+
+	if ociSpec.OciAuth != nil {
+		dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
+		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
+			authClient.Credential = auth.StaticCredential(registryHostname, auth.Credential{
+				Username: dockerAuth.Username,
+				Password: dockerAuth.Password,
+			})
+			log.WithFields(logrus.Fields{"registryHostname": registryHostname, "username": dockerAuth.Username}).Debug("Configured authentication for repository")
+		}
+	} else {
+		log.Debug("No authentication configured for repository")
+	}
+
+	repoRef.Client = authClient
 
 	return repoRef, scheme, registryHostname, nil
 }
 
 // fetchAndParseManifest fetches and parses the OCI manifest
-func (s *imageExportService) fetchAndParseManifest(ctx context.Context, repoRef *remote.Repository, manifestDigestStr string) (*ocispec.Manifest, error) {
+func (s *imageExportService) fetchAndParseManifest(ctx context.Context, repoRef *remote.Repository, manifestDigestStr string, log logrus.FieldLogger) (*ocispec.Manifest, error) {
 	manifestDigest, err := digest.Parse(manifestDigestStr)
 	if err != nil {
-		s.log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to parse manifest digest")
+		log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to parse manifest digest")
 		return nil, fmt.Errorf("%w: %w", ErrInvalidManifestDigest, err)
 	}
 
 	// Try to resolve the manifest reference using the digest
-	s.log.WithField("manifestDigest", manifestDigestStr).Debug("Attempting to resolve manifest")
+	log.WithField("manifestDigest", manifestDigestStr).Debug("Attempting to resolve manifest")
 	manifestDesc, err := repoRef.Resolve(ctx, manifestDigestStr)
 	if err != nil {
-		s.log.WithError(err).WithField("manifestDigest", manifestDigestStr).Warn("Failed to resolve manifest, will try Fetch directly")
+		log.WithError(err).WithField("manifestDigest", manifestDigestStr).Warn("Failed to resolve manifest, will try Fetch directly")
 		manifestDesc = ocispec.Descriptor{
 			Digest:    manifestDigest,
 			MediaType: ocispec.MediaTypeImageManifest,
 		}
 	} else {
-		s.log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType, "size": manifestDesc.Size}).Debug("Successfully resolved manifest")
+		log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType, "size": manifestDesc.Size}).Debug("Successfully resolved manifest")
 	}
 
 	// Fetch manifest
-	s.log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType}).Debug("Fetching manifest")
+	log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType}).Debug("Fetching manifest")
 	manifestReader, err := repoRef.Fetch(ctx, manifestDesc)
 	if err != nil {
-		s.log.WithError(err).WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType}).Error("Failed to fetch manifest from external service")
+		log.WithError(err).WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "mediaType": manifestDesc.MediaType}).Error("Failed to fetch manifest from external service")
 		return nil, fmt.Errorf("%w: failed to fetch manifest: %w", ErrExternalServiceUnavailable, err)
 	}
 	defer manifestReader.Close()
 
 	manifestBytes, err := io.ReadAll(manifestReader)
 	if err != nil {
-		s.log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to read manifest")
+		log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to read manifest")
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}
 
-	s.log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "manifestSize": len(manifestBytes)}).Debug("Read manifest bytes")
+	log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "manifestSize": len(manifestBytes)}).Debug("Read manifest bytes")
 
 	// Parse manifest
 	var manifest ocispec.Manifest
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		s.log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to parse manifest JSON")
+		log.WithError(err).WithField("manifestDigest", manifestDigestStr).Error("Failed to parse manifest JSON")
 		return nil, fmt.Errorf("failed to parse manifest: %w", err)
 	}
 
-	s.log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "layerCount": len(manifest.Layers), "mediaType": manifest.MediaType}).Debug("Parsed manifest")
+	log.WithFields(logrus.Fields{"manifestDigest": manifestDigestStr, "layerCount": len(manifest.Layers), "mediaType": manifest.MediaType}).Debug("Parsed manifest")
 
 	return &manifest, nil
 }
 
-// createTLSTransport creates an HTTP transport with TLS configuration
-func (s *imageExportService) createTLSTransport(ociSpec *coredomain.OciRepoSpec) (*http.Transport, error) {
-	// Clone the default transport to preserve default settings (timeouts, connection pooling, etc.)
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
-	// Configure TLS
+// createTLSConfig builds a TLS configuration from the OCI repository spec,
+// handling SkipServerVerification and custom CA certificates.
+func createTLSConfig(ociSpec *coredomain.OciRepoSpec) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
@@ -629,73 +645,40 @@ func (s *imageExportService) createTLSTransport(ociSpec *coredomain.OciRepoSpec)
 	if ociSpec.CaCrt != nil {
 		ca, err := base64.StdEncoding.DecodeString(*ociSpec.CaCrt)
 		if err != nil {
-			return nil, fmt.Errorf("createTLSTransport: decode CA: %w", err)
+			return nil, fmt.Errorf("decode CA certificate: %w", err)
 		}
 		rootCAs, err := x509.SystemCertPool()
 		if err != nil {
-			return nil, fmt.Errorf("createTLSTransport: system cert pool: %w", err)
-		}
-		if rootCAs == nil {
 			rootCAs = x509.NewCertPool()
 		}
 		if !rootCAs.AppendCertsFromPEM(ca) {
-			return nil, fmt.Errorf("createTLSTransport: failed to append CA certificates from PEM")
+			return nil, fmt.Errorf("failed to append CA certificates from PEM")
 		}
 		tlsConfig.RootCAs = rootCAs
 	}
-	transport.TLSClientConfig = tlsConfig
-
-	return transport, nil
+	return tlsConfig, nil
 }
 
-// createBlobFetchHTTPClient creates an HTTP client with TLS configuration for blob fetching (disables redirect following)
-func (s *imageExportService) createBlobFetchHTTPClient(ociSpec *coredomain.OciRepoSpec) (*http.Client, error) {
-	transport, err := s.createTLSTransport(ociSpec)
+// createHTTPClient creates an HTTP client with TLS configuration
+func (s *imageExportService) createHTTPClient(ociSpec *coredomain.OciRepoSpec) (*http.Client, error) {
+	tlsConfig, err := createTLSConfig(ociSpec)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("createHTTPClient: %w", err)
 	}
 
 	return &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: transport,
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}, nil
 }
 
-// createRepositoryClient creates a remote.Client with TLS configuration and optional authentication
-func (s *imageExportService) createRepositoryClient(ociSpec *coredomain.OciRepoSpec, registryHostname string) (remote.Client, error) {
-	transport, err := s.createTLSTransport(ociSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: transport,
-	}
-
-	// If credentials are provided, wrap in auth.Client
-	if ociSpec.OciAuth != nil {
-		dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
-		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
-			s.log.WithFields(logrus.Fields{"registryHostname": registryHostname, "username": dockerAuth.Username}).Debug("Configured authentication for repository")
-			return &auth.Client{
-				Client: httpClient,
-				Credential: auth.StaticCredential(registryHostname, auth.Credential{
-					Username: dockerAuth.Username,
-					Password: dockerAuth.Password,
-				}),
-			}, nil
-		}
-	}
-
-	return httpClient, nil
-}
-
 // addAuthenticationToRequest adds authentication headers to the request if needed
-func (s *imageExportService) addAuthenticationToRequest(ctx context.Context, req *http.Request, client *http.Client, scheme, registryHostname, repoName string, ociSpec *coredomain.OciRepoSpec) error {
+func (s *imageExportService) addAuthenticationToRequest(ctx context.Context, req *http.Request, client *http.Client, scheme, registryHostname, repoName string, ociSpec *coredomain.OciRepoSpec, log logrus.FieldLogger) error {
 	if ociSpec.OciAuth == nil {
 		return nil
 	}
@@ -705,31 +688,31 @@ func (s *imageExportService) addAuthenticationToRequest(ctx context.Context, req
 		return nil
 	}
 
-	s.log.WithFields(logrus.Fields{"registryHostname": registryHostname, "repoName": repoName}).Debug("Getting registry token for authentication")
+	log.WithFields(logrus.Fields{"registryHostname": registryHostname, "repoName": repoName}).Debug("Getting registry token for authentication")
 	token, err := s.getRegistryToken(ctx, client, scheme, registryHostname, repoName, dockerAuth.Username, dockerAuth.Password)
 	if err != nil {
-		s.log.WithError(err).WithField("registryHostname", registryHostname).Error("Failed to get registry token from external service")
+		log.WithError(err).WithField("registryHostname", registryHostname).Error("Failed to get registry token from external service")
 		return fmt.Errorf("%w: failed to get registry token: %w", ErrExternalServiceUnavailable, err)
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
-		s.log.WithField("hasToken", true).Debug("Added bearer token to GET request")
+		log.WithField("hasToken", true).Debug("Added bearer token to GET request")
 	}
 
 	return nil
 }
 
 // handleBlobResponse handles the HTTP response from the blob endpoint
-func (s *imageExportService) handleBlobResponse(resp *http.Response, blobURL string) (*ImageExportDownload, error) {
+func (s *imageExportService) handleBlobResponse(resp *http.Response, blobURL string, log logrus.FieldLogger) (*ImageExportDownload, error) {
 	// Handle redirect (3xx)
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		resp.Body.Close()
 		redirectURL := resp.Header.Get("Location")
 		if redirectURL == "" {
-			s.log.WithField("statusCode", resp.StatusCode).Error("Redirect response missing Location header")
+			log.WithField("statusCode", resp.StatusCode).Error("Redirect response missing Location header")
 			return nil, errors.New("redirect response missing Location header")
 		}
-		s.log.WithFields(logrus.Fields{"statusCode": resp.StatusCode, "redirectURL": redirectURL}).Info("Returning redirect response")
+		log.WithFields(logrus.Fields{"statusCode": resp.StatusCode, "redirectURL": redirectURL}).Info("Returning redirect response")
 		return &ImageExportDownload{
 			RedirectURL: redirectURL,
 			StatusCode:  resp.StatusCode,
@@ -739,7 +722,7 @@ func (s *imageExportService) handleBlobResponse(resp *http.Response, blobURL str
 	// Handle 200 OK - stream blob content
 	if resp.StatusCode == http.StatusOK {
 		contentLength := resp.Header.Get("Content-Length")
-		s.log.WithFields(logrus.Fields{"blobURL": blobURL, "statusCode": resp.StatusCode, "contentLength": contentLength}).Info("Successfully fetched blob, returning stream")
+		log.WithFields(logrus.Fields{"blobURL": blobURL, "statusCode": resp.StatusCode, "contentLength": contentLength}).Info("Successfully fetched blob, returning stream")
 		return &ImageExportDownload{
 			BlobReader: resp.Body,
 			Headers:    resp.Header,
@@ -749,7 +732,7 @@ func (s *imageExportService) handleBlobResponse(resp *http.Response, blobURL str
 
 	// Handle unexpected status codes
 	resp.Body.Close()
-	s.log.WithFields(logrus.Fields{"blobURL": blobURL, "statusCode": resp.StatusCode}).Error("Unexpected status code from external service")
+	log.WithFields(logrus.Fields{"blobURL": blobURL, "statusCode": resp.StatusCode}).Error("Unexpected status code from external service")
 	return nil, fmt.Errorf("%w: unexpected status code from blob endpoint: %d", ErrExternalServiceUnavailable, resp.StatusCode)
 }
 
@@ -965,11 +948,24 @@ func (s *imageExportService) validate(ctx context.Context, orgId uuid.UUID, imag
 			} else if source.ImageBuildRef == "" {
 				errs = append(errs, errors.New("spec.source.imageBuildRef is required for imageBuild source type"))
 			} else {
-				validationErrs, err := s.validateSourceImageBuild(ctx, orgId, source.ImageBuildRef)
-				if err != nil {
-					return nil, err
+				// Check that the referenced ImageBuild exists
+				imageBuild, err := s.imageBuildStore.Get(ctx, orgId, source.ImageBuildRef)
+				if errors.Is(err, flterrors.ErrResourceNotFound) {
+					errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q not found", source.ImageBuildRef))
+				} else if err != nil {
+					return nil, fmt.Errorf("failed to get ImageBuild %q: %w", source.ImageBuildRef, err)
+				} else {
+					// Validate that the ImageBuild has a destination configured
+					if imageBuild.Spec.Destination.Repository == "" {
+						errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination repository configured", source.ImageBuildRef))
+					}
+					if imageBuild.Spec.Destination.ImageName == "" {
+						errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination imageName configured", source.ImageBuildRef))
+					}
+					if imageBuild.Spec.Destination.ImageTag == "" {
+						errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination imageTag configured", source.ImageBuildRef))
+					}
 				}
-				errs = append(errs, validationErrs...)
 			}
 		default:
 			errs = append(errs, errors.New("spec.source.type must be 'imageBuild'"))
@@ -979,40 +975,6 @@ func (s *imageExportService) validate(ctx context.Context, orgId uuid.UUID, imag
 	// Validate formats
 	if imageExport.Spec.Format == "" {
 		errs = append(errs, errors.New("spec.format is required"))
-	}
-
-	return errs, nil
-}
-
-func (s *imageExportService) validateSourceImageBuild(ctx context.Context, orgId uuid.UUID, imageBuildRef string) ([]error, error) {
-	var errs []error
-
-	imageBuild, err := s.imageBuildStore.Get(ctx, orgId, imageBuildRef)
-	if errors.Is(err, flterrors.ErrResourceNotFound) {
-		return []error{fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q not found", imageBuildRef)}, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ImageBuild %q: %w", imageBuildRef, err)
-	}
-
-	buildState := getCurrentBuildState(imageBuild)
-	switch buildState {
-	case string(domain.ImageBuildConditionReasonFailed):
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q is in Failed state", imageBuildRef))
-	case string(domain.ImageBuildConditionReasonCanceled):
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q is in Canceled state", imageBuildRef))
-	case string(domain.ImageBuildConditionReasonCanceling):
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q is in Canceling state", imageBuildRef))
-	}
-
-	if imageBuild.Spec.Destination.Repository == "" {
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination repository configured", imageBuildRef))
-	}
-	if imageBuild.Spec.Destination.ImageName == "" {
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination imageName configured", imageBuildRef))
-	}
-	if imageBuild.Spec.Destination.ImageTag == "" {
-		errs = append(errs, fmt.Errorf("spec.source.imageBuildRef: ImageBuild %q does not have a destination imageTag configured", imageBuildRef))
 	}
 
 	return errs, nil

--- a/internal/imagebuilder_worker/tasks/imageexport_test.go
+++ b/internal/imagebuilder_worker/tasks/imageexport_test.go
@@ -1,0 +1,173 @@
+package tasks
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	coredomain "github.com/flightctl/flightctl/internal/domain"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	return l
+}
+
+func generateTestCACertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Test CA"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}))
+}
+
+func TestNewOCIAuthClient_Default(t *testing.T) {
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry: "registry.example.com",
+		Type:     coredomain.OciRepoSpecTypeOci,
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Nil(t, client.Client, "default transport should not be overridden when no TLS options set")
+	require.Nil(t, client.Credential, "no credentials should be set")
+}
+
+func TestNewOCIAuthClient_SkipVerification(t *testing.T) {
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry:               "registry.example.com",
+		Type:                   coredomain.OciRepoSpecTypeOci,
+		SkipServerVerification: lo.ToPtr(true),
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Client)
+
+	transport, ok := client.Client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	require.Nil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestNewOCIAuthClient_CaCrt(t *testing.T) {
+	caPEM := generateTestCACertPEM(t)
+	encoded := base64.StdEncoding.EncodeToString([]byte(caPEM))
+
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry: "registry.example.com",
+		Type:     coredomain.OciRepoSpecTypeOci,
+		CaCrt:    &encoded,
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Client)
+
+	transport, ok := client.Client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	require.NotNil(t, transport.TLSClientConfig.RootCAs)
+	require.Equal(t, tls.VersionTLS12, int(transport.TLSClientConfig.MinVersion))
+}
+
+func TestNewOCIAuthClient_BothCaCrtAndSkipVerification(t *testing.T) {
+	caPEM := generateTestCACertPEM(t)
+	encoded := base64.StdEncoding.EncodeToString([]byte(caPEM))
+
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry:               "registry.example.com",
+		Type:                   coredomain.OciRepoSpecTypeOci,
+		SkipServerVerification: lo.ToPtr(true),
+		CaCrt:                  &encoded,
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Client)
+
+	transport, ok := client.Client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	require.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestNewOCIAuthClient_WithCredentials(t *testing.T) {
+	ociAuth := &v1beta1.OciAuth{}
+	err := ociAuth.FromDockerAuth(v1beta1.DockerAuth{
+		AuthType: v1beta1.Docker,
+		Username: "testuser",
+		Password: "testpass",
+	})
+	require.NoError(t, err)
+
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry: "registry.example.com",
+		Type:     coredomain.OciRepoSpecTypeOci,
+		OciAuth:  ociAuth,
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.Credential, "credentials should be set")
+}
+
+func TestNewOCIAuthClient_InvalidBase64CaCrt(t *testing.T) {
+	invalid := "not-valid-base64!!!"
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry: "registry.example.com",
+		Type:     coredomain.OciRepoSpecTypeOci,
+		CaCrt:    &invalid,
+	}
+
+	_, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to decode CA certificate")
+}
+
+func TestNewOCIAuthClient_SkipVerificationFalse(t *testing.T) {
+	ociSpec := &coredomain.OciRepoSpec{
+		Registry:               "registry.example.com",
+		Type:                   coredomain.OciRepoSpecTypeOci,
+		SkipServerVerification: lo.ToPtr(false),
+	}
+
+	client, err := newOCIAuthClient(ociSpec, "registry.example.com", testLogger())
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Nil(t, client.Client, "default transport should not be overridden when SkipServerVerification is false")
+}


### PR DESCRIPTION
imagebuild/export tasks did not respect the provided ca.cert field for OCI Repository , now they do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CA certificate configuration when connecting to OCI registries, enabling secure registry authentication with custom certificate authorities.
  * Enhanced TLS handling with support for skipping server verification when needed.

* **Tests**
  * Re-enabled previously skipped tests for image export and download operations.
  * Added comprehensive test coverage for CA certificate and TLS-based registry access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->