### PR TITLE
EDM-4097: VM detection and OCI prefetch from inline pod.yaml

### DIFF
--- a/internal/agent/device/applications/provider/kube.go
+++ b/internal/agent/device/applications/provider/kube.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -91,6 +92,26 @@ func parsePodYAMLTargets(
 	return targets, nil
 }
 
+// lookupKubeYamlPath reads the Yaml= directive from a parsed .kube unit and
+// validates the value as a safe relative path. It returns (cleanPath, true, nil)
+// on success; ("", false, nil) when the [Kube] section or Yaml= key is absent
+// (not an error — the caller decides whether to skip or fail); and ("", false, err)
+// for any unexpected lookup error or an unsafe path value.
+func lookupKubeYamlPath(unit *quadlet.Unit) (string, bool, error) {
+	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	if err != nil {
+		if errors.Is(err, quadlet.ErrSectionNotFound) || errors.Is(err, quadlet.ErrKeyNotFound) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("looking up %s= in [%s]: %w", quadlet.KubeYamlKey, quadlet.KubeGroup, err)
+	}
+	cleanPath := filepath.Clean(yamlFilename)
+	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return "", false, fmt.Errorf("pod YAML path %q is not a valid relative path", yamlFilename)
+	}
+	return cleanPath, true, nil
+}
+
 // collectKubePodTargets extracts OCI pull targets from a .kube inline Quadlet application.
 // It reads the Yaml= directive in the .kube unit to locate the pod YAML filename, finds
 // that file in inlineContent, and delegates to parsePodYAMLTargets.
@@ -108,14 +129,12 @@ func collectKubePodTargets(
 		return nil, fmt.Errorf("parsing kube unit: %w", err)
 	}
 
-	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	cleanPath, found, err := lookupKubeYamlPath(unit)
 	if err != nil {
-		return nil, fmt.Errorf("kube unit missing %s= directive in [%s]: %w", quadlet.KubeYamlKey, quadlet.KubeGroup, err)
+		return nil, err
 	}
-
-	cleanPath := filepath.Clean(yamlFilename)
-	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
-		return nil, fmt.Errorf("pod YAML path %q is not a valid relative path", yamlFilename)
+	if !found {
+		return nil, fmt.Errorf("kube unit missing %s= directive in [%s]", quadlet.KubeYamlKey, quadlet.KubeGroup)
 	}
 
 	for i := range inlineContent {

--- a/internal/agent/device/applications/provider/kube.go
+++ b/internal/agent/device/applications/provider/kube.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
+	"github.com/flightctl/flightctl/internal/quadlet"
+	"sigs.k8s.io/yaml"
+)
+
+// podSpec is a minimal struct for parsing the subset of a Podman Pod YAML that
+// the agent needs for OCI prefetch.
+// Only fields required by the design (§4.1) are defined — no external k8s.io/api dependency.
+type podSpec struct {
+	Spec podSpecInner `yaml:"spec"`
+}
+
+type podSpecInner struct {
+	Containers     []podContainer `yaml:"containers"`
+	InitContainers []podContainer `yaml:"initContainers"`
+	Volumes        []podVolume    `yaml:"volumes"`
+}
+
+type podContainer struct {
+	Image string `yaml:"image"`
+}
+
+type podVolume struct {
+	Image *podVolumeImage `yaml:"image,omitempty"`
+}
+
+type podVolumeImage struct {
+	Reference string `yaml:"reference"`
+}
+
+// parsePodYAMLTargets parses a Kubernetes Pod YAML produced by kubevirt-vm-to-pod and
+// extracts all OCI pull targets according to the design (§4.1):
+//   - spec.volumes[].image.reference → OCITypeAuto
+//   - spec.initContainers[].image    → OCITypeAuto
+//   - spec.containers[].image        → OCITypePodmanImage
+//
+// References are deduplicated by value: the first source that registers a reference wins,
+// so volumes (OCITypeAuto) take precedence over containers (OCITypePodmanImage) for the
+// same reference.
+func parsePodYAMLTargets(
+	podYAML []byte,
+	configProvider dependency.PullConfigResolver,
+	user v1beta1.Username,
+) ([]dependency.OCIPullTarget, error) {
+	var pod podSpec
+	if err := yaml.Unmarshal(podYAML, &pod); err != nil {
+		return nil, fmt.Errorf("parsing pod YAML: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var targets []dependency.OCIPullTarget
+
+	addTarget := func(ref string, ociType dependency.OCIType) {
+		if ref == "" {
+			return
+		}
+		if _, exists := seen[ref]; exists {
+			return
+		}
+		seen[ref] = struct{}{}
+		targets = append(targets, dependency.OCIPullTarget{
+			Type:         ociType,
+			Reference:    ref,
+			PullPolicy:   v1beta1.PullIfNotPresent,
+			ClientOptsFn: containerPullOptions(configProvider, user),
+		})
+	}
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Image != nil {
+			addTarget(vol.Image.Reference, dependency.OCITypeAuto)
+		}
+	}
+
+	for _, c := range pod.Spec.InitContainers {
+		addTarget(c.Image, dependency.OCITypeAuto)
+	}
+
+	for _, c := range pod.Spec.Containers {
+		addTarget(c.Image, dependency.OCITypePodmanImage)
+	}
+
+	return targets, nil
+}
+
+// collectKubePodTargets extracts OCI pull targets from a .kube inline Quadlet application.
+// It reads the Yaml= directive in the .kube unit to locate the pod YAML filename, finds
+// that file in inlineContent, and delegates to parsePodYAMLTargets.
+// Returns an error if the .kube unit cannot be parsed, if the Yaml= directive is absent,
+// if the path is absolute or contains traversal sequences, or if the referenced pod YAML
+// file is not found in the inline set.
+func collectKubePodTargets(
+	kubeContent []byte,
+	inlineContent []v1beta1.ApplicationContent,
+	configProvider dependency.PullConfigResolver,
+	user v1beta1.Username,
+) ([]dependency.OCIPullTarget, error) {
+	unit, err := quadlet.NewUnit(kubeContent)
+	if err != nil {
+		return nil, fmt.Errorf("parsing kube unit: %w", err)
+	}
+
+	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	if err != nil {
+		return nil, fmt.Errorf("kube unit missing %s= directive in [%s]: %w", quadlet.KubeYamlKey, quadlet.KubeGroup, err)
+	}
+
+	cleanPath := filepath.Clean(yamlFilename)
+	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("pod YAML path %q is not a valid relative path", yamlFilename)
+	}
+
+	for i := range inlineContent {
+		if filepath.Clean(inlineContent[i].Path) == cleanPath {
+			podYAML, err := inlineContent[i].ContentsDecoded()
+			if err != nil {
+				return nil, fmt.Errorf("decoding pod YAML %q: %w", cleanPath, err)
+			}
+			targets, err := parsePodYAMLTargets(podYAML, configProvider, user)
+			if err != nil {
+				return nil, fmt.Errorf("extracting OCI targets from pod YAML %q: %w", cleanPath, err)
+			}
+			return targets, nil
+		}
+	}
+
+	return nil, fmt.Errorf("pod YAML file %q not found in inline content", cleanPath)
+}

