### PR TITLE
NO-ISSUE: Avoid spamming git config safe.directory config

### DIFF
--- a/hack/current-version
+++ b/hack/current-version
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 # Fix git ownership issue in CI environments
-git config --global --add safe.directory /__w/flightctl/flightctl 2>/dev/null || true
-git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+if ! git config --global --get-all safe.directory | grep -Fq "flightctl"; then
+  git config --global --add safe.directory /__w/flightctl/flightctl 2>/dev/null || true
+  git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+fi
 
 # Prefer proper release tags pointing at this exact commit first, prioritizing the highest version
 # tag. If there is no tag at this commit, then fallback to 'git describe' which will construct a


### PR DESCRIPTION
Everytime this script was run before it was adding a new set of entries to ~/.gitconfig and creating a ton of bloat. This ensures it is only added once while still preserving the CI functionality it was added for.

