### PR TITLE
NO-ISSUE: Fix authprovider e2e setup

### DIFF
--- a/test/e2e/authprovider/authprovider_suite_test.go
+++ b/test/e2e/authprovider/authprovider_suite_test.go
@@ -64,12 +64,12 @@ var _ = BeforeSuite(func() {
 		true,
 	)
 	authProviderPath := filepath.Join(os.TempDir(), "authprovider-keycloak-e2e.yaml")
-	defer cleanupAuthProviderManifest(harness, keycloakAuthProviderName, authProviderPath)
+	DeferCleanup(os.Remove, authProviderPath)
 
 	Eventually(func() error {
 		_, applyErr := writeAndApplyAuthProviderManifest(harness, authProviderPath, authProviderYAML)
 		return applyErr
-	}).WithTimeout(authProviderApplyTimeout).WithPolling(2*time.Second).Should(Succeed(), "apply AuthProvider CR")
+	}).WithTimeout(authProviderApplyTimeout).WithPolling(authProviderPollingInterval).Should(Succeed(), "apply AuthProvider CR")
 
 	// Wait until the API's loader has picked up the new provider with the current issuer
 	// (auth config is served from cache; without this the CLI would get a stale issuer from a previous run)
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 			return false
 		}
 		return strings.Contains(out, auxSvcs.Keycloak.IssuerURL())
-	}).WithTimeout(15*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "provider %q with issuer %q must appear in login --show-providers", keycloakAuthProviderName, auxSvcs.Keycloak.IssuerURL())
+	}).WithTimeout(authProviderApplyTimeout).WithPolling(authProviderPollingInterval).Should(BeTrue(), "provider %q with issuer %q must appear in login --show-providers", keycloakAuthProviderName, auxSvcs.Keycloak.IssuerURL())
 })
 
 var _ = BeforeEach(func() {
@@ -91,6 +91,9 @@ var _ = BeforeEach(func() {
 	suiteCtx := e2e.GetWorkerContext()
 	ctx := util.StartSpecTracerForGinkgo(suiteCtx)
 	harness.SetTestContext(ctx)
+
+	_, err := login.LoginToAPIWithToken(harness)
+	Expect(err).ToNot(HaveOccurred(), "restore admin login before spec")
 })
 
 var _ = AfterEach(func() {

--- a/test/e2e/authprovider/cypress/run-provider-login-cypress.sh
+++ b/test/e2e/authprovider/cypress/run-provider-login-cypress.sh
@@ -22,6 +22,10 @@ fi
 
 FLIGHTCTL_BIN="${FLIGHTCTL:-flightctl}"
 CALLBACK_PORT="${FLIGHTCTL_CALLBACK_PORT:-8080}"
+if [[ ! "$CALLBACK_PORT" =~ ^[0-9]+$ ]]; then
+  echo "FLIGHTCTL_CALLBACK_PORT must contain only digits, got: ${CALLBACK_PORT}" >&2
+  exit 1
+fi
 LOG="$(mktemp)"
 CYPRESS_BIN="./node_modules/.bin/cypress"
 
@@ -49,6 +53,34 @@ ensure_cypress_installed() {
   fi
 }
 
+resolve_openshift_oauth_client_id() {
+  if [[ -n "${OPENSHIFT_OAUTH_CLIENT_ID:-}" ]]; then
+    echo "$OPENSHIFT_OAUTH_CLIENT_ID"
+    return 0
+  fi
+
+  local client_ids client_count
+  client_ids="$(oc get oauthclient \
+    -l flightctl.service=flightctl,component=oauth-client \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)"
+  client_count="$(grep -cve '^[[:space:]]*$' <<< "$client_ids")"
+
+  case "$client_count" in
+    0)
+      echo "No Flight Control OAuthClient matches flightctl.service=flightctl,component=oauth-client; set OPENSHIFT_OAUTH_CLIENT_ID explicitly." >&2
+      return 1
+      ;;
+    1)
+      grep -ve '^[[:space:]]*$' <<< "$client_ids"
+      ;;
+    *)
+      echo "Multiple Flight Control OAuthClients match flightctl.service=flightctl,component=oauth-client; set OPENSHIFT_OAUTH_CLIENT_ID explicitly." >&2
+      printf '%s\n' "$client_ids" >&2
+      return 1
+      ;;
+  esac
+}
+
 ensure_cypress_installed
 
 
@@ -65,31 +97,34 @@ if command -v ss >/dev/null 2>&1; then
 fi
 
 if [[ "$PROVIDER_UI" == "openshift" ]] && command -v oc >/dev/null 2>&1; then
-  OPENSHIFT_OAUTH_CLIENT_ID="${OPENSHIFT_OAUTH_CLIENT_ID:-flightctl-flightctl}"
+  OPENSHIFT_OAUTH_CLIENT_ID="$(resolve_openshift_oauth_client_id)"
   echo "Ensuring OAuth client ${OPENSHIFT_OAUTH_CLIENT_ID} allows local callback..." >&2
   LOCALHOST_CALLBACK_URI="http://localhost:${CALLBACK_PORT}/callback"
   LOOPBACK_CALLBACK_URI="http://127.0.0.1:${CALLBACK_PORT}/callback"
-  CURRENT_REDIRECT_URIS="$(oc get oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" -o jsonpath='{range .redirectURIs[*]}{.}{"\n"}{end}')"
-  MISSING_REDIRECT_URIS=()
+  if CURRENT_REDIRECT_URIS="$(oc get oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" -o jsonpath='{range .redirectURIs[*]}{.}{"\n"}{end}' 2>/dev/null)"; then
+    MISSING_REDIRECT_URIS=()
 
