### PR TITLE
EDM-3599: strict ip/host check for SAN regenerate

### DIFF
--- a/deploy/helm/flightctl/scripts/generate-certificates.sh
+++ b/deploy/helm/flightctl/scripts/generate-certificates.sh
@@ -202,8 +202,15 @@ cert_has_expected_sans() {
     fi
 
     for san in "${expected_sans[@]}"; do
-        if ! openssl x509 -in "$cert_path" -noout -checkhost "$san" >/dev/null 2>&1 && \
-           ! openssl x509 -in "$cert_path" -noout -checkip "$san" >/dev/null 2>&1; then
+        if [[ "$san" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if ! openssl x509 -in "$cert_path" -noout -checkip "$san" >/dev/null 2>&1; then
+                echo "  Certificate $cert_path missing expected SAN: $san - will regenerate"
+                return 1
+            fi
+            continue
+        fi
+
+        if ! openssl x509 -in "$cert_path" -noout -checkhost "$san" >/dev/null 2>&1; then
             echo "  Certificate $cert_path missing expected SAN: $san - will regenerate"
             return 1
         fi


### PR DESCRIPTION
for some reason openssl pass the ip check if we are testing a certificate with ip against ip.nip.io

this fixes it so the input is checked against the correct one