### PR TITLE
[Backport to 1.2] Mass backport from PR 2911 to 3078

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ build-standalone: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-standalone
 
 build-mirror-images: bin
-	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./scripts/air-gap/mirror-images
+	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN)/flightctl-mirror-images ./scripts/air-gap/mirror-images
 
 # Container builds - Environment-aware caching
 flightctl-api-container: packaging/images/$(OS)/Containerfile.api go.mod go.sum $(GO_FILES)

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -397,7 +397,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |
 | telemetryGateway.image.tag | string | `""` | Telemetry gateway image tag |
-| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the mirror-images tool. |
+| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-flightctl-mirror-images tool. |
 | ubiMinimal.image | string | `"registry.access.redhat.com/ubi9/ubi-minimal"` | UBI minimal image repository |
 | ubiMinimal.tag | string | `"9.7-1763362218"` | UBI minimal image tag (pinned to avoid unexpected updates) |
 | ui | object | `{"additionalRouteLabels":null,"auth":{"caCert":"","insecureSkipTlsVerify":false},"enabled":true,"image":{"image":"quay.io/flightctl/flightctl-ui-el9","pluginImage":"quay.io/flightctl/flightctl-ocp-ui-el9","pullPolicy":"","tag":""},"trustXForwardedHeaders":true,"trustedProxyCidrs":""}` | UI Configuration |

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -397,7 +397,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |
 | telemetryGateway.image.tag | string | `""` | Telemetry gateway image tag |
-| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-flightctl-mirror-images tool. |
+| ubiMinimal | object | `{"image":"registry.access.redhat.com/ubi9/ubi-minimal","tag":"9.7-1763362218"}` | UBI Minimal base image used by init containers (cert setup, etc.) Override this when deploying in an air-gapped environment where registry.access.redhat.com is unreachable — set image and tag to the mirrored location produced by the flightctl-mirror-images tool. |
 | ubiMinimal.image | string | `"registry.access.redhat.com/ubi9/ubi-minimal"` | UBI minimal image repository |
 | ubiMinimal.tag | string | `"9.7-1763362218"` | UBI minimal image tag (pinned to avoid unexpected updates) |
 | ui | object | `{"additionalRouteLabels":null,"auth":{"caCert":"","insecureSkipTlsVerify":false},"enabled":true,"image":{"image":"quay.io/flightctl/flightctl-ui-el9","pluginImage":"quay.io/flightctl/flightctl-ocp-ui-el9","pullPolicy":"","tag":""},"trustXForwardedHeaders":true,"trustedProxyCidrs":""}` | UI Configuration |

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the mirror-images tool.
+# mirrored location produced by the flightctl-flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: registry.access.redhat.com/ubi9/ubi-minimal

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the flightctl-flightctl-mirror-images tool.
+# mirrored location produced by the flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: registry.access.redhat.com/ubi9/ubi-minimal

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -349,7 +349,7 @@ alertmanagerProxy:
 # -- UBI Minimal base image used by init containers (cert setup, etc.)
 # Override this when deploying in an air-gapped environment where
 # registry.access.redhat.com is unreachable — set image and tag to the
-# mirrored location produced by the mirror-images tool.
+# mirrored location produced by the flightctl-mirror-images tool.
 ubiMinimal:
   # -- UBI minimal image repository
   image: {{ .Images.ubiMinimal.Image }}

--- a/deploy/helm/helm-chart-opts.yaml
+++ b/deploy/helm/helm-chart-opts.yaml
@@ -47,7 +47,7 @@ community-el9:
     ubiMinimal:
       image: registry.access.redhat.com/ubi9/ubi-minimal
       tag: "9.7-1763362218"
-redhat-el9:
+rhem-el9:
   name: redhat-rhem
   description: A helm chart for Red Hat Edge Manager
   home: https://red.ht/rhem
@@ -148,7 +148,7 @@ community-el10:
     ubiMinimal:
       image: registry.access.redhat.com/ubi10/ubi-minimal
       tag: "10.1-1769677092"
-redhat-el10:
+rhem-el10:
   name: redhat-rhem
   description: A helm chart for Red Hat Edge Manager
   home: https://red.ht/rhem

--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -200,13 +200,14 @@ Configure the OAuth application with these settings:
 - **Redirect URIs:** Set to:
 
   ```bash
-  https://your-flightctl-base-domain:443/callback http://127.0.0.1/callback
+  https://your-flightctl-base-domain:443/callback http://localhost:8080/callback http://127.0.0.1:8080/callback
   ```
 
-Note: The redirect URIs should be a space delimited list. Two URIs are required:
+Note: The redirect URIs should be a space delimited list. Three URIs are required:
 
 - A URL to your UI with a /callback path appended. The default base domain and port combo is `https://your-flightctl-base-domain:443/callback`, but if you have different routing configured you will need to update the URL accordingly. Make sure to replace your-flightctl-base-domain with your actual domain.
-- A URL to `http://127.0.0.1/callback` to ensure login sessions using the CLI work
+- A URL to `http://localhost:8080/callback` to ensure login sessions using the CLI work with the default callback port
+- A URL to `http://127.0.0.1:8080/callback` to ensure loopback-only environments using the CLI work with the default callback port
 
 #### Step 4: Obtain client credentials
 

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -371,10 +371,10 @@ registry is reachable from both the prep machine and the cluster.
 
 ### Step 1: Mirror images on the prep machine
 
-Run `mirror-images` to copy all FlightCtl service images to the internal registry:
+Run `flightctl-mirror-images` to copy all FlightCtl service images to the internal registry:
 
 ```bash
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry my-internal.registry.example.com:5000 \
     --execute
 ```

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -374,7 +374,7 @@ registry is reachable from both the prep machine and the cluster.
 Run `flightctl-mirror-images` to copy all FlightCtl service images to the internal registry:
 
 ```bash
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry my-internal.registry.example.com:5000 \
     --execute
 ```

--- a/docs/user/installing/deploying-observability-linux.md
+++ b/docs/user/installing/deploying-observability-linux.md
@@ -41,8 +41,8 @@ the main bundle transfer.
 | `docker.io/prom/prometheus:v2.13.1` | `community-el9` |
 | `quay.io/ceph/grafana:9.4.10` | `community-el10` |
 | `quay.io/prometheus/prometheus:v2.43.1` | `community-el10` |
-| `registry.redhat.io/rhel9/grafana:9.7-1766395319` | `redhat-el9`, `redhat-el10` |
-| `registry.redhat.io/rhacm2/prometheus-rhel9:v2.14.2-1` | `redhat-el9`, `redhat-el10` |
+| `registry.redhat.io/rhel9/grafana:9.7-1766395319` | `rhem-el9`, `rhem-el10` |
+| `registry.redhat.io/rhacm2/prometheus-rhel9:v2.14.2-1` | `rhem-el9`, `rhem-el10` |
 
 ### Include the observability RPM in the bundle
 

--- a/docs/user/installing/deploying-observability-linux.md
+++ b/docs/user/installing/deploying-observability-linux.md
@@ -28,7 +28,7 @@ To store and visualize this telemetry data, you can deploy an observability stac
 
 ## Air-gapped installation
 
-The standard `mirror-images` bundle excludes Prometheus and Grafana because
+The standard `flightctl-mirror-images` bundle excludes Prometheus and Grafana because
 `flightctl-observability` is optional. If you plan to run the observability stack
 on an air-gapped target, you must mirror those images manually before or alongside
 the main bundle transfer.
@@ -46,11 +46,11 @@ the main bundle transfer.
 
 ### Include the observability RPM in the bundle
 
-When running `mirror-images`, add `flightctl-observability` to `--rpm-packages` so
+When running `flightctl-mirror-images`, add `flightctl-observability` to `--rpm-packages` so
 that the RPM and its dependencies are bundled alongside the core service packages:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -204,7 +204,7 @@ Flight Control points at the local registry instead of an internet-accessible re
    images and transfer it to the target:
 
    ```bash
-   ./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
+   ./bin/flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
    scp ~/workload-images.tar.gz <user>@<target_host>:~/
    ```
 

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -200,16 +200,16 @@ Flight Control points at the local registry instead of an internet-accessible re
    insecure = true
    ```
 
-3. On the prep machine, use `mirror-images` to create a bundle of the required workload
+3. On the prep machine, use `flightctl-mirror-images` to create a bundle of the required workload
    images and transfer it to the target:
 
    ```bash
-   ./bin/mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
+   ./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
    scp ~/workload-images.tar.gz <user>@<target_host>:~/
    ```
 
    See the [air-gap mirroring guide](../../../scripts/air-gap/README.md) for full
-   `mirror-images` options and bundle transfer steps.
+   `flightctl-mirror-images` options and bundle transfer steps.
 
 4. On the target machine, extract the bundle and run `import.sh` to push the images
    into the local registry:

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -56,8 +56,8 @@ Replace `community-el9` with your target variant:
 |---------|----------|
 | `community-el9` | RHEL 9 or CentOS Stream 9 |
 | `community-el10` | RHEL 10 or CentOS Stream 10 |
-| `redhat-el9` | RHEL 9 with Red Hat registry images (requires registry.redhat.io credentials) |
-| `redhat-el10` | RHEL 10 with Red Hat registry images |
+| `rhem-el9` | RHEL 9 with Red Hat registry images (requires registry.redhat.io credentials) |
+| `rhem-el10` | RHEL 10 with Red Hat registry images |
 
 ### Pinning to a specific release version
 
@@ -230,7 +230,7 @@ location = "localhost:5000"
 insecure = true
 ```
 
-For `redhat-el9` or `redhat-el10` variants, add a mirror entry for
+For `rhem-el9` or `rhem-el10` variants, add a mirror entry for
 `registry.redhat.io` in place of `registry.access.redhat.com`.
 
 > [!IMPORTANT]

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -13,7 +13,7 @@ For the connected (online) installation procedure, see
 
 On the **prep machine** (internet-connected):
 
-- RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
+- RHEL 9 or RHEL 10 with `skopeo` and `createrepo_c` installed (`sudo dnf install -y skopeo createrepo_c`)
 - The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - Sufficient disk space for the bundle (~5–10 GB depending on the variant)
 

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -23,6 +23,7 @@ On the **target machine** (air-gapped):
 - `podman` installed
 - `skopeo` installed (`skopeo` must be available before network is removed,
   or transferred as an RPM in the bundle)
+- `containernetworking-plugins` installed (`sudo dnf install -y containernetworking-plugins`)
 - A transfer method — see [Packaging artifacts for portable media](offline-portable-media.md)
 
 ## Step 1: Create the offline bundle on the prep machine
@@ -47,8 +48,14 @@ install script on the target can install packages by name rather than by file gl
     --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
-    --rpm-createrepo
+    --rpm-createrepo \
+    --rpm-exclude flightctl-agent
 ```
+
+The `--rpm-exclude flightctl-agent` flag downloads the agent RPM into the bundle's
+`rpms/` directory (for use when building device OS images with the image builder) but
+does not auto-install it on the server. Omit this flag only if you intentionally want
+the agent installed on the server machine.
 
 Replace `community-el9` with your target variant:
 
@@ -289,7 +296,7 @@ sudo systemctl status flightctl.target
 Confirm the API is reachable using the FQDN you set in `global.baseDomain`:
 
 ```bash
-curl -k https://<baseDomain>:3443/api/v1/fleets
+flightctl get fleets
 ```
 
 ## Optional: deploying the observability stack offline

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -1,7 +1,7 @@
 # Installing the Flight Control service offline on Linux
 
 This document describes how to install the Flight Control server on a RHEL machine
-that has no internet access. The `mirror-images` tool running on a connected prep
+that has no internet access. The `flightctl-mirror-images` tool running on a connected prep
 machine creates a single portable archive containing all required container images
 and optionally the `flightctl-services` RPM. You then transfer the archive to the
 air-gapped target and use the included scripts to complete the installation.
@@ -14,7 +14,7 @@ For the connected (online) installation procedure, see
 On the **prep machine** (internet-connected):
 
 - RHEL 9 or RHEL 10 with `skopeo` and `createrepo_c` installed (`sudo dnf install -y skopeo createrepo_c`)
-- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- The `flightctl-mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - Sufficient disk space for the bundle (~5–10 GB depending on the variant)
 
 On the **target machine** (air-gapped):
@@ -28,7 +28,7 @@ On the **target machine** (air-gapped):
 
 ## Step 1: Create the offline bundle on the prep machine
 
-Run `mirror-images` with the `--bundle` flag. The command downloads all container
+Run `flightctl-mirror-images` with the `--bundle` flag. The command downloads all container
 images required for your chosen deployment variant and packages them into a single
 `.tar.gz` archive. The `--bundle-rpms` flag includes the `flightctl-services` RPM
 and its dependencies so you can complete the installation without any network access.
