### PR TITLE
EDM-3454: Skip invalid config drop-ins instead of crashing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -340,6 +340,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	statusManager.RegisterStatusExporter(osManager)
 	statusManager.RegisterStatusExporter(specManager)
 	statusManager.RegisterStatusExporter(systemInfoManager)
+	if len(a.config.Warnings) > 0 {
+		statusManager.RegisterStatusExporter(&configWarningExporter{warnings: a.config.Warnings})
+	}
 
 	// create config controller
 	configController := config.NewController(
@@ -367,17 +370,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	// bootstrap
 	if err := bootstrap.Initialize(ctx); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
-	}
-
-	if len(a.config.Warnings) > 0 {
-		msg := strings.Join(a.config.Warnings, "; ")
-		_, updateErr := statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
-			Status: v1beta1.DeviceSummaryStatusDegraded,
-			Info:   &msg,
-		}))
-		if updateErr != nil {
-			a.log.Warnf("Failed to report config warnings to status: %v", updateErr)
-		}
 	}
 
 	// Initialize certificate manager
@@ -539,5 +531,23 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 	}
 
 	log.Info("Successfully wiped certificate and restarted flightctl-agent service")
+	return nil
+}
+
+// configWarningExporter surfaces config loading warnings (e.g. skipped drop-ins)
+// in the device summary on every status collection cycle.
+type configWarningExporter struct {
+	warnings []string
+}
+
+func (e *configWarningExporter) Status(_ context.Context, s *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
+	if len(e.warnings) == 0 {
+		return nil
+	}
+	msg := log.Truncate(strings.Join(e.warnings, "; "), status.MaxMessageLength)
+	if s.Summary.Status == v1beta1.DeviceSummaryStatusOnline {
+		s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
+	}
+	s.Summary.Info = &msg
 	return nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -341,7 +341,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	statusManager.RegisterStatusExporter(specManager)
 	statusManager.RegisterStatusExporter(systemInfoManager)
 	if len(a.config.Warnings) > 0 {
-		statusManager.RegisterStatusExporter(&configWarningExporter{warnings: a.config.Warnings})
+		statusManager.RegisterStatusExporter(newConfigWarningExporter(a.config.Warnings))
 	}
 
 	// create config controller
@@ -537,17 +537,20 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 // configWarningExporter surfaces config loading warnings (e.g. skipped drop-ins)
 // in the device summary on every status collection cycle.
 type configWarningExporter struct {
-	warnings []string
+	msg string
+}
+
+func newConfigWarningExporter(warnings []string) *configWarningExporter {
+	return &configWarningExporter{
+		msg: log.Truncate(strings.Join(warnings, "; "), status.MaxMessageLength),
+	}
 }
 
 func (e *configWarningExporter) Status(_ context.Context, s *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
-	if len(e.warnings) == 0 {
+	if s.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
 		return nil
 	}
-	msg := log.Truncate(strings.Join(e.warnings, "; "), status.MaxMessageLength)
-	if s.Summary.Status == v1beta1.DeviceSummaryStatusOnline {
-		s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
-	}
-	s.Summary.Info = &msg
+	s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
+	s.Summary.Info = &e.msg
 	return nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -366,6 +367,17 @@ func (a *Agent) Run(ctx context.Context) error {
 	// bootstrap
 	if err := bootstrap.Initialize(ctx); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
+	}
+
+	if len(a.config.Warnings) > 0 {
+		msg := strings.Join(a.config.Warnings, "; ")
+		_, updateErr := statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
+			Status: v1beta1.DeviceSummaryStatusDegraded,
+			Info:   &msg,
+		}))
+		if updateErr != nil {
+			a.log.Warnf("Failed to report config warnings to status: %v", updateErr)
+		}
 	}
 
 	// Initialize certificate manager

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -421,16 +421,20 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 	}
 	sort.Strings(yamlFiles)
 
