### PR TITLE
EDM-3884: Add flightctl-backup to CLI download artifacts

### DIFF
--- a/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-console.yaml
+++ b/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-console.yaml
@@ -48,4 +48,28 @@ spec:
       text: Download flightctl-restore for Windows for x86_64
     - href: '{{ $url }}/arm64/windows/flightctl-restore-windows-arm64.zip'
       text: Download flightctl-restore for Windows for ARM64
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: flightctl-backup-cli-downloads
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-cli-artifacts
+spec:
+  description: flightctl-backup creates a backup of the Flight Control database. Use for backing up Flight Control data.
+  displayName: flightctl-backup - Database Backup CLI
+  links:
+    - href: '{{ $url }}/amd64/linux/flightctl-backup-linux-amd64.tar.gz'
+      text: Download flightctl-backup for Linux for x86_64
+    - href: '{{ $url }}/arm64/linux/flightctl-backup-linux-arm64.tar.gz'
+      text: Download flightctl-backup for Linux for ARM64
+    - href: '{{ $url }}/amd64/mac/flightctl-backup-darwin-amd64.zip'
+      text: Download flightctl-backup for Mac for x86_64
+    - href: '{{ $url }}/arm64/mac/flightctl-backup-darwin-arm64.zip'
+      text: Download flightctl-backup for Mac for ARM64
+    - href: '{{ $url }}/amd64/windows/flightctl-backup-windows-amd64.zip'
+      text: Download flightctl-backup for Windows for x86_64
+    - href: '{{ $url }}/arm64/windows/flightctl-backup-windows-arm64.zip'
+      text: Download flightctl-backup for Windows for ARM64
 {{ end }}

--- a/hack/build_multiarch_clis.sh
+++ b/hack/build_multiarch_clis.sh
@@ -14,74 +14,93 @@ set -euo pipefail
 # │   ├── amd64
 # │   │   ├── linux
 # │   │   │   ├── flightctl.tar.gz
-# │   │   │   └── flightctl-restore.tar.gz
+# │   │   │   ├── flightctl-restore.tar.gz
+# │   │   │   └── flightctl-backup.tar.gz
 # │   │   ├── mac
 # │   │   │   ├── flightctl.zip
-# │   │   │   └── flightctl-restore.zip
+# │   │   │   ├── flightctl-restore.zip
+# │   │   │   └── flightctl-backup.zip
 # │   │   └── windows
 # │   │       ├── flightctl.zip
-# │   │       └── flightctl-restore.zip
+# │   │       ├── flightctl-restore.zip
+# │   │       └── flightctl-backup.zip
 # │   └── arm64
 # │       ├── linux
 # │       │   ├── flightctl.tar.gz
-# │       │   └── flightctl-restore.tar.gz
+# │       │   ├── flightctl-restore.tar.gz
+# │       │   └── flightctl-backup.tar.gz
 # │       ├── mac
 # │       │   ├── flightctl.zip
-# │       │   └── flightctl-restore.zip
+# │       │   ├── flightctl-restore.zip
+# │       │   └── flightctl-backup.zip
 # │       └── windows
 # │           ├── flightctl.zip
-# │           └── flightctl-restore.zip
+# │           ├── flightctl-restore.zip
+# │           └── flightctl-backup.zip
 # ├── binaries
 # │   ├── amd64
 # │   │   ├── linux
 # │   │   │   ├── flightctl
-# │   │   │   └── flightctl-restore
+# │   │   │   ├── flightctl-restore
+# │   │   │   └── flightctl-backup
 # │   │   ├── mac
 # │   │   │   ├── flightctl
-# │   │   │   └── flightctl-restore
+# │   │   │   ├── flightctl-restore
+# │   │   │   └── flightctl-backup
 # │   │   └── windows
 # │   │       ├── flightctl.exe
-# │   │       └── flightctl-restore.exe
+# │   │       ├── flightctl-restore.exe
+# │   │       └── flightctl-backup.exe
 # │   └── arm64
 # │       ├── linux
 # │       │   ├── flightctl
-# │       │   └── flightctl-restore
+# │       │   ├── flightctl-restore
+# │       │   └── flightctl-backup
 # │       ├── mac
 # │       │   ├── flightctl
-# │       │   └── flightctl-restore
+# │       │   ├── flightctl-restore
+# │       │   └── flightctl-backup
 # │       └── windows
 # │           ├── flightctl.exe
