### PR TITLE
EDM-3844: Add E2E tests for automated dependency synchronization

### DIFF
--- a/deploy/helm/flightctl/values.e2e.yaml
+++ b/deploy/helm/flightctl/values.e2e.yaml
@@ -12,10 +12,12 @@ api:
 cliArtifacts:
   enabled: true
 worker:
+  clusterLevelSecretAccess: true
   env:
     GORM_TRACE_ENFORCE_FATAL: "true"
     GORM_TRACE_INCLUDE_QUERY_VARIABLES: "true"
 periodic:
+  clusterLevelSecretAccess: true
   env:
     GORM_TRACE_ENFORCE_FATAL: "true"
     GORM_TRACE_INCLUDE_QUERY_VARIABLES: "true"

--- a/test/e2e/dependency_sync/dependency_sync_suite_test.go
+++ b/test/e2e/dependency_sync/dependency_sync_suite_test.go
@@ -1,0 +1,135 @@
+package dependency_sync_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	POLLING       = "5s"
+	RENDERTIMEOUT = "3m"
+	EVENTTIMEOUT  = "4m"
+
+	fastPollInterval = 30 * time.Second
+)
+
+var (
+	auxSvcs            *auxiliary.Services
+	originalConfigYAML string
+)
+
+func TestDependencySync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dependency Sync E2E Suite")
+}
+
+// patchPollInterval lowers the dependency-sync poll interval for fast E2E testing.
+func patchPollInterval(interval time.Duration) (originalConfig string, err error) {
+	providers := setup.GetDefaultProviders()
+	if providers == nil {
+		return "", fmt.Errorf("providers not initialized")
+	}
+
+	// 1. Read the current periodic config and save it for restore after the suite.
+	content, err := providers.Infra.GetServiceConfig(infra.ServicePeriodic)
+	if err != nil {
+		return "", fmt.Errorf("failed to read periodic config: %w", err)
+	}
+	originalConfig = content
+
+	// 2. Parse the config and inject the faster poll interval.
+	var cfg config.Config
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		return "", fmt.Errorf("failed to parse periodic config: %w", err)
+	}
+
+	if cfg.DependenciesSync == nil {
+		cfg.DependenciesSync = &config.DependenciesSyncConfig{}
+	}
+	cfg.DependenciesSync.PollInterval = util.Duration(interval)
+
+	// 3. Write the patched config back to the periodic service.
+	updated, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return originalConfig, fmt.Errorf("failed to marshal periodic config: %w", err)
+	}
+
+	if err := providers.Infra.SetServiceConfig(infra.ServicePeriodic, "config.yaml", string(updated)); err != nil {
+		return originalConfig, fmt.Errorf("failed to write periodic config: %w", err)
+	}
+
+	// 4. Restart the periodic service so it picks up the new interval.
+	if err := providers.Lifecycle.Restart(infra.ServicePeriodic); err != nil {
+		return originalConfig, fmt.Errorf("failed to restart periodic: %w", err)
+	}
+
+	if err := providers.Lifecycle.WaitForReady(infra.ServicePeriodic, 2*time.Minute); err != nil {
+		return originalConfig, fmt.Errorf("periodic not ready after restart: %w", err)
+	}
+
+	return originalConfig, nil
+}
+
+// restorePollInterval restores the original periodic config and restarts the deployment.
+func restorePollInterval(original string) error {
+	if original == "" {
+		return nil
+	}
+	providers := setup.GetDefaultProviders()
+	if providers == nil {
+		return fmt.Errorf("providers not initialized during restore")
+	}
+	if err := providers.Infra.SetServiceConfig(infra.ServicePeriodic, "config.yaml", original); err != nil {
+		return fmt.Errorf("failed to restore periodic config: %w", err)
+	}
+	if err := providers.Lifecycle.Restart(infra.ServicePeriodic); err != nil {
+		return fmt.Errorf("failed to restart periodic: %w", err)
+	}
+	if err := providers.Lifecycle.WaitForReady(infra.ServicePeriodic, 2*time.Minute); err != nil {
+		return fmt.Errorf("periodic not ready after restore: %w", err)
+	}
+	return nil
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	ctx := context.Background()
+	auxSvcs = auxiliary.Get(ctx)
+
+	fileServerSvcs, err := auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceFileServer})
+	Expect(err).ToNot(HaveOccurred(), "failed to start file server")
+	auxSvcs.FileServer = fileServerSvcs.FileServer
+
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+
+	originalConfigYAML, err = patchPollInterval(fastPollInterval)
+	Expect(err).ToNot(HaveOccurred(), "patchPollInterval must succeed; tests assume a 30s poll interval")
+	GinkgoWriter.Printf("Lowered dependency sync poll interval to %v\n", fastPollInterval)
+	return []byte(originalConfigYAML)
+}, func(data []byte) {
+	originalConfigYAML = string(data)
+	e2e.SetupWorkerHarnessOrAbort()
+})
+
+var _ = SynchronizedAfterSuite(func() {
+}, func() {
+	err := restorePollInterval(originalConfigYAML)
+	if err != nil {
+		GinkgoWriter.Printf("WARNING: restorePollInterval failed: %v\n", err)
+	}
+	_ = auxiliary.StopServices([]auxiliary.Service{auxiliary.ServiceFileServer})
+	if auxSvcs != nil {
+		auxSvcs.Cleanup(context.Background())
+	}
+})

