### PR TITLE
NO-ISSUE: Skip observability tests in quadlets

### DIFF
--- a/test/e2e/observability/observability_test.go
+++ b/test/e2e/observability/observability_test.go
@@ -37,10 +37,8 @@ func getPrometheusURL() (string, error) {
 var _ = Describe("Device observability", func() {
 	BeforeEach(func() {
 		p := setup.GetDefaultProviders()
-		envType := p.Infra.GetEnvironmentType()
-		// Allow KIND and Quadlet environments
-		if envType != infra.EnvironmentKind && envType != infra.EnvironmentQuadlet {
-			Skip("KIND or Quadlet context required for telemetry gateway metrics")
+		if p.Infra.GetEnvironmentType() != infra.EnvironmentKind {
+			Skip("KIND context required for telemetry gateway metrics")
 		}
 	})
 
@@ -240,9 +238,8 @@ var _ = Describe("Device observability", func() {
 var _ = Describe("Service observability", func() {
 	BeforeEach(func() {
 		p := setup.GetDefaultProviders()
-		envType := p.Infra.GetEnvironmentType()
-		if envType != infra.EnvironmentKind && envType != infra.EnvironmentQuadlet {
-			Skip("KIND or Quadlet context required for service observability metrics")
+		if p.Infra.GetEnvironmentType() != infra.EnvironmentKind {
+			Skip("KIND context required for service observability metrics")
 		}
 	})
 


### PR DESCRIPTION
Until the env is adjusted to run the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated observability test suite environment configuration to enforce stricter environment validation for telemetry and metrics testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->