### PR TITLE
EDM-4053: Suppress nginx version header

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
@@ -12,6 +12,8 @@ http {
   ssl_ecdh_curve auto;
   ssl_prefer_server_ciphers off;
 
+  server_tokens off;
+
   server {
     server_name {{.global.baseDomain}};
     listen 8443 ssl;


### PR DESCRIPTION
This prevents the nginx version number from being returned in the Server header.

It is not possible to completely suppress the Server header but with this it will only be 'Server: nginx' and won't include the version.
