### PR TITLE
EDM-3988: Fix cert rotation flakiness

### DIFF
--- a/test/e2e/certificate_rotation/certificate_rotation_test.go
+++ b/test/e2e/certificate_rotation/certificate_rotation_test.go
@@ -353,33 +353,30 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 		})
 
 		It("should handle renewal with intermittent network disruption", Label("87911"), func() {
-			By("Verifying metrics endpoint is accessible")
-			Eventually(func() error {
-				_, err := harness.GetAgentMetrics()
-				return err
-			}, e2e.TIMEOUT, e2e.POLLINGLONG).Should(Succeed(), "metrics endpoint should be accessible before test starts")
-
 			By("Waiting for initial certificate info to be reported")
-			var initialSerial, initialNotAfter string
-			Eventually(func() bool {
-				serial, notAfter, fetchErr := getDeviceCertInfo(harness, deviceId)
-				if fetchErr != nil {
-					GinkgoWriter.Printf("[87911] waiting for initial cert info: %v\n", fetchErr)
-					return false
-				}
-				initialSerial = serial
-				initialNotAfter = notAfter
-				return true
-			}, e2e.LONGTIMEOUT, e2e.POLLINGLONG).Should(BeTrue(), "initial cert info should appear in system info")
-			GinkgoWriter.Printf("[87911] initial cert serial: %s, notAfter: %s\n", initialSerial, initialNotAfter)
+			initialSerial, initialNotAfter, err := waitForInitialCertInfo(harness, deviceId, e2e.LONGTIMEOUT, e2e.POLLINGLONG)
+			Expect(err).ToNot(HaveOccurred(), "initial cert info should appear in system info")
 
-			notAfterTime, err := time.Parse(time.RFC3339, initialNotAfter)
-			Expect(err).ToNot(HaveOccurred(), "initialNotAfter should be a valid RFC3339 timestamp")
+			notAfterTime, parseErr := time.Parse(time.RFC3339, initialNotAfter)
+			Expect(parseErr).ToNot(HaveOccurred(), "initialNotAfter should be a valid RFC3339 timestamp")
+
+			renewBeforeSeconds, atoiErr := strconv.Atoi(certRenewBeforeSeconds)
+			Expect(atoiErr).ToNot(HaveOccurred(), "certRenewBeforeSeconds should be parseable")
+			renewWindowStart := notAfterTime.Add(-time.Duration(renewBeforeSeconds) * time.Second)
 
 			By("Extracting API server endpoint from VM agent config")
 			apiIP, apiPort, err := harness.GetAPIEndpointFromVM()
-			GinkgoWriter.Printf("[87911] resolved API endpoint: %s:%s\n", apiIP, apiPort)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Block slightly before the renewal window opens so the first
+			// renewal attempt hits a network error and is deferred to the
+			// next reconciliation cycle (FLIGHTCTL_TEST_CERT_MANAGER_SYNC_INTERVAL).
+			outageWindowStart := renewWindowStart.Add(-outageLeadTime)
+			if time.Until(outageWindowStart) > 0 {
+				By("Waiting to block API traffic before the renewal window opens")
+				waitUntilTime(outageWindowStart, e2e.LONGTIMEOUT, e2e.POLLINGLONG,
+					"should reach the outage start time before blocking API traffic")
+			}
 
 			By("Blocking agent→API traffic to prevent CSR submission")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
@@ -389,26 +386,22 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 				}
 			})
 
-			By("Verifying iptables block is effective")
-			verifyOutput, verifyErr := harness.VM.RunSSH([]string{
-				"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-				"--connect-timeout", "5", "--max-time", "10",
-				"-k", fmt.Sprintf("https://%s:%s/", apiIP, apiPort),
-			}, nil)
-			if verifyErr != nil {
-				GinkgoWriter.Printf("[87911] block verified: curl failed as expected: %v\n", verifyErr)
-			} else {
-				GinkgoWriter.Printf("[87911] WARNING: curl succeeded despite block (status=%s), iptables may not be effective\n",
-					strings.TrimSpace(verifyOutput.String()))
-			}
+			By("Verifying the management endpoint becomes unreachable from this VM")
+			Eventually(managementAPIUnreachableStatusFunc(harness, apiIP, apiPort), e2e.LONGTIMEOUT, e2e.POLLINGLONG).ShouldNot(BeEmpty(),
+				"management endpoint should fail with a connection error or timeout while blocked")
 
