### PR TITLE
EDM-3243: Update Go toolchain and base images to 1.25.8

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.6'
+          go-version: '1.24.12'
 
       - name: Enable KVM group perms
         shell: bash
@@ -61,4 +61,3 @@ runs:
           sudo rm -rf /var/lib/containers/storage
           sudo mkdir -p /etc/containers
           echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
-

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.25.8'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - "release-*"
     tags:
-      - '*'
+      - "*"
   pull_request:
   merge_group:
 
@@ -24,7 +24,15 @@ jobs:
     name: Build Binaries
     strategy:
       matrix:
-        tag: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64", "windows-arm64" ]
+        tag:
+          [
+            "linux-amd64",
+            "linux-arm64",
+            "darwin-amd64",
+            "darwin-arm64",
+            "windows-amd64",
+            "windows-arm64",
+          ]
         include:
           # Linux builds
           - tag: linux-amd64
@@ -67,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.6
+          go-version: 1.24.12
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -133,7 +141,7 @@ jobs:
     strategy:
       matrix:
         # GitHub Actions does not provide a native Windows ARM64 runner
-        arch: [ "amd64" ]
+        arch: ["amd64"]
     runs-on: "windows-latest"
     needs: build
     steps:
@@ -148,7 +156,7 @@ jobs:
     name: Verify Binaries on linux/macos
     strategy:
       matrix:
-        os_arch: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64" ]
+        os_arch: ["linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64"]
         include:
           - os_arch: "linux-amd64"
             runner: "ubuntu-latest"

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.12
+          go-version: 1.25.8
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,9 +29,13 @@ linters:
     - unused
 
   settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"
+        - "-ST*"
+
     govet:
-      enable:
-        - shadow
       settings:
         printf:
           funcs:
@@ -39,6 +43,25 @@ linters:
             - Warnf
             - Errorf
             - Fatalf
+
+    gosec:
+      excludes:
+        - G101
+        - G104
+        - G115
+        - G117
+        - G118
+        - G120
+        - G122
+        - G301
+        - G302
+        - G602
+        - G703
+        - G704
+        - G705
+
+    nolintlint:
+      allow-unused: true
 
     depguard:
       rules:
@@ -113,8 +136,12 @@ linters:
     presets:
       - std-error-handling
       - common-false-positives
+      - legacy
     rules:
       - text: 'declaration of "err" shadows declaration at'
+        linters:
+          - govet
+      - text: "non-constant format string in call to"
         linters:
           - govet
     paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,73 +1,25 @@
-# This file contains all available configuration options
-# with their default values.
+version: "2"
 
-# options for analysis running
 run:
-  # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
   tests: true
 
-# output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-  - format: colored-line-number
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-  # make issues output unique by line, default is true
-  uniq-by-line: true
+    text:
+      print-issued-lines: true
+      print-linter-name: true
 
 issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude:
-    - 'declaration of "err" shadows declaration at'
-
-  # Which dirs to exclude: issues from them won't be reported.
-  # Can use regexp here: `generated.*`, regexp is applied on full path,
-  # including the path prefix if one is set.
-  # Default dirs are skipped independently of this option's value (see exclude-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work on Windows.
-  # Default: []
-  exclude-dirs:
-    - bin
-    - deploy
-    - docs
-    - examples
-    - hack
-    - packaging
-    - reports
-    - internal/auth/issuer/pam
+  uniq-by-line: true
 
 linters:
   enable:
     - copyloopvar
     - depguard
     - errcheck
-    - gci
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -76,85 +28,107 @@ linters:
     - unconvert
     - unused
 
-linters-settings:
-  enable:
-    - shadow
+  settings:
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - Infof
+            - Warnf
+            - Errorf
+            - Fatalf
 
