### PR TITLE
EDM-3798: e2e tests for enrollment-time system information label mapping

### DIFF
--- a/test/e2e/agent/agent_label_from_systeminfo_test.go
+++ b/test/e2e/agent/agent_label_from_systeminfo_test.go
@@ -1,0 +1,601 @@
+package agent_test
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	labelFromSystemInfoBuiltInLabelArch     = "arch"
+	labelFromSystemInfoBuiltInLabelOS       = "os"
+	labelFromSystemInfoCustomLabelSite      = "site"
+	labelFromSystemInfoDefaultAliasLabel    = "alias"
+	labelFromSystemInfoMissingBuiltInLabel  = "missingBuiltin"
+	labelFromSystemInfoMissingCustomLabel   = "missingCustom"
+	labelFromSystemInfoManualArchValue      = "manually-set"
+	labelFromSystemInfoExpectedOSValue      = "linux"
+	labelFromSystemInfoExpectedSiteName     = "my site"
+	labelFromSystemInfoCustomKeySiteName    = "siteName"
+	labelFromSystemInfoCustomKeyEmptyValue  = "emptyValue"
+	labelFromSystemInfoCustomFieldPrefix    = "customInfo."
+	labelFromSystemInfoFieldArchitecture    = "architecture"
+	labelFromSystemInfoFieldOperatingSystem = "operatingSystem"
+	labelFromSystemInfoFieldProductName     = "productName"
+	labelFromSystemInfoFieldHostname        = "hostname"
+	labelFromSystemInfoMissingFieldName     = "doesNotExist"
+)
+
+var (
+	labelFromSystemInfoBuiltInFieldsScenario = labelFromSystemInfoScenario{
+		name: "built-in systemInfo fields become labels",
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+			labelFromSystemInfoBuiltInLabelOS:   labelFromSystemInfoFieldOperatingSystem,
+		},
+		wantLabels: map[string]string{
+			labelFromSystemInfoBuiltInLabelOS: labelFromSystemInfoExpectedOSValue,
+		},
+		wantLabelsFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+	}
+
+	labelFromSystemInfoCustomFieldsScenario = labelFromSystemInfoScenario{
+		name:                     "customInfo fields become labels",
+		overrideSystemInfoCustom: true,
+		systemInfoCustom:         []string{labelFromSystemInfoCustomKeySiteName},
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoCustomFieldPrefix + labelFromSystemInfoCustomKeySiteName,
+		},
+		wantLabels: map[string]string{
+			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoExpectedSiteName,
+		},
+		wantCustomInfo: map[string]string{
+			labelFromSystemInfoCustomKeySiteName: labelFromSystemInfoExpectedSiteName,
+		},
+	}
+
+	labelFromSystemInfoPrecedenceScenario = labelFromSystemInfoScenario{
+		name: "default-labels override mapped labels",
+		defaultLabels: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoManualArchValue,
+		},
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		wantLabels: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoManualArchValue,
+		},
+	}
+
+	labelFromSystemInfoDefaultAliasScenario = labelFromSystemInfoScenario{
+		name: "default alias follows useful hostname behavior",
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		wantLabelsFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		wantDefaultAliasFromHostname: true,
+	}
+
+	labelFromSystemInfoExplicitAliasScenario = labelFromSystemInfoScenario{
+		name: "explicit alias mapping uses productName",
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoDefaultAliasLabel: labelFromSystemInfoFieldProductName,
+		},
+	}
+
+	labelFromSystemInfoMissingFieldsScenario = labelFromSystemInfoScenario{
+		name: "missing mapped fields are skipped",
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch:    labelFromSystemInfoFieldArchitecture,
+			labelFromSystemInfoMissingBuiltInLabel: labelFromSystemInfoMissingFieldName,
+			labelFromSystemInfoMissingCustomLabel:  labelFromSystemInfoCustomFieldPrefix + labelFromSystemInfoMissingFieldName,
+		},
+		wantLabelsFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		wantAbsentLabels: []string{
+			labelFromSystemInfoMissingBuiltInLabel,
+			labelFromSystemInfoMissingCustomLabel,
+		},
+	}
+
+	labelFromSystemInfoCustomCollectionDisabledScenario = labelFromSystemInfoScenario{
+		name:                     "customInfo mapping without collection is skipped",
+		overrideSystemInfoCustom: true,
+		systemInfoCustom:         []string{},
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoCustomFieldPrefix + labelFromSystemInfoCustomKeySiteName,
+		},
+		wantAbsentLabels: []string{labelFromSystemInfoCustomLabelSite},
+		wantAbsentCustomInfo: []string{
+			labelFromSystemInfoCustomKeySiteName,
+			labelFromSystemInfoCustomKeyEmptyValue,
+		},
+	}
+)
+
+var _ = Describe("SystemInfo label mapping", func() {
+	var harness *e2e.Harness
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+	})
+
+	It("When built-in systemInfo fields are mapped it should create matching labels", Label("88946", "sanity", "agent"), func() {
+		scenario := labelFromSystemInfoBuiltInFieldsScenario
+
+		By("Configuring the agent and completing enrollment")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment, systemInfo, and mapped labels")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoSystemInfo(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When customInfo fields are mapped it should create matching labels", Label("88947", "sanity", "agent"), func() {
+		scenario := labelFromSystemInfoCustomFieldsScenario
+
+		By("Configuring the agent and completing enrollment")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment, customInfo, and mapped labels")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoCustomInfo(result, scenario)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When default-labels conflict with mapped labels it should keep default-labels precedence", Label("88948", "sanity", "agent"), func() {
+		scenario := labelFromSystemInfoPrecedenceScenario
+
+		By("Configuring conflicting default-labels and systemInfo label mappings")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment and default-label precedence")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When alias is not explicitly mapped it should apply default alias hostname behavior", Label("88949", "agent"), func() {
+		scenario := labelFromSystemInfoDefaultAliasScenario
+
+		By("Configuring label mapping without an explicit alias")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment, hostname, and default alias behavior")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoSystemInfo(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When alias is explicitly mapped it should use the mapped field instead of hostname fallback", Label("88950", "agent"), func() {
+		scenario := labelFromSystemInfoExplicitAliasScenario
+
+		By("Configuring alias to map from productName")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment and explicit alias mapping")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateExplicitAliasFromProductName(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When mapped fields are missing it should skip labels for those fields", Label("88951", "agent"), func() {
+		scenario := labelFromSystemInfoMissingFieldsScenario
+
+		By("Configuring mappings for existing and missing fields")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment and skipped missing-field labels")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
+	It("When custom collection is disabled it should skip customInfo mappings", Label("88952", "agent"), func() {
+		scenario := labelFromSystemInfoCustomCollectionDisabledScenario
+
+		By("Configuring customInfo mapping without enabling the custom collector")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment and skipped customInfo mapping")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoCustomInfo(result, scenario)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+})
+
+type labelFromSystemInfoScenario struct {
+	name                         string
+	defaultLabels                map[string]string
+	labelFromSystemInfo          map[string]string
+	overrideSystemInfoCustom     bool
+	systemInfoCustom             []string
+	wantLabels                   map[string]string
+	wantLabelsFromSystemInfo     map[string]string
+	wantAbsentLabels             []string
+	wantDefaultAliasFromHostname bool
+	wantCustomInfo               map[string]string
+	wantAbsentCustomInfo         []string
+}
+
+type labelFromSystemInfoScenarioResult struct {
+	enrollmentRequest    *v1beta1.EnrollmentRequest
+	device               *v1beta1.Device
+	enrollmentLabels     map[string]string
+	deviceLabels         map[string]string
+	enrollmentSystemInfo v1beta1.DeviceSystemInfo
+	deviceSystemInfo     v1beta1.DeviceSystemInfo
+	approvalStatusCode   int
+}
+
+// runLabelFromSystemInfoEnrollmentScenario applies an agent configuration, starts a fresh enrollment,
+// approves it, and returns both the EnrollmentRequest and Device state for assertions.
+func runLabelFromSystemInfoEnrollmentScenario(harness *e2e.Harness, scenario labelFromSystemInfoScenario) (*labelFromSystemInfoScenarioResult, error) {
+	if harness == nil {
+		return nil, fmt.Errorf("harness is nil")
+	}
+	if strings.TrimSpace(scenario.name) == "" {
+		return nil, fmt.Errorf("scenario name is empty")
+	}
+
+	if err := harness.DeleteCurrentEnrollmentRequestFromAgentLogs(); err != nil {
+		return nil, fmt.Errorf("deleting pre-existing enrollment request before %q: %w", scenario.name, err)
+	}
+
+	if err := harness.ResetAgentEnrollmentState(); err != nil {
+		return nil, err
+	}
+
+	if err := configureAgentForLabelFromSystemInfoScenario(harness, scenario); err != nil {
+		return nil, err
+	}
+
+	if err := harness.StartFlightCtlAgent(); err != nil {
+		return nil, err
+	}
+
+	enrollmentID, err := harness.WaitForEnrollmentIDFromAgentLogs(TIMEOUT, POLLING)
+	if err != nil {
+		return nil, err
+	}
+	GinkgoWriter.Printf("SystemInfo label mapping scenario %q using enrollment ID %s\n", scenario.name, enrollmentID)
+
+	enrollmentRequest, err := harness.WaitForEnrollmentRequestResource(enrollmentID, TIMEOUT, POLLING)
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := harness.TestResourceLabels()
+	if err != nil {
+		return nil, err
+	}
+	approvalStatus, err := harness.ApproveEnrollmentRequestWithLabels(enrollmentID, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	device, err := harness.WaitForDeviceWithSystemInfo(enrollmentID, TIMEOUT, POLLING)
+	if err != nil {
+		return nil, err
+	}
+	if enrollmentRequest.Spec.DeviceStatus == nil {
+		return nil, fmt.Errorf("enrollment request %s has nil deviceStatus", enrollmentID)
+	}
+	if device.Status == nil {
+		return nil, fmt.Errorf("device %s has nil status", enrollmentID)
+	}
+
+	result := &labelFromSystemInfoScenarioResult{
+		enrollmentRequest:    enrollmentRequest,
+		device:               device,
+		enrollmentLabels:     dereferenceLabels(enrollmentRequest.Spec.Labels),
+		deviceLabels:         dereferenceLabels(device.Metadata.Labels),
+		enrollmentSystemInfo: enrollmentRequest.Spec.DeviceStatus.SystemInfo,
+		deviceSystemInfo:     device.Status.SystemInfo,
+		approvalStatusCode:   approvalStatus,
+	}
+	GinkgoWriter.Printf("SystemInfo label mapping scenario %q labels: enrollment=%v device=%v\n", scenario.name, result.enrollmentLabels, result.deviceLabels)
+	return result, nil
+}
+
+// configureAgentForLabelFromSystemInfoScenario writes the scenario-specific agent config
+// before enrollment starts.
+func configureAgentForLabelFromSystemInfoScenario(harness *e2e.Harness, scenario labelFromSystemInfoScenario) error {
+	cfg, err := harness.GetAgentConfig()
+	if err != nil {
+		return fmt.Errorf("reading agent config for scenario %q: %w", scenario.name, err)
+	}
+
+	cfg.DefaultLabels = map[string]string{}
+	cfg.LabelFromSystemInfo = map[string]string{}
+	maps.Copy(cfg.DefaultLabels, scenario.defaultLabels)
+	maps.Copy(cfg.LabelFromSystemInfo, scenario.labelFromSystemInfo)
+	if scenario.overrideSystemInfoCustom {
+		cfg.SystemInfoCustom = slices.Clone(scenario.systemInfoCustom)
+	}
+
+	if err := harness.SetAgentConfig(cfg); err != nil {
+		return fmt.Errorf("setting agent config for scenario %q: %w", scenario.name, err)
+	}
+	return nil
+}
+
+// validateLabelFromSystemInfoEnrollment verifies the common enrollment result.
+func validateLabelFromSystemInfoEnrollment(result *labelFromSystemInfoScenarioResult) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+	if result.approvalStatusCode != http.StatusOK {
+		return fmt.Errorf("enrollment approval status = %d, want %d", result.approvalStatusCode, http.StatusOK)
+	}
+	if result.enrollmentRequest == nil {
+		return fmt.Errorf("enrollment request is nil")
+	}
+	if result.device == nil {
+		return fmt.Errorf("device is nil")
+	}
+	if result.enrollmentLabels == nil {
+		return fmt.Errorf("enrollment labels are nil")
+	}
+	if result.deviceLabels == nil {
+		return fmt.Errorf("device labels are nil")
+	}
+	return nil
+}
+
+// validateLabelFromSystemInfoSystemInfo verifies common systemInfo fields.
+func validateLabelFromSystemInfoSystemInfo(result *labelFromSystemInfoScenarioResult) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+	enrollmentHostname := systemInfoValue(result.enrollmentSystemInfo, labelFromSystemInfoFieldHostname)
+	if strings.TrimSpace(enrollmentHostname) == "" {
+		return fmt.Errorf("enrollment request hostname is empty")
+	}
+	deviceHostname := systemInfoValue(result.deviceSystemInfo, labelFromSystemInfoFieldHostname)
+	if strings.TrimSpace(deviceHostname) == "" {
+		return fmt.Errorf("device hostname is empty")
+	}
+	if deviceHostname != enrollmentHostname {
+		return fmt.Errorf("device hostname = %q, want enrollment hostname %q", deviceHostname, enrollmentHostname)
+	}
+	return nil
+}
+
+// validateLabelFromSystemInfoLabels verifies expected and absent labels on both
+// the EnrollmentRequest and resulting Device.
+func validateLabelFromSystemInfoLabels(result *labelFromSystemInfoScenarioResult, scenario labelFromSystemInfoScenario) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+	for key, value := range scenario.wantLabels {
+		got, ok := result.enrollmentLabels[key]
+		if !ok {
+			return fmt.Errorf("enrollment request label %q is absent, want %q", key, value)
+		}
+		if got != value {
+			return fmt.Errorf("enrollment request label %q = %q, want %q", key, got, value)
+		}
+		got, ok = result.deviceLabels[key]
+		if !ok {
+			return fmt.Errorf("device label %q is absent, want %q", key, value)
+		}
+		if got != value {
+			return fmt.Errorf("device label %q = %q, want %q", key, got, value)
+		}
+	}
+
+	for key, field := range scenario.wantLabelsFromSystemInfo {
+		value := systemInfoValue(result.enrollmentSystemInfo, field)
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("enrollment request systemInfo field %q is empty for expected label %q", field, key)
+		}
+		if deviceValue := systemInfoValue(result.deviceSystemInfo, field); strings.TrimSpace(deviceValue) != "" && deviceValue != value {
+			return fmt.Errorf("device systemInfo field %q = %q, want enrollment request value %q", field, deviceValue, value)
+		}
+		got, ok := result.enrollmentLabels[key]
+		if !ok {
+			return fmt.Errorf("enrollment request label %q is absent, want systemInfo.%s value %q", key, field, value)
+		}
+		if got != value {
+			return fmt.Errorf("enrollment request label %q = %q, want systemInfo.%s value %q", key, got, field, value)
+		}
+		got, ok = result.deviceLabels[key]
+		if !ok {
+			return fmt.Errorf("device label %q is absent, want systemInfo.%s value %q", key, field, value)
+		}
+		if got != value {
+			return fmt.Errorf("device label %q = %q, want systemInfo.%s value %q", key, got, field, value)
+		}
+	}
+
+	for _, key := range scenario.wantAbsentLabels {
+		if got, ok := result.enrollmentLabels[key]; ok {
+			return fmt.Errorf("enrollment request label %q should be absent, got %q", key, got)
+		}
+		if got, ok := result.deviceLabels[key]; ok {
+			return fmt.Errorf("device label %q should be absent, got %q", key, got)
+		}
+	}
+
+	if scenario.wantDefaultAliasFromHostname {
+		if err := validateDefaultAliasFromHostname(result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateDefaultAliasFromHostname verifies default alias behavior for useful
+// and non-useful hostnames.
+func validateDefaultAliasFromHostname(result *labelFromSystemInfoScenarioResult) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+	enrollmentHostname := systemInfoValue(result.enrollmentSystemInfo, labelFromSystemInfoFieldHostname)
+	deviceHostname := systemInfoValue(result.deviceSystemInfo, labelFromSystemInfoFieldHostname)
+	if isUsefulLabelFromSystemInfoHostname(enrollmentHostname) {
+		got, ok := result.enrollmentLabels[labelFromSystemInfoDefaultAliasLabel]
+		if !ok {
+			return fmt.Errorf("enrollment request alias is absent, want hostname %q", enrollmentHostname)
+		}
+		if got != enrollmentHostname {
+			return fmt.Errorf("enrollment request alias = %q, want hostname %q", got, enrollmentHostname)
+		}
+	} else if got, ok := result.enrollmentLabels[labelFromSystemInfoDefaultAliasLabel]; ok {
+		return fmt.Errorf("enrollment request alias should be absent for hostname %q, got %q", enrollmentHostname, got)
+	}
+
+	if isUsefulLabelFromSystemInfoHostname(deviceHostname) {
+		got, ok := result.deviceLabels[labelFromSystemInfoDefaultAliasLabel]
+		if !ok {
+			return fmt.Errorf("device alias is absent, want hostname %q", deviceHostname)
+		}
+		if got != deviceHostname {
+			return fmt.Errorf("device alias = %q, want hostname %q", got, deviceHostname)
+		}
+	} else if got, ok := result.deviceLabels[labelFromSystemInfoDefaultAliasLabel]; ok {
+		return fmt.Errorf("device alias should be absent for hostname %q, got %q", deviceHostname, got)
+	}
+	return nil
+}
+
+// isUsefulLabelFromSystemInfoHostname returns false for hostnames that should
+// not become the default alias.
+func isUsefulLabelFromSystemInfoHostname(hostname string) bool {
+	if hostname == "" || hostname == "(none)" {
+		return false
+	}
+
+	h := strings.ToLower(hostname)
+	if strings.HasPrefix(h, "localhost") {
+		return false
+	}
+	return h != "127.0.0.1" && h != "::1"
+}
+
+// validateExplicitAliasFromProductName verifies an explicit alias mapping uses
+// the live productName reported during enrollment and by the device.
+func validateExplicitAliasFromProductName(result *labelFromSystemInfoScenarioResult) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+
+	enrollmentProductName := systemInfoValue(result.enrollmentSystemInfo, labelFromSystemInfoFieldProductName)
+	if strings.TrimSpace(enrollmentProductName) == "" {
+		return fmt.Errorf("enrollment request productName is empty")
+	}
+	deviceProductName := systemInfoValue(result.deviceSystemInfo, labelFromSystemInfoFieldProductName)
+	if strings.TrimSpace(deviceProductName) == "" {
+		return fmt.Errorf("device productName is empty")
+	}
+	if deviceProductName != enrollmentProductName {
+		return fmt.Errorf("device productName = %q, want enrollment productName %q", deviceProductName, enrollmentProductName)
+	}
+	got, ok := result.enrollmentLabels[labelFromSystemInfoDefaultAliasLabel]
+	if !ok {
+		return fmt.Errorf("enrollment request alias is absent, want productName %q", enrollmentProductName)
+	}
+	if got != enrollmentProductName {
+		return fmt.Errorf("enrollment request alias = %q, want productName %q", got, enrollmentProductName)
+	}
+	got, ok = result.deviceLabels[labelFromSystemInfoDefaultAliasLabel]
+	if !ok {
+		return fmt.Errorf("device alias is absent, want productName %q", deviceProductName)
+	}
+	if got != deviceProductName {
+		return fmt.Errorf("device alias = %q, want productName %q", got, deviceProductName)
+	}
+	return nil
+}
+
+// validateLabelFromSystemInfoCustomInfo verifies expected and absent customInfo
+// fields on both the EnrollmentRequest and resulting Device.
+func validateLabelFromSystemInfoCustomInfo(result *labelFromSystemInfoScenarioResult, scenario labelFromSystemInfoScenario) error {
+	if result == nil {
+		return fmt.Errorf("scenario result is nil")
+	}
+
+	enrollmentCustomInfo := customInfoMap(result.enrollmentSystemInfo)
+	deviceCustomInfo := customInfoMap(result.deviceSystemInfo)
+	for key, value := range scenario.wantCustomInfo {
+		got, ok := enrollmentCustomInfo[key]
+		if !ok {
+			return fmt.Errorf("enrollment request customInfo %q is absent, want %q", key, value)
+		}
+		if got != value {
+			return fmt.Errorf("enrollment request customInfo %q = %q, want %q", key, got, value)
+		}
+		got, ok = deviceCustomInfo[key]
+		if !ok {
+			return fmt.Errorf("device customInfo %q is absent, want %q", key, value)
+		}
+		if got != value {
+			return fmt.Errorf("device customInfo %q = %q, want %q", key, got, value)
+		}
+	}
+
+	for _, key := range scenario.wantAbsentCustomInfo {
+		if got, ok := enrollmentCustomInfo[key]; ok {
+			return fmt.Errorf("enrollment request customInfo %q should be absent, got %q", key, got)
+		}
+		if got, ok := deviceCustomInfo[key]; ok {
+			return fmt.Errorf("device customInfo %q should be absent, got %q", key, got)
+		}
+	}
+	return nil
+}
+
+// dereferenceLabels returns a copy of labels, or an empty map when labels is nil.
+func dereferenceLabels(labels *map[string]string) map[string]string {
+	if labels == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(*labels))
+	maps.Copy(out, *labels)
+	return out
+}
+
+// customInfoMap returns a copy of customInfo, or an empty map when customInfo is nil.
+func customInfoMap(systemInfo v1beta1.DeviceSystemInfo) map[string]string {
+	if systemInfo.CustomInfo == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(*systemInfo.CustomInfo))
+	maps.Copy(out, *systemInfo.CustomInfo)
+	return out
+}
+
+// systemInfoValue returns the value for a systemInfo key, or an empty string when the key is absent.
+func systemInfoValue(systemInfo v1beta1.DeviceSystemInfo, key string) string {
+	switch key {
+	case labelFromSystemInfoFieldArchitecture:
+		return systemInfo.Architecture
+	case labelFromSystemInfoFieldOperatingSystem:
+		return systemInfo.OperatingSystem
+	}
+
+	value, found := systemInfo.Get(key)
+	if !found {
+		return ""
+	}
+	return value
+}

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -755,6 +755,21 @@ func (h *Harness) TestEnrollmentApproval(labels ...map[string]string) *v1beta1.E
 	}
 }
 
+// TestResourceLabels returns the test-id label used by e2e cleanup.
+func (h *Harness) TestResourceLabels() (map[string]string, error) {
+	if h == nil {
+		return nil, fmt.Errorf("harness is nil")
+	}
+	if h.Context == nil {
+		return nil, fmt.Errorf("test ID not found in harness context")
+	}
+	testID, ok := h.Context.Value(util.TestIDKey).(string)
+	if !ok || testID == "" {
+		return nil, fmt.Errorf("test ID not found in harness context")
+	}
+	return map[string]string{"test-id": testID}, nil
+}
+
 func (h *Harness) CleanUpAllTestResources() error {
 	if h.VM != nil {
 		if err := h.StopFlightCtlAgent(); err != nil {

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	agentcfg "github.com/flightctl/flightctl/internal/agent/config"
+	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
@@ -63,6 +66,174 @@ func (h *Harness) RestartFlightCtlAgent() error {
 		return fmt.Errorf("failed to restart flightctl-agent: %w", err)
 	}
 	return nil
+}
+
+// ResetAgentEnrollmentState stops the agent and removes local enrollment identity state.
+func (h *Harness) ResetAgentEnrollmentState() error {
+	if h == nil {
+		return fmt.Errorf("harness is nil")
+	}
+	if h.VM == nil {
+		return fmt.Errorf("harness VM is nil")
+	}
+
+	script := `
+set -e
+systemctl stop flightctl-agent || true
+rm -rf /var/lib/flightctl/*
+journalctl --rotate || true
+systemctl reset-failed flightctl-agent || true
+`
+	_, err := h.RunScriptOnVM(script)
+	if err != nil {
+		return fmt.Errorf("resetting agent enrollment state: %w", err)
+	}
+	return nil
+}
+
+// DeleteCurrentEnrollmentRequestFromAgentLogs deletes the latest pending EnrollmentRequest
+// identified in flightctl-agent logs. If no enrollment ID is present, it is a no-op.
+func (h *Harness) DeleteCurrentEnrollmentRequestFromAgentLogs() error {
+	logs, err := h.GetServiceLogs("flightctl-agent")
+	if err != nil {
+		return fmt.Errorf("reading flightctl-agent logs: %w", err)
+	}
+	enrollmentID := testutil.GetEnrollmentIdFromText(logs)
+	if enrollmentID == "" {
+		return nil
+	}
+
+	resp, err := h.Client.DeleteEnrollmentRequestWithResponse(h.Context, enrollmentID)
+	if err != nil {
+		return fmt.Errorf("deleting enrollment request %s: %w", enrollmentID, err)
+	}
+	if resp == nil {
+		return fmt.Errorf("deleting enrollment request %s returned nil response", enrollmentID)
+	}
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNotFound && resp.StatusCode() != http.StatusConflict {
+		return fmt.Errorf("deleting enrollment request %s returned status %d: %s", enrollmentID, resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}
+
+// WaitForEnrollmentIDFromAgentLogs polls the flightctl-agent logs until an enrollment ID is present.
+func (h *Harness) WaitForEnrollmentIDFromAgentLogs(timeout, polling string) (string, error) {
+	return pollUntil(timeout, polling, "enrollment ID in agent logs", func() (string, bool, error) {
+		logs, err := h.GetServiceLogs("flightctl-agent")
+		if err != nil {
+			return "", false, err
+		}
+		enrollmentID := testutil.GetEnrollmentIdFromText(logs)
+		if enrollmentID != "" {
+			return enrollmentID, true, nil
+		}
+		return "", false, nil
+	})
+}
+
+// WaitForEnrollmentRequestResource polls until the expected EnrollmentRequest exists.
+func (h *Harness) WaitForEnrollmentRequestResource(enrollmentID, timeout, polling string) (*v1beta1.EnrollmentRequest, error) {
+	if strings.TrimSpace(enrollmentID) == "" {
+		return nil, fmt.Errorf("enrollment ID is empty")
+	}
+
+	return pollUntil(timeout, polling, fmt.Sprintf("enrollment request %s", enrollmentID), func() (*v1beta1.EnrollmentRequest, bool, error) {
+		resp, err := h.Client.GetEnrollmentRequestWithResponse(h.Context, enrollmentID)
+		if err != nil {
+			return nil, false, err
+		}
+		if resp != nil && resp.JSON200 != nil {
+			return resp.JSON200, true, nil
+		}
+		return nil, false, nil
+	})
+}
+
+// ApproveEnrollmentRequestWithLabels approves an EnrollmentRequest and returns the HTTP status code.
+func (h *Harness) ApproveEnrollmentRequestWithLabels(enrollmentID string, labels map[string]string) (int, error) {
+	if strings.TrimSpace(enrollmentID) == "" {
+		return 0, fmt.Errorf("enrollment ID is empty")
+	}
+
+	approvalLabels := map[string]string{}
+	maps.Copy(approvalLabels, labels)
+	approval := v1beta1.EnrollmentRequestApproval{
+		Approved: true,
+		Labels:   &approvalLabels,
+	}
+
+	resp, err := h.Client.ApproveEnrollmentRequestWithResponse(h.Context, enrollmentID, approval)
+	if err != nil {
+		return 0, fmt.Errorf("approving enrollment request %s: %w", enrollmentID, err)
+	}
+	if resp == nil {
+		return 0, fmt.Errorf("approving enrollment request %s returned nil response", enrollmentID)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return resp.StatusCode(), fmt.Errorf("approving enrollment request %s returned status %d: %s", enrollmentID, resp.StatusCode(), string(resp.Body))
+	}
+	return resp.StatusCode(), nil
+}
+
+// WaitForDeviceWithSystemInfo polls until the Device exists and reports populated systemInfo.
+func (h *Harness) WaitForDeviceWithSystemInfo(deviceID, timeout, polling string) (*v1beta1.Device, error) {
+	if strings.TrimSpace(deviceID) == "" {
+		return nil, fmt.Errorf("device ID is empty")
+	}
+
+	return pollUntil(timeout, polling, fmt.Sprintf("device %s systemInfo", deviceID), func() (*v1beta1.Device, bool, error) {
+		resp, err := h.Client.GetDeviceWithResponse(h.Context, deviceID)
+		if err != nil {
+			return nil, false, err
+		}
+		if resp != nil && resp.JSON200 != nil && resp.JSON200.Status != nil && !resp.JSON200.Status.SystemInfo.IsEmpty() {
+			return resp.JSON200, true, nil
+		}
+		return nil, false, nil
+	})
+}
+
+// pollUntil retries fetch until it reports success, the timeout expires, or the last error persists.
+func pollUntil[T any](timeout, polling, description string, fetch func() (T, bool, error)) (T, error) {
+	var zero T
+	if fetch == nil {
+		return zero, fmt.Errorf("fetch function is nil")
+	}
+
+	timeoutDuration, err := time.ParseDuration(timeout)
+	if err != nil {
+		return zero, fmt.Errorf("parsing timeout %q: %w", timeout, err)
+	}
+	pollingDuration, err := time.ParseDuration(polling)
+	if err != nil {
+		return zero, fmt.Errorf("parsing polling interval %q: %w", polling, err)
+	}
+	if timeoutDuration <= 0 {
+		return zero, fmt.Errorf("timeout must be positive, got %s", timeoutDuration)
+	}
+	if pollingDuration <= 0 {
+		return zero, fmt.Errorf("polling interval must be positive, got %s", pollingDuration)
+	}
+
+	deadline := time.Now().Add(timeoutDuration)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		value, ok, err := fetch()
+		if err != nil {
+			lastErr = err
+			time.Sleep(pollingDuration)
+			continue
+		}
+		if ok {
+			return value, nil
+		}
+		time.Sleep(pollingDuration)
+	}
+
+	if lastErr != nil {
+		return zero, fmt.Errorf("waiting for %s: %w", description, lastErr)
+	}
+	return zero, fmt.Errorf("timed out waiting for %s", description)
 }
 
 // CopyAgentFile copies a file on the VM using sudo cp.


### PR DESCRIPTION
This PR adds e2e coverage for enrollment-time label-from-systeminfo behavior. The tests verify built-in systemInfo mappings, customInfo mappings, default-label precedence, alias handling, missing-field behavior, and disabled custom collection handling.