### PR TITLE
NO-ISSUE: Do not add safe directory duplicates

### DIFF
--- a/hack/current-version
+++ b/hack/current-version
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
-# Fix git ownership issue in CI environments
-git config --global --add safe.directory /__w/flightctl/flightctl 2>/dev/null || true
-git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+# Fix git ownership issue in CI environments (idempotent — do not append duplicates).
+ensure_safe_directory() {
+  local dir="$1"
+  git config --global --get-all safe.directory 2>/dev/null | grep -qxF "$dir" || \
+    git config --global --add safe.directory "$dir" 2>/dev/null || true
+}
+ensure_safe_directory /__w/flightctl/flightctl
+ensure_safe_directory "$(pwd)"
 
 # Prefer proper release tags pointing at this exact commit first, prioritizing the highest version
 # tag. If there is no tag at this commit, then fallback to 'git describe' which will construct a


### PR DESCRIPTION
Every time the system runs `./hack/current-version`, we were adding 2 duplicate entries to `~/.gitconfig`
My `~/.gitconfig` size was 185KB, after I deleted the duplicate entires it's down to less than 1KB.

Now the script will ensure that the entries are only added once. 

Made-with: Cursor

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [x] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