-			// Block traffic until 60s before cert expiry. This ensures:
-			// 1. The renewal window is open (opens at certExpiry - certRenewBefore = 90s after issuance)
-			// 2. At least one renewal attempt has failed (within 2s of the window opening)
-			// 3. The agent still has a valid cert (60s remaining) to authenticate the renewal after unblock
-			//
-			// Without this safeguard, the cert can expire while blocked, permanently
-			// locking the agent out of mTLS and making renewal impossible.
+			By("Verifying the current certificate remains installed while the network is unavailable")
+			observeUntil := renewWindowStart.Add(outageLeadTime)
+			observeDuration := time.Until(observeUntil)
+			if observeDuration < minimumObservationDuration {
+				observeDuration = minimumObservationDuration
+			}
+			Consistently(deviceCertSerialOrFallbackFunc(harness, deviceId, initialSerial), observeDuration.String(), e2e.POLLINGLONG).
+				Should(Equal(initialSerial), "certificate serial should remain unchanged while the network is unavailable")
+
+			// Keep traffic blocked until 60s before cert expiry. This ensures
+			// the agent still has a valid cert to authenticate the renewal CSR
+			// after connectivity is restored.
 			safeBlockEnd := notAfterTime.Add(-remainingBeforeUnblockSafetySeconds)
 			if time.Until(safeBlockEnd) > 0 {
 				By("Waiting until it is safe to restore connectivity before certificate expiry")
@@ -419,25 +412,14 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Restoring network connectivity")
 			err = harness.UnblockTrafficOnVM(apiIP, apiPort)
 			Expect(err).ToNot(HaveOccurred(), "failed to remove iptables block")
-			GinkgoWriter.Printf("[87911] traffic unblocked, %v remaining before cert expiry\n", time.Until(notAfterTime))
 
-			By("Waiting for certificate rotation")
-			var newNotAfter string
-			Eventually(func() bool {
-				serial, notAfter, fetchErr := getDeviceCertInfo(harness, deviceId)
-				if fetchErr != nil {
-					GinkgoWriter.Printf("[87911] waiting for rotation: %v\n", fetchErr)
-					return false
-				}
-				GinkgoWriter.Printf("[87911] current serial: %s (initial: %s)\n", serial, initialSerial)
-				if serial != initialSerial {
-					newNotAfter = notAfter
-					return true
-				}
-				return false
-			}, certRotationTimeout, e2e.POLLINGLONG).Should(BeTrue(), "cert serial should change after unblocking traffic")
+			By("Waiting for certificate rotation after connectivity recovery")
+			Eventually(deviceCertSerialOrFallbackFunc(harness, deviceId, initialSerial), certRotationTimeout, e2e.POLLINGLONG).
+				ShouldNot(Equal(initialSerial), "certificate should rotate after network connectivity is restored")
 
 			By("Verifying new certificate notAfter is in the future")
+			_, newNotAfter, err := getDeviceCertInfo(harness, deviceId)
+			Expect(err).ToNot(HaveOccurred())
 			parsedNotAfter, parseErr := time.Parse(time.RFC3339, newNotAfter)
 			Expect(parseErr).ToNot(HaveOccurred(), "new cert notAfter should be valid RFC3339")
 			Expect(parsedNotAfter.After(time.Now())).To(BeTrue(), "new cert notAfter should be in the future")
@@ -450,7 +432,6 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 
 			By("Checking renewal metrics")
 			successCount, mErr := harness.GetAgentMetricValue(metricRenewalAttemptsSuccess)
-			GinkgoWriter.Printf("[87911] renewal success count: %s\n", successCount)
 			Expect(mErr).ToNot(HaveOccurred())
 			Expect(successCount).ToNot(BeEmpty(), "renewal success metric should be present")
 			Expect(successCount).ToNot(Equal("0"), "at least one successful renewal should have occurred")

--- a/test/e2e/certificate_rotation/certificate_rotation_test.go
+++ b/test/e2e/certificate_rotation/certificate_rotation_test.go
@@ -61,7 +61,7 @@ const (
 	certExpiryGraceWindow               = 5 * time.Second
 	outageLeadTime                      = 15 * time.Second
 	minimumObservationDuration          = 5 * time.Second
-	remainingBeforeUnblockSafetySeconds = 60 * time.Second
+	remainingBeforeUnblockSafetySeconds = 90 * time.Second
 )
 
 var errImmutableBitUnsupported = errors.New("immutable bit unsupported")
@@ -399,7 +399,7 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			Consistently(deviceCertSerialOrFallbackFunc(harness, deviceId, initialSerial), observeDuration.String(), e2e.POLLINGLONG).
 				Should(Equal(initialSerial), "certificate serial should remain unchanged while the network is unavailable")
 
-			// Keep traffic blocked until 60s before cert expiry. This ensures
+			// Keep traffic blocked until 90s before cert expiry. This ensures
 			// the agent still has a valid cert to authenticate the renewal CSR
 			// after connectivity is restored.
 			safeBlockEnd := notAfterTime.Add(-remainingBeforeUnblockSafetySeconds)

--- a/test/e2e/certificate_rotation/certificate_rotation_test.go
+++ b/test/e2e/certificate_rotation/certificate_rotation_test.go
@@ -287,7 +287,9 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			Expect(apiPort).ToNot(BeEmpty())
 
 			DeferCleanup(func() {
-				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				if harness.IsTrafficBlockedOnVM(apiIP, apiPort) {
+					_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				}
 			})
 
 			By("Blocking this worker VM from reaching the API during the renewal window")
@@ -382,7 +384,9 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic to prevent CSR submission")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				if harness.IsTrafficBlockedOnVM(apiIP, apiPort) {
+					_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				}
 			})
 
 			By("Verifying iptables block is effective")
