### PR TITLE
[Backport to 1.2] Mass backport from PR 3096 to 3097

### DIFF
--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -1,9 +1,9 @@
 # Installing the Flight Control agent offline on RHEL
 
 This document describes how to install `flightctl-agent` and `flightctl-cli` on a RHEL
-machine that has no internet access. The procedure uses a connected prep machine to
-download the required packages, transfers them using portable media, and installs them
-locally on the target.
+machine that has no internet access. The `flightctl-mirror-images` tool running on a
+connected prep machine creates a portable RPM bundle. You then transfer the bundle to
+the target device and run the included install script.
 
 The agent itself does not require container images to run. However, if the agent manages
 containerized workloads on the device, those images must also be made available offline.
@@ -11,102 +11,89 @@ Both scenarios are covered here.
 
 ## Prerequisites
 
-- A connected RHEL 9 or RHEL 10 prep machine running the same major RHEL version as
-  the target
-- An air-gapped target RHEL machine
+On the **prep machine** (internet-connected):
+
+- RHEL 9 or RHEL 10 with `createrepo_c` installed (`sudo dnf install -y createrepo_c`)
+- The `flightctl-mirror-images` binary — either installed via the `flightctl-cli` RPM or
+  built from source (`make build-mirror-images`)
+
+On the **target device** (air-gapped):
+
+- RHEL 9 or RHEL 10
+- `sudo` access
 - A transfer method — see [Packaging artifacts for portable media](offline-portable-media.md)
-- `sudo` access on both machines
 
 ## Part 1: Installing the agent and CLI
 
-### Step 1: Download the packages on the prep machine
+### Step 1: Create the agent bundle on the prep machine
 
-Add the FlightCtl repository on the prep machine:
-
-```bash
-sudo dnf config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo
-```
-
-Download `flightctl-agent`, `flightctl-cli`, and the system packages that the
-agent's OS image requires (`open-vm-tools`, `ignition`, `afterburn`, `cloud-init`):
+Run `flightctl-mirror-images` with the `--agent-only` flag. This creates a portable
+`.tar.gz` archive containing the agent, CLI, and the system packages required on edge
+devices (`open-vm-tools`, `ignition`, `afterburn`, `cloud-init`). No container images
+are included — the bundle is RPM-only and much smaller than a full service bundle.
 
 ```bash
-mkdir -p ~/flightctl-rpms
-dnf download --resolve --alldeps --destdir ~/flightctl-rpms \
-    flightctl-agent flightctl-cli \
-    open-vm-tools ignition afterburn cloud-init
+flightctl-mirror-images \
+    --agent-only \
+    --bundle ~/flightctl-agent-bundle.tar.gz \
+    --rpm-createrepo \
+    --tag-override 1.2.0
 ```
 
-> [!NOTE]
-> `open-vm-tools`, `ignition`, `afterburn`, and `cloud-init` are standard RHEL
-> packages, not FlightCtl packages. They are resolved from your existing RHEL
-> subscription repos and do not require the FlightCtl repo.
-
-To pin to a specific FlightCtl release version, include the version number:
+Replace `1.2.0` with your target FlightCtl release version. The `--tag-override` flag
+pins both the RPM version and is used to ensure the agent matches the server version.
+To find available versions:
 
 ```bash
-dnf download --resolve --alldeps --destdir ~/flightctl-rpms \
-    flightctl-agent-1.1.2 flightctl-cli-1.1.2 \
-    open-vm-tools ignition afterburn cloud-init
+dnf list --showduplicates flightctl-agent --disablerepo='*' \
+    --enablerepo=flightctl 2>/dev/null | tail -10
 ```
 
-To see which versions are available:
+To use a version from the COPR repository:
 
 ```bash
-dnf list --showduplicates flightctl-agent
+flightctl-mirror-images \
+    --agent-only \
+    --bundle ~/flightctl-agent-bundle.tar.gz \
+    --rpm-createrepo \
+    --tag-override 1.2.0-rc3 \
+    --rpm-repo-url https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/repo/epel-9/group_redhat-et-flightctl-epel-9.repo
 ```
 
-> [!NOTE]
-> If you need a full offline repo that lets the target machine resolve packages with
-> `dnf install` instead of installing from flat `.rpm` files, use `dnf reposync`
-> instead. See [Setting up a local RPM repository](offline-rpm-repository.md) for both
-> approaches and when to choose each.
+The bundle contains:
 
