### PR TITLE
EDM-3949: Added backup and restore test suite

### DIFF
--- a/test/e2e/backup_restore/backup_restore_suite_test.go
+++ b/test/e2e/backup_restore/backup_restore_suite_test.go
@@ -37,10 +37,8 @@ func TestBackupRestore(t *testing.T) {
 var _ = BeforeSuite(func() {
 	auxSvcs = auxiliary.Get(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
-	if reason := backupRestoreExternalDBSkipReason(); reason != "" {
-		Skip(reason)
-	}
-	e2e.SetupWorkerHarnessOrAbort()
+	_, _, err := e2e.SetupWorkerHarness()
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/backup_restore/backup_restore_test.go
+++ b/test/e2e/backup_restore/backup_restore_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
-	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
@@ -22,7 +21,6 @@ import (
 )
 
 const (
-	// 84934: fleet and device labels
 	backupRestoreFleetName = "backup-restore-fleet"
 	devYesLabel            = "dev"
 	devYesValue            = "yes"
@@ -34,14 +32,19 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 
 	BeforeEach(func() {
 		harness = e2e.GetWorkerHarness()
-		_, err := login.LoginToAPIWithToken(harness)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			_, err := login.LoginToAPIWithToken(harness)
+			return err
+		}, testutil.DURATION_TIMEOUT, testutil.POLLING).Should(Succeed(), "API should become responsive for login")
 		br = newBackupRestore(harness, setup.GetDefaultProviders())
 	})
 
 	// full backup/restore flow with 3 ERs, fleet, post-backup changes, and resume.
 	Context("All flightctl resources can be resumed after a backup and restore", func() {
-		It("3 ERs, fleet rollout, backup, restore, then verify states and resume", Label("84934", "sanity", "slow"), func() {
+		It("3 ERs, fleet rollout, backup, restore, then verify states and resume", Label("89141", "sanity", "slow"), func() {
+			if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+				Skip(reason)
+			}
 			// --- Setup: 3 ERs (2 approved, 1 unapproved) ---
 			By("Setting up 3 VMs and enrollment requests (2 approved with different labels, 1 unapproved)")
 			ctx := harness.GetTestContext()
@@ -105,9 +108,9 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 
 			// --- Step 2: Create backup archive (service has rvAtBackup) ---
 			By("Step 2: Creating backup archive (service RV=rvAtBackup)")
-			archivePath, cleanup, err := br.RunFlightCtlBackup()
-			Expect(err).ToNot(HaveOccurred(), "backup must succeed (build with: make flightctl-backup)")
-			defer cleanup()
+			backupDir := GinkgoT().TempDir()
+			archivePath, _, err := br.RunFlightCtlBackup(backupDir)
+			Expect(err).ToNot(HaveOccurred(), "backup must succeed")
 
 			// --- Step 3: Update fleet to OS v3 + inline config (new RV) ---
 			var rvAfterUpdate int
@@ -138,9 +141,12 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 			}, testutil.LONGTIMEOUT)
 			Expect(rvAfterUpdate).To(BeNumerically(">", rvAtBackup), "step 4: new RV must be greater than previous")
 
-			// --- Step 5: Restore from backup; flightctl-restore handles service stop/start ---
-			By("Step 5: Restoring from backup (flightctl-restore stops services, restores DB, starts services)")
-			Expect(br.RunFlightCtlRestore(archivePath)).To(Succeed(), "flightctl-restore must succeed (build with: make flightctl-restore)")
+			// --- Step 5: Restore from backup archive (do not restart device); service back to RV=N ---
+			By("Step 5: Restoring from backup archive (flightctl-restore handles service stop/start)")
+			defer func() {
+				Expect(br.VerifyAllServicesRunning()).To(Succeed(), "all services must be running after restore cleanup")
+			}()
+			Expect(br.RunFlightCtlRestoreFromArchive(archivePath)).To(Succeed(), "flightctl-restore must succeed")
 
 			By("Verifying all services were restarted by the restore binary")
 			Eventually(func() error {
@@ -273,7 +279,10 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 		})
 
 		// 84938: Backup taken while device update is in progress; after restore, device version <= server → AwaitingReconnect then Online (no ConflictPaused).
-		It("backup during update in progress, restore then devices reach Online", Label("84938", "slow"), func() {
+		It("backup during update in progress, restore then devices reach Online", Label("89194", "slow"), func() {
+			if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+				Skip(reason)
+			}
 			ctx := harness.GetTestContext()
 
 			workerID2 := GinkgoParallelProcess()*100 + 1
@@ -309,12 +318,15 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(harness.CreateOrUpdateTestFleet(backupRestoreFleetName, selector, deviceSpecV3)).To(Succeed())
 			// Verify device is still on v2 (update not yet applied) so backup truly occurs while update is in progress.
-			archivePath, cleanup, err := br.RunFlightCtlBackup()
-			Expect(err).ToNot(HaveOccurred(), "backup must succeed (build with: make flightctl-backup)")
-			defer cleanup()
+			backupDir := GinkgoT().TempDir()
+			archivePath, _, err := br.RunFlightCtlBackup(backupDir)
+			Expect(err).ToNot(HaveOccurred(), "backup must succeed")
 
 			By("Restore process: flightctl-restore (handles service stop/start internally)")
-			Expect(br.RunFlightCtlRestore(archivePath)).To(Succeed(), "flightctl-restore must succeed (build with: make flightctl-restore)")
+			defer func() {
+				Expect(br.VerifyAllServicesRunning()).To(Succeed(), "all services must be running after restore cleanup")
+			}()
+			Expect(br.RunFlightCtlRestoreFromArchive(archivePath)).To(Succeed(), "flightctl-restore must succeed")
 
 			By("Verifying all services were restarted by the restore binary")
 			Eventually(func() error {
@@ -353,26 +365,3 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 		})
 	})
 })
-
-// motdInlineConfigProviderSpec returns a ConfigProviderSpec that writes content to /etc/motd (per test plan 4.1).
-func motdInlineConfigProviderSpec() v1beta1.ConfigProviderSpec {
-	mode := 0644
-	inline := v1beta1.InlineConfigProviderSpec{
-		Inline: []v1beta1.FileSpec{{
-			Path:    "/etc/motd",
-			Mode:    &mode,
-			Content: "backup-restore-e2e\n",
-		}},
-		Name: "motd-inline",
-	}
-	var spec v1beta1.ConfigProviderSpec
-	if err := spec.FromInlineConfigProviderSpec(inline); err != nil {
-		panic(err)
-	}
-	return spec
-}
-
-// newBackupRestore returns a BackupRestore for running the backup/restore binaries.
-func newBackupRestore(harness *e2e.Harness, p *infra.Providers) *e2e.BackupRestore {
-	return harness.NewBackupRestore(p)
-}

--- a/test/e2e/backup_restore/backup_test.go
+++ b/test/e2e/backup_restore/backup_test.go
@@ -1,0 +1,141 @@
+package backup_restore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	archiveNamePattern = `^flightctl-backup-\d{8}T\d{6}Z\.tar\.gz$`
+	checksumSuffix     = ".sha256"
+)
+
+var _ = Describe("Backup command", Label("backup-restore", "backup"), func() {
+	var harness *e2e.Harness
+	var br *e2e.BackupRestore
+	var archivePath, checksumPath, extractDir string
+	var entries []string
+
+	BeforeEach(func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		harness = e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, setup.GetDefaultProviders())
+
+		outputDir := GinkgoT().TempDir()
+		var err error
+		archivePath, checksumPath, err = br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred(), "backup should succeed on healthy deployment")
+		Expect(archivePath).To(BeAnExistingFile(), "archive file should exist")
+		Expect(checksumPath).To(BeAnExistingFile(), "checksum file should exist")
+
+		entries, err = extractTarGzEntries(archivePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		extractDir = GinkgoT().TempDir()
+		Expect(extractTarGzToDir(archivePath, extractDir)).To(Succeed())
+	})
+
+	It("When backup runs it should produce valid archive with checksum and expected structure", Label("89120"), func() {
+		By("Verifying archive filename matches timestamp naming convention")
+		Expect(filepath.Base(archivePath)).To(MatchRegexp(archiveNamePattern))
+
+		By("Verifying checksum matches archive content")
+		computedHash, err := computeSHA256(archivePath)
+		Expect(err).ToNot(HaveOccurred())
+		fileHash, err := readChecksumHash(checksumPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fileHash).To(Equal(computedHash), "SHA256 checksum should match archive content")
+
+		By("Verifying archive contains expected directory structure")
+		Expect(entries).To(ContainElement("metadata.json"), "archive should contain metadata.json")
+		Expect(hasEntryWithPrefix(entries, "pki/")).To(BeTrue(), "archive should contain pki/ directory")
+	})
+
+	It("When backup runs on deployment with internal DB it should include db/dump.sql", Label("89121"), func() {
+		p := setup.GetDefaultProviders()
+		if p == nil || p.Infra == nil || !p.Infra.BuiltinDatabaseWorkloadAvailable() {
+			Skip("requires internal DB (db.type=builtin)")
+		}
+
+		Expect(hasEntryWithPrefix(entries, "db/")).To(BeTrue(), "archive should contain db/ directory")
+		dumpPath := filepath.Join(extractDir, "db", "dump.sql")
+		Expect(dumpPath).To(BeAnExistingFile())
+		dumpContent, err := os.ReadFile(dumpPath)
+		Expect(err).ToNot(HaveOccurred())
+		dump := string(dumpContent)
+		Expect(dump).To(ContainSubstring("PostgreSQL database dump"), "dump should have PostgreSQL header")
+		for _, table := range []string{"devices", "fleets", "enrollment_requests", "repositories"} {
+			Expect(dump).To(ContainSubstring(table), "dump should contain table: %s", table)
+		}
+	})
+
+	It("When backup runs it should collect PKI materials", Label("89122"), func() {
+		Expect(hasEntryWithPrefix(entries, "pki/")).To(BeTrue(), "archive should contain pki/ directory")
+		pkiDir := filepath.Join(extractDir, "pki")
+		Expect(pkiDir).To(BeADirectory())
+		pkiFiles, err := os.ReadDir(pkiDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(pkiFiles)).To(BeNumerically(">", 0), "pki/ should contain files")
+		for _, f := range pkiFiles {
+			if f.IsDir() {
+				continue
+			}
+			info, err := f.Info()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Size()).To(BeNumerically(">", 0), "PKI file %s should have content", f.Name())
+		}
+	})
+
+	It("When backup runs it should include correct version and deployment type in metadata", Label("89126"), func() {
+		metadata, err := readBackupMetadata(filepath.Join(extractDir, "metadata.json"))
+		Expect(err).ToNot(HaveOccurred())
+
+		versionOutput, err := br.RunFlightCtlBackupRaw("version")
+		Expect(err).ToNot(HaveOccurred(), "flightctl-backup version should succeed")
+		expectedVersion := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(versionOutput), "Flight Control Backup Version:"))
+		Expect(metadata.Version).To(Equal(expectedVersion), "metadata version should match the backup binary version")
+		Expect(string(metadata.DeploymentType)).To(BeElementOf("kubernetes", "podman"), "deployment type should be kubernetes or podman")
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.BuiltinDatabaseWorkloadAvailable() {
+			Expect(metadata.DatabaseIncluded).To(BeTrue(), "database should be included for internal DB")
+		} else {
+			Expect(metadata.DatabaseIncluded).To(BeFalse(), "database should not be included for external DB")
+		}
+		Expect(metadata.Timestamp.IsZero()).To(BeFalse(), "timestamp should be set")
+	})
+
+	It("When backup runs it should collect service configuration", Label("89123"), func() {
+		Expect(hasEntryWithPrefix(entries, "config/")).To(BeTrue(), "archive should contain config/ directory")
+		configDir := filepath.Join(extractDir, "config")
+		Expect(configDir).To(BeADirectory())
+		configFiles, err := os.ReadDir(configDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(configFiles)).To(BeNumerically(">", 0), "config/ should contain files")
+	})
+
+	It("When backup runs without TTY it should complete non-interactively", Label("89125"), func() {
+		Expect(archivePath).To(BeAnExistingFile(), "backup should complete without interactive prompts")
+		Expect(checksumPath).To(BeAnExistingFile())
+	})
+
+	It("When backup runs without --output it should default to current directory and succeed", Label("89578"), func() {
+		output, err := br.RunFlightCtlBackupRaw()
+		Expect(err).ToNot(HaveOccurred(), "backup without --output should default to current directory")
+		Expect(output).To(ContainSubstring("Backup completed"), "backup should complete successfully using default output directory")
+	})
+
+	It("When backup binary exists it should be executable", Label("89127"), func() {
+		binaryPath := harness.GetFlightctlBackupPath()
+		info, err := os.Stat(binaryPath)
+		Expect(err).ToNot(HaveOccurred(), "flightctl-backup binary should exist at %s", binaryPath)
+		Expect(info.Mode().Perm()&0o111).ToNot(BeZero(), "binary should have execute permission")
+	})
+})

