### PR TITLE
EDM-3384: Add SELinux ptmx_t:chr_file lock permission

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -141,7 +141,7 @@ allow flightctl_agent_t install_t:process2 { nnp_transition nosuid_transition };
 
 # Terminal and PTY access for console sessions
 term_use_all_terms(flightctl_agent_t)
-allow flightctl_agent_t ptmx_t:chr_file { create read write open ioctl getattr setattr };
+allow flightctl_agent_t ptmx_t:chr_file { create read write lock open ioctl getattr setattr };
 allow flightctl_agent_t devpts_t:chr_file { create read write append open getattr ioctl setattr };
 allow flightctl_agent_t devpts_t:filesystem associate;
 


### PR DESCRIPTION
This is necessary for console session handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system security policies to enhance device compatibility and improve overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->