### PR TITLE
EDM-3378: Map disk space message on stderr to proper error

### DIFF
--- a/internal/agent/device/errors/errors.go
+++ b/internal/agent/device/errors/errors.go
@@ -232,7 +232,8 @@ var (
 		// container image resolution
 		"short-name resolution enforced": ErrImageShortName,
 		// no such object
-		"no such object": ErrNotFound,
+		"no such object":          ErrNotFound,
+		"no space left on device": ErrNoSpaceLeft,
 	}
 
 	// errorTypeToCode maps error types from stderrKeywords to status codes.


### PR DESCRIPTION
This results in a more specific error message shown on the device status when the image prefetch fails due to disk exhaustion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recognition for disk space constraints, enabling the system to properly identify and report disk full scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->