-Verify that the downloaded files include the expected packages:
+```console
+~/flightctl-agent-bundle.tar.gz
+├── rpms/            — agent, CLI, and dependency RPMs with repodata/
+└── install-rpms.sh  — installs packages using the local repo metadata
+```
+
+### Step 2: Transfer the bundle to the target device
 
 ```bash
-ls ~/flightctl-rpms/ | grep -E 'flightctl-(agent|cli)|open-vm-tools|ignition|afterburn|cloud-init'
+scp ~/flightctl-agent-bundle.tar.gz <user>@<device>:~/
 ```
 
-### Step 2: Transfer the packages to the target machine
+See [Packaging artifacts for portable media](offline-portable-media.md) for USB drive
+and other transfer formats.
 
-Package the downloaded RPMs into an archive:
+### Step 3: Extract and install on the target device
 
 ```bash
-tar -czf ~/flightctl-agent-rpms.tar.gz -C ~ flightctl-rpms/
+mkdir ~/flightctl-agent-bundle
+tar -xzf ~/flightctl-agent-bundle.tar.gz -C ~/flightctl-agent-bundle
+cd ~/flightctl-agent-bundle
+./install-rpms.sh
 ```
 
-Transfer the archive to the target machine. The transfer method depends on your
-environment — see [Packaging artifacts for portable media](offline-portable-media.md)
-for full instructions. For a target reachable via a jump host:
-
-```bash
-scp ~/flightctl-agent-rpms.tar.gz <user>@<target_host>:~/
-```
-
-### Step 3: Install on the target machine
-
-On the target machine, extract the archive:
-
-```bash
-tar -xzf ~/flightctl-agent-rpms.tar.gz -C ~/
-```
-
-Install all packages from the local directory:
-
-```bash
-sudo dnf install -y ~/flightctl-rpms/*.rpm
-```
-
-> [!NOTE]
-> If `dnf` reports unresolved dependencies, the prep machine may be running a different
-> RHEL minor version than the target. Re-run `dnf download --resolve --alldeps` on a prep machine
-> that matches the target's exact RHEL version and rebuild the archive.
+The install script detects the repo metadata generated by `--rpm-createrepo` and
+installs the agent and CLI by name using `dnf`, avoiding conflicts with protected
+system packages.
 
 ### Step 4: Configure the agent
 
-The agent reads its configuration from `/etc/flightctl/config.yaml`. At minimum, you
-must configure the URL of the Flight Control enrollment service:
+The agent reads its configuration from `/etc/flightctl/config.yaml`. At minimum,
+configure the URL of the Flight Control enrollment service:
 
 ```bash
 sudo tee /etc/flightctl/config.yaml << 'EOF'
@@ -128,29 +115,15 @@ your provisioning pipeline before the agent can connect.
 
 ### Step 5: Start and enable the agent
 
-Enable and start the `flightctl-agent` service:
-
 ```bash
 sudo systemctl enable --now flightctl-agent
 ```
 
 ### Step 6: Verify the installation
 
-Check that the agent service is running:
-
 ```bash
 systemctl status flightctl-agent
-```
-
-Verify the CLI is available:
-
-```bash
 flightctl version
-```
-
-Check the agent logs for enrollment activity:
-
-```bash
 journalctl -u flightctl-agent -f
 ```
 
@@ -204,7 +177,7 @@ Flight Control points at the local registry instead of an internet-accessible re
    images and transfer it to the target:
 
    ```bash
-   ./bin/flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
+   flightctl-mirror-images --variant community-el9 --bundle ~/workload-images.tar.gz
    scp ~/workload-images.tar.gz <user>@<target_host>:~/
    ```
 

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -102,19 +102,6 @@ bundled images and the installed RPM reference the same version:
     --tag-override 1.1.2
 ```
 
