### PR TITLE
EDM-3564: api/validation: enforce http(s) and ssh url for git repo

### DIFF
--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -696,6 +696,7 @@ func (r *Repository) Validate() []error {
 			return allErrs
 		}
 		allErrs = append(allErrs, validation.ValidateString(&gitRepoSpec.Url, "spec.url", 1, 2048, nil, "")...)
+		allErrs = append(allErrs, validateGitRepoURL(gitRepoSpec.Url)...)
 		// Validate that only one of httpConfig or sshConfig is specified
 		if gitRepoSpec.HttpConfig != nil && gitRepoSpec.SshConfig != nil {
 			allErrs = append(allErrs, fmt.Errorf("only one of httpConfig or sshConfig can be specified for a Git repository"))
@@ -719,6 +720,20 @@ func (r *Repository) ValidateUpdate(newObj *Repository) []error {
 		r.ApiVersion, newObj.ApiVersion,
 		r.Kind, newObj.Kind,
 		r.Status, newObj.Status)
+}
+
+func validateGitRepoURL(url string) []error {
+	lower := strings.ToLower(url)
+	switch {
+	case strings.HasPrefix(lower, "https://"),
+		strings.HasPrefix(lower, "http://"),
+		strings.HasPrefix(lower, "ssh://"):
+		return nil
+	case strings.Contains(url, "@") && strings.Contains(url, ":"):
+		return nil
+	default:
+		return []error{fmt.Errorf("spec.url: %q is not a valid remote Git URL; use an http(s) or SSH URL", url)}
+	}
 }
 
 func (r ResourceSync) Validate() []error {

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -2298,6 +2298,85 @@ func TestRepository_Validate_BackwardCompatibility(t *testing.T) {
 		require.NotEmpty(t, errs, "GitRepoSpec with both configs should fail validation")
 	})
 
+	t.Run("GitRepoSpec accepts ssh:// URLs", func(t *testing.T) {
+		repoSpec := RepositorySpec{}
+		err := repoSpec.FromGitRepoSpec(GitRepoSpec{
+			Url:  "ssh://git@github.com/example/repo.git",
+			Type: GitRepoSpecTypeGit,
+		})
+		require.NoError(t, err)
+
+		repo := Repository{
+			ApiVersion: "v1beta1",
+			Kind:       "Repository",
+			Metadata: ObjectMeta{
+				Name: lo.ToPtr("test-git-ssh-scheme-repo"),
+			},
+			Spec: repoSpec,
+		}
+
+		errs := repo.Validate()
+		require.Empty(t, errs, "GitRepoSpec with ssh:// URL should validate successfully")
+	})
+
+	t.Run("GitRepoSpec rejects file:// URLs", func(t *testing.T) {
+		for _, url := range []string{
+			"file:///tmp/git-repos/my-repo.git",
+			"FILE:///tmp/git-repos/my-repo.git",
+			"File:///tmp/git-repos/my-repo.git",
+		} {
+			t.Run(url, func(t *testing.T) {
+				repoSpec := RepositorySpec{}
+				err := repoSpec.FromGitRepoSpec(GitRepoSpec{
+					Url:  url,
+					Type: GitRepoSpecTypeGit,
+				})
+				require.NoError(t, err)
+
+				repo := Repository{
+					ApiVersion: "v1beta1",
+					Kind:       "Repository",
+					Metadata: ObjectMeta{
+						Name: lo.ToPtr("test-git-file-repo"),
+					},
+					Spec: repoSpec,
+				}
+
+				errs := repo.Validate()
+				require.NotEmpty(t, errs, "GitRepoSpec with %s should fail validation", url)
+			})
+		}
+	})
+
+	t.Run("GitRepoSpec rejects unsupported schemes", func(t *testing.T) {
+		for _, url := range []string{
+			"ftp://example.com/repo.git",
+			"gopher://example.com/repo",
+			"/tmp/git-repos/my-repo.git",
+		} {
+			t.Run(url, func(t *testing.T) {
+				repoSpec := RepositorySpec{}
+				err := repoSpec.FromGitRepoSpec(GitRepoSpec{
+					Url:  url,
+					Type: GitRepoSpecTypeGit,
+				})
+				require.NoError(t, err)
+
+				repo := Repository{
+					ApiVersion: "v1beta1",
+					Kind:       "Repository",
+					Metadata: ObjectMeta{
+						Name: lo.ToPtr("test-git-bad-scheme"),
+					},
+					Spec: repoSpec,
+				}
+
+				errs := repo.Validate()
+				require.NotEmpty(t, errs, "GitRepoSpec with %s should fail validation", url)
+			})
+		}
+	})
+
 	t.Run("HttpRepoSpec still works", func(t *testing.T) {
 		repoSpec := RepositorySpec{}
 		err := repoSpec.FromHttpRepoSpec(HttpRepoSpec{

--- a/internal/service/repository_test.go
+++ b/internal/service/repository_test.go
@@ -28,7 +28,7 @@ func newOciAuth(username, password string) *domain.OciAuth {
 func testRepositoryPatch(require *require.Assertions, patch domain.PatchRequest) (*domain.Repository, domain.Repository, domain.Status) {
 	spec := domain.RepositorySpec{}
 	err := spec.FromGitRepoSpec(domain.GitRepoSpec{
-		Url:  "foo",
+		Url:  "https://github.com/example/repo.git",
 		Type: domain.GitRepoSpecTypeGit,
 	})
 	require.NoError(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Git repository URL validation to reject file:// and other non-remote formats, enforcing remote HTTP(S) or SSH-style URLs.

* **Tests**
  * Added unit tests covering file-based and bare filesystem Git URLs alongside existing HTTP cases to verify validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->