### PR TITLE
EDM-1042: Mount secret content instead of injecting it via env variables

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -358,38 +358,20 @@ Parameters:
   - name: DB_NAME
     value: "{{ $context.Values.db.name }}"
   {{- if eq $userType "app" }}
-  - name: DB_USER
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "flightctl.dbAppUserSecret" $context }}
-        key: user
-  - name: DB_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "flightctl.dbAppUserSecret" $context }}
-        key: userPassword
+  - name: DB_USER_FILE
+    value: /run/secrets/db/user
+  - name: DB_PASSWORD_FILE
+    value: /run/secrets/db/userPassword
   {{- else if eq $userType "migration" }}
-  - name: DB_USER
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "flightctl.dbMigrationUserSecret" $context }}
-        key: migrationUser
-  - name: DB_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "flightctl.dbMigrationUserSecret" $context }}
-        key: migrationPassword
+  - name: DB_USER_FILE
+    value: /run/secrets/db-migration/migrationUser
+  - name: DB_PASSWORD_FILE
+    value: /run/secrets/db-migration/migrationPassword
   {{- else if eq $userType "admin" }}
-  - name: DB_USER
-    valueFrom:
-      secretKeyRef:
-        name: {{ default "flightctl-db-admin-secret" $context.Values.db.builtin.masterUserSecretName }}
-        key: masterUser
-  - name: DB_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: {{ default "flightctl-db-admin-secret" $context.Values.db.builtin.masterUserSecretName }}
-        key: masterPassword
+  - name: DB_USER_FILE
+    value: /run/secrets/db-admin/masterUser
+  - name: DB_PASSWORD_FILE
+    value: /run/secrets/db-admin/masterPassword
   {{- else }}
   {{- fail (printf "Invalid userType '%s'. Must be one of: app, migration, admin" $userType) }}
   {{- end }}
@@ -410,6 +392,13 @@ Parameters:
   {{- end }}
   {{- end }}
   volumeMounts:
+  {{- if eq $userType "app" }}
+  {{- include "flightctl.dbAppSecretVolumeMount" $context | nindent 2 }}
+  {{- else if eq $userType "migration" }}
+  {{- include "flightctl.dbMigrationSecretVolumeMount" $context | nindent 2 }}
+  {{- else if eq $userType "admin" }}
+  {{- include "flightctl.dbAdminSecretVolumeMount" $context | nindent 2 }}
+  {{- end }}
   {{- include "flightctl.dbSslVolumeMounts" $context | nindent 2 }}
 {{- end }}
 
@@ -527,6 +516,63 @@ Usage: {{- include "flightctl.dbSslVolumes" . | nindent X }}
           mode: 0400
     {{- end }}
 {{- end }}
+{{- end }}
+
+{{- /*
+Secret volume helpers – mount credentials as files instead of env vars.
+Mount paths:
+  KV password:      /run/secrets/kv/password
+  DB app user:      /run/secrets/db/user, /run/secrets/db/userPassword
+  DB admin:         /run/secrets/db-admin/masterUser, /run/secrets/db-admin/masterPassword
+  DB migration:     /run/secrets/db-migration/migrationUser, /run/secrets/db-migration/migrationPassword
+*/}}
+
+{{- define "flightctl.kvSecretVolume" -}}
+- name: kv-secret
+  secret:
+    secretName: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
+{{- end }}
+
+{{- define "flightctl.kvSecretVolumeMount" -}}
+- name: kv-secret
+  mountPath: /run/secrets/kv
+  readOnly: true
+{{- end }}
+
+{{- define "flightctl.dbAppSecretVolume" -}}
+- name: db-app-secret
+  secret:
+    secretName: {{ include "flightctl.dbAppUserSecret" . }}
+{{- end }}
+
+{{- define "flightctl.dbAppSecretVolumeMount" -}}
+- name: db-app-secret
+  mountPath: /run/secrets/db
+  readOnly: true
+{{- end }}
+
+{{- define "flightctl.dbAdminSecretVolume" -}}
+- name: db-admin-secret
+  secret:
+    secretName: {{ default "flightctl-db-admin-secret" .Values.db.builtin.masterUserSecretName }}
+{{- end }}
+
+{{- define "flightctl.dbAdminSecretVolumeMount" -}}
+- name: db-admin-secret
+  mountPath: /run/secrets/db-admin
+  readOnly: true
+{{- end }}
+
+{{- define "flightctl.dbMigrationSecretVolume" -}}
+- name: db-migration-secret
+  secret:
+    secretName: {{ include "flightctl.dbMigrationUserSecret" . }}
+{{- end }}
+
+{{- define "flightctl.dbMigrationSecretVolumeMount" -}}
+- name: db-migration-secret
+  mountPath: /run/secrets/db-migration
+  readOnly: true
 {{- end }}
 
 {{- define "flightctl.dbAppUserSecret" -}}

--- a/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-deployment.yaml
+++ b/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-deployment.yaml
@@ -40,21 +40,6 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
             {{- if eq .Values.db.type "external" }}
             {{- if .Values.db.external.sslmode }}
             - name: DB_SSL_MODE
@@ -78,6 +63,8 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl
               name: flightctl-alert-exporter-config
               readOnly: true
@@ -100,6 +87,8 @@ spec:
 
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-alert-exporter-config
           configMap:
             name: flightctl-alert-exporter-config

--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-deployment.yaml
@@ -56,17 +56,8 @@ spec:
               value: "/root"
             - name: ALERTMANAGER_URL
               value: "http://flightctl-alertmanager.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local:9093"
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
           volumeMounts:
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /app/certs
               name: flightctl-alertmanager-proxy-certs
             - mountPath: /root/.flightctl/config.yaml
@@ -122,6 +113,7 @@ spec:
 
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-alertmanager-proxy-certs
           secret:
             secretName: flightctl-alertmanager-proxy-certs

--- a/deploy/helm/flightctl/templates/api/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-deployment.yaml
@@ -34,21 +34,6 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
             {{- if .Values.api.env }}
             {{- range $key, $value := .Values.api.env }}
             - name: {{ $key }}
@@ -89,6 +74,8 @@ spec:
             failureThreshold: 10
             successThreshold: 1
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-api-config
               subPath: config.yaml
@@ -127,6 +114,8 @@ spec:
 
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-api-config
           configMap:
             name: flightctl-api-config

--- a/deploy/helm/flightctl/templates/db/_db-migration-job.tpl
+++ b/deploy/helm/flightctl/templates/db/_db-migration-job.tpl
@@ -63,38 +63,6 @@ spec:
           value: "{{ include "flightctl.dbPort" $ctx }}"
         - name: DB_NAME
           value: "{{ $ctx.Values.db.name }}"