-If the RPM version differs from the image tag (for example, builds
-where the image tag uses a hyphen and the RPM version uses a tilde), use
-`--rpm-version` to set the RPM version explicitly:
-
-```bash
-./bin/flightctl-mirror-images \
-    --variant community-el9 \
-    --bundle ~/flightctl-bundle-1.2.0-rc3.tar.gz \
-    --bundle-rpms \
-    --tag-override 1.2.0-rc3 \
-    --rpm-version 1.2.0~rc3
-```
-
 To see which RPM versions are available in the FlightCtl repository before running
 the command:
 

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -90,15 +90,29 @@ make build-mirror-images
 #### Alternative: use flag overrides without switching branches
 
 If you cannot check out the release tag, pass `--tag-override` to pin the container
-image tags and include the version in `--rpm-packages` to pin the RPM:
+image tags. The tool automatically pins the RPM version to match — converting the
+image tag format (`1.1.2`) to the RPM version format (`1.1.2`) — so both the
+bundled images and the installed RPM reference the same version:
 
 ```bash
 ./bin/flightctl-mirror-images \
     --variant community-el9 \
     --bundle ~/flightctl-bundle-1.1.2.tar.gz \
     --bundle-rpms \
-    --tag-override v1.1.2 \
-    --rpm-packages flightctl-services-1.1.2
+    --tag-override 1.1.2
+```
+
+If the RPM version differs from the image tag (for example, builds
+where the image tag uses a hyphen and the RPM version uses a tilde), use
+`--rpm-version` to set the RPM version explicitly:
+
+```bash
+./bin/flightctl-mirror-images \
+    --variant community-el9 \
+    --bundle ~/flightctl-bundle-1.2.0-rc3.tar.gz \
+    --bundle-rpms \
+    --tag-override 1.2.0-rc3 \
+    --rpm-version 1.2.0~rc3
 ```
 
 To see which RPM versions are available in the FlightCtl repository before running

