### PR TITLE
EDM-4096: render VmApplication into QuadletApplication via kubevirt-vm-to-pod

### DIFF
--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -1116,6 +1117,7 @@ func validateQuadletApplication(app ApplicationProviderSpec, appName string, fle
 			allErrs = append(allErrs, fmt.Errorf("invalid quadlet inline provider: %w", err))
 		} else {
 			allErrs = append(allErrs, inlineSpec.Validate(AppTypeQuadlet, fleetTemplate)...)
+			allErrs = append(allErrs, validateKubeYamlDirectives(inlineSpec, pathPrefix)...)
 		}
 	default:
 		allErrs = append(allErrs, fmt.Errorf("unknown quadlet provider type: %s", providerType))
@@ -1125,6 +1127,90 @@ func validateQuadletApplication(app ApplicationProviderSpec, appName string, fle
 	allErrs = append(allErrs, validateApplicationVolumes(quadlet.Volumes, appName, AppTypeQuadlet, fleetTemplate)...)
 
 	return allErrs
+}
+
+// validateKubeYamlDirectives checks that every .kube file in inlineSpec has its
+// Yaml= target present in the inline set and that the target is a valid Pod manifest.
+// Content is decoded from base64 when necessary so validation is consistent regardless
+// of how the caller encoded the inline files.
+func validateKubeYamlDirectives(inlineSpec InlineApplicationProviderSpec, pathPrefix string) []error {
+	// Build a lookup map of path → decoded content for all inline files.
+	fileContents := make(map[string][]byte, len(inlineSpec.Inline))
+	for _, f := range inlineSpec.Inline {
+		if f.Content == nil {
+			continue
+		}
+		decoded, err := decodeApplicationContent(f)
+		if err != nil {
+			continue // malformed encoding is already caught by ApplicationContent.Validate
+		}
+		fileContents[f.Path] = decoded
+	}
+
+	var errs []error
+	for _, f := range inlineSpec.Inline {
+		if !strings.HasSuffix(f.Path, ".kube") || f.Content == nil {
+			continue
+		}
+		kubeBytes, ok := fileContents[f.Path]
+		if !ok {
+			continue
+		}
+		yamlFile := parseKubeYamlDirective(string(kubeBytes))
+		if yamlFile == "" {
+			continue
+		}
+		targetBytes, ok := fileContents[yamlFile]
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s.inline[%s]: Yaml=%s references a file not present in the inline set",
+				pathPrefix, f.Path, yamlFile))
+			continue
+		}
+		errs = append(errs, validatePodManifest(targetBytes, pathPrefix+".inline["+yamlFile+"]")...)
+	}
+	return errs
+}
+
+// decodeApplicationContent returns the decoded byte content of an ApplicationContent entry,
+// handling both plain and base64 encodings.
+func decodeApplicationContent(f ApplicationContent) ([]byte, error) {
+	if f.Content == nil {
+		return nil, fmt.Errorf("nil content")
+	}
+	if f.IsBase64() {
+		return base64.StdEncoding.DecodeString(*f.Content)
+	}
+	return []byte(*f.Content), nil
+}
+
+// parseKubeYamlDirective extracts the value of the Yaml= key from a [Kube] unit file.
+// Returns an empty string if the directive is absent or the content cannot be parsed.
+func parseKubeYamlDirective(kubeContent string) string {
+	for _, line := range strings.Split(kubeContent, "\n") {
+		line = strings.TrimSpace(line)
+		key, value, found := strings.Cut(line, "=")
+		if found && strings.TrimSpace(key) == "Yaml" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+type podManifestMeta struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+}
+
+// validatePodManifest checks that the given YAML content is a valid Kubernetes Pod manifest.
+func validatePodManifest(content []byte, pathPrefix string) []error {
+	var meta podManifestMeta
+	if err := yaml.Unmarshal(content, &meta); err != nil {
+		return []error{fmt.Errorf("%s: must be valid YAML: %w", pathPrefix, err)}
+	}
+	if meta.Kind != "Pod" {
+		return []error{fmt.Errorf("%s: kind must be \"Pod\", got %q", pathPrefix, meta.Kind)}
+	}
+	return nil
 }
 
 func validateVmApplication(app ApplicationProviderSpec, appName string, fleetTemplate bool) []error {

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/api/common"
 	"github.com/flightctl/flightctl/internal/contextutil"
+	"github.com/flightctl/flightctl/internal/quadlet"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/robfig/cron/v3"
@@ -1183,17 +1184,19 @@ func decodeApplicationContent(f ApplicationContent) ([]byte, error) {
 	return []byte(*f.Content), nil
 }
 
-// parseKubeYamlDirective extracts the value of the Yaml= key from a [Kube] unit file.
-// Returns an empty string if the directive is absent or the content cannot be parsed.
+// parseKubeYamlDirective extracts the value of the Yaml= key from the [Kube] section
+// of a quadlet unit file. Returns an empty string if the directive is absent or the
+// content cannot be parsed.
 func parseKubeYamlDirective(kubeContent string) string {
-	for _, line := range strings.Split(kubeContent, "\n") {
-		line = strings.TrimSpace(line)
-		key, value, found := strings.Cut(line, "=")
-		if found && strings.TrimSpace(key) == "Yaml" {
-			return strings.TrimSpace(value)
-		}
+	unit, err := quadlet.NewUnit([]byte(kubeContent))
+	if err != nil {
+		return ""
 	}
-	return ""
+	v, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(v)
 }
 
 type podManifestMeta struct {
@@ -1206,6 +1209,9 @@ func validatePodManifest(content []byte, pathPrefix string) []error {
 	var meta podManifestMeta
 	if err := yaml.Unmarshal(content, &meta); err != nil {
 		return []error{fmt.Errorf("%s: must be valid YAML: %w", pathPrefix, err)}
+	}
+	if strings.TrimSpace(meta.APIVersion) == "" {
+		return []error{fmt.Errorf("%s: apiVersion must be set", pathPrefix)}
 	}
 	if meta.Kind != "Pod" {
 		return []error{fmt.Errorf("%s: kind must be \"Pod\", got %q", pathPrefix, meta.Kind)}

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1989,6 +1990,13 @@ PublishPort=8080:80`,
 			wantErrCount:  1,
 			wantErrSubstr: "badfunction",
 		},
+		{
+			name: "valid kube quadlet",
+			content: `[Kube]
+Yaml=pod.yaml`,
+			path:         "my-vm.kube",
+			wantErrCount: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2000,6 +2008,87 @@ PublishPort=8080:80`,
 			require.Len(errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
 			if tt.wantErrSubstr != "" && len(errs) > 0 {
 				require.Contains(errs[0].Error(), tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateQuadletApplication_KubeYamlValidation(t *testing.T) {
+	t.Parallel()
+
+	validPodYAML := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-vm\n"
+	validKubeUnit := "[Kube]\nYaml=pod.yaml\n"
+
+	newQuadletInlineApp := func(t *testing.T, files map[string]string) ApplicationProviderSpec {
+		t.Helper()
+		contents := make([]ApplicationContent, 0, len(files))
+		for path, content := range files {
+			c := content
+			contents = append(contents, ApplicationContent{Path: path, Content: &c})
+		}
+		inlineSpec := InlineApplicationProviderSpec{Inline: contents}
+		app := QuadletApplication{AppType: AppTypeQuadlet, Name: lo.ToPtr("my-vm")}
+		require.NoError(t, app.FromInlineApplicationProviderSpec(inlineSpec))
+		var spec ApplicationProviderSpec
+		require.NoError(t, spec.FromQuadletApplication(app))
+		return spec
+	}
+
+	tests := []struct {
+		name     string
+		files    map[string]string
+		wantErrs []string
+		wantPass bool
+	}{
+		{
+			name: "When .kube has Yaml=pod.yaml and pod.yaml is a valid Pod manifest it should be valid",
+			files: map[string]string{
+				"my-vm.kube": validKubeUnit,
+				"pod.yaml":   validPodYAML,
+			},
+			wantPass: true,
+		},
+		{
+			name: "When .kube has Yaml=pod.yaml but pod.yaml is absent it should fail",
+			files: map[string]string{
+				"my-vm.kube": validKubeUnit,
+			},
+			wantErrs: []string{"pod.yaml", "not present in the inline set"},
+		},
+		{
+			name: "When .kube has Yaml=pod.yaml but pod.yaml has kind Deployment it should fail",
+			files: map[string]string{
+				"my-vm.kube": validKubeUnit,
+				"pod.yaml":   "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-vm\n",
+			},
+			wantErrs: []string{"kind must be \"Pod\""},
+		},
+		{
+			name: "When .kube has no Yaml= directive it should be valid (no target to check)",
+			files: map[string]string{
+				"my-vm.kube": "[Kube]\n",
+			},
+			wantPass: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spec := newQuadletInlineApp(t, tc.files)
+			errs := validateQuadletApplication(spec, "my-vm", false)
+
+			if tc.wantPass {
+				assert.Empty(t, errs, "expected no errors but got: %v", errs)
+				return
+			}
+			require.NotEmpty(t, errs)
+			allErrText := ""
+			for _, e := range errs {
+				allErrText += e.Error() + "\n"
+			}
+			for _, substr := range tc.wantErrs {
+				assert.Contains(t, allErrText, substr)
 			}
 		})
 	}

--- a/internal/agent/device/applications/provider/embedded_test.go
+++ b/internal/agent/device/applications/provider/embedded_test.go
@@ -395,9 +395,6 @@ func TestParseEmbeddedQuadlet(t *testing.T) {
 				"build-app": {
 					"app.build": "[Build]\n",
 				},
-				"kube-app": {
-					"app.kube": "[Kube]\n",
-				},
 			},
 			expectedCount: 0,
 			expectedNames: []string{},

--- a/internal/api/common/quadlet.go
+++ b/internal/api/common/quadlet.go
@@ -17,6 +17,7 @@ const (
 	QuadletTypeNetwork   QuadletType = "network"
 	QuadletTypeImage     QuadletType = "image"
 	QuadletTypePod       QuadletType = "pod"
+	QuadletTypeKube      QuadletType = "kube"
 )
 
 var (
@@ -31,16 +32,15 @@ var (
 		quadlet.NetworkExtension:   {},
 		quadlet.ImageExtension:     {},
 		quadlet.PodExtension:       {},
+		quadlet.KubeExtension:      {},
 	}
 	UnsupportedQuadletExtensions = map[string]struct{}{
 		quadlet.BuildExtension:    {},
 		quadlet.ArtifactExtension: {},
-		quadlet.KubeExtension:     {},
 	}
 	UnsupportedQuadletSections = map[string]struct{}{
 		quadlet.BuildGroup:    {},
 		quadlet.ArtifactGroup: {},
-		quadlet.KubeGroup:     {},
 	}
 )
 
@@ -63,6 +63,9 @@ type QuadletReferences struct {
 	Pods []string
 	// The Name of the quadlet if the default will be overwritten
 	Name *string
+	// YamlFile is the Yaml= value from a [Kube] section, naming the Pod manifest file.
+	// Only populated for QuadletTypeKube.
+	YamlFile *string
 }
 
 // ParseQuadletReferences parses unit file data into a QuadletSpec
@@ -73,6 +76,7 @@ func ParseQuadletReferences(data []byte) (*QuadletReferences, error) {
 		quadlet.NetworkGroup:   QuadletTypeNetwork,
 		quadlet.ImageGroup:     QuadletTypeImage,
 		quadlet.PodGroup:       QuadletTypePod,
+		quadlet.KubeGroup:      QuadletTypeKube,
 	}
 
 	unit, err := quadlet.NewUnit(data)
@@ -177,6 +181,17 @@ func ParseQuadletReferences(data []byte) (*QuadletReferences, error) {
 			}
 		} else {
 			spec.Name = &name
+		}
+	}
+
+	if spec.Type == QuadletTypeKube {
+		yamlFile, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+		if err != nil {
+			if !errors.Is(err, quadlet.ErrKeyNotFound) {
+				return nil, fmt.Errorf("finding Yaml key in [Kube] section: %w", err)
+			}
+		} else {
+			spec.YamlFile = &yamlFile
 		}
 	}
 

--- a/internal/api/common/quadlet_test.go
+++ b/internal/api/common/quadlet_test.go
@@ -22,6 +22,7 @@ func TestParseQuadletSpec(t *testing.T) {
 		wantNetworks     []string
 		wantPods         []string
 		wantName         *string
+		wantYamlFile     *string
 		wantErr          bool
 		wantErrType      error
 		wantErrSubstr    string
@@ -113,12 +114,12 @@ ContextDir=/tmp/build`,
 			wantErrSubstr: "Build",
 		},
 		{
-			name: "unsupported type: Kube",
+			name: "valid kube type with Yaml directive",
 			data: `[Kube]
-Yaml=/path/to/kube.yaml`,
-			wantErr:       true,
-			wantErrType:   ErrUnsupportedQuadletType,
-			wantErrSubstr: "Kube",
+Yaml=pod.yaml`,
+			wantErr:      false,
+			wantType:     QuadletTypeKube,
+			wantYamlFile: lo.ToPtr("pod.yaml"),
 		},
 		{
 			name: "unsupported type: Artifact",
@@ -421,6 +422,12 @@ PodName=pod-one`,
 				require.Equal(*tt.wantName, *spec.Name)
 			} else {
 				require.Nil(spec.Name)
+			}
+			if tt.wantYamlFile != nil {
+				require.NotNil(spec.YamlFile, "expected YamlFile to be populated")
+				require.Equal(*tt.wantYamlFile, *spec.YamlFile)
+			} else {
+				require.Nil(spec.YamlFile)
 			}
 		})
 	}

--- a/internal/domain/application.go
+++ b/internal/domain/application.go
@@ -91,6 +91,10 @@ const (
 	AppTypeVm        = v1beta1.AppTypeVm
 )
 
+// ========== VM Application Types ==========
+
+type VmApplication = v1beta1.VmApplication
+
 // ========== Image Pull Policy ==========
 
 type ImagePullPolicy = v1beta1.ImagePullPolicy

--- a/internal/kvstore/keys.go
+++ b/internal/kvstore/keys.go
@@ -109,3 +109,15 @@ type AwaitingReconnectionKey struct {
 func (a *AwaitingReconnectionKey) ComposeKey() string {
 	return fmt.Sprintf("v1/%s/device/%s/awaiting-reconnect", a.OrgID, a.DeviceName)
 }
+
+// VmPodYamlKey is a content-addressed KV key for caching the pod.yaml output
+// of the kubevirt-vm-to-pod conversion. The key is global (not scoped to
+// org/fleet/templateVersion) because the conversion is deterministic: the same
+// vm.yaml input always produces the same pod.yaml output.
+type VmPodYamlKey struct {
+	Sha256 string // hex-encoded SHA-256 of the vm.yaml content
+}
+
+func (k *VmPodYamlKey) ComposeKey() string {
+	return fmt.Sprintf("v1/vm-pod-yaml/%s", k.Sha256)
+}

--- a/internal/quadlet/quadlet.go
+++ b/internal/quadlet/quadlet.go
@@ -73,6 +73,8 @@ const (
 	PublishPortKey = "PublishPort"
 	// DriverKey is the key name for specifying a Volume driver
 	DriverKey = "Driver"
+	// KubeYamlKey is the key name for the Pod YAML file reference in a [Kube] section.
+	KubeYamlKey = "Yaml"
 )
 
 // Sections maps quadlet section names to their corresponding file extensions.
@@ -261,7 +263,9 @@ func NamespaceResource(id string, resource string) string {
 	return fmt.Sprintf("%s-%s", id, resource)
 }
 
-// IsWorkload returns true if a quadlet file is considered to be a workload
+// IsWorkload returns true if a quadlet file is considered to be a workload.
+// Both .container and .kube files are workloads — they describe running processes.
 func IsWorkload(quadlet string) bool {
-	return filepath.Ext(quadlet) == ContainerExtension
+	ext := filepath.Ext(quadlet)
+	return ext == ContainerExtension || ext == KubeExtension
 }

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -72,10 +72,29 @@ type DeviceRenderLogic struct {
 	templateVersion *string
 	deviceConfig    *[]domain.ConfigProviderSpec
 	applications    *[]domain.ApplicationProviderSpec
+	vmConverter     VmConverterFn
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, serviceHandler service.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
-	return DeviceRenderLogic{log: log, serviceHandler: serviceHandler, k8sClient: k8sClient, kvStore: kvStore, cfg: cfg, orgId: orgId, event: event}
+	return DeviceRenderLogic{
+		log:            log,
+		serviceHandler: serviceHandler,
+		k8sClient:      k8sClient,
+		kvStore:        kvStore,
+		cfg:            cfg,
+		orgId:          orgId,
+		event:          event,
+		vmConverter:    defaultVmConverter,
+	}
+}
+
+// WithVmConverter returns a copy of DeviceRenderLogic using the given converter
+// for VM application rendering. Intended for integration tests that extract the
+// kubevirt-vm-to-pod binary into a temporary directory and supply its path via
+// NewVmConverter.
+func (t DeviceRenderLogic) WithVmConverter(fn VmConverterFn) DeviceRenderLogic {
+	t.vmConverter = fn
+	return t
 }
 
 func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
@@ -214,7 +233,7 @@ func (t *DeviceRenderLogic) renderApplications(ctx context.Context) ([]byte, err
 
 	for i := range *t.applications {
 		application := (*t.applications)[i]
-		name, renderedApplication, renderErr := renderApplication(ctx, &application)
+		name, renderedApplication, renderErr := renderApplication(ctx, &application, t.vmConverter, t.kvStore)
 		applicationName := util.DefaultIfNil(name, "<unknown>")
 
 		// Append invalid configs only if there's an error
@@ -334,7 +353,7 @@ func (t *DeviceRenderLogic) renderConfigItem(ctx context.Context, configItem *do
 	}
 }
 
-func renderApplication(_ context.Context, app *domain.ApplicationProviderSpec) (*string, *domain.ApplicationProviderSpec, error) {
+func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec, vmConverter VmConverterFn, kvStore kvstore.KVStore) (*string, *domain.ApplicationProviderSpec, error) {
 	appType, err := (*app).GetAppType()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get app type: %w", err)
@@ -350,7 +369,16 @@ func renderApplication(_ context.Context, app *domain.ApplicationProviderSpec) (
 	case domain.AppTypeQuadlet:
 		_, err = (*app).AsQuadletApplication()
 	case domain.AppTypeVm:
-		_, err = (*app).AsVmApplication()
+		vmApp, parseErr := (*app).AsVmApplication()
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("failed to parse application spec for type %s: %w", appType, parseErr)
+		}
+		appName := vmApp.Name
+		converted, renderErr := renderVmApplication(ctx, vmApp, vmConverter, kvStore)
+		if renderErr != nil {
+			return appName, nil, renderErr
+		}
+		return appName, converted, nil
 	default:
 		return nil, nil, fmt.Errorf("%w: unsupported application type: %q", ErrUnknownApplicationType, appType)
 	}

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -18,7 +18,18 @@ const (
 	vmWorkloadTypeAnnotationValue = "vm"
 	vmYamlFileName                = "vm.yaml"
 	defaultKubeUnit               = "[Kube]\nYaml=pod.yaml\n"
+	maxStderrLen                  = 512
 )
+
+// truncateStderr trims and caps subprocess stderr to avoid embedding large or
+// sensitive tool output directly in error messages.
+func truncateStderr(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > maxStderrLen {
+		return s[:maxStderrLen] + "... (truncated)"
+	}
+	return s
+}
 
 // VmConverterFn accepts KubeVirt VM YAML on stdin and returns pod YAML and
 // stderr output. Passed explicitly to renderVmApplication — no package-level
@@ -119,6 +130,9 @@ func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, conver
 	if vmApp.Name != nil {
 		name = *vmApp.Name
 	}
+	if name == "" {
+		return nil, fmt.Errorf("VmApplication must have a non-empty name")
+	}
 
 	outInlineSpec := domain.InlineApplicationProviderSpec{
 		Inline: []domain.ApplicationContent{
@@ -164,7 +178,7 @@ func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, 
 
 	podYAML, stderr, err := converter(ctx, vmYAML)
 	if err != nil {
-		return nil, fmt.Errorf("kubevirt-vm-to-pod: %s: %w", strings.TrimSpace(stderr), err)
+		return nil, fmt.Errorf("kubevirt-vm-to-pod: %s: %w", truncateStderr(stderr), err)
 	}
 	if len(podYAML) == 0 {
 		return nil, fmt.Errorf("kubevirt-vm-to-pod produced empty output")

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -1,0 +1,180 @@
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/kvstore"
+)
+
+const (
+	kubevirtVmToPodBinary         = "kubevirt-vm-to-pod"
+	vmWorkloadTypeAnnotationKey   = "flightctl.io/workload-type"
+	vmWorkloadTypeAnnotationValue = "vm"
+	vmYamlFileName                = "vm.yaml"
+	defaultKubeUnit               = "[Kube]\nYaml=pod.yaml\n"
+)
+
+// VmConverterFn accepts KubeVirt VM YAML on stdin and returns pod YAML and
+// stderr output. Passed explicitly to renderVmApplication — no package-level
+// variable is used so tests can inject stubs without sharing state.
+type VmConverterFn func(ctx context.Context, vmYAML []byte) (podYAML []byte, stderr string, err error)
+
+// NewVmConverter returns a VmConverterFn that invokes the kubevirt-vm-to-pod
+// binary at binaryPath. binaryPath may be an absolute path or a bare binary
+// name resolved via PATH. Exported so integration tests can point the converter
+// at a binary extracted to a temporary directory.
+func NewVmConverter(binaryPath string) VmConverterFn {
+	return func(ctx context.Context, vmYAML []byte) ([]byte, string, error) {
+		cmd := exec.CommandContext(ctx, binaryPath)
+		cmd.Stdin = bytes.NewReader(vmYAML)
+
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+
+		if err := cmd.Run(); err != nil {
+			return nil, stderrBuf.String(), err
+		}
+		return stdoutBuf.Bytes(), stderrBuf.String(), nil
+	}
+}
+
+// defaultVmConverter is the production converter backed by the
+// kubevirt-vm-to-pod binary that must be present in PATH at runtime.
+var defaultVmConverter = NewVmConverter(kubevirtVmToPodBinary)
+
+// buildKubeUnit returns the Quadlet .kube unit file content. When kubeContent
+// is non-nil it is returned verbatim (the operator supplied a .kube file in
+// the VmApplication inline set). Otherwise the minimal default unit is used.
+func buildKubeUnit(kubeContent *string) string {
+	if kubeContent != nil {
+		return *kubeContent
+	}
+	return defaultKubeUnit
+}
+
+// renderVmApplication converts a VmApplication (inline: provider) into a
+// QuadletApplication by:
+//  1. Extracting vm.yaml from the VmApplication inline set.
+//  2. Checking the KV-store cache (SHA-256 of vm.yaml content); returning
+//     the cached pod.yaml directly on a hit.
+//  3. On a cache miss: invoking the kubevirt-vm-to-pod subprocess via the
+//     provided converter, then storing the result in the cache.
+//  4. Extracting the .kube file from the inline set (if present) or
+//     generating a minimal default unit.
+//  5. Emitting a QuadletApplication with the flightctl.io/workload-type: vm
+//     annotation so the agent can identify the workload without inspecting
+//     image names.
+func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, converter VmConverterFn, kvStore kvstore.KVStore) (*domain.ApplicationProviderSpec, error) {
+	providerType, err := vmApp.Type()
+	if err != nil {
+		return nil, fmt.Errorf("invalid vm application provider type: %w", err)
+	}
+	if providerType != domain.InlineApplicationProviderType {
+		return nil, fmt.Errorf("VmApplication with %q provider is not yet supported for server-side rendering; use inline: with a vm.yaml file", providerType)
+	}
+
+	inlineSpec, err := vmApp.AsInlineApplicationProviderSpec()
+	if err != nil {
+		return nil, fmt.Errorf("extracting inline spec from vm application: %w", err)
+	}
+
+	// Locate vm.yaml and optional .kube file in the inline set.
+	var vmYAMLContent *string
+	var kubeContent *string
+	for i := range inlineSpec.Inline {
+		f := &inlineSpec.Inline[i]
+		switch {
+		case f.Path == vmYamlFileName:
+			vmYAMLContent = f.Content
+		case strings.HasSuffix(f.Path, ".kube"):
+			if kubeContent != nil {
+				return nil, fmt.Errorf("VmApplication inline set contains multiple .kube files; only one is allowed")
+			}
+			kubeContent = f.Content
+		}
+	}
+	if vmYAMLContent == nil {
+		return nil, fmt.Errorf("vm.yaml not found in VmApplication inline set")
+	}
+	if strings.TrimSpace(*vmYAMLContent) == "" {
+		return nil, fmt.Errorf("vm.yaml content is empty in VmApplication inline set")
+	}
+
+	podYAMLBytes, err := convertVmYAML(ctx, []byte(*vmYAMLContent), converter, kvStore)
+	if err != nil {
+		return nil, err
+	}
+
+	podYAMLStr := string(podYAMLBytes)
+	kubeUnit := buildKubeUnit(kubeContent)
+
+	name := ""
+	if vmApp.Name != nil {
+		name = *vmApp.Name
+	}
+
+	outInlineSpec := domain.InlineApplicationProviderSpec{
+		Inline: []domain.ApplicationContent{
+			{Path: "pod.yaml", Content: &podYAMLStr},
+			{Path: name + ".kube", Content: &kubeUnit},
+		},
+	}
+
+	annotations := map[string]string{vmWorkloadTypeAnnotationKey: vmWorkloadTypeAnnotationValue}
+	quadlet := domain.QuadletApplication{
+		AppType:     domain.AppTypeQuadlet,
+		Name:        vmApp.Name,
+		Annotations: &annotations,
+	}
+	if err := quadlet.FromInlineApplicationProviderSpec(outInlineSpec); err != nil {
+		return nil, fmt.Errorf("building QuadletApplication: %w", err)
+	}
+
+	var appSpec domain.ApplicationProviderSpec
+	if err := appSpec.FromQuadletApplication(quadlet); err != nil {
+		return nil, fmt.Errorf("wrapping QuadletApplication: %w", err)
+	}
+
+	return &appSpec, nil
+}
+
+// convertVmYAML converts vm.yaml to pod.yaml using the KV cache and the
+// converter subprocess. On a cache hit the subprocess is skipped entirely.
+func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, kvStore kvstore.KVStore) ([]byte, error) {
+	sum := sha256.Sum256(vmYAML)
+	sha256hex := fmt.Sprintf("%x", sum)
+	cacheKey := (&kvstore.VmPodYamlKey{Sha256: sha256hex}).ComposeKey()
+
+	if kvStore != nil {
+		cached, err := kvStore.Get(ctx, cacheKey)
+		if err != nil {
+			return nil, fmt.Errorf("checking vm pod YAML cache: %w", err)
+		}
+		if len(cached) > 0 {
+			return cached, nil
+		}
+	}
+
+	podYAML, stderr, err := converter(ctx, vmYAML)
+	if err != nil {
+		return nil, fmt.Errorf("kubevirt-vm-to-pod: %s: %w", strings.TrimSpace(stderr), err)
+	}
+	if len(podYAML) == 0 {
+		return nil, fmt.Errorf("kubevirt-vm-to-pod produced empty output")
+	}
+
+	if kvStore != nil {
+		if _, err := kvStore.SetNX(ctx, cacheKey, podYAML); err != nil {
+			return nil, fmt.Errorf("storing vm pod YAML in cache: %w", err)
+		}
+	}
+
+	return podYAML, nil
+}

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/quadlet"
 )
 
 const (
@@ -17,7 +18,6 @@ const (
 	vmWorkloadTypeAnnotationKey   = "flightctl.io/workload-type"
 	vmWorkloadTypeAnnotationValue = "vm"
 	vmYamlFileName                = "vm.yaml"
-	defaultKubeUnit               = "[Kube]\nYaml=pod.yaml\n"
 	maxStderrLen                  = 512
 )
 
@@ -60,22 +60,37 @@ func NewVmConverter(binaryPath string) VmConverterFn {
 // kubevirt-vm-to-pod binary that must be present in PATH at runtime.
 var defaultVmConverter = NewVmConverter(kubevirtVmToPodBinary)
 
-// buildKubeUnit returns the Quadlet .kube unit file content.
-//
-//   - If kubeContent is nil, the minimal default unit ("[Kube]\nYaml=pod.yaml\n") is used.
-//   - If kubeContent is provided but omits a Yaml= directive, "Yaml=pod.yaml" is injected
-//     immediately after the [Kube] section header so that Podman/Quadlet always has a
-//     valid pod manifest reference.
-//   - If kubeContent already contains a Yaml= directive it is returned verbatim.
-func buildKubeUnit(kubeContent *string) string {
-	if kubeContent == nil {
-		return defaultKubeUnit
+// buildKubeUnit returns the Quadlet .kube unit file content with Yaml=pod.yaml
+// always set. When kubeContent is non-nil it is parsed and any existing Yaml=
+// directive is overridden; otherwise the minimal default unit is used.
+// Yaml= is always forced to pod.yaml because renderVmApplication always emits
+// the converted pod YAML under that name.
+func buildKubeUnit(kubeContent *string) (string, error) {
+	var u *quadlet.Unit
+	if kubeContent != nil {
+		var err error
+		u, err = quadlet.NewUnit([]byte(*kubeContent))
+		if err != nil {
+			return "", fmt.Errorf("parsing .kube unit: %w", err)
+		}
+	} else {
+		u = quadlet.NewEmptyUnit()
 	}
-	content := *kubeContent
-	if !strings.Contains(content, "Yaml=") {
-		content = strings.Replace(content, "[Kube]", "[Kube]\nYaml=pod.yaml", 1)
+
+	yamlSet := false
+	_ = u.Transform(quadlet.KubeGroup, quadlet.KubeYamlKey, func(_ string) (string, error) {
+		yamlSet = true
+		return "pod.yaml", nil
+	})
+	if !yamlSet {
+		u.Add(quadlet.KubeGroup, quadlet.KubeYamlKey, "pod.yaml")
 	}
-	return content
+
+	b, err := u.Write()
+	if err != nil {
+		return "", fmt.Errorf("serializing .kube unit: %w", err)
+	}
+	return string(b), nil
 }
 
 // renderVmApplication converts a VmApplication (inline: provider) into a
@@ -132,7 +147,10 @@ func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, conver
 	}
 
 	podYAMLStr := string(podYAMLBytes)
-	kubeUnit := buildKubeUnit(kubeContent)
+	kubeUnit, err := buildKubeUnit(kubeContent)
+	if err != nil {
+		return nil, fmt.Errorf("building .kube unit: %w", err)
+	}
 
 	name := ""
 	if vmApp.Name != nil {

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -176,6 +176,10 @@ func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, 
 		}
 	}
 
+	if converter == nil {
+		return nil, fmt.Errorf("vm converter function is required but was not provided")
+	}
+
 	podYAML, stderr, err := converter(ctx, vmYAML)
 	if err != nil {
 		return nil, fmt.Errorf("kubevirt-vm-to-pod: %s: %w", truncateStderr(stderr), err)

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -60,14 +60,22 @@ func NewVmConverter(binaryPath string) VmConverterFn {
 // kubevirt-vm-to-pod binary that must be present in PATH at runtime.
 var defaultVmConverter = NewVmConverter(kubevirtVmToPodBinary)
 
-// buildKubeUnit returns the Quadlet .kube unit file content. When kubeContent
-// is non-nil it is returned verbatim (the operator supplied a .kube file in
-// the VmApplication inline set). Otherwise the minimal default unit is used.
+// buildKubeUnit returns the Quadlet .kube unit file content.
+//
+//   - If kubeContent is nil, the minimal default unit ("[Kube]\nYaml=pod.yaml\n") is used.
+//   - If kubeContent is provided but omits a Yaml= directive, "Yaml=pod.yaml" is injected
+//     immediately after the [Kube] section header so that Podman/Quadlet always has a
+//     valid pod manifest reference.
+//   - If kubeContent already contains a Yaml= directive it is returned verbatim.
 func buildKubeUnit(kubeContent *string) string {
-	if kubeContent != nil {
-		return *kubeContent
+	if kubeContent == nil {
+		return defaultKubeUnit
 	}
-	return defaultKubeUnit
+	content := *kubeContent
+	if !strings.Contains(content, "Yaml=") {
+		content = strings.Replace(content, "[Kube]", "[Kube]\nYaml=pod.yaml", 1)
+	}
+	return content
 }
 
 // renderVmApplication converts a VmApplication (inline: provider) into a

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -142,8 +142,9 @@ var _ kvstore.KVStore = (*fakeKVStore)(nil)
 // ─── renderVmApplication ──────────────────────────────────────────────────────
 
 const (
-	fakePodYAML    = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-vm\n"
-	customKubeUnit = "[Kube]\nYaml=pod.yaml\nKubeDownForce=true\nPublishPort=8080:8080/tcp\n"
+	fakePodYAML     = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-vm\n"
+	defaultKubeUnit = "[Kube]\nYaml=pod.yaml\n"
+	customKubeUnit  = "[Kube]\nYaml=pod.yaml\nKubeDownForce=true\nPublishPort=8080:8080/tcp\n"
 )
 
 func TestRenderVmApplication(t *testing.T) {
@@ -239,7 +240,7 @@ func TestRenderVmApplication(t *testing.T) {
 			converter:      stubbedConverter(fakePodYAML),
 			kvStore:        newFakeKVStore(),
 			wantPodYAML:    fakePodYAML,
-			wantKubeUnit:   "[Kube]\nYaml=pod.yaml\nPublishPort=8080:8080/tcp\n",
+			wantKubeUnit:   "[Kube]\nPublishPort=8080:8080/tcp\nYaml=pod.yaml\n",
 			wantAnnotation: true,
 		},
 	}
@@ -341,6 +342,7 @@ func TestBuildKubeUnit(t *testing.T) {
 		name        string
 		kubeContent *string
 		want        string
+		wantErr     bool
 	}{
 		{
 			name:        "When kubeContent is nil it should return the default unit",
@@ -348,25 +350,36 @@ func TestBuildKubeUnit(t *testing.T) {
 			want:        defaultKubeUnit,
 		},
 		{
-			name:        "When kubeContent is provided it should return it verbatim",
+			name:        "When kubeContent already has Yaml= it should preserve it and re-serialize",
 			kubeContent: lo.ToPtr(customKubeUnit),
 			want:        customKubeUnit,
 		},
 		{
-			name:        "When kubeContent is an empty string it should return it verbatim",
+			name:        "When kubeContent is an empty string it should add [Kube] with Yaml=pod.yaml",
 			kubeContent: lo.ToPtr(""),
-			want:        "",
+			want:        defaultKubeUnit,
 		},
 		{
-			name:        "When kubeContent omits Yaml= it should inject Yaml=pod.yaml into the [Kube] section",
+			name:        "When kubeContent omits Yaml= it should append Yaml=pod.yaml to the [Kube] section",
 			kubeContent: lo.ToPtr("[Kube]\nPublishPort=8080:8080/tcp\n"),
-			want:        "[Kube]\nYaml=pod.yaml\nPublishPort=8080:8080/tcp\n",
+			want:        "[Kube]\nPublishPort=8080:8080/tcp\nYaml=pod.yaml\n",
+		},
+		{
+			name:        "When kubeContent is malformed it should return an error",
+			kubeContent: lo.ToPtr("[InvalidSection\nYaml=pod.yaml\n"),
+			wantErr:     true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, buildKubeUnit(tc.kubeContent))
+			got, err := buildKubeUnit(tc.kubeContent)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -1,0 +1,354 @@
+package tasks
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+// newTestVmInlineApp builds a VmApplication with inline: provider from a
+// map[path]content, wrapped in an ApplicationProviderSpec.
+func newTestVmInlineApp(t *testing.T, name string, files map[string]string) domain.ApplicationProviderSpec {
+	t.Helper()
+	contents := make([]domain.ApplicationContent, 0, len(files))
+	for path, content := range files {
+		c := content
+		contents = append(contents, domain.ApplicationContent{Path: path, Content: &c})
+	}
+	inlineSpec := domain.InlineApplicationProviderSpec{Inline: contents}
+
+	vm := domain.VmApplication{
+		AppType: domain.AppTypeVm,
+		Name:    lo.ToPtr(name),
+	}
+	require.NoError(t, vm.FromInlineApplicationProviderSpec(inlineSpec))
+
+	var spec domain.ApplicationProviderSpec
+	require.NoError(t, spec.FromVmApplication(vm))
+	return spec
+}
+
+// minimalVmYAML returns a minimal valid KubeVirt VirtualMachine YAML for test input.
+func minimalVmYAML(name string) string {
+	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: %s
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 1
+        memory:
+          guest: 1Gi
+        devices: {}
+      networks: []
+      volumes: []
+`, name)
+}
+
+// stubbedConverter returns a VmConverterFn that always emits a fixed pod YAML string.
+func stubbedConverter(podYAML string) VmConverterFn {
+	return func(_ context.Context, _ []byte) ([]byte, string, error) {
+		return []byte(podYAML), "", nil
+	}
+}
+
+// failingConverter returns a VmConverterFn that always returns an error with the given stderr.
+func failingConverter(stderr string) VmConverterFn {
+	return func(_ context.Context, _ []byte) ([]byte, string, error) {
+		return nil, stderr, errors.New("exit status 1")
+	}
+}
+
+// emptyConverter returns a VmConverterFn that returns empty stdout without an error.
+func emptyConverter() VmConverterFn {
+	return func(_ context.Context, _ []byte) ([]byte, string, error) {
+		return []byte{}, "", nil
+	}
+}
+
+// vmPodCacheKey returns the KV key for a given vm.yaml content, matching the
+// production implementation so tests can pre-populate the cache.
+func vmPodCacheKey(vmYAML string) string {
+	sum := sha256.Sum256([]byte(vmYAML))
+	return (&kvstore.VmPodYamlKey{Sha256: fmt.Sprintf("%x", sum)}).ComposeKey()
+}
+
+// ─── fakeKVStore ──────────────────────────────────────────────────────────────
+
+// fakeKVStore is a minimal in-memory KVStore for unit tests.
+type fakeKVStore struct {
+	data map[string][]byte
+}
+
+func newFakeKVStore() *fakeKVStore {
+	return &fakeKVStore{data: make(map[string][]byte)}
+}
+
+func (f *fakeKVStore) Close()                                                         {}
+func (f *fakeKVStore) PrintAllKeys(_ context.Context)                                 {}
+func (f *fakeKVStore) DeleteAllKeys(_ context.Context) error                          { return nil }
+func (f *fakeKVStore) DeleteKeysForTemplateVersion(_ context.Context, _ string) error { return nil }
+func (f *fakeKVStore) Delete(_ context.Context, key string) error                     { delete(f.data, key); return nil }
+func (f *fakeKVStore) SetIfGreater(_ context.Context, _ string, _ int64) (bool, error) {
+	return false, nil
+}
+func (f *fakeKVStore) SetExpire(_ context.Context, _ string, _ time.Duration) error { return nil }
+func (f *fakeKVStore) StreamAdd(_ context.Context, _ string, _ []byte) (string, error) {
+	return "", nil
+}
+func (f *fakeKVStore) StreamRange(_ context.Context, _ string, _, _ string) ([]kvstore.StreamEntry, error) {
+	return nil, nil
+}
+func (f *fakeKVStore) StreamRead(_ context.Context, _ string, _ string, _ time.Duration, _ int64) ([]kvstore.StreamEntry, error) {
+	return nil, nil
+}
+func (f *fakeKVStore) GetOrSetNX(_ context.Context, key string, value []byte) ([]byte, error) {
+	if existing := f.data[key]; existing != nil {
+		return existing, nil
+	}
+	f.data[key] = value
+	return value, nil
+}
+
+func (f *fakeKVStore) SetNX(_ context.Context, key string, value []byte) (bool, error) {
+	if _, ok := f.data[key]; ok {
+		return false, nil
+	}
+	f.data[key] = value
+	return true, nil
+}
+
+func (f *fakeKVStore) Get(_ context.Context, key string) ([]byte, error) {
+	return f.data[key], nil
+}
+
+var _ kvstore.KVStore = (*fakeKVStore)(nil)
+
+// ─── renderVmApplication ──────────────────────────────────────────────────────
+
+const (
+	fakePodYAML    = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-vm\n"
+	customKubeUnit = "[Kube]\nYaml=pod.yaml\nKubeDownForce=true\nPublishPort=8080:8080/tcp\n"
+)
+
+func TestRenderVmApplication(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		vmName         string
+		files          map[string]string
+		converter      VmConverterFn
+		kvStore        kvstore.KVStore
+		wantPodYAML    string
+		wantKubeUnit   string
+		wantAnnotation bool
+		wantErr        string
+	}{
+		{
+			name:   "When inline set has only vm.yaml it should generate the default .kube unit",
+			vmName: "my-vm",
+			files: map[string]string{
+				"vm.yaml": minimalVmYAML("my-vm"),
+			},
+			converter:      stubbedConverter(fakePodYAML),
+			kvStore:        newFakeKVStore(),
+			wantPodYAML:    fakePodYAML,
+			wantKubeUnit:   defaultKubeUnit,
+			wantAnnotation: true,
+		},
+		{
+			name:   "When inline set contains a .kube file it should pass it through unchanged",
+			vmName: "my-vm",
+			files: map[string]string{
+				"vm.yaml":    minimalVmYAML("my-vm"),
+				"my-vm.kube": customKubeUnit,
+			},
+			converter:      stubbedConverter(fakePodYAML),
+			kvStore:        newFakeKVStore(),
+			wantPodYAML:    fakePodYAML,
+			wantKubeUnit:   customKubeUnit,
+			wantAnnotation: true,
+		},
+		{
+			name:   "When KV cache has a hit it should skip the converter",
+			vmName: "my-vm",
+			files: map[string]string{
+				"vm.yaml": minimalVmYAML("my-vm"),
+			},
+			converter: func(_ context.Context, _ []byte) ([]byte, string, error) {
+				t.Error("converter must not be called on a cache hit")
+				return nil, "", nil
+			},
+			kvStore: func() kvstore.KVStore {
+				kv := newFakeKVStore()
+				kv.data[vmPodCacheKey(minimalVmYAML("my-vm"))] = []byte(fakePodYAML)
+				return kv
+			}(),
+			wantPodYAML:    fakePodYAML,
+			wantKubeUnit:   defaultKubeUnit,
+			wantAnnotation: true,
+		},
+		{
+			name:      "When converter exits non-zero it should surface the subprocess stderr as the error",
+			vmName:    "my-vm",
+			files:     map[string]string{"vm.yaml": minimalVmYAML("my-vm")},
+			converter: failingConverter("unsupported vm feature"),
+			kvStore:   newFakeKVStore(),
+			wantErr:   "unsupported vm feature",
+		},
+		{
+			name:      "When converter returns empty stdout it should return an error",
+			vmName:    "my-vm",
+			files:     map[string]string{"vm.yaml": minimalVmYAML("my-vm")},
+			converter: emptyConverter(),
+			kvStore:   newFakeKVStore(),
+			wantErr:   "produced empty output",
+		},
+		{
+			name:      "When vm.yaml is absent from inline set it should return an error",
+			vmName:    "my-vm",
+			files:     map[string]string{"other.yaml": "some content"},
+			converter: stubbedConverter(fakePodYAML),
+			kvStore:   newFakeKVStore(),
+			wantErr:   "vm.yaml not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			appSpec := newTestVmInlineApp(t, tc.vmName, tc.files)
+			vmApp, err := appSpec.AsVmApplication()
+			require.NoError(t, err)
+
+			result, err := renderVmApplication(ctx, vmApp, tc.converter, tc.kvStore)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			quadlet, err := result.AsQuadletApplication()
+			require.NoError(t, err)
+
+			if tc.wantAnnotation {
+				require.NotNil(t, quadlet.Annotations)
+				assert.Equal(t, vmWorkloadTypeAnnotationValue, (*quadlet.Annotations)[vmWorkloadTypeAnnotationKey])
+			}
+
+			inlineOut, err := quadlet.AsInlineApplicationProviderSpec()
+			require.NoError(t, err)
+
+			fileMap := make(map[string]string, len(inlineOut.Inline))
+			for _, f := range inlineOut.Inline {
+				if f.Content != nil {
+					fileMap[f.Path] = *f.Content
+				}
+			}
+
+			assert.Equal(t, tc.wantPodYAML, fileMap["pod.yaml"], "pod.yaml content")
+			assert.Equal(t, tc.wantKubeUnit, fileMap[tc.vmName+".kube"], ".kube unit content")
+			assert.NotContains(t, fileMap, vmYamlFileName, "vm.yaml must not appear in the rendered QuadletApplication")
+		})
+	}
+}
+
+// TestRenderVmApplication_CachePopulatedOnMiss verifies that after a cache miss
+// the pod.yaml is stored, and a second identical call returns the cached value
+// without invoking the converter again.
+func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kv := newFakeKVStore()
+	callCount := 0
+	converter := func(_ context.Context, _ []byte) ([]byte, string, error) {
+		callCount++
+		return []byte(fakePodYAML), "", nil
+	}
+
+	vmYAML := minimalVmYAML("my-vm")
+	appSpec := newTestVmInlineApp(t, "my-vm", map[string]string{"vm.yaml": vmYAML})
+	vmApp, err := appSpec.AsVmApplication()
+	require.NoError(t, err)
+
+	_, err = renderVmApplication(ctx, vmApp, converter, kv)
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "converter should be called on the first (cache miss) call")
+
+	_, err = renderVmApplication(ctx, vmApp, converter, kv)
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "converter must not be called again on the second (cache hit) call")
+}
+
+// TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication
+// using the image: provider returns a clear error.
+func TestRenderVmApplication_ImageProviderUnsupported(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	imageSpec := domain.ImageApplicationProviderSpec{Image: "quay.io/org/vm-disk:latest"}
+	vm := domain.VmApplication{AppType: domain.AppTypeVm, Name: lo.ToPtr("my-vm")}
+	require.NoError(t, vm.FromImageApplicationProviderSpec(imageSpec))
+	var appSpec domain.ApplicationProviderSpec
+	require.NoError(t, appSpec.FromVmApplication(vm))
+
+	vmApp, err := appSpec.AsVmApplication()
+	require.NoError(t, err)
+
+	_, err = renderVmApplication(ctx, vmApp, stubbedConverter(fakePodYAML), newFakeKVStore())
+	require.ErrorContains(t, err, "not yet supported")
+}
+
+// ─── buildKubeUnit ────────────────────────────────────────────────────────────
+
+func TestBuildKubeUnit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		kubeContent *string
+		want        string
+	}{
+		{
+			name:        "When kubeContent is nil it should return the default unit",
+			kubeContent: nil,
+			want:        defaultKubeUnit,
+		},
+		{
+			name:        "When kubeContent is provided it should return it verbatim",
+			kubeContent: lo.ToPtr(customKubeUnit),
+			want:        customKubeUnit,
+		},
+		{
+			name:        "When kubeContent is an empty string it should return it verbatim",
+			kubeContent: lo.ToPtr(""),
+			want:        "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, buildKubeUnit(tc.kubeContent))
+		})
+	}
+}

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -229,6 +229,19 @@ func TestRenderVmApplication(t *testing.T) {
 			kvStore:   newFakeKVStore(),
 			wantErr:   "vm.yaml not found",
 		},
