### PR TITLE
EDM-3671: adapt flightctl-pam-issuer template to port normalization in flightctl-ui 1.1rc6

### DIFF
--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer-config/config.yaml.template
@@ -39,6 +39,7 @@ auth:
 {{- end}}
 {{- else}}
       - https://{{.global.baseDomain}}:443/callback
+      - https://{{.global.baseDomain}}/callback
       - http://localhost:8080/callback
 {{- end}}
     pamService: {{if .global.auth.pamOidcIssuer.pamService}}{{.global.auth.pamOidcIssuer.pamService}}{{else}}flightctl{{end}}


### PR DESCRIPTION
Fixes redirect errors during login introduced by port normalization in flightctl-ui (1.1RC6) https://github.com/flightctl/flightctl-ui/compare/v1.1.0-rc5...v1.1.0-rc6#diff-050a86eecfc34c3a4c1f75b974ec29ff12fb40e586bee28f0d0efed38856f5b3R134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication callback handling by adding a default HTTPS callback redirect (without an explicit port) alongside the existing redirect, improving compatibility with providers or environments that expect the standard HTTPS host form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->