### PR TITLE
NO-ISSUE: Fix api test flakes

### DIFF
--- a/deploy/helm/flightctl/templates/api/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-config.yaml
@@ -35,6 +35,7 @@ data:
         httpMaxHeaderBytes: {{ default 33010 .Values.api.httpMaxHeaderBytes }}
         httpMaxUrlLength: {{ default 2000 .Values.api.httpMaxUrlLength }}
         httpMaxRequestSize: {{ default 53137200 .Values.api.httpMaxRequestSize }}
+        renderedWaitTimeout: {{ .Values.api.renderedSpecPollTimeout | default "2m" | quote }}
         {{- if eq (include "flightctl.getServiceExposeMethod" .) "nodePort" }}
         baseUrl: https://api.{{ include "flightctl.getBaseDomain" . }}:{{ .Values.dev.nodePorts.api }}/
         baseAgentEndpointUrl: https://agent-api.{{ include "flightctl.getBaseDomain" . }}:{{ .Values.dev.nodePorts.agent }}/

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -415,6 +415,10 @@
           "type": ["object", "null"],
           "description": "Additional labels for API PVCs.",
           "additionalProperties": { "type": "string" }
+        },
+        "renderedSpecPollTimeout": {
+          "type": "string",
+          "description": "Timeout for the rendered device spec long-poll (e.g., 2m, 30s)"
         }
       }
     },

--- a/test/api/README.md
+++ b/test/api/README.md
@@ -18,7 +18,7 @@ Run the curl command to reproduce the failure and read the response body for det
 ## How the test run works
 
 - Deploy the backend: `make deploy`
-- To increase API rate limits for testing, apply the override values to the running deployment:
+- To apply API test overrides (rate limits, rendered spec poll timeout) to the running deployment:
 
   ```bash
   helm upgrade flightctl ./deploy/helm/flightctl/ -n flightctl-external --reuse-values --values test/api/values.api-tests.yaml
@@ -60,7 +60,7 @@ test/api/
   run_suite.sh        -- Per-suite runner (schemathesis CLI + pytest)
   report.py           -- Generates consolidated markdown report from JUnit, TraceCov, and HAR data
   render_log.py       -- Strips ANSI codes from schemathesis output
-  values.api-tests.yaml -- Helm overrides for API rate limits during testing
+  values.api-tests.yaml -- Helm overrides for API testing (rate limits, rendered spec poll timeout)
   Containerfile       -- Container image: schemathesis + openssl + pyte
 ```
 

--- a/test/api/core/v1alpha1/schemathesis.toml
+++ b/test/api/core/v1alpha1/schemathesis.toml
@@ -1,6 +1,7 @@
 hooks = "core.v1alpha1.hooks"
 base-url = "${BASE_URL}"
 rate-limit = "400/m"
+seed = 42
 suppress-health-check = ["filter_too_much"]
 continue-on-failure = true
 tls-verify = false

--- a/test/api/core/v1beta1/schemathesis.toml
+++ b/test/api/core/v1beta1/schemathesis.toml
@@ -1,6 +1,7 @@
 hooks = "core.v1beta1.hooks"
 base-url = "${BASE_URL}"
 rate-limit = "400/m"
+seed = 42
 suppress-health-check = ["filter_too_much"]
 continue-on-failure = true
 tls-verify = false
@@ -64,6 +65,11 @@ parameters = { "path.name" = "default" }
 [[operations]]
 include-path = "/fleets/{fleet}/templateversions"
 parameters = { "path.fleet" = "default" }
+
+# knownRenderedVersion triggers a server-side long-poll; allow enough time for it to complete
+[[operations]]
+include-path = "/devices/{name}/rendered"
+request-timeout = 60.0
 
 [reports.vcr]
 enabled = true

--- a/test/api/imagebuilder/v1alpha1/schemathesis.toml
+++ b/test/api/imagebuilder/v1alpha1/schemathesis.toml
@@ -1,6 +1,7 @@
 hooks = "imagebuilder.v1alpha1.hooks"
 base-url = "${BASE_URL}"
 rate-limit = "400/m"
+seed = 42
 suppress-health-check = ["filter_too_much"]
 continue-on-failure = true
 tls-verify = false
@@ -57,6 +58,14 @@ enabled = false
 [[operations]]
 include-path = "/api/v1/imageexports/{name}/log"
 [operations.checks.response_schema_conformance]
+enabled = false
+
+# DELETE /imagebuilds cascade-deletes child ImageExports; stateful chains (non-deterministic seed)
+# may DELETE the parent before GET-ting the child, producing a legitimate 404
+[[operations]]
+include-path = "/api/v1/imageexports/{name}"
+include-method = "GET"
+[operations.checks.ensure_resource_availability]
 enabled = false
 
 # Download is only available after async export processing completes, not immediately after creation

--- a/test/api/run_tests.sh
+++ b/test/api/run_tests.sh
@@ -63,7 +63,7 @@ run_schemathesis() {
         -e "SCHEMATHESIS_TOKEN=${AUTH_TOKEN}"
         -e "BASE_URL=${base_url}"
         -e "CORE_URL=${core_url}"
-        -e "CI=${CI:-}"
+        ${CI:+-e "CI=${CI}"}
         -e "SCHEMATHESIS_COVERAGE_REPORT_HTML_PATH=/app/results/schema-coverage.html"
     )
 

--- a/test/api/values.api-tests.yaml
+++ b/test/api/values.api-tests.yaml
@@ -4,3 +4,4 @@ api:
     window: "1m"
     authRequests: 10000
     authWindow: "1m"
+  renderedSpecPollTimeout: "30s"


### PR DESCRIPTION

1. `GET /devices/{name}/rendered` with `knownRenderedVersion` triggers a server-side long-poll, causing test timeouts. Fixed by exposing the poll timeout as a Helm parameter (`renderedSpecPollTimeout`), reducing it to 30s for API tests, and increasing the per-operation request timeout to 60s.
2. Disabled the `ensure_resource_availability` check for `GET /api/v1/imageexports/{name}` because deleting an
 `ImageBuild` cascade-deletes its child I`mageExports`, stateful chains may `DELETE` the parent before `GET`-ting the child, producing a legitimate 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout parameter for API service polling functionality with customizable default values.

* **Documentation**
  * Updated testing documentation to reflect new configuration options.

* **Tests**
  * Enhanced test configurations to support new timeout settings and improve test reliability for specific API scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->