### PR TITLE
EDM-4177: Fix flightctl-restore service recovery on database connection failure

### DIFF
--- a/internal/store/gorm.go
+++ b/internal/store/gorm.go
@@ -35,7 +35,7 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 
 	if cfg.Database.Type != "pgsql" {
 		errString := fmt.Sprintf("failed to connect database %s: only PostgreSQL is supported", cfg.Database.Type)
-		log.Fatal(errString)
+		log.Error(errString)
 		return nil, errors.New(errString)
 	}
 	dsn := createDSN(cfg, user, password)
@@ -69,8 +69,15 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 		TranslateError: true,
 	})
 	if err != nil {
-		log.Fatalf("failed to connect database: %v", err)
-		return nil, err
+		log.Errorf("failed to connect database: %v", err)
+		return nil, fmt.Errorf("failed to connect database: %w", err)
+	}
+
+	// Get sql.DB early so we can close it on error
+	sqlDB, err := newDB.DB()
+	if err != nil {
+		log.Errorf("failed to get underlying sql.DB: %v", err)
+		return nil, fmt.Errorf("failed to get underlying sql.DB: %w", err)
 	}
 
 	// TODO: Make exposing DB metrics optional
@@ -82,15 +89,11 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 	}))
 
 	if err != nil {
-		log.Fatalf("Failed to register prometheus exporter: %v", err)
-		return nil, err
+		sqlDB.Close()
+		log.Errorf("Failed to register prometheus exporter: %v", err)
+		return nil, fmt.Errorf("failed to register prometheus exporter: %w", err)
 	}
 
-	sqlDB, err := newDB.DB()
-	if err != nil {
-		log.Fatalf("failed to configure connections: %v", err)
-		return nil, err
-	}
 	sqlDB.SetMaxIdleConns(10)
 	sqlDB.SetMaxOpenConns(100)
 
@@ -103,8 +106,9 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 
 	if cfg.Tracing != nil && cfg.Tracing.Enabled {
 		if err = newDB.Use(NewTraceContextEnforcer()); err != nil {
-			log.Fatalf("failed to register OpenTelemetry GORM plugin: %v", err)
-			return nil, err
+			sqlDB.Close()
+			log.Errorf("failed to register OpenTelemetry GORM plugin: %v", err)
+			return nil, fmt.Errorf("failed to register OpenTelemetry GORM plugin: %w", err)
 		}
 	}
 
@@ -117,8 +121,9 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 	}
 
 	if err = newDB.Use(tracing.NewPlugin(traceOpts...)); err != nil {
-		log.Fatalf("failed to register OpenTelemetry GORM plugin: %v", err)
-		return nil, err
+		sqlDB.Close()
+		log.Errorf("failed to register OpenTelemetry GORM plugin: %v", err)
+		return nil, fmt.Errorf("failed to register OpenTelemetry GORM plugin: %w", err)
 	}
 
 	return newDB, nil

--- a/test/e2e/backup_restore/backup_restore_test.go
+++ b/test/e2e/backup_restore/backup_restore_test.go
@@ -140,17 +140,18 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 
 			// --- Step 5: Restore from backup; flightctl-restore handles service stop/start ---
 			By("Step 5: Restoring from backup (flightctl-restore stops services, restores DB, starts services)")
-			defer func() {
-				// Safety net: ensure services are up even if the restore binary is killed before its own deferred start.
-				_ = br.ScaleUpFlightCtlServices()
-			}()
 			Expect(br.RunFlightCtlRestore(archivePath)).To(Succeed(), "flightctl-restore must succeed (build with: make flightctl-restore)")
 
