### PR TITLE
Make sure the CLI tests close console sessions

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -174,6 +174,7 @@ var _ = Describe("CLI - device console", func() {
 		harness := e2e.GetWorkerHarness()
 
 		session := harness.NewConsoleSession(deviceID)
+		DeferCleanup(session.Close)
 
 		session.MustSend(`whoami`)
 		session.MustExpect(`flightctl-console`)
@@ -277,6 +278,9 @@ var _ = Describe("CLI - device console", func() {
 
 		By("verifying that the ~. sequence exits the shell")
 		cs := harness.NewConsoleSession(deviceID)
+		cs.SkipGracefulExitOnClose()
+		DeferCleanup(cs.Close)
+
 		Expect(cs.Stdin.Write([]byte("\n~.\n"))).To(BeNumerically(">", 0))
 		Eventually(cs.Stdout.Closed).Should(BeTrue())
 

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -553,15 +553,23 @@ func (h *Harness) RunInteractiveCLI(args ...string) (io.WriteCloser, io.ReadClos
 	cmd := exec.Command(flightctlPath()) //nolint:gosec // flightctlPath constructs path from project directory structure for test purposes
 	h.setArgsInCmd(cmd, args...)
 
-	// create a pty/tty pair
-	ptmx, tty, err := pty.Open()
-	if err != nil {
-		return nil, nil, err
-	}
+	// create a pty/tty pair (requires /dev/ptmx + devpts so slaves exist under /dev/pts/)
 
+	var ptmx, tty *os.File
+	var err error
+
+	Eventually(func() error {
+		ptmx, tty, err = pty.Open()
+		if err != nil {
+			return err
+		}
+		return nil
+	}, TIMEOUT, POLLING).Should(Succeed(), "failed to open pty/tty pair")
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
 
 	if err := cmd.Start(); err != nil {
+		_ = ptmx.Close()
+		_ = tty.Close()
 		return nil, nil, fmt.Errorf("error starting interactive process: %w", err)
 	}
 	go func() {

--- a/test/harness/e2e/harness_console.go
+++ b/test/harness/e2e/harness_console.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -12,8 +13,10 @@ import (
 
 // ConsoleSession represents a PTY console session to a device
 type ConsoleSession struct {
-	Stdin  io.WriteCloser
-	Stdout *Buffer
+	Stdin            io.WriteCloser
+	Stdout           *Buffer
+	closeOnce        sync.Once
+	skipGracefulExit bool // when true, Close only releases fds (e.g. after flightctl "~." disconnect)
 }
 
 // NewConsoleSession starts a PTY console session to the specified device.
@@ -45,17 +48,30 @@ func (cs *ConsoleSession) MustExpect(pattern string) {
 	Expect(cs.Stdout.Clear()).To(Succeed())
 }
 
-// Close terminates the console session
-func (cs *ConsoleSession) Close() {
-	cs.MustSend("exit")
-	Consistently(cs.Stdout, 2*time.Second).ShouldNot(Say(".*panic:"))
+// When called set Close function not to semd the "exit" command before disconnecting the client
+// (e.g. flightctl "~." escape) and only release local PTY fds.
+func (cs *ConsoleSession) SkipGracefulExitOnClose() {
+	cs.skipGracefulExit = true
+}
 
-	if err := cs.Stdin.Close(); err != nil {
-		GinkgoWriter.Printf("failed to close console stdin: %v\n", err)
-	}
-	if err := cs.Stdout.Close(); err != nil {
-		GinkgoWriter.Printf("failed to close console stdout: %v\n", err)
-	}
+// Close terminates the console session. When SkipGracefulExitOnClose was set (e.g. after "~."),
+// it only closes stdin/stdout without sending "exit".
+func (cs *ConsoleSession) Close() {
+	cs.closeOnce.Do(func() {
+		if !cs.skipGracefulExit {
+			cs.MustSend("exit")
+			Consistently(cs.Stdout, 2*time.Second).ShouldNot(Say(".*panic:"))
+		}
+
+		if err := cs.Stdin.Close(); err != nil {
+			GinkgoWriter.Printf("failed to close console stdin: %v\n", err)
+		}
+		if cs.Stdout != nil {
+			if err := cs.Stdout.Close(); err != nil {
+				GinkgoWriter.Printf("failed to close console stdout: %v\n", err)
+			}
+		}
+	})
 }
 
 // RunConsoleCommand executes the flightctl console command for the given


### PR DESCRIPTION
- Add CloseAfterDisconnect to be used when sending '~.'
- Make sure console sessions are closed in CLI console tests.
- Retry allocation of pseudo terminal in RunInteractiveCLI