### PR TITLE
EDM-4038: Own license dirs in CLI RPM for clean uninstall

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -347,6 +347,10 @@ fi
         install -Dv -m0644 "${LICENSE_FILE}" "%{buildroot}%{_datadir}/licenses/%{NAME}/${LICENSE_FILE}"
         echo "%%license %{_datadir}/licenses/%{NAME}/${LICENSE_FILE}" >> licenses.list
     done
+    # Own intermediate directories so RPM removes them on uninstall
+    find "%{buildroot}%{_datadir}/licenses/%{NAME}" -mindepth 1 -type d | sort -r | while read DIR; do
+        echo "%%dir ${DIR#%{buildroot}}" >> licenses.list
+    done
     touch licenses.list
 
     # flightctl-services sub-package steps
@@ -458,6 +462,7 @@ fi
 # No %%files section for the main package, so it won't be built
 
 %files cli -f licenses.list
+    %dir %{_datadir}/licenses/%{NAME}
     %{_bindir}/flightctl
     %{_bindir}/flightctl-restore
     %{_datadir}/bash-completion/completions/flightctl-completion.bash


### PR DESCRIPTION
## Summary
- Backport of #3033 (cherry-pick of 646bdc65 from main) to release-1.2
- Ensures RPM owns intermediate license directories so they are properly cleaned up on uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)