### PR TITLE
EDM-3953: fix --tag-override not pinning RPM version, causing bundle mismatch

### DIFF
--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -102,19 +102,6 @@ bundled images and the installed RPM reference the same version:
     --tag-override 1.1.2
 ```
 
-If the RPM version differs from the image tag (for example, builds
-where the image tag uses a hyphen and the RPM version uses a tilde), use
-`--rpm-version` to set the RPM version explicitly:
-
-```bash
-./bin/flightctl-mirror-images \
-    --variant community-el9 \
-    --bundle ~/flightctl-bundle-1.2.0-rc3.tar.gz \
-    --bundle-rpms \
-    --tag-override 1.2.0-rc3 \
-    --rpm-version 1.2.0~rc3
-```
-
 To see which RPM versions are available in the FlightCtl repository before running
 the command:
 

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -90,15 +90,29 @@ make build-mirror-images
 #### Alternative: use flag overrides without switching branches
 
 If you cannot check out the release tag, pass `--tag-override` to pin the container
-image tags and include the version in `--rpm-packages` to pin the RPM:
+image tags. The tool automatically pins the RPM version to match — converting the
+image tag format (`1.1.2`) to the RPM version format (`1.1.2`) — so both the
+bundled images and the installed RPM reference the same version:
 
 ```bash
 ./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms \
-    --tag-override v1.1.2 \
-    --rpm-packages flightctl-services-1.1.2
+    --tag-override 1.1.2
+```
+
+If the RPM version differs from the image tag (for example, builds
+where the image tag uses a hyphen and the RPM version uses a tilde), use
+`--rpm-version` to set the RPM version explicitly:
+
+```bash
+./bin/flightctl-mirror-images \
+    --variant community-el9 \
+    --bundle ~/flightctl-bundle-1.2.0-rc3.tar.gz \
+    --bundle-rpms \
+    --tag-override 1.2.0-rc3 \
+    --rpm-version 1.2.0~rc3
 ```
 
 To see which RPM versions are available in the FlightCtl repository before running

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -71,8 +71,10 @@ make build-mirror-images
 |------|---------|-------------|
 | `--bundle <path>` | — | Create a `.tar.gz` archive at path. Mutually exclusive with `--execute`. |
 | `--bundle-rpms` | false | Add RPMs and `install-rpms.sh` to the bundle. Requires `--bundle`. |
-| `--rpm-packages` | `flightctl-services` | Comma-separated packages to download. Use `flightctl-agent,flightctl-cli,open-vm-tools,ignition,afterburn,cloud-init` for edge devices (these are the `--agent-only` defaults). |
-| `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. |
+| `--rpm-packages` | `flightctl-services,flightctl-cli,flightctl-agent` | Comma-separated packages to download. |
+| `--rpm-exclude` | — | Comma-separated packages to download but exclude from auto-installation. Excluded packages remain in `rpms/` for manual use (e.g. embedding `flightctl-agent` into device OS images). |
+| `--rpm-version` | — | Pin flightctl RPM packages to this exact version (e.g. `1.2.0~rc3`). When omitted and `--tag-override` is set, the version is derived automatically so RPM and image versions stay in sync. Use when the RPM version differs from the image tag. |
+| `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. Override to use a COPR or custom repo. |
 | `--rpm-reposync` | false | Use `dnf reposync` to mirror the full repo with metadata. Mutually exclusive with `--rpm-createrepo`. |
 | `--rpm-createrepo` | false | Run `createrepo_c` after `dnf download` to generate `repodata/`. Mutually exclusive with `--rpm-reposync`. |
 | `--agent-only` | false | RPM-only bundle, no images, no `--variant` required. Defaults `--rpm-packages` to `flightctl-agent,flightctl-cli,open-vm-tools,ignition,afterburn,cloud-init`. |
@@ -119,7 +121,7 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 |------|---------|-------------|
 | `--execute` | false | Run skopeo commands immediately. |
 | `--insecure` | false | Add `--dest-tls-verify=false` (required for HTTP registries). |
-| `--tag-override <tag>` | — | Override the image tag for untagged FlightCtl service images (e.g. `v1.1.2`). Third-party images with pinned tags are unaffected. |
+| `--tag-override <tag>` | — | Override the image tag for untagged FlightCtl service images (e.g. `1.2.0-rc3`). Third-party images with pinned tags are unaffected. When `--bundle-rpms` is set, also pins flightctl RPM packages to the matching version (converting `-` to `~` for pre-release, e.g. `1.2.0-rc3` → `1.2.0~rc3`) unless `--rpm-packages` or `--rpm-version` is explicitly set. |
 
 ---
 

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -73,7 +73,6 @@ make build-mirror-images
 | `--bundle-rpms` | false | Add RPMs and `install-rpms.sh` to the bundle. Requires `--bundle`. |
 | `--rpm-packages` | `flightctl-services,flightctl-cli,flightctl-agent` | Comma-separated packages to download. |
 | `--rpm-exclude` | — | Comma-separated packages to download but exclude from auto-installation. Excluded packages remain in `rpms/` for manual use (e.g. embedding `flightctl-agent` into device OS images). |
-| `--rpm-version` | — | Pin flightctl RPM packages to this exact version (e.g. `1.2.0~rc3`). When omitted and `--tag-override` is set, the version is derived automatically so RPM and image versions stay in sync. Use when the RPM version differs from the image tag. |
 | `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. Override to use a COPR or custom repo. |
 | `--rpm-reposync` | false | Use `dnf reposync` to mirror the full repo with metadata. Mutually exclusive with `--rpm-createrepo`. |
 | `--rpm-createrepo` | false | Run `createrepo_c` after `dnf download` to generate `repodata/`. Mutually exclusive with `--rpm-reposync`. |

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -173,22 +173,15 @@ func pinRPMPackages(packages []string, version string) []string {
 	return pinned
 }
 
