### PR TITLE
EDM-4184: multi-org cleanup to fix regression in parameterizable templates

### DIFF
--- a/test/e2e/infra/quadlet/rbac.go
+++ b/test/e2e/infra/quadlet/rbac.go
@@ -60,8 +60,7 @@ func (p *PAMRBACProvider) isRemote() bool {
 	return p.sshUser != "" && p.host != "localhost" && p.host != "127.0.0.1"
 }
 
-// runCommand executes a command, using SSH if the host is remote.
-func (p *PAMRBACProvider) runCommand(command ...string) (string, error) {
+func (p *PAMRBACProvider) runCommandContext(ctx context.Context, command ...string) (string, error) {
 	var cmd *exec.Cmd
 
 	if p.isRemote() {
@@ -90,17 +89,17 @@ func (p *PAMRBACProvider) runCommand(command ...string) (string, error) {
 		sshArgs = append(sshArgs, remoteCmd)
 
 		if usePassword {
-			cmd = exec.Command("sshpass", append([]string{"-e", "ssh"}, sshArgs...)...) //nolint:gosec // G204: sshArgs from internal config (host, user, key path)
+			cmd = exec.CommandContext(ctx, "sshpass", append([]string{"-e", "ssh"}, sshArgs...)...) //nolint:gosec // G204: sshArgs from internal config (host, user, key path)
 			cmd.Env = append(os.Environ(), "SSHPASS="+sshPassword)
 		} else {
-			cmd = exec.Command("ssh", sshArgs...)
+			cmd = exec.CommandContext(ctx, "ssh", sshArgs...)
 		}
 	} else {
 		// Local execution
 		if p.useSudo {
-			cmd = exec.Command("sudo", command...)
+			cmd = exec.CommandContext(ctx, "sudo", command...)
 		} else {
-			cmd = exec.Command(command[0], command[1:]...) //nolint:gosec // G204: command args are from internal test config
+			cmd = exec.CommandContext(ctx, command[0], command[1:]...) //nolint:gosec // G204: command args are from internal test config
 		}
 	}
 
@@ -113,8 +112,12 @@ func (p *PAMRBACProvider) runCommand(command ...string) (string, error) {
 
 // runPodmanExec executes a command in the PAM issuer container.
 func (p *PAMRBACProvider) runPodmanExec(args ...string) (string, error) {
+	return p.runPodmanExecContext(context.Background(), args...)
+}
+
+func (p *PAMRBACProvider) runPodmanExecContext(ctx context.Context, args ...string) (string, error) {
 	cmdArgs := append([]string{"podman", "exec", "--user", "0", p.pamIssuerContainer}, args...)
-	return p.runCommand(cmdArgs...)
+	return p.runCommandContext(ctx, cmdArgs...)
 }
 
 // shellQuote wraps s in single quotes for safe use in a remote shell command.
@@ -150,9 +153,9 @@ func (p *PAMRBACProvider) UpdateRole(_ context.Context, _ *infra.RoleSpec) error
 }
 
 // DeleteRole deletes the Linux group for the role.
-func (p *PAMRBACProvider) DeleteRole(_ context.Context, namespace, name string) error {
+func (p *PAMRBACProvider) DeleteRole(ctx context.Context, namespace, name string) error {
 	groupName := buildGroupName(namespace, name)
-	return p.deleteGroup(groupName)
+	return p.deleteGroup(ctx, groupName)
 }
 
 // CreateRoleBinding adds the user to the role's group.
@@ -205,8 +208,8 @@ func (p *PAMRBACProvider) UpdateClusterRole(_ context.Context, _ *infra.RoleSpec
 }
 
 // DeleteClusterRole deletes the Linux group for the cluster role.
-func (p *PAMRBACProvider) DeleteClusterRole(_ context.Context, name string) error {
-	return p.deleteGroup(name)
+func (p *PAMRBACProvider) DeleteClusterRole(ctx context.Context, name string) error {
+	return p.deleteGroup(ctx, name)
 }
 
 // CreateClusterRoleBinding adds the user to the cluster role's group.
@@ -240,10 +243,10 @@ func (p *PAMRBACProvider) AddUserToOrg(_ context.Context, orgName, userName stri
 }
 
 // DeleteOrganization deletes an organization (org-<name> group).
-func (p *PAMRBACProvider) DeleteOrganization(_ context.Context, name string) error {
+func (p *PAMRBACProvider) DeleteOrganization(ctx context.Context, name string) error {
 	groupName := OrgGroupName(name)
 	logrus.Infof("PAM RBAC: deleting organization group %s", groupName)
-	return p.deleteGroup(groupName)
+	return p.deleteGroup(ctx, groupName)
 }
 
 // --- Internal helper methods ---
@@ -264,8 +267,8 @@ func (p *PAMRBACProvider) createGroup(groupName string) error {
 }
 
 // deleteGroup deletes a Linux group from the PAM issuer container.
-func (p *PAMRBACProvider) deleteGroup(groupName string) error {
-	_, err := p.runPodmanExec("groupdel", groupName)
+func (p *PAMRBACProvider) deleteGroup(ctx context.Context, groupName string) error {
+	_, err := p.runPodmanExecContext(ctx, "groupdel", groupName)
 	if err != nil {
 		// Ignore "does not exist" errors
 		if strings.Contains(err.Error(), "does not exist") {

--- a/test/e2e/multiorg/multiorg_suite_test.go
+++ b/test/e2e/multiorg/multiorg_suite_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/quadlet"
@@ -17,7 +19,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const quadletOrgName = "multiorg-test"
+const (
+	quadletOrgName           = "multiorg-test"
+	quadletOrgCleanupTimeout = 60 * time.Second
+)
 
 // quadletSharedOrgID holds the org ID for the shared test organization on quadlet.
 // On quadlet, cluster-admin users default to the system org (00000000...),
@@ -192,6 +197,7 @@ var _ = AfterEach(func() {
 	harness.CaptureDeploymentLogsIfFailed()
 
 	creds := testUserCreds()
+	// Best-effort reset before cleanup; cleanup itself is still asserted below.
 	_ = loginAndSetOrg(harness, creds[0].name, creds[0].password)
 
 	err := harness.CleanUpAllTestResources()
@@ -210,6 +216,7 @@ var _ = AfterSuite(func() {
 	case infra.EnvironmentOCP:
 		flightCtlNs := os.Getenv("FLIGHTCTL_NS")
 		if flightCtlNs != "" {
+			// Best-effort cleanup of test users; failures should not mask suite results.
 			_ = login.CleanupTestUsers(harness, flightCtlNs, rbacTestUsers())
 		}
 
@@ -222,10 +229,14 @@ var _ = AfterSuite(func() {
 			GinkgoWriter.Printf("Warning: failed to re-login as kubeadmin in AfterSuite: %v\n", err)
 			return
 		}
+		// Best-effort refresh after restoring the kubeadmin login for following suites.
 		_ = harness.RefreshCluster()
 		GinkgoWriter.Println("AfterSuite: restored kubeadmin context for subsequent test suites")
 
 	case infra.EnvironmentQuadlet:
+		if err := restoreDefaultOrganization(harness); err != nil {
+			Fail(fmt.Sprintf("failed to restore default organization in AfterSuite: %v", err))
+		}
 		providers := setup.GetDefaultProviders()
 		if providers == nil || providers.RBAC == nil {
 			GinkgoWriter.Println("Warning: no providers available for quadlet cleanup")
@@ -241,7 +252,22 @@ var _ = AfterSuite(func() {
 				GinkgoWriter.Printf("Warning: failed to cleanup PAM user %s: %v\n", u.Name, err)
 			}
 		}
-		_ = pamRBAC.DeleteOrganization(context.Background(), quadletOrgName)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), quadletOrgCleanupTimeout)
+		defer cancel()
+		if err := pamRBAC.DeleteOrganization(cleanupCtx, quadletOrgName); err != nil {
+			GinkgoWriter.Printf("Warning: failed to cleanup PAM org %s: %v\n", quadletOrgName, err)
+			GinkgoWriter.Println("AfterSuite: cleaned up PAM test users; PAM org cleanup had partial failures")
+			return
+		}
 		GinkgoWriter.Println("AfterSuite: cleaned up PAM test users and org")
 	}
 })
+
+// restoreDefaultOrganization resets the persisted client organization after quadlet multiorg tests.
+func restoreDefaultOrganization(harness *e2e.Harness) error {
+	if err := harness.SetCurrentOrganization(org.DefaultID.String()); err != nil {
+		return fmt.Errorf("set default organization: %w", err)
+	}
+	GinkgoWriter.Printf("AfterSuite: restored default organization %s for subsequent test suites\n", org.DefaultID.String())
+	return nil
+}


### PR DESCRIPTION
## Summary

Reset the quadlet multiorg suite back to the default org during cleanup.

## Why

The quadlet job has a shared client config across suites in the same Jenkins workspace/test VM. The multiorg suite switches that config to the PAM org, for example `multiorg-test` / `b2be...`.

Later suites, such as `parametrisable_templates`, reuse the same harness/client config. However, quadlet agent enrollment creates EnrollmentRequests in the default org:

`00000000-0000-0000-0000-000000000000`

So the ER exists, but the next suite polls for it in the leaked multiorg context and gets `404` until `WaitForEnrollmentRequest()` times out.

This is why the issue shows up in quadlets: it combines PAM multiorg org switching, shared persisted client config, and default-org agent enrollment.

## Change

During quadlet multiorg `AfterSuite`, restore the persisted current organization to the default org before cleaning up the multiorg users/org. The PAM org cleanup now has bounded timeout handling and reports partial cleanup failures.

https://reportportal-ecosystem-qe.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#edge-management-qe/launches/all/38139/2198131