--- a/docs/user/installing/installing-service-on-linux-offline.md
+++ b/docs/user/installing/installing-service-on-linux-offline.md
@@ -312,6 +312,24 @@ See [Deploying Observability Offline](deploying-observability-linux.md#air-gappe
 for the complete procedure, including image lists, `skopeo` commands, and
 configuration notes.
 
+## flightctl-mirror-images flag reference
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--variant` | — | Deployment variant: `community-el9`, `community-el10`, `rhem-el9`, `rhem-el10`. Required unless `--agent-only` is set. |
+| `--dest-registry` | `localhost:5000` (bundle mode) | Destination registry `host:port` — no scheme. Required in live-push mode. |
+| `--execute` | `false` | Execute skopeo copy commands immediately. Mutually exclusive with `--bundle`. |
+| `--insecure` | `false` | Disable TLS verification for the destination registry. Required for plain HTTP registries. |
+| `--tag-override` | — | Pin the image tag for all untagged FlightCtl images (e.g. `1.2.0`). Also pins the RPM version automatically when `--bundle-rpms` or `--agent-only` is set. Third-party images with explicit tags are unaffected. |
+| `--bundle` | — | Create a self-contained `.tar.gz` archive at the given path. Mutually exclusive with `--execute`. |
+| `--bundle-rpms` | `false` | Include RPMs and an `install-rpms.sh` script in the bundle. Requires `--bundle`. |
+| `--rpm-packages` | `flightctl-services,`<br>`flightctl-cli,`<br>`flightctl-agent` | Comma-separated list of RPM packages to download into the bundle. |
+| `--rpm-exclude` | — | Comma-separated packages to download but skip during auto-install. RPMs remain in `rpms/` for manual use (e.g. embedding `flightctl-agent` into device OS images). |
+| `--rpm-repo-url` | `https://rpm.flightctl.io/`<br>`flightctl-epel.repo` | URL of the `.repo` file used for RPM downloads. Override to use COPR or a custom repo. |
+| `--rpm-createrepo` | `false` | Run `createrepo_c` after `dnf download` to generate `repodata/` in the bundle. Prevents `dnf` protected-package conflicts on install. Mutually exclusive with `--rpm-reposync`. |
+| `--rpm-reposync` | `false` | Mirror the full FlightCtl RPM repo using `dnf reposync`, including repodata. Requires `dnf-plugins-core`. Mutually exclusive with `--rpm-createrepo`. |
+| `--agent-only` | `false` | RPM-only bundle for edge device installation — skips all image bundling, `--variant` not required. Defaults `--rpm-packages` to `flightctl-agent,flightctl-cli,open-vm-tools,ignition,afterburn,cloud-init`. |
+
 ## Next steps
 
 - [Configuring Authentication and Authorization](configuring-auth/overview.md) —

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -71,8 +71,10 @@ make build-mirror-images
 |------|---------|-------------|
 | `--bundle <path>` | — | Create a `.tar.gz` archive at path. Mutually exclusive with `--execute`. |
 | `--bundle-rpms` | false | Add RPMs and `install-rpms.sh` to the bundle. Requires `--bundle`. |
-| `--rpm-packages` | `flightctl-services` | Comma-separated packages to download. Use `flightctl-agent,flightctl-cli,open-vm-tools,ignition,afterburn,cloud-init` for edge devices (these are the `--agent-only` defaults). |
-| `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. |
+| `--rpm-packages` | `flightctl-services,flightctl-cli,flightctl-agent` | Comma-separated packages to download. |
+| `--rpm-exclude` | — | Comma-separated packages to download but exclude from auto-installation. Excluded packages remain in `rpms/` for manual use (e.g. embedding `flightctl-agent` into device OS images). |
+| `--rpm-version` | — | Pin flightctl RPM packages to this exact version (e.g. `1.2.0~rc3`). When omitted and `--tag-override` is set, the version is derived automatically so RPM and image versions stay in sync. Use when the RPM version differs from the image tag. |
+| `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. Override to use a COPR or custom repo. |
 | `--rpm-reposync` | false | Use `dnf reposync` to mirror the full repo with metadata. Mutually exclusive with `--rpm-createrepo`. |
 | `--rpm-createrepo` | false | Run `createrepo_c` after `dnf download` to generate `repodata/`. Mutually exclusive with `--rpm-reposync`. |
 | `--agent-only` | false | RPM-only bundle, no images, no `--variant` required. Defaults `--rpm-packages` to `flightctl-agent,flightctl-cli,open-vm-tools,ignition,afterburn,cloud-init`. |
@@ -119,7 +121,7 @@ Pass multiple packages as a comma-separated list or by repeating the flag — bo
 |------|---------|-------------|
 | `--execute` | false | Run skopeo commands immediately. |
 | `--insecure` | false | Add `--dest-tls-verify=false` (required for HTTP registries). |
-| `--tag-override <tag>` | — | Override the image tag for untagged FlightCtl service images (e.g. `v1.1.2`). Third-party images with pinned tags are unaffected. |
+| `--tag-override <tag>` | — | Override the image tag for untagged FlightCtl service images (e.g. `1.2.0-rc3`). Third-party images with pinned tags are unaffected. When `--bundle-rpms` is set, also pins flightctl RPM packages to the matching version (converting `-` to `~` for pre-release, e.g. `1.2.0-rc3` → `1.2.0~rc3`) unless `--rpm-packages` or `--rpm-version` is explicitly set. |
 
 ---
 

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -73,7 +73,6 @@ make build-mirror-images
 | `--bundle-rpms` | false | Add RPMs and `install-rpms.sh` to the bundle. Requires `--bundle`. |
 | `--rpm-packages` | `flightctl-services,flightctl-cli,flightctl-agent` | Comma-separated packages to download. |
 | `--rpm-exclude` | — | Comma-separated packages to download but exclude from auto-installation. Excluded packages remain in `rpms/` for manual use (e.g. embedding `flightctl-agent` into device OS images). |
-| `--rpm-version` | — | Pin flightctl RPM packages to this exact version (e.g. `1.2.0~rc3`). When omitted and `--tag-override` is set, the version is derived automatically so RPM and image versions stay in sync. Use when the RPM version differs from the image tag. |
 | `--rpm-repo-url` | `https://rpm.flightctl.io/flightctl-epel.repo` | `.repo` file URL for RPM downloads. Override to use a COPR or custom repo. |
 | `--rpm-reposync` | false | Use `dnf reposync` to mirror the full repo with metadata. Mutually exclusive with `--rpm-createrepo`. |
 | `--rpm-createrepo` | false | Run `createrepo_c` after `dnf download` to generate `repodata/`. Mutually exclusive with `--rpm-reposync`. |

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -173,22 +173,15 @@ func pinRPMPackages(packages []string, version string) []string {
 	return pinned
 }
 
-// resolveRPMVersion pins flightctl RPM packages to a specific version when
-// bundling RPMs so the downloaded RPM version matches the bundled image tags.
-// --rpm-version takes precedence; when absent and --tag-override is set and the
-// caller did not explicitly set --rpm-packages, the version is derived from the
-// tag override (converting image-tag hyphens to RPM-version tildes).
-func resolveRPMVersion(packages []string, rpmVersion, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
-	if !shouldPin {
+// resolveRPMVersion pins flightctl RPM packages to the version derived from
+// tagOverride when bundling RPMs, so the downloaded RPM version matches the
+// bundled image tags. Only applies when tagOverride is set and the caller did
+// not explicitly set --rpm-packages.
+func resolveRPMVersion(packages []string, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
+	if !shouldPin || tagOverride == "" || packagesExplicitlySet {
 		return packages
 	}
-	effective := rpmVersion
-	if effective == "" && tagOverride != "" && !packagesExplicitlySet {
-		effective = imageTagToRPMVersion(tagOverride)
-	}
-	if effective == "" {
-		return packages
-	}
+	effective := imageTagToRPMVersion(tagOverride)
 	pinned := pinRPMPackages(packages, effective)
 	logInfo("  RPM version pin:  %s", effective)
 	return pinned
@@ -312,7 +305,6 @@ func NewRootCommand() *cobra.Command {
 		bundleRPMs    bool
 		rpmPackages   []string
 		rpmExclude    []string
-		rpmVersion    string
 		rpmRepoURL    string
 		rpmReposync   bool
 		rpmCreaterepo bool
@@ -397,7 +389,7 @@ Examples:
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
 			}
 
-			rpmPackages = resolveRPMVersion(rpmPackages, rpmVersion, tagOverride,
+			rpmPackages = resolveRPMVersion(rpmPackages, tagOverride,
 				bundleRPMs || agentOnly, cmd.Flags().Changed("rpm-packages"))
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
@@ -537,7 +529,6 @@ Examples:
 	cmd.Flags().BoolVar(&bundleRPMs, "bundle-rpms", false, "Include RPMs in the bundle for bare-metal quadlet installation (requires --bundle)")
 	cmd.Flags().StringSliceVar(&rpmPackages, "rpm-packages", []string{"flightctl-services", "flightctl-cli", "flightctl-agent"}, "RPM package names to download into the bundle (comma-separated). The default includes flightctl-cli for server-side fleet management and flightctl-agent for offline image building — the agent RPM is not enabled on the server but is available in the bundle rpms/ directory for embedding into device OS images.")
 	cmd.Flags().StringSliceVar(&rpmExclude, "rpm-exclude", nil, "RPM package names to download but exclude from auto-installation (comma-separated). Excluded packages are still present in rpms/ for manual use (e.g. embedding into device OS images).")
-	cmd.Flags().StringVar(&rpmVersion, "rpm-version", "", "Pin flightctl RPM packages to this exact version (e.g. 1.2.0~rc3). When omitted and --tag-override is set, the version is derived automatically from the tag override so that RPM and image versions stay in sync. Use this flag to override the derived version or when the RPM version differs from the image tag.")
 	cmd.Flags().StringVar(&rpmRepoURL, "rpm-repo-url", "https://rpm.flightctl.io/flightctl-epel.repo", "URL of the .repo file to configure dnf for RPM downloads")
 	cmd.Flags().BoolVar(&rpmReposync, "rpm-reposync", false, "Mirror the full FlightCtl RPM repository using 'dnf reposync' (includes repodata/; requires dnf-plugins-core; mutually exclusive with --rpm-createrepo)")
 	cmd.Flags().BoolVar(&rpmCreaterepo, "rpm-createrepo", false, "Generate repodata/ after 'dnf download' using 'createrepo_c' so the bundle can be used as a local dnf repository source (mutually exclusive with --rpm-reposync)")

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -140,6 +140,39 @@ func validateFlags(variant, bundle string, execute, bundleRPMs, rpmReposync, rpm
 	return nil
 }
 
+// imageTagToRPMVersion converts an image tag (e.g. "1.2.0-rc3") to the
+// equivalent RPM version string (e.g. "1.2.0~rc3"). RPM uses tildes (~) for
+// pre-release suffixes so they sort before the release version; container image
+// tags use hyphens instead.  A plain release version like "1.2.0" is unchanged.
+func imageTagToRPMVersion(tag string) string {
+	// Replace the first hyphen before a pre-release label (rc, alpha, beta) with a tilde.
+	// "1.2.0-rc3"    → "1.2.0~rc3"
+	// "1.2.0-main-5" → "1.2.0~main-5"  (dev build suffix)
+	// "1.2.0"        → "1.2.0"          (release — unchanged)
+	for i := 0; i < len(tag); i++ {
+		if tag[i] == '-' {
+			return tag[:i] + "~" + tag[i+1:]
+		}
+	}
+	return tag
+}
+
+// pinRPMPackages appends the given version to each flightctl package name so
+// that dnf downloads exactly that version rather than the latest available.
+// Third-party packages (those that do not start with "flightctl-") are left
+// unpinned so their upstream version is used unchanged.
+func pinRPMPackages(packages []string, version string) []string {
+	pinned := make([]string, len(packages))
+	for i, p := range packages {
+		if strings.HasPrefix(p, "flightctl-") || p == "flightctl" {
+			pinned[i] = p + "-" + version
+		} else {
+			pinned[i] = p
+		}
+	}
+	return pinned
+}
+
 // excludePackages returns packages with any entry found in exclude removed.
 func excludePackages(packages, exclude []string) []string {
 	if len(exclude) == 0 {
@@ -258,6 +291,7 @@ func NewRootCommand() *cobra.Command {
 		bundleRPMs    bool
 		rpmPackages   []string
 		rpmExclude    []string
+		rpmVersion    string
 		rpmRepoURL    string
 		rpmReposync   bool
 		rpmCreaterepo bool
@@ -318,7 +352,16 @@ Examples:
 
   # Server bundle: download agent RPM for image building but skip auto-install on server
   flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
-    --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent`,
+    --bundle-rpms --rpm-createrepo --rpm-exclude flightctl-agent
+
+  # Bundle with explicit version pin — image tags and RPM version stay in sync automatically
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+    --bundle-rpms --rpm-createrepo --tag-override 1.2.0-rc3
+
+  # Bundle pointing to a custom RPM repo (e.g. COPR) with explicit version pin
+  flightctl-mirror-images --variant community-el9 --bundle ~/flightctl-bundle.tar.gz \
+    --bundle-rpms --rpm-createrepo --tag-override 1.2.0-rc3 \
+    --rpm-repo-url https://copr.fedorainfracloud.org/coprs/g/redhat-et/flightctl/repo/epel-9/group_redhat-et-flightctl-epel-9.repo`,
 
 		// SilenceUsage prevents cobra from printing the full usage block on every
 		// RunE error — our logError calls provide targeted messages instead.
@@ -331,6 +374,22 @@ Examples:
 
 			if agentOnly && !cmd.Flags().Changed("rpm-packages") {
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
+			}
+
+			// Pin RPM packages to a specific version when requested.
+			// --rpm-version takes precedence; if not set, derive it from --tag-override
+			// so that the bundled RPM version matches the bundled image tags.
+			// Only applies when --rpm-packages was not explicitly overridden by the user
+			// (if the user already pinned versions in --rpm-packages, respect that).
+			if bundleRPMs || agentOnly {
+				effectiveRPMVersion := rpmVersion
+				if effectiveRPMVersion == "" && tagOverride != "" && !cmd.Flags().Changed("rpm-packages") {
+					effectiveRPMVersion = imageTagToRPMVersion(tagOverride)
+				}
+				if effectiveRPMVersion != "" {
+					rpmPackages = pinRPMPackages(rpmPackages, effectiveRPMVersion)
+					logInfo("  RPM version pin:  %s", effectiveRPMVersion)
+				}
 			}
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
@@ -470,6 +529,7 @@ Examples:
 	cmd.Flags().BoolVar(&bundleRPMs, "bundle-rpms", false, "Include RPMs in the bundle for bare-metal quadlet installation (requires --bundle)")
 	cmd.Flags().StringSliceVar(&rpmPackages, "rpm-packages", []string{"flightctl-services", "flightctl-cli", "flightctl-agent"}, "RPM package names to download into the bundle (comma-separated). The default includes flightctl-cli for server-side fleet management and flightctl-agent for offline image building — the agent RPM is not enabled on the server but is available in the bundle rpms/ directory for embedding into device OS images.")
 	cmd.Flags().StringSliceVar(&rpmExclude, "rpm-exclude", nil, "RPM package names to download but exclude from auto-installation (comma-separated). Excluded packages are still present in rpms/ for manual use (e.g. embedding into device OS images).")
+	cmd.Flags().StringVar(&rpmVersion, "rpm-version", "", "Pin flightctl RPM packages to this exact version (e.g. 1.2.0~rc3). When omitted and --tag-override is set, the version is derived automatically from the tag override so that RPM and image versions stay in sync. Use this flag to override the derived version or when the RPM version differs from the image tag.")
 	cmd.Flags().StringVar(&rpmRepoURL, "rpm-repo-url", "https://rpm.flightctl.io/flightctl-epel.repo", "URL of the .repo file to configure dnf for RPM downloads")
 	cmd.Flags().BoolVar(&rpmReposync, "rpm-reposync", false, "Mirror the full FlightCtl RPM repository using 'dnf reposync' (includes repodata/; requires dnf-plugins-core; mutually exclusive with --rpm-createrepo)")
 	cmd.Flags().BoolVar(&rpmCreaterepo, "rpm-createrepo", false, "Generate repodata/ after 'dnf download' using 'createrepo_c' so the bundle can be used as a local dnf repository source (mutually exclusive with --rpm-reposync)")

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -173,6 +173,27 @@ func pinRPMPackages(packages []string, version string) []string {
 	return pinned
 }
 
+// resolveRPMVersion pins flightctl RPM packages to a specific version when
+// bundling RPMs so the downloaded RPM version matches the bundled image tags.
+// --rpm-version takes precedence; when absent and --tag-override is set and the
+// caller did not explicitly set --rpm-packages, the version is derived from the
+// tag override (converting image-tag hyphens to RPM-version tildes).
+func resolveRPMVersion(packages []string, rpmVersion, tagOverride string, shouldPin, packagesExplicitlySet bool) []string {
+	if !shouldPin {
+		return packages
+	}
+	effective := rpmVersion
+	if effective == "" && tagOverride != "" && !packagesExplicitlySet {
+		effective = imageTagToRPMVersion(tagOverride)
+	}
+	if effective == "" {
+		return packages
+	}
+	pinned := pinRPMPackages(packages, effective)
+	logInfo("  RPM version pin:  %s", effective)
+	return pinned
+}
+
 // excludePackages returns packages with any entry found in exclude removed.
 func excludePackages(packages, exclude []string) []string {
 	if len(exclude) == 0 {
@@ -376,21 +397,8 @@ Examples:
 				rpmPackages = []string{"flightctl-agent", "flightctl-cli", "open-vm-tools", "ignition", "afterburn", "cloud-init"}
 			}
 
-			// Pin RPM packages to a specific version when requested.
-			// --rpm-version takes precedence; if not set, derive it from --tag-override
-			// so that the bundled RPM version matches the bundled image tags.
-			// Only applies when --rpm-packages was not explicitly overridden by the user
-			// (if the user already pinned versions in --rpm-packages, respect that).
-			if bundleRPMs || agentOnly {
-				effectiveRPMVersion := rpmVersion
-				if effectiveRPMVersion == "" && tagOverride != "" && !cmd.Flags().Changed("rpm-packages") {
-					effectiveRPMVersion = imageTagToRPMVersion(tagOverride)
-				}
-				if effectiveRPMVersion != "" {
-					rpmPackages = pinRPMPackages(rpmPackages, effectiveRPMVersion)
-					logInfo("  RPM version pin:  %s", effectiveRPMVersion)
-				}
-			}
+			rpmPackages = resolveRPMVersion(rpmPackages, rpmVersion, tagOverride,
+				bundleRPMs || agentOnly, cmd.Flags().Changed("rpm-packages"))
 
 			installPackages := excludePackages(rpmPackages, rpmExclude)
 			if len(rpmExclude) > 0 {


### PR DESCRIPTION
*Backporting PRs for release 1.2:*

PR 3096 *[EDM-3953: fix --tag-override not pinning RPM version, causing bundle mismatch](https://github.com/flightctl/flightctl/pull/3096)*
PR 3097 *[EDM-3953: update agent offline install doc to use flightctl-mirror-images tool](https://github.com/flightctl/flightctl/pull/3097)*
