### PR TITLE
EDM-3392: fix imagebuild/imageexport , not respecting ca.cert - using /etc/containers/cert.d

### DIFF
--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -393,6 +393,11 @@ func (c *Consumer) executeExport(
 		return "", cleanup, fmt.Errorf("failed to initialize podman storage: %w", err)
 	}
 
+	// Step 2.6: Install CA certificate for source registry if configured
+	if err := installCACertInWorker(ctx, exportSource.OciRepoSpec.CaCrt, worker.ContainerName, registryHostname, log); err != nil {
+		return "", cleanup, fmt.Errorf("failed to install CA cert for source registry: %w", err)
+	}
+
 	// Step 3: Login to registry if credentials are provided
 	if exportSource.OciRepoSpec.OciAuth != nil {
 		dockerAuth, err := exportSource.OciRepoSpec.OciAuth.AsDockerAuth()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced CA certificate handling for container registries. Certificates for custom certificate authorities are now properly integrated during image build and export operations, improving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->