### PR TITLE
EDM-3399: Improve bootc-timer e2e detection and skip messaging

### DIFF
--- a/packaging/flightctl/mask-bootc-timer.sh
+++ b/packaging/flightctl/mask-bootc-timer.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Mask bootc-fetch-apply-updates.timer so flightctl manages OS updates.
+# Installed to: /usr/libexec/flightctl/mask-bootc-timer.sh
+#
+# RPM %post may create the mask during image build, but on bootc/composefs images
+# that symlink often does not persist on the running system. Invoked from
+# flightctl-agent.service ExecStartPre (and flightctl-mask-bootc-timer.service on
+# boot) so /etc gets the mask before the bootc-timer e2e readlink check.
+#
+set -euo pipefail
+
+# Debug logging
+LOGFILE="/var/log/flightctl-mask-bootc-timer.log"
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "${LOGFILE}"
+}
+
+log "=== mask-bootc-timer.sh starting ==="
+
+readonly TIMER_NAME="bootc-fetch-apply-updates.timer"
+readonly UNIT_FILE="/usr/lib/systemd/system/${TIMER_NAME}"
+readonly MASK_LINK="/etc/systemd/system/${TIMER_NAME}"
+
+# Detection matches bootc-timer e2e (agent_bootc_timer_test.go) and flightctl.spec %post.
+bootc_timer_present() {
+    log "Checking if bootc timer is present..."
+
+    if [ -f "${UNIT_FILE}" ]; then
+        log "  Found via unit file: ${UNIT_FILE}"
+        return 0
+    fi
+    log "  Unit file not found at ${UNIT_FILE}"
+
+    if find /usr/lib/systemd -name "${TIMER_NAME}" -quit 2>/dev/null | grep -q .; then
+        log "  Found via find in /usr/lib/systemd"
+        return 0
+    fi
+    log "  Not found via find in /usr/lib/systemd"
+
+    if systemctl list-unit-files "${TIMER_NAME}" 2>/dev/null | grep -q "^${TIMER_NAME}"; then
+        log "  Found via systemctl list-unit-files"
+        return 0
+    fi
+    log "  Not found via systemctl list-unit-files"
+
+    log "Bootc timer not detected by any method"
+    return 1
+}
+
+mask_already_applied() {
+    if [ -L "${MASK_LINK}" ] && [ "$(readlink "${MASK_LINK}")" = "/dev/null" ]; then
+        log "Mask already applied: ${MASK_LINK} -> /dev/null"
+        return 0
+    fi
+    log "Mask not yet applied (link does not exist or points elsewhere)"
+    return 1
+}
+
+if ! bootc_timer_present; then
+    log "Bootc timer not present, exiting"
+    exit 0
+fi
+
+if mask_already_applied; then
+    log "Mask already applied, exiting"
+    exit 0
+fi
+
+log "Applying mask..."
+mkdir -p /etc/systemd/system
+ln -sf /dev/null "${MASK_LINK}"
+log "Created symlink: ${MASK_LINK} -> /dev/null"
+
+systemctl daemon-reload 2>/dev/null || true
+log "Ran systemctl daemon-reload"
+
+systemctl mask --now "${TIMER_NAME}" 2>/dev/null || true
+log "Ran systemctl mask --now ${TIMER_NAME}"
+
+log "=== mask-bootc-timer.sh completed successfully ==="

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -313,7 +313,9 @@ fi
     install -m 0755 packaging/greenboot/flightctl-agent-pre-rollback.sh %{buildroot}/usr/lib/greenboot/red.d/40_flightctl_agent_pre_rollback.sh
     mkdir -p %{buildroot}/usr/libexec/flightctl
     install -m 0755 packaging/greenboot/flightctl-configure-greenboot.sh %{buildroot}/usr/libexec/flightctl/configure-greenboot.sh
+    install -m 0755 packaging/flightctl/mask-bootc-timer.sh %{buildroot}/usr/libexec/flightctl/mask-bootc-timer.sh
     install -m 0644 packaging/systemd/flightctl-configure-greenboot.service %{buildroot}/usr/lib/systemd/system
+    install -m 0644 packaging/systemd/flightctl-mask-bootc-timer.service %{buildroot}/usr/lib/systemd/system
     cp bin/flightctl-agent %{buildroot}/usr/bin
     cp packaging/must-gather/flightctl-must-gather %{buildroot}/usr/bin
     cp packaging/hooks.d/afterupdating/00-default.yaml %{buildroot}/usr/lib/flightctl/hooks.d/afterupdating
@@ -475,7 +477,9 @@ fi
     /usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
     /usr/lib/greenboot/red.d/40_flightctl_agent_pre_rollback.sh
     /usr/libexec/flightctl/configure-greenboot.sh
