### PR TITLE
EDM-3694: Do not log disconnect as errors

### DIFF
--- a/internal/agent/device/console/outgoing_streams.go
+++ b/internal/agent/device/console/outgoing_streams.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -167,8 +168,16 @@ func (o *outgoingErrorStream) emit(err error) {
 	case *exec.ExitError:
 		exitCode = actual.ExitCode()
 	default:
-		o.log.Errorf("unexpected error type %T: %v", err, err)
-		exitCode = 255
+		if errors.Is(err, context.Canceled) {
+			o.log.Debugf("console command wait ended after disconnect: %v", err)
+			exitCode = 0
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			o.log.Debugf("console command wait with exceeded context deadline: %v", err)
+			exitCode = 0
+		} else {
+			o.log.Errorf("unexpected error type %T: %v", err, err)
+			exitCode = 255
+		}
 	}
 	status := metav1.Status{
 		Status: lo.Ternary[string](exitCode == 0, metav1.StatusSuccess, metav1.StatusFailure),

--- a/internal/agent/device/console/outgoing_streams.go
+++ b/internal/agent/device/console/outgoing_streams.go
@@ -172,8 +172,8 @@ func (o *outgoingErrorStream) emit(err error) {
 			o.log.Debugf("console command wait ended after disconnect: %v", err)
 			exitCode = 0
 		} else if errors.Is(err, context.DeadlineExceeded) {
-			o.log.Debugf("console command wait with exceeded context deadline: %v", err)
-			exitCode = 0
+			o.log.Errorf("console command wait exceeded context deadline: %v", err)
+			exitCode = 124
 		} else {
 			o.log.Errorf("unexpected error type %T: %v", err, err)
 			exitCode = 255


### PR DESCRIPTION
When working on device logs, the flightctl-agent.service log will show "unexpected error type" whenever the client disconnects the session.

This PR makes session cancellations only log at Debug level.

```
May 19 10:04:35 localhost.localdomain sudo[1318]:     root : PWD=/var/lib/flightctl ; USER=flightctl-console ; COMMAND=/bin/bash -s
May 19 10:04:36 localhost.localdomain flightctl-agent[1270]: time="2026-05-19T10:04:36.505545Z" level=info msg="Spec reconciliation complete: current version 2"
May 19 10:05:28 localhost.localdomain flightctl-agent[1270]: time="2026-05-19T10:05:28.763912Z" level=error msg="unexpected error type *errors.errorString: context canceled" file="device/console/outgoing_streams.go:170"

```