--- a/test/e2e/backup_restore/helpers_test.go
+++ b/test/e2e/backup_restore/helpers_test.go
@@ -1,0 +1,317 @@
+package backup_restore
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/backup"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/gomega"
+)
+
+// --- Backup/restore shared helpers ---
+
+// newBackupRestore returns a BackupRestore using the production backup/restore binaries.
+func newBackupRestore(harness *e2e.Harness, p *infra.Providers) *e2e.BackupRestore {
+	return harness.NewBackupRestore(p)
+}
+
+// motdInlineConfigProviderSpec returns a ConfigProviderSpec that writes content to /etc/motd (per test plan 4.1).
+func motdInlineConfigProviderSpec() v1beta1.ConfigProviderSpec {
+	mode := 0644
+	inline := v1beta1.InlineConfigProviderSpec{
+		Inline: []v1beta1.FileSpec{{
+			Path:    "/etc/motd",
+			Mode:    &mode,
+			Content: "backup-restore-e2e\n",
+		}},
+		Name: "motd-inline",
+	}
+	var spec v1beta1.ConfigProviderSpec
+	if err := spec.FromInlineConfigProviderSpec(inline); err != nil {
+		panic(err)
+	}
+	return spec
+}
+
+// --- Archive helpers ---
+
+// computeSHA256 returns the hex-encoded SHA256 hash of the file at the given path.
+func computeSHA256(filePath string) (string, error) {
+	if filePath == "" {
+		return "", fmt.Errorf("filePath must not be empty")
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read file for checksum: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+// readChecksumHash reads a .sha256 sidecar file and returns the hex hash string.
+// Expects the standard format: "<hex-hash>  <filename>\n".
+func readChecksumHash(checksumPath string) (string, error) {
+	if checksumPath == "" {
+		return "", fmt.Errorf("checksumPath must not be empty")
+	}
+	content, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return "", fmt.Errorf("read checksum file: %w", err)
+	}
+	if len(content) == 0 {
+		return "", fmt.Errorf("checksum file is empty")
+	}
+	parts := strings.SplitN(string(content), "  ", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("malformed checksum file: expected '<hash>  <filename>', got %q", string(content))
+	}
+	return parts[0], nil
+}
+
+// readBackupMetadata reads and parses metadata.json from an extracted backup directory.
+func readBackupMetadata(metadataPath string) (*backup.BackupMetadata, error) {
+	if metadataPath == "" {
+		return nil, fmt.Errorf("metadataPath must not be empty")
+	}
+	metadataBytes, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata.json: %w", err)
+	}
+	if len(metadataBytes) == 0 {
+		return nil, fmt.Errorf("metadata.json is empty")
+	}
+	var metadata backup.BackupMetadata
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		return nil, fmt.Errorf("parse metadata.json: %w", err)
+	}
+	return &metadata, nil
+}
+
+// extractTarGzEntries returns the list of entry names (files and directories) in a .tar.gz archive.
+func extractTarGzEntries(archivePath string) ([]string, error) {
+	if archivePath == "" {
+		return nil, fmt.Errorf("archivePath must not be empty")
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("open archive: %w", err)
+	}
+	defer file.Close()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	var entries []string
+	tarReader := tar.NewReader(gzr)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar entry: %w", err)
+		}
+		entries = append(entries, header.Name)
+	}
+	return entries, nil
+}
+
+// extractTarGzToDir extracts a .tar.gz archive into the given destination directory.
+func extractTarGzToDir(archivePath string, destDir string) error {
+	if archivePath == "" || destDir == "" {
+		return fmt.Errorf("archivePath and destDir must not be empty")
+	}
+
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer file.Close()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	tarReader := tar.NewReader(gzr)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar entry: %w", err)
+		}
+
+		target := filepath.Join(destDir, header.Name) //nolint:gosec
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("create directory %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent directory for %s: %w", target, err)
+			}
+			outFile, err := os.Create(target)
+			if err != nil {
+				return fmt.Errorf("create file %s: %w", target, err)
+			}
+			_, err = io.Copy(outFile, tarReader) //nolint:gosec
+			outFile.Close()
+			if err != nil {
+				return fmt.Errorf("write file %s: %w", target, err)
+			}
+		}
+	}
+	return nil
+}
+
+// hasEntryWithPrefix returns true if any entry in the list starts with the given prefix.
+func hasEntryWithPrefix(entries []string, prefix string) bool {
+	for _, e := range entries {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeMatchingChecksum computes SHA256 of the file and writes a matching .sha256 sidecar.
+func writeMatchingChecksum(archivePath string) error {
+	if archivePath == "" {
+		return fmt.Errorf("archivePath must not be empty")
+	}
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		return fmt.Errorf("read archive for checksum: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	content := fmt.Sprintf("%s  %s\n", hex.EncodeToString(hash[:]), filepath.Base(archivePath))
+	return os.WriteFile(archivePath+checksumSuffix, []byte(content), 0644) //nolint:gosec // G306: checksum is non-sensitive
+}
+
+// createMinimalTarGz creates a .tar.gz archive with the given file entries.
+func createMinimalTarGz(destPath string, files map[string]string) error {
+	if destPath == "" {
+		return fmt.Errorf("destPath must not be empty")
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("files must not be empty")
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("create archive file: %w", err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	for name, content := range files {
+		dir := filepath.Dir(name)
+		if dir != "." {
+			if err := tw.WriteHeader(&tar.Header{
+				Name:     dir + "/",
+				Typeflag: tar.TypeDir,
+				Mode:     0755,
+			}); err != nil {
+				return fmt.Errorf("write dir header %s: %w", dir, err)
+			}
+		}
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0600,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("write file header %s: %w", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			return fmt.Errorf("write file content %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// corruptArchive overwrites the first 100 bytes of an archive with zeros to simulate corruption.
+func corruptArchive(archivePath string) error {
+	if archivePath == "" {
+		return fmt.Errorf("archivePath must not be empty")
+	}
+	f, err := os.OpenFile(archivePath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open archive for corruption: %w", err)
+	}
+	defer f.Close()
+	_, err = f.Write(make([]byte, 100))
+	if err != nil {
+		return fmt.Errorf("write corruption bytes: %w", err)
+	}
+	return nil
+}
+
+// --- Deployment type helpers ---
+
+// oppositeDeploymentType returns "podman" for K8s environments and "kubernetes" for quadlet.
+func oppositeDeploymentType() string {
+	p := setup.GetDefaultProviders()
+	if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		return "kubernetes"
+	}
+	return "podman"
+}
+
+// currentDeploymentType returns the deployment type string matching the current environment.
+func currentDeploymentType() string {
+	p := setup.GetDefaultProviders()
+	if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		return "podman"
+	}
+	return "kubernetes"
+}
+
+// --- Security helpers ---
+
+// assertNoSensitiveData checks that the given content does not contain any known sensitive patterns
+// (private key material, PEM headers, passwords). The word "secret" is intentionally excluded
+// because the restore binary legitimately logs Kubernetes Secret resource names.
+func assertNoSensitiveData(content, source string) {
+	lower := strings.ToLower(content)
+	for _, pattern := range sensitivePatterns {
+		Expect(strings.Contains(lower, strings.ToLower(pattern))).To(BeFalse(),
+			"%s should not contain sensitive pattern: %s", source, pattern)
+	}
+}
+
+// assertNoRestoreTempDirs verifies that no flightctl-restore temp directories remain in os.TempDir().
+func assertNoRestoreTempDirs() {
+	matches, err := filepath.Glob(os.TempDir() + restoreTempDirPattern)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(matches).To(BeEmpty(), "temp extraction directories should be cleaned up")
+}
+
+// restoreDirPermissions resets directory permissions to 0755 for cleanup.
+func restoreDirPermissions(dir string) {
+	os.Chmod(dir, 0755) //nolint:errcheck
+}

--- a/test/e2e/backup_restore/negative_test.go
+++ b/test/e2e/backup_restore/negative_test.go
@@ -1,0 +1,238 @@
+package backup_restore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	nonexistentOutputPath  = "/nonexistent/path/that/does/not/exist"
+	nonexistentArchivePath = "/nonexistent/archive.tar.gz"
+	fakeChecksumLine       = "0000000000000000000000000000000000000000000000000000000000000000  fake.tar.gz\n"
+	fakeVersion            = "v0.0.0-fake"
+)
+
+var _ = Describe("Backup negative cases", Label("backup-restore", "negative"), func() {
+	var br *e2e.BackupRestore
+
+	BeforeEach(func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		harness := e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, setup.GetDefaultProviders())
+	})
+
+	It("When --output points to nonexistent parent it should fail with clear error", Label("89592"), func() {
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("quadlet runs with sudo which auto-creates directories")
+		}
+		output, err := br.RunFlightCtlBackupRaw("--output", nonexistentOutputPath)
+		Expect(err).To(HaveOccurred(), "backup should fail with nonexistent output path")
+		Expect(output).To(ContainSubstring("nonexistent"), "error should reference the bad path")
+	})
+
+	It("When --output path has no write permissions it should fail", Label("89591"), func() {
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("quadlet runs with sudo which bypasses file permissions")
+		}
+		readOnlyDir := GinkgoT().TempDir()
+		Expect(os.Chmod(readOnlyDir, 0444)).To(Succeed())
+		DeferCleanup(restoreDirPermissions, readOnlyDir)
+
+		output, err := br.RunFlightCtlBackupRaw("--output", readOnlyDir)
+		Expect(err).To(HaveOccurred(), "backup should fail with read-only output path")
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("permission"),
+			ContainSubstring("Permission"),
+			ContainSubstring("read-only"),
+		), "error should indicate permission issue")
+	})
+})
+
+var _ = Describe("External database backup and restore", Label("backup-restore"), func() {
+	var harness *e2e.Harness
+	var br *e2e.BackupRestore
+
+	BeforeEach(func() {
+		p := setup.GetDefaultProviders()
+		if p == nil || p.Infra == nil || p.Infra.BuiltinDatabaseWorkloadAvailable() {
+			Skip("test only applies to external DB deployments (ACM, quadlets with db.type=external)")
+		}
+		harness = e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, p)
+	})
+
+	It("When backup runs on external DB it should produce archive without database dump", Label("89590"), func() {
+		outputDir := GinkgoT().TempDir()
+		archivePath, checksumPath, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred(), "backup should succeed on external DB (skipping database dump)")
+		Expect(archivePath).To(BeAnExistingFile(), "archive file should exist")
+		Expect(checksumPath).To(BeAnExistingFile(), "checksum file should exist")
+
+		By("Verifying archive does not contain db/dump.sql")
+		entries, err := extractTarGzEntries(archivePath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasEntryWithPrefix(entries, "db/")).To(BeFalse(), "archive should not contain db/ directory for external DB")
+
+		By("Verifying archive contains PKI and config")
+		Expect(hasEntryWithPrefix(entries, "pki/")).To(BeTrue(), "archive should contain pki/ directory")
+		Expect(entries).To(ContainElement("metadata.json"), "archive should contain metadata.json")
+
+		By("Verifying metadata shows databaseIncluded=false")
+		extractDir := GinkgoT().TempDir()
+		Expect(extractTarGzToDir(archivePath, extractDir)).To(Succeed())
+		metadata, err := readBackupMetadata(filepath.Join(extractDir, "metadata.json"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metadata.DatabaseIncluded).To(BeFalse(), "metadata should indicate database was not included")
+	})
+
+	It("When restoring external DB archive it should restore PKI and config without database", Label("89589"), func() {
+		outputDir := GinkgoT().TempDir()
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred(), "backup should succeed on external DB")
+
+		By("Running restore from external DB backup archive")
+		defer func() {
+			Expect(br.VerifyAllServicesRunning()).To(Succeed(), "all services must be running after restore cleanup")
+		}()
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).ToNot(HaveOccurred(), "restore should succeed for external DB archive")
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("external database"),
+			ContainSubstring("No database dump found"),
+			ContainSubstring("database dump"),
+		), "restore output should indicate external database was detected")
+
+		By("Verifying all services were restarted after restore")
+		Eventually(func() error {
+			return br.VerifyAllServicesRunning()
+		}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "all services must be running after restore")
+
+		By("Verifying API is responsive after restore")
+		Eventually(func() error {
+			_, loginErr := login.LoginToAPIWithToken(harness)
+			return loginErr
+		}, testutil.DURATION_TIMEOUT, testutil.POLLING).Should(Succeed(), "API should be responsive after restore")
+	})
+})
+
+var _ = Describe("Restore negative cases", Label("backup-restore", "negative"), func() {
+	var br *e2e.BackupRestore
+
+	BeforeEach(func() {
+		harness := e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, setup.GetDefaultProviders())
+	})
+
+	It("When archive path does not exist it should fail with clear error", Label("89582"), func() {
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("restore binary must run on quadlet host to detect deployment type")
+		}
+		output, err := br.RunFlightCtlRestoreRaw(nonexistentArchivePath)
+		Expect(err).To(HaveOccurred())
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("no such file"),
+			ContainSubstring("not found"),
+			ContainSubstring("does not exist"),
+		))
+	})
+
+	It("When archive is corrupted it should fail with checksum mismatch", Label("89588"), func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("restore binary must run on quadlet host to detect deployment type")
+		}
+		outputDir := GinkgoT().TempDir()
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archivePath).To(BeAnExistingFile())
+
+		Expect(corruptArchive(archivePath)).To(Succeed())
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).To(HaveOccurred())
+		Expect(output).To(ContainSubstring("checksum mismatch"), "should detect corruption via checksum verification")
+	})
+
+	It("When checksum mismatches it should fail before destructive operations", Label("89586"), func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("restore binary must run on quadlet host to detect deployment type")
+		}
+		outputDir := GinkgoT().TempDir()
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		checksumPath := archivePath + checksumSuffix
+		Expect(os.WriteFile(checksumPath, []byte(fakeChecksumLine), 0644)).To(Succeed()) //nolint:gosec // G306: checksum is non-sensitive
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).To(HaveOccurred())
+		Expect(output).To(ContainSubstring("checksum mismatch"), "should fail with checksum mismatch before any destructive operations")
+	})
+
+	It("When restoring archive from different deployment type it should fail with mismatch error", Label("89195"), func() {
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("restore binary must run on quadlet host to detect deployment type")
+		}
+		wrongType := oppositeDeploymentType()
+
+		archivePath := filepath.Join(GinkgoT().TempDir(), "wrong-type.tar.gz")
+		Expect(createMinimalTarGz(archivePath, map[string]string{
+			"metadata.json": fmt.Sprintf(`{"timestamp":"2026-01-01T00:00:00Z","version":"test","deploymentType":"%s","databaseIncluded":false}`, wrongType),
+			"pki/ca.yaml":   "apiVersion: v1\nkind: Secret\n",
+		})).To(Succeed())
+		Expect(writeMatchingChecksum(archivePath)).To(Succeed())
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).To(HaveOccurred())
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("deployment type"),
+			ContainSubstring("mismatch"),
+			ContainSubstring("type mismatch"),
+		))
+	})
+
+	It("When restoring archive from different Flight Control version it should fail with version error", Label("89196"), func() {
+		p := setup.GetDefaultProviders()
+		if p != nil && p.Infra != nil && p.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+			Skip("restore binary must run on quadlet host to detect deployment type")
+		}
+		deployType := currentDeploymentType()
+
+		archivePath := filepath.Join(GinkgoT().TempDir(), "wrong-version.tar.gz")
+		Expect(createMinimalTarGz(archivePath, map[string]string{
+			"metadata.json": fmt.Sprintf(`{"timestamp":"2026-01-01T00:00:00Z","version":"%s","deploymentType":"%s","databaseIncluded":false}`, fakeVersion, deployType),
+			"pki/ca.yaml":   "apiVersion: v1\nkind: Secret\n",
+		})).To(Succeed())
+		Expect(writeMatchingChecksum(archivePath)).To(Succeed())
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).To(HaveOccurred())
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("version"),
+			ContainSubstring("mismatch"),
+			ContainSubstring("version mismatch"),
+		))
+	})
+})