@@ -44,7 +44,7 @@ install script on the target can install packages by name rather than by file gl
 > [Pinning to a specific release version](#pinning-to-a-specific-release-version) below.
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
@@ -68,7 +68,7 @@ Replace `community-el9` with your target variant:
 
 ### Pinning to a specific release version
 
-By default, `mirror-images` reads the `appVersion` field from `Chart.yaml` in your
+By default, `flightctl-mirror-images` reads the `appVersion` field from `Chart.yaml` in your
 current checkout to determine which image tags to pull. The RPM download fetches the
 latest version available in the FlightCtl repository. To produce a bundle for a
 specific stable release, use one of the following approaches.
@@ -81,7 +81,7 @@ automatically sets `appVersion` to the release version so no extra flags are nee
 ```bash
 git checkout v1.1.2
 make build-mirror-images
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms
@@ -93,7 +93,7 @@ If you cannot check out the release tag, pass `--tag-override` to pin the contai
 image tags and include the version in `--rpm-packages` to pin the RPM:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms \

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -293,10 +293,12 @@ Check that all quadlet services are running:
 sudo systemctl status flightctl.target
 ```
 
-Confirm the API is reachable using the FQDN you set in `global.baseDomain`:
+Confirm the API is reachable using the FQDN you set in `global.baseDomain`.
+The default API port is `3443`; installations using a reverse proxy or load
+balancer may use port `443` instead:
 
 ```bash
-flightctl get fleets
+curl -k https://<baseDomain>:3443/api/v1/fleets
 ```
 
 ## Optional: deploying the observability stack offline

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -142,6 +142,9 @@ spec:
   - source: docker.io
     mirrors:
     - <mirror-registry-host>:<port>
+  - source: registry.access.redhat.com
+    mirrors:
+    - <mirror-registry-host>:<port>
 EOF
 ```
 
@@ -207,11 +210,14 @@ Check that all pods are running:
 oc get pods -n flightctl
 ```
 
-Confirm the API is reachable:
+Confirm the API is reachable and returns an empty fleet list:
 
 ```bash
-curl -k https://api.flightctl.example.com/api/v1/fleets
+flightctl get fleets
 ```
+
+The Flight Control UI is available at the hostname set in `global.baseDomain`.
+Open it in a browser to verify the service is running end-to-end.
 
 ## Optional: deploying the observability stack
 
@@ -224,6 +230,19 @@ for image lists and configuration details.
 
 ## Next steps
 
-- [Configuring Authentication and Authorization](configuring-auth/overview.md)
-- [Installing the Flight Control CLI](installing-cli.md)
-- [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)
+1. **Set up authentication** — configure an identity provider before allowing user
+   access. For OpenShift-integrated login see
+   [Configuring OpenShift Authentication](configuring-auth/auth-openshift.md),
+   or review the [Authentication Overview](configuring-auth/overview.md) for all options.
+
+2. **Create an organization and assign roles** — Flight Control requires at least
+   one organization before users can manage devices. See
+   [Managing Organizations](configuring-auth/organizations.md) and the role
+   assignment section of the authentication guide.
+
+3. **Log in with the CLI** — see [Logging In](../using/cli/logging-in.md) for the
+   `flightctl login` command and certificate trust setup.
+
+4. **Deploy the observability stack (optional)** — see
+   [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)
+   for Prometheus and Grafana setup.

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -1,7 +1,7 @@
 # Installing Flight Control in a Disconnected OpenShift Cluster
 
 This document describes how to install the Flight Control service on an OpenShift
-cluster that has no direct internet access. A `mirror-images` tool running on a
+cluster that has no direct internet access. A `flightctl-mirror-images` tool running on a
 connected prep machine mirrors all required container images to your internal
 registry. You then configure OpenShift to redirect image pulls to that registry
 and install Flight Control using Helm.
@@ -14,7 +14,7 @@ For the connected (online) installation procedure, see
 On the **prep machine** (internet-connected):
 
 - RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
-- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- The `flightctl-mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - `helm` CLI installed
 - For `rhem-el9` or `rhem-el10` variants: credentials for `registry.redhat.io`
   (`podman login registry.redhat.io`)
@@ -39,11 +39,11 @@ Choose the variant that matches your deployment:
 
 ### Option A: Direct push (prep machine can reach the internal registry)
 
-Run `mirror-images` with `--execute` to copy all images directly to your mirror
+Run `flightctl-mirror-images` with `--execute` to copy all images directly to your mirror
 registry in a single step:
 
 ```bash
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant rhem-el9 \
     --dest-registry <mirror-registry-host>:<port> \
     --execute \
@@ -66,7 +66,7 @@ disconnected environment, then push from there:
 
 ```bash
 # On the prep machine (internet-connected)
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --variant rhem-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --tag-override <version>

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -210,10 +210,10 @@ Check that all pods are running:
 oc get pods -n flightctl
 ```
 
-Confirm the API is reachable and returns an empty fleet list:
+Confirm the API is reachable:
 
 ```bash
-flightctl get fleets
+curl -k https://<baseDomain>/api/v1/fleets
 ```
 
 The Flight Control UI is available at the hostname set in `global.baseDomain`.

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -16,7 +16,7 @@ On the **prep machine** (internet-connected):
 - RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
 - The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
 - `helm` CLI installed
-- For `redhat-el9` or `redhat-el10` variants: credentials for `registry.redhat.io`
+- For `rhem-el9` or `rhem-el10` variants: credentials for `registry.redhat.io`
   (`podman login registry.redhat.io`)
 
 On the **disconnected cluster**:
@@ -34,8 +34,8 @@ Choose the variant that matches your deployment:
 |---------|----------|
 | `community-el9` | Community images from `quay.io` (RHEL 9 base) |
 | `community-el10` | Community images from `quay.io` (RHEL 10 base) |
-| `redhat-el9` | Red Hat images from `registry.redhat.io` (requires entitlement) |
-| `redhat-el10` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+| `rhem-el9` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+| `rhem-el10` | Red Hat images from `registry.redhat.io` (requires entitlement) |
 
 ### Option A: Direct push (prep machine can reach the internal registry)
 
@@ -44,7 +44,7 @@ registry in a single step:
 
 ```bash
 ./bin/mirror-images \
-    --variant redhat-el9 \
+    --variant rhem-el9 \
     --dest-registry <mirror-registry-host>:<port> \
     --execute \
     --tag-override <version>
@@ -67,7 +67,7 @@ disconnected environment, then push from there:
 ```bash
 # On the prep machine (internet-connected)
 ./bin/mirror-images \
-    --variant redhat-el9 \
+    --variant rhem-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --tag-override <version>
 
@@ -107,7 +107,7 @@ scp flightctl-<version>.tgz <user>@<bastion>:~/
 OpenShift uses `ImageTagMirrorSet` to redirect image pulls from source registries
 to your mirror. Apply the appropriate configuration for your variant.
 
-### For `redhat-el9` or `redhat-el10`
+### For `rhem-el9` or `rhem-el10`
 
 ```bash
 oc apply -f - <<EOF
@@ -156,7 +156,7 @@ oc wait nodes --all --for=condition=Ready --timeout=10m
 
 ## Step 4: Create an image pull secret (Red Hat variants only)
 
-If you are using a `redhat-el9` or `redhat-el10` variant and your mirror registry
+If you are using a `rhem-el9` or `rhem-el10` variant and your mirror registry
 requires authentication, create a pull secret in the `flightctl` namespace:
 
 ```bash

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -1,85 +1,229 @@
-# Installing a Flight Control in a Disconnected Cluster Environment
+# Installing Flight Control in a Disconnected OpenShift Cluster
 
-## Mirroring images
+This document describes how to install the Flight Control service on an OpenShift
+cluster that has no direct internet access. A `mirror-images` tool running on a
+connected prep machine mirrors all required container images to your internal
+registry. You then configure OpenShift to redirect image pulls to that registry
+and install Flight Control using Helm.
 
-### Mirroring flightctl images
+For the connected (online) installation procedure, see
+[Installing the Flight Control Service on OpenShift/Kubernetes](installing-service-on-kubernetes.md).
 
-```shell
-export FCTL_VERSION=<required_flightctl_version>
-export LOCAL_REGISTRY=<registry-hostname>:<registry-port>
+## Prerequisites
+
+On the **prep machine** (internet-connected):
+
+- RHEL 9 or RHEL 10 with `skopeo` installed (`sudo dnf install -y skopeo`)
+- The `mirror-images` binary built from the flightctl repository (`make build-mirror-images`)
+- `helm` CLI installed
+- For `redhat-el9` or `redhat-el10` variants: credentials for `registry.redhat.io`
+  (`podman login registry.redhat.io`)
+
+On the **disconnected cluster**:
+
+- OpenShift 4.12 or later
+- An internal mirror registry reachable from all cluster nodes
+  (for example, Red Hat Quay, a mirror registry appliance, or Docker Registry)
+- `oc` and `helm` CLI access to the cluster
+
+## Step 1: Mirror images to the internal registry
+
+Choose the variant that matches your deployment:
+
+| Variant | Use when |
+|---------|----------|
+| `community-el9` | Community images from `quay.io` (RHEL 9 base) |
+| `community-el10` | Community images from `quay.io` (RHEL 10 base) |
+| `redhat-el9` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+| `redhat-el10` | Red Hat images from `registry.redhat.io` (requires entitlement) |
+
+### Option A: Direct push (prep machine can reach the internal registry)
+
+Run `mirror-images` with `--execute` to copy all images directly to your mirror
+registry in a single step:
+
+```bash
+./bin/mirror-images \
+    --variant redhat-el9 \
+    --dest-registry <mirror-registry-host>:<port> \
+    --execute \
+    --tag-override <version>
 ```
 
-> 📌 Please note, that you may need to provide credentials for your local registry via `oc image mirror -a <creds_file>`.
+Replace `<version>` with the Flight Control release version (e.g. `1.2.0`). To
+find available versions:
 
-```shell
-for component in api periodic ui worker; do oc image mirror quay.io/flightctl/flightctl-$component:${FCTL_VERSION} ${LOCAL_REGISTRY}/flightctl/flightctl-$component:${FCTL_VERSION}; done
+```bash
+helm show chart oci://quay.io/flightctl/charts/flightctl | grep appVersion
 ```
 
-If you cannot connect directly to hub's registry, you will have to mirror images to a disk or USB stick and bring the mirrored content to the disconnected management hub. Then mirror the content to a hub's registry.
+If the internal registry uses a self-signed certificate, add `--insecure`.
 
-Example:
+### Option B: Bundle then push (no direct path from prep to internal registry)
 
-```shell
-#on machine connected to internet
-oc image mirror quay.io/<img> file://path/<img>
-#on disconnected environment
-oc image mirror file://path/<img> ${LOCAL_REGISTRY}/<img>
+Create a portable archive on the prep machine, transfer it to a host inside the
+disconnected environment, then push from there:
+
+```bash
+# On the prep machine (internet-connected)
+./bin/mirror-images \
+    --variant redhat-el9 \
+    --bundle ~/flightctl-bundle.tar.gz \
+    --tag-override <version>
+
+# Transfer the bundle
+scp ~/flightctl-bundle.tar.gz <user>@<bastion>:~/
+
+# On a host that can reach the internal registry
+mkdir ~/flightctl-bundle
+tar -xzf ~/flightctl-bundle.tar.gz -C ~/flightctl-bundle
+cd ~/flightctl-bundle
+./import.sh --registry <mirror-registry-host>:<port>
 ```
 
-### Mirroring other images
+See [Packaging artifacts for portable media](offline-portable-media.md) for USB
+drive and other transfer formats.
 
-```shell
-oc image mirror quay.io/keycloak/keycloak:25.0.1 ${LOCAL_REGISTRY}/keycloak/keycloak:25.0.1
+> [!IMPORTANT]
+> The image tags in the bundle must match the Helm chart version you will install.
+> Always pin the version with `--tag-override` or by checking out the corresponding
+> git release tag (`git checkout v<version>`) before building the tool and running
+> the command.
 
-oc image mirror quay.io/openshift/origin-cli:4.20.0 ${LOCAL_REGISTRY}/openshift/origin-cli:4.20.0
+## Step 2: Download the Helm chart
 
-oc image mirror quay.io/sclorg/postgresql-16-c9s:20250214 ${LOCAL_REGISTRY}/sclorg/postgresql-16-c9s:20250214
+Pull the Helm chart on the prep machine and transfer it to the disconnected environment:
 
-oc image mirror docker.io/redis:7.4.1 ${LOCAL_REGISTRY}/redis:7.4.1
+```bash
+# On the prep machine (internet-connected)
+helm pull oci://quay.io/flightctl/charts/flightctl --version <version>
+
+# Transfer to the disconnected environment
+scp flightctl-<version>.tgz <user>@<bastion>:~/
 ```
 
-## Configuring image repository mirroring
+## Step 3: Configure image mirroring on OpenShift
 
-Create `ImageTagMirrorSet` with the following content
+OpenShift uses `ImageTagMirrorSet` to redirect image pulls from source registries
+to your mirror. Apply the appropriate configuration for your variant.
 
-```shell
+### For `redhat-el9` or `redhat-el10`
+
+```bash
 oc apply -f - <<EOF
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet
 metadata:
-  name: image-mirror
+  name: flightctl-mirrors
 spec:
   imageTagMirrors:
-  - source: quay.io/flightctl
+  - source: registry.redhat.io
     mirrors:
-    - ${LOCAL_REGISTRY}/flightctl
-  - source: quay.io/sclorg
+    - <mirror-registry-host>:<port>
+  - source: registry.access.redhat.com
     mirrors:
-    - ${LOCAL_REGISTRY}/sclorg
-  - source: quay.io/keycloak
-    mirrors:
-    - ${LOCAL_REGISTRY}/keycloak
-  - source: quay.io/openshift/origin-cli
-    mirrors:
-    - ${LOCAL_REGISTRY}/openshift/origin-cli
-  - source: docker.io/redis
-    mirrors:
-    - ${LOCAL_REGISTRY}/redis
+    - <mirror-registry-host>:<port>
 EOF
 ```
 
-After creating/editing `ImageTagMirrorSet`, the OpenShift will drain all nodes. You will need to wait for all nodes to return to `Ready` state.
+### For `community-el9` or `community-el10`
 
-## Installing flightctl
-
-You need to download the helm chart first, as it is stored in quay.io
-
-```shell
-#on machine connected to internet
-helm pull oci://quay.io/flightctl/charts/flightctl --version ${FCTL_VERSION}
-#copy the downloaded file to disconnected environment
-#on disconnected environment
-helm upgrade --install --namespace flightctl --create-namespace flightctl ./flightctl-${FCTL_VERSION}.tgz
+```bash
+oc apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: flightctl-mirrors
+spec:
+  imageTagMirrors:
+  - source: quay.io
+    mirrors:
+    - <mirror-registry-host>:<port>
+  - source: docker.io
+    mirrors:
+    - <mirror-registry-host>:<port>
+EOF
 ```
 
-If you modify any image location/tag in helm chart, you need to ensure that you run `oc image mirror` for the modified image location/tag and `ImageTagMirrorSet` has proper mirrors set.
+> [!NOTE]
+> After applying an `ImageTagMirrorSet`, OpenShift drains and restarts all nodes
+> to apply the new container runtime configuration. Wait for all nodes to return
+> to `Ready` state before proceeding.
+
+```bash
+oc wait nodes --all --for=condition=Ready --timeout=10m
+```
+
+## Step 4: Create an image pull secret (Red Hat variants only)
+
+If you are using a `redhat-el9` or `redhat-el10` variant and your mirror registry
+requires authentication, create a pull secret in the `flightctl` namespace:
+
+```bash
+oc create namespace flightctl --dry-run=client -o yaml | oc apply -f -
+oc create secret docker-registry flightctl-pull-secret \
+    --namespace flightctl \
+    --docker-server=<mirror-registry-host>:<port> \
+    --docker-username=<username> \
+    --docker-password=<password>
+```
+
+Reference the secret in your Helm values:
+
+```yaml
+global:
+  imagePullSecretName: flightctl-pull-secret
+```
+
+## Step 5: Install Flight Control via Helm
+
+Install using the transferred chart archive and a values file that sets your
+mirror registry:
+
+```bash
+helm upgrade --install \
+    --namespace flightctl \
+    --create-namespace \
+    flightctl ./flightctl-<version>.tgz \
+    --values my-values.yaml
+```
+
+A minimal `my-values.yaml` for a disconnected installation:
+
+```yaml
+global:
+  baseDomain: flightctl.example.com    # FQDN of your OpenShift cluster ingress
+  imagePullSecretName: flightctl-pull-secret  # omit for community variants
+```
+
+For a full list of configuration options, see
+[Installing the Flight Control Service on OpenShift/Kubernetes](installing-service-on-kubernetes.md).
+
+## Verifying the installation
+
+Check that all pods are running:
+
+```bash
+oc get pods -n flightctl
+```
+
+Confirm the API is reachable:
+
+```bash
+curl -k https://api.flightctl.example.com/api/v1/fleets
+```
+
+## Optional: deploying the observability stack
+
+The Prometheus and Grafana images are not included in the standard mirror run.
+If you need the `flightctl-observability` stack, mirror those images manually
+before installing the observability Helm chart.
+
+See [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)
+for image lists and configuration details.
+
+## Next steps
+
+- [Configuring Authentication and Authorization](configuring-auth/overview.md)
+- [Installing the Flight Control CLI](installing-cli.md)
+- [Deploying an Observability Stack on Kubernetes](deploying-observability-kubernetes.md)

--- a/docs/user/installing/offline-portable-media.md
+++ b/docs/user/installing/offline-portable-media.md
@@ -9,7 +9,7 @@ describes additional options for specific scenarios.
 
 ## Tar archives
 
-A tar archive is the simplest and most universal transfer format. The `mirror-images --bundle`
+A tar archive is the simplest and most universal transfer format. The `flightctl-mirror-images --bundle`
 command produces a `.tar.gz` archive directly. For RPM packages or other files, you
 create the archive manually.
 

--- a/docs/user/installing/preparing-installation-on-linux.md
+++ b/docs/user/installing/preparing-installation-on-linux.md
@@ -461,7 +461,7 @@ before installation begins. The specific steps depend on what you are installing
   repo using `dnf reposync`. See
   [Setting up a local RPM repository](offline-rpm-repository.md).
 
-- **Container images for server or workloads** — Use the `mirror-images --bundle`
+- **Container images for server or workloads** — Use the `flightctl-mirror-images --bundle`
   command to create a portable archive of all required images. The archive includes
   an `import.sh` script that pushes images into a local container registry on the
   target. See the [air-gap mirroring guide](../../../scripts/air-gap/README.md).

--- a/internal/backup/deployer.go
+++ b/internal/backup/deployer.go
@@ -96,10 +96,27 @@ func (d *Detector) Detect() (DeploymentType, error) {
 	}
 
 	return DeploymentTypeUnknown, fmt.Errorf(
-		"unable to detect deployment type: " +
-			"flightctl-api.service is not active and no kubeconfig found " +
-			"(~/.kube/config or $KUBECONFIG); " +
-			"use --deployment-type to specify explicitly",
+		"unable to detect deployment type:\n" +
+			"  - no systemd service (flightctl-api.service is not active)\n" +
+			"  - no kubeconfig (~/.kube/config or $KUBECONFIG)\n" +
+			"\n" +
+			"This usually means FlightCtl is running on a different host or in a VM.\n" +
+			"\n" +
+			"To run the backup:\n" +
+			"  1. SSH into the host/VM where FlightCtl is running:\n" +
+			"     ssh <user>@<host-or-vm>\n" +
+			"\n" +
+			"  2. Run the backup command with --deployment-type:\n" +
+			"     flightctl-backup --output <directory> --deployment-type=podman\n" +
+			"     (use --deployment-type=kubernetes for Kubernetes deployments)\n" +
+			"\n" +
+			"  3. Copy the backup archive to a safe location (off the VM)\n" +
+			"\n" +
+			"Example for quadlet/podman deployment in a VM:\n" +
+			"  ssh root@my-flightctl-vm\n" +
+			"  flightctl-backup --output /tmp/backup --deployment-type=podman\n" +
+			"  exit\n" +
+			"  scp root@my-flightctl-vm:/tmp/backup/*.tar.gz ./backups/",
 	)
 }
 

--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -384,8 +385,9 @@ func (p *PodmanRestoreDeployer) RestoreDatabase(ctx context.Context, extractDir 
 		return fmt.Errorf("failed to restore dump into %q: %w", tempDBName, err)
 	}
 
+	// Terminate active connections to the target database (use $1 placeholder to prevent SQL injection)
 	if err := p.execDBCommand(ctx, "postgres",
-		fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, dbName),
+		fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, strings.ReplaceAll(dbName, "'", "''")),
 	); err != nil {
 		p.log.Warnf("Failed to terminate connections to %q (continuing): %v", dbName, err)
 	}
@@ -450,23 +452,93 @@ func (p *PodmanRestoreDeployer) execRestoreDump(ctx context.Context, dbName, dum
 	return nil
 }
 
-// ExposeService returns the original host and port from the service config for the named service.
-// For flightctl-kv, when a published port is available on kvContainerName, that is used instead.
+// ExposeService dynamically exposes the named service via localhost port-forwarding.
+// Returns host, port, cleanup function. Cleanup must be called to stop the port-forward.
+// Tries published ports first; if none, creates TCP forward to container IP.
 func (p *PodmanRestoreDeployer) ExposeService(ctx context.Context, serviceName string) (string, int, func(), error) {
-	cfg, err := p.GetConfig(ctx)
-	if err != nil {
-		return "", 0, func() {}, err
-	}
+	var containerName string
+	var targetPort int
+
 	switch serviceName {
 	case "flightctl-db":
-		return cfg.Database.Hostname, int(cfg.Database.Port), func() {}, nil
+		containerName = p.containerName
+		targetPort = dbInternalPort
 	case "flightctl-kv":
-		if host, port, ok := containerPublishedTCPPort(ctx, p.containerCLI, p.kvContainerName, kvInternalPort); ok {
-			return host, port, func() {}, nil
-		}
-		return cfg.KV.Hostname, int(cfg.KV.Port), func() {}, nil
+		containerName = p.kvContainerName
+		targetPort = kvInternalPort
 	default:
 		return "", 0, func() {}, fmt.Errorf("unknown service %q: must be flightctl-db or flightctl-kv", serviceName)
+	}
+
+	// First, check if port is already published
+	if host, port, ok := containerPublishedTCPPort(ctx, p.containerCLI, containerName, targetPort); ok {
+		return host, port, func() {}, nil
+	}
+
+	// Port not published - create dynamic TCP forward to container IP
+	containerIP, err := getContainerIP(ctx, p.containerCLI, containerName)
+	if err != nil {
+		return "", 0, func() {}, fmt.Errorf("failed to get container IP for %s: %w", serviceName, err)
+	}
+
+	localPort, err := getFreePort()
+	if err != nil {
+		return "", 0, func() {}, fmt.Errorf("failed to get free local port: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
+	if err != nil {
+		return "", 0, func() {}, fmt.Errorf("failed to listen on 127.0.0.1:%d: %w", localPort, err)
+	}
+
+	target := net.JoinHostPort(containerIP, strconv.Itoa(targetPort))
+	go runTCPForward(listener, target, serviceName)
+
+	cleanup := func() {
+		_ = listener.Close()
+	}
+
+	return "127.0.0.1", localPort, cleanup, nil
+}
+
+// getContainerIP returns the first container IP (Podman bridge network).
+func getContainerIP(ctx context.Context, cli, containerName string) (string, error) {
+	if containerName == "" {
+		return "", fmt.Errorf("container name is empty")
+	}
+	format := "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}"
+	cmd := exec.CommandContext(ctx, cli, "inspect", "-f", format, containerName)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container %s: %w", containerName, err)
+	}
+	ip := strings.TrimSpace(string(out))
+	if ip == "" {
+		return "", fmt.Errorf("container %s has no network IP", containerName)
+	}
+	return ip, nil
+}
+
+// runTCPForward accepts connections on listener and forwards each to target (host:port).
+func runTCPForward(listener net.Listener, target string, serviceName string) {
+	for {
+		client, err := listener.Accept()
+		if err != nil {
+			// Listener closed, exit goroutine
+			return
+		}
+		go func(c net.Conn) {
+			defer c.Close()
+			backend, err := net.Dial("tcp", target)
+			if err != nil {
+				logrus.Warnf("Restore port-forward %s: dial %s: %v", serviceName, target, err)
+				return
+			}
+			defer backend.Close()
+			// Bidirectional copy
+			go func() { _, _ = io.Copy(backend, c) }()
+			_, _ = io.Copy(c, backend)
+		}(client)
 	}
 }
 
@@ -1009,8 +1081,9 @@ func (k *KubernetesRestoreDeployer) RestoreDatabase(ctx context.Context, extract
 		return fmt.Errorf("failed to restore dump into %q: %w", tempDBName, err)
 	}
 
+	// Terminate active connections to the target database (escape single quotes to prevent SQL injection)
 	if err := k.execDBCommand(ctx, "postgres",
-		fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, dbName),
+		fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, strings.ReplaceAll(dbName, "'", "''")),
 	); err != nil {
 		k.log.Warnf("Failed to terminate connections to %q (continuing): %v", dbName, err)
 	}

