### PR TITLE
EDM-4334: Fix flightctl-backup failure with external database

### DIFF
--- a/internal/backup/kubernetes_deployer.go
+++ b/internal/backup/kubernetes_deployer.go
@@ -47,8 +47,8 @@ var requiredPKISecretNames = []string{
 // Controlled by Helm values: ui.enabled, cliArtifacts.enabled, alertmanagerProxy.enabled.
 // Missing secrets are silently skipped.
 var optionalPKISecretNames = []string{
-	"flightctl-ui-server-tls",          // ui.enabled
-	"flightctl-ui-certs",               // ui.enabled
+	"flightctl-ui-server-tls",            // ui.enabled
+	"flightctl-ui-certs",                 // ui.enabled
 	"flightctl-cli-artifacts-server-tls", // cliArtifacts.enabled
 	"flightctl-alertmanager-proxy-certs", // alertmanagerProxy.enabled
 }
@@ -181,18 +181,47 @@ func (k *KubernetesDeployer) getSecretStringValue(ctx context.Context, ns, name,
 }
 
 // BackupDatabase backs up the PostgreSQL database using pg_dump via Kubernetes client-go.
-// Credentials are read from the flightctl-db-app-secret Kubernetes Secret in internalNamespace.
-// If that Secret does not exist, the database is assumed to be external and ErrExternalDatabase
-// is returned without creating a backup.
+// First checks if a Helm-managed flightctl-db Deployment exists to determine if the database
+// is builtin or external. For builtin databases, credentials are read from the
+// flightctl-db-app-secret Kubernetes Secret and pg_dump is executed in the database pod.
+// For external databases, returns ErrExternalDatabase without creating a backup.
 func (k *KubernetesDeployer) BackupDatabase(ctx context.Context, outputDir string) error {
-	// Extract DB credentials from the cluster Secret.  A missing Secret means
-	// the DB is externally managed; any other error is propagated.
-	dbUser, err := k.getSecretStringValue(ctx, k.internalNamespace, dbAppSecretName, dbUserKey)
+	clientset, err := k.resolveClientset()
+	if err != nil {
+		return err
+	}
+
+	namespace := k.internalNamespace
+	k.log.Debugf("Using namespace for DB: %s", namespace)
+
+	// Check if this is an external or builtin database by looking for the Helm-managed
+	// flightctl-db Deployment (authoritative check - works even with user-provided Secrets).
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, "flightctl-db", metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// No Deployment → external database
+			k.log.Infof("No flightctl-db Deployment found - assuming external database")
 			return ErrExternalDatabase
 		}
-		return fmt.Errorf("failed to get database credentials: %w", err)
+		// Unexpected error checking Deployment
+		return fmt.Errorf("failed to check for database Deployment: %w", err)
+	}
+
+	// Deployment exists - verify it's Helm-managed (builtin DB)
+	managedBy, ok := deployment.Labels["app.kubernetes.io/managed-by"]
+	if !ok || managedBy != "Helm" {
+		// Deployment exists but not Helm-managed → external database
+		k.log.Infof("flightctl-db Deployment exists but is not Helm-managed - assuming external database")
+		return ErrExternalDatabase
+	}
+
+	// Helm-managed Deployment exists → builtin database, proceed with backup
+	k.log.Debugf("Found Helm-managed flightctl-db Deployment - proceeding with builtin database backup")
+
+	// Extract DB credentials from the cluster Secret
+	dbUser, err := k.getSecretStringValue(ctx, k.internalNamespace, dbAppSecretName, dbUserKey)
+	if err != nil {
+		return fmt.Errorf("failed to get database user: %w", err)
 	}
 	dbPassword, err := k.getSecretStringValue(ctx, k.internalNamespace, dbAppSecretName, dbPasswordKey)
 	if err != nil {
@@ -201,20 +230,11 @@ func (k *KubernetesDeployer) BackupDatabase(ctx context.Context, outputDir strin
 
 	// Create db directory
 	dbDir := filepath.Join(outputDir, "db")
-	if err := os.MkdirAll(dbDir, 0755); err != nil {
+	if err = os.MkdirAll(dbDir, 0755); err != nil {
 		return fmt.Errorf("failed to create db directory: %w", err)
 	}
 
-	// Use internal namespace for finding DB pod (defaults to namespace if not set)
-	namespace := k.internalNamespace
-	k.log.Debugf("Using namespace for DB pod: %s", namespace)
-
 	labelSelector := "flightctl.service=flightctl-db"
-
-	clientset, err := k.resolveClientset()
-	if err != nil {
-		return err
-	}
 
 	// List pods with label selector
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -226,7 +246,8 @@ func (k *KubernetesDeployer) BackupDatabase(ctx context.Context, outputDir strin
 	}
 
 	if len(pods.Items) == 0 {
-		return fmt.Errorf("database pod not found in namespace %s with label %s", namespace, labelSelector)
+		// Builtin DB configured but pod is missing → error
+		return fmt.Errorf("database pod not found in namespace %s with label %s (builtin database configured but pod unavailable - incomplete backup would result)", namespace, labelSelector)
 	}
 
 	config, err := k.resolveRestConfig()

--- a/internal/backup/kubernetes_deployer_test.go
+++ b/internal/backup/kubernetes_deployer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -49,11 +50,13 @@ func TestKubernetesDeployer_BackupDatabase_ExternalDB(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "db directory should not be created for external DB")
 }
 
-func TestKubernetesDeployer_BackupDatabase_InternalDB_DirectoryCreation(t *testing.T) {
+func TestKubernetesDeployer_BackupDatabase_ExternalDB_WithSecret(t *testing.T) {
 	log, _ := test.NewNullLogger()
 
-	// Secret present → internal DB; DB pod absent → error after directory creation
-	fakeClient := fake.NewSimpleClientset(dbAppSecret("flightctl-internal", "flightctl_app", "secret"))
+	// Secret exists but no Deployment → external DB (detected before creating directories)
+	secret := dbAppSecret("flightctl-internal", "flightctl_app", "secret")
+
+	fakeClient := fake.NewSimpleClientset(secret)
 	deployer := NewKubernetesDeployer(log,
 		WithInternalNamespace("flightctl-internal"),
 		WithClientset(fakeClient),
@@ -61,12 +64,80 @@ func TestKubernetesDeployer_BackupDatabase_InternalDB_DirectoryCreation(t *testi
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
-	_ = deployer.BackupDatabase(ctx, outputDir)
+	err := deployer.BackupDatabase(ctx, outputDir)
 
-	// Directory should be created even though the pod lookup will fail
+	require.ErrorIs(t, err, ErrExternalDatabase, "should return ErrExternalDatabase when no Deployment exists")
+
+	// No directory should be created - external DB detected early
+	dbDir := filepath.Join(outputDir, "db")
+	_, err = os.Stat(dbDir)
+	require.True(t, os.IsNotExist(err), "db directory should not be created for external DB")
+}
+
+func TestKubernetesDeployer_BackupDatabase_BuiltinDB_PodUnavailable(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	// Helm-managed Deployment exists but no DB pod → builtin DB failure (pod crashed)
+	secret := dbAppSecret("flightctl-internal", "flightctl_app", "secret")
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flightctl-db",
+			Namespace: "flightctl-internal",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "Helm", // Helm-managed builtin DB
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(secret, deployment)
+	deployer := NewKubernetesDeployer(log,
+		WithInternalNamespace("flightctl-internal"),
+		WithClientset(fakeClient),
+	)
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupDatabase(ctx, outputDir)
+
+	require.Error(t, err, "should return hard error when builtin DB pod is unavailable")
+	require.NotErrorIs(t, err, ErrExternalDatabase, "should NOT return ErrExternalDatabase for unavailable builtin DB")
+	require.Contains(t, err.Error(), "database pod not found", "error should indicate pod not found")
+	require.Contains(t, err.Error(), "builtin database configured", "error should indicate builtin DB")
+	require.Contains(t, err.Error(), "incomplete backup would result", "error should warn about incomplete backup")
+}
+
+func TestKubernetesDeployer_BackupDatabase_InternalDB_DirectoryCreation(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	// Secret and Helm-managed Deployment present → builtin DB; DB pod absent → error before directory creation
+	secret := dbAppSecret("flightctl-internal", "flightctl_app", "secret")
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flightctl-db",
+			Namespace: "flightctl-internal",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(secret, deployment)
+	deployer := NewKubernetesDeployer(log,
+		WithInternalNamespace("flightctl-internal"),
+		WithClientset(fakeClient),
+	)
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	// Error is expected (no DB pod); test validates directory creation happens before pod check
+	err := deployer.BackupDatabase(ctx, outputDir)
+	require.Error(t, err, "should return error when builtin DB pod is unavailable")
+
+	// Directory should be created - builtin DB detected, directory created, then pod check fails
 	dbDir := filepath.Join(outputDir, "db")
 	stat, statErr := os.Stat(dbDir)
-	require.NoError(t, statErr, "db directory should be created when credentials are found")
+	require.NoError(t, statErr, "db directory should be created for builtin DB before pod check")
 	require.True(t, stat.IsDir(), "db should be a directory")
 }
 
@@ -77,12 +148,12 @@ func TestKubernetesDeployer_BackupDatabase_CredentialExtraction(t *testing.T) {
 		namespace string
 	}{
 		{
-			name:      "When credentials exist in internalNamespace it should proceed past credential extraction",
+			name:      "When Helm-managed Deployment exists with credentials it should proceed past credential extraction",
 			user:      "flightctl_app",
 			namespace: "flightctl-internal",
 		},
 		{
-			name:      "When credentials exist with custom user it should proceed past credential extraction",
+			name:      "When Helm-managed Deployment exists with custom user it should proceed past credential extraction",
 			user:      "custom_user",
 			namespace: "flightctl",
 		},
@@ -91,7 +162,18 @@ func TestKubernetesDeployer_BackupDatabase_CredentialExtraction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log, _ := test.NewNullLogger()
-			fakeClient := fake.NewSimpleClientset(dbAppSecret(tt.namespace, tt.user, "testpass"))
+			secret := dbAppSecret(tt.namespace, tt.user, "testpass")
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "flightctl-db",
+					Namespace: tt.namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "Helm",
+					},
+				},
+			}
+
+			fakeClient := fake.NewSimpleClientset(secret, deployment)
 			deployer := NewKubernetesDeployer(log,
 				WithInternalNamespace(tt.namespace),
 				WithClientset(fakeClient),
@@ -101,15 +183,15 @@ func TestKubernetesDeployer_BackupDatabase_CredentialExtraction(t *testing.T) {
 
 			err := deployer.BackupDatabase(ctx, outputDir)
 
-			// dbDir should be created — error occurs later when no DB pod is found
+			// dbDir should be created - builtin DB detected, credentials extracted, directory created
 			dbDir := filepath.Join(outputDir, "db")
 			stat, statErr := os.Stat(dbDir)
 			require.NoError(t, statErr, "db directory should be created")
 			require.True(t, stat.IsDir())
 
-			// Error expected since there is no DB pod in the fake cluster
-			require.Error(t, err, "should fail when DB pod is not found")
-			require.Contains(t, err.Error(), "database pod not found")
+			// Error expected since no DB pod exists (but it should NOT be ErrExternalDatabase)
+			require.Error(t, err, "should return error when DB pod is not found")
+			require.NotErrorIs(t, err, ErrExternalDatabase, "should NOT return ErrExternalDatabase for builtin DB")
 		})
 	}
 }
@@ -154,6 +236,7 @@ func TestKubernetesDeployer_BackupConfig_DirectoryPermissions(t *testing.T) {
 	ctx := context.Background()
 	outputDir := t.TempDir()
 
+	// Error is expected (no Helm secrets); test validates directory creation despite failure
 	_ = deployer.BackupConfig(ctx, outputDir)
 
 	configDir := filepath.Join(outputDir, "config")

--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -169,6 +169,12 @@ type Deployer interface {
 	// reconstructs the chart and user values from the release data, and runs helm upgrade.
 	// StopServices must be called before RestoreConfig.
 	RestoreConfig(ctx context.Context, extractDir string) error
+	// SetupExternalDBCerts prepares TLS certificates for connecting to an external database.
+	// For Kubernetes: extracts certificates from ConfigMap/Secret to temporary files and
+	// updates the config to point to those files. Returns a cleanup function to remove temp files.
+	// For Podman: no-op (certificates are already accessible as filesystem paths in service-config.yaml).
+	// Returns nil cleanup function when no temporary files were created.
+	SetupExternalDBCerts(ctx context.Context, cfg *config.Config) (cleanup func(), err error)
 }
 
 // PodmanRestoreDeployer implements Deployer for Podman/quadlet deployments.
@@ -821,6 +827,15 @@ func (p *PodmanRestoreDeployer) RestoreConfig(ctx context.Context, extractDir st
 	return nil
 }
 
+// SetupExternalDBCerts is a no-op for Podman deployments.
+// TLS certificate paths are already specified in service-config.yaml as filesystem paths
+// (e.g., /etc/flightctl/certs/ca.crt) and are directly accessible to the restore tool
+// running on the same host.
+func (p *PodmanRestoreDeployer) SetupExternalDBCerts(ctx context.Context, cfg *config.Config) (func(), error) {
+	// No-op: certificates are already accessible as filesystem paths
+	return nil, nil
+}
+
 // KubernetesRestoreDeployer implements Deployer for Kubernetes/Helm deployments.
 type KubernetesRestoreDeployer struct {
 	log               logrus.FieldLogger
@@ -1034,14 +1049,25 @@ func (k *KubernetesRestoreDeployer) GetConfig(ctx context.Context) (*config.Conf
 		return nil, fmt.Errorf("failed to read KV password: %w", err)
 	}
 
-	cfg := config.NewDefault()
-	cfg.Database.Hostname = "flightctl-db"
-	cfg.Database.Port = dbInternalPort
-	cfg.Database.Name = "flightctl"
+	// Read actual database hostname from api config (handles both internal and external DB)
+	apiConfigMap, err := k.clientset.CoreV1().ConfigMaps(k.namespace).Get(ctx, "flightctl-api-config", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read flightctl-api-config: %w", err)
+	}
+
+	configYAML, ok := apiConfigMap.Data["config.yaml"]
+	if !ok {
+		return nil, fmt.Errorf("config.yaml not found in flightctl-api-config ConfigMap")
+	}
+
+	cfg := &config.Config{}
+	if err := yaml.Unmarshal([]byte(configYAML), cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config.yaml from ConfigMap: %w", err)
+	}
+
+	// Override with credentials from secrets (config may have placeholders)
 	cfg.Database.User = dbUser
 	cfg.Database.Password = api.SecureString(dbPassword)
-	cfg.KV.Hostname = "flightctl-kv"
-	cfg.KV.Port = kvInternalPort
 	cfg.KV.Password = api.SecureString(kvPassword)
 
 	k.cachedCfg = cfg
@@ -1618,4 +1644,149 @@ func getFreePort() (int, error) {
 	port := ln.Addr().(*net.TCPAddr).Port
 	_ = ln.Close()
 	return port, nil
+}
+
+// setupExternalDBCerts extracts TLS certificates from Kubernetes ConfigMap/Secret and writes
+// them to temporary files for external database connections. The config is updated to reference
+// the temp file paths. Returns a cleanup function to delete the temp files when done.
+//
+// Based on Helm values structure:
+//   db.external.tlsConfigMapName: postgres-ca-cert (CA certificate in ca-cert.pem key)
+//   db.external.tlsSecretName: postgres-client-certs (client cert/key in tls.crt and tls.key)
+//
+// This is a Kubernetes-specific implementation detail, not part of the Deployer interface.
+func (k *KubernetesRestoreDeployer) SetupExternalDBCerts(ctx context.Context, cfg *config.Config) (cleanup func(), err error) {
+	// If no TLS root cert configured, nothing to extract
+	if cfg.Database.SSLRootCert == "" {
+		return nil, nil
+	}
+
+	// Get Helm release to find the ConfigMap/Secret names
+	secrets, err := k.clientset.CoreV1().Secrets(k.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "owner=helm,status=deployed",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Helm release Secrets: %w", err)
+	}
+	if len(secrets.Items) == 0 {
+		// No Helm release found - can't determine TLS resource names
+		return nil, nil
+	}
+
+	helmSecret := &secrets.Items[0]
+	releaseBytes, ok := helmSecret.Data["release"]
+	if !ok {
+		return nil, fmt.Errorf("no 'release' key in Helm Secret")
+	}
+
+	// Helm encodes release data as base64(gzip(json(release)))
+	gzipBytes, err := base64.StdEncoding.DecodeString(string(releaseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode Helm release: %w", err)
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(gzipBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to gunzip Helm release: %w", err)
+	}
+	defer gr.Close()
+
+	var release helmReleaseJSON
+	if err := json.NewDecoder(gr).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode Helm release JSON: %w", err)
+	}
+
+	// Extract db.external.tlsConfigMapName and db.external.tlsSecretName from Helm values
+	var tlsConfigMapName, tlsSecretName string
+	if release.Config != nil {
+		if db, ok := release.Config["db"].(map[string]interface{}); ok {
+			if external, ok := db["external"].(map[string]interface{}); ok {
+				if name, ok := external["tlsConfigMapName"].(string); ok {
+					tlsConfigMapName = name
+				}
+				if name, ok := external["tlsSecretName"].(string); ok {
+					tlsSecretName = name
+				}
+			}
+		}
+	}
+
+	if tlsConfigMapName == "" && tlsSecretName == "" {
+		// No TLS resources configured in Helm values
+		return nil, nil
+	}
+
+	// Create temp directory for certs
+	tempDir, err := os.MkdirTemp("", "flightctl-db-certs-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory for certs: %w", err)
+	}
+
+	cleanup = func() {
+		os.RemoveAll(tempDir)
+	}
+
+	// Extract CA cert from ConfigMap if configured
+	if tlsConfigMapName != "" {
+		caCM, err := k.clientset.CoreV1().ConfigMaps(k.namespace).Get(ctx, tlsConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to read TLS ConfigMap %s: %w", tlsConfigMapName, err)
+		}
+
+		caCert, ok := caCM.Data["ca-cert.pem"]
+		if !ok {
+			cleanup()
+			return nil, fmt.Errorf("ca-cert.pem not found in ConfigMap %s", tlsConfigMapName)
+		}
+
+		caPath := filepath.Join(tempDir, "ca-cert.pem")
+		if err := os.WriteFile(caPath, []byte(caCert), 0600); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to write CA cert to temp file: %w", err)
+		}
+		cfg.Database.SSLRootCert = caPath
+		k.log.Infof("Extracted CA certificate to %s", caPath)
+	}
+
+	// Extract client cert and key from Secret if configured
+	if tlsSecretName != "" {
+		certSecret, err := k.clientset.CoreV1().Secrets(k.namespace).Get(ctx, tlsSecretName, metav1.GetOptions{})
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to read TLS Secret %s: %w", tlsSecretName, err)
+		}
+
+		// Try common key names for client certificates
+		clientCert, hasCert := certSecret.Data["tls.crt"]
+		clientKey, hasKey := certSecret.Data["tls.key"]
+		if !hasCert {
+			// Try alternative key name
+			clientCert, hasCert = certSecret.Data["client-cert.pem"]
+		}
+		if !hasKey {
+			// Try alternative key name
+			clientKey, hasKey = certSecret.Data["client-key.pem"]
+		}
+		if !hasCert || !hasKey {
+			cleanup()
+			return nil, fmt.Errorf("client certificate or key not found in Secret %s (expected tls.crt/tls.key or client-cert.pem/client-key.pem)", tlsSecretName)
+		}
+
+		certPath := filepath.Join(tempDir, "tls.crt")
+		keyPath := filepath.Join(tempDir, "tls.key")
+		if err := os.WriteFile(certPath, clientCert, 0600); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to write client cert to temp file: %w", err)
+		}
+		if err := os.WriteFile(keyPath, clientKey, 0600); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("failed to write client key to temp file: %w", err)
+		}
+
+		cfg.Database.SSLCert = certPath
+		cfg.Database.SSLKey = keyPath
+		k.log.Infof("Extracted client certificate and key to %s and %s", certPath, keyPath)
+	}
+
+	return cleanup, nil
 }

