### PR TITLE
EDM-3948: Use Eventually when checking for fleet vulnerabilities

### DIFF
--- a/test/e2e/vulnerability/vulnerability_suite_test.go
+++ b/test/e2e/vulnerability/vulnerability_suite_test.go
@@ -36,6 +36,12 @@ const (
 	DigestBCVECount = 4 // 1 High + 3 Medium
 	DigestCCVECount = 0 // Fully patched, no vulnerabilities
 
+	// Fleet with digest-A and digest-B devices: deduplicated unique CVE union (same counts as digest-A)
+	FleetDigestCriticalCount = 1
+	FleetDigestHighCount     = 1
+	FleetDigestMediumCount   = 4
+	FleetDigestLowCount      = 1
+
 	// CVE IDs for test verification
 	// CVE-2021-35942: glibc wordexp buffer overflow (CRITICAL, CVSS 9.1)
 	CVEGlibcCritical = "CVE-2021-35942"

--- a/test/e2e/vulnerability/vulnerability_test.go
+++ b/test/e2e/vulnerability/vulnerability_test.go
@@ -318,11 +318,11 @@ var _ = Describe("Vulnerability API", Label("vulnerability"), func() {
 			err := harness.CreateFleetWithSelector(fleetName, map[string]string{"fleet": fleetName})
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Creating first device with digest-a (5 CVEs: Critical, 2 High, Medium, Low)")
+			By("Creating first device with digest-a (7 CVEs: Critical, 1 High, 4 Medium, 1 Low)")
 			err = harness.CreateDeviceWithDigest(deviceName1, fleetName, DigestA)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Creating second device with digest-b (3 CVEs: High, Medium, Low)")
+			By("Creating second device with digest-b (4 CVEs: 1 High, 3 Medium)")
 			err = harness.CreateDeviceWithDigest(deviceName2, fleetName, DigestB)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -330,14 +330,24 @@ var _ = Describe("Vulnerability API", Label("vulnerability"), func() {
 			harness.WaitForVulnerabilitySyncComplete(v1alpha1Client, syncWaitTimeoutExtended, syncInterval)
 
 			By("Verifying fleet summary aggregates CVEs from both devices")
+			Eventually(func() int {
+				harness.DumpVulnerabilityState(v1alpha1Client, fleetName, deviceName1, deviceName2)
+
+				vulns, err := harness.GetFleetVulnerabilities(v1alpha1Client, fleetName, nil)
+				if err != nil {
+					return 0
+				}
+				return len(vulns.Items)
+			}, syncWaitTimeoutExtended, syncInterval).Should(BeNumerically(">=", DigestACVECount))
+
+			By("Verifying fleet summary severity counts")
 			summary, err := harness.GetFleetVulnerabilitySummary(v1alpha1Client, fleetName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(summary).ToNot(BeNil())
-
-			By("Verifying fleet vulnerabilities list includes CVEs from all severity levels")
-			fleetVulns, err := harness.GetFleetVulnerabilities(v1alpha1Client, fleetName, nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(fleetVulns.Items)).To(BeNumerically(">=", DigestACVECount))
+			Expect(summary.Summary.Critical).To(BeNumerically(">=", FleetDigestCriticalCount))
+			Expect(summary.Summary.High).To(BeNumerically(">=", FleetDigestHighCount))
+			Expect(summary.Summary.Medium).To(BeNumerically(">=", FleetDigestMediumCount))
+			Expect(summary.Summary.Low).To(BeNumerically(">=", FleetDigestLowCount))
 		})
 	})
 


### PR DESCRIPTION
Making sure to wait for all the devices' data in the fleet.
