### PR TITLE
EDM-3781: Fix devices stuck in AwaitingReconnect after backup/restore

### DIFF
--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -328,11 +328,11 @@ func (h *ServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid.UUID,
 
 func (h *ServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, params domain.GetRenderedDeviceParams) (*domain.Device, domain.Status) {
 	var (
-		isNew                 bool
-		kvRenderedVersion     string
-		err                   error
-		isAgent               bool
-		movedToConflictPaused bool
+		isNew                   bool
+		kvRenderedVersion       string
+		err                     error
+		isAgent                 bool
+		processedAwaitReconnect bool
 	)
 
 	if _, isAgent = ctx.Value(consts.AgentCtxKey).(string); isAgent {
@@ -342,10 +342,10 @@ func (h *ServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid.UUID,
 		}
 
 		// Process awaiting reconnect annotation if present and KV store contains the awaiting reconnection key
-		movedToConflictPaused = h.processAwaitingReconnectIfNeeded(ctx, orgId, name, params.KnownRenderedVersion)
+		processedAwaitReconnect = h.processAwaitingReconnectIfNeeded(ctx, orgId, name, params.KnownRenderedVersion)
 	}
 
-	if params.KnownRenderedVersion != nil && !movedToConflictPaused {
+	if params.KnownRenderedVersion != nil && !processedAwaitReconnect {
 		isNew, kvRenderedVersion, err = rendered.Bus.Instance().WaitForNewVersion(ctx, orgId, name, *params.KnownRenderedVersion)
 		if err != nil {
 			h.log.Errorf("GetRenderedDevice %s/%s: failed to wait for new rendered version: %v", orgId, name, err)
@@ -355,7 +355,8 @@ func (h *ServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid.UUID,
 			return nil, domain.StatusNoContent()
 		}
 	}
-	// When movedToConflictPaused we skip WaitForNewVersion and return the current device (200) so the agent sees ConflictPaused and invalidates lastStatus.
+	// When processedAwaitReconnect we skip WaitForNewVersion and return the current device (200)
+	// so the agent sees the updated state and re-pushes its status.
 
 	if isAgent {
 		if h.agentGate.Acquire(ctx, 1) == nil {
@@ -645,7 +646,7 @@ func (h *ServiceHandler) callbackDeviceDeleted(ctx context.Context, resourceKind
 }
 
 // processAwaitingReconnectIfNeeded processes the awaiting reconnect annotation only if the KV store contains the awaiting reconnection key.
-// Returns true if the device was moved to ConflictPaused state, false otherwise.
+// Returns true if the annotation was processed (regardless of whether the device ended up ConflictPaused or Online).
 func (h *ServiceHandler) processAwaitingReconnectIfNeeded(ctx context.Context, orgId uuid.UUID, deviceName string, deviceReportedVersion *string) bool {
 	// Check if KV store contains the awaiting reconnection key
 	key := kvstore.AwaitingReconnectionKey{
@@ -693,7 +694,7 @@ func (h *ServiceHandler) processAwaitingReconnectIfNeeded(ctx context.Context, o
 				h.log.Warnf("Failed to create conflict paused event for device %s - event is nil", deviceName)
 			}
 		}
-		return wasConflictPaused
+		return true
 	}
 	h.log.Debugf("Skipping awaiting reconnect annotation processing for device %s - KV value is not 'true' (value: %s)", deviceName, string(kvValue))
 	return false

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -826,7 +826,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			Expect(result2).To(BeNil())
 		})
 
-		It("returns 204 when moved to normal (Online) and version unchanged", func() {
+		It("returns 200 when moved to normal (Online) and version unchanged", func() {
 			deviceName := "awaiting-reconnect-normal-device"
 			knownVersion := "1" // device reports "1", service has "1" -> normal, not ConflictPaused
 
@@ -861,11 +861,11 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			params := domain.GetRenderedDeviceParams{KnownRenderedVersion: &knownVersion}
 			result, status := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
 
-			// ProcessAwaitingReconnect runs with deviceReportedVersion from params - we pass knownVersion "1"
-			// So device version 1 <= service version 1 -> moved to normal. movedToConflictPaused=false.
-			// Version unchanged -> should return 204
-			Expect(status.Code).To(Equal(int32(204)))
-			Expect(result).To(BeNil())
+			// ProcessAwaitingReconnect runs: device version 1 <= service version 1 -> Online.
+			// WaitForNewVersion is skipped because the annotation was processed, so the agent
+			// gets a 200 with the current device and can re-push its status.
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result).ToNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
## Problem

After a database backup and restore, devices whose rendered version matches the server (the common case — most devices are not mid-update) can get stuck in `AwaitingReconnect` status instead of transitioning to `Online`.

## Root Cause

`processAwaitingReconnectIfNeeded` returned `wasConflictPaused` (false for non-conflicted devices) instead of `true` (annotation was processed). This caused `GetRenderedDevice` to enter the `WaitForNewVersion` long-poll (120s → HTTP 204) instead of immediately returning HTTP 200. Without a 200 response, a concurrent agent status heartbeat could race with the annotation removal and overwrite the device status back to `AwaitingReconnect`, leaving it stuck.

## Solution

Return `true` from `processAwaitingReconnectIfNeeded` whenever the annotation was successfully processed, regardless of whether the device ended up ConflictPaused or Online. This skips the long-poll for all reconnecting devices so the agent gets a 200 and re-pushes its status.

## Test Plan

- [x] Integration test updated (was asserting old buggy 204 behavior, now correctly expects 200)
- [x] `make integration-test` passes (service suite including AwaitingReconnect tests)
- [x] E2e backup_restore test (label `84938`) should no longer flake