### PR TITLE
[Backport to 1.2] EDM-3783: Expose old ports by default on quadlets deploy

### DIFF
--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -170,6 +170,4 @@ userinfoProxy:
   insecureSkipTlsVerify:
 
 gateway:
-  # This is for backwards compatibility. Existing installations won't have this set so the nginx gateway
-  # will maintain the old API port exposed on 3443 for existing clients configured with that.
-  suppressOldPorts: true
+  suppressOldPorts: false


### PR DESCRIPTION
Backporting PR *[EDM-3783: Expose old ports by default on quadlets deploy](https://github.com/flightctl/flightctl/pull/3041)* for **1.2** release.