-# │           └── flightctl-restore.exe
+# │           ├── flightctl-restore.exe
+# │           └── flightctl-backup.exe
 # └── gh-archives
 #     ├── index.json   (artifact manifest)
 #     ├── amd64
 #     │   ├── linux
 #     │   │   ├── flightctl-linux-amd64.tar.gz (+ .sha256)
-#     │   │   └── flightctl-restore-linux-amd64.tar.gz (+ .sha256)
+#     │   │   ├── flightctl-restore-linux-amd64.tar.gz (+ .sha256)
+#     │   │   └── flightctl-backup-linux-amd64.tar.gz (+ .sha256)
 #     │   ├── mac
 #     │   │   ├── flightctl-darwin-amd64.zip (+ .sha256)
-#     │   │   └── flightctl-restore-darwin-amd64.zip (+ .sha256)
+#     │   │   ├── flightctl-restore-darwin-amd64.zip (+ .sha256)
+#     │   │   └── flightctl-backup-darwin-amd64.zip (+ .sha256)
 #     │   └── windows
 #     │       ├── flightctl-windows-amd64.zip (+ .sha256)
-#     │       └── flightctl-restore-windows-amd64.zip (+ .sha256)
+#     │       ├── flightctl-restore-windows-amd64.zip (+ .sha256)
+#     │       └── flightctl-backup-windows-amd64.zip (+ .sha256)
 #     └── arm64
 #         ├── linux
 #         │   ├── flightctl-linux-arm64.tar.gz (+ .sha256)
-#         │   └── flightctl-restore-linux-arm64.tar.gz (+ .sha256)
+#         │   ├── flightctl-restore-linux-arm64.tar.gz (+ .sha256)
+#         │   └── flightctl-backup-linux-arm64.tar.gz (+ .sha256)
 #         ├── mac
 #         │   ├── flightctl-darwin-arm64.zip (+ .sha256)
-#         │   └── flightctl-restore-darwin-arm64.zip (+ .sha256)
+#         │   ├── flightctl-restore-darwin-arm64.zip (+ .sha256)
+#         │   └── flightctl-backup-darwin-arm64.zip (+ .sha256)
 #         └── windows
 #             ├── flightctl-windows-arm64.zip (+ .sha256)
-#             └── flightctl-restore-windows-arm64.zip (+ .sha256)
+#             ├── flightctl-restore-windows-arm64.zip (+ .sha256)
+#             └── flightctl-backup-windows-arm64.zip (+ .sha256)
 #
 # When adding a new CLI, each index.json row includes "tool" set to that binary name.
-CLI_TOOLS=(flightctl flightctl-restore)
+CLI_TOOLS=(flightctl flightctl-restore flightctl-backup)
 
 get_cli_make_target() {
   case "$1" in
     flightctl) echo build-cli ;;
     flightctl-restore) echo build-restore ;;
+    flightctl-backup) echo build-backup ;;
     *)
       echo "Unknown downloadable CLI '$1': add a Makefile target mapping in get_cli_make_target()." >&2
       exit 1


### PR DESCRIPTION
## EDM-3884: Add flightctl-backup to CLI download artifacts

### Summary

Adds `flightctl-backup` to the multi-architecture CLI build system and OpenShift console download listings, following the same pattern established in #2851 for `flightctl-restore`.

This enables users to download the `flightctl-backup` CLI tool for all supported platforms through the OpenShift console, alongside the existing `flightctl` and `flightctl-restore` downloads.

### Changes

**`hack/build_multiarch_clis.sh`:**
- Added `flightctl-backup` to the `CLI_TOOLS` array
- Added mapping `flightctl-backup → build-backup` in `get_cli_make_target()` function
- Updated documentation tree to include `flightctl-backup` artifacts across all platforms

**`deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-console.yaml`:**
- Added new `ConsoleCLIDownload` resource for `flightctl-backup`
- Includes download links for all platform combinations:
  - Linux (x86_64, ARM64)
  - Mac (x86_64, ARM64)
  - Windows (x86_64, ARM64)

### Testing

- ✓ Bash script syntax validation passed
- ✓ Helm template lint passed
- ✓ `flightctl-backup` binary builds successfully
- ✓ Binary version and help commands work correctly
- ✓ Makefile `build-backup` target verified

### Pattern Compliance

This PR follows the exact pattern from #2851:
- CLI tool registered in the build array
- Make target mapping configured
- ConsoleCLIDownload resource structure matches existing tools
- All 6 platform variants included per tool (3 OS × 2 architectures)
- The build system will automatically populate `tool: "flightctl-backup"` in `index.json`

---

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
