### PR TITLE
NO-ISSUE: Guard against dep activation failure in standalone gateway

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Flight Control Gateway service
 After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service flightctl-remote-access.service
-Requires=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service flightctl-remote-access.service
+Wants=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service flightctl-remote-access.service
 PartOf=flightctl.target
 
 [Container]
@@ -33,3 +33,11 @@ Restart=always
 RestartSec=30
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-gateway/nginx.conf.template --output-file /etc/flightctl/flightctl-gateway/nginx.conf
+
+ExecStartPre=/usr/bin/systemctl is-active flightctl-api
+ExecStartPre=/usr/bin/systemctl is-active flightctl-telemetry-gateway
+ExecStartPre=/usr/bin/systemctl is-active flightctl-ui
+ExecStartPre=/usr/bin/systemctl is-active flightctl-pam-issuer
+ExecStartPre=/usr/bin/systemctl is-active flightctl-alertmanager-proxy
+ExecStartPre=/usr/bin/systemctl is-active flightctl-cli-artifacts
+ExecStartPre=/usr/bin/systemctl is-active flightctl-remote-access


### PR DESCRIPTION
This helps ensure the gateway eventually gets started when there is dep activation failures from one of the dependent services.

