### PR TITLE
Use images from quay.io for UI in local Quadlets deployment

### DIFF
--- a/packaging/images/el10/local-images.yaml
+++ b/packaging/images/el10/local-images.yaml
@@ -23,7 +23,8 @@ db-setup:
   image: flightctl-db-setup-el10
   tag: latest
 ui:
-  image: flightctl-ui-el10
+  # UI images are built from flightctl-ui repo
+  image: quay.io/flightctl/flightctl-ui-el10
   tag: latest
 db:
   # Using CentOS Stream 10 PostgreSQL for EL10 flavor

--- a/packaging/images/el9/local-images.yaml
+++ b/packaging/images/el9/local-images.yaml
@@ -23,7 +23,8 @@ db-setup:
   image: flightctl-db-setup-el9
   tag: latest
 ui:
-  image: flightctl-ui-el9
+  # UI images are built from flightctl-ui repo
+  image: quay.io/flightctl/flightctl-ui-el9
   tag: latest
 db:
   image: quay.io/sclorg/postgresql-16-c9s


### PR DESCRIPTION
UI images are built in flightctl-ui and must be retrieved from `quay.io`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image registry references for UI components across multiple platform configurations to use fully-qualified registry paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->