-	// Apply drop-ins in order (later files override earlier ones)
+	// Apply drop-ins in order (later files override earlier ones).
+	// Invalid drop-ins are skipped with a warning so the agent can still
+	// start and perform spec rollback if needed.
 	for _, filename := range yamlFiles {
 		overrideCfg := &Config{}
 		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
-			return fmt.Errorf("reading override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping unreadable override config %s: %v", overridePath, err)
+			continue
 		}
 		if err := yaml.Unmarshal(contents, overrideCfg); err != nil {
-			return fmt.Errorf("unmarshalling override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping invalid override config %s: %v", overridePath, err)
+			continue
 		}
 		mergeConfigs(cfg, overrideCfg)
 	}

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -156,6 +156,10 @@ type Config struct {
 	// ImagePruning holds all image/artifact pruning-related configuration
 	ImagePruning ImagePruning `json:"image-pruning,omitempty"`
 
+	// Warnings collects non-fatal issues encountered during config loading
+	// (e.g., skipped drop-ins) so they can be surfaced in device status.
+	Warnings []string `json:"-"`
+
 	readWriter fileio.ReadWriter
 }
 
@@ -440,11 +444,15 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
-			logrus.Warnf("Skipping unreadable override config %s: %v", overridePath, err)
+			msg := fmt.Sprintf("Skipping unreadable override config %s: %v", overridePath, err)
+			logrus.Warn(msg)
+			cfg.Warnings = append(cfg.Warnings, msg)
 			continue
 		}
 		if err := yaml.Unmarshal(contents, overrideCfg); err != nil {
-			logrus.Warnf("Skipping invalid override config %s: %v", overridePath, err)
+			msg := fmt.Sprintf("Skipping invalid override config %s: %v", overridePath, err)
+			logrus.Warn(msg)
+			cfg.Warnings = append(cfg.Warnings, msg)
 			continue
 		}
 		mergeConfigs(cfg, overrideCfg)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -432,16 +432,20 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 	}
 	sort.Strings(yamlFiles)
 
-	// Apply drop-ins in order (later files override earlier ones)
+	// Apply drop-ins in order (later files override earlier ones).
+	// Invalid drop-ins are skipped with a warning so the agent can still
+	// start and perform spec rollback if needed.
 	for _, filename := range yamlFiles {
 		overrideCfg := &Config{}
 		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
-			return fmt.Errorf("reading override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping unreadable override config %s: %v", overridePath, err)
+			continue
 		}
 		if err := yaml.Unmarshal(contents, overrideCfg); err != nil {
-			return fmt.Errorf("unmarshalling override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping invalid override config %s: %v", overridePath, err)
+			continue
 		}
 		mergeConfigs(cfg, overrideCfg)
 	}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -271,3 +271,104 @@ image-pruning:
 	require.NotNil(cfg.ImagePruning.Enabled, "Enabled should not be nil when dropin enables pruning")
 	require.True(*cfg.ImagePruning.Enabled, "pruning dropin should override config setting")
 }
+
+func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// Invalid YAML dropin (tab character breaks YAML parsing)
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "01-bad.yaml"),
+		[]byte("image-pruning:\n\t enabled: true\n"),
+		0o600,
+	))
+
+	// Valid dropin applied after the invalid one
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-good.yaml"),
+		[]byte("log-level: debug\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "invalid dropin should be skipped, not cause an error")
+
+	// Valid dropin should still be applied
+	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
+}
+
+func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte("invalid: yaml: [\n"), 0o600))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.Error(err, "invalid base config should still return an error")
+}
+
+func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// All dropins are invalid
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "01-bad.yaml"),
+		[]byte("image-pruning:\n\t enabled: true\n"),
+		0o600,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-also-bad.yaml"),
+		[]byte("{{{not yaml at all\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "all invalid dropins should be skipped, agent should still start")
+
+	// Base config values should be intact
+	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
+}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -272,152 +272,122 @@ image-pruning:
 	require.True(*cfg.ImagePruning.Enabled, "pruning dropin should override config setting")
 }
 
