### PR TITLE
EDM-3953: mirror-images bug fixes — tag-override and missing nginx image

### DIFF
--- a/scripts/air-gap/mirror-images/parser.go
+++ b/scripts/air-gap/mirror-images/parser.go
@@ -116,8 +116,10 @@ func ParseHelmChartOpts(path, variant, appVersion string) ([]ImagePair, error) {
 	pairs := make([]ImagePair, 0, len(cv.Images))
 	for _, spec := range cv.Images {
 		tag := spec.Tag
-		if tag == "" {
-			// No explicit tag: use the chart appVersion as the fallback.
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: use the
+			// chart appVersion (or --tag-override) so the bundled images match
+			// the installed RPM version.
 			tag = appVersion
 		}
 		image := normalizeDockerImage(spec.Image)
@@ -205,7 +207,11 @@ func ParseObsImages(el9Path, el10Path, rhel9Path, rhel10Path, variant, tagFallba
 		}
 
 		tag := spec.Tag
-		if tag == "" {
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: apply the
+			// effective tag (appVersion or --tag-override) so RPM-only images
+			// such as pam-issuer and userinfo-proxy are bundled at the correct
+			// release version rather than always pulling :latest.
 			tag = tagFallback
 		}
 


### PR DESCRIPTION
## Summary

- **Fix `--tag-override` ignored for images with `tag: latest`**: Images in `packaging/images/el9/images.yaml` (e.g. `pam-issuer`, `userinfo-proxy`) carry an explicit `tag: latest` field. The parser only applied the effective tag fallback when the tag field was *empty*, so `--tag-override` had no effect on these images. Both `ParseHelmChartOpts` and `ParseObsImages` now treat `"latest"` the same as an empty tag — it is a placeholder, not a pinned version. Pinned third-party tags (`"20250214"`, `"v0.28.1"`, etc.) are unaffected.

- **Add missing nginx gateway image to `el9/images.yaml`**: The `gateway` entry (`quay.io/sclorg/nginx-124-c9s`) was dropped during the PR #2987 merge and must be present in the bundle for air-gapped installations.

## Test plan

- [ ] Build bundle with `--tag-override <version>` and verify `pam-issuer` and `userinfo-proxy` images are tagged with the override version, not `:latest`
- [ ] Verify `quay.io/sclorg/nginx-124-c9s` is included in the bundle image list for `community-el9`
- [ ] Verify pinned third-party images (postgresql, redis, alertmanager) are unaffected by `--tag-override`

🤖 Generated with [Claude Code](https://claude.com/claude-code)