### PR TITLE
NO-ISSUE: fix e2e health report missing system dependencies

### DIFF
--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -64,6 +64,7 @@ jobs:
           else
             MSG="E2E Health Report — report generation failed; see run for details."
           fi
+          [ -z "$SLACK_WEBHOOK_URL" ] && { echo "SLACK_WEBHOOK_URL not set, skipping."; exit 0; }
           curl -sf -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "$(jq -n \

--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # Monday 09:00 UTC
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/e2e-health-report.yml'
+      - '.github/actions/setup-dependencies/**'
+      - 'test/scripts/analyze_e2e_health/**'
+      - 'test/scripts/pkg/e2etestutils/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,10 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
 
       - name: Generate health report
         working-directory: test/scripts


### PR DESCRIPTION
## Summary

- The weekly e2e health report CI job was failing because it tried to compile `./test/e2e/...` (via a ginkgo dry-run to auto-generate the spec discovery file) without the required `libvirt-dev` system headers — needed by `test/harness/e2e/vm/vm_linux.go` which imports `libvirt.org/go/libvirt` (a CGO package).
- Replaced the standalone `actions/setup-go` step with the repo's existing `.github/actions/setup-dependencies` composite action, which installs `libvirt-dev` and other required packages (same as `pr-e2e-testing.yaml` and `run-e2e-tests.yaml`).
- Added a scoped `pull_request` trigger so the fix can be verified on this PR 

## Test plan

- [ ] Confirm the "Weekly E2E Health Report" check passes on this PR

Made with [Cursor](https://cursor.com)