### PR TITLE
EDM-4038: Add alertmanager dir ownership to services RPM

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -589,6 +589,7 @@ fi
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-cli-artifacts
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-gateway
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-pam-issuer
+    %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-alertmanager
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-alert-exporter
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-periodic
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-worker


### PR DESCRIPTION
## Summary
- Adds explicit `%dir` ownership for `/usr/share/flightctl/flightctl-alertmanager/` in the `flightctl-services` RPM spec
- Without this, the directory persists as an empty stale directory after package removal
- Verified on a local VM that the directory is properly cleaned up on `rpm -e flightctl-services`

## Test plan
- [x] Build the RPM (`make rpm`)
- [x] Install `flightctl-services` on a test VM
- [x] Verify `/usr/share/flightctl/flightctl-alertmanager/` exists and is owned by the package (`rpm -qf`)
- [x] Remove the package (`rpm -e flightctl-services`)
- [x] Verify the directory is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)