### PR TITLE
NO-ISSUE: Get rid of step numbering in generate-certificates.sh

### DIFF
--- a/deploy/helm/flightctl/scripts/generate-certificates.sh
+++ b/deploy/helm/flightctl/scripts/generate-certificates.sh
@@ -336,35 +336,35 @@ echo "=== Generating Flight Control Certificates in $CERT_DIR ==="
 
 # Create certificate directory if it doesn't exist
 
-# Step 1: Flight Control CA (self-signed root certificate)
+# Flight Control CA (self-signed root certificate)
 mkdir -p "$CERT_DIR"
 
 FLIGHTCTL_CA_KEY="$CERT_DIR/ca.key"
 FLIGHTCTL_CA_CERT="$CERT_DIR/ca.crt"
 
 if [[ -f "$FLIGHTCTL_CA_CERT" ]] && [[ -f "$FLIGHTCTL_CA_KEY" ]]; then
-    echo "[1/14] Skipped generation of Flight Control CA certificate (already exists)"
+    echo "Skipped generation of Flight Control CA certificate (already exists)"
 else
     generate_root_ca "flightctl-ca" "$FLIGHTCTL_CA_KEY" "$FLIGHTCTL_CA_CERT"
-    echo "[1/14] Generated Flight Control CA certificate (10 years, ECDSA P-256)"
+    echo "Generated Flight Control CA certificate (10 years, ECDSA P-256)"
 fi
 
-# Step 2: Client Signer CA (intermediate CA signed by Flight Control CA)
+# Client Signer CA (intermediate CA signed by Flight Control CA)
 mkdir -p "$CERT_DIR/flightctl-api"
 
 CLIENT_SIGNER_CA_KEY="$CERT_DIR/flightctl-api/client-signer.key"
 CLIENT_SIGNER_CA_CERT="$CERT_DIR/flightctl-api/client-signer.crt"
 
 if [[ -f "$CLIENT_SIGNER_CA_CERT" ]] && [[ -f "$CLIENT_SIGNER_CA_KEY" ]]; then
-    echo "[2/14] Skipped generation of Client Signer CA certificate (already exists)"
+    echo "Skipped generation of Client Signer CA certificate (already exists)"
 else
     generate_intermediate_ca "flightctl-client-signer-ca" \
         "$CLIENT_SIGNER_CA_KEY" "$CLIENT_SIGNER_CA_CERT" \
         "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY"
-    echo "[2/14] Generated Client Signer CA certificate (10 years, ECDSA P-256)"
+    echo "Generated Client Signer CA certificate (10 years, ECDSA P-256)"
 fi
 
-# Step 3: PAM Issuer Token Signer CA (intermediate CA signed by Flight Control CA)
+# PAM Issuer Token Signer CA (intermediate CA signed by Flight Control CA)
 if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-pam-issuer"
 
@@ -372,34 +372,34 @@ if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
     PAM_ISSUER_TOKEN_SIGNER_CA_CERT="$CERT_DIR/flightctl-pam-issuer/token-signer.crt"
 
     if [[ -f "$PAM_ISSUER_TOKEN_SIGNER_CA_CERT" ]] && [[ -f "$PAM_ISSUER_TOKEN_SIGNER_CA_KEY" ]]; then
-        echo "[3/14] Skipped generation of PAM Issuer Token Signer CA certificate (already exists)"
+        echo "Skipped generation of PAM Issuer Token Signer CA certificate (already exists)"
     else
         generate_intermediate_ca "flightctl-pam-issuer-token-signer-ca" \
             "$PAM_ISSUER_TOKEN_SIGNER_CA_KEY" "$PAM_ISSUER_TOKEN_SIGNER_CA_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY"
-        echo "[3/14] Generated PAM Issuer Token Signer CA certificate (10 years, ECDSA P-256)"
+        echo "Generated PAM Issuer Token Signer CA certificate (10 years, ECDSA P-256)"
     fi
 else
-    echo "[3/14] Skipped generation of PAM Issuer Token Signer CA certificate (no PAM Issuer SANs specified)"
+    echo "Skipped generation of PAM Issuer Token Signer CA certificate (no PAM Issuer SANs specified)"
 fi
 