--- a/test/e2e/backup_restore/security_test.go
+++ b/test/e2e/backup_restore/security_test.go
@@ -1,0 +1,122 @@
+package backup_restore
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	restoreTempDirPattern = "/flightctl-restore-*"
+)
+
+var sensitivePatterns = []string{"PRIVATE KEY", "BEGIN RSA", "BEGIN EC", "password"}
+
+var _ = Describe("Backup security", Label("backup-restore", "security"), func() {
+	var br *e2e.BackupRestore
+
+	BeforeEach(func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		harness := e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, setup.GetDefaultProviders())
+	})
+
+	It("When backup creates archive it should have 0600 permissions", Label("89572"), func() {
+		outputDir := GinkgoT().TempDir()
+
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archivePath).To(BeAnExistingFile())
+
+		info, err := os.Stat(archivePath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0600)), "archive should have owner-only permissions")
+	})
+
+	It("When backup creates checksum it should have 0644 permissions", Label("89571"), func() {
+		outputDir := GinkgoT().TempDir()
+
+		_, checksumPath, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(checksumPath).To(BeAnExistingFile())
+
+		info, err := os.Stat(checksumPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0644)), "checksum file should be world-readable")
+	})
+
+	It("When backup logs it should not contain sensitive data", Label("89576"), func() {
+		outputDir := GinkgoT().TempDir()
+
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archivePath).To(BeAnExistingFile())
+
+		extractDir := GinkgoT().TempDir()
+		Expect(extractTarGzToDir(archivePath, extractDir)).To(Succeed())
+
+		metadataPath := filepath.Join(extractDir, "metadata.json")
+		Expect(metadataPath).To(BeAnExistingFile())
+		content, err := os.ReadFile(metadataPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(content)).To(BeNumerically(">", 0), "metadata.json should not be empty")
+
+		assertNoSensitiveData(string(content), "metadata.json")
+	})
+})
+
+var _ = Describe("Restore security", Label("backup-restore", "security"), func() {
+	var br *e2e.BackupRestore
+
+	BeforeEach(func() {
+		harness := e2e.GetWorkerHarness()
+		br = newBackupRestore(harness, setup.GetDefaultProviders())
+	})
+
+	It("When restore completes it should remove temp directory", Label("89574"), func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		outputDir := GinkgoT().TempDir()
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(br.RunFlightCtlRestoreFromArchive(archivePath)).To(Succeed(), "restore should succeed")
+
+		assertNoRestoreTempDirs()
+	})
+
+	It("When restore fails it should remove temp directory", Label("89573"), func() {
+		archivePath := filepath.Join(GinkgoT().TempDir(), "corrupt.tar.gz")
+		Expect(createMinimalTarGz(archivePath, map[string]string{
+			"metadata.json": `{"timestamp":"2026-01-01T00:00:00Z","version":"test","deploymentType":"invalid","databaseIncluded":false}`,
+		})).To(Succeed())
+		Expect(writeMatchingChecksum(archivePath)).To(Succeed())
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).To(HaveOccurred(), "restore should fail with invalid deployment type")
+		Expect(output).ToNot(BeEmpty(), "error output should not be empty")
+
+		assertNoRestoreTempDirs()
+	})
+
+	It("When restore logs it should not contain sensitive data", Label("89579"), func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		outputDir := GinkgoT().TempDir()
+		archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		output, err := br.RunFlightCtlRestoreRaw(archivePath)
+		Expect(err).ToNot(HaveOccurred(), "restore should succeed before checking output for sensitive data")
+
+		assertNoSensitiveData(output, "restore output")
+	})
+})

