### PR TITLE
NO-ISSUE: add system requirements sizing table to installation docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -354,6 +354,9 @@ dropdown
 ClusterIssuer
 Issuer
 air-gapped
+vCPU
+vRAM
+vDisk
 resolution
 Fedora
 bastion

--- a/docs/user/installing/installing-service-on-kubernetes.md
+++ b/docs/user/installing/installing-service-on-kubernetes.md
@@ -1,5 +1,26 @@
 # Installing the Flight Control Service on OpenShift/Kubernetes
 
+## System requirements
+
+The following table shows the minimum recommended resources for the Flight Control
+server based on the number of managed devices. These values were established through
+benchmarking and represent the resources needed for the server workload — not the
+managed edge devices themselves.
+
+| Deployment size | Managed devices | vCPU (cores) | vRAM (GB) | vDisk (GB) |
+|---|---|---|---|---|
+| **Small** | 100 | 4 | 4 | 70 |
+| **Medium** | 1,000 | 4 | 8 | 70 |
+| **Large** | 10,000 | 4 | 16 | 70 |
+| **Super Large** | 100,000 | 8 | 40 | 120 |
+
+> [!NOTE]
+> These figures are based on benchmarking with an earlier version of Flight Control
+> and represent a reasonable baseline. Actual resource usage depends on polling
+> intervals, fleet template complexity, and observability stack configuration. Add
+> approximately 3 GB disk for each additional service component (image builder,
+> observability stack).
+
 ## Installing on Kubernetes
 
 You can install the Flight Control Service on any certified Kubernetes distribution that supports the Gateway API. If you have an OpenShift Kubernetes cluster available, refer to [Installing on OpenShift](#installing-on-openshift) for a more streamlined experience. If you are running RHEL and need a lightweight Kubernetes distribution, refer to [Installing on MicroShift](#installing-on-microshift).

--- a/docs/user/installing/preparing-installation-on-linux.md
+++ b/docs/user/installing/preparing-installation-on-linux.md
@@ -2,6 +2,27 @@
 
 This document outlines the network requirements, port configurations, and firewall settings necessary for deploying and operating Flight Control.
 
+## System requirements
+
+The following table shows the minimum recommended VM resources for the Flight Control
+server based on the number of managed devices. These values were established through
+benchmarking and represent the resources needed for the server host — not the managed
+edge devices themselves.
+
+| Deployment size | Managed devices | vCPU (cores) | vRAM (GB) | vDisk (GB) |
+|---|---|---|---|---|
+| **Small** | 100 | 4 | 4 | 70 |
+| **Medium** | 1,000 | 4 | 8 | 70 |
+| **Large** | 10,000 | 4 | 16 | 70 |
+| **Super Large** | 100,000 | 8 | 40 | 120 |
+
+> [!NOTE]
+> These figures are based on benchmarking with an earlier version of Flight Control
+> and represent a reasonable baseline. Actual resource usage depends on polling
+> intervals, fleet template complexity, and observability stack configuration. Add
+> approximately 3 GB disk for each additional service component (image builder,
+> observability stack).
+
 ## Overview
 
 Flight Control is a distributed system consisting of multiple services that communicate over the network. This document provides the information needed to configure firewalls, load balancers, and network policies to ensure proper operation.


### PR DESCRIPTION
## Summary

Adds minimum recommended server resource sizing based on number of managed devices, derived from Flight Control benchmarking. Added to both the Linux (`preparing-installation-on-linux.md`) and Kubernetes/OpenShift (`installing-service-on-kubernetes.md`) installation docs so the guidance applies equally to both deployment types.

| Deployment size | Managed devices | vCPU | vRAM | vDisk |
|---|---|---|---|---|
| Small | 100 | 4 cores | 4 GB | 70 GB |
| Medium | 1,000 | 4 cores | 8 GB | 70 GB |
| Large | 10,000 | 4 cores | 16 GB | 70 GB |
| Super Large | 100,000 | 8 cores | 40 GB | 120 GB |

Note included clarifying these are benchmarked baselines from an earlier version and actual usage depends on workload.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)