### PR TITLE
Update timeout for Repository status check in agent test

### DIFF
--- a/test/e2e/agent/agent_suite_test.go
+++ b/test/e2e/agent/agent_suite_test.go
@@ -17,6 +17,8 @@ import (
 const TIMEOUT = "5m"
 const POLLING = "125ms"
 const LONGPOLLING = "500ms"
+const TENSECPOLLING = 10 * time.Second
+const MEDIUMTIMEOUT = "5m"
 const LONGTIMEOUT = "10m"
 const TENMINTIMEOUT = 10 * time.Minute
 const TENSECTIMEOUT = 10 * time.Second

--- a/test/e2e/agent/agent_update_test.go
+++ b/test/e2e/agent/agent_update_test.go
@@ -195,7 +195,7 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(Or(Equal(v1beta1.ConditionStatusTrue), Equal(v1beta1.ConditionStatusFalse)))
 				repositoryAccessible = cond.Status == v1beta1.ConditionStatusTrue
-			}, "1m", POLLING).Should(Succeed())
+			}, MEDIUMTIMEOUT, TENSECPOLLING).Should(Succeed())
 
 			// Add more factories here if desired. In disconnected environments the public
 			// repository-backed config is not reachable, so use a local inline config instead.


### PR DESCRIPTION
Increase the timeout for a repository In agent_update_test as the interval of the reposiory update is 2 minutes.