-# Step 4: API Server TLS certificate
+# API Server TLS certificate
 mkdir -p "$CERT_DIR/flightctl-api"
 
 API_SERVER_KEY="$CERT_DIR/flightctl-api/server.key"
 API_SERVER_CERT="$CERT_DIR/flightctl-api/server.crt"
 
 if [[ -f "$API_SERVER_CERT" ]] && [[ -f "$API_SERVER_KEY" ]] && cert_has_expected_sans "$API_SERVER_CERT" "${API_SANS[@]}"; then
-    echo "[4/14] Skipped generation of API Server TLS certificate (already exists with correct SANs)"
+    echo "Skipped generation of API Server TLS certificate (already exists with correct SANs)"
 else
     generate_server_cert "flightctl-api" \
         "$API_SERVER_KEY" "$API_SERVER_CERT" \
         "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
         "${API_SANS[@]}"
-    echo "[4/14] Generated API Server TLS certificate (2 years, ECDSA P-256)"
+    echo "Generated API Server TLS certificate (2 years, ECDSA P-256)"
 fi
 
-# Step 5: PAM Issuer Server TLS certificate
+# PAM Issuer Server TLS certificate
 if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-pam-issuer"
 
@@ -407,19 +407,19 @@ if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
     PAM_ISSUER_SERVER_CERT="$CERT_DIR/flightctl-pam-issuer/server.crt"
 
     if [[ -f "$PAM_ISSUER_SERVER_CERT" ]] && [[ -f "$PAM_ISSUER_SERVER_KEY" ]] && cert_has_expected_sans "$PAM_ISSUER_SERVER_CERT" "${PAM_ISSUER_SANS[@]}"; then
-        echo "[5/14] Skipped generation of PAM Issuer Server TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of PAM Issuer Server TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-pam-issuer" \
             "$PAM_ISSUER_SERVER_KEY" "$PAM_ISSUER_SERVER_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${PAM_ISSUER_SANS[@]}"
-        echo "[5/14] Generated PAM Issuer Server TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated PAM Issuer Server TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[5/14] Skipped generation of PAM Issuer Server TLS certificate (no PAM Issuer SANs specified)"
+    echo "Skipped generation of PAM Issuer Server TLS certificate (no PAM Issuer SANs specified)"
 fi
 
