### PR TITLE
EDM-3953: add mirror-images binary to flightctl-cli RPM package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ build-standalone: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-standalone
 
 build-mirror-images: bin
-	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./scripts/air-gap/mirror-images
+	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN)/flightctl-mirror-images ./scripts/air-gap/mirror-images
 
 # Container builds - Environment-aware caching
 flightctl-api-container: packaging/images/$(OS)/Containerfile.api go.mod go.sum $(GO_FILES)

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -397,7 +397,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |
 | telemetryGateway.image.tag | string | `""` | Telemetry gateway image tag |
-| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the mirror-images tool. |
+| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-flightctl-mirror-images tool. |
 | ubiMinimal.image | string | `"registry.access.redhat.com/ubi9/ubi-minimal"` | UBI minimal image repository |
 | ubiMinimal.tag | string | `"9.7-1763362218"` | UBI minimal image tag (pinned to avoid unexpected updates) |
 | ui | object | `{"additionalRouteLabels":null,"auth":{"caCert":"","insecureSkipTlsVerify":false},"enabled":true,"image":{"image":"quay.io/flightctl/flightctl-ui-el9","pluginImage":"quay.io/flightctl/flightctl-ocp-ui-el9","pullPolicy":"","tag":""},"trustXForwardedHeaders":true,"trustedProxyCidrs":""}` | UI Configuration |

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -397,7 +397,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |
 | telemetryGateway.image.tag | string | `""` | Telemetry gateway image tag |
-| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-flightctl-mirror-images tool. |
+| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-mirror-images tool. |
 | ubiMinimal.image | string | `"registry.access.redhat.com/ubi9/ubi-minimal"` | UBI minimal image repository |
 | ubiMinimal.tag | string | `"9.7-1763362218"` | UBI minimal image tag (pinned to avoid unexpected updates) |
 | ui | object | `{"additionalRouteLabels":null,"auth":{"caCert":"","insecureSkipTlsVerify":false},"enabled":true,"image":{"image":"quay.io/flightctl/flightctl-ui-el9","pluginImage":"quay.io/flightctl/flightctl-ocp-ui-el9","pullPolicy":"","tag":""},"trustXForwardedHeaders":true,"trustedProxyCidrs":""}` | UI Configuration |

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the mirror-images tool.
+# mirrored location produced by the flightctl-flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: registry.access.redhat.com/ubi9/ubi-minimal

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the flightctl-flightctl-mirror-images tool.
+# mirrored location produced by the flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: registry.access.redhat.com/ubi9/ubi-minimal

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the mirror-images tool.
+# mirrored location produced by the flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: {{ .Images.ubiMinimal.Image }}

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -371,10 +371,10 @@ registry is reachable from both the prep machine and the cluster.
 
 ### Step 1: Mirror images on the prep machine
 
-Run `mirror-images` to copy all FlightCtl service images to the internal registry:
+Run `flightctl-mirror-images` to copy all FlightCtl service images to the internal registry:
 
 ```bash
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry my-internal.registry.example.com:5000 \
     --execute
 ```

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -374,7 +374,7 @@ registry is reachable from both the prep machine and the cluster.
 Run `flightctl-mirror-images` to copy all FlightCtl service images to the internal registry:
 
 ```bash
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry my-internal.registry.example.com:5000 \
     --execute
 ```

--- a/docs/user/installing/deploying-observability-linux.md
+++ b/docs/user/installing/deploying-observability-linux.md
@@ -28,7 +28,7 @@ To store and visualize this telemetry data, you can deploy an observability stac
 
 ## Air-gapped installation
 
-The standard `mirror-images` bundle excludes Prometheus and Grafana because
+The standard `flightctl-mirror-images` bundle excludes Prometheus and Grafana because
 `flightctl-observability` is optional. If you plan to run the observability stack
 on an air-gapped target, you must mirror those images manually before or alongside
 the main bundle transfer.
@@ -46,11 +46,11 @@ the main bundle transfer.
 
 ### Include the observability RPM in the bundle
 
