### PR TITLE
EDM-3812: Add e2e test of default device alias during registration

### DIFF
--- a/test/e2e/agent/agent_label_from_systeminfo_test.go
+++ b/test/e2e/agent/agent_label_from_systeminfo_test.go
@@ -1,6 +1,7 @@
 package agent_test
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -33,6 +34,8 @@ const (
 	labelFromSystemInfoFieldProductName       = "productName"
 	labelFromSystemInfoFieldHostname          = "hostname"
 	labelFromSystemInfoMissingFieldName       = "doesNotExist"
+	// Valid OS hostname (64 chars); raw value is not a valid Kubernetes label — default alias must be sanitized.
+	labelFromSystemInfoLongHostnameForDefaultAlias = "device-testing-long-hostname-for-label-length-validation-edge-01"
 )
 
 var (
@@ -110,6 +113,18 @@ var (
 			labelFromSystemInfoMissingBuiltInLabel,
 			labelFromSystemInfoMissingCustomLabel,
 		},
+	}
+
+	labelFromSystemInfoSanitizedDefaultAliasScenario = labelFromSystemInfoScenario{
+		name: "default alias sanitizes hostname that is not a valid label value",
+		labelFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		wantLabelsFromSystemInfo: map[string]string{
+			labelFromSystemInfoBuiltInLabelArch: labelFromSystemInfoFieldArchitecture,
+		},
+		preEnrollHostname:            labelFromSystemInfoLongHostnameForDefaultAlias,
+		wantDefaultAliasFromHostname: true,
 	}
 
 	labelFromSystemInfoCustomCollectionDisabledScenario = labelFromSystemInfoScenario{
@@ -198,6 +213,21 @@ var _ = Describe("SystemInfo label mapping", func() {
 		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
 	})
 
+	It("When hostname is not a valid label value it should sanitize default alias and enroll successfully", Label("89229", "agent"), func() {
+		scenario := labelFromSystemInfoSanitizedDefaultAliasScenario
+
+		By("Setting a hostname whose raw value is not a valid label and completing enrollment without explicit alias mapping")
+		result, err := runLabelFromSystemInfoEnrollmentScenario(harness, scenario)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying enrollment succeeds with a sanitized alias label derived from hostname")
+		reportedHostname := systemInfoValue(result.enrollmentSystemInfo, labelFromSystemInfoFieldHostname)
+		Expect(reportedHostname).To(Equal(scenario.preEnrollHostname), "systemInfo.hostname must match the hostname set before enrollment")
+		Expect(validateLabelFromSystemInfoEnrollment(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoSystemInfo(result)).To(Succeed())
+		Expect(validateLabelFromSystemInfoLabels(result, scenario)).To(Succeed())
+	})
+
 	It("When mapped fields are missing it should skip labels for those fields", Label("88951", "agent"), func() {
 		scenario := labelFromSystemInfoMissingFieldsScenario
 
@@ -233,6 +263,7 @@ type labelFromSystemInfoScenario struct {
 	wantLabels                   map[string]string
 	wantLabelsFromSystemInfo     map[string]string
 	wantAbsentLabels             []string
+	preEnrollHostname            string
 	wantDefaultAliasFromHostname bool
 	wantCustomInfo               map[string]string
 	wantAbsentCustomInfo         []string
@@ -250,7 +281,7 @@ type labelFromSystemInfoScenarioResult struct {
 
 // runLabelFromSystemInfoEnrollmentScenario applies an agent configuration, starts a fresh enrollment,
 // approves it, and returns both the EnrollmentRequest and Device state for assertions.
-func runLabelFromSystemInfoEnrollmentScenario(harness *e2e.Harness, scenario labelFromSystemInfoScenario) (*labelFromSystemInfoScenarioResult, error) {
+func runLabelFromSystemInfoEnrollmentScenario(harness *e2e.Harness, scenario labelFromSystemInfoScenario) (result *labelFromSystemInfoScenarioResult, retErr error) {
 	if harness == nil {
 		return nil, fmt.Errorf("harness is nil")
 	}
@@ -264,6 +295,21 @@ func runLabelFromSystemInfoEnrollmentScenario(harness *e2e.Harness, scenario lab
 
 	if err := harness.ResetAgentEnrollmentState(); err != nil {
 		return nil, err
+	}
+
+	if strings.TrimSpace(scenario.preEnrollHostname) != "" {
+		previousHostname, err := harness.GetVMHostname()
+		if err != nil {
+			return nil, fmt.Errorf("reading VM hostname before %q: %w", scenario.name, err)
+		}
+		defer func() {
+			if restoreErr := harness.SetVMHostname(previousHostname); restoreErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("restoring VM hostname after %q: %w", scenario.name, restoreErr))
+			}
+		}()
+		if err := harness.SetVMHostname(scenario.preEnrollHostname); err != nil {
+			return nil, fmt.Errorf("setting VM hostname for %q: %w", scenario.name, err)
+		}
 	}
 
 	if err := configureAgentForLabelFromSystemInfoScenario(harness, scenario); err != nil {
@@ -305,7 +351,7 @@ func runLabelFromSystemInfoEnrollmentScenario(harness *e2e.Harness, scenario lab
 		return nil, fmt.Errorf("device %s has nil status", enrollmentID)
 	}
 
-	result := &labelFromSystemInfoScenarioResult{
+	result = &labelFromSystemInfoScenarioResult{
 		enrollmentRequest:    enrollmentRequest,
 		device:               device,
 		enrollmentLabels:     dereferenceLabels(enrollmentRequest.Spec.Labels),
@@ -455,24 +501,32 @@ func validateDefaultAliasFromHostname(result *labelFromSystemInfoScenarioResult)
 	enrollmentHostname := systemInfoValue(result.enrollmentSystemInfo, labelFromSystemInfoFieldHostname)
 	deviceHostname := systemInfoValue(result.deviceSystemInfo, labelFromSystemInfoFieldHostname)
 	if isUsefulLabelFromSystemInfoHostname(enrollmentHostname) {
+		expectedSanitizedAlias, err := sanitizedLabelFromSystemInfoValue(enrollmentHostname, labelFromSystemInfoFieldHostname, labelFromSystemInfoDefaultAliasLabel)
+		if err != nil {
+			return err
+		}
 		got, ok := result.enrollmentLabels[labelFromSystemInfoDefaultAliasLabel]
 		if !ok {
-			return fmt.Errorf("enrollment request alias is absent, want hostname %q", enrollmentHostname)
+			return fmt.Errorf("enrollment request alias is absent, want sanitized hostname %q from raw hostname %q", expectedSanitizedAlias, enrollmentHostname)
 		}
-		if got != enrollmentHostname {
-			return fmt.Errorf("enrollment request alias = %q, want hostname %q", got, enrollmentHostname)
+		if got != expectedSanitizedAlias {
+			return fmt.Errorf("enrollment request alias = %q, want sanitized hostname %q from raw hostname %q", got, expectedSanitizedAlias, enrollmentHostname)
 		}
 	} else if got, ok := result.enrollmentLabels[labelFromSystemInfoDefaultAliasLabel]; ok {
 		return fmt.Errorf("enrollment request alias should be absent for hostname %q, got %q", enrollmentHostname, got)
 	}
 
 	if isUsefulLabelFromSystemInfoHostname(deviceHostname) {
+		expectedSanitizedAlias, err := sanitizedLabelFromSystemInfoValue(deviceHostname, labelFromSystemInfoFieldHostname, labelFromSystemInfoDefaultAliasLabel)
+		if err != nil {
+			return err
+		}
 		got, ok := result.deviceLabels[labelFromSystemInfoDefaultAliasLabel]
 		if !ok {
-			return fmt.Errorf("device alias is absent, want hostname %q", deviceHostname)
+			return fmt.Errorf("device alias is absent, want sanitized hostname %q from raw hostname %q", expectedSanitizedAlias, deviceHostname)
 		}
-		if got != deviceHostname {
-			return fmt.Errorf("device alias = %q, want hostname %q", got, deviceHostname)
+		if got != expectedSanitizedAlias {
+			return fmt.Errorf("device alias = %q, want sanitized hostname %q from raw hostname %q", got, expectedSanitizedAlias, deviceHostname)
 		}
 	} else if got, ok := result.deviceLabels[labelFromSystemInfoDefaultAliasLabel]; ok {
 		return fmt.Errorf("device alias should be absent for hostname %q, got %q", deviceHostname, got)

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -101,6 +101,52 @@ systemctl reset-failed flightctl-agent || true
 	return nil
 }
 
+// GetVMHostname returns the current hostname of the agent VM as seen by the kernel.
+// Uses the hostname command via SSH, which returns the same value the agent reads
+// via os.Hostname() when running on the VM.
+func (h *Harness) GetVMHostname() (string, error) {
+	if h == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if h.VM == nil {
+		return "", fmt.Errorf("harness VM is nil")
+	}
+	stdout, err := h.VM.RunSSH([]string{"hostname"}, nil)
+	if err != nil {
+		return "", fmt.Errorf("reading VM hostname: %w", err)
+	}
+	hostname := strings.TrimSpace(stdout.String())
+	if hostname == "" {
+		return "", fmt.Errorf("VM hostname is empty")
+	}
+	return hostname, nil
+}
+
+// SetVMHostname sets the hostname on the agent VM and verifies it was applied.
+func (h *Harness) SetVMHostname(hostname string) error {
+	if h == nil {
+		return fmt.Errorf("harness is nil")
+	}
+	if h.VM == nil {
+		return fmt.Errorf("harness VM is nil")
+	}
+	hostname = strings.TrimSpace(hostname)
+	if hostname == "" {
+		return fmt.Errorf("hostname is empty")
+	}
+	if _, err := h.VM.RunSSH([]string{"sudo", "hostnamectl", "set-hostname", hostname}, nil); err != nil {
+		return fmt.Errorf("setting VM hostname: %w", err)
+	}
+	got, err := h.GetVMHostname()
+	if err != nil {
+		return err
+	}
+	if got != hostname {
+		return fmt.Errorf("VM hostname = %q after set-hostname, want %q", got, hostname)
+	}
+	return nil
+}
+
 // DeleteCurrentEnrollmentRequestFromAgentLogs deletes the latest pending EnrollmentRequest
 // identified in flightctl-agent logs. If no enrollment ID is present, it is a no-op.
 func (h *Harness) DeleteCurrentEnrollmentRequestFromAgentLogs() error {


### PR DESCRIPTION
Add an e2e test (89229) for the default device alias feature when the agent hostname
exceeds the 63-character Kubernetes label value limit. The test sets a 64-character
hostname on the agent VM before enrollment and verifies that the alias label on both
the EnrollmentRequest and Device is sanitized (truncated), not the raw hostname.

Fix the existing default alias validator to compare against the sanitized hostname
instead of the raw value. The old validator assumed the alias
always equals the raw hostname, which breaks for hostnames needing sanitization.

Add GetVMHostname and SetVMHostname harness helpers and deferred hostname restore after the test.