+		{
+			name:   "When inline set contains a .kube file without Yaml= it should inject the default Yaml=pod.yaml",
+			vmName: "my-vm",
+			files: map[string]string{
+				"vm.yaml":    minimalVmYAML("my-vm"),
+				"my-vm.kube": "[Kube]\nPublishPort=8080:8080/tcp\n",
+			},
+			converter:      stubbedConverter(fakePodYAML),
+			kvStore:        newFakeKVStore(),
+			wantPodYAML:    fakePodYAML,
+			wantKubeUnit:   "[Kube]\nYaml=pod.yaml\nPublishPort=8080:8080/tcp\n",
+			wantAnnotation: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -343,6 +356,11 @@ func TestBuildKubeUnit(t *testing.T) {
 			name:        "When kubeContent is an empty string it should return it verbatim",
 			kubeContent: lo.ToPtr(""),
 			want:        "",
+		},
+		{
+			name:        "When kubeContent omits Yaml= it should inject Yaml=pod.yaml into the [Kube] section",
+			kubeContent: lo.ToPtr("[Kube]\nPublishPort=8080:8080/tcp\n"),
+			want:        "[Kube]\nYaml=pod.yaml\nPublishPort=8080:8080/tcp\n",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -362,7 +362,7 @@ func (f FleetRolloutsLogic) getDeviceApps(device *domain.Device, templateVersion
 		case domain.AppTypeQuadlet:
 			newAppItem, errs = f.replaceQuadletApplicationParameters(device, appItem)
 		case domain.AppTypeVm:
-			newAppItem = &appItem
+			newAppItem, errs = f.replaceVmApplicationParameters(device, appItem)
 		default:
 			errs = append(errs, fmt.Errorf("unsupported app type for app %d: %s", appIndex, appType))
 		}
@@ -589,6 +589,53 @@ func (f FleetRolloutsLogic) replaceQuadletApplicationParameters(device *domain.D
 	var newItem domain.ApplicationProviderSpec
 	if err := newItem.FromQuadletApplication(quadletApp); err != nil {
 		return nil, []error{fmt.Errorf("failed converting quadlet application: %w", err)}
+	}
+
+	return &newItem, nil
+}
+
+func (f FleetRolloutsLogic) replaceVmApplicationParameters(device *domain.Device, app domain.ApplicationProviderSpec) (*domain.ApplicationProviderSpec, []error) {
+	vmApp, err := app.AsVmApplication()
+	if err != nil {
+		return nil, []error{fmt.Errorf("failed to convert to vm application: %w", err)}
+	}
+	appName := lo.FromPtr(vmApp.Name)
+
+	providerType, err := vmApp.Type()
+	if err != nil {
+		return nil, []error{fmt.Errorf("failed getting provider type for vm app %s: %w", appName, err)}
+	}
+
+	switch providerType {
+	case domain.ImageApplicationProviderType:
+		imageSpec, err := vmApp.AsImageApplicationProviderSpec()
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to get image spec for vm app %s: %w", appName, err)}
+		}
+		imageSpec.Image, err = ReplaceParametersInString(imageSpec.Image, device)
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed replacing parameters in image for vm app %s: %w", appName, err)}
+		}
+		if err := vmApp.FromImageApplicationProviderSpec(imageSpec); err != nil {
+			return nil, []error{fmt.Errorf("failed updating image spec for vm app %s: %w", appName, err)}
+		}
+
+	case domain.InlineApplicationProviderType:
+		inlineSpec, err := vmApp.AsInlineApplicationProviderSpec()
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to get inline spec for vm app %s: %w", appName, err)}
+		}
+		if inlineErrs := f.replaceInlineContentParameters(device, appName, &inlineSpec); len(inlineErrs) > 0 {
+			return nil, inlineErrs
+		}
+		if err := vmApp.FromInlineApplicationProviderSpec(inlineSpec); err != nil {
+			return nil, []error{fmt.Errorf("failed updating inline spec for vm app %s: %w", appName, err)}
+		}
+	}
+
+	var newItem domain.ApplicationProviderSpec
+	if err := newItem.FromVmApplication(vmApp); err != nil {
+		return nil, []error{fmt.Errorf("failed converting vm application: %w", err)}
 	}
 
 	return &newItem, nil

