### PR TITLE
[Backport to 1.2] Add gateway image back

### DIFF
--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -25,6 +25,9 @@ ui:
 db-setup:
   image: quay.io/flightctl/flightctl-db-setup-el9
   tag: latest
+gateway:
+  image: quay.io/sclorg/nginx-124-c9s
+  tag: "20260422"
 db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"


### PR DESCRIPTION
Backporting PR *[Add gateway image back](https://github.com/flightctl/flightctl/pull/3049)* for **1.2** release.