### PR TITLE
EDM-89237: Add label 89237 to bootc timer e2e test

### DIFF
--- a/test/e2e/agent/agent_bootc_timer_test.go
+++ b/test/e2e/agent/agent_bootc_timer_test.go
@@ -15,7 +15,7 @@ const (
 )
 
 var _ = Describe("Bootc timer masking", func() {
-	It("should automatically mask bootc timer on installation", Label("bootc-timer", "sanity", "agent"), func() {
+	It("should automatically mask bootc timer on installation", Label("89237", "bootc-timer", "sanity", "agent"), func() {
 		harness := e2e.GetWorkerHarness()
 
 		By("Enrolling a device")


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
