### PR TITLE
EDM-4162: Reject consecutive dots in config name validation

### DIFF
--- a/internal/util/validation/formats.go
+++ b/internal/util/validation/formats.go
@@ -16,10 +16,11 @@ const (
 	DNS1123MaxLength      int    = 253
 	envVarNameFmt         string = `[A-Za-z_][A-Za-z0-9_]*`
 
-	// ConfigNameFmt extends the DNS 1123 label format to also allow dots,
-	// supporting config names like "example.json" or "config.yaml".
-	// Must start and end with an alphanumeric character.
-	ConfigNameFmt       string = `[a-z0-9]([-a-z0-9.]*[a-z0-9])?`
+	// ConfigNameFmt validates config names as dot-separated labels,
+	// supporting names like "example.json" or "my.config.v2".
+	// Each label must start and end with an alphanumeric character,
+	// and consecutive dots are not allowed.
+	ConfigNameFmt       string = `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`
 	configNameMaxLength int    = 253
 
 	// HostnameOrFQDNFmt validates a hostname or FQDN (Fully Qualified Domain Name).

--- a/internal/util/validation/formats_test.go
+++ b/internal/util/validation/formats_test.go
@@ -61,17 +61,11 @@ func TestValidateConfigName(t *testing.T) {
 		"has spaces",
 		"has_underscores",
 		strings.Repeat("a", 254),
-	}
-
-	// These are technically allowed by the current regex but could be
-	// considered ugly. Documenting them as accepted to track the decision.
-	acceptedEdgeCases := []string{
+		"ex..com",
+		"a...b",
+		"example..json",
 		"example.-json",
 		"example-.json",
-		"example..json",
-	}
-	for _, val := range acceptedEdgeCases {
-		assert.Empty(ValidateConfigName(&val, "edge.config.name"), fmt.Sprintf("value: %q", val))
 	}
 	for _, val := range badValues {
 		assert.NotEmpty(ValidateConfigName(&val, "bad.config.name"), fmt.Sprintf("value: %q", val))


### PR DESCRIPTION
## Problem

The `ConfigNameFmt` regex allows consecutive dots in configuration names
(e.g. `ex..com`, `a...b`), which are not meaningful and should be invalid.
This was a gap introduced by the EDM-3683 fix that added dot support.

## Root Cause

The middle group `[-a-z0-9.]*` in the regex accepts any sequence of those
characters, including multiple consecutive dots.

## Fix

Replace the regex with a dot-separated label structure where each label
must start and end with an alphanumeric character. This is consistent with
how `HostnameOrFQDNFmt` handles dot-separated labels in the same file.

**Before:** `[a-z0-9]([-a-z0-9.]*[a-z0-9])?`
**After:** `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`

## Testing

- Updated unit tests: moved edge cases (`example..json`, `example.-json`,
  `example-.json`) from accepted to rejected, added `ex..com` and `a...b`
- All existing valid names (`a`, `a.b`, `example.json`, `my.config.v2`, etc.)
  continue to pass

## Confidence

High — single regex change with comprehensive test coverage.

## Risk Assessment

Low — rejects names that were previously accepted but are not meaningful.
No real-world usage of consecutive-dot config names is expected.

Made with [Cursor](https://cursor.com)