### PR TITLE
EDM-3396: improving the misleading message in E2E BeforeSuite

### DIFF
--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -2447,7 +2447,12 @@ func printAgentFilesForVM(vm vm.TestVMInterface, context string) {
 		// Regular file handling
 		stdout, err := vm.RunSSH([]string{"sudo", "cat", filePath}, nil)
 		if err != nil {
-			fmt.Printf("❌ [%s] Failed to read %s: %v\n", context, fileType, err)
+			// Missing agent state files are expected before the agent is started.
+			if strings.Contains(err.Error(), "No such file or directory") {
+				fmt.Printf("✅ [%s] %s is absent (expected before agent start)\n", context, fileType)
+			} else {
+				fmt.Printf("❌ [%s] Failed to read %s: %v\n", context, fileType, err)
+			}
 		} else {
 			content := stdout.String()
 			if content == "" {


### PR DESCRIPTION
Before fix

```
20:45:50  ✅ [VMPool] Worker 1: Pristine snapshot created successfully
20:45:50  🔍 [VMPool] Worker 1: Printing agent files after snapshot creation:
20:45:50  🔍 [After Snapshot Creation] Printing agent files:
20:45:50  📄 [After Snapshot Creation] current.json:
20:45:50  ❌ [After Snapshot Creation] Failed to read current.json: failed to run ssh command: exit status 1, stderr: cat: /var/lib/flightctl/current.json: No such file or directory
20:45:50  , stdout: 
20:45:50  ---
20:45:50  📄 [After Snapshot Creation] desired.json:
20:45:51  ❌ [After Snapshot Creation] Failed to read desired.json: failed to run ssh command: exit status 1, stderr: cat: /var/lib/flightctl/desired.json: No such file or directory
20:45:51  , stdout: 
20:45:51  ---
20:45:51  📄 [After Snapshot Creation] agent secret:
20:45:51  ❌ [After Snapshot Creation] Failed to read agent secret: failed to run ssh command: exit status 1, stderr: cat: /etc/flightctl/certs/agent.crt: No such file or directory
20:45:51  , stdout: 
20:45:51  ---
20:45:51  ✅ [VMPool] Worker 1: VM setup completed, VM is running
20:45:51  time="2026-04-16T14:45:51-04:00" level=info msg="✅ [SetupWorkerHarness] Worker 1: VM and harness setup completed"
20:45:51    < Exit [BeforeSuite] TOP-LEVEL - /home/kni/flightctl/test/e2e/agent/agent_suite_test.go:48 @ 04/16/26 14:45:51.079 (5m58.71s)
20:45:51  [BeforeSuite] PASSED [358.710 seconds]
```

After fix

```
13:42:48  time="2026-04-17T07:42:46-04:00" level=info msg="🔄 [SetupWorkerHarness] Worker 1: Setting up VM and harness"
13:42:48  🔄 [VMPool] Worker 1: Creating VM flightctl-e2e-worker-1
13:42:48  🔄 [VMPool] Worker 1: Creating shared base disk at /tmp/shared-base-disk.qcow2
13:42:48  ✅ [VMPool] Worker 1: Shared base disk created successfully
13:42:48  🔄 [VMPool] Worker 1: Creating qcow2 overlay disk with shared backing file at /tmp/flightctl-e2e-worker-1/worker-1-disk.qcow2
13:42:48  ✅ [VMPool] Worker 1: Overlay disk created successfully
13:42:48  ✅ [VMPool] Worker 1: VM struct created
13:42:48  🔄 [VMPool] Worker 1: Pristine revert if reusing existing domain (before SSH)
13:42:48  🔄 [VMPool] Worker 1: Starting VM and waiting for SSH
13:42:48  time="2026-04-17T07:42:46-04:00" level=info msg="[VMPool-bootstrap] vm=flightctl-e2e-worker-1: no existing libvirt domain, skipping pristine revert before SSH"
13:42:48  time="2026-04-17T07:42:46-04:00" level=info msg="Starting VM flightctl-e2e-worker-1"
13:42:50  time="2026-04-17T07:42:49-04:00" level=info msg="Waiting for VM SSH to be ready via RunSSH on 127.0.0.1:2234 (timeout 3m0s)"
13:43:48  ✅ [VMPool] Worker 1: VM started and SSH ready
13:43:48  🔄 [VMPool] Worker 1: Creating pristine snapshot
13:44:57  🔄 [VMPool] Worker 1: Stopping flightctl-agent before cleanup
13:45:01  ✅ [VMPool] Worker 1: Pristine snapshot created successfully
13:45:01  time="2026-04-17T07:45:00-04:00" level=info msg="Created external snapshot pristine for VM flightctl-e2e-worker-1 with memory file /tmp/flightctl-e2e-worker-1/flightctl-e2e-worker-1.mem"
13:45:01  🔍 [VMPool] Worker 1: Printing agent files after snapshot creation:
13:45:01  🔍 [After Snapshot Creation] Printing agent files:
13:45:01  📄 [After Snapshot Creation] current.json:
13:45:01  ✅ [After Snapshot Creation] current.json is absent (expected before agent start)
13:45:01  ---
13:45:01  📄 [After Snapshot Creation] desired.json:
13:45:02  ✅ [After Snapshot Creation] desired.json is absent (expected before agent start)
13:45:02  ---
13:45:02  📄 [After Snapshot Creation] agent secret:
13:45:02  ✅ [After Snapshot Creation] agent secret is absent (expected before agent start)
13:45:02  ---
13:45:02  ✅ [VMPool] Worker 1: VM setup completed, VM is running
13:45:02  time="2026-04-17T07:45:01-04:00" level=info msg="✅ [SetupWorkerHarness] Worker 1: VM and harness setup completed"
13:45:02    < Exit [BeforeSuite] TOP-LEVEL - /home/kni/flightctl/test/e2e/agent/agent_suite_test.go:48 @ 04/17/26 07:45:01.777 (5m58.547s)
13:45:02  [BeforeSuite] PASSED [358.548 seconds]
```
https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-flightctl-gotests/420/consoleFull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling in test harness for file operations, with better detection of missing files and clearer messaging during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->