### PR TITLE
NO-ISSUE: fix fips for kubevirt-vm-to-pod

### DIFF
--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
     cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
-    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+    CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
 
 # ── flightctl worker build stage ─────────────────────────────────────────────
 FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
     cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
-    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+    CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
 
 # ── flightctl worker build stage ─────────────────────────────────────────────
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build

--- a/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
+++ b/test/integration/tasks/vmrender/Containerfile.kubevirt-vm-to-pod
@@ -4,7 +4,7 @@ USER 0
 ARG KUBEVIRT_VM_TO_POD_COMMIT=d64fa7fd95361fdcc5ddd6c4c2714600821482a1
 RUN git clone https://github.com/vladikr/kubevirt-vm-to-pod /src && \
     cd /src && git checkout ${KUBEVIRT_VM_TO_POD_COMMIT} && \
-    CGO_ENABLED=0 GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
+    CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime GOOS=linux go build -o /out/kubevirt-vm-to-pod ./cmd
 
 # Final stage: copy only the binary; no toolchain, non-root user.
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
fixes fips validation for flightctl-worker (kubevirt-vm-to-pod exec)