--- a/internal/util/validation/quadlet.go
+++ b/internal/util/validation/quadlet.go
@@ -60,6 +60,7 @@ func ValidateQuadletSpec(spec *common.QuadletReferences, path string, opts ...Sp
 		common.QuadletTypeNetwork:   quadlet.NetworkExtension,
 		common.QuadletTypeImage:     quadlet.ImageExtension,
 		common.QuadletTypePod:       quadlet.PodExtension,
+		common.QuadletTypeKube:      quadlet.KubeExtension,
 	}
 
 	if expectedExt, ok := typeToExtension[spec.Type]; !ok {
@@ -106,8 +107,8 @@ func ValidateQuadletSpec(spec *common.QuadletReferences, path string, opts ...Sp
 			}
 		}
 
-	case common.QuadletTypeNetwork, common.QuadletTypePod:
-		// no validation required
+	case common.QuadletTypeNetwork, common.QuadletTypePod, common.QuadletTypeKube:
+		// no validation required beyond the type/extension check above
 
 	default:
 		errs = append(errs, fmt.Errorf("%w: %q", common.ErrUnsupportedQuadletType, spec.Type))

--- a/internal/util/validation/quadlet_test.go
+++ b/internal/util/validation/quadlet_test.go
@@ -376,10 +376,9 @@ func TestValidateQuadletPaths(t *testing.T) {
 			wantErrSubstr: "unsupported quadlet type \".artifact\"",
 		},
 		{
-			name:          "contains kube file - unsupported",
-			paths:         []string{"app.kube"},
-			wantErr:       true,
-			wantErrSubstr: "unsupported quadlet type \".kube\"",
+			name:    "contains kube file - supported workload",
+			paths:   []string{"app.kube"},
+			wantErr: false,
 		},
 		{
 			name:          "mix of valid and unsupported",

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,3 +1,16 @@
+# ── kubevirt-vm-to-pod build stage ──────────────────────────────────────────
+# Isolated from the main build to avoid module-cache contamination — the tool
+# pins k8s.io at a different version than flightctl.
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as kubevirt-vm-to-pod-build
+USER 0
+ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
+    cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
+    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+
+# ── flightctl worker build stage ─────────────────────────────────────────────
 FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
@@ -48,5 +61,6 @@ LABEL \
   name="flightctl-worker" \
   summary="Flight Control Edge management service task worker"
 COPY --from=build /app/bin/flightctl-worker .
+COPY --from=kubevirt-vm-to-pod-build /out/kubevirt-vm-to-pod /usr/local/bin/kubevirt-vm-to-pod
 
 CMD ["./flightctl-worker"]

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,3 +1,16 @@
+# ── kubevirt-vm-to-pod build stage ──────────────────────────────────────────
+# Isolated from the main build to avoid module-cache contamination — the tool
+# pins k8s.io at a different version than flightctl.
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as kubevirt-vm-to-pod-build
+USER 0
+ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
+    cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
+    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+
+# ── flightctl worker build stage ─────────────────────────────────────────────
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
 WORKDIR /app
 
@@ -48,4 +61,5 @@ LABEL \
   name="flightctl-worker" \
   summary="Flight Control Edge management service, async job worker"
 COPY --from=build /app/bin/flightctl-worker .
+COPY --from=kubevirt-vm-to-pod-build /out/kubevirt-vm-to-pod /usr/local/bin/kubevirt-vm-to-pod
 CMD ["./flightctl-worker"]

--- a/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
+++ b/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
@@ -1,10 +1,12 @@
-# Standalone build for the kubevirt-vm-to-pod converter tool.
-# Uses the same base image as the worker build stages so the binary is built
-# in an identical environment. Used by the integration test suite via
-# testcontainers FromDockerfile — no cache mounts to maximise compatibility.
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347
+# Build stage: compile kubevirt-vm-to-pod in an isolated toolset image.
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 AS build
 USER 0
 ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
 RUN git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
     cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
-    CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/kubevirt-vm-to-pod ./cmd
+    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+
+# Final stage: copy only the binary; no toolchain, non-root user.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY --from=build /out/kubevirt-vm-to-pod /usr/local/bin/kubevirt-vm-to-pod
+USER 1000

--- a/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
+++ b/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
@@ -1,0 +1,10 @@
+# Standalone build for the kubevirt-vm-to-pod converter tool.
+# Uses the same base image as the worker build stages so the binary is built
+# in an identical environment. Used by the integration test suite via
+# testcontainers FromDockerfile — no cache mounts to maximise compatibility.
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347
+USER 0
+ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+RUN git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
+    cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
+    CGO_ENABLED=0 GOOS=linux go build -o /usr/local/bin/kubevirt-vm-to-pod ./cmd

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -91,8 +91,11 @@ var _ = Describe("VmApplicationRender", func() {
 		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
 
-		kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
-		Expect(err).ToNot(HaveOccurred())
+		if kvStoreInst == nil {
+			kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { kvStoreInst.Close() })
+		}
 
 		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{}, false)
 
@@ -106,9 +109,6 @@ var _ = Describe("VmApplicationRender", func() {
 	})
 
 	AfterEach(func() {
-		if kvStoreInst != nil {
-			kvStoreInst.Close()
-		}
 		_ = storeInst.Close()
 		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
 		ctrl.Finish()
@@ -265,9 +265,16 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(inline.Inline).To(HaveLen(2))
 
-			paths := []string{inline.Inline[0].Path, inline.Inline[1].Path}
-			Expect(paths).To(ContainElement("pod.yaml"))
-			Expect(paths).To(ContainElement(fmt.Sprintf("%s.kube", deviceName)))
+			fileMap := map[string]string{}
+			for _, f := range inline.Inline {
+				if f.Content != nil {
+					fileMap[f.Path] = *f.Content
+				}
+			}
+			Expect(fileMap).To(HaveKey("pod.yaml"))
+			kubeKey := fmt.Sprintf("%s.kube", deviceName)
+			Expect(fileMap).To(HaveKey(kubeKey))
+			Expect(fileMap[kubeKey]).To(Equal(customKube), "user-provided .kube content must be preserved verbatim")
 		})
 	})
 })

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -213,6 +213,74 @@ spec:
 		})
 	})
 
