### PR TITLE
EDM-3683: Allow dots in configuration provider names

### DIFF
--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -342,7 +342,7 @@ func (r ResourceAlertRule) Validate(specSampleInterval string) []error {
 
 func (c GitConfigProviderSpec) Validate(fleetTemplate bool) []error {
 	allErrs := []error{}
-	allErrs = append(allErrs, validation.ValidateGenericName(&c.Name, "spec.config[].name")...)
+	allErrs = append(allErrs, validation.ValidateConfigName(&c.Name, "spec.config[].name")...)
 	allErrs = append(allErrs, validation.ValidateResourceNameReference(&c.GitRef.Repository, "spec.config[].gitRef.repository")...)
 
 	containsParams, paramErrs := validateParametersInString(&c.GitRef.TargetRevision, "spec.config[].gitRef.targetRevision", fleetTemplate)
@@ -361,7 +361,7 @@ func (c GitConfigProviderSpec) Validate(fleetTemplate bool) []error {
 
 func (c KubernetesSecretProviderSpec) Validate(fleetTemplate bool) []error {
 	allErrs := []error{}
-	allErrs = append(allErrs, validation.ValidateGenericName(&c.Name, "spec.config[].name")...)
+	allErrs = append(allErrs, validation.ValidateConfigName(&c.Name, "spec.config[].name")...)
 
 	containsParams, paramErrs := validateParametersInString(&c.SecretRef.Name, "spec.config[].secretRef.name", fleetTemplate)
 	allErrs = append(allErrs, paramErrs...)
@@ -389,7 +389,7 @@ func (c KubernetesSecretProviderSpec) Validate(fleetTemplate bool) []error {
 
 func (c InlineConfigProviderSpec) Validate(fleetTemplate bool) []error {
 	allErrs := []error{}
-	allErrs = append(allErrs, validation.ValidateGenericName(&c.Name, "spec.config[].name")...)
+	allErrs = append(allErrs, validation.ValidateConfigName(&c.Name, "spec.config[].name")...)
 	for i := range c.Inline {
 		containsParams, paramErrs := validateParametersInString(&c.Inline[i].Path, fmt.Sprintf("spec.config[].inline[%d].path", i), fleetTemplate)
 		allErrs = append(allErrs, paramErrs...)
@@ -425,7 +425,7 @@ func (c InlineConfigProviderSpec) Validate(fleetTemplate bool) []error {
 
 func (h HttpConfigProviderSpec) Validate(fleetTemplate bool) []error {
 	allErrs := []error{}
-	allErrs = append(allErrs, validation.ValidateGenericName(&h.Name, "spec.config[].name")...)
+	allErrs = append(allErrs, validation.ValidateConfigName(&h.Name, "spec.config[].name")...)
 	allErrs = append(allErrs, validation.ValidateResourceNameReference(&h.HttpRef.Repository, "spec.config[].httpRef.repository")...)
 
 	containsParams, paramErrs := validateParametersInString(&h.HttpRef.FilePath, "spec.config[].httpRef.filePath", fleetTemplate)

--- a/internal/util/validation/formats.go
+++ b/internal/util/validation/formats.go
@@ -16,6 +16,12 @@ const (
 	DNS1123MaxLength      int    = 253
 	envVarNameFmt         string = `[A-Za-z_][A-Za-z0-9_]*`
 
+	// ConfigNameFmt extends the DNS 1123 label format to also allow dots,
+	// supporting config names like "example.json" or "config.yaml".
+	// Must start and end with an alphanumeric character.
+	ConfigNameFmt       string = `[a-z0-9]([-a-z0-9.]*[a-z0-9])?`
+	configNameMaxLength int    = 253
+
 	// HostnameOrFQDNFmt validates a hostname or FQDN (Fully Qualified Domain Name).
 	// A hostname is a single DNS label, an FQDN is one or more labels separated by dots.
 	// Each label follows DNS rules: lowercase alphanumerics and hyphens, start and end with alphanumeric.
@@ -44,6 +50,7 @@ const (
 
 var (
 	GenericNameRegexp                    = regexp.MustCompile("^" + Dns1123LabelFmt + "$")
+	ConfigNameRegexp                     = regexp.MustCompile("^" + ConfigNameFmt + "$")
 	EnvVarNameRegexp                     = regexp.MustCompile("^" + envVarNameFmt + "$")
 	HostnameOrFQDNRegexp                 = regexp.MustCompile("^" + HostnameOrFQDNFmt + "$")
 	HostnameOrFQDNWithOptionalPortRegexp = regexp.MustCompile("^" + HostnameOrFQDNWithOptionalPortFmt + "$")
@@ -52,6 +59,13 @@ var (
 
 func ValidateGenericName(name *string, path string) []error {
 	return ValidateString(name, path, 1, dns1123LabelMaxLength, GenericNameRegexp, Dns1123LabelFmt)
+}
+
+// ValidateConfigName validates a configuration provider name.
+// It allows dots in addition to the characters permitted by ValidateGenericName,
+// supporting names like "example.json" or "config.yaml".
+func ValidateConfigName(name *string, path string) []error {
+	return ValidateString(name, path, 1, configNameMaxLength, ConfigNameRegexp, ConfigNameFmt, "example.json", "my-config")
 }
 
 func ValidateHostnameOrFQDN(name *string, path string) []error {

--- a/internal/util/validation/formats_test.go
+++ b/internal/util/validation/formats_test.go
@@ -33,6 +33,51 @@ func TestValidateGenericName(t *testing.T) {
 	}
 }
 
+func TestValidateConfigName(t *testing.T) {
+	assert := assert.New(t)
+
+	goodValues := []string{
+		"a",
+		"a-good-name",
+		"example.json",
+		"example.env",
+		"config.yaml",
+		"my.config.v2",
+		"a.b",
+		"my-app.config",
+		strings.Repeat("a", 253),
+	}
+	for _, val := range goodValues {
+		assert.Empty(ValidateConfigName(&val, "good.config.name"), fmt.Sprintf("value: %q", val))
+	}
+
+	badValues := []string{
+		"",
+		".starts-with-dot",
+		"ends-with-dot.",
+		"-starts-with-dash",
+		"ends-with-dash-",
+		"WITH-CAPITAL-LETTERS",
+		"has spaces",
+		"has_underscores",
+		strings.Repeat("a", 254),
+	}
+
+	// These are technically allowed by the current regex but could be
+	// considered ugly. Documenting them as accepted to track the decision.
+	acceptedEdgeCases := []string{
+		"example.-json",
+		"example-.json",
+		"example..json",
+	}
+	for _, val := range acceptedEdgeCases {
+		assert.Empty(ValidateConfigName(&val, "edge.config.name"), fmt.Sprintf("value: %q", val))
+	}
+	for _, val := range badValues {
+		assert.NotEmpty(ValidateConfigName(&val, "bad.config.name"), fmt.Sprintf("value: %q", val))
+	}
+}
+
 func TestValidateOciImageReference(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
## Problem

Configuration names are validated using DNS 1123 label format (`[a-z0-9]([-a-z0-9]*[a-z0-9])?`), which only allows lowercase letters, numbers, and hyphens. Names like `example.json`, `config.yaml`, or `example.env` are rejected, despite the UI indicating dots are allowed.

## Root Cause

All 4 config provider validators (`GitConfigProviderSpec`, `InlineConfigProviderSpec`, `HttpConfigProviderSpec`, `KubernetesSecretProviderSpec`) use `ValidateGenericName` for the `Name` field, which enforces DNS 1123 label format — no dots.

## Fix

1. Added `ValidateConfigName` with regex `[a-z0-9]([-a-z0-9.]*[a-z0-9])?` that allows dots while still requiring alphanumeric start/end characters.
2. Updated the 4 config provider `Validate` methods to use `ValidateConfigName` for the `Name` field only.
3. `ValidateGenericName` remains unchanged — it is still used for Kubernetes secret names, namespaces, Helm namespaces, and volume names where DNS 1123 label format is correct.

## Testing

- Unit tests added for `ValidateConfigName` covering valid names (`example.json`, `config.yaml`, `my.config.v2`) and invalid names (leading/trailing dots, dashes, uppercase, underscores, spaces, length overflow).
- All existing tests pass with zero regressions.
- E2E verified: applied a fleet with `name: example.json` config — API returned `201 Created`, fleet status `Valid`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced configuration name validation:
    - Now supports dot-separated naming patterns (e.g., "example.json", "my-config")
    - Maximum name length enforced at 253 characters
    - Names must start and end with alphanumeric characters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->