### PR TITLE
EDM-3783: Quadlet Gateway After Dependencies

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Flight Control Gateway service
-After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service
-Wants=flightctl-certs-init.service
+After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
+Requires=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
 PartOf=flightctl.target
 
 [Container]


### PR DESCRIPTION
Ensure that pam-issuer, alertmanager-proxy and cli-artifacts are all started before the gateway to help prevent startup failures on the gateway.
