### PR TITLE
EDM-3878: Sanitize and validate enrollment labels

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -278,6 +278,7 @@ pprof
 RFC3339
 RPC
 sos
+sanitization
 sudo
 systemInfo
 ts

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -255,7 +255,7 @@ label-from-systeminfo:
 
 In this case, the device will have `env=production` (from `default-labels`) and `region` mapped from custom info.
 
-**Label validation:** `label-from-systeminfo` values are automatically **sanitized** to meet Kubernetes requirements (spaces become hyphens, special characters are replaced), while `default-labels` values are **validated** but not modified. Invalid `default-labels` are skipped with an error log, allowing the agent to enroll successfully while alerting administrators to fix their configuration.
+**Label validation:** `label-from-systeminfo` values are automatically **sanitized** to meet Kubernetes requirements (spaces and special characters become hyphens), while `default-labels` values are **validated** but not modified. Invalid `default-labels` are skipped with an error log, allowing the agent to enroll successfully while alerting administrators to fix their configuration.
 
 ### Complete example
 

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -18,7 +18,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 | `enrollment-service`     | `EnrollmentService` | Y | Connection details for the device owner's Flight Control service used by the agent to enroll the device. |
 | `spec-fetch-interval`    | `Duration` | | **Deprecated**: This parameter is no longer used. The agent now uses long-polling to receive specification updates immediately when available. |
 | `status-update-interval` | `Duration` | | Interval in which the agent reports its device status under normal conditions. The agent immediately sends status reports on major events related to the health of the system and application workloads as well as on the progress during a system update. Default: `60s` |
