### PR TITLE
EDM-1799: Add IPv6 Support to automations

### DIFF
--- a/test/e2e/infra/auxiliary/gitserver.go
+++ b/test/e2e/infra/auxiliary/gitserver.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/flightctl/flightctl/test/util"
 	"github.com/sirupsen/logrus"
@@ -72,7 +74,7 @@ func (g *GitServer) Start(ctx context.Context, network string, reuse bool) error
 	}
 	g.Port = port.Int()
 	g.InternalPort = g.Port
-	g.URL = fmt.Sprintf("ssh://user@%s:%d", g.Host, g.Port)
+	g.URL = fmt.Sprintf("ssh://user@%s", net.JoinHostPort(g.Host, strconv.Itoa(g.Port)))
 	logrus.Infof("Git server container started: %s", g.URL)
 	return nil
 }

--- a/test/e2e/infra/auxiliary/jaeger.go
+++ b/test/e2e/infra/auxiliary/jaeger.go
@@ -3,6 +3,7 @@ package auxiliary
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -56,12 +57,12 @@ func (j *Jaeger) Start(ctx context.Context, network string, reuse bool) error {
 		return fmt.Errorf("get mapped port for %s: %w", jaegerUIPort, err)
 	}
 	j.Port = uiPort.Port()
-	j.URL = fmt.Sprintf("http://%s:%s", j.Host, j.Port)
+	j.URL = fmt.Sprintf("http://%s", net.JoinHostPort(j.Host, j.Port))
 	otlpPort, err := container.MappedPort(ctx, jaegerOTLPHTTPPort)
 	if err != nil {
 		return fmt.Errorf("get mapped port for %s: %w", jaegerOTLPHTTPPort, err)
 	}
-	j.OTLPEndpoint = fmt.Sprintf("%s:%s", j.Host, otlpPort.Port())
+	j.OTLPEndpoint = net.JoinHostPort(j.Host, otlpPort.Port())
 	logrus.Infof("Jaeger container started: UI=%s OTLP=%s", j.URL, j.OTLPEndpoint)
 	return nil
 }

--- a/test/e2e/infra/auxiliary/keycloak.go
+++ b/test/e2e/infra/auxiliary/keycloak.go
@@ -3,6 +3,7 @@ package auxiliary
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -77,7 +78,7 @@ func (k *Keycloak) Start(ctx context.Context, network string, reuse bool) error 
 		return fmt.Errorf("failed to get Keycloak mapped port: %w", err)
 	}
 	k.Port = port.Port()
-	k.URL = fmt.Sprintf("http://%s:%s", k.Host, k.Port)
+	k.URL = fmt.Sprintf("http://%s", net.JoinHostPort(k.Host, k.Port))
 	logrus.Infof("Keycloak container started: %s (realm: %s)", k.URL, keycloakRealmName)
 
 	// Wait until the realm is reachable from the host (same path the CLI will use).

--- a/test/e2e/infra/auxiliary/prometheus.go
+++ b/test/e2e/infra/auxiliary/prometheus.go
@@ -3,6 +3,7 @@ package auxiliary
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func (p *Prometheus) Start(ctx context.Context, network string, reuse bool) erro
 	p.Host = GetHostIP()
 	port, _ := container.MappedPort(ctx, "9090")
 	p.Port = port.Port()
-	p.URL = fmt.Sprintf("http://%s:%s", p.Host, p.Port)
+	p.URL = fmt.Sprintf("http://%s", net.JoinHostPort(p.Host, p.Port))
 	logrus.Infof("Prometheus container started: %s", p.URL)
 	return nil
 }

--- a/test/e2e/infra/auxiliary/registry.go
+++ b/test/e2e/infra/auxiliary/registry.go
@@ -112,9 +112,19 @@ func (r *Registry) Start(ctx context.Context, network string, reuse bool) error 
 		return fmt.Errorf("failed to start registry container: %w", err)
 	}
 	r.container = container
-	r.Host = GetHostIP()
+	hostIP := GetHostIP()
 	r.Port = registryHostPort
-	r.URL = fmt.Sprintf("%s:%s", r.Host, r.Port)
+	// For IPv6: use localhost for host-side podman and container name for container-to-container DNS.
+	// IPv6 addresses in image names are parsed as transport prefixes (e.g., "fd2e:" looks like "docker:")
+	if strings.Contains(hostIP, ":") {
+		r.URL = fmt.Sprintf("localhost:%s", r.Port)
+		r.Host = registryContainerName
+		logrus.Infof("IPv6 detected (%s) - using localhost:%s for host, %s for containers",
+			hostIP, r.Port, r.Host)
+	} else {
+		r.Host = hostIP
+		r.URL = fmt.Sprintf("%s:%s", r.Host, r.Port)
+	}
 	if err := configureInsecureRegistry(r.URL); err != nil {
 		logrus.Warnf("Failed to configure insecure registry: %v", err)
 	}