+	Context("when a VmApplication with a user-provided .kube file that omits Yaml= is rendered", func() {
+		It("should inject the default Yaml=pod.yaml entry and preserve the rest of the .kube content", func() {
+			vmYAML := fmt.Sprintf(`apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: %s
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 1
+        memory:
+          guest: 1Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/containerdisks/fedora:40
+`, deviceName)
+
+			kubeNoYaml := "[Kube]\nPublishPort=9090:9090/tcp\n"
+			inlineSpec := api.InlineApplicationProviderSpec{
+				Inline: []api.ApplicationContent{
+					{Path: "vm.yaml", Content: lo.ToPtr(vmYAML)},
+					{Path: fmt.Sprintf("%s.kube", deviceName), Content: lo.ToPtr(kubeNoYaml)},
+				},
+			}
+			vmApp := api.VmApplication{AppType: api.AppTypeVm, Name: lo.ToPtr(deviceName)}
+			Expect(vmApp.FromInlineApplicationProviderSpec(inlineSpec)).To(Succeed())
+
+			apps := buildAndRenderVmDevice(vmApp)
+			Expect(apps).To(HaveLen(1))
+
+			quadlet, err := apps[0].AsQuadletApplication()
+			Expect(err).ToNot(HaveOccurred())
+
+			inline, err := quadlet.AsInlineApplicationProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inline.Inline).To(HaveLen(2))
+
+			fileMap := map[string]string{}
+			for _, f := range inline.Inline {
+				if f.Content != nil {
+					fileMap[f.Path] = *f.Content
+				}
+			}
+			Expect(fileMap).To(HaveKey("pod.yaml"))
+			kubeKey := fmt.Sprintf("%s.kube", deviceName)
+			Expect(fileMap).To(HaveKey(kubeKey))
+			Expect(fileMap[kubeKey]).To(ContainSubstring("Yaml=pod.yaml"),
+				"renderer must inject Yaml=pod.yaml when absent from the user-provided .kube")
+			Expect(fileMap[kubeKey]).To(ContainSubstring("PublishPort=9090:9090/tcp"),
+				"user-provided .kube directives must be preserved after injection")
+		})
+	})
+
 	Context("when a VmApplication with a user-provided .kube file is rendered", func() {
 		It("should preserve the user-provided .kube unit in the output", func() {
 			vmYAML := fmt.Sprintf(`apiVersion: kubevirt.io/v1

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -1,0 +1,273 @@
+package vmrender_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/rendered"
+	"github.com/flightctl/flightctl/internal/service"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	"github.com/flightctl/flightctl/pkg/k8sclient"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// mockK8sClient is a no-op K8s client sufficient for VM render tests,
+// which do not exercise any K8s secret or RBAC paths.
+type mockK8sClient struct{}
+
+func (m *mockK8sClient) GetSecret(_ context.Context, _, _ string) (*corev1.Secret, error) {
+	return &corev1.Secret{}, nil
+}
+
+func (m *mockK8sClient) PostCRD(_ context.Context, _ string, _ []byte, _ ...k8sclient.Option) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockK8sClient) ListRoleBindings(_ context.Context, _ string) (*rbacv1.RoleBindingList, error) {
+	return nil, nil
+}
+
+func (m *mockK8sClient) ListProjects(_ context.Context, _ string, _ ...k8sclient.ListProjectsOption) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockK8sClient) ListRoleBindingsForUser(_ context.Context, _, _ string, _ []string) ([]string, error) {
+	return nil, nil
+}
+
+var _ = Describe("VmApplicationRender", func() {
+	var (
+		log               *logrus.Logger
+		ctx               context.Context
+		orgId             uuid.UUID
+		deviceStore       store.Device
+		storeInst         store.Store
+		serviceHandler    service.Service
+		cfg               *config.Config
+		dbName            string
+		db                *gorm.DB
+		workerClient      worker_client.WorkerClient
+		mockQueueProducer *queues.MockQueueProducer
+		ctrl              *gomock.Controller
+		kvStoreInst       kvstore.KVStore
+		queuesProvider    queues.Provider
+		deviceName        string
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
+		orgId = store.NullOrgId
+		log = flightlog.InitLogs()
+		deviceName = "vm-test-device-" + uuid.New().String()[:8]
+
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		storeInst = store.NewStore(db, log.WithField("pkg", "store"))
+		deviceStore = storeInst.Device()
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer = queues.NewMockQueueProducer(ctrl)
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
+
+		kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+		Expect(err).ToNot(HaveOccurred())
+
+		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{}, false)
+
+		if queuesProvider == nil {
+			processID := fmt.Sprintf("vm-render-test-%s", uuid.New().String())
+			queuesProvider, err = queues.NewRedisProvider(ctx, log, processID, redisHost, redisPort, redisPassword, queues.DefaultRetryConfig())
+			Expect(err).ToNot(HaveOccurred())
+			err = rendered.Bus.Initialize(ctx, kvStoreInst, queuesProvider, 10*time.Second, log)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		if kvStoreInst != nil {
+			kvStoreInst.Close()
+		}
+		_ = storeInst.Close()
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+		ctrl.Finish()
+	})
+
+	// buildAndRenderVmDevice creates a device with the given VmApplication spec,
+	// runs RenderDevice using the suite-level vmConverter, and returns the
+	// rendered applications from the store.
+	buildAndRenderVmDevice := func(vmApp api.VmApplication) []api.ApplicationProviderSpec {
+		GinkgoHelper()
+
+		appSpec := api.ApplicationProviderSpec{}
+		Expect(appSpec.FromVmApplication(vmApp)).To(Succeed())
+
+		device := &api.Device{
+			Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec:     &api.DeviceSpec{Applications: &[]api.ApplicationProviderSpec{appSpec}},
+		}
+		_, err := deviceStore.Create(ctx, orgId, device, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		event := api.Event{
+			Reason:         api.EventReasonResourceUpdated,
+			InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: deviceName},
+		}
+
+		logic := tasks.NewDeviceRenderLogic(log, serviceHandler, &mockK8sClient{}, kvStoreInst, nil, orgId, event).
+			WithVmConverter(vmConverter)
+		Expect(logic.RenderDevice(ctx)).To(Succeed())
+
+		rendered, err := deviceStore.GetRendered(ctx, orgId, deviceName, nil, "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rendered.Spec).ToNot(BeNil())
+		Expect(rendered.Spec.Applications).ToNot(BeNil())
+		return *rendered.Spec.Applications
+	}
+
+	// newInlineVmApp constructs a VmApplication with an inline KubeVirt VirtualMachine manifest.
+	newInlineVmApp := func(name, vmYAML string) api.VmApplication {
+		GinkgoHelper()
+		inlineSpec := api.InlineApplicationProviderSpec{
+			Inline: []api.ApplicationContent{
+				{Path: "vm.yaml", Content: lo.ToPtr(vmYAML)},
+			},
+		}
+		vmApp := api.VmApplication{
+			AppType: api.AppTypeVm,
+			Name:    lo.ToPtr(name),
+		}
+		Expect(vmApp.FromInlineApplicationProviderSpec(inlineSpec)).To(Succeed())
+		return vmApp
+	}
+
+	Context("when a VmApplication with an inline vm.yaml is rendered", func() {
+		It("should produce a QuadletApplication with pod.yaml and <name>.kube inline files", func() {
+			vmYAML := fmt.Sprintf(`apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: %s
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        memory:
+          guest: 2Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/containerdisks/fedora:40
+`, deviceName)
+
+			vmApp := newInlineVmApp(deviceName, vmYAML)
+
+			apps := buildAndRenderVmDevice(vmApp)
+			Expect(apps).To(HaveLen(1))
+
+			quadlet, err := apps[0].AsQuadletApplication()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(quadlet.AppType).To(Equal(api.AppTypeQuadlet))
+
+			inline, err := quadlet.AsInlineApplicationProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inline.Inline).To(HaveLen(2))
+
+			paths := []string{inline.Inline[0].Path, inline.Inline[1].Path}
+			Expect(paths).To(ContainElement("pod.yaml"))
+			Expect(paths).To(ContainElement(fmt.Sprintf("%s.kube", deviceName)))
+		})
+	})
+
+	Context("when a VmApplication with a user-provided .kube file is rendered", func() {
+		It("should preserve the user-provided .kube unit in the output", func() {
+			vmYAML := fmt.Sprintf(`apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: %s
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 1
+        memory:
+          guest: 1Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/containerdisks/fedora:40
+`, deviceName)
+
+			customKube := "[Kube]\nYaml=pod.yaml\nPublishPort=8080:8080/tcp\n"
+			inlineSpec := api.InlineApplicationProviderSpec{
+				Inline: []api.ApplicationContent{
+					{Path: "vm.yaml", Content: lo.ToPtr(vmYAML)},
+					{Path: fmt.Sprintf("%s.kube", deviceName), Content: lo.ToPtr(customKube)},
+				},
+			}
+			vmApp := api.VmApplication{AppType: api.AppTypeVm, Name: lo.ToPtr(deviceName)}
+			Expect(vmApp.FromInlineApplicationProviderSpec(inlineSpec)).To(Succeed())
+
+			apps := buildAndRenderVmDevice(vmApp)
+			Expect(apps).To(HaveLen(1))
+
+			quadlet, err := apps[0].AsQuadletApplication()
+			Expect(err).ToNot(HaveOccurred())
+
+			inline, err := quadlet.AsInlineApplicationProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inline.Inline).To(HaveLen(2))
+
+			paths := []string{inline.Inline[0].Path, inline.Inline[1].Path}
+			Expect(paths).To(ContainElement("pod.yaml"))
+			Expect(paths).To(ContainElement(fmt.Sprintf("%s.kube", deviceName)))
+		})
+	})
+})

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -91,12 +91,8 @@ var _ = Describe("VmApplicationRender", func() {
 		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
 
-		if kvStoreInst == nil {
-			kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() { kvStoreInst.Close() })
-		}
-
+		kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+		Expect(err).ToNot(HaveOccurred())
 		serviceHandler = service.NewServiceHandler(storeInst, workerClient, kvStoreInst, nil, log, "", "", []string{}, false)
 
 		if queuesProvider == nil {

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -102,7 +102,7 @@ func buildKubevirtVmToPodBinary(ctx context.Context) (string, func(), error) {
 			KeepImage:  true, // reuse across test runs; rebuilds only on Containerfile changes
 		},
 		// Keep the container alive so CopyFileFromContainer can read from it.
-		Cmd: []string{"/bin/bash", "-c", "sleep 300"},
+		Cmd: []string{"/bin/bash", "-c", "sleep infinity"},
 	}
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ProviderType:     containers.GetProviderType(),

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -1,0 +1,145 @@
+package vmrender_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/tasks"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	containers "github.com/flightctl/flightctl/test/harness/containers"
+	"github.com/flightctl/flightctl/test/integration/integrationstack"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+const (
+	kubevirtVmToPodImageRepo = "flightctl/kubevirt-vm-to-pod-test"
+	kubevirtVmToPodImageTag  = "latest"
+)
+
+var (
+	suiteCtx      context.Context
+	redisHost     string
+	redisPort     uint
+	redisPassword domain.SecureString
+	redisCleanup  func()
+
+	vmConverter     tasks.VmConverterFn
+	vmBinaryCleanup func()
+)
+
+func TestVmRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VmRender Suite")
+}
+
+// SynchronizedBeforeSuite ensures the expensive binary extraction runs only
+// once (on proc 1). The resulting path is broadcast as []byte to all procs,
+// which each initialise their own vmConverter, Redis connection, and tracer.
+var _ = SynchronizedBeforeSuite(
+	// Proc 1 only: extract the kubevirt-vm-to-pod binary from a container.
+	func(ctx context.Context) []byte {
+		Expect(integrationstack.EnsureRunning(ctx)).To(Succeed())
+		binaryPath, cleanup, err := buildKubevirtVmToPodBinary(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to extract kubevirt-vm-to-pod binary")
+		vmBinaryCleanup = cleanup
+		return []byte(binaryPath)
+	},
+	// All procs: receive the shared binary path; set up per-process state.
+	func(ctx context.Context, binaryPathBytes []byte) {
+		suiteCtx = testutil.InitSuiteTracerForGinkgo("VmRender Suite")
+		Expect(integrationstack.EnsureRunning(ctx)).To(Succeed())
+
+		var err error
+		redisHost, redisPort, redisPassword, redisCleanup, err = testdb.CreateTestRedis(
+			suiteCtx, flightlog.InitLogs())
+		Expect(err).NotTo(HaveOccurred())
+
+		vmConverter = tasks.NewVmConverter(string(binaryPathBytes))
+	},
+)
+
+// SynchronizedAfterSuite mirrors the above: per-process cleanup first, then
+// proc-1 teardown (binary container + temp dir) last.
+var _ = SynchronizedAfterSuite(
+	func() {
+		if redisCleanup != nil {
+			redisCleanup()
+		}
+	},
+	func() {
+		if vmBinaryCleanup != nil {
+			vmBinaryCleanup()
+		}
+	},
+)
+
+// buildKubevirtVmToPodBinary builds the kubevirt-vm-to-pod image from the
+// Containerfile.kubevirt-vm-to-pod that lives alongside this test (same
+// ubi9/go-toolset base as the production worker). The built image is kept so
+// subsequent runs skip the build. The binary is copied out of the running
+// container via CopyFileFromContainer, written to a temp directory, and the
+// container is terminated. Returns the absolute binary path and a cleanup func.
+func buildKubevirtVmToPodBinary(ctx context.Context) (string, func(), error) {
+	containers.ConfigureDockerHost()
+
+	req := testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			// The Containerfile lives alongside this test file; Go tests run
+			// with cwd set to the package directory.
+			Context:    ".",
+			Dockerfile: "Containerfile.kubevirt-vm-to-pod",
+			Repo:       kubevirtVmToPodImageRepo,
+			Tag:        kubevirtVmToPodImageTag,
+			KeepImage:  true, // reuse across test runs; rebuilds only on Containerfile changes
+		},
+		// Keep the container alive so CopyFileFromContainer can read from it.
+		Cmd: []string{"/bin/bash", "-c", "sleep 300"},
+	}
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ProviderType:     containers.GetProviderType(),
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("start kubevirt-vm-to-pod container: %w", err)
+	}
+	cleanup := func() { _ = c.Terminate(ctx) }
+
+	rc, err := c.CopyFileFromContainer(ctx, "/usr/local/bin/kubevirt-vm-to-pod")
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("copy binary from container: %w", err)
+	}
+	data, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("read binary: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "flightctl-kubevirt-vm-to-pod-*")
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	combinedCleanup := func() {
+		cleanup()
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	binaryPath := filepath.Join(tmpDir, "kubevirt-vm-to-pod")
+	if err := os.WriteFile(binaryPath, data, 0700); err != nil { //nolint:gosec // executable binary requires execute permission
+		combinedCleanup()
+		return "", nil, fmt.Errorf("write binary: %w", err)
+	}
+	return binaryPath, combinedCleanup, nil
+}


### PR DESCRIPTION
## EDM-4096: render VmApplication into QuadletApplication via kubevirt-vm-to-pod

**Jira:** https://redhat.atlassian.net/browse/EDM-4096
**Story type:** [DEV]
**Depends on:** #3093 (EDM-4095 — VmApplication API types) — this PR stacks on top of that branch; please review after #3093 merges or review only the EDM-4096 commits (`87f9e55d7..b3f7add32`).

### Summary

Implements the server-side render task that converts a `VmApplication` (carrying an inline `vm.yaml` KubeVirt manifest) into a standard `QuadletApplication` by invoking the `kubevirt-vm-to-pod` converter binary as a subprocess. The rendered `QuadletApplication` replaces `vm.yaml` with the generated `pod.yaml` and a Podman `.kube` unit file, making VM workloads transparent to the agent.

### Changes

**Core render pipeline (`internal/tasks/`)**
- `device_render_vm.go` (new): `renderVmApplication` extracts `vm.yaml` from the inline set, invokes `kubevirt-vm-to-pod` (or returns a cached result), and emits a `QuadletApplication` with `pod.yaml` and a `.kube` unit; user-provided `.kube` files are passed through unchanged; adds `flightctl.io/workload-type: vm` annotation.
- `device_render.go`: threads `kvstore.KVStore` through `renderApplication` so the VM path can use the cache.
- `device_render_vm_test.go` (new): 7 unit test cases covering all documented behaviors; uses a `fakeKVStore` to exercise cache hit/miss and error paths.

**KV-store caching (`internal/kvstore/`)**
- `keys.go`: adds `VmPodYamlKey` (SHA-256 of `vm.yaml` content) for content-addressed caching of `pod.yaml` output.

**Quadlet `.kube` support (`internal/quadlet/`, `internal/api/common/`, `internal/util/validation/`)**
- `quadlet.go`: adds `KubeYamlKey` constant; extends `IsWorkload` to include `.kube` alongside `.container`.
- `common/quadlet.go`: promotes `.kube` from `UnsupportedQuadletExtensions` to `SupportedQuadletExtensions`; adds `QuadletTypeKube`; populates `YamlFile` in `QuadletReferences` from `Yaml=` in `[Kube]` sections.
- `util/validation/quadlet.go`: extends `ValidateQuadletSpec` to accept `QuadletTypeKube`.

**API validation (`api/core/v1beta1/`)**
- `validation.go`: adds `validateKubeYamlDirectives` (called from `validateQuadletApplication` for inline specs) — verifies that every `.kube` file's `Yaml=` target exists in the inline set and is a valid Kubernetes `Pod` manifest; decodes base64 content before inspection.
- `validation_test.go`: `TestValidateQuadletApplication_KubeYamlValidation` with 4 cases (valid Pod, absent target, wrong Kind, no directive); one new case in `TestValidateApplicationContentQuadlet` for a `.kube` quadlet.

**Container images (`packaging/images/el{9,10}/Containerfile.worker`)**
- Adds a dedicated `kubevirt-vm-to-pod` build stage pinned to SHA `d64fa7fd9...`.

**Domain types (`internal/domain/application.go`)**
- Removes obsolete guided-form aliases (`VmCredentials`, `VmPort`, etc.) that were deleted in EDM-4095.

**Integration tests (`test/integration/tasks/vmrender/`)**
- New suite using testcontainers to provision `kubevirt-vm-to-pod` and exercise the full render pipeline end-to-end.

**E2E harness (`test/harness/e2e/harness_application.go`)**
- `NewVmApplicationSpec` rewritten for the new inline provider pattern; adds `BuildVmYAML` helper.

### Testing
- **Unit tests:** 7 new cases in `device_render_vm_test.go`; 4 new cases in `validation_test.go`; updated cases in `quadlet_test.go`, `embedded_test.go`, `common/quadlet_test.go`, `util/validation/quadlet_test.go`.
- **Integration tests:** new `test/integration/tasks/vmrender/` suite validates the full `vm.yaml → kubevirt-vm-to-pod → QuadletApplication` pipeline.
- **Coverage:** all public interfaces introduced in this story are tested.

### Notes

- **AC-3 intentional deviation:** the default `.kube` unit omits `KubeDownForce=false` for compatibility with older Podman versions that reject the key.

### Acceptance Criteria

- [x] AC-1: `vm.yaml` → `kubevirt-vm-to-pod` → `pod.yaml` in `QuadletApplication`; `vm.yaml` absent from output.
- [x] AC-2: `.kube` file in inline set passed through unchanged.
- [x] AC-3: Default `[Kube]` unit generated when no `.kube` present (intentional deviation: no `KubeDownForce=false`).
- [x] AC-4: `flightctl.io/workload-type: vm` annotation on emitted `QuadletApplication`.
- [x] AC-5: SHA-256 KV-store cache for `pod.yaml`; cache hit bypasses subprocess.
- [x] AC-6: `validateQuadletApplication()` validates `.kube` `Yaml=` target is present and is a valid `Pod` manifest.
- [x] AC-7: `vm` case in `getDeviceApps()` in `fleet_rollout.go` (pre-existing, verified present).
- [x] AC-8: Non-zero subprocess exit → error with stderr.
- [x] AC-9: `kubevirt-vm-to-pod` in worker image, version-pinned.
- [x] AC-10: Unit tests + validation tests + integration tests.