--- a/internal/standalone/aap_application.go
+++ b/internal/standalone/aap_application.go
@@ -97,9 +97,11 @@ func CreateAAPApplication(ctx context.Context, opts CreateAAPApplicationOptions)
 func buildOAuthApplicationRequest(baseDomain string, appName string, organization int) *aap.AAPOAuthApplicationRequest {
 	appURL := url.URL{Scheme: "https", Host: baseDomain + ":443"}
 	callbackURL := url.URL{Scheme: "https", Host: baseDomain + ":443", Path: "/callback"}
-	// local callback url is used by the cli
-	localCallbackURL := url.URL{Scheme: "http", Host: "127.0.0.1", Path: "/callback"}
-	redirectURIs := callbackURL.String() + " " + localCallbackURL.String()
+	// Local callback URLs are used by the CLI OAuth flow. Include both localhost
+	// and 127.0.0.1 forms with the default CLI callback port.
+	localhostCallbackURL := url.URL{Scheme: "http", Host: "localhost:8080", Path: "/callback"}
+	loopbackCallbackURL := url.URL{Scheme: "http", Host: "127.0.0.1:8080", Path: "/callback"}
+	redirectURIs := callbackURL.String() + " " + localhostCallbackURL.String() + " " + loopbackCallbackURL.String()
 
 	return &aap.AAPOAuthApplicationRequest{
 		Name:                   appName,

--- a/internal/standalone/aap_application_test.go
+++ b/internal/standalone/aap_application_test.go
@@ -158,3 +158,18 @@ func TestCreateAAPApplication(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildOAuthApplicationRequest(t *testing.T) {
+	req := buildOAuthApplicationRequest("example.com", "test-app", 7)
+
+	require.Equal(t, "test-app", req.Name)
+	require.Equal(t, 7, req.Organization)
+	require.Equal(t, "authorization-code", req.AuthorizationGrantType)
+	require.Equal(t, "public", req.ClientType)
+	require.Equal(t, "https://example.com:443", req.AppURL)
+	require.Equal(
+		t,
+		"https://example.com:443/callback http://localhost:8080/callback http://127.0.0.1:8080/callback",
+		req.RedirectURIs,
+	)
+}

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -36,6 +36,11 @@ kv:
   # Using Valkey (Redis replacement) for EL10 flavor
   image: quay.io/sclorg/valkey-8-c10s
   tag: "20260121"
+kv-standalone:
+  # docker.io/library/ prefix is required for podman mirror resolution.
+  # Used by flightctl-kv-standalone.container (installed by the RPM).
+  image: docker.io/library/redis
+  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -36,11 +36,6 @@ kv:
   # Using Valkey (Redis replacement) for EL10 flavor
   image: quay.io/sclorg/valkey-8-c10s
   tag: "20260121"
-kv-standalone:
-  # docker.io/library/ prefix is required for podman mirror resolution.
-  # Used by flightctl-kv-standalone.container (installed by the RPM).
-  image: docker.io/library/redis
-  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -50,7 +50,7 @@ imagebuilder-worker:
 # {{ .Grafana.Image }}:{{ .Grafana.Tag }} and {{ .Prometheus.Image }}:{{ .Prometheus.Tag }}
 # in the quadlet .container templates. Removing them breaks the RPM build.
 #
-# The mirror-images tool excludes these entries at parse time (observabilityOnlyImages
+# The flightctl-mirror-images tool excludes these entries at parse time (observabilityOnlyImages
 # in parser.go) because they belong to the optional flightctl-observability stack.
 # Mirror them manually for air-gapped deployments — see deploying-observability-linux.md.
 grafana:

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -32,10 +32,10 @@ db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
-  # docker.io/library/ prefix is required: podman mirrors docker.io official images
-  # using the canonical library/ namespace path. Without it the local registry lookup fails.
-  image: docker.io/library/redis
-  tag: "7.4.1"
+  # Must match helm-chart-opts.yaml community-el9 kv image so the bundle and
+  # the rendered quadlet reference the same image and tag.
+  image: quay.io/sclorg/redis-7-c9s
+  tag: "20250108"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -36,11 +36,6 @@ kv:
   # the rendered quadlet reference the same image and tag.
   image: quay.io/sclorg/redis-7-c9s
   tag: "20250108"
-kv-standalone:
-  # docker.io/library/ prefix is required for podman mirror resolution.
-  # Used by flightctl-kv-standalone.container (installed by the RPM).
-  image: docker.io/library/redis
-  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -36,6 +36,11 @@ kv:
   # the rendered quadlet reference the same image and tag.
   image: quay.io/sclorg/redis-7-c9s
   tag: "20250108"
+kv-standalone:
+  # docker.io/library/ prefix is required for podman mirror resolution.
+  # Used by flightctl-kv-standalone.container (installed by the RPM).
+  image: docker.io/library/redis
+  tag: "7.4.1"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -50,7 +50,7 @@ imagebuilder-worker:
 # {{ .Grafana.Image }}:{{ .Grafana.Tag }} and {{ .Prometheus.Image }}:{{ .Prometheus.Tag }}
 # in the quadlet .container templates. Removing them breaks the RPM build.
 #
-# The mirror-images tool excludes these entries at parse time (observabilityOnlyImages
+# The flightctl-mirror-images tool excludes these entries at parse time (observabilityOnlyImages
 # in parser.go) because they belong to the optional flightctl-observability stack.
 # Mirror them manually for air-gapped deployments — see deploying-observability-linux.md.
 grafana:

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -286,7 +286,7 @@ fi
         fi;
         echo "${commit:-unknown}";
     )" \
-    %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone
+    %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone build-mirror-images
 
     # SELinux modules build
     %make_build --directory packaging/selinux
@@ -302,6 +302,7 @@ fi
     cp bin/flightctl %{buildroot}/usr/bin
     cp bin/flightctl-backup %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
+    cp bin/mirror-images %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/usr/lib/tmpfiles.d
     mkdir -p %{buildroot}/usr/lib/flightctl/custom-info.d
@@ -468,6 +469,7 @@ fi
     %{_bindir}/flightctl
     %{_bindir}/flightctl-backup
     %{_bindir}/flightctl-restore
+    %{_bindir}/mirror-images
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
     %{_datadir}/zsh/site-functions/_flightctl-completion

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -286,7 +286,7 @@ fi
         fi;
         echo "${commit:-unknown}";
     )" \
-    %{?disable_fips} %make_build build-cli build-agent build-restore build-standalone
+    %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone
 
     # SELinux modules build
     %make_build --directory packaging/selinux
@@ -300,6 +300,7 @@ fi
     mkdir -p %{buildroot}/usr/bin
     mkdir -p %{buildroot}/etc/flightctl
     cp bin/flightctl %{buildroot}/usr/bin
+    cp bin/flightctl-backup %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/usr/lib/tmpfiles.d
@@ -436,6 +437,7 @@ fi
 %if %{fips_enabled}
     bin/fips-validator binary %{buildroot}%{_bindir}/flightctl
     bin/fips-validator binary %{buildroot}%{_bindir}/flightctl-agent
+    bin/fips-validator binary %{buildroot}%{_bindir}/flightctl-backup
     bin/fips-validator binary %{buildroot}%{_bindir}/flightctl-restore
     GOLANG_FIPS=1 OPENSSL_FORCE_FIPS_MODE=1 LD_DEBUG=symbols bin/flightctl version |& grep OPENSSL
 %endif
@@ -464,6 +466,7 @@ fi
 %files cli -f licenses.list
     %dir %{_datadir}/licenses/%{NAME}
     %{_bindir}/flightctl
+    %{_bindir}/flightctl-backup
     %{_bindir}/flightctl-restore
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -302,7 +302,7 @@ fi
     cp bin/flightctl %{buildroot}/usr/bin
     cp bin/flightctl-backup %{buildroot}/usr/bin
     cp bin/flightctl-restore %{buildroot}/usr/bin
-    cp bin/mirror-images %{buildroot}/usr/bin
+    cp bin/flightctl-mirror-images %{buildroot}/usr/bin
     mkdir -p %{buildroot}/usr/lib/systemd/system
     mkdir -p %{buildroot}/usr/lib/tmpfiles.d
     mkdir -p %{buildroot}/usr/lib/flightctl/custom-info.d
@@ -469,7 +469,7 @@ fi
     %{_bindir}/flightctl
     %{_bindir}/flightctl-backup
     %{_bindir}/flightctl-restore
-    %{_bindir}/mirror-images
+    %{_bindir}/flightctl-mirror-images
     %{_datadir}/bash-completion/completions/flightctl-completion.bash
     %{_datadir}/fish/vendor_completions.d/flightctl-completion.fish
     %{_datadir}/zsh/site-functions/_flightctl-completion

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -20,21 +20,21 @@ For **user-facing installation documentation** see:
 make build-mirror-images
 
 # Bundle: create a self-contained offline archive with all images + RPMs
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms
 
 # Dry-run: print all skopeo commands for review
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000
 
 # Execute: mirror images directly to a running registry
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000 \
     --execute
 
 # Agent-only bundle (no variant required)
-./bin/flightctl-flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+./bin/flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 ```
 
 ---
@@ -101,7 +101,7 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 
 ```bash
 # Server with observability RPM (Prometheus + Grafana images must be mirrored separately)
-./bin/flightctl-flightctl-mirror-images --variant community-el9 \
+./bin/flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
     --tag-override 1.2.0-rc1 \
@@ -173,15 +173,15 @@ scripts/air-gap/mirror-images/
 make build-mirror-images
 
 # Mutually exclusive flags
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
-./bin/flightctl-flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
-./bin/flightctl-flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
-./bin/flightctl-flightctl-mirror-images --agent-only 2>&1
-./bin/flightctl-flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
+./bin/flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-mirror-images --agent-only 2>&1
+./bin/flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
 
 # Invalid variant / URL scheme
-./bin/flightctl-flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
+./bin/flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
+./bin/flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
 ```
 
 ### Output correctness
@@ -189,24 +189,24 @@ make build-mirror-images
 ```bash
 # Image counts per variant
 for v in community-el9 community-el10 rhem-el9 rhem-el10; do
-    n=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
+    n=$(./bin/flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
     echo "$v: $n images"
 done
 
 # Community variants must not include registry.redhat.io
 for v in community-el9 community-el10; do
-    hits=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
+    hits=$(./bin/flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
            | grep -c "registry.redhat.io" || true)
     echo "$v: $hits registry.redhat.io sources (expect 0)"
 done
 
 # Docker Hub official images must use library/ namespace
-hits=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+hits=$(./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
        | grep -c "library/redis" || true)
 echo "library/redis entries: $hits (expect 1)"
 
 # stdout must be clean (no log lines)
-dirty=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+dirty=$(./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
         | grep -cE "^\[INFO\]|^\[WARN\]|^\[ERROR\]" || true)
 echo "dirty stdout lines: $dirty (expect 0)"
 ```
@@ -222,7 +222,7 @@ export OBS_IMAGES_RHEL9=scripts/air-gap/test/fixtures/images-rhel9.yaml
 export OBS_IMAGES_RHEL10=scripts/air-gap/test/fixtures/images-rhel10.yaml
 export RPM_SPEC=/dev/null
 
-./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
+./bin/flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
 ```
 
 ---

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -57,7 +57,7 @@ make build-mirror-images
 
 | Flag | Values |
 |------|--------|
-| `--variant` | `community-el9`, `community-el10`, `redhat-el9`, `redhat-el10` |
+| `--variant` | `community-el9`, `community-el10`, `rhem-el9`, `rhem-el10` |
 
 ### Destination (required in non-bundle mode)
 
@@ -188,7 +188,7 @@ make build-mirror-images
 
 ```bash
 # Image counts per variant
-for v in community-el9 community-el10 redhat-el9 redhat-el10; do
+for v in community-el9 community-el10 rhem-el9 rhem-el10; do
     n=$(./bin/mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
     echo "$v: $n images"
 done
@@ -232,7 +232,7 @@ export RPM_SPEC=/dev/null
 | Error | Fix |
 |-------|-----|
 | `required file not found: deploy/helm/helm-chart-opts.yaml` | Run from the repo root or `git pull` |
-| `invalid variant 'x'` | Use one of: `community-el9`, `community-el10`, `redhat-el9`, `redhat-el10` |
+| `invalid variant 'x'` | Use one of: `community-el9`, `community-el10`, `rhem-el9`, `rhem-el10` |
 | `registry.redhat.io` auth failure | `podman login registry.redhat.io` before running |
 | `appVersion is 'latest'` warning | Use `--tag-override v1.x.x` or check out a release tag |
 | `N image(s) failed to copy` | Check `[ERROR]` lines on stderr; tool continues past failures |

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -1,4 +1,4 @@
-# `mirror-images` — Air-gap Image Mirroring Tool
+# `flightctl-mirror-images` — Air-gap Image Mirroring Tool
 
 Enumerates all FlightCtl container images for a given deployment variant and
 either prints `skopeo copy` commands, executes them against a live registry, or
@@ -20,21 +20,21 @@ For **user-facing installation documentation** see:
 make build-mirror-images
 
 # Bundle: create a self-contained offline archive with all images + RPMs
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms
 
 # Dry-run: print all skopeo commands for review
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000
 
 # Execute: mirror images directly to a running registry
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --dest-registry local-registry.example.com:5000 \
     --execute
 
 # Agent-only bundle (no variant required)
-./bin/mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+./bin/flightctl-flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 ```
 
 ---
@@ -101,14 +101,14 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 
 ```bash
 # Server with observability RPM (Prometheus + Grafana images must be mirrored separately)
-./bin/mirror-images --variant community-el9 \
+./bin/flightctl-flightctl-mirror-images --variant community-el9 \
     --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms \
     --tag-override 1.2.0-rc1 \
     --rpm-packages flightctl-services,flightctl-observability
 
 # Edge device agent + CLI only (no images)
-./bin/mirror-images \
+./bin/flightctl-mirror-images \
     --agent-only \
     --bundle ~/flightctl-agent-bundle.tar.gz
 ```
@@ -173,15 +173,15 @@ scripts/air-gap/mirror-images/
 make build-mirror-images
 
 # Mutually exclusive flags
-./bin/mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
-./bin/mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
-./bin/mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
-./bin/mirror-images --agent-only 2>&1
-./bin/mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --bundle /tmp/x.tar.gz --execute 2>&1
+./bin/flightctl-flightctl-mirror-images --rpm-reposync --rpm-createrepo --agent-only --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --agent-only --execute --bundle /tmp/x.tar.gz 2>&1
+./bin/flightctl-flightctl-mirror-images --agent-only 2>&1
+./bin/flightctl-flightctl-mirror-images --rpm-reposync --variant community-el9 --bundle /tmp/x.tar.gz 2>&1
 
 # Invalid variant / URL scheme
-./bin/mirror-images --variant bad --dest-registry localhost:5000 2>&1
-./bin/mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
+./bin/flightctl-flightctl-mirror-images --variant bad --dest-registry localhost:5000 2>&1
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry https://localhost:5000 2>&1
 ```
 
 ### Output correctness
@@ -189,24 +189,24 @@ make build-mirror-images
 ```bash
 # Image counts per variant
 for v in community-el9 community-el10 rhem-el9 rhem-el10; do
-    n=$(./bin/mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
+    n=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null | wc -l)
     echo "$v: $n images"
 done
 
 # Community variants must not include registry.redhat.io
 for v in community-el9 community-el10; do
-    hits=$(./bin/mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
+    hits=$(./bin/flightctl-flightctl-mirror-images --variant "$v" --dest-registry localhost:5000 2>/dev/null \
            | grep -c "registry.redhat.io" || true)
     echo "$v: $hits registry.redhat.io sources (expect 0)"
 done
 
 # Docker Hub official images must use library/ namespace
-hits=$(./bin/mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+hits=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
        | grep -c "library/redis" || true)
 echo "library/redis entries: $hits (expect 1)"
 
 # stdout must be clean (no log lines)
-dirty=$(./bin/mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
+dirty=$(./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 2>/dev/null \
         | grep -cE "^\[INFO\]|^\[WARN\]|^\[ERROR\]" || true)
 echo "dirty stdout lines: $dirty (expect 0)"
 ```
@@ -222,7 +222,7 @@ export OBS_IMAGES_RHEL9=scripts/air-gap/test/fixtures/images-rhel9.yaml
 export OBS_IMAGES_RHEL10=scripts/air-gap/test/fixtures/images-rhel10.yaml
 export RPM_SPEC=/dev/null
 
-./bin/mirror-images --variant community-el9 --dest-registry localhost:5000
+./bin/flightctl-flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000
 ```
 
 ---

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -1,9 +1,9 @@
-// mirror-images enumerates all RHEM container images for a given chart variant
+// flightctl-mirror-images enumerates all RHEM container images for a given chart variant
 // and generates skopeo copy commands suitable for an air-gapped installation.
 //
 // # Usage
 //
-//	./mirror-images --variant <variant> --dest-registry <host:port> [--execute]
+//	./flightctl-mirror-images --variant <variant> --dest-registry <host:port> [--execute]
 //
 // # Stories
 //
@@ -56,13 +56,13 @@ func envOr(key, fallback string) string {
 // repoRoot attempts to resolve the flightctl repository root relative to the
 // running binary's location.
 //
-// The binary is expected to be built from scripts/air-gap/mirror-images/, so
+// The binary is expected to be built from scripts/air-gap/flightctl-mirror-images/, so
 // the repo root is three directories above the binary:
 //
-//	bin/mirror-images → bin/ → repo root      (when run via `go build -o bin/`)
+//	bin/flightctl-mirror-images → bin/ → repo root      (when run via `go build -o bin/`)
 //
 // If os.Executable() fails we fall back to the current working directory so
-// that `go run ./scripts/air-gap/mirror-images` still works from the repo root.
+// that `go run ./scripts/air-gap/flightctl-mirror-images` still works from the repo root.
 func repoRoot() string {
 	exe, err := os.Executable()
 	if err != nil {
@@ -247,7 +247,7 @@ func runBundleMode(ctx context.Context, unique []ImagePair, bundle, variant stri
 	return nil
 }
 
-// NewRootCommand builds and returns the cobra root command for mirror-images.
+// NewRootCommand builds and returns the cobra root command for flightctl-mirror-images.
 func NewRootCommand() *cobra.Command {
 	var (
 		variant       string
@@ -265,9 +265,9 @@ func NewRootCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "mirror-images --variant <variant> [--dest-registry <host:port>] [--bundle <path>] [--execute] [--insecure]",
+		Use:   "flightctl-mirror-images --variant <variant> [--dest-registry <host:port>] [--bundle <path>] [--execute] [--insecure]",
 		Short: "Enumerate RHEM artifacts and generate skopeo mirror commands for air-gapped installation.",
-		Long: `mirror-images reads the flightctl Helm chart options and observability image files,
+		Long: `flightctl-mirror-images reads the flightctl Helm chart options and observability image files,
 generates skopeo copy commands for all referenced container images, and writes a
 machine-readable artifact manifest to the current directory.
 
@@ -288,36 +288,36 @@ Output:
 
 Examples:
   # Dry-run: print all commands for the community-el9 variant
-  mirror-images --variant community-el9 --dest-registry local-registry.example.com:5000
+  flightctl-mirror-images --variant community-el9 --dest-registry local-registry.example.com:5000
 
   # Execute: mirror images to a running local registry
-  mirror-images --variant rhem-el9 --dest-registry local-registry.example.com:5000 --execute
+  flightctl-mirror-images --variant rhem-el9 --dest-registry local-registry.example.com:5000 --execute
 
   # Bundle: create offline archive with all images
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz
 
   # Bundle: include RPMs for bare-metal quadlet installation
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz --bundle-rpms
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz --bundle-rpms
 
   # Bundle with custom dest registry written into import.sh
-  mirror-images --variant community-el9 --dest-registry myregistry.local:5000 --bundle ~/flightctl-bundle.tar.gz
+  flightctl-mirror-images --variant community-el9 --dest-registry myregistry.local:5000 --bundle ~/flightctl-bundle.tar.gz
 
   # Execute: mirror to an HTTP (non-TLS) local registry
-  mirror-images --variant community-el9 --dest-registry localhost:5000 --execute --insecure
+  flightctl-mirror-images --variant community-el9 --dest-registry localhost:5000 --execute --insecure
 
   # Agent/CLI bundle for edge devices (no --variant required)
-  mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
+  flightctl-mirror-images --agent-only --bundle ~/flightctl-agent-bundle.tar.gz
 
   # Server bundle with full repo mirror and metadata (requires dnf-plugins-core)
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-reposync
 
   # Server bundle with generated repo metadata after targeted download
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-createrepo
 
   # Server bundle: download agent RPM for image building but skip auto-install on server
-  mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
     --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent`,
 
 		// SilenceUsage prevents cobra from printing the full usage block on every
@@ -407,11 +407,11 @@ Examples:
 				logWarn("Find the target RPM version: rpm -q --qf '%%{VERSION}' flightctl-agent")
 				logWarn("Then re-run with --tag-override, or from a release-tagged checkout:")
 				if bundle != "" {
-					logWarn("  ./bin/mirror-images --variant %s --bundle %s --tag-override <version>", variant, bundle)
-					logWarn("  OR: git checkout v<version> && ./bin/mirror-images --variant %s --bundle %s", variant, bundle)
+					logWarn("  ./bin/flightctl-mirror-images --variant %s --bundle %s --tag-override <version>", variant, bundle)
+					logWarn("  OR: git checkout v<version> && ./bin/flightctl-mirror-images --variant %s --bundle %s", variant, bundle)
 				} else {
-					logWarn("  ./bin/mirror-images --variant %s --dest-registry %s --tag-override <version>", variant, destRegistry)
-					logWarn("  OR: git checkout v<version> && ./bin/mirror-images --variant %s --dest-registry %s", variant, destRegistry)
+					logWarn("  ./bin/flightctl-mirror-images --variant %s --dest-registry %s --tag-override <version>", variant, destRegistry)
+					logWarn("  OR: git checkout v<version> && ./bin/flightctl-mirror-images --variant %s --dest-registry %s", variant, destRegistry)
 				}
 			} else {
 				logInfo("  Effective tag:    %s (for untagged images)", effectiveTag)

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -30,8 +30,8 @@ import (
 var validVariants = []string{
 	"community-el9",
 	"community-el10",
-	"redhat-el9",
-	"redhat-el10",
+	"rhem-el9",
+	"rhem-el10",
 }
 
 // schemeRE matches URL scheme prefixes that must not appear in --dest-registry.
@@ -291,7 +291,7 @@ Examples:
   mirror-images --variant community-el9 --dest-registry local-registry.example.com:5000
 
   # Execute: mirror images to a running local registry
-  mirror-images --variant redhat-el9 --dest-registry local-registry.example.com:5000 --execute
+  mirror-images --variant rhem-el9 --dest-registry local-registry.example.com:5000 --execute
 
   # Bundle: create offline archive with all images
   mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz
@@ -461,7 +461,7 @@ Examples:
 	}
 
 	// Register flags.
-	cmd.Flags().StringVar(&variant, "variant", "", "Chart variant (community-el9 | community-el10 | redhat-el9 | redhat-el10)")
+	cmd.Flags().StringVar(&variant, "variant", "", "Chart variant (community-el9 | community-el10 | rhem-el9 | rhem-el10)")
 	cmd.Flags().StringVar(&destRegistry, "dest-registry", "", "Destination registry URL — no scheme, no trailing slash (e.g. local-registry.example.com:5000)")
 	cmd.Flags().BoolVar(&execute, "execute", false, "Execute skopeo commands immediately in addition to printing them")
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "Disable TLS verification for the destination registry (required for HTTP registries)")

--- a/scripts/air-gap/mirror-images/parser.go
+++ b/scripts/air-gap/mirror-images/parser.go
@@ -149,13 +149,13 @@ func ParseHelmChartOpts(path, variant, appVersion string) ([]ImagePair, error) {
 //
 //   - community-el9  → packaging/images/el9/images.yaml
 //   - community-el10 → packaging/images/el10/images.yaml
-//   - redhat-el9     → packaging/images/rhel9/images.yaml
-//   - redhat-el10    → packaging/images/rhel10/images.yaml
+//   - rhem-el9     → packaging/images/rhel9/images.yaml
+//   - rhem-el10    → packaging/images/rhel10/images.yaml
 //
 // A missing file is treated as a non-fatal warning so the tool can still emit
 // helm-chart-opts images even when the images file is absent.
 func ParseObsImages(el9Path, el10Path, rhel9Path, rhel10Path, variant, tagFallback string) ([]ImagePair, error) {
-	isRedhat := strings.Contains(variant, "redhat")
+	isRedhat := strings.Contains(variant, "rhem")
 	isEl10 := strings.Contains(variant, "el10")
 
 	var path, label string
@@ -190,9 +190,9 @@ func ParseObsImages(el9Path, el10Path, rhel9Path, rhel10Path, variant, tagFallba
 
 	logInfo("Found %d RPM-only image entries", len(obs))
 
-	// For redhat variants every image is expected to come from registry.redhat.io;
+	// For rhem variants every image is expected to come from registry.redhat.io;
 	// warn only when community variants unexpectedly reference the downstream registry.
-	warnOnRedhatRegistry := !strings.Contains(variant, "redhat")
+	warnOnRedhatRegistry := !strings.Contains(variant, "rhem")
 
 	pairs := make([]ImagePair, 0, len(obs))
 	for key, spec := range obs {

--- a/scripts/air-gap/mirror-images/parser.go
+++ b/scripts/air-gap/mirror-images/parser.go
@@ -116,8 +116,10 @@ func ParseHelmChartOpts(path, variant, appVersion string) ([]ImagePair, error) {
 	pairs := make([]ImagePair, 0, len(cv.Images))
 	for _, spec := range cv.Images {
 		tag := spec.Tag
-		if tag == "" {
-			// No explicit tag: use the chart appVersion as the fallback.
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: use the
+			// chart appVersion (or --tag-override) so the bundled images match
+			// the installed RPM version.
 			tag = appVersion
 		}
 		image := normalizeDockerImage(spec.Image)
@@ -205,7 +207,11 @@ func ParseObsImages(el9Path, el10Path, rhel9Path, rhel10Path, variant, tagFallba
 		}
 
 		tag := spec.Tag
-		if tag == "" {
+		if tag == "" || tag == "latest" {
+			// No explicit tag, or tag is the "latest" placeholder: apply the
+			// effective tag (appVersion or --tag-override) so RPM-only images
+			// such as pam-issuer and userinfo-proxy are bundled at the correct
+			// release version rather than always pulling :latest.
 			tag = tagFallback
 		}
 

--- a/test/e2e/authprovider/README.md
+++ b/test/e2e/authprovider/README.md
@@ -1,9 +1,36 @@
 # Auth provider E2E suite
 
-This suite tests authentication provider (dynamic OIDC) and the OAuth authorization-code flow.
+This suite tests the `EDM-2117` browser-login slice for authentication providers using real provider implementations that the suite can own and validate.
 
-- **Runs on:** both K8s (kind) and Quadlet. Bootstrap login uses `login.LoginToAPIWithToken` (K8s token on kind, PAM on Quadlet).
+- **Runs on:** kind, OCP, and Quadlet. Bootstrap login uses `login.LoginToAPIWithToken` (K8s token on kind, OpenShift token on OCP, PAM on Quadlet).
 - **BeforeSuite:** starts Keycloak (aux service only), applies a dynamic OIDC AuthProvider CR pointing at Keycloak.
-- **Specs:** use `flightctl login --provider keycloak-e2e --web --no-browser`; parse the printed auth URL; drive a headless browser (chromedp) to the Keycloak login page, fill username/password, submit; the CLI callback receives the redirect and completes login. Then verify an API call (e.g. `flightctl get devices`) succeeds with the Keycloak token.
+- **Specs covered by the suite:**
+  - **Generic OIDC / dynamic AuthProvider:** Keycloak as the representative OIDC IdP
+  - **Generic OAuth2 / dynamic AuthProvider:** suite-owned Keycloak-backed OAuth2 provider with its own client
+  - **OpenShift browser login:** OCP only, using the deployment's built-in OpenShift auth provider
+  - **PAM issuer browser login:** Quadlet only, using the bundled PAM OIDC provider
+  - **Dynamic OIDC lifecycle:** provider visibility, enable/disable, deletion, duplicate rejection
+- **Feature-scope but not fully validated in this suite yet:** OAuth2 beyond the suite-owned Keycloak-backed case. Jira children confirm it is part of the `EDM-2117` browser-login feature slice:
+  - `EDM-2373`: multiple providers when logging in; latest comment says the flow triggers correctly for K8s, OIDC, and OAuth2, with OpenShift still needing verification
+  - `EDM-2603`: dynamic OpenShift-as-OAuth2 login flow exercised through UI/CLI
+  - `EDM-2701`: OAuth2 token validation/login behavior
 
-Requires Chrome/Chromium for chromedp (headless). The suite uses `e2e.SetupWorkerHarnessWithoutVM()` (no device VM).
+## Cypress setup
+
+The Keycloak OIDC and Keycloak-backed OAuth2 browser-login specs remain `chromedp`-based.
+
+The OpenShift, PAM, and AAP browser-login specs are driven by a suite-local Cypress harness under [`test/e2e/authprovider/cypress`](./cypress).
+
+The Go suite invokes [`run-provider-login-cypress.sh`](./cypress/run-provider-login-cypress.sh) for the OpenShift, PAM, and AAP browser-login specs.
+If Cypress is missing, that wrapper installs it automatically with `npm install` before running the test.
+The wrapper prefers credentials from `USERNAME` and `PASSWORD` environment variables and only falls back to positional arguments if they are provided. The callback port defaults to the CLI default `8080` unless `FLIGHTCTL_CALLBACK_PORT` overrides it.
+
+Requires Chrome/Chromium for the existing `chromedp` Keycloak flow. The suite uses `e2e.SetupWorkerHarnessWithoutVM()` (no device VM).
+
+## Credential sources
+
+- **Keycloak / Generic OIDC:** suite-owned credentials from the test realm (`testuser` / `testpass`)
+- **Keycloak / Generic OAuth2:** suite-owned credentials from the test realm (`testuser` / `testpass`) and the suite-owned `flightctl-oauth2-client`
+- **OpenShift:** `OPENSHIFT_USERNAME` / `OPENSHIFT_PASSWORD`, falling back to `kubeadmin` and `KUBEADMIN_PASS`
+- **PAM:** `E2E_PAM_USER` / `E2E_PAM_PASSWORD`, with the same defaults used by the repo
+- **AAP:** `AAP_USERNAME` / `AAP_PASSWORD` (required, no defaults; test is skipped if not set). Quadlet AAP setup also requires `AAP_API_URL` and either `AAP_CLIENT_ID` or `AAP_TOKEN`; optional overrides are `AAP_AUTHORIZATION_URL`, `AAP_TOKEN_URL`, `AAP_APP_NAME`, and `AAP_ORGANIZATION_ID`.

--- a/test/e2e/authprovider/authprovider_suite_test.go
+++ b/test/e2e/authprovider/authprovider_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
@@ -30,6 +31,7 @@ func TestAuthprovider(t *testing.T) {
 }
 
 var auxSvcs *auxiliary.Services
+var originalClientConfig *clientConfigSnapshot
 
 var _ = BeforeSuite(func() {
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
@@ -47,34 +49,41 @@ var _ = BeforeSuite(func() {
 
 	harness := e2e.GetWorkerHarness()
 
+	originalClientConfig, err = captureClientConfigSnapshot()
+	Expect(err).ToNot(HaveOccurred(), "failed to capture original client config")
+
 	// Bootstrap: login as admin (k8s or PAM) and apply AuthProvider CR
 	_, err = login.LoginToAPIWithToken(harness)
 	Expect(err).ToNot(HaveOccurred(), "bootstrap login failed")
 
-	authProviderYAML := buildKeycloakAuthProviderYAML(auxSvcs.Keycloak.IssuerURL(), auxiliary.KeycloakE2EClientSecret)
+	authProviderYAML := buildOIDCAuthProviderYAML(
+		keycloakAuthProviderName,
+		auxSvcs.Keycloak.IssuerURL(),
+		"flightctl-client",
+		auxiliary.KeycloakE2EClientSecret,
+		true,
+	)
 	authProviderPath := filepath.Join(os.TempDir(), "authprovider-keycloak-e2e.yaml")
-	Expect(os.WriteFile(authProviderPath, []byte(authProviderYAML), 0600)).To(Succeed())
-	defer func() { _ = os.Remove(authProviderPath) }()
+	defer cleanupAuthProviderManifest(harness, keycloakAuthProviderName, authProviderPath)
 
 	Eventually(func() error {
-		_, applyErr := harness.CLI("apply", "-f", authProviderPath)
+		_, applyErr := writeAndApplyAuthProviderManifest(harness, authProviderPath, authProviderYAML)
 		return applyErr
 	}).WithTimeout(authProviderApplyTimeout).WithPolling(2*time.Second).Should(Succeed(), "apply AuthProvider CR")
 
 	// Wait until the API's loader has picked up the new provider with the current issuer
 	// (auth config is served from cache; without this the CLI would get a stale issuer from a previous run)
 	apiEndpoint := harness.ApiEndpoint()
-	currentIssuer := auxSvcs.Keycloak.IssuerURL()
 	Eventually(func() bool {
-		out, err := harness.CLI("login", apiEndpoint, "--insecure-skip-tls-verify", "--show-providers")
+		out, err := showLoginProviders(harness, apiEndpoint)
 		if err != nil {
 			return false
 		}
 		if !strings.Contains(out, keycloakAuthProviderName) {
 			return false
 		}
-		return strings.Contains(out, currentIssuer)
-	}).WithTimeout(15*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "provider %q with issuer %q must appear in login --show-providers", keycloakAuthProviderName, currentIssuer)
+		return strings.Contains(out, auxSvcs.Keycloak.IssuerURL())
+	}).WithTimeout(15*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "provider %q with issuer %q must appear in login --show-providers", keycloakAuthProviderName, auxSvcs.Keycloak.IssuerURL())
 })
 
 var _ = BeforeEach(func() {
@@ -100,16 +109,21 @@ var _ = AfterSuite(func() {
 
 	// Restore admin authentication before cleanup
 	_, err := login.LoginToAPIWithToken(harness)
-	if err != nil {
+	adminLoginRestored := err == nil
+	if !adminLoginRestored {
 		logrus.Warnf("Failed to restore admin login: %v", err)
+	} else {
+		// Clean up the Keycloak AuthProvider CR to prevent interfering with subsequent test suites
+		_, err = deleteAuthProviderByName(harness, keycloakAuthProviderName)
+		if err != nil {
+			logrus.Warnf("Failed to delete authprovider %s: %v", keycloakAuthProviderName, err)
+		} else {
+			logrus.Infof("Deleted authprovider %s", keycloakAuthProviderName)
+		}
 	}
 
-	// Clean up the Keycloak AuthProvider CR to prevent interfering with subsequent test suites
-	_, err = harness.CLI("delete", "authprovider", keycloakAuthProviderName)
-	if err != nil {
-		logrus.Warnf("Failed to delete authprovider %s: %v", keycloakAuthProviderName, err)
-	} else {
-		logrus.Infof("Deleted authprovider %s", keycloakAuthProviderName)
+	if err = restoreClientConfigSnapshot(harness, originalClientConfig); err != nil {
+		logrus.Warnf("Failed to restore original client config: %v", err)
 	}
 
 	// Clean up Keycloak container
@@ -119,30 +133,62 @@ var _ = AfterSuite(func() {
 	}
 })
 
-func buildKeycloakAuthProviderYAML(issuerURL, clientSecret string) string {
-	return fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
-kind: AuthProvider
-metadata:
-  name: %s
-spec:
-  providerType: oidc
-  displayName: Keycloak E2E
-  issuer: %s
-  clientId: flightctl-client
-  clientSecret: %s
-  enabled: true
-  scopes:
-    - openid
-    - profile
-    - email
-  usernameClaim:
-    - preferred_username
-  organizationAssignment:
-    type: static
-    organizationName: default
-  roleAssignment:
-    type: static
-    roles:
-      - flightctl-admin
-`, keycloakAuthProviderName, issuerURL, clientSecret)
+// clientConfigSnapshot stores the original local client config so the suite can restore it after bootstrap login.
+type clientConfigSnapshot struct {
+	path    string
+	exists  bool
+	content []byte
+}
+
+// captureClientConfigSnapshot records the current client config file contents, if any.
+func captureClientConfigSnapshot() (*clientConfigSnapshot, error) {
+	configPath, err := client.DefaultFlightctlClientConfigPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve default client config path: %w", err)
+	}
+
+	snapshot := &clientConfigSnapshot{path: configPath}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return snapshot, nil
+		}
+		return nil, fmt.Errorf("read client config %q: %w", configPath, err)
+	}
+
+	snapshot.exists = true
+	snapshot.content = append([]byte(nil), content...)
+	return snapshot, nil
+}
+
+// restoreClientConfigSnapshot restores the original client config file and refreshes the harness client when appropriate.
+func restoreClientConfigSnapshot(harness *e2e.Harness, snapshot *clientConfigSnapshot) error {
+	if snapshot == nil {
+		return fmt.Errorf("client config snapshot is nil")
+	}
+	if strings.TrimSpace(snapshot.path) == "" {
+		return fmt.Errorf("client config snapshot path is empty")
+	}
+
+	if snapshot.exists {
+		if err := os.MkdirAll(filepath.Dir(snapshot.path), 0o755); err != nil {
+			return fmt.Errorf("create client config directory for %q: %w", snapshot.path, err)
+		}
+		if err := os.WriteFile(snapshot.path, snapshot.content, 0o600); err != nil {
+			return fmt.Errorf("restore client config %q: %w", snapshot.path, err)
+		}
+		logrus.Infof("Restored original client config at %s", snapshot.path)
+		if harness != nil {
+			if err := harness.RefreshClient(); err != nil {
+				return fmt.Errorf("refresh client after restoring config %q: %w", snapshot.path, err)
+			}
+		}
+		return nil
+	}
+
+	if err := os.Remove(snapshot.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove generated client config %q: %w", snapshot.path, err)
+	}
+	logrus.Infof("Removed generated client config at %s to restore original disconnected state", snapshot.path)
+	return nil
 }

--- a/test/e2e/authprovider/authprovider_test.go
+++ b/test/e2e/authprovider/authprovider_test.go
@@ -8,69 +8,744 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"github.com/flightctl/flightctl/internal/quadlet/renderer"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	quadletinfra "github.com/flightctl/flightctl/test/e2e/infra/quadlet"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	keycloakTestUser = "testuser"
-	keycloakTestPass = "testpass"
-	loginURLTimeout  = 30 * time.Second
-	chromedpTimeout  = 60 * time.Second
-	loginFlowTimeout = 2 * time.Minute // covers URL wait + chromedp + CLI callback
+	keycloakTestUser             = "testuser"
+	keycloakTestPass             = "testpass"
+	keycloakDuplicateName        = "keycloak-e2e-duplicate"
+	keycloakLifecycleName        = "keycloak-e2e-lifecycle"
+	keycloakLifecycleClientID    = "flightctl-client-lifecycle"
+	keycloakOAuth2ProviderName   = "keycloak-oauth2-e2e"
+	keycloakOAuth2ClientID       = "flightctl-oauth2-client"
+	defaultOrganizationName      = "default"
+	defaultAdminRole             = "flightctl-admin"
+	openshiftDefaultUsername     = "kubeadmin"
+	pamDefaultUsername           = "admin"
+	pamDefaultPassword           = "flightctl-e2e"
+	defaultCypressLoginScript    = "cypress/run-provider-login-cypress.sh"
+	providerVisibilityArg        = "--show-providers"
+	loginInsecureTLSArg          = "--insecure-skip-tls-verify"
+	aapConfigSkipMessage         = "AAP quadlet tests require AAP_API_URL and either AAP_CLIENT_ID or AAP_TOKEN"
+	aapCredentialSkipMessage     = "AAP browser login requires AAP_USERNAME and AAP_PASSWORD"
+	openshiftPasswordMessage     = "OPENSHIFT_PASSWORD or KUBEADMIN_PASS must be set for OpenShift browser login"
+	duplicateOIDCErrorSubstring  = "same issuer and clientId already exists"
+	loginURLTimeout              = 30 * time.Second
+	chromedpTimeout              = 60 * time.Second
+	loginFlowTimeout             = 2 * time.Minute
+	authProviderLifecycleTimeout = 30 * time.Second
+	authProviderPollingInterval  = 2 * time.Second
 )
 
 var loginURLRe = regexp.MustCompile(`(?:Opening login URL in default browser|Please open this URL in your browser):\s*(.+)`)
 
-var _ = Describe("Auth provider (Keycloak OIDC)", Label("authprovider"), func() {
-	It("logs in via OAuth --web --no-browser with Keycloak and headless browser", Label("88168", "authprovider"), func() {
-		harness := e2e.GetWorkerHarness()
-		ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
-		defer cancel()
+// browserLoginScenario defines the provider-specific inputs needed by the browser-login helpers.
+type browserLoginScenario struct {
+	name         string
+	providerName string
+	providerUI   string
+	username     string
+	password     string
+}
 
-		apiEndpoint := harness.ApiEndpoint()
-		authURL, done, err := runLoginCLIWithURL(ctx, harness, apiEndpoint)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(authURL).ToNot(BeEmpty())
+type quadletAAPConfig struct {
+	APIURL           string
+	AuthorizationURL string
+	TokenURL         string
+	ClientID         string
+	Token            string
+	AppName          string
+	OrganizationID   int
+}
 
-		err = fillKeycloakLoginForm(ctx, authURL, keycloakTestUser, keycloakTestPass)
-		Expect(err).ToNot(HaveOccurred(), "chromedp Keycloak login form fill failed")
+type quadletAAPClientIDSnapshot struct {
+	exists  bool
+	content string
+}
 
-		select {
-		case waitErr := <-done:
-			Expect(waitErr).ToNot(HaveOccurred(), "CLI login process should exit successfully")
-		case <-ctx.Done():
-			Fail("CLI login did not complete within timeout")
-		}
+var _ = Describe("Auth provider browser login", func() {
+	var harness *e2e.Harness
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
 	})
 
-	It("can call API after Keycloak login", Label("88539", "authprovider"), func() {
-		harness := e2e.GetWorkerHarness()
-		_, err := harness.RunGetDevices()
-		Expect(err).ToNot(HaveOccurred(), "get devices after Keycloak login should succeed")
+	Context("dynamic OIDC provider on kind and quadlet", func() {
+		It("logs in via OAuth --web --no-browser with Keycloak and can call the API", Label("88539", "authprovider"), func() {
+			ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
+			defer cancel()
+
+			By("starting a Keycloak-backed browser login flow from the CLI")
+			apiEndpoint := harness.ApiEndpoint()
+			authURL, done, err := runLoginCLIWithURL(ctx, harness, apiEndpoint)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authURL).ToNot(BeEmpty())
+
+			By("completing the Keycloak login form in a headless browser")
+			err = fillKeycloakLoginForm(ctx, authURL, keycloakTestUser, keycloakTestPass)
+			Expect(err).ToNot(HaveOccurred(), "chromedp Keycloak login form fill failed")
+
+			By("waiting for the CLI callback to complete the login")
+			select {
+			case waitErr := <-done:
+				Expect(waitErr).ToNot(HaveOccurred(), "CLI login process should exit successfully")
+			case <-ctx.Done():
+				Fail("CLI login did not complete within timeout")
+			}
+
+			By("calling the devices API through the logged-in CLI session")
+			out, err := harness.RunGetDevices()
+			Expect(err).ToNot(HaveOccurred(), "get devices after Keycloak login should succeed")
+			Expect(strings.TrimSpace(out)).ToNot(BeEmpty(), "get devices after Keycloak login should produce CLI output")
+		})
+
+		It("validates dynamic OIDC provider visibility and enable-disable lifecycle", Label("88168", "authprovider"), func() {
+			apiEndpoint := harness.ApiEndpoint()
+			providerPath := authProviderManifestPath(keycloakLifecycleName)
+
+			By("showing the bootstrap Keycloak provider in login --show-providers")
+			out, err := showLoginProviders(harness, apiEndpoint)
+			Expect(err).ToNot(HaveOccurred(), "login --show-providers should succeed")
+			Expect(out).To(ContainSubstring(keycloakAuthProviderName))
+			Expect(out).To(ContainSubstring(auxSvcs.Keycloak.IssuerURL()))
+
+			registerAuthProviderManifestCleanup(harness, keycloakLifecycleName, providerPath)
+
+			By("creating a disabled dynamic OIDC provider")
+			out, err = writeAndApplyAuthProviderManifest(
+				harness,
+				providerPath,
+				buildOIDCAuthProviderYAML(keycloakLifecycleName, auxSvcs.Keycloak.IssuerURL(), keycloakLifecycleClientID, auxiliary.KeycloakE2EClientSecret, false),
+			)
+			Expect(err).ToNot(HaveOccurred(), "apply disabled authprovider")
+			Expect(out).To(ContainSubstring(keycloakLifecycleName), "apply disabled authprovider should mention provider name")
+
+			By("verifying a disabled provider is not shown for login")
+			Eventually(providerShownInLogin(harness, apiEndpoint, keycloakLifecycleName, false)).
+				WithTimeout(authProviderLifecycleTimeout).WithPolling(authProviderPollingInterval).
+				Should(BeTrue(), "disabled provider must not appear in login --show-providers")
+
+			By("enabling the provider without redeploying the service")
+			out, err = writeAndApplyAuthProviderManifest(
+				harness,
+				providerPath,
+				buildOIDCAuthProviderYAML(keycloakLifecycleName, auxSvcs.Keycloak.IssuerURL(), keycloakLifecycleClientID, auxiliary.KeycloakE2EClientSecret, true),
+			)
+			Expect(err).ToNot(HaveOccurred(), "apply enabled authprovider")
+			Expect(out).To(ContainSubstring(keycloakLifecycleName), "apply enabled authprovider should mention provider name")
+
+			By("verifying the enabled provider becomes available for login")
+			Eventually(providerShownInLogin(harness, apiEndpoint, keycloakLifecycleName, true)).
+				WithTimeout(authProviderLifecycleTimeout).WithPolling(authProviderPollingInterval).
+				Should(BeTrue(), "enabled provider must appear in login --show-providers")
+
+			By("deleting the provider and confirming it disappears")
+			out, err = deleteAuthProviderByName(harness, keycloakLifecycleName)
+			Expect(err).ToNot(HaveOccurred(), "delete authprovider")
+			Expect(out).To(ContainSubstring(keycloakLifecycleName), "delete authprovider should mention provider name")
+
+			Eventually(providerShownInLogin(harness, apiEndpoint, keycloakLifecycleName, false)).
+				WithTimeout(authProviderLifecycleTimeout).WithPolling(authProviderPollingInterval).
+				Should(BeTrue(), "deleted provider must disappear from login --show-providers")
+		})
+
+		It("rejects duplicate dynamic OIDC provider configuration", Label("88165", "authprovider"), func() {
+			providerPath := authProviderManifestPath(keycloakDuplicateName)
+
+			DeferCleanup(os.Remove, providerPath)
+
+			By("attempting to create a second provider with the same issuer and client ID")
+			out, err := writeAndApplyAuthProviderManifest(
+				harness,
+				providerPath,
+				buildOIDCAuthProviderYAML(keycloakDuplicateName, auxSvcs.Keycloak.IssuerURL(), "flightctl-client", auxiliary.KeycloakE2EClientSecret, true),
+			)
+			Expect(err).To(HaveOccurred(), "duplicate authprovider creation must fail")
+			Expect(out).To(
+				ContainSubstring(duplicateOIDCErrorSubstring),
+				"duplicate provider creation should report a duplicate issuer/clientId conflict",
+			)
+		})
+
+		It("logs in through a dynamically created OAuth2 provider and can call the API", Label("88167", "authprovider"), func() {
+			ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
+			defer cancel()
+
+			providerPath := authProviderManifestPath(keycloakOAuth2ProviderName)
+			registerAuthProviderManifestCleanup(harness, keycloakOAuth2ProviderName, providerPath)
+
+			By("creating a dynamic Keycloak-backed OAuth2 provider")
+			out, err := writeAndApplyAuthProviderManifest(
+				harness,
+				providerPath,
+				buildKeycloakOAuth2AuthProviderYAML(
+					keycloakOAuth2ProviderName,
+					auxSvcs.Keycloak.IssuerURL(),
+					keycloakOAuth2ClientID,
+					auxiliary.KeycloakE2EOAuth2ClientSecret,
+				),
+			)
+			Expect(err).ToNot(HaveOccurred(), "apply OAuth2 authprovider")
+			Expect(out).To(ContainSubstring(keycloakOAuth2ProviderName), "apply OAuth2 authprovider should mention provider name")
+
+			apiEndpoint := harness.ApiEndpoint()
+			By("verifying the OAuth2 provider becomes available for login")
+			Eventually(providerShownInLogin(harness, apiEndpoint, keycloakOAuth2ProviderName, true)).
+				WithTimeout(authProviderLifecycleTimeout).WithPolling(authProviderPollingInterval).
+				Should(BeTrue(), "OAuth2 provider must appear in login --show-providers")
+
+			By("starting an OAuth2 browser login flow from the CLI")
+			authURL, done, err := runProviderLoginCLIWithURL(ctx, harness, apiEndpoint, keycloakOAuth2ProviderName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authURL).ToNot(BeEmpty())
+
+			By("completing the Keycloak login form for the OAuth2 provider")
+			err = fillKeycloakLoginForm(ctx, authURL, keycloakTestUser, keycloakTestPass)
+			Expect(err).ToNot(HaveOccurred(), "chromedp Keycloak login form fill failed for OAuth2 provider")
+
+			By("waiting for the CLI callback to complete the OAuth2 login")
+			select {
+			case waitErr := <-done:
+				Expect(waitErr).ToNot(HaveOccurred(), "CLI OAuth2 login process should exit successfully")
+			case <-ctx.Done():
+				Fail("CLI OAuth2 login did not complete within timeout")
+			}
+
+			By("calling the devices API through the logged-in CLI session")
+			out, err = harness.RunGetDevices()
+			Expect(err).ToNot(HaveOccurred(), "get devices after OAuth2 login should succeed")
+			Expect(strings.TrimSpace(out)).ToNot(BeEmpty(), "get devices after OAuth2 login should produce CLI output")
+		})
+	})
+
+	Context("OpenShift auth on OCP", func() {
+		It("is visible as an available auth provider", Label("83576", "authprovider"), func() {
+			if infra.DetectEnvironment() != infra.EnvironmentOCP {
+				Skip(fmt.Sprintf("OpenShift provider only applies to OCP deployments (current environment: %s)", infra.DetectEnvironment()))
+			}
+
+			By("checking that OpenShift appears in --show-providers")
+			apiEndpoint := harness.ApiEndpoint()
+			out, err := showLoginProviders(harness, apiEndpoint)
+			Expect(err).ToNot(HaveOccurred(), "login --show-providers should succeed")
+			Expect(strings.ToLower(out)).To(ContainSubstring("openshift"), "OpenShift provider should be listed")
+		})
+
+		It("logs in through the browser and can call the API", Label("83576", "authprovider"), func() {
+			if infra.DetectEnvironment() != infra.EnvironmentOCP {
+				Skip(fmt.Sprintf("OpenShift browser login only applies to OCP deployments (current environment: %s)", infra.DetectEnvironment()))
+			}
+
+			scenario := openshiftBrowserScenario()
+			Expect(scenario.password).ToNot(BeEmpty(), openshiftPasswordMessage+". Set these environment variables to test OpenShift browser login flow.")
+
+			ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
+			defer cancel()
+
+			By("logging in through the OpenShift browser flow")
+			apiEndpoint := harness.ApiEndpoint()
+			Expect(runLoginWithCypressHarness(ctx, harness, apiEndpoint, scenario)).To(Succeed())
+
+			By("calling the devices API through the logged-in CLI session")
+			out, err := harness.RunGetDevices()
+			Expect(err).ToNot(HaveOccurred(), "get devices after OpenShift login should succeed")
+			Expect(strings.TrimSpace(out)).ToNot(BeEmpty(), "get devices after OpenShift login should produce CLI output")
+		})
+	})
+
+	Context("bundled PAM issuer on quadlet", func() {
+		It("logs in through the browser and can call the API", Label("authprovider", "quadlets"), func() {
+			infra.SkipIfNotQuadlet("PAM issuer browser login only applies to quadlet deployments")
+
+			ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
+			defer cancel()
+
+			By("logging in through the bundled PAM browser flow")
+			apiEndpoint := harness.ApiEndpoint()
+			Expect(runLoginWithCypressHarness(ctx, harness, apiEndpoint, pamBrowserScenario())).To(Succeed())
+
+			By("calling the devices API through the logged-in CLI session")
+			out, err := harness.RunGetDevices()
+			Expect(err).ToNot(HaveOccurred(), "get devices after PAM login should succeed")
+			Expect(strings.TrimSpace(out)).ToNot(BeEmpty(), "get devices after PAM login should produce CLI output")
+		})
+	})
+
+	Context("AAP auth on quadlet", func() {
+		It("is visible as an available auth provider", Label("authprovider", "quadlets"), func() {
+			infra.SkipIfNotQuadlet("AAP provider only applies to quadlet deployments")
+			Expect(ensureQuadletAAPProviderConfiguredForCurrentSpec()).To(Succeed())
+
+			By("checking that AAP appears in --show-providers")
+			apiEndpoint := harness.ApiEndpoint()
+			out, err := showLoginProviders(harness, apiEndpoint)
+			Expect(err).ToNot(HaveOccurred(), "login --show-providers should succeed")
+			Expect(strings.ToLower(out)).To(ContainSubstring("aap"), "AAP provider should be listed")
+		})
+
+		It("logs in through the browser and can call the API", Label("authprovider", "quadlets"), func() {
+			infra.SkipIfNotQuadlet("AAP browser login only applies to quadlet deployments")
+
+			scenario := aapBrowserScenario()
+			if scenario.username == "" || scenario.password == "" {
+				Skip(aapCredentialSkipMessage + ". Set these environment variables to test AAP browser login flow. " +
+					"Credentials must match a user in the AAP instance configured in the quadlet deployment.")
+			}
+			Expect(ensureQuadletAAPProviderConfiguredForCurrentSpec()).To(Succeed())
+
+			ctx, cancel := context.WithTimeout(harness.GetTestContext(), loginFlowTimeout)
+			defer cancel()
+
+			By("logging in through the AAP browser flow")
+			apiEndpoint := harness.ApiEndpoint()
+			Expect(runLoginWithCypressHarness(ctx, harness, apiEndpoint, scenario)).To(Succeed())
+
+			By("calling the devices API through the logged-in CLI session")
+			out, err := harness.RunGetDevices()
+			Expect(err).ToNot(HaveOccurred(), "get devices after AAP login should succeed")
+			Expect(strings.TrimSpace(out)).ToNot(BeEmpty(), "get devices after AAP login should produce CLI output")
+		})
 	})
 })
 
-// runLoginCLIWithURL starts `flightctl login ... --web --no-browser` with the given context.
+// openshiftBrowserScenario returns the browser-login inputs for the OpenShift provider flow.
+func openshiftBrowserScenario() browserLoginScenario {
+	username := os.Getenv("OPENSHIFT_USERNAME")
+	if username == "" {
+		username = openshiftDefaultUsername
+	}
+
+	password := os.Getenv("OPENSHIFT_PASSWORD")
+	if password == "" {
+		password = os.Getenv("KUBEADMIN_PASS")
+	}
+
+	return browserLoginScenario{
+		name:       "openshift",
+		providerUI: "openshift",
+		username:   username,
+		password:   password,
+	}
+}
+
+// pamBrowserScenario returns the browser-login inputs for the bundled PAM provider flow.
+func pamBrowserScenario() browserLoginScenario {
+	username := os.Getenv("E2E_PAM_USER")
+	if username == "" {
+		username = pamDefaultUsername
+	}
+
+	password := os.Getenv("E2E_PAM_PASSWORD")
+	if password == "" {
+		password = os.Getenv("E2E_DEFAULT_PAM_PASSWORD")
+	}
+	if password == "" {
+		password = pamDefaultPassword //nolint:gosec // G101: test-only fallback password
+	}
+
+	return browserLoginScenario{
+		name:       "pam",
+		providerUI: "pam",
+		username:   username,
+		password:   password,
+	}
+}
+
+// aapBrowserScenario returns the browser-login inputs for the AAP provider flow.
+func aapBrowserScenario() browserLoginScenario {
+	return browserLoginScenario{
+		name:       "aap",
+		providerUI: "aap",
+		username:   strings.TrimSpace(os.Getenv("AAP_USERNAME")),
+		password:   strings.TrimSpace(os.Getenv("AAP_PASSWORD")),
+	}
+}
+
+func ensureQuadletAAPProviderConfiguredForCurrentSpec() error {
+	aapConfig, skipMessage, err := quadletAAPConfigFromEnv()
+	if err != nil {
+		return err
+	}
+	if skipMessage != "" {
+		Skip(skipMessage + ". Set AAP_API_URL and either AAP_CLIENT_ID or AAP_TOKEN for the quadlet deployment.")
+	}
+	return configureQuadletAAPProviderForTest(aapConfig)
+}
+
+func quadletAAPConfigFromEnv() (*quadletAAPConfig, string, error) {
+	apiURL := strings.TrimSpace(os.Getenv("AAP_API_URL"))
+	clientID := strings.TrimSpace(os.Getenv("AAP_CLIENT_ID"))
+	token := strings.TrimSpace(os.Getenv("AAP_TOKEN"))
+	if apiURL == "" || (clientID == "" && token == "") {
+		return nil, aapConfigSkipMessage, nil
+	}
+
+	organizationID := 0
+	if raw := strings.TrimSpace(os.Getenv("AAP_ORGANIZATION_ID")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, "", fmt.Errorf("parse AAP_ORGANIZATION_ID %q: %w", raw, err)
+		}
+		organizationID = parsed
+	}
+
+	return &quadletAAPConfig{
+		APIURL:           apiURL,
+		AuthorizationURL: firstNonEmpty(strings.TrimSpace(os.Getenv("AAP_AUTHORIZATION_URL")), defaultAAPAuthorizationURL(apiURL)),
+		TokenURL:         firstNonEmpty(strings.TrimSpace(os.Getenv("AAP_TOKEN_URL")), defaultAAPTokenURL(apiURL)),
+		ClientID:         clientID,
+		Token:            token,
+		AppName:          strings.TrimSpace(os.Getenv("AAP_APP_NAME")),
+		OrganizationID:   organizationID,
+	}, "", nil
+}
+
+func configureQuadletAAPProviderForTest(aapConfig *quadletAAPConfig) error {
+	if aapConfig == nil {
+		return fmt.Errorf("AAP config is required")
+	}
+
+	providers := setup.GetDefaultProviders()
+	if providers == nil || providers.Infra == nil || providers.Lifecycle == nil {
+		return fmt.Errorf("quadlet providers are not initialized")
+	}
+
+	quadletProvider, ok := providers.Infra.(*quadletinfra.InfraProvider)
+	if !ok {
+		return fmt.Errorf("infra provider %T is not quadlet", providers.Infra)
+	}
+
+	originalConfig, err := quadletProvider.GetStandaloneServiceConfig()
+	if err != nil {
+		return fmt.Errorf("read standalone service config: %w", err)
+	}
+	clientIDSnapshot, err := captureQuadletAAPClientIDSnapshot(quadletProvider)
+	if err != nil {
+		return fmt.Errorf("capture AAP client ID snapshot: %w", err)
+	}
+
+	DeferCleanup(func() {
+		if err := restoreQuadletAAPClientIDSnapshot(quadletProvider, clientIDSnapshot); err != nil {
+			logrus.Warnf("[authprovider] failed to restore AAP client ID file: %v", err)
+		}
+		if err := quadletProvider.SetStandaloneServiceConfig(originalConfig); err != nil {
+			logrus.Warnf("[authprovider] failed to restore standalone service config: %v", err)
+			return
+		}
+		if err := providers.Lifecycle.Restart(infra.ServiceAPI); err != nil {
+			logrus.Warnf("[authprovider] failed to restart API after restoring standalone service config: %v", err)
+			return
+		}
+		if err := providers.Lifecycle.WaitForReady(infra.ServiceAPI, loginFlowTimeout); err != nil {
+			logrus.Warnf("[authprovider] API not ready after restoring standalone service config: %v", err)
+		}
+	})
+
+	updatedConfig, err := withQuadletAAPServiceConfig(originalConfig, aapConfig)
+	if err != nil {
+		return err
+	}
+	if err := quadletProvider.SetStandaloneServiceConfig(updatedConfig); err != nil {
+		return fmt.Errorf("write standalone service config: %w", err)
+	}
+	if aapConfig.Token != "" && aapConfig.ClientID == "" {
+		if _, err := quadletProvider.RunCommand("flightctl-standalone", "aap", "create-oauth-application"); err != nil {
+			return fmt.Errorf("create AAP OAuth application: %w", err)
+		}
+	}
+	if err := providers.Lifecycle.Restart(infra.ServiceAPI); err != nil {
+		return fmt.Errorf("restart API with AAP config: %w", err)
+	}
+	if err := providers.Lifecycle.WaitForReady(infra.ServiceAPI, loginFlowTimeout); err != nil {
+		return fmt.Errorf("wait for API after AAP config: %w", err)
+	}
+
+	return nil
+}
+
+func withQuadletAAPServiceConfig(configYAML string, aapConfig *quadletAAPConfig) (string, error) {
+	if aapConfig == nil {
+		return "", fmt.Errorf("AAP config is required")
+	}
+
+	var root map[string]interface{}
+	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
+		return "", fmt.Errorf("parse standalone service config: %w", err)
+	}
+
+	global := ensureNestedMap(root, "global")
+	auth := ensureNestedMap(global, "auth")
+	aap := ensureNestedMap(auth, "aap")
+
+	auth["type"] = "aap"
+	auth["insecureSkipTlsVerify"] = true
+
+	if pam, ok := auth["pamOidcIssuer"].(map[string]interface{}); ok {
+		pam["enabled"] = false
+	}
+
+	aap["enabled"] = true
+	aap["apiUrl"] = aapConfig.APIURL
+	aap["authorizationUrl"] = aapConfig.AuthorizationURL
+	aap["tokenUrl"] = aapConfig.TokenURL
+
+	if aapConfig.ClientID != "" {
+		aap["clientId"] = aapConfig.ClientID
+	} else {
+		delete(aap, "clientId")
+	}
+
+	if aapConfig.Token != "" {
+		aap["token"] = aapConfig.Token
+	} else {
+		delete(aap, "token")
+	}
+
+	if aapConfig.AppName != "" {
+		aap["appName"] = aapConfig.AppName
+	} else {
+		delete(aap, "appName")
+	}
+
+	if aapConfig.OrganizationID > 0 {
+		aap["organizationId"] = aapConfig.OrganizationID
+	} else {
+		delete(aap, "organizationId")
+	}
+
+	updated, err := yaml.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("marshal standalone service config: %w", err)
+	}
+	return string(updated), nil
+}
+
+func ensureNestedMap(root map[string]interface{}, key string) map[string]interface{} {
+	if existing, ok := root[key].(map[string]interface{}); ok {
+		return existing
+	}
+
+	created := map[string]interface{}{}
+	root[key] = created
+	return created
+}
+
+func defaultAAPAuthorizationURL(apiURL string) string {
+	return strings.TrimRight(apiURL, "/") + "/o/authorize/"
+}
+
+func defaultAAPTokenURL(apiURL string) string {
+	return strings.TrimRight(apiURL, "/") + "/o/token/"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func captureQuadletAAPClientIDSnapshot(provider *quadletinfra.InfraProvider) (*quadletAAPClientIDSnapshot, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("quadlet provider is required")
+	}
+
+	content, err := provider.ReadHostFile(renderer.DefaultAAPClientIDPath)
+	if err != nil {
+		if isMissingHostFileError(err) {
+			return &quadletAAPClientIDSnapshot{}, nil
+		}
+		return nil, err
+	}
+
+	return &quadletAAPClientIDSnapshot{
+		exists:  true,
+		content: content,
+	}, nil
+}
+
+func restoreQuadletAAPClientIDSnapshot(provider *quadletinfra.InfraProvider, snapshot *quadletAAPClientIDSnapshot) error {
+	if provider == nil {
+		return fmt.Errorf("quadlet provider is required")
+	}
+	if snapshot == nil {
+		return fmt.Errorf("AAP client ID snapshot is required")
+	}
+
+	if !snapshot.exists {
+		return provider.RemoveHostFile(renderer.DefaultAAPClientIDPath)
+	}
+
+	return provider.WriteHostFile(renderer.DefaultAAPClientIDPath, []byte(snapshot.content))
+}
+
+func isMissingHostFileError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "No such file or directory")
+}
+
+// authProviderManifestPath returns the temp-file path used for a provider manifest in this suite.
+func authProviderManifestPath(providerName string) string {
+	return filepath.Join(os.TempDir(), providerName+".yaml")
+}
+
+// registerAuthProviderManifestCleanup removes a dynamic authprovider and its manifest after the spec finishes.
+func registerAuthProviderManifestCleanup(harness *e2e.Harness, providerName, providerPath string) {
+	DeferCleanup(cleanupAuthProviderManifest, harness, providerName, providerPath)
+}
+
+// cleanupAuthProviderManifest removes a dynamic authprovider and its manifest file.
+func cleanupAuthProviderManifest(harness *e2e.Harness, providerName, providerPath string) {
+	if harness != nil && providerName != "" {
+		if out, err := deleteAuthProviderByName(harness, providerName); err != nil {
+			logrus.Warnf("[authprovider] cleanup delete failed for %s: %v\n%s", providerName, err, out)
+		}
+	}
+	if providerPath != "" {
+		if err := os.Remove(providerPath); err != nil && !os.IsNotExist(err) {
+			logrus.Warnf("[authprovider] cleanup remove manifest failed for %s: %v", providerPath, err)
+		}
+	}
+}
+
+// showLoginProviders runs `flightctl login --show-providers` for the current API endpoint.
+func showLoginProviders(harness *e2e.Harness, apiEndpoint string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("worker harness is required")
+	}
+	if strings.TrimSpace(apiEndpoint) == "" {
+		return "", fmt.Errorf("api endpoint is required")
+	}
+
+	return harness.CLI("login", apiEndpoint, loginInsecureTLSArg, providerVisibilityArg)
+}
+
+// providerShownInLogin returns a poll function that reports whether a provider is visible in login output.
+func providerShownInLogin(harness *e2e.Harness, apiEndpoint, providerName string, wantVisible bool) func() (bool, error) {
+	return func() (bool, error) {
+		out, err := showLoginProviders(harness, apiEndpoint)
+		if err != nil {
+			return false, err
+		}
+		isVisible := strings.Contains(out, providerName)
+		return isVisible == wantVisible, nil
+	}
+}
+
+// writeAndApplyAuthProviderManifest writes a provider manifest to disk and applies it through the harness.
+func writeAndApplyAuthProviderManifest(harness *e2e.Harness, providerPath, providerYAML string) (string, error) {
+	if strings.TrimSpace(providerPath) == "" {
+		return "", fmt.Errorf("provider manifest path is required")
+	}
+	if strings.TrimSpace(providerYAML) == "" {
+		return "", fmt.Errorf("provider manifest content is required")
+	}
+	if err := os.WriteFile(providerPath, []byte(providerYAML), 0600); err != nil {
+		return "", fmt.Errorf("write authprovider manifest %q: %w", providerPath, err)
+	}
+	if harness == nil {
+		return "", fmt.Errorf("worker harness is required")
+	}
+	return harness.ApplyResource(providerPath)
+}
+
+// deleteAuthProviderByName deletes a dynamic authprovider through the harness resource API.
+func deleteAuthProviderByName(harness *e2e.Harness, providerName string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("worker harness is required")
+	}
+	if strings.TrimSpace(providerName) == "" {
+		return "", fmt.Errorf("provider name is required")
+	}
+	return harness.ManageResource("delete", "authprovider", providerName)
+}
+
+// runLoginWithCypressHarness runs the suite-local Cypress harness for browser-based provider login.
+func runLoginWithCypressHarness(ctx context.Context, harness *e2e.Harness, apiEndpoint string, scenario browserLoginScenario) error {
+	if harness == nil {
+		return fmt.Errorf("worker harness is required")
+	}
+	if strings.TrimSpace(apiEndpoint) == "" {
+		return fmt.Errorf("api endpoint is required")
+	}
+	if strings.TrimSpace(scenario.name) == "" {
+		return fmt.Errorf("browser login scenario name is required")
+	}
+	if strings.TrimSpace(scenario.providerUI) == "" {
+		return fmt.Errorf("browser login provider UI is required for scenario %q", scenario.name)
+	}
+
+	scriptPath, err := resolveCypressScriptPath(defaultCypressLoginScript)
+	if err != nil {
+		return err
+	}
+
+	scriptDir := filepath.Dir(scriptPath)
+	cmdArgs := []string{apiEndpoint, scenario.providerName, scenario.providerUI, scenario.username, scenario.password}
+	cmd := exec.CommandContext(ctx, scriptPath, cmdArgs...) //nolint:gosec // G204: scriptPath is the suite-owned Cypress launcher after path validation
+	cmd.Dir = filepath.Dir(scriptDir)
+	cmd.Env = append(os.Environ(),
+		"FLIGHTCTL="+harness.GetFlightctlPath(),
+		"API_ENDPOINT="+apiEndpoint,
+	)
+
+	sanitizedArgs := sanitizeCommandArgsForLog(cmdArgs, scenario.password)
+	logrus.Infof("[authprovider] running Cypress login helper for %s: %s %s", scenario.name, scriptPath, strings.Join(sanitizedArgs, " "))
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		logrus.Infof("[authprovider] cypress login output:\n%s", string(out))
+	}
+	if err != nil {
+		return fmt.Errorf("run cypress login helper %q for %s: %w", scriptPath, scenario.name, err)
+	}
+	return nil
+}
+
+// runProviderLoginCLIWithURL starts `flightctl login ... --web --no-browser` for the given provider.
 // When ctx is cancelled, the process is killed. Returns the printed auth URL and a channel
 // that receives the process exit error when the CLI exits. done is nil when err != nil.