-        {{- if eq $ctx.Values.db.type "builtin" }}
-        - name: DB_ADMIN_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ default "flightctl-db-admin-secret" $ctx.Values.db.builtin.masterUserSecretName }}
-              key: masterUser
-        - name: DB_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ default "flightctl-db-admin-secret" $ctx.Values.db.builtin.masterUserSecretName }}
-              key: masterPassword
-        {{- end }}
-        - name: DB_MIGRATION_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationUser
-        - name: DB_MIGRATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationPassword
-        - name: DB_APP_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" $ctx }}
-              key: user
-        - name: DB_APP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" $ctx }}
-              key: userPassword
         command:
         - /bin/bash
         - -c
@@ -103,21 +71,13 @@ spec:
 
           echo "Database is ready. Setting up users..."
 
-          # Create temporary SQL file with environment variable substitution
-          export DB_HOST DB_PORT DB_NAME DB_ADMIN_USER DB_ADMIN_PASSWORD
-          export DB_MIGRATION_USER DB_MIGRATION_PASSWORD DB_APP_USER DB_APP_PASSWORD
-
-          SQL_FILE="/tmp/setup_database_users.sql"
-          envsubst < ./deploy/scripts/setup_database_users.sql > "$SQL_FILE"
-
-          # Execute the SQL file
-          echo "Running database user setup SQL..."
-          PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" -f "$SQL_FILE"
-
-          # Clean up temporary file
-          rm -f "$SQL_FILE"
+          ./deploy/scripts/setup_database_users.sh --direct
 
           echo "Database users setup completed successfully!"
+        volumeMounts:
+        {{- include "flightctl.dbAdminSecretVolumeMount" $ctx | nindent 8 }}
+        {{- include "flightctl.dbMigrationSecretVolumeMount" $ctx | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolumeMount" $ctx | nindent 8 }}
       {{- end }}
       {{- end }}
       containers:
@@ -127,48 +87,6 @@ spec:
         env:
         - name: HOME
           value: "/root"
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationUser
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationPassword
-        - name: DB_MIGRATION_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationUser
-        - name: DB_MIGRATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbMigrationUserSecret" $ctx }}
-              key: migrationPassword
-        - name: DB_APP_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" $ctx }}
-              key: user
-        - name: DB_APP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" $ctx }}
-              key: userPassword
-        {{- if eq $ctx.Values.db.type "builtin" }}
-        - name: DB_ADMIN_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ default "flightctl-db-admin-secret" $ctx.Values.db.builtin.masterUserSecretName }}
-              key: masterUser
-        - name: DB_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ default "flightctl-db-admin-secret" $ctx.Values.db.builtin.masterUserSecretName }}
-              key: masterPassword
-        {{- end }}
         {{- if eq $ctx.Values.db.type "external" }}
         {{- if $ctx.Values.db.external.sslmode }}
         - name: PGSSLMODE
@@ -190,42 +108,53 @@ spec:
         - -c
         - |
           set -eo pipefail
+
           echo "Running database migrations..."
 
           # Copy config file to a writable location
           mkdir -p /tmp/.flightctl
           cp /root/.flightctl/config.yaml /tmp/.flightctl/config.yaml
-          export HOME=/tmp
-
-          /usr/local/bin/flightctl-db-migrate{{ if $isDryRun }} --dry-run{{ end }}
+          HOME=/tmp \
+            /usr/local/bin/flightctl-db-migrate{{ if $isDryRun }} --dry-run{{ end }}
           echo "Migrations completed successfully!"
 
           {{- if not $isDryRun }}
-          # Grant permissions on all existing tables to the application user
           echo "Granting permissions on existing tables to application user..."
           {{- if eq $ctx.Values.db.type "external" }}
-            export PGPASSWORD="$DB_MIGRATION_PASSWORD"
-            psql -v ON_ERROR_STOP=1 -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_MIGRATION_USER" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" -c "GRANT USAGE ON SCHEMA public TO \"${DB_APP_USER}\";"
-            psql -v ON_ERROR_STOP=1 -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_MIGRATION_USER" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"${DB_APP_USER}\";"
-            psql -v ON_ERROR_STOP=1 -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_MIGRATION_USER" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"${DB_APP_USER}\";"
-            # Optional but recommended: ensure future objects carry privileges
-            psql -v ON_ERROR_STOP=1 -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_MIGRATION_USER" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"${DB_APP_USER}\";"
-            psql -v ON_ERROR_STOP=1 -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_MIGRATION_USER" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO \"${DB_APP_USER}\";"
+            APP_USER="$(cat /run/secrets/db/user)"
+            PGPASSWORD="$(cat /run/secrets/db-migration/migrationPassword)" \
+              psql -v ON_ERROR_STOP=1 -v app_user="$APP_USER" \
+              -h {{ $ctx.Values.db.external.hostname }} -p {{ include "flightctl.dbPort" $ctx | int }} \
+              -U "$(cat /run/secrets/db-migration/migrationUser)" -d "{{ (default "flightctl" $ctx.Values.db.name) }}" \
+              -c 'GRANT USAGE ON SCHEMA public TO :"app_user";' \
+              -c 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO :"app_user";' \
+              -c 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO :"app_user";' \
+              -c 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO :"app_user";' \
+              -c 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO :"app_user";'
           {{- else -}}
-            # Need to get admin credentials from init container environment
-            DB_HOST="{{ include "flightctl.dbHostname" $ctx }}"
-            # Get admin credentials from the same secrets used by init container
-            export PGPASSWORD="$DB_ADMIN_PASSWORD"
-            psql -h "$DB_HOST" -p {{ include "flightctl.dbPort" $ctx | int }} -U "$DB_ADMIN_USER" -d "{{ $ctx.Values.db.name }}" -c "SELECT grant_app_permissions_on_existing_tables();"
+            PGPASSWORD="$(cat /run/secrets/db-admin/masterPassword)" \
+              psql -h "{{ include "flightctl.dbHostname" $ctx }}" -p {{ include "flightctl.dbPort" $ctx | int }} \
+              -U "$(cat /run/secrets/db-admin/masterUser)" -d "{{ $ctx.Values.db.name }}" \
+              -c "SELECT grant_app_permissions_on_existing_tables();"
           {{- end }}
           echo "Permission granting completed successfully!"
           {{- end }}
         volumeMounts:
