### PR TITLE
EDM-3953: fix kv image in el9/images.yaml causing Redis crash-loop in offline install

### DIFF
--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -36,6 +36,11 @@ kv:
   # Using Valkey (Redis replacement) for EL10 flavor
   image: quay.io/sclorg/valkey-8-c10s
   tag: "20260121"
+kv-standalone:
+  # docker.io/library/ prefix is required for podman mirror resolution.
+  # Used by flightctl-kv-standalone.container (installed by the RPM).
+  image: docker.io/library/redis
+  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -36,11 +36,6 @@ kv:
   # Using Valkey (Redis replacement) for EL10 flavor
   image: quay.io/sclorg/valkey-8-c10s
   tag: "20260121"
-kv-standalone:
-  # docker.io/library/ prefix is required for podman mirror resolution.
-  # Used by flightctl-kv-standalone.container (installed by the RPM).
-  image: docker.io/library/redis
-  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -32,10 +32,10 @@ db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
-  # docker.io/library/ prefix is required: podman mirrors docker.io official images
-  # using the canonical library/ namespace path. Without it the local registry lookup fails.
-  image: docker.io/library/redis
-  tag: "7.4.1"
+  # Must match helm-chart-opts.yaml community-el9 kv image so the bundle and
+  # the rendered quadlet reference the same image and tag.
+  image: quay.io/sclorg/redis-7-c9s
+  tag: "20250108"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -36,11 +36,6 @@ kv:
   # the rendered quadlet reference the same image and tag.
   image: quay.io/sclorg/redis-7-c9s
   tag: "20250108"
-kv-standalone:
-  # docker.io/library/ prefix is required for podman mirror resolution.
-  # Used by flightctl-kv-standalone.container (installed by the RPM).
-  image: docker.io/library/redis
-  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -36,6 +36,11 @@ kv:
   # the rendered quadlet reference the same image and tag.
   image: quay.io/sclorg/redis-7-c9s
   tag: "20250108"
+kv-standalone:
+  # docker.io/library/ prefix is required for podman mirror resolution.
+  # Used by flightctl-kv-standalone.container (installed by the RPM).
+  image: docker.io/library/redis
+  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1


### PR DESCRIPTION
## Summary

The `flightctl-kv.container` quadlet rendered by the `1.2.0-rc2` RPM contains `Image=quay.io/sclorg/redis-7-c9s` with no tag. Podman treats a missing tag as `:latest`. The offline bundle imports `quay.io/sclorg/redis-7-c9s:20250108` (from `helm-chart-opts.yaml`), but the quadlet pulls `:latest` — which is absent from the local registry. Redis crash-loops, cascading to failures in API, worker, periodic, and imagebuilder.

**Root cause:** `packaging/images/el9/images.yaml` had `docker.io/library/redis:7.4.1` which does not match what the RPM actually renders. The RPM was built from a commit where the kv image was `quay.io/sclorg/redis-7-c9s` with no explicit tag.

**Fix:** Align `el9/images.yaml` kv entry with `helm-chart-opts.yaml` (`quay.io/sclorg/redis-7-c9s:20250108`) so the rendered quadlet uses the pinned tag that is present in the bundle.

## Test plan

- [ ] Build bundle with `--variant community-el9` and verify `quay.io/sclorg/redis-7-c9s:20250108` is in the image list
- [ ] Verify rendered `flightctl-kv.container` has `Image=quay.io/sclorg/redis-7-c9s:20250108`
- [ ] Confirm Redis starts successfully in offline install

🤖 Generated with [Claude Code](https://claude.com/claude-code)