### PR TITLE
EDM-3984: Fleet-owned devices never re-render after dependency sync change

### DIFF
--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -1110,25 +1110,6 @@ func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name,
 		return false, "", nil
 	}
 
-	// Spec unchanged but fingerprints provided (dependency-change-triggered render):
-	// only update service_conditions with new fingerprints, skip the full re-render.
-	if specUnchanged {
-		if updatedServiceConditions != nil {
-			result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-				"service_conditions": updatedServiceConditions,
-				"resource_version":   gorm.Expr("resource_version + 1"),
-			})
-			err = ErrorFromGormError(result.Error)
-			if err != nil {
-				return strings.Contains(err.Error(), "deadlock"), "", err
-			}
-			if result.RowsAffected == 0 {
-				return true, "", flterrors.ErrNoRowsUpdated
-			}
-		}
-		return false, "", nil
-	}
-
 	existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] = hash
 
 	renderedApplicationsJSON := renderedApplications

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -111,9 +111,13 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		}
 
 		// Don't render if the device spec hash hasn't changed since the last render.
-		// Bypass for DependencyChangeDetected: standalone devices need to re-render
+		// Bypass for DependencyChangeDetected (standalone devices) and
+		// FleetRolloutDeviceSelected (fleet-owned devices): both need to re-render
 		// when external dependencies change even though the device spec is unchanged.
