### PR TITLE
EDM-3702: Add negative test coverage for Container Application Type Support

### DIFF
--- a/test/e2e/applications/containers/containers_test.go
+++ b/test/e2e/applications/containers/containers_test.go
@@ -16,9 +16,11 @@ const (
 	containerAppName  = "container-app"
 	containerAppName2 = "container-app-2"
 	nginxImage        = "quay.io/flightctl-tests/nginx:1.28-alpine-slim"
+	nonExistentImage  = "quay.io/flightctl-tests/does-not-exist:never"
 
-	hostPort      = "8080"
-	containerPort = "80"
+	hostPort       = "8080"
+	secondHostPort = "8081"
+	containerPort  = "80"
 
 	defaultCPU    = "4"
 	defaultMemory = "256m"
@@ -30,14 +32,16 @@ var _ = Describe("Single Container Applications", Ordered, func() {
 		deviceId string
 		harness  *e2e.Harness
 
-		defaultAppSpec   v1beta1.ApplicationProviderSpec
-		lowMemoryAppSpec v1beta1.ApplicationProviderSpec
-		secondAppSpec    v1beta1.ApplicationProviderSpec
+		defaultAppSpec        v1beta1.ApplicationProviderSpec
+		lowMemoryAppSpec      v1beta1.ApplicationProviderSpec
+		secondAppSpec         v1beta1.ApplicationProviderSpec
+		badImageAppSpec       v1beta1.ApplicationProviderSpec
+		samePortSecondAppSpec v1beta1.ApplicationProviderSpec
 	)
 
 	BeforeAll(func() {
 		defaultPorts := []v1beta1.ApplicationPort{getPortMapping()}
-		secondPorts := []v1beta1.ApplicationPort{"8081:80"}
+		secondPorts := []v1beta1.ApplicationPort{v1beta1.ApplicationPort(secondHostPort + ":" + containerPort)}
 
 		var err error
 		defaultAppSpec, err = e2e.NewContainerApplicationSpec(
@@ -57,11 +61,97 @@ var _ = Describe("Single Container Applications", Ordered, func() {
 			lo.ToPtr(defaultCPU), lo.ToPtr(defaultMemory), nil,
 		)
 		Expect(err).ToNot(HaveOccurred())
+
+		badImageAppSpec, err = e2e.NewContainerApplicationSpec(
+			containerAppName, nonExistentImage, defaultPorts,
+			lo.ToPtr(defaultCPU), lo.ToPtr(defaultMemory), nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		samePortSecondAppSpec, err = e2e.NewContainerApplicationSpec(
+			containerAppName2, nginxImage, defaultPorts,
+			lo.ToPtr(defaultCPU), lo.ToPtr(defaultMemory), nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	BeforeEach(func() {
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ = harness.EnrollAndWaitForOnlineStatus()
+	})
+
+	It("fails on image update to nonexistent reference and recovers when fixed", Label("88860", "sanity"), func() {
+		By("Deploying a container application with valid image, ports, and resource limits")
+		GinkgoWriter.Printf("Updating device %s with container application %s\n", deviceId, containerAppName)
+		err := harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the container application is running with port mapped")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+		containerPorts, err := harness.GetContainerPorts()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(containerPorts).To(ContainSubstring(hostPort), "expected host port %s to be mapped", hostPort)
+		harness.VerifyQuadletApplicationFolderExists(containerAppName)
+
+		By("Updating the image to a nonexistent reference while keeping ports and resources")
+		GinkgoWriter.Printf("Updating container app %s to nonexistent image %s\n", containerAppName, nonExistentImage)
+		err = harness.UpdateDeviceAndWaitForFailure(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{badImageAppSpec}
+		}, "prefetch failed")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the quadlet folder from the previous working deployment still exists on the device")
+		harness.VerifyQuadletApplicationFolderExists(containerAppName)
+
+		By("Fixing the image back to a valid reference")
+		GinkgoWriter.Printf("Restoring container app %s to valid image %s\n", containerAppName, nginxImage)
+		newVersion, err := harness.PrepareNextDeviceVersionFromCurrentStatus(deviceId)
+		Expect(err).ToNot(HaveOccurred())
+		err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+		err = harness.WaitForDeviceNewRenderedVersion(deviceId, newVersion)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the application recovers to Running status")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+		err = harness.WaitForApplicationSummary(deviceId, testutil.TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("reports error status when a second container application binds to an already used port", Label("88861", "sanity"), func() {
+		By("Deploying first container application on port " + getPortMapping())
+		err := harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying first application is running with port mapped")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+		containerPorts, err := harness.GetContainerPorts()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(containerPorts).To(ContainSubstring(hostPort), "expected host port %s to be mapped for first app", hostPort)
+
+		By("Deploying second container application on the same port")
+		GinkgoWriter.Printf("Deploying second container app %s on conflicting port %s\n", containerAppName2, getPortMapping())
+		err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec, samePortSecondAppSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying second application enters Error status due to port conflict")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName2, v1beta1.ApplicationStatusError, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying first application remains Running")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Verifies that a Single Container Application can be deployed to an Edge Manager device", Label("86285", "sanity"), func() {


### PR DESCRIPTION
Added two negative e2e test cases for container applications:

88860 – Verifies that updating a container application to a nonexistent image causes a prefetch failure, that the existing quadlet folder is preserved, and that the application recovers to Running after restoring a valid image.
88861 – Verifies that deploying a second container application on an already bound host port results in an Error status for the conflicting app while the first application remains Running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test scenarios for single container applications. Tests cover successful deployment validation with port mapping, error handling for invalid container images, application recovery and status restoration, and detection of port conflicts between multiple applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->