-| `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. Default: `{}` |
+| `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. **Important:** Label values must be valid Kubernetes labels (alphanumeric, `-`, `_`, `.`, max 63 chars). Invalid labels are skipped with an error log. Default: `{}` |
 | `label-from-systeminfo`  | `object` (`string`) | | Maps system information fields to device labels at enrollment time. See [Enrollment-time label mapping](#enrollment-time-label-mapping). Default: `{}` |
 | `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
 | `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
@@ -183,6 +183,8 @@ The `label-from-systeminfo` configuration parameter enables automatic device lab
 
 During enrollment, the agent collects system information and applies the configured label mappings. The resulting labels are included in the enrollment request and become part of the device's metadata. These labels can then be used by fleet selectors to automatically assign devices to the appropriate fleets.
 
+**Label value sanitization:** System information values are automatically sanitized to ensure they meet Kubernetes label requirements. Values containing spaces or special characters (e.g., `"CentOS Stream"`, `"9.5 (Plow)"`) are transformed into valid label values (e.g., `"CentOS-Stream"`, `"9.5--Plow"`). Invalid characters are replaced with hyphens, and values are truncated to 63 characters if needed. If a value cannot be sanitized into a valid label, the label is skipped and a warning is logged.
+
 ### Mapping built-in fields
 
 You can map any built-in system information field to a label. Reference built-in fields by their field name:
@@ -252,6 +254,8 @@ label-from-systeminfo:
 ```
 
 In this case, the device will have `env=production` (from `default-labels`) and `region` mapped from custom info.
+
+**Label validation:** `label-from-systeminfo` values are automatically **sanitized** to meet Kubernetes requirements (spaces become hyphens, special characters are replaced), while `default-labels` values are **validated** but not modified. Invalid `default-labels` are skipped with an error log, allowing the agent to enroll successfully while alerting administrators to fix their configuration.
 
 ### Complete example
 

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,6 +19,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/status"
 	"github.com/flightctl/flightctl/internal/agent/identity"
 	"github.com/flightctl/flightctl/internal/tpm"
+	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/skip2/go-qrcode"
 	"github.com/stoewer/go-strcase"
@@ -459,33 +459,67 @@ func (m *LifecycleManager) enrollmentRequest(ctx context.Context, deviceStatus *
 }
 
 // buildEnrollmentLabels creates the final label map for enrollment by:
-// 1. Mapping systemInfo fields (built-in and customInfo) to labels based on labelFromSystemInfo config
-// 2. Adding default alias=hostname if no "alias" label is configured
-// 3. Merging with defaultLabels (defaultLabels take precedence on conflicts)
+// 1. Mapping systemInfo fields (built-in and customInfo) to labels based on labelFromSystemInfo config (sanitized)
+// 2. Adding default alias=hostname if no "alias" label is configured (sanitized)
+// 3. Merging with defaultLabels (validated but not sanitized - invalid labels are skipped)
 func (m *LifecycleManager) buildEnrollmentLabels(deviceStatus *v1beta1.DeviceStatus) map[string]string {
 	// Start with labels from systemInfo mappings
 	labels := make(map[string]string, len(m.labelFromSystemInfo)+len(m.defaultLabels)+1)
 
-	// Extract systemInfo field mappings (includes both built-in and customInfo fields)
+	// Extract and sanitize systemInfo field mappings (includes both built-in and customInfo fields)
 	for labelName, fieldName := range m.labelFromSystemInfo {
-		value := m.extractSystemInfoField(&deviceStatus.SystemInfo, fieldName)
-		if value != "" {
-			labels[labelName] = value
-		} else {
-			m.log.Warnf("Failed to extract systemInfo field %q for label %q", fieldName, labelName)
+		// Validate label key (user-configured in config file)
+		if keyErrs := validation.ValidateLabelKey(labelName); len(keyErrs) > 0 {
+			m.log.Errorf("Invalid label key %q in label-from-systeminfo: %v - skipping this label. Please fix your agent configuration.", labelName, keyErrs)
+			continue
 		}
+
+		value := m.extractSystemInfoField(&deviceStatus.SystemInfo, fieldName)
+		if value == "" {
+			m.log.Warnf("Failed to extract systemInfo field %q for label %q", fieldName, labelName)
+			continue
+		}
+
+		// Sanitize the value to ensure it's a valid Kubernetes label value
+		// (systemInfo values like "CentOS Stream" need sanitization)
+		sanitized := validation.SanitizeLabelValue(value)
+		if sanitized == "" {
+			m.log.Warnf("Failed to sanitize systemInfo field %q (original value: %q) for label %q - value cannot be made valid", fieldName, value, labelName)
+			continue
+		}
+
+		if sanitized != value {
+			m.log.Infof("Sanitized systemInfo field %q for label %q: %q -> %q", fieldName, labelName, value, sanitized)
+		}
+		labels[labelName] = sanitized
 	}
 
 	// Add default alias=hostname if no "alias" label is configured
 	if _, hasAlias := m.labelFromSystemInfo["alias"]; !hasAlias {
 		hostname := m.extractSystemInfoField(&deviceStatus.SystemInfo, "hostname")
 		if isUsefulHostname(hostname) {
-			labels["alias"] = hostname
+			// Sanitize hostname as well (it's auto-generated)
+			sanitized := validation.SanitizeLabelValue(hostname)
+			if sanitized != "" {
+				if sanitized != hostname {
+					m.log.Infof("Sanitized hostname for default alias: %q -> %q", hostname, sanitized)
+				}
+				labels["alias"] = sanitized
+			} else {
+				m.log.Warnf("Failed to sanitize hostname %q for default alias", hostname)
+			}
 		}
 	}
 
-	// Then apply defaultLabels, which take precedence on conflicts
-	maps.Copy(labels, m.defaultLabels)
+	// Validate and apply defaultLabels (which take precedence on conflicts)
+	// These are user-configured, so we validate but don't sanitize - invalid labels are skipped
+	for labelName, labelValue := range m.defaultLabels {
+		if err := validation.ValidateLabelValue(labelName, labelValue); len(err) > 0 {
+			m.log.Errorf("Invalid default-label %q=%q: %v - skipping this label. Please fix your agent configuration.", labelName, labelValue, err)
+			continue
+		}
+		labels[labelName] = labelValue
+	}
 
 	return labels
 }

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -533,6 +533,124 @@ func TestLifecycleManager_buildEnrollmentLabels(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
+		{
+			name: "When systemInfo value contains spaces it should be sanitized",
+			labelFromSystemInfo: map[string]string{
+				"os-name": "distroName",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname":   "test-host",
+						"distroName": "CentOS Stream",
+					},
+				},
+			},
+			expected: map[string]string{
+				"os-name": "CentOS-Stream", // Sanitized: space replaced with hyphen
+				"alias":   "test-host",
+			},
+		},
+		{
+			name: "When systemInfo value has special characters it should be sanitized",
+			labelFromSystemInfo: map[string]string{
+				"distro": "distroVersion",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname":      "test-host",
+						"distroVersion": "9.5 (Plow)",
+					},
+				},
+			},
+			expected: map[string]string{
+				"distro": "9.5--Plow", // Sanitized: space and parens replaced
+				"alias":  "test-host",
+			},
+		},
+		{
+			name:                "When default-labels contain invalid values they should be skipped",
+			labelFromSystemInfo: map[string]string{},
+			defaultLabels: map[string]string{
+				"valid-label":   "valid-value",
+				"invalid-label": "value with spaces", // Invalid: contains spaces
+			},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname": "test-host",
+					},
+				},
+			},
+			expected: map[string]string{
+				"valid-label": "valid-value",
+				"alias":       "test-host",
+				// "invalid-label" is skipped
+			},
+		},
+		{
+			name: "When hostname contains spaces it should be sanitized",
+			labelFromSystemInfo: map[string]string{
+				"arch": "architecture",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname": "my host name",
+					},
+				},
+			},
+			expected: map[string]string{
+				"arch":  "x86_64",
+				"alias": "my-host-name", // Sanitized hostname
+			},
+		},
+		{
+			name: "When sanitization results in empty string it should skip the label",
+			labelFromSystemInfo: map[string]string{
+				"bad-label": "customField",
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					AdditionalProperties: map[string]string{
+						"hostname":    "test-host",
+						"customField": "!!!", // Cannot be sanitized to valid label
+					},
+				},
+			},
+			expected: map[string]string{
+				"alias": "test-host",
+				// "bad-label" is skipped because sanitization results in empty string
+			},
+		},
+		{
+			name: "When label-from-systeminfo has invalid key it should be skipped",
+			labelFromSystemInfo: map[string]string{
+				"valid-key":           "architecture",
+				"bad key with spaces": "distroName", // Invalid key
+			},
+			defaultLabels: map[string]string{},
+			deviceStatus: &v1beta1.DeviceStatus{
+				SystemInfo: v1beta1.DeviceSystemInfo{
+					Architecture: "x86_64",
+					AdditionalProperties: map[string]string{
+						"hostname":   "test-host",
+						"distroName": "CentOS Stream",
+					},
+				},
+			},
+			expected: map[string]string{
+				"valid-key": "x86_64",
+				"alias":     "test-host",
+				// "bad key with spaces" is skipped due to invalid key
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -70,6 +70,83 @@ func ValidateLabelsWithPath(labels *map[string]string, path string) []error {
 	return asErrors(errs)
 }
 
+// ValidateLabelKey validates a Kubernetes label key.
+// Returns a list of validation error messages, or an empty list if valid.
+func ValidateLabelKey(key string) []string {
+	return k8sutilvalidation.IsQualifiedName(key)
+}
+
+// ValidateLabelValue validates a single Kubernetes label key-value pair.
+// Returns a list of validation error messages, or an empty list if valid.
+func ValidateLabelValue(key, value string) []string {
+	var errs []string
+
+	// Validate key
+	keyErrs := ValidateLabelKey(key)
+	for _, err := range keyErrs {
+		errs = append(errs, fmt.Sprintf("invalid label key %q: %s", key, err))
+	}
+
+	// Validate value
+	valueErrs := k8sutilvalidation.IsValidLabelValue(value)
+	for _, err := range valueErrs {
+		errs = append(errs, fmt.Sprintf("invalid label value %q: %s", value, err))
+	}
+
+	return errs
+}
+
+// SanitizeLabelValue converts an arbitrary string into a valid Kubernetes label value.
+// It transforms invalid characters, ensures proper start/end characters, and truncates to 63 characters.
+// Returns an empty string if the input cannot be sanitized into a valid label value.
+//
+// Kubernetes label value requirements (from k8s.io/apimachinery/pkg/util/validation):
+//   - Must be 63 characters or less (can be empty)
+//   - Must be empty OR consist of alphanumeric characters, '-', '_' or '.'
+//   - Must start and end with an alphanumeric character
+//
+// Examples:
+//   - "CentOS Stream" -> "CentOS-Stream"
+//   - "Red Hat Enterprise Linux" -> "Red-Hat-Enterprise-Linux"
+//   - "!!invalid!!" -> "" (empty, cannot be sanitized)
+//   - "valid-label" -> "valid-label" (unchanged)
+func SanitizeLabelValue(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	// Replace invalid characters with hyphen
+	// Valid chars: A-Z, a-z, 0-9, -, _, .
+	sanitized := strings.Map(func(r rune) rune {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			return r
+		}
+		return '-'
+	}, value)
+
+	// Trim non-alphanumeric characters from start and end
+	sanitized = strings.TrimFunc(sanitized, func(r rune) bool {
+		return !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+
+	// Truncate to maximum length
+	if len(sanitized) > k8sutilvalidation.LabelValueMaxLength {
+		sanitized = sanitized[:k8sutilvalidation.LabelValueMaxLength]
+		// Re-trim end in case truncation left non-alphanumeric at the end
+		sanitized = strings.TrimRightFunc(sanitized, func(r rune) bool {
+			return !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+		})
+	}
+
+	// Verify the result is valid (could still be invalid after transformations)
+	if len(k8sutilvalidation.IsValidLabelValue(sanitized)) > 0 {
+		return ""
+	}
+
+	return sanitized
+}
+
 // ValidateStringMap validates that the k,v elements in a map are correctly defined as a string.
 func ValidateStringMap(m *map[string]string, path string, minLen int, maxLen int, keyPatternRegexp, valuePatternRegexp *regexp.Regexp, patternFmt string, patternExample ...string) []error {
 	allErrs := []error{}

--- a/internal/util/validation/validation_test.go
+++ b/internal/util/validation/validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	k8sutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 func TestValidateRelativePath(t *testing.T) {
@@ -106,6 +107,200 @@ func TestDenyForbiddenDevicePath(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateLabelKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		wantValid bool
+	}{
+		{
+			name:      "valid simple key",
+			key:       "environment",
+			wantValid: true,
+		},
+		{
+			name:      "valid key with hyphens",
+			key:       "my-label-key",
+			wantValid: true,
+		},
+		{
+			name:      "valid key with dots",
+			key:       "example.com/my-key",
+			wantValid: true,
+		},
+		{
+			name:      "valid key with underscores",
+			key:       "my_key",
+			wantValid: true,
+		},
+		{
+			name:      "invalid key with spaces",
+			key:       "bad key",
+			wantValid: false,
+		},
+		{
+			name:      "invalid key with special chars",
+			key:       "key@value",
+			wantValid: false,
+		},
+		{
+			name:      "invalid key starting with hyphen",
+			key:       "-badkey",
+			wantValid: false,
+		},
+		{
+			name:      "invalid key ending with hyphen",
+			key:       "badkey-",
+			wantValid: false,
+		},
+		{
+			name:      "empty key",
+			key:       "",
+			wantValid: false, // K8s does not allow empty keys
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateLabelKey(tt.key)
+			isValid := len(errs) == 0
+			require.Equal(t, tt.wantValid, isValid, "key %q validation mismatch. Errors: %v", tt.key, errs)
+		})
+	}
+}
+
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "valid label unchanged",
+			input:    "valid-label",
+			expected: "valid-label",
+		},
+		{
+			name:     "valid with underscores and dots",
+			input:    "test_value.123",
+			expected: "test_value.123",
+		},
+		{
+			name:     "spaces replaced with hyphens",
+			input:    "CentOS Stream",
+			expected: "CentOS-Stream",
+		},
+		{
+			name:     "multiple spaces",
+			input:    "Red Hat Enterprise Linux",
+			expected: "Red-Hat-Enterprise-Linux",
+		},
+		{
+			name:     "special characters replaced",
+			input:    "version@2.0!test",
+			expected: "version-2.0-test",
+		},
+		{
+			name:     "leading special chars trimmed",
+			input:    "!!!valid-label",
+			expected: "valid-label",
+		},
+		{
+			name:     "trailing special chars trimmed",
+			input:    "valid-label!!!",
+			expected: "valid-label",
+		},
+		{
+			name:     "leading and trailing special chars trimmed",
+			input:    "---valid-label---",
+			expected: "valid-label",
+		},
+		{
+			name:     "only special characters",
+			input:    "!!!",
+			expected: "",
+		},
+		{
+			name:     "only hyphens",
+			input:    "---",
+			expected: "",
+		},
+		{
+			name:     "IP address is valid",
+			input:    "127.0.0.1",
+			expected: "127.0.0.1",
+		},
+		{
+			name:     "IPv6 colons replaced",
+			input:    "::1",
+			expected: "1",
+		},
+		{
+			name:     "single character",
+			input:    "a",
+			expected: "a",
+		},
+		{
+			name:     "truncate long value",
+			input:    strings.Repeat("a", 100),
+			expected: strings.Repeat("a", 63),
+		},
+		{
+			name:     "truncate and trim trailing hyphens",
+			input:    strings.Repeat("a", 60) + "---" + strings.Repeat("b", 10),
+			expected: strings.Repeat("a", 60), // trailing hyphens are trimmed
+		},
+		{
+			name:     "parentheses replaced",
+			input:    "version(1.2.3)",
+			expected: "version-1.2.3",
+		},
+		{
+			name:     "mixed valid and invalid chars",
+			input:    "Test_Label-123.v2",
+			expected: "Test_Label-123.v2",
+		},
+		{
+			name:     "unicode replaced",
+			input:    "label™",
+			expected: "label",
+		},
+		{
+			name:     "slashes replaced",
+			input:    "path/to/value",
+			expected: "path-to-value",
+		},
+		{
+			name:     "realistic distro name",
+			input:    "Red Hat Enterprise Linux 9.5 (Plow)",
+			expected: "Red-Hat-Enterprise-Linux-9.5--Plow",
+		},
+		{
+			name:     "realistic product name",
+			input:    "Dell PowerEdge R640",
+			expected: "Dell-PowerEdge-R640",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeLabelValue(tt.input)
+			require.Equal(t, tt.expected, result)
+
+			// Verify result is valid if non-empty
+			if result != "" {
+				errs := k8sutilvalidation.IsValidLabelValue(result)
+				require.Empty(t, errs, "sanitized value should be valid: %q produced %v", result, errs)
 			}
 		})
 	}

--- a/test/e2e/agent/agent_label_from_systeminfo_test.go
+++ b/test/e2e/agent/agent_label_from_systeminfo_test.go
@@ -14,23 +14,24 @@ import (
 )
 
 const (
-	labelFromSystemInfoBuiltInLabelArch     = "arch"
-	labelFromSystemInfoBuiltInLabelOS       = "os"
-	labelFromSystemInfoCustomLabelSite      = "site"
-	labelFromSystemInfoDefaultAliasLabel    = "alias"
-	labelFromSystemInfoMissingBuiltInLabel  = "missingBuiltin"
-	labelFromSystemInfoMissingCustomLabel   = "missingCustom"
-	labelFromSystemInfoManualArchValue      = "manually-set"
-	labelFromSystemInfoExpectedOSValue      = "linux"
-	labelFromSystemInfoExpectedSiteName     = "my site"
-	labelFromSystemInfoCustomKeySiteName    = "siteName"
-	labelFromSystemInfoCustomKeyEmptyValue  = "emptyValue"
-	labelFromSystemInfoCustomFieldPrefix    = "customInfo."
-	labelFromSystemInfoFieldArchitecture    = "architecture"
-	labelFromSystemInfoFieldOperatingSystem = "operatingSystem"
-	labelFromSystemInfoFieldProductName     = "productName"
-	labelFromSystemInfoFieldHostname        = "hostname"
-	labelFromSystemInfoMissingFieldName     = "doesNotExist"
+	labelFromSystemInfoBuiltInLabelArch       = "arch"
+	labelFromSystemInfoBuiltInLabelOS         = "os"
+	labelFromSystemInfoCustomLabelSite        = "site"
+	labelFromSystemInfoDefaultAliasLabel      = "alias"
+	labelFromSystemInfoMissingBuiltInLabel    = "missingBuiltin"
+	labelFromSystemInfoMissingCustomLabel     = "missingCustom"
+	labelFromSystemInfoManualArchValue        = "manually-set"
+	labelFromSystemInfoExpectedOSValue        = "linux"
+	labelFromSystemInfoRawSiteNameValue       = "my site" // Raw value from script (stored in customInfo)
+	labelFromSystemInfoSanitizedSiteNameValue = "my-site" // Sanitized value (used in labels)
+	labelFromSystemInfoCustomKeySiteName      = "siteName"
+	labelFromSystemInfoCustomKeyEmptyValue    = "emptyValue"
+	labelFromSystemInfoCustomFieldPrefix      = "customInfo."
+	labelFromSystemInfoFieldArchitecture      = "architecture"
+	labelFromSystemInfoFieldOperatingSystem   = "operatingSystem"
+	labelFromSystemInfoFieldProductName       = "productName"
+	labelFromSystemInfoFieldHostname          = "hostname"
+	labelFromSystemInfoMissingFieldName       = "doesNotExist"
 )
 
 var (
@@ -56,10 +57,10 @@ var (
 			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoCustomFieldPrefix + labelFromSystemInfoCustomKeySiteName,
 		},
 		wantLabels: map[string]string{
-			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoExpectedSiteName,
+			labelFromSystemInfoCustomLabelSite: labelFromSystemInfoSanitizedSiteNameValue,
 		},
 		wantCustomInfo: map[string]string{
-			labelFromSystemInfoCustomKeySiteName: labelFromSystemInfoExpectedSiteName,
+			labelFromSystemInfoCustomKeySiteName: labelFromSystemInfoRawSiteNameValue,
 		},
 	}
 

--- a/test/integration/agent/label_from_systeminfo_test.go
+++ b/test/integration/agent/label_from_systeminfo_test.go
@@ -192,4 +192,69 @@ var _ = Describe("Agent label-from-systeminfo", func() {
 		Expect(labels).To(HaveKeyWithValue("env", "production"))
 		Expect(labels).To(HaveKey("alias")) // default alias
 	})
+
+	It("should sanitize systemInfo values with spaces during enrollment", func() {
+		// Create custom-info script that returns a value with spaces
+		customInfoDir := filepath.Join(h.TestDirPath, "usr", "lib", "flightctl", "custom-info.d")
+		Expect(os.MkdirAll(customInfoDir, 0o755)).To(Succeed())
+
+		scriptPath := filepath.Join(customInfoDir, "distroName")
+		scriptContent := "#!/bin/bash\necho 'CentOS Stream'"
+		Expect(os.WriteFile(scriptPath, []byte(scriptContent), 0o600)).To(Succeed())
+		Expect(os.Chmod(scriptPath, 0o700)).To(Succeed())
+
+		h.AgentConfig().SystemInfoCustom = []string{"distroName"}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"os-name": "customInfo.distroName",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify the label value was sanitized (space replaced with hyphen)
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKeyWithValue("os-name", "CentOS-Stream"))
+		Expect(labels).To(HaveKey("alias")) // default alias
+	})
+
+	It("should skip invalid default-labels but still enroll successfully", func() {
+		h.AgentConfig().DefaultLabels = map[string]string{
+			"valid-label":   "valid-value",
+			"invalid-label": "value with spaces", // Invalid - contains spaces
+		}
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"arch": "architecture",
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify device enrolled successfully with only valid labels
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKeyWithValue("valid-label", "valid-value"))
+		Expect(labels).To(HaveKey("arch"))
+		Expect(labels).To(HaveKey("alias"))
+		// Invalid label should not be present
+		Expect(labels).ToNot(HaveKey("invalid-label"))
+	})
+
+	It("should skip label-from-systeminfo with invalid key", func() {
+		h.AgentConfig().LabelFromSystemInfo = map[string]string{
+			"valid-key":           "architecture",
+			"bad key with spaces": "operatingSystem", // Invalid key
+		}
+		h.StartAgent()
+
+		dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
+
+		// Verify device enrolled successfully with only valid label
+		Expect(dev.Metadata.Labels).ToNot(BeNil())
+		labels := *dev.Metadata.Labels
+		Expect(labels).To(HaveKey("valid-key"))
+		Expect(labels).To(HaveKey("alias"))
+		// Invalid key should not be present
+		Expect(labels).ToNot(HaveKey("bad key with spaces"))
+	})
 })


### PR DESCRIPTION
Agent now sanitizes auto-generated label values (label-from-systeminfo, alias) and validates user-configured labels (default-labels keys/values, label-from-systeminfo keys). Invalid labels are skipped with error logs, allowing enrollment to succeed.