--- a/test/harness/e2e/harness_backup_restore.go
+++ b/test/harness/e2e/harness_backup_restore.go
@@ -17,7 +17,16 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
-// BackupRestore performs backup/restore operations. Create with Harness.NewBackupRestore.
+const (
+	vmBackupBinaryPath  = "/tmp/flightctl-backup"
+	vmRestoreBinaryPath = "/tmp/flightctl-restore"
+	vmRestoreArchive    = "/tmp/flightctl-restore.tar.gz"
+)
+
+// BackupRestore performs backup/restore operations using the production flightctl-backup
+// and flightctl-restore binaries. The binaries read credentials from the deployment
+// environment (K8s Secrets or /etc/flightctl/service-config.yaml for Podman).
+// Create with Harness.NewBackupRestore.
 type BackupRestore struct {
 	*Harness
 	providers *infra.Providers
@@ -61,8 +70,6 @@ func (br *BackupRestore) VerifyAllServicesRunning() error {
 // ScaleUpFlightCtlServices scales API, worker, periodic, alert-exporter, and alertmanager-proxy
 // back up to 1 replica. Used as a safety net after restore in case the binary is killed before
 // its own deferred startup.
-// DEPRECATED: This method is kept for backward compatibility but should not be used in new tests.
-// Tests should verify that the restore binary itself restarts all services via VerifyAllServicesRunning.
 func (br *BackupRestore) ScaleUpFlightCtlServices() error {
 	services := []infra.ServiceName{
 		infra.ServiceAPI,
@@ -84,169 +91,89 @@ func (br *BackupRestore) ScaleUpFlightCtlServices() error {
 	return nil
 }
 
-// RunFlightCtlBackup runs the flightctl-backup binary. Credentials are read directly from the
-// cluster (K8s Secrets or /etc/flightctl/service-config.yaml for Podman). Returns the path to
-// the generated archive and a cleanup function that removes the work directory.
-func (br *BackupRestore) RunFlightCtlBackup() (archivePath string, cleanup func(), err error) {
+// RunFlightCtlBackup runs the flightctl-backup binary.
+// For quadlet: copies binary to the VM via base64, runs there, downloads archive via base64.
+// For K8s: runs locally (binary uses kubeconfig to connect to cluster).
+// The binary auto-detects deployment type and reads credentials from the environment.
+func (br *BackupRestore) RunFlightCtlBackup(outputDir string) (archivePath string, checksumPath string, err error) {
 	backupBinary := br.GetFlightctlBackupPath()
-	if _, err := os.Stat(backupBinary); os.IsNotExist(err) {
-		return "", func() {}, fmt.Errorf("binary not found: %s (build with: make flightctl-backup)", backupBinary)
+	if _, statErr := os.Stat(backupBinary); os.IsNotExist(statErr) {
+		return "", "", fmt.Errorf("binary not found: %s (build with: make flightctl-backup)", backupBinary)
 	}
 
 	ctx, cancel := context.WithTimeout(br.Context, util.DURATION_TIMEOUT)
 	defer cancel()
 
-	workDir, err := os.MkdirTemp("", "flightctl-backup-e2e-")
-	if err != nil {
-		return "", func() {}, fmt.Errorf("create work dir: %w", err)
-	}
-	workDirCleanup := func() { os.RemoveAll(workDir) }
-
-	outputDir := filepath.Join(workDir, "output")
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		workDirCleanup()
-		return "", func() {}, fmt.Errorf("create output dir: %w", err)
-	}
-
-	var backupCmd *exec.Cmd
-	// For quadlet deployments, run backup inside the VM.
-	// Note: This is test infrastructure automation. External users should manually
-	// SSH into their VM and run the backup command there (see error message guidance
-	// in internal/backup/deployer.go for user-facing instructions).
 	if br.providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
-		// Type assert to quadlet provider to access RunCommand
-		quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
-		if !ok {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("expected quadlet provider but got different type")
-		}
-
-		// Use random temp dir inside VM for backup output to avoid cross-test conflicts
-		vmOutputDir := fmt.Sprintf("/tmp/flightctl-backup-%d", time.Now().UnixNano())
-		vmArgs := []string{"--output", vmOutputDir, "--deployment-type", "podman"}
-		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-			vmArgs = append(vmArgs, "--namespace", ns)
-		}
-		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-			vmArgs = append(vmArgs, "--internal-namespace", ns)
-		}
-
-		// Run backup inside the VM using the infra provider (handles SSH automatically)
-		// All commands use context for proper timeout/cancellation handling
-
-		// Copy flightctl-backup binary from host to VM for testing
-		// Edge devices don't have CLI tools pre-installed, but tests need them
-		vmBackupBinary := "/tmp/flightctl-backup"
-		backupBinaryData, err := os.ReadFile(backupBinary)
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to read backup binary: %w", err)
-		}
-		// Use stdin to pipe binary data (too large for command args)
-		encodedBinary := base64.StdEncoding.EncodeToString(backupBinaryData)
-		copyCmd := fmt.Sprintf("base64 -d > %s && chmod +x %s", vmBackupBinary, vmBackupBinary)
-		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedBinary), "sh", "-c", copyCmd); err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to copy backup binary to VM: %w", err)
-		}
-
-		mkdirCmd := []string{"mkdir", "-p", vmOutputDir}
-		if _, err := quadletProvider.RunCommandContext(ctx, mkdirCmd...); err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to create output dir in VM: %w", err)
-		}
-
-		// Use the binary we just copied to the VM
-		backupCmdArgs := append([]string{vmBackupBinary}, vmArgs...)
-		output, err := quadletProvider.RunCommandContext(ctx, backupCmdArgs...)
-		fmt.Fprint(ginkgo.GinkgoWriter, output)
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("flightctl-backup failed: %w", err)
-		}
-
-		// Copy backup archive from VM to host
-		// Find the archive name using find command
-		findOutput, err := quadletProvider.RunCommandContext(ctx, "find", vmOutputDir, "-name", "*.tar.gz", "-print", "-quit")
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to find backup archive: %w", err)
-		}
-		vmArchive := strings.TrimSpace(findOutput)
-		if vmArchive == "" {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("no backup archive found in %s", vmOutputDir)
-		}
-
-		// Read the archive content from VM using base64 encoding to safely transfer binary data
-		base64Output, err := quadletProvider.RunCommandContext(ctx, "base64", vmArchive)
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to encode backup archive from VM: %w", err)
-		}
-
-		// Decode base64 to get the binary archive data
-		archiveBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(base64Output))
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to decode backup archive: %w", err)
-		}
-
-		// Write it to the host
-		archiveName := filepath.Base(vmArchive)
-		hostArchivePath := filepath.Join(outputDir, archiveName)
-		if err := os.WriteFile(hostArchivePath, archiveBytes, 0600); err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to write backup archive: %w", err)
-		}
-
-		// Copy checksum file (.sha256) from VM to host
-		vmChecksumPath := vmArchive + ".sha256"
-		checksumOutput, err := quadletProvider.RunCommandContext(ctx, "base64", vmChecksumPath)
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to encode checksum from VM: %w", err)
-		}
-		checksumBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(checksumOutput))
-		if err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to decode checksum: %w", err)
-		}
-		hostChecksumPath := hostArchivePath + ".sha256"
-		if err := os.WriteFile(hostChecksumPath, checksumBytes, 0600); err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("failed to write checksum file: %w", err)
-		}
-
-		return hostArchivePath, workDirCleanup, nil
-	} else {
-		args := []string{"--output", outputDir}
-		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-			args = append(args, "--namespace", ns)
-		}
-		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-			args = append(args, "--internal-namespace", ns)
-		}
-		backupCmd = exec.CommandContext(ctx, backupBinary, args...)
-		backupCmd.Stdout = ginkgo.GinkgoWriter
-		backupCmd.Stderr = ginkgo.GinkgoWriter
-		if err := backupCmd.Run(); err != nil {
-			workDirCleanup()
-			return "", func() {}, fmt.Errorf("flightctl-backup failed: %w", err)
-		}
+		return br.runBackupOnQuadlet(ctx, backupBinary, outputDir)
 	}
 
