### PR TITLE
EDM-3512: Add tool field to cli download artifacts

### DIFF
--- a/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-console.yaml
+++ b/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-console.yaml
@@ -14,16 +14,16 @@ spec:
   links:
     - href: '{{ $url }}/amd64/linux/flightctl-linux-amd64.tar.gz'
       text: Download flightctl for Linux for x86_64
+    - href: '{{ $url }}/arm64/linux/flightctl-linux-arm64.tar.gz'
+      text: Download flightctl for Linux for ARM64
     - href: '{{ $url }}/amd64/mac/flightctl-darwin-amd64.zip'
       text: Download flightctl for Mac for x86_64
+    - href: '{{ $url }}/arm64/mac/flightctl-darwin-arm64.zip'
+      text: Download flightctl for Mac for ARM64
     - href: '{{ $url }}/amd64/windows/flightctl-windows-amd64.zip'
       text: Download flightctl for Windows for x86_64
-    - href: '{{ $url }}/arm64/linux/flightctl-linux-arm64.tar.gz'
-      text: Download flightctl for Linux for ARM 64
-    - href: '{{ $url }}/arm64/mac/flightctl-darwin-arm64.zip'
-      text: Download flightctl for Mac for ARM 64
     - href: '{{ $url }}/arm64/windows/flightctl-windows-arm64.zip'
-      text: Download flightctl for Windows for ARM 64
+      text: Download flightctl for Windows for ARM64
 ---
 apiVersion: console.openshift.io/v1
 kind: ConsoleCLIDownload
@@ -38,14 +38,14 @@ spec:
   links:
     - href: '{{ $url }}/amd64/linux/flightctl-restore-linux-amd64.tar.gz'
       text: Download flightctl-restore for Linux for x86_64
+    - href: '{{ $url }}/arm64/linux/flightctl-restore-linux-arm64.tar.gz'
+      text: Download flightctl-restore for Linux for ARM64
     - href: '{{ $url }}/amd64/mac/flightctl-restore-darwin-amd64.zip'
       text: Download flightctl-restore for Mac for x86_64
+    - href: '{{ $url }}/arm64/mac/flightctl-restore-darwin-arm64.zip'
+      text: Download flightctl-restore for Mac for ARM64
     - href: '{{ $url }}/amd64/windows/flightctl-restore-windows-amd64.zip'
       text: Download flightctl-restore for Windows for x86_64
-    - href: '{{ $url }}/arm64/linux/flightctl-restore-linux-arm64.tar.gz'
-      text: Download flightctl-restore for Linux for ARM 64
-    - href: '{{ $url }}/arm64/mac/flightctl-restore-darwin-arm64.zip'
-      text: Download flightctl-restore for Mac for ARM 64
     - href: '{{ $url }}/arm64/windows/flightctl-restore-windows-arm64.zip'
-      text: Download flightctl-restore for Windows for ARM 64
+      text: Download flightctl-restore for Windows for ARM64
 {{ end }}

--- a/hack/build_multiarch_clis.sh
+++ b/hack/build_multiarch_clis.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script builds flightctl and flightctl-restore for multiple OS/arch combinations
-# and generates archives in the following layout:
+# This script builds downloadable CLI tools for multiple OS/arch combinations, lays out
+# archives under bin/clis/, and writes gh-archives/index.json.
+#
+# Each tool is built sequentially for every platform (GOARCH, GOOS) before the next tool.
+#
+# Directory layout:
 #
 # $ tree bin/clis/
 # bin/clis/
@@ -49,6 +53,7 @@ set -euo pipefail
 # │           ├── flightctl.exe
 # │           └── flightctl-restore.exe
 # └── gh-archives
+#     ├── index.json   (artifact manifest)
 #     ├── amd64
 #     │   ├── linux
 #     │   │   ├── flightctl-linux-amd64.tar.gz (+ .sha256)
@@ -69,12 +74,29 @@ set -euo pipefail
 #         └── windows
 #             ├── flightctl-windows-arm64.zip (+ .sha256)
 #             └── flightctl-restore-windows-arm64.zip (+ .sha256)