-		if t.event.Reason != domain.EventReasonDependencyChangeDetected {
+		// fleet-owned devices receive FleetRolloutDeviceSelected (not
+		// DependencyChangeDetected) after dependency sync triggers a new template version.
+		if t.event.Reason != domain.EventReasonDependencyChangeDetected &&
+			t.event.Reason != domain.EventReasonFleetRolloutDeviceSelected {
 			if val, ok := annotations[domain.DeviceAnnotationRenderedSpecHash]; ok {
 				if val == specHash {
 					t.log.Infof("Device %s spec hash hasn't changed since the last render", t.event.InvolvedObject.Name)

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -728,4 +728,116 @@ var _ = Describe("DeviceRender", func() {
 			}
 		})
 	})
+
+	Context("spec-hash bypass for fleet rollout events", func() {
+		// The spec-hash optimization at device_render.go:116 fires before config
+		// rendering begins, so it blocks ALL config provider types (git, HTTP, and
+		// K8s secrets) equally. We use K8s secrets here because mockK8sClient is
+		// available without needing external infrastructure.
+		It("When a fleet-owned device receives FleetRolloutDeviceSelected after initial render it should re-render", func() {
+			k8sConfig := &api.KubernetesSecretProviderSpec{Name: "fleet-secret"}
+			k8sConfig.SecretRef.Name = "my-secret"
+			k8sConfig.SecretRef.Namespace = "default"
+			k8sConfig.SecretRef.MountPath = "/etc/secrets"
+
+			configProvider := api.ConfigProviderSpec{}
+			err := configProvider.FromKubernetesSecretProviderSpec(*k8sConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleet := &api.Fleet{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(fleetName)},
+				Spec: api.FleetSpec{
+					Selector: &api.LabelSelector{MatchLabels: &map[string]string{"fleet": fleetName}},
+					Template: struct {
+						Metadata *api.ObjectMeta `json:"metadata,omitempty"`
+						Spec     api.DeviceSpec  `json:"spec"`
+					}{
+						Spec: api.DeviceSpec{Config: &[]api.ConfigProviderSpec{configProvider}},
+					},
+				},
+			}
+			_, err = fleetStore.Create(ctx, orgId, fleet, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			tvStatus := api.TemplateVersionStatus{Config: &[]api.ConfigProviderSpec{configProvider}}
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "v1", &tvStatus)
+			Expect(err).ToNot(HaveOccurred())
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "v1-abc12345", &tvStatus)
+			Expect(err).ToNot(HaveOccurred())
+
+			testDeviceName := deviceName + "-fleet-rollout-" + uuid.New().String()[:8]
+			device := &api.Device{
+				Metadata: api.ObjectMeta{
+					Name:  lo.ToPtr(testDeviceName),
+					Owner: lo.ToPtr("Fleet/" + fleetName),
+				},
+				Spec: &api.DeviceSpec{Config: &[]api.ConfigProviderSpec{configProvider}},
+			}
+			_, err = deviceStore.Create(ctx, orgId, device, nil)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _, _ = deviceStore.Delete(ctx, orgId, testDeviceName, nil) }()
+
+			// First render: ResourceCreated — should succeed (no hash stored yet)
+			firstEvent := api.Event{
+				Reason:         api.EventReasonResourceCreated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
+			}
+			annotations := map[string]string{
+				api.DeviceAnnotationTemplateVersion: "v1",
+			}
+			status := serviceHandler.UpdateDeviceAnnotations(ctx, orgId, testDeviceName, annotations, nil)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			logic := tasks.NewDeviceRenderLogic(log, serviceHandler, &mockK8sClient{}, kvStoreInst, nil, orgId, firstEvent)
+			err = logic.RenderDevice(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify renderedVersion was set (render completed)
+			device, err = deviceStore.Get(ctx, orgId, testDeviceName)
+			Expect(err).ToNot(HaveOccurred())
+			firstRenderedVersion := ""
+			if device.Metadata.Annotations != nil {
+				firstRenderedVersion = (*device.Metadata.Annotations)[api.DeviceAnnotationRenderedVersion]
+			}
+			Expect(firstRenderedVersion).To(Equal("1"), "First render should set renderedVersion to 1")
+
+			// Verify the spec hash is now stored
+			specHash := (*device.Metadata.Annotations)[api.DeviceAnnotationRenderedSpecHash]
+			Expect(specHash).ToNot(BeEmpty(), "Spec hash should be stored after first render")
+
+			// Simulate dependency-change rollout: update templateVersion annotation
+			// to a new version (as fleet_rollout.go would do)
+			annotations = map[string]string{
+				api.DeviceAnnotationTemplateVersion: "v1-abc12345",
+			}
+			status = serviceHandler.UpdateDeviceAnnotations(ctx, orgId, testDeviceName, annotations, nil)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			// Second render: FleetRolloutDeviceSelected — previously skipped because
+			// the spec hash hadn't changed and the bypass only covered
+			// DependencyChangeDetected.
+			secondEvent := api.Event{
+				Reason:         api.EventReasonFleetRolloutDeviceSelected,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
+			}
+			logic = tasks.NewDeviceRenderLogic(log, serviceHandler, &mockK8sClient{}, kvStoreInst, nil, orgId, secondEvent)
+			err = logic.RenderDevice(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify rendering proceeded by checking that dependencySync fingerprints
+			// were written for the new template version. If the render was skipped
+			// (the bug), no fingerprints would be stored.
+			device, err = deviceStore.Get(ctx, orgId, testDeviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(device.Status).ToNot(BeNil())
+			Expect(device.Status.DependencySync).ToNot(BeNil(),
+				"Fleet-owned device should re-render on FleetRolloutDeviceSelected even when spec hash is unchanged")
+			Expect(device.Status.DependencySync.ConfigRefs).ToNot(BeNil())
+			Expect(len(*device.Status.DependencySync.ConfigRefs)).To(Equal(1))
+			ref := (*device.Status.DependencySync.ConfigRefs)[0]
+			Expect(ref.ConfigProviderName).To(Equal("fleet-secret"))
+			Expect(ref.Fingerprint).ToNot(BeNil())
+			Expect(*ref.Fingerprint).To(Equal("42"))
+		})
+	})
 })

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -824,14 +824,20 @@ var _ = Describe("DeviceRender", func() {
 			err = logic.RenderDevice(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify rendering proceeded by checking that dependencySync fingerprints
-			// were written for the new template version. If the render was skipped
-			// (the bug), no fingerprints would be stored.
+			// Verify rendering proceeded: renderedVersion should bump to "2" and
+			// dependencySync fingerprints should be written.
 			device, err = deviceStore.Get(ctx, orgId, testDeviceName)
 			Expect(err).ToNot(HaveOccurred())
+
+			secondRenderedVersion := ""
+			if device.Metadata.Annotations != nil {
+				secondRenderedVersion = (*device.Metadata.Annotations)[api.DeviceAnnotationRenderedVersion]
+			}
+			Expect(secondRenderedVersion).To(Equal("2"),
+				"Fleet-owned device should bump renderedVersion on FleetRolloutDeviceSelected even when spec hash is unchanged")
+
 			Expect(device.Status).ToNot(BeNil())
-			Expect(device.Status.DependencySync).ToNot(BeNil(),
-				"Fleet-owned device should re-render on FleetRolloutDeviceSelected even when spec hash is unchanged")
+			Expect(device.Status.DependencySync).ToNot(BeNil())
 			Expect(device.Status.DependencySync.ConfigRefs).ToNot(BeNil())
 			Expect(len(*device.Status.DependencySync.ConfigRefs)).To(Equal(1))
 			ref := (*device.Status.DependencySync.ConfigRefs)[0]


### PR DESCRIPTION
## Problem

Fleet-owned devices did not re-render their configuration after a dependency sync (git repo change, secret rotation, etc.) triggered a new template version rollout. The device appeared stuck on stale configuration until a manual spec change forced a re-render.

## Root Cause

Two issues prevented fleet-owned devices from updating after a dependency change:

1. **Spec-hash bypass** (`internal/tasks/device_render.go`): The spec-hash optimization short-circuits rendering when the device spec hash hasn't changed. This bypass only applied to `DependencyChangeDetected` events (standalone devices). Fleet-owned devices receive `FleetRolloutDeviceSelected` events — this event was not bypassed, causing the optimization to skip the re-render.

2. **Store fast-path** (`internal/store/device.go`): The `updateRendered` function had a `specUnchanged` fast-path that only updated `service_conditions` (fingerprints) without updating `rendered_config` or bumping `renderedVersion`. Even after bypassing the spec-hash check, the rendered content was never persisted and the agent never saw a new version to consume.

## Fix

1. Add `FleetRolloutDeviceSelected` to the spec-hash bypass condition alongside `DependencyChangeDetected`. Both event types indicate that external dependencies changed and the device must re-render regardless of spec hash.

2. Remove the `specUnchanged` fast-path in `updateRendered` so that dependency-change-triggered renders always persist the full rendered state, ensuring `renderedVersion` increments and the agent picks up the new configuration.

## Testing

- Added integration test in `test/integration/tasks/device_render_test.go` that:
  1. Creates a fleet-owned device with a K8s secret config provider
  2. Performs an initial render (ResourceCreated) — verifies spec hash is stored
  3. Simulates a dependency-change rollout by updating the template version annotation
  4. Triggers a second render with `FleetRolloutDeviceSelected`
  5. Asserts that `renderedVersion` bumps to "2" (proving the full update path ran)
  6. Asserts that `dependencySync.ConfigRefs` fingerprints are populated
- Test fails without either fix, passes with both