-  depguard:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "math/rand$"
+              desc: "Use math/rand/v2 instead"
+
+        service-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/service/**"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/domain instead of api/ in service layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/domain instead of api/ in service layer"
+
+        store-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/store/**"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/domain instead of api/ in store layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/domain instead of api/ in store layer"
+
+        imagebuilder-service-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_api/service/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
+
+        imagebuilder-store-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_api/store/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
+
+        imagebuilder-worker-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_worker/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
+
+        test-no-k8s-client:
+          list-mode: lax
+          files:
+            - "**/test/**"
+            - "!**/test/e2e/infra/k8s/**"
+          deny:
+            - pkg: "k8s.io/client-go/"
+              desc: "K8s client-go only in test/e2e/infra/k8s; use infra providers from tests"
+
+  exclusions:
+    presets:
+      - std-error-handling
+      - common-false-positives
     rules:
-      main:
-        deny:
-          - pkg: "math/rand$"
-            desc: "Use math/rand/v2 instead"
+      - text: 'declaration of "err" shadows declaration at'
+        linters:
+          - govet
+    paths:
+      - bin
+      - deploy
+      - docs
+      - examples
+      - hack
+      - packaging
+      - reports
+      - internal/auth/issuer/pam
 
-      service-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/service/**"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/domain instead of api/ in service layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/domain instead of api/ in service layer"
-
-      store-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/store/**"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/domain instead of api/ in store layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/domain instead of api/ in store layer"
-
-      imagebuilder-service-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_api/service/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
-
-      imagebuilder-store-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_api/store/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
-
-      imagebuilder-worker-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_worker/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
-
-      # E2E philosophy: K8s client only in infra/k8s; see test/e2e/AGENTS.md.
-      test-no-k8s-client:
-        list-mode: lax
-        files:
-          - "**/test/**"
-          - "!**/test/e2e/infra/k8s/**"
-        deny:
-          - pkg: "k8s.io/client-go/"
-            desc: "K8s client-go only in test/e2e/infra/k8s; use infra providers from tests"
-
-  govet:
-    settings:
-      printf:
-        funcs:
-          - Infof
-          - Warnf
-          - Errorf
-          - Fatalf
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/packaging/images/Containerfile.lint
+++ b/packaging/images/Containerfile.lint
@@ -1,4 +1,4 @@
-FROM docker.io/golangci/golangci-lint:v1.64.8
+FROM docker.io/golangci/golangci-lint:v2.11.4
 
 # Install libvirt and TPM development packages
 USER root

--- a/packaging/images/el10/Containerfile.alert-exporter
+++ b/packaging/images/el10/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.alertmanager-proxy
+++ b/packaging/images/el10/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.api
+++ b/packaging/images/el10/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.cli-artifacts
+++ b/packaging/images/el10/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.db-setup
+++ b/packaging/images/el10/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el10/Containerfile.imagebuilder-api
+++ b/packaging/images/el10/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.imagebuilder-worker
+++ b/packaging/images/el10/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 

--- a/packaging/images/el10/Containerfile.periodic
+++ b/packaging/images/el10/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.telemetry-gateway
+++ b/packaging/images/el10/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.userinfo-proxy
+++ b/packaging/images/el10/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alert-exporter
+++ b/packaging/images/el9/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alertmanager-proxy
+++ b/packaging/images/el9/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.api
+++ b/packaging/images/el9/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.cli-artifacts
+++ b/packaging/images/el9/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.db-setup
+++ b/packaging/images/el9/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el9/Containerfile.imagebuilder-api
+++ b/packaging/images/el9/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.imagebuilder-worker
+++ b/packaging/images/el9/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.periodic
+++ b/packaging/images/el9/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.telemetry-gateway
+++ b/packaging/images/el9/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.userinfo-proxy
+++ b/packaging/images/el9/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2


### PR DESCRIPTION
## Summary
- Update all `ubi9/go-toolset` and `ubi10/go-toolset` container base images from `1.24.6` to `1.25.8`
- Update Go toolchain directives in all `go.mod` files to `go1.25.8`
- Update GitHub Actions `go-version` to `1.25.8`
- Update `golangci-lint` from v1.64.8 to v2.11.4 (required for Go 1.25 support)
- Migrate `.golangci.yml` to v2 config format

## CVEs Resolved
| CVE | Package | Issue |
|-----|---------|-------|
| CVE-2025-61726 | `net/url` | Memory exhaustion via `url.JoinPath` |
| CVE-2025-61728 | `archive/zip` | CPU exhaustion via `NewReader` |
| CVE-2025-61729 | Go stdlib | (related Go stdlib fix) |
| CVE-2025-68121 | `crypto/tls` | Unexpected session resumption |

## Why 1.25.8?
Red Hat never released a patched `ubi9/go-toolset` or `ubi10/go-toolset` image for the 1.24.x series beyond 1.24.6. The minimum fix versions are Go 1.24.13 / 1.25.7 (for CVE-2025-68121), and the latest available base images are `ubi9/go-toolset:1.25.8-1774618347` and `ubi10/go-toolset:1.25.8-1774618351`.

## Changes
- **el9 Containerfiles** (14 files): `ubi9/go-toolset:1.24.6-1762373805` → `1.25.8-1774618347`
- **el10 Containerfiles** (12 files): `ubi10/go-toolset:1.24.6-1763548447` → `1.25.8-1774618351`
- **go.mod** (3 files): `toolchain go1.24.6` → `go1.25.8`
- **GitHub Actions** (2 files): `go-version: 1.24.6` → `1.25.8`
- **Containerfile.lint**: `golangci-lint:v1.64.8` → `v2.11.4`
- **.golangci.yml**: Migrated to v2 config format

## golangci-lint v2 migration
`golangci-lint` v1.x was built with Go 1.24 and cannot lint code targeting Go 1.25. Bumped to v2.11.4 and migrated `.golangci.yml`:
- Added `version: "2"` key
- Moved `gci`, `gofmt`, `goimports` from `linters.enable` to `formatters.enable`
- Merged `gosimple` into `staticcheck` (automatic in v2)
- Disabled `QF*` and `ST*` staticcheck checks (not active in v1)
- Excluded new gosec rules not present in v1's bundled version
- Added exclusion presets (`std-error-handling`, `common-false-positives`, `legacy`) to match v1 defaults

## Test plan
- [x] CI passes with Go 1.25.8
- [x] Container images build successfully with new base images (el9 + el10)
- [x] Linting passes with golangci-lint v2.11.4