### PR TITLE
NO-ISSUE: Fix helm chart os qualified image handling

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -828,7 +828,7 @@ Usage: {{ include "flightctl.ensureOsQualifiedImage" .Values.api.image.image }}
 {{- define "flightctl.ensureOsQualifiedImage" -}}
   {{- $imageName := . -}}
   {{- /* Check if image already has OS suffix (-el9, -el10, -cs9, -cs10) */ -}}
-  {{- if or (hasSuffix "-el9" $imageName) (hasSuffix "-el10" $imageName) (hasSuffix "-cs9" $imageName) (hasSuffix "-cs10" $imageName) -}}
+  {{- if or (hasSuffix "-el9" $imageName) (hasSuffix "-el10" $imageName) (hasSuffix "-cs9" $imageName) (hasSuffix "-cs10" $imageName) (hasSuffix "-rhel9" $imageName) (hasSuffix "-rhel10" $imageName) -}}
     {{- /* Image already has OS suffix, use as-is */ -}}
     {{- $imageName -}}
   {{- else -}}


### PR DESCRIPTION
It was previously broken on downstream by adding additional unnessary suffixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image naming pattern recognition in deployment configuration to support additional image format variants, improving compatibility with broader image naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->