### PR TITLE
EDM-3391: take k8/openshift groups into account for auth

### DIFF
--- a/internal/auth/authn/k8s.go
+++ b/internal/auth/authn/k8s.go
@@ -176,7 +176,7 @@ func (o *K8sAuthN) GetIdentity(ctx context.Context, token string) (common.Identi
 	var roles []string
 	if o.spec.RbacNs != nil && *o.spec.RbacNs != "" {
 		var err error
-		roles, err = o.k8sClient.ListRoleBindingsForUser(ctx, *o.spec.RbacNs, review.Status.User.Username)
+		roles, err = o.k8sClient.ListRoleBindingsForUser(ctx, *o.spec.RbacNs, review.Status.User.Username, review.Status.User.Groups)
 		if err != nil {
 			logrus.WithError(err).WithField("namespace", *o.spec.RbacNs).Warn("Failed to list role bindings")
 			roles = []string{}

--- a/internal/auth/authn/k8s_test.go
+++ b/internal/auth/authn/k8s_test.go
@@ -1,0 +1,158 @@
+package authn
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/pkg/k8sclient"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestK8sAuthN(t *testing.T, k8sClient k8sclient.K8SClient) *K8sAuthN {
+	t.Helper()
+	auth, err := NewK8sAuthN(
+		api.ObjectMeta{Name: lo.ToPtr("test-k8s-provider")},
+		api.K8sProviderSpec{
+			Enabled:    lo.ToPtr(true),
+			ApiUrl:     "https://api.k8s.example.com:6443",
+			RbacNs:     lo.ToPtr("flightctl-ext"),
+			RoleSuffix: lo.ToPtr("flightctl"),
+		},
+		k8sClient,
+	)
+	require.NoError(t, err)
+	return auth
+}
+
+func TestK8sGetIdentity_GroupRolesResolved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestK8sAuthN(t, mock)
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user01", "uid-001", []string{"developers", "system:authenticated"}), nil)
+
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "user01", []string{"developers", "system:authenticated"}).
+		Return([]string{"flightctl-viewer-flightctl"}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user01", identity.GetUsername())
+	assert.Equal(t, "uid-001", identity.GetUID())
+
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Equal(t, "default", orgs[0].Name)
+	assert.Contains(t, orgs[0].Roles, "flightctl-viewer")
+}
+
+func TestK8sGetIdentity_NoGroupsNoRoles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestK8sAuthN(t, mock)
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user04", "uid-004", []string{"system:authenticated"}), nil)
+
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "user04", []string{"system:authenticated"}).
+		Return([]string{}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-2")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user04", identity.GetUsername())
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Empty(t, orgs[0].Roles)
+}
+
+func TestK8sGetIdentity_AdminViaGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestK8sAuthN(t, mock)
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("admin-user", "uid-admin", []string{"platform-admins", "system:authenticated"}), nil)
+
+	// Group platform-admins is bound to flightctl-admin role
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "admin-user", []string{"platform-admins", "system:authenticated"}).
+		Return([]string{"flightctl-admin-flightctl"}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-3")
+	require.NoError(t, err)
+
+	assert.True(t, identity.IsSuperAdmin())
+}
+
+func TestK8sGetIdentity_UserAndGroupRolesCombined(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestK8sAuthN(t, mock)
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user05", "uid-005", []string{"ops-team", "system:authenticated"}), nil)
+
+	// User gets viewer directly + operator through group
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "user05", []string{"ops-team", "system:authenticated"}).
+		Return([]string{"flightctl-viewer-flightctl", "flightctl-operator-flightctl"}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-4")
+	require.NoError(t, err)
+
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Contains(t, orgs[0].Roles, "flightctl-viewer")
+	assert.Contains(t, orgs[0].Roles, "flightctl-operator")
+}
+
+func TestK8sGetIdentity_NoRbacNs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+
+	auth, err := NewK8sAuthN(
+		api.ObjectMeta{Name: lo.ToPtr("test-k8s-no-rbac")},
+		api.K8sProviderSpec{
+			Enabled: lo.ToPtr(true),
+			ApiUrl:  "https://api.k8s.example.com:6443",
+		},
+		mock,
+	)
+	require.NoError(t, err)
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user06", "uid-006", []string{"developers"}), nil)
+
+	// No ListRoleBindingsForUser call expected since RbacNs is nil
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-5")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user06", identity.GetUsername())
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Empty(t, orgs[0].Roles)
+}

