### PR TITLE
Add /etc/flightctl/tpm-cas directory in quadlets installation

### DIFF
--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -35,6 +35,12 @@ service:
     window: {{if .service.rateLimit.window}}{{.service.rateLimit.window}}{{else}}1m{{end}}
     authRequests: {{if .service.rateLimit.authRequests}}{{.service.rateLimit.authRequests}}{{else}}20{{end}}
     authWindow: {{if .service.rateLimit.authWindow}}{{.service.rateLimit.authWindow}}{{else}}1h{{end}}
+  {{- with index .service "tpmCAPaths" }}
+  tpmCAPaths:
+  {{- range . }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
 kv:
   hostname: flightctl-kv
   port: 6379

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -23,6 +23,8 @@ Volume=/etc/flightctl/pki/flightctl-api/client-signer.crt:/root/.flightctl/certs
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.key:/root/.flightctl/certs/client-signer.key:ro,z
 Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
 Volume=/etc/flightctl/flightctl-api/config.yaml:/root/.flightctl/config.yaml:ro,z
+# TPM CA PEMs for enrollment (paths in service.tpmCAPaths must exist inside the container)
+Volume=/etc/flightctl/tpm-cas:/etc/flightctl/tpm-cas:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 Ulimit=nofile=300000:300000

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -75,6 +75,11 @@ db:
   type: "builtin"
 
 service:
+  # Optional: TPM manufacturer / swtpm CA PEM paths for device enrollment (rendered into flightctl-api config).
+  # Must be a YAML list, e.g.:
+  # tpmCAPaths:
+  #   - /etc/flightctl/tpm-cas/swtpm-localca-rootca-cert.pem
+  #   - /etc/flightctl/tpm-cas/issuercert.pem
   # Rate limiting configuration
   # Note: Only flightctl-api and flightctl-alertmanager-proxy services use rate limiting
   # Other services ignore this configuration

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -10,6 +10,9 @@ OS="${OS:-el9}"
 
 echo "Starting Deployment"
 
+# Host directory for TPM manufacturer / swtpm CA PEMs (mounted read-only into flightctl-api)
+install -d -m 0755 /etc/flightctl/tpm-cas
+
 # Render quadlet files
 bin/flightctl-standalone render quadlets --config "packaging/images/${OS}/local-images.yaml"
 

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -356,6 +356,8 @@ fi
         --var-tmp-dir "%{buildroot}%{_var}/tmp" \
         --var-lib-dir "%{buildroot}/var/lib"
 
+    mkdir -p %{buildroot}%{_sysconfdir}/flightctl/tpm-cas
+
     # Copy services must gather script
     cp packaging/must-gather/flightctl-services-must-gather %{buildroot}%{_bindir}
 
@@ -521,6 +523,7 @@ fi
     %dir %{_sysconfdir}/flightctl/flightctl-alert-exporter
     %dir %{_sysconfdir}/flightctl/flightctl-alertmanager-proxy
     %dir %{_sysconfdir}/flightctl/flightctl-api
+    %dir %{_sysconfdir}/flightctl/tpm-cas
     %dir %{_sysconfdir}/flightctl/flightctl-cli-artifacts
     %dir %{_sysconfdir}/flightctl/flightctl-pam-issuer
     %dir %{_sysconfdir}/flightctl/flightctl-db-migrate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional TPM Certificate Authority paths configuration to the Flightctl API service to allow specifying CA PEM locations.
  * Configured TPM CA certificate volume mount for Podman container deployments so certificates can be provided from the host.
  * Ensured creation and packaging of a dedicated /etc/flightctl/tpm-cas directory so TPM CA files are installed with correct permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->