### PR TITLE
Backport EDM-3953/EDM-3955: mirror-images tool and OCP disconnected install docs to release-1.2

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -42,6 +42,12 @@ Welcome to the Flight Control user documentation.
     * [Installing the Flight Control service offline on Linux](installing/installing-service-on-linux-offline.md)
     * [Installing the Flight Control agent offline on RHEL](installing/installing-agent-offline.md)
 
+  * Offline and Air-Gapped Installation
+    * [Setting up a local RPM repository](installing/offline-rpm-repository.md)
+    * [Packaging artifacts for portable media](installing/offline-portable-media.md)
+    * [Installing the Flight Control service offline on Linux](installing/installing-service-on-linux-offline.md)
+    * [Installing the Flight Control agent offline on RHEL](installing/installing-agent-offline.md)
+
 * **[Installing the Flight Control CLI](installing/installing-cli.md)**
 
 * **[Installing the Flight Control Agent](installing/installing-agent.md)**

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -1,85 +1,248 @@
-# Installing a Flight Control in a Disconnected Cluster Environment
+# Installing Flight Control in a Disconnected OpenShift Cluster
 
-## Mirroring images
+This document describes how to install the Flight Control service on an OpenShift
+cluster that has no direct internet access. A `mirror-images` tool running on a
+connected prep machine mirrors all required container images to your internal
+registry. You then configure OpenShift to redirect image pulls to that registry
+and install Flight Control using Helm.
 
-### Mirroring flightctl images
+For the connected (online) installation procedure, see
+[Installing the Flight Control Service on OpenShift/Kubernetes](installing-service-on-kubernetes.md).
 
-```shell
-export FCTL_VERSION=<required_flightctl_version>
-export LOCAL_REGISTRY=<registry-hostname>:<registry-port>
+## Prerequisites
+
+On the **prep machine** (internet-connected):
+
+- RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
+- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- `helm` CLI installed
+- For `rhem-el9` or `rhem-el10` variants: credentials for `registry.redhat.io`
+  (`podman login registry.redhat.io`)
+
+On the **disconnected cluster**:
+
+- OpenShift 4.12 or later
+- An internal mirror registry reachable from all cluster nodes
+  (for example, Red Hat Quay, a mirror registry appliance, or Docker Registry)
+- `oc` and `helm` CLI access to the cluster
+
+## Step 1: Mirror images to the internal registry
+
+Choose the variant that matches your deployment:
+
+| Variant | Use when |
+|---------|----------|
+| `community-el9` | Community images from `quay.io` (RHEL 9 base) |
+| `community-el10` | Community images from `quay.io` (RHEL 10 base) |
+| `rhem-el9` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+| `rhem-el10` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+
+### Option A: Direct push (prep machine can reach the internal registry)
+
+Run `mirror-images` with `--execute` to copy all images directly to your mirror
+registry in a single step:
+
+```bash
+./bin/mirror-images \
+    --variant rhem-el9 \
+    --dest-registry <mirror-registry-host>:<port> \
+    --execute \
+    --tag-override <version>
 ```
 
-> 📌 Please note, that you may need to provide credentials for your local registry via `oc image mirror -a <creds_file>`.
+Replace `<version>` with the Flight Control release version (e.g. `1.2.0`). To
+find available versions:
 
-```shell
-for component in api periodic ui worker; do oc image mirror quay.io/flightctl/flightctl-$component:${FCTL_VERSION} ${LOCAL_REGISTRY}/flightctl/flightctl-$component:${FCTL_VERSION}; done
+```bash
+helm show chart oci://quay.io/flightctl/charts/flightctl | grep appVersion
 ```
 
-If you cannot connect directly to hub's registry, you will have to mirror images to a disk or USB stick and bring the mirrored content to the disconnected management hub. Then mirror the content to a hub's registry.
+If the internal registry uses a self-signed certificate, add `--insecure`.
 
-Example:
+### Option B: Bundle then push (no direct path from prep to internal registry)
 
