### PR TITLE
EDM-3766: Fix for 'Alertmanager proxy denies authenticated user without alerts' standalone failure

### DIFF
--- a/test/e2e/alertmanager_proxy/alertmanager_proxy_test.go
+++ b/test/e2e/alertmanager_proxy/alertmanager_proxy_test.go
@@ -193,18 +193,58 @@ var _ = Describe("Alertmanager proxy", func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to start proxy service access")
 		defer cleanup()
 
-		clusterToken, _, err := login.LoginToEnv(testHarness, nonAdminUser, nonAdminPassword, "")
-		if err != nil {
-			Skip(fmt.Sprintf("unable to login as non-admin user %q for authz-denied test: %v", nonAdminUser, err))
+		testID := testHarness.GetTestIDFromContext()
+		testIDSuffix := testID
+		if len(testIDSuffix) >= 8 {
+			testIDSuffix = testIDSuffix[:8]
 		}
-		err = login.LoginToFlightctl(testHarness, clusterToken)
-		Expect(err).ToNot(HaveOccurred(), "failed to log non-admin user into flightctl")
-		DeferCleanup(restoreAdminLoginForTest, testHarness)
+		if strings.TrimSpace(testIDSuffix) == "" {
+			testIDSuffix = "default"
+		}
+		testOrgName := fmt.Sprintf("alertproxy-%s", testIDSuffix)
+		rbac := testProviders.RBAC
+		Expect(rbac).ToNot(BeNil(), "RBAC provider should be available for authz-denied flow")
+		Expect(rbac.CreateOrganization(testHarness.Context, testOrgName)).To(Succeed(), "failed to create temporary organization for non-admin user")
+		Expect(rbac.AddUserToOrg(testHarness.Context, testOrgName, nonAdminUser)).To(Succeed(), "failed to grant non-admin user organization access")
 
-		orgID, err := testHarness.GetOrganizationID()
-		Expect(err).ToNot(HaveOccurred(), "failed to resolve organization id")
+		DeferCleanup(func() error {
+			restoreErr := restoreAdminLoginForTest(testHarness)
+			deleteErr := rbac.DeleteOrganization(testHarness.Context, testOrgName)
+			if restoreErr != nil && deleteErr != nil {
+				return fmt.Errorf("failed to restore admin login: %w; failed to delete organization %q: %v", restoreErr, testOrgName, deleteErr)
+			}
+			if restoreErr != nil {
+				return fmt.Errorf("failed to restore admin login: %w", restoreErr)
+			}
+			if deleteErr != nil {
+				return fmt.Errorf("failed to delete organization %q: %w", testOrgName, deleteErr)
+			}
+			return nil
+		})
+
+		var clusterToken string
+		var orgID string
+		Eventually(func() error {
+			token, _, loginErr := login.LoginToEnv(testHarness, nonAdminUser, nonAdminPassword, "")
+			if loginErr != nil {
+				return loginErr
+			}
+			if err := login.LoginToFlightctl(testHarness, token); err != nil {
+				return err
+			}
+			resolvedOrgID, err := testHarness.GetOrganizationIDForNamespace(testOrgName)
+			if err != nil {
+				return err
+			}
+			if err := testHarness.SetCurrentOrganization(resolvedOrgID); err != nil {
+				return err
+			}
+			clusterToken = token
+			orgID = resolvedOrgID
+			return nil
+		}, util.TIMEOUT, util.POLLING).Should(Succeed(), "failed to log non-admin user into flightctl")
+
 		Expect(orgID).ToNot(BeEmpty(), errOrgIDEmpty)
-
 		Expect(clusterToken).ToNot(BeEmpty(), "non-admin cluster token should not be empty")
 
 		alertsPath := buildAlertsFilterPath(orgID, "", "")


### PR DESCRIPTION
- Updated the alertmanager proxy authz-denied e2e test to stop relying on pre-seeded non-admin org membership.
- The test now creates a temporary organization and grants demouser1 access to it before attempting flightctl login.
- Added a retry loop around non-admin login plus explicit selection of the temporary organization in the client config.
- Added cleanup to restore admin login and remove the temporary organization after the test (like @siserafin requested in previous PR)


This makes the test validate alert permission denial instead of failing earlier with “no organizations” in standalone/OCP standalone profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced RBAC authorization testing for non-admin user scenarios with improved retry logic and organization provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->