### PR TITLE
NO-ISSUE: Fix console flakiness

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -30,6 +30,9 @@ var _ = Describe("CLI - device console", func() {
 		// Get harness directly - no shared package-level variable
 		harness := e2e.GetWorkerHarness()
 
+		By("resetting the agent config for console tests")
+		Expect(resetConsoleTestAgentConfig(harness)).To(Succeed())
+
 		By("enrolling the device")
 		deviceID, _ = harness.EnrollAndWaitForOnlineStatus()
 	})
@@ -371,3 +374,32 @@ var _ = Describe("CLI - device console", func() {
 
 // 	return validateIntervalTiming(timestamps, expectedInterval)
 // }
+
+// resetConsoleTestAgentConfig clears enrollment state and label-from-system-info
+// mappings so console tests start from a predictable enrollment configuration.
+func resetConsoleTestAgentConfig(harness *e2e.Harness) error {
+	if harness == nil {
+		return fmt.Errorf("harness is nil")
+	}
+
+	if err := harness.ResetAgentEnrollmentState(); err != nil {
+		return fmt.Errorf("resetting agent enrollment state: %w", err)
+	}
+
+	cfg, err := harness.GetAgentConfig()
+	if err != nil {
+		return fmt.Errorf("getting agent config: %w", err)
+	}
+
+	cfg.LabelFromSystemInfo = map[string]string{}
+
+	if err := harness.SetAgentConfig(cfg); err != nil {
+		return fmt.Errorf("setting agent config: %w", err)
+	}
+
+	if err := harness.StartFlightCtlAgent(); err != nil {
+		return fmt.Errorf("starting flightctl-agent: %w", err)
+	}
+
+	return nil
+}

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -41,11 +41,11 @@ func (h *Harness) RunScriptOnVM(script string) (*bytes.Buffer, error) {
 	return h.VM.RunSSH(vmShellCommandArgs(remote), nil)
 }
 
-// StartFlightCtlAgent starts the flightctl-agent service
+// StartFlightCtlAgent starts or restarts the flightctl-agent service so config changes are picked up.
 func (h *Harness) StartFlightCtlAgent() error {
-	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "start", "flightctl-agent"}, nil)
+	_, err := h.VM.RunSSH([]string{"sudo", "systemctl", "restart", "flightctl-agent"}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to start flightctl-agent: %w", err)
+		return fmt.Errorf("failed to start or restart flightctl-agent: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Make StartFlightCtlAgent restart the agent so test config changes are picked up even when the service is already running.

The console E2E setup now resets enrollment config before enrolling, preventing stale agent configuration from making the test fail before it reaches the console assertion.
