### PR TITLE
EDM-3767: CI fix - VM Agent behavior Resources Alert Validation Rules [78853]

### DIFF
--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -508,7 +508,7 @@ var _ = Describe("VM Agent behavior", func() {
 				GinkgoWriter.Printf("Updating %s with resources %v\n", fleet1Name, fleet.Spec.Template.Spec.Resources)
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`string doesn't match the regular expression "^[1-9]\d*[smh]$`))
+			Expect(err.Error()).To(ContainSubstring(`string doesn't match the regular expression "^[1-9]\d*[smh]$"`))
 
 			By("Should fail with invalid percentage")
 			err = harness.UpdateFleet(fleet1Name, func(fleet *v1beta1.Fleet) {

--- a/test/harness/e2e/harness_fleet.go
+++ b/test/harness/e2e/harness_fleet.go
@@ -272,7 +272,28 @@ func (h *Harness) UpdateFleet(fleetName string, updateFunc func(*v1beta1.Fleet))
 	if replaceResp.StatusCode() != 200 {
 		logrus.Errorf("Unexpected http status code received: %d", replaceResp.StatusCode())
 		logrus.Errorf("Unexpected http response: %s", string(replaceResp.Body))
-		return fmt.Errorf("unexpected status code %d: %s", replaceResp.StatusCode(), string(replaceResp.Body))
+
+		statusMessage := ""
+		switch {
+		case replaceResp.JSON400 != nil:
+			statusMessage = replaceResp.JSON400.Message
+		case replaceResp.JSON401 != nil:
+			statusMessage = replaceResp.JSON401.Message
+		case replaceResp.JSON403 != nil:
+			statusMessage = replaceResp.JSON403.Message
+		case replaceResp.JSON404 != nil:
+			statusMessage = replaceResp.JSON404.Message
+		case replaceResp.JSON409 != nil:
+			statusMessage = replaceResp.JSON409.Message
+		case replaceResp.JSON429 != nil:
+			statusMessage = replaceResp.JSON429.Message
+		case replaceResp.JSON503 != nil:
+			statusMessage = replaceResp.JSON503.Message
+		default:
+			statusMessage = string(replaceResp.Body)
+		}
+
+		return fmt.Errorf("unexpected status code %d: %s", replaceResp.StatusCode(), statusMessage)
 	}
 
 	return nil


### PR DESCRIPTION
The failure was in the agent e2e test, not in validation itself: standalone OCP returned the 400 error as a JSON Status body, and Harness.UpdateFleet() turned that raw JSON into the error string.

Because of that, regex text like \d appeared escaped as \\d, so the test’s substring assertion failed only in standalone even though the API was correctly rejecting the invalid config.

Changes:
1) I changed test/harness/e2e/harness_fleet.go so UpdateFleet() now uses the parsed API status message (JSON400.Message, etc.) when available instead of the raw response body.
2) I then simplified the two affected assertions in test/e2e/agent/agent_test.go back to matching the plain validation message.

The test now checks the actual API validation message consistently across environments, instead of depending on whether the transport body was JSON-escaped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to properly validate sampling interval error messages
  * Improved test infrastructure error handling to use structured error messages from HTTP responses, replacing generic response body fallbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->