### PR TITLE
EDM-2859: Use only FIPS crypto for SSH when on FIPS machine

### DIFF
--- a/internal/ssh/crypto.go
+++ b/internal/ssh/crypto.go
@@ -1,0 +1,161 @@
+package ssh
+
+import (
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/util"
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHCryptoSettings contains the SSH crypto algorithm configuration
+type SSHCryptoSettings struct {
+	KeyExchanges      []string
+	Ciphers           []string
+	MACs              []string
+	HostKeyAlgorithms []string
+}
+
+// GetSSHCryptoSettings returns SSH crypto algorithm configuration based on FIPS mode
+// detection and configuration overrides.
+//
+// The algorithm selection follows this precedence:
+//  1. Explicit SSH configuration in cfg.CryptoPolicy.SSH (if provided)
+//  2. FIPS-compliant algorithms if FIPS mode is detected or forced
+//  3. Empty (golang.org/x/crypto/ssh will use defaults)
+//
+// This ensures that SSH connections use FIPS-approved algorithms when required
+// while maintaining backward compatibility in non-FIPS environments.
+func GetSSHCryptoSettings(cfg *config.Config) SSHCryptoSettings {
+	settings := SSHCryptoSettings{}
+
+	// Determine if we should use FIPS-compliant algorithms
+	// Priority: 1) SSH-specific override, 2) Global crypto policy, 3) Auto-detection
+	useFIPSAlgorithms := util.IsFIPSEnabled()
+
+	// Check global crypto policy FIPS override
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.ForceFIPSMode != nil {
+		useFIPSAlgorithms = *cfg.CryptoPolicy.ForceFIPSMode
+	}
+
+	// Check SSH-specific FIPS override (takes precedence over global)
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.SSH != nil && cfg.CryptoPolicy.SSH.ForceFIPSMode != nil {
+		useFIPSAlgorithms = *cfg.CryptoPolicy.SSH.ForceFIPSMode
+	}
+
+	// Configure Key Exchange Algorithms
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.SSH != nil && len(cfg.CryptoPolicy.SSH.KeyExchangeAlgorithms) > 0 {
+		// Use explicitly configured algorithms
+		settings.KeyExchanges = cfg.CryptoPolicy.SSH.KeyExchangeAlgorithms
+	} else if useFIPSAlgorithms {
+		// Use FIPS-compliant algorithms
+		settings.KeyExchanges = getFIPSKeyExchangeAlgorithms()
+	}
+	// else: use golang.org/x/crypto/ssh defaults (empty slice)
+
+	// Configure Ciphers
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.SSH != nil && len(cfg.CryptoPolicy.SSH.Ciphers) > 0 {
+		settings.Ciphers = cfg.CryptoPolicy.SSH.Ciphers
+	} else if useFIPSAlgorithms {
+		settings.Ciphers = getFIPSCiphers()
+	}
+
+	// Configure MACs (Message Authentication Codes)
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.SSH != nil && len(cfg.CryptoPolicy.SSH.MACs) > 0 {
+		settings.MACs = cfg.CryptoPolicy.SSH.MACs
+	} else if useFIPSAlgorithms {
+		settings.MACs = getFIPSMACs()
+	}
+
+	// Configure Host Key Algorithms
+	if cfg != nil && cfg.CryptoPolicy != nil && cfg.CryptoPolicy.SSH != nil && len(cfg.CryptoPolicy.SSH.HostKeyAlgorithms) > 0 {
+		settings.HostKeyAlgorithms = cfg.CryptoPolicy.SSH.HostKeyAlgorithms
+	} else if useFIPSAlgorithms {
+		settings.HostKeyAlgorithms = getFIPSHostKeyAlgorithms()
+	}
+
+	return settings
+}
+
+// ApplyCryptoSettingsToClientConfig applies crypto settings to an ssh.ClientConfig
+func (s *SSHCryptoSettings) ApplyCryptoSettingsToClientConfig(cfg *ssh.ClientConfig) {
+	if cfg == nil {
+		return
+	}
+
+	if len(s.KeyExchanges) > 0 {
+		cfg.Config.KeyExchanges = s.KeyExchanges
+	}
+
+	if len(s.Ciphers) > 0 {
+		cfg.Config.Ciphers = s.Ciphers
+	}
+
+	if len(s.MACs) > 0 {
+		cfg.Config.MACs = s.MACs
+	}
+
+	if len(s.HostKeyAlgorithms) > 0 {
+		cfg.HostKeyAlgorithms = s.HostKeyAlgorithms
+	}
+}
+
+// getFIPSKeyExchangeAlgorithms returns FIPS 140-2 compliant key exchange algorithms.
+//
+// These algorithms are based on:
+// - ArgoCD's FIPS implementation (https://github.com/argoproj/argo-cd/pull/24086)
+// - NIST FIPS 140-2 approved algorithms
+//
+// Excluded non-FIPS algorithms:
+// - curve25519-sha256 (causes panics in FIPS mode)
+// - diffie-hellman-group1-sha1 (SHA-1 not approved for key exchange in FIPS 140-2)
+func getFIPSKeyExchangeAlgorithms() []string {
+	return []string{
+		"ecdh-sha2-nistp256",
+		"ecdh-sha2-nistp384",
+		"ecdh-sha2-nistp521",
+		"diffie-hellman-group-exchange-sha256",
+		"diffie-hellman-group14-sha256",
+	}
+}
+
+// getFIPSCiphers returns FIPS 140-2 compliant ciphers for SSH connections.
+//
+// These are AES-based ciphers using approved modes (GCM, CTR).
+// Excluded: ChaCha20-Poly1305 and other non-AES ciphers.
+func getFIPSCiphers() []string {
+	return []string{
+		"aes128-gcm@openssh.com",
+		"aes256-gcm@openssh.com",
+		"aes128-ctr",
+		"aes192-ctr",
+		"aes256-ctr",
+	}
+}
+
+// getFIPSMACs returns FIPS 140-2 compliant MAC algorithms.
+//
+// These use SHA-2 family hash functions (SHA-256, SHA-512).
+// Excluded: SHA-1 based MACs (not approved in FIPS 140-2).
+func getFIPSMACs() []string {
+	return []string{
+		"hmac-sha2-256-etm@openssh.com",
+		"hmac-sha2-512-etm@openssh.com",
+		"hmac-sha2-256",
+		"hmac-sha2-512",
+	}
+}
+
+// getFIPSHostKeyAlgorithms returns FIPS 140-2 compliant host key algorithms.
+//
+// These include ECDSA with NIST curves and RSA with SHA-2.
+// Excluded:
+// - ssh-rsa (uses SHA-1)
+// - ssh-ed25519 (Ed25519 not FIPS approved)
+func getFIPSHostKeyAlgorithms() []string {
+	return []string{
+		"ecdsa-sha2-nistp256",
+		"ecdsa-sha2-nistp384",
+		"ecdsa-sha2-nistp521",
+		"rsa-sha2-256",
+		"rsa-sha2-512",
+	}
+}

--- a/internal/ssh/crypto_test.go
+++ b/internal/ssh/crypto_test.go
@@ -1,0 +1,317 @@
+package ssh
+
+import (
+	"os"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSSHCryptoSettings_FIPSMode(t *testing.T) {
+	require := require.New(t)
+
+	// Save and restore environment
+	origOpenSSL, origSet := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	defer func() {
+		if origSet {
+			os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		} else {
+			os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+		}
+		util.ResetFIPSCache()
+	}()
+
+	// Force FIPS mode via environment
+	os.Setenv("OPENSSL_FORCE_FIPS_MODE", "1")
+	util.ResetFIPSCache()
+
+	// Get SSH config with nil config (should use FIPS defaults)
+	settings := GetSSHCryptoSettings(nil)
+
+	// Verify FIPS-compliant algorithms are selected
+	require.NotEmpty(settings.KeyExchanges, "Key exchanges should be set in FIPS mode")
+	require.NotEmpty(settings.Ciphers, "Ciphers should be set in FIPS mode")
+	require.NotEmpty(settings.MACs, "MACs should be set in FIPS mode")
+	require.NotEmpty(settings.HostKeyAlgorithms, "Host key algorithms should be set in FIPS mode")
+
+	// Verify specific FIPS algorithms are present
+	require.Contains(settings.KeyExchanges, "ecdh-sha2-nistp256")
+	require.Contains(settings.Ciphers, "aes256-gcm@openssh.com")
+	require.Contains(settings.MACs, "hmac-sha2-256")
+	require.Contains(settings.HostKeyAlgorithms, "rsa-sha2-256")
+
+	// Verify non-FIPS algorithms are NOT present
+	require.NotContains(settings.KeyExchanges, "curve25519-sha256", "curve25519 should not be in FIPS mode")
+	require.NotContains(settings.HostKeyAlgorithms, "ssh-ed25519", "Ed25519 should not be in FIPS mode")
+}
+
+func TestGetSSHCryptoSettings_NonFIPSMode(t *testing.T) {
+	require := require.New(t)
+
+	// Ensure FIPS mode is NOT active via environment variables
+	origOpenSSL, origOpenSSLSet := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	origGolang, origGolangSet := os.LookupEnv("GOLANG_FIPS")
+	defer func() {
+		if origOpenSSLSet {
+			os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		} else {
+			os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+		}
+		if origGolangSet {
+			os.Setenv("GOLANG_FIPS", origGolang)
+		} else {
+			os.Unsetenv("GOLANG_FIPS")
+		}
+		util.ResetFIPSCache()
+	}()
+
+	os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+	os.Unsetenv("GOLANG_FIPS")
+	util.ResetFIPSCache()
+
+	// Check if FIPS is still active despite unsetting env vars
+	// This would mean the host OS itself enforces FIPS mode
+	if util.IsFIPSEnabled() {
+		t.Skip("Skipping non-FIPS mode test: host OS enforces FIPS mode via crypto/fips140 or /proc/sys/crypto/fips_enabled")
+	}
+
+	// Get SSH config with nil config (should use library defaults)
+	settings := GetSSHCryptoSettings(nil)
+
+	// In non-FIPS mode with nil config, settings should be empty
+	// which allows golang.org/x/crypto/ssh to use its own defaults
+	require.Empty(settings.KeyExchanges, "Should use library defaults when FIPS is not active")
+	require.Empty(settings.Ciphers, "Should use library defaults when FIPS is not active")
+	require.Empty(settings.MACs, "Should use library defaults when FIPS is not active")
+	require.Empty(settings.HostKeyAlgorithms, "Should use library defaults when FIPS is not active")
+}
+
+func TestGetSSHCryptoSettings_ExplicitFIPSForce(t *testing.T) {
+	require := require.New(t)
+
+	// Ensure environment doesn't force FIPS
+	origOpenSSL, origSet := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	defer func() {
+		if origSet {
+			os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		} else {
+			os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+		}
+		util.ResetFIPSCache()
+	}()
+	os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+	util.ResetFIPSCache()
+
+	// Create config that explicitly forces FIPS mode
+	cfg := &config.Config{
+		CryptoPolicy: &config.CryptoPolicyConfig{
+			SSH: &config.SSHCryptoConfig{
+				ForceFIPSMode: lo.ToPtr(true),
+			},
+		},
+	}
+
+	settings := GetSSHCryptoSettings(cfg)
+
+	// Should use FIPS algorithms even if environment detection says otherwise
+	require.NotEmpty(settings.KeyExchanges)
+	require.Contains(settings.KeyExchanges, "ecdh-sha2-nistp256")
+	require.NotContains(settings.KeyExchanges, "curve25519-sha256")
+}
+
+func TestGetSSHCryptoSettings_ExplicitFIPSDisable(t *testing.T) {
+	require := require.New(t)
+
+	// Force FIPS mode via environment
+	origOpenSSL, origSet := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	defer func() {
+		if origSet {
+			os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		} else {
+			os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+		}
+		util.ResetFIPSCache()
+	}()
+	os.Setenv("OPENSSL_FORCE_FIPS_MODE", "1")
+	util.ResetFIPSCache()
+
+	// Create config that explicitly disables FIPS mode
+	cfg := &config.Config{
+		CryptoPolicy: &config.CryptoPolicyConfig{
+			SSH: &config.SSHCryptoConfig{
+				ForceFIPSMode: lo.ToPtr(false),
+			},
+		},
+	}
+
+	settings := GetSSHCryptoSettings(cfg)
+
+	// Should NOT set FIPS algorithms even though environment detection says FIPS is active
+	// Empty slices mean golang.org/x/crypto/ssh will use its defaults
+	require.Empty(settings.KeyExchanges, "Should use library defaults when FIPS is explicitly disabled")
+	require.Empty(settings.Ciphers, "Should use library defaults when FIPS is explicitly disabled")
+}
+
+func TestGetSSHCryptoSettings_ManualOverride(t *testing.T) {
+	require := require.New(t)
+
+	// Create config with manual algorithm specification
+	customKex := []string{"custom-kex-1", "custom-kex-2"}
+	customCiphers := []string{"custom-cipher-1"}
+	customMACs := []string{"custom-mac-1", "custom-mac-2"}
+	customHostKeys := []string{"custom-hostkey-1"}
+
+	cfg := &config.Config{
+		CryptoPolicy: &config.CryptoPolicyConfig{
+			SSH: &config.SSHCryptoConfig{
+				KeyExchangeAlgorithms: customKex,
+				Ciphers:               customCiphers,
+				MACs:                  customMACs,
+				HostKeyAlgorithms:     customHostKeys,
+			},
+		},
+	}
+
+	settings := GetSSHCryptoSettings(cfg)
+
+	// Should use explicitly configured algorithms, not FIPS defaults
+	require.Equal(customKex, settings.KeyExchanges)
+	require.Equal(customCiphers, settings.Ciphers)
+	require.Equal(customMACs, settings.MACs)
+	require.Equal(customHostKeys, settings.HostKeyAlgorithms)
+}
+
+func TestGetSSHCryptoSettings_PartialManualOverride(t *testing.T) {
+	require := require.New(t)
+
+	// Force FIPS mode
+	origOpenSSL, origSet := os.LookupEnv("OPENSSL_FORCE_FIPS_MODE")
+	defer func() {
+		if origSet {
+			os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		} else {
+			os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+		}
+		util.ResetFIPSCache()
+	}()
+	os.Setenv("OPENSSL_FORCE_FIPS_MODE", "1")
+	util.ResetFIPSCache()
+
+	// Create config with only some algorithms specified
+	customKex := []string{"custom-kex-1", "custom-kex-2"}
+
+	cfg := &config.Config{
+		CryptoPolicy: &config.CryptoPolicyConfig{
+			SSH: &config.SSHCryptoConfig{
+				KeyExchangeAlgorithms: customKex,
+				// Other fields left empty - should use FIPS defaults
+			},
+		},
+	}
+
+	settings := GetSSHCryptoSettings(cfg)
+
+	// Should use custom key exchange but FIPS defaults for others
+	require.Equal(customKex, settings.KeyExchanges, "Should use custom key exchange")
+	require.NotEmpty(settings.Ciphers, "Should use FIPS ciphers")
+	require.Contains(settings.Ciphers, "aes256-gcm@openssh.com", "Should contain FIPS cipher")
+}
+
+func TestFIPSKeyExchangeAlgorithms(t *testing.T) {
+	require := require.New(t)
+
+	algorithms := getFIPSKeyExchangeAlgorithms()
+
+	// Verify expected FIPS algorithms are present
+	expectedAlgorithms := []string{
+		"ecdh-sha2-nistp256",
+		"ecdh-sha2-nistp384",
+		"ecdh-sha2-nistp521",
+		"diffie-hellman-group-exchange-sha256",
+		"diffie-hellman-group14-sha256",
+	}
+
+	for _, expected := range expectedAlgorithms {
+		require.Contains(algorithms, expected, "FIPS key exchange should include %s", expected)
+	}
+
+	// Verify non-FIPS algorithms are absent
+	forbiddenAlgorithms := []string{
+		"curve25519-sha256",
+		"diffie-hellman-group1-sha1", // SHA-1 not FIPS approved
+	}
+
+	for _, forbidden := range forbiddenAlgorithms {
+		require.NotContains(algorithms, forbidden, "FIPS key exchange should NOT include %s", forbidden)
+	}
+}
+
+func TestFIPSCiphers(t *testing.T) {
+	require := require.New(t)
+
+	ciphers := getFIPSCiphers()
+
+	// Verify all ciphers are AES-based
+	for _, cipher := range ciphers {
+		require.Contains(cipher, "aes", "FIPS ciphers should be AES-based, got: %s", cipher)
+	}
+
+	// Verify ChaCha20 is not included (not FIPS approved)
+	for _, cipher := range ciphers {
+		require.NotContains(cipher, "chacha20", "FIPS ciphers should not include ChaCha20")
+	}
+}
+
+func TestFIPSMACs(t *testing.T) {
+	require := require.New(t)
+
+	macs := getFIPSMACs()
+
+	// Verify all MACs use SHA-2
+	for _, mac := range macs {
+		require.Contains(mac, "sha2", "FIPS MACs should use SHA-2, got: %s", mac)
+	}
+
+	// Verify SHA-1 MACs are not included
+	forbiddenMACs := []string{
+		"hmac-sha1",
+		"hmac-sha1-96",
+	}
+
+	for _, forbidden := range forbiddenMACs {
+		require.NotContains(macs, forbidden, "FIPS MACs should not include %s", forbidden)
+	}
+}
+
+func TestFIPSHostKeyAlgorithms(t *testing.T) {
+	require := require.New(t)
+
+	algorithms := getFIPSHostKeyAlgorithms()
+
+	// Verify ECDSA and RSA-SHA2 are included
+	expectedAlgorithms := []string{
+		"ecdsa-sha2-nistp256",
+		"ecdsa-sha2-nistp384",
+		"ecdsa-sha2-nistp521",
+		"rsa-sha2-256",
+		"rsa-sha2-512",
+	}
+
+	for _, expected := range expectedAlgorithms {
+		require.Contains(algorithms, expected, "FIPS host keys should include %s", expected)
+	}
+
+	// Verify non-FIPS algorithms are absent
+	forbiddenAlgorithms := []string{
+		"ssh-rsa",     // Uses SHA-1
+		"ssh-ed25519", // Ed25519 not FIPS approved
+		"ssh-dss",     // DSA deprecated
+	}
+
+	for _, forbidden := range forbiddenAlgorithms {
+		require.NotContains(algorithms, forbidden, "FIPS host keys should NOT include %s", forbidden)
+	}
+}

--- a/internal/tasks/consumer_test.go
+++ b/internal/tasks/consumer_test.go
@@ -474,7 +474,7 @@ func TestDispatchTasks_WithNilMetrics(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, mock.MatchedBy(func(e error) bool { return e == nil })).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil)
+	handler := dispatchTasks(nil, nil, nil, nil, nil)
 
 	// Execute handler
 	err = handler(ctx, payload, "entry-123", mockConsumer, log)
@@ -509,7 +509,7 @@ func TestDispatchTasks_WithNilMetrics_SuccessfulProcessing(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, mock.MatchedBy(func(e error) bool { return e == nil })).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil)
+	handler := dispatchTasks(nil, nil, nil, nil, nil)
 
 	// Execute handler
 	err = handler(ctx, payload, "entry-123", mockConsumer, log)