-```shell
-#on machine connected to internet
-oc image mirror quay.io/<img> file://path/<img>
-#on disconnected environment
-oc image mirror file://path/<img> ${LOCAL_REGISTRY}/<img>
+Create a portable archive on the prep machine, transfer it to a host inside the
+disconnected environment, then push from there:
+
+```bash
+# On the prep machine (internet-connected)
+./bin/mirror-images \
+    --variant rhem-el9 \
+    --bundle ~/flightctl-bundle.tar.gz \
+    --tag-override <version>
+
+# Transfer the bundle
+scp ~/flightctl-bundle.tar.gz <user>@<bastion>:~/
+
+# On a host that can reach the internal registry
+mkdir ~/flightctl-bundle
+tar -xzf ~/flightctl-bundle.tar.gz -C ~/flightctl-bundle
+cd ~/flightctl-bundle
+./import.sh --registry <mirror-registry-host>:<port>
 ```
 
-### Mirroring other images
+See [Packaging artifacts for portable media](offline-portable-media.md) for USB
+drive and other transfer formats.
 
-```shell
-oc image mirror quay.io/keycloak/keycloak:25.0.1 ${LOCAL_REGISTRY}/keycloak/keycloak:25.0.1
+> [!IMPORTANT]
+> The image tags in the bundle must match the Helm chart version you will install.
+> Always pin the version with `--tag-override` or by checking out the corresponding
+> git release tag (`git checkout v<version>`) before building the tool and running
+> the command.
 
-oc image mirror quay.io/openshift/origin-cli:4.20.0 ${LOCAL_REGISTRY}/openshift/origin-cli:4.20.0
+## Step 2: Download the Helm chart
 
-oc image mirror quay.io/sclorg/postgresql-16-c9s:20250214 ${LOCAL_REGISTRY}/sclorg/postgresql-16-c9s:20250214
+Pull the Helm chart on the prep machine and transfer it to the disconnected environment:
 
-oc image mirror docker.io/redis:7.4.1 ${LOCAL_REGISTRY}/redis:7.4.1
+```bash
+# On the prep machine (internet-connected)
+helm pull oci://quay.io/flightctl/charts/flightctl --version <version>
+
+# Transfer to the disconnected environment
+scp flightctl-<version>.tgz <user>@<bastion>:~/
 ```
 
-## Configuring image repository mirroring
+## Step 3: Configure image mirroring on OpenShift
 
-Create `ImageTagMirrorSet` with the following content
+OpenShift uses `ImageTagMirrorSet` to redirect image pulls from source registries
+to your mirror. Apply the appropriate configuration for your variant.
 
-```shell
+### For `rhem-el9` or `rhem-el10`
+
+```bash
 oc apply -f - <<EOF
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet
 metadata:
-  name: image-mirror
+  name: flightctl-mirrors
 spec:
   imageTagMirrors:
-  - source: quay.io/flightctl
+  - source: registry.redhat.io
     mirrors:
-    - ${LOCAL_REGISTRY}/flightctl
-  - source: quay.io/sclorg
+    - <mirror-registry-host>:<port>
+  - source: registry.access.redhat.com
     mirrors:
-    - ${LOCAL_REGISTRY}/sclorg
-  - source: quay.io/keycloak
-    mirrors:
-    - ${LOCAL_REGISTRY}/keycloak
-  - source: quay.io/openshift/origin-cli
-    mirrors:
-    - ${LOCAL_REGISTRY}/openshift/origin-cli
-  - source: docker.io/redis
-    mirrors:
-    - ${LOCAL_REGISTRY}/redis
+    - <mirror-registry-host>:<port>
 EOF
 ```
 
-After creating/editing `ImageTagMirrorSet`, the OpenShift will drain all nodes. You will need to wait for all nodes to return to `Ready` state.
+### For `community-el9` or `community-el10`
 
-## Installing flightctl
-
-You need to download the helm chart first, as it is stored in quay.io
-
-```shell
-#on machine connected to internet
-helm pull oci://quay.io/flightctl/charts/flightctl --version ${FCTL_VERSION}
-#copy the downloaded file to disconnected environment
-#on disconnected environment
-helm upgrade --install --namespace flightctl --create-namespace flightctl ./flightctl-${FCTL_VERSION}.tgz
+```bash
+oc apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: flightctl-mirrors
+spec:
+  imageTagMirrors:
+  - source: quay.io
+    mirrors:
+    - <mirror-registry-host>:<port>
+  - source: docker.io
+    mirrors:
+    - <mirror-registry-host>:<port>
+  - source: registry.access.redhat.com
+    mirrors:
+    - <mirror-registry-host>:<port>
+EOF
 ```
 
