### PR TITLE
EDM-3768: UI connects to alertmanager-proxy via internal service URL

### DIFF
--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -261,6 +261,10 @@ Usage: {{- $authType := include "flightctl.getEffectiveAuthType" . }}
   {{- end }}
 {{- end }}
 
+{{- define "flightctl.getInternalAlertManagerProxyUrl" }}
+  {{- print "https://flightctl-alertmanager-proxy:8443"}}
+{{- end }}
+
 {{- define "flightctl.getAlertManagerProxyUrl" }}
   {{- $baseDomain := (include "flightctl.getBaseDomain" . )}}
   {{- $scheme := (include "flightctl.getHttpScheme" . )}}

--- a/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
+++ b/deploy/helm/flightctl/templates/ui/flightctl-ui-cm.yaml
@@ -14,7 +14,7 @@ data:
   FLIGHTCTL_CLI_ARTIFACTS_SERVER: {{ include "flightctl.getInternalCliArtifactsUrl" . }}
   {{- end }}
   {{- if .Values.alertmanagerProxy.enabled }}
-  FLIGHTCTL_ALERTMANAGER_PROXY: {{ include "flightctl.getAlertManagerProxyUrl" . }}
+  FLIGHTCTL_ALERTMANAGER_PROXY: {{ include "flightctl.getInternalAlertManagerProxyUrl" . }}
   {{- end }}
   {{- if and .Values.imageBuilderApi .Values.imageBuilderApi.enabled }}
   FLIGHTCTL_IMAGEBUILDER_SERVER: {{ include "flightctl.getInternalImagebuilderApiUrl" . }}


### PR DESCRIPTION
Instead of modifying `getAlertManagerProxyUrl`, I chose the same pattern that for other services where we have a "getInternal...Url".

Now `getAlertManagerProxyUrl` would not be used anymore, we can either keep it for future reference, or delete it and bring it back if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Helm deployment templates updated to configure Alertmanager proxy routing through internal infrastructure endpoints instead of external proxy services
  * Proxy endpoint configuration modified to route monitoring and alerting service communications through internal infrastructure components
  * Deployment behavior changed for how alert management integrations establish connections across the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->