-	matches, err := filepath.Glob(filepath.Join(outputDir, "*.tar.gz"))
-	if err != nil || len(matches) == 0 {
-		workDirCleanup()
-		return "", func() {}, fmt.Errorf("no archive found in %s after backup", outputDir)
+	args := []string{"--output", outputDir}
+	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+		args = append(args, "--namespace", ns)
 	}
-	return matches[0], workDirCleanup, nil
+	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+		args = append(args, "--internal-namespace", ns)
+	}
+	backupCmd := exec.CommandContext(ctx, backupBinary, args...)
+	backupCmd.Stdout = ginkgo.GinkgoWriter
+	backupCmd.Stderr = ginkgo.GinkgoWriter
+	if err := backupCmd.Run(); err != nil {
+		return "", "", fmt.Errorf("flightctl-backup failed: %w", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "flightctl-backup-*.tar.gz"))
+	if err != nil {
+		return "", "", fmt.Errorf("glob backup archives: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("no backup archive found in %s", outputDir)
+	}
+
+	archivePath = matches[0]
+	checksumPath = archivePath + ".sha256"
+	return archivePath, checksumPath, nil
 }
 
-// RunFlightCtlRestore runs the flightctl-restore binary with the given archive path.
-// The binary reads credentials from the cluster and handles service stop/start internally.
-func (br *BackupRestore) RunFlightCtlRestore(archivePath string) error {
+// RunFlightCtlBackupRaw runs the flightctl-backup binary with the given arguments.
+// Useful for negative tests (bad flags, missing args, etc.).
+// Returns combined stdout+stderr and any execution error.
+func (br *BackupRestore) RunFlightCtlBackupRaw(args ...string) (output string, err error) {
+	backupBinary := br.GetFlightctlBackupPath()
+	if _, statErr := os.Stat(backupBinary); os.IsNotExist(statErr) {
+		return "", fmt.Errorf("binary not found: %s (build with: make flightctl-backup)", backupBinary)
+	}
+
+	ctx, cancel := context.WithTimeout(br.Context, util.DURATION_TIMEOUT)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, backupBinary, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// RunFlightCtlRestoreRaw runs the flightctl-restore binary with the given arguments.
+// Useful for negative tests (bad args, corrupted archives, etc.).
+// Returns combined stdout+stderr and any execution error.
+func (br *BackupRestore) RunFlightCtlRestoreRaw(args ...string) (output string, err error) {
+	restoreBinary := br.GetFlightctlRestorePath()
+	if _, statErr := os.Stat(restoreBinary); os.IsNotExist(statErr) {
+		return "", fmt.Errorf("binary not found: %s (build with: make flightctl-restore)", restoreBinary)
+	}
+
+	ctx, cancel := context.WithTimeout(br.Context, util.DURATION_TIMEOUT)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, restoreBinary, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// RunFlightCtlRestoreFromArchive runs the flightctl-restore binary with the given archive path.
+// For quadlet: copies binary+archive to the VM via base64, runs there.
+// For K8s: runs locally (binary uses kubeconfig to connect to cluster).
+// The binary reads credentials from the environment and handles service stop/start internally.
+func (br *BackupRestore) RunFlightCtlRestoreFromArchive(archivePath string) error {
 	restoreBinary := br.GetFlightctlRestorePath()
 	if _, err := os.Stat(restoreBinary); os.IsNotExist(err) {
 		return fmt.Errorf("binary not found: %s (build with: make flightctl-restore)", restoreBinary)
@@ -255,89 +182,164 @@ func (br *BackupRestore) RunFlightCtlRestore(archivePath string) error {
 	ctx, cancel := context.WithTimeout(br.Context, util.DURATION_TIMEOUT)
 	defer cancel()
 
-	var restoreCmd *exec.Cmd
-	// For quadlet deployments, run restore inside the VM.
-	// Note: This is test infrastructure automation. External users should manually
-	// copy their backup archive to the VM and run restore there.
 	if br.providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
-		// Type assert to quadlet provider to access RunCommand
-		quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
-		if !ok {
-			return fmt.Errorf("expected quadlet provider but got different type")
-		}
-
-		// Copy backup archive from host to VM
-		vmArchivePath := "/tmp/flightctl-restore.tar.gz"
-
-		// Read archive from host
-		archiveContent, err := os.ReadFile(archivePath)
-		if err != nil {
-			return fmt.Errorf("failed to read backup archive: %w", err)
-		}
-
-		// Copy flightctl-restore binary from host to VM for testing
-		// Edge devices don't have CLI tools pre-installed, but tests need them
-		vmRestoreBinary := "/tmp/flightctl-restore"
-		restoreBinaryData, err := os.ReadFile(restoreBinary)
-		if err != nil {
-			return fmt.Errorf("failed to read restore binary: %w", err)
-		}
-		// Use stdin to pipe binary data (too large for command args)
-		encodedRestoreBinary := base64.StdEncoding.EncodeToString(restoreBinaryData)
-		copyRestoreCmd := fmt.Sprintf("base64 -d > %s && chmod +x %s", vmRestoreBinary, vmRestoreBinary)
-		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedRestoreBinary), "sh", "-c", copyRestoreCmd); err != nil {
-			return fmt.Errorf("failed to copy restore binary to VM: %w", err)
-		}
-
-		// Write archive to VM using stdin for safe binary transfer
-		encoded := base64.StdEncoding.EncodeToString(archiveContent)
-		decodeCmd := fmt.Sprintf("base64 -d > %s", vmArchivePath)
-		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encoded), "sh", "-c", decodeCmd); err != nil {
-			return fmt.Errorf("failed to copy backup to VM: %w", err)
-		}
-
-		// Copy checksum file (.sha256) to VM
-		checksumPath := archivePath + ".sha256"
-		checksumContent, err := os.ReadFile(checksumPath)
-		if err != nil {
-			return fmt.Errorf("failed to read checksum file: %w", err)
-		}
-		encodedChecksum := base64.StdEncoding.EncodeToString(checksumContent)
-		checksumCmd := fmt.Sprintf("base64 -d > %s", vmArchivePath+".sha256")
-		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedChecksum), "sh", "-c", checksumCmd); err != nil {
-			return fmt.Errorf("failed to copy checksum to VM: %w", err)
-		}
-
-		// Run restore inside the VM using the binary we copied
-		restoreCmdArgs := []string{vmRestoreBinary, vmArchivePath}
-		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-			restoreCmdArgs = append(restoreCmdArgs, "--namespace", ns)
-		}
-		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-			restoreCmdArgs = append(restoreCmdArgs, "--internal-namespace", ns)
-		}
-
-		output, err := quadletProvider.RunCommandContext(ctx, restoreCmdArgs...)
-		fmt.Fprint(ginkgo.GinkgoWriter, output)
-		if err != nil {
-			return fmt.Errorf("flightctl-restore failed: %w", err)
-		}
-		return nil
-	} else {
-		args := []string{archivePath}
-		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-			args = append(args, "--namespace", ns)
-		}
-		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-			args = append(args, "--internal-namespace", ns)
-		}
-		restoreCmd = exec.CommandContext(ctx, restoreBinary, args...)
+		return br.runRestoreOnQuadlet(ctx, restoreBinary, archivePath)
 	}
 
