### PR TITLE
EDM-3802: stream image export bytes so we can set filename

### DIFF
--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -72,10 +72,10 @@ type ImageExportService interface {
 
 // ImageExportDownload contains information for downloading an ImageExport artifact
 type ImageExportDownload struct {
-	RedirectURL string
-	BlobReader  io.ReadCloser
-	Headers     http.Header
-	StatusCode  int
+	BlobReader io.ReadCloser
+	Headers    http.Header
+	StatusCode int
+	Filename   string
 }
 
 // imageExportService is the concrete implementation of ImageExportService
@@ -531,7 +531,13 @@ func (s *imageExportService) Download(ctx context.Context, orgId uuid.UUID, name
 
 	log.WithFields(logrus.Fields{"blobURL": blobURLStr, "statusCode": getResp.StatusCode}).Debug("Received GET response")
 
-	return s.handleBlobResponse(getResp, blobURLStr, log)
+	download, err := s.handleBlobResponse(ctx, getResp, httpClient, blobURLStr, log)
+	if err != nil {
+		return nil, err
+	}
+
+	download.Filename = getDownloadFilename(*imageBuild.Metadata.Name, imageExport.Spec.Format)
+	return download, nil
 }
 
 // setupRepositoryReference creates a repository reference and configures authentication
@@ -672,9 +678,11 @@ func (s *imageExportService) createHTTPClient(ociSpec *coredomain.OciRepoSpec) (
 	}
 
 	return &http.Client{
-		Timeout: 30 * time.Second,
+		// No client-level timeout - we're streaming potentially large files (GB-sized)
+		// Connection timeouts are handled at the transport level
 		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
+			TLSClientConfig:       tlsConfig,
+			ResponseHeaderTimeout: 30 * time.Second, // Timeout for response headers only, not body
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -708,19 +716,67 @@ func (s *imageExportService) addAuthenticationToRequest(ctx context.Context, req
 }
 
 // handleBlobResponse handles the HTTP response from the blob endpoint
-func (s *imageExportService) handleBlobResponse(resp *http.Response, blobURL string, log logrus.FieldLogger) (*ImageExportDownload, error) {
-	// Handle redirect (3xx)
+// If the response is a redirect, it follows the redirect and returns the actual blob content
+func (s *imageExportService) handleBlobResponse(ctx context.Context, resp *http.Response, httpClient *http.Client, blobURL string, log logrus.FieldLogger) (*ImageExportDownload, error) {
+	// Handle redirect (3xx) - follow it to get the actual blob content
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		resp.Body.Close()
-		redirectURL := resp.Header.Get("Location")
-		if redirectURL == "" {
+		locationHeader := resp.Header.Get("Location")
+		if locationHeader == "" {
 			log.WithField("statusCode", resp.StatusCode).Error("Redirect response missing Location header")
 			return nil, errors.New("redirect response missing Location header")
 		}
-		log.WithFields(logrus.Fields{"statusCode": resp.StatusCode, "redirectURL": redirectURL}).Info("Returning redirect response")
+
+		// Parse and resolve the redirect URL (handles relative redirects)
+		redirectURL, err := url.Parse(locationHeader)
+		if err != nil {
+			log.WithError(err).WithField("statusCode", resp.StatusCode).Error("Failed to parse redirect Location header")
+			return nil, fmt.Errorf("failed to parse redirect Location: %w", err)
+		}
+
+		// Resolve relative URLs against the original request URL
+		if !redirectURL.IsAbs() {
+			redirectURL = resp.Request.URL.ResolveReference(redirectURL)
+		}
+
+		// Validate scheme (only allow http/https)
+		if redirectURL.Scheme != "http" && redirectURL.Scheme != "https" {
+			log.WithFields(logrus.Fields{"statusCode": resp.StatusCode, "scheme": redirectURL.Scheme}).Error("Redirect URL has invalid scheme")
+			return nil, fmt.Errorf("redirect URL has invalid scheme: %s", redirectURL.Scheme)
+		}
+
+		// Log only safe parts of the URL (no query params which may contain presigned tokens)
+		redirectLogFields := logrus.Fields{
+			"statusCode":   resp.StatusCode,
+			"redirectHost": redirectURL.Host,
+			"redirectPath": redirectURL.Path,
+		}
+		log.WithFields(redirectLogFields).Info("Following redirect to fetch blob")
+
+		redirectReq, err := http.NewRequestWithContext(ctx, "GET", redirectURL.String(), nil)
+		if err != nil {
+			log.WithError(err).WithFields(redirectLogFields).Error("Failed to create redirect request")
+			return nil, fmt.Errorf("failed to create redirect request: %w", err)
+		}
+
+		redirectResp, err := httpClient.Do(redirectReq)
+		if err != nil {
+			log.WithError(err).WithFields(redirectLogFields).Error("Failed to follow redirect")
+			return nil, fmt.Errorf("%w: failed to follow redirect: %w", ErrExternalServiceUnavailable, err)
+		}
+
+		if redirectResp.StatusCode != http.StatusOK {
+			redirectResp.Body.Close()
+			log.WithFields(logrus.Fields{"redirectHost": redirectURL.Host, "redirectPath": redirectURL.Path, "statusCode": redirectResp.StatusCode}).Error("Unexpected status code from redirect")
+			return nil, fmt.Errorf("%w: unexpected status code from redirect: %d", ErrExternalServiceUnavailable, redirectResp.StatusCode)
+		}
+
+		contentLength := redirectResp.Header.Get("Content-Length")
+		log.WithFields(logrus.Fields{"redirectHost": redirectURL.Host, "statusCode": redirectResp.StatusCode, "contentLength": contentLength}).Info("Successfully fetched blob from redirect")
 		return &ImageExportDownload{
-			RedirectURL: redirectURL,
-			StatusCode:  resp.StatusCode,
+			BlobReader: redirectResp.Body,
+			Headers:    redirectResp.Header,
+			StatusCode: redirectResp.StatusCode,
 		}, nil
 	}
 
@@ -820,6 +876,20 @@ func (s *imageExportService) getRegistryToken(ctx context.Context, client *http.
 	}
 
 	return "", fmt.Errorf("empty token received")
+}
+
+// getDownloadFilename returns the suggested download filename based on the base name and export format
+func getDownloadFilename(baseName string, format domain.ExportFormatType) string {
+	ext := ".bin"
+	switch format {
+	case domain.ExportFormatTypeISO:
+		ext = ".iso"
+	case domain.ExportFormatTypeQCOW2, domain.ExportFormatTypeQCOW2DiskContainer:
+		ext = ".qcow2"
+	case domain.ExportFormatTypeVMDK:
+		ext = ".vmdk"
+	}
+	return baseName + ext
 }
 
 // validateImageExportForDownload validates that an ImageExport is ready for download.

--- a/internal/imagebuilder_api/service/imageexport_test.go
+++ b/internal/imagebuilder_api/service/imageexport_test.go
@@ -967,6 +967,7 @@ func newOciRepositoryWithRegistry(name string, accessMode v1beta1.OciRepoSpecAcc
 }
 
 // TestDownloadImageExportWithRedirect tests successful download with redirect response.
+// The service follows redirects and returns the blob content.
 func TestDownloadImageExportWithRedirect(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
@@ -975,7 +976,7 @@ func TestDownloadImageExportWithRedirect(t *testing.T) {
 	// Create a test HTTP server that mocks an OCI registry
 	manifestDigest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 	layerDigest := "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-	presignedURL := "https://storage.example.com/presigned-blob-url"
+	blobContent := []byte("test blob content from redirect")
 
 	// Create manifest JSON
 	manifest := ocispec.Manifest{
@@ -1008,9 +1009,16 @@ func TestDownloadImageExportWithRedirect(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(manifestBytes)
 		case "/v2/test-image/blobs/" + layerDigest:
-			// Blob fetch - return redirect
-			w.Header().Set("Location", presignedURL)
+			// Blob fetch - return redirect to internal presigned URL
+			redirectURL := "https://" + r.Host + "/presigned-blob"
+			w.Header().Set("Location", redirectURL)
 			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/presigned-blob":
+			// Presigned URL serves the actual blob content
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobContent)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(blobContent)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -1044,13 +1052,19 @@ func TestDownloadImageExportWithRedirect(t *testing.T) {
 	_, err = imageExportStore.Create(ctx, orgId, &imageExport)
 	require.NoError(err)
 
-	// Download
+	// Download - now follows redirects and returns blob content
 	result, err := svc.Download(ctx, orgId, "test-export")
 	require.NoError(err)
 	require.NotNil(result)
-	require.Equal(presignedURL, result.RedirectURL)
-	require.Equal(http.StatusTemporaryRedirect, result.StatusCode)
-	require.Nil(result.BlobReader)
+	require.NotNil(result.BlobReader)
+	require.Equal(http.StatusOK, result.StatusCode)
+	require.NotEmpty(result.Filename)
+
+	// Read blob content
+	defer result.BlobReader.Close()
+	readContent, err := io.ReadAll(result.BlobReader)
+	require.NoError(err)
+	require.Equal(blobContent, readContent)
 }
 
 // TestDownloadImageExportWithBlobReader tests successful download with direct blob stream.
@@ -1137,18 +1151,16 @@ func TestDownloadImageExportWithBlobReader(t *testing.T) {
 	result, err := svc.Download(ctx, orgId, "test-export")
 	require.NoError(err)
 	require.NotNil(result)
-	require.Empty(result.RedirectURL)
 	require.NotNil(result.BlobReader)
 	require.Equal(http.StatusOK, result.StatusCode)
 	require.NotNil(result.Headers)
+	require.NotEmpty(result.Filename)
 
 	// Read blob content
-	if result.BlobReader != nil {
-		defer result.BlobReader.Close()
-		readContent, err := io.ReadAll(result.BlobReader)
-		require.NoError(err)
-		require.Equal(blobContent, readContent)
-	}
+	defer result.BlobReader.Close()
+	readContent, err := io.ReadAll(result.BlobReader)
+	require.NoError(err)
+	require.Equal(blobContent, readContent)
 }
 
 // TestDownloadImageExportManifestWrongLayerCount tests validation of manifest layer count.

--- a/internal/imagebuilder_api/transport/handler.go
+++ b/internal/imagebuilder_api/transport/handler.go
@@ -273,18 +273,6 @@ func (h *TransportHandler) DownloadImageExport(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Handle redirect
-	if download.RedirectURL != "" {
-		statusCode := download.StatusCode
-		if statusCode == 0 {
-			// Default to 302 if status code not set
-			statusCode = http.StatusFound
-		}
-		w.Header().Set("Location", download.RedirectURL)
-		w.WriteHeader(statusCode)
-		return
-	}
-
 	// Handle blob streaming
 	if download.BlobReader != nil {
 		defer download.BlobReader.Close()
@@ -296,12 +284,22 @@ func (h *TransportHandler) DownloadImageExport(w http.ResponseWriter, r *http.Re
 			}
 		}
 
+		// Set Content-Disposition header for proper filename
+		if download.Filename != "" {
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", download.Filename))
+		}
+
 		// Set status code
 		statusCode := download.StatusCode
 		if statusCode == 0 {
 			statusCode = http.StatusOK
 		}
 		w.WriteHeader(statusCode)
+
+		// Flush headers immediately so the browser can show download dialog
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
 
 		// Stream the blob content
 		_, err := io.Copy(w, download.BlobReader)
@@ -313,7 +311,7 @@ func (h *TransportHandler) DownloadImageExport(w http.ResponseWriter, r *http.Re
 	}
 
 	// Should not reach here, but handle gracefully
-	h.log.WithField("name", name).Error("download returned neither redirect nor blob")
+	h.log.WithField("name", name).Error("download returned no blob content")
 	h.SetResponse(w, nil, service.StatusInternalServerError("Invalid download response"))
 }
 


### PR DESCRIPTION
related to [ui PR ](https://github.com/flightctl/flightctl-ui/pull/632) (the backend one should be merged first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Image export downloads now serve content directly with automatically-generated filenames based on image build name and export format, eliminating external redirect handling.
  * Improved download reliability, consistency, and user experience with direct content delivery and proper file naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->