+        {{- include "flightctl.dbMigrationSecretVolumeMount" $ctx | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolumeMount" $ctx | nindent 8 }}
+        {{- if eq $ctx.Values.db.type "builtin" }}
+        {{- include "flightctl.dbAdminSecretVolumeMount" $ctx | nindent 8 }}
+        {{- end }}
         - mountPath: /root/.flightctl/
           name: flightctl-db-migration-config
           readOnly: true
         {{- include "flightctl.dbSslVolumeMounts" $ctx | nindent 8 }}
       volumes:
+      {{- include "flightctl.dbMigrationSecretVolume" $ctx | nindent 6 }}
+      {{- include "flightctl.dbAppSecretVolume" $ctx | nindent 6 }}
+      {{- if eq $ctx.Values.db.type "builtin" }}
+      {{- include "flightctl.dbAdminSecretVolume" $ctx | nindent 6 }}
+      {{- end }}
       - name: flightctl-db-migration-config
         configMap:
           name: flightctl-db-migration-config

--- a/deploy/helm/flightctl/templates/db/flightctl-db-deployment.yaml
+++ b/deploy/helm/flightctl/templates/db/flightctl-db-deployment.yaml
@@ -32,35 +32,27 @@ spec:
         - env:
             - name: POSTGRESQL_DATABASE
               value: {{ required "Values.db.name is required" $.Values.db.name }}
-            - name: POSTGRESQL_MASTER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-db-admin-secret" .Values.db.builtin.masterUserSecretName }}
-                  key: masterPassword
-            - name: POSTGRESQL_MASTER_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-db-admin-secret" .Values.db.builtin.masterUserSecretName }}
-                  key: masterUser
-            - name: POSTGRESQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: POSTGRESQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
             - name: POSTGRESQL_MAX_CONNECTIONS
               value: {{ .Values.db.builtin.maxConnections | quote }}
           image: {{ .Values.db.builtin.image.image }}:{{ .Values.db.builtin.image.tag }}
           imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.db.builtin.image.pullPolicy }}
           name: flightctl-db
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              POSTGRESQL_MASTER_USER="$(cat /run/secrets/db-admin/masterUser)" \
+              POSTGRESQL_MASTER_PASSWORD="$(cat /run/secrets/db-admin/masterPassword)" \
+              POSTGRESQL_USER="$(cat /run/secrets/db/user)" \
+              POSTGRESQL_PASSWORD="$(cat /run/secrets/db/userPassword)" \
+              exec run-postgresql
           ports:
             - containerPort: 5432
               protocol: TCP
           volumeMounts:
+            {{- include "flightctl.dbAdminSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /var/lib/pgsql/data
               name: flightctl-db
             - mountPath: /usr/share/container-scripts/postgresql/start/enable-superuser.sh
@@ -72,6 +64,8 @@ spec:
               memory: {{ .Values.db.builtin.resources.requests.memory}}
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.dbAdminSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-db
           persistentVolumeClaim:
             claimName: flightctl-db

--- a/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-deployment.yaml
@@ -39,22 +39,9 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-imagebuilder-api-config
               subPath: config.yaml
@@ -88,6 +75,8 @@ spec:
             periodSeconds: 10
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-imagebuilder-api-config
           configMap:
             name: flightctl-imagebuilder-api-config

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
@@ -35,22 +35,9 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-imagebuilder-worker-config
               subPath: config.yaml
@@ -128,6 +115,8 @@ spec:
 
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-imagebuilder-worker-config
           configMap:
             name: flightctl-imagebuilder-worker-config

--- a/deploy/helm/flightctl/templates/kv/flightctl-kv-deployment.yaml
+++ b/deploy/helm/flightctl/templates/kv/flightctl-kv-deployment.yaml
@@ -61,21 +61,20 @@ spec:
           ports:
             - name: kv
               containerPort: 6379
-          env:
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
           command:
-            - "redis-server"
-            - "/etc/redis/redis.conf"
-            - "--requirepass"
-            - "$(REDIS_PASSWORD)"
+            - /bin/sh
+            - -c
+            - |
+              printf 'requirepass ' > /run/redis/auth.conf
+              cat /run/secrets/kv/password >> /run/redis/auth.conf
+              exec redis-server /etc/redis/redis.conf --include /run/redis/auth.conf
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
             - name: flightctl-kv-config
               mountPath: /etc/redis/redis.conf
               subPath: redis.conf
+            - name: kv-runtime
+              mountPath: /run/redis
           resources:
             requests:
               cpu: "1000m"
@@ -87,7 +86,12 @@ spec:
             tcpSocket: { port: 6379 }
             periodSeconds: 10
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
         - name: flightctl-kv-config
           configMap:
             name: flightctl-kv-config
             defaultMode: 0644
+        - name: kv-runtime
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi

--- a/deploy/helm/flightctl/templates/periodic/flightctl-periodic-deployment.yaml
+++ b/deploy/helm/flightctl/templates/periodic/flightctl-periodic-deployment.yaml
@@ -34,21 +34,6 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
             {{- if .Values.periodic.env }}
             {{- range $key, $value := .Values.periodic.env }}
             - name: {{ $key }}
@@ -56,6 +41,8 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-periodic-config
               subPath: config.yaml
@@ -67,6 +54,8 @@ spec:
 
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-periodic-config
           configMap:
             name: flightctl-periodic-config

--- a/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
+++ b/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
@@ -24,21 +24,6 @@ spec:
       - env:
         - name: HOME
           value: "/root"
-        - name: KV_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-              key: password
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" . }}
-              key: userPassword
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "flightctl.dbAppUserSecret" . }}
-              key: user
         image: "{{ include "flightctl.ensureOsQualifiedImage" .Values.telemetryGateway.image.image }}:{{ default .Chart.AppVersion .Values.telemetryGateway.image.tag }}"
         imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.telemetryGateway.image.pullPolicy }}
         name: telemetry-gateway
@@ -57,6 +42,8 @@ spec:
             cpu: "500m"
             memory: "512Mi"
         volumeMounts:
+        {{- include "flightctl.kvSecretVolumeMount" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 8 }}
         - mountPath: /root/.flightctl/config.yaml
           name: flightctl-telemetry-gateway-config
           readOnly: true
@@ -76,6 +63,8 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
+      {{- include "flightctl.kvSecretVolume" . | nindent 6 }}
+      {{- include "flightctl.dbAppSecretVolume" . | nindent 6 }}
       - configMap:
           name: flightctl-telemetry-gateway-config
         name: flightctl-telemetry-gateway-config

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-deployment.yaml
@@ -38,21 +38,6 @@ spec:
           env:
             - name: HOME
               value: "/root"
-            - name: KV_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ default "flightctl-kv-secret" .Values.kv.passwordSecretName }}
-                  key: password
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: userPassword
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flightctl.dbAppUserSecret" . }}
-                  key: user
             {{- if .Values.worker.env }}
             {{- range $key, $value := .Values.worker.env }}
             - name: {{ $key }}
@@ -60,6 +45,8 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
+            {{- include "flightctl.kvSecretVolumeMount" . | nindent 12 }}
+            {{- include "flightctl.dbAppSecretVolumeMount" . | nindent 12 }}
             - mountPath: /root/.flightctl/config.yaml
               name: flightctl-worker-config
               subPath: config.yaml
@@ -70,6 +57,8 @@ spec:
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
       restartPolicy: Always
       volumes:
