### PR TITLE
EDM-1932: E2E FIPS readiness

### DIFF
--- a/test/e2e/fips/fips_suite_test.go
+++ b/test/e2e/fips/fips_suite_test.go
@@ -1,0 +1,57 @@
+package fips_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFips(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FIPS E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	auxiliary.Get(context.Background())
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+	// FIPS tests do not require a VM for cluster/repo checks; use harness without VM.
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
+
+	// FIPS tests require OpenShift with FIPS enabled (see OpenShift FIPS readiness doc section 4.1).
+	if env := infra.DetectEnvironment(); env != infra.EnvironmentOCP {
+		Skip("FIPS suite requires OpenShift (OCP) deployment with FIPS enabled; current environment: " + env)
+	}
+	if !testutil.BinaryExistsOnPath("oc") {
+		Skip("FIPS suite requires 'oc' on PATH for OpenShift cluster checks")
+	}
+})
+
+var _ = BeforeEach(func() {
+	if os.Getenv("FLIGHTCTL_NS") == "" {
+		Skip("FLIGHTCTL_NS environment variable must be set for FIPS tests")
+	}
+
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	_, err := login.LoginToAPIWithToken(harness)
+	Expect(err).ToNot(HaveOccurred(), "login to API with token")
+})
+
+var _ = AfterEach(func() {
+	harness := e2e.GetWorkerHarness()
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/e2e/fips/fips_test.go
+++ b/test/e2e/fips/fips_test.go
@@ -1,0 +1,113 @@
+// FIPS verification e2e tests based on OpenShift FIPS readiness document section 4.1
+// (Functional Tests - FIPS verification). Requires OpenShift deployment with FIPS enabled.
+
+package fips_test
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	fipsTestTimeout  = 2 * time.Minute
+	fipsTestPolling  = 2 * time.Second
+	fipsRepoBaseName = "fips-private-repo"
+)
+
+var _ = Describe("FIPS verification", Label("fips"), func() {
+
+	// 88250 - FIPS enablement checks
+	// Step: Check on OpenShift deployment that fips is enabled with
+	//   oc get cm cluster-config-v1 -n kube-system -o jsonpath='{.data.install-config}' | grep -i fips
+	// Expected: fips=true
+	It("cluster has FIPS enabled in install-config", Label("88250"), func() {
+		harness := e2e.GetWorkerHarness()
+
+		By("getting cluster install-config from cluster-config-v1")
+		out, err := harness.SH("oc", "get", "cm", "cluster-config-v1", "-n", "kube-system", "-o", "jsonpath={.data.install-config}")
+		if err != nil {
+			// ConfigMap may not exist on non-OCP or older clusters
+			GinkgoWriter.Printf("oc get cluster-config-v1 failed (cluster may not be OCP or FIPS-capable): %v\n", err)
+			Skip("cluster-config-v1 not available or oc failed: " + err.Error())
+		}
+
+		By("verifying install-config contains \"fips: true\"")
+		Expect(out).To(ContainSubstring("fips"), "install-config should mention fips")
+		Expect(strings.ToLower(out)).To(MatchRegexp("fips: *true"), "FIPS must be enabled (fips: true) for FIPS readiness")
+	})
+
+	// 88252 - FIPS private repo creation
+	// Step: Create a private repo; add repo to flightctl via UI with private key.
+	// Expected: Private repo should add all the machines and be on green (repository accessible).
+	// This test uses the API with SSH credentials (equivalent to adding via UI with private key).
+	It("private repo with SSH credentials becomes accessible", Label("88252"), func() {
+		harness := e2e.GetWorkerHarness()
+		ctx := harness.Context
+		svc := auxiliary.Get(ctx)
+		if svc == nil || svc.GitServer == nil {
+			Skip("git server not available for private repo test")
+		}
+		gs := svc.GitServer
+
+		config := e2e.GitServerConfig{
+			Host: gs.Host,
+			Port: gs.Port,
+			User: "user",
+		}
+		keyPath, err := svc.GetGitSSHPrivateKeyPath()
+		Expect(err).ToNot(HaveOccurred())
+		keyContent, err := svc.GetGitSSHPrivateKey()
+		Expect(err).ToNot(HaveOccurred())
+
+		repoName := fipsRepoBaseName + "-" + harness.GetTestIDFromContext()
+		internalHost := gs.InternalHost
+		internalPort := gs.InternalPort
+
+		By("creating a private repo on the e2e git server")
+		err = harness.CreateGitRepositoryOnServer(config, keyPath, repoName)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			_ = harness.DeleteGitRepositoryOnServer(config, keyPath, repoName)
+			_ = harness.DeleteRepository(repoName)
+		}()
+
+		By("adding the repo to flightctl with SSH credentials (private key)")
+		err = harness.CreateRepositoryWithValidE2ECredentials(internalHost, internalPort, repoName, keyContent)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("waiting for repository to become accessible (green)")
+		err = harness.WaitForRepositoryAccessible(repoName, fipsTestTimeout, fipsTestPolling)
+		Expect(err).ToNot(HaveOccurred(), "private repo with SSH key should become accessible")
+	})
+
+	// 88251 - FIPS agent enrollment
+	// Step: Create a VM with FIPS enabled (01-fips.toml with kargs = ["fips=1"],
+	//       containerfile: COPY 01-fips.toml /usr/lib/bootc/kargs.d/, dnf install crypto-policies, set FIPS).
+	//       Enroll FIPS-enabled VM.
+	// Expected: VM has FIPS enabled and enrollment request is created; VM is correctly enrolled.
+	// This test is skipped unless a FIPS-enabled agent image/VM is provided (see README).
+	It("FIPS-enabled VM can enroll", Label("88251"), func() {
+		if os.Getenv("E2E_FIPS_VM") != "1" {
+			Skip("88251 requires a FIPS-enabled VM image. Set E2E_FIPS_VM=1 and use an agent image built with FIPS (01-fips.toml, crypto-policies). See test/e2e/fips/README.md")
+		}
+		// When E2E_FIPS_VM=1, the test runner is expected to provide a FIPS-enabled VM pool or image.
+		// Here we only run enrollment flow if the harness has a VM (same as agent suite).
+		harness := e2e.GetWorkerHarness()
+		workerID := GinkgoParallelProcess()
+		err := harness.SetupVMFromPoolAndStartAgent(workerID)
+		if err != nil {
+			Skip("FIPS VM pool or agent not available: " + err.Error())
+		}
+		enrollmentID := harness.GetEnrollmentIDFromServiceLogs("flightctl-agent")
+		Expect(enrollmentID).NotTo(BeEmpty())
+		_ = harness.WaitForEnrollmentRequest(enrollmentID)
+		harness.ApproveEnrollment(enrollmentID, harness.TestEnrollmentApproval())
+		Eventually(harness.GetDeviceWithStatusSystem, fipsTestTimeout, fipsTestPolling).WithArguments(enrollmentID).ShouldNot(BeNil())
+	})
+})