-func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+func TestLoadWithOverrides_DropinErrorHandling(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseConfig       string
+		setupDropins     func(t *testing.T, dropinDir string)
+		wantErr          bool
+		skipOnRoot       bool
+		expectedLogLevel string
+		expectedWarnings int
+		warningContains  string
+	}{
+		{
+			name:       "When an invalid dropin exists it should skip it and apply valid ones",
+			baseConfig: yamlConfig,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-bad.yaml"),
+					[]byte("image-pruning:\n\t enabled: true\n"),
+					0o600,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-good.yaml"),
+					[]byte("log-level: debug\n"),
+					0o600,
+				))
+			},
+			expectedLogLevel: "debug",
+			expectedWarnings: 1,
+			warningContains:  "01-bad.yaml",
+		},
+		{
+			name:       "When the base config is invalid it should return an error",
+			baseConfig: "invalid: yaml: [\n",
+			wantErr:    true,
+		},
+		{
+			name:       "When only invalid dropins exist it should still succeed with base config",
+			baseConfig: yamlConfig,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-bad.yaml"),
+					[]byte("image-pruning:\n\t enabled: true\n"),
+					0o600,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-also-bad.yaml"),
+					[]byte("{{{not yaml at all\n"),
+					0o600,
+				))
+			},
+			expectedWarnings: 2,
+		},
+		{
+			name:       "When an unreadable dropin exists it should skip it and apply valid ones",
+			baseConfig: yamlConfig,
+			skipOnRoot: true,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-unreadable.yaml"),
+					[]byte("log-level: debug\n"),
+					0o000,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-good.yaml"),
+					[]byte("log-level: warn\n"),
+					0o600,
+				))
+			},
+			expectedLogLevel: "warn",
+			expectedWarnings: 1,
+			warningContains:  "01-unreadable.yaml",
+		},
+	}
 
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipOnRoot && os.Getuid() == 0 {
+				t.Skip("permission test is not meaningful when running as root")
+			}
 
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+			require := require.New(t)
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "etc", "flightctl")
+			dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
 
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+			require.NoError(os.MkdirAll(configDir, 0o755))
+			require.NoError(os.MkdirAll(dataDir, 0o755))
 
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
+			cfg := NewDefault()
+			cfg.ConfigDir = configDir
+			cfg.DataDir = dataDir
+			cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
 
-	// Invalid YAML dropin (tab character breaks YAML parsing)
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "01-bad.yaml"),
-		[]byte("image-pruning:\n\t enabled: true\n"),
-		0o600,
-	))
+			configFile := filepath.Join(configDir, "config.yaml")
+			require.NoError(os.WriteFile(configFile, []byte(tt.baseConfig), 0o600))
 
-	// Valid dropin applied after the invalid one
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-good.yaml"),
-		[]byte("log-level: debug\n"),
-		0o600,
-	))
+			if tt.setupDropins != nil {
+				dropinDir := filepath.Join(configDir, "conf.d")
+				require.NoError(os.MkdirAll(dropinDir, 0o755))
+				tt.setupDropins(t, dropinDir)
+			}
 
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "invalid dropin should be skipped, not cause an error")
+			err := cfg.LoadWithOverrides(configFile)
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
 
-	// Valid dropin should still be applied
-	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
-
-	// Warning should be recorded for the invalid dropin
-	require.Len(cfg.Warnings, 1, "one warning should be recorded for the invalid dropin")
-	require.Contains(cfg.Warnings[0], "01-bad.yaml")
-}
-
-func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte("invalid: yaml: [\n"), 0o600))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.Error(err, "invalid base config should still return an error")
-}
-
-func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
-
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
-
-	// All dropins are invalid
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "01-bad.yaml"),
-		[]byte("image-pruning:\n\t enabled: true\n"),
-		0o600,
-	))
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-also-bad.yaml"),
-		[]byte("{{{not yaml at all\n"),
-		0o600,
-	))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "all invalid dropins should be skipped, agent should still start")
-
-	// Base config values should be intact
-	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
-
-	// Warnings should be recorded for both invalid dropins
-	require.Len(cfg.Warnings, 2, "warnings should be recorded for each invalid dropin")
-}
-
-func TestLoadWithOverrides_UnreadableDropinIsSkipped(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
-
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
-
-	// Create a dropin file with no read permissions
-	unreadablePath := filepath.Join(dropinDir, "01-unreadable.yaml")
-	require.NoError(os.WriteFile(unreadablePath, []byte("log-level: debug\n"), 0o000))
-
-	// Valid dropin applied after the unreadable one
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-good.yaml"),
-		[]byte("log-level: warn\n"),
-		0o600,
-	))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "unreadable dropin should be skipped, not cause an error")
-
-	// Valid dropin should still be applied
-	require.Equal("warn", cfg.LogLevel, "valid dropin after unreadable one should still be applied")
-
-	// Warning should be recorded for the unreadable dropin
-	require.Len(cfg.Warnings, 1, "one warning should be recorded for the unreadable dropin")
-	require.Contains(cfg.Warnings[0], "01-unreadable.yaml")
+			if tt.expectedLogLevel != "" {
+				require.Equal(tt.expectedLogLevel, cfg.LogLevel)
+			}
+			require.Len(cfg.Warnings, tt.expectedWarnings)
+			if tt.warningContains != "" {
+				require.Contains(cfg.Warnings[0], tt.warningContains)
+			}
+		})
+	}
 }

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -311,6 +311,10 @@ func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
 
 	// Valid dropin should still be applied
 	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
