### PR TITLE
EDM-3989: Persist bootc timer mask in flightctl-agent %post

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -522,9 +522,17 @@ mkdir -p ~flightctl/.config/{containers/systemd,systemd/user}
 mkdir -p ~flightctl/.local
 chown -R flightctl:flightctl ~flightctl/{.config,.local}
 
-# Disable bootc automatic updates on bootc systems (flightctl manages updates)
-# Only masks the timer if it exists; silently succeeds otherwise
-systemctl mask --now bootc-fetch-apply-updates.timer 2>/dev/null || true
+# Disable bootc automatic updates on bootc systems (flightctl manages updates).
+# Mask when the unit is present. systemctl mask --now may exit non-zero in image
+# build chroots (no running systemd) but usually still creates the symlink; the
+# ln -sf fallback ensures bootc e2e images and offline installs are covered.
+if systemctl list-unit-files 'bootc-fetch-apply-updates.timer' 2>/dev/null | grep -q '^bootc-fetch-apply-updates.timer'; then
+    systemctl mask --now bootc-fetch-apply-updates.timer 2>/dev/null || true
+    mkdir -p /etc/systemd/system
+    if [ ! -e /etc/systemd/system/bootc-fetch-apply-updates.timer ]; then
+        ln -sf /dev/null /etc/systemd/system/bootc-fetch-apply-updates.timer
+    fi
+fi
 
 %postun agent
 # Restore bootc automatic-update timer only on full removal (not upgrade)


### PR DESCRIPTION
Guard mask with list-unit-files and add ln -sf /dev/null fallback when systemctl mask does not create the symlink during image-build chroots.

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
