### PR TITLE
EDM-3408: Use exec form for CMD primitives

### DIFF
--- a/Containerfile.alert-exporter
+++ b/Containerfile.alert-exporter
@@ -49,4 +49,4 @@ LABEL \
   name="flightctl-alert-exporter" \
   summary="Flight Control Edge management service, alert exporter"
 COPY --from=build /app/bin/flightctl-alert-exporter .
-CMD ./flightctl-alert-exporter
+CMD ["./flightctl-alert-exporter"]

--- a/Containerfile.alertmanager-proxy
+++ b/Containerfile.alertmanager-proxy
@@ -50,4 +50,4 @@ LABEL \
   summary="Flight Control Edge management service, alertmanager proxy"
 COPY --from=build /app/bin/flightctl-alertmanager-proxy .
 EXPOSE 8443
-CMD ./flightctl-alertmanager-proxy
+CMD ["./flightctl-alertmanager-proxy"]

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -49,4 +49,4 @@ LABEL \
   summary="Flight Control Edge management API server"
 COPY --from=build /app/bin/flightctl-api .
 
-CMD ./flightctl-api
+CMD ["./flightctl-api"]

--- a/Containerfile.cli-artifacts
+++ b/Containerfile.cli-artifacts
@@ -56,11 +56,10 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 ENV USER_UID=1001 \
     USER_NAME=server \
     HOME=/home/server \
-    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
-    ENTRYPOINT_PATH=/usr/local/bin/entrypoint.sh
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf
 
 COPY --from=builder /app/packaging/containers/cli-artifacts/nginx.conf ${NGINX_CONF_PATH}
-COPY --chmod=0755 --from=builder /app/packaging/containers/cli-artifacts/entrypoint.sh ${ENTRYPOINT_PATH}
+COPY --chmod=0755 --from=builder /app/packaging/containers/cli-artifacts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 USER root
 
@@ -94,4 +93,4 @@ LABEL \
   summary="Container image exposing multi-arch Flight Control CLI binaries over HTTP"
 EXPOSE 8090
 
-ENTRYPOINT ${ENTRYPOINT_PATH}
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Containerfile.imagebuilder-api
+++ b/Containerfile.imagebuilder-api
@@ -49,4 +49,4 @@ LABEL \
   summary="Flight Control ImageBuilder API server"
 COPY --from=build /app/bin/flightctl-imagebuilder-api .
 
-CMD ./flightctl-imagebuilder-api
+CMD ["./flightctl-imagebuilder-api"]

--- a/Containerfile.periodic
+++ b/Containerfile.periodic
@@ -49,4 +49,4 @@ LABEL \
   name="flightctl-periodic" \
   summary="Flight Control Edge management service, periodic job worker"
 COPY --from=build /app/bin/flightctl-periodic .
-CMD ./flightctl-periodic
+CMD ["./flightctl-periodic"]

--- a/Containerfile.telemetry-gateway
+++ b/Containerfile.telemetry-gateway
@@ -49,4 +49,4 @@ LABEL \
   name="flightctl-telemetry-gateway" \
   summary="Flight Control Edge management service, telemetry gateway"
 COPY --from=build /app/bin/flightctl-telemetry-gateway .
-CMD ./flightctl-telemetry-gateway
+CMD ["./flightctl-telemetry-gateway"]

--- a/Containerfile.userinfo-proxy
+++ b/Containerfile.userinfo-proxy
@@ -52,4 +52,4 @@ COPY --from=build /app/bin/flightctl-userinfo-proxy .
 
 EXPOSE 8080
 
-CMD ./flightctl-userinfo-proxy
+CMD ["./flightctl-userinfo-proxy"]

--- a/Containerfile.worker
+++ b/Containerfile.worker
@@ -49,4 +49,4 @@ LABEL \
   name="flightctl-worker" \
   summary="Flight Control Edge management service, async job worker"
 COPY --from=build /app/bin/flightctl-worker .
-CMD ./flightctl-worker
+CMD ["./flightctl-worker"]


### PR DESCRIPTION
This PR fixes the problem that most of the `Containerfile`s run the application using the Shell Form of the CMD primitive (e.g. `CMD ./application`) instead of the Exec Form (`CMD ["./application"]`).

With Shell Form, `/bin/sh` runs as PID 1, not the application. This breaks graceful shutdown as it's the shell receiving the SIGTERM signal and not the application itself, which may thus be forcibly killed (SIGKILL) and only after the timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container execution configurations across eight services (alert-exporter, alertmanager-proxy, api, imagebuilder-api, periodic, telemetry-gateway, userinfo-proxy, and worker) to enhance signal handling and process management during startup.
  * Enhanced entrypoint path configuration in cli-artifacts container, removing environment variable indirection for more reliable and simplified runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->