### PR TITLE
Backport EDM-4033/4023/4028/4034/4035/4032/4036: air-gapped operations documentation to release-1.2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -348,6 +348,29 @@ CatalogItem
 URI
 CatalogItems
 multicluster
+ImagePromotion
+semver
+dropdown
+ClusterIssuer
+Issuer
+air-gapped
+resolution
+Fedora
+bastion
+checksums
+quadlet
+bootc-image-builder
+OCP
+rhem-el9
+rhem-el10
+syft
+ITMS
+MachineConfig
+MachineConfigPool
+mirrorSourcePolicy
+NeverContactSource
+AllowContactingSource
+CRI-O
  - docs/user/installing/configuring-imagebuilder.md
  RLIMIT
  NOFILE
@@ -688,3 +711,4 @@ parameterized
 SharedInformer
 sha256
 runbook
+sha256

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -36,10 +36,12 @@ Welcome to the Flight Control user documentation.
     * [Backup and Restore](installing/backup-restore.md)
 
   * Offline and Air-Gapped Installation
+    * [Air-gapped Installation Guide](installing/air-gapped-installation.md)
     * [Setting up a local RPM repository](installing/offline-rpm-repository.md)
     * [Packaging artifacts for portable media](installing/offline-portable-media.md)
     * [Installing the Flight Control service offline on Linux](installing/installing-service-on-linux-offline.md)
     * [Installing the Flight Control agent offline on RHEL](installing/installing-agent-offline.md)
+    * [Air-gapped fleet operations and OS image updates](installing/air-gapped-operations.md)
 
 * **[Installing the Flight Control CLI](installing/installing-cli.md)**
 