-When running `mirror-images`, add `flightctl-observability` to `--rpm-packages` so
+When running `flightctl-mirror-images`, add `flightctl-observability` to `--rpm-packages` so
 that the RPM and its dependencies are bundled alongside the core service packages:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -204,7 +204,7 @@ Flight Control points at the local registry instead of an internet-accessible re
    images and transfer it to the target:
 
    ```bash
-   ./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
+   ./bin/flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
    scp ~/workload-images.tar.gz <user>@<target_host>:~/
    ```
 

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -200,16 +200,16 @@ Flight Control points at the local registry instead of an internet-accessible re
    insecure = true
    ```
 
-3. On the prep machine, use `mirror-images` to create a bundle of the required workload
+3. On the prep machine, use `flightctl-mirror-images` to create a bundle of the required workload
    images and transfer it to the target:
 
    ```bash
-   ./bin/mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
+   ./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
    scp ~/workload-images.tar.gz <user>@<target_host>:~/
    ```
 
    See the [air-gap mirroring guide](../../../scripts/air-gap/README.md) for full
-   `mirror-images` options and bundle transfer steps.
+   `flightctl-mirror-images` options and bundle transfer steps.
 
 4. On the target machine, extract the bundle and run `import.sh` to push the images
    into the local registry:

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -1,7 +1,7 @@
 # Installing the Flight Control service offline on Linux
 
 This document describes how to install the Flight Control server on a RHEL machine
-that has no internet access. The `mirror-images` tool running on a connected prep
+that has no internet access. The `flightctl-mirror-images` tool running on a connected prep
 machine creates a single portable archive containing all required container images
 and optionally the `flightctl-services` RPM. You then transfer the archive to the
 air-gapped target and use the included scripts to complete the installation.
@@ -14,7 +14,7 @@ For the connected (online) installation procedure, see
 On the **prep machine** (internet-connected):
 
 - RHEL 9 or RHEL 10 with `skopeo` and `createrepo_c` installed (`sudo dnf install -y skopeo createrepo_c`)
-- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- The `flightctl-mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - Sufficient disk space for the bundle (~5–10 GB depending on the variant)
 
 On the **target machine** (air-gapped):
@@ -28,7 +28,7 @@ On the **target machine** (air-gapped):
 
 ## Step 1: Create the offline bundle on the prep machine
 
-Run `mirror-images` with the `--bundle` flag. The command downloads all container
+Run `flightctl-mirror-images` with the `--bundle` flag. The command downloads all container
 images required for your chosen deployment variant and packages them into a single
 `.tar.gz` archive. The `--bundle-rpms` flag includes the `flightctl-services` RPM
 and its dependencies so you can complete the installation without any network access.
