### PR TITLE
EDM-3761: Improve status reporting for critical resource alerts

### DIFF
--- a/internal/agent/device/dependency/dependency.go
+++ b/internal/agent/device/dependency/dependency.go
@@ -346,7 +346,8 @@ func (m *prefetchManager) BeforeUpdate(ctx context.Context, current, desired *v1
 
 	if len(newTargets) > 0 {
 		if m.resourceManager.IsCriticalAlert(resource.DiskMonitorType) {
-			return fmt.Errorf("%w: insufficient disk storage space, please clear storage", errors.ErrCriticalResourceAlert)
+			return fmt.Errorf("%w: %w", errors.WithElement("Disk"),
+				fmt.Errorf("%w: insufficient disk storage space, please clear storage", errors.ErrCriticalResourceAlert))
 		}
 		m.log.Debugf("Scheduling %d new targets for prefetch", len(newTargets))
 		if err := m.Schedule(ctx, newTargets); err != nil {

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -620,10 +620,18 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 	}
 
 	se := errors.FormatError(syncErr)
-	if !errors.IsRetryable(syncErr) {
+
+	// Handle critical resource alerts differently from update failures
+	if errors.Is(syncErr, errors.ErrCriticalResourceAlert) {
+		msg := fmt.Sprintf("Update to renderedVersion %s deferred due to critical resource alerts. Will retry when resources are available.", version)
+		conditionUpdate.Reason = string(v1beta1.UpdateStateApplyingUpdate)
+		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
+		conditionUpdate.Status = v1beta1.ConditionStatusTrue
+		a.log.Warn(msg, se.Timestamp)
+	} else if !errors.IsRetryable(syncErr) {
 		msg := fmt.Sprintf("Failed to update to renderedVersion: %s: %v", version, syncErr.Error())
 		conditionUpdate.Reason = string(v1beta1.UpdateStateError)
-		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
+		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusFalse
 		a.pullConfigResolver.Cleanup()
 		a.prefetchManager.Cleanup()
@@ -631,11 +639,10 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 	} else {
 		msg := fmt.Sprintf("Failed to update to renderedVersion: %s: retrying: %v", version, syncErr.Error())
 		conditionUpdate.Reason = string(v1beta1.UpdateStateApplyingUpdate)
-		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
+		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusTrue
 		a.log.Warn(msg, se.Timestamp)
 	}
-	conditionUpdate.Message = se.Message()
 	if err := a.statusManager.UpdateCondition(ctx, conditionUpdate); err != nil {
 		a.log.Warnf("Failed to update device status condition: %v", err)
 	}

--- a/internal/agent/device/errors/structured.go
+++ b/internal/agent/device/errors/structured.go
@@ -154,7 +154,7 @@ func statusCodeMessage(code codes.Code) string {
 	case codes.PermissionDenied:
 		return "permission denied"
 	case codes.ResourceExhausted:
-		return "resource limit exceeded (CPU, memory, or disk)"
+		return "resource limit exceeded, will retry when resources are available"
 	case codes.FailedPrecondition:
 		return "precondition not met (waiting for dependencies)"
 	case codes.Aborted:

--- a/test/e2e/agent/agent_structured_errors_test.go
+++ b/test/e2e/agent/agent_structured_errors_test.go
@@ -40,6 +40,7 @@ const (
 	StatusMsgPermissionDenied  = "permission denied"
 	StatusMsgUnavailable       = "service unavailable (network issue)"
 	StatusMsgInternal          = "internal error occurred"
+	StatusMsgResourceExhausted = "resource limit exceeded"
 )
 
 var _ = Describe("Agent structured error messages", Ordered, func() {
@@ -66,8 +67,8 @@ var _ = Describe("Agent structured error messages", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "failed to apply bad image and wait for error")
 			Expect(cond.Message).ToNot(BeEmpty())
 			GinkgoWriter.Printf("Structured error: %s\n", cond.Message)
-			Expect(util.ValidateStructuredError(cond.Message, "Preparing", "prefetch", StatusMsgAuthFailed, StatusMsgNotFound, StatusMsgPermissionDenied, StatusMsgUnavailable, StatusMsgInternal)).To(Succeed(),
-				"expected Preparing/prefetch with one of auth failed, not found, "+StatusMsgPermissionDenied+", service unavailable, or internal error")
+			Expect(util.ValidateStructuredError(cond.Message, "Preparing", "prefetch", StatusMsgAuthFailed, StatusMsgNotFound, StatusMsgPermissionDenied, StatusMsgUnavailable, StatusMsgInternal, StatusMsgResourceExhausted)).To(Succeed(),
+				"expected Preparing/prefetch with one of auth failed, not found, "+StatusMsgPermissionDenied+", service unavailable, internal error, or resource limit exceeded")
 			Expect(cond.Message).To(ContainSubstring(fmt.Sprintf("failed for %s", NonExistentImage)),
 				"should contain 'failed for <image>'")
 


### PR DESCRIPTION
Critical resource alerts were showing as update failures instead of proper deferral messages. This fix:

- Preserves original blocking behavior for safety
- Improves status reporting to show deferred updates clearly
- Handles critical resource alerts separately in error handling
- Shows "Update deferred due to critical resource alerts" instead of confusing error messages

The fix maintains all existing safety mechanisms while providing better UX.