### PR TITLE
EDM-3353: Accept hostnames for login

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -245,6 +245,15 @@ func (o *LoginOptions) Complete(cmd *cobra.Command, args []string) error {
 	if o.ConfigFilePath != defaultConfigPath {
 		fmt.Printf("Using a non-default configuration file path: %s (Default: %s)\n", o.ConfigFilePath, defaultConfigPath)
 	}
+
+	if len(args) > 0 {
+		trimmedURL := strings.TrimSpace(args[0])
+		if !strings.Contains(trimmedURL, "://") {
+			trimmedURL = "https://" + trimmedURL
+		}
+		args[0] = trimmedURL
+	}
+
 	return nil
 }
 

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -10,6 +10,73 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLoginOptions_Complete(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "hostname without schema",
+			input:    "my.service.com",
+			expected: "https://my.service.com",
+		},
+		{
+			name:     "hostname with port without schema",
+			input:    "my.service.com:8443",
+			expected: "https://my.service.com:8443",
+		},
+		{
+			name:     "URL with https schema",
+			input:    "https://my.service.com",
+			expected: "https://my.service.com",
+		},
+		{
+			name:     "URL with http schema",
+			input:    "http://my.service.com",
+			expected: "http://my.service.com",
+		},
+		{
+			name:     "hostname with leading/trailing whitespace",
+			input:    " my.service.com ",
+			expected: "https://my.service.com",
+		},
+		{
+			name:     "URL with schema and whitespace",
+			input:    " https://my.service.com ",
+			expected: "https://my.service.com",
+		},
+		{
+			name:     "URL with ftp schema",
+			input:    "ftp://my.service.com",
+			expected: "ftp://my.service.com",
+		},
+		{
+			name:     "IPv6 hostname without schema",
+			input:    "[2001:db8::1]",
+			expected: "https://[2001:db8::1]",
+		},
+		{
+			name:     "IPv6 hostname with port without schema",
+			input:    "[2001:db8::1]:8443",
+			expected: "https://[2001:db8::1]:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := DefaultLoginOptions()
+			args := []string{tt.input}
+			cmd := NewCmdLogin()
+
+			err := o.Complete(cmd, args)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, args[0])
+		})
+	}
+}
+
 func TestLoginOptions_Validate(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login command now normalizes URLs by trimming whitespace and automatically adding the https:// scheme when no scheme is provided.

* **Tests**
  * Added comprehensive test coverage for URL normalization scenarios in the login command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->