-// resolveRPMVersion pins flightctl RPM packages to a specific version when
-// bundling RPMs so the downloaded RPM version matches the bundled image tags.
-// --rpm-version takes precedence; when absent and --tag-override is set and the
-// caller did not explicitly set --rpm-packages, the version is derived from the
-// tag override (converting image-tag hyphens to RPM-version tildes).
-func resolveRPMVersion(packages []string, rpmVersion, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
-	if !shouldPin {
+// resolveRPMVersion pins flightctl RPM packages to the version derived from
+// tagOverride when bundling RPMs, so the downloaded RPM version matches the
+// bundled image tags. Only applies when tagOverride is set and the caller did
+// not explicitly set --rpm-packages.
+func resolveRPMVersion(packages []string, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
+	if !shouldPin || tagOverride == "" || packagesExplicitlySet {
 		return packages
 	}
-	effective := rpmVersion
-	if effective == "" && tagOverride != "" && !packagesExplicitlySet {
-		effective = imageTagToRPMVersion(tagOverride)
-	}
-	if effective == "" {
-		return packages
-	}
+	effective := imageTagToRPMVersion(tagOverride)
 	pinned := pinRPMPackages(packages, effective)
 	logInfo("  RPM version pin:  %s", effective)
 	return pinned
@@ -312,7 +305,6 @@ func NewRootCommand() *cobra.Command {
 		bundleRPMs    bool
 		rpmPackages   []string
 		rpmExclude    []string
-		rpmVersion    string
 		rpmRepoURL    string
 		rpmReposync   bool
 		rpmCreaterepo bool
@@ -397,7 +389,7 @@ Examples:
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
 			}
 
-			rpmPackages = resolveRPMVersion(rpmPackages, rpmVersion, tagOverride,
+			rpmPackages = resolveRPMVersion(rpmPackages, tagOverride,
 				bundleRPMs || agentOnly, cmd.Flags().Changed("rpm-packages"))
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
@@ -537,7 +529,6 @@ Examples:
 	cmd.Flags().BoolVar(&bundleRPMs, "bundle-rpms", false, "Include RPMs in the bundle for bare-metal quadlet installation (requires --bundle)")
 	cmd.Flags().StringSliceVar(&rpmPackages, "rpm-packages", []string{"flightctl-services", "flightctl-cli", "flightctl-agent"}, "RPM package names to download into the bundle (comma-separated). The default includes flightctl-cli for server-side fleet management and flightctl-agent for offline image building — the agent RPM is not enabled on the server but is available in the bundle rpms/ directory for embedding into device OS images.")
 	cmd.Flags().StringSliceVar(&rpmExclude, "rpm-exclude", nil, "RPM package names to download but exclude from auto-installation (comma-separated). Excluded packages are still present in rpms/ for manual use (e.g. embedding into device OS images).")
-	cmd.Flags().StringVar(&rpmVersion, "rpm-version", "", "Pin flightctl RPM packages to this exact version (e.g. 1.2.0~rc3). When omitted and --tag-override is set, the version is derived automatically from the tag override so that RPM and image versions stay in sync. Use this flag to override the derived version or when the RPM version differs from the image tag.")
 	cmd.Flags().StringVar(&rpmRepoURL, "rpm-repo-url", "https://rpm.flightctl.io/flightctl-epel.repo", "URL of the .repo file to configure dnf for RPM downloads")
 	cmd.Flags().BoolVar(&rpmReposync, "rpm-reposync", false, "Mirror the full FlightCtl RPM repository using 'dnf reposync' (includes repodata/; requires dnf-plugins-core; mutually exclusive with --rpm-createrepo)")
 	cmd.Flags().BoolVar(&rpmCreaterepo, "rpm-createrepo", false, "Generate repodata/ after 'dnf download' using 'createrepo_c' so the bundle can be used as a local dnf repository source (mutually exclusive with --rpm-reposync)")

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -140,6 +140,39 @@ func validateFlags(variant, bundle string, execute, bundleRPMs, rpmReposync, rpm
 	return nil
 }
 
+// imageTagToRPMVersion converts an image tag (e.g. "1.2.0-rc3") to the
+// equivalent RPM version string (e.g. "1.2.0~rc3"). RPM uses tildes (~) for
+// pre-release suffixes so they sort before the release version; container image
+// tags use hyphens instead.  A plain release version like "1.2.0" is unchanged.
+func imageTagToRPMVersion(tag string) string {
+	// Replace the first hyphen before a pre-release label (rc, alpha, beta) with a tilde.
+	// "1.2.0-rc3"    → "1.2.0~rc3"
+	// "1.2.0-main-5" → "1.2.0~main-5"  (dev build suffix)
+	// "1.2.0"        → "1.2.0"          (release — unchanged)
+	for i := 0; i < len(tag); i++ {
+		if tag[i] == '-' {
+			return tag[:i] + "~" + tag[i+1:]
+		}
+	}
+	return tag
+}
+
+// pinRPMPackages appends the given version to each flightctl package name so
+// that dnf downloads exactly that version rather than the latest available.
+// Third-party packages (those that do not start with "flightctl-") are left
+// unpinned so their upstream version is used unchanged.
+func pinRPMPackages(packages []string, version string) []string {
+	pinned := make([]string, len(packages))
+	for i, p := range packages {
+		if strings.HasPrefix(p, "flightctl-") || p == "flightctl" {
+			pinned[i] = p + "-" + version
+		} else {
+			pinned[i] = p
+		}
+	}
+	return pinned
+}
+
 // excludePackages returns packages with any entry found in exclude removed.
 func excludePackages(packages, exclude []string) []string {
 	if len(exclude) == 0 {
@@ -258,6 +291,7 @@ func NewRootCommand() *cobra.Command {
 		bundleRPMs    bool
 		rpmPackages   []string
 		rpmExclude    []string
+		rpmVersion    string
 		rpmRepoURL    string
 		rpmReposync   bool
 		rpmCreaterepo bool
@@ -318,7 +352,16 @@ Examples:
 
   # Server bundle: download agent RPM for image building but skip auto-install on server
   flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
-    --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent`,
+    --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent
+
+  # Bundle with explicit version pin — image tags and RPM version stay in sync automatically
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+    --bundle-rpms --rpm-createrepo --tag-override 1.2.0-rc3
+
+  # Bundle pointing to a custom RPM repo (e.g. COPR) with explicit version pin
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+    --bundle-rpms --rpm-createrepo --tag-override 1.2.0-rc3 \
+    --rpm-repo-url https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/repo/epel-9/group_redhat-et-flightctl-epel-9.repo`,
 
 		// SilenceUsage prevents cobra from printing the full usage block on every
 		// RunE error — our logError calls provide targeted messages instead.
@@ -331,6 +374,22 @@ Examples:
 
 			if agentOnly && !cmd.Flags().Changed("rpm-packages") {
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
+			}
+
+			// Pin RPM packages to a specific version when requested.
+			// --rpm-version takes precedence; if not set, derive it from --tag-override
+			// so that the bundled RPM version matches the bundled image tags.
+			// Only applies when --rpm-packages was not explicitly overridden by the user
+			// (if the user already pinned versions in --rpm-packages, respect that).
+			if bundleRPMs || agentOnly {
+				effectiveRPMVersion := rpmVersion
+				if effectiveRPMVersion == "" && tagOverride != "" && !cmd.Flags().Changed("rpm-packages") {
+					effectiveRPMVersion = imageTagToRPMVersion(tagOverride)
+				}
+				if effectiveRPMVersion != "" {
+					rpmPackages = pinRPMPackages(rpmPackages, effectiveRPMVersion)
+					logInfo("  RPM version pin:  %s", effectiveRPMVersion)
+				}
 			}
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
@@ -470,6 +529,7 @@ Examples:
 	cmd.Flags().BoolVar(&bundleRPMs, "bundle-rpms", false, "Include RPMs in the bundle for bare-metal quadlet installation (requires --bundle)")
 	cmd.Flags().StringSliceVar(&rpmPackages, "rpm-packages", []string{"flightctl-services", "flightctl-cli", "flightctl-agent"}, "RPM package names to download into the bundle (comma-separated). The default includes flightctl-cli for server-side fleet management and flightctl-agent for offline image building — the agent RPM is not enabled on the server but is available in the bundle rpms/ directory for embedding into device OS images.")
 	cmd.Flags().StringSliceVar(&rpmExclude, "rpm-exclude", nil, "RPM package names to download but exclude from auto-installation (comma-separated). Excluded packages are still present in rpms/ for manual use (e.g. embedding into device OS images).")
+	cmd.Flags().StringVar(&rpmVersion, "rpm-version", "", "Pin flightctl RPM packages to this exact version (e.g. 1.2.0~rc3). When omitted and --tag-override is set, the version is derived automatically from the tag override so that RPM and image versions stay in sync. Use this flag to override the derived version or when the RPM version differs from the image tag.")
 	cmd.Flags().StringVar(&rpmRepoURL, "rpm-repo-url", "https://rpm.flightctl.io/flightctl-epel.repo", "URL of the .repo file to configure dnf for RPM downloads")
 	cmd.Flags().BoolVar(&rpmReposync, "rpm-reposync", false, "Mirror the full FlightCtl RPM repository using 'dnf reposync' (includes repodata/; requires dnf-plugins-core; mutually exclusive with --rpm-createrepo)")
 	cmd.Flags().BoolVar(&rpmCreaterepo, "rpm-createrepo", false, "Generate repodata/ after 'dnf download' using 'createrepo_c' so the bundle can be used as a local dnf repository source (mutually exclusive with --rpm-reposync)")

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -173,6 +173,27 @@ func pinRPMPackages(packages []string, version string) []string {
 	return pinned
 }
 
+// resolveRPMVersion pins flightctl RPM packages to a specific version when
+// bundling RPMs so the downloaded RPM version matches the bundled image tags.
+// --rpm-version takes precedence; when absent and --tag-override is set and the
+// caller did not explicitly set --rpm-packages, the version is derived from the
+// tag override (converting image-tag hyphens to RPM-version tildes).
+func resolveRPMVersion(packages []string, rpmVersion, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
+	if !shouldPin {
+		return packages
+	}
+	effective := rpmVersion
+	if effective == "" && tagOverride != "" && !packagesExplicitlySet {
+		effective = imageTagToRPMVersion(tagOverride)
+	}
+	if effective == "" {
+		return packages
+	}
+	pinned := pinRPMPackages(packages, effective)
+	logInfo("  RPM version pin:  %s", effective)
+	return pinned
+}
+
 // excludePackages returns packages with any entry found in exclude removed.
 func excludePackages(packages, exclude []string) []string {
 	if len(exclude) == 0 {
@@ -376,21 +397,8 @@ Examples:
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
 			}
 
-			// Pin RPM packages to a specific version when requested.
-			// --rpm-version takes precedence; if not set, derive it from --tag-override
-			// so that the bundled RPM version matches the bundled image tags.
-			// Only applies when --rpm-packages was not explicitly overridden by the user
-			// (if the user already pinned versions in --rpm-packages, respect that).
-			if bundleRPMs || agentOnly {
-				effectiveRPMVersion := rpmVersion
-				if effectiveRPMVersion == "" && tagOverride != "" && !cmd.Flags().Changed("rpm-packages") {
-					effectiveRPMVersion = imageTagToRPMVersion(tagOverride)
-				}
-				if effectiveRPMVersion != "" {
-					rpmPackages = pinRPMPackages(rpmPackages, effectiveRPMVersion)
-					logInfo("  RPM version pin:  %s", effectiveRPMVersion)
-				}
-			}
+			rpmPackages = resolveRPMVersion(rpmPackages, rpmVersion, tagOverride,
+				bundleRPMs || agentOnly, cmd.Flags().Changed("rpm-packages"))
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
 			if len(rpmExclude) > 0 {


### PR DESCRIPTION
## Summary

When `--tag-override 1.2.0-rc3` is set and `--rpm-repo-url` points to a repo containing multiple versions (e.g. a COPR repo with both `1.2.0~rc3` and `1.3.0~main`), dnf downloads the **latest** RPM regardless of the image tag override. The RPM's baked-in quadlet files reference image tags from the RPM version (`1.3.0-main`), while the bundled images are tagged `1.2.0-rc3`. All services fail to start on the target machine.

## Fix

When `--tag-override` is set and `--rpm-packages` was not explicitly overridden by the user, automatically pin flightctl RPM packages to the corresponding version. Image tags use hyphens for pre-release suffixes (`1.2.0-rc3`) while RPM versions use tildes (`1.2.0~rc3`); the tool converts automatically.

Also adds `--rpm-version` for cases where the RPM version differs from the image tag.

## Behaviour

| Command | Result |
|---------|--------|
| `--tag-override 1.2.0-rc3` | RPMs pinned to `1.2.0~rc3` automatically |
| `--tag-override 1.2.0-rc3 --rpm-version 1.2.0~rc2` | RPMs pinned to `1.2.0~rc2` (explicit override wins) |
| `--tag-override 1.2.0-rc3 --rpm-packages flightctl-services-1.2.0~rc3` | User-specified packages respected, no auto-pin |
| `--tag-override 1.2.0` | RPMs pinned to `1.2.0` |

## Test plan

- [ ] Run with `--tag-override 1.2.0-rc3 --rpm-repo-url <copr-with-multiple-versions>` and verify downloaded RPM is `1.2.0~rc3` not the latest
- [ ] Verify `1.2.0-rc3` → `1.2.0~rc3` tilde conversion
- [ ] Verify `--rpm-version` explicit override works
- [ ] Verify `--rpm-packages` explicit override skips auto-pin

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)