### PR TITLE
EDM-3765: CLI decommission test API error handling Should return 500 …

### DIFF
--- a/test/e2e/decommission/decommission_test.go
+++ b/test/e2e/decommission/decommission_test.go
@@ -24,9 +24,7 @@ type DecommissionCLITestParams struct {
 }
 
 var _ = Describe("CLI decommission test", func() {
-
 	Context("Decommission", func() {
-
 		It("Should decommission a device via CLI", Label("decommission", "81782"), func() {
 			harness := e2e.GetWorkerHarness()
 
@@ -94,7 +92,6 @@ var _ = Describe("CLI decommission test", func() {
 	})
 
 	Context("CLI argument validation", func() {
-
 		It("Should reject invalid decommission CLI arguments", Label("88265"), func() {
 			harness := e2e.GetWorkerHarness()
 
@@ -119,7 +116,6 @@ var _ = Describe("CLI decommission test", func() {
 	})
 
 	Context("API error handling", func() {
-
 		It("Should return 404 when decommissioning a non-existent device", Label("88271"), func() {
 			harness := e2e.GetWorkerHarness()
 
@@ -183,12 +179,11 @@ var _ = Describe("CLI decommission test", func() {
 			Expect(response.HTTPResponse).NotTo(BeNil())
 			Expect(response.HTTPResponse.StatusCode).To(Equal(http.StatusBadRequest),
 				"Expected 400 for malformed JSON body, got %d", response.HTTPResponse.StatusCode)
-			Expect(string(response.Body)).To(ContainSubstring("can't decode JSON body"),
+			Expect(string(response.Body)).To(ContainSubstring("failed to decode request body"),
 				"Expected parse failure message in response body")
 			GinkgoWriter.Printf("Received expected 400 response: %s\n", string(response.Body))
 		})
 	})
-
 })
 
 // decommissionCLIEntry creates a table-driven test case for CLI argument validation.


### PR DESCRIPTION
Enter [BeforeEach] TOP-LEVEL - /home/kni/flightctl/test/e2e/decommission/decommission_suite_test.go:41 @ 04/22/26 03:38:34.924
[BeforeEach] Worker 1: Setting up test with VM from pool
Generated new test ID: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a for test: CLI decommission test API error handling Should return 500 when sending a malformed JSON body to the decommission endpoint
Verified test ID in new context: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a
SetTestContext called with test ID: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a
🔄 Starting flightctl-agent after snapshot revert
✅ flightctl-agent started successfully after snapshot revert
[BeforeEach] Worker 1: Test setup completed
< Exit [BeforeEach] TOP-LEVEL - /home/kni/flightctl/test/e2e/decommission/decommission_suite_test.go:41 @ 04/22/26 03:39:45.302 (1m10.378s)
> Enter [It] Should return 500 when sending a malformed JSON body to the decommission endpoint - /home/kni/flightctl/test/e2e/decommission/decommission_test.go:169 @ 04/22/26 03:39:45.303
STEP: Enrolling a device and waiting for it to come online - /home/kni/flightctl/test/e2e/decommission/decommission_test.go:172 @ 04/22/26 03:39:45.303
Harness using test ID: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a
Harness using test ID: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a
Enrolled device for malformed body test: fvjjpg89j59509jkj75vrtq495ck598pjafgk1mojat8prt4s4q0
STEP: Sending a malformed JSON body directly to the decommission API - /home/kni/flightctl/test/e2e/decommission/decommission_test.go:177 @ 04/22/26 03:39:55.762
[FAILED] Expected parse failure message in response body
Expected
    <string>: {"apiVersion":"flightctl.io/v1beta1","code":400,"kind":"Status","message":"API Error: request body has an error: failed to decode request body: invalid character 'o' in literal null (expecting 'u')","reason":"Bad Request","status":"Failure"}
to contain substring
    <string>: can't decode JSON body
In [It] at: /home/kni/flightctl/test/e2e/decommission/decommission_test.go:186 @ 04/22/26 03:39:55.899
< Exit [It] Should return 500 when sending a malformed JSON body to the decommission endpoint - /home/kni/flightctl/test/e2e/decommission/decommission_test.go:169 @ 04/22/26 03:39:55.9 (10.597s)
> Enter [AfterEach] TOP-LEVEL - /home/kni/flightctl/test/e2e/decommission/decommission_suite_test.go:57 @ 04/22/26 03:39:55.9
[AfterEach] Worker 1: Cleaning up test resources
Harness using test ID: test-a7144ac5-4636-4d99-a4c0-2cf7f0cce20a
SetTestContext called with context that has NO test ID
[AfterEach] Worker 1: Test cleanup completed
< Exit [AfterEach] TOP-LEVEL - /home/kni/flightctl/test/e2e/decommission/decommission_suite_test.go:57 @ 04/22/26 03:39:57.14 (1.24s)
> Enter [DeferCleanup (Each)] TOP-LEVEL - /home/kni/flightctl/test/harness/e2e/harness.go:1644 @ 04/22/26 03:39:57.141
checkLogsForPanicAVC: no panic/AVC found in service/agent logs
< Exit [DeferCleanup (Each)] TOP-LEVEL - /home/kni/flightctl/test/harness/e2e/harness.go:1644 @ 04/22/26 03:39:58.935 (1.795s)
> Enter [DeferCleanup (Each)] TOP-LEVEL - /home/kni/flightctl/test/util/tracing.go:93 @ 04/22/26 03:39:58.936
< Exit [DeferCleanup (Each)] TOP-LEVEL - /home/kni/flightctl/test/util/tracing.go:93 @ 04/22/26 03:39:58.936 (1ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error-handling test assertions for the decommission endpoint's malformed request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->