### PR TITLE
EDM-2708: Add agent VM PR check

### DIFF
--- a/.github/workflows/pr-agent-vm-testing.yaml
+++ b/.github/workflows/pr-agent-vm-testing.yaml
@@ -1,0 +1,201 @@
+name: "Agent VM smoke test"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 'release-*'
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Enable BuildKit for cache mounts
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+
+  QUAY_ORG: quay.io/flightctl
+  REGISTRY: quay.io
+  REGISTRY_OWNER: flightctl
+  REGISTRY_OWNER_TESTS: flightctl-tests
+  GITHUB_ACTIONS: true
+
+jobs:
+  agent-vm:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: flightctl-ci-runner
+    timeout-minutes: 120
+    steps:
+      # ========== PREPARE ENVIRONMENT ==========
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          since_last_remote_commit: true
+          files_ignore: |
+            .spelling
+            README.md
+            docs/**
+            examples/**
+            packaging/rpm/**
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          sudo rm -rf /usr/local/lib/android >/dev/null 2>&1 &
+          echo "Started background removal of /usr/local/lib/android (PID: $!)"
+          df -h
+
+      # ========== SETUP DEPENDENCIES ==========
+      - name: Setup dependencies (KVM, libvirt, etc)
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: ./.github/actions/setup-dependencies
+        with:
+          setup_kvm: yes
+
+      - name: Cache Go modules
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Cache DNF packages
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-agent-vm
+          restore-keys: |
+            ${{ runner.os }}-dnf-
+
+      - name: Cache bootc-image-builder
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            bin/dnf-cache
+            bin/osbuild-cache
+          key: ${{ runner.os }}-bootc-cache-agent-vm-${{ hashFiles('test/scripts/agent-images/containerfiles/*/Containerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-bootc-cache-agent-vm-
+            ${{ runner.os }}-bootc-cache-e2e-
+
+      # ========== DEPLOY BACKEND AND AGENT VM ==========
+      - name: Prepare libvirt
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          sudo systemctl enable --now libvirtd
+          sudo virsh list --all
+          make clean-agent-vm
+
+      - name: Deploy backend and boot agent VM
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: DISABLE_FIPS="true" make deploy agent-vm
+
+      - name: Verify agent VM
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: |
+          set -euo pipefail
+
+          sudo virsh dominfo flightctl-device-default
+          MAX_VM_WAIT_SECONDS=120
+          SLEEP_INTERVAL=5
+          elapsed=0
+
+          while [ "${elapsed}" -lt "${MAX_VM_WAIT_SECONDS}" ]; do
+            state=$(sudo virsh domstate flightctl-device-default | xargs)
+            echo "Agent VM state after ${elapsed}s: ${state}"
+            if [ "${state}" = "running" ]; then
+              break
+            fi
+            sleep "${SLEEP_INTERVAL}"
+            elapsed=$((elapsed + SLEEP_INTERVAL))
+          done
+
+          if [ "${state}" != "running" ]; then
+            echo "Timed out waiting for agent VM to reach running state"
+            exit 1
+          fi
+
+          MAX_ENROLLMENT_WAIT_SECONDS=180
+          elapsed=0
+
+          while [ "${elapsed}" -lt "${MAX_ENROLLMENT_WAIT_SECONDS}" ]; do
+            echo "Checking enrollment requests after ${elapsed}s"
+            enrollment_requests_output=$(./bin/flightctl get enrollmentrequests 2>&1 || true)
+            echo "${enrollment_requests_output}"
+
+            enrollment_request=$(echo "${enrollment_requests_output}" | awk 'NR > 1 && $2 == "Pending" {print $1; exit}')
+            if [ -n "${enrollment_request}" ]; then
+              echo "Approving enrollment request ${enrollment_request}"
+              ./bin/flightctl approve "enrollmentrequest/${enrollment_request}"
+              break
+            fi
+
+            sleep "${SLEEP_INTERVAL}"
+            elapsed=$((elapsed + SLEEP_INTERVAL))
+          done
+
+          if [ -z "${enrollment_request:-}" ]; then
+            echo "Timed out waiting for pending enrollment request"
+            ./bin/flightctl get enrollmentrequests || true
+            exit 1
+          fi
+
+          MAX_AGENT_WAIT_SECONDS=300
+          elapsed=0
+
+          while [ "${elapsed}" -lt "${MAX_AGENT_WAIT_SECONDS}" ]; do
+            echo "Checking agent device status after ${elapsed}s"
+            devices_output=$(./bin/flightctl get devices 2>&1 || true)
+            echo "${devices_output}"
+
+            online_device=$(echo "${devices_output}" | awk 'NR > 1 && $4 == "Online" && $5 == "UpToDate" {print $1; exit}')
+            if [ -n "${online_device}" ]; then
+              echo "Agent device ${online_device} is Online and UpToDate"
+              ./bin/flightctl get "devices/${online_device}" -o yaml
+              exit 0
+            fi
+
+            sleep "${SLEEP_INTERVAL}"
+            elapsed=$((elapsed + SLEEP_INTERVAL))
+          done
+
+          echo "Timed out waiting for agent device to report Online and UpToDate"
+          ./bin/flightctl get enrollmentrequests || true
+          ./bin/flightctl get devices || true
+          exit 1
+
+      # ========== COLLECT LOGS ==========
+      - name: Collect and Upload Logs
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        uses: ./.github/actions/collect-logs
+        with:
+          namespace-external: 'flightctl-external'
+          namespace-internal: 'flightctl-internal'
+          log-directory: 'agent-vm-smoke-logs'
+
+      - name: Clean agent VM
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        run: make clean-agent-vm

--- a/.github/workflows/rpmlint.yaml
+++ b/.github/workflows/rpmlint.yaml
@@ -21,7 +21,7 @@ jobs:
   rpmlint:
     runs-on: "ubuntu-24.04"
     container:
-      image: fedora:latest
+      image: quay.io/fedora/fedora:latest
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Adds a PR smoke workflow that exercises `make deploy agent-vm` on the VM-capable CI runner. The check sets up KVM/libvirt, deploys the backend, boots the agent VM, and verifies the VM reaches the `running` state.