-			By("Waiting for API server to be responsive after scale up")
+			By("Verifying all services were restarted by the restore binary")
+			Eventually(func() error {
+				return br.VerifyAllServicesRunning()
+			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "All 8 services must be running after restore")
+
+			By("Waiting for API server to be responsive after restore")
 			Eventually(func() error {
 				_, err := harness.Client.GetDeviceWithResponse(harness.Context, device1ID)
 				return err
-			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "API server must respond after scale up")
+			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "API server must respond after restore")
 
 			// --- Step 6: Service RV=rvAtBackup (restored), device RV=rvAfterUpdate (> rvAtBackup) → ConflictPaused ---
 			By("Step 6: Waiting for devices to reach AwaitingReconnect or ConflictPaused or Online")
@@ -313,18 +314,18 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 			defer cleanup()
 
 			By("Restore process: flightctl-restore (handles service stop/start internally)")
-			defer func() {
-				// Safety net: ensure services are up even if the restore binary is killed before its own deferred start.
-				_ = br.ScaleUpFlightCtlServices()
-			}()
 			Expect(br.RunFlightCtlRestore(archivePath)).To(Succeed(), "flightctl-restore must succeed (build with: make flightctl-restore)")
-			Expect(br.ScaleUpFlightCtlServices()).To(Succeed())
 
-			By("Waiting for API server to be responsive after scale up")
+			By("Verifying all services were restarted by the restore binary")
+			Eventually(func() error {
+				return br.VerifyAllServicesRunning()
+			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "All 8 services must be running after restore")
+
+			By("Waiting for API server to be responsive after restore")
 			Eventually(func() error {
 				_, err := harness.Client.GetDeviceWithResponse(harness.Context, device1ID)
 				return err
-			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "API server must respond after scale up")
+			}, testutil.TIMEOUT_5M, testutil.POLLING).Should(Succeed(), "API server must respond after restore")
 
 			By("84938: Devices should move to AwaitingReconnect then Online (device version <= server, no ConflictPaused)")
 			harness.WaitForDeviceContents(device1ID, "device 1 AwaitingReconnect or Online", func(device *v1beta1.Device) bool {

--- a/test/harness/e2e/harness_backup_restore.go
+++ b/test/harness/e2e/harness_backup_restore.go
@@ -32,9 +32,37 @@ func (h *Harness) NewBackupRestore(p *infra.Providers) *BackupRestore {
 	return &BackupRestore{Harness: h, providers: p}
 }
 
+// VerifyAllServicesRunning verifies that all FlightCtl services that are stopped during restore
+// are back up and running. This includes all 8 services: API, worker, periodic, imagebuilder-api,
+// imagebuilder-worker, gateway, alert-exporter, and alertmanager-proxy.
+func (br *BackupRestore) VerifyAllServicesRunning() error {
+	services := []infra.ServiceName{
+		infra.ServiceAPI,
+		infra.ServiceWorker,
+		infra.ServicePeriodic,
+		infra.ServiceImageBuilderAPI,
+		infra.ServiceImageBuilderWorker,
+		infra.ServiceTelemetryGateway,
+		infra.ServiceAlertExporter,
+		infra.ServiceAlertmanagerProxy,
+	}
+	for _, svc := range services {
+		running, err := br.providers.Lifecycle.IsRunning(svc)
+		if err != nil {
+			return fmt.Errorf("failed to check if %s is running: %w", svc, err)
+		}
+		if !running {
+			return fmt.Errorf("service %s is not running", svc)
+		}
+	}
+	return nil
+}
+
 // ScaleUpFlightCtlServices scales API, worker, periodic, alert-exporter, and alertmanager-proxy
 // back up to 1 replica. Used as a safety net after restore in case the binary is killed before
 // its own deferred startup.
+// DEPRECATED: This method is kept for backward compatibility but should not be used in new tests.
+// Tests should verify that the restore binary itself restarts all services via VerifyAllServicesRunning.
 func (br *BackupRestore) ScaleUpFlightCtlServices() error {
 	services := []infra.ServiceName{
 		infra.ServiceAPI,


### PR DESCRIPTION
## Problem

The `flightctl-restore` binary fails to restart FlightCtl services when database connection fails during post-restore initialization. This occurs because `log.Fatalf()` calls in `internal/store/gorm.go` invoke `os.Exit(1)`, which bypasses Go's defer mechanism and prevents the critical deferred `StartServices()` cleanup from executing.

### Impact
- 8 services stopped by restore, but only 5 restarted by test harness safety net
- 3 services remain down: `imagebuilder-api`, `imagebuilder-worker`, **`gateway`**
- Gateway down = all API calls fail (connection refused)
- Test safety net was masking the production bug

## Root Cause

`internal/store/gorm.go` had 6 `log.Fatalf()` calls that invoked `os.Exit(1)`:
- Line 38: Unsupported database type
- Line 72: Database connection failure
- Line 85: Prometheus exporter registration failure
- Line 91: Connection configuration failure
- Line 106: OpenTelemetry plugin registration failure (tracing enabled)
- Line 120: OpenTelemetry plugin registration failure (tracing plugin)

Go's `defer` is bypassed by `os.Exit()` - process terminates immediately without running deferred functions, so the deferred `StartServices()` at `restore.go:78` never executed.

## Solution

### 1. Fix log.Fatalf() in gorm.go (Root Cause)
- Replaced all 6 `log.Fatalf()` calls with proper error returns
- Changed `log.Fatalf()` → `log.Errorf()` + `return nil, fmt.Errorf(...)`
- Respects Go idioms: library code should return errors, not call `os.Exit`
- Allows defer cleanup to execute properly
- Better error handling and testability

### 2. Remove Test Harness Safety Net
- Removed deferred `br.ScaleUpFlightCtlServices()` from both test cases
- Removed explicit `br.ScaleUpFlightCtlServices()` call from test 84938
- Tests now verify restore binary itself restarts services (no masking)
- If restore fails, test fails immediately (exposes production issues)

### 3. Add Service Verification Assertions
- New method: `VerifyAllServicesRunning()` - checks all 8 services
- Verifies: API, worker, periodic, imagebuilder-api, imagebuilder-worker, gateway, alert-exporter, alertmanager-proxy
- Added explicit assertions to both test cases after restore
- Deprecated `ScaleUpFlightCtlServices()` with warning comment

## Testing

- ✅ `make lint` (0 issues)
- ✅ `go test ./internal/store ./internal/restore`
- ⏳ E2E tests: `test/e2e/backup_restore` (will verify all 8 services restart)

## Files Modified

- `internal/store/gorm.go`: Removed 6 `log.Fatalf()` calls, return errors instead
- `test/e2e/backup_restore/backup_restore_test.go`: Removed safety net, added verification
- `test/harness/e2e/harness_backup_restore.go`: Added `VerifyAllServicesRunning()`

## Related

- Discovered during: EDM-3697 (password sync testing)
- Test plan: EDM-415 (Recover and restore Test Plan, section 4)
- Test cases: 84934 (full restore), 84938 (restore during update)

## Detailed Documentation

See [BUG_REPORT_RESTORE_SERVICE_RECOVERY.md](https://github.com/amalykhi/flightctl/blob/EDM-4177/BUG_REPORT_RESTORE_SERVICE_RECOVERY.md) for complete analysis with logs and evidence.
