### PR TITLE
NO-ISSUE: Fix version tiebreak when multiple tags share a commit

### DIFF
--- a/hack/current-version
+++ b/hack/current-version
@@ -9,8 +9,19 @@ git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
 # "human-readable" artificial tag.
 tag=$(git -c "versionsort.suffix=-rc" tag --points-at HEAD --sort version:refname -l 'v*' | tail -n 1 2>/dev/null)
 
+# When multiple tags exist on the same commit (e.g. v1.3.0-main and v1.2.0-rc1),
+# git describe may pick the wrong one. Re-resolve using version sorting at the
+# base commit and re-attach the distance and hash suffix.
 if [[ -z "$tag" ]]; then
-  tag=$(git describe --tags --always --first-parent --match 'v*' 2>/dev/null)
+  nearest_tag=$(git describe --tags --always --first-parent --match 'v*' --abbrev=0 2>/dev/null)
+  full_describe=$(git describe --tags --always --first-parent --match 'v*' 2>/dev/null)
+  base_commit=$(git rev-parse "$nearest_tag"^{commit})
+  best_tag=$(git -c "versionsort.suffix=-rc" tag --points-at "$base_commit" --sort version:refname -l 'v*' | tail -n 1)
+  if [[ -n "$best_tag" ]]; then
+    tag="${best_tag}${full_describe#"$nearest_tag"}"
+  else
+    tag="$full_describe"
+  fi
 fi
 
 if [[ -z "$tag" ]]; then


### PR DESCRIPTION
## Summary

When a release branch is cut at the same commit where the `-main` development tag is placed (e.g. `v1.2.0-rc1` and `v1.3.0-main` both on `8b4fb3ec`), `git describe` may pick the wrong tag due to its hardcoded tiebreaking: annotated tags always win over lightweight tags, regardless of version.

This caused COPR dev builds from `main` to be versioned as `1.2.0~rc1` instead of `1.3.0~main`.

### What happened

In the v1.1.0 cycle, the rc tag landed on a release-branch-only commit (CODEOWNERS update), so `git describe` on main never saw it:

```
             v1.2.0-main
                 │
main:  ──── c4cf4025 ──── ...
                 │
release-1.1:     └── 42021c88 ── ...
                         │
                    v1.1.0-rc1
```

In the v1.2.0 cycle, no such commit existed — the release branch was cut at the exact same commit where the `-main` tag was placed:

```
            v1.3.0-main (lightweight)
            v1.2.0-rc1  (annotated)
                 │
main:  ──── 8b4fb3ec ──── ... ──── HEAD
                 │
release-1.2:     └── d91d255d ── 9bb0fa65 ── ...
                                     │
                                v1.2.0-rc2
```

`git describe` on main walks back to `8b4fb3ec`, finds both tags, and always picks `v1.2.0-rc1` (annotated wins over lightweight). Every build after this commit gets the wrong version.

### Example

Two tags on the same commit:
- `v1.2.0-rc1` (annotated)
- `v1.3.0-main` (lightweight)

**Before (broken):**
```
$ git describe --tags --match 'v*' HEAD
v1.2.0-rc1-58-gbf7e90b5

$ hack/current-version
v1.2.0-rc1-58-gbf7e90b5
```

**After (fixed):**
```
$ git describe --tags --match 'v*' HEAD
v1.2.0-rc1-58-gbf7e90b5       # git describe still picks the wrong one

$ hack/current-version
v1.3.0-main-58-gbf7e90b5      # but the script re-resolves using version sorting
```

### How it works

The script uses `git describe` to find the nearest tagged commit and the distance/hash suffix, then re-resolves the tag at that commit using `git tag --sort version:refname` (with `versionsort.suffix=-rc`) to pick the highest version. This matches the same sorting logic already used for the `--points-at HEAD` path.

This fix is resilient to tag type (annotated vs lightweight) and works correctly with single tags, multiple tags, or any combination.

## Test plan

- [x] Tested with lightweight `-main` + annotated `-rc` on the same commit (the broken case)
- [x] Tested with both annotated
- [x] Tested with both lightweight
- [x] Tested with a single tag (no conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)