+#
+# When adding a new CLI, each index.json row includes "tool" set to that binary name.
+CLI_TOOLS=(flightctl flightctl-restore)
 
-build() {
-  local GOARCH=$1
-  local GOOS=$2
+get_cli_make_target() {
+  case "$1" in
+    flightctl) echo build-cli ;;
+    flightctl-restore) echo build-restore ;;
+    *)
+      echo "Unknown downloadable CLI '$1': add a Makefile target mapping in get_cli_make_target()." >&2
+      exit 1
+      ;;
+  esac
+}
 
-  DISABLE_FIPS=true GOARCH="${GOARCH}" GOOS="${GOOS}" make build-cli build-restore
+# Build and archive one CLI tool for a specific platform
+build_platform_cli() {
+  local CLI=$1
+  local GOARCH=$2
+  local GOOS=$3
+  local make_target=$4
+
+  DISABLE_FIPS=true GOARCH="${GOARCH}" GOOS="${GOOS}" make "${make_target}"
 
   local OS="${GOOS}"
   local TGZ=".tar.gz"
@@ -94,75 +116,60 @@ build() {
 
   mkdir -p "${BIN}" "${ARCHIVES}" "${GH_ARCHIVES}"
 
-  for CLI in flightctl flightctl-restore; do
-    cp "bin/${CLI}${EXE}" "${BIN}/"
-    cp "bin/${CLI}${EXE}" "${CLI}-${GOOS}-${GOARCH}${EXE}"
+  cp "bin/${CLI}${EXE}" "${BIN}/"
+  cp "bin/${CLI}${EXE}" "${CLI}-${GOOS}-${GOARCH}${EXE}"
 
-    if [ "${GOOS}" == "linux" ]; then
-      tar -zhcf "${ARCHIVES}/${CLI}.tar.gz" -C "${BIN}" "${CLI}"
-    else
-      zip -9 -r -q -j "${ARCHIVES}/${CLI}.zip" "${BIN}/${CLI}${EXE}"
-    fi
+  if [ "${GOOS}" == "linux" ]; then
+    tar -zhcf "${ARCHIVES}/${CLI}.tar.gz" -C "${BIN}" "${CLI}"
+  else
+    zip -9 -r -q -j "${ARCHIVES}/${CLI}.zip" "${BIN}/${CLI}${EXE}"
+  fi
 
-    local GH_OUT="${GH_ARCHIVES}/${CLI}-${GOOS}-${GOARCH}${TGZ}"
-    cp "${ARCHIVES}/${CLI}${TGZ}" "${GH_OUT}"
-    sha256sum "${GH_OUT}" | awk '{ print $1 }' > "${GH_OUT}.sha256"
-  done
+  local GH_OUT="${GH_ARCHIVES}/${CLI}-${GOOS}-${GOARCH}${TGZ}"
+  cp "${ARCHIVES}/${CLI}${TGZ}" "${GH_OUT}"
+  sha256sum "${GH_OUT}" | awk '{ print $1 }' > "${GH_OUT}.sha256"
+
+  local sha256_content filename
+  sha256_content=$(cat "${GH_OUT}.sha256")
+  filename=$(basename "${GH_OUT}")
+  jq -n -c \
+    --arg os "${OS}" \
+    --arg arch "${GOARCH}" \
+    --arg filename "${filename}" \
+    --arg sha256 "${sha256_content}" \
+    --arg tool "${CLI}" \
+    '{os: $os, arch: $arch, filename: $filename, sha256: $sha256, tool: $tool}' >>"${ARTIFACTS_JSONL}"
 }
 
-for GOARCH in amd64 arm64; do
-  for GOOS in linux darwin windows; do
-    echo -e "\033[0;37m>>>> Start building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
-    build "$GOARCH" "$GOOS"
-    echo -e "\033[0;37m>>>> Finish building cli for GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+# The artifacts JSONL file is built as a stream of JSON objects, one per archive file.
+ARTIFACTS_JSONL=$(mktemp)
+trap 'rm -f "${ARTIFACTS_JSONL}"' EXIT
+
+echo -e "\033[0;37m>>>> Building multi-arch CLI archives\033[0m"
+
+for CLI in "${CLI_TOOLS[@]}"; do
+  cli_make_target=$(get_cli_make_target "${CLI}")
+  echo -e "\033[0;37m>>>> Start all platforms for CLI=${CLI} (${cli_make_target})\033[0m"
+  for GOARCH in amd64 arm64; do
+    for GOOS in linux darwin windows; do
+      echo -e "\033[0;37m>>>>   GOARCH=${GOARCH} GOOS=${GOOS}\033[0m"
+      build_platform_cli "${CLI}" "${GOARCH}" "${GOOS}" "${cli_make_target}"
+    done
   done
+  echo -e "\033[0;37m>>>> Finished all platforms for CLI=${CLI}\033[0m"
 done
 
-echo -e "\033[0;37m>>>> building index.json\033[0m"
+echo -e "\033[0;37m>>>> writing index.json\033[0m"
 
-SOURCE_DIR="bin/clis/gh-archives"
-OUTPUT_JSON="index.json"
+OUTPUT_JSON="bin/clis/gh-archives/index.json"
 PLACEHOLDER_BASE_URL="{{CLI_ARTIFACTS_BASE_URL}}"
 
-cd "$SOURCE_DIR"
+mkdir -p "$(dirname "${OUTPUT_JSON}")"
+artifacts=$(jq -s '.' "${ARTIFACTS_JSONL}")
 
-# Build JSON array of artifact entries
-artifacts=$(find . -type f | while read -r file; do
-  filename=$(basename "$file")
-
-  # Skip index.json and .sha256 files
-  [[ "$filename" == "$OUTPUT_JSON" || "$filename" == *.sha256 ]] && continue
-
-  # Extract arch and os from path
-  parts=(${file//\// })
-  arch="${parts[1]}"
-  os="${parts[2]}"
-
-  # Read SHA256 if it exists
-  sha256_file="${file}.sha256"
-  sha256_content=""
-  [[ -f "$sha256_file" ]] && sha256_content=$(cat "$sha256_file")
-
-  # Emit artifact JSON object
-  jq -n \
-    --arg os "$os" \
-    --arg arch "$arch" \
-    --arg filename "$filename" \
-    --arg sha256 "$sha256_content" \
-    '{
-      os: $os,
-      arch: $arch,
-      filename: $filename,
-      sha256: $sha256
-    }'
-done | jq -s '.')
-
-# Write final JSON with baseUrl as placeholder
 jq -n \
   --arg baseUrl "$PLACEHOLDER_BASE_URL" \
   --argjson artifacts "$artifacts" \
-  '{baseUrl: $baseUrl, artifacts: $artifacts}' > "$OUTPUT_JSON"
-
-cd -
+  '{baseUrl: $baseUrl, artifacts: $artifacts}' >"${OUTPUT_JSON}"
 
 echo -e "\033[0;32mAll CLI binaries have been built in bin/clis/binaries and archived in bin/clis/archives and bin/clis/gh-archives\033[0m"


### PR DESCRIPTION
Adds a `tool` field to the response of cliArtifacts. Since this is a new field, the result is backwards-compatible.

I restructured the script to make the flow more explicit so that when new CLI artifacts are added the `tool` will be populated automatically for consumers.

Co-authored by `Cursor`

Example output:

```
  {
      "os": "windows",
      "arch": "arm64",
      "filename": "flightctl-windows-arm64.zip",
      "sha256": "e9087be01f5f880e5894921c48e776c6ede4611a016cb13ce934dbb1a05a693f",
      "tool": "flightctl"
    },
    {
      "os": "linux",
      "arch": "amd64",
      "filename": "flightctl-restore-linux-amd64.tar.gz",
      "sha256": "999eb3f880dd0bb76f809e77b4042d57d2f1169b5ffe1f630038b96f18085d40",
      "tool": "flightctl-restore"
    },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the multi-architecture CLI build and artifact generation flow for more reliable, incremental builds and manifest output.
* **Bug Fixes**
  * Updated Console CLI download listings to add ARM64 Linux/macOS packages and standardize ARM64 label formatting (including Windows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->