-func runLoginCLIWithURL(ctx context.Context, harness *e2e.Harness, apiEndpoint string) (authURL string, done <-chan error, err error) {
+func runProviderLoginCLIWithURL(ctx context.Context, harness *e2e.Harness, apiEndpoint, providerName string) (authURL string, done <-chan error, err error) {
+	if harness == nil {
+		return "", nil, fmt.Errorf("worker harness is required")
+	}
+	if strings.TrimSpace(apiEndpoint) == "" {
+		return "", nil, fmt.Errorf("api endpoint is required")
+	}
+	if strings.TrimSpace(providerName) == "" {
+		return "", nil, fmt.Errorf("provider name is required")
+	}
+
 	args := []string{
 		"login", apiEndpoint,
 		"--insecure-skip-tls-verify",
-		"--provider", keycloakAuthProviderName,
+		"--provider", providerName,
 		"--web", "--no-browser",
 	}
 	flightctlPath := harness.GetFlightctlPath()
-	logrus.Infof("[authprovider] Keycloak login command: %s %s (env: API_ENDPOINT=%s)", flightctlPath, strings.Join(args, " "), apiEndpoint)
+	logrus.Infof("[authprovider] provider login command for %s: %s %s (env: API_ENDPOINT=%s)", providerName, flightctlPath, strings.Join(args, " "), apiEndpoint)
 	cmd := exec.CommandContext(ctx, flightctlPath, args...)
 	cmd.Env = append(os.Environ(), "API_ENDPOINT="+apiEndpoint)
 
@@ -152,6 +827,38 @@ func runLoginCLIWithURL(ctx context.Context, harness *e2e.Harness, apiEndpoint s
 	}
 }
 
+// runLoginCLIWithURL starts `flightctl login ... --web --no-browser` for the bootstrap Keycloak OIDC provider.
+func runLoginCLIWithURL(ctx context.Context, harness *e2e.Harness, apiEndpoint string) (authURL string, done <-chan error, err error) {
+	return runProviderLoginCLIWithURL(ctx, harness, apiEndpoint, keycloakAuthProviderName)
+}
+
+func sanitizeCommandArgsForLog(args []string, password string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+
+	sanitizedArgs := make([]string, 0, len(args))
+	maskNextValue := false
+	for _, arg := range args {
+		switch {
+		case maskNextValue:
+			sanitizedArgs = append(sanitizedArgs, "<REDACTED>")
+			maskNextValue = false
+		case arg == "--password":
+			sanitizedArgs = append(sanitizedArgs, arg)
+			maskNextValue = true
+		case password != "" && arg == password:
+			sanitizedArgs = append(sanitizedArgs, "<REDACTED>")
+		case strings.HasPrefix(arg, "--password="):
+			sanitizedArgs = append(sanitizedArgs, "--password=<REDACTED>")
+		default:
+			sanitizedArgs = append(sanitizedArgs, arg)
+		}
+	}
+
+	return sanitizedArgs
+}
+
 // fillKeycloakLoginForm uses chromedp to navigate to the auth URL, fill username/password, and submit.
 func fillKeycloakLoginForm(ctx context.Context, authURL, username, password string) error {
 	headless := os.Getenv("E2E_HEADED") == ""
@@ -196,4 +903,102 @@ func fillKeycloakLoginForm(ctx context.Context, authURL, username, password stri
 			}
 		}),
 	)
