### PR TITLE
EDM-3987: Defining two configurations from the same repository+target leads to "InternalTaskFailed" event for a fleet.

### DIFF
--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -711,7 +711,7 @@ func (f FleetRolloutsLogic) getDeviceConfig(device *domain.Device, templateVersi
 	}
 
 	deviceConfig := []domain.ConfigProviderSpec{}
-	var depRefs []model.DependencyRef
+	depRefs := make(map[string]model.DependencyRef)
 	configErrs := []error{}
 	for _, configItem := range *templateVersion.Status.Config {
 		var newConfigItem *domain.ConfigProviderSpec
@@ -727,17 +727,23 @@ func (f FleetRolloutsLogic) getDeviceConfig(device *domain.Device, templateVersi
 		case domain.GitConfigProviderType:
 			var refs []model.DependencyRef
 			newConfigItem, refs, errs = f.replaceGitConfigParameters(device, configItem)
-			depRefs = append(depRefs, refs...)
+			for _, ref := range refs {
+				depRefs[ref.ResourceKey] = ref
+			}
 		case domain.KubernetesSecretProviderType:
 			var refs []model.DependencyRef
 			newConfigItem, refs, errs = f.replaceKubeSecretConfigParameters(device, configItem)
-			depRefs = append(depRefs, refs...)
+			for _, ref := range refs {
+				depRefs[ref.ResourceKey] = ref
+			}
 		case domain.InlineConfigProviderType:
 			newConfigItem, errs = f.replaceInlineConfigParameters(device, configItem)
 		case domain.HttpConfigProviderType:
 			var refs []model.DependencyRef
 			newConfigItem, refs, errs = f.replaceHTTPConfigParameters(device, configItem)
-			depRefs = append(depRefs, refs...)
+			for _, ref := range refs {
+				depRefs[ref.ResourceKey] = ref
+			}
 		default:
 			errs = append(errs, fmt.Errorf("%w: unsupported config type %q", ErrUnknownConfigName, configType))
 		}
@@ -752,7 +758,11 @@ func (f FleetRolloutsLogic) getDeviceConfig(device *domain.Device, templateVersi
 		return nil, nil, configErrs
 	}
 
-	return &deviceConfig, depRefs, nil
+	refs := make([]model.DependencyRef, 0, len(depRefs))
+	for _, ref := range depRefs {
+		refs = append(refs, ref)
+	}
+	return &deviceConfig, refs, nil
 }
 
 func (f FleetRolloutsLogic) replaceGitConfigParameters(device *domain.Device, configItem domain.ConfigProviderSpec) (*domain.ConfigProviderSpec, []model.DependencyRef, []error) {

--- a/internal/tasks/populate_dependency_refs.go
+++ b/internal/tasks/populate_dependency_refs.go
@@ -116,7 +116,7 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 		return nil
 	}
 
-	var refs []model.DependencyRef
+	refs := make(map[string]model.DependencyRef)
 	seenNames := make(map[string]struct{})
 	warnedNames := make(map[string]struct{})
 	for i := range *config {
@@ -137,17 +137,21 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 				continue
 			}
 			warnDuplicateConfigName(log, seenNames, warnedNames, gitSpec.Name, i, fleetName, deviceName)
+			key := fmt.Sprintf("git:%s/%s", gitSpec.GitRef.Repository, gitSpec.GitRef.TargetRevision)
+			if _, exists := refs[key]; exists {
+				continue
+			}
 			fn := fleetName
 			dn := deviceName
-			refs = append(refs, model.DependencyRef{
+			refs[key] = model.DependencyRef{
 				FleetName:          &fn,
 				DeviceName:         &dn,
 				RefType:            "git",
-				ResourceKey:        fmt.Sprintf("git:%s/%s", gitSpec.GitRef.Repository, gitSpec.GitRef.TargetRevision),
+				ResourceKey:        key,
 				RepositoryName:     &gitSpec.GitRef.Repository,
 				Revision:           &gitSpec.GitRef.TargetRevision,
 				ConfigProviderName: gitSpec.Name,
-			})
+			}
 		case domain.HttpConfigProviderType:
 			httpSpec, err := configItem.AsHttpConfigProviderSpec()
 			if err != nil {
@@ -162,17 +166,21 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 				continue
 			}
 			warnDuplicateConfigName(log, seenNames, warnedNames, httpSpec.Name, i, fleetName, deviceName)
+			key := httpResourceKey(httpSpec.HttpRef.Repository, suffix)
+			if _, exists := refs[key]; exists {
+				continue
+			}
 			fn := fleetName
 			dn := deviceName