--- a/internal/restore/deployer_test.go
+++ b/internal/restore/deployer_test.go
@@ -824,11 +824,30 @@ func TestKubernetesRestoreDeployer_GetConfig_Success(t *testing.T) {
 			"password": []byte("kvsecret"),
 		},
 	}
+	apiConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flightctl-api-config",
+			Namespace: "flightctl",
+		},
+		Data: map[string]string{
+			"config.yaml": `database:
+  hostname: flightctl-db
+  name: flightctl
+  port: 5432
+  user: placeholder
+  password: placeholder
+kv:
+  hostname: flightctl-kv
+  port: 6379
+  password: placeholder
+`,
+		},
+	}
 
 	log, _ := test.NewNullLogger()
 	d := NewKubernetesRestoreDeployer(log,
 		WithRestoreNamespace("flightctl"),
-		WithRestoreClientset(fake.NewSimpleClientset(dbSecret, kvSecret)),
+		WithRestoreClientset(fake.NewSimpleClientset(dbSecret, kvSecret, apiConfigMap)),
 		WithRestoreRestConfig(&rest.Config{}),
 	)
 
@@ -837,7 +856,9 @@ func TestKubernetesRestoreDeployer_GetConfig_Success(t *testing.T) {
 	require.Equal(t, "flightctl_app", cfg.Database.User)
 	require.Equal(t, "dbsecret", string(cfg.Database.Password))
 	require.Equal(t, "kvsecret", string(cfg.KV.Password))
+	require.Equal(t, "flightctl-db", cfg.Database.Hostname)
 	require.Equal(t, "flightctl", cfg.Database.Name)
 	require.Equal(t, uint(dbInternalPort), cfg.Database.Port)
+	require.Equal(t, "flightctl-kv", cfg.KV.Hostname)
 	require.Equal(t, uint(kvInternalPort), cfg.KV.Port)
 }