+}
+
+// resolveCypressScriptPath resolves the configured Cypress harness path to an executable file.
+func resolveCypressScriptPath(script string) (string, error) {
+	if filepath.IsAbs(script) {
+		if _, err := os.Stat(script); err != nil {
+			return "", fmt.Errorf("stat cypress login helper %q: %w", script, err)
+		}
+		return script, nil
+	}
+
+	if strings.ContainsRune(script, os.PathSeparator) {
+		absPath := filepath.Join(authProviderPackageDir(), script)
+		if _, err := os.Stat(absPath); err != nil {
+			return "", fmt.Errorf("stat cypress login helper %q: %w", absPath, err)
+		}
+		return absPath, nil
+	}
+
+	scriptPath, err := exec.LookPath(script)
+	if err != nil {
+		return "", fmt.Errorf("resolve cypress login helper %q: %w", script, err)
+	}
+	return scriptPath, nil
+}
+
+// authProviderPackageDir returns the absolute path to this package directory.
+func authProviderPackageDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Dir(file)
+}
+
+// buildOIDCAuthProviderYAML renders a dynamic OIDC authprovider manifest for this suite.
+func buildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret string, enabled bool) string {
+	return fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
+kind: AuthProvider
+metadata:
+  name: %s
+spec:
+  providerType: oidc
+  displayName: %s
+  issuer: %s
+  clientId: %s
+  clientSecret: %s
+  enabled: %t
+  scopes:
+    - openid
+    - profile
+    - email
+  usernameClaim:
+    - preferred_username
+  organizationAssignment:
+    type: static
+    organizationName: %s
+  roleAssignment:
+    type: static
+    roles:
+      - %s
+`, name, name, issuerURL, clientID, clientSecret, enabled, defaultOrganizationName, defaultAdminRole)
+}
+
+// buildKeycloakOAuth2AuthProviderYAML renders a Keycloak-backed dynamic OAuth2 authprovider manifest for this suite.
+func buildKeycloakOAuth2AuthProviderYAML(name, issuerURL, clientID, clientSecret string) string {
+	authorizationURL := issuerURL + "/protocol/openid-connect/auth"
+	tokenURL := issuerURL + "/protocol/openid-connect/token"
+	userinfoURL := issuerURL + "/protocol/openid-connect/userinfo"
+
+	return fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
+kind: AuthProvider
+metadata:
+  name: %s
+spec:
+  providerType: oauth2
+  displayName: %s
+  issuer: %s
+  authorizationUrl: %s
+  tokenUrl: %s
+  userinfoUrl: %s
+  clientId: %s
+  clientSecret: %s
+  enabled: true
+  scopes:
+    - openid
+    - profile
+    - email
+  usernameClaim:
+    - preferred_username
+  organizationAssignment:
+    type: static
+    organizationName: %s
+  roleAssignment:
+    type: static
+    roles:
+      - %s
+`, name, name, issuerURL, authorizationURL, tokenURL, userinfoURL, clientID, clientSecret, defaultOrganizationName, defaultAdminRole)
 }

