### PR TITLE
NO-ISSUE: Fix flaky greenboot rollback e2e test

### DIFF
--- a/test/e2e/agent/agent_update_test.go
+++ b/test/e2e/agent/agent_update_test.go
@@ -275,16 +275,23 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 			initialStatusImage, postRollbackBootID := waitForGreenbootOSRollbackFromV11BrokenAgent(harness, deviceId, false)
 
 			By("Verifying device does NOT retry the failed v11 image")
-			// Wait for the device to stabilize as Online after rollback. With greenboot-rs
-			// (0.16.x), the device may do an extra boot cycle before rolling back, causing
-			// a longer disconnect that temporarily shows as Unknown.
-			harness.WaitForDeviceContents(deviceId, "device should be online after rollback", func(device *v1beta1.Device) bool {
+			// Wait for the device to be Online on the original image. With
+			// greenboot-rs (0.16.x) the device may do extra boot cycles after
+			// rollback, so we don't pin a boot ID — just wait for Online +
+			// correct image, then capture the stable boot ID.
+			harness.WaitForDeviceContents(deviceId, "device should be online on original image after rollback", func(device *v1beta1.Device) bool {
 				return device.Status.Summary.Status == v1beta1.DeviceSummaryStatusOnline &&
-					device.Status.SystemInfo.BootID == postRollbackBootID
+					device.Status.Os.Image == initialStatusImage
 			}, TIMEOUT)
+
+			stableDev, err := harness.GetDevice(deviceId)
+			Expect(err).NotTo(HaveOccurred())
+			stableBootID := stableDev.Status.SystemInfo.BootID
+			GinkgoWriter.Printf("Stable boot ID after rollback: %s (initially captured: %s)\n", stableBootID, postRollbackBootID)
+
 			harness.EnsureDeviceContents(deviceId, "device should remain stable and not retry failed image", func(device *v1beta1.Device) bool {
 				return device.Status.Os.Image == initialStatusImage &&
-					device.Status.SystemInfo.BootID == postRollbackBootID &&
+					device.Status.SystemInfo.BootID == stableBootID &&
 					device.Status.Summary.Status == v1beta1.DeviceSummaryStatusOnline
 			}, "2m")
 			GinkgoWriter.Println("Confirmed: device did not retry the failed v11 image after rollback")

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -486,17 +486,20 @@ func (h *Harness) PrepareNextDeviceVersion(deviceId string) (int, error) {
 	return currentVersion + 1, nil
 }
 
-// PrepareNextDeviceVersionFromCurrentStatus returns Status.Config.RenderedVersion+1 from a single API read
-// without requiring the device to be UpToDate. Use after greenboot rollback (OutOfDate) when the status
-// still reports the last rendered config version.
+// PrepareNextDeviceVersionFromCurrentStatus polls until Status.Config.RenderedVersion
+// becomes valid (> 0) and returns RenderedVersion+1. Unlike PrepareNextDeviceVersion it
+// does not require the device to be UpToDate, so it is safe to call after greenboot
+// rollback when the device is OutOfDate and may still be re-enrolling.
 func (h *Harness) PrepareNextDeviceVersionFromCurrentStatus(deviceID string) (int, error) {
-	d, err := h.GetDevice(deviceID)
-	if err != nil {
-		return -1, fmt.Errorf("get device: %w", err)
-	}
-	cur, err := GetRenderedVersion(d)
-	if err != nil {
-		return -1, err
+	var cur int
+	var lastErr error
+	h.WaitForDeviceContents(deviceID, "rendered version should be valid (> 0)",
+		func(device *v1beta1.Device) bool {
+			cur, lastErr = GetRenderedVersion(device)
+			return lastErr == nil
+		}, TIMEOUT)
+	if lastErr != nil {
+		return -1, lastErr
 	}
 	return cur + 1, nil
 }


### PR DESCRIPTION
## Problem
The `Should trigger greenboot rollback when agent fails to start` e2e test flakes intermittently with two distinct failures.

## Root Cause
1. **`version: 0: invalid rendered version`** — After greenboot rolls back from v11, the agent re-enrolls from scratch (new CSR, fresh bootstrap + spec rollback). `PrepareNextDeviceVersionFromCurrentStatus` did a single API read of the rendered version, which races with re-enrollment — the server hasn't assigned a rendered spec yet so the version is still `0`.
2. **`resource not updated`** — The boot ID captured during rollback detection can go stale if greenboot-rs (0.16.x) does extra boot cycles after the initial rollback. `EnsureDeviceContents` then fails because the device has a different boot ID than expected.

## Solution
1. Replace the one-shot read in `PrepareNextDeviceVersionFromCurrentStatus` with a `WaitForDeviceContents` polling loop that retries until the rendered version becomes valid (> 0).
2. Wait for Online + correct image without pinning a boot ID, then capture a fresh boot ID before the 2-minute stability assertion.

## Test Plan
- [x] `go build ./test/e2e/agent/...` compiles cleanly
- [x] `go vet ./test/e2e/agent/...` passes
- [ ] CI e2e sanity agent suite passes (greenboot-rollback label)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test harness device version preparation to use polling-based detection instead of a single API read for more reliable version confirmation
  * Enhanced rollback stabilization test to wait for device online status before capturing stable boot state for validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->