### PR TITLE
EDM-3843: HTTP change detection

### DIFF
--- a/internal/periodic_checker/task_definitions.go
+++ b/internal/periodic_checker/task_definitions.go
@@ -41,6 +41,7 @@ const (
 	PeriodicTaskTypeQueueMaintenance       PeriodicTaskType = "queue-maintenance"
 	PeriodicTaskTypeVulnerabilitySync      PeriodicTaskType = "vulnerability-sync"
 	PeriodicTaskTypeDependencySyncGit      PeriodicTaskType = "dependency-sync-git"
+	PeriodicTaskTypeDependencySyncHttp     PeriodicTaskType = "dependency-sync-http"
 )
 
 type PeriodicTaskMetadata struct {
@@ -58,6 +59,7 @@ var periodicTasks = map[PeriodicTaskType]PeriodicTaskMetadata{
 	PeriodicTaskTypeQueueMaintenance:       {Interval: QueueMaintenanceInterval, SystemWide: true},
 	PeriodicTaskTypeVulnerabilitySync:      {Interval: tasks.VulnerabilitySyncInterval, SystemWide: true},
 	PeriodicTaskTypeDependencySyncGit:      {Interval: config.DefaultDependencySyncTaskInterval, SystemWide: false},
+	PeriodicTaskTypeDependencySyncHttp:     {Interval: config.DefaultDependencySyncTaskInterval, SystemWide: false},
 }
 
 // MergeTasksWithConfig merges configured task intervals with defaults.
@@ -259,6 +261,18 @@ func (e *DependencySyncGitExecutor) Execute(ctx context.Context, log logrus.Fiel
 	depSync.Poll(taskCtx, orgId)
 }
 
+type DependencySyncHttpExecutor struct {
+	log            logrus.FieldLogger
+	serviceHandler service.Service
+	cfg            *config.Config
+}
+
+func (e *DependencySyncHttpExecutor) Execute(ctx context.Context, log logrus.FieldLogger, orgId uuid.UUID) {
+	taskCtx := createTaskContext(ctx, PeriodicTaskTypeDependencySyncHttp)
+	depSync := tasks.NewDependencySyncHttp(e.log, e.serviceHandler, e.cfg)
+	depSync.Poll(taskCtx, orgId)
+}
+
 func InitializeTaskExecutors(log logrus.FieldLogger, serviceHandler service.Service, cfg *config.Config, queuesProvider queues.Provider, workerClient worker_client.WorkerClient, workerMetrics *worker.WorkerCollector, findingStore store.VulnerabilityFinding, vulnClient trustifyv2.VulnerabilityClient) map[PeriodicTaskType]PeriodicTaskExecutor {
 	executors := map[PeriodicTaskType]PeriodicTaskExecutor{
 		PeriodicTaskTypeRepositoryTester: &RepositoryTesterExecutor{
@@ -307,6 +321,12 @@ func InitializeTaskExecutors(log logrus.FieldLogger, serviceHandler service.Serv
 
 	executors[PeriodicTaskTypeDependencySyncGit] = &DependencySyncGitExecutor{
 		log:            log.WithField("pkg", "dependency-sync-git"),
+		serviceHandler: serviceHandler,
+		cfg:            cfg,
+	}
+
+	executors[PeriodicTaskTypeDependencySyncHttp] = &DependencySyncHttpExecutor{
+		log:            log.WithField("pkg", "dependency-sync-http"),
 		serviceHandler: serviceHandler,
 		cfg:            cfg,
 	}

--- a/internal/service/dependency_ref.go
+++ b/internal/service/dependency_ref.go
@@ -59,6 +59,11 @@ func (h *ServiceHandler) ListDueGitDependencies(ctx context.Context, orgId uuid.
 	return probes, StoreErrorToApiStatus(err, false, "", nil)
 }
 
+func (h *ServiceHandler) ListDueHttpDependencies(ctx context.Context, orgId uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, domain.Status) {
+	probes, err := h.store.DependencyRef().ListDueHttpDependencies(ctx, orgId, pollInterval)
+	return probes, StoreErrorToApiStatus(err, false, "", nil)
+}
+
 func (h *ServiceHandler) ListSecretDependencyTargets(ctx context.Context, secretNamespace, secretName, newFingerprint string) ([]model.SecretDependencyRef, domain.Status) {
 	refs, err := h.store.DependencyRef().ListSecretDependencyTargets(ctx, secretNamespace, secretName, newFingerprint)
 	return refs, StoreErrorToApiStatus(err, false, "", nil)

--- a/internal/service/mock_service.go
+++ b/internal/service/mock_service.go
@@ -1212,6 +1212,21 @@ func (mr *MockServiceMockRecorder) ListDueGitDependencies(ctx, orgId, pollInterv
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDueGitDependencies", reflect.TypeOf((*MockService)(nil).ListDueGitDependencies), ctx, orgId, pollInterval)
 }
 
+// ListDueHttpDependencies mocks base method.
+func (m *MockService) ListDueHttpDependencies(ctx context.Context, orgId uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, domain.Status) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDueHttpDependencies", ctx, orgId, pollInterval)
+	ret0, _ := ret[0].([]model.HttpDependencyProbe)
+	ret1, _ := ret[1].(domain.Status)
+	return ret0, ret1
+}
+
+// ListDueHttpDependencies indicates an expected call of ListDueHttpDependencies.
+func (mr *MockServiceMockRecorder) ListDueHttpDependencies(ctx, orgId, pollInterval any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDueHttpDependencies", reflect.TypeOf((*MockService)(nil).ListDueHttpDependencies), ctx, orgId, pollInterval)
+}
+
 // ListEnrollmentRequests mocks base method.
 func (m *MockService) ListEnrollmentRequests(ctx context.Context, orgId uuid.UUID, params domain.ListEnrollmentRequestsParams) (*domain.EnrollmentRequestList, domain.Status) {
 	m.ctrl.T.Helper()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -150,6 +150,7 @@ type Service interface {
 	BulkUpsertDeviceDependencyRefs(ctx context.Context, orgId uuid.UUID, refs []model.DependencyRef) domain.Status
 	ListDependencyRefsByRefType(ctx context.Context, orgId uuid.UUID, refType string) ([]model.DependencyRef, domain.Status)
 	ListDueGitDependencies(ctx context.Context, orgId uuid.UUID, pollInterval time.Duration) ([]model.GitDependencyProbe, domain.Status)
+	ListDueHttpDependencies(ctx context.Context, orgId uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, domain.Status)
 	ListSecretDependencyTargets(ctx context.Context, secretNamespace, secretName, newFingerprint string) ([]model.SecretDependencyRef, domain.Status)
 
 	// SyncState

--- a/internal/service/traced_service.go
+++ b/internal/service/traced_service.go
@@ -697,6 +697,12 @@ func (t *TracedService) ListDueGitDependencies(ctx context.Context, orgId uuid.U
 	endSpan(span, st)
 	return resp, st
 }
+func (t *TracedService) ListDueHttpDependencies(ctx context.Context, orgId uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, domain.Status) {
+	ctx, span := startSpan(ctx, "ListDueHttpDependencies")
+	resp, st := t.inner.ListDueHttpDependencies(ctx, orgId, pollInterval)
+	endSpan(span, st)
+	return resp, st
+}
 func (t *TracedService) ListSecretDependencyTargets(ctx context.Context, secretNamespace, secretName, newFingerprint string) ([]model.SecretDependencyRef, domain.Status) {
 	ctx, span := startSpan(ctx, "ListSecretDependencyTargets")
 	resp, st := t.inner.ListSecretDependencyTargets(ctx, secretNamespace, secretName, newFingerprint)

--- a/internal/store/dependencyref.go
+++ b/internal/store/dependencyref.go
@@ -25,6 +25,7 @@ type DependencyRef interface {
 	ReplaceByStandaloneDevice(ctx context.Context, orgID uuid.UUID, deviceName string, refs []model.DependencyRef) error
 	BulkUpsertDeviceRefs(ctx context.Context, orgID uuid.UUID, refs []model.DependencyRef) error
 	ListDueGitDependencies(ctx context.Context, orgID uuid.UUID, pollInterval time.Duration) ([]model.GitDependencyProbe, error)
+	ListDueHttpDependencies(ctx context.Context, orgID uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, error)
 	ListSecretDependencyTargets(ctx context.Context, secretNamespace, secretName, newFingerprint string) ([]model.SecretDependencyRef, error)
 }
 
@@ -178,6 +179,31 @@ func (s *DependencyRefStore) ListDueGitDependencies(ctx context.Context, orgID u
 		Where("dr.revision NOT LIKE ?", "%{{%").
 		Where("ss.last_checked_at IS NULL OR ss.last_checked_at + ? * INTERVAL '1 second' < NOW()", pollInterval.Seconds()).
 		Group("dr.repository_name, dr.revision, ss.fingerprint, r.spec").
+		Scan(&probes).Error
+	if err != nil {
+		return nil, ErrorFromGormError(err)
+	}
+	return probes, nil
+}
+
+// ListDueHttpDependencies returns HTTP dependency probes that are due for
+// polling. Mirrors ListDueGitDependencies but filters by ref_type='http' and
+// groups by (repository_name, http_suffix).
+func (s *DependencyRefStore) ListDueHttpDependencies(ctx context.Context, orgID uuid.UUID, pollInterval time.Duration) ([]model.HttpDependencyProbe, error) {
+	var probes []model.HttpDependencyProbe
+	err := s.getDB(ctx).
+		Table("dependency_refs dr").
+		Select(
+			"dr.repository_name, dr.http_suffix, ss.fingerprint, r.spec AS repo_spec, "+
+				"array_agg(DISTINCT dr.fleet_name) FILTER (WHERE dr.fleet_name <> '' AND dr.device_name = '') AS fleet_names, "+
+				"array_agg(DISTINCT dr.device_name) FILTER (WHERE dr.device_name <> '') AS device_names",
+		).
+		Joins("LEFT JOIN sync_states ss ON ss.org_id = dr.org_id AND ss.resource_key = dr.resource_key").
+		Joins("LEFT JOIN repositories r ON r.org_id = dr.org_id AND r.name = dr.repository_name").
+		Where("dr.org_id = ?", orgID).
+		Where("dr.ref_type = 'http'").
+		Where("ss.last_checked_at IS NULL OR ss.last_checked_at + ? * INTERVAL '1 second' < NOW()", pollInterval.Seconds()).
+		Group("dr.repository_name, dr.http_suffix, ss.fingerprint, r.spec").
 		Scan(&probes).Error
 	if err != nil {
 		return nil, ErrorFromGormError(err)

--- a/internal/store/model/dependencyref.go
+++ b/internal/store/model/dependencyref.go
@@ -92,3 +92,14 @@ type GitDependencyProbe struct {
 	DeviceNames    StringArray
 	RepoSpec       *JSONField[domain.RepositorySpec] `gorm:"type:jsonb"`
 }
+
+// HttpDependencyProbe is the result of ListDueHttpDependencies — one row per
+// unique (repository_name, http_suffix) pair that is due for polling.
+type HttpDependencyProbe struct {
+	RepositoryName string
+	HTTPSuffix     string
+	Fingerprint    *string
+	FleetNames     StringArray
+	DeviceNames    StringArray
+	RepoSpec       *JSONField[domain.RepositorySpec] `gorm:"type:jsonb"`
+}

--- a/internal/tasks/dependency_sync_git.go
+++ b/internal/tasks/dependency_sync_git.go
@@ -81,7 +81,9 @@ func (d *DependencySyncGit) Poll(ctx context.Context, orgId uuid.UUID) {
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			res := d.probeRepo(ctx, repoName, group)
+			probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			res := d.probeRepo(probeCtx, repoName, group)
 			mu.Lock()
 			results = append(results, res...)
 			mu.Unlock()

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -104,7 +105,7 @@ func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.Htt
 	}
 
 	repoURL := httpSpec.Url + probe.HTTPSuffix
-	rk := fmt.Sprintf("http:%s/%s", probe.RepositoryName, probe.HTTPSuffix)
+	rk := httpResourceKey(probe.RepositoryName, probe.HTTPSuffix)
 
 	storedFP := ""
 	if probe.Fingerprint != nil {
@@ -114,7 +115,7 @@ func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.Htt
 	fingerprint, statusCode, err := d.conditionalGet(ctx, repoURL, httpSpec, storedFP)
 	if err != nil {
 		d.log.WithError(err).Warnf("HTTP probe failed for %s (status %d)", repoURL, statusCode)
-		return httpProbeResult{probe: probe, skip: true}
+		return httpProbeResult{probe: probe, resourceKey: rk, skip: true}
 	}
 
 	r := httpProbeResult{
@@ -163,10 +164,12 @@ func (d *DependencySyncHttp) reconcile(ctx context.Context, orgId uuid.UUID, res
 	var unchangedKeys []string
 
 	for _, r := range results {
-		if r.skip {
+		if r.resourceKey == "" {
 			continue
 		}
-		if r.firstSeen || r.changed {
+		if r.skip {
+			unchangedKeys = append(unchangedKeys, r.resourceKey)
+		} else if r.firstSeen || r.changed {
 			upsertStates = append(upsertStates, model.SyncState{
 				OrgID:         orgId,
 				ResourceKey:   r.resourceKey,
@@ -193,6 +196,10 @@ func (d *DependencySyncHttp) reconcile(ctx context.Context, orgId uuid.UUID, res
 	}
 }
 
+func httpResourceKey(repoName, suffix string) string {
+	return fmt.Sprintf("http:%s/%s", repoName, strings.TrimPrefix(suffix, "/"))
+}
+
 // httpConditionalGet sends a conditional GET to the given URL using stored
 // fingerprint for If-None-Match/If-Modified-Since headers.
 func httpConditionalGet(_ context.Context, repoURL string,
@@ -208,8 +215,17 @@ func httpConditionalGet(_ context.Context, repoURL string,
 	}
 
 	if storedFingerprint != "" {
-		req.Header.Set("If-None-Match", storedFingerprint)
-		req.Header.Set("If-Modified-Since", storedFingerprint)
+		// ETags always start with `"` or `W/"` (RFC 7232 §2.3), while
+		// Last-Modified is an HTTP-date. We must send the correct header
+		// for the stored fingerprint type: If-None-Match for ETags,
+		// If-Modified-Since for dates. Sending an ETag as If-Modified-Since
+		// (or vice versa) is a protocol violation that may cause servers to
+		// ignore the condition or return 400.
+		if strings.HasPrefix(storedFingerprint, `"`) || strings.HasPrefix(storedFingerprint, `W/"`) {
+			req.Header.Set("If-None-Match", storedFingerprint)
+		} else {
+			req.Header.Set("If-Modified-Since", storedFingerprint)
+		}
 	}
 
 	client := &http.Client{

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -1,0 +1,60 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/flightctl/flightctl/internal/domain"
+)
+
+// httpConditionalGetFunc is the injectable function type for testing.
+// Returns: fingerprint (ETag or Last-Modified value), HTTP status code, error.
+// Empty fingerprint with status 200 means the endpoint doesn't support
+// conditional requests (no ETag or Last-Modified in response).
+type httpConditionalGetFunc func(ctx context.Context, repoURL string,
+	httpSpec domain.HttpRepoSpec, storedFingerprint string) (fingerprint string, statusCode int, err error)
+
+// httpConditionalGet sends a conditional GET to the given URL using stored
+// fingerprint for If-None-Match/If-Modified-Since headers.
+func httpConditionalGet(_ context.Context, repoURL string,
+	httpSpec domain.HttpRepoSpec, storedFingerprint string) (string, int, error) {
+	req, err := http.NewRequest("GET", repoURL, nil)
+	if err != nil {
+		return "", 0, fmt.Errorf("creating request: %w", err)
+	}
+
+	req, tlsConfig, err := buildHttpRepoRequestAuth(httpSpec, req)
+	if err != nil {
+		return "", 0, fmt.Errorf("building request auth: %w", err)
+	}
+
+	if storedFingerprint != "" {
+		req.Header.Set("If-None-Match", storedFingerprint)
+		req.Header.Set("If-Modified-Since", storedFingerprint)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return "", http.StatusNotModified, nil
+	case http.StatusOK:
+		fingerprint := resp.Header.Get("ETag")
+		if fingerprint == "" {
+			fingerprint = resp.Header.Get("Last-Modified")
+		}
+		return fingerprint, http.StatusOK, nil
+	default:
+		return "", resp.StatusCode, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, repoURL)
+	}
+}

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -3,8 +3,8 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -18,29 +18,29 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// httpConditionalGetFunc is the injectable function type for testing.
+// httpConditionalHeadFunc is the injectable function type for testing.
 // Returns: fingerprint (ETag or Last-Modified value), HTTP status code, error.
 // Empty fingerprint with status 200 means the endpoint doesn't support
 // conditional requests (no ETag or Last-Modified in response).
-type httpConditionalGetFunc func(ctx context.Context, repoURL string,
+type httpConditionalHeadFunc func(ctx context.Context, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (fingerprint string, statusCode int, err error)
 
 type DependencySyncHttp struct {
-	log            logrus.FieldLogger
-	serviceHandler service.Service
-	cfg            *config.Config
-	conditionalGet httpConditionalGetFunc
-	maxConcurrent  int
+	log             logrus.FieldLogger
+	serviceHandler  service.Service
+	cfg             *config.Config
+	conditionalHead httpConditionalHeadFunc
+	maxConcurrent   int
 }
 
 func NewDependencySyncHttp(log logrus.FieldLogger, serviceHandler service.Service,
 	cfg *config.Config) *DependencySyncHttp {
 	return &DependencySyncHttp{
-		log:            log,
-		serviceHandler: serviceHandler,
-		cfg:            cfg,
-		conditionalGet: httpConditionalGet,
-		maxConcurrent:  10,
+		log:             log,
+		serviceHandler:  serviceHandler,
+		cfg:             cfg,
+		conditionalHead: httpConditionalHead,
+		maxConcurrent:   10,
 	}
 }
 
@@ -105,7 +105,11 @@ func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.Htt
 		return httpProbeResult{probe: probe, skip: true}
 	}
 
-	repoURL := httpSpec.Url + probe.HTTPSuffix
+	repoURL, err := url.JoinPath(httpSpec.Url, probe.HTTPSuffix)
+	if err != nil {
+		d.log.WithError(err).Warnf("failed joining URL for repository %s", probe.RepositoryName)
+		return httpProbeResult{probe: probe, skip: true}
+	}
 	rk := httpResourceKey(probe.RepositoryName, probe.HTTPSuffix)
 
 	storedFP := ""
@@ -113,7 +117,7 @@ func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.Htt
 		storedFP = *probe.Fingerprint
 	}
 
-	fingerprint, statusCode, err := d.conditionalGet(ctx, repoURL, httpSpec, storedFP)
+	fingerprint, statusCode, err := d.conditionalHead(ctx, repoURL, httpSpec, storedFP)
 	if err != nil {
 		d.log.WithError(err).Warnf("HTTP probe failed for %s (status %d)", repoURL, statusCode)
 		return httpProbeResult{probe: probe, resourceKey: rk, skip: true}
@@ -201,11 +205,12 @@ func httpResourceKey(repoName, suffix string) string {
 	return fmt.Sprintf("http:%s/%s", repoName, strings.TrimPrefix(suffix, "/"))
 }
 
-// httpConditionalGet sends a conditional GET to the given URL using stored
-// fingerprint for If-None-Match/If-Modified-Since headers.
-func httpConditionalGet(ctx context.Context, repoURL string,
+// httpConditionalHead sends a conditional HEAD to the given URL using stored
+// fingerprint for If-None-Match/If-Modified-Since headers. HEAD avoids
+// transferring the response body since we only need ETag/Last-Modified headers.
+func httpConditionalHead(ctx context.Context, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (string, int, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", repoURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "HEAD", repoURL, nil)
 	if err != nil {
 		return "", 0, fmt.Errorf("creating request: %w", err)
 	}
@@ -249,7 +254,6 @@ func httpConditionalGet(ctx context.Context, repoURL string,
 		if fingerprint == "" {
 			fingerprint = resp.Header.Get("Last-Modified")
 		}
-		io.Copy(io.Discard, resp.Body) //nolint:errcheck
 		return fingerprint, http.StatusOK, nil
 	default:
 		return "", resp.StatusCode, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, repoURL)

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -4,8 +4,16 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/service"
+	"github.com/flightctl/flightctl/internal/service/common"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 // httpConditionalGetFunc is the injectable function type for testing.
@@ -14,6 +22,176 @@ import (
 // conditional requests (no ETag or Last-Modified in response).
 type httpConditionalGetFunc func(ctx context.Context, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (fingerprint string, statusCode int, err error)
+
+type DependencySyncHttp struct {
+	log            logrus.FieldLogger
+	serviceHandler service.Service
+	cfg            *config.Config
+	conditionalGet httpConditionalGetFunc
+	maxConcurrent  int
+}
+
+func NewDependencySyncHttp(log logrus.FieldLogger, serviceHandler service.Service,
+	cfg *config.Config) *DependencySyncHttp {
+	return &DependencySyncHttp{
+		log:            log,
+		serviceHandler: serviceHandler,
+		cfg:            cfg,
+		conditionalGet: httpConditionalGet,
+		maxConcurrent:  10,
+	}
+}
+
+type httpProbeResult struct {
+	probe       *model.HttpDependencyProbe
+	resourceKey string
+	fingerprint string
+	changed     bool
+	firstSeen   bool
+	skip        bool // true for HttpNotConditional or errors
+}
+
+func (d *DependencySyncHttp) Poll(ctx context.Context, orgId uuid.UUID) {
+	pollInterval := d.cfg.GetDependenciesSyncPollInterval()
+
+	probes, status := d.serviceHandler.ListDueHttpDependencies(ctx, orgId, pollInterval)
+	if status.Code != http.StatusOK {
+		d.log.Errorf("failed listing due HTTP dependencies: %s", status.Message)
+		return
+	}
+	if len(probes) == 0 {
+		return
+	}
+
+	var (
+		mu      sync.Mutex
+		results []httpProbeResult
+	)
+
+	sem := make(chan struct{}, d.maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i := range probes {
+		probe := &probes[i]
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			r := d.probeEndpoint(ctx, probe)
+			mu.Lock()
+			results = append(results, r)
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	d.reconcile(ctx, orgId, results)
+}
+
+func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.HttpDependencyProbe) httpProbeResult {
+	if probe.RepoSpec == nil {
+		d.log.Warnf("repository %s not found (no spec in JOIN result)", probe.RepositoryName)
+		return httpProbeResult{probe: probe, skip: true}
+	}
+
+	spec := probe.RepoSpec.Data
+	httpSpec, err := spec.AsHttpRepoSpec()
+	if err != nil {
+		d.log.WithError(err).Warnf("failed decoding HTTP spec for repository %s", probe.RepositoryName)
+		return httpProbeResult{probe: probe, skip: true}
+	}
+
+	repoURL := httpSpec.Url + probe.HTTPSuffix
+	rk := fmt.Sprintf("http:%s/%s", probe.RepositoryName, probe.HTTPSuffix)
+
+	storedFP := ""
+	if probe.Fingerprint != nil {
+		storedFP = *probe.Fingerprint
+	}
+
+	fingerprint, statusCode, err := d.conditionalGet(ctx, repoURL, httpSpec, storedFP)
+	if err != nil {
+		d.log.WithError(err).Warnf("HTTP probe failed for %s (status %d)", repoURL, statusCode)
+		return httpProbeResult{probe: probe, skip: true}
+	}
+
+	r := httpProbeResult{
+		probe:       probe,
+		resourceKey: rk,
+		fingerprint: fingerprint,
+	}
+
+	switch {
+	case statusCode == http.StatusNotModified:
+		// No change
+	case statusCode == http.StatusOK && fingerprint == "":
+		d.log.Warnf("endpoint %s does not support conditional requests (no ETag or Last-Modified)", repoURL)
+		r.skip = true
+	case probe.Fingerprint == nil:
+		r.firstSeen = true
+	case fingerprint != *probe.Fingerprint:
+		r.changed = true
+	}
+
+	return r
+}
+
+func (d *DependencySyncHttp) reconcile(ctx context.Context, orgId uuid.UUID, results []httpProbeResult) {
+	now := time.Now().UTC()
+
+	for _, r := range results {
+		if !r.changed {
+			continue
+		}
+		for _, fleetName := range r.probe.FleetNames {
+			event := common.GetDependencyChangeDetectedEvent(ctx, domain.FleetKind, fleetName, r.resourceKey, r.fingerprint)
+			if event != nil {
+				d.serviceHandler.CreateEvent(ctx, orgId, event)
+			}
+		}
+		for _, deviceName := range r.probe.DeviceNames {
+			event := common.GetDependencyChangeDetectedEvent(ctx, domain.DeviceKind, deviceName, r.resourceKey, r.fingerprint)
+			if event != nil {
+				d.serviceHandler.CreateEvent(ctx, orgId, event)
+			}
+		}
+	}
+
+	var upsertStates []model.SyncState
+	var unchangedKeys []string
+
+	for _, r := range results {
+		if r.skip {
+			continue
+		}
+		if r.firstSeen || r.changed {
+			upsertStates = append(upsertStates, model.SyncState{
+				OrgID:         orgId,
+				ResourceKey:   r.resourceKey,
+				Fingerprint:   r.fingerprint,
+				LastCheckedAt: now,
+				LastChangeAt:  &now,
+			})
+		} else {
+			unchangedKeys = append(unchangedKeys, r.resourceKey)
+		}
+	}
+
+	if len(upsertStates) > 0 {
+		if st := d.serviceHandler.BulkUpsertSyncState(ctx, orgId, upsertStates); st.Code != http.StatusOK {
+			d.log.Errorf("failed bulk upserting sync states: %s", st.Message)
+			return
+		}
+	}
+
+	if len(unchangedKeys) > 0 {
+		if st := d.serviceHandler.BulkUpdateSyncStateLastCheckedAt(ctx, orgId, unchangedKeys, now); st.Code != http.StatusOK {
+			d.log.Errorf("failed bulk updating last_checked_at: %s", st.Message)
+		}
+	}
+}
 
 // httpConditionalGet sends a conditional GET to the given URL using stored
 // fingerprint for If-None-Match/If-Modified-Since headers.

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -202,9 +203,9 @@ func httpResourceKey(repoName, suffix string) string {
 
 // httpConditionalGet sends a conditional GET to the given URL using stored
 // fingerprint for If-None-Match/If-Modified-Since headers.
-func httpConditionalGet(_ context.Context, repoURL string,
+func httpConditionalGet(ctx context.Context, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (string, int, error) {
-	req, err := http.NewRequest("GET", repoURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", repoURL, nil)
 	if err != nil {
 		return "", 0, fmt.Errorf("creating request: %w", err)
 	}
@@ -229,6 +230,7 @@ func httpConditionalGet(_ context.Context, repoURL string,
 	}
 
 	client := &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
@@ -247,6 +249,7 @@ func httpConditionalGet(_ context.Context, repoURL string,
 		if fingerprint == "" {
 			fingerprint = resp.Header.Get("Last-Modified")
 		}
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
 		return fingerprint, http.StatusOK, nil
 	default:
 		return "", resp.StatusCode, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, repoURL)

--- a/internal/tasks/dependency_sync_http.go
+++ b/internal/tasks/dependency_sync_http.go
@@ -22,7 +22,7 @@ import (
 // Returns: fingerprint (ETag or Last-Modified value), HTTP status code, error.
 // Empty fingerprint with status 200 means the endpoint doesn't support
 // conditional requests (no ETag or Last-Modified in response).
-type httpConditionalHeadFunc func(ctx context.Context, repoURL string,
+type httpConditionalHeadFunc func(ctx context.Context, client *http.Client, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (fingerprint string, statusCode int, err error)
 
 type DependencySyncHttp struct {
@@ -65,6 +65,11 @@ func (d *DependencySyncHttp) Poll(ctx context.Context, orgId uuid.UUID) {
 		return
 	}
 
+	repoGroups := make(map[string][]*model.HttpDependencyProbe)
+	for i := range probes {
+		repoGroups[probes[i].RepositoryName] = append(repoGroups[probes[i].RepositoryName], &probes[i])
+	}
+
 	var (
 		mu      sync.Mutex
 		results []httpProbeResult
@@ -73,16 +78,15 @@ func (d *DependencySyncHttp) Poll(ctx context.Context, orgId uuid.UUID) {
 	sem := make(chan struct{}, d.maxConcurrent)
 	var wg sync.WaitGroup
 
-	for i := range probes {
-		probe := &probes[i]
+	for _, group := range repoGroups {
 		wg.Add(1)
 		sem <- struct{}{}
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			r := d.probeEndpoint(ctx, probe)
+			res := d.probeRepoGroup(ctx, group)
 			mu.Lock()
-			results = append(results, r)
+			results = append(results, res...)
 			mu.Unlock()
 		}()
 	}
@@ -92,18 +96,49 @@ func (d *DependencySyncHttp) Poll(ctx context.Context, orgId uuid.UUID) {
 	d.reconcile(ctx, orgId, results)
 }
 
-func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.HttpDependencyProbe) httpProbeResult {
-	if probe.RepoSpec == nil {
-		d.log.Warnf("repository %s not found (no spec in JOIN result)", probe.RepositoryName)
-		return httpProbeResult{probe: probe, skip: true}
+func (d *DependencySyncHttp) probeRepoGroup(ctx context.Context, group []*model.HttpDependencyProbe) []httpProbeResult {
+	first := group[0]
+	if first.RepoSpec == nil {
+		var results []httpProbeResult
+		for _, p := range group {
+			d.log.Warnf("repository %s not found (no spec in JOIN result)", p.RepositoryName)
+			results = append(results, httpProbeResult{probe: p, skip: true})
+		}
+		return results
 	}
 
-	spec := probe.RepoSpec.Data
-	httpSpec, err := spec.AsHttpRepoSpec()
+	httpSpec, err := first.RepoSpec.Data.AsHttpRepoSpec()
 	if err != nil {
-		d.log.WithError(err).Warnf("failed decoding HTTP spec for repository %s", probe.RepositoryName)
-		return httpProbeResult{probe: probe, skip: true}
+		var results []httpProbeResult
+		for _, p := range group {
+			d.log.WithError(err).Warnf("failed decoding HTTP spec for repository %s", p.RepositoryName)
+			results = append(results, httpProbeResult{probe: p, skip: true})
+		}
+		return results
 	}
+
+	client, err := buildHTTPClient(httpSpec)
+	if err != nil {
+		var results []httpProbeResult
+		for _, p := range group {
+			d.log.WithError(err).Warnf("failed building HTTP client for repository %s", p.RepositoryName)
+			results = append(results, httpProbeResult{probe: p, skip: true})
+		}
+		return results
+	}
+
+	var results []httpProbeResult
+	for _, probe := range group {
+		probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		r := d.probeEndpoint(probeCtx, client, httpSpec, probe)
+		cancel()
+		results = append(results, r)
+	}
+	return results
+}
+
+func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, client *http.Client,
+	httpSpec domain.HttpRepoSpec, probe *model.HttpDependencyProbe) httpProbeResult {
 
 	repoURL, err := url.JoinPath(httpSpec.Url, probe.HTTPSuffix)
 	if err != nil {
@@ -117,7 +152,7 @@ func (d *DependencySyncHttp) probeEndpoint(ctx context.Context, probe *model.Htt
 		storedFP = *probe.Fingerprint
 	}
 
-	fingerprint, statusCode, err := d.conditionalHead(ctx, repoURL, httpSpec, storedFP)
+	fingerprint, statusCode, err := d.conditionalHead(ctx, client, repoURL, httpSpec, storedFP)
 	if err != nil {
 		d.log.WithError(err).Warnf("HTTP probe failed for %s (status %d)", repoURL, statusCode)
 		return httpProbeResult{probe: probe, resourceKey: rk, skip: true}
@@ -205,17 +240,34 @@ func httpResourceKey(repoName, suffix string) string {
 	return fmt.Sprintf("http:%s/%s", repoName, strings.TrimPrefix(suffix, "/"))
 }
 
+func buildHTTPClient(httpSpec domain.HttpRepoSpec) (*http.Client, error) {
+	req, err := http.NewRequest("HEAD", "http://unused", nil)
+	if err != nil {
+		return nil, err
+	}
+	_, tlsConfig, err := buildHttpRepoRequestAuth(httpSpec, req)
+	if err != nil {
+		return nil, fmt.Errorf("building TLS config: %w", err)
+	}
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
 // httpConditionalHead sends a conditional HEAD to the given URL using stored
 // fingerprint for If-None-Match/If-Modified-Since headers. HEAD avoids
 // transferring the response body since we only need ETag/Last-Modified headers.
-func httpConditionalHead(ctx context.Context, repoURL string,
+func httpConditionalHead(ctx context.Context, client *http.Client, repoURL string,
 	httpSpec domain.HttpRepoSpec, storedFingerprint string) (string, int, error) {
 	req, err := http.NewRequestWithContext(ctx, "HEAD", repoURL, nil)
 	if err != nil {
 		return "", 0, fmt.Errorf("creating request: %w", err)
 	}
 
-	req, tlsConfig, err := buildHttpRepoRequestAuth(httpSpec, req)
+	req, _, err = buildHttpRepoRequestAuth(httpSpec, req)
 	if err != nil {
 		return "", 0, fmt.Errorf("building request auth: %w", err)
 	}
@@ -234,12 +286,6 @@ func httpConditionalHead(ctx context.Context, repoURL string,
 		}
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", 0, fmt.Errorf("sending request: %w", err)

--- a/internal/tasks/dependency_sync_http_test.go
+++ b/internal/tasks/dependency_sync_http_test.go
@@ -1,0 +1,331 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/service"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func httpRepoSpec(t *testing.T, url string) *model.JSONField[api.RepositorySpec] {
+	t.Helper()
+	spec := api.RepositorySpec{}
+	err := spec.FromHttpRepoSpec(api.HttpRepoSpec{
+		Type: api.HttpRepoSpecTypeHttp,
+		Url:  url,
+	})
+	require.NoError(t, err)
+	return model.MakeJSONField(spec)
+}
+
+func makeHttpProbe(repoName, suffix string, fingerprint *string, fleetNames, deviceNames model.StringArray, repoSpec *model.JSONField[api.RepositorySpec]) model.HttpDependencyProbe {
+	return model.HttpDependencyProbe{
+		RepositoryName: repoName,
+		HTTPSuffix:     suffix,
+		Fingerprint:    fingerprint,
+		FleetNames:     fleetNames,
+		DeviceNames:    deviceNames,
+		RepoSpec:       repoSpec,
+	}
+}
+
+func TestDependencySyncHttp_Poll(t *testing.T) {
+	orgId := uuid.New()
+	ctx := context.Background()
+	pollInterval := 15 * time.Minute
+
+	t.Run("When a change is detected it should bulk upsert sync state and emit events", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("http-repo", "/config.json", lo.ToPtr(`"old-etag"`), model.StringArray{"fleet-1"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, states []model.SyncState) domain.Status {
+				require.Len(t, states, 1)
+				assert.Equal(t, `"new-etag"`, states[0].Fingerprint)
+				assert.Equal(t, "http:http-repo//config.json", states[0].ResourceKey)
+				return statusOK
+			})
+
+		var events []emittedEvent
+		mockService.EXPECT().CreateEvent(gomock.Any(), orgId, gomock.Any()).Do(func(_ context.Context, _ uuid.UUID, event *domain.Event) {
+			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
+		})
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return `"new-etag"`, http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+
+		require.Len(t, events, 1)
+		assert.Equal(t, string(domain.FleetKind), events[0].kind)
+		assert.Equal(t, "fleet-1", events[0].name)
+	})
+
+	t.Run("When no change is detected (304) it should bulk update last_checked_at only", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("http-repo", "/config.json", lo.ToPtr(`"same-etag"`), model.StringArray{"fleet-1"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpdateSyncStateLastCheckedAt(gomock.Any(), orgId, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, keys []string, _ time.Time) domain.Status {
+				require.Len(t, keys, 1)
+				assert.Equal(t, "http:http-repo//config.json", keys[0])
+				return statusOK
+			})
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return "", http.StatusNotModified, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When endpoint lacks ETag and Last-Modified it should log warning and skip", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("http-repo", "/config.json", lo.ToPtr(`"old-etag"`), model.StringArray{"fleet-1"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return "", http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When HTTP request errors it should skip that probe without affecting others", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("failing-repo", "/fail", lo.ToPtr(`"etag1"`), model.StringArray{"fleet-1"}, nil, repoSpec),
+			makeHttpProbe("ok-repo", "/ok", lo.ToPtr(`"old-etag"`), model.StringArray{"fleet-2"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, states []model.SyncState) domain.Status {
+				require.Len(t, states, 1)
+				assert.Equal(t, `"new-etag"`, states[0].Fingerprint)
+				return statusOK
+			})
+
+		mockService.EXPECT().CreateEvent(gomock.Any(), orgId, gomock.Any()).Do(func(_ context.Context, _ uuid.UUID, event *domain.Event) {
+			assert.Equal(t, "fleet-2", event.InvolvedObject.Name)
+		})
+
+		conditionalGet := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			if url == "https://example.com/fail" {
+				return "", 0, fmt.Errorf("connection refused")
+			}
+			return `"new-etag"`, http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When work list is empty it should be a no-op", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return([]model.HttpDependencyProbe{}, statusOK)
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+				t.Fatal("conditionalGet should not be called with empty work list")
+				return "", 0, nil
+			}, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When multiple fleets reference the same repo+suffix it should fan out events to each", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("shared-repo", "/config.json", lo.ToPtr(`"old-etag"`), model.StringArray{"fleet-a", "fleet-b"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).Return(statusOK)
+
+		var events []emittedEvent
+		mockService.EXPECT().CreateEvent(gomock.Any(), orgId, gomock.Any()).Times(2).Do(func(_ context.Context, _ uuid.UUID, event *domain.Event) {
+			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
+		})
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return `"new-etag"`, http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+		assert.Len(t, events, 2)
+	})
+
+	t.Run("When standalone device has a dependency it should emit device event", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("http-repo", "/config.json", lo.ToPtr(`"old-etag"`), nil, model.StringArray{"device-standalone"}, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).Return(statusOK)
+
+		var events []emittedEvent
+		mockService.EXPECT().CreateEvent(gomock.Any(), orgId, gomock.Any()).Do(func(_ context.Context, _ uuid.UUID, event *domain.Event) {
+			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
+		})
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return `"new-etag"`, http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+
+		require.Len(t, events, 1)
+		assert.Equal(t, string(domain.DeviceKind), events[0].kind)
+		assert.Equal(t, "device-standalone", events[0].name)
+	})
+
+	t.Run("When first seen it should store fingerprint without emitting events", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("http-repo", "/config.json", nil, model.StringArray{"fleet-1"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, states []model.SyncState) domain.Status {
+				require.Len(t, states, 1)
+				assert.Equal(t, `"initial-etag"`, states[0].Fingerprint)
+				return statusOK
+			})
+
+		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			return `"initial-etag"`, http.StatusOK, nil
+		}
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When multiple probes exist each should get its own HTTP request", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		repoSpec := httpRepoSpec(t, "https://example.com")
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("repo-1", "/a.json", lo.ToPtr(`"etag-a"`), model.StringArray{"fleet-1"}, nil, repoSpec),
+			makeHttpProbe("repo-1", "/b.json", lo.ToPtr(`"etag-b"`), model.StringArray{"fleet-2"}, nil, repoSpec),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		requestedURLs := make(map[string]bool)
+		var mu sync.Mutex
+		conditionalGet := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			mu.Lock()
+			requestedURLs[url] = true
+			mu.Unlock()
+			return `"new-etag"`, http.StatusOK, nil
+		}
+
+		mockService.EXPECT().BulkUpsertSyncState(gomock.Any(), orgId, gomock.Any()).Return(statusOK)
+		mockService.EXPECT().CreateEvent(gomock.Any(), orgId, gomock.Any()).Times(2)
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+
+		assert.True(t, requestedURLs["https://example.com/a.json"])
+		assert.True(t, requestedURLs["https://example.com/b.json"])
+	})
+}
+
+func TestNewDependencySyncHttp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockService := service.NewMockService(ctrl)
+
+	d := NewDependencySyncHttp(logrus.New(), mockService, &config.Config{})
+	require.NotNil(t, d)
+	assert.Equal(t, 10, d.maxConcurrent)
+	assert.NotNil(t, d.conditionalGet)
+}

--- a/internal/tasks/dependency_sync_http_test.go
+++ b/internal/tasks/dependency_sync_http_test.go
@@ -72,13 +72,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 
@@ -106,13 +106,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return "", http.StatusNotModified, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 	})
@@ -135,13 +135,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return "", http.StatusOK, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 	})
@@ -176,7 +176,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			assert.Equal(t, "fleet-2", event.InvolvedObject.Name)
 		})
 
-		conditionalGet := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			if url == "https://example.com/fail" {
 				return "", 0, fmt.Errorf("connection refused")
 			}
@@ -185,7 +185,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 	})
@@ -199,8 +199,8 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
-				t.Fatal("conditionalGet should not be called with empty work list")
+			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+				t.Fatal("conditionalHead should not be called with empty work list")
 				return "", 0, nil
 			}, maxConcurrent: 10,
 		}
@@ -225,13 +225,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 		assert.Len(t, events, 2)
@@ -255,13 +255,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 
@@ -288,13 +288,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"initial-etag"`, http.StatusOK, nil
 		}
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 	})
@@ -312,8 +312,8 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
-				t.Fatal("conditionalGet should not be called when RepoSpec is nil")
+			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+				t.Fatal("conditionalHead should not be called when RepoSpec is nil")
 				return "", 0, nil
 			}, maxConcurrent: 10,
 		}
@@ -334,7 +334,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		requestedURLs := make(map[string]bool)
 		var mu sync.Mutex
-		conditionalGet := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			mu.Lock()
 			requestedURLs[url] = true
 			mu.Unlock()
@@ -346,7 +346,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+			cfg: &config.Config{}, conditionalHead: conditionalHead, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 
@@ -363,5 +363,5 @@ func TestNewDependencySyncHttp(t *testing.T) {
 	d := NewDependencySyncHttp(logrus.New(), mockService, &config.Config{})
 	require.NotNil(t, d)
 	assert.Equal(t, 10, d.maxConcurrent)
-	assert.NotNil(t, d.conditionalGet)
+	assert.NotNil(t, d.conditionalHead)
 }

--- a/internal/tasks/dependency_sync_http_test.go
+++ b/internal/tasks/dependency_sync_http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -364,4 +365,118 @@ func TestNewDependencySyncHttp(t *testing.T) {
 	require.NotNil(t, d)
 	assert.Equal(t, 10, d.maxConcurrent)
 	assert.NotNil(t, d.conditionalHead)
+}
+
+func plainHttpSpec() domain.HttpRepoSpec {
+	return domain.HttpRepoSpec{
+		Type: domain.HttpRepoSpecTypeHttp,
+		Url:  "http://ignored",
+	}
+}
+
+func TestHttpConditionalHead(t *testing.T) {
+	ctx := context.Background()
+	spec := plainHttpSpec()
+
+	t.Run("When endpoint returns ETag and supports conditional HEAD it should return 304 on match", func(t *testing.T) {
+		etag := `"abc123"`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodHead, r.Method)
+			if r.Header.Get("If-None-Match") == etag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", etag)
+		}))
+		defer srv.Close()
+
+		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, etag, fp)
+
+		fp, status, err = httpConditionalHead(ctx, srv.URL, spec, etag)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotModified, status)
+		assert.Empty(t, fp)
+	})
+
+	t.Run("When endpoint returns ETag but ignores conditional HEAD it should return new ETag", func(t *testing.T) {
+		etag := `"v2"`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodHead, r.Method)
+			w.Header().Set("ETag", etag)
+		}))
+		defer srv.Close()
+
+		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, `"v1"`)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, etag, fp)
+	})
+
+	t.Run("When endpoint returns Last-Modified and supports conditional HEAD it should return 304 on match", func(t *testing.T) {
+		lastMod := "Wed, 14 May 2026 08:00:00 GMT"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodHead, r.Method)
+			if r.Header.Get("If-Modified-Since") == lastMod {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("Last-Modified", lastMod)
+		}))
+		defer srv.Close()
+
+		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, lastMod, fp)
+
+		fp, status, err = httpConditionalHead(ctx, srv.URL, spec, lastMod)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotModified, status)
+		assert.Empty(t, fp)
+	})
+
+	t.Run("When endpoint returns Last-Modified but ignores conditional HEAD it should return new timestamp", func(t *testing.T) {
+		lastMod := "Wed, 14 May 2026 09:00:00 GMT"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodHead, r.Method)
+			w.Header().Set("Last-Modified", lastMod)
+		}))
+		defer srv.Close()
+
+		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "Tue, 13 May 2026 08:00:00 GMT")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, lastMod, fp)
+	})
+
+	t.Run("When endpoint does not support HEAD it should return error with 405", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		defer srv.Close()
+
+		_, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		require.Error(t, err)
+		assert.Equal(t, http.StatusMethodNotAllowed, status)
+		assert.Contains(t, err.Error(), "405")
+	})
+
+	t.Run("When endpoint returns 4xx or 5xx it should return error with status code", func(t *testing.T) {
+		codes := []int{http.StatusForbidden, http.StatusNotFound, http.StatusInternalServerError, http.StatusBadGateway}
+		for _, code := range codes {
+			t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(code)
+				}))
+				defer srv.Close()
+
+				_, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+				require.Error(t, err)
+				assert.Equal(t, code, status)
+			})
+		}
+	})
 }

--- a/internal/tasks/dependency_sync_http_test.go
+++ b/internal/tasks/dependency_sync_http_test.go
@@ -63,7 +63,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			func(_ context.Context, _ uuid.UUID, states []model.SyncState) domain.Status {
 				require.Len(t, states, 1)
 				assert.Equal(t, `"new-etag"`, states[0].Fingerprint)
-				assert.Equal(t, "http:http-repo//config.json", states[0].ResourceKey)
+				assert.Equal(t, "http:http-repo/config.json", states[0].ResourceKey)
 				return statusOK
 			})
 
@@ -87,6 +87,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 		assert.Equal(t, "fleet-1", events[0].name)
 	})
 
+	// gomock strict mode: any unexpected call (e.g. BulkUpsertSyncState, CreateEvent) fails the test.
 	t.Run("When no change is detected (304) it should bulk update last_checked_at only", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -101,7 +102,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 		mockService.EXPECT().BulkUpdateSyncStateLastCheckedAt(gomock.Any(), orgId, gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ uuid.UUID, keys []string, _ time.Time) domain.Status {
 				require.Len(t, keys, 1)
-				assert.Equal(t, "http:http-repo//config.json", keys[0])
+				assert.Equal(t, "http:http-repo/config.json", keys[0])
 				return statusOK
 			})
 
@@ -116,7 +117,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 		d.Poll(ctx, orgId)
 	})
 
-	t.Run("When endpoint lacks ETag and Last-Modified it should log warning and skip", func(t *testing.T) {
+	t.Run("When endpoint lacks ETag and Last-Modified it should log warning and still update last_checked_at", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockService := service.NewMockService(ctrl)
@@ -126,6 +127,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			makeHttpProbe("http-repo", "/config.json", lo.ToPtr(`"old-etag"`), model.StringArray{"fleet-1"}, nil, repoSpec),
 		}
 		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+
+		mockService.EXPECT().BulkUpdateSyncStateLastCheckedAt(gomock.Any(), orgId, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, keys []string, _ time.Time) domain.Status {
+				require.Len(t, keys, 1)
+				assert.Equal(t, "http:http-repo/config.json", keys[0])
+				return statusOK
+			})
 
 		conditionalGet := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return "", http.StatusOK, nil
@@ -154,6 +162,13 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			func(_ context.Context, _ uuid.UUID, states []model.SyncState) domain.Status {
 				require.Len(t, states, 1)
 				assert.Equal(t, `"new-etag"`, states[0].Fingerprint)
+				return statusOK
+			})
+
+		mockService.EXPECT().BulkUpdateSyncStateLastCheckedAt(gomock.Any(), orgId, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, keys []string, _ time.Time) domain.Status {
+				require.Len(t, keys, 1)
+				assert.Equal(t, "http:failing-repo/fail", keys[0])
 				return statusOK
 			})
 
@@ -280,6 +295,27 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
 			cfg: &config.Config{}, conditionalGet: conditionalGet, maxConcurrent: 10,
+		}
+		d.Poll(ctx, orgId)
+	})
+
+	t.Run("When repository spec is nil it should skip the probe entirely", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockService := service.NewMockService(ctrl)
+
+		probes := []model.HttpDependencyProbe{
+			makeHttpProbe("orphan-repo", "/config.json", nil, model.StringArray{"fleet-1"}, nil, nil),
+		}
+		mockService.EXPECT().ListDueHttpDependencies(gomock.Any(), orgId, pollInterval).Return(probes, statusOK)
+		// gomock strict mode: no BulkUpsert/BulkUpdate/CreateEvent calls expected.
+
+		d := &DependencySyncHttp{
+			log: logrus.New(), serviceHandler: mockService,
+			cfg: &config.Config{}, conditionalGet: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+				t.Fatal("conditionalGet should not be called when RepoSpec is nil")
+				return "", 0, nil
+			}, maxConcurrent: 10,
 		}
 		d.Poll(ctx, orgId)
 	})

--- a/internal/tasks/dependency_sync_http_test.go
+++ b/internal/tasks/dependency_sync_http_test.go
@@ -73,7 +73,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
@@ -107,7 +107,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return "", http.StatusNotModified, nil
 		}
 
@@ -136,7 +136,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return "", http.StatusOK, nil
 		}
 
@@ -177,7 +177,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			assert.Equal(t, "fleet-2", event.InvolvedObject.Name)
 		})
 
-		conditionalHead := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			if url == "https://example.com/fail" {
 				return "", 0, fmt.Errorf("connection refused")
 			}
@@ -200,7 +200,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 				t.Fatal("conditionalHead should not be called with empty work list")
 				return "", 0, nil
 			}, maxConcurrent: 10,
@@ -226,7 +226,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
@@ -256,7 +256,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 			events = append(events, emittedEvent{kind: event.InvolvedObject.Kind, name: event.InvolvedObject.Name})
 		})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"new-etag"`, http.StatusOK, nil
 		}
 
@@ -289,7 +289,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 				return statusOK
 			})
 
-		conditionalHead := func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			return `"initial-etag"`, http.StatusOK, nil
 		}
 
@@ -313,7 +313,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		d := &DependencySyncHttp{
 			log: logrus.New(), serviceHandler: mockService,
-			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+			cfg: &config.Config{}, conditionalHead: func(_ context.Context, _ *http.Client, _ string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 				t.Fatal("conditionalHead should not be called when RepoSpec is nil")
 				return "", 0, nil
 			}, maxConcurrent: 10,
@@ -335,7 +335,7 @@ func TestDependencySyncHttp_Poll(t *testing.T) {
 
 		requestedURLs := make(map[string]bool)
 		var mu sync.Mutex
-		conditionalHead := func(_ context.Context, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
+		conditionalHead := func(_ context.Context, _ *http.Client, url string, _ domain.HttpRepoSpec, _ string) (string, int, error) {
 			mu.Lock()
 			requestedURLs[url] = true
 			mu.Unlock()
@@ -377,6 +377,7 @@ func plainHttpSpec() domain.HttpRepoSpec {
 func TestHttpConditionalHead(t *testing.T) {
 	ctx := context.Background()
 	spec := plainHttpSpec()
+	client := &http.Client{Timeout: 5 * time.Second}
 
 	t.Run("When endpoint returns ETag and supports conditional HEAD it should return 304 on match", func(t *testing.T) {
 		etag := `"abc123"`
@@ -390,12 +391,12 @@ func TestHttpConditionalHead(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		fp, status, err := httpConditionalHead(ctx, client, srv.URL, spec, "")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, etag, fp)
 
-		fp, status, err = httpConditionalHead(ctx, srv.URL, spec, etag)
+		fp, status, err = httpConditionalHead(ctx, client, srv.URL, spec, etag)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNotModified, status)
 		assert.Empty(t, fp)
@@ -409,7 +410,7 @@ func TestHttpConditionalHead(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, `"v1"`)
+		fp, status, err := httpConditionalHead(ctx, client, srv.URL, spec, `"v1"`)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, etag, fp)
@@ -427,12 +428,12 @@ func TestHttpConditionalHead(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		fp, status, err := httpConditionalHead(ctx, client, srv.URL, spec, "")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, lastMod, fp)
 
-		fp, status, err = httpConditionalHead(ctx, srv.URL, spec, lastMod)
+		fp, status, err = httpConditionalHead(ctx, client, srv.URL, spec, lastMod)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNotModified, status)
 		assert.Empty(t, fp)
@@ -446,7 +447,7 @@ func TestHttpConditionalHead(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		fp, status, err := httpConditionalHead(ctx, srv.URL, spec, "Tue, 13 May 2026 08:00:00 GMT")
+		fp, status, err := httpConditionalHead(ctx, client, srv.URL, spec, "Tue, 13 May 2026 08:00:00 GMT")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, lastMod, fp)
@@ -458,7 +459,7 @@ func TestHttpConditionalHead(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+		_, status, err := httpConditionalHead(ctx, client, srv.URL, spec, "")
 		require.Error(t, err)
 		assert.Equal(t, http.StatusMethodNotAllowed, status)
 		assert.Contains(t, err.Error(), "405")
@@ -473,7 +474,7 @@ func TestHttpConditionalHead(t *testing.T) {
 				}))
 				defer srv.Close()
 
-				_, status, err := httpConditionalHead(ctx, srv.URL, spec, "")
+				_, status, err := httpConditionalHead(ctx, client, srv.URL, spec, "")
 				require.Error(t, err)
 				assert.Equal(t, code, status)
 			})

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -735,7 +735,9 @@ func (f FleetRolloutsLogic) getDeviceConfig(device *domain.Device, templateVersi
 		case domain.InlineConfigProviderType:
 			newConfigItem, errs = f.replaceInlineConfigParameters(device, configItem)
 		case domain.HttpConfigProviderType:
-			newConfigItem, errs = f.replaceHTTPConfigParameters(device, configItem)
+			var refs []model.DependencyRef
+			newConfigItem, refs, errs = f.replaceHTTPConfigParameters(device, configItem)
+			depRefs = append(depRefs, refs...)
 		default:
 			errs = append(errs, fmt.Errorf("%w: unsupported config type %q", ErrUnknownConfigName, configType))
 		}
@@ -905,13 +907,17 @@ func (f FleetRolloutsLogic) replaceInlineConfigParameters(device *domain.Device,
 	return &newConfigItem, nil
 }
 
-func (f FleetRolloutsLogic) replaceHTTPConfigParameters(device *domain.Device, configItem domain.ConfigProviderSpec) (*domain.ConfigProviderSpec, []error) {
+func (f FleetRolloutsLogic) replaceHTTPConfigParameters(device *domain.Device, configItem domain.ConfigProviderSpec) (*domain.ConfigProviderSpec, []model.DependencyRef, []error) {
 	httpSpec, err := configItem.AsHttpConfigProviderSpec()
 	if err != nil {
-		return nil, []error{fmt.Errorf("failed to convert config to http config: %w", err)}
+		return nil, nil, []error{fmt.Errorf("failed to convert config to http config: %w", err)}
 	}
 
 	errs := []error{}
+	var originalSuffix string
+	if httpSpec.HttpRef.Suffix != nil {
+		originalSuffix = *httpSpec.HttpRef.Suffix
+	}
 
 	if httpSpec.HttpRef.Suffix != nil {
 		suffix, err := ReplaceParametersInString(*httpSpec.HttpRef.Suffix, device)
@@ -927,16 +933,34 @@ func (f FleetRolloutsLogic) replaceHTTPConfigParameters(device *domain.Device, c
 	}
 
 	if len(errs) > 0 {
-		return nil, errs
+		return nil, nil, errs
+	}
+
+	var refs []model.DependencyRef
+	if isParameterized(originalSuffix) {
+		deviceName := lo.FromPtr(device.Metadata.Name)
+		ownerFleetName, _, _ := getOwnerFleet(device)
+		resolvedSuffix := ""
+		if httpSpec.HttpRef.Suffix != nil {
+			resolvedSuffix = *httpSpec.HttpRef.Suffix
+		}
+		refs = append(refs, model.DependencyRef{
+			FleetName:      &ownerFleetName,
+			DeviceName:     &deviceName,
+			RefType:        "http",
+			ResourceKey:    fmt.Sprintf("http:%s/%s", httpSpec.HttpRef.Repository, resolvedSuffix),
+			RepositoryName: &httpSpec.HttpRef.Repository,
+			HTTPSuffix:     httpSpec.HttpRef.Suffix,
+		})
 	}
 
 	newConfigItem := domain.ConfigProviderSpec{}
 	err = newConfigItem.FromHttpConfigProviderSpec(httpSpec)
 	if err != nil {
-		return nil, []error{fmt.Errorf("failed converting http config: %w", err)}
+		return nil, nil, []error{fmt.Errorf("failed converting http config: %w", err)}
 	}
 
-	return &newConfigItem, nil
+	return &newConfigItem, refs, nil
 }
 
 func (f FleetRolloutsLogic) updateDeviceInStore(ctx context.Context, device *domain.Device, newDeviceSpec *domain.DeviceSpec, delayDeviceRender bool) error {

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -948,7 +948,7 @@ func (f FleetRolloutsLogic) replaceHTTPConfigParameters(device *domain.Device, c
 			FleetName:      &ownerFleetName,
 			DeviceName:     &deviceName,
 			RefType:        "http",
-			ResourceKey:    fmt.Sprintf("http:%s/%s", httpSpec.HttpRef.Repository, resolvedSuffix),
+			ResourceKey:    httpResourceKey(httpSpec.HttpRef.Repository, resolvedSuffix),
 			RepositoryName: &httpSpec.HttpRef.Repository,
 			HTTPSuffix:     httpSpec.HttpRef.Suffix,
 		})

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -1525,7 +1525,7 @@ func TestDeviceHttpDependencyRefLifecycle(t *testing.T) {
 		assert.Equal(t, fleetName, *refs[0].FleetName)
 		assert.Equal(t, "device-1", *refs[0].DeviceName)
 		assert.Equal(t, "http", refs[0].RefType)
-		assert.Equal(t, "http:http-repo//prod/config.json", refs[0].ResourceKey)
+		assert.Equal(t, "http:http-repo/prod/config.json", refs[0].ResourceKey)
 		assert.Equal(t, "/prod/config.json", *refs[0].HTTPSuffix)
 	})
 
@@ -1549,7 +1549,7 @@ func TestDeviceHttpDependencyRefLifecycle(t *testing.T) {
 		_, refsBefore, errsBefore := logic.replaceHTTPConfigParameters(deviceBefore, configItem)
 		require.Empty(t, errsBefore)
 		require.Len(t, refsBefore, 1)
-		assert.Equal(t, "http:http-repo//staging/config.json", refsBefore[0].ResourceKey)
+		assert.Equal(t, "http:http-repo/staging/config.json", refsBefore[0].ResourceKey)
 
 		deviceAfter := &domain.Device{
 			Metadata: domain.ObjectMeta{
@@ -1561,7 +1561,7 @@ func TestDeviceHttpDependencyRefLifecycle(t *testing.T) {
 		_, refsAfter, errsAfter := logic.replaceHTTPConfigParameters(deviceAfter, configItem)
 		require.Empty(t, errsAfter)
 		require.Len(t, refsAfter, 1)
-		assert.Equal(t, "http:http-repo//prod/config.json", refsAfter[0].ResourceKey)
+		assert.Equal(t, "http:http-repo/prod/config.json", refsAfter[0].ResourceKey)
 		assert.NotEqual(t, refsBefore[0].ResourceKey, refsAfter[0].ResourceKey)
 	})
 
@@ -1591,7 +1591,7 @@ func TestDeviceHttpDependencyRefLifecycle(t *testing.T) {
 		require.Empty(t, errs)
 		require.Len(t, refs, 1)
 		assert.Equal(t, "http", refs[0].RefType)
-		assert.Equal(t, "http:http-repo//prod/config.json", refs[0].ResourceKey)
+		assert.Equal(t, "http:http-repo/prod/config.json", refs[0].ResourceKey)
 	})
 }
 

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -1479,6 +1479,122 @@ func TestDeviceSecretDependencyRefLifecycle(t *testing.T) {
 	})
 }
 
+func TestDeviceHttpDependencyRefLifecycle(t *testing.T) {
+	fleetName := "fleet-a"
+	owner := util.SetResourceOwner(domain.FleetKind, fleetName)
+
+	t.Run("When HTTP suffix is not parameterized it should produce no device-level refs", func(t *testing.T) {
+		logic := FleetRolloutsLogic{
+			log: logrus.New(),
+			event: domain.Event{
+				InvolvedObject: domain.ObjectReference{Name: fleetName},
+			},
+		}
+		device := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:  lo.ToPtr("device-1"),
+				Owner: owner,
+			},
+		}
+		suffix := "/config.json"
+		configItem := makeHttpConfigItem(t, "http-cfg", "http-repo", &suffix)
+		_, refs, errs := logic.replaceHTTPConfigParameters(device, configItem)
+		require.Empty(t, errs)
+		assert.Empty(t, refs, "non-parameterized suffix should not produce device-level refs")
+	})
+
+	t.Run("When HTTP suffix is parameterized it should create device-level ref with resolved value", func(t *testing.T) {
+		logic := FleetRolloutsLogic{
+			log: logrus.New(),
+			event: domain.Event{
+				InvolvedObject: domain.ObjectReference{Name: fleetName},
+			},
+		}
+		device := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("device-1"),
+				Owner:  owner,
+				Labels: &map[string]string{"env": "prod"},
+			},
+		}
+		suffix := "/{{ .metadata.labels.env }}/config.json"
+		configItem := makeHttpConfigItem(t, "http-cfg", "http-repo", &suffix)
+		_, refs, errs := logic.replaceHTTPConfigParameters(device, configItem)
+		require.Empty(t, errs)
+		require.Len(t, refs, 1)
+		assert.Equal(t, fleetName, *refs[0].FleetName)
+		assert.Equal(t, "device-1", *refs[0].DeviceName)
+		assert.Equal(t, "http", refs[0].RefType)
+		assert.Equal(t, "http:http-repo//prod/config.json", refs[0].ResourceKey)
+		assert.Equal(t, "/prod/config.json", *refs[0].HTTPSuffix)
+	})
+
+	t.Run("When device labels change and HTTP suffix uses label template it should produce different ref", func(t *testing.T) {
+		logic := FleetRolloutsLogic{
+			log: logrus.New(),
+			event: domain.Event{
+				InvolvedObject: domain.ObjectReference{Name: fleetName},
+			},
+		}
+		suffix := "/{{ .metadata.labels.env }}/config.json"
+		configItem := makeHttpConfigItem(t, "http-cfg", "http-repo", &suffix)
+
+		deviceBefore := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("device-1"),
+				Owner:  owner,
+				Labels: &map[string]string{"env": "staging"},
+			},
+		}
+		_, refsBefore, errsBefore := logic.replaceHTTPConfigParameters(deviceBefore, configItem)
+		require.Empty(t, errsBefore)
+		require.Len(t, refsBefore, 1)
+		assert.Equal(t, "http:http-repo//staging/config.json", refsBefore[0].ResourceKey)
+
+		deviceAfter := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("device-1"),
+				Owner:  owner,
+				Labels: &map[string]string{"env": "prod"},
+			},
+		}
+		_, refsAfter, errsAfter := logic.replaceHTTPConfigParameters(deviceAfter, configItem)
+		require.Empty(t, errsAfter)
+		require.Len(t, refsAfter, 1)
+		assert.Equal(t, "http:http-repo//prod/config.json", refsAfter[0].ResourceKey)
+		assert.NotEqual(t, refsBefore[0].ResourceKey, refsAfter[0].ResourceKey)
+	})
+
+	t.Run("When getDeviceConfig has parameterized HTTP suffix it should include HTTP refs in output", func(t *testing.T) {
+		logic := FleetRolloutsLogic{
+			log: logrus.New(),
+			event: domain.Event{
+				InvolvedObject: domain.ObjectReference{Name: fleetName},
+			},
+		}
+		device := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("device-1"),
+				Owner:  owner,
+				Labels: &map[string]string{"env": "prod"},
+			},
+		}
+		suffix := "/{{ .metadata.labels.env }}/config.json"
+		tv := &domain.TemplateVersion{
+			Status: &domain.TemplateVersionStatus{
+				Config: &[]domain.ConfigProviderSpec{
+					makeHttpConfigItem(t, "http-cfg", "http-repo", &suffix),
+				},
+			},
+		}
+		_, refs, errs := logic.getDeviceConfig(device, tv)
+		require.Empty(t, errs)
+		require.Len(t, refs, 1)
+		assert.Equal(t, "http", refs[0].RefType)
+		assert.Equal(t, "http:http-repo//prod/config.json", refs[0].ResourceKey)
+	})
+}
+
 func TestFleetRolloutIterationContext(t *testing.T) {
 	t.Run("child not expired when parent deadline passed", func(t *testing.T) {
 		parent, cancel := context.WithTimeout(context.Background(), 0)

--- a/internal/tasks/populate_dependency_refs.go
+++ b/internal/tasks/populate_dependency_refs.go
@@ -163,7 +163,7 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 				FleetName:      &fn,
 				DeviceName:     &dn,
 				RefType:        "http",
-				ResourceKey:    fmt.Sprintf("http:%s/%s", httpSpec.HttpRef.Repository, suffix),
+				ResourceKey:    httpResourceKey(httpSpec.HttpRef.Repository, suffix),
 				RepositoryName: &httpSpec.HttpRef.Repository,
 				HTTPSuffix:     httpSpec.HttpRef.Suffix,
 			})

--- a/internal/tasks/populate_dependency_refs.go
+++ b/internal/tasks/populate_dependency_refs.go
@@ -154,6 +154,9 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 			if httpSpec.HttpRef.Suffix != nil {
 				suffix = *httpSpec.HttpRef.Suffix
 			}
+			if isParameterized(suffix) {
+				continue
+			}
 			fn := fleetName
 			dn := deviceName
 			refs = append(refs, model.DependencyRef{

--- a/internal/tasks/populate_dependency_refs_test.go
+++ b/internal/tasks/populate_dependency_refs_test.go
@@ -269,6 +269,126 @@ func TestPopulateDependencyRefs_Fleet(t *testing.T) {
 		assert.Empty(t, capturedRefs)
 	})
 
+	t.Run("When fleet has parameterized HTTP suffix it should skip that ref", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSvc := service.NewMockService(ctrl)
+
+		paramSuffix := "/{{ .metadata.labels.env }}/config.json"
+		fleet := &domain.Fleet{
+			Metadata: domain.ObjectMeta{Name: &fleetName},
+			Spec: domain.FleetSpec{
+				Template: struct {
+					Metadata *domain.ObjectMeta "json:\"metadata,omitempty\""
+					Spec     domain.DeviceSpec  "json:\"spec\""
+				}{
+					Spec: domain.DeviceSpec{
+						Config: &[]domain.ConfigProviderSpec{
+							makeHttpConfigItem(t, "http-cfg", "http-repo", &paramSuffix),
+						},
+					},
+				},
+			},
+		}
+
+		mockSvc.EXPECT().GetFleet(gomock.Any(), orgId, fleetName, gomock.Any()).Return(fleet, okStatus)
+
+		var capturedRefs []model.DependencyRef
+		mockSvc.EXPECT().ReplaceDependencyRefsByFleet(gomock.Any(), orgId, fleetName, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, _ string, refs []model.DependencyRef) domain.Status {
+				capturedRefs = refs
+				return okStatus
+			},
+		)
+
+		logic := NewPopulateDependencyRefsLogic(logrus.New(), mockSvc, orgId)
+		err := logic.PopulateForFleet(context.Background(), fleetName)
+
+		require.NoError(t, err)
+		assert.Empty(t, capturedRefs)
+	})
+
+	t.Run("When fleet has static HTTP suffix it should create fleet-level ref", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSvc := service.NewMockService(ctrl)
+
+		suffix := "/config.json"
+		fleet := &domain.Fleet{
+			Metadata: domain.ObjectMeta{Name: &fleetName},
+			Spec: domain.FleetSpec{
+				Template: struct {
+					Metadata *domain.ObjectMeta "json:\"metadata,omitempty\""
+					Spec     domain.DeviceSpec  "json:\"spec\""
+				}{
+					Spec: domain.DeviceSpec{
+						Config: &[]domain.ConfigProviderSpec{
+							makeHttpConfigItem(t, "http-cfg", "http-repo", &suffix),
+						},
+					},
+				},
+			},
+		}
+
+		mockSvc.EXPECT().GetFleet(gomock.Any(), orgId, fleetName, gomock.Any()).Return(fleet, okStatus)
+
+		var capturedRefs []model.DependencyRef
+		mockSvc.EXPECT().ReplaceDependencyRefsByFleet(gomock.Any(), orgId, fleetName, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, _ string, refs []model.DependencyRef) domain.Status {
+				capturedRefs = refs
+				return okStatus
+			},
+		)
+
+		logic := NewPopulateDependencyRefsLogic(logrus.New(), mockSvc, orgId)
+		err := logic.PopulateForFleet(context.Background(), fleetName)
+
+		require.NoError(t, err)
+		require.Len(t, capturedRefs, 1)
+		assert.Equal(t, "http", capturedRefs[0].RefType)
+		assert.Equal(t, "http:http-repo//config.json", capturedRefs[0].ResourceKey)
+	})
+
+	t.Run("When fleet has nil HTTP suffix it should create fleet-level ref with empty suffix", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSvc := service.NewMockService(ctrl)
+
+		fleet := &domain.Fleet{
+			Metadata: domain.ObjectMeta{Name: &fleetName},
+			Spec: domain.FleetSpec{
+				Template: struct {
+					Metadata *domain.ObjectMeta "json:\"metadata,omitempty\""
+					Spec     domain.DeviceSpec  "json:\"spec\""
+				}{
+					Spec: domain.DeviceSpec{
+						Config: &[]domain.ConfigProviderSpec{
+							makeHttpConfigItem(t, "http-cfg", "http-repo", nil),
+						},
+					},
+				},
+			},
+		}
+
+		mockSvc.EXPECT().GetFleet(gomock.Any(), orgId, fleetName, gomock.Any()).Return(fleet, okStatus)
+
+		var capturedRefs []model.DependencyRef
+		mockSvc.EXPECT().ReplaceDependencyRefsByFleet(gomock.Any(), orgId, fleetName, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ uuid.UUID, _ string, refs []model.DependencyRef) domain.Status {
+				capturedRefs = refs
+				return okStatus
+			},
+		)
+
+		logic := NewPopulateDependencyRefsLogic(logrus.New(), mockSvc, orgId)
+		err := logic.PopulateForFleet(context.Background(), fleetName)
+
+		require.NoError(t, err)
+		require.Len(t, capturedRefs, 1)
+		assert.Equal(t, "http", capturedRefs[0].RefType)
+		assert.Equal(t, "http:http-repo/", capturedRefs[0].ResourceKey)
+	})
+
 	t.Run("When fleet has no config it should replace with empty refs", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/internal/tasks/populate_dependency_refs_test.go
+++ b/internal/tasks/populate_dependency_refs_test.go
@@ -69,7 +69,7 @@ func TestPopulateDependencyRefs_Fleet(t *testing.T) {
 		assert.Equal(t, &fleetName, capturedRefs[0].FleetName)
 
 		assert.Equal(t, "http", capturedRefs[1].RefType)
-		assert.Equal(t, "http:http-repo//config.yaml", capturedRefs[1].ResourceKey)
+		assert.Equal(t, "http:http-repo/config.yaml", capturedRefs[1].ResourceKey)
 	})
 
 	t.Run("When fleet has multiple git configs it should produce refs with independent pointers", func(t *testing.T) {
@@ -346,7 +346,7 @@ func TestPopulateDependencyRefs_Fleet(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, capturedRefs, 1)
 		assert.Equal(t, "http", capturedRefs[0].RefType)
-		assert.Equal(t, "http:http-repo//config.json", capturedRefs[0].ResourceKey)
+		assert.Equal(t, "http:http-repo/config.json", capturedRefs[0].ResourceKey)
 	})
 
 	t.Run("When fleet has nil HTTP suffix it should create fleet-level ref with empty suffix", func(t *testing.T) {

--- a/test/integration/store/dependencyref_test.go
+++ b/test/integration/store/dependencyref_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	domain "github.com/flightctl/flightctl/api/core/v1beta1"
@@ -60,7 +61,7 @@ var _ = Describe("DependencyRefStore", func() {
 			}
 			httpRef := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:my-http-repo//config.json",
+				ResourceKey:    "http:my-http-repo/config.json",
 				FleetName:      lo.ToPtr("fleet-1"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -131,7 +132,7 @@ var _ = Describe("DependencyRefStore", func() {
 			}
 			ref2 := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:repo-b//data",
+				ResourceKey:    "http:repo-b/data",
 				FleetName:      lo.ToPtr("fleet-1"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -342,7 +343,7 @@ var _ = Describe("DependencyRefStore", func() {
 		It("should return probes for HTTP refs that have never been checked", func() {
 			ref := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -365,7 +366,7 @@ var _ = Describe("DependencyRefStore", func() {
 		It("should not return probes that were recently checked", func() {
 			ref := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -376,7 +377,7 @@ var _ = Describe("DependencyRefStore", func() {
 
 			syncState := &model.SyncState{
 				OrgID:         orgId,
-				ResourceKey:   "http:http-repo-1//config.json",
+				ResourceKey:   "http:http-repo-1/config.json",
 				Fingerprint:   `"etag-abc"`,
 				LastCheckedAt: time.Now(),
 			}
@@ -390,7 +391,7 @@ var _ = Describe("DependencyRefStore", func() {
 		It("should return probes whose last check exceeds the poll interval", func() {
 			ref := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -401,7 +402,7 @@ var _ = Describe("DependencyRefStore", func() {
 
 			syncState := &model.SyncState{
 				OrgID:         orgId,
-				ResourceKey:   "http:http-repo-1//config.json",
+				ResourceKey:   "http:http-repo-1/config.json",
 				Fingerprint:   `"etag-abc"`,
 				LastCheckedAt: time.Now().Add(-20 * time.Minute),
 			}
@@ -418,7 +419,7 @@ var _ = Describe("DependencyRefStore", func() {
 			for _, fleet := range []string{"fleet-a", "fleet-b"} {
 				ref := &model.DependencyRef{
 					OrgID:          orgId,
-					ResourceKey:    "http:http-repo-1//config.json",
+					ResourceKey:    "http:http-repo-1/config.json",
 					FleetName:      lo.ToPtr(fleet),
 					DeviceName:     lo.ToPtr(""),
 					RefType:        "http",
@@ -429,7 +430,7 @@ var _ = Describe("DependencyRefStore", func() {
 			}
 			deviceRef := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr("device-x"),
 				RefType:        "http",
@@ -449,7 +450,7 @@ var _ = Describe("DependencyRefStore", func() {
 			for _, suffix := range []string{"/config.json", "/data.yaml"} {
 				ref := &model.DependencyRef{
 					OrgID:          orgId,
-					ResourceKey:    "http:http-repo-1/" + suffix,
+					ResourceKey:    "http:http-repo-1/" + strings.TrimPrefix(suffix, "/"),
 					FleetName:      lo.ToPtr("fleet-a"),
 					DeviceName:     lo.ToPtr(""),
 					RefType:        "http",
@@ -467,7 +468,7 @@ var _ = Describe("DependencyRefStore", func() {
 		It("should carry the repository spec for URL and auth extraction", func() {
 			ref := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",
@@ -506,7 +507,7 @@ var _ = Describe("DependencyRefStore", func() {
 		It("should enforce org isolation", func() {
 			ref := &model.DependencyRef{
 				OrgID:          orgId,
-				ResourceKey:    "http:http-repo-1//config.json",
+				ResourceKey:    "http:http-repo-1/config.json",
 				FleetName:      lo.ToPtr("fleet-a"),
 				DeviceName:     lo.ToPtr(""),
 				RefType:        "http",

--- a/test/integration/store/dependencyref_test.go
+++ b/test/integration/store/dependencyref_test.go
@@ -2,7 +2,9 @@ package store_test
 
 import (
 	"context"
+	"time"
 
+	domain "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
@@ -310,6 +312,221 @@ var _ = Describe("DependencyRefStore", func() {
 			refs, err := storeInst.DependencyRef().ListSecretDependencyTargets(ctx, "prod", "nonexistent", "sha256:any")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(BeEmpty())
+		})
+	})
+
+	Context("When listing due HTTP dependencies", func() {
+		var httpRepoName string
+
+		createHttpRepo := func(name, url string) {
+			spec := domain.RepositorySpec{}
+			Expect(spec.FromHttpRepoSpec(domain.HttpRepoSpec{
+				Url:  url,
+				Type: domain.HttpRepoSpecTypeHttp,
+			})).To(Succeed())
+			repo := &domain.Repository{
+				ApiVersion: "v1beta1",
+				Kind:       domain.RepositoryKind,
+				Metadata:   domain.ObjectMeta{Name: lo.ToPtr(name)},
+				Spec:       spec,
+			}
+			_, err := storeInst.Repository().Create(ctx, orgId, repo, nil)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		BeforeEach(func() {
+			httpRepoName = "http-repo-1"
+			createHttpRepo(httpRepoName, "https://example.com/config")
+		})
+
+		It("should return probes for HTTP refs that have never been checked", func() {
+			ref := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(HaveLen(1))
+			Expect(probes[0].RepositoryName).To(Equal(httpRepoName))
+			Expect(probes[0].HTTPSuffix).To(Equal("/config.json"))
+			Expect(probes[0].Fingerprint).To(BeNil())
+			Expect(probes[0].FleetNames).To(ContainElement("fleet-a"))
+			Expect(probes[0].DeviceNames).To(BeNil())
+			Expect(probes[0].RepoSpec).ToNot(BeNil())
+		})
+
+		It("should not return probes that were recently checked", func() {
+			ref := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+
+			syncState := &model.SyncState{
+				OrgID:         orgId,
+				ResourceKey:   "http:http-repo-1//config.json",
+				Fingerprint:   `"etag-abc"`,
+				LastCheckedAt: time.Now(),
+			}
+			Expect(storeInst.SyncState().Set(ctx, orgId, syncState)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(BeEmpty())
+		})
+
+		It("should return probes whose last check exceeds the poll interval", func() {
+			ref := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+
+			syncState := &model.SyncState{
+				OrgID:         orgId,
+				ResourceKey:   "http:http-repo-1//config.json",
+				Fingerprint:   `"etag-abc"`,
+				LastCheckedAt: time.Now().Add(-20 * time.Minute),
+			}
+			Expect(storeInst.SyncState().Set(ctx, orgId, syncState)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(HaveLen(1))
+			Expect(probes[0].Fingerprint).ToNot(BeNil())
+			Expect(*probes[0].Fingerprint).To(Equal(`"etag-abc"`))
+		})
+
+		It("should aggregate multiple fleets and devices referencing the same repo+suffix", func() {
+			for _, fleet := range []string{"fleet-a", "fleet-b"} {
+				ref := &model.DependencyRef{
+					OrgID:          orgId,
+					ResourceKey:    "http:http-repo-1//config.json",
+					FleetName:      lo.ToPtr(fleet),
+					DeviceName:     lo.ToPtr(""),
+					RefType:        "http",
+					RepositoryName: lo.ToPtr(httpRepoName),
+					HTTPSuffix:     lo.ToPtr("/config.json"),
+				}
+				Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+			}
+			deviceRef := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr("device-x"),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, deviceRef)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(HaveLen(1))
+			Expect(probes[0].FleetNames).To(ContainElements("fleet-a", "fleet-b"))
+			Expect(probes[0].DeviceNames).To(ContainElement("device-x"))
+		})
+
+		It("should return separate probes for different suffixes on the same repo", func() {
+			for _, suffix := range []string{"/config.json", "/data.yaml"} {
+				ref := &model.DependencyRef{
+					OrgID:          orgId,
+					ResourceKey:    "http:http-repo-1/" + suffix,
+					FleetName:      lo.ToPtr("fleet-a"),
+					DeviceName:     lo.ToPtr(""),
+					RefType:        "http",
+					RepositoryName: lo.ToPtr(httpRepoName),
+					HTTPSuffix:     lo.ToPtr(suffix),
+				}
+				Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+			}
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(HaveLen(2))
+		})
+
+		It("should carry the repository spec for URL and auth extraction", func() {
+			ref := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(HaveLen(1))
+			Expect(probes[0].RepoSpec).ToNot(BeNil())
+
+			httpSpec, err := probes[0].RepoSpec.Data.AsHttpRepoSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(httpSpec.Url).To(Equal("https://example.com/config"))
+		})
+
+		It("should not return git refs", func() {
+			gitRef := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "git:http-repo-1/main",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "git",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				Revision:       lo.ToPtr("main"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, gitRef)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(BeEmpty())
+		})
+
+		It("should enforce org isolation", func() {
+			ref := &model.DependencyRef{
+				OrgID:          orgId,
+				ResourceKey:    "http:http-repo-1//config.json",
+				FleetName:      lo.ToPtr("fleet-a"),
+				DeviceName:     lo.ToPtr(""),
+				RefType:        "http",
+				RepositoryName: lo.ToPtr(httpRepoName),
+				HTTPSuffix:     lo.ToPtr("/config.json"),
+			}
+			Expect(storeInst.DependencyRef().Upsert(ctx, orgId, ref)).To(Succeed())
+
+			otherOrg := uuid.New()
+			Expect(testutil.CreateTestOrganization(ctx, storeInst, otherOrg)).To(Succeed())
+
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, otherOrg, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(BeEmpty())
+		})
+
+		It("should return empty when no HTTP refs exist", func() {
+			probes, err := storeInst.DependencyRef().ListDueHttpDependencies(ctx, orgId, 15*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(probes).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
## EDM-3843: HTTP change detection

**Jira:** [EDM-3843](https://redhat.atlassian.net/browse/EDM-3843)

### Summary

Adds HTTP change detection to `flightctl-periodic`, building on the sync infrastructure from EDM-3840/EDM-3841:

* **`DependencySyncHttp` periodic task** — sends conditional GETs (ETag / Last-Modified) against HTTP-type repositories, compares fingerprints against `sync_state`, emits `DependencyChangeDetected` events on change
* **Conditional header dispatch** — sends `If-None-Match` for ETags, `If-Modified-Since` for HTTP-dates (RFC 7232 compliant)
* **Parameterized suffix handling** — fleet-level refs with template parameters in suffix are skipped during collection and resolved to device-level refs during rollout (same pattern as git/secret)
* **Skip-probe rate limiting** — endpoints that don't support conditional requests (HttpNotConditional) or return errors still update `last_checked_at` to avoid re-polling every cycle

### Testing

* Unit tests for change detection, 304 no-change, first-seen, HttpNotConditional, HTTP errors, multi-fleet/device fan-out, parameterized suffix lifecycle, nil RepoSpec guard
* Integration tests for `ListDueHttpDependencies` store query (poll-interval gate, multi-fleet aggregation, org isolation, repo spec JOIN)