--- a/test/e2e/authprovider/cypress/cypress.config.js
+++ b/test/e2e/authprovider/cypress/cypress.config.js
@@ -1,0 +1,24 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  chromeWebSecurity: false,
+  e2e: {
+    specPattern: 'e2e/**/*.cy.js',
+    supportFile: false,
+    setupNodeEvents(on, config) {
+      config.env.authProviderAuthorizeUrl =
+        process.env.CYPRESS_AUTHPROVIDER_AUTHORIZE_URL || config.env.authProviderAuthorizeUrl || ''
+      config.env.authProviderCallbackPort =
+        process.env.CYPRESS_AUTHPROVIDER_CALLBACK_PORT || config.env.authProviderCallbackPort || '8080'
+      config.env.authProviderUI =
+        process.env.CYPRESS_AUTHPROVIDER_UI || config.env.authProviderUI || ''
+      config.env.authProviderUsername =
+        process.env.CYPRESS_AUTHPROVIDER_USERNAME || config.env.authProviderUsername || ''
+      config.env.authProviderPassword =
+        process.env.CYPRESS_AUTHPROVIDER_PASSWORD || config.env.authProviderPassword || ''
+      return config
+    },
+  },
+  video: false,
+  screenshotOnRunFailure: true,
+})

--- a/test/e2e/authprovider/cypress/e2e/provider-login.cy.js
+++ b/test/e2e/authprovider/cypress/e2e/provider-login.cy.js
@@ -1,0 +1,134 @@
+const resolveAuthorizeUrl = () => String(Cypress.env('authProviderAuthorizeUrl') || '').trim()
+const providerUI = () => String(Cypress.env('authProviderUI') || '').trim().toLowerCase()
+const callbackPort = () => String(Cypress.env('authProviderCallbackPort') || '8080').trim()
+const username = () => String(Cypress.env('authProviderUsername') || '').trim()
+const password = () => String(Cypress.env('authProviderPassword') || '').trim()
+const callbackLocationFragment = () => `localhost:${callbackPort()}`
+
+describe('Auth provider browser login', () => {
+  it('authenticates through the configured provider UI', () => {
+    const authorizeUrl = resolveAuthorizeUrl()
+    expect(authorizeUrl, 'CYPRESS_AUTHPROVIDER_AUTHORIZE_URL must be set').not.to.eq('')
+    expect(providerUI(), 'CYPRESS_AUTHPROVIDER_UI must be set').not.to.eq('')
+    expect(username(), 'CYPRESS_AUTHPROVIDER_USERNAME must be set').not.to.eq('')
+    expect(password(), 'CYPRESS_AUTHPROVIDER_PASSWORD must be set').not.to.eq('')
+
+    cy.visit(authorizeUrl, { timeout: 120000, retryOnStatusCodeFailure: true })
+
+    switch (providerUI()) {
+      case 'keycloak':
+        completeKeycloakLogin()
+        break
+      case 'pam':
+        completePamLogin()
+        break
+      case 'openshift':
+        completeOpenShiftLogin()
+        break
+      case 'aap':
+        completeAAPLogin()
+        break
+      default:
+        throw new Error(`unsupported auth provider UI: ${providerUI()}`)
+    }
+
+    cy.url({ timeout: 180000 }).should('include', `localhost:${callbackPort()}`)
+  })
+})
+
+function completeKeycloakLogin() {
+  cy.get('#username', { timeout: 120000 }).should('be.visible').clear().type(username())
+  cy.get('#password').should('be.visible').clear().type(password(), { log: false })
+  cy.get('#kc-login').should('be.visible').click()
+}
+
+function completePamLogin() {
+  cy.get('#username', { timeout: 120000 }).should('be.visible').clear().type(username())
+  cy.get('#password').should('be.visible').clear().type(password(), { log: false })
+  cy.get('button[type="submit"]').contains(/log in/i).should('be.visible').click()
+}
+
+function completeOpenShiftLogin() {
+  cy.get('body', { timeout: 120000 }).then(($body) => {
+    const text = $body.text() || ''
+    const hasLoginForm = $body.find('#inputUsername').length > 0
+    if (!hasLoginForm && /kube:admin/i.test(text)) {
+      cy.contains('button, a, span', /kube:admin/i, { timeout: 120000 }).click({ force: true })
+      return false
+    }
+
+    return hasLoginForm
+  }).then((shouldSubmitCredentials) => {
+    if (!shouldSubmitCredentials) {
+      return
+    }
+
+    cy.get('#inputUsername', { timeout: 120000 }).should('be.visible').clear().type(username())
+    cy.get('#inputPassword').should('be.visible').clear().type(password(), { log: false })
+    cy.get('#co-login-button').should('be.visible').click()
+  })
+}
+
+function completeAAPLogin() {
+  cy.document({ timeout: 120000 }).should((doc) => {
+    if (isCallbackDocument(doc)) {
+      return
+    }
+
+    expect(detectAAPLoginForm(doc.body), 'AAP login form').to.not.be.null
+  }).then((doc) => {
+    if (isCallbackDocument(doc)) {
+      return
+    }
+
+    submitUsernamePasswordForm(detectAAPLoginForm(doc.body))
+  })
+}
+
+function isCallbackDocument(doc) {
+  const href = String(doc.location && doc.location.href ? doc.location.href : '')
+  return href.includes(callbackLocationFragment())
+}
+
+function submitUsernamePasswordForm(form) {
+  cy.get(form.usernameSelector, { timeout: 120000 }).should('be.visible').clear().type(username())
+  cy.get(form.passwordSelector).should('be.visible').clear().type(password(), { log: false })
+  cy.get(form.submitSelector).first().should('be.visible').click({ force: true })
+}
+
+function detectAAPLoginForm(body) {
+  const selectors = [
+    {
+      usernameSelector: '#username',
+      passwordSelector: '#password',
+      submitSelector: 'button[type="submit"]',
+    },
+    {
+      usernameSelector: 'input[name="username"]',
+      passwordSelector: 'input[name="password"]',
+      submitSelector: 'button[type="submit"]',
+    },
+    {
+      usernameSelector: 'input[type="text"]',
+      passwordSelector: 'input[type="password"]',
+      submitSelector: 'button[type="submit"]',
+    },
+    {
+      usernameSelector: 'input[type="email"]',
+      passwordSelector: 'input[type="password"]',
+      submitSelector: 'button[type="submit"]',
+    },
+  ]
+
+  for (const candidate of selectors) {
+    if (
+      body.querySelector(candidate.usernameSelector) &&
+      body.querySelector(candidate.passwordSelector) &&
+      body.querySelector(candidate.submitSelector)
+    ) {
+      return candidate
+    }
+  }
+
+  return null
+}