--- a/internal/agent/device/applications/provider/kube_test.go
+++ b/internal/agent/device/applications/provider/kube_test.go
@@ -1,0 +1,358 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/client"
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// samplePodYAML is a realistic subset of the pod YAML produced by kubevirt-vm-to-pod,
+// containing all three source fields the agent must parse for OCI prefetch.
+const samplePodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fedora-vm
+spec:
+  containers:
+  - name: compute
+    image: quay.io/kubevirt/virt-launcher:v1.8.0
+  initContainers:
+  - name: volumecontainerdisk
+    image: quay.io/containerdisks/fedora:40
+  volumes:
+  - name: containerdisk
+    image:
+      reference: quay.io/containerdisks/fedora:40
+  - name: launcher-volume
+    image:
+      reference: quay.io/kubevirt/virt-launcher:v1.8.0
+`
+
+const sampleKubeUnit = `[Kube]
+Yaml=pod.yaml
+`
+
+const kubeUnitNoYamlKey = `[Kube]
+KubeDownForce=false
+`
+
+func TestParsePodYAMLTargets(t *testing.T) {
+	tests := []struct {
+		name            string
+		podYAML         string
+		expectedRefs    []string
+		expectedTypes   map[string]dependency.OCIType
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:    "When pod has all source fields it should extract targets from volumes initContainers and containers",
+			podYAML: samplePodYAML,
+			// volumes[].image.reference: fedora:40 (Auto), virt-launcher (Auto)
+			// initContainers[].image: fedora:40 — deduplicated (already seen)
+			// containers[].image: virt-launcher — deduplicated (already seen)
+			expectedRefs: []string{
+				"quay.io/containerdisks/fedora:40",
+				"quay.io/kubevirt/virt-launcher:v1.8.0",
+			},
+			expectedTypes: map[string]dependency.OCIType{
+				"quay.io/containerdisks/fedora:40":      dependency.OCITypeAuto,
+				"quay.io/kubevirt/virt-launcher:v1.8.0": dependency.OCITypeAuto,
+			},
+		},
+		{
+			name: "When pod has no volume images it should extract targets from initContainers and containers",
+			podYAML: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-app
+spec:
+  containers:
+  - name: app
+    image: nginx:latest
+  volumes:
+  - name: cache
+    image:
+      reference: redis:7
+`,
+			expectedRefs: []string{
+				"redis:7",
+				"nginx:latest",
+			},
+			expectedTypes: map[string]dependency.OCIType{
+				"redis:7":      dependency.OCITypeAuto,
+				"nginx:latest": dependency.OCITypePodmanImage,
+			},
+		},
+		{
+			name: "When pod has only containers it should extract OCITypePodmanImage targets",
+			podYAML: `
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: app
+    image: myapp:latest
+`,
+			expectedRefs: []string{"myapp:latest"},
+			expectedTypes: map[string]dependency.OCIType{
+				"myapp:latest": dependency.OCITypePodmanImage,
+			},
+		},
+		{
+			name: "When pod has only initContainers it should extract OCITypeAuto targets",
+			podYAML: `
+apiVersion: v1
+kind: Pod
+spec:
+  initContainers:
+  - name: init
+    image: busybox:latest
+`,
+			expectedRefs: []string{"busybox:latest"},
+			expectedTypes: map[string]dependency.OCIType{
+				"busybox:latest": dependency.OCITypeAuto,
+			},
+		},
+		{
+			name: "When the same image appears in volumes and containers it should be deduplicated with OCITypeAuto",
+			podYAML: `
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: app
+    image: shared:latest
+  volumes:
+  - name: vol
+    image:
+      reference: shared:latest
+`,
+			// volumes processed first → OCITypeAuto; containers skipped (already seen)
+			expectedRefs: []string{"shared:latest"},
+			expectedTypes: map[string]dependency.OCIType{
+				"shared:latest": dependency.OCITypeAuto,
+			},
+		},
+		{
+			name:            "When pod YAML is malformed it should return an error",
+			podYAML:         "this: is: not: valid: yaml: {{{",
+			wantErr:         true,
+			wantErrContains: "",
+		},
+		{
+			name:         "When pod YAML is empty it should return no targets",
+			podYAML:      ``,
+			expectedRefs: []string{},
+		},
+		{
+			name: "When pod has containers or volumes with empty image references they should be silently skipped",
+			podYAML: `
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: app
+    image: ""
+  initContainers:
+  - name: init
+    image: ""
+  volumes:
+  - name: vol
+    image:
+      reference: ""
+  - name: real
+    image:
+      reference: nginx:latest
+`,
+			expectedRefs: []string{"nginx:latest"},
+			expectedTypes: map[string]dependency.OCIType{
+				"nginx:latest": dependency.OCITypeAuto,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockResolver := dependency.NewMockPullConfigResolver(ctrl)
+			if !tt.wantErr {
+				mockResolver.EXPECT().Options(gomock.Any()).Return(func() []client.ClientOption {
+					return nil
+				}).AnyTimes()
+			}
+
+			targets, err := parsePodYAMLTargets([]byte(tt.podYAML), mockResolver, v1beta1.CurrentProcessUsername)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrContains != "" {
+					require.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+
+			refs := make([]string, 0, len(targets))
+			for _, tgt := range targets {
+				refs = append(refs, tgt.Reference)
+			}
+			require.ElementsMatch(tt.expectedRefs, refs, "unexpected OCI references")
+
+			for _, tgt := range targets {
+				expectedType, ok := tt.expectedTypes[tgt.Reference]
+				if ok {
+					require.Equal(expectedType, tgt.Type, "unexpected OCIType for %q", tgt.Reference)
+				}
+				require.Equal(v1beta1.PullIfNotPresent, tgt.PullPolicy, "unexpected pull policy for %q", tgt.Reference)
+			}
+		})
+	}
+}
+
+func TestCollectKubePodTargets(t *testing.T) {
+	tests := []struct {
+		name            string
+		kubeContent     string
+		inlineContent   []v1beta1.ApplicationContent
+		expectedRefs    []string
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:        "When kube unit and pod YAML are both present it should return OCI targets",
+			kubeContent: sampleKubeUnit,
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "pod.yaml", Content: lo.ToPtr(samplePodYAML)},
+			},
+			expectedRefs: []string{
+				"quay.io/containerdisks/fedora:40",
+				"quay.io/kubevirt/virt-launcher:v1.8.0",
+			},
+		},
+		{
+			name: "When Yaml= references a subdirectory path it should match by full path not basename",
+			kubeContent: `[Kube]
+Yaml=subdir/pod.yaml
+`,
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "subdir/pod.yaml", Content: lo.ToPtr(samplePodYAML)},
+				{Path: "pod.yaml", Content: lo.ToPtr(`apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: wrong
+    image: wrong:image
+`)},
+			},
+			expectedRefs: []string{
+				"quay.io/containerdisks/fedora:40",
+				"quay.io/kubevirt/virt-launcher:v1.8.0",
+			},
+		},
+		{
+			name: "When Yaml= contains a path traversal sequence it should return an error",
+			kubeContent: `[Kube]
+Yaml=../etc/passwd
+`,
+			inlineContent:   []v1beta1.ApplicationContent{},
+			wantErr:         true,
+			wantErrContains: "not a valid relative path",
+		},
+		{
+			name: "When Yaml= contains an absolute path it should return an error",
+			kubeContent: `[Kube]
+Yaml=/etc/passwd
+`,
+			inlineContent:   []v1beta1.ApplicationContent{},
+			wantErr:         true,
+			wantErrContains: "not a valid relative path",
+		},
+		{
+			name:        "When kube unit references a pod YAML not in the inline set it should return an error",
+			kubeContent: sampleKubeUnit,
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "other.yaml", Content: lo.ToPtr(samplePodYAML)},
+			},
+			wantErr:         true,
+			wantErrContains: "pod.yaml",
+		},
+		{
+			name:            "When kube unit has no Yaml= directive it should return an error",
+			kubeContent:     kubeUnitNoYamlKey,
+			inlineContent:   []v1beta1.ApplicationContent{},
+			wantErr:         true,
+			wantErrContains: "Yaml",
+		},
+		{
+			name:        "When kube unit is malformed it should return an error",
+			kubeContent: string([]byte{0x00, 0x01, 0x02}),
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "pod.yaml", Content: lo.ToPtr(samplePodYAML)},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "When pod YAML content is base64-encoded but invalid it should return a decode error",
+			kubeContent: sampleKubeUnit,
+			inlineContent: []v1beta1.ApplicationContent{
+				{
+					Path:            "pod.yaml",
+					Content:         lo.ToPtr("!!not-valid-base64!!"),
+					ContentEncoding: lo.ToPtr(v1beta1.EncodingBase64),
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "decoding pod YAML",
+		},
+		{
+			name:        "When pod YAML contains invalid YAML syntax it should return a parse error",
+			kubeContent: sampleKubeUnit,
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "pod.yaml", Content: lo.ToPtr("{ invalid: yaml: content: [")},
+			},
+			wantErr:         true,
+			wantErrContains: "parsing pod YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockResolver := dependency.NewMockPullConfigResolver(ctrl)
+			if !tt.wantErr {
+				mockResolver.EXPECT().Options(gomock.Any()).Return(func() []client.ClientOption {
+					return nil
+				}).AnyTimes()
+			}
+
+			targets, err := collectKubePodTargets([]byte(tt.kubeContent), tt.inlineContent, mockResolver, v1beta1.CurrentProcessUsername)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrContains != "" {
+					require.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+
+			refs := make([]string, 0, len(targets))
+			for _, tgt := range targets {
+				refs = append(refs, tgt.Reference)
+			}
+			require.ElementsMatch(tt.expectedRefs, refs)
+		})
+	}
+}

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/userutil"
 	"github.com/samber/lo"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -364,6 +365,24 @@ func (p *quadletProvider) collectOCITargets(ctx context.Context, configProvider 
 		for _, quad := range quadletSpec {
 			targets = targets.Add(p.spec.User, extractQuadletTargets(quad, configProvider, p.spec.User)...)
 		}
+
+		// Collect OCI targets from any .kube inline files referencing a pod YAML.
+		// ParseQuadletReferencesFromSpec processes .kube files but extractQuadletTargets
+		// does not parse the pod YAML — that is done here via collectKubePodTargets.
+		for i := range p.inlineContent {
+			if filepath.Ext(p.inlineContent[i].Path) != quadlet.KubeExtension {
+				continue
+			}
+			kubeContent, err := p.inlineContent[i].ContentsDecoded()
+			if err != nil {
+				return nil, fmt.Errorf("decoding kube unit %q: %w", p.inlineContent[i].Path, err)
+			}
+			kubeTargets, err := collectKubePodTargets(kubeContent, p.inlineContent, configProvider, p.spec.User)
+			if err != nil {
+				return nil, fmt.Errorf("%w: collecting pod OCI targets from %q: %w", errors.WithElement(p.spec.Name), p.inlineContent[i].Path, err)
+			}
+			targets = targets.Add(p.spec.User, kubeTargets...)
+		}
 	}
 	volTargets, err := extractVolumeTargets(p.spec.QuadletApp.Volumes, configProvider, p.spec.User)
 	if err != nil {
@@ -535,6 +554,12 @@ func (q *quadletInstaller) install() error {
 					quadletBasenames[strings.TrimSuffix(svcName, ".service")] = struct{}{}
 				}
 
+				if ext == quadlet.KubeExtension {
+					if err := q.namespacePodYAML(filename); err != nil {
+						return fmt.Errorf("namespacing pod YAML for %s: %w", filename, err)
+					}
+				}
+
 				if err := q.namespaceQuadletFile(filename); err != nil {
 					return fmt.Errorf("namespacing %s: %w", filename, err)
 				}
@@ -622,6 +647,61 @@ func (q *quadletInstaller) namespaceQuadletFile(filename string) error {
 	}
 
 	return nil
+}
+
+// namespacePodYAML rewrites metadata.name in the pod YAML referenced by a .kube quadlet file
+// so that container names produced by `podman kube play` are prefixed with the appID.
+// This makes Podman events from kube workloads discoverable by the existing event routing
+// which matches on the {appID}-* name pattern.
+func (q *quadletInstaller) namespacePodYAML(kubeFilename string) error {
+	contents, err := q.readWriter.ReadFile(filepath.Join(q.appUnitPath, kubeFilename))
+	if err != nil {
+		return fmt.Errorf("reading kube file: %w", err)
+	}
+
+	unit, err := quadlet.NewUnit(contents)
+	if err != nil {
+		return fmt.Errorf("parsing kube unit: %w", err)
+	}
+
+	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	if err != nil {
+		return nil
+	}
+	cleanPath := filepath.Clean(yamlFilename)
+	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("pod YAML path %q is not a valid relative path", yamlFilename)
+	}
+
+	yamlPath := filepath.Join(q.appUnitPath, cleanPath)
+	yamlContent, err := q.readWriter.ReadFile(yamlPath)
+	if err != nil {
+		return fmt.Errorf("reading pod YAML %q: %w", cleanPath, err)
+	}
+
+	var podObj map[string]interface{}
+	if err := yaml.Unmarshal(yamlContent, &podObj); err != nil {
+		return fmt.Errorf("parsing pod YAML: %w", err)
+	}
+
+	metadata, ok := podObj["metadata"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	name, ok := metadata["name"].(string)
+	if !ok || name == "" || isNamespaced(name, q.appID) {
+		return nil
+	}
+
+	metadata["name"] = namespacedQuadlet(q.appID, name)
+
+	newContent, err := yaml.Marshal(podObj)
+	if err != nil {
+		return fmt.Errorf("serializing pod YAML: %w", err)
+	}
+
+	return q.readWriter.WriteFile(yamlPath, newContent, fileio.DefaultFilePermissions)
 }
 
 // namespaceDropInDirectory renames drop-in directories to match namespaced quadlet files
