### PR TITLE
NO-ISSUE: Adjust API port in quadlets

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -97,7 +97,7 @@ When running e2e against a Quadlet deployment (e.g. after `make deploy-quadlets`
 | `E2E_SSH_PASSWORD` | SSH password (alternative to key). Used when `E2E_SSH_KEY_PATH` is not set; requires `sshpass` on the test host. |
 | `E2E_USE_SUDO` | Use sudo for systemctl/podman on the device. Default: `true` for Quadlet. |
 | `E2E_CONFIG_DIR` | FlightCtl config directory on the device. Default: `/etc/flightctl`. |
-| `E2E_API_ENDPOINT` | FlightCtl API URL (e.g. `https://<host>:3443`). Inferred from host if unset. |
+| `E2E_API_ENDPOINT` | FlightCtl API URL (e.g. `https://<host>`). Inferred from host if unset. |
 | `E2E_PAM_USER` | PAM user for `flightctl login` (Quadlet/standalone API). Default: `admin`. |
 | `E2E_PAM_PASSWORD` | PAM password for login. |
 | `E2E_DEFAULT_PAM_PASSWORD` | Fallback PAM password if `E2E_PAM_PASSWORD` is unset (e.g. test default). |

--- a/test/e2e/infra/factory.go
+++ b/test/e2e/infra/factory.go
@@ -34,7 +34,7 @@ type EnvironmentConfig struct {
 	// Namespace is the K8s namespace for flightctl services (K8s only)
 	Namespace string
 
-	// APIEndpoint is the FlightCtl API endpoint URL (e.g., "https://api.flightctl.example.com:3443")
+	// APIEndpoint is the FlightCtl API endpoint URL (e.g., "https://api.flightctl.example.com")
 	APIEndpoint string
 
 	// KubeConfig is the path to kubeconfig file (K8s only, defaults to ~/.kube/config)
@@ -80,7 +80,7 @@ const (
 	// DefaultQuadletConfigDir is the default config directory for Quadlet deployments
 	DefaultQuadletConfigDir = "/etc/flightctl"
 	// DefaultAPIPort is the default port for the FlightCtl API
-	DefaultAPIPort = "3443"
+	DefaultAPIPort = "443"
 )
 
 // GetDefaultQuadletAPIEndpoint returns the default API endpoint for Quadlet deployments.
@@ -142,7 +142,7 @@ func GetEnvironmentConfig() *EnvironmentConfig {
 
 // GetAPIEndpoint returns the API endpoint, using defaults if not explicitly set.
 // For K8s: checks API_ENDPOINT env var (set by run_e2e_tests.sh from K8s route)
-// For Quadlet: defaults to https://<host-ip>:3443 (uses host IP so VMs can reach it)
+// For Quadlet: defaults to https://<host-ip> (uses host IP so VMs can reach it)
 func (c *EnvironmentConfig) GetAPIEndpoint() string {
 	// First check our config
 	if c.APIEndpoint != "" {

--- a/test/scripts/functions
+++ b/test/scripts/functions
@@ -194,7 +194,7 @@ function get_endpoints() {
     else
       QUADLET_HOST=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "localhost")
     fi
-    export FLIGHTCTL_API_ENDPOINT=${FLIGHTCTL_API_ENDPOINT:-https://${QUADLET_HOST}:3443}
+    export FLIGHTCTL_API_ENDPOINT=${FLIGHTCTL_API_ENDPOINT:-https://${QUADLET_HOST}}
     export FLIGHTCTL_AGENT_ENDPOINT=${FLIGHTCTL_AGENT_ENDPOINT:-https://${QUADLET_HOST}:7443}
     export FLIGHTCTL_UI_ENDPOINT=${FLIGHTCTL_UI_ENDPOINT:-https://${QUADLET_HOST}:9001}
     echo "Using Quadlet endpoints: API=${FLIGHTCTL_API_ENDPOINT}, Agent=${FLIGHTCTL_AGENT_ENDPOINT}"

--- a/test/scripts/run_e2e_tests.sh
+++ b/test/scripts/run_e2e_tests.sh
@@ -105,7 +105,7 @@ case "${E2E_ENVIRONMENT}" in
             echo "Using local Quadlet host: ${QUADLET_HOST} (set E2E_SSH_HOST for remote Quadlet)"
         fi
         export QUADLET_HOST
-        API_ENDPOINT="https://${QUADLET_HOST}:3443"
+        API_ENDPOINT="https://${QUADLET_HOST}"
         echo "Using Quadlet API endpoint: ${API_ENDPOINT}"
         ;;
     *)


### PR DESCRIPTION
It should be reached now via port 443
