### PR TITLE
NO-ISSUE: fix TPM NV read chunk size to respect TPM_PT_NV_BUFFER_MAX,…

### DIFF
--- a/internal/tpm/session.go
+++ b/internal/tpm/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 
 	"github.com/flightctl/flightctl/pkg/log"
@@ -24,9 +25,11 @@ const (
 	persistentHandleStart = tpm2.TPMHandle(0x81008000)
 	persistentHandleEnd   = tpm2.TPMHandle(0x8100FFFF)
 
-	nvReadChunkSize = uint16(1024) // Maximum chunk size for NVRead operations
-	ekRSANVIndex    = gotpmclient.EKCertNVIndexRSA
-	ekECCNVIndex    = gotpmclient.EKCertNVIndexECC
+	// nvReadChunkSizeFallback is used when TPM_PT_NV_BUFFER_MAX cannot be queried.
+	// 512 bytes is safe across all known TPM implementations.
+	nvReadChunkSizeFallback = uint16(512)
+	ekRSANVIndex            = gotpmclient.EKCertNVIndexRSA
+	ekECCNVIndex            = gotpmclient.EKCertNVIndexECC
 
 	// TCG EK Credential Profile v2.6, Section 2.2.1.4 — NV indices for manufacturer EK templates.
 	ekRSATemplateNVIndex uint32 = 0x01C00004
@@ -738,12 +741,16 @@ func (s *tpmSession) readEKCertFromNVRAM(nvIndex uint32) ([]byte, error) {
 		}
 	}
 
-	// Read the certificate data using Owner hierarchy with chunking
+	// Read the certificate data using Owner hierarchy with chunking.
+	// Chunk size is capped to TPM_PT_NV_BUFFER_MAX to avoid TPM_RC_SIZE on
+	// TPMs that report a limit smaller than the previous hardcoded 1024 B
+	// (e.g. Infineon SLB 9670 with NV_BUFFER_MAX = 768 B).
 	var certData []byte
 	dataSize := nvPublic.DataSize
+	chunkMaxSize := s.nvBufferMax()
 
