### PR TITLE
EDM-3377: Validate Rootless Quadlet Lingering State

### DIFF
--- a/internal/agent/device/systemd/systemd.go
+++ b/internal/agent/device/systemd/systemd.go
@@ -16,6 +16,8 @@ import (
 	"github.com/samber/lo"
 )
 
+const LingerDir = "/var/lib/systemd/linger"
+
 type Manager interface {
 	// EnsurePatterns sets the match patterns for systemd units.
 	EnsurePatterns([]string) error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for application user provisioning, now verifies systemd lingering configuration for non-root users.
  * Enhanced error messages to better identify invalid user configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->