@@ -176,7 +186,7 @@ func (r *Registry) startAuthenticatedEndpoint(ctx context.Context, certDir, netw
 	}
 
 	r.Authenticated = AuthenticatedEndpoint{
-		HostPort: fmt.Sprintf("%s:%s", r.Host, privateRegistryHostPort),
+		HostPort: net.JoinHostPort(r.Host, privateRegistryHostPort),
 		Port:     privateRegistryHostPort,
 		Username: defaultAuthUsername,
 		Password: defaultAuthPassword,
@@ -187,6 +197,7 @@ func (r *Registry) startAuthenticatedEndpoint(ctx context.Context, certDir, netw
 }
 
 func generateNginxConf(registryHost, registryPort string) string {
+	upstreamAddr := net.JoinHostPort(registryHost, registryPort)
 	return fmt.Sprintf(`error_log /dev/stderr warn;
 
 events {
@@ -195,7 +206,7 @@ events {
 
 http {
   upstream registry {
-    server %s:%s;
+    server %s;
   }
 
   server {
@@ -219,7 +230,7 @@ http {
     }
   }
 }
-`, registryHost, registryPort)
+`, upstreamAddr)
 }
 
 // generateHtpasswd creates an Apache-style htpasswd entry using SHA1.

--- a/test/e2e/infra/factory.go
+++ b/test/e2e/infra/factory.go
@@ -2,6 +2,7 @@
 package infra
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -98,7 +99,7 @@ func GetDefaultQuadletAPIEndpoint() string {
 	// Fallback to IP address if FQDN not available
 	hostIP := auxiliary.GetHostIP()
 	if hostIP != "" {
-		return "https://" + hostIP + ":" + DefaultAPIPort
+		return "https://" + net.JoinHostPort(hostIP, DefaultAPIPort)
 	}
 
 	// Last resort fallback

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -289,7 +289,7 @@ func (p *InfraProvider) ExposeService(service infra.ServiceName, protocol string
 		if err != nil {
 			return "", nil, err
 		}
-		return fmt.Sprintf("%s://%s:%d", protocol, host, port), func() {}, nil
+		return fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(host, strconv.Itoa(port))), func() {}, nil
 	}
 	cacheKey := string(service) + ":" + protocol
 	p.exposeCacheMu.Lock()
@@ -312,7 +312,7 @@ func (p *InfraProvider) ExposeService(service infra.ServiceName, protocol string
 		if host == "localhost" {
 			host = "127.0.0.1"
 		}
-		url := fmt.Sprintf("%s://%s:%d", protocol, host, hostPort)
+		url := fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(host, strconv.Itoa(hostPort)))
 		p.exposeCacheMu.Lock()
 		if e, ok := p.exposeCache[cacheKey]; ok {
 			p.exposeCacheMu.Unlock()

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -985,13 +985,30 @@ func (h *Harness) DeleteRepository(name string) error {
 	return err
 }
 
+// getIPTablesCommand returns the appropriate iptables command (iptables or ip6tables)
+// based on the IP version. Resolves hostnames and respects IPV6_ONLY environment variable.
+func getIPTablesCommand(host string) string {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		if ips, err := net.LookupIP(host); err == nil && len(ips) > 0 {
+			ip = ips[0]
+		}
+	}
+	if ip != nil && ip.To4() == nil {
+		return "ip6tables"
+	}
+	return "iptables"
+}
+
 func tcpNetworkTableRule(ip, port string, remove bool) []string {
 	flag := "-A" // Add rule
 	if remove {
 		flag = "-D" // Delete rule
 	}
 
-	rule := []string{"iptables", flag, "OUTPUT"}
+	iptablesCmd := getIPTablesCommand(ip)
+
+	rule := []string{iptablesCmd, flag, "OUTPUT"}
 
 	if ip != "" {
 		rule = append(rule, "-d", ip)
@@ -1007,7 +1024,8 @@ func tcpNetworkTableRule(ip, port string, remove bool) []string {
 }
 
 func buildIPTablesCmd(ip, port string, remove bool) []string {
-	return append([]string{"sudo"}, tcpNetworkTableRule(ip, port, remove)...)
+	rule := tcpNetworkTableRule(ip, port, remove)
+	return append([]string{"sudo"}, rule...)
 }
 
 // SimulateNetworkFailure blocks VM traffic to the given registry host:port via iptables.
@@ -1016,7 +1034,9 @@ func (h *Harness) SimulateNetworkFailure(registryHost, registryPort string) erro
 	if registryHost == "" || registryPort == "" {
 		return fmt.Errorf("registry host and port are required for network failure simulation")
 	}
-	blockCommands := [][]string{buildIPTablesCmd(registryHost, registryPort, false)}
+
+	blockCmd := buildIPTablesCmd(registryHost, registryPort, false)
+	blockCommands := [][]string{blockCmd}
 
 	for _, cmd := range blockCommands {
 		stdout, err := h.VM.RunSSH(cmd, nil)
@@ -1025,11 +1045,13 @@ func (h *Harness) SimulateNetworkFailure(registryHost, registryPort string) erro
 		}
 	}
 
-	stdout, err := h.VM.RunSSH([]string{"sudo", "iptables", "-L", "OUTPUT"}, nil)
+	// List iptables rules for debugging (use appropriate command based on IP version)
+	iptablesListCmd := getIPTablesCommand(registryHost)
+	stdout, err := h.VM.RunSSH([]string{"sudo", iptablesListCmd, "-L", "OUTPUT"}, nil)
 	if err != nil {
-		logrus.Warnf("Failed to list iptables rules: %v", err)
+		logrus.Warnf("Failed to list %s rules: %v", iptablesListCmd, err)
 	} else {
-		logrus.Debugf("Current iptables rules:\n%s", stdout.String())
+		logrus.Debugf("Current %s rules:\n%s", iptablesListCmd, stdout.String())
 	}
 
 	return nil
@@ -1039,6 +1061,7 @@ func (h *Harness) SimulateNetworkFailure(registryHost, registryPort string) erro
 // It returns a function that will only execute once to undo the iptables modification
 func (h *Harness) SimulateNetworkFailureForCLI(ip, port string) (func() error, error) {
 	args := tcpNetworkTableRule(ip, port, false)
+
 	_, err := h.SH("sudo", args...)
 	noop := func() error { return nil }
 	if err != nil {
@@ -1059,7 +1082,9 @@ func (h *Harness) FixNetworkFailure(registryHost, registryPort string) error {
 	if registryHost == "" || registryPort == "" {
 		return fmt.Errorf("registry host and port are required for network failure fix")
 	}
-	unblockCommands := [][]string{buildIPTablesCmd(registryHost, registryPort, true)}
+
+	unblockCmd := buildIPTablesCmd(registryHost, registryPort, true)
+	unblockCommands := [][]string{unblockCmd}
 
 	for _, cmd := range unblockCommands {
 		stdout, err := h.VM.RunSSH(cmd, nil)
@@ -1071,11 +1096,13 @@ func (h *Harness) FixNetworkFailure(registryHost, registryPort string) error {
 	// Clear any remaining DNS cache
 	_, _ = h.VM.RunSSH([]string{"sudo", "systemd-resolve", "--flush-caches"}, nil)
 
-	stdout, err := h.VM.RunSSH([]string{"sudo", "iptables", "-L", "OUTPUT"}, nil)
+	// List iptables rules for debugging (use appropriate command based on IP version)
+	iptablesListCmd := getIPTablesCommand(registryHost)
+	stdout, err := h.VM.RunSSH([]string{"sudo", iptablesListCmd, "-L", "OUTPUT"}, nil)
 	if err != nil {
-		logrus.Warnf("Failed to list iptables rules: %v", err)
+		logrus.Warnf("Failed to list %s rules: %v", iptablesListCmd, err)
 	} else {
-		logrus.Debugf("Current iptables rules after recovery:\n%s", stdout.String())
+		logrus.Debugf("Current %s rules after recovery:\n%s", iptablesListCmd, stdout.String())
 	}
 
 	return nil
@@ -1085,9 +1112,10 @@ func (h *Harness) FixNetworkFailure(registryHost, registryPort string) error {
 // if no entry for the ip:port combo exists
 func (h *Harness) FixNetworkFailureForCLI(ip, port string) error {
 	args := tcpNetworkTableRule(ip, port, true)
+
 	_, err := h.SH("sudo", args...)
 	if err != nil {
-		return fmt.Errorf("failed to add iptables rule %v: %w", args, err)
+		return fmt.Errorf("failed to remove iptables rule %v: %w", args, err)
 	}
 	_, _ = h.SH("sudo", "systemd-resolve", "--flush-caches")
 

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -391,20 +391,24 @@ func (h *Harness) GetAPIEndpointFromVM() (ip string, port string, err error) {
 	return hostname, p, nil
 }
 
-// BlockTrafficOnVM adds an iptables rule on the VM to reject TCP traffic to the
-// specified IP and port.
+// BlockTrafficOnVM adds an iptables/ip6tables rule on the VM to reject TCP traffic to the
+// specified IP and port. Automatically detects IPv4 vs IPv6 and uses the appropriate command.
 func (h *Harness) BlockTrafficOnVM(ip, port string) {
+	iptablesCmd := getIPTablesCommand(ip)
+
 	_, err := h.VM.RunSSH([]string{
-		"sudo", "iptables", "-A", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
+		"sudo", iptablesCmd, "-A", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
 	}, nil)
-	Expect(err).ToNot(HaveOccurred(), "failed to add iptables rule on VM")
+	Expect(err).ToNot(HaveOccurred(), "failed to add %s rule on VM", iptablesCmd)
 }
 
-// UnblockTrafficOnVM removes the iptables rule on the VM that blocks TCP
+// UnblockTrafficOnVM removes the iptables/ip6tables rule on the VM that blocks TCP
 // traffic to the specified IP and port. Silently ignores errors.
 func (h *Harness) UnblockTrafficOnVM(ip, port string) {
+	iptablesCmd := getIPTablesCommand(ip)
+
 	_, _ = h.VM.RunSSH([]string{
-		"sudo", "iptables", "-D", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
+		"sudo", iptablesCmd, "-D", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
 	}, nil)
 }
 

--- a/test/harness/e2e/harness_git.go
+++ b/test/harness/e2e/harness_git.go
@@ -2,9 +2,11 @@ package e2e
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -94,8 +96,8 @@ func (h *Harness) CreateGitRepositoryOnServer(config GitServerConfig, keyPath ut
 	}
 
 	// Store the repository name for cleanup
-	h.gitRepos[repoName] = fmt.Sprintf("ssh://%s@%s:%d/home/user/repos/%s.git",
-		config.User, config.Host, config.Port, repoName)
+	h.gitRepos[repoName] = fmt.Sprintf("ssh://%s@%s/home/user/repos/%s.git",
+		config.User, net.JoinHostPort(config.Host, strconv.Itoa(config.Port)), repoName)
 
 	logrus.Infof("Created git repository: %s on git server", repoName)
 	return nil
@@ -133,8 +135,8 @@ func (h *Harness) CloneGitRepositoryFromServer(config GitServerConfig, keyPath u
 		return fmt.Errorf("SSH private key path is required to clone from git server")
 	}
 
-	repoURL := fmt.Sprintf("ssh://%s@%s:%d/home/user/repos/%s.git",
-		config.User, config.Host, config.Port, repoName)
+	repoURL := fmt.Sprintf("ssh://%s@%s/home/user/repos/%s.git",
+		config.User, net.JoinHostPort(config.Host, strconv.Itoa(config.Port)), repoName)
 
 	// Create parent directory if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {

--- a/test/scripts/agent-images/prepare_otel_config.sh
+++ b/test/scripts/agent-images/prepare_otel_config.sh
@@ -41,11 +41,33 @@ b64dec() {
 server_url="$(yq -e -r '.["enrollment-service"].service.server // ""' "$CFG" 2>/dev/null || true)"
 [ -n "${server_url:-}" ] || die "Missing enrollment-service.service.server in $CFG"
 
-# Extract IPv4 ahead of '.nip.io' specifically; fallback to loose grep if pattern differs
-ip="$(printf '%s\n' "$server_url" | sed -n 's#.*://\([0-9.]\+\)\.nip\.io.*#\1#p')"
+# Extract IP and determine DNS suffix (nip.io for IPv4, sslip.io for IPv6)
+dns_suffix=""
+ip=""
+
+# Try sslip.io pattern (IPv6: fd2e-6f44-fddb--6a.sslip.io or api.fd2e-6f44-fddb--6a.sslip.io)
+if [[ "$server_url" == *".sslip.io"* ]]; then
+  # Extract segment immediately before .sslip.io (handles optional service prefixes)
+  host="$(printf '%s\n' "$server_url" | sed -n 's#.*://\(.*\)\.sslip\.io.*#\1#p')"
+  if [[ -n "$host" ]]; then
+    ip="${host##*.}"
+    dns_suffix="sslip.io"
+  fi
+fi
+
+# Try nip.io pattern (IPv4: 192.168.122.75.nip.io or api.192.168.122.75.nip.io)
+if [ -z "$ip" ] && [[ "$server_url" == *".nip.io"* ]]; then
+  # Match full IPv4 address (4 octets) before .nip.io to avoid matching service prefixes
+  ip="$(printf '%s\n' "$server_url" | sed -n 's#.*\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\.nip\.io.*#\1#p')"
+  dns_suffix="nip.io"
+fi
+
+# Fallback: try to extract IPv4 from URL
 if [ -z "$ip" ]; then
   ip="$(printf '%s\n' "$server_url" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' || true)"
+  dns_suffix="nip.io"
 fi
+
 [ -n "$ip" ] || die "Could not extract IP from server URL: $server_url"
 
 # Read CA (base64)
@@ -64,8 +86,8 @@ chmod 0640 "$tmp_ca"
 mv -f "$tmp_ca" "$DIR/certs/gateway-ca.crt"
 log "Wrote CA to $DIR/certs/gateway-ca.crt"
 
-# Build gateway endpoint (gRPC/4317)
-gateway="telemetry-gateway.${ip}.nip.io:4317"
+# Build gateway endpoint (gRPC/4317) using the same DNS suffix as server URL
+gateway="telemetry-gateway.${ip}.${dns_suffix}:4317"
 log "Derived OTEL_GATEWAY=${gateway}"
 
 # Build OTEL options; allow optional server_name_override via env OTLP_SERVER_NAME

--- a/test/scripts/agent-images/variants/v10/prepare_otel_config.sh
+++ b/test/scripts/agent-images/variants/v10/prepare_otel_config.sh
@@ -41,11 +41,33 @@ b64dec() {
 server_url="$(yq -e -r '.["enrollment-service"].service.server // ""' "$CFG" 2>/dev/null || true)"
 [ -n "${server_url:-}" ] || die "Missing enrollment-service.service.server in $CFG"
 
-# Extract IPv4 ahead of '.nip.io' specifically; fallback to loose grep if pattern differs
-ip="$(printf '%s\n' "$server_url" | sed -n 's#.*://\([0-9.]\+\)\.nip\.io.*#\1#p')"
+# Extract IP and determine DNS suffix (nip.io for IPv4, sslip.io for IPv6)
+dns_suffix=""
+ip=""
+
+# Try sslip.io pattern (IPv6: fd2e-6f44-fddb--6a.sslip.io or api.fd2e-6f44-fddb--6a.sslip.io)
+if [[ "$server_url" == *".sslip.io"* ]]; then
+  # Extract segment immediately before .sslip.io (handles optional service prefixes)
+  host="$(printf '%s\n' "$server_url" | sed -n 's#.*://\(.*\)\.sslip\.io.*#\1#p')"
+  if [[ -n "$host" ]]; then
+    ip="${host##*.}"
+    dns_suffix="sslip.io"
+  fi
+fi
+
+# Try nip.io pattern (IPv4: 192.168.122.75.nip.io or api.192.168.122.75.nip.io)
+if [ -z "$ip" ] && [[ "$server_url" == *".nip.io"* ]]; then
+  # Match full IPv4 address (4 octets) before .nip.io to avoid matching service prefixes
+  ip="$(printf '%s\n' "$server_url" | sed -n 's#.*\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\.nip\.io.*#\1#p')"
+  dns_suffix="nip.io"
+fi
+
+# Fallback: try to extract IPv4 from URL
 if [ -z "$ip" ]; then
   ip="$(printf '%s\n' "$server_url" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' || true)"
+  dns_suffix="nip.io"
 fi
+
 [ -n "$ip" ] || die "Could not extract IP from server URL: $server_url"
 
 # Read CA (base64)
@@ -70,8 +92,8 @@ chmod 0640 "$tmp_ca"
 mv -f "$tmp_ca" "$DIR/certs/gateway-ca.crt"
 log "Wrote CA to $DIR/certs/gateway-ca.crt"
 
-# Build gateway endpoint (gRPC/4317)
-gateway="telemetry.${ip}.nip.io:4317"
+# Build gateway endpoint (gRPC/4317) using the same DNS suffix as server URL
+gateway="telemetry.${ip}.${dns_suffix}:4317"
 log "Derived OTEL_GATEWAY=${gateway}"
 
 # Build OTEL options; allow optional server_name_override via env OTLP_SERVER_NAME

--- a/test/scripts/create_vm_libvirt.sh
+++ b/test/scripts/create_vm_libvirt.sh
@@ -268,13 +268,16 @@ wait_for_vm_ips() {
     export INTERFACE_DEFAULT=$(sudo virsh domiflist ${VM_NAME} 2>/dev/null | grep default | awk '{print $1}')
     export INTERFACE_BM=$(sudo virsh domiflist ${VM_NAME} 2>/dev/null | grep ${NETWORK_NAME} | awk '{print $1}')
 
-    # Try to get the IPs
     if [ -n "${INTERFACE_DEFAULT}" ]; then
       VM_DEFAULT_IP=$(sudo virsh domifaddr ${VM_NAME} --interface ${INTERFACE_DEFAULT} 2>/dev/null | awk '/ipv4/ {print $4}' | cut -d'/' -f1)
     fi
 
     if [ -n "${INTERFACE_BM}" ]; then
-      VM_IP=$(sudo virsh domifaddr ${VM_NAME} --interface ${INTERFACE_BM} 2>/dev/null | awk '/ipv4/ {print $4}' | cut -d'/' -f1)
+      if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+        VM_IP=$(sudo virsh domifaddr "${VM_NAME}" --interface "${INTERFACE_BM}" 2>/dev/null | awk '/ipv6/ {print $4}' | cut -d'/' -f1 | grep -v '^fe80' | head -1)
+      else
+        VM_IP=$(sudo virsh domifaddr ${VM_NAME} --interface ${INTERFACE_BM} 2>/dev/null | awk '/ipv4/ {print $4}' | cut -d'/' -f1)
+      fi
     fi
 
     # Check if both VM's IPs are available
@@ -298,11 +301,11 @@ wait_for_vm_ips() {
 
 wait_for_ssh() {
   local ssh_timeout="${1:-${TIMEOUT_SECONDS}}"
-  echo "Waiting for SSH to be ready on ${VM_DEFAULT_IP} (timeout: ${ssh_timeout}s)..."
+  echo "Waiting for SSH to be ready on ${SSH_VM_TARGET} (timeout: ${ssh_timeout}s)..."
   ELAPSED=0
   while [ $ELAPSED -lt $ssh_timeout ]; do
     if ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -o BatchMode=yes -o ConnectTimeout=5 ${USER}@${VM_DEFAULT_IP} "true" 2>/dev/null; then
+        -o BatchMode=yes -o ConnectTimeout=5 ${SSH_VM_TARGET} "true" 2>/dev/null; then
       echo "SSH is ready"
       return 0
     fi
@@ -312,22 +315,28 @@ wait_for_ssh() {
   echo "ERROR: SSH did not become ready within ${ssh_timeout} seconds"
   echo "VM state: $(virsh domstate ${VM_NAME} 2>/dev/null || echo 'unknown')"
   virsh domifaddr ${VM_NAME} 2>/dev/null || true
-  # Attempt SSH with verbose output for diagnostics
   ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-      -o BatchMode=yes -o ConnectTimeout=5 -v ${USER}@${VM_DEFAULT_IP} "true" 2>&1 || true
+      -o BatchMode=yes -o ConnectTimeout=5 -v ${SSH_VM_TARGET} "true" 2>&1 || true
   return 1
 }
 
 wait_for_vm_ips || exit 1
-wait_for_ssh || exit 1
 
 # Configure the VM
 echo "Provisioning the VM..."
 
+if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+  SSH_VM_TARGET="${USER}@${VM_IP}"
+else
+  SSH_VM_TARGET="${USER}@${VM_DEFAULT_IP}"
+fi
+
+wait_for_ssh || exit 1
+
 # Executing commands
 echo "Executing commands in the VM..."
 
-ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${USER}@${VM_DEFAULT_IP} bash -s <<'REMOTE_EOF'
+ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${SSH_VM_TARGET} bash -s <<'REMOTE_EOF'
 set -e
   # Install packages; retry on failure (e.g. baseos mirror/checksum).
   install_pkgs() {
@@ -354,7 +363,7 @@ set -e
   done
 REMOTE_EOF
 
-ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${USER}@${VM_DEFAULT_IP} <<EOF
+ssh -i ${SSH_PRIVATE_KEY_PATH} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${SSH_VM_TARGET} <<EOF
   # Install OpenShift client
   echo "Installing OpenShift client..."
   curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux-amd64-rhel9.tar.gz | sudo tar xvz -C /usr/local/bin
@@ -398,5 +407,5 @@ if [ "${ENABLE_TPM_PASSTHROUGH}" = "true" ]; then
 fi
 
 # Greetings
-echo "You can access the created VM with ssh ${USER}@${VM_IP}"
+echo "You can access the created VM with ssh ${SSH_VM_TARGET}"
 echo "VM creation and provisioning complete!"

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -135,9 +135,16 @@ AUTH_ARGS="--set global.auth.type=k8s"
 
 helm dependency build ./deploy/helm/flightctl
 
+# Format IP for DNS: use sslip.io for IPv6 (replace : with -), nip.io for IPv4
+if [[ "$IP" == *":"* ]]; then
+  BASE_DOMAIN="$(echo $IP | tr ':' '-').sslip.io"
+else
+  BASE_DOMAIN="${IP}.nip.io"
+fi
+
 helm upgrade --install --namespace flightctl-external \
                   --values ./deploy/helm/flightctl/values.dev.yaml \
-                  --set global.baseDomain=${IP}.nip.io \
+                  --set global.baseDomain=${BASE_DOMAIN} \
                   ${ONLY_DB} ${DB_SIZE_PARAMS} ${AUTH_ARGS} ${SQL_ARG} ${GATEWAY_ARGS} ${KV_ARG} ${SERVICE_IMAGE_ARGS} flightctl \
               ./deploy/helm/flightctl/ --kube-context kind-kind
 

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -3,11 +3,25 @@
 # on the same network
 function _get_ext_ip() {
     if which ip 2>/dev/null 1>/dev/null; then
-        ip route get 1.1.1.1 | grep -oP 'src \K\S+'
+        # Support IPv6-only mode via environment variable
+        local result
+        if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+            # IPv6-only: use IPv6 route
+            result=$(ip -6 route get 2001:4860:4860::8888 2>/dev/null | grep -oP 'src \K\S+' || true)
+        else
+            result=$(ip route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || true)
+        fi
+        echo "$result"
     else
         # MacOS does not have ip, so we use route and ifconfig instead
-        INTERFACE=$(route get 1.1.1.1 | grep interface | awk '{print $2}')
-        ifconfig | grep $INTERFACE -A 10 | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1
+        if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+            # IPv6-only for MacOS
+            INTERFACE=$(route get -inet6 2001:4860:4860::8888 2>/dev/null | grep interface | awk '{print $2}')
+            ifconfig | grep $INTERFACE -A 10 | grep "inet6 " | grep -Fv "::1" | grep -Fv "fe80:" | awk '{print $2}' | head -n 1
+        else
+            INTERFACE=$(route get 1.1.1.1 | grep interface | awk '{print $2}')
+            ifconfig | grep $INTERFACE -A 10 | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1
+        fi
     fi
 }
 
@@ -64,20 +78,34 @@ kind_load_image() {
 function registry_address() {
     # E2E_AUX_HOST overrides for both Quadlet and K8s (e.g. test host IP on OCP NIC)
     if [[ -n "${E2E_AUX_HOST:-}" ]]; then
-        echo "${E2E_AUX_HOST}:5000"
+        local ip="${E2E_AUX_HOST}"
+        if [[ "$ip" == *":"* ]]; then
+            echo "[${ip}]:5000"
+        else
+            echo "${ip}:5000"
+        fi
         return
+    fi
+
+    # Format IP:port with IPv6 bracket support
+    local ip=$(get_ext_ip)
+    local addr
+    if [[ "$ip" == *":"* ]]; then
+        addr="[${ip}]:5000"
+    else
+        addr="${ip}:5000"
     fi
 
     # Quadlet: registry on test host
     if [[ "${E2E_ENVIRONMENT:-}" == "quadlet" ]] || \
        { ! kubectl config current-context &>/dev/null && \
          (systemctl is-active flightctl-api.service &>/dev/null || sudo systemctl is-active flightctl-api.service &>/dev/null); }; then
-        echo "$(get_ext_ip):5000"
+        echo "${addr}"
         return
     fi
 
     # K8s (kind or other): registry on test host via testcontainers
-    echo "$(get_ext_ip):5000"
+    echo "${addr}"
 }
 
 
@@ -106,6 +134,13 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 IP=$(get_ext_ip)
 
+# Format IP for DNS wildcard: sslip.io for IPv6 (replace : with -), nip.io for IPv4
+if [[ "$IP" == *":"* ]]; then
+    DNS_IP="$(echo "$IP" | tr ':' '-').sslip.io"
+else
+    DNS_IP="${IP}.nip.io"
+fi
+
 function get_endpoint_host() {
     local name=$1
     kubectl get route "${name}" -n "${FLIGHTCTL_NS}" -o jsonpath='{.spec.host}' ${KUBECTL_ARGS} 2>/dev/null || \
@@ -115,13 +150,13 @@ function get_endpoint_host() {
     # nodeport services instead pointing to our local IP address
     case "${name}" in
         flightctl-api)
-            echo "api.${IP}.nip.io:3443"
+            echo "api.${DNS_IP}:3443"
             ;;
         flightctl-api-agent)
-            echo "agent-api.${IP}.nip.io:7443"
+            echo "agent-api.${DNS_IP}:7443"
             ;;
         flightctl-ui)
-            echo "ui.${IP}.nip.io:9001"
+            echo "ui.${DNS_IP}:9001"
             ;;
         *)
             echo "Unable to find endpoint for ${name}" >&2
@@ -401,15 +436,27 @@ function get_ocp_nodes_network() {
     echo "No nodes found" >&2
     return 1
   fi
-   ip=${ip%.*}
-  if [[ -z "$ip" ]]; then
+
+  # Detect IPv4 vs IPv6 and extract appropriate subnet prefix
+  if [[ "$ip" == *":"* ]]; then
+    # IPv6: if the address is already compressed, don't drop an extra hextet
+    if [[ "$ip" == *"::"* ]]; then
+      prefix="${ip%%::*}"
+    else
+      prefix="${ip%:*}"
+    fi
+  else
+    prefix=${ip%.*}
+  fi
+
+  if [[ -z "$prefix" ]]; then
     echo "Invalid IP format" >&2
     return 1
   fi
 
-  # get the network name from the ip
+  # get the network name from the prefix
   for net in $(sudo virsh net-list --name); do
-    if [[ "$(sudo virsh net-dumpxml $net |grep $ip)" != "" ]];
+    if [[ "$(sudo virsh net-dumpxml $net | grep "$prefix")" != "" ]];
       then echo $net;
       break;
     fi;

--- a/test/scripts/get_ext_ip.sh
+++ b/test/scripts/get_ext_ip.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 if which ip 2>/dev/null 1>/dev/null; then
-    ip route get 1.1.1.1 | grep -oP 'src \K\S+'
+    # Support IPv6-only mode via environment variable
+    if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+        # IPv6-only: use IPv6 route
+        result=$(ip -6 route get 2001:4860:4860::8888 2>/dev/null | grep -oP 'src \K\S+' || true)
+    else
+        result=$(ip route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || true)
+    fi
+    echo "$result"
 else
     # MacOS does not have ip, so we use route and ifconfig instead
-    INTERFACE=$(route get 1.1.1.1 | grep interface | awk '{print $2}')
-    ifconfig | grep $INTERFACE -A 10 | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1
+    if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+        # IPv6-only for MacOS
+        INTERFACE=$(route get -inet6 2001:4860:4860::8888 2>/dev/null | grep interface | awk '{print $2}')
+        ifconfig | grep $INTERFACE -A 10 | grep "inet6 " | grep -Fv "::1" | grep -Fv "fe80:" | awk '{print $2}' | head -n 1
+    else
+        INTERFACE=$(route get 1.1.1.1 | grep interface | awk '{print $2}')
+        ifconfig | grep $INTERFACE -A 10 | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1
+    fi
 fi

--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -24,6 +24,7 @@ QCOW="${QCOW:-bin/output/qcow2/disk.qcow2}"
 AGENT_DIR="${AGENT_DIR:-bin/agent/etc/flightctl}"
 MOUNT_DIR="${MOUNT_DIR:-/mnt/qcow}"
 REGISTRY_ADDRESS="${REGISTRY_ADDRESS:-}"
+REGISTRY_HOSTNAME="${REGISTRY_HOSTNAME:-e2e-registry}"
 E2E_CA="${E2E_CA:-bin/e2e-certs/pki/CA/ca.crt}"
 SOURCE_REPO="quay.io/flightctl"
 
@@ -53,8 +54,27 @@ if [[ -z "$REGISTRY_ADDRESS" ]]; then
   [[ -n "$REGISTRY_ADDRESS" ]] || fail "Could not determine REGISTRY_ADDRESS using registry_address function"
 fi
 
-# CA install directory must match the host:port of the registry
-REG_TLS_HOSTPORT="$REGISTRY_ADDRESS"
+# Extract port from REGISTRY_ADDRESS with proper IPv6 handling
+if [[ "$REGISTRY_ADDRESS" =~ ^\[.*\]:([0-9]+)$ ]]; then
+    # Bracketed IPv6 with port: [fd00::1]:5000
+    REGISTRY_PORT="${BASH_REMATCH[1]}"
+elif [[ "$REGISTRY_ADDRESS" =~ :([0-9]+)$ ]]; then
+    # IPv4/hostname with port: 192.168.1.1:5000 or hostname:5000
+    REGISTRY_PORT="${BASH_REMATCH[1]}"
+else
+    # No port specified, use default
+    REGISTRY_PORT="5000"
+fi
+
+# TLS certificate path must match the registry address used by VMs.
+# In IPv6 mode, use hostname to avoid container tool parsing issues.
+if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+  REG_TLS_HOSTPORT="${REGISTRY_HOSTNAME}:${REGISTRY_PORT}"
+  log "IPv6 mode: VMs will use registry hostname: $REG_TLS_HOSTPORT"
+else
+  REG_TLS_HOSTPORT="$REGISTRY_ADDRESS"
+  log "IPv4 mode: VMs will use registry IP: $REG_TLS_HOSTPORT"
+fi
 
 SOURCE_REPO="${SOURCE_REPO%/}"
 if [[ "$SOURCE_REPO" != */* ]]; then
@@ -66,8 +86,10 @@ log "QCOW=$QCOW"
 log "AGENT_DIR=$AGENT_DIR"
 log "MOUNT_DIR=$MOUNT_DIR"
 log "REGISTRY_ADDRESS=$REGISTRY_ADDRESS"
-log "E2E_CA=$E2E_CA"
+log "REGISTRY_HOSTNAME=$REGISTRY_HOSTNAME"
 log "REG_TLS_HOSTPORT=$REG_TLS_HOSTPORT"
+log "IPV6_ONLY=${IPV6_ONLY:-false}"
+log "E2E_CA=$E2E_CA"
 log "SOURCE_REPO=$SOURCE_REPO"
 
 sudo modprobe nbd max_part=16 || true
@@ -175,6 +197,12 @@ inject_registry_ca() {
     return
   fi
 
+  local target_dir="$base/containers/certs.d/$REG_TLS_HOSTPORT"
+  log "Installing E2E CA to $target_dir/ca.crt"
+  sudo install -d "$target_dir"
+  sudo install -m 0644 "$E2E_CA" "$target_dir/ca.crt"
+  sudo chown -R root:root "$base/containers"
+
   local anchors_dir="$base/pki/ca-trust/source/anchors"
   log "Installing E2E CA to $anchors_dir/"
   sudo install -d "$anchors_dir"
@@ -229,7 +257,7 @@ EOF
 inject_hosts_entry() {
   local base="$1"
   local hosts_file="$base/hosts"
-  
+
   # Get host IP and hostname
   local host_ip
   host_ip=$(get_ext_ip)
@@ -237,37 +265,50 @@ inject_hosts_entry() {
   host_fqdn=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "")
   local host_short
   host_short=$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo "")
-  
-  if [[ -z "$host_ip" ]] || [[ -z "$host_fqdn" ]]; then
-    log "Could not determine host IP or hostname - skipping /etc/hosts injection"
+
+  if [[ -z "$host_ip" ]]; then
+    log "Could not determine host IP - skipping /etc/hosts injection"
     return
   fi
-  
-  # Skip if localhost
-  if [[ "$host_fqdn" == "localhost" ]] || [[ "$host_fqdn" == "localhost.localdomain" ]]; then
-    log "Host FQDN is localhost - skipping /etc/hosts injection"
-    return
-  fi
-  
-  log "Adding hosts entry: $host_ip -> $host_fqdn $host_short"
-  
-  # Append to existing hosts file or create new one
-  if [[ -f "$hosts_file" ]]; then
-    # Check if entry already exists
-    if sudo grep -q "$host_fqdn" "$hosts_file" 2>/dev/null; then
-      log "Hosts entry for $host_fqdn already exists"
-      return
-    fi
-    # Append entry
-    echo "$host_ip $host_fqdn $host_short" | sudo tee -a "$hosts_file" >/dev/null
-  else
-    # Create hosts file with standard entries plus our host
-    sudo tee "$hosts_file" >/dev/null <<EOF
+
+  # Add host FQDN entry only if hostname is valid (not localhost or empty)
+  if [[ -n "$host_fqdn" ]] && [[ "$host_fqdn" != "localhost" ]] && [[ "$host_fqdn" != "localhost.localdomain" ]]; then
+    log "Adding hosts entry: $host_ip -> $host_fqdn $host_short"
+
+    if [[ -f "$hosts_file" ]]; then
+      if ! sudo grep -qF -- "$host_fqdn" "$hosts_file" 2>/dev/null; then
+        echo "$host_ip $host_fqdn $host_short" | sudo tee -a "$hosts_file" >/dev/null
+      else
+        log "Hosts entry for $host_fqdn already exists"
+      fi
+    else
+      sudo tee "$hosts_file" >/dev/null <<EOF
 127.0.0.1   localhost localhost.localdomain
 ::1         localhost localhost.localdomain
 $host_ip $host_fqdn $host_short
 EOF
+    fi
+  else
+    log "Host FQDN is localhost or empty - skipping host FQDN entry"
+    # Ensure minimal hosts file exists for registry entry below
+    if [[ ! -f "$hosts_file" ]]; then
+      sudo tee "$hosts_file" >/dev/null <<EOF
+127.0.0.1   localhost localhost.localdomain
+::1         localhost localhost.localdomain
+EOF
+    fi
   fi
+
+  # Add registry hostname entry for IPv6 mode
+  if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
+    if ! sudo grep -qF -- "$REGISTRY_HOSTNAME" "$hosts_file" 2>/dev/null; then
+      log "IPv6 mode: Adding hosts entry $host_ip -> $REGISTRY_HOSTNAME"
+      echo "$host_ip $REGISTRY_HOSTNAME" | sudo tee -a "$hosts_file" >/dev/null
+    else
+      log "IPv6 mode: Registry hostname entry already exists"
+    fi
+  fi
+
   sudo chown root:root "$hosts_file"
   log "Hosts entry added successfully"
 }

--- a/test/scripts/run_e2e_tests.sh
+++ b/test/scripts/run_e2e_tests.sh
@@ -126,6 +126,12 @@ else
     fi
 fi
 
+# Export E2E_AUX_HOST for Go tests to use correct host IP (IPv6-aware)
+# This overrides GetHostIP() which otherwise dials 1.1.1.1 (IPv4-only)
+E2E_AUX_HOST="${E2E_AUX_HOST:-$(get_ext_ip)}"
+export E2E_AUX_HOST
+echo "E2E_AUX_HOST: ${E2E_AUX_HOST}"
+
 # Set PAM authentication credentials for Quadlet environments
 if [[ "${E2E_ENVIRONMENT}" == "quadlet" ]]; then
     # Default PAM admin user credentials for E2E tests

--- a/test/test.mk
+++ b/test/test.mk
@@ -148,7 +148,7 @@ deploy-e2e-extras:
 
 deploy-e2e-ocp-test-vm: VM_DISK_SIZE_INC := $(or $(VM_DISK_SIZE_INC),50)
 deploy-e2e-ocp-test-vm:
-	sudo VM_DISK_SIZE_INC=$(VM_DISK_SIZE_INC) --preserve-env=VM_DISK_SIZE_INC test/scripts/create_vm_libvirt.sh $(KUBECONFIG_PATH)
+	sudo VM_DISK_SIZE_INC=$(VM_DISK_SIZE_INC) IPV6_ONLY=$(IPV6_ONLY) --preserve-env=VM_DISK_SIZE_INC --preserve-env=IPV6_ONLY test/scripts/create_vm_libvirt.sh $(KUBECONFIG_PATH)
 
 deploy-quadlets-vm:
 	sudo --preserve-env=VM_DISK_SIZE_INC --preserve-env=USER --preserve-env=REDHAT_USER --preserve-env=REDHAT_PASSWORD --preserve-env=GIT_VERSION --preserve-env=BREW_BUILD_URL test/scripts/deploy_quadlets_rhel.sh
@@ -162,7 +162,7 @@ clean-quadlets-vm:
 	@echo "quadlets-vm cleanup completed"
 
 bin/.e2e-agent-injected: bin/output/qcow2/disk.qcow2 bin/.e2e-agent-certs
-	QCOW=bin/output/qcow2/disk.qcow2 AGENT_DIR=bin/agent/etc/flightctl test/scripts/inject_agent_files_into_qcow.sh
+	QCOW=bin/output/qcow2/disk.qcow2 AGENT_DIR=bin/agent/etc/flightctl IPV6_ONLY=${IPV6_ONLY} test/scripts/inject_agent_files_into_qcow.sh
 	touch bin/.e2e-agent-injected
 
 prepare-e2e-qcow-config: bin/.e2e-agent-injected

--- a/test/util/ip.go
+++ b/test/util/ip.go
@@ -55,6 +55,7 @@ func BinaryExistsOnPath(binaryName string) bool {
 
 // resolveIPAddressForHostname resolves the ip address associated with the hostname. Prefers ip4 addresses
 // but will return ip6 address if there are no ip4 addresses.
+// If the IPV6_ONLY environment variable is set to "true", IPv6 addresses are preferred instead.
 func resolveIPAddressForHostname(hostname string) (string, error) {
 	if ip := net.ParseIP(hostname); ip != nil {
 		return ip.String(), nil
@@ -67,6 +68,16 @@ func resolveIPAddressForHostname(hostname string) (string, error) {
 	if len(ips) == 0 {
 		return "", fmt.Errorf("hostname '%s' resolved to no IP addresses", hostname)
 	}
+
+	// In IPv6 mode, prefer IPv6 addresses
+	if os.Getenv("IPV6_ONLY") == "true" {
+		for _, ip := range ips {
+			if ip.To4() == nil && ip.To16() != nil {
+				return ip.String(), nil
+			}
+		}
+	}
+
 	for _, ip := range ips {
 		if ip.To4() != nil {
 			return ip.String(), nil


### PR DESCRIPTION
## Summary

Add IPv6-only testing support to the FlightCtl E2E test infrastructure, gated behind the `IPV6_ONLY` environment variable. All existing IPv4 behavior is preserved when the variable is unset or `false`.

## Changes

### Go test infrastructure

- Use `net.JoinHostPort()` across all auxiliary service URLs (git server, jaeger, keycloak, prometheus, registry, quadlet infra) to correctly format IPv6 addresses with brackets in `host:port` pairs
- **Registry**: in IPv6 mode, use `localhost` for host-side podman and container name (`e2e-registry`) for container-to-container DNS — raw IPv6 addresses in image names are misinterpreted as transport prefixes by container tools (e.g. `fd2e:` looks like `docker:`)
- Add `getIPTablesCommand()` helper in the test harness that resolves the target host and selects `iptables` or `ip6tables` accordingly, used by `SimulateNetworkFailure`, `RestoreNetwork`, `BlockTrafficOnVM`, and `UnblockTrafficOnVM`
- add `IPV6_ONLY` in `resolveIPAddressForHostname()` to prefer IPv6

### Shell scripts

- **`get_ext_ip.sh` / `functions`**: add `IPV6_ONLY` mode — uses IPv6 route (`2001:4860:4860::8888`) for IP detection; compute `DNS_IP` using `sslip.io` (IPv6, colons replaced with dashes) or `nip.io` (IPv4)
- **`create_vm_libvirt.sh`**: in `IPV6_ONLY` mode, get VM IP from `virsh domifaddr` IPv6 output (filtering link-local `fe80::`), select appropriate SSH target, extract wait logic into `wait_for_ssh()` function
- **`inject_agent_files_into_qcow.sh`**: in IPv6 mode, use registry hostname instead of raw IP for `REG_TLS_HOSTPORT`; inject `/etc/hosts` entry for `e2e-registry` into guest VMs; install E2E CA into both `containers/certs.d/` (for container tools) and system trust anchors with `update-ca-trust` oneshot service
- **`prepare_otel_config.sh`**: detect DNS suffix (`sslip.io` or `nip.io`) from server URL for telemetry gateway endpoint, instead of hardcoding `nip.io`
- **`functions`**: make `get_ocp_nodes_network()` IPv6-aware — detects address format and extracts appropriate subnet prefix for libvirt network matching

## Backward compatibility

All changes are gated behind `IPV6_ONLY=true`. Default behavior (IPv4) is unchanged.

## Tests done

- [ ] Run E2E suite with `IPV6_ONLY=false` (v4)/(v4v6) — verify backward compability
- [ ] Run E2E suite with `IPV6_ONLY=true` (IPv6-only cluster) — verify tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved host:port and URL construction across tooling for correct IPv6 formatting and more robust endpoint composition.

* **Tests**
  * Enhanced e2e test tooling, harnesses, and and helper scripts to support IPv6-only environments, auto-select IPv4/IPv6 packet-filtering commands, derive appropriate DNS suffixes for services, and reliably compute reachable service and SSH endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->