### PR TITLE
EDM-3819: cherry-pick alertmanager-proxy RBAC fix to release-1.1

### DIFF
--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrole.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanagerProxy.enabled (eq (include "flightctl.getEffectiveAuthType" .) "k8s") }}
+{{- $effectiveAuthType := include "flightctl.getEffectiveAuthType" . }}
+{{- if and .Values.alertmanagerProxy.enabled (or (eq $effectiveAuthType "k8s") (eq $effectiveAuthType "openshift")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrolebinding.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanagerProxy.enabled (eq (include "flightctl.getEffectiveAuthType" .) "k8s") }}
+{{- $effectiveAuthType := include "flightctl.getEffectiveAuthType" . }}
+{{- if and .Values.alertmanagerProxy.enabled (or (eq $effectiveAuthType "k8s") (eq $effectiveAuthType "openshift")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Summary

Cherry-pick of commit `eea21f3cf` (EDM-3476) from `main` to `release-1.1`.

- The alertmanager proxy `ClusterRole` and `ClusterRoleBinding` were conditioned on auth type `"k8s"` only. On OpenShift deployments (auth type `"openshift"`), neither resource was ever created.
- As a result, the proxy's service account had no `tokenreviews:create` permission on the Kubernetes API, causing every OpenShift token validation to fail with 403 from the K8s API, which surfaced as 401 "failed to validate token" to callers.
- Fix extends the condition to `(k8s OR openshift)` so the RBAC resources are deployed on both cluster types.

## Root cause (EDM-3819)

`test/e2e/alertmanager_proxy` started failing post-upgrade to v1.1.1 because the `flightctl-alertmanager-proxy` service account lacked `authentication.k8s.io/tokenreviews:create` on OpenShift — the Helm template guard was `eq authType "k8s"` instead of `or (eq authType "k8s") (eq authType "openshift")`.

## Files changed

- `deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrole.yaml`
- `deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-clusterrolebinding.yaml`

## Test plan

- [ ] Deploy on OCP with `global.auth.type = openshift`
- [ ] Verify `ClusterRole` and `ClusterRoleBinding` are created
- [ ] Run `test/e2e/alertmanager_proxy` — all three tests should pass (admin 200, non-admin 403)

Made with [Cursor](https://cursor.com)