### PR TITLE
EDM-3814: Adjust timeout values for helm test

### DIFF
--- a/test/e2e/applications/helm/helm_application_test.go
+++ b/test/e2e/applications/helm/helm_application_test.go
@@ -552,7 +552,7 @@ image-pruning:
 					return false
 				}
 				return !exists
-			}, util.TIMEOUT, util.POLLING).Should(BeTrue(), "shared image %s should be pruned after all apps removed", sharedImage)
+			}, util.TIMEOUT_5M, util.LONG_POLLING).Should(BeTrue(), "shared image %s should be pruned after all apps are removed", sharedImage)
 		})
 	})
 })


### PR DESCRIPTION
[It] VM Agent Helm Application Tests helm application Helm application images can be pruned [88005, agent, slow] sometimes fails with:

```
[FAILED] Timed out after 60.184s.
shared image quay.io/flightctl-tests/alpine should be pruned after all apps removed
Expected
    : false
to be true
```
Extending the timetout and polling for checking the image pruning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for Helm application image pruning verification with enhanced timeout handling and clearer assertion messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->