-If you modify any image location/tag in helm chart, you need to ensure that you run `oc image mirror` for the modified image location/tag and `ImageTagMirrorSet` has proper mirrors set.
+> [!NOTE]
+> After applying an `ImageTagMirrorSet`, OpenShift drains and restarts all nodes
+> to apply the new container runtime configuration. Wait for all nodes to return
+> to `Ready` state before proceeding.
+
+```bash
+oc wait nodes --all --for=condition=Ready --timeout=10m
+```
+
+## Step 4: Create an image pull secret (Red Hat variants only)
+
+If you are using a `rhem-el9` or `rhem-el10` variant and your mirror registry
+requires authentication, create a pull secret in the `flightctl` namespace:
+
+```bash
+oc create namespace flightctl --dry-run=client -o yaml | oc apply -f -
+oc create secret docker-registry flightctl-pull-secret \
+    --namespace flightctl \
+    --docker-server=<mirror-registry-host>:<port> \
+    --docker-username=<username> \
+    --docker-password=<password>
+```
+
+Reference the secret in your Helm values:
+
+```yaml
+global:
+  imagePullSecretName: flightctl-pull-secret
+```
+
+## Step 5: Install Flight Control via Helm
+
+Install using the transferred chart archive and a values file that sets your
+mirror registry:
+
+```bash
+helm upgrade --install \
+    --namespace flightctl \
+    --create-namespace \
+    flightctl ./flightctl-<version>.tgz \
+    --values my-values.yaml
+```
+
+A minimal `my-values.yaml` for a disconnected installation:
+
+```yaml
+global:
+  baseDomain: flightctl.example.com    # FQDN of your OpenShift cluster ingress
+  imagePullSecretName: flightctl-pull-secret  # omit for community variants
+```
+
+For a full list of configuration options, see
+[Installing the Flight Control Service on OpenShift/Kubernetes](installing-service-on-kubernetes.md).
+
+## Verifying the installation
+
+Check that all pods are running:
+
+```bash
+oc get pods -n flightctl
+```
+
+Confirm the API is reachable:
+
+```bash
+curl -k https://<baseDomain>/api/v1/fleets
+```
+
+The Flight Control UI is available at the hostname set in `global.baseDomain`.
+Open it in a browser to verify the service is running end-to-end.
+
+## Optional: deploying the observability stack
+
+The Prometheus and Grafana images are not included in the standard mirror run.
+If you need the `flightctl-observability` stack, mirror those images manually
+before installing the observability Helm chart.
+
+See [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)
+for image lists and configuration details.
+
+## Next steps
+
+1. **Set up authentication** — configure an identity provider before allowing user
+   access. For OpenShift-integrated login see
+   [Configuring OpenShift Authentication](configuring-auth/auth-openshift.md),
+   or review the [Authentication Overview](configuring-auth/overview.md) for all options.
+
+2. **Create an organization and assign roles** — Flight Control requires at least
+   one organization before users can manage devices. See
+   [Managing Organizations](configuring-auth/organizations.md) and the role
+   assignment section of the authentication guide.
+
+3. **Log in with the CLI** — see [Logging In](../using/cli/logging-in.md) for the
+   `flightctl login` command and certificate trust setup.
+
+4. **Deploy the observability stack (optional)** — see
+   [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)
+   for Prometheus and Grafana setup.

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -25,9 +25,6 @@ ui:
 db-setup:
   image: quay.io/flightctl/flightctl-db-setup-el10
   tag: latest
-gateway:
-  image: quay.io/sclorg/nginx-126-c10s
-  tag: "20260421"
 db:
   # Using CentOS Stream 10 PostgreSQL for EL10 flavor
   image: quay.io/sclorg/postgresql-16-c10s

--- a/scripts/air-gap/mirror-images/parser.go
+++ b/scripts/air-gap/mirror-images/parser.go
@@ -116,8 +116,10 @@ func ParseHelmChartOpts(path, variant, appVersion string) ([]ImagePair, error) {
 	pairs := make([]ImagePair, 0, len(cv.Images))
 	for _, spec := range cv.Images {
 		tag := spec.Tag
-		if tag == "" {
-			// No explicit tag: use the chart appVersion as the fallback.
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: use the
+			// chart appVersion (or --tag-override) so the bundled images match
+			// the installed RPM version.
 			tag = appVersion
 		}
 		image := normalizeDockerImage(spec.Image)
@@ -205,7 +207,11 @@ func ParseObsImages(el9Path, el10Path, rhel9Path, rhel10Path, variant, tagFallba
 		}
 
 		tag := spec.Tag
-		if tag == "" {
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: apply the
+			// effective tag (appVersion or --tag-override) so RPM-only images
+			// such as pam-issuer and userinfo-proxy are bundled at the correct
+			// release version rather than always pulling :latest.
 			tag = tagFallback
 		}
 


### PR DESCRIPTION
Backport of the following PRs to `release-1.2`:

- #2987 — EDM-3953: mirror-images tool for air-gapped FlightCtl installation
- #3055 — EDM-3953: fix `--tag-override` ignored for images with explicit `tag: latest`
- #3060 — EDM-3955: rewrite OCP disconnected install documentation

Cherry-picked with `git cherry-pick -x`. One conflict resolved in `packaging/images/el9/images.yaml` (retained the `gateway` entry already present in `release-1.2`). The OCP disconnected install doc was written in full since `release-1.2` had the stale version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)