@@ -84,6 +86,9 @@ Welcome to the Flight Control user documentation.
   * [Catalog items](using/managing-catalogs.md#catalog-items)
   * [Importing catalogs using ResourceSync](using/managing-catalogs.md#importing-catalogs-using-resourcesync)
 * **[Managing Image Builds and Exports](using/managing-image-builds.md)** - How to build and export OS images using the Flight Control API.
+  * [ImageBuild resource](using/managing-image-builds.md#imagebuild-resource)
+  * [ImageExport resource](using/managing-image-builds.md#imageexport-resource)
+  * [ImagePromotion resource](using/managing-image-builds.md#imagepromotion-resource)
 * **Solving Specific Use Cases** - How to solve specific use cases in Flight Control.
   * [Auto-Registering Devices with MicroShift into ACM](using/registering-microshift-devices-acm.md)
   * [Diagnosing Agent Issues](using/diagnosing-agent-issues.md)

--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -1,0 +1,342 @@
+# Air-gapped Flight Control Installation Guide
+
+This guide provides an end-to-end overview of installing and operating Flight Control
+in environments with no internet access. It covers both RHEL (quadlet/systemd) and
+OpenShift (Helm) deployment paths, with decision guidance to help you choose the right
+approach for your environment.
+
+## Table of contents
+
+- [Choosing your installation path](#choosing-your-installation-path)
+- [Common prerequisites](#common-prerequisites)
+- [Quick-start: RHEL installation](#quick-start-rhel-installation)
+- [Quick-start: OpenShift installation](#quick-start-openshift-installation)
+- [Enrolling and managing devices](#enrolling-and-managing-devices)
+- [Troubleshooting](#troubleshooting)
+- [Reference: all air-gap documentation](#reference-all-air-gap-documentation)
+
+---
+
+## Choosing your installation path
+
+```text
+Do you have an OpenShift or Kubernetes cluster?
+│
+├── YES → Use the OpenShift/Helm installation path
+│         Choose a variant when running flightctl-mirror-images:
+│           community-el9/el10  — quay.io images, no entitlement required
+│           rhem-el9/rhem-el10  — registry.redhat.io images, requires entitlement
+│
+└── NO  → Use the Linux quadlet installation path
+          (systemd + podman, RPM-based)
+          Target machine: RHEL 9 or RHEL 10
+          Prep machine: RHEL or CentOS Stream (same major version as target)
+          recommended when using --bundle-rpms; any Linux with skopeo
+          works for image-only bundles
+```
+
+### Linux quadlet vs OpenShift at a glance
+
+| | Linux quadlet | OpenShift (Helm) |
+|---|---|---|
+| **Runtime** | systemd + podman | Kubernetes pods |
+| **Package format** | RPM (`flightctl-services`) | Helm chart |
+| **Image redirection** | `registries.conf` | `ImageTagMirrorSet` |
+| **Bundle includes** | Images + RPMs | Images only |
+| **Typical bundle size** | 5–10 GB | 5–15 GB |
+| **Prerequisites on target** | podman, skopeo | OCP cluster, internal registry |
+
+---
+
+## Common prerequisites
+
+Regardless of which path you choose, the prep machine requires:
+
+- `skopeo` installed (`sudo dnf install -y skopeo`) — required for all bundle modes
+- For `--bundle-rpms`: the prep machine should run RHEL or CentOS Stream at
+  the same major version as the target (e.g. RHEL 9 prep for a RHEL 9 target).
+  Using a different OS family (e.g. Fedora) risks pulling package versions
+  from that OS that conflict with the target's system packages.
+- For image-only bundles (no `--bundle-rpms`): any Linux with `skopeo` works
+- `createrepo_c` installed (`sudo dnf install -y createrepo_c`) — required for
+  `--rpm-createrepo` and `--agent-only` bundles
+- The `flightctl-mirror-images` binary — installed via `flightctl-cli` RPM, or built
+  from the flightctl repository (`make build-mirror-images`)
+- Sufficient disk space (10–20 GB depending on variant)
+- A transfer method to move artifacts to the air-gapped environment
+
+---
+
+## Quick-start: RHEL installation
+
+Complete checklist for installing Flight Control on a RHEL machine with no internet
+access.
+
+### On the prep machine
+
+- [ ] Install prerequisites: `sudo dnf install -y skopeo createrepo_c`
+- [ ] Install or build `flightctl-mirror-images`
+- [ ] Determine the target RPM version:
+
+  ```bash
+  dnf list --showduplicates flightctl-services | tail -5
+
+  ```
+
+- [ ] Create the bundle:
+
+  ```bash
+  flightctl-mirror-images \
+      --variant community-el9 \
+      --bundle ~/flightctl-bundle.tar.gz \
+      --bundle-rpms \
+      --rpm-createrepo \
+      --rpm-exclude flightctl-agent \
+      --tag-override <version>
+
+  ```
+
+- [ ] Transfer the bundle to the target machine:
+
+  ```bash
+  scp ~/flightctl-bundle.tar.gz <user>@<target>:~/
+
+  ```
+
+### On the target RHEL machine
+
+- [ ] Install prerequisites (while connected): `sudo dnf install -y skopeo podman containernetworking-plugins`
+- [ ] Extract the bundle:
+
+  ```bash
+  mkdir ~/flightctl-bundle
+  tar -xzf ~/flightctl-bundle.tar.gz -C ~/flightctl-bundle
+
+  ```
+
+- [ ] Bootstrap the local registry from the bundle:
+
+  ```bash
+  skopeo copy \
+      "dir:$HOME/flightctl-bundle/images/library/registry:2" \
+      "containers-storage:docker.io/library/registry:2"
+  mkdir -p ~/registry-data
+  podman run -d --name local-registry --network=host \
+      --security-opt label=disable \
+      -v ~/registry-data:/var/lib/registry \
+      --restart=always docker.io/library/registry:2
+
+  ```
+
+- [ ] Verify registry is ready: `curl http://localhost:5000/v2/`
+- [ ] Import all images (wait for completion): `cd ~/flightctl-bundle && ./import.sh`
+- [ ] Verify all images imported: `curl http://localhost:5000/v2/_catalog`
+- [ ] Install the RPMs: `./install-rpms.sh`
+- [ ] Configure registry redirection in `/etc/containers/registries.conf`:
+
+  ```toml
+  [[registry]]
+  prefix = "quay.io"
+  location = "localhost:5000"
+  insecure = true
+
+  [[registry]]
+  prefix = "docker.io"
+  location = "localhost:5000"
+  insecure = true
+
+  [[registry]]
+  prefix = "registry.access.redhat.com"
+  location = "localhost:5000"
+  insecure = true
+
+  ```
+
+- [ ] Create `/etc/flightctl/service-config.yaml`:
+
+  ```yaml
+  global:
+    baseDomain: <your-server-fqdn>
+    generateCertificates: builtin
+    auth:
+      type: oidc
+
+  ```
+
+- [ ] Start services: `sudo systemctl enable --now flightctl.target`
+- [ ] Verify all units running: `sudo systemctl list-units flightctl-*.service`
+- [ ] Confirm API is reachable:
+
+  ```bash
+  curl -k https://<baseDomain>:3443/api/v1/fleets
+
+  ```
+
+**Full instructions:** [Installing the Flight Control service offline on Linux](installing-service-on-linux-offline.md)
+
+---
+
+## Quick-start: OpenShift installation
+
+Complete checklist for installing Flight Control on a disconnected OpenShift cluster.
+
+### On the prep machine
+
+- [ ] Install prerequisites: `sudo dnf install -y skopeo` and `helm` CLI
+- [ ] Install or build `flightctl-mirror-images`
+- [ ] For `rhem-*` variants: `podman login registry.redhat.io`
+- [ ] Mirror images to your internal registry:
+
+  ```bash
+  # Option A: direct push
+  flightctl-mirror-images \
+      --variant rhem-el9 \
+      --dest-registry <mirror-registry>:<port> \
+      --execute \
+      --tag-override <version>
+
+  # Option B: bundle then push
+  flightctl-mirror-images \
+      --variant rhem-el9 \
+      --bundle ~/flightctl-bundle.tar.gz \
+      --tag-override <version>
+
+  ```
+
+- [ ] Download the Helm chart:
+
+  ```bash
+  helm pull oci://quay.io/flightctl/charts/flightctl --version <version>
+
+  ```
+
+- [ ] Transfer bundle and chart to the disconnected environment
+
+### Inside the disconnected environment
+
+- [ ] Push images to internal mirror registry (if using bundle):
+
+  ```bash
+  cd ~/flightctl-bundle && ./import.sh --registry <mirror-registry>:<port>
+
+  ```
+
+- [ ] Apply `ImageTagMirrorSet` for your variant (see
+  [Step 3: Configure image mirroring on OpenShift](installing-service-on-openshift-disconnected.md#step-3-configure-image-mirroring-on-openshift)):
+
+  ```bash
+  oc apply -f flightctl-mirrors.yaml
+  oc wait nodes --all --for=condition=Ready --timeout=30m
+
+  ```
+
+- [ ] Create image pull secret (Red Hat variants only)
+- [ ] Install via Helm:
+
+  ```bash
+  helm upgrade --install --namespace flightctl --create-namespace \
+      flightctl ./flightctl-<version>.tgz --values my-values.yaml
+
+  ```
+
+- [ ] Verify all pods running: `oc get pods -n flightctl`
+- [ ] Confirm API is reachable: `curl -k https://<baseDomain>/api/v1/fleets`
+
+**Full instructions:** [Installing Flight Control in a Disconnected OpenShift Cluster](installing-service-on-openshift-disconnected.md)
+
+---
+
+## Enrolling and managing devices
+
+Once the Flight Control service is running, device enrollment and fleet management
+operate identically to connected deployments — the only requirement is that devices
+can reach the Flight Control API server on the internal network.
+
+### Device enrollment checklist
+
+- [ ] Install `flightctl-agent` on the device (see
+  [Installing the Flight Control agent offline on RHEL](installing-agent-offline.md))
+- [ ] Distribute CA certificate and enrollment credentials to the device
+- [ ] Configure `/etc/flightctl/config.yaml` with the internal server FQDN
+- [ ] Start the agent: `sudo systemctl enable --now flightctl-agent`
+- [ ] Approve the enrollment request: `flightctl approve enrollmentrequest/<name>`
+- [ ] Verify device appears: `flightctl get devices`
+
+### OS image updates
+
+To deliver OS image updates to devices in an air-gapped environment, stage the new
+image in the local registry and update the fleet's `os.image` reference. See
+[Air-gapped fleet operations and OS image updates](air-gapped-operations.md) for the
+full workflow.
+
+---
+
+## Troubleshooting
+
+### Image pull fails on the target machine (RHEL)
+
+**Symptom:** A quadlet service fails to start with `manifest unknown` or `image not found`.
+
+1. Verify the image is in the local registry:
+
+   ```bash
+   curl http://localhost:5000/v2/_catalog
+   curl http://localhost:5000/v2/<image-path>/tags/list
+   ```
+
+2. Verify `registries.conf` has the correct mirror prefix for the image's source registry.
+3. Check the image tag — the tag in the local registry must match what the quadlet references.
+   Rebuild the bundle with `--tag-override <version>` matching the installed RPM version.
+
+### Image pull fails on OpenShift
+
+**Symptom:** Pods remain in `ImagePullBackOff`.
+
+1. Verify the `MachineConfig` rollout completed: `oc get mcp`
+2. Verify the image is in the mirror registry.
+3. Check the ITMS source prefix covers the image's registry.
+
+See [ITMS troubleshooting](installing-service-on-openshift-disconnected.md#troubleshooting-common-itms-issues)
+for detailed steps.
+
+### RPM install fails with dependency conflict
+
+**Symptom:** `install-rpms.sh` fails with version conflict on system packages (e.g. `librepo`).
+
+This occurs when the bundle was built on a newer RHEL minor version than the target.
+The `--nobest` flag in `install-rpms.sh` handles most cases automatically. If the
+install still fails, rebuild the bundle on a machine matching the target's RHEL
+minor version.
+
+### Device fails to enroll
+
+**Symptom:** Agent logs show connection errors or certificate errors.
+
+1. Verify the device can reach the server FQDN on port `7443`: `curl -k https://<server>:7443/`
+2. Verify the CA certificate on the device matches the server's CA.
+3. Check the agent logs: `journalctl -u flightctl-agent --no-pager | tail -30`
+
+---
+
+## Reference: all air-gap documentation
+
+### Artifact preparation
+
+- [flightctl-mirror-images tool](../../../scripts/air-gap/README.md) — complete flag reference
+- [Setting up a local RPM repository](offline-rpm-repository.md) — `dnf reposync` and local repo setup
+- [Packaging artifacts for portable media](offline-portable-media.md) — USB, tar, checksums, size estimates
+
+### RHEL installation
+
+- [Installing the Flight Control service offline on Linux](installing-service-on-linux-offline.md)
+- [Installing the Flight Control agent offline on RHEL](installing-agent-offline.md)
+
+### OpenShift installation
+
+- [Installing Flight Control in a Disconnected OpenShift Cluster](installing-service-on-openshift-disconnected.md)
+- [Image Builder configuration for air-gapped environments](configuring-imagebuilder.md#end-to-end-disconnected-image-build-walkthrough)
+
+### Day-2 operations
+
+- [Air-gapped fleet operations and OS image updates](air-gapped-operations.md)
+- [Deploying Observability Offline (Linux)](deploying-observability-linux.md#air-gapped-installation)

--- a/docs/user/installing/air-gapped-operations.md
+++ b/docs/user/installing/air-gapped-operations.md
@@ -1,0 +1,183 @@
+# Operating Flight Control in an air-gapped environment
+
+This document covers day-2 operations for Flight Control deployments with no internet
+access: managing fleets, delivering configuration updates, and applying OS image updates
+to devices using a local registry.
+
+For installation procedures see:
+
+- [Installing the Flight Control service offline on Linux](installing-service-on-linux-offline.md)
+- [Installing the Flight Control agent offline on RHEL](installing-agent-offline.md)
+
+## Fleet management in an air-gapped environment
+
+Fleet management operations — applying configuration, monitoring device status, rolling
+out policies — work identically in air-gapped deployments. No external DNS, internet
+access, or connection to public registries is required at runtime.
+
+### How it works
+
+- Devices communicate with the Flight Control API server exclusively over the internal
+  network using mTLS. All traffic stays within the air-gapped environment.
+- The agent polls the API server at a configured interval to check for new configuration
+  or OS image targets. No inbound connection to the device is needed.
+- Configuration updates, fleet policy changes, and rollout operations are delivered
+  through the standard Flight Control workflow — the air-gap is transparent to the
+  operator.
+
+### Verifying device connectivity
+
+Confirm that enrolled devices are reporting status to the API server:
+
+```bash
+flightctl get devices
+```
+
+A device with `Online` status is actively communicating with the server over the
+internal network. A device showing `Unknown` or `Offline` may have a network path
+problem between the device and the server — verify that the device can reach the
+server's FQDN on port `7443`.
+
+### Applying configuration updates
+
+Configuration updates are delivered through the standard fleet workflow. Create or
+update a fleet configuration:
+
+```bash
+flightctl apply -f my-fleet-config.yaml
+```
+
+The agent picks up the change on its next poll cycle and applies it locally. No
+internet access is involved — only the internal API server connection.
+
+To check rollout progress:
+
+```bash
+flightctl get fleet <fleet-name>
+flightctl get devices -l fleet=<fleet-name>
+```
+
+For full fleet management documentation see
+[Managing Fleets](../using/managing-fleets.md).
+
+---
+
+## Image updates using a local registry
+
+In an air-gapped environment, container images must be staged in a local registry
+before devices can pull them. This applies to both OS (bootc) image updates and
+application workload images managed by the agent. The workflow is the same in both
+cases: mirror the image to the local registry, then target it in the fleet or device
+configuration.
+
+> [!NOTE]
+> For application workload images (non-OS containers), see
+> [Making container images available for managed workloads](installing-agent-offline.md#part-2-making-container-images-available-for-managed-workloads)
+> for the device-side setup including local registry and direct image loading.
+
+### OS image update workflow
+
+### Prerequisites
+
+- A local container registry reachable from all devices on the internal network
+- The new OS image mirrored into that registry (see below)
+- `flightctl-cli` configured to reach the internal API server
+
+### Step 1: Mirror the new OS image to the local registry
+
+On a connected prep machine, pull the new OS image and push it to your internal
+registry using `skopeo`:
+
+```bash
+# Mirror from the upstream source to the local registry
+skopeo copy \
+    docker://<source-registry>/<org>/<image>:<tag> \
+    docker://<local-registry-host>:<port>/<org>/<image>:<tag>
+```
+
+For images built with the Flight Control image builder, export the built image
+from the image builder service and push it to the local registry:
+
+```bash
+skopeo copy \
+    docker://<imagebuilder-registry>/<image>:<tag> \
+    docker://<local-registry-host>:<port>/<image>:<tag>
+```
+
+Transfer via portable media if the prep machine cannot reach the local registry
+directly — see [Packaging artifacts for portable media](offline-portable-media.md).
+
+### Step 2: Configure registry authentication on devices (if required)
+
+If the local registry requires authentication, configure devices to authenticate
+using image pull secrets. See
+[Using Image Pull Secrets](../using/managing-devices.md#using-image-pull-secrets)
+for the full procedure.
+
+### Step 3: Target the new OS image in the fleet configuration
+
+Update the fleet's `osImage` reference to point at the new image in the local
+registry:
+
+```yaml
+apiVersion: v1alpha1
+kind: Fleet
+metadata:
+  name: my-fleet
+spec:
+  template:
+    spec:
+      os:
+        image: <local-registry-host>:<port>/<image>:<tag>
+```
+
+Apply the updated fleet configuration:
+
+```bash
+flightctl apply -f my-fleet.yaml
+```
+
+### Step 4: Monitor the rollout
+
+The agent picks up the new image target on its next poll cycle, pulls the image from
+the local registry, and applies the update using `bootc`. Monitor rollout progress:
+
+```bash
+flightctl get fleet my-fleet
+flightctl get devices -l fleet=my-fleet
+```
+
+Individual device update status is visible in the device's `status.updated` field:
+
+```bash
+flightctl get device <device-name> -o yaml | grep -A5 "updated:"
+```
+
+### Step 5: Verify the update completed
+
+After the device reboots into the new image, confirm the update succeeded by
+checking the device status from the Flight Control server:
+
+```bash
+flightctl get device <device-name> -o yaml | grep -A10 "os:"
+```
+
+The `status.os.image` field will show the currently running image once the device
+has applied the update and reported back.
+
+> [!NOTE]
+> OS updates use the `bootc` container storage transport. The device pulls the image
+> directly from the local registry over the internal network — no external registry
+> access or internet connectivity is required at any point in the update process.
+
+---
+
+## Next steps
+
+- [Managing Fleets](../using/managing-fleets.md) — full fleet management reference
+- [Managing Image Builds](../using/managing-image-builds.md) — building device OS
+  images with the Flight Control image builder
+- [Installing the Flight Control agent offline on RHEL](installing-agent-offline.md) —
+  agent installation and enrollment
+- [Packaging artifacts for portable media](offline-portable-media.md) — transferring
+  OS images and other artifacts to air-gapped environments

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -435,8 +435,9 @@ For a full repo mirror with proper metadata, use `dnf reposync` — see
 
 ### Step 3: Configure the imagebuilder-worker
 
-Override the service images and RPM repo URL before (or alongside) deploying the
-updated Helm release.
+Override the service images and RPM repo URL to use your internal registry.
+
+#### Kubernetes / Helm
 
 Create a `disconnected-values.yaml`:
 
@@ -458,6 +459,29 @@ Apply:
 helm upgrade flightctl flightctl-chart.tgz \
     --reuse-values \
     -f disconnected-values.yaml
+```
+
+#### Podman Quadlet (RHEL)
+
+Add the following to `/etc/flightctl/service-config.yaml`:
+
+```yaml
+imagebuilderWorker:
+  rpmRepoUrl: "http://my-rpm-mirror.example.com:8080/flightctl-local.repo"
+  serviceImages:
+    podman:
+      image: "my-internal.registry.example.com:5000/podman/stable:v5.7.1"
+    bootcImageBuilder:
+      image: "my-internal.registry.example.com:5000/centos-bootc/bootc-image-builder:latest"
+    syft:
+      image: "my-internal.registry.example.com:5000/anchore/syft:v1.44.0"
+```
+
+Restart the imagebuilder services to apply:
+
+```bash
+sudo systemctl restart flightctl-imagebuilder-api.service \
+                       flightctl-imagebuilder-worker.service
 ```
 
 If the internal registry uses a private CA, also mount it into the worker pod — see
@@ -649,17 +673,30 @@ spec:
 This sets `DefaultLimitNOFILE=1048576:1048576` in systemd, which raises the limit for all
 processes on the node, including container runtimes.
 
-On a Podman Quadlet (Linux host), add the following file instead:
+> [!NOTE]
+> `DefaultLimitNOFILE` is a system-wide default that applies to every service started by systemd
+> that does not have its own `LimitNOFILE=` directive in its unit file.
+
+On a Podman Quadlet (Linux host), use a systemd drop-in to raise the limit only for
+`flightctl-imagebuilder-worker.service`, without affecting any other service on the host:
 
 ```ini
-# /etc/systemd/system.conf.d/60-nofile.conf
-[Manager]
-DefaultLimitNOFILE=1048576:1048576
+# /etc/systemd/system/flightctl-imagebuilder-worker.service.d/limits.conf
+[Service]
+LimitNOFILE=1048576:1048576
 ```
 
-Then reload and restart the relevant services:
+Then reload and restart the service:
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl restart flightctl-imagebuilder-worker.service
 ```
+
+Verify the running service has the new limit:
+
+```bash
+systemctl show flightctl-imagebuilder-worker.service | grep LimitNOFILE
+```
+
+The output should show `LimitNOFILE=1048576` and `LimitNOFILESoft=1048576`.

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -230,10 +230,28 @@ local registry.
    The agent can then start containers from images in podman's local storage without
    any network access.
 
+---
+
+## Part 3: Enrolling the device
+
+Device enrollment works identically in air-gapped environments. The only requirement
+is that the device can reach the Flight Control API server on the internal network —
+no external internet access is needed at any point.
+
+Ensure the server CA certificate and enrollment credentials are distributed to the
+device through your provisioning pipeline (the agent config in Part 1, Step 4 already
+references them), then follow the standard enrollment procedure:
+
+[Enrolling Devices](../using/managing-devices.md#enrolling-devices)
+
+---
+
 ## Next steps
 
 - [Configuring the Flight Control Agent](installing-agent.md) — full configuration
   reference for `config.yaml`
+- [Air-gapped fleet operations](air-gapped-operations.md) — managing devices and
+  applying OS image updates in an air-gapped environment
 - [Setting up a local RPM repository](offline-rpm-repository.md) — `dnf reposync`
   and `dnf download` approaches for creating offline RPM sources
 - [Packaging artifacts for portable media](offline-portable-media.md) — USB, tar,

--- a/docs/user/installing/installing-service-on-openshift-disconnected.md
+++ b/docs/user/installing/installing-service-on-openshift-disconnected.md
@@ -104,10 +104,30 @@ scp flightctl-<version>.tgz <user>@<bastion>:~/
 
 ## Step 3: Configure image mirroring on OpenShift
 
-OpenShift uses `ImageTagMirrorSet` to redirect image pulls from source registries
-to your mirror. Apply the appropriate configuration for your variant.
+### What is ImageTagMirrorSet and why is it recommended?
 
-### For `rhem-el9` or `rhem-el10`
+`ImageTagMirrorSet` (ITMS) is an OpenShift cluster-level resource that tells the
+container runtime (CRI-O) to redirect image pulls from one registry to another.
+When a pod tries to pull `quay.io/flightctl/flightctl-api-el9:1.2.0`, CRI-O
+transparently fetches it from your local mirror instead — no changes to pod specs,
+Helm values, or quadlet files are required.
+
+ITMS is the recommended approach for OpenShift air-gapped installations because:
+
+- It operates at the cluster level — one configuration covers all namespaces and pods
+- It survives Helm upgrades without re-patching image references
+- It supports fallback mirrors if the primary is unavailable
+- It is the official OpenShift mechanism for image content source redirection
+  (replacing the deprecated `ImageContentSourcePolicy`)
+
+> [!IMPORTANT]
+> Applying an `ImageTagMirrorSet` triggers a `MachineConfig` rollout that drains
+> and restarts all nodes one at a time. Plan a maintenance window for production
+> clusters. On a 3-node cluster this typically takes 15–30 minutes.
+
+### Apply the ImageTagMirrorSet for your variant
+
+#### For `rhem-el9` or `rhem-el10`
 
 ```bash
 oc apply -f - <<EOF
@@ -120,13 +140,15 @@ spec:
   - source: registry.redhat.io
     mirrors:
     - <mirror-registry-host>:<port>
+    mirrorSourcePolicy: NeverContactSource
   - source: registry.access.redhat.com
     mirrors:
     - <mirror-registry-host>:<port>
+    mirrorSourcePolicy: NeverContactSource
 EOF
 ```
 
-### For `community-el9` or `community-el10`
+#### For `community-el9` or `community-el10`
 
 ```bash
 oc apply -f - <<EOF
@@ -139,22 +161,100 @@ spec:
   - source: quay.io
     mirrors:
     - <mirror-registry-host>:<port>
+    mirrorSourcePolicy: NeverContactSource
   - source: docker.io
     mirrors:
     - <mirror-registry-host>:<port>
+    mirrorSourcePolicy: NeverContactSource
   - source: registry.access.redhat.com
     mirrors:
     - <mirror-registry-host>:<port>
+    mirrorSourcePolicy: NeverContactSource
 EOF
 ```
 
-> [!NOTE]
-> After applying an `ImageTagMirrorSet`, OpenShift drains and restarts all nodes
-> to apply the new container runtime configuration. Wait for all nodes to return
-> to `Ready` state before proceeding.
+### Mirror policy options
+
+The `mirrorSourcePolicy` field controls what happens when the mirror is unavailable:
+
+| Policy | Behaviour | Use when |
+|--------|-----------|----------|
+| `NeverContactSource` | Only pull from mirrors; fail if no mirror works | Fully air-gapped — source registry is unreachable |
+| `AllowContactingSource` | Try mirrors first, fall back to source registry | Restricted network — source is reachable but slow or rate-limited |
+
+Use `NeverContactSource` in a fully disconnected environment to ensure no accidental
+outbound connections are attempted.
+
+### Wait for the rollout to complete
+
+After applying the ITMS, OpenShift triggers a `MachineConfig` rollout. Wait for all
+nodes to return to `Ready` state before proceeding:
 
 ```bash
-oc wait nodes --all --for=condition=Ready --timeout=10m
+oc wait nodes --all --for=condition=Ready --timeout=30m
+```
+
+Monitor rollout progress:
+
+```bash
+oc get mcp
+```
+
+All `MachineConfigPool` objects should show `UPDATED=True` and `DEGRADED=False`
+before you continue.
+
+### Verify the mirror configuration is active
+
+Confirm that CRI-O picked up the new mirror rules on a node:
+
+```bash
+# Open a debug shell on any node
+oc debug node/<node-name>
+
+# Inside the debug shell
+chroot /host
+cat /etc/containers/registries.conf.d/
+```
+
+The registry configuration directory should contain a file referencing your mirror.
+
+### Troubleshooting common ITMS issues
+
+**Image pull still fails after ITMS applied:**
+
+1. Verify the `MachineConfig` rollout is complete (`oc get mcp`). If nodes are still
+   updating, wait for the rollout to finish.
+2. Check that the image was actually mirrored to the local registry:
+
+   ```bash
+   curl https://<mirror-registry-host>:<port>/v2/<image-path>/tags/list
+   ```
+
+3. Verify the ITMS source matches the registry prefix in the image reference — ITMS
+   matches on prefix, not exact registry. `quay.io` covers all `quay.io/*` images.
+
+**Digest mismatch error (`manifest unknown` or `digest did not match`):**
+
+The image was mirrored by tag but the pod is pulling by digest. Ensure you mirrored
+the image after its final tag was pushed and that the same digest is present in the
+mirror:
+
+```bash
+skopeo inspect docker://<mirror-registry-host>:<port>/<image>:<tag> | grep Digest
+skopeo inspect docker://quay.io/<image>:<tag> | grep Digest
+```
+
+Both digests must match.
+
+**`NeverContactSource` causing failures on a partially connected cluster:**
+
+Switch to `AllowContactingSource` temporarily while diagnosing, then switch back once
+the mirror is populated:
+
+```bash
+oc patch imagetag mirrorset flightctl-mirrors \
+    --type=merge \
+    -p '{"spec":{"imageTagMirrors":[{"source":"quay.io","mirrors":["<mirror>"],"mirrorSourcePolicy":"AllowContactingSource"}]}}'
 ```
 
 ## Step 4: Create an image pull secret (Red Hat variants only)

--- a/docs/user/installing/offline-portable-media.md
+++ b/docs/user/installing/offline-portable-media.md
@@ -193,8 +193,116 @@ curl -O http://<prep_machine_ip>:8080/flightctl-artifacts.tar.gz
 
 Stop the server on the prep machine when the transfer is complete.
 
+## OpenShift artifacts
+
+Transferring artifacts for a disconnected OpenShift installation involves container
+images, the Helm chart, and optionally OS images for the image builder. This section
+covers the OCP-specific considerations.
+
+### Size estimates
+
+| Artifact set | Approximate size | Recommended media |
+|---|---|---|
+| Community variant images (`community-el9` or `community-el10`) | 5–8 GB | 16 GB+ USB or network share |
+| Red Hat variant images (`rhem-el9` or `rhem-el10`) | 10–15 GB | 32 GB+ USB or network share |
+| Helm chart only (`flightctl-<version>.tgz`) | < 1 MB | Any |
+| Image builder service images (podman, bootc-image-builder, syft) | ~3 GB additional | Add to above |
+
+> [!WARNING]
+> FAT32 has a 4 GB maximum file size. The community variant bundle
+> fits within this limit as individual images but the Red Hat variant may produce
+> files exceeding 4 GB. Format USB drives with **exFAT** or **ext4** — see
+> [USB drives](#usb-drives) above.
+
+### Transferring the bundle archive
+
+The `flightctl-mirror-images --bundle` command produces a single `.tar.gz` archive
+containing all images and an `import.sh` script. This is the recommended format for
+OCP transfers — transfer the archive to any machine inside the disconnected
+environment that can reach the internal mirror registry, then run `import.sh`:
+
+```bash
+# On a machine with registry access inside the disconnected environment
+mkdir ~/flightctl-bundle
+tar -xzf ~/flightctl-bundle.tar.gz -C ~/flightctl-bundle
+cd ~/flightctl-bundle
+./import.sh --registry <internal-mirror-registry-host>:<port>
+```
+
+### Checksum verification
+
+Generate a checksum on the prep machine before transfer:
+
+```bash
+sha256sum ~/flightctl-bundle.tar.gz > ~/flightctl-bundle.tar.gz.sha256
+```
+
+Transfer the `.sha256` file alongside the archive. Verify on the target machine
+before extracting:
+
+```bash
+sha256sum --check ~/flightctl-bundle.tar.gz.sha256
+```
+
+A `OK` result confirms the archive arrived intact. Do not proceed with import if
+verification fails — re-transfer the archive.
+
+### Splitting large archives
+
+If the archive exceeds the capacity of your transfer media, split it into smaller
+chunks:
+
+```bash
+# Split into 3 GB chunks
+split -b 3G ~/flightctl-bundle.tar.gz ~/flightctl-bundle.tar.gz.part-
+
+# List the parts
+ls ~/flightctl-bundle.tar.gz.part-*
+```
+
+Transfer all parts. Reassemble on the target before extraction:
+
+```bash
+cat ~/flightctl-bundle.tar.gz.part-* > ~/flightctl-bundle.tar.gz
+sha256sum --check ~/flightctl-bundle.tar.gz.sha256
+tar -xzf ~/flightctl-bundle.tar.gz -C ~/flightctl-bundle
+```
+
+### Transferring the Helm chart
+
+Download the Helm chart on the prep machine:
+
+```bash
+helm pull oci://quay.io/flightctl/charts/flightctl --version <version>
+# Produces: flightctl-<version>.tgz
+```
+
+Transfer the `.tgz` file using any of the methods above. The chart is small (< 1 MB)
+and does not require splitting.
+
+### Network share deployment
+
+For sites with a restricted local network, serve the bundle from a temporary HTTP
+server on a bastion host that can reach both the prep machine and the internal
+mirror registry:
+
+```bash
+# On the bastion host
+python3 -m http.server 8080 --directory ~/
+```
+
+From the target machine (or the machine with registry access):
+
+```bash
+curl -O http://<bastion_ip>:8080/flightctl-bundle.tar.gz
+curl -O http://<bastion_ip>:8080/flightctl-bundle.tar.gz.sha256
+sha256sum --check flightctl-bundle.tar.gz.sha256
+```
+
 ## Next steps
 
+- [Installing Flight Control in a disconnected OpenShift cluster](installing-service-on-openshift-disconnected.md) —
+  end-to-end OCP disconnected installation procedure
 - [Setting up a local RPM repository](offline-rpm-repository.md) — how to prepare
   packages before packaging them for transfer
 - [Installing the Flight Control agent offline on RHEL](installing-agent-offline.md) —


### PR DESCRIPTION
Backport of PRs #3114 and #3115 to `release-1.2`. Applied as a single commit to avoid cherry-pick conflicts from commits that depend on main-only changes.

**Includes:**
- `air-gapped-operations.md` — fleet management and OS/workload image updates in disconnected environments
- `air-gapped-installation.md` — consolidated guide with decision tree, quick-start checklists, and troubleshooting
- `installing-agent-offline.md` — simplified enrollment section
- `configuring-imagebuilder.md` — Podman Quadlet disconnected config
- `installing-service-on-openshift-disconnected.md` — expanded ITMS section
- `offline-portable-media.md` — OCP artifact packaging section
- `README.md` — links to new docs

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)