### PR TITLE
EDM-3406: Fix Helm 4.1.1 post-renderer plugin.yaml compatibility

### DIFF
--- a/internal/agent/device/applications/lifecycle/helm.go
+++ b/internal/agent/device/applications/lifecycle/helm.go
@@ -316,8 +316,6 @@ func (h *HelmHandler) createPluginDir() (string, func(), error) {
 name: %s
 version: 1.0.0
 type: postrenderer/v1
-usage: "Post-renderer that injects flightctl app labels"
-description: "Wraps flightctl-agent helm-render to inject app labels into manifests"
 runtime: subprocess
 runtimeConfig:
   platformCommand:


### PR DESCRIPTION
Helm 4.1 added strict validation on v1 plugins. I've removed the two fields that aren't defined on that spec so that newer versions of helm don't error out for the post renderer. 

Defined here: https://github.com/helm/helm/blob/main/internal/plugin/metadata_v1.go#L23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Helm plugin manifest generation by removing redundant metadata fields from generated configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->