### PR TITLE
EDM-3626: Agent stuck in "updating" forever when greenboot is not installed but boot-complete.target exists

### DIFF
--- a/internal/agent/client/systemd.go
+++ b/internal/agent/client/systemd.go
@@ -136,6 +136,22 @@ func (s *Systemd) IsActive(ctx context.Context, name string) (bool, error) {
 	return false, fmt.Errorf("is-active systemd unit %s: %w", name, errors.FromStderr(stderr, exitCode))
 }
 
+// IsEnabled checks if a systemd unit is enabled (will start on boot).
+// Returns true for enabled, enabled-runtime, static, indirect, and generated states.
+// Returns false for disabled, masked, and not-found states.
+func (s *Systemd) IsEnabled(ctx context.Context, name string) (bool, error) {
+	command, args := s.createArgs("is-enabled", name)
+	_, stderr, exitCode := s.exec.ExecuteWithContext(ctx, command, args...)
+	if exitCode == 0 {
+		return true, nil
+	}
+	// Exit code 1 means disabled, masked, or not-found — not an error
+	if exitCode == 1 {
+		return false, nil
+	}
+	return false, fmt.Errorf("is-enabled systemd unit %s: %w", name, errors.FromStderr(stderr, exitCode))
+}
+
 func (s *Systemd) DaemonReload(ctx context.Context) error {
 	command, args := s.createArgs("daemon-reload")
 	_, stderr, exitCode := s.exec.ExecuteWithContext(ctx, command, args...)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -680,9 +680,20 @@ func (a *Agent) ReloadConfig(ctx context.Context, config *agent_config.Config) e
 // by greenboot after all required health checks in required.d/ pass.
 // Returns true if boot-complete.target is active, or if greenboot is not installed.
 func (a *Agent) isBootSuccessful(ctx context.Context) bool {
+	// Check if greenboot is actually managing boot validation.
+	// On systems where boot-complete.target exists but greenboot is not installed,
+	// the target stays inactive forever — we must not block on it.
+	enabled, err := a.systemdClient.IsEnabled(ctx, "greenboot-healthcheck.service")
+	if err != nil {
+		a.log.Warnf("Failed to check greenboot-healthcheck.service: %v", err)
+		return true
+	}
+	if !enabled {
+		return true
+	}
+
 	active, err := a.systemdClient.IsActive(ctx, "boot-complete.target")
 	if err != nil {
-		// Unit not found or other error — unexpected on systemd-based systems
 		a.log.Warnf("Failed to check boot-complete.target: %v", err)
 		return true
 	}

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -680,9 +680,9 @@ func (a *Agent) ReloadConfig(ctx context.Context, config *agent_config.Config) e
 // by greenboot after all required health checks in required.d/ pass.
 // Returns true if boot-complete.target is active, or if greenboot is not installed.
 func (a *Agent) isBootSuccessful(ctx context.Context) bool {
-	// Check if greenboot is actually managing boot validation.
-	// On systems where boot-complete.target exists but greenboot is not installed,
-	// the target stays inactive forever — we must not block on it.
+	// Defensive check: greenboot is a hard RPM dependency, but the agent binary
+	// may be deployed without RPM (e.g., dev/test environments). If greenboot is
+	// absent, boot-complete.target stays inactive forever — don't block on it.
 	enabled, err := a.systemdClient.IsEnabled(ctx, "greenboot-healthcheck.service")
 	if err != nil {
 		a.log.Warnf("Failed to check greenboot-healthcheck.service: %v", err)

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -121,7 +121,8 @@ func TestSync(t *testing.T) {
 				mockLifecycleManager.EXPECT().Sync(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockLifecycleManager.EXPECT().AfterUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("", true, nil).AnyTimes()
-				// Mock systemctl for boot success check (via systemd client)
+				// Mock systemctl for greenboot presence and boot success check
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("enabled\n", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-active", "boot-complete.target").Return("active\n", "", 0).AnyTimes()
 				// OnAfterUpdating is called twice - once with error, once without during rollback
 				mockHookManager.EXPECT().OnAfterUpdating(ctx, current.Spec, desired.Spec, false).Return(nonRetryableHookError).AnyTimes()
@@ -132,6 +133,124 @@ func TestSync(t *testing.T) {
 				mockPrefetchManager.EXPECT().Cleanup().AnyTimes()
 				// Upgrade should NOT be called when sync fails, but allow it for flexibility
 				mockSpecManager.EXPECT().Upgrade(gomock.Any()).Return(nil).AnyTimes()
+			},
+		},
+		{
+			name:    "When greenboot is not installed it should complete the OS update",
+			current: newVersionedDevice("0"),
+			desired: newVersionedDevice("1"),
+			setupMocks: func(
+				current *v1beta1.Device,
+				desired *v1beta1.Device,
+				mockOSClient *os.MockClient,
+				mockManagementClient *client.MockManagement,
+				mockSystemInfoManager *systeminfo.MockManager,
+				mockExec *executer.MockExecuter,
+				mockRouterService *console.MockRouterServiceClient,
+				mockResourceManager *resource.MockManager,
+				mockSystemdManager *systemd.MockManager,
+				mockHookManager *hook.MockManager,
+				mockAppManager *applications.MockManager,
+				mockLifecycleManager *lifecycle.MockManager,
+				mockPolicyManager *policy.MockManager,
+				mockSpecManager *spec.MockManager,
+				mockPrefetchManager *dependency.MockPrefetchManager,
+				mockOSManager *os.MockManager,
+				mockPruningManager *imagepruning.MockManager,
+				mockPullConfigResolver *dependency.MockPullConfigResolver,
+			) {
+				mockPullConfigResolver.EXPECT().BeforeUpdate(gomock.Any()).AnyTimes()
+				mockPullConfigResolver.EXPECT().Cleanup().AnyTimes()
+				mockResourceManager.EXPECT().IsCriticalAlert(gomock.Any()).Return(false).AnyTimes()
+				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
+				mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
+				mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+				mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil).AnyTimes()
+				mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil).AnyTimes()
+				mockResourceManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockPruningManager.EXPECT().RecordReferences(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockAppManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockHookManager.EXPECT().OnBeforeUpdating(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockHookManager.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockLifecycleManager.EXPECT().Sync(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockLifecycleManager.EXPECT().AfterUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("", true, nil).AnyTimes()
+				mockHookManager.EXPECT().OnAfterUpdating(gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).AnyTimes()
+				mockAppManager.EXPECT().AfterUpdate(gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().Cleanup().AnyTimes()
+				mockPruningManager.EXPECT().RequestPrune().AnyTimes()
+				mockPruningManager.EXPECT().PrunePending().Return(false).AnyTimes()
+
+				mockSpecManager.EXPECT().IsUpgrading().Return(true).AnyTimes()
+				mockSpecManager.EXPECT().IsOSUpdate().Return(true).AnyTimes()
+
+				// greenboot-healthcheck.service is not enabled (exit 1) — greenboot not installed
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("not-found\n", "", 1).AnyTimes()
+
+				// Upgrade() should be called — greenboot is not installed, so boot is considered successful
+				mockSpecManager.EXPECT().Upgrade(gomock.Any()).Return(nil).AnyTimes()
+			},
+		},
+		{
+			name:    "When greenboot is installed but boot-complete.target is inactive it should wait",
+			current: newVersionedDevice("0"),
+			desired: newVersionedDevice("1"),
+			setupMocks: func(
+				current *v1beta1.Device,
+				desired *v1beta1.Device,
+				mockOSClient *os.MockClient,
+				mockManagementClient *client.MockManagement,
+				mockSystemInfoManager *systeminfo.MockManager,
+				mockExec *executer.MockExecuter,
+				mockRouterService *console.MockRouterServiceClient,
+				mockResourceManager *resource.MockManager,
+				mockSystemdManager *systemd.MockManager,
+				mockHookManager *hook.MockManager,
+				mockAppManager *applications.MockManager,
+				mockLifecycleManager *lifecycle.MockManager,
+				mockPolicyManager *policy.MockManager,
+				mockSpecManager *spec.MockManager,
+				mockPrefetchManager *dependency.MockPrefetchManager,
+				mockOSManager *os.MockManager,
+				mockPruningManager *imagepruning.MockManager,
+				mockPullConfigResolver *dependency.MockPullConfigResolver,
+			) {
+				mockPullConfigResolver.EXPECT().BeforeUpdate(gomock.Any()).AnyTimes()
+				mockPullConfigResolver.EXPECT().Cleanup().AnyTimes()
+				mockResourceManager.EXPECT().IsCriticalAlert(gomock.Any()).Return(false).AnyTimes()
+				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
+				mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
+				mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+				mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil).AnyTimes()
+				mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil).AnyTimes()
+				mockResourceManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockPruningManager.EXPECT().RecordReferences(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockAppManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockHookManager.EXPECT().OnBeforeUpdating(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockHookManager.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockLifecycleManager.EXPECT().Sync(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockLifecycleManager.EXPECT().AfterUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("", true, nil).AnyTimes()
+				mockHookManager.EXPECT().OnAfterUpdating(gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).AnyTimes()
+				mockAppManager.EXPECT().AfterUpdate(gomock.Any()).Return(nil).AnyTimes()
+				mockPrefetchManager.EXPECT().Cleanup().AnyTimes()
+
+				mockSpecManager.EXPECT().IsUpgrading().Return(true).AnyTimes()
+				mockSpecManager.EXPECT().IsOSUpdate().Return(true).AnyTimes()
+
+				// greenboot IS installed and enabled
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("enabled\n", "", 0).AnyTimes()
+				// boot-complete.target is inactive — greenboot hasn't validated yet
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-active", "boot-complete.target").Return("inactive\n", "", 3).AnyTimes()
+
+				// Upgrade() must NOT be called — greenboot is pending
+				mockSpecManager.EXPECT().Upgrade(gomock.Any()).Times(0)
 			},
 		},
 		{

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -190,8 +190,8 @@ func TestSync(t *testing.T) {
 				// greenboot-healthcheck.service is not enabled (exit 1) — greenboot not installed
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("not-found\n", "", 1).AnyTimes()
 
-				// Upgrade() should be called — greenboot is not installed, so boot is considered successful
-				mockSpecManager.EXPECT().Upgrade(gomock.Any()).Return(nil).AnyTimes()
+				// Upgrade() must be called — greenboot is not installed, so boot is considered successful
+				mockSpecManager.EXPECT().Upgrade(gomock.Any()).Return(nil).MinTimes(1)
 			},
 		},
 		{

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -48,6 +48,7 @@ flightctl is the CLI for controlling the Flight Control service.
 Summary: Flight Control management agent
 
 Requires: flightctl-selinux = %{version}
+Requires: greenboot
 Requires: jq
 Requires: sudo
 


### PR DESCRIPTION
## Problem

On devices where greenboot is not installed but `boot-complete.target` exists as a systemd unit, the flightctl-agent gets permanently stuck in the "Updating" state after an OS image update. The agent never calls `Upgrade()` and the device cannot progress.

## Root Cause

`isBootSuccessful()` checks `systemctl is-active boot-complete.target` to determine whether greenboot has validated the boot. On systems without greenboot, `boot-complete.target` exists (shipped by systemd v256+) but is never activated — so it stays `inactive` forever. The function cannot distinguish "greenboot is pending" from "greenboot is not installed", causing an infinite wait.

## Fix

Before checking `boot-complete.target`, the agent now checks whether `greenboot-healthcheck.service` is enabled via `systemctl is-enabled`. If greenboot is not installed or not enabled, `isBootSuccessful()` returns `true` immediately, allowing the OS update to proceed.

Changes:
1. Added `IsEnabled()` method to the systemd client (`internal/agent/client/systemd.go`)
2. Updated `isBootSuccessful()` to gate on greenboot presence (`internal/agent/device/device.go`)
3. Added regression tests covering both greenboot-absent and greenboot-present-but-pending scenarios (`internal/agent/device/device_test.go`)

## Testing

- **Unit tests**: Two new table-driven test cases verify correct behavior when greenboot is absent (update proceeds) and when greenboot is present but pending (update waits). Existing tests updated with greenboot mocks.
- **E2E VM test**: Built a qcow2 image without greenboot, deployed to a kind cluster, triggered an OS image update. Verified the agent completed the full update cycle (prefetch → bootc switch → reboot → UpToDate). Also confirmed the unfixed RPM agent gets stuck in the same scenario.