### PR TITLE
[EDMRFE-98] Deploy Flightctl into a single namespace (without cluster-admin permissions)

### DIFF
--- a/deploy/helm/flightctl/templates/api/flightctl-api-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-clusterrole.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   labels:
     {{- include "flightctl.standardLabels" . | nindent 4 }}
     flightctl.service: flightctl-api
   name: flightctl-api-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]

--- a/deploy/helm/flightctl/templates/api/flightctl-api-clusterrolebinding.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-clusterrolebinding.yaml
@@ -1,15 +1,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     {{- include "flightctl.standardLabels" . | nindent 4 }}
     flightctl.service: flightctl-api
   name: flightctl-api-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: flightctl-api
     namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: flightctl-api-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/flightctl/templates/flightctl-default-user-roles.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-default-user-roles.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: flightctl-admin-{{ .Release.Namespace }}
   labels:
@@ -14,7 +14,7 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: flightctl-viewer-{{ .Release.Namespace }}
   labels:
@@ -33,7 +33,7 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: flightctl-operator-{{ .Release.Namespace }}
   labels:
@@ -80,7 +80,7 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: flightctl-installer-{{ .Release.Namespace }}
   labels:

--- a/deploy/helm/flightctl/templates/flightctl-secrets-sa.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-secrets-sa.yaml
@@ -95,10 +95,11 @@ metadata:
     {{- include "flightctl.standardLabels" . | nindent 4 }}
 
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flightctl-cleanup-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -111,18 +112,19 @@ rules:
     resources:
       - secrets
       - persistentvolumeclaims
-  # Cluster-scoped RBAC resources
+
   - verbs: [get, list, delete]
     apiGroups: ['rbac.authorization.k8s.io']
     resources:
-      - clusterrolebindings
-      - clusterroles
+      - rolebindings
+      - roles
 
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flightctl-cleanup-{{ .Release.Namespace }}
+  name: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -134,5 +136,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: flightctl-cleanup-{{ .Release.Namespace }}


### PR DESCRIPTION
This is a hack job to get the Flightcontrol Helm chart running on an OpenShift / Kubernetes cluster when you only have namespace-admin permissions (as opposed to cluster-admin permissions for deploying ClusterRoles etc.).

I'm not expecting this to get merged, just sharing here for visibility in case it might be useful to others.

For reference, these are the Helm values I used in combination with this patch.

```yaml
global:
  auth:
    aap:
      apiUrl: 'https://aap.example.com'
    insecureSkipTlsVerify: true
    type: aap
  baseDomain: flightctl.example.com
  enableMulticlusterExtensions: 'false'
  enableOpenShiftExtensions: 'false'
  exposeServicesMethod: route
  generateCertificates: builtin
  imagePullPolicy: IfNotPresent
alertmanager:
  enabled: false
alertExporter:
  enabled: false
alertmanagerProxy:
  enabled: false
ui:
  auth:
    insecureSkipTlsVerify: true
db:
  builtin:
    resources:
      requests:
        cpu: 250m
        memory: 250Mi
    storage:
      size: 10Gi
```