### PR TITLE
NO-ISSUE: Allow reusing local CA for quadlets deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,3 +52,5 @@ __pycache__/
 
 # Go cache
 .cache/ 
+
+deploy/scripts/local-ca/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /rpmbuild/
 /reports/
 deploy/helm/charttmpl
+deploy/scripts/local-ca
 test/e2e/cli/*.crt
 test/e2e/cli/*.key
 /packaging/rpm/flightctl-*.tar.gz

--- a/deploy/scripts/deploy_quadlets.sh
+++ b/deploy/scripts/deploy_quadlets.sh
@@ -16,6 +16,11 @@ install -d -m 0755 /etc/flightctl/tpm-cas
 # Render quadlet files
 bin/flightctl-standalone render quadlets --config "packaging/images/${OS}/local-images.yaml"
 
+if [[ -f $SCRIPT_DIR/local-ca/ca.crt ]] && [[ -f $SCRIPT_DIR/local-ca/ca.key ]]; then
+  cp "$SCRIPT_DIR"/local-ca/ca.* /etc/flightctl/pki/
+  chown root:root /etc/flightctl/pki/ca.*
+fi
+
 echo "Starting all Flight Control services via target..."
 start_service "flightctl.target"
 


### PR DESCRIPTION
This simplifies the browser experience by being able to add this cert to the browser and not have to go through the exception routine on each fresh deployment.