### PR TITLE
EDM-3858: Fix quadlet E2E for remote VM environments

### DIFF
--- a/test/scripts/deploy_quadlets_rhel.sh
+++ b/test/scripts/deploy_quadlets_rhel.sh
@@ -325,7 +325,7 @@ EOF2
   # Start flightctl services
   sudo systemctl start flightctl.target
   cd $USER_HOME/flightctl
-  flightctl login https://localhost:3443 -k
+  flightctl login https://localhost -k
 EOF
 
 # Clean up

--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -303,6 +303,16 @@ EOF
     fi
   fi
 
+  # For quadlet environment, add flightctl-vm.local entry
+  if [[ -n "${QUADLET_HOST:-}" ]] && [[ "$QUADLET_HOST" != "localhost" ]]; then
+    if ! sudo grep -qF -- "flightctl-vm.local" "$hosts_file" 2>/dev/null; then
+      log "Adding FlightCtl VM hosts entry: $QUADLET_HOST -> flightctl-vm.local"
+      echo "$QUADLET_HOST flightctl-vm.local" | sudo tee -a "$hosts_file" >/dev/null
+    else
+      log "FlightCtl VM hosts entry already exists"
+    fi
+  fi
+
   # Add registry hostname entry for IPv6 mode
   if [[ "${IPV6_ONLY:-false}" == "true" ]]; then
     if ! sudo grep -qF -- "$REGISTRY_HOSTNAME" "$hosts_file" 2>/dev/null; then

--- a/test/test.mk
+++ b/test/test.mk
@@ -134,7 +134,7 @@ clean-quadlets-vm:
 	@echo "quadlets-vm cleanup completed"
 
 bin/.e2e-agent-injected: bin/output/qcow2/disk.qcow2 bin/.e2e-agent-certs
-	QCOW=bin/output/qcow2/disk.qcow2 AGENT_DIR=bin/agent/etc/flightctl IPV6_ONLY=${IPV6_ONLY} test/scripts/inject_agent_files_into_qcow.sh
+	QCOW=bin/output/qcow2/disk.qcow2 AGENT_DIR=bin/agent/etc/flightctl IPV6_ONLY=${IPV6_ONLY} QUADLET_HOST=${E2E_SSH_HOST} test/scripts/inject_agent_files_into_qcow.sh
 	touch bin/.e2e-agent-injected
 
 prepare-e2e-qcow-config: bin/.e2e-agent-injected


### PR DESCRIPTION
## Summary
- Add /etc/hosts entry for flightctl-vm.local on agent VMs for
  quadlet host DNS resolution in isolated networks
- Pass QUADLET_HOST to qcow inject script
- Use port 443 for deploy login (aligned with #3068)