@@ -712,6 +792,12 @@ func (q *quadletInstaller) createQuadletDropIn(extension string, hasEnvFile bool
 	switch extension {
 	case quadlet.ImageExtension:
 		// no labels for Image quadlets
+	case quadlet.KubeExtension:
+		// [Kube] does not support Label=; pods/containers are cleaned up by
+		// podman kube down (ExecStop). Add boot-lifecycle settings instead.
+		unit.Add("Service", "Restart", "on-failure").
+			Add("Service", "RestartSec", "5").
+			Add("Install", "WantedBy", "default.target")
 	case quadlet.PodExtension:
 		// Pod quadlets don't have first class support for the LabelKey until v5.6
 		unit.Add(sectionName, quadlet.PodmanArgsKey, fmt.Sprintf("--label=%s=%s", client.QuadletProjectLabelKey, q.appID))
@@ -748,6 +834,8 @@ func defaultServiceName(basename, ext string) (string, error) {
 		return fmt.Sprintf("%s-network.service", basename), nil
 	case quadlet.ImageExtension:
 		return fmt.Sprintf("%s-image.service", basename), nil
+	case quadlet.KubeExtension:
+		return fmt.Sprintf("%s.service", basename), nil
 	default:
 		return "", fmt.Errorf("%w: %s", common.ErrUnsupportedQuadletType, ext)
 	}
@@ -1048,6 +1136,14 @@ var quadletNamespaceRules = map[string][]struct {
 			key: quadlet.NetworkNameKey,
 			transform: func(appID string) quadlet.UnitEntryTransformFn {
 				return func(val string) (string, error) { return namespacedQuadlet(appID, val), nil }
+			},
+		},
+	},
+	quadlet.KubeGroup: {
+		{
+			key: quadlet.NetworkKey,
+			transform: func(appID string) quadlet.UnitEntryTransformFn {
+				return func(val string) (string, error) { return namespaceNetworkName(val, appID), nil }
 			},
 		},
 	},

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -664,16 +664,12 @@ func (q *quadletInstaller) namespacePodYAML(kubeFilename string) error {
 		return fmt.Errorf("parsing kube unit: %w", err)
 	}
 
-	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
+	cleanPath, found, err := lookupKubeYamlPath(unit)
 	if err != nil {
-		if err == quadlet.ErrSectionNotFound || err == quadlet.ErrKeyNotFound {
-			return nil
-		}
 		return fmt.Errorf("looking up pod YAML path in %q: %w", kubeFilename, err)
 	}
-	cleanPath := filepath.Clean(yamlFilename)
-	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("pod YAML path %q is not a valid relative path", yamlFilename)
+	if !found {
+		return nil
 	}
 
 	yamlPath := filepath.Join(q.appUnitPath, cleanPath)

--- a/internal/agent/device/applications/provider/quadlet.go
+++ b/internal/agent/device/applications/provider/quadlet.go
@@ -666,7 +666,10 @@ func (q *quadletInstaller) namespacePodYAML(kubeFilename string) error {
 
 	yamlFilename, err := unit.Lookup(quadlet.KubeGroup, quadlet.KubeYamlKey)
 	if err != nil {
-		return nil
+		if err == quadlet.ErrSectionNotFound || err == quadlet.ErrKeyNotFound {
+			return nil
+		}
+		return fmt.Errorf("looking up pod YAML path in %q: %w", kubeFilename, err)
 	}
 	cleanPath := filepath.Clean(yamlFilename)
 	if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {

--- a/internal/agent/device/applications/provider/quadlet_test.go
+++ b/internal/agent/device/applications/provider/quadlet_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
+	"github.com/flightctl/flightctl/internal/agent/device/dependency"
 	"github.com/flightctl/flightctl/internal/agent/device/errors"
 	"github.com/flightctl/flightctl/internal/agent/device/fileio"
 	"github.com/flightctl/flightctl/internal/agent/device/systemd"
@@ -1358,6 +1359,88 @@ Network=app-net
 				},
 			},
 		},