--- a/internal/auth/authn/openshift_auth.go
+++ b/internal/auth/authn/openshift_auth.go
@@ -208,7 +208,7 @@ func (o *OpenShiftAuth) GetIdentity(ctx context.Context, token string) (common.I
 	// Get roles per project
 	orgRoles := make(map[string][]string)
 	for _, project := range projects {
-		roles, err := o.getRolesForUserInProject(ctx, project, username)
+		roles, err := o.getRolesForUserInProject(ctx, project, username, review.Status.User.Groups)
 		if err != nil {
 			o.log.WithError(err).WithField("project", project).Warn("Failed to get roles for project")
 			continue
@@ -342,8 +342,8 @@ func (o *OpenShiftAuth) getProjectsForUser(ctx context.Context, token string) ([
 }
 
 // getRolesForUserInProject gets roles from RoleBindings in a project
-func (o *OpenShiftAuth) getRolesForUserInProject(ctx context.Context, project, username string) ([]string, error) {
-	roles, err := o.k8sClient.ListRoleBindingsForUser(ctx, project, username)
+func (o *OpenShiftAuth) getRolesForUserInProject(ctx context.Context, project, username string, groups []string) ([]string, error) {
+	roles, err := o.k8sClient.ListRoleBindingsForUser(ctx, project, username, groups)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/authn/openshift_auth_test.go
+++ b/internal/auth/authn/openshift_auth_test.go
@@ -1,0 +1,202 @@
+package authn
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/pkg/k8sclient"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	k8sAuthenticationV1 "k8s.io/api/authentication/v1"
+)
+
+func newTestOpenShiftAuth(t *testing.T, k8sClient k8sclient.K8SClient) *OpenShiftAuth {
+	t.Helper()
+	auth, err := NewOpenShiftAuth(
+		api.ObjectMeta{Name: lo.ToPtr("test-provider")},
+		api.OpenShiftProviderSpec{
+			Enabled:                lo.ToPtr(true),
+			AuthorizationUrl:       lo.ToPtr("https://oauth.example.com/authorize"),
+			TokenUrl:               lo.ToPtr("https://oauth.example.com/token"),
+			ClientId:               lo.ToPtr("flightctl"),
+			ClientSecret:           lo.ToPtr("secret"),
+			ClusterControlPlaneUrl: lo.ToPtr("https://api.example.com:6443"),
+			Issuer:                 lo.ToPtr("https://oauth.example.com"),
+			RoleSuffix:             lo.ToPtr("flightctl"),
+		},
+		k8sClient,
+		nil,
+		logrus.New(),
+	)
+	require.NoError(t, err)
+	return auth
+}
+
+func tokenReviewJSON(username, uid string, groups []string) []byte {
+	review := k8sAuthenticationV1.TokenReview{
+		Status: k8sAuthenticationV1.TokenReviewStatus{
+			Authenticated: true,
+			User: k8sAuthenticationV1.UserInfo{
+				Username: username,
+				UID:      uid,
+				Groups:   groups,
+			},
+		},
+	}
+	data, _ := json.Marshal(review)
+	return data
+}
+
+func projectListJSON(names ...string) []byte {
+	type item struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	list := struct {
+		Items []item `json:"items"`
+	}{}
+	for _, n := range names {
+		it := item{}
+		it.Metadata.Name = n
+		list.Items = append(list.Items, it)
+	}
+	data, _ := json.Marshal(list)
+	return data
+}
+
+func TestGetIdentity_GroupRolesResolved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestOpenShiftAuth(t, mock)
+
+	// TokenReview: user01 is in groups RedHat and system:authenticated
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user01", "uid-001", []string{"RedHat", "system:authenticated"}), nil)
+
+	// ListProjects: user has access to flightctl-ext
+	mock.EXPECT().
+		ListProjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(projectListJSON("flightctl-ext"), nil)
+
+	// ListRoleBindingsForUser: called with username AND groups; returns viewer role via group
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "user01", []string{"RedHat", "system:authenticated"}).
+		Return([]string{"flightctl-viewer-flightctl"}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user01", identity.GetUsername())
+	assert.Equal(t, "uid-001", identity.GetUID())
+
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Equal(t, "flightctl-ext", orgs[0].Name)
+	assert.Contains(t, orgs[0].Roles, "flightctl-viewer")
+}
+
+func TestGetIdentity_NoGroupsNoRoles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestOpenShiftAuth(t, mock)
+
+	// TokenReview: user04 has no custom groups
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user04", "uid-004", []string{"system:authenticated"}), nil)
+
+	mock.EXPECT().
+		ListProjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(projectListJSON("flightctl-ext"), nil)
+
+	// No role bindings match this user or their groups
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "user04", []string{"system:authenticated"}).
+		Return([]string{}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-2")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user04", identity.GetUsername())
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 1)
+	assert.Empty(t, orgs[0].Roles)
+}
+
+func TestGetIdentity_ClusterAdminViaGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestOpenShiftAuth(t, mock)
+
+	// TokenReview: user is in system:cluster-admins
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("admin-user", "uid-admin", []string{"system:cluster-admins", "system:authenticated"}), nil)
+
+	mock.EXPECT().
+		ListProjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(projectListJSON("flightctl-ext"), nil)
+
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "flightctl-ext", "admin-user", []string{"system:cluster-admins", "system:authenticated"}).
+		Return([]string{}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-3")
+	require.NoError(t, err)
+
+	assert.True(t, identity.IsSuperAdmin())
+}
+
+func TestGetIdentity_MultipleProjectsWithGroupRoles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := k8sclient.NewMockK8SClient(ctrl)
+	auth := newTestOpenShiftAuth(t, mock)
+
+	groups := []string{"RedHat", "Engineering", "system:authenticated"}
+
+	mock.EXPECT().
+		PostCRD(gomock.Any(), gomock.Eq("authentication.k8s.io/v1/tokenreviews"), gomock.Any()).
+		Return(tokenReviewJSON("user02", "uid-002", groups), nil)
+
+	mock.EXPECT().
+		ListProjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(projectListJSON("project-a", "project-b"), nil)
+
+	// project-a: group RedHat has operator
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "project-a", "user02", groups).
+		Return([]string{"flightctl-operator-flightctl"}, nil)
+
+	// project-b: group Engineering has viewer
+	mock.EXPECT().
+		ListRoleBindingsForUser(gomock.Any(), "project-b", "user02", groups).
+		Return([]string{"flightctl-viewer-flightctl"}, nil)
+
+	identity, err := auth.GetIdentity(context.Background(), "test-token-4")
+	require.NoError(t, err)
+
+	orgs := identity.GetOrganizations()
+	require.Len(t, orgs, 2)
+
+	orgMap := map[string][]string{}
+	for _, org := range orgs {
+		orgMap[org.Name] = org.Roles
+	}
+	assert.Contains(t, orgMap["project-a"], "flightctl-operator")
+	assert.Contains(t, orgMap["project-b"], "flightctl-viewer")
+}

