### PR TITLE
EDM-3986: Fix incomplete message in DeviceOSImageChanged event

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -343,9 +343,15 @@ func ComputeDeviceStatusChanges(ctx context.Context, oldDevice, newDevice *domai
 	oldDigest := getOSImageDigest(oldDevice)
 	newDigest := getOSImageDigest(newDevice)
 	if oldDigest != newDigest && newDigest != "" {
+		var details string
+		if oldDigest == "" {
+			details = fmt.Sprintf("Initial OS image detected: %s", newDigest)
+		} else {
+			details = fmt.Sprintf("OS image changed from %s to %s", oldDigest, newDigest)
+		}
 		resourceUpdates = append(resourceUpdates, ResourceUpdate{
 			Reason:  domain.EventReasonDeviceOSImageChanged,
-			Details: fmt.Sprintf("OS image changed from %s to %s", oldDigest, newDigest),
+			Details: details,
 		})
 	}
 

--- a/internal/service/common/device_test.go
+++ b/internal/service/common/device_test.go
@@ -76,6 +76,79 @@ func TestComputeDeviceStatusChanges_DeviceUpdateFailed(t *testing.T) {
 	assert.Contains(t, updates[0].Details, "has not been updated")
 }
 
+func TestComputeDeviceStatusChanges_OSImageChanged_EDM3986(t *testing.T) {
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	tests := []struct {
+		name            string
+		oldDigest       string
+		newDigest       string
+		expectEvent     bool
+		expectedDetails string
+	}{
+		{
+			name:            "When initial OS image is reported it should emit event with 'Initial OS image detected' message",
+			oldDigest:       "",
+			newDigest:       "sha256:abc123",
+			expectEvent:     true,
+			expectedDetails: "Initial OS image detected: sha256:abc123",
+		},
+		{
+			name:            "When OS image changes it should emit event with from/to message",
+			oldDigest:       "sha256:old111",
+			newDigest:       "sha256:new222",
+			expectEvent:     true,
+			expectedDetails: "OS image changed from sha256:old111 to sha256:new222",
+		},
+		{
+			name:        "When OS image is unchanged it should not emit event",
+			oldDigest:   "sha256:same",
+			newDigest:   "sha256:same",
+			expectEvent: false,
+		},
+		{
+			name:        "When new digest is empty it should not emit event",
+			oldDigest:   "sha256:old",
+			newDigest:   "",
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldDevice := &domain.Device{
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr("test-device")},
+				Status: &domain.DeviceStatus{
+					Os: domain.DeviceOsStatus{ImageDigest: tt.oldDigest},
+				},
+			}
+			newDevice := &domain.Device{
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr("test-device")},
+				Status: &domain.DeviceStatus{
+					Os: domain.DeviceOsStatus{ImageDigest: tt.newDigest},
+				},
+			}
+
+			updates := ComputeDeviceStatusChanges(ctx, oldDevice, newDevice, orgId, nil)
+
+			var osImageEvents []ResourceUpdate
+			for _, u := range updates {
+				if u.Reason == domain.EventReasonDeviceOSImageChanged {
+					osImageEvents = append(osImageEvents, u)
+				}
+			}
+
+			if tt.expectEvent {
+				assert.Len(t, osImageEvents, 1)
+				assert.Equal(t, tt.expectedDetails, osImageEvents[0].Details)
+			} else {
+				assert.Empty(t, osImageEvents)
+			}
+		})
+	}
+}
+
 func TestComputeDeviceStatusChanges_StatusTransition(t *testing.T) {
 	ctx := context.Background()
 	orgId := uuid.New()


### PR DESCRIPTION
## Problem

When a device first reports its OS image after enrollment, the `DeviceOSImageChanged` event message reads "OS image changed from  to sha256:..." — the empty "from" field is confusing for operators querying events.

## Root Cause

`ComputeDeviceStatusChanges` emits the event whenever `oldDigest != newDigest && newDigest != ""`. For a newly enrolled device, `oldDigest` is `""` (no prior image), so the format string produces a blank "from" value.

## Fix

Add a conditional: when `oldDigest == ""`, emit `"Initial OS image detected: <digest>"` instead. The event is still emitted (required by CVE lifecycle processing in `vulnerability_sync.go`) — only the message text is fixed.

## Testing

- Added `TestComputeDeviceStatusChanges_OSImageChanged_EDM3986` with 4 table-driven sub-tests covering: initial image, image change, no change, empty new digest
- All existing unit tests pass