@@ -466,7 +470,9 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic on the VM")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				if harness.IsTrafficBlockedOnVM(apiIP, apiPort) {
+					_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				}
 			})
 
 			By("Waiting for renewal failure indicators in metrics")
@@ -576,7 +582,9 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic to cause renewal failures")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				if harness.IsTrafficBlockedOnVM(apiIP, apiPort) {
+					_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
+				}
 			})
 
 			By("Verifying agent service remains running while blocked")

--- a/test/e2e/certificate_rotation/certificate_rotation_test.go
+++ b/test/e2e/certificate_rotation/certificate_rotation_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			Expect(apiPort).ToNot(BeEmpty())
 
 			DeferCleanup(func() {
-				harness.UnblockTrafficOnVM(apiIP, apiPort)
+				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
 			})
 
 			By("Blocking this worker VM from reaching the API during the renewal window")
@@ -307,7 +307,8 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 				Should(Equal(initialSerial), "certificate serial should remain unchanged while the API is unavailable")
 
 			By("Restoring API connectivity for this worker VM")
-			harness.UnblockTrafficOnVM(apiIP, apiPort)
+			err = harness.UnblockTrafficOnVM(apiIP, apiPort)
+			Expect(err).ToNot(HaveOccurred(), "failed to remove iptables block")
 
 			By("Waiting for certificate rotation after service recovery")
 			Eventually(deviceCertSerialOrFallbackFunc(harness, deviceId, initialSerial), certRotationTimeout, e2e.POLLINGLONG).
@@ -381,7 +382,7 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic to prevent CSR submission")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				harness.UnblockTrafficOnVM(apiIP, apiPort)
+				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
 			})
 
 			By("Verifying iptables block is effective")
@@ -412,7 +413,8 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			}
 
 			By("Restoring network connectivity")
-			harness.UnblockTrafficOnVM(apiIP, apiPort)
+			err = harness.UnblockTrafficOnVM(apiIP, apiPort)
+			Expect(err).ToNot(HaveOccurred(), "failed to remove iptables block")
 			GinkgoWriter.Printf("[87911] traffic unblocked, %v remaining before cert expiry\n", time.Until(notAfterTime))
 
 			By("Waiting for certificate rotation")
@@ -464,7 +466,7 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic on the VM")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				harness.UnblockTrafficOnVM(apiIP, apiPort)
+				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
 			})
 
 			By("Waiting for renewal failure indicators in metrics")
@@ -486,7 +488,8 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			}
 
 			By("Unblocking agent→API traffic")
