### PR TITLE
NO-ISSUE: Fix flaky dependency ref tests assuming map iteration order

### DIFF
--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -1045,11 +1045,16 @@ func TestReplaceGitConfigParameters_DeviceLevelRefs(t *testing.T) {
 		require.Empty(t, errs)
 		require.Len(t, refs, 2)
 
-		assert.Equal(t, "git:repo-a/dev", refs[0].ResourceKey)
-		assert.Equal(t, "device-1", *refs[0].DeviceName)
+		refsByKey := make(map[string]model.DependencyRef, len(refs))
+		for _, r := range refs {
+			refsByKey[r.ResourceKey] = r
+		}
 
-		assert.Equal(t, "git:repo-c/staging", refs[1].ResourceKey)
-		assert.Equal(t, "device-1", *refs[1].DeviceName)
+		assert.Contains(t, refsByKey, "git:repo-a/dev")
+		assert.Equal(t, "device-1", *refsByKey["git:repo-a/dev"].DeviceName)
+
+		assert.Contains(t, refsByKey, "git:repo-c/staging")
+		assert.Equal(t, "device-1", *refsByKey["git:repo-c/staging"].DeviceName)
 	})
 }
 

--- a/internal/tasks/populate_dependency_refs_test.go
+++ b/internal/tasks/populate_dependency_refs_test.go
@@ -682,8 +682,12 @@ func TestCollectConfigRefs_DeduplicatesByResourceKey(t *testing.T) {
 		refs := collectConfigRefs(logrus.New(), config, testFleet, "")
 
 		require.Len(t, refs, 2)
-		assert.Equal(t, "git:repo-a/main", refs[0].ResourceKey)
-		assert.Equal(t, "git:repo-b/main", refs[1].ResourceKey)
+		keys := make(map[string]bool, len(refs))
+		for _, r := range refs {
+			keys[r.ResourceKey] = true
+		}
+		assert.True(t, keys["git:repo-a/main"])
+		assert.True(t, keys["git:repo-b/main"])
 	})
 }
 


### PR DESCRIPTION
## Summary
- `getDeviceConfig` and `collectConfigRefs` both use a map for deduplication then convert to a slice, making output order non-deterministic across Go runtime invocations.
- `TestReplaceGitConfigParameters_DeviceLevelRefs` and `TestCollectConfigRefs_DeduplicatesByResourceKey` were asserting by slice index, causing intermittent failures in the merge queue.
- Switched both tests to map-based lookups (by `ResourceKey`) so assertions are order-independent.

## Verification
- Audited all multi-ref test assertions across `internal/tasks/` and `internal/store/` — no other tests assert positional order on map-derived slices.
- Ran affected tests with `-count=10` — all pass consistently.


Made with [Cursor](https://cursor.com)