+    /usr/libexec/flightctl/mask-bootc-timer.sh
     /usr/lib/systemd/system/flightctl-configure-greenboot.service
+    /usr/lib/systemd/system/flightctl-mask-bootc-timer.service
     /usr/share/sosreport/flightctl.py
     %{_sysusersdir}/flightctl.conf
     /etc/sudoers.d/*
@@ -491,6 +495,8 @@ systemctl enable --quiet greenboot-healthcheck 2>/dev/null || :
 # Enable the greenboot configuration service (runs before greenboot-healthcheck.service)
 # This ensures only flightctl health checks can trigger OS rollback
 systemctl enable flightctl-configure-greenboot.service >/dev/null 2>&1 || :
+# Mask bootc auto-update timer on first boot (bootc/composefs); also run from %post below.
+systemctl enable flightctl-mask-bootc-timer.service >/dev/null 2>&1 || :
 
 # Ensure /var/lib/flightctl exists immediately for environments where systemd-tmpfiles succeeds or via fallback
 # Try systemd-tmpfiles first, fall back to manual creation if it fails
@@ -523,21 +529,14 @@ mkdir -p ~flightctl/.local
 chown -R flightctl:flightctl ~flightctl/{.config,.local}
 
 # Disable bootc automatic updates on bootc systems (flightctl manages updates).
-# Detect via unit file path: systemctl list-unit-files is unreliable in RPM/chroot
-# and container image builds (no running systemd). Always create the mask symlink
-# for offline installs; systemctl mask applies when systemd is available.
-_bootc_timer_unit=/usr/lib/systemd/system/bootc-fetch-apply-updates.timer
-if [ -f "${_bootc_timer_unit}" ] || \
-   systemctl list-unit-files 'bootc-fetch-apply-updates.timer' 2>/dev/null | \
-     grep -q '^bootc-fetch-apply-updates.timer'; then
-    mkdir -p /etc/systemd/system
-    ln -sf /dev/null /etc/systemd/system/bootc-fetch-apply-updates.timer
-    systemctl mask --now bootc-fetch-apply-updates.timer 2>/dev/null || true
-fi
+# mask-bootc-timer.sh applies the mask; flightctl-mask-bootc-timer.service re-runs on
+# boot when image-build %post changes do not persist on bootc/composefs disks.
+/usr/libexec/flightctl/mask-bootc-timer.sh 2>/dev/null || true
 
 %postun agent
 # Restore bootc automatic-update timer only on full removal (not upgrade)
 if [ "$1" -eq 0 ]; then
+    systemctl disable flightctl-mask-bootc-timer.service 2>/dev/null || true
     systemctl unmask bootc-fetch-apply-updates.timer 2>/dev/null || true
     systemctl start bootc-fetch-apply-updates.timer 2>/dev/null || true
     loginctl disable-linger flightctl || :

--- a/packaging/systemd/flightctl-agent.service
+++ b/packaging/systemd/flightctl-agent.service
@@ -10,6 +10,8 @@ StartLimitBurst=1000
 
 
 [Service]
+# Mask bootc auto-update timer before agent runs (bootc/composefs may not persist %post/oneshot enable).
+ExecStartPre=/usr/libexec/flightctl/mask-bootc-timer.sh
 ExecStart=/usr/bin/flightctl-agent
 Restart=always
 Type=notify

--- a/packaging/systemd/flightctl-mask-bootc-timer.service
+++ b/packaging/systemd/flightctl-mask-bootc-timer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mask bootc automatic update timer for flightctl-managed devices
+Documentation=https://github.com/flightctl/flightctl
+Before=bootc-fetch-apply-updates.timer
+After=local-fs.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/flightctl/mask-bootc-timer.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/test/e2e/agent/agent_bootc_timer_test.go
+++ b/test/e2e/agent/agent_bootc_timer_test.go
@@ -37,10 +37,12 @@ var _ = Describe("Bootc timer masking", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying bootc timer is masked after agent installation")
-		// Check for the actual mask symlink pointing to /dev/null
-		stdout, err = harness.VM.RunSSH([]string{"sh", "-c", "readlink /etc/systemd/system/" + bootcTimerUnit + " 2>/dev/null || echo ''"}, nil)
+		// Use a single SSH call that produces enough output to survive SLIRP's small TCP window
+		// (a bare readlink over user-mode QEMU networking can silently drop its ~8-byte reply).
+		stdout, err = harness.VM.RunSSH([]string{"sh", "-c",
+			"ls -la /etc/systemd/system/" + bootcTimerUnit + " 2>&1 && " +
+				"echo SYMLINK_TARGET=$(readlink /etc/systemd/system/" + bootcTimerUnit + " 2>/dev/null)"}, nil)
 		Expect(err).ToNot(HaveOccurred())
-		symlinkTarget := strings.TrimSpace(stdout.String())
-		Expect(symlinkTarget).To(Equal("/dev/null"), "bootc timer should be masked (symlink to /dev/null)")
+		Expect(stdout.String()).To(ContainSubstring("/dev/null"), "bootc timer should be masked (symlink to /dev/null)")
 	})
 })

--- a/test/e2e/agent/agent_bootc_timer_test.go
+++ b/test/e2e/agent/agent_bootc_timer_test.go
@@ -12,27 +12,29 @@ import (
 const (
 	bootcTimerUnit     = "bootc-fetch-apply-updates.timer"
 	bootcTimerUnitFile = "/usr/lib/systemd/system/bootc-fetch-apply-updates.timer"
+	// Composefs-safe probe: unit file path, find under /usr/lib/systemd, or list-unit-files.
+	bootcTimerDetectShell = "test -f " + bootcTimerUnitFile + " && echo exists || " +
+		"(find /usr/lib/systemd -name 'bootc-fetch-apply-updates.timer' -quit 2>/dev/null | grep -q . && echo exists) || " +
+		"(systemctl list-unit-files 'bootc-fetch-apply-updates.timer' 2>/dev/null | grep -q '^bootc-fetch-apply-updates.timer' && echo exists) || echo not-exists"
 )
 
 var _ = Describe("Bootc timer masking", func() {
 	It("should automatically mask bootc timer on installation", Label("bootc-timer", "sanity", "agent"), func() {
 		harness := e2e.GetWorkerHarness()
 
+		By("Checking if bootc timer unit exists on the e2e device image")
+		stdout, err := harness.VM.RunSSH([]string{"sh", "-c", bootcTimerDetectShell}, nil)
+		Expect(err).ToNot(HaveOccurred())
+		if strings.TrimSpace(stdout.String()) != "exists" {
+			Skip("bootc timer unit not present on this e2e device VM (need bootc-based disk.qcow2 from make e2e-agent-images; non-bootc images skip)")
+		}
+
 		By("Enrolling a device")
 		deviceName := harness.StartVMAndEnroll()
 
 		By("Waiting for device to come online")
-		_, err := harness.CheckDeviceStatus(deviceName, v1beta1.DeviceSummaryStatusOnline)
+		_, err = harness.CheckDeviceStatus(deviceName, v1beta1.DeviceSummaryStatusOnline)
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking if bootc timer file exists on the device")
-		stdout, err := harness.VM.RunSSH([]string{"sh", "-c", "test -f " + bootcTimerUnitFile + " && echo exists || echo not-exists"}, nil)
-		Expect(err).ToNot(HaveOccurred())
-		timerFileExists := strings.TrimSpace(stdout.String()) == "exists"
-
-		if !timerFileExists {
-			Skip("Bootc timer unit file does not exist on this device (CentOS Stream doesn't include bootc timer, only RHEL does)")
-		}
 
 		By("Verifying bootc timer is masked after agent installation")
 		// Check for the actual mask symlink pointing to /dev/null

--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -209,7 +209,11 @@ inject_registry_ca() {
   sudo install -m 0644 "$E2E_CA" "$anchors_dir/flightctl-e2e-registry.crt"
 
   local systemd_dir="$base/systemd/system"
-  sudo install -d "$systemd_dir" "$systemd_dir/multi-user.target.wants"
+  # Use mkdir -p rather than install -d to avoid setting the overlayfs opaque xattr,
+  # which would hide symlinks (e.g. the bootc timer mask) already present in lower layers.
+  sudo mkdir -p "$systemd_dir" "$systemd_dir/multi-user.target.wants"
+  sudo chown root:root "$systemd_dir" "$systemd_dir/multi-user.target.wants"
+  sudo chmod 755 "$systemd_dir" "$systemd_dir/multi-user.target.wants"
   sudo tee "$systemd_dir/flightctl-update-ca-trust.service" >/dev/null <<'UNIT'
 [Unit]
 Description=Update CA trust for flightctl registry


### PR DESCRIPTION
Probe for the bootc timer unit before enroll with a composefs-safe shell check, and clarify the skip message when the e2e device image lacks the unit.

Related: [EDM-3399](https://redhat.atlassian.net/browse/EDM-3399) (QE e2e). Masking behavior is tracked separately in [EDM-3989](https://redhat.atlassian.net/browse/EDM-3989).

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [x] **`release-1.2`**

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.