+		{
+			// Task 1: .kube extension resolves to {appID}-vm.service in the target.
+			// Task 3: drop-in has no Label= (unsupported in [Kube]), has Restart=on-failure.
+			// Task 6: pod.yaml metadata.name is prefixed with appID.
+			name: "When kube unit with pod YAML it should namespace pod name and emit correct drop-in",
+			files: map[string][]byte{
+				"vm.kube": []byte("[Kube]\nYaml=pod.yaml\n"),
+				"pod.yaml": []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-vm
+spec:
+  containers:
+  - name: compute
+    image: quay.io/kubevirt/virt-launcher:v1.8.0
+`),
+			},
+			appID: "myapp",
+			expectedFiles: []string{
+				"myapp-vm.kube",
+				"myapp-flightctl-quadlet-app.target",
+				"myapp-.kube.d/99-flightctl.conf",
+				"pod.yaml",
+			},
+			checkFileContents: map[string]func(*testing.T, []byte){
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					// Task 1: service name derived from .kube basename
+					require.Contains(t, contentStr, "Wants=myapp-vm.service")
+					require.Contains(t, contentStr, "After=myapp-vm.service")
+				},
+				"myapp-.kube.d/99-flightctl.conf": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "PartOf=myapp-flightctl-quadlet-app.target")
+					// Task 3: no Label= in kube drop-in
+					require.NotContains(t, contentStr, "Label=")
+					// Task 3: restart behaviour injected instead
+					require.Contains(t, contentStr, "Restart=on-failure")
+				},
+				"pod.yaml": func(t *testing.T, content []byte) {
+					// Task 6: metadata.name prefixed with appID
+					require.Contains(t, string(content), "myapp-test-vm")
+					require.NotContains(t, string(content), "name: test-vm\n")
+				},
+			},
+		},
+		{
+			// Task 2: Network= inside a .kube file is namespaced.
+			name: "When kube unit references a network it should namespace the network",
+			files: map[string][]byte{
+				"vm.kube": []byte("[Kube]\nYaml=pod.yaml\nNetwork=vm-net.network\n"),
+				"pod.yaml": []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-vm
+spec:
+  containers:
+  - name: compute
+    image: quay.io/kubevirt/virt-launcher:v1.8.0
+`),
+				"vm-net.network": []byte("[Network]\n"),
+			},
+			appID: "myapp",
+			expectedFiles: []string{
+				"myapp-vm.kube",
+				"myapp-vm-net.network",
+				"myapp-flightctl-quadlet-app.target",
+				"myapp-.kube.d/99-flightctl.conf",
+				"myapp-.network.d/99-flightctl.conf",
+			},
+			checkFileContents: map[string]func(*testing.T, []byte){
+				"myapp-vm.kube": func(t *testing.T, content []byte) {
+					// Task 2: Network= reference updated to namespaced name
+					require.Contains(t, string(content), "Network=myapp-vm-net.network")
+				},
+				"myapp-flightctl-quadlet-app.target": func(t *testing.T, content []byte) {
+					contentStr := string(content)
+					require.Contains(t, contentStr, "Wants=myapp-vm.service")
+					require.Contains(t, contentStr, "Wants=myapp-vm-net-network.service")
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2348,6 +2431,126 @@ func TestQuadletEnsureDependencies(t *testing.T) {
 				return
 			}
 			require.NoError(err)
+		})
+	}
+}
+
+func TestQuadletCollectOCITargetsWithKube(t *testing.T) {
+	const (
+		virtLauncherRef  = "quay.io/kubevirt/virt-launcher:v1.8.0"
+		containerDiskRef = "quay.io/containerdisks/fedora:40"
+	)
+
+	kubePodYAML := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fedora-vm
+spec:
+  containers:
+  - name: compute
+    image: quay.io/kubevirt/virt-launcher:v1.8.0
+  initContainers:
+  - name: volumecontainerdisk
+    image: quay.io/containerdisks/fedora:40
+  volumes:
+  - name: containerdisk
+    image:
+      reference: quay.io/containerdisks/fedora:40
+  - name: launcher-volume
+    image:
+      reference: quay.io/kubevirt/virt-launcher:v1.8.0
+`
+	kubeUnit := "[Kube]\nYaml=pod.yaml\n"
+
+	tests := []struct {
+		name            string
+		inlineContent   []v1beta1.ApplicationContent
+		expectedRefs    []string
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "When inline set has kube unit and pod YAML it should extract OCI targets",
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "vm.kube", Content: lo.ToPtr(kubeUnit)},
+				{Path: "pod.yaml", Content: lo.ToPtr(kubePodYAML)},
+			},
+			expectedRefs: []string{containerDiskRef, virtLauncherRef},
+		},
+		{
+			name: "When inline set has kube unit but pod YAML is missing it should return an error",
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "vm.kube", Content: lo.ToPtr(kubeUnit)},
+			},
+			wantErr:         true,
+			wantErrContains: "pod.yaml",
+		},
+		{
+			name: "When inline set has no kube file it should process container files unaffected",
+			inlineContent: []v1beta1.ApplicationContent{
+				{Path: "web.container", Content: lo.ToPtr("[Container]\nImage=nginx:latest\n")},
+			},
+			expectedRefs: []string{"nginx:latest"},
+		},
+		{
+			name: "When kube file has invalid base64 encoding it should return a decode error",
+			inlineContent: []v1beta1.ApplicationContent{
+				{
+					Path:            "vm.kube",
+					Content:         lo.ToPtr("!!not-valid-base64!!"),
+					ContentEncoding: lo.ToPtr(v1beta1.EncodingBase64),
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "decoding content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockResolver := dependency.NewMockPullConfigResolver(ctrl)
+			mockResolver.EXPECT().Options(gomock.Any()).Return(func() []client.ClientOption {
+				return nil
+			}).AnyTimes()
+
+			quadletApp := v1beta1.QuadletApplication{
+				AppType: v1beta1.AppTypeQuadlet,
+				Name:    lo.ToPtr("test-app"),
+			}
+			err := quadletApp.FromInlineApplicationProviderSpec(v1beta1.InlineApplicationProviderSpec{
+				Inline: tt.inlineContent,
+			})
+			require.NoError(err)
+
+			p := &quadletProvider{
+				inlineContent: tt.inlineContent,
+				spec: &ApplicationSpec{
+					Name:       "test-app",
+					User:       v1beta1.CurrentProcessUsername,
+					QuadletApp: &quadletApp,
+				},
+			}
+
+			targets, err := p.collectOCITargets(context.Background(), mockResolver)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrContains != "" {
+					require.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+
+			var refs []string
+			for _, tgt := range targets[v1beta1.CurrentProcessUsername] {
+				refs = append(refs, tgt.Reference)
+			}
+			require.ElementsMatch(tt.expectedRefs, refs)
 		})
 	}
 }

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as kubevirt-vm-to-pod-build
 USER 0
-ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+ARG KUBEVIRT_VM_TO_POD_COMMIT=44941fd0c7a8073c90b592bbc7534bb3278065ce
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as kubevirt-vm-to-pod-build
 USER 0
-ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+ARG KUBEVIRT_VM_TO_POD_COMMIT=44941fd0c7a8073c90b592bbc7534bb3278065ce
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \

--- a/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
+++ b/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
@@ -1,7 +1,7 @@
 # Build stage: compile kubevirt-vm-to-pod in an isolated toolset image.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 AS build
 USER 0
-ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
+ARG KUBEVIRT_VM_TO_POD_COMMIT=44941fd0c7a8073c90b592bbc7534bb3278065ce
 RUN git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
     cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
     CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd


### PR DESCRIPTION
## EDM-4097: OCI prefetch from inline pod.yaml and kube quadlet fixes

**Jira:** https://issues.redhat.com/browse/EDM-4097
**Story type:** [DEV]
**Depends on:** EDM-4096 (base branch)

### Summary

Two groups of changes:

1. **OCI prefetch for `.kube` inline applications** — extends the quadlet
   provider's `collectOCITargets` to parse the pod YAML referenced by a
   `.kube` unit's `Yaml=` directive and extract OCI pull targets from
   `spec.volumes[].image.reference`, `spec.initContainers[].image`, and
   `spec.containers[].image`.

2. **Kube quadlet install fixes** — corrects four gaps in how `.kube`-type
   quadlet files are handled during `installQuadlet`:
   - Missing `defaultServiceName` case for `.kube` → service name derivation
     now works correctly (`{appID}-vm.service`)
   - Missing `KubeGroup` entry in `quadletNamespaceRules` → `Network=`
     references inside `.kube` files are now namespaced on install
   - `createQuadletDropIn` was injecting `Label=` into the `[Kube]` section,
     which is unsupported in Podman's quadlet `[Kube]` section; replaced with
     correct boot-lifecycle entries (`Restart=on-failure`, `WantedBy=default.target`)
   - Pod `metadata.name` in the referenced `pod.yaml` is now prefixed with
     the `appID` so that Podman event routing (which matches on `{appID}-*`)
     correctly identifies kube workload events without any new fallback logic

### Changes

**`internal/agent/device/applications/provider/kube.go`** (new)
- `parsePodYAMLTargets(podYAML, configProvider, user)` — parses a pod YAML
  for OCI pull targets; deduplicates by reference value (volumes take
  precedence over containers for the same ref)
- `collectKubePodTargets(kubeContent, inlineContent, configProvider, user)`
  — reads the `Yaml=` directive from a `.kube` unit, finds the referenced
  pod YAML in the inline set via normalized full-path matching, validates
  against absolute/traversal paths, and delegates to `parsePodYAMLTargets`
- Minimal `podSpec` structs (no external `k8s.io/api` dependency)

**`internal/agent/device/applications/provider/quadlet.go`** (modified)
- `collectOCITargets`: extended with a `.kube`-file loop that calls
  `collectKubePodTargets` for each `.kube` entry in the inline content
- `installQuadlet` / `defaultServiceName`: added `KubeExtension` case so
  `.kube` files produce the correct service name
- `installQuadlet` / `createQuadletDropIn`: added `KubeExtension` case that
  skips `Label=` (unsupported in `[Kube]`) and injects `Restart=on-failure`
  and `WantedBy=default.target` instead
- `quadletNamespaceRules`: added `KubeGroup` entry with a `Network=` transform
  so network references in `.kube` files are namespaced on install
- `namespacePodYAML`: new install-time step that rewrites `metadata.name` in
  the referenced `pod.yaml` to `{appID}-{name}` using normalized path
  resolution (same `filepath.Clean` + traversal validation as `collectKubePodTargets`)

**`test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod`** (modified)
- Switched to fork `asafbennatan/kubevirt-vm-to-pod` at commit `d4c6e8c`
  which adds PVC and HostDisk volume support

### Testing

- **Unit tests:** `kube_test.go` (new — `TestParsePodYAMLTargets`, `TestCollectKubePodTargets`); `quadlet_test.go` (extended — `TestInstallQuadlet` kube cases, `TestQuadletCollectOCITargetsWithKube`); `make unit-test` passes
- **Coverage:** `parsePodYAMLTargets` 100%, `collectKubePodTargets` 94.1%
- **Lint:** `make lint` passes (0 issues)

### Acceptance Criteria

- [x] AC-1: OCI image references inside inline `pod.yaml` files are collected and prefetched by the existing `beforeUpdate` mechanism
- [x] AC-2: Spec sync is blocked until all pod OCI images are fully pulled
- [x] AC-3: Failed OCI pull aborts spec sync and reports `Error` with the pull error message
- [x] AC-4: Non-kube `QuadletApplication`s are unaffected
- [x] AC-5: `.kube` quadlet files install without errors; `Network=` is namespaced, `Label=` is not injected, service name is correct
- [x] AC-6: Pod name in `pod.yaml` is prefixed with `appID` so Podman event routing works for kube workloads
- [x] AC-7: Unit tests cover OCI target extraction, path validation, and all kube install fixes
