### PR TITLE
NO-ISSUE: pull E2E registry image from quay.io

### DIFF
--- a/test/e2e/infra/auxiliary/registry.go
+++ b/test/e2e/infra/auxiliary/registry.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	registryImage         = "registry:2"
+	registryImage         = "quay.io/flightctl/e2eregistry:2"
 	registryContainerName = "e2e-registry"
 	registryPort          = "5000/tcp"
 	registryHostPort      = "5000"


### PR DESCRIPTION
Pulling E2E registry image from quay.io instead of docker, to avoind th ci pull rate limit
https://jenkins-csb-kniqe-ci.dno.corp.redhat.com/job/ocp-flightctl-gotests/1466/consoleFull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container image used by the end-to-end test registry. This only affects internal test tooling and does not change product functionality, user-facing behavior, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->