### PR TITLE
Add Appliance Containerfile for flightctl

### DIFF
--- a/packaging/images/Containerfile.appliance
+++ b/packaging/images/Containerfile.appliance
@@ -1,0 +1,26 @@
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
+# 1. Install Flightctl and system updates
+RUN dnf config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo && \
+    dnf -y install flightctl-services && \
+    dnf -y clean all && \
+    systemctl enable flightctl.target && \
+    systemctl mask bootc-fetch-apply-updates.timer
+
+# 2. Install EPEL and Podman utilities
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf -y install podman-compose && \
+    dnf -y clean all && \
+    systemctl enable podman.service
+    
+ # 3. Install the GUI environment (GNOME)
+# This installs the full desktop environment and windowing system
+RUN dnf -y groupinstall "Server with GUI" && \
+    dnf clean all
+
+# 4. Set the boot target to graphical and enable the display manager
+RUN systemctl set-default graphical.target && \
+    systemctl enable gdm
+
+# Set root password - DEMO PURPOSES ONLY
+RUN echo root:redhat123 | chpasswd


### PR DESCRIPTION
Upstream containerfile for appliance install of CentOS + flightctl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* **New Appliance Container Image**: Introduced a pre-configured container image for appliance deployment with GNOME GUI support, enabling graphical desktop functionality.
* **Pre-installed Components**: Image includes Flightctl for system management and Podman container utilities for containerized application support, ready for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->