--- a/pkg/k8sclient/mock_k8s_client.go
+++ b/pkg/k8sclient/mock_k8s_client.go
@@ -92,18 +92,18 @@ func (mr *MockK8SClientMockRecorder) ListRoleBindings(ctx, namespace any) *gomoc
 }
 
 // ListRoleBindingsForUser mocks base method.
-func (m *MockK8SClient) ListRoleBindingsForUser(ctx context.Context, namespace, username string) ([]string, error) {
+func (m *MockK8SClient) ListRoleBindingsForUser(ctx context.Context, namespace, username string, groups []string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRoleBindingsForUser", ctx, namespace, username)
+	ret := m.ctrl.Call(m, "ListRoleBindingsForUser", ctx, namespace, username, groups)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListRoleBindingsForUser indicates an expected call of ListRoleBindingsForUser.
-func (mr *MockK8SClientMockRecorder) ListRoleBindingsForUser(ctx, namespace, username any) *gomock.Call {
+func (mr *MockK8SClientMockRecorder) ListRoleBindingsForUser(ctx, namespace, username, groups any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleBindingsForUser", reflect.TypeOf((*MockK8SClient)(nil).ListRoleBindingsForUser), ctx, namespace, username)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleBindingsForUser", reflect.TypeOf((*MockK8SClient)(nil).ListRoleBindingsForUser), ctx, namespace, username, groups)
 }
 
 // PostCRD mocks base method.

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -53,7 +53,7 @@ func (m *mockK8sClient) ListProjects(ctx context.Context, token string, opts ...
 	return nil, nil
 }
 
-func (m *mockK8sClient) ListRoleBindingsForUser(ctx context.Context, namespace, username string) ([]string, error) {
+func (m *mockK8sClient) ListRoleBindingsForUser(ctx context.Context, namespace, username string, groups []string) ([]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced authentication to consider user group membership when resolving roles and permissions in Kubernetes and OpenShift environments, enabling more granular access control.

* **Tests**
  * Added comprehensive unit test coverage for group-aware identity resolution and role assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->