@@ -44,7 +44,7 @@ install script on the target can install packages by name rather than by file gl
 > [Pinning to a specific release version](#pinning-to-a-specific-release-version) below.
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
@@ -68,7 +68,7 @@ Replace `community-el9` with your target variant:
 
 ### Pinning to a specific release version
 
-By default, `mirror-images` reads the `appVersion` field from `Chart.yaml` in your
+By default, `flightctl-mirror-images` reads the `appVersion` field from `Chart.yaml` in your
 current checkout to determine which image tags to pull. The RPM download fetches the
 latest version available in the FlightCtl repository. To produce a bundle for a
 specific stable release, use one of the following approaches.
@@ -81,7 +81,7 @@ automatically sets `appVersion` to the release version so no extra flags are nee
 ```bash
 git checkout v1.1.2
 make build-mirror-images
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms
@@ -93,7 +93,7 @@ If you cannot check out the release tag, pass `--tag-override` to pin the contai
 image tags and include the version in `--rpm-packages` to pin the RPM:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms \

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -1,7 +1,7 @@
 # Installing Flight Control in a Disconnected OpenShift Cluster
 
 This document describes how to install the Flight Control service on an OpenShift
-cluster that has no direct internet access. A `mirror-images` tool running on a
+cluster that has no direct internet access. A `flightctl-mirror-images` tool running on a
 connected prep machine mirrors all required container images to your internal
 registry. You then configure OpenShift to redirect image pulls to that registry
 and install Flight Control using Helm.
@@ -14,7 +14,7 @@ For the connected (online) installation procedure, see
 On the **prep machine** (internet-connected):
 
 - RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
-- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- The `flightctl-mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - `helm` CLI installed
 - For `rhem-el9` or `rhem-el10` variants: credentials for `registry.redhat.io`
   (`podman login registry.redhat.io`)
@@ -39,11 +39,11 @@ Choose the variant that matches your deployment:
 
 ### Option A: Direct push (prep machine can reach the internal registry)
 
-Run `mirror-images` with `--execute` to copy all images directly to your mirror
+Run `flightctl-mirror-images` with `--execute` to copy all images directly to your mirror
 registry in a single step:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant rhem-el9 \
     --dest-registry <mirror-registry-host>:<port> \
     --execute \
@@ -66,7 +66,7 @@ disconnected environment, then push from there:
 
 ```bash
 # On the prep machine (internet-connected)
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant rhem-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --tag-override <version>

--- a/docs/user/installing/offline-portable-media.md
+++ b/docs/user/installing/offline-portable-media.md
@@ -9,7 +9,7 @@ describes additional options for specific scenarios.
 
 ## Tar archives
 
-A tar archive is the simplest and most universal transfer format. The `mirror-images --bundle`
+A tar archive is the simplest and most universal transfer format. The `flightctl-mirror-images --bundle`
 command produces a `.tar.gz` archive directly. For RPM packages or other files, you
 create the archive manually.
 

--- a/docs/user/installing/preparing-installation-on-linux.md
+++ b/docs/user/installing/preparing-installation-on-linux.md
@@ -461,7 +461,7 @@ before installation begins. The specific steps depend on what you are installing
   repo using `dnf reposync`. See
   [Setting up a local RPM repository](offline-rpm-repository.md).
 
-- **Container images for server or workloads** — Use the `mirror-images --bundle`
+- **Container images for server or workloads** — Use the `flightctl-mirror-images --bundle`
   command to create a portable archive of all required images. The archive includes
   an `import.sh` script that pushes images into a local container registry on the
   target. See the [air-gap mirroring guide](../../../scripts/air-gap/README.md).

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -50,7 +50,7 @@ imagebuilder-worker:
 # {{ .Grafana.Image }}:{{ .Grafana.Tag }} and {{ .Prometheus.Image }}:{{ .Prometheus.Tag }}
 # in the quadlet .container templates. Removing them breaks the RPM build.
 #
-# The mirror-images tool excludes these entries at parse time (observabilityOnlyImages
+# The flightctl-mirror-images tool excludes these entries at parse time (observabilityOnlyImages
 # in parser.go) because they belong to the optional flightctl-observability stack.
 # Mirror them manually for air-gapped deployments — see deploying-observability-linux.md.
 grafana:

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -50,7 +50,7 @@ imagebuilder-worker:
 # {{ .Grafana.Image }}:{{ .Grafana.Tag }} and {{ .Prometheus.Image }}:{{ .Prometheus.Tag }}
 # in the quadlet .container templates. Removing them breaks the RPM build.
 #
-# The mirror-images tool excludes these entries at parse time (observabilityOnlyImages
+# The flightctl-mirror-images tool excludes these entries at parse time (observabilityOnlyImages
 # in parser.go) because they belong to the optional flightctl-observability stack.
 # Mirror them manually for air-gapped deployments — see deploying-observability-linux.md.
 grafana:

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -286,7 +286,7 @@ fi
         fi;
         echo "${commit:-unknown}";
     )" \
-    %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone
+    %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone build-mirror-images
 
     # SELinux modules build
     %make_build --directory packaging/selinux
@@ -302,6 +302,7 @@ fi
     cp bin/flightctl %{buildroot}/usr/bin
     cp bin/flightctl-backup %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
+    cp bin/mirror-images %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/usr/lib/tmpfiles.d
     mkdir -p %{buildroot}/usr/lib/flightctl/custom-info.d
@@ -468,6 +469,7 @@ fi
     %{_bindir}/flightctl
     %{_bindir}/flightctl-backup
     %{_bindir}/flightctl-restore
+    %{_bindir}/mirror-images
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
     %{_datadir}/zsh/site-functions/_flightctl-completion

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -302,7 +302,7 @@ fi
     cp bin/flightctl %{buildroot}/usr/bin
     cp bin/flightctl-backup %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
-    cp bin/mirror-images %{buildroot}/usr/bin
+    cp bin/flightctl-mirror-images %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/usr/lib/tmpfiles.d
     mkdir -p %{buildroot}/usr/lib/flightctl/custom-info.d
@@ -469,7 +469,7 @@ fi
     %{_bindir}/flightctl
     %{_bindir}/flightctl-backup
     %{_bindir}/flightctl-restore
-    %{_bindir}/mirror-images
+    %{_bindir}/flightctl-mirror-images
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
     %{_datadir}/zsh/site-functions/_flightctl-completion

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -20,21 +20,21 @@ For **user-facing installation documentation** see:
 make build-mirror-images
 
 # Bundle: create a self-contained offline archive with all images + RPMs
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms
 
 # Dry-run: print all skopeo commands for review
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000
 
 # Execute: mirror images directly to a running registry
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000 \
     --execute
 
 # Agent-only bundle (no variant required)
-./bin/flightctl-flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+./bin/flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 ```
 
 ---
@@ -101,7 +101,7 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 
 ```bash
 # Server with observability RPM (Prometheus + Grafana images must be mirrored separately)
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
     --tag-override 1.2.0-rc1 \
@@ -173,15 +173,15 @@ scripts/air-gap/mirror-images/
 make build-mirror-images
 
 # Mutually exclusive flags
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
-./bin/flightctl-flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
-./bin/flightctl-flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
-./bin/flightctl-flightctl-mirror-images --agent-only 2>&1
-./bin/flightctl-flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
+./bin/flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --agent-only 2>&1
+./bin/flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
 
 # Invalid variant / URL scheme
-./bin/flightctl-flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
+./bin/flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
+./bin/flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
 ```
 
 ### Output correctness
@@ -189,24 +189,24 @@ make build-mirror-images
 ```bash
 # Image counts per variant
 for v in community-el9 community-el10 rhem-el9 rhem-el10; do
-    n=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
+    n=$(./bin/flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
     echo "$v: $n images"
 done
 
 # Community variants must not include registry.redhat.io
 for v in community-el9 community-el10; do
-    hits=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
+    hits=$(./bin/flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
            | grep -c "registry.redhat.io" || true)
     echo "$v: $hits registry.redhat.io sources (expect 0)"
 done
 
 # Docker Hub official images must use library/ namespace
-hits=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+hits=$(./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
        | grep -c "library/redis" || true)
 echo "library/redis entries: $hits (expect 1)"
 
 # stdout must be clean (no log lines)
-dirty=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+dirty=$(./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
         | grep -cE "^\[INFO\]|^\[WARN\]|^\[ERROR\]" || true)
 echo "dirty stdout lines: $dirty (expect 0)"
 ```
@@ -222,7 +222,7 @@ export OBS_IMAGES_RHEL9=scripts/air-gap/test/fixtures/images-rhel9.yaml
 export OBS_IMAGES_RHEL10=scripts/air-gap/test/fixtures/images-rhel10.yaml
 export RPM_SPEC=/dev/null
 
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
+./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
 ```
 
 ---

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -1,4 +1,4 @@
-# `mirror-images` — Air-gap Image Mirroring Tool
+# `flightctl-mirror-images` — Air-gap Image Mirroring Tool
 
 Enumerates all FlightCtl container images for a given deployment variant and
 either prints `skopeo copy` commands, executes them against a live registry, or
@@ -20,21 +20,21 @@ For **user-facing installation documentation** see:
 make build-mirror-images
 
 # Bundle: create a self-contained offline archive with all images + RPMs
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms
 
 # Dry-run: print all skopeo commands for review
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000
 
 # Execute: mirror images directly to a running registry
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000 \
     --execute
 
 # Agent-only bundle (no variant required)
-./bin/mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+./bin/flightctl-flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 ```
 
 ---
@@ -101,14 +101,14 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 
 ```bash
 # Server with observability RPM (Prometheus + Grafana images must be mirrored separately)
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
     --tag-override 1.2.0-rc1 \
     --rpm-packages flightctl-services,flightctl-observability
 
 # Edge device agent + CLI only (no images)
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --agent-only \
     --bundle ~/flightctl-agent-bundle.tar.gz
 ```
@@ -173,15 +173,15 @@ scripts/air-gap/mirror-images/
 make build-mirror-images
 
 # Mutually exclusive flags
-./bin/mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
-./bin/mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
-./bin/mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
-./bin/mirror-images --agent-only 2>&1
-./bin/mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
+./bin/flightctl-flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --agent-only 2>&1
+./bin/flightctl-flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
 
 # Invalid variant / URL scheme
-./bin/mirror-images --variant bad --dest-registry localhost:5000 2>&1
-./bin/mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
+./bin/flightctl-flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
 ```
 
 ### Output correctness
@@ -189,24 +189,24 @@ make build-mirror-images
 ```bash
 # Image counts per variant
 for v in community-el9 community-el10 rhem-el9 rhem-el10; do
-    n=$(./bin/mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
+    n=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
     echo "$v: $n images"
 done
 
 # Community variants must not include registry.redhat.io
 for v in community-el9 community-el10; do
-    hits=$(./bin/mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
+    hits=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
            | grep -c "registry.redhat.io" || true)
     echo "$v: $hits registry.redhat.io sources (expect 0)"
 done
 
 # Docker Hub official images must use library/ namespace
-hits=$(./bin/mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+hits=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
        | grep -c "library/redis" || true)
 echo "library/redis entries: $hits (expect 1)"
 
 # stdout must be clean (no log lines)
-dirty=$(./bin/mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+dirty=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
         | grep -cE "^\[INFO\]|^\[WARN\]|^\[ERROR\]" || true)
 echo "dirty stdout lines: $dirty (expect 0)"
 ```
@@ -222,7 +222,7 @@ export OBS_IMAGES_RHEL9=scripts/air-gap/test/fixtures/images-rhel9.yaml
 export OBS_IMAGES_RHEL10=scripts/air-gap/test/fixtures/images-rhel10.yaml
 export RPM_SPEC=/dev/null
 
-./bin/mirror-images --variant community-el9 --dest-registry localhost:5000
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
 ```
 
 ---

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -1,9 +1,9 @@
-// mirror-images enumerates all RHEM container images for a given chart variant
+// flightctl-mirror-images enumerates all RHEM container images for a given chart variant
 // and generates skopeo copy commands suitable for an air-gapped installation.
 //
 // # Usage
 //
-//	./mirror-images --variant <variant> --dest-registry <host:port> [--execute]
+//	./flightctl-mirror-images --variant <variant> --dest-registry <host:port> [--execute]
 //
 // # Stories
 //
@@ -56,13 +56,13 @@ func envOr(key, fallback string) string {
 // repoRoot attempts to resolve the flightctl repository root relative to the
 // running binary's location.
 //
-// The binary is expected to be built from scripts/air-gap/mirror-images/, so
+// The binary is expected to be built from scripts/air-gap/flightctl-mirror-images/, so
 // the repo root is three directories above the binary:
 //
-//	bin/mirror-images → bin/ → repo root      (when run via `go build -o bin/`)
+//	bin/flightctl-mirror-images → bin/ → repo root      (when run via `go build -o bin/`)
 //
 // If os.Executable() fails we fall back to the current working directory so
-// that `go run ./scripts/air-gap/mirror-images` still works from the repo root.
+// that `go run ./scripts/air-gap/flightctl-mirror-images` still works from the repo root.
 func repoRoot() string {
 	exe, err := os.Executable()
 	if err != nil {
@@ -247,7 +247,7 @@ func runBundleMode(ctx context.Context, unique []ImagePair, bundle, variant stri
 	return nil
 }
 
-// NewRootCommand builds and returns the cobra root command for mirror-images.
+// NewRootCommand builds and returns the cobra root command for flightctl-mirror-images.
 func NewRootCommand() *cobra.Command {
 	var (
 		variant       string
@@ -265,9 +265,9 @@ func NewRootCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "mirror-images --variant <variant> [--dest-registry <host:port>] [--bundle <path>] [--execute] [--insecure]",
+		Use:   "flightctl-mirror-images --variant <variant> [--dest-registry <host:port>] [--bundle <path>] [--execute] [--insecure]",
 		Short: "Enumerate RHEM artifacts and generate skopeo mirror commands for air-gapped installation.",
-		Long: `mirror-images reads the flightctl Helm chart options and observability image files,
+		Long: `flightctl-mirror-images reads the flightctl Helm chart options and observability image files,
 generates skopeo copy commands for all referenced container images, and writes a
 machine-readable artifact manifest to the current directory.
 
@@ -288,36 +288,36 @@ Output:
 
 Examples:
   # Dry-run: print all commands for the community-el9 variant
-  mirror-images --variant community-el9 --dest-registry local-registry.example.com:5000
+  flightctl-mirror-images --variant community-el9 --dest-registry local-registry.example.com:5000
 
   # Execute: mirror images to a running local registry
-  mirror-images --variant rhem-el9 --dest-registry local-registry.example.com:5000 --execute
+  flightctl-mirror-images --variant rhem-el9 --dest-registry local-registry.example.com:5000 --execute
 
   # Bundle: create offline archive with all images
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz
 
   # Bundle: include RPMs for bare-metal quadlet installation
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz --bundle-rpms
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz --bundle-rpms
 
   # Bundle with custom dest registry written into import.sh
-  mirror-images --variant community-el9 --dest-registry myregistry.local:5000 --bundle ~/flightctl-bundle.tar.gz
+  flightctl-mirror-images --variant community-el9 --dest-registry myregistry.local:5000 --bundle ~/flightctl-bundle.tar.gz
 
   # Execute: mirror to an HTTP (non-TLS) local registry
-  mirror-images --variant community-el9 --dest-registry localhost:5000 --execute --insecure
+  flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 --execute --insecure
 
   # Agent/CLI bundle for edge devices (no --variant required)
-  mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+  flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 
   # Server bundle with full repo mirror and metadata (requires dnf-plugins-core)
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-reposync
 
   # Server bundle with generated repo metadata after targeted download
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-createrepo
 
   # Server bundle: download agent RPM for image building but skip auto-install on server
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent`,
 
 		// SilenceUsage prevents cobra from printing the full usage block on every
@@ -407,11 +407,11 @@ Examples:
 				logWarn("Find the target RPM version: rpm -q --qf '%%{VERSION}' flightctl-agent")
 				logWarn("Then re-run with --tag-override, or from a release-tagged checkout:")
 				if bundle != "" {
-					logWarn("  ./bin/mirror-images --variant %s --bundle %s --tag-override <version>", variant, bundle)
-					logWarn("  OR: git checkout v<version> && ./bin/mirror-images --variant %s --bundle %s", variant, bundle)
+					logWarn("  ./bin/flightctl-mirror-images --variant %s --bundle %s --tag-override <version>", variant, bundle)
+					logWarn("  OR: git checkout v<version> && ./bin/flightctl-mirror-images --variant %s --bundle %s", variant, bundle)
 				} else {
-					logWarn("  ./bin/mirror-images --variant %s --dest-registry %s --tag-override <version>", variant, destRegistry)
-					logWarn("  OR: git checkout v<version> && ./bin/mirror-images --variant %s --dest-registry %s", variant, destRegistry)
+					logWarn("  ./bin/flightctl-mirror-images --variant %s --dest-registry %s --tag-override <version>", variant, destRegistry)
+					logWarn("  OR: git checkout v<version> && ./bin/flightctl-mirror-images --variant %s --dest-registry %s", variant, destRegistry)
 				}
 			} else {
 				logInfo("  Effective tag:    %s (for untagged images)", effectiveTag)


### PR DESCRIPTION
## Summary

Builds the `mirror-images` air-gap tool as part of the RPM build and ships it in the `flightctl-cli` package so operators have it available without needing to build from source.

Three changes to `packaging/rpm/flightctl.spec`:
1. Add `build-mirror-images` to the `%build` make targets
2. Install `bin/mirror-images` to `%{buildroot}/usr/bin` in `%install`
3. Add `%{_bindir}/mirror-images` to `%files cli`

## Test plan

- [ ] Build RPM and verify `mirror-images` binary is present in the `flightctl-cli` package
- [ ] Verify `mirror-images --help` works after RPM install

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)