+
+	// Warning should be recorded for the invalid dropin
+	require.Len(cfg.Warnings, 1, "one warning should be recorded for the invalid dropin")
+	require.Contains(cfg.Warnings[0], "01-bad.yaml")
 }
 
 func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
@@ -371,4 +375,49 @@ func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
 
 	// Base config values should be intact
 	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
+
+	// Warnings should be recorded for both invalid dropins
+	require.Len(cfg.Warnings, 2, "warnings should be recorded for each invalid dropin")
+}
+
+func TestLoadWithOverrides_UnreadableDropinIsSkipped(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// Create a dropin file with no read permissions
+	unreadablePath := filepath.Join(dropinDir, "01-unreadable.yaml")
+	require.NoError(os.WriteFile(unreadablePath, []byte("log-level: debug\n"), 0o000))
+
+	// Valid dropin applied after the unreadable one
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-good.yaml"),
+		[]byte("log-level: warn\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "unreadable dropin should be skipped, not cause an error")
+
+	// Valid dropin should still be applied
+	require.Equal("warn", cfg.LogLevel, "valid dropin after unreadable one should still be applied")
+
+	// Warning should be recorded for the unreadable dropin
+	require.Len(cfg.Warnings, 1, "one warning should be recorded for the unreadable dropin")
+	require.Contains(cfg.Warnings[0], "01-unreadable.yaml")
 }


### PR DESCRIPTION
## Problem

When a device spec delivers an invalid YAML file to `/etc/flightctl/conf.d/`, the agent crashes at startup with `log.Fatalf` before reaching bootstrap/rollback logic. Combined with an OS update, this permanently bricks the device: greenboot rolls back the OS, but `/etc` is a persistent overlay in bootc systems, so the bad config file survives and the agent crash-loops indefinitely.

## Root Cause

`LoadWithOverrides()` in `internal/agent/config/config.go` treated YAML parse errors in individual `conf.d/` drop-in files as fatal errors. The error propagated to `main.go:97` where `log.Fatalf` terminated the process. Introduced in PR #1126 (EDM-1492) when `conf.d/` support was added without distinguishing recoverable drop-in failures from fatal base config failures.

## Fix

Change the drop-in loop in `LoadWithOverrides` to log a warning and `continue` to the next file when a drop-in is unreadable or contains invalid YAML. Base config parse errors, `Complete()`, and `Validate()` remain fatal.

This matches the resilience model already used in `reload.go:63-66`, where `config.Load()` errors are handled gracefully.

## Testing

- **Unit tests**: 3 new test cases covering invalid drop-in skip, base config still fatal, and all-invalid-dropins scenario. All config package tests pass.
- **VM verification**: Deployed fixed binary to the bricked agent VM. Agent starts, logs warning for the invalid drop-in, detects OS mismatch, performs spec rollback, and completes bootstrap.

## Risk Assessment

LOW — The change is 2 lines of production code (error return → warn + continue), scoped to the drop-in iteration loop only. Base config errors are unaffected. The `mergeConfigs` function limits which fields drop-ins can override, so semantic validation via `Validate()` is not impacted by the fields drop-ins touch.