--- a/test/e2e/authprovider/cypress/package.json
+++ b/test/e2e/authprovider/cypress/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "flightctl-authprovider-cypress",
+  "private": true,
+  "devDependencies": {
+    "cypress": "13.15.2"
+  }
+}

--- a/test/e2e/authprovider/cypress/run-provider-login-cypress.sh
+++ b/test/e2e/authprovider/cypress/run-provider-login-cypress.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+API_URL="${1:?usage: run-provider-login-cypress.sh <api-url> [provider-name] [provider-ui] [username] [password] (prefer USERNAME/PASSWORD env vars for credentials)}"
+PROVIDER_NAME="${2:-}"
+PROVIDER_UI="${3:?provider-ui is required}"
+USERNAME="${USERNAME:-${4:-}}"
+PASSWORD="${PASSWORD:-${5:-}}"
+
+if [[ -z "$USERNAME" ]]; then
+  echo "username is required (set USERNAME or pass argv[4])" >&2
+  exit 1
+fi
+
+if [[ -z "$PASSWORD" ]]; then
+  echo "password is required (set PASSWORD or pass argv[5])" >&2
+  exit 1
+fi
+
+FLIGHTCTL_BIN="${FLIGHTCTL:-flightctl}"
+CALLBACK_PORT="${FLIGHTCTL_CALLBACK_PORT:-8080}"
+LOG="$(mktemp)"
+CYPRESS_BIN="./node_modules/.bin/cypress"
+
+cleanup() {
+  rm -f "$LOG"
+}
+trap cleanup EXIT
+
+ensure_cypress_installed() {
+  if [[ -x "$CYPRESS_BIN" ]]; then
+    return 0
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "Cypress is not installed in $SCRIPT_DIR and npm is not available to install it." >&2
+    exit 1
+  fi
+
+  echo "Cypress is not installed in $SCRIPT_DIR. Installing dependencies automatically..." >&2
+  npm install --no-fund --no-audit >&2
+
+  if [[ ! -x "$CYPRESS_BIN" ]]; then
+    echo "Cypress install completed, but $CYPRESS_BIN is still missing." >&2
+    exit 1
+  fi
+}
+
+ensure_cypress_installed
+
+
+if command -v ss >/dev/null 2>&1; then
+  PIDS="$(ss -ltnp "sport = :${CALLBACK_PORT}" 2>/dev/null | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | sort -u)"
+  if [[ -n "$PIDS" ]]; then
+    echo "Killing stale process(es) on ${CALLBACK_PORT}: $PIDS" >&2
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] || continue
+      kill "$pid" || true
+    done <<< "$PIDS"
+    sleep 1
+  fi
+fi
+
+if [[ "$PROVIDER_UI" == "openshift" ]] && command -v oc >/dev/null 2>&1; then
+  OPENSHIFT_OAUTH_CLIENT_ID="${OPENSHIFT_OAUTH_CLIENT_ID:-flightctl-flightctl}"
+  echo "Ensuring OAuth client ${OPENSHIFT_OAUTH_CLIENT_ID} allows local callback..." >&2
+  LOCALHOST_CALLBACK_URI="http://localhost:${CALLBACK_PORT}/callback"
+  LOOPBACK_CALLBACK_URI="http://127.0.0.1:${CALLBACK_PORT}/callback"
+  CURRENT_REDIRECT_URIS="$(oc get oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" -o jsonpath='{range .redirectURIs[*]}{.}{"\n"}{end}')"
+  MISSING_REDIRECT_URIS=()
+
+  for uri in "$LOCALHOST_CALLBACK_URI" "$LOOPBACK_CALLBACK_URI"; do
+    if ! grep -Fxq "$uri" <<< "$CURRENT_REDIRECT_URIS"; then
+      MISSING_REDIRECT_URIS+=("$uri")
+    fi
+  done
+
+  if (( ${#MISSING_REDIRECT_URIS[@]} > 0 )); then
+    if [[ -n "$CURRENT_REDIRECT_URIS" ]]; then
+      PATCH_OPS=()
+      for uri in "${MISSING_REDIRECT_URIS[@]}"; do
+        PATCH_OPS+=("{\"op\":\"add\",\"path\":\"/redirectURIs/-\",\"value\":\"${uri}\"}")
+      done
+      PATCH_PAYLOAD="[$(IFS=,; echo "${PATCH_OPS[*]}")]"
+      oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=json -p "$PATCH_PAYLOAD" >/dev/null
+    else
+      PATCH_PAYLOAD="{\"redirectURIs\":[\"$LOCALHOST_CALLBACK_URI\",\"$LOOPBACK_CALLBACK_URI\"]}"
+      oc patch oauthclient "$OPENSHIFT_OAUTH_CLIENT_ID" --type=merge -p "$PATCH_PAYLOAD" >/dev/null
+    fi
+  fi
+fi
+
+LOGIN_ARGS=(login "$API_URL" --web --no-browser --insecure-skip-tls-verify --callback-port "$CALLBACK_PORT")
+if [[ -n "$PROVIDER_NAME" ]]; then
+  LOGIN_ARGS+=(--provider "$PROVIDER_NAME")
+fi
+
+"$FLIGHTCTL_BIN" "${LOGIN_ARGS[@]}" >"$LOG" 2>&1 &
+FLT_PID=$!
+
+AUTHORIZE_URL=""
+for _ in $(seq 1 240); do
+  if grep -qE 'Please open this URL in your browser:|Opening login URL in default browser:' "$LOG" 2>/dev/null; then
+    AUTHORIZE_URL="$(grep -E 'Please open this URL in your browser:|Opening login URL in default browser:' "$LOG" | sed -E 's/^.*browser:[[:space:]]*//' | tail -1 | tr -d '\r' || true)"
+    if [[ -n "$AUTHORIZE_URL" ]]; then
+      break
+    fi
+  fi
+
+  sleep 0.5
+
+  if ! kill -0 "$FLT_PID" 2>/dev/null; then
+    echo "flightctl exited before printing an authorization URL. Output:" >&2
+    cat "$LOG" >&2
+    wait "$FLT_PID" || true
+    exit 1
+  fi
+done
+
+if [[ -z "$AUTHORIZE_URL" ]]; then
+  echo "Timed out waiting for authorization URL in flightctl output." >&2
+  cat "$LOG" >&2
+  kill "$FLT_PID" 2>/dev/null || true
+  wait "$FLT_PID" 2>/dev/null || true
+  exit 1
+fi
+
+export CYPRESS_AUTHPROVIDER_AUTHORIZE_URL="$AUTHORIZE_URL"
+export CYPRESS_AUTHPROVIDER_CALLBACK_PORT="$CALLBACK_PORT"
+export CYPRESS_AUTHPROVIDER_UI="$PROVIDER_UI"
+export CYPRESS_AUTHPROVIDER_USERNAME="$USERNAME"
+export CYPRESS_AUTHPROVIDER_PASSWORD="$PASSWORD"
+
+set +e
+"$CYPRESS_BIN" run --config-file cypress.config.js --spec e2e/provider-login.cy.js
+CYPRESS_EXIT=$?
+set -e
+if [[ "$CYPRESS_EXIT" -ne 0 ]]; then
+  cat "$LOG" >&2 || true
+  kill "$FLT_PID" 2>/dev/null || true
+  wait "$FLT_PID" 2>/dev/null || true
+  exit "$CYPRESS_EXIT"
+fi
+
+wait "$FLT_PID"

--- a/test/e2e/backup_restore/backup_restore_suite_test.go
+++ b/test/e2e/backup_restore/backup_restore_suite_test.go
@@ -40,8 +40,7 @@ var _ = BeforeSuite(func() {
 	if reason := backupRestoreExternalDBSkipReason(); reason != "" {
 		Skip(reason)
 	}
-	_, _, err := e2e.SetupWorkerHarness()
-	Expect(err).ToNot(HaveOccurred())
+	e2e.SetupWorkerHarnessOrAbort()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/infra/auxiliary/keycloak.go
+++ b/test/e2e/infra/auxiliary/keycloak.go
@@ -21,6 +21,8 @@ const (
 	keycloakRealmName      = "flightctl"
 	// KeycloakE2EClientSecret is the client secret for flightctl-client in the e2e realm.
 	KeycloakE2EClientSecret = "e2e-flightctl-client-secret" //nolint:gosec // G101: e2e test client secret only
+	// KeycloakE2EOAuth2ClientSecret is the client secret for the suite-owned OAuth2 client in the e2e realm.
+	KeycloakE2EOAuth2ClientSecret = "e2e-flightctl-oauth2-client-secret" //nolint:gosec // G101: e2e test client secret only
 )
 
 // Keycloak holds connection info and the container for the aux Keycloak.

--- a/test/e2e/infra/auxiliary/keycloak/flightctl-realm.json
+++ b/test/e2e/infra/auxiliary/keycloak/flightctl-realm.json
@@ -26,6 +26,20 @@
       "protocol": "openid-connect",
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true
+    },
+    {
+      "clientId": "flightctl-oauth2-client",
+      "name": "flightctl-oauth2-client",
+      "enabled": true,
+      "redirectUris": [
+        "http://localhost:8080/callback"
+      ],
+      "webOrigins": ["+"],
+      "publicClient": false,
+      "secret": "e2e-flightctl-oauth2-client-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true
     }
   ],
   "users": [

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -105,6 +105,31 @@ func (p *InfraProvider) RunCommand(command ...string) (string, error) {
 	return p.runCommand(command...)
 }
 
+// ReadHostFile reads a raw file from the quadlet host.
+func (p *InfraProvider) ReadHostFile(path string) (string, error) {
+	output, err := p.runCommand("cat", path)
+	if err != nil {
+		return "", fmt.Errorf("read host file %s: %w", path, err)
+	}
+	return output, nil
+}
+
+// WriteHostFile writes raw content to a file on the quadlet host.
+func (p *InfraProvider) WriteHostFile(path string, content []byte) error {
+	if err := p.writeHostFile(path, content); err != nil {
+		return fmt.Errorf("write host file %s: %w", path, err)
+	}
+	return nil
+}
+
+// RemoveHostFile removes a file from the quadlet host.
+func (p *InfraProvider) RemoveHostFile(path string) error {
+	if _, err := p.runCommand("rm", "-f", path); err != nil {
+		return fmt.Errorf("remove host file %s: %w", path, err)
+	}
+	return nil
+}
+
 // quoteForRemoteShell returns a single-quoted string safe for the remote POSIX shell; inner single quotes are escaped as backslash-quote.
 func quoteForRemoteShell(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
@@ -230,6 +255,26 @@ func (p *InfraProvider) serviceToHostConfigPath(service infra.ServiceName) strin
 // the template engine uses to generate per-service configs.
 func (p *InfraProvider) serviceConfigPath() string {
 	return filepath.Join(p.configDir, "service-config.yaml")
+}
+
+// GetStandaloneServiceConfig returns the raw /etc/flightctl/service-config.yaml contents.
+// This is quadlet-specific and is useful for tests that need to reconfigure
+// standalone auth or other top-level settings that are not exposed via
+// per-service config mappings.
+func (p *InfraProvider) GetStandaloneServiceConfig() (string, error) {
+	path := p.serviceConfigPath()
+	output, err := p.runCommand("cat", path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read standalone service config from %s: %w", path, err)
+	}
+	return output, nil
+}
+
+// SetStandaloneServiceConfig writes raw content to /etc/flightctl/service-config.yaml.
+// This is quadlet-specific and bypasses per-service config mappings.
+func (p *InfraProvider) SetStandaloneServiceConfig(content string) error {
+	path := p.serviceConfigPath()
+	return p.writeHostFile(path, []byte(content))
 }
 
 // GetSecretValue retrieves a secret value from secret files or environment.
@@ -566,11 +611,7 @@ func (p *InfraProvider) SetServiceConfig(service infra.ServiceName, configKey, c
 	}
 
 	hostPath := p.serviceToHostConfigPath(service)
-	b64 := base64.StdEncoding.EncodeToString([]byte(content))
-	escaped := strings.ReplaceAll(b64, "'", "'\"'\"'")
-	script := fmt.Sprintf("printf '%%s' '%s' | base64 -d > %s", escaped, hostPath)
-	_, err = p.runCommand("sh", "-c", script)
-	if err != nil {
+	if err := p.writeHostFile(hostPath, []byte(content)); err != nil {
 		return fmt.Errorf("write config to %s: %w", hostPath, err)
 	}
 	return nil
@@ -599,11 +640,18 @@ func (p *InfraProvider) mergeAndWriteServiceConfig(updates map[string]interface{
 	if err != nil {
 		return fmt.Errorf("marshal service-config: %w", err)
 	}
-	b64 := base64.StdEncoding.EncodeToString(out)
+	if err := p.writeHostFile(path, out); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func (p *InfraProvider) writeHostFile(path string, content []byte) error {
+	b64 := base64.StdEncoding.EncodeToString(content)
 	escaped := strings.ReplaceAll(b64, "'", "'\"'\"'")
 	script := fmt.Sprintf("printf '%%s' '%s' | base64 -d > %s", escaped, path)
 	if _, err := p.runCommand("sh", "-c", script); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
+		return err
 	}
 	return nil
 }

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -112,6 +112,12 @@ func (p *InfraProvider) RunCommandContext(ctx context.Context, command ...string
 	return p.runCommandWithOptionalStdinContext(ctx, nil, command...)
 }
 
+// RunCommandWithStdinContext runs a command with stdin data and context cancellation support.
+// Useful for piping large data that would exceed command argument length limits.
+func (p *InfraProvider) RunCommandWithStdinContext(ctx context.Context, stdin io.Reader, command ...string) (string, error) {
+	return p.runCommandWithOptionalStdinContext(ctx, stdin, command...)
+}
+
 // ReadHostFile reads a raw file from the quadlet host.
 func (p *InfraProvider) ReadHostFile(path string) (string, error) {
 	output, err := p.runCommand("cat", path)

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -2,6 +2,7 @@
 package quadlet
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -105,6 +106,12 @@ func (p *InfraProvider) RunCommand(command ...string) (string, error) {
 	return p.runCommand(command...)
 }
 
+// RunCommandContext runs a command on the Quadlet host with context cancellation support.
+// If ctx is canceled, the command is killed. Returns context.Canceled if ctx was canceled.
+func (p *InfraProvider) RunCommandContext(ctx context.Context, command ...string) (string, error) {
+	return p.runCommandWithOptionalStdinContext(ctx, nil, command...)
+}
+
 // ReadHostFile reads a raw file from the quadlet host.
 func (p *InfraProvider) ReadHostFile(path string) (string, error) {
 	output, err := p.runCommand("cat", path)
@@ -140,8 +147,9 @@ func getSSHPassword() string {
 	return os.Getenv("E2E_SSH_PASSWORD")
 }
 
-// runCommandWithOptionalStdin runs a command (SSH if remote, else local). If stdin is non-nil it is attached to the process.
-func (p *InfraProvider) runCommandWithOptionalStdin(stdin io.Reader, command ...string) (string, error) {
+// runCommandWithOptionalStdinContext runs a command with context cancellation support.
+// If ctx is canceled, the command is killed. Returns context.Canceled if ctx was canceled.
+func (p *InfraProvider) runCommandWithOptionalStdinContext(ctx context.Context, stdin io.Reader, command ...string) (string, error) {
 	var cmd *exec.Cmd
 
 	if p.isRemote() {
@@ -165,16 +173,17 @@ func (p *InfraProvider) runCommandWithOptionalStdin(stdin io.Reader, command ...
 		sshArgs = append(sshArgs, strings.Join(remoteParts, " "))
 
 		if usePassword {
-			cmd = exec.Command("sshpass", append([]string{"-e", "ssh"}, sshArgs...)...) //nolint:gosec // G204: sshArgs from internal config (host, user, key path)
+			cmd = exec.CommandContext(ctx, "sshpass", append([]string{"-e", "ssh"}, sshArgs...)...) //nolint:gosec // G204: sshArgs from trusted config
 			cmd.Env = append(os.Environ(), "SSHPASS="+getSSHPassword())
 		} else {
-			cmd = exec.Command("ssh", sshArgs...)
+			cmd = exec.CommandContext(ctx, "ssh", sshArgs...) //nolint:gosec // G204: sshArgs from trusted config
 		}
 	} else {
+		// Local execution
 		if p.useSudo {
-			cmd = exec.Command("sudo", command...)
+			cmd = exec.CommandContext(ctx, "sudo", command...) //nolint:gosec // G204: command from trusted caller
 		} else {
-			cmd = exec.Command(command[0], command[1:]...) //nolint:gosec // G204: command args are from internal test config
+			cmd = exec.CommandContext(ctx, command[0], command[1:]...) //nolint:gosec // G204: command from trusted caller
 		}
 	}
 
@@ -186,6 +195,12 @@ func (p *InfraProvider) runCommandWithOptionalStdin(stdin io.Reader, command ...
 		return string(output), fmt.Errorf("command failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 	return string(output), nil
+}
+
+// runCommandWithOptionalStdin runs a command (SSH if remote, else local). If stdin is non-nil it is attached to the process.
+// Calls runCommandWithOptionalStdinContext with a background context.
+func (p *InfraProvider) runCommandWithOptionalStdin(stdin io.Reader, command ...string) (string, error) {
+	return p.runCommandWithOptionalStdinContext(context.Background(), stdin, command...)
 }
 
 // runCommand executes a command, using SSH if the host is remote.

--- a/test/harness/e2e/harness_backup_restore.go
+++ b/test/harness/e2e/harness_backup_restore.go
@@ -114,9 +114,10 @@ func (br *BackupRestore) RunFlightCtlBackup() (archivePath string, cleanup func(
 			workDirCleanup()
 			return "", func() {}, fmt.Errorf("failed to read backup binary: %w", err)
 		}
+		// Use stdin to pipe binary data (too large for command args)
 		encodedBinary := base64.StdEncoding.EncodeToString(backupBinaryData)
-		copyCmd := fmt.Sprintf("echo %s | base64 -d > %s && chmod +x %s", encodedBinary, vmBackupBinary, vmBackupBinary)
-		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", copyCmd); err != nil {
+		copyCmd := fmt.Sprintf("base64 -d > %s && chmod +x %s", vmBackupBinary, vmBackupBinary)
+		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedBinary), "sh", "-c", copyCmd); err != nil {
 			workDirCleanup()
 			return "", func() {}, fmt.Errorf("failed to copy backup binary to VM: %w", err)
 		}
@@ -169,6 +170,24 @@ func (br *BackupRestore) RunFlightCtlBackup() (archivePath string, cleanup func(
 		if err := os.WriteFile(hostArchivePath, archiveBytes, 0600); err != nil {
 			workDirCleanup()
 			return "", func() {}, fmt.Errorf("failed to write backup archive: %w", err)
+		}
+
+		// Copy checksum file (.sha256) from VM to host
+		vmChecksumPath := vmArchive + ".sha256"
+		checksumOutput, err := quadletProvider.RunCommandContext(ctx, "base64", vmChecksumPath)
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to encode checksum from VM: %w", err)
+		}
+		checksumBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(checksumOutput))
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to decode checksum: %w", err)
+		}
+		hostChecksumPath := hostArchivePath + ".sha256"
+		if err := os.WriteFile(hostChecksumPath, checksumBytes, 0600); err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to write checksum file: %w", err)
 		}
 
 		return hostArchivePath, workDirCleanup, nil
@@ -235,18 +254,30 @@ func (br *BackupRestore) RunFlightCtlRestore(archivePath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read restore binary: %w", err)
 		}
+		// Use stdin to pipe binary data (too large for command args)
 		encodedRestoreBinary := base64.StdEncoding.EncodeToString(restoreBinaryData)
-		copyRestoreCmd := fmt.Sprintf("echo %s | base64 -d > %s && chmod +x %s", encodedRestoreBinary, vmRestoreBinary, vmRestoreBinary)
-		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", copyRestoreCmd); err != nil {
+		copyRestoreCmd := fmt.Sprintf("base64 -d > %s && chmod +x %s", vmRestoreBinary, vmRestoreBinary)
+		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedRestoreBinary), "sh", "-c", copyRestoreCmd); err != nil {
 			return fmt.Errorf("failed to copy restore binary to VM: %w", err)
 		}
 
-		// Write archive to VM using base64 encoding for safe binary transfer
-		// Use context-aware RunCommand for proper timeout/cancellation handling
+		// Write archive to VM using stdin for safe binary transfer
 		encoded := base64.StdEncoding.EncodeToString(archiveContent)
-		decodeCmd := fmt.Sprintf("echo %s | base64 -d > %s", encoded, vmArchivePath)
-		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", decodeCmd); err != nil {
+		decodeCmd := fmt.Sprintf("base64 -d > %s", vmArchivePath)
+		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encoded), "sh", "-c", decodeCmd); err != nil {
 			return fmt.Errorf("failed to copy backup to VM: %w", err)
+		}
+
+		// Copy checksum file (.sha256) to VM
+		checksumPath := archivePath + ".sha256"
+		checksumContent, err := os.ReadFile(checksumPath)
+		if err != nil {
+			return fmt.Errorf("failed to read checksum file: %w", err)
+		}
+		encodedChecksum := base64.StdEncoding.EncodeToString(checksumContent)
+		checksumCmd := fmt.Sprintf("base64 -d > %s", vmArchivePath+".sha256")
+		if _, err := quadletProvider.RunCommandWithStdinContext(ctx, strings.NewReader(encodedChecksum), "sh", "-c", checksumCmd); err != nil {
+			return fmt.Errorf("failed to copy checksum to VM: %w", err)
 		}
 
 		// Run restore inside the VM using the binary we copied

--- a/test/harness/e2e/harness_backup_restore.go
+++ b/test/harness/e2e/harness_backup_restore.go
@@ -2,13 +2,16 @@ package e2e
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/quadlet"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/util"
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -77,20 +80,113 @@ func (br *BackupRestore) RunFlightCtlBackup() (archivePath string, cleanup func(
 		return "", func() {}, fmt.Errorf("create output dir: %w", err)
 	}
 
-	args := []string{"--output", outputDir}
-	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-		args = append(args, "--namespace", ns)
-	}
-	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-		args = append(args, "--internal-namespace", ns)
-	}
+	var backupCmd *exec.Cmd
+	// For quadlet deployments, run backup inside the VM.
+	// Note: This is test infrastructure automation. External users should manually
+	// SSH into their VM and run the backup command there (see error message guidance
+	// in internal/backup/deployer.go for user-facing instructions).
+	if br.providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		// Type assert to quadlet provider to access RunCommand
+		quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
+		if !ok {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("expected quadlet provider but got different type")
+		}
 
-	backupCmd := exec.CommandContext(ctx, backupBinary, args...)
-	backupCmd.Stdout = ginkgo.GinkgoWriter
-	backupCmd.Stderr = ginkgo.GinkgoWriter
-	if err := backupCmd.Run(); err != nil {
-		workDirCleanup()
-		return "", func() {}, fmt.Errorf("flightctl-backup failed: %w", err)
+		// Use random temp dir inside VM for backup output to avoid cross-test conflicts
+		vmOutputDir := fmt.Sprintf("/tmp/flightctl-backup-%d", time.Now().UnixNano())
+		vmArgs := []string{"--output", vmOutputDir, "--deployment-type", "podman"}
+		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+			vmArgs = append(vmArgs, "--namespace", ns)
+		}
+		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+			vmArgs = append(vmArgs, "--internal-namespace", ns)
+		}
+
+		// Run backup inside the VM using the infra provider (handles SSH automatically)
+		// All commands use context for proper timeout/cancellation handling
+
+		// Copy flightctl-backup binary from host to VM for testing
+		// Edge devices don't have CLI tools pre-installed, but tests need them
+		vmBackupBinary := "/tmp/flightctl-backup"
+		backupBinaryData, err := os.ReadFile(backupBinary)
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to read backup binary: %w", err)
+		}
+		encodedBinary := base64.StdEncoding.EncodeToString(backupBinaryData)
+		copyCmd := fmt.Sprintf("echo %s | base64 -d > %s && chmod +x %s", encodedBinary, vmBackupBinary, vmBackupBinary)
+		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", copyCmd); err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to copy backup binary to VM: %w", err)
+		}
+
+		mkdirCmd := []string{"mkdir", "-p", vmOutputDir}
+		if _, err := quadletProvider.RunCommandContext(ctx, mkdirCmd...); err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to create output dir in VM: %w", err)
+		}
+
+		// Use the binary we just copied to the VM
+		backupCmdArgs := append([]string{vmBackupBinary}, vmArgs...)
+		output, err := quadletProvider.RunCommandContext(ctx, backupCmdArgs...)
+		fmt.Fprint(ginkgo.GinkgoWriter, output)
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("flightctl-backup failed: %w", err)
+		}
+
+		// Copy backup archive from VM to host
+		// Find the archive name using find command
+		findOutput, err := quadletProvider.RunCommandContext(ctx, "find", vmOutputDir, "-name", "*.tar.gz", "-print", "-quit")
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to find backup archive: %w", err)
+		}
+		vmArchive := strings.TrimSpace(findOutput)
+		if vmArchive == "" {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("no backup archive found in %s", vmOutputDir)
+		}
+
+		// Read the archive content from VM using base64 encoding to safely transfer binary data
+		base64Output, err := quadletProvider.RunCommandContext(ctx, "base64", vmArchive)
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to encode backup archive from VM: %w", err)
+		}
+
+		// Decode base64 to get the binary archive data
+		archiveBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(base64Output))
+		if err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to decode backup archive: %w", err)
+		}
+
+		// Write it to the host
+		archiveName := filepath.Base(vmArchive)
+		hostArchivePath := filepath.Join(outputDir, archiveName)
+		if err := os.WriteFile(hostArchivePath, archiveBytes, 0600); err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("failed to write backup archive: %w", err)
+		}
+
+		return hostArchivePath, workDirCleanup, nil
+	} else {
+		args := []string{"--output", outputDir}
+		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+			args = append(args, "--namespace", ns)
+		}
+		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+			args = append(args, "--internal-namespace", ns)
+		}
+		backupCmd = exec.CommandContext(ctx, backupBinary, args...)
+		backupCmd.Stdout = ginkgo.GinkgoWriter
+		backupCmd.Stderr = ginkgo.GinkgoWriter
+		if err := backupCmd.Run(); err != nil {
+			workDirCleanup()
+			return "", func() {}, fmt.Errorf("flightctl-backup failed: %w", err)
+		}
 	}
 
 	matches, err := filepath.Glob(filepath.Join(outputDir, "*.tar.gz"))
