### PR TITLE
EDM-3833: Mutate old pre-upgrade script to fix hardcoded db-setup image upgrade

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -635,6 +635,24 @@ if [ "$1" -eq 2 ]; then
     IMAGE_TAG="$(echo %{version} | tr '~' '-')"
     echo "flightctl: running pre upgrade checks, target version $IMAGE_TAG"
     if [ -x "%{_libexecdir}/flightctl/pre-upgrade-dry-run.sh" ]; then
+        SCRIPT="%{_libexecdir}/flightctl/pre-upgrade-dry-run.sh"
+        # Versions before the EDM-3833 fix hardcode the wrong image name and overwrite
+        # the DB_SETUP_IMAGE env var. Detect this and patch just that line in a temp copy
+        # so the rest of the script (config reading, secrets, network) stays correct for
+        # the currently installed system state.
+        # Can be removed once all deployments have upgraded past the fix.
+        if grep -q 'DB_SETUP_IMAGE="quay.io/flightctl/flightctl-db-setup:' "$SCRIPT" 2>/dev/null; then
+            TMPSCRIPT=$(mktemp /tmp/flightctl-dry-run.XXXXXX.sh)
+            cp "$SCRIPT" "$TMPSCRIPT"
+            chmod +x "$TMPSCRIPT"
+%if 0%{?rhel} == 10
+            CORRECT_IMAGE="quay.io/flightctl/flightctl-db-setup-el10:${IMAGE_TAG}"
+%else
+            CORRECT_IMAGE="quay.io/flightctl/flightctl-db-setup-el9:${IMAGE_TAG}"
+%endif
+            sed -i "s|DB_SETUP_IMAGE=.*|DB_SETUP_IMAGE=\"${CORRECT_IMAGE}\"|" "$TMPSCRIPT"
+            SCRIPT="$TMPSCRIPT"
+        fi
         IMAGE_TAG="$IMAGE_TAG" \
         DB_SETUP_REGISTRY="quay.io" \
 %if 0%{?rhel} == 10
@@ -643,10 +661,12 @@ if [ "$1" -eq 2 ]; then
         DB_SETUP_IMAGE="flightctl/flightctl-db-setup-el9" \
 %endif
         CONFIG_PATH="%{_sysconfdir}/flightctl/flightctl-api/config.yaml" \
-        "%{_libexecdir}/flightctl/pre-upgrade-dry-run.sh" "$IMAGE_TAG" "%{_sysconfdir}/flightctl/flightctl-api/config.yaml" || {
+        bash "$SCRIPT" "$IMAGE_TAG" "%{_sysconfdir}/flightctl/flightctl-api/config.yaml" || {
+            [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
             echo "flightctl: dry-run failed; aborting upgrade." >&2
             exit 1
         }
+        [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
     else
         echo "flightctl: pre-upgrade-dry-run.sh not found at %{_libexecdir}/flightctl; skipping."
     fi


### PR DESCRIPTION
## Summary

- When upgrading from a version before #2907 , \`%pre\` runs the old on-disk script which hardcodes \`DB_SETUP_IMAGE="quay.io/flightctl/flightctl-db-setup:\${IMAGE_TAG}"\` and overwrites the env var passed by the spec, causing the dry-run to attempt pulling a non-existent image and blocking the upgrade
- The \`%pre\` scriptlet now detects this case by grepping for the hardcoded pattern, copies the script to a temp file, and uses \`sed\` to replace just the image reference with the correct OS-suffixed image before running it
- All other script logic (config reading, secret names, network, DB connection) remains from the installed version, which is correct since \`%pre\` runs against the current system state

## Test plan

Tested on a RHEL 9 VM with \`FLIGHTCTL_MIGRATION_DRY_RUN=1\` enabled and a minimal service config in place so the dry-run progresses past the early-exit check:

- **1.0.2 → new**: old script detected, image mutated to \`quay.io/flightctl/flightctl-db-setup-el9\`, upgrade proceeds correctly
- **1.1.2 → new**: same result
- **1.0.2 → 1.1.2** (neither has the fix): dry-run attempts \`quay.io/flightctl/flightctl-db-setup:1.1.2\`, image pull fails, upgrade correctly blocked — confirms the pre-fix behavior this PR addresses

The dev build image is not published so the pull fails in all cases, but the correct image name is used and the failure mode is the right one (image not found, not wrong image name).
