### PR TITLE
EDM-4057: Gateway handling of Quadlet container restarts

### DIFF
--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
@@ -23,5 +23,7 @@ RestartSec=30
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-alertmanager-proxy/config.yaml.template --output-file /etc/flightctl/flightctl-alertmanager-proxy/config.yaml
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-alertmanager-proxy/env.template --output-file /etc/flightctl/flightctl-alertmanager-proxy/env
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -34,6 +34,7 @@ LimitNOFILE=300000
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-api/config.yaml.template --output-file /etc/flightctl/flightctl-api/config.yaml
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-api/env.template --output-file /etc/flightctl/flightctl-api/env
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
 
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts.container
+++ b/deploy/podman/flightctl-cli-artifacts/flightctl-cli-artifacts.container
@@ -16,5 +16,7 @@ RestartSec=30
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-cli-artifacts/env.template --output-file /etc/flightctl/flightctl-cli-artifacts/env
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -17,6 +17,7 @@ Volume=/etc/flightctl/pki/flightctl-gateway/server.key:/etc/flightctl/pki/flight
 User=1001
 Group=0
 Exec=nginx -g "daemon off;"
+ReloadCmd=nginx -s reload
 
 PublishPort=443:8443
 # Backwards-compat: pre-gateway installations used port 3443 for the API and 8445 for imagebuilder.

--- a/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
+++ b/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
@@ -24,5 +24,7 @@ RestartSec=30
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-imagebuilder-api/config.yaml.template --output-file /etc/flightctl/flightctl-imagebuilder-api/config.yaml
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer.container
+++ b/deploy/podman/flightctl-pam-issuer/flightctl-pam-issuer.container
@@ -23,5 +23,7 @@ RestartSec=30
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-pam-issuer/config.yaml.template --output-file /etc/flightctl/flightctl-pam-issuer/config.yaml
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=flightctl.target

--- a/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway.container
+++ b/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway.container
@@ -25,5 +25,7 @@ Volume=/etc/flightctl/flightctl-telemetry-gateway/forward:/etc/flightctl/flightc
 Restart=on-failure
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-telemetry-gateway/config.yaml.template --output-file /etc/flightctl/flightctl-telemetry-gateway/config.yaml
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=multi-user.target

--- a/deploy/podman/flightctl-ui/flightctl-ui.container
+++ b/deploy/podman/flightctl-ui/flightctl-ui.container
@@ -20,5 +20,7 @@ RestartSec=30
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-ui/env.template --output-file /etc/flightctl/flightctl-ui/env
 
+ExecStartPost=bash -c '! systemctl is-active --quiet flightctl-gateway || podman exec flightctl-gateway nginx -s reload'
+
 [Install]
 WantedBy=flightctl.target


### PR DESCRIPTION
This ensures that nginx gets reloaded if any of the upstream containers get restarted.

Nginx resolves DNS for the upstream containers only once at startup and the config to make it do it dynamically is not supported in the versions of nginx that we are using, so we need to manually trigger nginx to reload in the ExecStartPost section of each upstream service definition.

Due to circular dependencies between quadlets/podman/systemd we cannot use 'systemctl reload flightctl-gateway' but must use 'podman exec' instead.