### PR TITLE
[EDM-4005]: deny console access to viewer role

### DIFF
--- a/internal/auth/authz/static.go
+++ b/internal/auth/authz/static.go
@@ -47,6 +47,7 @@ var resourcePermissions = map[string]map[string][]string{
 	},
 	v1beta1.RoleViewer: {
 		"*":                     {"get", "list"}, // Default read access to all resources
+		"devices/console":       {},              // Explicitly denied - console access requires operator or admin role
 		"imageexports/download": {},              // Explicitly denied - empty list overrides wildcard
 	},
 	v1beta1.RoleInstaller: {

--- a/internal/auth/authz/static_test.go
+++ b/internal/auth/authz/static_test.go
@@ -182,6 +182,20 @@ func TestStaticAuthZ_CheckPermission(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "viewer cannot access device console",
+			roles:    []string{v1beta1.RoleViewer},
+			resource: "devices/console",
+			op:       "get",
+			expected: false,
+		},
+		{
+			name:     "operator can access device console",
+			roles:    []string{v1beta1.RoleOperator},
+			resource: "devices/console",
+			op:       "get",
+			expected: true,
+		},
+		{
 			name:     "viewer can list catalog",
 			roles:    []string{v1beta1.RoleViewer},
 			resource: "catalogs",
@@ -429,6 +443,10 @@ func TestStaticAuthZ_GetUserPermissions(t *testing.T) {
 					Operations: []string{"get", "list"},
 				},
 				{
+					Resource:   "devices/console",
+					Operations: []string{}, // Explicitly denied
+				},
+				{
 					Resource:   "imageexports/download",
 					Operations: []string{}, // Explicitly denied
 				},
@@ -479,6 +497,10 @@ func TestStaticAuthZ_GetUserPermissions(t *testing.T) {
 				{
 					Resource:   "certificatesigningrequests",
 					Operations: []string{"create", "get", "list", "update"},
+				},
+				{
+					Resource:   "devices/console",
+					Operations: []string{}, // Explicitly denied by viewer, installer does not grant it
 				},
 				{
 					Resource:   "enrollmentrequests",


### PR DESCRIPTION
## Problem
A user with the `viewer` role could open an interactive device console session via `flightctl console`, which should be restricted to operators and admins.

## Root Cause
The viewer role's wildcard `get`/`list` permission in `internal/auth/authz/static.go` granted access to every resource, including `devices/console`. The authorization middleware resolves the WebSocket console endpoint (`/ws/v1/devices/{name}/console`) to resource `devices/console` with action `get`, and no explicit denial existed for that resource.

## Fix
Add `"devices/console": {}` to the viewer role's permission table — the same explicit-denial pattern already used for `imageexports/download`. Operators and admins continue to have access via their wildcard `get` grant.

## Testing
- Added `viewer cannot access device console` test case to `TestStaticAuthZ_CheckPermission`
- Added `operator can access device console` test case to `TestStaticAuthZ_CheckPermission`
- Updated `viewer user has read-only permissions` in `TestStaticAuthZ_GetUserPermissions` to include the new denial
- Updated multi-role viewer+installer test to include the new denial entry
- All `./internal/auth/...` tests pass

## Confidence
High — the authorization middleware path is covered by existing tests; the fix follows an established pattern in the codebase.

## Rollback
Revert the single-line addition of `"devices/console": {}` from `internal/auth/authz/static.go`.

## Risk Assessment
Low — change is contained to the RBAC permission table; no API contracts or data models are affected.

Made with [Cursor](https://cursor.com)