--- a/test/e2e/dependency_sync/dependency_sync_test.go
+++ b/test/e2e/dependency_sync/dependency_sync_test.go
@@ -1,0 +1,837 @@
+package dependency_sync_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	gitBranch        = "main"
+	configFileName   = "configuration/etc/flightctl/config.conf"
+	configFilePath   = "/configuration"
+	deviceConfigFile = "/etc/flightctl/config.conf"
+	httpMountPath    = "/etc/app/remote.conf"
+
+	initialContent     = "initial-content=true\n"
+	updatedContent     = "updated-content=true\nversion=2\n"
+	initialHTTPContent = "initial-http-content"
+	updatedHTTPContent = "updated-http-content-v2"
+
+	gitConfigName    = "git-config"
+	httpConfigName   = "http-config"
+	secretConfigName = "secret-config"
+	fleetLabelKey    = "fleet"
+
+	secretDataKey      = "app-key"
+	initialSecretValue = "initial-value"
+	updatedSecretValue = "updated-value"
+	secretMountPath    = "/etc/app/secret-data"
+
+	repoNotAccessibleTimeout = 2 * time.Minute
+	repoAccessInterval       = 5 * time.Second
+	repoAccessible           = 3 * time.Minute
+	updatedContentMarker     = "updated-content=true"
+
+	probeCycleCompleteMsg = "Expected DependencySyncProbeFailed from invalid probe fleet — periodic completed a full probe cycle"
+
+	invalidHTTPProbeMountPath = "/etc/invalid-probe"
+	parameterizedBranchLabel  = "branch"
+	parameterizedTargetBranch = "staging"
+)
+
+var _ = Describe("Dependency Sync", Label("dependency-sync"), func() {
+	var (
+		harness          *e2e.Harness
+		testID           string
+		gitServer        e2e.GitServerConfig
+		gitInternalHost  string
+		gitInternalPort  int
+		sshKeyPath       util.SSHPrivateKeyPath
+		sshKeyContent    util.SSHPrivateKeyContent
+		secretNamespace  string
+		releaseNamespace string
+		fileServer       *auxiliary.FileServer
+	)
+
+	BeforeEach(func() {
+		workerID := GinkgoParallelProcess()
+		harness = e2e.GetWorkerHarness()
+
+		suiteCtx := e2e.GetWorkerContext()
+		ctx := util.StartSpecTracerForGinkgo(suiteCtx)
+		harness.SetTestContext(ctx)
+		testID = harness.GetTestIDFromContext()
+		Expect(harness.SetupVMFromPoolAndStartAgent(workerID)).To(Succeed())
+
+		svc := auxiliary.Get(harness.Context)
+		Expect(svc).ToNot(BeNil(), "auxiliary services must be initialized")
+		fileServer = svc.FileServer
+		gitServer = e2e.GitServerConfig{Host: svc.GitServer.Host, Port: svc.GitServer.Port, User: "user"}
+		gitInternalHost = svc.GitServer.InternalHost
+		gitInternalPort = svc.GitServer.InternalPort
+
+		var sshErr error
+		sshKeyPath, sshErr = svc.GetGitSSHPrivateKeyPath()
+		Expect(sshErr).ToNot(HaveOccurred(), "failed to get git SSH private key path")
+		Expect(string(sshKeyPath)).ToNot(BeEmpty())
+		sshKeyContent, sshErr = svc.GetGitSSHPrivateKey()
+		Expect(sshErr).ToNot(HaveOccurred(), "failed to get git SSH private key content")
+		Expect(string(sshKeyContent)).ToNot(BeEmpty())
+
+		p := setup.GetDefaultProviders()
+		Expect(p).ToNot(BeNil(), "infra providers must be initialized")
+		releaseNamespace = p.Infra.GetExternalNamespace()
+		Expect(releaseNamespace).ToNot(BeEmpty(), "could not resolve release namespace")
+		secretNamespace = p.Infra.GetInternalNamespace()
+		if secretNamespace == "" {
+			secretNamespace = releaseNamespace
+		}
+
+	})
+
+	AfterEach(func() {
+		workerID := GinkgoParallelProcess()
+		GinkgoWriter.Printf("[AfterEach] Worker %d: Cleaning up test resources\n", workerID)
+
+		harness.PrintAgentLogsIfFailed()
+		harness.CaptureDeploymentLogsIfFailed()
+
+		err := harness.CleanUpAllTestResources()
+		Expect(err).ToNot(HaveOccurred())
+
+		suiteCtx := e2e.GetWorkerContext()
+		harness.SetTestContext(suiteCtx)
+
+		GinkgoWriter.Printf("[AfterEach] Worker %d: Test cleanup completed\n", workerID)
+	})
+
+	Context("dependency sync", func() {
+		It("should create a new TV, emit DependencyChangeDetected, and update device when a git commit is pushed", Label("89092", "sanity", "agent"), func() {
+			repoName := fmt.Sprintf("dep-sync-git-%s", testID)
+			fleetName := fmt.Sprintf("dep-sync-git-fleet-%s", testID)
+
+			By("setting up a git repository with initial content and registering it")
+			err := harness.SetupGitRepoWithContent(e2e.GitRepoSetupOpts{
+				GitServer:     gitServer,
+				SSHKeyPath:    sshKeyPath,
+				SSHKeyContent: sshKeyContent,
+				InternalHost:  gitInternalHost,
+				InternalPort:  gitInternalPort,
+				RepoName:      repoName,
+				FilePath:      configFileName,
+				Content:       initialContent,
+				CommitMsg:     "Initial config commit",
+				AccessTimeout: repoAccessible,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.DeleteGitRepositoryOnServer(gitServer, sshKeyPath, repoName) })
+
+			By("creating a fleet referencing the git config and enrolling a device")
+			gitConfig, err := util.BuildGitConfigSpec(gitConfigName, repoName, gitBranch, configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, initialVersion, err := harness.CreateFleetAndEnrollDevice(fleetName, fleetLabelKey, gitConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceID).ToNot(BeEmpty())
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+
+			By("capturing the initial template version count")
+			initialTVCount, err := harness.CountTemplateVersions(fleetName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialTVCount).To(BeNumerically(">=", 1))
+			GinkgoWriter.Printf("Initial template version count: %d\n", initialTVCount)
+
+			By("waiting for the first fingerprint and a full git probe cycle before pushing changes")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).ShouldNot(BeEmpty())
+			gitProbeRepoName, gitProbeErr := setupInvalidGitProbeFleet(harness, testID, gitInternalHost, gitInternalPort, sshKeyContent)
+			Expect(gitProbeErr).ToNot(HaveOccurred(), "failed to create git probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(gitProbeRepoName, gitBranch)), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("pushing a new commit to the git repository")
+			err = harness.PushContentToGitServerRepo(gitServer, sshKeyPath, repoName,
+				configFileName, updatedContent, "Update config")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying a new template version is created")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">", initialTVCount))
+
+			By("retrieving the latest commit SHA from the git server")
+			commitSHA, err := harness.GetRemoteHeadSHA(gitServer, sshKeyPath, repoName, gitBranch)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commitSHA).ToNot(BeEmpty(), "Expected a non-empty commit SHA from the git server")
+			GinkgoWriter.Printf("Expected commit SHA: %s\n", commitSHA)
+
+			By("verifying DependencyChangeDetected event was emitted with the correct fingerprint")
+			Eventually(dependencyChangeDetectedPoll(harness, gitResourceKey(repoName, gitBranch), commitSHA), EVENTTIMEOUT, POLLING).Should(BeTrue(),
+				"Expected DependencyChangeDetected event with fingerprint matching commit SHA")
+
+			By("verifying device dependencySync fingerprint matches the new commit SHA")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), RENDERTIMEOUT, POLLING).Should(Equal(commitSHA),
+				"Expected device dependencySync fingerprint to match the latest git commit SHA")
+
+			By("verifying the device rendered version bumped after the dependency sync")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+
+			By("verifying the updated content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, deviceConfigFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedContentMarker))
+		})
+
+		It("should re-render a standalone device when a git commit is pushed", Label("89098", "sanity", "agent"), func() {
+			repoName := fmt.Sprintf("dep-sync-standalone-%s", testID)
+
+			By("setting up a git repository with initial content and registering it")
+			err := harness.SetupGitRepoWithContent(e2e.GitRepoSetupOpts{
+				GitServer:     gitServer,
+				SSHKeyPath:    sshKeyPath,
+				SSHKeyContent: sshKeyContent,
+				InternalHost:  gitInternalHost,
+				InternalPort:  gitInternalPort,
+				RepoName:      repoName,
+				FilePath:      configFileName,
+				Content:       initialContent,
+				CommitMsg:     "Initial config commit",
+				AccessTimeout: repoAccessible,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.DeleteGitRepositoryOnServer(gitServer, sshKeyPath, repoName) })
+
+			By("enrolling a standalone device (no fleet)")
+			deviceID, _ := harness.EnrollAndWaitForOnlineStatus()
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("applying a git config spec directly to the standalone device")
+			gitConfig, err := util.BuildGitConfigSpec(gitConfigName, repoName, gitBranch, configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.UpdateDeviceConfigWithRetries(deviceID, []v1beta1.ConfigProviderSpec{gitConfig}, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the device to render and become UpToDate")
+			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+			GinkgoWriter.Printf("Standalone device initial rendered version: %d\n", initialVersion)
+
+			By("waiting for the first fingerprint and a full git probe cycle before pushing changes")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).ShouldNot(BeEmpty())
+			gitProbeRepoName, gitProbeErr := setupInvalidGitProbeFleet(harness, testID, gitInternalHost, gitInternalPort, sshKeyContent)
+			Expect(gitProbeErr).ToNot(HaveOccurred(), "failed to create git probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(gitProbeRepoName, gitBranch)), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("pushing a new commit to the git repository")
+			err = harness.PushContentToGitServerRepo(gitServer, sshKeyPath, repoName,
+				configFileName, updatedContent, "Update config")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying the standalone device re-renders with the new commit SHA")
+			commitSHA, err := harness.GetRemoteHeadSHA(gitServer, sshKeyPath, repoName, gitBranch)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commitSHA).ToNot(BeEmpty())
+			GinkgoWriter.Printf("Expected standalone device fingerprint: %s\n", commitSHA)
+
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).Should(Equal(commitSHA),
+				"Standalone device should re-render with the new git commit SHA")
+
+			By("verifying the rendered version bumped")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+
+			By("verifying the updated content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, deviceConfigFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedContentMarker))
+		})
+
+		It("should create a new TV and show fingerprint in device status when HTTP content changes", Label("89091", "sanity", "agent"), func() {
+			fleetName := fmt.Sprintf("dep-sync-http-fleet-%s", testID)
+			repoName := fmt.Sprintf("dep-sync-http-repo-%s", testID)
+			httpFilePath := fmt.Sprintf("%s/http-content.txt", testID)
+
+			By("setting up HTTP content and registering the repository")
+			repo, err := harness.SetupHTTPRepoWithContent(e2e.HTTPRepoSetupOpts{
+				FileServer: fileServer,
+				RepoName:   repoName,
+				FilePath:   httpFilePath,
+				Content:    initialHTTPContent,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repo).ToNot(BeNil())
+
+			By("creating a fleet referencing the HTTP config and enrolling a device")
+			httpConfig, err := util.BuildHTTPConfigSpec(httpConfigName, repoName, httpMountPath, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, _, err := harness.CreateFleetAndEnrollDevice(fleetName, fleetLabelKey, httpConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("waiting for the initial template version and capturing count")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">=", 1))
+			initialTVCount, err := harness.CountTemplateVersions(fleetName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the first HTTP fingerprint and a full HTTP probe cycle")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, httpConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			preUpdateFingerprint, err := harness.GetDeviceConfigRefFingerprint(deviceID, httpConfigName)
+			Expect(err).ToNot(HaveOccurred())
+			httpProbeRepoName, httpProbeErr := setupInvalidHTTPProbeFleet(harness, testID, fileServer.GetInternalURL())
+			Expect(httpProbeErr).ToNot(HaveOccurred(), "failed to create HTTP probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, httpResourceKey(httpProbeRepoName, "")), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("updating the HTTP file content on the file server")
+			err = fileServer.PushFile(httpFilePath, updatedHTTPContent)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying a new template version is created after HTTP content change")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">", initialTVCount))
+
+			By("verifying device dependencySync fingerprint changed after HTTP update")
+			Eventually(fingerprintChangedPoll(harness, deviceID, httpConfigName, preUpdateFingerprint), RENDERTIMEOUT, POLLING).Should(BeTrue())
+
+			By("verifying the updated HTTP content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, httpMountPath), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedHTTPContent))
+		})
+
+		It("should re-render a standalone device when HTTP content changes", Label("89299", "sanity", "agent"), func() {
+			repoName := fmt.Sprintf("dep-sync-http-standalone-%s", testID)
+			httpFilePath := fmt.Sprintf("%s/http-standalone-content.txt", testID)
+
+			By("setting up HTTP content and registering the repository")
+			repo, err := harness.SetupHTTPRepoWithContent(e2e.HTTPRepoSetupOpts{
+				FileServer: fileServer,
+				RepoName:   repoName,
+				FilePath:   httpFilePath,
+				Content:    initialHTTPContent,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repo).ToNot(BeNil())
+
+			By("enrolling a standalone device (no fleet)")
+			deviceID, _ := harness.EnrollAndWaitForOnlineStatus()
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("applying an HTTP config spec directly to the standalone device")
+			httpConfig, err := util.BuildHTTPConfigSpec(httpConfigName, repoName, httpMountPath, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.UpdateDeviceConfigWithRetries(deviceID, []v1beta1.ConfigProviderSpec{httpConfig}, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the device to render and capturing initial state")
+			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+			GinkgoWriter.Printf("Standalone HTTP device initial rendered version: %d\n", initialVersion)
+
+			By("waiting for the first HTTP fingerprint and a full HTTP probe cycle")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, httpConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			preUpdateFingerprint, err := harness.GetDeviceConfigRefFingerprint(deviceID, httpConfigName)
+			Expect(err).ToNot(HaveOccurred())
+			httpProbeRepoName, httpProbeErr := setupInvalidHTTPProbeFleet(harness, testID, fileServer.GetInternalURL())
+			Expect(httpProbeErr).ToNot(HaveOccurred(), "failed to create HTTP probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, httpResourceKey(httpProbeRepoName, "")), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("updating the HTTP file content on the file server")
+			err = fileServer.PushFile(httpFilePath, updatedHTTPContent)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying the standalone device fingerprint changed")
+			Eventually(fingerprintChangedPoll(harness, deviceID, httpConfigName, preUpdateFingerprint), e2e.TIMEOUT, POLLING).Should(BeTrue())
+
+			By("verifying the rendered version bumped")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+
+			By("verifying the updated HTTP content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, httpMountPath), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedHTTPContent))
+		})
+
+		It("should create a new TV and update device fingerprint when a K8s secret is updated", Label("89094", "sanity", "agent"), func() {
+			fleetName := fmt.Sprintf("dep-sync-secret-fleet-%s", testID)
+			secretName := fmt.Sprintf("dep-sync-secret-%s", testID)
+
+			By("creating a K8s secret for the test")
+			err := harness.ManageK8sSecret(e2e.K8sSecretCreate, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: initialSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.ManageK8sSecret(e2e.K8sSecretDelete, secretNamespace, secretName, "", nil) })
+
+			By("creating a fleet referencing the K8s secret config and enrolling a device")
+			secretConfig, err := util.BuildK8sSecretConfigSpec(secretConfigName, secretName, secretNamespace, secretMountPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, initialVersion, err := harness.CreateFleetAndEnrollDevice(fleetName, fleetLabelKey, secretConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceID).ToNot(BeEmpty())
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+
+			By("capturing the initial template version count")
+			initialTVCount, err := harness.CountTemplateVersions(fleetName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialTVCount).To(BeNumerically(">=", 1))
+
+			By("re-applying the K8s secret to seed the initial fingerprint via the informer")
+			err = harness.ManageK8sSecret(e2e.K8sSecretPatch, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: initialSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("capturing the pre-update secret fingerprint")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, secretConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			preUpdateSecretFingerprint, err := harness.GetDeviceConfigRefFingerprint(deviceID, secretConfigName)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Pre-update secret fingerprint: %s\n", preUpdateSecretFingerprint)
+
+			By("verifying initial secret content was delivered to the device")
+			secretDeviceFile := secretDeviceFilePath(secretMountPath)
+			Eventually(deviceFileContentPoll(harness, secretDeviceFile), RENDERTIMEOUT, POLLING).Should(ContainSubstring(initialSecretValue))
+
+			By("patching the K8s secret to trigger a change")
+			err = harness.ManageK8sSecret(e2e.K8sSecretPatch, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: updatedSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying a new template version is created after secret change")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">", initialTVCount))
+
+			By("verifying device dependencySync fingerprint changed after secret update")
+			Eventually(fingerprintChangedPoll(harness, deviceID, secretConfigName, preUpdateSecretFingerprint), RENDERTIMEOUT, POLLING).Should(BeTrue())
+
+			By("verifying the updated secret content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, secretDeviceFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedSecretValue))
+
+			By("verifying the device rendered version bumped after the secret sync")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+		})
+
+		It("should re-render a standalone device when a K8s secret is updated", Label("89321", "sanity", "agent"), func() {
+			secretName := fmt.Sprintf("ds-secret-sa-%s", testID)
+
+			By("creating a K8s secret for the test")
+			err := harness.ManageK8sSecret(e2e.K8sSecretCreate, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: initialSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.ManageK8sSecret(e2e.K8sSecretDelete, secretNamespace, secretName, "", nil) })
+
+			By("enrolling a standalone device (no fleet)")
+			deviceID, _ := harness.EnrollAndWaitForOnlineStatus()
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("applying a K8s secret config spec directly to the standalone device")
+			secretConfig, err := util.BuildK8sSecretConfigSpec(secretConfigName, secretName, secretNamespace, secretMountPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.UpdateDeviceConfigWithRetries(deviceID, []v1beta1.ConfigProviderSpec{secretConfig}, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the device to render its initial spec")
+			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+
+			By("re-applying the K8s secret to seed the initial fingerprint via the informer")
+			err = harness.ManageK8sSecret(e2e.K8sSecretPatch, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: initialSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("capturing the pre-update secret fingerprint")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, secretConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			preUpdateFingerprint, err := harness.GetDeviceConfigRefFingerprint(deviceID, secretConfigName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying initial secret content was delivered to the device")
+			secretDeviceFile := secretDeviceFilePath(secretMountPath)
+			Eventually(deviceFileContentPoll(harness, secretDeviceFile), RENDERTIMEOUT, POLLING).Should(ContainSubstring(initialSecretValue))
+
+			By("patching the K8s secret to trigger a change")
+			err = harness.ManageK8sSecret(e2e.K8sSecretPatch, secretNamespace, secretName, releaseNamespace, map[string]string{secretDataKey: updatedSecretValue})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying device dependencySync fingerprint changed after secret update")
+			Eventually(fingerprintChangedPoll(harness, deviceID, secretConfigName, preUpdateFingerprint), e2e.TIMEOUT, POLLING).Should(BeTrue())
+
+			By("verifying the device rendered version bumped")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+
+			By("verifying the updated secret content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, secretDeviceFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedSecretValue))
+		})
+
+		It("should sync the good fleet and emit DependencySyncProbeFailed for the bad fleet without blocking", Label("89093", "sanity"), func() {
+			badRepoName := fmt.Sprintf("dep-sync-badcred-%s", testID)
+			badFleetName := fmt.Sprintf("dep-sync-badcred-fleet-%s", testID)
+			goodRepoName := fmt.Sprintf("dep-sync-goodcred-%s", testID)
+			goodFleetName := fmt.Sprintf("dep-sync-goodcred-fleet-%s", testID)
+
+			By("setting up a git repository with initial content for the good fleet")
+			err := harness.SetupGitRepoWithContent(e2e.GitRepoSetupOpts{
+				GitServer:     gitServer,
+				SSHKeyPath:    sshKeyPath,
+				SSHKeyContent: sshKeyContent,
+				InternalHost:  gitInternalHost,
+				InternalPort:  gitInternalPort,
+				RepoName:      goodRepoName,
+				FilePath:      configFileName,
+				Content:       initialContent,
+				CommitMsg:     "Initial good config",
+				AccessTimeout: repoAccessible,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.DeleteGitRepositoryOnServer(gitServer, sshKeyPath, goodRepoName) })
+
+			By("creating the fleet with good credentials")
+			goodConfig, err := util.BuildGitConfigSpec("good-config", goodRepoName, gitBranch, configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.CreateFleetWithLabelConfig(goodFleetName, fleetLabelKey, goodConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the good fleet to get its initial template version")
+			Eventually(templateVersionCountPoll(harness, goodFleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">=", 1))
+			initialGoodTVCount, err := harness.CountTemplateVersions(goodFleetName)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Good fleet initial TV count: %d\n", initialGoodTVCount)
+
+			By("creating a Repository with invalid credentials for the bad fleet")
+			err = harness.CreateRepositoryWithSSHCredentials(badRepoName, invalidGitRepositoryURL(gitInternalHost, gitInternalPort), sshKeyContent)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating the fleet with bad credentials")
+			badConfig, err := util.BuildGitConfigSpec("bad-config", badRepoName, gitBranch, configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.CreateFleetWithLabelConfig(badFleetName, fleetLabelKey, badConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the periodic to run its first probe (indicated by DependencySyncProbeFailed for the bad fleet)")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(badRepoName, gitBranch)), e2e.TIMEOUT, POLLING).Should(BeTrue(),
+				"Expected the periodic to probe the bad fleet and emit a ProbeFailed event")
+
+			By("pushing a new commit to the good repo to trigger dependency sync")
+			err = harness.PushContentToGitServerRepo(gitServer, sshKeyPath, goodRepoName,
+				configFileName, updatedContent, "Update good config")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying the good fleet gets a NEW template version from dependency sync")
+			Eventually(templateVersionCountPoll(harness, goodFleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">", initialGoodTVCount))
+
+			By("verifying the bad fleet did not get a dependency-sync-triggered template version")
+			Consistently(templateVersionCountPoll(harness, badFleetName), "10s", POLLING).Should(BeNumerically("<=", 1),
+				"Bad fleet should have at most its initial TV (no dependency sync TV)")
+
+			By("verifying the bad fleet repository is not accessible")
+			err = harness.WaitForRepositoryNotAccessible(badRepoName, repoNotAccessibleTimeout, repoAccessInterval)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying DependencySyncProbeFailed event was emitted with resourceKey and error")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(badRepoName, gitBranch)), EVENTTIMEOUT, POLLING).Should(BeTrue(),
+				"Expected DependencySyncProbeFailed event for invalid credentials")
+		})
+
+		It("should sync both git and HTTP providers independently in a multi-provider fleet", Label("89272", "sanity", "agent"), func() {
+			repoName := fmt.Sprintf("dep-sync-multi-%s", testID)
+			fleetName := fmt.Sprintf("dep-sync-multi-fleet-%s", testID)
+
+			By("setting up a git repository with initial content and registering it")
+			err := harness.SetupGitRepoWithContent(e2e.GitRepoSetupOpts{
+				GitServer:     gitServer,
+				SSHKeyPath:    sshKeyPath,
+				SSHKeyContent: sshKeyContent,
+				InternalHost:  gitInternalHost,
+				InternalPort:  gitInternalPort,
+				RepoName:      repoName,
+				FilePath:      configFileName,
+				Content:       initialContent,
+				CommitMsg:     "Initial config commit",
+				AccessTimeout: repoAccessible,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.DeleteGitRepositoryOnServer(gitServer, sshKeyPath, repoName) })
+
+			By("setting up HTTP content and registering the repository")
+			httpRepoName := fmt.Sprintf("dep-sync-multi-http-%s", testID)
+			httpFilePath := fmt.Sprintf("%s/multi-http-content.txt", testID)
+			repo, err := harness.SetupHTTPRepoWithContent(e2e.HTTPRepoSetupOpts{
+				FileServer: fileServer,
+				RepoName:   httpRepoName,
+				FilePath:   httpFilePath,
+				Content:    initialHTTPContent,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(repo).ToNot(BeNil())
+
+			By("creating a fleet with both git and HTTP config providers")
+			gitConfig, err := util.BuildGitConfigSpec(gitConfigName, repoName, gitBranch, configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			httpConfig, err := util.BuildHTTPConfigSpec(httpConfigName, httpRepoName, httpMountPath, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, _, err := harness.CreateFleetAndEnrollDevice(fleetName, fleetLabelKey, gitConfig, httpConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("waiting for initial template version and both fingerprints to populate")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(BeNumerically(">=", 1))
+			initialTVCount, err := harness.CountTemplateVersions(fleetName)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, httpConfigName), RENDERTIMEOUT, POLLING).ShouldNot(BeEmpty())
+			preHTTPFingerprint, err := harness.GetDeviceConfigRefFingerprint(deviceID, httpConfigName)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for full git and HTTP probe cycles before pushing changes")
+			gitProbeRepoName, gitProbeErr := setupInvalidGitProbeFleet(harness, testID, gitInternalHost, gitInternalPort, sshKeyContent)
+			Expect(gitProbeErr).ToNot(HaveOccurred(), "failed to create git probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(gitProbeRepoName, gitBranch)), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+			httpProbeRepoName, httpProbeErr := setupInvalidHTTPProbeFleet(harness, testID, fileServer.GetInternalURL())
+			Expect(httpProbeErr).ToNot(HaveOccurred(), "failed to create HTTP probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, httpResourceKey(httpProbeRepoName, "")), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("pushing a new git commit to trigger dependency sync")
+			err = harness.PushContentToGitServerRepo(gitServer, sshKeyPath, repoName,
+				configFileName, updatedContent, "Update config")
+			Expect(err).ToNot(HaveOccurred())
+
+			commitSHA, err := harness.GetRemoteHeadSHA(gitServer, sshKeyPath, repoName, gitBranch)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("updating the HTTP file content on the file server")
+			err = fileServer.PushFile(httpFilePath, updatedHTTPContent)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying both fingerprints updated")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).Should(Equal(commitSHA),
+				"Git fingerprint should update to new commit SHA")
+			Eventually(fingerprintChangedPoll(harness, deviceID, httpConfigName, preHTTPFingerprint), e2e.TIMEOUT, POLLING).Should(BeTrue())
+
+			By("verifying new template versions were created")
+			Eventually(templateVersionCountPoll(harness, fleetName), e2e.TIMEOUT, POLLING).Should(
+				BeNumerically(">", initialTVCount),
+				"Multi-provider fleet should get new TVs from dependency sync")
+
+			By("verifying both updated contents were delivered to the device")
+			Eventually(deviceFileContentPoll(harness, deviceConfigFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedContentMarker))
+			Eventually(deviceFileContentPoll(harness, httpMountPath), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedHTTPContent))
+		})
+
+		It("should sync a parameterized targetRevision resolved per-device label", Label("89301", "sanity", "agent"), func() {
+			repoName := fmt.Sprintf("dep-sync-param-%s", testID)
+			fleetName := fmt.Sprintf("dep-sync-param-fleet-%s", testID)
+
+			By("setting up a git repository with initial content on main")
+			err := harness.SetupGitRepoWithContent(e2e.GitRepoSetupOpts{
+				GitServer:     gitServer,
+				SSHKeyPath:    sshKeyPath,
+				SSHKeyContent: sshKeyContent,
+				InternalHost:  gitInternalHost,
+				InternalPort:  gitInternalPort,
+				RepoName:      repoName,
+				FilePath:      configFileName,
+				Content:       initialContent,
+				CommitMsg:     "Initial config on main",
+				AccessTimeout: repoAccessible,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = harness.DeleteGitRepositoryOnServer(gitServer, sshKeyPath, repoName) })
+
+			By("creating the staging branch with initial content")
+			err = harness.CreateGitBranchOnServer(gitServer, sshKeyPath, repoName, parameterizedTargetBranch)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating a fleet with parameterized targetRevision referencing device label")
+			gitConfig, err := util.BuildGitConfigSpec(gitConfigName, repoName, "{{ .metadata.labels.branch }}", configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.CreateFleetWithLabelConfig(fleetName, fleetLabelKey, gitConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("enrolling a device with the fleet selector and branch label")
+			deviceID, _ := harness.EnrollAndWaitForOnlineStatus(
+				map[string]string{fleetLabelKey: fleetName, parameterizedBranchLabel: parameterizedTargetBranch},
+			)
+			Expect(deviceID).ToNot(BeEmpty())
+
+			By("waiting for the device to render its initial spec")
+			initialVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Parameterized device initial rendered version: %d\n", initialVersion)
+			Expect(initialVersion).To(BeNumerically(">=", 1))
+
+			By("capturing the initial template version count")
+			initialTVCount, err := harness.CountTemplateVersions(fleetName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(initialTVCount).To(BeNumerically(">=", 1))
+
+			By("waiting for the first fingerprint and a full git probe cycle before pushing changes")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).ShouldNot(BeEmpty())
+			gitProbeRepoName, gitProbeErr := setupInvalidGitProbeFleet(harness, testID, gitInternalHost, gitInternalPort, sshKeyContent)
+			Expect(gitProbeErr).ToNot(HaveOccurred(), "failed to create git probe canary")
+			Eventually(dependencySyncProbeFailedPoll(harness, gitResourceKey(gitProbeRepoName, gitBranch)), e2e.TIMEOUT, POLLING).Should(BeTrue(), probeCycleCompleteMsg)
+
+			By("pushing updated content to the staging branch")
+			err = harness.PushContentToGitServerRepoBranch(gitServer, sshKeyPath, repoName,
+				parameterizedTargetBranch, configFileName, updatedContent, "Update config on staging")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("retrieving the latest commit SHA from the staging branch")
+			commitSHA, err := harness.GetRemoteHeadSHA(gitServer, sshKeyPath, repoName, parameterizedTargetBranch)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Expected staging commit SHA: %s\n", commitSHA)
+			Expect(commitSHA).ToNot(BeEmpty())
+
+			By("verifying DependencyChangeDetected event was emitted for the device")
+			Eventually(dependencyChangeDetectedPoll(harness, gitResourceKey(repoName, parameterizedTargetBranch), commitSHA), e2e.TIMEOUT, POLLING).Should(BeTrue(),
+				"Expected DependencyChangeDetected event with fingerprint matching staging commit SHA")
+
+			By("verifying device dependencySync fingerprint matches the new staging commit SHA")
+			Eventually(deviceConfigRefFingerprintPoll(harness, deviceID, gitConfigName), e2e.TIMEOUT, POLLING).Should(Equal(commitSHA),
+				"Expected device fingerprint to match staging branch commit SHA")
+
+			By("verifying the template version count did NOT increase (parameterized path skips fleet-level TV)")
+			Consistently(templateVersionCountPoll(harness, fleetName), "10s", POLLING).Should(Equal(initialTVCount),
+				"Parameterized fleet should NOT get a new TV from dependency sync")
+
+			By("verifying the device rendered version bumped after the dependency sync")
+			Eventually(renderedVersionPoll(harness, deviceID), RENDERTIMEOUT, POLLING).Should(BeNumerically(">", initialVersion))
+
+			By("verifying the updated content was delivered to the device")
+			Eventually(deviceFileContentPoll(harness, deviceConfigFile), e2e.TIMEOUT, POLLING).Should(ContainSubstring(updatedContentMarker))
+		})
+
+	})
+})
+
+// invalidGitRepositoryURL returns a syntactically valid but unreachable git SSH URL.
+func invalidGitRepositoryURL(gitInternalHost string, gitInternalPort int) string {
+	return fmt.Sprintf("user@%s:%d:/home/user/repos/nonexistent.git", gitInternalHost, gitInternalPort)
+}
+
+// gitResourceKey returns the full resource key for a git dependency sync event.
+func gitResourceKey(repoName, branch string) string {
+	return fmt.Sprintf("git:%s/%s", repoName, branch)
+}
+
+// httpResourceKey returns the full resource key for an HTTP dependency sync event.
+func httpResourceKey(repoName, suffix string) string {
+	return fmt.Sprintf("http:%s/%s", repoName, suffix)
+}
+
+// secretDeviceFilePath returns the on-device path where the secret key is mounted.
+func secretDeviceFilePath(mountPath string) string {
+	return fmt.Sprintf("%s/%s", mountPath, secretDataKey)
+}
+
+// deviceConfigRefFingerprintPoll returns a poller that fetches the device's config-ref fingerprint.
+func deviceConfigRefFingerprintPoll(h *e2e.Harness, deviceID, configProviderName string) func() (string, error) {
+	return func() (string, error) {
+		return h.GetDeviceConfigRefFingerprint(deviceID, configProviderName)
+	}
+}
+
+// templateVersionCountPoll returns a poller that counts template versions for a fleet.
+func templateVersionCountPoll(h *e2e.Harness, fleetName string) func() (int, error) {
+	return func() (int, error) {
+		return h.CountTemplateVersions(fleetName)
+	}
+}
+
+// dependencyChangeDetectedPoll returns a poller that checks for a DependencyChangeDetected event.
+func dependencyChangeDetectedPoll(h *e2e.Harness, resourceKey, fingerprint string) func() (bool, error) {
+	return func() (bool, error) {
+		return h.HasEventWithDetails(v1beta1.EventReasonDependencyChangeDetected, resourceKey, fingerprint)
+	}
+}
+
+// deviceFileContentPoll returns a poller that reads a file from the enrolled device.
+func deviceFileContentPoll(h *e2e.Harness, filePath string) func() (string, error) {
+	return func() (string, error) {
+		return h.ReadFileFromDevice(filePath)
+	}
+}
+
+// fingerprintChangedPoll returns a poller that succeeds when the fingerprint differs from the previous one.
+func fingerprintChangedPoll(h *e2e.Harness, deviceID, configProviderName, previousFingerprint string) func() (bool, error) {
+	return func() (bool, error) {
+		fp, err := h.GetDeviceConfigRefFingerprint(deviceID, configProviderName)
+		if err != nil {
+			return false, err
+		}
+		return fp != "" && fp != previousFingerprint, nil
+	}
+}
+
+// dependencySyncProbeFailedPoll returns a poller that checks for a DependencySyncProbeFailed event.
+func dependencySyncProbeFailedPoll(h *e2e.Harness, resourceKey string) func() (bool, error) {
+	return func() (bool, error) {
+		return h.HasEventWithDetails(v1beta1.EventReasonDependencySyncProbeFailed, resourceKey, "")
+	}
+}
+
+// renderedVersionPoll returns a poller that fetches the device's current rendered version.
+func renderedVersionPoll(h *e2e.Harness, deviceID string) func() (int, error) {
+	return func() (int, error) {
+		return h.GetCurrentDeviceRenderedVersion(deviceID)
+	}
+}
+
+// setupInvalidGitProbeFleet registers a git repo with invalid credentials and a fleet
+// that references it. Callers wait for DependencySyncProbeFailed on the returned repo
+// name before pushing content changes: the periodic only emits that event after a full
+// git probe cycle, by which time real dependency refs should already be stored as firstSeen.
+// Parameterized targetRevision refs are skipped at fleet level but resolved per-device
+// during rollout; those device-level git refs are polled in the same git periodic task.
+func setupInvalidGitProbeFleet(h *e2e.Harness, testID, gitInternalHost string, gitInternalPort int, sshKey util.SSHPrivateKeyContent) (repoName string, err error) {
+	if h == nil {
+		return "", fmt.Errorf("harness must not be nil")
+	}
+	if testID == "" {
+		return "", fmt.Errorf("test ID must not be empty")
+	}
+	repoName = fmt.Sprintf("invalid-git-probe-repo-%s", testID)
+	fleetName := fmt.Sprintf("invalid-git-probe-fleet-%s", testID)
+
+	if err := h.CreateRepositoryWithSSHCredentials(repoName, invalidGitRepositoryURL(gitInternalHost, gitInternalPort), sshKey); err != nil {
+		return "", err
+	}
+
+	configSpec, err := util.BuildGitConfigSpec("invalid-probe-config", repoName, gitBranch, configFilePath)
+	if err != nil {
+		return "", err
+	}
+	if err := h.CreateFleetWithLabelConfig(fleetName, fleetLabelKey, configSpec); err != nil {
+		return "", err
+	}
+
+	return repoName, nil
+}
+
+// setupInvalidHTTPProbeFleet registers an HTTP repo pointing at a missing file and a fleet
+// that references it. Callers wait for DependencySyncProbeFailed on the returned repo name
+// before pushing HTTP content changes — same firstSeen gate as setupInvalidGitProbeFleet,
+// but for the separate HTTP periodic task.
+func setupInvalidHTTPProbeFleet(h *e2e.Harness, testID, fileServerInternalURL string) (repoName string, err error) {
+	if h == nil {
+		return "", fmt.Errorf("harness must not be nil")
+	}
+	if testID == "" {
+		return "", fmt.Errorf("test ID must not be empty")
+	}
+	if fileServerInternalURL == "" {
+		return "", fmt.Errorf("file server internal URL must not be empty")
+	}
+	repoName = fmt.Sprintf("invalid-http-probe-repo-%s", testID)
+	fleetName := fmt.Sprintf("invalid-http-probe-fleet-%s", testID)
+
+	invalidURL := fmt.Sprintf("%s/invalid-http-probe-%s.txt", fileServerInternalURL, testID)
+	if _, err := h.CreateHTTPRepository(repoName, invalidURL, nil, nil); err != nil {
+		return "", err
+	}
+
+	configSpec, err := util.BuildHTTPConfigSpec("invalid-http-probe-config", repoName, invalidHTTPProbeMountPath, nil)
+	if err != nil {
+		return "", err
+	}
+	if err := h.CreateFleetWithLabelConfig(fleetName, fleetLabelKey, configSpec); err != nil {
+		return "", err
+	}
+
+	return repoName, nil
+}

--- a/test/e2e/infra/auxiliary/fileserver.go
+++ b/test/e2e/infra/auxiliary/fileserver.go
@@ -101,3 +101,8 @@ func (f *FileServer) PushFile(relativePath, content string) error {
 	}
 	return os.WriteFile(fullPath, []byte(content), 0600)
 }
+
+// GetInternalURL returns the internal (cluster-reachable) URL of the file server.
+func (f *FileServer) GetInternalURL() string {
+	return f.InternalURL
+}

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -759,17 +759,22 @@ func (h *Harness) RunInteractiveCLI(args ...string) (io.WriteCloser, io.ReadClos
 }
 
 func (h *Harness) CLIWithStdin(stdin string, args ...string) (string, error) {
-	return h.SHWithStdin(stdin, flightctlPath(), args...)
+	return h.SHWithStdin(stdin, flightctlPath(), false, args...)
 }
 
-func (h *Harness) SHWithStdin(stdin, command string, args ...string) (string, error) {
+// SHWithStdin runs a command with stdin. Set redactStdin to true to suppress stdin from logs (e.g. secrets).
+func (h *Harness) SHWithStdin(stdin, command string, redactStdin bool, args ...string) (string, error) {
 	cmd := exec.Command(command)
 
 	cmd.Stdin = strings.NewReader(stdin)
 
 	h.setArgsInCmd(cmd, args...)
 
-	logrus.Infof("running: %s with stdin: %s", strings.Join(cmd.Args, " "), stdin)
+	stdinLog := stdin
+	if redactStdin {
+		stdinLog = "<redacted>"
+	}
+	logrus.Infof("running: %s with stdin: %s", strings.Join(cmd.Args, " "), stdinLog)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		logrus.Errorf("executing cli: %s", err)
@@ -829,7 +834,7 @@ func (h *Harness) CLIWithEnvAndShell(env map[string]string, shellCommand string)
 }
 
 func (h *Harness) SH(command string, args ...string) (string, error) {
-	return h.SHWithStdin("", command, args...)
+	return h.SHWithStdin("", command, false, args...)
 }
 
 func updateResourceWithRetries(updateFunc func() error) {

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -1182,3 +1182,24 @@ func (h *Harness) DecommissionDevice(deviceName string) (string, error) {
 	}
 	return h.CLI("decommission", "devices/"+deviceName)
 }
+
+// GetDeviceConfigRefFingerprint returns the fingerprint for a specific config provider
+// from the device's DependencySync status. Returns empty string if not found.
+func (h *Harness) GetDeviceConfigRefFingerprint(deviceID, configProviderName string) (string, error) {
+	if deviceID == "" {
+		return "", fmt.Errorf("deviceID is empty")
+	}
+	device, err := h.GetDevice(deviceID)
+	if err != nil {
+		return "", err
+	}
+	if device.Status == nil || device.Status.DependencySync == nil || device.Status.DependencySync.ConfigRefs == nil {
+		return "", nil
+	}
+	for _, ref := range *device.Status.DependencySync.ConfigRefs {
+		if ref.ConfigProviderName == configProviderName && ref.Fingerprint != nil && *ref.Fingerprint != "" {
+			return *ref.Fingerprint, nil
+		}
+	}
+	return "", nil
+}

--- a/test/harness/e2e/harness_events.go
+++ b/test/harness/e2e/harness_events.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
 )
 
 // RunGetEvents executes "get events" CLI command with optional arguments.
@@ -31,6 +32,24 @@ func (h *Harness) GetDeviceEvents(deviceName string, reason *v1beta1.EventReason
 	return resp.JSON200.Items, nil
 }
 
+// ListEventsByReason retrieves events filtered by reason (not scoped to a specific device).
+func (h *Harness) ListEventsByReason(reason string) ([]v1beta1.Event, error) {
+	fieldSelector := fmt.Sprintf("reason=%s", reason)
+	resp, err := h.Client.ListEventsWithResponse(h.Context, &v1beta1.ListEventsParams{
+		FieldSelector: &fieldSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events with reason %s: %w", reason, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("nil response listing events with reason %s", reason)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected status %d listing events with reason %s", resp.StatusCode(), reason)
+	}
+	return resp.JSON200.Items, nil
+}
+
 // HasEventWithReason checks if the event list contains an event with the specified reason.
 func HasEventWithReason(events []v1beta1.Event, reason v1beta1.EventReason) bool {
 	for _, ev := range events {
@@ -39,4 +58,39 @@ func HasEventWithReason(events []v1beta1.Event, reason v1beta1.EventReason) bool
 		}
 	}
 	return false
+}
+
+// HasEventWithDetails checks for an event matching the reason and resourceKey. For
+// DependencyChangeDetected it also requires an exact fingerprint match; for
+// DependencySyncProbeFailed it requires a non-empty error field.
+func (h *Harness) HasEventWithDetails(reason v1beta1.EventReason, expectedResourceKey, expectedFingerprint string) (bool, error) {
+	events, err := h.ListEventsByReason(string(reason))
+	if err != nil {
+		return false, err
+	}
+	for _, ev := range events {
+		switch reason {
+		case v1beta1.EventReasonDependencyChangeDetected:
+			details, detailErr := ev.Details.AsDependencyChangeDetectedDetails()
+			if detailErr != nil {
+				continue
+			}
+			if details.ResourceKey == expectedResourceKey && details.Fingerprint == expectedFingerprint {
+				GinkgoWriter.Printf("DependencyChangeDetected: resourceKey=%s fingerprint=%s\n",
+					details.ResourceKey, details.Fingerprint)
+				return true, nil
+			}
+		case v1beta1.EventReasonDependencySyncProbeFailed:
+			details, detailErr := ev.Details.AsDependencySyncProbeFailedDetails()
+			if detailErr != nil {
+				continue
+			}
+			if details.ResourceKey == expectedResourceKey && details.Error != "" {
+				GinkgoWriter.Printf("DependencySyncProbeFailed: resourceKey=%s error=%s\n",
+					details.ResourceKey, details.Error)
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/test/harness/e2e/harness_fleet.go
+++ b/test/harness/e2e/harness_fleet.go
@@ -142,6 +142,38 @@ func (h *Harness) CreateTestFleetWithConfig(testFleetName string, testFleetSelec
 	return err
 }
 
+// CreateFleetWithLabelConfig creates a fleet that selects devices by a single label key/value
+// and applies the given config providers.
+func (h *Harness) CreateFleetWithLabelConfig(fleetName, labelKey string, configs ...v1beta1.ConfigProviderSpec) error {
+	selector := v1beta1.LabelSelector{MatchLabels: &map[string]string{labelKey: fleetName}}
+	deviceSpec := v1beta1.DeviceSpec{
+		Config: &configs,
+	}
+	return h.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+}
+
+// CreateFleetAndEnrollDevice creates a fleet with the given config providers, enrolls a device
+// with a matching label, waits for it to become UpToDate, and returns the device ID and initial
+// rendered version. Returns an error if any step fails.
+func (h *Harness) CreateFleetAndEnrollDevice(fleetName, labelKey string, configs ...v1beta1.ConfigProviderSpec) (string, int, error) {
+	if err := h.CreateFleetWithLabelConfig(fleetName, labelKey, configs...); err != nil {
+		return "", 0, fmt.Errorf("failed to create fleet %s: %w", fleetName, err)
+	}
+
+	deviceID, _ := h.EnrollAndWaitForOnlineStatus(map[string]string{labelKey: fleetName})
+	if deviceID == "" {
+		return "", 0, fmt.Errorf("enrolled device ID is empty for fleet %s", fleetName)
+	}
+
+	initialVersion, err := h.GetCurrentDeviceRenderedVersion(deviceID)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get rendered version for device %s: %w", deviceID, err)
+	}
+
+	logrus.Infof("Fleet %s: device %s enrolled with initial rendered version %d", fleetName, deviceID, initialVersion)
+	return deviceID, initialVersion, nil
+}
+
 func (h *Harness) DeleteFleet(testFleetName string) error {
 	_, err := h.Client.DeleteFleet(h.Context, testFleetName)
 	return err
@@ -339,4 +371,19 @@ func (h *Harness) WaitForFleetCount(params *v1beta1.ListFleetsParams, expectedCo
 		return len(resp.JSON200.Items), nil
 	}, timeout, polling).Should(Equal(expectedCount),
 		fmt.Sprintf("Expected %d fleets matching params", expectedCount))
+}
+
+// CountTemplateVersions returns the number of template versions for a fleet.
+func (h *Harness) CountTemplateVersions(fleetName string) (int, error) {
+	resp, err := h.Client.ListTemplateVersionsWithResponse(h.Context, fleetName, &v1beta1.ListTemplateVersionsParams{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list template versions for fleet %s: %w", fleetName, err)
+	}
+	if resp == nil {
+		return 0, fmt.Errorf("nil response listing template versions for fleet %s", fleetName)
+	}
+	if resp.JSON200 == nil {
+		return 0, fmt.Errorf("unexpected status %d listing template versions for fleet %s", resp.StatusCode(), fleetName)
+	}
+	return len(resp.JSON200.Items), nil
 }

--- a/test/harness/e2e/harness_git.go
+++ b/test/harness/e2e/harness_git.go
@@ -1,13 +1,16 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/test/util"
@@ -89,7 +92,7 @@ func (h *Harness) CreateGitRepositoryOnServer(config GitServerConfig, keyPath ut
 		return fmt.Errorf("repository name cannot be empty")
 	}
 
-	createCmd := fmt.Sprintf("create-repo %s", repoName)
+	createCmd := fmt.Sprintf("create-repo '%s'", repoName)
 	err := h.runGitServerSSHCommand(config, keyPath, createCmd)
 	if err != nil {
 		return fmt.Errorf("failed to create git repository %s: %w", repoName, err)
@@ -109,7 +112,7 @@ func (h *Harness) DeleteGitRepositoryOnServer(config GitServerConfig, keyPath ut
 		return fmt.Errorf("repository name cannot be empty")
 	}
 
-	deleteCmd := fmt.Sprintf("delete-repo %s", repoName)
+	deleteCmd := fmt.Sprintf("delete-repo '%s'", repoName)
 	err := h.runGitServerSSHCommand(config, keyPath, deleteCmd)
 	if err != nil {
 		return fmt.Errorf("failed to delete git repository %s: %w", repoName, err)
@@ -158,6 +161,21 @@ func (h *Harness) CloneGitRepositoryFromServer(config GitServerConfig, keyPath u
 
 // pushToGitServerRepo is a helper that clones a repo, calls prepareContent to set up files,
 // then commits and pushes changes.
+// sanitizeFilePath cleans filePath, rejects absolute paths, and verifies the
+// result stays inside workDir. Returns the full path and cleaned relative path.
+func sanitizeFilePath(workDir, filePath string) (fullPath, relPath string, err error) {
+	cleaned := filepath.Clean(filePath)
+	if filepath.IsAbs(cleaned) {
+		return "", "", fmt.Errorf("file path %q must be relative", filePath)
+	}
+	full := filepath.Join(workDir, cleaned)
+	rel, err := filepath.Rel(workDir, full)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", "", fmt.Errorf("file path %q escapes work directory", filePath)
+	}
+	return full, rel, nil
+}
+
 func (h *Harness) pushToGitServerRepo(config GitServerConfig, keyPath util.SSHPrivateKeyPath, repoName, addPath, commitMessage string, prepareContent func(workDir string) error) error {
 	workDir := filepath.Join(h.gitWorkDir, "temp-"+uuid.New().String())
 	defer os.RemoveAll(workDir)
@@ -191,7 +209,10 @@ func (h *Harness) PushContentToGitServerRepo(config GitServerConfig, keyPath uti
 	}
 
 	err := h.pushToGitServerRepo(config, keyPath, repoName, filePath, commitMessage, func(workDir string) error {
-		fullFilePath := filepath.Join(workDir, filePath)
+		fullFilePath, _, err := sanitizeFilePath(workDir, filePath)
+		if err != nil {
+			return err
+		}
 		if err := os.MkdirAll(filepath.Dir(fullFilePath), 0755); err != nil {
 			return fmt.Errorf("failed to create directory for file: %w", err)
 		}
@@ -234,6 +255,57 @@ func (h *Harness) CreateGitBranchOnServer(config GitServerConfig, keyPath util.S
 	}
 
 	logrus.Infof("Created branch %s in git repository %s", branchName, repoName)
+	return nil
+}
+
+// PushContentToGitServerRepoBranch pushes content to a specific branch of a git repository on the server.
+func (h *Harness) PushContentToGitServerRepoBranch(config GitServerConfig, keyPath util.SSHPrivateKeyPath, repoName, branch, filePath, content, commitMessage string) error {
+	if repoName == "" {
+		return fmt.Errorf("repository name cannot be empty")
+	}
+	if branch == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+	if filePath == "" {
+		return fmt.Errorf("file path cannot be empty")
+	}
+	if commitMessage == "" {
+		commitMessage = "Add content via test harness"
+	}
+
+	workDir := filepath.Join(h.gitWorkDir, "temp-"+uuid.New().String())
+	defer os.RemoveAll(workDir)
+
+	if err := h.CloneGitRepositoryFromServer(config, keyPath, repoName, workDir); err != nil {
+		return fmt.Errorf("failed to clone repository for push: %w", err)
+	}
+
+	if err := h.runGitCommands(workDir, keyPath, [][]string{
+		{"git", "checkout", branch},
+	}); err != nil {
+		return fmt.Errorf("failed to checkout branch %s: %w", branch, err)
+	}
+
+	fullFilePath, cleanedPath, err := sanitizeFilePath(workDir, filePath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(fullFilePath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for file: %w", err)
+	}
+	if err := os.WriteFile(fullFilePath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write content to file: %w", err)
+	}
+
+	if err := h.runGitCommands(workDir, keyPath, [][]string{
+		{"git", "add", cleanedPath},
+		{"git", "commit", "-m", commitMessage},
+		{"git", "push", "origin", branch},
+	}); err != nil {
+		return err
+	}
+
+	logrus.Infof("Pushed content to git repository %s branch %s, file: %s", repoName, branch, filePath)
 	return nil
 }
 
@@ -479,6 +551,44 @@ func (h *Harness) ReadFileFromDevice(filePath string) (string, error) {
 	return stdout.String(), nil
 }
 
+// GetRemoteHeadSHA returns the HEAD commit SHA of a remote git repository on the E2E git server.
+func (h *Harness) GetRemoteHeadSHA(config GitServerConfig, keyPath util.SSHPrivateKeyPath, repoName, branch string) (string, error) {
+	if keyPath == "" {
+		return "", fmt.Errorf("ssh key path cannot be empty")
+	}
+	if repoName == "" {
+		return "", fmt.Errorf("repository name cannot be empty")
+	}
+	if branch == "" {
+		branch = "main"
+	}
+
+	gitEnv := append(os.Environ(),
+		fmt.Sprintf("GIT_SSH_COMMAND=ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o BatchMode=yes -o LogLevel=ERROR", string(keyPath)),
+	)
+
+	repoURL := fmt.Sprintf("ssh://%s@%s/home/user/repos/%s.git",
+		config.User, net.JoinHostPort(config.Host, strconv.Itoa(config.Port)), repoName)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", repoURL, fmt.Sprintf("refs/heads/%s", branch))
+	cmd.Env = gitEnv
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("timed out querying remote HEAD for branch %s: %w", branch, ctx.Err())
+		}
+		return "", fmt.Errorf("failed to get remote HEAD SHA: %w, output: %s", err, string(output))
+	}
+
+	parts := strings.Fields(string(output))
+	if len(parts) == 0 {
+		return "", fmt.Errorf("no output from git ls-remote for branch %s", branch)
+	}
+	return parts[0], nil
+}
+
 // PushTemplatedFilesToGitRepo updates an existing git repo with templated files, commits and pushes.
 func (h *Harness) PushTemplatedFilesToGitRepo(workDir string, keyPath util.SSHPrivateKeyPath, sourceDir string, data interface{}) error {
 	err := writeTemplatedFilesToDir(sourceDir, workDir, data)
@@ -489,6 +599,54 @@ func (h *Harness) PushTemplatedFilesToGitRepo(workDir string, keyPath util.SSHPr
 	err = h.CommitAndPushGitRepo(workDir, keyPath, "")
 	if err != nil {
 		return fmt.Errorf("failed to commit and push: %w", err)
+	}
+
+	return nil
+}
+
+// GitRepoSetupOpts holds options for SetupGitRepoWithContent.
+type GitRepoSetupOpts struct {
+	GitServer     GitServerConfig
+	SSHKeyPath    util.SSHPrivateKeyPath
+	SSHKeyContent util.SSHPrivateKeyContent
+	InternalHost  string
+	InternalPort  int
+	RepoName      string
+	FilePath      string
+	Content       string
+	CommitMsg     string
+	// Timeout for waiting for the Repository to become accessible. Defaults to 2 minutes.
+	AccessTimeout time.Duration
+	// Polling interval for accessibility check. Defaults to 5 seconds.
+	AccessInterval time.Duration
+}
+
+// SetupGitRepoWithContent creates a git repo on the server, pushes initial content,
+// registers a Repository resource with SSH credentials, and waits for it to become accessible.
+func (h *Harness) SetupGitRepoWithContent(opts GitRepoSetupOpts) error {
+	if opts.AccessTimeout == 0 {
+		opts.AccessTimeout = 2 * time.Minute
+	}
+	if opts.AccessInterval == 0 {
+		opts.AccessInterval = 5 * time.Second
+	}
+
+	if err := h.CreateGitRepositoryOnServer(opts.GitServer, opts.SSHKeyPath, opts.RepoName); err != nil {
+		return fmt.Errorf("create git repo on server: %w", err)
+	}
+
+	if err := h.PushContentToGitServerRepo(opts.GitServer, opts.SSHKeyPath, opts.RepoName,
+		opts.FilePath, opts.Content, opts.CommitMsg); err != nil {
+		return fmt.Errorf("push initial content: %w", err)
+	}
+
+	if err := h.CreateRepositoryWithValidE2ECredentials(opts.InternalHost, opts.InternalPort,
+		opts.RepoName, opts.SSHKeyContent); err != nil {
+		return fmt.Errorf("create Repository resource: %w", err)
+	}
+
+	if err := h.WaitForRepositoryAccessible(opts.RepoName, opts.AccessTimeout, opts.AccessInterval); err != nil {
+		return fmt.Errorf("wait for repository accessible: %w", err)
 	}
 
 	return nil

--- a/test/harness/e2e/harness_repository.go
+++ b/test/harness/e2e/harness_repository.go
@@ -69,6 +69,8 @@ func (h *Harness) CreateRepositoryWithSSHCredentials(repoName, repoURL string, k
 		Spec: repoSpec,
 	}
 
+	h.addTestLabelToRepositoryMetadata(&repository.Metadata)
+
 	resp, err := h.Client.CreateRepositoryWithResponse(h.Context, repository)
 	if err != nil {
 		return fmt.Errorf("failed to create repository: %w", err)
@@ -317,4 +319,42 @@ func (h *Harness) CreateGitRepositoryNoAuth(name, url string) (*v1beta1.Reposito
 // addTestLabelToRepositoryMetadata adds test labels to repository metadata.
 func (h *Harness) addTestLabelToRepositoryMetadata(metadata *v1beta1.ObjectMeta) {
 	h.SetLabelsForRepositoryMetadata(metadata, nil)
+}
+
+// FileContentPusher is satisfied by auxiliary.FileServer.
+type FileContentPusher interface {
+	PushFile(relativePath, content string) error
+	GetInternalURL() string
+}
+
+// HTTPRepoSetupOpts holds options for SetupHTTPRepoWithContent.
+type HTTPRepoSetupOpts struct {
+	FileServer FileContentPusher
+	RepoName   string
+	FilePath   string
+	Content    string
+}
+
+// SetupHTTPRepoWithContent pushes content to the file server and creates an HTTP Repository resource.
+func (h *Harness) SetupHTTPRepoWithContent(opts HTTPRepoSetupOpts) (*v1beta1.Repository, error) {
+	if opts.FileServer == nil {
+		return nil, fmt.Errorf("missing FileServer in HTTPRepoSetupOpts")
+	}
+	if opts.RepoName == "" {
+		return nil, fmt.Errorf("missing RepoName in HTTPRepoSetupOpts")
+	}
+	if opts.FilePath == "" {
+		return nil, fmt.Errorf("missing FilePath in HTTPRepoSetupOpts")
+	}
+	if err := opts.FileServer.PushFile(opts.FilePath, opts.Content); err != nil {
+		return nil, fmt.Errorf("push file to server: %w", err)
+	}
+
+	repoURL := fmt.Sprintf("%s/%s", opts.FileServer.GetInternalURL(), opts.FilePath)
+	repo, err := h.CreateHTTPRepository(opts.RepoName, repoURL, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP repository: %w", err)
+	}
+
+	return repo, nil
 }

--- a/test/harness/e2e/harness_secret.go
+++ b/test/harness/e2e/harness_secret.go
@@ -1,0 +1,90 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// K8sSecretAction specifies the operation to perform on a Kubernetes secret.
+type K8sSecretAction string
+
+const (
+	K8sSecretCreate K8sSecretAction = "create"
+	K8sSecretDelete K8sSecretAction = "delete"
+	K8sSecretPatch  K8sSecretAction = "patch"
+)
+
+// ManageK8sSecret performs create, delete, or patch on a Kubernetes secret.
+// releaseNamespace is only required for create (it sets the sync label).
+// data is required for create and patch.
+func (h *Harness) ManageK8sSecret(action K8sSecretAction, namespace, name, releaseNamespace string, data map[string]string) error {
+	if namespace == "" || name == "" {
+		return fmt.Errorf("namespace and name must not be empty")
+	}
+
+	switch action {
+	case K8sSecretCreate:
+		if releaseNamespace == "" {
+			return fmt.Errorf("releaseNamespace must not be empty for create")
+		}
+		if len(data) == 0 {
+			return fmt.Errorf("data must not be empty for create")
+		}
+		manifest := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]string{
+					fmt.Sprintf("flightctl.io/sync-%s", releaseNamespace): "true",
+				},
+			},
+			"stringData": data,
+		}
+		manifestBytes, err := json.Marshal(manifest)
+		if err != nil {
+			return fmt.Errorf("failed to marshal secret manifest %s/%s: %w", namespace, name, err)
+		}
+		if _, err := h.SHWithStdin(string(manifestBytes), "kubectl", true, "apply", "-f", "-"); err != nil {
+			return fmt.Errorf("failed to create secret %s/%s: %w", namespace, name, err)
+		}
+
+	case K8sSecretDelete:
+		if _, err := h.SH("kubectl", "delete", "secret", name, "-n", namespace, "--ignore-not-found"); err != nil {
+			return fmt.Errorf("failed to delete secret %s/%s: %w", namespace, name, err)
+		}
+
+	case K8sSecretPatch:
+		if len(data) == 0 {
+			return fmt.Errorf("data must not be empty for patch")
+		}
+		if releaseNamespace == "" {
+			return fmt.Errorf("releaseNamespace must not be empty for patch")
+		}
+		manifest := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]string{
+					fmt.Sprintf("flightctl.io/sync-%s", releaseNamespace): "true",
+				},
+			},
+			"stringData": data,
+		}
+		manifestBytes, err := json.Marshal(manifest)
+		if err != nil {
+			return fmt.Errorf("failed to marshal secret manifest %s/%s: %w", namespace, name, err)
+		}
+		if _, err := h.SHWithStdin(string(manifestBytes), "kubectl", true, "apply", "-f", "-"); err != nil {
+			return fmt.Errorf("failed to patch secret %s/%s: %w", namespace, name, err)
+		}
+
+	default:
+		return fmt.Errorf("unknown action: %s", action)
+	}
+
+	return nil
+}

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -133,6 +133,14 @@ fi
 # Always deploy with Kubernetes auth
 AUTH_ARGS="--set global.auth.type=k8s"
 
+# Opt-in cluster-level secret access for dependency-sync K8s secret tests.
+# Disabled by default to avoid broadening RBAC for normal deploys.
+# Usage: ENABLE_SECRET_SYNC=true make deploy-helm
+SECRET_ACCESS_ARGS=""
+if [ "${ENABLE_SECRET_SYNC:-}" = "true" ]; then
+  SECRET_ACCESS_ARGS="--set periodic.clusterLevelSecretAccess=true --set worker.clusterLevelSecretAccess=true"
+fi
+
 helm dependency build ./deploy/helm/flightctl
 
 # Format IP for DNS: use sslip.io for IPv6 (replace : with -), nip.io for IPv4
@@ -145,6 +153,7 @@ fi
 helm upgrade --install --namespace flightctl-external \
                   --values ./deploy/helm/flightctl/values.dev.yaml \
                   --set global.baseDomain=${BASE_DOMAIN} \
+                  ${SECRET_ACCESS_ARGS} \
                   ${ONLY_DB} ${DB_SIZE_PARAMS} ${AUTH_ARGS} ${SQL_ARG} ${GATEWAY_ARGS} ${KV_ARG} ${SERVICE_IMAGE_ARGS} flightctl \
               ./deploy/helm/flightctl/ --kube-context kind-kind
 
@@ -162,7 +171,6 @@ kubectl exec -n flightctl-internal --context kind-kind "${DB_POD}" -- createdb a
 if [ "$ONLY_DB" ]; then
   exit 0
 fi
-
 
 kubectl rollout status deployment flightctl-api -n flightctl-external -w --timeout=300s
 

--- a/test/util/create_utils.go
+++ b/test/util/create_utils.go
@@ -554,3 +554,68 @@ func BuildInlineConfigSpec(name, filePath, content, user string) (api.ConfigProv
 	})
 	return provider, err
 }
+
+// BuildGitConfigSpec creates a ConfigProviderSpec for a git-backed config provider.
+func BuildGitConfigSpec(name, repository, targetRevision, path string) (api.ConfigProviderSpec, error) {
+	if name == "" || repository == "" || targetRevision == "" || path == "" {
+		return api.ConfigProviderSpec{}, fmt.Errorf("name, repository, targetRevision, and path must not be empty")
+	}
+	var provider api.ConfigProviderSpec
+	err := provider.FromGitConfigProviderSpec(api.GitConfigProviderSpec{
+		Name: name,
+		GitRef: struct {
+			Path           string `json:"path"`
+			Repository     string `json:"repository"`
+			TargetRevision string `json:"targetRevision"`
+		}{
+			Path:           path,
+			Repository:     repository,
+			TargetRevision: targetRevision,
+		},
+	})
+	return provider, err
+}
+
+// BuildHTTPConfigSpec creates a ConfigProviderSpec for an HTTP-backed config provider.
+func BuildHTTPConfigSpec(name, repository, filePath string, suffix *string) (api.ConfigProviderSpec, error) {
+	if name == "" || repository == "" || filePath == "" {
+		return api.ConfigProviderSpec{}, fmt.Errorf("name, repository, and filePath must not be empty")
+	}
+	var provider api.ConfigProviderSpec
+	err := provider.FromHttpConfigProviderSpec(api.HttpConfigProviderSpec{
+		Name: name,
+		HttpRef: struct {
+			FilePath   string  `json:"filePath"`
+			Repository string  `json:"repository"`
+			Suffix     *string `json:"suffix,omitempty"`
+		}{
+			FilePath:   filePath,
+			Repository: repository,
+			Suffix:     suffix,
+		},
+	})
+	return provider, err
+}
+
+// BuildK8sSecretConfigSpec creates a ConfigProviderSpec for a Kubernetes secret-backed config provider.
+func BuildK8sSecretConfigSpec(name, secretName, namespace, mountPath string) (api.ConfigProviderSpec, error) {
+	if name == "" || secretName == "" || namespace == "" || mountPath == "" {
+		return api.ConfigProviderSpec{}, fmt.Errorf("name, secretName, namespace, and mountPath must not be empty")
+	}
+	var provider api.ConfigProviderSpec
+	err := provider.FromKubernetesSecretProviderSpec(api.KubernetesSecretProviderSpec{
+		Name: name,
+		SecretRef: struct {
+			Group     string       `json:"group,omitempty"`
+			MountPath string       `json:"mountPath"`
+			Name      string       `json:"name"`
+			Namespace string       `json:"namespace"`
+			User      api.Username `json:"user,omitempty"`
+		}{
+			MountPath: mountPath,
+			Name:      secretName,
+			Namespace: namespace,
+		},
+	})
+	return provider, err
+}


### PR DESCRIPTION
E2E tests:

Git fleet sync (89092) - pushes a git commit, verifies new template version, DependencyChangeDetected event, device fingerprint matches commit SHA, and rendered version bumps
Git standalone device sync (89098) - same as above but for a device not owned by a fleet, exercising the direct device re-render path
HTTP fleet sync (89091) - updates HTTP server content/ETag, verifies new template version and device fingerprint
K8s secret fleet sync (89094) - patches a K8s secret, verifies new template version via the informer (event-driven, not polling)
Bad repo resilience (89093) - creates a fleet with invalid credentials alongside a good fleet, verifies the good fleet syncs while the bad fleet emits DependencySyncProbeFailed
New harness helpers:

CreateK8sSecret, DeleteK8sSecret, PatchK8sSecret - with automatic informer label (flightctl.io/sync-<releaseNamespace>=true)
GetDeviceConfigRefFingerprint, GetDeviceDependencySyncConfigRefs - device dependency sync status accessors
ListEventsByReason - event filtering by reason
CountTemplateVersions - template version count for a fleet
GetRemoteHeadSHA - fetch latest commit SHA from the E2E git server
New config builder utilities:

BuildGitConfigSpec, BuildHTTPConfigSpec, BuildK8sSecretConfigSpec in test/util/create_utils.go
Test performance:

Suite patches the periodic ConfigMap to lower the dependency sync poll interval to 30s (restored in AfterSuite)
Total suite time ~25 minutes (5 tests × ~5 min each), within the 40-minute CI budget