--- a/test/harness/e2e/harness_repository.go
+++ b/test/harness/e2e/harness_repository.go
@@ -12,6 +12,8 @@ import (
 	"github.com/samber/lo"
 )
 
+const RemoteRepositoryEmptyMessage = "remote repository is empty"
+
 func (h *Harness) GetRepository(repositoryName string) (*v1beta1.Repository, error) {
 	response, err := h.Client.GetRepositoryWithResponse(h.Context, repositoryName)
 	if err != nil {
@@ -107,6 +109,10 @@ func (h *Harness) WaitForRepositoryAccessible(name string, timeout, polling time
 			if cond.Type == v1beta1.ConditionTypeRepositoryAccessible {
 				if cond.Status == v1beta1.ConditionStatusTrue {
 					GinkgoWriter.Printf("Repository %s is accessible\n", name)
+					return true, nil
+				}
+				if cond.Message == RemoteRepositoryEmptyMessage {
+					GinkgoWriter.Printf("Repository %s is accessible but empty\n", name)
 					return true, nil
 				}
 				GinkgoWriter.Printf("Repository %s Accessible condition: status=%s reason=%s message=%s\n",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end FIPS test suite for OpenShift environments; suite auto-skips unless the cluster and CLI tool are available.
  * Validates cluster FIPS configuration, registers and cleans up a private repo via SSH, and treats an empty remote repository as accessible.
  * Includes an optional VM-based enrollment scenario (enabled via env) to verify device enrollment and system status.
  * Ensures per-test setup, authentication, and thorough resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->