### PR TITLE
EDM-3403: respect http oci repo

### DIFF
--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -580,6 +580,11 @@ func (s *imageExportService) setupRepositoryReference(ctx context.Context, ociSp
 
 	repoRef.Client = authClient
 
+	if ociSpec.Scheme != nil && *ociSpec.Scheme == coredomain.OciRepoSchemeHttp {
+		repoRef.PlainHTTP = true
+		log.Debug("Using PlainHTTP for HTTP registry")
+	}
+
 	return repoRef, scheme, registryHostname, nil
 }
 

--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -637,10 +637,12 @@ func (c *Consumer) loginToRegistryForExport(
 	// Build podman login command arguments
 	loginArgs := []string{"login", "-u", username, "--password-stdin"}
 
-	// Skip TLS verification if requested
-	if ociRepoSpec != nil && ociRepoSpec.SkipServerVerification != nil && *ociRepoSpec.SkipServerVerification {
+	if ociRepoSpec != nil && ociRepoSpec.Scheme != nil && *ociRepoSpec.Scheme == coredomain.OciRepoSchemeHttp {
 		loginArgs = append(loginArgs, "--tls-verify=false")
-		log.Debug("Using --tls-verify=false for podman login")
+		log.Debug("Using --tls-verify=false for HTTP registry login")
+	} else if ociRepoSpec != nil && ociRepoSpec.SkipServerVerification != nil && *ociRepoSpec.SkipServerVerification {
+		loginArgs = append(loginArgs, "--tls-verify=false")
+		log.Debug("Using --tls-verify=false due to SkipServerVerification for login")
 	}
 
 	loginArgs = append(loginArgs, registryHostname)
@@ -676,10 +678,12 @@ func (c *Consumer) pullSourceImage(ctx context.Context, worker *privilegedPodman
 	// Build podman pull command
 	pullArgs := []string{"pull"}
 
-	// Skip TLS verification if requested
-	if ociRepoSpec != nil && ociRepoSpec.SkipServerVerification != nil && *ociRepoSpec.SkipServerVerification {
+	if ociRepoSpec != nil && ociRepoSpec.Scheme != nil && *ociRepoSpec.Scheme == coredomain.OciRepoSchemeHttp {
 		pullArgs = append(pullArgs, "--tls-verify=false")
-		log.Debug("Using --tls-verify=false for podman pull")
+		log.Debug("Using --tls-verify=false for HTTP registry pull")
+	} else if ociRepoSpec != nil && ociRepoSpec.SkipServerVerification != nil && *ociRepoSpec.SkipServerVerification {
+		pullArgs = append(pullArgs, "--tls-verify=false")
+		log.Debug("Using --tls-verify=false due to SkipServerVerification for pull")
 	}
 
 	pullArgs = append(pullArgs, bootcImageRef)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS verification handling for HTTP registries, automatically disabling TLS when connecting to HTTP-based registries instead of always enforcing it
  * Enhanced support for plain HTTP (non-TLS) registry connections for improved compatibility with various registry configurations
  * Refined registry authentication flow to more intelligently handle different registry schemes and server verification settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->