### PR TITLE
EDM-3783: Relative PAM Issuer paths

### DIFF
--- a/internal/auth/oidc/pam/provider.go
+++ b/internal/auth/oidc/pam/provider.go
@@ -1063,7 +1063,7 @@ func (s *PAMOIDCProvider) Login(ctx context.Context, username, password, encrypt
 	s.log.Debugf("Login: created encrypted session cookie for %s", username)
 
 	// Redirect back to authorization endpoint with all parameters
-	authURL := fmt.Sprintf("/api/v1/auth/authorize?response_type=code&client_id=%s&redirect_uri=%s",
+	authURL := fmt.Sprintf("authorize?response_type=code&client_id=%s&redirect_uri=%s",
 		url.QueryEscape(pendingReq.ClientID), url.QueryEscape(pendingReq.RedirectURI))
 	if pendingReq.State != "" {
 		authURL += fmt.Sprintf("&state=%s", url.QueryEscape(pendingReq.State))
@@ -1443,8 +1443,8 @@ func (s *PAMOIDCProvider) createEncryptedCookieAndReturnLoginForm(req *pamapi.Au
 
 const (
 	defaultDisplayName = "Flight Control"
-	defaultLogoSrc     = "/auth/assets/flight-control-logo.svg"
-	defaultFaviconSrc  = "/auth/assets/favicon.png"
+	defaultLogoSrc     = "../../../auth/assets/flight-control-logo.svg"
+	defaultFaviconSrc  = "../../../auth/assets/favicon.png"
 )
 
 // buildLoginFormData constructs the template data from the provider's branding config.

--- a/internal/auth/oidc/pam/provider_test.go
+++ b/internal/auth/oidc/pam/provider_test.go
@@ -938,16 +938,16 @@ var _ = Describe("Login Form Branding", func() {
 
 			faviconLink := findNodeByAttr(doc, "link", "rel", "icon")
 			Expect(faviconLink).ToNot(BeNil(), "expected <link rel=\"icon\"> element")
-			Expect(getAttr(faviconLink, "href")).To(Equal("/auth/assets/favicon.png"))
+			Expect(getAttr(faviconLink, "href")).To(Equal("../../../auth/assets/favicon.png"))
 
 			lightLogo := findNodeByID(doc, "brand-logo-light")
 			Expect(lightLogo).ToNot(BeNil(), "expected #brand-logo-light element")
-			Expect(getAttr(lightLogo, "src")).To(Equal("/auth/assets/flight-control-logo.svg"))
+			Expect(getAttr(lightLogo, "src")).To(Equal("../../../auth/assets/flight-control-logo.svg"))
 			Expect(getAttr(lightLogo, "alt")).To(Equal("Flight Control"))
 
 			darkLogo := findNodeByID(doc, "brand-logo-dark")
 			Expect(darkLogo).ToNot(BeNil(), "expected #brand-logo-dark element")
-			Expect(getAttr(darkLogo, "src")).To(Equal("/auth/assets/flight-control-logo.svg"))
+			Expect(getAttr(darkLogo, "src")).To(Equal("../../../auth/assets/flight-control-logo.svg"))
 
 			Expect(rawHTML).NotTo(ContainSubstring("--pf-t--global--color--brand--default"))
 		})
@@ -1022,7 +1022,7 @@ var _ = Describe("Login Form Branding", func() {
 
 			lightLogo := findNodeByID(doc, "brand-logo-light")
 			Expect(lightLogo).ToNot(BeNil())
-			Expect(getAttr(lightLogo, "src")).To(Equal("/auth/assets/flight-control-logo.svg"))
+			Expect(getAttr(lightLogo, "src")).To(Equal("../../../auth/assets/flight-control-logo.svg"))
 
 			darkLogo := findNodeByID(doc, "brand-logo-dark")
 			Expect(darkLogo).ToNot(BeNil())

--- a/internal/auth/oidc/pam/templates/login.js
+++ b/internal/auth/oidc/pam/templates/login.js
@@ -80,7 +80,7 @@ function handleSubmit(event) {
     var params = new URLSearchParams(formData);
 
     // Submit form data
-    fetch('/api/v1/auth/login', {
+    fetch('login', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/internal/auth/oidc/pam/templates/login_form.html
+++ b/internal/auth/oidc/pam/templates/login_form.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="{{.FaviconSrc}}">
-    <link rel="stylesheet" href="/auth/assets/patternfly.min.css">
-    <link rel="stylesheet" href="/auth/assets/login.css">
+    <link rel="stylesheet" href="../../../auth/assets/patternfly.min.css">
+    <link rel="stylesheet" href="../../../auth/assets/login.css">
 </head>
 <body>
   <button id="theme-toggle" class="pf-v6-c-button pf-m-plain" type="button"></button>
@@ -78,6 +78,6 @@
 
     </div>
   </div>
-  <script src="/auth/assets/login.js"></script>
+  <script src="../../../auth/assets/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Instead of a fixed absolute path for the login and authorize paths, use
relative paths.

Also use relative paths for the web assets.

This will allow the login to work in different deployment models where the
PAM Issuer is not at the root path of the URL.