+        {{- include "flightctl.kvSecretVolume" . | nindent 8 }}
+        {{- include "flightctl.dbAppSecretVolume" . | nindent 8 }}
         - name: flightctl-worker-config
           configMap:
             name: flightctl-worker-config

--- a/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
+++ b/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Environment=HOME=/root
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/etc/flightctl/flightctl-alert-exporter/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 EnvironmentFile=/etc/flightctl/flightctl-api/env
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 
 PublishPort=3443:3443
 PublishPort=7443:7443

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-migrate.container
@@ -10,9 +10,8 @@ Image={{ .DbSetup.Image }}:{{ .DbSetup.Tag }}
 Network=flightctl.network
 AddHost=%H:host-gateway
 AutoUpdate=none
-Environment=DB_MIGRATION_USER=flightctl_migrator
-Secret=flightctl-postgresql-migrator-password,type=env,target=DB_PASSWORD
-Secret=flightctl-postgresql-migrator-password,type=env,target=DB_MIGRATION_PASSWORD
+Secret=flightctl-postgresql-migrator-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-postgresql-migrator-password,type=mount,target=/run/secrets/db-migration/migrationPassword
 Volume=/etc/flightctl/flightctl-db-migrate/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Exec=/usr/local/bin/flightctl-db-migrate

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-users-init.container
@@ -17,16 +17,11 @@ Environment=DB_APP_USER=flightctl_app
 Environment=DB_MIGRATION_USER=flightctl_migrator
 Environment=DB_ADMIN_USER=admin
 
-Secret=flightctl-postgresql-master-password,type=env,target=DB_ADMIN_PASSWORD
-Secret=flightctl-postgresql-migrator-password,type=env,target=DB_MIGRATION_PASSWORD
-Secret=flightctl-postgresql-user-password,type=env,target=DB_APP_PASSWORD
+Secret=flightctl-postgresql-master-password,type=mount,target=/run/secrets/db-admin/masterPassword
+Secret=flightctl-postgresql-migrator-password,type=mount,target=/run/secrets/db-migration/migrationPassword
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
 
-Exec=/bin/bash -c 'set -euo pipefail; export DB_HOST DB_PORT DB_NAME DB_ADMIN_USER DB_ADMIN_PASSWORD \
-  DB_MIGRATION_USER DB_MIGRATION_PASSWORD DB_APP_USER DB_APP_PASSWORD && \
-  SQL_FILE=/tmp/setup_database_users.sql && \
-  envsubst < /app/deploy/scripts/setup_database_users.sql > "$SQL_FILE" && \
-  PGPASSWORD="$DB_ADMIN_PASSWORD" psql -v ON_ERROR_STOP=1 \
-    -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" -f "$SQL_FILE"'
+Exec=./deploy/scripts/setup_database_users.sh --direct
 
 [Service]
 Type=oneshot

--- a/deploy/podman/flightctl-db-migrate/flightctl-db-wait.container
+++ b/deploy/podman/flightctl-db-migrate/flightctl-db-wait.container
@@ -11,7 +11,7 @@ Network=flightctl.network
 AutoUpdate=none
 Environment=DB_USER=flightctl_app
 Environment=SERVICE_CONFIG_PATH=/etc/flightctl/config.yaml
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
 Volume=/etc/flightctl/flightctl-db-migrate/config.yaml:/etc/flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Exec=/app/deploy/scripts/wait-for-database.sh --timeout=60 --sleep=1

--- a/deploy/podman/flightctl-db/flightctl-db-standalone.container
+++ b/deploy/podman/flightctl-db/flightctl-db-standalone.container
@@ -8,12 +8,15 @@ Image=quay.io/sclorg/postgresql-16-c9s:20250214
 Pull=missing
 PublishPort=5432:5432
 Volume=flightctl-db:/var/lib/pgsql/data:Z
-Secret=flightctl-postgresql-password,type=env,target=PGPASSWORD
-Secret=flightctl-postgresql-master-password,type=env,target=POSTGRESQL_MASTER_PASSWORD
-Secret=flightctl-postgresql-user-password,type=env,target=POSTGRESQL_PASSWORD
-# Note: Migrator password removed to prevent credential leakage - migrator user creation
-# is now handled by the migration service which has its own credentials
+Secret=flightctl-postgresql-password,type=mount,target=/run/secrets/db-admin/pgpassword
+Secret=flightctl-postgresql-master-password,type=mount,target=/run/secrets/db-admin/masterPassword
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
 Volume=/usr/share/flightctl/flightctl-db/enable-superuser.sh:/usr/share/container-scripts/postgresql/start/enable-superuser.sh
+Exec=/bin/sh -ec '\
+  PGPASSWORD="$$(cat /run/secrets/db-admin/pgpassword)" \
+  POSTGRESQL_MASTER_PASSWORD="$$(cat /run/secrets/db-admin/masterPassword)" \
+  POSTGRESQL_PASSWORD="$$(cat /run/secrets/db/userPassword)" \
+  exec run-postgresql'
 
 [Service]
 Restart=always

--- a/deploy/podman/flightctl-db/flightctl-db.container
+++ b/deploy/podman/flightctl-db/flightctl-db.container
@@ -11,10 +11,15 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Volume=flightctl-db:/var/lib/pgsql/data:Z
-Secret=flightctl-postgresql-password,type=env,target=PGPASSWORD
-Secret=flightctl-postgresql-master-password,type=env,target=POSTGRESQL_MASTER_PASSWORD
-Secret=flightctl-postgresql-user-password,type=env,target=POSTGRESQL_PASSWORD
+Secret=flightctl-postgresql-password,type=mount,target=/run/secrets/db-admin/pgpassword
+Secret=flightctl-postgresql-master-password,type=mount,target=/run/secrets/db-admin/masterPassword
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
 Volume=/usr/share/flightctl/flightctl-db/enable-superuser.sh:/usr/share/container-scripts/postgresql/start/enable-superuser.sh
+Exec=/bin/sh -ec '\
+  PGPASSWORD="$$(cat /run/secrets/db-admin/pgpassword)" \
+  POSTGRESQL_MASTER_PASSWORD="$$(cat /run/secrets/db-admin/masterPassword)" \
+  POSTGRESQL_PASSWORD="$$(cat /run/secrets/db/userPassword)" \
+  exec run-postgresql'
 
 [Service]
 ExecStartPre=/usr/share/flightctl/init_db.sh

--- a/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
+++ b/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Environment=HOME=/root
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 PublishPort=8445:8445
 Volume=/etc/flightctl/flightctl-imagebuilder-api/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/flightctl-imagebuilder-api/server.crt:/root/.flightctl/certs/server.crt:ro,z

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Environment=HOME=/root
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/etc/flightctl/flightctl-imagebuilder-worker/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.crt:/root/.flightctl/certs/client-signer.crt:ro,z
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.key:/root/.flightctl/certs/client-signer.key:ro,z