-			harness.UnblockTrafficOnVM(apiIP, apiPort)
+			err = harness.UnblockTrafficOnVM(apiIP, apiPort)
+			Expect(err).ToNot(HaveOccurred(), "failed to remove iptables block")
 
 			By("Verifying certificate serial does NOT change (expired cert cannot renew)")
 			Consistently(func() string {
@@ -573,7 +576,7 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			By("Blocking agent→API traffic to cause renewal failures")
 			harness.BlockTrafficOnVM(apiIP, apiPort)
 			DeferCleanup(func() {
-				harness.UnblockTrafficOnVM(apiIP, apiPort)
+				_ = harness.UnblockTrafficOnVM(apiIP, apiPort)
 			})
 
 			By("Verifying agent service remains running while blocked")
@@ -603,7 +606,8 @@ var _ = Describe("Certificate Rotation", Label("certificate-rotation"), func() {
 			Expect(hasDuration).To(BeTrue(), "renewal duration histogram metric should be present")
 
 			By("Restoring network connectivity")
-			harness.UnblockTrafficOnVM(apiIP, apiPort)
+			err = harness.UnblockTrafficOnVM(apiIP, apiPort)
+			Expect(err).ToNot(HaveOccurred(), "failed to remove iptables block")
 
 			By("Verifying device recovers connectivity after network restore")
 			Eventually(func() v1beta1.DeviceSummaryStatusType {

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -400,14 +400,18 @@ func (h *Harness) checkLogsForPanicAVC(sinceTime time.Time) {
 	}
 	if isK8sEnvironment() {
 		for _, svc := range []string{ServiceAPI, ServiceWorker, ServicePeriodic} {
-			nsOut, err := exec.Command("kubectl", "get", "pods", "--all-namespaces", //nolint:gosec // svc iterates a hardcoded list
+			cmdCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			nsOut, err := exec.CommandContext(cmdCtx, "kubectl", "get", "pods", "--all-namespaces", //nolint:gosec // svc iterates a hardcoded list
 				"-l", "flightctl.service="+svc, "-o", "jsonpath={.items[0].metadata.namespace}").Output()
+			cancel()
 			if err != nil || len(nsOut) == 0 {
 				continue
 			}
 			ns := string(nsOut)
-			out, err := exec.Command("kubectl", "logs", "-n", ns, "-l", "flightctl.service="+svc,
+			cmdCtx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+			out, err := exec.CommandContext(cmdCtx, "kubectl", "logs", "-n", ns, "-l", "flightctl.service="+svc,
 				"--since-time="+sinceArg).Output()
+			cancel()
 			if err != nil {
 				logrus.Warnf("checkLogsForPanicAVC: failed to read logs for %s: %v", svc, err)
 				continue
@@ -446,7 +450,9 @@ func isK8sEnvironment() bool {
 	if env := os.Getenv("E2E_ENVIRONMENT"); env != "" {
 		return env == "kind" || env == "ocp" || env == "k8s"
 	}
-	return exec.Command("kubectl", "config", "current-context").Run() == nil
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "kubectl", "config", "current-context").Run() == nil
 }
 
 // isQuadletEnvironment returns true if running in a quadlet (systemd + Podman) environment.

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -754,6 +754,17 @@ func (h *Harness) UnblockTrafficOnVM(ip, port string) error {
 	return err
 }
 
+// IsTrafficBlockedOnVM checks whether an iptables/ip6tables REJECT rule exists
+// for the given IP and port in the OUTPUT chain on the VM.
+func (h *Harness) IsTrafficBlockedOnVM(ip, port string) bool {
+	iptablesCmd := getIPTablesCommand(ip)
+
+	_, err := h.VM.RunSSH([]string{
+		"sudo", iptablesCmd, "-C", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
+	}, nil)
+	return err == nil
+}
+
 func (h *Harness) IsAgentServiceRunning() bool {
 	output, err := h.VM.RunSSH([]string{
 		"sudo", "systemctl", "is-active", "flightctl-agent",

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -744,13 +744,14 @@ func (h *Harness) BlockTrafficOnVM(ip, port string) {
 }
 
 // UnblockTrafficOnVM removes the iptables/ip6tables rule on the VM that blocks TCP
-// traffic to the specified IP and port. Silently ignores errors.
-func (h *Harness) UnblockTrafficOnVM(ip, port string) {
+// traffic to the specified IP and port. Returns an error if the rule could not be removed.
+func (h *Harness) UnblockTrafficOnVM(ip, port string) error {
 	iptablesCmd := getIPTablesCommand(ip)
 
-	_, _ = h.VM.RunSSH([]string{
+	_, err := h.VM.RunSSH([]string{
 		"sudo", iptablesCmd, "-D", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
 	}, nil)
+	return err
 }
 
 func (h *Harness) IsAgentServiceRunning() bool {

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -743,15 +743,20 @@ func (h *Harness) BlockTrafficOnVM(ip, port string) {
 	Expect(err).ToNot(HaveOccurred(), "failed to add %s rule on VM", iptablesCmd)
 }
 
-// UnblockTrafficOnVM removes the iptables/ip6tables rule on the VM that blocks TCP
-// traffic to the specified IP and port. Returns an error if the rule could not be removed.
+// UnblockTrafficOnVM removes all iptables/ip6tables rules on the VM that block TCP
+// traffic to the specified IP and port. Loops until no matching rules remain.
 func (h *Harness) UnblockTrafficOnVM(ip, port string) error {
 	iptablesCmd := getIPTablesCommand(ip)
 
-	_, err := h.VM.RunSSH([]string{
-		"sudo", iptablesCmd, "-D", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
-	}, nil)
-	return err
+	for h.IsTrafficBlockedOnVM(ip, port) {
+		_, err := h.VM.RunSSH([]string{
+			"sudo", iptablesCmd, "-D", "OUTPUT", "-d", ip, "-p", "tcp", "--dport", port, "-j", "REJECT",
+		}, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // IsTrafficBlockedOnVM checks whether an iptables/ip6tables REJECT rule exists


### PR DESCRIPTION
fix cert rotation flakiness, seems an issue with traffic blocking after repeating the test
Change UnblockTrafficOnVM to return an error, and add a verification helper that confirms the rule is actually gone.
