### PR TITLE
[EDM-4021]: clean up temporary container storage dirs on job completion and rpm uninstall

### DIFF
--- a/internal/imagebuilder_worker/tasks/imagebuild.go
+++ b/internal/imagebuilder_worker/tasks/imagebuild.go
@@ -33,6 +33,11 @@ import (
 const (
 	// agentConfigPath is the destination path for the agent config in the image
 	agentConfigPath = "/etc/flightctl/config.yaml"
+
+	// buildStorageBaseDir is the base directory for temporary container storage used
+	// during image builds. A unique subdirectory is created per job and removed when
+	// the job completes. Any leftovers from a crash are swept on worker startup.
+	buildStorageBaseDir = "/var/tmp/flightctl-builds"
 )
 
 // containerfileTemplate is embedded from the templates directory for easier editing
@@ -739,11 +744,9 @@ func (c *Consumer) startPodmanWorker(
 		return nil, fmt.Errorf("failed to create temporary output directory: %w", err)
 	}
 
-	baseStorageDir := "/var/tmp/flightctl-builds"
-
 	// This creates a unique, throw-away directory for THIS specific build.
 	// It ensures no caching between jobs.
-	tmpContainerStorage, err := os.MkdirTemp(baseStorageDir, "storage-*")
+	tmpContainerStorage, err := os.MkdirTemp(buildStorageBaseDir, "storage-*")
 	if err != nil {
 		return nil, err
 	}
@@ -834,9 +837,15 @@ ignore_chown_errors = "true"
 		if err := exec.CommandContext(killCtx, "podman", "kill", containerName).Run(); err != nil {
 			log.WithError(err).Warn("Failed to kill worker container during cleanup")
 		}
-		os.RemoveAll(tmpDir)
-		os.RemoveAll(tmpOutDir)
-		os.RemoveAll(tmpContainerStorage)
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.WithError(err).WithField("path", tmpDir).Warn("Failed to remove temporary directory")
+		}
+		if err := os.RemoveAll(tmpOutDir); err != nil {
+			log.WithError(err).WithField("path", tmpOutDir).Warn("Failed to remove temporary output directory")
+		}
+		if err := os.RemoveAll(tmpContainerStorage); err != nil {
+			log.WithError(err).WithField("path", tmpContainerStorage).Warn("Failed to remove temporary container storage directory")
+		}
 	}
 
 	return &podmanWorker{

--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -35,6 +35,13 @@ import (
 //go:embed templates/Containerfile.containerdisk.tmpl
 var containerdiskTemplate string
 
+const (
+	// exportStorageBaseDir is the base directory for temporary container storage used
+	// during image export. A unique subdirectory is created per job and removed when
+	// the job completes. Any leftovers from a crash are swept on worker startup.
+	exportStorageBaseDir = "/var/tmp/flightctl-exports"
+)
+
 var (
 	// errImageBuildNotReady is returned when ImageBuild is not ready yet (pending state)
 	errImageBuildNotReady = fmt.Errorf("imageBuild not ready")
@@ -477,8 +484,7 @@ func (c *Consumer) startBootcImageBuilderContainer(
 		return nil, fmt.Errorf("failed to create temporary output directory: %w", err)
 	}
 
-	baseStorageDir := "/var/tmp/flightctl-exports"
-	tmpContainerStorage, err := os.MkdirTemp(baseStorageDir, "storage-*")
+	tmpContainerStorage, err := os.MkdirTemp(exportStorageBaseDir, "storage-*")
 	if err != nil {
 		os.RemoveAll(tmpDir)
 		os.RemoveAll(tmpOutDir)
@@ -528,9 +534,13 @@ func (c *Consumer) startBootcImageBuilderContainer(
 		if err := exec.CommandContext(killCtx, "podman", "kill", containerName).Run(); err != nil {
 			log.WithError(err).Warn("Failed to kill bootc-image-builder container during cleanup")
 		}
-		os.RemoveAll(tmpDir)
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.WithError(err).WithField("path", tmpDir).Warn("Failed to remove temporary directory")
+		}
 		// Don't remove tmpOutDir here - it's cleaned up separately after pushArtifact completes
-		os.RemoveAll(tmpContainerStorage)
+		if err := os.RemoveAll(tmpContainerStorage); err != nil {
+			log.WithError(err).WithField("path", tmpContainerStorage).Warn("Failed to remove temporary container storage directory")
+		}
 	}
 
 	return &privilegedPodmanWorker{

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -771,6 +771,13 @@ fi
 # On upgrade: mark services for restart after transaction completes
 %systemd_postun_with_restart %{flightctl_target}
 
+# On full removal: delete temporary build/export storage that may contain
+# leftover subdirectories from interrupted jobs (non-empty dirs RPM won't remove).
+if [ "$1" -eq 0 ]; then
+    rm -rf %{_var}/tmp/flightctl-builds
+    rm -rf %{_var}/tmp/flightctl-exports
+fi
+
 # If contexts were managed via policy, no cleanup is needed here.
 
 %changelog

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -774,8 +774,8 @@ fi
 # On full removal: delete temporary build/export storage that may contain
 # leftover subdirectories from interrupted jobs (non-empty dirs RPM won't remove).
 if [ "$1" -eq 0 ]; then
-    rm -rf %{_var}/tmp/flightctl-builds
-    rm -rf %{_var}/tmp/flightctl-exports
+    rm -rf %{_var}/tmp/flightctl-builds || true
+    rm -rf %{_var}/tmp/flightctl-exports || true
 fi
 
 # If contexts were managed via policy, no cleanup is needed here.


### PR DESCRIPTION
## Problem

After uninstalling the `flightctl` RPM, `/var/tmp/flightctl-exports` (and `/var/tmp/flightctl-builds`) were not removed. RPM only removes `%dir`-owned directories if they are empty, but these directories accumulate leftover `storage-*` subdirectories from interrupted image build/export jobs.

## Root Cause

The imagebuilder worker creates a per-job `storage-*` subdirectory inside each base dir and mounts it as `/var/lib/containers` inside a privileged nested container. After the job completes (or errors), the cleanup function calls `os.RemoveAll` on these subdirectories, but the errors were silently discarded. Any failure (process killed mid-job, OOM, SIGKILL) left subdirectories behind with no log evidence, causing the base directories to be non-empty and therefore skipped by RPM on uninstall.

## Fix

- **Error logging**: All `os.RemoveAll` calls in the per-job cleanup functions now log a warning on failure, making disk leak incidents visible in logs.
- **Named constants**: Extracted `buildStorageBaseDir` and `exportStorageBaseDir` constants to avoid duplicated hardcoded paths.
- **RPM `%postun`**: Added cleanup of both directories in `%postun services`, guarded by `$1 -eq 0` (full removal only, not upgrade).

## Testing

- Verified no linter errors on changed files.
- The RPM `%postun` guard (`$1 -eq 0`) follows the existing pattern used by other scriptlets in the spec.

## Risk Assessment

Low — the Go changes are observability-only (adding error logging). The RPM spec change only runs on full package removal and uses `rm -rf` on well-known temporary paths.

## Notes

The Kubernetes `hostPath` equivalent (dirs left on nodes after `helm uninstall`) is a separate issue — `hostPath` volumes are not cleaned up by Kubernetes and would require a pre-delete hook Job. Filed as a follow-up.

Made with [Cursor](https://cursor.com)