--- a/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv-standalone.container
@@ -5,8 +5,8 @@ Description=Flight Control Key Value service
 ContainerName=flightctl-kv
 Image=docker.io/redis:7.4.1
 Pull=missing
-Exec=/bin/sh -c 'exec redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
+Exec=/bin/sh -c 'exec redis-server /usr/local/etc/redis/redis.conf --requirepass "$$(cat /run/secrets/kv/password)"'
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
 
 PublishPort=6379:6379

--- a/deploy/podman/flightctl-kv/flightctl-kv.container
+++ b/deploy/podman/flightctl-kv/flightctl-kv.container
@@ -8,8 +8,8 @@ Image={{ .Kv.Image }}:{{ .Kv.Tag }}
 Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
-Exec=/bin/sh -c 'exec redis-server /usr/local/etc/redis/redis.conf --requirepass $${KV_PASSWORD}'
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
+Exec=/bin/sh -c 'password="$$(cat /run/secrets/kv/password)" && exec redis-server /usr/local/etc/redis/redis.conf --requirepass "$$password"'
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/usr/share/flightctl/flightctl-kv/redis.conf:/usr/local/etc/redis/redis.conf
 
 [Service]

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Environment=HOME=/root
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/etc/flightctl/flightctl-periodic/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/ssh:/etc/flightctl/ssh:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -11,9 +11,8 @@ Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
 Environment=HOME=/root
-Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
-Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
-Environment=DB_USER=flightctl_app
+Secret=flightctl-postgresql-user-password,type=mount,target=/run/secrets/db/userPassword
+Secret=flightctl-kv-password,type=mount,target=/run/secrets/kv/password
 Volume=/etc/flightctl/flightctl-worker/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/ssh:/etc/flightctl/ssh:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z

--- a/deploy/scripts/setup_database_users.sh
+++ b/deploy/scripts/setup_database_users.sh
@@ -3,33 +3,63 @@
 set -eo pipefail
 
 # Flight Control Database User Setup Script
-# This script creates the database users with appropriate permissions for production deployments
+# This script creates the database users with appropriate permissions for production deployments.
+#
+# Modes:
+#   Default (podman): wraps psql calls inside a podman container (for host execution)
+#   --direct:         calls psql directly (for execution inside a container that has psql)
+#
+# Credentials can be supplied via environment variables (DB_ADMIN_USER, DB_ADMIN_PASSWORD, etc.)
+# or via secret-mounted files at well-known default paths under /run/secrets/.
+# The environment variable takes precedence; if unset, the default file path is tried.
+# The script exits with an error if a value is not provided by either mechanism.
+# Passwords are never passed on the psql command line; they are fed via stdin (\set).
+
+DIRECT_PSQL=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --direct)
+            DIRECT_PSQL=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
 
 # Configuration variables
 DB_HOST=${DB_HOST:-localhost}
 DB_PORT=${DB_PORT:-5432}
 DB_NAME=${DB_NAME:-flightctl}
-DB_ADMIN_USER=${DB_ADMIN_USER:-admin}
-DB_ADMIN_PASSWORD=${DB_ADMIN_PASSWORD:-adminpass}
-DB_MIGRATION_USER=${DB_MIGRATION_USER:-flightctl_migrator}
-DB_MIGRATION_PASSWORD=${DB_MIGRATION_PASSWORD:-migrator_password}
-DB_APP_USER=${DB_APP_USER:-flightctl_app}
-DB_APP_PASSWORD=${DB_APP_PASSWORD:-app_password}
 
-# PostgreSQL image to use for database connections
+# Resolve value: prefer env var, fall back to default secret file path, error if neither.
+resolve_value() {
+    local name="$1" default_file="$2" env_val="${3:-}"
+    if [[ -n "${env_val}" ]]; then
+        echo "$env_val"
+    elif [[ -f "${default_file}" && -r "${default_file}" ]]; then
+        cat "$default_file"
+    else
+        echo "Error: ${name} must be set via environment variable or available at ${default_file}" >&2
+        exit 1
+    fi
+}
+
+DB_ADMIN_USER="$(resolve_value DB_ADMIN_USER /run/secrets/db-admin/masterUser "${DB_ADMIN_USER:-}")"
+DB_MIGRATION_USER="$(resolve_value DB_MIGRATION_USER /run/secrets/db-migration/migrationUser "${DB_MIGRATION_USER:-}")"
+DB_APP_USER="$(resolve_value DB_APP_USER /run/secrets/db/user "${DB_APP_USER:-}")"
+
+DB_ADMIN_PASSWORD="$(resolve_value DB_ADMIN_PASSWORD /run/secrets/db-admin/masterPassword "${DB_ADMIN_PASSWORD:-}")"
+DB_MIGRATION_PASSWORD="$(resolve_value DB_MIGRATION_PASSWORD /run/secrets/db-migration/migrationPassword "${DB_MIGRATION_PASSWORD:-}")"
+DB_APP_PASSWORD="$(resolve_value DB_APP_PASSWORD /run/secrets/db/userPassword "${DB_APP_PASSWORD:-}")"
+
+# PostgreSQL image to use for database connections (podman mode only)
 POSTGRES_IMAGE=${POSTGRES_IMAGE:-quay.io/sclorg/postgresql-16-c9s:latest}
 