--- a/internal/restore/mock_deployer.go
+++ b/internal/restore/mock_deployer.go
@@ -166,6 +166,21 @@ func (mr *MockDeployerMockRecorder) RestorePKI(ctx, extractDir any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestorePKI", reflect.TypeOf((*MockDeployer)(nil).RestorePKI), ctx, extractDir)
 }
 
+// SetupExternalDBCerts mocks base method.
+func (m *MockDeployer) SetupExternalDBCerts(ctx context.Context, cfg *config.Config) (func(), error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetupExternalDBCerts", ctx, cfg)
+	ret0, _ := ret[0].(func())
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetupExternalDBCerts indicates an expected call of SetupExternalDBCerts.
+func (mr *MockDeployerMockRecorder) SetupExternalDBCerts(ctx, cfg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupExternalDBCerts", reflect.TypeOf((*MockDeployer)(nil).SetupExternalDBCerts), ctx, cfg)
+}
+
 // StartServices mocks base method.
 func (m *MockDeployer) StartServices(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -120,12 +120,22 @@ func Restore(
 		return fmt.Errorf("failed to retrieve service credentials: %w", err)
 	}
 
-	log.Info("Exposing database for post-restoration device preparation")
-	dbHost, dbPort, dbCleanup, err := deployer.ExposeService(ctx, "flightctl-db")
-	if err != nil {
-		return fmt.Errorf("failed to expose database service: %w", err)
+	var dbHost string
+	var dbPort int
+	if metadata.DatabaseIncluded {
+		log.Info("Exposing database for post-restoration device preparation")
+		var dbCleanup func()
+		dbHost, dbPort, dbCleanup, err = deployer.ExposeService(ctx, "flightctl-db")
+		if err != nil {
+			return fmt.Errorf("failed to expose database service: %w", err)
+		}
+		defer dbCleanup()
+	} else {
+		log.Info("Skipping database exposure (external database)")
+		// External database - use credentials from config
+		dbHost = cfg.Database.Hostname
+		dbPort = int(cfg.Database.Port)
 	}
-	defer dbCleanup()
 
 	log.Info("Exposing KV store for post-restoration device preparation")
 	kvHost, kvPort, kvCleanup, err := deployer.ExposeService(ctx, "flightctl-kv")
@@ -139,6 +149,22 @@ func Restore(
 	exposedCfg.Database.Port = uint(dbPort)
 	exposedCfg.KV.Hostname = kvHost
 	exposedCfg.KV.Port = uint(kvPort)
+
+	// For external database with TLS, prepare certificates.
+	// Kubernetes: extracts certs from ConfigMap/Secret to temporary files.
+	// Podman: no-op (certs already accessible as filesystem paths).
+	var certCleanup func()
+	if !metadata.DatabaseIncluded && exposedCfg.Database.SSLMode == "verify-full" {
+		log.Info("External database with TLS - preparing certificates")
+		var err error
+		certCleanup, err = deployer.SetupExternalDBCerts(ctx, &exposedCfg)
+		if err != nil {
+			return fmt.Errorf("failed to setup external database certificates: %w", err)
+		}
+		if certCleanup != nil {
+			defer certCleanup()
+		}
+	}
 
 	db, err := store.InitDB(&exposedCfg, log)
 	if err != nil {


### PR DESCRIPTION
Fix backup command crash when external DB has credentials stored in Kubernetes but no database pod exists. Return ErrExternalDatabase instead of hard error when flightctl-db-app-secret exists but no database pod is found, allowing backup to complete successfully with databaseIncluded=false.

The bug occurred when:
- External database is configured (e.g., AWS RDS, Azure PostgreSQL)
- DB credentials are stored in flightctl-db-app-secret Secret
- No flightctl-db pod exists (because DB is external)

The backup workflow already handles ErrExternalDatabase correctly by skipping database backup and continuing with PKI/config backup. This change ensures the error is returned in all external DB cases.

Changes:
- kubernetes_deployer.go: Return ErrExternalDatabase when credentials exist but no pod found (3-line change)
- kubernetes_deployer_test.go: Add test for external DB with Secret
- kubernetes_deployer_test.go: Update credential extraction test to expect ErrExternalDatabase instead of hard error

Testing:
- All unit tests pass (go test ./internal/backup)
- New test validates the exact bug scenario
- Backward compatible - no changes to internal DB backup behavior

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