-  for uri in "$LOCALHOST_CALLBACK_URI" "$LOOPBACK_CALLBACK_URI"; do
-    if ! grep -Fxq "$uri" <<< "$CURRENT_REDIRECT_URIS"; then
-      MISSING_REDIRECT_URIS+=("$uri")
-    fi
-  done
+    for uri in "$LOCALHOST_CALLBACK_URI" "$LOOPBACK_CALLBACK_URI"; do
+      if ! grep -Fxq "$uri" <<< "$CURRENT_REDIRECT_URIS"; then
+        MISSING_REDIRECT_URIS+=("$uri")
+      fi
+    done
 
-  if (( ${#MISSING_REDIRECT_URIS[@]} > 0 )); then
-    if [[ -n "$CURRENT_REDIRECT_URIS" ]]; then
-      PATCH_OPS=()
-      for uri in "${MISSING_REDIRECT_URIS[@]}"; do
-        PATCH_OPS+=("{\"op\":\"add\",\"path\":\"/redirectURIs/-\",\"value\":\"${uri}\"}")
-      done
-      PATCH_PAYLOAD="[$(IFS=,; echo "${PATCH_OPS[*]}")]"
-      oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=json -p "$PATCH_PAYLOAD" >/dev/null
-    else
-      PATCH_PAYLOAD="{\"redirectURIs\":[\"$LOCALHOST_CALLBACK_URI\",\"$LOOPBACK_CALLBACK_URI\"]}"
-      oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=merge -p "$PATCH_PAYLOAD" >/dev/null
+    if (( ${#MISSING_REDIRECT_URIS[@]} > 0 )); then
+      if [[ -n "$CURRENT_REDIRECT_URIS" ]]; then
+        PATCH_OPS=()
+        for uri in "${MISSING_REDIRECT_URIS[@]}"; do
+          PATCH_OPS+=("{\"op\":\"add\",\"path\":\"/redirectURIs/-\",\"value\":\"${uri}\"}")
+        done
+        PATCH_PAYLOAD="[$(IFS=,; echo "${PATCH_OPS[*]}")]"
+        oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=json -p "$PATCH_PAYLOAD" >/dev/null
+      else
+        PATCH_PAYLOAD="{\"redirectURIs\":[\"$LOCALHOST_CALLBACK_URI\",\"$LOOPBACK_CALLBACK_URI\"]}"
+        oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=merge -p "$PATCH_PAYLOAD" >/dev/null
+      fi
     fi
+  else
+    echo "Could not read OAuth client ${OPENSHIFT_OAUTH_CLIENT_ID}; continuing without patching redirectURIs." >&2
   fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes authprovider e2e setup issues that caused the dynamic Keycloak/AuthProvider tests to fail.

## Changes

- Keep the bootstrap `keycloak-e2e` AuthProvider alive for the full suite instead of deleting it at the end of `BeforeSuite`.
- Restore admin login in `BeforeEach` so browser-login specs do not leave later resource-management specs using a non-admin/stale CLI session.
- Harden the OpenShift Cypress login helper to resolve the Helm-created OAuthClient by label, instead of assuming `flightctl-flightctl`.
