### PR TITLE
EDM-2839: Suppress misleading worker warning logs

### DIFF
--- a/cmd/flightctl-worker/main.go
+++ b/cmd/flightctl-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -20,6 +21,7 @@ import (
 	"github.com/flightctl/flightctl/pkg/queues"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
 )
 
 func main() {
@@ -64,8 +66,11 @@ func main() {
 
 	k8sClient, err := k8sclient.NewK8SClient()
 	if err != nil {
-		log.WithError(err).Warning("initializing k8s client, assuming k8s is not supported")
-		k8sClient = nil
+		if errors.Is(err, rest.ErrNotInCluster) {
+			log.Info("Kubernetes environment not detected, kubernetes features are disabled")
+		} else {
+			log.WithError(err).Error("initializing k8s client, kubernetes features are disabled")
+		}
 	}
 
 	// Initialize metrics collectors

--- a/internal/periodic_checker/consumer_test.go
+++ b/internal/periodic_checker/consumer_test.go
@@ -264,7 +264,12 @@ func TestPeriodicTaskConsumer_ContextCanceled(t *testing.T) {
 
 	consumerCtx, consumerCancel := context.WithCancel(context.Background())
 	defer consumerCancel()
-	go consumer.Run(consumerCtx)
+
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		consumer.Run(consumerCtx)
+	}()
 
 	taskRef := createTaskReference(PeriodicTaskTypeRepositoryTester)
 	err = channelManager.PublishTask(ctx, taskRef)
@@ -275,14 +280,20 @@ func TestPeriodicTaskConsumer_ContextCanceled(t *testing.T) {
 		return mockExecutor.GetExecuteCallCount() == 1
 	}, 1*time.Second, 10*time.Millisecond)
 
+	// Wait for all consumer goroutines to exit before publishing more work,
+	// otherwise a goroutine may select the task channel over ctx.Done().
 	consumerCancel()
+	select {
+	case <-consumerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumer did not stop in time")
+	}
 
+	// All goroutines have exited — no one is alive to dequeue this.
 	taskRef2 := createTaskReference(PeriodicTaskTypeRepositoryTester)
 	err = channelManager.PublishTask(ctx, taskRef2)
-	require.NoError(t, err) // Publishing should succeed
+	require.NoError(t, err)
 
-	// Wait a bit and verify no additional tasks were processed
-	time.Sleep(100 * time.Millisecond)
 	finalCount := mockExecutor.GetExecuteCallCount()
 	require.Equal(t, 1, finalCount, "no additional tasks should be processed after stopping consumer")
 }

--- a/internal/tasks/queue_maintenance.go
+++ b/internal/tasks/queue_maintenance.go
@@ -239,13 +239,14 @@ func (t *QueueMaintenanceTask) recoverFromMissingCheckpoint(ctx context.Context,
 			return fmt.Errorf("failed to get checkpoint from database: %s", status.Message)
 		}
 	} else {
-		// Success case - parse the database checkpoint
-		if parsedTime, err := time.Parse(time.RFC3339Nano, string(dbCheckpointBytes)); err == nil {
+		rawCheckpoint := string(dbCheckpointBytes)
+		if rawCheckpoint == "" {
+			log.Info("Database checkpoint is empty, treating as fresh system")
+		} else if parsedTime, err := time.Parse(time.RFC3339Nano, rawCheckpoint); err != nil {
+			log.WithError(err).WithField("checkpoint", rawCheckpoint).Error("Failed to parse database checkpoint, treating as fresh system")
+		} else {
 			lastCheckpointTime = parsedTime
 			log.WithField("lastCheckpoint", lastCheckpointTime.Format(time.RFC3339Nano)).Info("Found last checkpoint in database")
-		} else {
-			log.WithError(err).Warn("Failed to parse database checkpoint, treating as fresh system")
-			lastCheckpointTime = time.Time{}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Distinguishes between missing Kubernetes environment variables (`rest.ErrNotInCluster`) and actual k8s client errors during worker startup. Missing env vars log at `Info` level; other errors log at `Error` level. Both allow the worker to continue with k8s features disabled.
- Downgrades the checkpoint parse log in `queue_maintenance.go` for fresh systems: empty checkpoint logs `Info`, malformed non-empty checkpoint logs `Error` with the value included.
- Fixes flaky `TestPeriodicTaskConsumer_ContextCanceled` test by waiting for all consumer goroutines to exit before publishing a second task, eliminating a `select` race condition.

Fixes: [EDM-2839](https://redhat.atlassian.net/browse/EDM-2839), [EDM-2415](https://redhat.atlassian.net/browse/EDM-2415)

## Test plan
- [x] `make unit-test` passes
- [x] `make lint` passes
- [x] Deploy via Helm (`make deploy`) — worker starts cleanly, no misleading warnings
- [x] Run worker container outside k8s (`podman run`) — logs `"Kubernetes environment not detected, kubernetes features are disabled"` at info level
- [x] Flaky test fix verified with 50 consecutive passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes cluster detection to distinguish between running outside a cluster and other initialization failures, with appropriate logging for each scenario.
  * Enhanced checkpoint recovery error logging to provide more detailed diagnostic information, including the raw checkpoint value, for better troubleshooting.
  * Improved consumer shutdown handling with more reliable signal verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->