### PR TITLE
EDM-4057: Remove ReloadCmd directive from flightctl-gateway.container

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -17,7 +17,6 @@ Volume=/etc/flightctl/pki/flightctl-gateway/server.key:/etc/flightctl/pki/flight
 User=1001
 Group=0
 Exec=nginx -g "daemon off;"
-ReloadCmd=nginx -s reload
 
 PublishPort=443:8443
 # Backwards-compat: pre-gateway installations used port 3443 for the API and 8445 for imagebuilder.


### PR DESCRIPTION
https://github.com/flightctl/flightctl/pull/3034 added ReloadCmd which is not supported in podman 5.4.0