@@ -532,7 +532,7 @@ func TestDispatchTasks_WithNilMetrics_InvalidPayload(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, nil).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil)
+	handler := dispatchTasks(nil, nil, nil, nil, nil)
 
 	// Execute handler
 	err := handler(ctx, payload, "entry-123", mockConsumer, log)

--- a/internal/tasks/repotester.go
+++ b/internal/tasks/repotester.go
@@ -159,7 +159,7 @@ func (r *GitRepoTester) TestAccess(repository *domain.Repository) error {
 	})
 
 	listOps := &git.ListOptions{}
-	auth, err := GetAuth(repository)
+	auth, err := GetAuth(repository, nil) // nil config for test
 	if err != nil {
 		return err
 	}

--- a/internal/tasks/resourcesync_test.go
+++ b/internal/tasks/resourcesync_test.go
@@ -16,7 +16,7 @@ func TestResourceSync_GetRepositoryAndValidateAccess_NilResourceSync(t *testing.
 	var serviceHandler service.Service
 	log := logrus.New()
 
-	resourceSync := NewResourceSync(serviceHandler, log, nil)
+	resourceSync := NewResourceSync(serviceHandler, log, nil, nil)
 
 	// Test with nil ResourceSync
 	testOrgId := uuid.New()
@@ -32,7 +32,7 @@ func TestResourceSync_ParseFleetsFromResources_ValidResources(t *testing.T) {
 	var serviceHandler service.Service
 	log := logrus.New()
 
-	resourceSync := NewResourceSync(serviceHandler, log, nil)
+	resourceSync := NewResourceSync(serviceHandler, log, nil, nil)
 
 	// Create valid resources
 	resources := []GenericResourceMap{
@@ -72,7 +72,7 @@ func TestResourceSync_ParseFleetsFromResources_InvalidResources(t *testing.T) {
 	var serviceHandler service.Service
 	log := logrus.New()
 
-	resourceSync := NewResourceSync(serviceHandler, log, nil)
+	resourceSync := NewResourceSync(serviceHandler, log, nil, nil)
 
 	// Create invalid resources
 	resources := []GenericResourceMap{
@@ -345,7 +345,7 @@ func TestResourceSync_WithIgnoredFields(t *testing.T) {
 	log := logrus.New()
 
 	ignorePaths := []string{"metadata/labels/environment", "status"}
-	resourceSync := NewResourceSync(serviceHandler, log, ignorePaths)
+	resourceSync := NewResourceSync(serviceHandler, log, nil, ignorePaths)
 
 	// Create resources with fields that should be ignored
 	resources := []GenericResourceMap{

--- a/internal/util/fips.go
+++ b/internal/util/fips.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"crypto/fips140"
+	"os"
+	"sync"
+)
+
+var (
+	// Cache the FIPS detection result to avoid repeated filesystem/runtime checks
+	fipsEnabled    bool
+	fipsChecked    bool
+	fipsCheckMutex sync.RWMutex
+)
+
+// IsFIPSEnabled detects if the system is running in FIPS mode using multiple detection methods.
+// The result is cached after the first check for performance.
+//
+// Detection methods (in order of precedence):
+//  1. Go 1.24's crypto/fips140.Enabled() - Runtime FIPS mode detection
+//  2. /proc/sys/crypto/fips_enabled - Linux kernel FIPS mode indicator
+//  3. OPENSSL_FORCE_FIPS_MODE environment variable - OpenSSL forced FIPS mode
+//  4. GOLANG_FIPS environment variable - Go FIPS mode indicator
+func IsFIPSEnabled() bool {
+	// Fast path: return cached result if already checked
+	fipsCheckMutex.RLock()
+	if fipsChecked {
+		result := fipsEnabled
+		fipsCheckMutex.RUnlock()
+		return result
+	}
+	fipsCheckMutex.RUnlock()
+
+	// Slow path: perform detection and cache result
+	fipsCheckMutex.Lock()
+	defer fipsCheckMutex.Unlock()
+
+	// Double-check in case another goroutine already did the check
+	if fipsChecked {
+		return fipsEnabled
+	}
+
+	// Method 1: Use Go 1.24's native crypto/fips140 package (primary detection)
+	if fips140.Enabled() {
+		fipsEnabled = true
+		fipsChecked = true
+		return true
+	}
+
+	// Method 2: Check /proc/sys/crypto/fips_enabled on Linux
+	// This file contains "1" if FIPS mode is enabled at the kernel level
+	if data, err := os.ReadFile("/proc/sys/crypto/fips_enabled"); err == nil {
+		if len(data) > 0 && data[0] == '1' {
+			fipsEnabled = true
+			fipsChecked = true
+			return true
+		}
+	}
+
+	// Method 3: Check OPENSSL_FORCE_FIPS_MODE environment variable
+	// This is used to force OpenSSL into FIPS mode and is useful for testing
+	if os.Getenv("OPENSSL_FORCE_FIPS_MODE") == "1" {
+		fipsEnabled = true
+		fipsChecked = true
+		return true
+	}
+
+	// Method 4: Check GOLANG_FIPS environment variable
+	// Some Go FIPS builds use this environment variable
+	if os.Getenv("GOLANG_FIPS") == "1" {
+		fipsEnabled = true
+		fipsChecked = true
+		return true
+	}
+
+	// No FIPS mode detected
+	fipsEnabled = false
+	fipsChecked = true
+	return false
+}
+
+// ResetFIPSCache clears the cached FIPS detection result.
+// This is primarily useful for testing and should not be called in production code.
+func ResetFIPSCache() {
+	fipsCheckMutex.Lock()
+	defer fipsCheckMutex.Unlock()
+	fipsChecked = false
+	fipsEnabled = false
+}

--- a/internal/util/fips_test.go
+++ b/internal/util/fips_test.go
@@ -1,0 +1,235 @@
+package util
+
+import (
+	"crypto/fips140"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsFIPSEnabled_EnvironmentVariables(t *testing.T) {
+	// Save original environment
+	origOpenSSL := os.Getenv("OPENSSL_FORCE_FIPS_MODE")
+	origGolang := os.Getenv("GOLANG_FIPS")
+	defer func() {
+		os.Setenv("OPENSSL_FORCE_FIPS_MODE", origOpenSSL)
+		os.Setenv("GOLANG_FIPS", origGolang)
+	}()
+
+	tests := []struct {
+		name            string
+		opensslValue    string
+		golangValue     string
+		expectedEnabled bool
+	}{
+		{
+			name:            "OPENSSL_FORCE_FIPS_MODE=1 enables FIPS",
+			opensslValue:    "1",
+			golangValue:     "",
+			expectedEnabled: true,
+		},
+		{
+			name:            "GOLANG_FIPS=1 enables FIPS",
+			opensslValue:    "",
+			golangValue:     "1",
+			expectedEnabled: true,
+		},
+		{
+			name:            "Both environment variables set enables FIPS",
+			opensslValue:    "1",
+			golangValue:     "1",
+			expectedEnabled: true,
+		},
+		{
+			name:            "OPENSSL_FORCE_FIPS_MODE=0 does not enable FIPS",
+			opensslValue:    "0",
+			golangValue:     "",
+			expectedEnabled: false,
+		},
+		{
+			name:            "Neither environment variable set does not enable FIPS",
+			opensslValue:    "",
+			golangValue:     "",
+			expectedEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Reset cache before each test
+			ResetFIPSCache()
+
+			// Set environment variables
+			if tt.opensslValue != "" {
+				os.Setenv("OPENSSL_FORCE_FIPS_MODE", tt.opensslValue)
+			} else {
+				os.Unsetenv("OPENSSL_FORCE_FIPS_MODE")
+			}
+
+			if tt.golangValue != "" {
+				os.Setenv("GOLANG_FIPS", tt.golangValue)
+			} else {
+				os.Unsetenv("GOLANG_FIPS")
+			}
+
+			// Test detection
+			result := IsFIPSEnabled()
+
+			// Check if higher-priority detection methods are forcing FIPS
+			// If they are, we can't reliably test env var behavior
+			higherPriorityFIPS := false
+			if fips140.Enabled() {
+				higherPriorityFIPS = true
+			} else if data, err := os.ReadFile("/proc/sys/crypto/fips_enabled"); err == nil && len(data) > 0 && data[0] == '1' {
+				higherPriorityFIPS = true
+			}
+
+			// Only assert the expected value if higher-priority methods aren't forcing FIPS
+			if !higherPriorityFIPS {
+				require.Equal(tt.expectedEnabled, result,
+					"When higher-priority detection methods are inactive, env vars should determine FIPS state")
+			} else if tt.expectedEnabled {
+				// If higher-priority methods detect FIPS and we expect FIPS, result must be true
+				require.True(result, "FIPS should be enabled when detected by higher-priority methods or env vars")
+			}
+			// Note: if higherPriorityFIPS=true but expectedEnabled=false, we can't assert false
+			// because the higher-priority methods override the env vars
+
+			// Test that subsequent calls return the same cached result
+			result2 := IsFIPSEnabled()
+			require.Equal(result, result2, "Cached result should match initial result")
+		})
+	}
+}
+
+func TestIsFIPSEnabled_Caching(t *testing.T) {
+	require := require.New(t)
+
+	// Reset cache
+	ResetFIPSCache()
+
+	// First call should perform detection
+	result1 := IsFIPSEnabled()
+
+	// Subsequent calls should return cached result
+	result2 := IsFIPSEnabled()
+	result3 := IsFIPSEnabled()
+
+	require.Equal(result1, result2, "Second call should return cached result")
+	require.Equal(result1, result3, "Third call should return cached result")
+}
+
+func TestResetFIPSCache(t *testing.T) {
+	require := require.New(t)
+
+	// Get initial result
+	result1 := IsFIPSEnabled()
+
+	// Reset cache
+	ResetFIPSCache()
+
+	// Should be able to detect again
+	result2 := IsFIPSEnabled()
+
+	// Results should be the same (environment hasn't changed)
+	require.Equal(result1, result2, "Results should be consistent after cache reset")
+}
+
+// TestFIPSDetection_Integration is an integration-style test that verifies
+// the actual FIPS detection on the system where the test runs
+func TestFIPSDetection_Integration(t *testing.T) {
+	require := require.New(t)
+
+	// Reset cache to ensure fresh detection
+	ResetFIPSCache()
+
+	// Perform detection
+	result := IsFIPSEnabled()
+
+	// Log the result for visibility
+	if result {
+		t.Log("FIPS mode detected on this system")
+
+		// If FIPS is detected, verify we can find evidence
+		// Check if any of the detection methods would return true
+		hasEvidence := false
+
+		// Check environment variables
+		if os.Getenv("OPENSSL_FORCE_FIPS_MODE") == "1" {
+			t.Log("  - OPENSSL_FORCE_FIPS_MODE=1")
+			hasEvidence = true
+		}
+		if os.Getenv("GOLANG_FIPS") == "1" {
+			t.Log("  - GOLANG_FIPS=1")
+			hasEvidence = true
+		}
+
+		// Check kernel FIPS mode file
+		if data, err := os.ReadFile("/proc/sys/crypto/fips_enabled"); err == nil {
+			if len(data) > 0 && data[0] == '1' {
+				t.Log("  - /proc/sys/crypto/fips_enabled=1")
+				hasEvidence = true
+			}
+		}
+
+		// Note: crypto/fips140.Enabled() might be true even without file/env evidence
+		// in Go builds with FIPS support
+		if !hasEvidence {
+			t.Log("  - crypto/fips140.Enabled() returned true (Go runtime FIPS mode)")
+		}
+	} else {
+		t.Log("FIPS mode NOT detected on this system")
+	}
+
+	// The result should be boolean (no error case)
+	require.IsType(false, result, "IsFIPSEnabled should return a boolean")
+}
+
+// TestFIPSDetection_SimulatedKernelFile tests the /proc/sys/crypto/fips_enabled file reading
+func TestFIPSDetection_SimulatedKernelFile(t *testing.T) {
+	// This test is informational - it documents how the kernel file is read
+	// but can't easily mock it without changing the implementation
+
+	t.Run("read /proc/sys/crypto/fips_enabled if it exists", func(t *testing.T) {
+		// Try to read the actual file if it exists
+		data, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+		if err != nil {
+			t.Logf("/proc/sys/crypto/fips_enabled not found (expected on non-Linux or non-FIPS systems): %v", err)
+		} else {
+			t.Logf("/proc/sys/crypto/fips_enabled exists, content: %q", string(data))
+			if len(data) > 0 {
+				if data[0] == '1' {
+					t.Log("  -> Kernel FIPS mode is ENABLED")
+				} else if data[0] == '0' {
+					t.Log("  -> Kernel FIPS mode is DISABLED")
+				} else {
+					t.Logf("  -> Unexpected value: %c", data[0])
+				}
+			}
+		}
+	})
+}
+
+// TestFIPSDetection_WithTempProcFile tests FIPS detection with a simulated proc file
+// This requires temporarily changing how the code reads the file (or using build tags)
+// For now, this is a placeholder for future enhancement
+func TestFIPSDetection_WithTempProcFile(t *testing.T) {
+	t.Skip("Skipping - would require refactoring to inject file path or use build tags")
+
+	// Future enhancement: Could refactor IsFIPSEnabled to accept optional config
+	// that includes a custom path for the FIPS enabled file, allowing for testing
+	// with temporary files
+	tempDir := t.TempDir()
+	fipsFile := filepath.Join(tempDir, "fips_enabled")
+
+	// Test with FIPS enabled
+	err := os.WriteFile(fipsFile, []byte("1\n"), 0600)
+	require.NoError(t, err)
+
+	// Would need to somehow inject this path into IsFIPSEnabled
+	// For example: IsFIPSEnabledWithPath(fipsFile)
+}

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -80,7 +80,7 @@ func (s *Server) Run(ctx context.Context) error {
 	serviceHandler := service.WrapWithTracing(
 		service.NewServiceHandler(s.store, workerClient, kvStore, nil, s.log, "", "", []string{}))
 
-	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, serviceHandler, s.k8sClient, kvStore, 1, 1, s.workerMetrics); err != nil {
+	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, serviceHandler, s.k8sClient, kvStore, s.cfg, 1, 1, s.workerMetrics); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")
 		return err
 	}

--- a/test/integration/git_ssh_fips_test.go
+++ b/test/integration/git_ssh_fips_test.go
@@ -1,0 +1,198 @@
+package integration_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	b64 "encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/gliderlabs/ssh"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// startSshGitServerForFIPSTest starts a minimal SSH server for testing git clone operations
+// Returns the port number and a cleanup function that should be called to stop the server
+func startSshGitServerForFIPSTest(t *testing.T, pubKey gossh.PublicKey) (string, func()) {
+	t.Helper()
+
+	// Use port 0 to let the OS assign a free ephemeral port
+	// This avoids port conflicts in parallel CI
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Extract the actual port that was assigned
+	port := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+
+	// Create SSH server with handler
+	server := &ssh.Server{
+		Handler: func(s ssh.Session) {
+			// Simulate a minimal git server response
+			// In a real scenario, this would be a proper git-upload-pack interaction
+			fmt.Fprintf(s, "# service=git-upload-pack\n")
+			fmt.Fprintf(s, "0000")
+			<-s.Context().Done()
+		},
+		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+			return ssh.KeysEqual(key, pubKey)
+		},
+	}
+
+	// Start server in background
+	go func() {
+		if err := server.Serve(ln); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			log.Printf("SSH server error: %v", err)
+		}
+	}()
+
+	// Give the server a moment to start accepting connections
+	time.Sleep(100 * time.Millisecond)
+
+	// Return port and cleanup function
+	return port, func() {
+		server.Close()
+		ln.Close()
+	}
+}
+
+// TestGitSSHCloneWithFIPS tests that SSH git clone operations work correctly in FIPS mode
+// This test reproduces the bug where go-git defaults to non-FIPS-compliant algorithms like curve25519
+func TestGitSSHCloneWithFIPS(t *testing.T) {
+	// Check if OPENSSL_FORCE_FIPS_MODE is set to simulate FIPS environment
+	fipsMode := os.Getenv("OPENSSL_FORCE_FIPS_MODE") == "1"
+	if !fipsMode {
+		t.Skip("Skipping FIPS test - set OPENSSL_FORCE_FIPS_MODE=1 to run")
+	}
+
+	require := require.New(t)
+
+	// Generate RSA key pair for SSH authentication
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(err)
+
+	publicRsaKey, err := gossh.NewPublicKey(&privateKey.PublicKey)
+	require.NoError(err)
+
+	// Start SSH git server with OS-assigned ephemeral port
+	testPort, cleanup := startSshGitServerForFIPSTest(t, publicRsaKey)
+	defer cleanup()
+
+	// Encode private key to PEM format
+	privatePEM := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	privKey := b64.StdEncoding.EncodeToString(privatePEM)
+
+	// Create Repository spec with SSH configuration
+	spec := api.RepositorySpec{}
+	err = spec.FromGitRepoSpec(api.GitRepoSpec{
+		Url:  fmt.Sprintf("ssh://root@127.0.0.1:%s/test.git", testPort),
+		Type: api.GitRepoSpecTypeGit,
+		SshConfig: &api.SshConfig{
+			SshPrivateKey:          &privKey,
+			SkipServerVerification: lo.ToPtr(true), // Skip host key verification for test
+		},
+	})
+	require.NoError(err)
+
+	repo := &domain.Repository{
+		Metadata: api.ObjectMeta{Name: lo.ToPtr("test-fips-ssh-repo")},
+		Spec:     spec,
+	}
+
+	// Attempt to clone the repository
+	// In FIPS mode WITH the fix, this should succeed by using FIPS-compliant algorithms
+	_, _, err = tasks.CloneGitRepo(repo, nil, nil, nil)
+
+	// With the fix implemented, SSH clone should succeed in FIPS mode
+	// The fix applies FIPS-compliant algorithms (ecdh-sha2-nistp*, diffie-hellman-group*-sha256)
+	// instead of non-compliant ones (curve25519)
+	if err != nil {
+		// The clone may fail due to the minimal SSH server, but it must NOT fail
+		// due to FIPS algorithm restrictions
+		errMsg := err.Error()
+		require.NotContains(errMsg, "curve25519", "FIPS algorithm restriction should not cause failure")
+		require.NotContains(errMsg, "curve25519-sha256", "FIPS algorithm restriction should not cause failure")
+		require.NotContains(errMsg, "no common algorithm", "SSH algorithm negotiation should succeed in FIPS mode")
+		require.NotContains(errMsg, "ssh-ed25519", "Ed25519 should not be required in FIPS mode")
+		t.Logf("Clone error (unrelated to FIPS crypto): %v", err)
+	} else {
+		t.Logf("SSH clone succeeded in FIPS mode with FIPS-compliant algorithms")
+	}
+}
+
+// TestGitSSHCloneNonFIPS tests that SSH git clone works in non-FIPS mode
+// This ensures backward compatibility - existing functionality should continue to work
+func TestGitSSHCloneNonFIPS(t *testing.T) {
+	// Only run this when NOT in FIPS mode
+	fipsMode := os.Getenv("OPENSSL_FORCE_FIPS_MODE") == "1"
+	if fipsMode {
+		t.Skip("Skipping non-FIPS test - OPENSSL_FORCE_FIPS_MODE is set")
+	}
+
+	require := require.New(t)
+
+	// Generate RSA key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(err)
+
+	publicRsaKey, err := gossh.NewPublicKey(&privateKey.PublicKey)
+	require.NoError(err)
+
+	// Start SSH server with OS-assigned ephemeral port
+	testPort, cleanup := startSshGitServerForFIPSTest(t, publicRsaKey)
+	defer cleanup()
+
+	// Encode private key
+	privatePEM := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	privKey := b64.StdEncoding.EncodeToString(privatePEM)
+
+	// Create Repository spec
+	spec := api.RepositorySpec{}
+	err = spec.FromGitRepoSpec(api.GitRepoSpec{
+		Url:  fmt.Sprintf("ssh://root@127.0.0.1:%s/test.git", testPort),
+		Type: api.GitRepoSpecTypeGit,
+		SshConfig: &api.SshConfig{
+			SshPrivateKey:          &privKey,
+			SkipServerVerification: lo.ToPtr(true),
+		},
+	})
+	require.NoError(err)
+
+	repo := &domain.Repository{
+		Metadata: api.ObjectMeta{Name: lo.ToPtr("test-non-fips-ssh-repo")},
+		Spec:     spec,
+	}
+
+	// In non-FIPS mode, this should work with default algorithms
+	_, _, err = tasks.CloneGitRepo(repo, nil, nil, nil)
+
+	// Note: This might still fail because we're using a minimal SSH server
+	// The important part is that it should NOT fail due to FIPS restrictions
+	if err != nil {
+		// Ensure the error is not related to algorithm negotiation failures
+		errMsg := err.Error()
+		require.NotContains(errMsg, "no common algorithm", "SSH algorithm negotiation should succeed in non-FIPS mode")
+		t.Logf("Clone error (may be expected with minimal server): %v", err)
+	}
+}

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -156,7 +156,7 @@ var _ = Describe("DeviceRender", func() {
 					Reason:         api.EventReasonResourceUpdated,
 					InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
 				}
-				logic := tasks.NewDeviceRenderLogic(log, serviceHandler, mockK8s, kvStoreInst, orgId, event)
+				logic := tasks.NewDeviceRenderLogic(log, serviceHandler, mockK8s, kvStoreInst, nil, orgId, event)
 				err = logic.RenderDevice(ctx)
 
 				// Should succeed - safe paths pass validation
@@ -191,7 +191,7 @@ var _ = Describe("DeviceRender", func() {
 					Reason:         api.EventReasonResourceUpdated,
 					InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
 				}
-				logic := tasks.NewDeviceRenderLogic(log, serviceHandler, mockK8s, kvStoreInst, orgId, event)
+				logic := tasks.NewDeviceRenderLogic(log, serviceHandler, mockK8s, kvStoreInst, nil, orgId, event)
 				err = logic.RenderDevice(ctx)
 
 				// Should fail - derived paths under forbidden root are rejected

--- a/test/integration/tasks/resourcesync_test.go
+++ b/test/integration/tasks/resourcesync_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		kvStore, err := kvstore.NewKVStore(ctx, log, "localhost", 6379, "adminpass")
 		Expect(err).ToNot(HaveOccurred())
 		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStore, nil, log, "", "", []string{})
-		resourceSync = tasks.NewResourceSync(serviceHandler, log, nil)
+		resourceSync = tasks.NewResourceSync(serviceHandler, log, nil, nil)
 
 		// Set up mock expectations for the publisher
 		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -507,7 +507,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		It("should remove ignored fields during resource parsing", func() {
 			// Create a ResourceSync with custom ignore fields
 			ignoreFields := []string{"/metadata/resourceVersion", "/metadata/labels/test-label"}
-			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, ignoreFields)
+			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, nil, ignoreFields)
 
 			// Create test resources with fields that should be ignored
 			resources := []tasks.GenericResourceMap{
@@ -593,7 +593,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 
 		It("should not remove fields when no ignore list is provided", func() {
 			// Create a ResourceSync without ignore fields
-			resourceSyncNoIgnores := tasks.NewResourceSync(serviceHandler, log, nil)
+			resourceSyncNoIgnores := tasks.NewResourceSync(serviceHandler, log, nil, nil)
 
 			// Create test resources with fields that would normally be ignored
 			resources := []tasks.GenericResourceMap{
@@ -727,7 +727,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		It("should handle non-existent paths gracefully", func() {
 			// Create a ResourceSync with ignore fields that don't exist in the resource
 			ignoreFields := []string{"/metadata/nonExistentField", "/spec/nonExistentField"}
-			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, ignoreFields)
+			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, nil, ignoreFields)
 
 			// Create test resources without the fields that should be ignored
 			resources := []tasks.GenericResourceMap{
@@ -771,7 +771,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 		It("should apply field removal during full sync process", func() {
 			// Create a ResourceSync instance with ignore fields
 			ignoreFields := []string{"/metadata/resourceVersion"}
-			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, ignoreFields)
+			resourceSyncWithIgnores := tasks.NewResourceSync(serviceHandler, log, nil, ignoreFields)
 
 			// Create test resources with resourceVersion that should be removed
 			resources := []tasks.GenericResourceMap{


### PR DESCRIPTION
This PR addresses the issue that `golang.org/x/crypto/ssh` is not FIPS-aware and therefore defaults to non-FIPS-compliant crypto even when running on a machine in FIPS mode. This prevents accessing Git repositories using SSH on these machines.

The PR adds the following changes:

- Detects whether the service is running on a FIPS-enabled host using multiple methods for robustness (in `fips.go`).

- Adds a function that returns the SSH crypto settings to be used based on this detection or on user policies (in `ssh_config.go`).

- Wraps the Git Auth settings with the returned SSH crypto settings (in `git_helpers.go`).

- Allows users to configure whether to auto-detect, force on, or force off FIPS crypto as well as to override the used crypto to further restrict it (in `config.go`). Note this isn't exposed through the Helm chart / `service-config.yaml` yet, so it just an escape hatch at the moment.

- The rest of the file changes is just wiring through the configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FIPS mode support with global and SSH-specific cryptographic policy configuration.
  * Added SSH algorithm, cipher, and key exchange configuration for enhanced control over cryptographic settings.
  * Added FIPS mode detection capabilities with intelligent caching.
  * Added integration tests validating SSH operations under FIPS and non-FIPS environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->