### PR TITLE
[Backport to 1.2] EDM-4120: Unix socket for standalone agent API

### DIFF
--- a/cmd/flightctl-api/main.go
+++ b/cmd/flightctl-api/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -94,7 +95,18 @@ func main() {
 	}
 
 	// create the agent service listener as tcp (combined HTTP+gRPC)
-	agentListener, err := net.Listen("tcp", cfg.Service.AgentEndpointAddress)
+	network := "tcp"
+	agentAddress := cfg.Service.AgentEndpointAddress
+	if strings.HasPrefix(cfg.Service.AgentEndpointAddress, "unix://") {
+		network = "unix"
+		agentAddress = strings.TrimPrefix(cfg.Service.AgentEndpointAddress, "unix://")
+		if _, err := os.Stat(agentAddress); err == nil {
+			if err := os.Remove(agentAddress); err != nil {
+				log.Fatalf("Failed to remove previous unix socket at %s: %v", agentAddress, err)
+			}
+		}
+	}
+	agentListener, err := net.Listen(network, agentAddress)
 	if err != nil {
 		log.Fatalf("creating listener: %s", err)
 	}

--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -22,7 +22,7 @@ database:
 {{- end}}
 service:
   address: flightctl-api:3080
-  agentEndpointAddress: flightctl-api:7443
+  agentEndpointAddress: unix:///var/run/flightctl-listeners/api-agent.sock
   baseUrl: https://{{.global.baseDomain}}/_/flightctl/
   disableTLS: true
   baseAgentEndpointUrl: https://{{.global.baseDomain}}:7443/

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -24,6 +24,10 @@ Volume=/etc/flightctl/flightctl-api/config.yaml:/root/.flightctl/config.yaml:ro,
 # TPM CA PEMs for enrollment (paths in service.tpmCAPaths must exist inside the container)
 Volume=/etc/flightctl/tpm-cas:/etc/flightctl/tpm-cas:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
+Volume=flightctl-listeners:/var/run/flightctl-listeners/:z
+
+# This ensures that the unix socket allows root group access
+PodmanArgs=--umask=0002
 
 Ulimit=nofile=300000:300000
 

--- a/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
@@ -1,9 +1,14 @@
 include /usr/share/nginx/modules/mod-stream.conf;
 
-worker_processes auto;
 error_log stderr;
 pid /run/nginx.pid;
-events {}
+
+worker_processes auto;
+worker_rlimit_nofile 65535;
+
+events {
+  worker_connections 16384;
+}
 
 http {
   access_log /dev/stdout;
@@ -119,7 +124,7 @@ stream {
     listen 7443;
     listen [::]:7443 ipv6only=on;
 
-    proxy_pass flightctl-api:7443;
+    proxy_pass unix:/var/run/flightctl-listeners/api-agent.sock;
   }
 
   # Passthrough to the Telemetry Gateway service

--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -14,6 +14,7 @@ Volume=/etc/flightctl/pki:/etc/flightctl/pki:ro,z
 Volume=/etc/flightctl/flightctl-gateway/nginx.conf:/etc/nginx/nginx.conf:ro,z
 Volume=/etc/flightctl/pki/flightctl-gateway/server.crt:/etc/flightctl/pki/flightctl-gateway/server.crt:ro,z
 Volume=/etc/flightctl/pki/flightctl-gateway/server.key:/etc/flightctl/pki/flightctl-gateway/server.key:ro,z
+Volume=flightctl-listeners:/var/run/flightctl-listeners/:z
 User=1001
 Group=0
 Exec=nginx -g "daemon off;"

--- a/deploy/podman/flightctl-listeners.volume
+++ b/deploy/podman/flightctl-listeners.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=flightctl-listeners

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -102,6 +102,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		// Shared files
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl.network", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl.network"), Template: false, Mode: RegularFileMode},
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl.target", Destination: filepath.Join(config.SystemdUnitOutputDir, "flightctl.target"), Template: false, Mode: RegularFileMode},
+		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-listeners.volume", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-listeners.volume"), Template: false, Mode: RegularFileMode},
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-observability.target", Destination: filepath.Join(config.SystemdUnitOutputDir, "flightctl-observability.target"), Template: false, Mode: RegularFileMode},
 		{Action: ActionCopyFile, Source: "deploy/podman/service-config.yaml", Destination: filepath.Join(config.WriteableConfigOutputDir, "service-config.yaml"), Template: false, Mode: RegularFileMode},
 

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -647,6 +647,7 @@ fi
     %{_datadir}/containers/systemd/flightctl-alertmanager.volume
     %{_datadir}/containers/systemd/flightctl-telemetry-gateway.container
     %{_datadir}/containers/systemd/flightctl.network
+    %{_datadir}/containers/systemd/flightctl-listeners.volume
 
     # Handle permissions for scripts setting host config
     %attr(0755,root,root) %{_datadir}/flightctl/init_db.sh


### PR DESCRIPTION
Backporting PR *[EDM-4120: Unix socket for standalone agent API](https://github.com/flightctl/flightctl/pull/3069)* for **1.2** release.