-# Function to execute SQL command using podman
-execute_sql_command() {
-    local sql_command="$1"
-    local use_network=${2:-true}
-
-    local network_arg=""
-    if [ "$use_network" = "true" ]; then
-        network_arg="--network flightctl"
-    fi
-
-    # Build SSL environment arguments
+# Build SSL environment arguments for podman mode
+build_ssl_env_args() {
     local ssl_args=""
     if [[ -n "${PGSSLMODE:-}" ]]; then
         ssl_args="$ssl_args -e PGSSLMODE=$PGSSLMODE"
@@ -43,6 +73,27 @@ execute_sql_command() {
     if [[ -n "${PGSSLROOTCERT:-}" ]]; then
         ssl_args="$ssl_args -e PGSSLROOTCERT=$PGSSLROOTCERT"
     fi
+    echo "$ssl_args"
+}
+
+# Function to execute a single SQL command
+execute_sql_command() {
+    local sql_command="$1"
+    local use_network=${2:-true}
+
+    if [[ "$DIRECT_PSQL" == "true" ]]; then
+        PGPASSWORD="$DB_ADMIN_PASSWORD" \
+        psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" -c "$sql_command"
+        return
+    fi
+
+    local network_arg=""
+    if [ "$use_network" = "true" ]; then
+        network_arg="--network flightctl"
+    fi
+
+    local ssl_args
+    ssl_args="$(build_ssl_env_args)"
 
     sudo podman run --rm $network_arg \
         -e PGPASSWORD="$DB_ADMIN_PASSWORD" \
@@ -51,7 +102,8 @@ execute_sql_command() {
         psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" -c "$sql_command"
 }
 
-# Function to execute SQL file with environment variable substitution
+# Function to execute SQL file with passwords piped via stdin (never on the command line).
+# Non-sensitive identifiers (db_name, user names) are passed via -v.
 execute_sql_file() {
     local sql_file="$1"
     local use_network=${2:-true}
@@ -63,41 +115,39 @@ execute_sql_file() {
 
     echo "Executing SQL file: $sql_file"
 
-    # Create a temporary file with environment variable substitution
-    local temp_sql_file
-    temp_sql_file=$(mktemp)
-    envsubst < "$sql_file" > "$temp_sql_file"
+    if [[ "$DIRECT_PSQL" == "true" ]]; then
+        {
+            printf "\\set migration_password '%s'\n" "${DB_MIGRATION_PASSWORD//\'/\'\'}"
+            printf "\\set app_password '%s'\n" "${DB_APP_PASSWORD//\'/\'\'}"
+            cat "$sql_file"
+        } | PGPASSWORD="$DB_ADMIN_PASSWORD" \
+            psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" \
+                -v db_name="$DB_NAME" \
+                -v migration_user="$DB_MIGRATION_USER" \
+                -v app_user="$DB_APP_USER"
+        return
+    fi
 
     local network_arg=""
     if [ "$use_network" = "true" ]; then
         network_arg="--network flightctl"
     fi
 
-    # Build SSL environment arguments
-    local ssl_args=""
-    if [[ -n "${PGSSLMODE:-}" ]]; then
-        ssl_args="$ssl_args -e PGSSLMODE=$PGSSLMODE"
-    fi
-    if [[ -n "${PGSSLCERT:-}" ]]; then
-        ssl_args="$ssl_args -e PGSSLCERT=$PGSSLCERT"
-    fi
-    if [[ -n "${PGSSLKEY:-}" ]]; then
-        ssl_args="$ssl_args -e PGSSLKEY=$PGSSLKEY"
-    fi
-    if [[ -n "${PGSSLROOTCERT:-}" ]]; then
-        ssl_args="$ssl_args -e PGSSLROOTCERT=$PGSSLROOTCERT"
-    fi
+    local ssl_args
+    ssl_args="$(build_ssl_env_args)"
 
-    # Execute the SQL file using podman with stdin
-    sudo podman run --rm $network_arg \
+    {
+        printf "\\set migration_password '%s'\n" "${DB_MIGRATION_PASSWORD//\'/\'\'}"
+        printf "\\set app_password '%s'\n" "${DB_APP_PASSWORD//\'/\'\'}"
+        cat "$sql_file"
+    } | sudo podman run --rm -i $network_arg \
         -e PGPASSWORD="$DB_ADMIN_PASSWORD" \
         $ssl_args \
-        -i \
         "$POSTGRES_IMAGE" \
-        psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" < "$temp_sql_file"
-
-    # Clean up temporary file
-    rm -f "$temp_sql_file"
+        psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_ADMIN_USER" -d "$DB_NAME" \
+            -v db_name="$DB_NAME" \
+            -v migration_user="$DB_MIGRATION_USER" \
+            -v app_user="$DB_APP_USER"
 }
 
 # Check if database is accessible
@@ -112,9 +162,6 @@ echo "Setting up Flight Control database users..."
 # Find the SQL file relative to this script
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 SQL_FILE="$SCRIPT_DIR/setup_database_users.sql"
-
-# Export environment variables for substitution
-export DB_NAME DB_MIGRATION_USER DB_MIGRATION_PASSWORD DB_APP_USER DB_APP_PASSWORD
 
 # Execute the canonical SQL file
 execute_sql_file "$SQL_FILE"

--- a/deploy/scripts/setup_database_users.sql
+++ b/deploy/scripts/setup_database_users.sql
@@ -1,91 +1,100 @@
 -- Flight Control Database User Setup Script
 -- This script creates the database users with appropriate permissions for production deployments
--- Environment variables that must be set before running:
---   ${DB_NAME} - Database name (default: flightctl)
---   ${DB_MIGRATION_USER} - Migration user name (default: flightctl_migrator)
---   ${DB_MIGRATION_PASSWORD} - Migration user password
---   ${DB_APP_USER} - Application user name (default: flightctl_app)
---   ${DB_APP_PASSWORD} - Application user password
+--
+-- Required psql variables:
+--   db_name            - Database name (e.g. flightctl)                  [pass via -v]
+--   migration_user     - Migration user name (e.g. flightctl_migrator)   [pass via -v]
+--   migration_password - Migration user password                         [set via \set in stdin]
+--   app_user           - Application user name (e.g. flightctl_app)      [pass via -v]
+--   app_password       - Application user password                       [set via \set in stdin]
+--
+-- Passwords are piped through stdin as \set commands by the calling script
+-- (setup_database_users.sh) so they never appear in process arguments.
 
 -- Create users using simple SQL (will ignore errors if they already exist)
 \set ON_ERROR_STOP off
 
 -- Create the migration user with full privileges for schema changes
-CREATE USER "${DB_MIGRATION_USER}" WITH PASSWORD $$${DB_MIGRATION_PASSWORD}$$;
+CREATE USER :"migration_user" WITH PASSWORD :'migration_password';
 
 -- Create the application user with limited privileges
-CREATE USER "${DB_APP_USER}" WITH PASSWORD $$${DB_APP_PASSWORD}$$;
+CREATE USER :"app_user" WITH PASSWORD :'app_password';
 
 -- Ensure existing users get their passwords updated for true idempotency
-ALTER USER "${DB_MIGRATION_USER}" WITH PASSWORD $$${DB_MIGRATION_PASSWORD}$$;
-ALTER USER "${DB_APP_USER}" WITH PASSWORD $$${DB_APP_PASSWORD}$$;
+ALTER USER :"migration_user" WITH PASSWORD :'migration_password';
+ALTER USER :"app_user" WITH PASSWORD :'app_password';
 
 \set ON_ERROR_STOP on
 
 -- Grant database connection privileges
-GRANT CONNECT ON DATABASE "${DB_NAME}" TO "${DB_MIGRATION_USER}";
-GRANT CONNECT ON DATABASE "${DB_NAME}" TO "${DB_APP_USER}";
+GRANT CONNECT ON DATABASE :"db_name" TO :"migration_user";
+GRANT CONNECT ON DATABASE :"db_name" TO :"app_user";
 
 -- Grant schema usage privileges
-GRANT USAGE ON SCHEMA public TO "${DB_MIGRATION_USER}";
-GRANT USAGE ON SCHEMA public TO "${DB_APP_USER}";
+GRANT USAGE ON SCHEMA public TO :"migration_user";
+GRANT USAGE ON SCHEMA public TO :"app_user";
 
 -- Grant migration user privileges for schema migrations
 -- Following the principle of least privilege, these are the specific privileges needed:
 -- 1. CREATE on schema - for creating tables, indexes, sequences, functions, and triggers
 -- 2. CREATE on database - for creating additional schemas if needed
-GRANT CREATE ON SCHEMA public TO "${DB_MIGRATION_USER}";
-GRANT CREATE ON DATABASE "${DB_NAME}" TO "${DB_MIGRATION_USER}";
+GRANT CREATE ON SCHEMA public TO :"migration_user";
+GRANT CREATE ON DATABASE :"db_name" TO :"migration_user";
 
 -- Grant additional privileges needed for schema and post-migration operations
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${DB_MIGRATION_USER}";
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "${DB_MIGRATION_USER}";
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO :"migration_user";
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO :"migration_user";
 
 -- Grant migration user data-plane permissions WITH GRANT OPTION
 -- This allows the migrator to grant these permissions to the application user
 -- after running migrations, enabling support for external databases without admin access
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public
-    TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+    TO :"migration_user" WITH GRANT OPTION;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public
-    TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+    TO :"migration_user" WITH GRANT OPTION;
 
 -- Ensure future tables also get WITH GRANT OPTION for migrator
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO :"migration_user" WITH GRANT OPTION;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-    GRANT USAGE, SELECT ON SEQUENCES TO "${DB_MIGRATION_USER}" WITH GRANT OPTION;
+    GRANT USAGE, SELECT ON SEQUENCES TO :"migration_user" WITH GRANT OPTION;
 
 -- Grant application user limited privileges for data operations
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${DB_APP_USER}";
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${DB_APP_USER}";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO :"app_user";
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO :"app_user";
 
 -- Ensure future tables inherit the same permissions
-ALTER DEFAULT PRIVILEGES FOR ROLE "${DB_APP_USER}" IN SCHEMA public
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${DB_APP_USER}";
-ALTER DEFAULT PRIVILEGES FOR ROLE "${DB_APP_USER}" IN SCHEMA public
-  GRANT USAGE, SELECT ON SEQUENCES TO "${DB_APP_USER}";
+ALTER DEFAULT PRIVILEGES FOR ROLE :"app_user" IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO :"app_user";
+ALTER DEFAULT PRIVILEGES FOR ROLE :"app_user" IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO :"app_user";
 
+-- Persist app user name as a database-level GUC so that the event trigger
+-- function can resolve it in future sessions without envsubst.
+ALTER DATABASE :"db_name" SET flightctl.app_user = :'app_user';
+SET flightctl.app_user = :'app_user';
 
 -- Create function to grant permissions on existing tables (for post-migration)
 CREATE OR REPLACE FUNCTION grant_app_permissions_on_existing_tables()
-RETURNS void AS '
+RETURNS void AS $$
+DECLARE
+    v_app_user text := current_setting('flightctl.app_user');
 BEGIN
-    -- Grant table permissions
-    EXECUTE format(''GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %I'', ''${DB_APP_USER}'');
-    -- Grant sequence permissions
-    EXECUTE format(''GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I'', ''${DB_APP_USER}'');
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %I', v_app_user);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I', v_app_user);
 END;
-' LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;
 
 -- Create event trigger function for automatic permission granting
 CREATE OR REPLACE FUNCTION grant_app_permissions()
-RETURNS event_trigger AS '
+RETURNS event_trigger AS $$
+DECLARE
+    v_app_user text := current_setting('flightctl.app_user');
 BEGIN
-    -- Grant permissions on newly created tables/sequences
-    EXECUTE format(''GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %I'', ''${DB_APP_USER}'');
-    EXECUTE format(''GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I'', ''${DB_APP_USER}'');
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %I', v_app_user);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I', v_app_user);
 END;
-' LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;
 
 -- Drop existing trigger if it exists, then create new one
 DROP EVENT TRIGGER IF EXISTS grant_app_permissions_trigger;
@@ -97,5 +106,5 @@ CREATE EVENT TRIGGER grant_app_permissions_trigger
 -- Display created users
 SELECT rolname, rolsuper, rolcreaterole, rolcreatedb, rolcanlogin
 FROM pg_roles
-WHERE rolname IN ('${DB_MIGRATION_USER}', '${DB_APP_USER}')
+WHERE rolname IN (:'migration_user', :'app_user')
 ORDER BY rolname;

--- a/deploy/scripts/wait-for-database.sh
+++ b/deploy/scripts/wait-for-database.sh
@@ -2,16 +2,27 @@
 set -euo pipefail
 
 # Waits until a PostgreSQL database is ready for connections.
-# Uses DB_* env vars (mapped to PG* internally) and optional flags: --timeout, --sleep, --connection-timeout.
+# Reads credentials from mounted secret files at /run/secrets/db/ and optional flags: --timeout, --sleep, --connection-timeout.
 # Optionally reads database configuration from a YAML file specified by SERVICE_CONFIG_PATH.
-# Environment variables override values from the YAML file.
 
-# Set default values for DB_* variables
+# read_secret_file reads a secret from a file, returning the trimmed contents.
+# Usage: value=$(read_secret_file /path/to/file)
+read_secret_file() {
+    local file="$1"
+    if [ -f "$file" ]; then
+        tr -d '\n\r' < "$file"
+    fi
+}
+
+# Set default values for DB_* variables, preferring mounted secret files.
+# DB_USER_FILE / DB_PASSWORD_FILE point to the correct secret path for the user type.
+: "${DB_USER_FILE:=/run/secrets/db/user}"
+: "${DB_PASSWORD_FILE:=/run/secrets/db/userPassword}"
 : "${DB_HOST:=}"
 : "${DB_PORT:=}"
 : "${DB_NAME:=}"
-: "${DB_USER:=}"
-: "${DB_PASSWORD:=}"
+: "${DB_USER:=$(read_secret_file "$DB_USER_FILE")}"
+: "${DB_PASSWORD:=$(read_secret_file "$DB_PASSWORD_FILE")}"
 : "${DB_SSL_MODE:=}"
 : "${DB_SSL_CERT:=}"
 : "${DB_SSL_KEY:=}"
@@ -40,15 +51,16 @@ while [[ $# -gt 0 ]]; do
             echo "  --sleep=SECONDS         Sleep interval between attempts (default: 2)"
             echo "  --connection-timeout=SECONDS  Connection timeout per attempt (default: 3)"
             echo ""
-            echo "Environment variables:"
-            echo "  DB_USER, DB_PASSWORD - Database connection details (required)"
+            echo "Credentials (read from mounted secret files):"
+            echo "  DB_USER_FILE - Path to file containing DB username (default: /run/secrets/db/user)"
+            echo "  DB_PASSWORD_FILE - Path to file containing DB password (default: /run/secrets/db/userPassword)"
+            echo ""
+            echo "Configuration:"
             echo "  DB_HOST - Database hostname (optional, default: flightctl-db)"
             echo "  DB_PORT - Database port (optional, default: 5432)"
             echo "  DB_NAME - Database name (optional, default: flightctl)"
             echo "  DB_SSL_MODE, DB_SSL_CERT, DB_SSL_KEY, DB_SSL_ROOT_CERT - SSL configuration (optional)"
             echo "  SERVICE_CONFIG_PATH - Path to service config YAML file (optional)"
-            echo ""
-            echo "Note: Environment variables override values from the service config file."
             exit 0 ;;
         --*) echo "Unknown option $1" >&2; echo "Use --help for usage information" >&2; exit 1 ;;
         *) echo "Unknown argument: $1" >&2; echo "Use --help for usage information" >&2; exit 1 ;;
@@ -109,9 +121,9 @@ if [ -n "${SERVICE_CONFIG_PATH:-}" ]; then
 fi
 
 
-# Validate required DB_* environment variables
-: "${DB_USER:?DB_USER environment variable must be set}"
-: "${DB_PASSWORD:?DB_PASSWORD environment variable must be set}"
+# Validate required credentials
+: "${DB_USER:?DB_USER must be set (check DB_USER_FILE=${DB_USER_FILE} is mounted or set via SERVICE_CONFIG_PATH)}"
+: "${DB_PASSWORD:?DB_PASSWORD must be set (check DB_PASSWORD_FILE=${DB_PASSWORD_FILE} is mounted)}"
 
 # Log connection details
 echo "Waiting for PostgreSQL database to be ready..."

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -739,7 +739,7 @@ func Load(cfgFile string) (*Config, error) {
 		return nil, fmt.Errorf("decoding config: %v", err)
 	}
 
-	applyEnvVarOverrides(c)
+	applyRuntimeOverrides(c)
 	if err := applyAuthDefaults(c); err != nil {
 		return nil, fmt.Errorf("applying auth defaults: %w", err)
 	}
@@ -747,21 +747,35 @@ func Load(cfgFile string) (*Config, error) {
 	return c, nil
 }
 
-func applyEnvVarOverrides(c *Config) {
-	if kvPass := os.Getenv("KV_PASSWORD"); kvPass != "" {
-		c.KV.Password = api.SecureString(kvPass)
+// readSecretFile reads a secret value from a file, trimming any trailing newline.
+// Returns the file contents and true if the file exists and is readable, or empty string and false otherwise.
+func readSecretFile(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
 	}
-	if dbUser := os.Getenv("DB_USER"); dbUser != "" {
-		c.Database.User = dbUser
+	return strings.TrimRight(string(data), "\n\r"), true
+}
+
+func applyRuntimeOverrides(c *Config) {
+	if c.KV != nil {
+		if kvPass, ok := readSecretFile("/run/secrets/kv/password"); ok {
+			c.KV.Password = api.SecureString(kvPass)
+		}
 	}
-	if dbPass := os.Getenv("DB_PASSWORD"); dbPass != "" {
-		c.Database.Password = api.SecureString(dbPass)
-	}
-	if dbMigrationUser := os.Getenv("DB_MIGRATION_USER"); dbMigrationUser != "" {
-		c.Database.MigrationUser = dbMigrationUser
-	}
-	if dbMigrationPass := os.Getenv("DB_MIGRATION_PASSWORD"); dbMigrationPass != "" {
-		c.Database.MigrationPassword = api.SecureString(dbMigrationPass)
+	if c.Database != nil {
+		if dbUser, ok := readSecretFile("/run/secrets/db/user"); ok {
+			c.Database.User = dbUser
+		}
+		if dbPass, ok := readSecretFile("/run/secrets/db/userPassword"); ok {
+			c.Database.Password = api.SecureString(dbPass)
+		}
+		if dbMigrationUser, ok := readSecretFile("/run/secrets/db-migration/migrationUser"); ok {
+			c.Database.MigrationUser = dbMigrationUser
+		}
+		if dbMigrationPass, ok := readSecretFile("/run/secrets/db-migration/migrationPassword"); ok {
+			c.Database.MigrationPassword = api.SecureString(dbMigrationPass)
+		}
 	}
 	// CRYPTO_FORCE_FIPS environment variable sets the global crypto policy FIPS mode.
 	// This overrides auto-detection and applies to all cryptographic protocols.

--- a/test/scripts/run_migration.sh
+++ b/test/scripts/run_migration.sh
@@ -26,6 +26,15 @@ DB_MIGRATION_PASSWORD=${FLIGHTCTL_POSTGRESQL_MIGRATOR_PASSWORD:-adminpass}
 echo "Running database migration with image: $MIGRATION_IMAGE"
 echo "Target database: $DB_NAME"
 
+# flightctl-db-migrate (via migration-setup.sh) loads credentials from mounted secret files only
+# (see internal/config applyRuntimeOverrides). Provide the same paths as production quadlets/Helm.
+INTEGRATION_SECRET_DIR="$(mktemp -d)"
+trap 'rm -rf "$INTEGRATION_SECRET_DIR"' EXIT
+printf '%s' "$DB_MIGRATION_PASSWORD" >"$INTEGRATION_SECRET_DIR/migrationPassword"
+chmod 600 "$INTEGRATION_SECRET_DIR/migrationPassword"
+printf '%s' "$DB_MIGRATION_USER" >"$INTEGRATION_SECRET_DIR/migrationUser"
+chmod 600 "$INTEGRATION_SECRET_DIR/migrationUser"
+
 podman run --rm --network host \
     --pull=missing \
     -e DB_HOST="$DB_HOST" \
@@ -35,6 +44,8 @@ podman run --rm --network host \
     -e DB_ADMIN_PASSWORD="$DB_ADMIN_PASSWORD" \
     -e DB_MIGRATION_USER="$DB_MIGRATION_USER" \
     -e DB_MIGRATION_PASSWORD="$DB_MIGRATION_PASSWORD" \
+    -v "$INTEGRATION_SECRET_DIR/migrationPassword:/run/secrets/db-migration/migrationPassword:ro,Z" \
+    -v "$INTEGRATION_SECRET_DIR/migrationUser:/run/secrets/db-migration/migrationUser:ro,Z" \
     "$MIGRATION_IMAGE" \
     /app/deploy/scripts/migration-setup.sh
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Credentials are now delivered via mounted secret files under fixed /run/secrets/... paths instead of environment variables.
* **Helm / Deployment**
  * Chart templates add reusable secret volumes and mounts for KV and DB (app/admin/migration) across pods, containers, and init containers.
* **Database & Migration**
  * Migration and setup routines read credentials from secret files and pass them to DB commands without exporting secrets as env vars.
* **Scripts**
  * Setup/wait scripts support file-based secret inputs and a direct execution mode for DB setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->