### PR TITLE
EDM-3796: Add enrollment-time systemInfo label mapping

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -279,6 +279,7 @@ RFC3339
 RPC
 sos
 sudo
+systemInfo
 ts
 update_device_status_duration_seconds
 v1.0.0

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -19,6 +19,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 | `spec-fetch-interval`    | `Duration` | | **Deprecated**: This parameter is no longer used. The agent now uses long-polling to receive specification updates immediately when available. |
 | `status-update-interval` | `Duration` | | Interval in which the agent reports its device status under normal conditions. The agent immediately sends status reports on major events related to the health of the system and application workloads as well as on the progress during a system update. Default: `60s` |
 | `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. Default: `{}` |
+| `label-from-systeminfo`  | `object` (`string`) | | Maps system information fields to device labels at enrollment time. See [Enrollment-time label mapping](#enrollment-time-label-mapping). Default: `{}` |
 | `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
 | `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
 | `system-info-timeout`    | `Duration` | | The timeout for collecting system info. Default: `2m`. Maximum: `2m` |
@@ -33,7 +34,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 
 > [!NOTE]
 > The `/etc/flightctl/conf.d/` drop-in directory supports only a subset of the agent configuration. Currently supported keys include:
-> `log-level`, `system-info`, `system-info-custom`, and `system-info-timeout`.
+> `log-level`, `system-info`, `system-info-custom`, `system-info-timeout`, and `label-from-systeminfo`.
 
 ## Communication Timeouts
 
@@ -169,6 +170,128 @@ status:
     bootID: 87f7e27e-bdc0-42b1-b909-6dc81fe43ea2
     customInfo:
       fips: disabled
+```
+
+## Enrollment-time label mapping
+
+The `label-from-systeminfo` configuration parameter enables automatic device labeling during enrollment by mapping system information fields to device labels. This allows devices to self-describe their characteristics without manual intervention, enabling automatic fleet selection based on hardware, location, or custom attributes.
+
+> [!TIP]
+> Labels configured with `label-from-systeminfo` can be used in fleet selectors to automatically assign devices to fleets based on their characteristics. See [Selecting Devices into a Fleet](../using/managing-fleets.md#selecting-devices-into-a-fleet) for details on how fleet selectors work with device labels.
+
+### How it works
+
+During enrollment, the agent collects system information and applies the configured label mappings. The resulting labels are included in the enrollment request and become part of the device's metadata. These labels can then be used by fleet selectors to automatically assign devices to the appropriate fleets.
+
+### Mapping built-in fields
+
+You can map any built-in system information field to a label. Reference built-in fields by their field name:
+
+```yaml
+label-from-systeminfo:
+  arch: architecture
+  os-name: distroName
+  os-version: distroVersion
+```
+
+This configuration creates device labels by mapping built-in systemInfo fields:
+
+- Label `arch` ← `systemInfo.architecture` (e.g., `amd64`, `arm64`)
+- Label `os-name` ← `systemInfo.distroName` (e.g., `Red Hat Enterprise Linux`)
+- Label `os-version` ← `systemInfo.distroVersion` (e.g., `9.5 (Plow)`)
+
+The label name (left side) can be anything you choose; the field name (right side) must be one of the built-in system info fields. See [Built-in system info collectors](#built-in-system-info-collectors) for the complete list of available fields.
+
+### Mapping custom fields
+
+You can also map custom system information fields to labels. Reference custom fields using the `customInfo.` prefix followed by the field name:
+
+```yaml
+system-info-custom: [region, siteId, rackNumber]
+label-from-systeminfo:
+  region: customInfo.region
+  site: customInfo.siteId
+  rack: customInfo.rackNumber
+```
+
+This configuration:
+
+1. Enables collection of custom info from scripts in `/usr/lib/flightctl/custom-info.d/`
+2. Maps each custom field to a corresponding label
+
+See [Custom system info collectors](#custom-system-info-collectors) for details on creating custom info scripts.
+
+### Default alias behavior
+
+By default, the agent automatically adds an `alias` label set to the device's hostname if no `alias` mapping is configured in `label-from-systeminfo`. This provides a human-readable identifier for devices.
+
+To override this behavior and set the alias from a different source:
+
+```yaml
+system-info-custom: [productName]
+label-from-systeminfo:
+  alias: customInfo.productName
+```
+
+### Label precedence
+
+When the same label key is defined in multiple places, labels are applied in the following precedence order (highest to lowest):
+
+1. `default-labels` (highest precedence - always wins)
+2. `label-from-systeminfo` (mapped from system info)
+3. Default `alias=hostname` (lowest precedence - only if no alias is configured)
+
+Example showing precedence:
+
+```yaml
+default-labels:
+  env: production      # This value wins
+label-from-systeminfo:
+  env: customInfo.env  # This is ignored due to default-labels taking precedence
+  region: customInfo.region
+```
+
+In this case, the device will have `env=production` (from `default-labels`) and `region` mapped from custom info.
+
+### Complete example
+
+Here's a complete configuration for a wayside device that automatically selects the appropriate protocol fleet based on its installed protocol:
+
+```yaml
+# /usr/lib/flightctl/custom-info.d/waysideProtocol
+#!/bin/bash
+# Outputs: Wayside-Protocol-A or Wayside-Protocol-B
+cat /etc/wayside/protocol.txt
+```
+
+```yaml
+# /etc/flightctl/config.yaml
+system-info-custom: [waysideProtocol]
+label-from-systeminfo:
+  protocol: customInfo.waysideProtocol
+  arch: architecture
+default-labels:
+  env: production
+```
+
+With this configuration:
+
+- Devices automatically get a `protocol` label based on their installed protocol
+- Devices get an `arch` label based on their CPU architecture  
+- All devices get `env=production` from default-labels
+- Devices get `alias=hostname` automatically
+
+Fleets can then target devices by protocol:
+
+```yaml
+apiVersion: flightctl.io/v1beta1
+kind: Fleet
+metadata:
+  name: wayside-protocol-a
+spec:
+  selector:
+    matchLabels:
+      protocol: Wayside-Protocol-A
 ```
 
 ## Audit Configuration

--- a/docs/user/using/managing-fleets.md
+++ b/docs/user/using/managing-fleets.md
@@ -33,6 +33,9 @@ The same thing happens when an individually managed device joins a fleet or a de
 
 In Flight Control, devices are not explicitly assigned to a fleet. Instead, each fleet has a "selector" that defines which labels a device must have to be selected into the fleet. This allows decoupling the concerns of organizing devices from operating them.
 
+> [!TIP]
+> Devices can automatically populate their labels during enrollment based on system information (hardware, OS, custom attributes) using the agent's `label-from-systeminfo` configuration. This enables zero-touch fleet assignment based on device characteristics. See [Enrollment-time label mapping](../installing/installing-agent.md#enrollment-time-label-mapping) for details.
+
 Let us have a look at a practical example. Assume the following list of point-of-sales (PoS) terminal devices and their labels:
 
 | Device | Labels |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -342,6 +342,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		enrollmentClient,
 		csr,
 		a.config.DefaultLabels,
+		a.config.LabelFromSystemInfo,
 		statusManager,
 		rootSystemdClient,
 		identityProvider,

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -117,6 +118,15 @@ type Config struct {
 	// DefaultLabels are automatically applied to this device when the agent is enrolled in a service
 	DefaultLabels map[string]string `json:"default-labels,omitempty"`
 
+	// LabelFromSystemInfo maps label names to systemInfo field names.
+	// Labels are populated at enrollment time from the device systemInfo.
+	// Supports both built-in fields and customInfo fields.
+	// Format: {"labelName": "fieldName"} for built-in, {"labelName": "customInfo.fieldName"} for custom.
+	// Example: {"alias": "hostname", "arch": "architecture", "site": "customInfo.siteId"}
+	// These labels are merged with DefaultLabels, with DefaultLabels taking precedence on conflicts.
+	// If no label with key "alias" is specified, the agent automatically adds alias=hostname.
+	LabelFromSystemInfo map[string]string `json:"label-from-systeminfo,omitempty"`
+
 	// SystemInfo lists built-in system information keys to collect.
 	SystemInfo []string `json:"system-info,omitempty"`
 
@@ -190,6 +200,7 @@ func NewDefault() *Config {
 		readWriter:           fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter()),
 		LogLevel:             logrus.InfoLevel.String(),
 		DefaultLabels:        make(map[string]string),
+		LabelFromSystemInfo:  make(map[string]string),
 		ServiceConfig:        config.NewServiceConfig(),
 		SystemInfo:           DefaultSystemInfo,
 		SystemInfoTimeout:    DefaultSystemInfoTimeout,
@@ -371,7 +382,7 @@ func (cfg *Config) StringSanitized() string {
 		return "<error>"
 	}
 
-	var configMap map[string]interface{}
+	var configMap map[string]any
 	if err := json.Unmarshal(contents, &configMap); err != nil {
 		return "<error>"
 	}
@@ -471,9 +482,8 @@ func mergeConfigs(base, override *Config) {
 	// but a dropin with image-pruning.enabled: false will override to false.
 	overrideIfNotEmpty(&base.ImagePruning.Enabled, override.ImagePruning.Enabled)
 
-	for k, v := range override.DefaultLabels {
-		base.DefaultLabels[k] = v
-	}
+	maps.Copy(base.DefaultLabels, override.DefaultLabels)
+	maps.Copy(base.LabelFromSystemInfo, override.LabelFromSystemInfo)
 }
 
 func Load(configFile string) (*Config, error) {

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -479,7 +479,7 @@ func (m *LifecycleManager) buildEnrollmentLabels(deviceStatus *v1beta1.DeviceSta
 	// Add default alias=hostname if no "alias" label is configured
 	if _, hasAlias := m.labelFromSystemInfo["alias"]; !hasAlias {
 		hostname := m.extractSystemInfoField(&deviceStatus.SystemInfo, "hostname")
-		if hostname != "" {
+		if isUsefulHostname(hostname) {
 			labels["alias"] = hostname
 		}
 	}
@@ -488,6 +488,26 @@ func (m *LifecycleManager) buildEnrollmentLabels(deviceStatus *v1beta1.DeviceSta
 	maps.Copy(labels, m.defaultLabels)
 
 	return labels
+}
+
+// isUsefulHostname checks if a hostname is helpful for use as a device alias.
+// Returns false for empty strings, "(none)", localhost variants, or loopback IPs.
+func isUsefulHostname(hostname string) bool {
+	if hostname == "" || hostname == "(none)" {
+		return false
+	}
+
+	h := strings.ToLower(hostname)
+
+	if strings.HasPrefix(h, "localhost") {
+		return false
+	}
+
+	if h == "127.0.0.1" || h == "::1" {
+		return false
+	}
+
+	return true
 }
 
 // extractSystemInfoField extracts a field from DeviceSystemInfo (built-in or customInfo)

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -6,8 +6,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/flightctl/flightctl/internal/tpm"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/skip2/go-qrcode"
+	"github.com/stoewer/go-strcase"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/cert"
 )
@@ -44,12 +47,13 @@ type LifecycleManager struct {
 	dataDir              string
 	deviceReadWriter     fileio.ReadWriter
 
-	enrollmentClient client.Enrollment
-	defaultLabels    map[string]string
-	enrollmentCSR    []byte
-	statusManager    status.Manager
-	systemdClient    *client.Systemd
-	identityProvider identity.Provider
+	enrollmentClient    client.Enrollment
+	defaultLabels       map[string]string
+	labelFromSystemInfo map[string]string
+	enrollmentCSR       []byte
+	statusManager       status.Manager
+	systemdClient       *client.Systemd
+	identityProvider    identity.Provider
 
 	backoff wait.Backoff
 	log     *log.PrefixLogger
@@ -66,6 +70,7 @@ func NewManager(
 	enrollmentClient client.Enrollment,
 	enrollmentCSR []byte,
 	defaultLabels map[string]string,
+	labelFromSystemInfo map[string]string,
 	statusManager status.Manager,
 	systemdClient *client.Systemd,
 	identityProvider identity.Provider,
@@ -83,6 +88,7 @@ func NewManager(
 		enrollmentClient:     enrollmentClient,
 		enrollmentCSR:        enrollmentCSR,
 		defaultLabels:        defaultLabels,
+		labelFromSystemInfo:  labelFromSystemInfo,
 		backoff:              backoff,
 		statusManager:        statusManager,
 		systemdClient:        systemdClient,
@@ -420,6 +426,9 @@ func (m *LifecycleManager) enrollmentRequest(ctx context.Context, deviceStatus *
 		m.log.Debugf("Failed to read desired.json: %v", err)
 	}
 
+	// Build enrollment labels by merging labelFromSystemInfo with defaultLabels
+	enrollmentLabels := m.buildEnrollmentLabels(deviceStatus)
+
 	req := v1beta1.EnrollmentRequest{
 		ApiVersion: "v1beta1",
 		Kind:       "EnrollmentRequest",
@@ -429,7 +438,7 @@ func (m *LifecycleManager) enrollmentRequest(ctx context.Context, deviceStatus *
 		Spec: v1beta1.EnrollmentRequestSpec{
 			Csr:                  csrString,
 			DeviceStatus:         deviceStatus,
-			Labels:               &m.defaultLabels,
+			Labels:               &enrollmentLabels,
 			KnownRenderedVersion: knownRenderedVersion,
 		},
 	}
@@ -447,4 +456,74 @@ func (m *LifecycleManager) enrollmentRequest(ctx context.Context, deviceStatus *
 	}
 
 	return nil
+}
+
+// buildEnrollmentLabels creates the final label map for enrollment by:
+// 1. Mapping systemInfo fields (built-in and customInfo) to labels based on labelFromSystemInfo config
+// 2. Adding default alias=hostname if no "alias" label is configured
+// 3. Merging with defaultLabels (defaultLabels take precedence on conflicts)
+func (m *LifecycleManager) buildEnrollmentLabels(deviceStatus *v1beta1.DeviceStatus) map[string]string {
+	// Start with labels from systemInfo mappings
+	labels := make(map[string]string, len(m.labelFromSystemInfo)+len(m.defaultLabels)+1)
+
+	// Extract systemInfo field mappings (includes both built-in and customInfo fields)
+	for labelName, fieldName := range m.labelFromSystemInfo {
+		value := m.extractSystemInfoField(&deviceStatus.SystemInfo, fieldName)
+		if value != "" {
+			labels[labelName] = value
+		} else {
+			m.log.Warnf("Failed to extract systemInfo field %q for label %q", fieldName, labelName)
+		}
+	}
+
+	// Add default alias=hostname if no "alias" label is configured
+	if _, hasAlias := m.labelFromSystemInfo["alias"]; !hasAlias {
+		hostname := m.extractSystemInfoField(&deviceStatus.SystemInfo, "hostname")
+		if hostname != "" {
+			labels["alias"] = hostname
+		}
+	}
+
+	// Then apply defaultLabels, which take precedence on conflicts
+	maps.Copy(labels, m.defaultLabels)
+
+	return labels
+}
+
+// extractSystemInfoField extracts a field from DeviceSystemInfo (built-in or customInfo)
+// Supports both built-in fields (e.g., "hostname", "architecture") and customInfo fields
+// (e.g., "customInfo.siteId", "customInfo.rackNumber").
+func (m *LifecycleManager) extractSystemInfoField(systemInfo *v1beta1.DeviceSystemInfo, fieldName string) string {
+	// Check if this is a customInfo field (e.g., "customInfo.siteId")
+	const customInfoPrefix = "customInfo."
+	if customFieldName, found := strings.CutPrefix(fieldName, customInfoPrefix); found {
+		if systemInfo.CustomInfo != nil {
+			if value, ok := (*systemInfo.CustomInfo)[customFieldName]; ok {
+				return value
+			}
+		}
+		m.log.Debugf("CustomInfo field %q not found or is empty", customFieldName)
+		return ""
+	}
+
+	// Built-in field: use reflection to access struct fields
+	// Convert to UpperCamelCase to match Go struct field naming
+	structFieldName := strcase.UpperCamelCase(fieldName)
+	v := reflect.ValueOf(*systemInfo)
+	field := v.FieldByName(structFieldName)
+
+	// If field exists and is a string type, return its value
+	if field.IsValid() && field.Kind() == reflect.String {
+		return field.String()
+	}
+
+	// If not found in struct fields, try AdditionalProperties
+	if systemInfo.AdditionalProperties != nil {
+		if value, ok := systemInfo.AdditionalProperties[fieldName]; ok {
+			return value
+		}
+	}
+
+	m.log.Debugf("SystemInfo field %q not found or is empty", fieldName)
+	return ""
 }

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -429,6 +429,110 @@ func TestLifecycleManager_buildEnrollmentLabels(t *testing.T) {
 				"alias":       "test-host",
 			},
 		},
+		{
+			name:                "When hostname is empty it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is (none) it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "(none)",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is localhost it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "localhost",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is localhost.localdomain it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "localhost.localdomain",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is localhost6.localdomain6 it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "localhost6.localdomain6",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is LOCALHOST (uppercase) it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "LOCALHOST",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is 127.0.0.1 it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "127.0.0.1",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:                "When hostname is ::1 it should not add default alias",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels:       map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "::1",
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -224,3 +224,223 @@ func TestLifecycleManager_verifyEnrollment(t *testing.T) {
 		})
 	}
 }
+
+func TestLifecycleManager_buildEnrollmentLabels(t *testing.T) {
+	tests := []struct {
+		name                string
+		labelFromSystemInfo map[string]string
+		defaultLabels       map[string]string
+		deviceStatus        *v1beta1.DeviceStatus
+		expected            map[string]string
+	}{
+		{
+			name:                "When no label mappings it should add default alias and default labels",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels: map[string]string{
+				"env": "prod",
+			},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+				},
+			},
+			expected: map[string]string{
+				"alias": "test-host",
+				"env":   "prod",
+			},
+		},
+		{
+			name: "When mapping systemInfo fields it should extract them correctly and add default alias",
+			labelFromSystemInfo: map[string]string{
+				"arch": "architecture",
+				"os":   "operatingSystem",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture:    "x86_64",
+					OperatingSystem: "linux",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+				},
+			},
+			expected: map[string]string{
+				"arch":  "x86_64",
+				"os":    "linux",
+				"alias": "test-host",
+			},
+		},
+		{
+			name: "When mapping customInfo fields it should extract them correctly and add default alias",
+			labelFromSystemInfo: map[string]string{
+				"site": "customInfo.siteId",
+				"rack": "customInfo.rackNumber",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+					CustomInfo: &v1beta1.CustomDeviceInfo{
+						"siteId":     "site-123",
+						"rackNumber": "rack-5",
+					},
+				},
+			},
+			expected: map[string]string{
+				"site":  "site-123",
+				"rack":  "rack-5",
+				"alias": "test-host",
+			},
+		},
+		{
+			name: "When alias is configured it should not add default alias",
+			labelFromSystemInfo: map[string]string{
+				"alias": "productName",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname":    "test-host",
+						"productName": "my-product",
+					},
+				},
+			},
+			expected: map[string]string{
+				"alias": "my-product",
+			},
+		},
+		{
+			name: "When defaultLabels conflict with mapped labels it should use defaultLabels",
+			labelFromSystemInfo: map[string]string{
+				"env": "architecture",
+			},
+			defaultLabels: map[string]string{
+				"env": "prod",
+			},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+				},
+			},
+			expected: map[string]string{
+				"env":   "prod", // defaultLabels takes precedence
+				"alias": "test-host",
+			},
+		},
+		{
+			name: "When mixing built-in and customInfo fields it should extract both and add default alias",
+			labelFromSystemInfo: map[string]string{
+				"arch": "architecture",
+				"site": "customInfo.siteId",
+			},
+			defaultLabels: map[string]string{
+				"env": "prod",
+			},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "arm64",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+					CustomInfo: &v1beta1.CustomDeviceInfo{
+						"siteId": "site-456",
+					},
+				},
+			},
+			expected: map[string]string{
+				"arch":  "arm64",
+				"site":  "site-456",
+				"env":   "prod",
+				"alias": "test-host",
+			},
+		},
+		{
+			name: "When built-in field does not exist it should skip that label",
+			labelFromSystemInfo: map[string]string{
+				"arch":    "architecture",
+				"missing": "nonexistent",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+					CustomInfo: &v1beta1.CustomDeviceInfo{},
+				},
+			},
+			expected: map[string]string{
+				"arch":  "x86_64",
+				"alias": "test-host",
+				// "missing" should not be present
+			},
+		},
+		{
+			name: "When customInfo field does not exist it should skip that label",
+			labelFromSystemInfo: map[string]string{
+				"arch":    "architecture",
+				"missing": "customInfo.nonexistent",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+					CustomInfo: &v1beta1.CustomDeviceInfo{
+						"siteId": "site-123",
+					},
+				},
+			},
+			expected: map[string]string{
+				"arch":  "x86_64",
+				"alias": "test-host",
+				// "missing" should not be present
+			},
+		},
+		{
+			name: "When mapping AdditionalProperties it should extract them correctly and add default alias",
+			labelFromSystemInfo: map[string]string{
+				"customField": "myCustomField",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname":      "test-host",
+						"myCustomField": "custom-value",
+					},
+				},
+			},
+			expected: map[string]string{
+				"customField": "custom-value",
+				"alias":       "test-host",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &LifecycleManager{
+				labelFromSystemInfo: tt.labelFromSystemInfo,
+				defaultLabels:       tt.defaultLabels,
+				log:                 log.NewPrefixLogger("test"),
+			}
+
+			result := manager.buildEnrollmentLabels(tt.deviceStatus)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -328,8 +328,13 @@ func (h *TestHarness) AgentDownloadedCertificate() bool {
 }
 
 func (h *TestHarness) StopAgent() {
+	if h.cancelAgentCtx == nil || h.agentFinished == nil {
+		return
+	}
 	h.cancelAgentCtx()
 	<-h.agentFinished
+	h.cancelAgentCtx = nil
+	h.agentFinished = nil
 }
 
 func (h *TestHarness) StartAgent() {

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -42,6 +42,7 @@ type TestHarness struct {
 	cancelAgentCtx context.CancelFunc
 	agentFinished  chan struct{}
 	agentConfig    *agent_config.Config
+	skipAutoStart  bool
 
 	// internals for server
 	serverListener net.Listener
@@ -133,6 +134,12 @@ func WithAgentAudit() TestHarnessOption {
 			enabled := true
 			h.agentConfig.AuditLog.Enabled = &enabled
 		}
+	}
+}
+
+func WithoutAutoStartAgent() TestHarnessOption {
+	return func(h *TestHarness) {
+		h.skipAutoStart = true
 	}
 }
 
@@ -305,7 +312,10 @@ func NewTestHarness(ctx context.Context, testDirPath string, goRoutineErrorHandl
 	workerClient := worker_client.NewWorkerClient(publisher, serverLog)
 	testHarness.ServiceHandler = service.NewServiceHandler(store, workerClient, kvStore, ca, serverLog, "", "", []string{}, testHarness.vulnerabilityEnabled)
 
-	testHarness.StartAgent()
+	// Only auto-start agent if not explicitly disabled via WithoutAutoStartAgent()
+	if !testHarness.skipAutoStart {
+		testHarness.StartAgent()
+	}
 
 	return testHarness, nil
 }
@@ -365,6 +375,11 @@ func (h *TestHarness) GetMockK8sClient() *k8sclient.MockK8SClient {
 func (h *TestHarness) RestartAgent() {
 	h.StopAgent()
 	h.StartAgent()
+}
+
+// AgentConfig returns the agent configuration for test customization
+func (h *TestHarness) AgentConfig() *agent_config.Config {
+	return h.agentConfig
 }
 
 // AuthenticatedContext adds admin identities and org ID to the provided context for direct service calls

--- a/test/integration/agent/label_from_systeminfo_test.go
+++ b/test/integration/agent/label_from_systeminfo_test.go
@@ -1,0 +1,195 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/test/harness"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Agent label-from-systeminfo", func() {
+	var (
+		ctx context.Context
+		h   *harness.TestHarness
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+
+		var err error
+		h, err = harness.NewTestHarness(ctx,
+			GinkgoT().TempDir(),
+			func(err error) {
+				fmt.Fprintf(os.Stderr, "Error in test harness go routine: %v\n", err)
+				GinkgoWriter.Printf("Error in go routine: %v\n", err)
+				GinkgoRecover()
+			},
+			harness.WithoutAutoStartAgent())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if h != nil {
+			h.Cleanup()
+		}
+	})
+
+	It("should populate labels from built-in systemInfo fields at enrollment", func() {
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"arch": "architecture",
+			"os":   "operatingSystem",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify labels were populated from systemInfo
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKey("arch"))
+		Expect(labels).To(HaveKey("os"))
+		Expect(labels).To(HaveKey("alias")) // default alias=hostname
+	})
+
+	It("should populate labels from customInfo fields at enrollment", func() {
+		// Create custom-info script directory
+		customInfoDir := filepath.Join(h.TestDirPath, "usr", "lib", "flightctl", "custom-info.d")
+		Expect(os.MkdirAll(customInfoDir, 0o755)).To(Succeed())
+
+		// Create a custom-info script
+		scriptPath := filepath.Join(customInfoDir, "testCustomField")
+		scriptContent := "#!/bin/bash\necho 'test-value-123'"
+		Expect(os.WriteFile(scriptPath, []byte(scriptContent), 0o600)).To(Succeed())
+		Expect(os.Chmod(scriptPath, 0o700)).To(Succeed())
+
+		h.AgentConfig().SystemInfoCustom = []string{"testCustomField"}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"custom-label": "customInfo.testCustomField",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify custom label was populated
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKeyWithValue("custom-label", "test-value-123"))
+		Expect(labels).To(HaveKey("alias")) // default alias=hostname
+	})
+
+	It("should add default alias=hostname when no alias is configured", func() {
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"arch": "architecture",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify default alias was added
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKey("alias"))
+		Expect(labels["alias"]).ToNot(BeEmpty())
+	})
+
+	It("should not add default alias when custom alias is configured", func() {
+		// Create custom-info script for productName
+		customInfoDir := filepath.Join(h.TestDirPath, "usr", "lib", "flightctl", "custom-info.d")
+		Expect(os.MkdirAll(customInfoDir, 0o755)).To(Succeed())
+
+		scriptPath := filepath.Join(customInfoDir, "productName")
+		scriptContent := "#!/bin/bash\necho 'custom-product-name'"
+		Expect(os.WriteFile(scriptPath, []byte(scriptContent), 0o600)).To(Succeed())
+		Expect(os.Chmod(scriptPath, 0o700)).To(Succeed())
+
+		h.AgentConfig().SystemInfoCustom = []string{"productName"}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"alias": "customInfo.productName",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify alias is from productName, not hostname
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKeyWithValue("alias", "custom-product-name"))
+	})
+
+	It("should give default-labels precedence over label-from-systeminfo", func() {
+		h.AgentConfig().DefaultLabels = map[string]string{
+			"env": "production",
+		}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"env": "architecture", // This should be overridden by default-labels
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify default-labels took precedence
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKeyWithValue("env", "production"))
+	})
+
+	It("should handle missing systemInfo fields gracefully", func() {
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"arch":           "architecture",
+			"missing-field":  "nonExistentField",
+			"missing-custom": "customInfo.doesNotExist",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify device enrolled successfully with available labels only
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKey("arch"))              // This should exist
+		Expect(labels).ToNot(HaveKey("missing-field"))  // This should not
+		Expect(labels).ToNot(HaveKey("missing-custom")) // This should not
+		Expect(labels).To(HaveKey("alias"))             // Default alias should still be added
+	})
+
+	It("should populate multiple labels from mixed sources", func() {
+		// Create custom-info scripts
+		customInfoDir := filepath.Join(h.TestDirPath, "usr", "lib", "flightctl", "custom-info.d")
+		Expect(os.MkdirAll(customInfoDir, 0o755)).To(Succeed())
+
+		siteScript := filepath.Join(customInfoDir, "siteId")
+		Expect(os.WriteFile(siteScript, []byte("#!/bin/bash\necho 'site-123'"), 0o600)).To(Succeed())
+		Expect(os.Chmod(siteScript, 0o700)).To(Succeed())
+
+		rackScript := filepath.Join(customInfoDir, "rackNumber")
+		Expect(os.WriteFile(rackScript, []byte("#!/bin/bash\necho 'rack-5'"), 0o600)).To(Succeed())
+		Expect(os.Chmod(rackScript, 0o700)).To(Succeed())
+
+		h.AgentConfig().SystemInfoCustom = []string{"siteId", "rackNumber"}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"arch": "architecture",
+			"site": "customInfo.siteId",
+			"rack": "customInfo.rackNumber",
+		}
+		h.AgentConfig().DefaultLabels = map[string]string{
+			"env": "production",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify all labels were populated correctly
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKey("arch"))
+		Expect(labels).To(HaveKeyWithValue("site", "site-123"))
+		Expect(labels).To(HaveKeyWithValue("rack", "rack-5"))
+		Expect(labels).To(HaveKeyWithValue("env", "production"))
+		Expect(labels).To(HaveKey("alias")) // default alias
+	})
+})


### PR DESCRIPTION
Allow agents to automatically populate device labels from system information during enrollment via the label-from-systeminfo config field.

Supports both built-in fields (architecture, hostname) and customInfo fields (customInfo.siteId). Labels are merged with defaultLabels (which take precedence on conflicts). Automatically adds alias=hostname unless overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support to map enrollment labels from device system information.
  * Automatic alias population from hostname when no alias mapping is provided; explicit alias mappings suppress the default.
  * Default enrollment labels take precedence over mapped values on conflicts.

* **Tests**
  * Unit and integration tests for mapping scenarios, precedence, custom system-info scripts, and missing-field behavior.
  * Test harness option to skip agent auto-start and to expose agent config for test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->