-	for offset := uint16(0); offset < dataSize; offset += nvReadChunkSize {
-		chunkSize := nvReadChunkSize
+	for offset := uint16(0); offset < dataSize; offset += chunkMaxSize {
+		chunkSize := chunkMaxSize
 		if offset+chunkSize > dataSize {
 			chunkSize = dataSize - offset
 		}
@@ -972,6 +979,39 @@ func (s *tpmSession) isStorageHierarchyAuthSet() (bool, error) {
 	}
 
 	return false, fmt.Errorf("TPM_PT_PERMANENT property not found")
+}
+
+// nvBufferMax returns the maximum NVRead chunk size supported by this TPM.
+// It queries TPM_PT_NV_BUFFER_MAX (TCG spec part 2, section 6.13). If the
+// property is unavailable the fallback value is returned so that NVRead
+// operations still succeed on non-conformant implementations.
+func (s *tpmSession) nvBufferMax() uint16 {
+	cmd := tpm2.GetCapability{
+		Capability:    tpm2.TPMCapTPMProperties,
+		Property:      uint32(tpm2.TPMPTNVBufferMax),
+		PropertyCount: 1,
+	}
+	resp, err := cmd.Execute(transport.FromReadWriter(s.conn))
+	if err != nil {
+		s.log.Warnf("Failed to query TPM_PT_NV_BUFFER_MAX, using fallback %d: %v", nvReadChunkSizeFallback, err)
+		return nvReadChunkSizeFallback
+	}
+	data, err := resp.CapabilityData.Data.TPMProperties()
+	if err != nil {
+		s.log.Warnf("Failed to parse TPM_PT_NV_BUFFER_MAX response, using fallback %d: %v", nvReadChunkSizeFallback, err)
+		return nvReadChunkSizeFallback
+	}
+	for _, prop := range data.TPMProperty {
+		if prop.Property == tpm2.TPMPTNVBufferMax {
+			if prop.Value == 0 || prop.Value > math.MaxUint16 {
+				s.log.Warnf("TPM_PT_NV_BUFFER_MAX value %d out of range, using fallback %d", prop.Value, nvReadChunkSizeFallback)
+				return nvReadChunkSizeFallback
+			}
+			return uint16(prop.Value)
+		}
+	}
+	s.log.Warnf("TPM_PT_NV_BUFFER_MAX property not found in response, using fallback %d", nvReadChunkSizeFallback)
+	return nvReadChunkSizeFallback
 }
 
 func (s *tpmSession) generateStoragePassword() ([]byte, error) {

--- a/internal/tpm/session_test.go
+++ b/internal/tpm/session_test.go
@@ -684,6 +684,55 @@ func setupMocks(t *testing.T) (*gomock.Controller, *MockStorage, *mockReadWriteC
 	return ctrl, mockStorage, conn, rw, logger
 }
 
+func TestNvBufferMax(t *testing.T) {
+	testCases := []struct {
+		name         string
+		conn         func(t *testing.T) io.ReadWriteCloser
+		wantFallback bool
+	}{
+		{
+			name: "When simulator is available it should return TPM_PT_NV_BUFFER_MAX from the TPM",
+			conn: func(t *testing.T) io.ReadWriteCloser {
+				sim, err := simulator.Get()
+				require.NoError(t, err)
+				return sim
+			},
+			wantFallback: false,
+		},
+		{
+			name: "When TPM connection returns EOF it should return the fallback chunk size",
+			conn: func(t *testing.T) io.ReadWriteCloser {
+				return &mockReadWriteCloser{Buffer: bytes.NewBuffer(nil), validSRK: false}
+			},
+			wantFallback: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			conn := tc.conn(t)
+			defer conn.Close()
+
+			session := &tpmSession{
+				conn:    conn,
+				log:     log.NewPrefixLogger("test"),
+				handles: make(map[KeyType]*tpm2.NamedHandle),
+			}
+
+			result := session.nvBufferMax()
+
+			if tc.wantFallback {
+				require.Equal(nvReadChunkSizeFallback, result)
+			} else {
+				require.NotZero(result)
+				require.Greater(result, nvReadChunkSizeFallback, "simulator NV_BUFFER_MAX should exceed the conservative fallback")
+			}
+		})
+	}
+}
+
 func TestDetectEKAlgorithm(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
… Fixes #3126

# Release target (required before merge to `main`)

- [ ] **`release-1.2.1`**
- [ ] **`release-1.3`**

## Problem

On devices with Infineon SLB 9670 TPM 2.0 (e.g. ELO I-Series 3 kiosk terminals), `flightctl-agent` fails to read the EK certificate from NVRAM with `TPM_RC_SIZE`:
failed to read chunk at offset 0 from NVRAM index 0x...: TPM_RC_SIZE

**Root cause:** `nvReadChunkSize` was hardcoded to 1024 bytes. The Infineon SLB 9670 reports `TPM_PT_NV_BUFFER_MAX = 0x300 (768 bytes)` — the TPM rejects any NVRead request with a chunk larger than this limit. As a result, device identity via TPM was reported as `Unsupported` in RHEM.

`tpm2_nvread` works on the same hardware because tpm2-tools queries `TPM_PT_NV_BUFFER_MAX` dynamically and chunks accordingly.

 ## Fix

- Replace the hardcoded `nvReadChunkSize = 1024` constant with a runtime query of `TPM_PT_NV_BUFFER_MAX` via `GetCapability` in a new `nvBufferMax()` method.
- Fall back to 512 bytes if the property is unavailable (safe across all known TPM implementations).
- `readEKCertFromNVRAM` now uses `nvBufferMax()` as the chunk size.

## Testing

- Added `TestNvBufferMax` unit tests covering:
- simulator returns a valid `TPM_PT_NV_BUFFER_MAX` value greater than the fallback
- broken connection falls back to 512 bytes
- Full TPM unit test suite passes: `go test ./internal/tpm/...`
