### PR TITLE
EDM-4069: Fail ImagePromotion when required exports reach terminal non-completed state

### DIFF
--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -72,6 +72,9 @@ type ImageExportService interface {
 	// ListCompletedForBuild returns the most recently completed ImageExport for the given
 	// imageBuildRef and export format, or nil if none exists yet.
 	ListCompletedForBuild(ctx context.Context, orgId uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error)
+	// ListTerminalNonCompletedForBuild returns a terminal non-completed ImageExport (Failed or
+	// Canceled) for the given imageBuildRef and export format, or nil if none exists.
+	ListTerminalNonCompletedForBuild(ctx context.Context, orgId uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error)
 }
 
 // ImageExportDownload contains information for downloading an ImageExport artifact
@@ -1113,6 +1116,30 @@ func (s *imageExportService) ListCompletedForBuild(ctx context.Context, orgId uu
 		return nil, nil
 	}
 	return &exports.Items[0], nil
+}
+
+func (s *imageExportService) ListTerminalNonCompletedForBuild(ctx context.Context, orgId uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error) {
+	for _, reason := range []domain.ImageExportConditionReason{
+		domain.ImageExportConditionReasonFailed,
+		domain.ImageExportConditionReasonCanceled,
+	} {
+		fs, err := selector.NewFieldSelectorFromMap(map[string]string{
+			"spec.source.imageBuildRef":      imageBuildRef,
+			"spec.format":                    string(format),
+			"status.conditions.ready.reason": string(reason),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build field selector: %w", err)
+		}
+		exports, err := s.imageExportStore.List(ctx, orgId, mainstore.ListParams{FieldSelector: fs, Limit: 1})
+		if err != nil {
+			return nil, err
+		}
+		if len(exports.Items) > 0 {
+			return &exports.Items[0], nil
+		}
+	}
+	return nil, nil
 }
 
 // GetLogs retrieves logs for an ImageExport

--- a/internal/imagebuilder_worker/tasks/imageexport_status_updater_test.go
+++ b/internal/imagebuilder_worker/tasks/imageexport_status_updater_test.go
@@ -98,6 +98,10 @@ func (m *mockImageExportServiceForStatusUpdater) ListCompletedForBuild(ctx conte
 	return nil, nil
 }
 
+func (m *mockImageExportServiceForStatusUpdater) ListTerminalNonCompletedForBuild(_ context.Context, _ uuid.UUID, _ string, _ api.ExportFormatType) (*api.ImageExport, error) {
+	return nil, nil
+}
+
 func (m *mockImageExportServiceForStatusUpdater) getCallsCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/imagebuilder_worker/tasks/imagepromotion.go
+++ b/internal/imagebuilder_worker/tasks/imagepromotion.go
@@ -122,11 +122,16 @@ func (c *Consumer) evaluateAndTransition(ctx context.Context, orgID uuid.UUID, p
 		return c.evaluateAmendmentFailed(ctx, orgID, promotion, imageBuild)
 	}
 
-	allReady, _, err := c.computeArtifactsStatus(ctx, orgID, promotion, imageBuild)
+	allReady, _, terminalFailedFormats, err := c.computeArtifactsStatus(ctx, orgID, promotion, imageBuild)
 	if err != nil {
 		c.log.WithError(err).WithField("promotion", lo.FromPtr(promotion.Metadata.Name)).
 			Warn("failed to compute promotion artifact status")
 		return fmt.Errorf("failed to compute artifact status for promotion %q: %w", lo.FromPtr(promotion.Metadata.Name), err)
+	}
+
+	if len(terminalFailedFormats) > 0 {
+		msg := buildExportTerminalFailureMessage(promotion.Spec.Source.ImageBuildRef, terminalFailedFormats)
+		return c.transitionToFailed(ctx, orgID, promotion, domain.ImagePromotionConditionReasonFailed, msg)
 	}
 
 	if !allReady {
@@ -513,7 +518,9 @@ func (c *Consumer) resolveArtifactReferences(ctx context.Context, orgID uuid.UUI
 // Returns:
 //   - allUnpublishedReady: true when all unpublished artifacts have completed artifacts.
 //   - unpublishedFormats: export formats not yet published.
-func (c *Consumer) computeArtifactsStatus(ctx context.Context, orgID uuid.UUID, current *domain.ImagePromotion, imageBuild *domain.ImageBuild) (allUnpublishedReady bool, unpublishedFormats []domain.ExportFormatType, err error) {
+//   - terminalFailedFormats: export formats whose most recent export is in a terminal non-completed
+//     state (Failed or Canceled) and no completed export exists.
+func (c *Consumer) computeArtifactsStatus(ctx context.Context, orgID uuid.UUID, current *domain.ImagePromotion, imageBuild *domain.ImageBuild) (allUnpublishedReady bool, unpublishedFormats []domain.ExportFormatType, terminalFailedFormats []domain.ExportFormatType, err error) {
 	if current.Status == nil {
 		current.Status = &domain.ImagePromotionStatus{}
 	}
@@ -549,7 +556,7 @@ func (c *Consumer) computeArtifactsStatus(ctx context.Context, orgID uuid.UUID, 
 		}
 		export, checkErr := c.resolveLatestCompletedExport(ctx, orgID, current.Spec.Source.ImageBuildRef, format)
 		if checkErr != nil {
-			return false, nil, fmt.Errorf("%w: failed to check export readiness for format %s: %w", errTransientExportLookup, format, checkErr)
+			return false, nil, nil, fmt.Errorf("%w: failed to check export readiness for format %s: %w", errTransientExportLookup, format, checkErr)
 		}
 		ready := export != nil
 		entry := domain.ArtifactPromotionStatus{Format: string(format), Ready: ready}
@@ -557,17 +564,30 @@ func (c *Consumer) computeArtifactsStatus(ctx context.Context, orgID uuid.UUID, 
 			entry.ResolvedExport = export.Metadata.Name
 		} else {
 			allUnpublishedReady = false
+			terminal, terminalErr := c.resolveLatestTerminalNonCompletedExport(ctx, orgID, current.Spec.Source.ImageBuildRef, format)
+			if terminalErr != nil {
+				return false, nil, nil, fmt.Errorf("%w: failed to check terminal export for format %s: %w", errTransientExportLookup, format, terminalErr)
+			}
+			if terminal != nil {
+				terminalFailedFormats = append(terminalFailedFormats, format)
+			}
 		}
 		statuses = append(statuses, entry)
 		unpublishedFormats = append(unpublishedFormats, format)
 	}
 	current.Status.ArtifactStatuses = &statuses
-	return allUnpublishedReady, unpublishedFormats, nil
+	return allUnpublishedReady, unpublishedFormats, terminalFailedFormats, nil
 }
 
 // resolveLatestCompletedExport returns the most recently completed ImageExport for the given format.
 func (c *Consumer) resolveLatestCompletedExport(ctx context.Context, orgID uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error) {
 	return c.imageBuilderService.ImageExport().ListCompletedForBuild(ctx, orgID, imageBuildRef, format)
+}
+
+// resolveLatestTerminalNonCompletedExport returns the most recent terminal non-completed
+// (Failed or Canceled) ImageExport for the given format, or nil if none exists.
+func (c *Consumer) resolveLatestTerminalNonCompletedExport(ctx context.Context, orgID uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error) {
+	return c.imageBuilderService.ImageExport().ListTerminalNonCompletedForBuild(ctx, orgID, imageBuildRef, format)
 }
 
 // ---- state transition helpers ----
@@ -699,6 +719,18 @@ func getPromotionReadyReasonWorker(promotion *domain.ImagePromotion) string {
 		return ""
 	}
 	return cond.Reason
+}
+
+func buildExportTerminalFailureMessage(imageBuildRef string, formats []domain.ExportFormatType) string {
+	formatStrs := make([]string, len(formats))
+	for i, f := range formats {
+		formatStrs[i] = string(f)
+	}
+	return fmt.Sprintf(
+		"Export(s) for format(s) [%s] failed or were canceled for build %q. Please create new exports to retry.",
+		strings.Join(formatStrs, ", "),
+		imageBuildRef,
+	)
 }
 
 func conditionMessageForReasonWorker(reason domain.ImagePromotionConditionReason) string {

--- a/internal/imagebuilder_worker/tasks/imagepromotion_test.go
+++ b/internal/imagebuilder_worker/tasks/imagepromotion_test.go
@@ -378,6 +378,21 @@ func makeCompletedBuild(name, digest string) *domain.ImageBuild {
 	}
 }
 
+func makeTerminalExport(name, buildRef string, format domain.ExportFormatType, reason domain.ImageExportConditionReason) *domain.ImageExport {
+	now := time.Now()
+	src := api.ImageExportSource{}
+	_ = src.FromImageBuildRefSource(api.ImageBuildRefSource{Type: api.ImageBuildRefSourceTypeImageBuild, ImageBuildRef: buildRef})
+	return &api.ImageExport{
+		Metadata: v1beta1.ObjectMeta{Name: lo.ToPtr(name), CreationTimestamp: &now},
+		Spec:     api.ImageExportSpec{Source: src, Format: format},
+		Status: &api.ImageExportStatus{
+			Conditions: &[]api.ImageExportCondition{
+				{Type: api.ImageExportConditionTypeReady, Status: coredomain.ConditionStatusFalse, Reason: string(reason)},
+			},
+		},
+	}
+}
+
 func makeCompletedExport(name, buildRef string, format domain.ExportFormatType, digest string) *domain.ImageExport {
 	now := time.Now()
 	src := api.ImageExportSource{}
@@ -562,6 +577,36 @@ func (s *testExportSvc) ListCompletedForBuild(ctx context.Context, orgId uuid.UU
 		}
 		ready := domain.FindImageExportStatusCondition(*e.Status.Conditions, domain.ImageExportConditionTypeReady)
 		if ready != nil && ready.Reason == string(domain.ImageExportConditionReasonCompleted) {
+			var cp domain.ImageExport
+			deepCopyJSON(e, &cp)
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *testExportSvc) ListTerminalNonCompletedForBuild(_ context.Context, _ uuid.UUID, imageBuildRef string, format domain.ExportFormatType) (*domain.ImageExport, error) {
+	terminalReasons := map[string]bool{
+		string(domain.ImageExportConditionReasonFailed):   true,
+		string(domain.ImageExportConditionReasonCanceled): true,
+	}
+	for _, e := range s.store.data {
+		srcType, err := e.Spec.Source.Discriminator()
+		if err != nil || srcType != string(domain.ImageExportSourceTypeImageBuild) {
+			continue
+		}
+		src, err := e.Spec.Source.AsImageBuildRefSource()
+		if err != nil || src.ImageBuildRef != imageBuildRef {
+			continue
+		}
+		if string(e.Spec.Format) != string(format) {
+			continue
+		}
+		if e.Status == nil || e.Status.Conditions == nil {
+			continue
+		}
+		ready := domain.FindImageExportStatusCondition(*e.Status.Conditions, domain.ImageExportConditionTypeReady)
+		if ready != nil && terminalReasons[ready.Reason] {
 			var cp domain.ImageExport
 			deepCopyJSON(e, &cp)
 			return &cp, nil
@@ -969,5 +1014,146 @@ func TestEvaluator_PublishingRetry(t *testing.T) {
 		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
 
 		requirePromotionReasonWorker(t, svc.promotions, "promo", domain.ImagePromotionConditionReasonFailed)
+	})
+}
+
+// TestEvaluator_TerminalExportFailsPromotion verifies that when a required export is in a terminal
+// non-completed state (Canceled or Failed), the promotion transitions to Failed immediately rather
+// than waiting indefinitely in WaitingForArtifacts.
+func TestEvaluator_TerminalExportFailsPromotion(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	makePromoWithFormats := func(name, buildRef string, formats []domain.ExportFormatType) *domain.ImagePromotion {
+		target := api.ImagePromotionTarget{}
+		_ = target.FromNewCatalogItemTarget(api.NewCatalogItemTarget{
+			Type: api.NewCatalogItem, CatalogName: "cat", CatalogItemName: "item", Version: "1.0.0",
+		})
+		p := &api.ImagePromotion{
+			Metadata: v1beta1.ObjectMeta{Name: lo.ToPtr(name)},
+			Spec: api.ImagePromotionSpec{
+				Source: api.ImagePromotionSource{
+					ImageBuildRef: buildRef,
+					ExportFormats: lo.ToPtr(formats),
+				},
+				Target: target,
+			},
+			Status: &api.ImagePromotionStatus{},
+		}
+		setPromotionReadyCondition(p, domain.ImagePromotionConditionReasonWaitingForArtifacts,
+			conditionMessageForReasonWorker(domain.ImagePromotionConditionReasonWaitingForArtifacts))
+		return p
+	}
+
+	requireFailedWithMessage := func(t *testing.T, store *inMemoryPromotionStore, name string, substrings ...string) {
+		t.Helper()
+		requirePromotionReasonWorker(t, store, name, domain.ImagePromotionConditionReasonFailed)
+		p, _ := store.Get(ctx, store.orgID, name)
+		require.NotNil(t, p)
+		cond := domain.FindImagePromotionStatusCondition(*p.Status.Conditions, domain.ImagePromotionConditionTypeReady)
+		require.NotNil(t, cond)
+		for _, s := range substrings {
+			require.Contains(t, cond.Message, s)
+		}
+	}
+
+	t.Run("When a single export is canceled it should fail the promotion", func(t *testing.T) {
+		svc := newTestIBService(orgID)
+		catalogWriter := newDummyCatalogItemWriter()
+		catalogWriter.AddCatalog("cat")
+		coreStore := &dummyCoreStore{writer: catalogWriter}
+
+		build := makeCompletedBuild("build-1", "sha256:aabb")
+		_, _ = svc.builds.Create(ctx, orgID, build)
+
+		export := makeTerminalExport("exp-iso-canceled", "build-1", domain.ExportFormatTypeISO, domain.ImageExportConditionReasonCanceled)
+		_, _ = svc.exports.Create(ctx, orgID, export)
+
+		promotion := makePromoWithFormats("promo", "build-1", []domain.ExportFormatType{domain.ExportFormatTypeISO})
+		_, _ = svc.promotions.Create(ctx, orgID, promotion)
+
+		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
+
+		requireFailedWithMessage(t, svc.promotions, "promo", string(domain.ExportFormatTypeISO), "build-1")
+	})
+
+	t.Run("When a single export is failed it should fail the promotion", func(t *testing.T) {
+		svc := newTestIBService(orgID)
+		catalogWriter := newDummyCatalogItemWriter()
+		catalogWriter.AddCatalog("cat")
+		coreStore := &dummyCoreStore{writer: catalogWriter}
+
+		build := makeCompletedBuild("build-2", "sha256:bbcc")
+		_, _ = svc.builds.Create(ctx, orgID, build)
+
+		export := makeTerminalExport("exp-vmdk-failed", "build-2", domain.ExportFormatTypeVMDK, domain.ImageExportConditionReasonFailed)
+		_, _ = svc.exports.Create(ctx, orgID, export)
+
+		promotion := makePromoWithFormats("promo", "build-2", []domain.ExportFormatType{domain.ExportFormatTypeVMDK})
+		_, _ = svc.promotions.Create(ctx, orgID, promotion)
+
+		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
+
+		requireFailedWithMessage(t, svc.promotions, "promo", string(domain.ExportFormatTypeVMDK), "build-2")
+	})
+
+	t.Run("When multiple exports are terminal it should fail the promotion listing all formats", func(t *testing.T) {
+		svc := newTestIBService(orgID)
+		catalogWriter := newDummyCatalogItemWriter()
+		catalogWriter.AddCatalog("cat")
+		coreStore := &dummyCoreStore{writer: catalogWriter}
+
+		build := makeCompletedBuild("build-3", "sha256:ccdd")
+		_, _ = svc.builds.Create(ctx, orgID, build)
+
+		_, _ = svc.exports.Create(ctx, orgID, makeTerminalExport("exp-iso", "build-3", domain.ExportFormatTypeISO, domain.ImageExportConditionReasonCanceled))
+		_, _ = svc.exports.Create(ctx, orgID, makeTerminalExport("exp-vmdk", "build-3", domain.ExportFormatTypeVMDK, domain.ImageExportConditionReasonFailed))
+
+		promotion := makePromoWithFormats("promo", "build-3", []domain.ExportFormatType{domain.ExportFormatTypeISO, domain.ExportFormatTypeVMDK})
+		_, _ = svc.promotions.Create(ctx, orgID, promotion)
+
+		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
+
+		requireFailedWithMessage(t, svc.promotions, "promo", string(domain.ExportFormatTypeISO), string(domain.ExportFormatTypeVMDK), "build-3")
+	})
+
+	t.Run("When one format is terminal and another has no export yet it should fail immediately", func(t *testing.T) {
+		svc := newTestIBService(orgID)
+		catalogWriter := newDummyCatalogItemWriter()
+		catalogWriter.AddCatalog("cat")
+		coreStore := &dummyCoreStore{writer: catalogWriter}
+
+		build := makeCompletedBuild("build-4", "sha256:ddee")
+		_, _ = svc.builds.Create(ctx, orgID, build)
+
+		// ISO is canceled, but QCOW2 has no export yet (still pending).
+		_, _ = svc.exports.Create(ctx, orgID, makeTerminalExport("exp-iso", "build-4", domain.ExportFormatTypeISO, domain.ImageExportConditionReasonCanceled))
+
+		promotion := makePromoWithFormats("promo", "build-4", []domain.ExportFormatType{domain.ExportFormatTypeISO, domain.ExportFormatTypeQCOW2})
+		_, _ = svc.promotions.Create(ctx, orgID, promotion)
+
+		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
+
+		requireFailedWithMessage(t, svc.promotions, "promo", string(domain.ExportFormatTypeISO), "build-4")
+	})
+
+	t.Run("When a completed export exists for a format it should not be treated as terminal", func(t *testing.T) {
+		svc := newTestIBService(orgID)
+		catalogWriter := newDummyCatalogItemWriter()
+		catalogWriter.AddCatalog("cat")
+		coreStore := &dummyCoreStore{writer: catalogWriter}
+
+		build := makeCompletedBuild("build-5", "sha256:eeff")
+		_, _ = svc.builds.Create(ctx, orgID, build)
+
+		// QCOW2 is completed; no other exports are present.
+		_, _ = svc.exports.Create(ctx, orgID, makeCompletedExport("exp-qcow2", "build-5", domain.ExportFormatTypeQCOW2, "sha256:qcow2digest"))
+
+		promotion := makePromoWithFormats("promo", "build-5", []domain.ExportFormatType{domain.ExportFormatTypeQCOW2})
+		_, _ = svc.promotions.Create(ctx, orgID, promotion)
+
+		require.NoError(t, newTestConsumer(svc, coreStore).evaluateAndTransition(ctx, orgID, promotion, build))
+
+		requirePromotionReasonWorker(t, svc.promotions, "promo", domain.ImagePromotionConditionReasonCompleted)
 	})
 }

--- a/internal/imagebuilder_worker/tasks/timeout_test.go
+++ b/internal/imagebuilder_worker/tasks/timeout_test.go
@@ -285,6 +285,10 @@ func (m *mockImageExportService) ListCompletedForBuild(_ context.Context, _ uuid
 	return nil, nil
 }
 
+func (m *mockImageExportService) ListTerminalNonCompletedForBuild(_ context.Context, _ uuid.UUID, _ string, _ apiimagebuilder.ExportFormatType) (*apiimagebuilder.ImageExport, error) {
+	return nil, nil
+}
+
 func createTestImageBuild(name string, reason apiimagebuilder.ImageBuildConditionReason, lastSeen time.Time) *apiimagebuilder.ImageBuild {
 	now := time.Now().UTC()
 	conditions := []apiimagebuilder.ImageBuildCondition{


### PR DESCRIPTION
## Summary

- `ImagePromotion` was stuck in `WaitingForArtifacts` indefinitely when required `ImageExport`s reached a terminal non-completed state (`Failed` or `Canceled`), with no indication to the user of why it was blocked.
- Added `ListTerminalNonCompletedForBuild` to `ImageExportService` that queries for `Failed` or `Canceled` exports for a given build ref and format (two sequential field-selector queries, one per reason).
- In `computeArtifactsStatus`, when no completed export exists for a format, the new check is made and affected formats collected in `terminalFailedFormats`.
- In `evaluateAndTransition`, if `terminalFailedFormats` is non-empty, the promotion transitions to `Failed` immediately with a message naming the affected format(s) and the build ref (e.g. _"Export(s) for format(s) [iso, vmdk] failed or were canceled for build "2222". Please create new exports to retry."_).

## Test plan

- [ ] `TestEvaluator_TerminalExportFailsPromotion` — 5 new sub-tests covering: single canceled export, single failed export, multiple terminal formats, one terminal + one pending (fails immediately for the terminal one), completed export (regression guard — no false positives)
- [ ] All existing `imagebuilder_worker/tasks` and `imagebuilder_api/service` tests continue to pass

Fixes: EDM-4069

Made with [Cursor](https://cursor.com)