### PR TITLE
[Backport to 1.2] EDM-3783: Quadlet Gateway After Dependencies

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Flight Control Gateway service
-After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service
-Wants=flightctl-certs-init.service
+After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
+Requires=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
 PartOf=flightctl.target
 
 [Container]


### PR DESCRIPTION
Backporting PR *[EDM-3783: Quadlet Gateway After Dependencies](https://github.com/flightctl/flightctl/pull/3054)* for **1.2** release.