### PR TITLE
[Backport] EDM-3243: Update Go toolchain and base images to 1.25.8

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.12'
+          go-version: '1.25.8'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.6'
+          go-version: '1.24.12'
 
       - name: Enable KVM group perms
         shell: bash
@@ -58,4 +58,3 @@ runs:
           sudo rm -rf /var/lib/containers/storage
           sudo mkdir -p /etc/containers
           echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
-

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - "release-*"
     tags:
-      - '*'
+      - "*"
   pull_request:
   merge_group:
 
@@ -24,7 +24,15 @@ jobs:
     name: Build Binaries
     strategy:
       matrix:
-        tag: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64", "windows-arm64" ]
+        tag:
+          [
+            "linux-amd64",
+            "linux-arm64",
+            "darwin-amd64",
+            "darwin-arm64",
+            "windows-amd64",
+            "windows-arm64",
+          ]
         include:
           # Linux builds
           - tag: linux-amd64
@@ -67,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.6
+          go-version: 1.24.12
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -133,7 +141,7 @@ jobs:
     strategy:
       matrix:
         # GitHub Actions does not provide a native Windows ARM64 runner
-        arch: [ "amd64" ]
+        arch: ["amd64"]
     runs-on: "windows-latest"
     needs: build
     steps:
@@ -148,7 +156,7 @@ jobs:
     name: Verify Binaries on linux/macos
     strategy:
       matrix:
-        os_arch: [ "linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64" ]
+        os_arch: ["linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64"]
         include:
           - os_arch: "linux-amd64"
             runner: "ubuntu-latest"

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.12
+          go-version: 1.25.8
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,9 +29,13 @@ linters:
     - unused
 
   settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"
+        - "-ST*"
+
     govet:
-      enable:
-        - shadow
       settings:
         printf:
           funcs:
@@ -39,6 +43,25 @@ linters:
             - Warnf
             - Errorf
             - Fatalf
+
+    gosec:
+      excludes:
+        - G101
+        - G104
+        - G115
+        - G117
+        - G118
+        - G120
+        - G122
+        - G301
+        - G302
+        - G602
+        - G703
+        - G704
+        - G705
+
+    nolintlint:
+      allow-unused: true
 
     depguard:
       rules:
@@ -113,8 +136,12 @@ linters:
     presets:
       - std-error-handling
       - common-false-positives
+      - legacy
     rules:
       - text: 'declaration of "err" shadows declaration at'
+        linters:
+          - govet
+      - text: "non-constant format string in call to"
         linters:
           - govet
     paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
         - G301
         - G302
         - G602
+        - G702
         - G703
         - G704
         - G705
@@ -128,6 +129,8 @@ linters:
           files:
             - "**/test/**"
             - "!**/test/e2e/infra/k8s/**"
+            - "!**/test/harness/**"
+            - "!**/test/util/**"
           deny:
             - pkg: "k8s.io/client-go/"
               desc: "K8s client-go only in test/e2e/infra/k8s; use infra providers from tests"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,73 +1,25 @@
-# This file contains all available configuration options
-# with their default values.
+version: "2"
 
-# options for analysis running
 run:
-  # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
   tests: true
 
-# output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-  - format: colored-line-number
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-  # make issues output unique by line, default is true
-  uniq-by-line: true
+    text:
+      print-issued-lines: true
+      print-linter-name: true
 
 issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude:
-    - 'declaration of "err" shadows declaration at'
-
-  # Which dirs to exclude: issues from them won't be reported.
-  # Can use regexp here: `generated.*`, regexp is applied on full path,
-  # including the path prefix if one is set.
-  # Default dirs are skipped independently of this option's value (see exclude-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work on Windows.
-  # Default: []
-  exclude-dirs:
-    - bin
-    - deploy
-    - docs
-    - examples
-    - hack
-    - packaging
-    - reports
-    - internal/auth/issuer/pam
+  uniq-by-line: true
 
 linters:
   enable:
     - copyloopvar
     - depguard
     - errcheck
-    - gci
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -76,75 +28,107 @@ linters:
     - unconvert
     - unused
 
-linters-settings:
-  enable:
-    - shadow
+  settings:
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - Infof
+            - Warnf
+            - Errorf
+            - Fatalf
 
-  depguard:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "math/rand$"
+              desc: "Use math/rand/v2 instead"
+
+        service-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/service/**"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/domain instead of api/ in service layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/domain instead of api/ in service layer"
+
+        store-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/store/**"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/domain instead of api/ in store layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/domain instead of api/ in store layer"
+
+        imagebuilder-service-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_api/service/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
+
+        imagebuilder-store-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_api/store/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
+
+        imagebuilder-worker-no-api:
+          list-mode: lax
+          files:
+            - "**/internal/imagebuilder_worker/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/flightctl/flightctl/api$"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
+            - pkg: "github.com/flightctl/flightctl/api/"
+              desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
+
+        test-no-k8s-client:
+          list-mode: lax
+          files:
+            - "**/test/**"
+            - "!**/test/e2e/infra/k8s/**"
+          deny:
+            - pkg: "k8s.io/client-go/"
+              desc: "K8s client-go only in test/e2e/infra/k8s; use infra providers from tests"
+
+  exclusions:
+    presets:
+      - std-error-handling
+      - common-false-positives
     rules:
-      main:
-        deny:
-          - pkg: "math/rand$"
-            desc: "Use math/rand/v2 instead"
+      - text: 'declaration of "err" shadows declaration at'
+        linters:
+          - govet
+    paths:
+      - bin
+      - deploy
+      - docs
+      - examples
+      - hack
+      - packaging
+      - reports
+      - internal/auth/issuer/pam
 
-      service-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/service/**"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/domain instead of api/ in service layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/domain instead of api/ in service layer"
-
-      store-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/store/**"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/domain instead of api/ in store layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/domain instead of api/ in store layer"
-
-      imagebuilder-service-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_api/service/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder service layer"
-
-      imagebuilder-store-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_api/store/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder store layer"
-
-      imagebuilder-worker-no-api:
-        list-mode: lax
-        files:
-          - "**/internal/imagebuilder_worker/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "github.com/flightctl/flightctl/api$"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
-          - pkg: "github.com/flightctl/flightctl/api/"
-            desc: "Use internal/imagebuilder_api/domain instead of api/ in imagebuilder worker"
-
-  govet:
-    settings:
-      printf:
-        funcs:
-          - Infof
-          - Warnf
-          - Errorf
-          - Fatalf
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/packaging/images/Containerfile.lint
+++ b/packaging/images/Containerfile.lint
@@ -1,4 +1,4 @@
-FROM docker.io/golangci/golangci-lint:v1.64.8
+FROM docker.io/golangci/golangci-lint:v2.11.4
 
 # Install libvirt and TPM development packages
 USER root

--- a/packaging/images/el10/Containerfile.alert-exporter
+++ b/packaging/images/el10/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.alertmanager-proxy
+++ b/packaging/images/el10/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.api
+++ b/packaging/images/el10/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.cli-artifacts
+++ b/packaging/images/el10/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.db-setup
+++ b/packaging/images/el10/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el10/Containerfile.imagebuilder-api
+++ b/packaging/images/el10/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.imagebuilder-worker
+++ b/packaging/images/el10/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 

--- a/packaging/images/el10/Containerfile.periodic
+++ b/packaging/images/el10/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.telemetry-gateway
+++ b/packaging/images/el10/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.userinfo-proxy
+++ b/packaging/images/el10/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alert-exporter
+++ b/packaging/images/el9/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alertmanager-proxy
+++ b/packaging/images/el9/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.api
+++ b/packaging/images/el9/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.cli-artifacts
+++ b/packaging/images/el9/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.db-setup
+++ b/packaging/images/el9/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el9/Containerfile.imagebuilder-api
+++ b/packaging/images/el9/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.imagebuilder-worker
+++ b/packaging/images/el9/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.periodic
+++ b/packaging/images/el9/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.telemetry-gateway
+++ b/packaging/images/el9/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.userinfo-proxy
+++ b/packaging/images/el9/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.12
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.25.8
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2


### PR DESCRIPTION
# EDM-3243: Update Go toolchain and base images to 1.25.8

**Backport of PR #2774 from `main` to `release-1.1`**

## Summary

This backport addresses critical security vulnerabilities by updating the Go toolchain from 1.24.6 to 1.25.8 and upgrading all container base images and tooling configurations.

## Security Fixes

### CVEs Addressed:
- **CVE-2025-61726** (net/url): Memory exhaustion via url.JoinPath
- **CVE-2025-61728** (archive/zip): CPU exhaustion via NewReader  
- **CVE-2025-61729** (Go stdlib): Related Go stdlib security fix
- **CVE-2025-68121** (crypto/tls): Unexpected session resumption vulnerability

## Changes

### 🔧 **Go Toolchain Updates**
- Updated Go toolchain from `go1.24.6` to `go1.25.8` across all modules
- Updated GitHub Actions `go-version` from `1.24.6` to `1.25.8`
- Updated all `ubi9/go-toolset` base images: `1.24.6-1762373805` → `1.25.8-1774618347`
- Updated all `ubi10/go-toolset` base images: `1.24.6-1763548447` → `1.25.8-1774618351`

### 🛠 **golangci-lint v2 Migration**
- Updated from `golangci-lint:v1.64.8` to `v2.11.4` (required for Go 1.25 support)
- Migrated `.golangci.yml` configuration to v2 format
- Added formatters section with `gci`, `gofmt`, `goimports` support
- Aligned v2 config behavior with v1 defaults for compatibility

## Files Modified
- **26+ Containerfiles** (el9 + el10 variants)
- **3 go.mod files** with updated toolchain directives  
- **GitHub Actions workflows**
- **golangci-lint configuration**

## Cherry-picked Commits
1. `cedaf57c`: Update Go toolchain to 1.24.12 `(cherry picked from commit b06f9082)`
2. `32ef97f4`: Update Go toolchain and base images to 1.25.8 `(cherry picked from commit 155430ba)`
3. `1adccbf8`: Update golangci-lint configuration and base image version `(cherry picked from commit 4ad658b2)`
4. `41656155`: Align golangci-lint v2 config with v1 behavior `(cherry picked from commit 5f4a8258)`
5. `9fedf39b`: update el10 Containerfiles to Go 1.25.8 base image `(cherry picked from commit b8ef1e88)`

## Testing
✅ All commits cherry-picked successfully with proper traceability  
✅ Resolved `.golangci.yml` merge conflict during backport  
✅ Container images will build with updated Go 1.25.8 toolchain  
✅ CI linting will use updated golangci-lint v2.11.4