### PR TITLE
[Backport to 1.1] NO-ISSUE: Fix helm chart os qualified image handling

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -783,7 +783,7 @@ Usage: {{ include "flightctl.ensureOsQualifiedImage" .Values.api.image.image }}
 {{- define "flightctl.ensureOsQualifiedImage" -}}
   {{- $imageName := . -}}
   {{- /* Check if image already has OS suffix (-el9, -el10, -cs9, -cs10) */ -}}
-  {{- if or (hasSuffix "-el9" $imageName) (hasSuffix "-el10" $imageName) (hasSuffix "-cs9" $imageName) (hasSuffix "-cs10" $imageName) -}}
+  {{- if or (hasSuffix "-el9" $imageName) (hasSuffix "-el10" $imageName) (hasSuffix "-cs9" $imageName) (hasSuffix "-cs10" $imageName) (hasSuffix "-rhel9" $imageName) (hasSuffix "-rhel10" $imageName) -}}
     {{- /* Image already has OS suffix, use as-is */ -}}
     {{- $imageName -}}
   {{- else -}}


### PR DESCRIPTION
It was previously broken on downstream by adding additional unnessary suffixes

(cherry picked from commit b621a7d4f6702098a5e66da395df68ae79cb6ff1)