### PR TITLE
EDM-3981: Add user documentation for auto-sync feature

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -648,3 +648,11 @@ canonical
 unencoded
 - docs/user/using/viewing-vulnerabilities.md
 NVD
+- docs/user/using/auto-syncing-dependencies.md
+DependencyChangeDetected
+DependencySyncProbeFailed
+ETag
+ETags
+parameterized
+SharedInformer
+sha256

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -64,6 +64,7 @@ Welcome to the Flight Control user documentation.
   * [Selecting Devices into a Fleet](using/managing-fleets.md#selecting-devices-into-a-fleet)
   * [Defining Device Templates](using/managing-fleets.md#defining-device-templates)
   * [Defining Rollout Policies](using/managing-fleets.md#defining-rollout-policies)
+* **[Auto-syncing External Dependencies](using/auto-syncing-dependencies.md)** - How Flight Control automatically detects and applies upstream changes to device configurations.
 * **[Viewing Vulnerabilities](using/viewing-vulnerabilities.md)** - How to view vulnerability data for devices and fleets.
   * [Viewing the Vulnerability Summary](using/viewing-vulnerabilities.md#viewing-the-vulnerability-summary)
   * [Viewing Device Vulnerabilities](using/viewing-vulnerabilities.md#viewing-device-vulnerabilities)

--- a/docs/user/references/events.md
+++ b/docs/user/references/events.md
@@ -86,6 +86,25 @@ The event `details` contain `detailType: DeviceVulnerabilityCVE` with the follow
 | **Repositories**      | `RepositoryAccessible`, `RepositoryInaccessible`                                              |
 | **ResourceSync**      | `ResourceSyncAccessible`, `ResourceSyncInaccessible`, `ResourceSyncCommitDetected`, `ResourceSyncParsed`, `ResourceSyncParsingFailed`, `ResourceSyncSynced`, `ResourceSyncSyncFailed`, `ResourceSyncCompleted` |
 
+### Dependency sync events
+
+When [auto-sync](../using/auto-syncing-dependencies.md) is active, Flight Control emits events to track dependency change detection and probe failures. Each event has `involvedObject.kind` set to `Fleet` or `Device` depending on what owns the dependency.
+
+| Event Reason | Type | Description |
+|-------------|------|-------------|
+| `DependencyChangeDetected` | Normal | A dependency fingerprint changed — triggers template version creation or device re-render. |
+| `DependencySyncProbeFailed` | Warning | A probe failed (git, HTTP, or secret informer error). |
+
+**`DependencyChangeDetected`** event details (`detailType: DependencyChangeDetected`):
+
+* `resourceKey` — the dependency identifier (for example, `git:my-repo/main`, `http:my-repo/path`)
+* `fingerprint` — the new fingerprint value
+
+**`DependencySyncProbeFailed`** event details (`detailType: DependencySyncProbeFailed`):
+
+* `resourceKey` — the dependency that failed
+* `errorMessage` — sanitized error description (credentials redacted)
+
 ### System Events
 
 - `InternalTaskFailed`

--- a/docs/user/using/auto-syncing-dependencies.md
+++ b/docs/user/using/auto-syncing-dependencies.md
@@ -170,15 +170,7 @@ flightctl get events --field-selector="reason=DependencySyncProbeFailed"
 
 ### An HTTP endpoint is not triggering updates
 
-If the HTTP endpoint does not return ETag or Last-Modified headers, changes are only detected passively when a device re-renders for another reason.
-
-To verify whether an endpoint supports active change detection:
-
-```console
-curl -I <endpoint-url>
-```
-
-Look for `ETag` or `Last-Modified` in the response headers. If neither is present, consider configuring your HTTP server to return one of these headers for reliable active sync.
+Verify that the endpoint returns ETag or Last-Modified headers (see [HTTP endpoints](#http-endpoints) above). If neither is present, changes are only detected passively during re-renders triggered by other means.
 
 ### A Kubernetes secret is not being tracked
 

--- a/docs/user/using/auto-syncing-dependencies.md
+++ b/docs/user/using/auto-syncing-dependencies.md
@@ -1,47 +1,39 @@
 # Auto-syncing external dependencies
 
-Flight Control automatically detects changes in external dependencies referenced by fleet and device templates — git repositories, HTTP endpoints, and Kubernetes secrets. When a change is detected, the service creates a new template version and rolls it out to affected devices, or re-renders standalone devices directly.
+Flight Control automatically monitors external configuration references (git repositories, HTTP endpoints, and Kubernetes secrets) for changes. When a referenced dependency changes upstream, affected devices are updated automatically through the standard rollout pipeline.
 
 ## How auto-sync works
 
-Auto-sync is enabled by default for any fleet or device that references external configuration providers (git, HTTP, or Kubernetes secret). No opt-in is required.
+Any fleet or device that references an external config provider is automatically monitored for upstream changes. When a change is detected, fleet-owned devices receive a new template version and the rollout policy governs how the update reaches them. Standalone devices (not owned by a fleet) are re-rendered directly.
 
-A component called the **Dependency Sync Controller** runs inside the `flightctl-periodic` service. It periodically checks each dependency for upstream changes by comparing the current state against a stored fingerprint. When the fingerprint changes, the controller emits a `DependencyChangeDetected` event on the affected fleet or device, which triggers the standard rollout pipeline.
+Fleet templates can contain placeholders (for example, `{{ .metadata.labels.branch }}`) in fields such as git `targetRevision` or HTTP `suffix`. When placeholders are used, each device's resolved reference is tracked independently — only devices whose specific dependency changed receive an update.
 
-### What triggers a new template version
-
-For fleet-owned devices, a detected change creates a new template version named `v{generation}-{short-hash}`, where `short-hash` is the first 8 characters of the new fingerprint. The rollout policy then governs how the update reaches devices.
-
-For standalone devices (not owned by a fleet), a detected change triggers a direct re-render of the device specification without creating a template version.
-
-### Parameterized references
-
-Fleet templates can contain placeholders (for example, `{{ .metadata.labels.branch }}`) in fields such as git `targetRevision` or HTTP `suffix`. When a fleet references a parameterized field, the system resolves the concrete value per device during rollout and tracks each device's resolved dependency independently. Only devices whose specific resolved reference changed receive an update — the entire fleet is not re-rolled.
-
-## Detection mechanisms
+## Setting up auto-sync for each source type
 
 ### Git repositories
 
-The controller uses `git ls-remote` to resolve the current commit SHA for each referenced branch or tag. If the SHA differs from the stored fingerprint, a change is detected.
+Git-based config providers are monitored automatically. No additional setup is required beyond defining the git config provider in your fleet or device template. Flight Control checks each referenced branch or tag for new commits at a configurable polling interval (default: 15 minutes).
 
 ### HTTP endpoints
 
-The controller sends a conditional HEAD request using `If-None-Match` (for ETags) or `If-Modified-Since` headers:
+HTTP config providers are monitored automatically. For best results, use an endpoint that returns **ETag** or **Last-Modified** response headers — this enables efficient change detection without downloading the full response body each cycle.
 
-* If the endpoint responds with `304 Not Modified`, no change occurred.
-* If the endpoint responds with `200 OK` and a new ETag or Last-Modified value, a change is detected.
-* If the endpoint does not return ETag or Last-Modified headers, the probe skips active detection for that endpoint.
+To verify whether your endpoint supports these headers:
+
+```console
+curl -I <endpoint-url>
+```
+
+Look for `ETag` or `Last-Modified` in the response headers.
 
 > [!NOTE]
-> Endpoints that do not support conditional requests (no ETag or Last-Modified headers) cannot be actively monitored by the sync controller. However, the device render path always fetches the full response body and computes a `sha256` hash as the fingerprint. Changes to these endpoints are detected passively — the next time a device re-renders for any reason (for example, another dependency changes or the fleet template is updated), the new body hash is captured and reflected in the sync status.
+> If the endpoint does not return ETag or Last-Modified headers, changes are still detected, but only passively — the next time the device re-renders for any reason (for example, another dependency changes or the fleet template is updated), the new content is picked up and reflected in the sync status.
 
 ### Kubernetes secrets
 
-The controller uses a Kubernetes SharedInformer to watch labeled secrets in real time. This is push-based — there is no polling interval for secrets.
+To enable automatic change detection for Kubernetes secrets:
 
-To enable secret watching:
-
-1. Label each secret that Flight Control should watch:
+1. Label each secret that Flight Control should monitor:
 
    ```console
    kubectl label secret <secret-name> flightctl.io/sync-<release-namespace>=true
@@ -62,10 +54,10 @@ To enable secret watching:
      clusterLevelSecretAccess: true
    ```
 
-The `periodic` setting enables the informer to watch secrets. The `worker` setting enables embedding secret data into device configurations during rendering.
+   The `periodic` setting allows Flight Control to watch for secret changes. The `worker` setting allows embedding secret data into device configurations during rendering.
 
 > [!IMPORTANT]
-> The secret informer starts only when `flightctl-periodic` runs inside a Kubernetes cluster. Out-of-cluster deployments (such as Podman/Quadlet) do not support secret watching.
+> Secret watching requires `flightctl-periodic` to run inside a Kubernetes cluster. Out-of-cluster deployments (such as Podman/Quadlet) do not support secret change detection.
 
 ## Viewing sync status
 
@@ -118,10 +110,10 @@ dependenciesSync:
   pollInterval: 15m
 ```
 
-The polling interval does not affect Kubernetes secrets, which use a push-based watch.
+The polling interval does not affect Kubernetes secrets, which are watched in real time.
 
 > [!NOTE]
-> The sync task runs on a fixed internal interval (every 3 minutes, not user-configurable) to discover newly added dependencies and retry partial failures. The `pollInterval` controls how long each individual dependency must wait since its last successful probe before being checked again.
+> Newly added dependencies are discovered within approximately 3 minutes. The `pollInterval` controls how long each individual dependency waits between checks.
 
 ## Events
 
@@ -136,7 +128,7 @@ flightctl get events --field-selector="reason=DependencySyncProbeFailed"
 
 * **Type:** Normal
 * **Involved object:** Fleet or Device (depending on ownership)
-* **Meaning:** An external dependency fingerprint changed. For fleets, this triggers a new template version. For standalone devices, this triggers a re-render.
+* **Meaning:** An external dependency changed. For fleets, this triggers a new template version. For standalone devices, this triggers a re-render.
 * **Event details:**
   * `resourceKey` — the dependency identifier (for example, `git:my-repo/main` or `http:my-config/api/v1/config`)
   * `fingerprint` — the new fingerprint value
@@ -178,15 +170,15 @@ flightctl get events --field-selector="reason=DependencySyncProbeFailed"
 
 ### An HTTP endpoint is not triggering updates
 
-If the HTTP endpoint does not return ETag or Last-Modified headers, the sync controller cannot actively detect changes. Changes are only detected passively when a device re-renders for another reason.
+If the HTTP endpoint does not return ETag or Last-Modified headers, changes are only detected passively when a device re-renders for another reason.
 
-To verify whether an endpoint supports conditional requests:
+To verify whether an endpoint supports active change detection:
 
 ```console
 curl -I <endpoint-url>
 ```
 
-Look for `ETag` or `Last-Modified` in the response headers.
+Look for `ETag` or `Last-Modified` in the response headers. If neither is present, consider configuring your HTTP server to return one of these headers for reliable active sync.
 
 ### A Kubernetes secret is not being tracked
 
@@ -212,7 +204,7 @@ Look for `ETag` or `Last-Modified` in the response headers.
    curl http://localhost:15690/metrics | grep flightctl_dependency_sync_informer_connected
    ```
 
-   A value of `1` indicates the informer is connected. A value of `0` indicates a disconnect. For more details on available metrics, see [Metrics Configuration](../references/metrics.md).
+   A value of `1` indicates the watcher is connected. A value of `0` indicates a disconnect. For more details on available metrics, see [Metrics Configuration](../references/metrics.md).
 
 ### Git authentication failures
 
@@ -226,6 +218,6 @@ Git probe failures are reported through `DependencySyncProbeFailed` events. Veri
 
 * **Credential reuse:** Auto-sync uses the same credentials configured on Repository resources. No additional secret storage is required.
 * **Error sanitization:** Error messages in events and logs have credential-like patterns (passwords, tokens, bearer values) automatically redacted.
-* **Secret informer scope:** The informer watches only secrets that are explicitly labeled with `flightctl.io/sync-<release-namespace>=true`. Unlabeled secrets are invisible.
-* **RBAC:** The informer requires an opt-in `ClusterRole` enabled through the `clusterLevelSecretAccess` Helm value. Without it, secret watching is disabled.
-* **In-cluster only:** The secret informer starts only when Kubernetes in-cluster configuration is available. Deployments outside a Kubernetes cluster do not attempt to watch secrets.
+* **Secret watching scope:** Only secrets explicitly labeled with `flightctl.io/sync-<release-namespace>=true` are monitored. Unlabeled secrets are invisible to Flight Control.
+* **RBAC:** Secret watching requires an opt-in `ClusterRole` enabled through the `clusterLevelSecretAccess` Helm value. Without it, secret change detection is disabled.
+* **In-cluster only:** Secret watching is available only when Flight Control runs inside a Kubernetes cluster. Deployments outside a cluster do not attempt to watch secrets.

--- a/docs/user/using/auto-syncing-dependencies.md
+++ b/docs/user/using/auto-syncing-dependencies.md
@@ -1,0 +1,231 @@
+# Auto-syncing external dependencies
+
+Flight Control automatically detects changes in external dependencies referenced by fleet and device templates — git repositories, HTTP endpoints, and Kubernetes secrets. When a change is detected, the service creates a new template version and rolls it out to affected devices, or re-renders standalone devices directly.
+
+## How auto-sync works
+
+Auto-sync is enabled by default for any fleet or device that references external configuration providers (git, HTTP, or Kubernetes secret). No opt-in is required.
+
+A component called the **Dependency Sync Controller** runs inside the `flightctl-periodic` service. It periodically checks each dependency for upstream changes by comparing the current state against a stored fingerprint. When the fingerprint changes, the controller emits a `DependencyChangeDetected` event on the affected fleet or device, which triggers the standard rollout pipeline.
+
+### What triggers a new template version
+
+For fleet-owned devices, a detected change creates a new template version named `v{generation}-{short-hash}`, where `short-hash` is the first 8 characters of the new fingerprint. The rollout policy then governs how the update reaches devices.
+
+For standalone devices (not owned by a fleet), a detected change triggers a direct re-render of the device specification without creating a template version.
+
+### Parameterized references
+
+Fleet templates can contain placeholders (for example, `{{ .metadata.labels.branch }}`) in fields such as git `targetRevision` or HTTP `suffix`. When a fleet references a parameterized field, the system resolves the concrete value per device during rollout and tracks each device's resolved dependency independently. Only devices whose specific resolved reference changed receive an update — the entire fleet is not re-rolled.
+
+## Detection mechanisms
+
+### Git repositories
+
+The controller uses `git ls-remote` to resolve the current commit SHA for each referenced branch or tag. If the SHA differs from the stored fingerprint, a change is detected.
+
+### HTTP endpoints
+
+The controller sends a conditional HEAD request using `If-None-Match` (for ETags) or `If-Modified-Since` headers:
+
+* If the endpoint responds with `304 Not Modified`, no change occurred.
+* If the endpoint responds with `200 OK` and a new ETag or Last-Modified value, a change is detected.
+* If the endpoint does not return ETag or Last-Modified headers, the probe skips active detection for that endpoint.
+
+> [!NOTE]
+> Endpoints that do not support conditional requests (no ETag or Last-Modified headers) cannot be actively monitored by the sync controller. However, the device render path always fetches the full response body and computes a `sha256` hash as the fingerprint. Changes to these endpoints are detected passively — the next time a device re-renders for any reason (for example, another dependency changes or the fleet template is updated), the new body hash is captured and reflected in the sync status.
+
+### Kubernetes secrets
+
+The controller uses a Kubernetes SharedInformer to watch labeled secrets in real time. This is push-based — there is no polling interval for secrets.
+
+To enable secret watching:
+
+1. Label each secret that Flight Control should watch:
+
+   ```console
+   kubectl label secret <secret-name> flightctl.io/sync-<release-namespace>=true
+   ```
+
+   Replace `<release-namespace>` with the namespace where Flight Control is deployed. For example, if Flight Control is deployed in the `flightctl` namespace:
+
+   ```console
+   kubectl label secret my-secret flightctl.io/sync-flightctl=true
+   ```
+
+2. Enable cluster-level secret access in your Helm values:
+
+   ```yaml
+   periodic:
+     clusterLevelSecretAccess: true
+   worker:
+     clusterLevelSecretAccess: true
+   ```
+
+The `periodic` setting enables the informer to watch secrets. The `worker` setting enables embedding secret data into device configurations during rendering.
+
+> [!IMPORTANT]
+> The secret informer starts only when `flightctl-periodic` runs inside a Kubernetes cluster. Out-of-cluster deployments (such as Podman/Quadlet) do not support secret watching.
+
+## Viewing sync status
+
+Each device reports the fingerprints of its external dependencies in its status. Inspect them with:
+
+```console
+flightctl get device <device-name> -o yaml
+```
+
+Under `.status.dependencySync.configRefs`, each entry shows:
+
+| Field | Description |
+| ----- | ----------- |
+| `configProviderName` | The name of the config provider from the device or fleet template. |
+| `fingerprint` | The fingerprint captured at render time. For git: the commit SHA. For HTTP: `sha256:<hash>` of the response body. For secrets: the Kubernetes `ResourceVersion`. |
+| `lastUpdatedAt` | The last time the fingerprint changed. Preserved across re-renders if the content has not changed. |
+
+Example output:
+
+```yaml
+status:
+  dependencySync:
+    configRefs:
+      - configProviderName: app-config
+        fingerprint: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        lastUpdatedAt: "2026-05-18T10:30:00Z"
+      - configProviderName: tls-certs
+        fingerprint: "48291"
+        lastUpdatedAt: "2026-05-17T08:15:00Z"
+```
+
+> [!NOTE]
+> Only config providers that reference external dependencies (git, HTTP, or Kubernetes secret) produce `dependencySync` entries. Inline configuration providers do not appear.
+
+## Configuring the polling interval
+
+Git and HTTP dependencies are checked at a configurable global polling interval. The default is 15 minutes.
+
+**For Helm deployments**, the polling interval is set in the service configuration that gets mounted into the `flightctl-periodic` pod. Edit the `periodic` section of the Helm-generated ConfigMap (typically `flightctl-periodic-config`) or add the setting to your values override that populates `service-config.yaml`:
+
+```yaml
+dependenciesSync:
+  pollInterval: 15m
+```
+
+**For Podman (Quadlet) deployments**, edit `/etc/flightctl/service-config.yaml`:
+
+```yaml
+dependenciesSync:
+  pollInterval: 15m
+```
+
+The polling interval does not affect Kubernetes secrets, which use a push-based watch.
+
+> [!NOTE]
+> The sync task runs on a fixed internal interval (every 3 minutes, not user-configurable) to discover newly added dependencies and retry partial failures. The `pollInterval` controls how long each individual dependency must wait since its last successful probe before being checked again.
+
+## Events
+
+Auto-sync emits two event types. View them with:
+
+```console
+flightctl get events --field-selector="reason=DependencyChangeDetected"
+flightctl get events --field-selector="reason=DependencySyncProbeFailed"
+```
+
+### DependencyChangeDetected
+
+* **Type:** Normal
+* **Involved object:** Fleet or Device (depending on ownership)
+* **Meaning:** An external dependency fingerprint changed. For fleets, this triggers a new template version. For standalone devices, this triggers a re-render.
+* **Event details:**
+  * `resourceKey` — the dependency identifier (for example, `git:my-repo/main` or `http:my-config/api/v1/config`)
+  * `fingerprint` — the new fingerprint value
+
+### DependencySyncProbeFailed
+
+* **Type:** Warning
+* **Involved object:** Fleet or Device
+* **Meaning:** A probe failed while checking a dependency. The stored fingerprint is not updated and no rollout is triggered.
+* **Event details:**
+  * `resourceKey` — the dependency that failed
+  * `errorMessage` — a sanitized description of the error (credentials are automatically redacted)
+
+## Troubleshooting
+
+### A device does not pick up upstream changes
+
+1. Verify the device has external dependencies:
+
+   ```console
+   flightctl get device <device-name> -o yaml
+   ```
+
+   Check that `.status.dependencySync.configRefs` contains entries.
+
+2. Check for probe failure events:
+
+   ```console
+   flightctl get events --field-selector="reason=DependencySyncProbeFailed,involvedObject.name=<fleet-or-device-name>"
+   ```
+
+3. Verify the repository is accessible:
+
+   ```console
+   flightctl get repository <repo-name>
+   ```
+
+   Confirm that the `ACCESSIBLE` status is `True`.
+
+### An HTTP endpoint is not triggering updates
+
+If the HTTP endpoint does not return ETag or Last-Modified headers, the sync controller cannot actively detect changes. Changes are only detected passively when a device re-renders for another reason.
+
+To verify whether an endpoint supports conditional requests:
+
+```console
+curl -I <endpoint-url>
+```
+
+Look for `ETag` or `Last-Modified` in the response headers.
+
+### A Kubernetes secret is not being tracked
+
+1. Verify the secret has the correct label:
+
+   ```console
+   kubectl get secret <secret-name> -n <namespace> --show-labels
+   ```
+
+   The secret must have the label `flightctl.io/sync-<release-namespace>=true`.
+
+2. Verify that `clusterLevelSecretAccess` is enabled for the periodic service.
+
+3. Check the informer health metric. For Helm deployments, forward the periodic metrics port first:
+
+   ```console
+   kubectl port-forward svc/flightctl-periodic-metrics 15690:15690
+   ```
+
+   Then query the metric:
+
+   ```console
+   curl http://localhost:15690/metrics | grep flightctl_dependency_sync_informer_connected
+   ```
+
+   A value of `1` indicates the informer is connected. A value of `0` indicates a disconnect. For more details on available metrics, see [Metrics Configuration](../references/metrics.md).
+
+### Git authentication failures
+
+Git probe failures are reported through `DependencySyncProbeFailed` events. Verify that:
+
+* The repository resource has valid credentials configured.
+* The repository is reachable from the `flightctl-periodic` service.
+* The target branch or tag exists in the remote repository.
+
+## Security considerations
+
+* **Credential reuse:** Auto-sync uses the same credentials configured on Repository resources. No additional secret storage is required.
+* **Error sanitization:** Error messages in events and logs have credential-like patterns (passwords, tokens, bearer values) automatically redacted.
+* **Secret informer scope:** The informer watches only secrets that are explicitly labeled with `flightctl.io/sync-<release-namespace>=true`. Unlabeled secrets are invisible.
+* **RBAC:** The informer requires an opt-in `ClusterRole` enabled through the `clusterLevelSecretAccess` Helm value. Without it, secret watching is disabled.
+* **In-cluster only:** The secret informer starts only when Kubernetes in-cluster configuration is available. Deployments outside a Kubernetes cluster do not attempt to watch secrets.

--- a/docs/user/using/auto-syncing-dependencies.md
+++ b/docs/user/using/auto-syncing-dependencies.md
@@ -1,10 +1,10 @@
 # Auto-syncing external dependencies
 
-Flight Control automatically monitors external configuration references (git repositories, HTTP endpoints, and Kubernetes secrets) for changes. When a referenced dependency changes upstream, affected devices are updated automatically through the standard rollout pipeline.
+Flight Control can detect changes in external configuration references — git repositories, HTTP endpoints, and Kubernetes secrets — and automatically roll out updates to affected devices when an upstream change occurs.
 
 ## How auto-sync works
 
-Any fleet or device that references an external config provider is automatically monitored for upstream changes. When a change is detected, fleet-owned devices receive a new template version and the rollout policy governs how the update reaches them. Standalone devices (not owned by a fleet) are re-rendered directly.
+When Flight Control detects an upstream change in an external config provider, fleet-owned devices receive a new template version and the rollout policy governs how the update reaches them. Standalone devices (not owned by a fleet) are re-rendered directly. The detection mechanism varies by source type — see [Setting up auto-sync for each source type](#setting-up-auto-sync-for-each-source-type) for details.
 
 Fleet templates can contain placeholders (for example, `{{ .metadata.labels.branch }}`) in fields such as git `targetRevision` or HTTP `suffix`. When placeholders are used, each device's resolved reference is tracked independently — only devices whose specific dependency changed receive an update.
 
@@ -16,7 +16,7 @@ Git-based config providers are monitored automatically. No additional setup is r
 
 ### HTTP endpoints
 
-HTTP config providers are monitored automatically. For best results, use an endpoint that returns **ETag** or **Last-Modified** response headers — this enables efficient change detection without downloading the full response body each cycle.
+Active change detection for HTTP config providers requires the endpoint to return **ETag** or **Last-Modified** response headers. When these headers are present, Flight Control probes the endpoint at each polling interval and triggers a rollout when a change is detected.
 
 To verify whether your endpoint supports these headers:
 
@@ -27,7 +27,7 @@ curl -I <endpoint-url>
 Look for `ETag` or `Last-Modified` in the response headers.
 
 > [!NOTE]
-> If the endpoint does not return ETag or Last-Modified headers, changes are still detected, but only passively — the next time the device re-renders for any reason (for example, another dependency changes or the fleet template is updated), the new content is picked up and reflected in the sync status.
+> Endpoints that do not return ETag or Last-Modified headers are **not actively monitored**. Changes to these endpoints are only detected passively — the next time a device re-renders for another reason (for example, a different dependency changes or the fleet template is updated), the full body is fetched, a `sha256` hash is computed, and the new fingerprint is reflected in the device's sync status.
 
 ### Kubernetes secrets
 
@@ -94,7 +94,7 @@ status:
 
 ## Configuring the polling interval
 
-Git and HTTP dependencies are checked at a configurable global polling interval. The default is 15 minutes.
+Git repositories and HTTP endpoints that support ETag or Last-Modified are checked at a configurable global polling interval. The default is 15 minutes.
 
 **For Helm deployments**, the polling interval is set in the service configuration that gets mounted into the `flightctl-periodic` pod. Edit the `periodic` section of the Helm-generated ConfigMap (typically `flightctl-periodic-config`) or add the setting to your values override that populates `service-config.yaml`:
 

--- a/docs/user/using/managing-fleets.md
+++ b/docs/user/using/managing-fleets.md
@@ -119,7 +119,8 @@ The following fields in device templates support placeholders (including within 
 
 In addition to the templating mechanism, you can also reference Kubernetes secrets in your device templates. This is useful for injecting sensitive information like passwords or certificates into your devices.
 
-Note: When a Kubernetes secret referenced in a device template changes, a new template version is not created immediately. Instead, the secret change will be included in the next template version that gets created when you update the fleet's device template.
+> [!NOTE]
+> When a Kubernetes secret referenced in a device template changes and auto-sync is configured (the secret is labeled for watching and `clusterLevelSecretAccess` is enabled), a new template version is created automatically. See [Auto-syncing External Dependencies](auto-syncing-dependencies.md) for setup details. If auto-sync is not configured for the secret, the change is picked up the next time a template version is created for another reason (for example, a fleet template update).
 
 To use a Kubernetes secret, you can use the `secretRef` field in your device template. The `secretRef` field has the following subfields:
 
@@ -221,6 +222,10 @@ Note: Both the Role/ClusterRole and its corresponding RoleBinding/ClusterRoleBin
 
 * **Minimize Permissions**: The `ClusterRole` example above grants permission to read secrets in *all* namespaces. If you only need access to a few specific namespaces, it is more secure to create a `Role` and `RoleBinding` in each of those namespaces.
 * **Service Account Namespace**: The service account must be specified with the namespace where it is deployed (`<flightctl-namespace>`). This service account can then be granted permissions in other namespaces via `RoleBinding` or across the cluster via `ClusterRoleBinding`.
+
+### Auto-syncing external dependencies
+
+Flight Control can automatically detect changes in referenced git repositories, HTTP endpoints, and Kubernetes secrets and create new template versions without manual intervention. For details on configuration, secret labeling, and troubleshooting, see [Auto-syncing External Dependencies](auto-syncing-dependencies.md).
 
 ## Defining Rollout Policies
 


### PR DESCRIPTION
## Summary

- Adds new user documentation page `docs/user/using/auto-syncing-dependencies.md` covering how Flight Control automatically detects and applies upstream changes to git, HTTP, and Kubernetes secret dependencies
- Updates `docs/user/references/events.md` with new dependency sync event types
- Fixes stale statement in `docs/user/using/managing-fleets.md` about secret change behavior (now reflects auto-sync)
- Adds link in `docs/user/README.md`

## What's documented

- Auto-sync overview and detection mechanisms (git ls-remote, HTTP conditional HEAD, K8s SharedInformer)
- Polling interval configuration (`dependenciesSync.pollInterval` in service-config.yaml)
- Secret labeling requirements (`flightctl.io/sync-<releaseNamespace>=true`)
- Device-level sync status (`device.status.dependencySync.configRefs[]`)
- Events: `DependencyChangeDetected` and `DependencySyncProbeFailed`
- Parameterized reference handling (per-device tracking)
- Troubleshooting guide (HTTP conditional support, git auth, informer disconnect, missing labels)
- Security considerations (credential reuse, error sanitization, RBAC)

## Test plan

- [x] `make lint-docs` passes (0 errors across 56 files)
- [x] `make spellcheck-docs` passes (0 spelling errors across 56 files)
- [ ] Manual review of content accuracy against implementation