### PR TITLE
NO-ISSUE: Deny operator enrollment request access in static auth

### DIFF
--- a/internal/auth/authz/static.go
+++ b/internal/auth/authz/static.go
@@ -43,6 +43,8 @@ var resourcePermissions = map[string]map[string][]string{
 		"imagepromotions":              {"get", "list", "create", "update", "patch", "delete"},
 		"repositories/check-oci-tag":   {"create"},
 		"repositories/check-oci-image": {"create"},
+		"enrollmentrequests":           {},
+		"events":                       {},
 		"*":                            {"get", "list"}, // Default read access for other resources
 	},
 	v1beta1.RoleViewer: {

--- a/internal/auth/authz/static_test.go
+++ b/internal/auth/authz/static_test.go
@@ -91,7 +91,28 @@ func TestStaticAuthZ_CheckPermission(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "operator can get any resource",
+			name:     "operator cannot list enrollmentrequests",
+			roles:    []string{v1beta1.RoleOperator},
+			resource: "enrollmentrequests",
+			op:       "list",
+			expected: false,
+		},
+		{
+			name:     "operator cannot get enrollmentrequests",
+			roles:    []string{v1beta1.RoleOperator},
+			resource: "enrollmentrequests",
+			op:       "get",
+			expected: false,
+		},
+		{
+			name:     "operator cannot list events",
+			roles:    []string{v1beta1.RoleOperator},
+			resource: "events",
+			op:       "list",
+			expected: false,
+		},
+		{
+			name:     "operator can get repositories",
 			roles:    []string{v1beta1.RoleOperator},
 			resource: "repositories",
 			op:       "get",
@@ -427,6 +448,10 @@ func TestStaticAuthZ_GetUserPermissions(t *testing.T) {
 				{
 					Resource:   "repositories/check-oci-image",
 					Operations: []string{"create"},
+				},
+				{
+					Resource:   "enrollmentrequests",
+					Operations: []string{},
 				},
 				{
 					Resource:   "resourcesyncs",


### PR DESCRIPTION
Align quadlet/PAM operator permissions with the K8s ClusterRole by explicitly blocking enrollmentrequests, overriding the read wildcard.
