### PR TITLE
EDM-3621: add CLI autocompletion for catalog, catalogitem, and imagebuilder resource names

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	apiv1alpha1 "github.com/flightctl/flightctl/api/core/v1alpha1"
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
@@ -219,15 +220,33 @@ func (kna KindNameAutocomplete) ValidArgsFunction(cmd *cobra.Command, args []str
 	return uniqueNames, cobra.ShellCompDirectiveNoFileComp
 }
 
+// completionTimeout caps how long a single completion API call may block.
+// Tab completion must remain snappy, so we enforce a short upper bound.
+const completionTimeout = 10 * time.Second
+
+// completionContext returns a short-lived context for completion API calls.
+// It derives from cmd.Context() when available so that cancellation propagates,
+// and falls back to context.Background() when cmd is nil (e.g. in tests).
+func completionContext(cmd *cobra.Command) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		base = cmd.Context()
+	}
+	return context.WithTimeout(base, completionTimeout)
+}
+
 //nolint:gocyclo
 func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o ClientBuilderOptions, kind ResourceKind) []string {
 	if err := o.Complete(cmd, nil); err != nil {
 		return nil
 	}
 
+	ctx, cancel := completionContext(cmd)
+	defer cancel()
+
 	switch kind {
 	case ImageBuildKind, ImageExportKind, ImagePromotionKind:
-		return kna.getImageBuilderNames(o, kind)
+		return kna.getImageBuilderNames(ctx, o, kind)
 	}
 
 	var names []string
@@ -235,12 +254,12 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 	if err != nil {
 		return nil
 	}
-	c.Start(context.Background())
+	c.Start(ctx)
 	defer c.Stop()
 
 	switch kind {
 	case DeviceKind:
-		resp, err := c.ListDevicesWithResponse(context.Background(), &api.ListDevicesParams{})
+		resp, err := c.ListDevicesWithResponse(ctx, &api.ListDevicesParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -249,7 +268,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case EnrollmentRequestKind:
-		resp, err := c.ListEnrollmentRequestsWithResponse(context.Background(), &api.ListEnrollmentRequestsParams{})
+		resp, err := c.ListEnrollmentRequestsWithResponse(ctx, &api.ListEnrollmentRequestsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -258,7 +277,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case CertificateSigningRequestKind:
-		resp, err := c.ListCertificateSigningRequestsWithResponse(context.Background(), &api.ListCertificateSigningRequestsParams{})
+		resp, err := c.ListCertificateSigningRequestsWithResponse(ctx, &api.ListCertificateSigningRequestsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -267,7 +286,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case EventKind:
-		resp, err := c.ListEventsWithResponse(context.Background(), &api.ListEventsParams{})
+		resp, err := c.ListEventsWithResponse(ctx, &api.ListEventsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -276,7 +295,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case FleetKind:
-		resp, err := c.ListFleetsWithResponse(context.Background(), &api.ListFleetsParams{})
+		resp, err := c.ListFleetsWithResponse(ctx, &api.ListFleetsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -285,7 +304,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case OrganizationKind:
-		resp, err := c.ListOrganizationsWithResponse(context.Background(), &api.ListOrganizationsParams{})
+		resp, err := c.ListOrganizationsWithResponse(ctx, &api.ListOrganizationsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -294,7 +313,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case RepositoryKind:
-		resp, err := c.ListRepositoriesWithResponse(context.Background(), &api.ListRepositoriesParams{})
+		resp, err := c.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -303,7 +322,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case ResourceSyncKind:
-		resp, err := c.ListResourceSyncsWithResponse(context.Background(), &api.ListResourceSyncsParams{})
+		resp, err := c.ListResourceSyncsWithResponse(ctx, &api.ListResourceSyncsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -313,7 +332,7 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 		}
 	case TemplateVersionKind:
 		if kna.FleetName != nil {
-			resp, err := c.ListTemplateVersionsWithResponse(context.Background(), *kna.FleetName, &api.ListTemplateVersionsParams{})
+			resp, err := c.ListTemplateVersionsWithResponse(ctx, *kna.FleetName, &api.ListTemplateVersionsParams{})
 			if err == nil && resp.JSON200 != nil {
 				for _, er := range resp.JSON200.Items {
 					if er.Metadata.Name != nil {
@@ -323,7 +342,10 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case CatalogKind:
-		resp, err := c.V1Alpha1().ListCatalogsWithResponse(context.Background(), &apiv1alpha1.ListCatalogsParams{})
+		if c.V1Alpha1() == nil {
+			break
+		}
+		resp, err := c.V1Alpha1().ListCatalogsWithResponse(ctx, &apiv1alpha1.ListCatalogsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -332,12 +354,15 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 			}
 		}
 	case CatalogItemKind:
+		if c.V1Alpha1() == nil {
+			break
+		}
 		params := apiv1alpha1.ListAllCatalogItemsParams{}
-		if kna.CatalogName != nil && *kna.CatalogName != "" {
+		if kna.CatalogName != nil && *kna.CatalogName != "" && !strings.Contains(*kna.CatalogName, ",") {
 			fieldSelector := "metadata.catalog=" + *kna.CatalogName
 			params.FieldSelector = &fieldSelector
 		}
-		resp, err := c.V1Alpha1().ListAllCatalogItemsWithResponse(context.Background(), &params)
+		resp, err := c.V1Alpha1().ListAllCatalogItemsWithResponse(ctx, &params)
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -350,18 +375,18 @@ func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o Clie
 	return names
 }
 
-func (kna *KindNameAutocomplete) getImageBuilderNames(o ClientBuilderOptions, kind ResourceKind) []string {
+func (kna *KindNameAutocomplete) getImageBuilderNames(ctx context.Context, o ClientBuilderOptions, kind ResourceKind) []string {
 	ibClient, err := o.BuildImageBuilderClient()
 	if err != nil {
 		return nil
 	}
-	ibClient.Start(context.Background())
+	ibClient.Start(ctx)
 	defer ibClient.Stop()
 
 	var names []string
 	switch kind {
 	case ImageBuildKind:
-		resp, err := ibClient.ListImageBuildsWithResponse(context.Background(), &imagebuilderapi.ListImageBuildsParams{})
+		resp, err := ibClient.ListImageBuildsWithResponse(ctx, &imagebuilderapi.ListImageBuildsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -370,7 +395,7 @@ func (kna *KindNameAutocomplete) getImageBuilderNames(o ClientBuilderOptions, ki
 			}
 		}
 	case ImageExportKind:
-		resp, err := ibClient.ListImageExportsWithResponse(context.Background(), &imagebuilderapi.ListImageExportsParams{})
+		resp, err := ibClient.ListImageExportsWithResponse(ctx, &imagebuilderapi.ListImageExportsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {
@@ -379,7 +404,7 @@ func (kna *KindNameAutocomplete) getImageBuilderNames(o ClientBuilderOptions, ki
 			}
 		}
 	case ImagePromotionKind:
-		resp, err := ibClient.ListImagePromotionsWithResponse(context.Background(), &imagebuilderapi.ListImagePromotionsParams{})
+		resp, err := ibClient.ListImagePromotionsWithResponse(ctx, &imagebuilderapi.ListImagePromotionsParams{})
 		if err == nil && resp.JSON200 != nil {
 			for _, er := range resp.JSON200.Items {
 				if er.Metadata.Name != nil {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -7,7 +7,10 @@ import (
 	"slices"
 	"strings"
 
+	apiv1alpha1 "github.com/flightctl/flightctl/api/core/v1alpha1"
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	imagebuilderapi "github.com/flightctl/flightctl/api/imagebuilder/v1alpha1"
+	imagebuilderclient "github.com/flightctl/flightctl/internal/api/imagebuilder/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 )
@@ -158,6 +161,7 @@ func (o *CompletionOptions) Validate(args []string) error {
 type ClientBuilderOptions interface {
 	Complete(cmd *cobra.Command, args []string) error
 	BuildClient() (*client.Client, error)
+	BuildImageBuilderClient(opts ...imagebuilderclient.ClientOption) (*client.ImageBuilderClient, error)
 }
 
 type KindNameAutocomplete struct {
@@ -165,6 +169,7 @@ type KindNameAutocomplete struct {
 	AllowMultipleNames bool
 	AllowedKinds       []ResourceKind
 	FleetName          *string
+	CatalogName        *string
 }
 
 func (kna KindNameAutocomplete) ValidArgsFunction(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -216,100 +221,172 @@ func (kna KindNameAutocomplete) ValidArgsFunction(cmd *cobra.Command, args []str
 
 //nolint:gocyclo
 func (kna *KindNameAutocomplete) getAutocompleteNames(cmd *cobra.Command, o ClientBuilderOptions, kind ResourceKind) []string {
-	var names []string
 	if err := o.Complete(cmd, nil); err != nil {
 		return nil
 	}
+
+	switch kind {
+	case ImageBuildKind, ImageExportKind, ImagePromotionKind:
+		return kna.getImageBuilderNames(o, kind)
+	}
+
+	var names []string
 	c, err := o.BuildClient()
-	if err == nil {
-		c.Start(context.Background())
-		defer c.Stop()
-		switch kind {
-		case DeviceKind:
-			resp, err := c.ListDevicesWithResponse(context.Background(), &api.ListDevicesParams{})
+	if err != nil {
+		return nil
+	}
+	c.Start(context.Background())
+	defer c.Stop()
+
+	switch kind {
+	case DeviceKind:
+		resp, err := c.ListDevicesWithResponse(context.Background(), &api.ListDevicesParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case EnrollmentRequestKind:
+		resp, err := c.ListEnrollmentRequestsWithResponse(context.Background(), &api.ListEnrollmentRequestsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case CertificateSigningRequestKind:
+		resp, err := c.ListCertificateSigningRequestsWithResponse(context.Background(), &api.ListCertificateSigningRequestsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case EventKind:
+		resp, err := c.ListEventsWithResponse(context.Background(), &api.ListEventsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case FleetKind:
+		resp, err := c.ListFleetsWithResponse(context.Background(), &api.ListFleetsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case OrganizationKind:
+		resp, err := c.ListOrganizationsWithResponse(context.Background(), &api.ListOrganizationsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case RepositoryKind:
+		resp, err := c.ListRepositoriesWithResponse(context.Background(), &api.ListRepositoriesParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case ResourceSyncKind:
+		resp, err := c.ListResourceSyncsWithResponse(context.Background(), &api.ListResourceSyncsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case TemplateVersionKind:
+		if kna.FleetName != nil {
+			resp, err := c.ListTemplateVersionsWithResponse(context.Background(), *kna.FleetName, &api.ListTemplateVersionsParams{})
 			if err == nil && resp.JSON200 != nil {
 				for _, er := range resp.JSON200.Items {
 					if er.Metadata.Name != nil {
 						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case EnrollmentRequestKind:
-			resp, err := c.ListEnrollmentRequestsWithResponse(context.Background(), &api.ListEnrollmentRequestsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case CertificateSigningRequestKind:
-			resp, err := c.ListCertificateSigningRequestsWithResponse(context.Background(), &api.ListCertificateSigningRequestsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case EventKind:
-			resp, err := c.ListEventsWithResponse(context.Background(), &api.ListEventsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case FleetKind:
-			resp, err := c.ListFleetsWithResponse(context.Background(), &api.ListFleetsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case OrganizationKind:
-			resp, err := c.ListOrganizationsWithResponse(context.Background(), &api.ListOrganizationsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case RepositoryKind:
-			resp, err := c.ListRepositoriesWithResponse(context.Background(), &api.ListRepositoriesParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case ResourceSyncKind:
-			resp, err := c.ListResourceSyncsWithResponse(context.Background(), &api.ListResourceSyncsParams{})
-			if err == nil && resp.JSON200 != nil {
-				for _, er := range resp.JSON200.Items {
-					if er.Metadata.Name != nil {
-						names = append(names, *er.Metadata.Name)
-					}
-				}
-			}
-		case TemplateVersionKind:
-			if kna.FleetName != nil {
-				resp, err := c.ListTemplateVersionsWithResponse(context.Background(), *kna.FleetName, &api.ListTemplateVersionsParams{})
-				if err == nil && resp.JSON200 != nil {
-					for _, er := range resp.JSON200.Items {
-						if er.Metadata.Name != nil {
-							names = append(names, *er.Metadata.Name)
-						}
 					}
 				}
 			}
 		}
+	case CatalogKind:
+		resp, err := c.V1Alpha1().ListCatalogsWithResponse(context.Background(), &apiv1alpha1.ListCatalogsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case CatalogItemKind:
+		params := apiv1alpha1.ListAllCatalogItemsParams{}
+		if kna.CatalogName != nil && *kna.CatalogName != "" {
+			fieldSelector := "metadata.catalog=" + *kna.CatalogName
+			params.FieldSelector = &fieldSelector
+		}
+		resp, err := c.V1Alpha1().ListAllCatalogItemsWithResponse(context.Background(), &params)
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	}
 
+	return names
+}
+
+func (kna *KindNameAutocomplete) getImageBuilderNames(o ClientBuilderOptions, kind ResourceKind) []string {
+	ibClient, err := o.BuildImageBuilderClient()
+	if err != nil {
+		return nil
+	}
+	ibClient.Start(context.Background())
+	defer ibClient.Stop()
+
+	var names []string
+	switch kind {
+	case ImageBuildKind:
+		resp, err := ibClient.ListImageBuildsWithResponse(context.Background(), &imagebuilderapi.ListImageBuildsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case ImageExportKind:
+		resp, err := ibClient.ListImageExportsWithResponse(context.Background(), &imagebuilderapi.ListImageExportsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
+	case ImagePromotionKind:
+		resp, err := ibClient.ListImagePromotionsWithResponse(context.Background(), &imagebuilderapi.ListImagePromotionsParams{})
+		if err == nil && resp.JSON200 != nil {
+			for _, er := range resp.JSON200.Items {
+				if er.Metadata.Name != nil {
+					names = append(names, *er.Metadata.Name)
+				}
+			}
+		}
 	}
 	return names
 }

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"testing"
 
+	apiv1alpha1 "github.com/flightctl/flightctl/api/core/v1alpha1"
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	v1alpha1client "github.com/flightctl/flightctl/internal/api/client/v1alpha1"
 	imagebuilderclient "github.com/flightctl/flightctl/internal/api/imagebuilder/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
@@ -76,6 +78,69 @@ func (fo *fakeClientOptions) BuildClient() (*client.Client, error) {
 
 func (fo *fakeClientOptions) BuildImageBuilderClient(opts ...imagebuilderclient.ClientOption) (*client.ImageBuilderClient, error) {
 	return nil, fmt.Errorf("imagebuilder not configured in test")
+}
+
+// requestCapturingHTTPClient records every request it receives and returns a
+// fixed response body, refreshing the body reader on each call.
+type requestCapturingHTTPClient struct {
+	requests []*http.Request
+	body     []byte
+	header   http.Header
+}
+
+func (r *requestCapturingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	r.requests = append(r.requests, req.Clone(req.Context()))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     r.header,
+		Body:       io.NopCloser(bytes.NewReader(r.body)),
+	}, nil
+}
+
+func newRequestCapturingClientWithEmptyCatalogItemList(t *testing.T) *requestCapturingHTTPClient {
+	t.Helper()
+	body, err := json.Marshal(apiv1alpha1.CatalogItemList{
+		ApiVersion: "v1alpha1",
+		Kind:       "CatalogItemList",
+		Items:      []apiv1alpha1.CatalogItem{},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal CatalogItemList: %v", err)
+	}
+	return &requestCapturingHTTPClient{
+		body:   body,
+		header: http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// fakeClientOptionsWithV1Alpha1 extends fakeClientOptions with a real v1alpha1
+// client backed by a requestCapturingHTTPClient, so tests can assert on the
+// exact HTTP requests sent during completion.
+type fakeClientOptionsWithV1Alpha1 struct {
+	*fakeClientOptions
+	v1alpha1Fake *requestCapturingHTTPClient
+}
+
+func newFakeClientOptionsWithV1Alpha1(t *testing.T) *fakeClientOptionsWithV1Alpha1 {
+	t.Helper()
+	return &fakeClientOptionsWithV1Alpha1{
+		fakeClientOptions: newFakeClientOptionsWithResponses(t),
+		v1alpha1Fake:      newRequestCapturingClientWithEmptyCatalogItemList(t),
+	}
+}
+
+func (fo *fakeClientOptionsWithV1Alpha1) BuildClient() (*client.Client, error) {
+	if fo.fakeClientOptions.client == nil {
+		apiClient, fakeHTTP := newTestClient(fo.t)
+		fo.fakeClientOptions.fakeHTTPClient = fakeHTTP
+
+		v1alpha1C, err := v1alpha1client.NewClientWithResponses("http://example.com", v1alpha1client.WithHTTPClient(fo.v1alpha1Fake))
+		if err != nil {
+			return nil, err
+		}
+		fo.fakeClientOptions.client = client.NewTestClientWithV1Alpha1(apiClient, v1alpha1C)
+	}
+	return fo.fakeClientOptions.client, nil
 }
 
 func TestKindNameAutocompleter(t *testing.T) {
@@ -193,17 +258,37 @@ func TestKindNameAutocompleter(t *testing.T) {
 		}
 	})
 
-	t.Run("does not inject field selector when catalog name contains comma", func(t *testing.T) {
+	t.Run("sets field selector when catalog name is valid", func(t *testing.T) {
+		opts := newFakeClientOptionsWithV1Alpha1(t)
+		catalogName := "my-catalog"
+		kna := KindNameAutocomplete{
+			Options:      opts,
+			AllowedKinds: []ResourceKind{CatalogItemKind},
+			CatalogName:  &catalogName,
+		}
+
+		kna.ValidArgsFunction(nil, []string{CatalogItemKind.String()}, "")
+
+		require.Len(t, opts.v1alpha1Fake.requests, 1, "expected one API call")
+		gotFieldSelector := opts.v1alpha1Fake.requests[0].URL.Query().Get("fieldSelector")
+		require.Contains(t, gotFieldSelector, "metadata.catalog=my-catalog", "field selector should scope to the catalog")
+	})
+
+	t.Run("does not inject field selector when catalog name contains a comma", func(t *testing.T) {
+		opts := newFakeClientOptionsWithV1Alpha1(t)
 		maliciousCatalogName := "valid-catalog,extra=injected"
 		kna := KindNameAutocomplete{
-			Options:      newFakeClientOptionsWithResponses(t),
+			Options:      opts,
 			AllowedKinds: []ResourceKind{CatalogItemKind},
 			CatalogName:  &maliciousCatalogName,
 		}
 
-		// Expect empty results — the catalog name is rejected and V1Alpha1 is nil on the fake client.
-		// The important thing is it does not panic.
-		suggestions, _ := kna.ValidArgsFunction(nil, []string{CatalogItemKind.String()}, "")
-		require.Empty(t, suggestions)
+		// The comma guard must fire: the field selector must not contain the catalog
+		// name, preventing injection of additional filter conditions.
+		kna.ValidArgsFunction(nil, []string{CatalogItemKind.String()}, "")
+
+		require.Len(t, opts.v1alpha1Fake.requests, 1, "expected one API call even when catalog name is invalid")
+		gotFieldSelector := opts.v1alpha1Fake.requests[0].URL.Query().Get("fieldSelector")
+		require.NotContains(t, gotFieldSelector, "metadata.catalog=", "field selector must not contain catalog filter when catalog name has a comma")
 	})
 }

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -164,4 +164,46 @@ func TestKindNameAutocompleter(t *testing.T) {
 			}, suggestions)
 		}
 	})
+
+	t.Run("returns empty for imagebuilder kinds when imagebuilder not configured", func(t *testing.T) {
+		for _, kind := range []ResourceKind{ImageBuildKind, ImageExportKind, ImagePromotionKind} {
+			kna := KindNameAutocomplete{
+				Options:      newFakeClientOptionsWithResponses(t),
+				AllowedKinds: []ResourceKind{kind},
+			}
+
+			suggestions, directive := kna.ValidArgsFunction(nil, []string{kind.String()}, "")
+			require.Empty(t, suggestions, "expected no suggestions for kind %s when imagebuilder is not configured", kind)
+			require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+		}
+	})
+
+	t.Run("returns empty for catalog kinds when v1alpha1 client is not available", func(t *testing.T) {
+		catalogName := ""
+		for _, kind := range []ResourceKind{CatalogKind, CatalogItemKind} {
+			kna := KindNameAutocomplete{
+				Options:      newFakeClientOptionsWithResponses(t),
+				AllowedKinds: []ResourceKind{kind},
+				CatalogName:  &catalogName,
+			}
+
+			suggestions, directive := kna.ValidArgsFunction(nil, []string{kind.String()}, "")
+			require.Empty(t, suggestions, "expected no suggestions for kind %s when v1alpha1 is not configured", kind)
+			require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+		}
+	})
+
+	t.Run("does not inject field selector when catalog name contains comma", func(t *testing.T) {
+		maliciousCatalogName := "valid-catalog,extra=injected"
+		kna := KindNameAutocomplete{
+			Options:      newFakeClientOptionsWithResponses(t),
+			AllowedKinds: []ResourceKind{CatalogItemKind},
+			CatalogName:  &maliciousCatalogName,
+		}
+
+		// Expect empty results — the catalog name is rejected and V1Alpha1 is nil on the fake client.
+		// The important thing is it does not panic.
+		suggestions, _ := kna.ValidArgsFunction(nil, []string{CatalogItemKind.String()}, "")
+		require.Empty(t, suggestions)
+	})
 }

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	imagebuilderclient "github.com/flightctl/flightctl/internal/api/imagebuilder/client"
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -71,6 +72,10 @@ func (fo *fakeClientOptions) BuildClient() (*client.Client, error) {
 		}
 	}
 	return fo.client, nil
+}
+
+func (fo *fakeClientOptions) BuildImageBuilderClient(opts ...imagebuilderclient.ClientOption) (*client.ImageBuilderClient, error) {
+	return nil, fmt.Errorf("imagebuilder not configured in test")
 }
 
 func TestKindNameAutocompleter(t *testing.T) {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -98,6 +98,7 @@ func NewCmdGet() *cobra.Command {
 			AllowMultipleNames: true,
 			AllowedKinds:       validResourceKinds,
 			FleetName:          &o.FleetName,
+			CatalogName:        &o.CatalogName,
 		}.ValidArgsFunction,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -382,6 +382,15 @@ func NewTestClient(clientWithResponses *client.ClientWithResponses) *Client {
 	}
 }
 
+// NewTestClientWithV1Alpha1 creates a Client for testing purposes with both
+// v1beta1 and v1alpha1 clients pre-configured. This should only be used in tests.
+func NewTestClientWithV1Alpha1(clientWithResponses *client.ClientWithResponses, v1alpha1 *v1alpha1client.ClientWithResponses) *Client {
+	return &Client{
+		ClientWithResponses: clientWithResponses,
+		v1alpha1:            v1alpha1,
+	}
+}
+
 // ImageBuilderClient wraps the imagebuilder API client with token refresh capabilities.
 type ImageBuilderClient struct {
 	*imagebuilderclient.ClientWithResponses


### PR DESCRIPTION
## Summary

- Add tab-completion support for resource **names** of `catalog`, `catalogitem`, `imagebuild`, `imageexport`, and `imagepromotion` kinds — previously, `flightctl get catalog/<TAB>` (and similar) produced no suggestions for these types
- Extend `ClientBuilderOptions` interface with `BuildImageBuilderClient()` so the completion path can reach the ImageBuilder API
- Add `CatalogName *string` to `KindNameAutocomplete` (mirrors `FleetName` for `templateversion`) and wire it in `NewCmdGet()` — `catalogitem` name completion respects the `--catalog` flag when set
- Extract `getImageBuilderNames()` helper for the three imagebuilder kinds; gracefully returns no results when imagebuilder is not configured

## Test plan

- [ ] `go build ./internal/cli/...` passes
- [ ] `go test ./internal/cli/...` passes
- [ ] Manual smoke test: `source <(flightctl completion bash)` then `flightctl get catalog/<TAB>` shows catalog names
- [ ] Manual smoke test: `flightctl get imagebuild/<TAB>` shows imagebuild names (requires imagebuilder service configured)
- [ ] Manual smoke test: `flightctl get catalogitems --catalog <name> <TAB>` shows items scoped to that catalog

Fixes EDM-3621

Made with [Cursor](https://cursor.com)