### PR TITLE
NO-ISSUE: SELinux: Allow connecting to userdbd on RHEL10

### DIFF
--- a/packaging/selinux/flightctl_agent.te
+++ b/packaging/selinux/flightctl_agent.te
@@ -114,6 +114,11 @@ systemd_start_all_services(flightctl_agent_t)
 systemd_stop_systemd_services(flightctl_agent_t)
 allow flightctl_agent_t init_t:system { status stop start };
 
+# This is only available on RHEL10
+optional_policy(`
+    systemd_userdbd_stream_connect(flightctl_agent_t)
+')
+
 # sshd config/service permissions
 ssh_systemctl(flightctl_agent_t)
 


### PR DESCRIPTION
This is necessary for certain update paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system security policies to enhance compatibility with systemd service components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->