### PR TITLE
EDM-3775: Fix journalctl --since timestamp format for systemd < 255

### DIFF
--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -192,7 +192,7 @@ func (v *TestVM) RunSSH(inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer,
 }
 
 func (v *TestVM) JournalLogs(opts JournalOpts) (string, error) {
-	args := []string{"sudo", "journalctl", "--no-pager", "--no-hostname"}
+	args := []string{"sudo", "TZ=UTC", "journalctl", "--no-pager", "--no-hostname"}
 
 	if opts.Unit != "" {
 		args = append(args, "-u", opts.Unit)
@@ -205,7 +205,11 @@ func (v *TestVM) JournalLogs(opts JournalOpts) (string, error) {
 	}
 
 	if opts.Since != "" {
-		args = append(args, "--since", fmt.Sprintf("%q", opts.Since))
+		since := opts.Since
+		if t, err := time.Parse(time.RFC3339, since); err == nil {
+			since = t.UTC().Format("2006-01-02 15:04:05")
+		}
+		args = append(args, "--since", fmt.Sprintf("%q", since))
 	}
 
 	logrus.Debugf("Reading journal logs with command: %s", strings.Join(args, " "))


### PR DESCRIPTION
JournalLogs in test/harness/e2e/vm/vm.gopasses its Since argument
directly to journalctl --since over SSH. When callers pass RFC3339
timestamps (e.g. 2026-04-23T07:44:09Z), systemd < 255 (CentOS
Stream 9 v252) rejects them -- the T separator and Z suffix are
not accepted, failing with "Failed to parse timestamp."

Fix: detect RFC3339 input and convert to the systemd.time format
("YYYY-MM-DD HH:MM:SS") before passing to journalctl.
Relative timestamps like "10 minutes ago" pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Journal log timestamps are now consistently output in UTC timezone.
* Improved flexibility in timestamp format handling for log filtering with automatic timezone conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->