### PR TITLE
EDM-3833: fix pre-upgrade dry-run to use correct db-setup image

### DIFF
--- a/deploy/scripts/pre-upgrade-dry-run.sh
+++ b/deploy/scripts/pre-upgrade-dry-run.sh
@@ -3,14 +3,16 @@
 set -euo pipefail
 
 # Script parameters
-IMAGE_TAG="${1:-latest}"
-SERVICE_CONFIG_PATH="${2:-/etc/flightctl/flightctl-api/config.yaml}"
+IMAGE_TAG="${IMAGE_TAG:-${1:-latest}}"
+SERVICE_CONFIG_PATH="${SERVICE_CONFIG_PATH:-${2:-/etc/flightctl/flightctl-api/config.yaml}}"
 
 # Tool paths
 PODMAN="${PODMAN:-$(command -v podman || echo '/usr/bin/podman')}"
 
-# Configuration
-DB_SETUP_IMAGE="quay.io/flightctl/flightctl-db-setup:${IMAGE_TAG}"
+# Image configuration
+DB_SETUP_REGISTRY="${DB_SETUP_REGISTRY:-quay.io}"
+DB_SETUP_IMAGE="${DB_SETUP_IMAGE:-flightctl/flightctl-db-setup}"
+DB_SETUP_IMAGE_REF="${DB_SETUP_REGISTRY}/${DB_SETUP_IMAGE}:${IMAGE_TAG}"
 INSTALL_CONFIG_FILE="/etc/flightctl/flightctl-services-install.conf"
 SERVICE_CONFIG_DIR="/etc/flightctl"
 
@@ -74,7 +76,7 @@ wait_for_database() {
     [ -n "${DB_SSL_ROOT_CERT}" ] && podman_args+=("-e" "DB_SSL_ROOT_CERT=${DB_SSL_ROOT_CERT}")
 
     podman_args+=("--secret" "flightctl-postgresql-migrator-password,type=env,target=DB_PASSWORD")
-    podman_args+=("${DB_SETUP_IMAGE}")
+    podman_args+=("${DB_SETUP_IMAGE_REF}")
     podman_args+=("/app/deploy/scripts/wait-for-database.sh")
     podman_args+=("--timeout=${DB_WAIT_TIMEOUT}" "--sleep=${DB_WAIT_SLEEP}")
 
@@ -93,7 +95,7 @@ run_migration_dry_run() {
         --secret flightctl-postgresql-migrator-password,type=env,target=DB_MIGRATION_PASSWORD \
         -v "${SERVICE_CONFIG_PATH}":/root/.flightctl/config.yaml:ro,z \
         -v "${SERVICE_CONFIG_DIR}/service-config.yaml":/etc/flightctl/service-config.yaml:ro,z \
-        "${DB_SETUP_IMAGE}" /usr/local/bin/flightctl-db-migrate --dry-run; then
+        "${DB_SETUP_IMAGE_REF}" /usr/local/bin/flightctl-db-migrate --dry-run; then
         echo "[flightctl] dry-run completed successfully"
     else
         echo "[flightctl] dry-run failed"
@@ -105,7 +107,7 @@ run_migration_dry_run() {
 main() {
     echo "[flightctl] pre-upgrade migration dry-run (tag=${IMAGE_TAG})"
     echo "[flightctl] using service config: ${SERVICE_CONFIG_PATH}"
-    echo "[flightctl] using image: ${DB_SETUP_IMAGE}"
+    echo "[flightctl] using image: ${DB_SETUP_IMAGE_REF}"
 
     load_install_config
     

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -632,6 +632,12 @@ if [ "$1" -eq 2 ]; then
     echo "flightctl: running pre upgrade checks, target version $IMAGE_TAG"
     if [ -x "%{_libexecdir}/flightctl/pre-upgrade-dry-run.sh" ]; then
         IMAGE_TAG="$IMAGE_TAG" \
+        DB_SETUP_REGISTRY="quay.io" \
+%if 0%{?rhel} == 10
+        DB_SETUP_IMAGE="flightctl/flightctl-db-setup-el10" \
+%else
+        DB_SETUP_IMAGE="flightctl/flightctl-db-setup-el9" \
+%endif
         CONFIG_PATH="%{_sysconfdir}/flightctl/flightctl-api/config.yaml" \
         "%{_libexecdir}/flightctl/pre-upgrade-dry-run.sh" "$IMAGE_TAG" "%{_sysconfdir}/flightctl/flightctl-api/config.yaml" || {
             echo "flightctl: dry-run failed; aborting upgrade." >&2


### PR DESCRIPTION
## Summary
- The pre-upgrade dry-run script hardcoded `quay.io/flightctl/flightctl-db-setup:${IMAGE_TAG}` which doesn't exist in any registry (missing OS suffix)
- The script now accepts `DB_SETUP_REGISTRY` and `DB_SETUP_IMAGE` as environment variables, constructing the full image reference from `${DB_SETUP_REGISTRY}/${DB_SETUP_IMAGE}:${IMAGE_TAG}`
- The RPM spec `%pre services` section now passes the correct image name based on `%{?rhel}` (el9 default, el10 for RHEL 10), matching the existing pattern used by `IMAGES_CONFIG` selection
- Downstream dist-git specs can override with `registry.redhat.io` and `-rhel9`/`-rhel10` image names

## Test plan
- [x] Verify spec macro expansion produces correct image names on EL9, EL10, and Fedora builds
- [x] Verify the dry-run script constructs the correct full image reference from the env vars
- [x] Verify backward compatibility: script still works with positional args when env vars are not set

### RPM verification results

Extracted and verified preinstall scriptlets from all three Copr-built RPMs:

| Build | `DB_SETUP_IMAGE` expanded to |
|-------|------------------------------|
| Fedora 43 (x86_64) | `flightctl/flightctl-db-setup-el9` (fallback — `%{rhel}` undefined) |
| EPEL 9 (aarch64) | `flightctl/flightctl-db-setup-el9` |
| EPEL 10 (aarch64) | `flightctl/flightctl-db-setup-el10` |

All three pass `DB_SETUP_REGISTRY="quay.io"` and the script correctly constructs `DB_SETUP_IMAGE_REF` for podman calls.

### Backward compatibility

Ran the script with only positional args (`./pre-upgrade-dry-run.sh "1.2.3" "/tmp/nonexistent.yaml"`) and no env vars set. Output confirmed defaults apply correctly: `quay.io/flightctl/flightctl-db-setup:1.2.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)