@@ -112,15 +208,73 @@ func (br *BackupRestore) RunFlightCtlRestore(archivePath string) error {
 	ctx, cancel := context.WithTimeout(br.Context, util.DURATION_TIMEOUT)
 	defer cancel()
 
-	args := []string{archivePath}
-	if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
-		args = append(args, "--namespace", ns)
-	}
-	if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
-		args = append(args, "--internal-namespace", ns)
+	var restoreCmd *exec.Cmd
+	// For quadlet deployments, run restore inside the VM.
+	// Note: This is test infrastructure automation. External users should manually
+	// copy their backup archive to the VM and run restore there.
+	if br.providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		// Type assert to quadlet provider to access RunCommand
+		quadletProvider, ok := br.providers.Infra.(*quadlet.InfraProvider)
+		if !ok {
+			return fmt.Errorf("expected quadlet provider but got different type")
+		}
+
+		// Copy backup archive from host to VM
+		vmArchivePath := "/tmp/flightctl-restore.tar.gz"
+
+		// Read archive from host
+		archiveContent, err := os.ReadFile(archivePath)
+		if err != nil {
+			return fmt.Errorf("failed to read backup archive: %w", err)
+		}
+
+		// Copy flightctl-restore binary from host to VM for testing
+		// Edge devices don't have CLI tools pre-installed, but tests need them
+		vmRestoreBinary := "/tmp/flightctl-restore"
+		restoreBinaryData, err := os.ReadFile(restoreBinary)
+		if err != nil {
+			return fmt.Errorf("failed to read restore binary: %w", err)
+		}
+		encodedRestoreBinary := base64.StdEncoding.EncodeToString(restoreBinaryData)
+		copyRestoreCmd := fmt.Sprintf("echo %s | base64 -d > %s && chmod +x %s", encodedRestoreBinary, vmRestoreBinary, vmRestoreBinary)
+		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", copyRestoreCmd); err != nil {
+			return fmt.Errorf("failed to copy restore binary to VM: %w", err)
+		}
+
+		// Write archive to VM using base64 encoding for safe binary transfer
+		// Use context-aware RunCommand for proper timeout/cancellation handling
+		encoded := base64.StdEncoding.EncodeToString(archiveContent)
+		decodeCmd := fmt.Sprintf("echo %s | base64 -d > %s", encoded, vmArchivePath)
+		if _, err := quadletProvider.RunCommandContext(ctx, "sh", "-c", decodeCmd); err != nil {
+			return fmt.Errorf("failed to copy backup to VM: %w", err)
+		}
+
+		// Run restore inside the VM using the binary we copied
+		restoreCmdArgs := []string{vmRestoreBinary, vmArchivePath}
+		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+			restoreCmdArgs = append(restoreCmdArgs, "--namespace", ns)
+		}
+		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+			restoreCmdArgs = append(restoreCmdArgs, "--internal-namespace", ns)
+		}
+
+		output, err := quadletProvider.RunCommandContext(ctx, restoreCmdArgs...)
+		fmt.Fprint(ginkgo.GinkgoWriter, output)
+		if err != nil {
+			return fmt.Errorf("flightctl-restore failed: %w", err)
+		}
+		return nil
+	} else {
+		args := []string{archivePath}
+		if ns := br.providers.Infra.GetExternalNamespace(); ns != "" {
+			args = append(args, "--namespace", ns)
+		}
+		if ns := br.providers.Infra.GetInternalNamespace(); ns != "" {
+			args = append(args, "--internal-namespace", ns)
+		}
+		restoreCmd = exec.CommandContext(ctx, restoreBinary, args...)
 	}
 
-	restoreCmd := exec.CommandContext(ctx, restoreBinary, args...)
 	restoreCmd.Stdout = ginkgo.GinkgoWriter
 	restoreCmd.Stderr = ginkgo.GinkgoWriter
 	if err := restoreCmd.Run(); err != nil {


### PR DESCRIPTION
*Backporting PRs for release 1.2:*

PR *[EDM-2539: Auth provider tests](https://github.com/flightctl/flightctl/pull/2911)*
PR *[EDM-3953: mirror-images bug fixes — tag-override and missing nginx image](https://github.com/flightctl/flightctl/pull/3055)*
PR *[EDM-4083: Run e2e backup command on quadlet from flightctl-vm to have access to db and all necessary info](https://github.com/flightctl/flightctl/pull/3058)*
PR *[EDM-3955: rewrite OCP disconnected install documentation](https://github.com/flightctl/flightctl/pull/3060)*
PR *[EDM-3697: fix copy of flightctl-backup in E2E tests and start services at flightctl-restore](https://github.com/flightctl/flightctl/pull/3067)*
PR *[EDM-3953: fix kv image in el9/images.yaml causing Redis crash-loop in offline install](https://github.com/flightctl/flightctl/pull/3074)*
PR *[EDM-3953: add mirror-images binary to flightctl-cli RPM package](https://github.com/flightctl/flightctl/pull/3078)*