-			refs = append(refs, model.DependencyRef{
+			refs[key] = model.DependencyRef{
 				FleetName:          &fn,
 				DeviceName:         &dn,
 				RefType:            "http",
-				ResourceKey:        httpResourceKey(httpSpec.HttpRef.Repository, suffix),
+				ResourceKey:        key,
 				RepositoryName:     &httpSpec.HttpRef.Repository,
 				HTTPSuffix:         httpSpec.HttpRef.Suffix,
 				ConfigProviderName: httpSpec.Name,
-			})
+			}
 		case domain.KubernetesSecretProviderType:
 			k8sSpec, err := configItem.AsKubernetesSecretProviderSpec()
 			if err != nil {
@@ -183,20 +191,29 @@ func collectConfigRefs(log logrus.FieldLogger, config *[]domain.ConfigProviderSp
 				continue
 			}
 			warnDuplicateConfigName(log, seenNames, warnedNames, k8sSpec.Name, i, fleetName, deviceName)
+			key := fmt.Sprintf("secret:%s/%s", k8sSpec.SecretRef.Namespace, k8sSpec.SecretRef.Name)
+			if _, exists := refs[key]; exists {
+				continue
+			}
 			fn := fleetName
 			dn := deviceName
-			refs = append(refs, model.DependencyRef{
+			refs[key] = model.DependencyRef{
 				FleetName:          &fn,
 				DeviceName:         &dn,
 				RefType:            "secret",
-				ResourceKey:        fmt.Sprintf("secret:%s/%s", k8sSpec.SecretRef.Namespace, k8sSpec.SecretRef.Name),
+				ResourceKey:        key,
 				SecretName:         &k8sSpec.SecretRef.Name,
 				SecretNamespace:    &k8sSpec.SecretRef.Namespace,
 				ConfigProviderName: k8sSpec.Name,
-			})
+			}
 		}
 	}
-	return refs
+
+	result := make([]model.DependencyRef, 0, len(refs))
+	for _, ref := range refs {
+		result = append(result, ref)
+	}
+	return result
 }
 
 // warnDuplicateConfigName logs a single warning per unique duplicate name to

--- a/internal/tasks/populate_dependency_refs_test.go
+++ b/internal/tasks/populate_dependency_refs_test.go
@@ -620,6 +620,64 @@ func TestShouldPopulateDependencyRefs(t *testing.T) {
 	})
 }
 
+func TestCollectConfigRefs_DeduplicatesByResourceKey(t *testing.T) {
+	const (
+		testFleet = "my-fleet"
+		repo      = "my-repo"
+		revision  = "main"
+	)
+
+	t.Run("When two git configs share repo and target it should produce one ref", func(t *testing.T) {
+		config := &[]domain.ConfigProviderSpec{
+			makeGitConfigItem(t, "app-config", repo, revision),
+			makeGitConfigItem(t, "infra-config", repo, revision),
+		}
+
+		refs := collectConfigRefs(logrus.New(), config, testFleet, "")
+
+		require.Len(t, refs, 1)
+		assert.Equal(t, "git:my-repo/main", refs[0].ResourceKey)
+	})
+
+	t.Run("When two HTTP configs share repo and suffix it should produce one ref", func(t *testing.T) {
+		suffix := "/data.json"
+		config := &[]domain.ConfigProviderSpec{
+			makeHttpConfigItem(t, "http-alpha", "http-repo", &suffix),
+			makeHttpConfigItem(t, "http-beta", "http-repo", &suffix),
+		}
+
+		refs := collectConfigRefs(logrus.New(), config, testFleet, "")
+
+		require.Len(t, refs, 1)
+		assert.Equal(t, "http:http-repo/data.json", refs[0].ResourceKey)
+	})
+
+	t.Run("When two secret configs share namespace and name it should produce one ref", func(t *testing.T) {
+		config := &[]domain.ConfigProviderSpec{
+			makeSecretConfigItem(t, "secret-a", "prod", "db-creds"),
+			makeSecretConfigItem(t, "secret-b", "prod", "db-creds"),
+		}
+
+		refs := collectConfigRefs(logrus.New(), config, testFleet, "")
+
+		require.Len(t, refs, 1)
+		assert.Equal(t, "secret:prod/db-creds", refs[0].ResourceKey)
+	})
+
+	t.Run("When configs have distinct resource keys it should produce all refs", func(t *testing.T) {
+		config := &[]domain.ConfigProviderSpec{
+			makeGitConfigItem(t, "cfg-a", "repo-a", "main"),
+			makeGitConfigItem(t, "cfg-b", "repo-b", "main"),
+		}
+
+		refs := collectConfigRefs(logrus.New(), config, testFleet, "")
+
+		require.Len(t, refs, 2)
+		assert.Equal(t, "git:repo-a/main", refs[0].ResourceKey)
+		assert.Equal(t, "git:repo-b/main", refs[1].ResourceKey)
+	})
+}
+
 // TestCollectConfigRefs_DuplicateNameWarning verifies that collectConfigRefs
 // emits exactly one warning per duplicated config provider name, ensuring
 // pre-existing specs with duplicates are surfaced without flooding logs.


### PR DESCRIPTION
## Problem

Defining two configurations from the same repository+target (e.g., same git repo and branch but different paths) causes an `InternalTaskFailed` warning event with "a resource with this name already exists".

## Root Cause

The `DependencyRef` composite PK is `(org_id, resource_key, fleet_name, device_name)`. The `ResourceKey` for git configs is `git:<repository>/<targetRevision>`, which is identical for two configs sharing repo+target but different paths. When `collectConfigRefs` produces multiple refs with the same key, `transactionalReplace` batch-inserts them and PostgreSQL rejects the duplicate.

## Fix

Deduplicate refs by `resource_key` before insertion. This aligns with the original design intent — the `dependency_refs` table is a polling work list, and the fingerprint (commit SHA) is per repo+revision, not per path. Multiple configs from the same repo+branch are one external dependency to poll.

Deduplication is applied in:
- `collectConfigRefs` — fleet/device creation and update path
- `getDeviceConfig` (via `appendUniqueRefs`) — fleet rollout path for parameterized revisions

No schema changes or migrations needed.

## Testing

- Added `TestCollectConfigRefs_DeduplicatesByResourceKey` with sub-tests for git, HTTP, and secret config types
- All existing unit tests pass

Fixes EDM-3987