### PR TITLE
EDM-3989: Mask bootc timer in agent %post for chroot image builds

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -523,15 +523,16 @@ mkdir -p ~flightctl/.local
 chown -R flightctl:flightctl ~flightctl/{.config,.local}
 
 # Disable bootc automatic updates on bootc systems (flightctl manages updates).
-# Mask when the unit is present. systemctl mask --now may exit non-zero in image
-# build chroots (no running systemd) but usually still creates the symlink; the
-# ln -sf fallback ensures bootc e2e images and offline installs are covered.
-if systemctl list-unit-files 'bootc-fetch-apply-updates.timer' 2>/dev/null | grep -q '^bootc-fetch-apply-updates.timer'; then
-    systemctl mask --now bootc-fetch-apply-updates.timer 2>/dev/null || true
+# Detect via unit file path: systemctl list-unit-files is unreliable in RPM/chroot
+# and container image builds (no running systemd). Always create the mask symlink
+# for offline installs; systemctl mask applies when systemd is available.
+_bootc_timer_unit=/usr/lib/systemd/system/bootc-fetch-apply-updates.timer
+if [ -f "${_bootc_timer_unit}" ] || \
+   systemctl list-unit-files 'bootc-fetch-apply-updates.timer' 2>/dev/null | \
+     grep -q '^bootc-fetch-apply-updates.timer'; then
     mkdir -p /etc/systemd/system
-    if [ ! -e /etc/systemd/system/bootc-fetch-apply-updates.timer ]; then
-        ln -sf /dev/null /etc/systemd/system/bootc-fetch-apply-updates.timer
-    fi
+    ln -sf /dev/null /etc/systemd/system/bootc-fetch-apply-updates.timer
+    systemctl mask --now bootc-fetch-apply-updates.timer 2>/dev/null || true
 fi
 
 %postun agent


### PR DESCRIPTION
Detect bootc-fetch-apply-updates.timer by unit file path so RPM %post runs during bootc e2e image builds where systemctl list-unit-files is unreliable without a running systemd. Always ln -sf to /dev/null before systemctl mask so the mask symlink is present for offline installs.

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
