### PR TITLE
EDM-3818: fix 77672 CI failure in disconnected

### DIFF
--- a/test/e2e/agent/agent_update_test.go
+++ b/test/e2e/agent/agent_update_test.go
@@ -184,17 +184,43 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 				}
 			}()
 
-			// Add more factories here if desired. The first spec applied will add a repo spec
-			// and the second a simple inline spec.
+			repositoryAccessible := false
+			By("Checking whether the shared HTTP repository is accessible")
+			Eventually(func(g Gomega) {
+				repo, err := harness.GetRepository(validRepoName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(repo.Status).NotTo(BeNil())
+
+				cond := v1beta1.FindStatusCondition(repo.Status.Conditions, v1beta1.ConditionTypeRepositoryAccessible)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Or(Equal(v1beta1.ConditionStatusTrue), Equal(v1beta1.ConditionStatusFalse)))
+				repositoryAccessible = cond.Status == v1beta1.ConditionStatusTrue
+			}, "1m", POLLING).Should(Succeed())
+
+			// Add more factories here if desired. In disconnected environments the public
+			// repository-backed config is not reachable, so use a local inline config instead.
 			type providerFactory = func(providerSpec *v1beta1.ConfigProviderSpec) error
-			configFactories := []providerFactory{
-				func(providerSpec *v1beta1.ConfigProviderSpec) error {
+			configFactories := []providerFactory{}
+			if repositoryAccessible {
+				configFactories = append(configFactories, func(providerSpec *v1beta1.ConfigProviderSpec) error {
 					return providerSpec.FromHttpConfigProviderSpec(flightDemosHttpRepoConfig)
-				},
-				func(providerSpec *v1beta1.ConfigProviderSpec) error {
-					return providerSpec.FromInlineConfigProviderSpec(validInlineConfig)
-				},
+				})
+			} else {
+				GinkgoWriter.Printf("Repository %s is not accessible; using inline-only config updates for disconnected execution\n", validRepoName)
+				disconnectedInlineConfig := v1beta1.InlineConfigProviderSpec{
+					Name: "disconnected-inline-config",
+					Inline: []v1beta1.FileSpec{{
+						Path:    "/etc/motd.disconnected",
+						Content: "disconnected fallback config",
+					}},
+				}
+				configFactories = append(configFactories, func(providerSpec *v1beta1.ConfigProviderSpec) error {
+					return providerSpec.FromInlineConfigProviderSpec(disconnectedInlineConfig)
+				})
 			}
+			configFactories = append(configFactories, func(providerSpec *v1beta1.ConfigProviderSpec) error {
+				return providerSpec.FromInlineConfigProviderSpec(validInlineConfig)
+			})
 
 			// Build the device spec progressively and update through harness device-spec helpers,
 			// matching automation behavior.


### PR DESCRIPTION
The failure was that this test depended on flightctl-demos being reachable over HTTP. In disconnected envs it isn’t, so the first update never got picked up and the test just timed out waiting for a rendered-version change.

The fix is to make the test check whether that repo is actually accessible. If yes, it uses the original repo-backed update. If not, it uses an inline config instead, so the test still verifies “multiple updates, latest wins” without depending on internet access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced the multi-update resolution test to dynamically handle repository accessibility by gracefully switching between HTTP and inline configuration fallback paths based on runtime conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->