### PR TITLE
EDM-3851: Correct instructions for using the CLI with --org flag

### DIFF
--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -286,15 +286,8 @@ Flight Control validates these existing AAP tokens rather than providing a separ
 
 ## Multi-Organization Access
 
-Users with access to multiple AAP organizations will have access to multiple Flight Control organizations:
-
-```bash
-# User has access to org-a and org-b in AAP
-# After authentication, they can access both organizations in Flight Control
-
-flightctl get devices --org org-a
-flightctl get devices --org org-b
-```
+Users with access to multiple AAP organizations will have access to multiple Flight Control organizations.
+For CLI organization selection and `--org` usage, see [Usage with multiple organizations](organizations.md#usage-with-multiple-organizations).
 
 ## Related Documentation
 

--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -144,15 +144,8 @@ After login, the user will automatically have access to the Flight Control organ
 
 ## Multi-Project Access
 
-Users with access to multiple OpenShift projects will have access to multiple Flight Control organizations:
-
-```bash
-# User has access to project-a and project-b in OpenShift
-# After login, they can access both organizations in Flight Control
-
-flightctl get devices --org project-a
-flightctl get devices --org project-b
-```
+Users with access to multiple OpenShift projects will have access to multiple Flight Control organizations.
+For CLI organization selection and `--org` usage, see [Usage with multiple organizations](organizations.md#usage-with-multiple-organizations).
 
 ## Troubleshooting
 


### PR DESCRIPTION
The instructions on using `--org` were incorrect since the CLI expects the internal UUID and not the project name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenShift and AAP authentication guides: removed embedded CLI examples for multi-project/multi-organization access and now direct readers to the separate Organizations documentation for CLI organization selection and --org usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->