-# Step 6: Telemetry Gateway TLS certificate
+# Telemetry Gateway TLS certificate
 if [[ ${#TELEMETRY_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-telemetry-gateway"
 
@@ -427,19 +427,19 @@ if [[ ${#TELEMETRY_SANS[@]} -gt 0 ]]; then
     TELEMETRY_CERT="$CERT_DIR/flightctl-telemetry-gateway/server.crt"
 
     if [[ -f "$TELEMETRY_CERT" ]] && [[ -f "$TELEMETRY_KEY" ]] && cert_has_expected_sans "$TELEMETRY_CERT" "${TELEMETRY_SANS[@]}"; then
-        echo "[6/14] Skipped generation of Telemetry Gateway TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of Telemetry Gateway TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-telemetry-gateway" \
             "$TELEMETRY_KEY" "$TELEMETRY_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${TELEMETRY_SANS[@]}"
-        echo "[6/14] Generated Telemetry Gateway TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated Telemetry Gateway TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[6/14] Skipped generation of Telemetry Gateway TLS certificate (no SANs specified)"
+    echo "Skipped generation of Telemetry Gateway TLS certificate (no SANs specified)"
 fi
 
-# Step 7: Alertmanager Proxy TLS certificate
+# Alertmanager Proxy TLS certificate
 if [[ ${#ALERTMANAGER_PROXY_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-alertmanager-proxy"
 
@@ -447,19 +447,19 @@ if [[ ${#ALERTMANAGER_PROXY_SANS[@]} -gt 0 ]]; then
     ALERTMANAGER_PROXY_CERT="$CERT_DIR/flightctl-alertmanager-proxy/server.crt"
 
     if [[ -f "$ALERTMANAGER_PROXY_CERT" ]] && [[ -f "$ALERTMANAGER_PROXY_KEY" ]] && cert_has_expected_sans "$ALERTMANAGER_PROXY_CERT" "${ALERTMANAGER_PROXY_SANS[@]}"; then
-        echo "[7/14] Skipped generation of Alertmanager Proxy TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of Alertmanager Proxy TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-alertmanager-proxy" \
             "$ALERTMANAGER_PROXY_KEY" "$ALERTMANAGER_PROXY_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${ALERTMANAGER_PROXY_SANS[@]}"
-        echo "[7/14] Generated Alertmanager Proxy TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated Alertmanager Proxy TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[7/14] Skipped generation of Alertmanager Proxy TLS certificate (no SANs specified)"
+    echo "Skipped generation of Alertmanager Proxy TLS certificate (no SANs specified)"
 fi
 
-# Step 8: UI TLS certificate
+# UI TLS certificate
 if [[ ${#UI_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-ui"
 
@@ -467,19 +467,19 @@ if [[ ${#UI_SANS[@]} -gt 0 ]]; then
     UI_CERT="$CERT_DIR/flightctl-ui/server.crt"
 
     if [[ -f "$UI_CERT" ]] && [[ -f "$UI_KEY" ]] && cert_has_expected_sans "$UI_CERT" "${UI_SANS[@]}"; then
-        echo "[8/14] Skipped generation of UI TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of UI TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-ui" \
             "$UI_KEY" "$UI_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${UI_SANS[@]}"
-        echo "[8/14] Generated UI TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated UI TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[8/14] Skipped generation of UI TLS certificate (no SANs specified)"
+    echo "Skipped generation of UI TLS certificate (no SANs specified)"
 fi
 
-# Step 9: CLI Artifacts TLS certificate
+# CLI Artifacts TLS certificate
 if [[ ${#CLI_ARTIFACTS_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-cli-artifacts"
 
@@ -487,19 +487,19 @@ if [[ ${#CLI_ARTIFACTS_SANS[@]} -gt 0 ]]; then
     CLI_ARTIFACTS_CERT="$CERT_DIR/flightctl-cli-artifacts/server.crt"
 
     if [[ -f "$CLI_ARTIFACTS_CERT" ]] && [[ -f "$CLI_ARTIFACTS_KEY" ]] && cert_has_expected_sans "$CLI_ARTIFACTS_CERT" "${CLI_ARTIFACTS_SANS[@]}"; then
-        echo "[9/14] Skipped generation of CLI Artifacts TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of CLI Artifacts TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-cli-artifacts" \
             "$CLI_ARTIFACTS_KEY" "$CLI_ARTIFACTS_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${CLI_ARTIFACTS_SANS[@]}"
-        echo "[9/14] Generated CLI Artifacts TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated CLI Artifacts TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[9/14] Skipped generation of CLI Artifacts TLS certificate (no SANs specified)"
+    echo "Skipped generation of CLI Artifacts TLS certificate (no SANs specified)"
 fi
 
-# Step 10: ImageBuilder API TLS certificate
+# ImageBuilder API TLS certificate
 if [[ ${#IMAGEBUILDER_API_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-imagebuilder-api"
 
@@ -507,19 +507,19 @@ if [[ ${#IMAGEBUILDER_API_SANS[@]} -gt 0 ]]; then
     IMAGEBUILDER_API_CERT="$CERT_DIR/flightctl-imagebuilder-api/server.crt"
 
     if [[ -f "$IMAGEBUILDER_API_CERT" ]] && [[ -f "$IMAGEBUILDER_API_KEY" ]] && cert_has_expected_sans "$IMAGEBUILDER_API_CERT" "${IMAGEBUILDER_API_SANS[@]}"; then
-        echo "[10/14] Skipped generation of ImageBuilder API TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of ImageBuilder API TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-imagebuilder-api" \
             "$IMAGEBUILDER_API_KEY" "$IMAGEBUILDER_API_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${IMAGEBUILDER_API_SANS[@]}"
-        echo "[10/14] Generated ImageBuilder API TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated ImageBuilder API TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[10/14] Skipped generation of ImageBuilder API TLS certificate (no SANs specified)"
+    echo "Skipped generation of ImageBuilder API TLS certificate (no SANs specified)"
 fi
 
-# Step 11: Prometheus TLS certificate
+# Prometheus TLS certificate
 if [[ ${#PROMETHEUS_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-prometheus"
 
@@ -527,19 +527,19 @@ if [[ ${#PROMETHEUS_SANS[@]} -gt 0 ]]; then
     PROMETHEUS_CERT="$CERT_DIR/flightctl-prometheus/server.crt"
 
     if [[ -f "$PROMETHEUS_CERT" ]] && [[ -f "$PROMETHEUS_KEY" ]] && cert_has_expected_sans "$PROMETHEUS_CERT" "${PROMETHEUS_SANS[@]}"; then
-        echo "[11/14] Skipped generation of Prometheus TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of Prometheus TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-prometheus" \
             "$PROMETHEUS_KEY" "$PROMETHEUS_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${PROMETHEUS_SANS[@]}"
-        echo "[11/14] Generated Prometheus TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated Prometheus TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[11/14] Skipped generation of Prometheus TLS certificate (no SANs specified)"
+    echo "Skipped generation of Prometheus TLS certificate (no SANs specified)"
 fi
 
-# Step 12: Grafana TLS certificate
+# Grafana TLS certificate
 if [[ ${#GRAFANA_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-grafana"
 
@@ -547,19 +547,19 @@ if [[ ${#GRAFANA_SANS[@]} -gt 0 ]]; then
     GRAFANA_CERT="$CERT_DIR/flightctl-grafana/server.crt"
 
     if [[ -f "$GRAFANA_CERT" ]] && [[ -f "$GRAFANA_KEY" ]] && cert_has_expected_sans "$GRAFANA_CERT" "${GRAFANA_SANS[@]}"; then
-        echo "[12/14] Skipped generation of Grafana TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of Grafana TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-grafana" \
             "$GRAFANA_KEY" "$GRAFANA_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${GRAFANA_SANS[@]}"
-        echo "[12/14] Generated Grafana TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated Grafana TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[12/14] Skipped generation of Grafana TLS certificate (no SANs specified)"
+    echo "Skipped generation of Grafana TLS certificate (no SANs specified)"
 fi
 
-# Step 13: UserInfo Proxy TLS certificate
+# UserInfo Proxy TLS certificate
 if [[ ${#USERINFO_PROXY_SANS[@]} -gt 0 ]]; then
     mkdir -p "$CERT_DIR/flightctl-userinfo-proxy"
 
@@ -567,19 +567,19 @@ if [[ ${#USERINFO_PROXY_SANS[@]} -gt 0 ]]; then
     USERINFO_PROXY_CERT="$CERT_DIR/flightctl-userinfo-proxy/server.crt"
 
     if [[ -f "$USERINFO_PROXY_CERT" ]] && [[ -f "$USERINFO_PROXY_KEY" ]] && cert_has_expected_sans "$USERINFO_PROXY_CERT" "${USERINFO_PROXY_SANS[@]}"; then
-        echo "[13/14] Skipped generation of UserInfo Proxy TLS certificate (already exists with correct SANs)"
+        echo "Skipped generation of UserInfo Proxy TLS certificate (already exists with correct SANs)"
     else
         generate_server_cert "flightctl-userinfo-proxy" \
             "$USERINFO_PROXY_KEY" "$USERINFO_PROXY_CERT" \
             "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
             "${USERINFO_PROXY_SANS[@]}"
-        echo "[13/14] Generated UserInfo Proxy TLS certificate (2 years, ECDSA P-256)"
+        echo "Generated UserInfo Proxy TLS certificate (2 years, ECDSA P-256)"
     fi
 else
-    echo "[13/14] Skipped generation of UserInfo Proxy TLS certificate (no SANs specified)"
+    echo "Skipped generation of UserInfo Proxy TLS certificate (no SANs specified)"
 fi
 
-# Step 14: CA Bundle
+# CA Bundle
 CA_BUNDLE="$CERT_DIR/ca-bundle.crt"
 
 if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
@@ -587,7 +587,7 @@ if [[ ${#PAM_ISSUER_SANS[@]} -gt 0 ]]; then
 else
     cat "$FLIGHTCTL_CA_CERT" "$CLIENT_SIGNER_CA_CERT" > "$CA_BUNDLE"
 fi
-echo "[14/14] Generated CA Bundle"
+echo "Generated CA Bundle"
 
 # Clean up serial files
 rm -f "$CERT_DIR"/*.srl


### PR DESCRIPTION
It is pretty much AI slop and makes adding and removing steps very annoying and verbose in the commit diff.