+	args := []string{archivePath}
+	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+		args = append(args, "--namespace", ns)
+	}
+	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+		args = append(args, "--internal-namespace", ns)
+	}
+	restoreCmd := exec.CommandContext(ctx, restoreBinary, args...)
 	restoreCmd.Stdout = ginkgo.GinkgoWriter
 	restoreCmd.Stderr = ginkgo.GinkgoWriter
 	if err := restoreCmd.Run(); err != nil {
 		return fmt.Errorf("flightctl-restore failed: %w", err)
+	}
+	return nil
+}
+
+// --- Quadlet helpers (binary copy via base64) ---
+
+// runBackupOnQuadlet copies the backup binary to the quadlet VM, runs it there,
+// and downloads the resulting archive and checksum via base64 encoding.
+func (br *BackupRestore) runBackupOnQuadlet(ctx context.Context, backupBinary, outputDir string) (string, string, error) {
+	quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
+	if !ok {
+		return "", "", fmt.Errorf("expected quadlet provider but got different type")
+	}
+
+	vmOutputDir := fmt.Sprintf("/tmp/flightctl-backup-%d", time.Now().UnixNano())
+	vmArgs := []string{"--output", vmOutputDir, "--deployment-type", "podman"}
+	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+		vmArgs = append(vmArgs, "--namespace", ns)
+	}
+	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+		vmArgs = append(vmArgs, "--internal-namespace", ns)
+	}
+
+	if err := copyBinaryToVM(ctx, quadletProvider, backupBinary, vmBackupBinaryPath); err != nil {
+		return "", "", err
+	}
+
+	if _, err := quadletProvider.RunCommandContext(ctx, "mkdir", "-p", vmOutputDir); err != nil {
+		return "", "", fmt.Errorf("failed to create output dir in VM: %w", err)
+	}
+
+	backupCmdArgs := append([]string{vmBackupBinaryPath}, vmArgs...)
+	output, err := quadletProvider.RunCommandContext(ctx, backupCmdArgs...)
+	fmt.Fprint(ginkgo.GinkgoWriter, output)
+	if err != nil {
+		return "", "", fmt.Errorf("flightctl-backup failed: %w", err)
+	}
+
+	findOutput, err := quadletProvider.RunCommandContext(ctx, "find", vmOutputDir, "-name", "*.tar.gz", "-print", "-quit")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to find backup archive: %w", err)
+	}
+	vmArchive := strings.TrimSpace(findOutput)
+	if vmArchive == "" {
+		return "", "", fmt.Errorf("no backup archive found in %s", vmOutputDir)
+	}
+
+	hostArchivePath := filepath.Join(outputDir, filepath.Base(vmArchive))
+	if err := downloadFileFromVM(ctx, quadletProvider, vmArchive, hostArchivePath, 0600); err != nil {
+		return "", "", fmt.Errorf("download archive: %w", err)
+	}
+
+	hostChecksumPath := hostArchivePath + ".sha256"
+	if err := downloadFileFromVM(ctx, quadletProvider, vmArchive+".sha256", hostChecksumPath, 0644); err != nil { //nolint:gosec // G306: checksum is non-sensitive
+		return "", "", fmt.Errorf("download checksum: %w", err)
+	}
+
+	return hostArchivePath, hostChecksumPath, nil
+}
+
+// runRestoreOnQuadlet copies the restore binary and archive to the quadlet VM, then runs restore there.
+func (br *BackupRestore) runRestoreOnQuadlet(ctx context.Context, restoreBinary, archivePath string) error {
+	quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
+	if !ok {
+		return fmt.Errorf("expected quadlet provider but got different type")
+	}
+
+	if err := copyBinaryToVM(ctx, quadletProvider, restoreBinary, vmRestoreBinaryPath); err != nil {
+		return err
+	}
+
+	archiveContent, err := os.ReadFile(archivePath)
+	if err != nil {
+		return fmt.Errorf("failed to read backup archive: %w", err)
+	}
+	if len(archiveContent) == 0 {
+		return fmt.Errorf("backup archive %s is empty", archivePath)
+	}
+	if err := uploadFileToVM(ctx, quadletProvider, archiveContent, vmRestoreArchive); err != nil {
+		return fmt.Errorf("failed to copy backup to VM: %w", err)
+	}
+
+	checksumContent, err := os.ReadFile(archivePath + ".sha256")
+	if err != nil {
+		return fmt.Errorf("failed to read checksum file: %w", err)
+	}
+	if err := uploadFileToVM(ctx, quadletProvider, checksumContent, vmRestoreArchive+".sha256"); err != nil {
+		return fmt.Errorf("failed to copy checksum to VM: %w", err)
+	}
+
+	restoreCmdArgs := []string{vmRestoreBinaryPath, vmRestoreArchive}
+	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+		restoreCmdArgs = append(restoreCmdArgs, "--namespace", ns)
+	}
+	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+		restoreCmdArgs = append(restoreCmdArgs, "--internal-namespace", ns)
+	}
+
+	output, err := quadletProvider.RunCommandContext(ctx, restoreCmdArgs...)
+	fmt.Fprint(ginkgo.GinkgoWriter, output)
+	if err != nil {
+		return fmt.Errorf("flightctl-restore failed: %w", err)
+	}
+	return nil
+}
+
+// copyBinaryToVM reads a local binary and copies it to the VM via base64-encoded stdin.
+func copyBinaryToVM(ctx context.Context, qp *quadlet.InfraProvider, localPath, remotePath string) error {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to read binary %s: %w", localPath, err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+	cmd := fmt.Sprintf("base64 -d > %s && chmod +x %s", remotePath, remotePath)
+	if _, err := qp.RunCommandWithStdinContext(ctx, strings.NewReader(encoded), "sh", "-c", cmd); err != nil {
+		return fmt.Errorf("failed to copy binary to VM at %s: %w", remotePath, err)
+	}
+	return nil
+}
+
+// uploadFileToVM uploads raw content to a file on the VM via base64-encoded stdin.
+func uploadFileToVM(ctx context.Context, qp *quadlet.InfraProvider, content []byte, remotePath string) error {
+	encoded := base64.StdEncoding.EncodeToString(content)
+	cmd := fmt.Sprintf("base64 -d > %s", remotePath)
+	if _, err := qp.RunCommandWithStdinContext(ctx, strings.NewReader(encoded), "sh", "-c", cmd); err != nil {
+		return fmt.Errorf("failed to upload file to VM at %s: %w", remotePath, err)
+	}
+	return nil
+}
+
+// downloadFileFromVM reads a file from the VM via base64 encoding and writes it locally.
+func downloadFileFromVM(ctx context.Context, qp *quadlet.InfraProvider, remotePath, localPath string, perm os.FileMode) error {
+	base64Output, err := qp.RunCommandContext(ctx, "base64", remotePath)
+	if err != nil {
+		return fmt.Errorf("failed to encode %s from VM: %w", remotePath, err)
+	}
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(base64Output))
+	if err != nil {
+		return fmt.Errorf("failed to decode %s: %w", remotePath, err)
+	}
+	if err := os.WriteFile(localPath, data, perm); err != nil {
+		return fmt.Errorf("failed to write %s: %w", localPath, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add automated E2E test suite for the flightctl backup and restore feature
- Introduce test harness methods (`RunFlightCtlBackup`, `RunFlightCtlBackupRaw`, `RunFlightCtlRestoreFromArchive`, `GetFlightctlBackupPath`) to support backup/restore test operations
- Include 5 backup positive tests (OCP-89120-89127) covering archive creation, checksum validation, metadata inspection, config collection, non-interactive execution, and binary availability
- Tests requiring infrastructure control or pending restore archive support are guarded with `Skip()`

## Files changed

| File | Description |
|------|-------------|
| `test/harness/e2e/harness.go` | Added `GetFlightctlBackupPath()` helper |
| `test/harness/e2e/harness_backup_restore.go` | New harness methods for backup/restore operations |
| `test/e2e/backup_restore/backup_test.go` | Backup positive E2E tests |
| `test/e2e/backup_restore/negative_test.go` | Backup and restore negative E2E tests |
| `test/e2e/backup_restore/security_test.go` | Backup and restore security E2E tests |

## Test plan

- [x] Verify backup tests pass against a deployed flightctl environment
- [x] Verify negative tests correctly validate error conditions
- [x] Confirm skipped tests are appropriately guarded for infrastructure/archive dependencies
- [x] Run `make lint` to confirm code style compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)