### PR TITLE
EDM-2349: Expand RBAC multi org tests

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -77,6 +77,7 @@ func main() {
 	sourceIPs := pflag.StringSlice("source-ips", []string{}, "comma-separated list of source IP addresses for device management HTTP connections")
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
+	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -177,6 +178,7 @@ func main() {
 		agentConfigTemplate: agentConfigTemplate,
 		parsedSourceIPs:     parsedSourceIPs,
 		maxConcurrency:      *maxConcurrency,
+		simulatorLabels:     formattedLables,
 	})
 
 	sigShutdown := make(chan os.Signal, 1)
@@ -206,6 +208,7 @@ func main() {
 		formattedLabels: formattedLables,
 		sem:             sem,
 		jitterDuration:  jitterDuration,
+		skipAutoApprove: *skipAutoApprove,
 	}
 	for i := range *numDevices {
 		if err := sem.Acquire(ctx, 1); err != nil {
@@ -237,7 +240,31 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 	// leave the agent process running in the background
 	// when the agent is approved, we return and release the semaphore to allow other agents to onboard
 	go startAgent(ctx, params.agents[i], params.log, i)
+	if params.skipAutoApprove {
+		waitForEnrollmentRequest(ctx, params.log, params.agentFolders[i])
+		return
+	}
 	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+}
+
+func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
+		bannerFileData, err := readBannerFile(agentDir)
+		if err != nil {
+			return false, nil
+		}
+		enrollmentID := testutil.GetEnrollmentIdFromText(bannerFileData)
+		if enrollmentID == "" {
+			log.Warnf("No enrollment id found in banner file %s", bannerFileData)
+			return false, nil
+		}
+		log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
+		return true, nil
+	})
+	if err != nil && ctx.Err() == nil {
+		log.Errorf("Error waiting for enrollment request: %v", err)
+	}
 }
 
 func reportVersion(versionFormat *string) error {
@@ -336,6 +363,7 @@ type createAgentsConfig struct {
 	agentConfigTemplate *agent_config.Config
 	parsedSourceIPs     []net.IP
 	maxConcurrency      int
+	simulatorLabels     *map[string]string
 }
 
 type agentLaunchParams struct {
@@ -346,6 +374,7 @@ type agentLaunchParams struct {
 	formattedLabels *map[string]string
 	sem             *semaphore.Weighted
 	jitterDuration  time.Duration
+	skipAutoApprove bool
 }
 
 func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
@@ -382,6 +411,11 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		copyAgentFiles(logger, certDir, agentDir)
 
 		cfg := agent_config.NewDefault()
+		if agentCfg.simulatorLabels != nil {
+			for k, v := range *agentCfg.simulatorLabels {
+				cfg.DefaultLabels[k] = v
+			}
+		}
 		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent_config.DefaultConfigDir
 		cfg.DataDir = agent_config.DefaultConfigDir

--- a/test/e2e/multiorg/multiorg_suite_test.go
+++ b/test/e2e/multiorg/multiorg_suite_test.go
@@ -179,9 +179,6 @@ var _ = BeforeEach(func() {
 	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
 	harness.SetTestContext(ctx)
 
-	_, err := harness.SetupDeviceSimulatorAgentConfig(0, 0)
-	Expect(err).ToNot(HaveOccurred())
-
 	GinkgoWriter.Printf("[BeforeEach] Worker %d: Multiorg test setup completed\n", workerID)
 })
 

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -2,10 +2,12 @@ package multiorg_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
@@ -78,20 +80,20 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			simulatorCmds = nil
 		})
 
-		It("should enroll 30 devices as admin and all users should see them", Label("88359"), func() {
+		It("should enroll 30 devices as admin and all users except installer should see them", Label("88359"), func() {
 			testID := harness.GetTestIDFromContext()
+			deferOrgSimulatorConfig(harness, users)
 
 			By("Logging in as admin to setup simulator config and create devices")
 			err := loginAndSetOrg(harness, users.admin.name, users.admin.password)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = harness.SetupDeviceSimulatorAgentConfig(0, 0)
-			Expect(err).ToNot(HaveOccurred(), "Failed to setup simulator agent config as admin")
+			setupSharedOrgSimulatorConfig(harness)
 
 			By(fmt.Sprintf("Starting 3 device simulators (%d devices each) as admin", devicesPerUser))
 			for i := 0; i < 3; i++ {
 				initialIndex := i * devicesPerUser
-				cmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, users.admin.name, initialIndex, devicesPerUser)
+				cmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, users.admin.name, initialIndex, devicesPerUser, false)
 				Expect(simErr).ToNot(HaveOccurred(), fmt.Sprintf("Failed to start simulator batch %d", i))
 				simulatorCmds = append(simulatorCmds, cmd)
 				GinkgoWriter.Printf("Simulator batch %d started (devices %d-%d)\n",
@@ -115,6 +117,12 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 					fmt.Sprintf("%s should see all %d devices in the shared organization", u.name, totalDevices))
 				GinkgoWriter.Printf("%s sees %d devices (expected %d)\n", u.name, count, totalDevices)
 			}
+
+			By("Switching to installer and verifying device list is denied")
+			err = loginAndSetOrg(harness, users.installer.name, users.installer.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectReadOnlyListForbidden(harness, util.Device)
 		})
 	})
 
@@ -152,8 +160,11 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("operator should have full CRUD access to devices and fleets", Label("88361"), func() {
+		It("operator should have full CRUD access to devices, fleets, and repositories and limited access to enrollment requests", Label("88361"), func() {
 			suiteCtx := e2e.GetWorkerContext()
+			testID := harness.GetTestIDFromContext()
+			var erName string
+			deferOrgSimulatorConfig(harness, users)
 
 			By("Logging in as operator")
 			err := loginAndSetOrg(harness, users.operator.name, users.operator.password)
@@ -172,10 +183,70 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				[]string{util.Fleet},
 				true, operatorLabels, flightCtlNs, []string{e2e.OperationAll})
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that operator can perform all CRUD operations on repositories")
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness,
+				[]string{util.Repository},
+				true, operatorLabels, flightCtlNs, []string{e2e.OperationAll})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating an enrollment request as admin so operator can read it")
+			err = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			setupSharedOrgSimulatorConfig(harness)
+
+			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "operator-er-rbac", 0, 1, true)
+			Expect(simErr).ToNot(HaveOccurred())
+			simulatorCmds = append(simulatorCmds, erSimCmd)
+
+			Eventually(func() error {
+				var waitErr error
+				erName, waitErr = harness.WaitForSimulatorEnrollmentRequest(
+					testID, e2e.DeviceSimulatorAgentAlias(0), deviceEnrollTimeout, deviceEnrollPolling)
+				return waitErr
+			}, deviceEnrollTimeout, deviceEnrollPolling).Should(Succeed(),
+				"Expected an enrollment request from the simulator")
+
+			err = loginAndSetOrg(harness, users.operator.name, users.operator.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			if infra.IsQuadletEnvironment() {
+				By("Testing that operator can list events")
+				err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"events"}, true)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Testing that operator can list enrollment requests")
+				err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests"}, true)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Testing that operator can get a specific enrollment request")
+				_, getErr := harness.GetResourcesByName("enrollmentrequests", erName)
+				Expect(getErr).ToNot(HaveOccurred(), "Operator should be able to get an enrollment request on quadlet")
+			} else {
+				By("Testing that operator cannot list events on OCP")
+				expectReadOnlyListForbidden(harness, "events")
+
+				By("Testing that operator cannot list enrollment requests on OCP")
+				expectReadOnlyListForbidden(harness, "enrollmentrequests")
+
+				By("Testing that operator cannot get a specific enrollment request on OCP")
+				out, getErr := harness.GetResourcesByName("enrollmentrequests", erName)
+				Expect(getErr).To(HaveOccurred(), "Operator should not be able to get an enrollment request on OCP")
+				Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for operator enrollment request get")
+			}
+
+			By("Testing that operator cannot approve an enrollment request")
+			status, approveErr := harness.ApproveEnrollmentRequestWithLabels(erName, nil)
+			Expect(approveErr).To(HaveOccurred(), "Operator should not be able to approve an enrollment request")
+			Expect(status).To(Equal(http.StatusForbidden), "Expected 403 Forbidden for operator enrollment approval")
 		})
 
 		It("viewer should only be able to read devices and fleets, not create or delete", Label("88362"), func() {
 			suiteCtx := e2e.GetWorkerContext()
+			testID := harness.GetTestIDFromContext()
+			var erName string
+			deferOrgSimulatorConfig(harness, users)
 
 			By("Logging in as viewer")
 			err := loginAndSetOrg(harness, users.viewer.name, users.viewer.password)
@@ -199,27 +270,62 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				false, viewerLabels, flightCtlNs, []string{e2e.OperationCreate})
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Creating resources as admin so viewer can attempt to delete them")
+			By("Creating resources as admin for viewer RBAC tests")
 			err = loginAndSetOrg(harness, users.admin.name, users.admin.password)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, deviceName, _, deviceCreateErr := harness.CreateResource(util.Device)
-			Expect(deviceCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a device for viewer delete test")
+			_, deviceName, deviceData, deviceCreateErr := harness.CreateResource(util.Device)
+			Expect(deviceCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a device for viewer RBAC test")
 			DeferCleanup(func() {
 				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
 				_, _ = harness.CleanUpResource(util.Device, deviceName)
 			})
 
-			_, fleetName, _, fleetCreateErr := harness.CreateResource(util.Fleet)
-			Expect(fleetCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a fleet for viewer delete test")
+			_, fleetName, fleetData, fleetCreateErr := harness.CreateResource(util.Fleet)
+			Expect(fleetCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a fleet for viewer RBAC test")
 			DeferCleanup(func() {
 				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
 				_, _ = harness.CleanUpResource(util.Fleet, fleetName)
 			})
 
-			By("Switching back to viewer and attempting to delete admin-created resources")
+			_, repoName, _, repoCreateErr := harness.CreateResource(util.Repository)
+			Expect(repoCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a repository for viewer RBAC test")
+			DeferCleanup(func() {
+				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				_, _ = harness.CleanUpResource(util.Repository, repoName)
+			})
+
+			setupSharedOrgSimulatorConfig(harness)
+
+			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "viewer-er-rbac", 0, 1, true)
+			Expect(simErr).ToNot(HaveOccurred())
+			simulatorCmds = append(simulatorCmds, erSimCmd)
+
+			Eventually(func() error {
+				var waitErr error
+				erName, waitErr = harness.WaitForSimulatorEnrollmentRequest(
+					testID, e2e.DeviceSimulatorAgentAlias(0), deviceEnrollTimeout, deviceEnrollPolling)
+				return waitErr
+			}, deviceEnrollTimeout, deviceEnrollPolling).Should(Succeed(),
+				"Expected an enrollment request from the simulator")
+
+			By("Switching back to viewer for update, delete, and read tests")
 			err = loginAndSetOrg(harness, users.viewer.name, users.viewer.password)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that viewer cannot update a device")
+			updatedDeviceYAML, updateErr := harness.AddLabelsToYAML(string(deviceData), *viewerLabels)
+			Expect(updateErr).ToNot(HaveOccurred())
+			out, applyErr := harness.CLIWithStdin(updatedDeviceYAML, "apply", "-f", "-")
+			Expect(applyErr).To(HaveOccurred(), "Viewer should not be able to update a device")
+			Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for viewer device update")
+
+			By("Testing that viewer cannot update a fleet")
+			updatedFleetYAML, updateErr := harness.AddLabelsToYAML(string(fleetData), *viewerLabels)
+			Expect(updateErr).ToNot(HaveOccurred())
+			out, applyErr = harness.CLIWithStdin(updatedFleetYAML, "apply", "-f", "-")
+			Expect(applyErr).To(HaveOccurred(), "Viewer should not be able to update a fleet")
+			Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for viewer fleet update")
 
 			By("Testing that viewer cannot delete a device")
 			out, deleteErr := harness.CleanUpResource(util.Device, deviceName)
@@ -230,15 +336,101 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			out, deleteErr = harness.CleanUpResource(util.Fleet, fleetName)
 			Expect(deleteErr).To(HaveOccurred(), "Viewer should not be able to delete a fleet")
 			Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for viewer fleet delete")
+
+			By("Testing that viewer cannot create repositories")
+			err = e2e.ExecuteResourceOperations(suiteCtx, harness,
+				[]string{util.Repository},
+				false, viewerLabels, flightCtlNs, []string{e2e.OperationCreate})
+			Expect(err).ToNot(HaveOccurred())
+
+			if infra.IsQuadletEnvironment() {
+				By("Testing that viewer can list and get repositories")
+				err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"repositories"}, true)
+				Expect(err).ToNot(HaveOccurred())
+				_, getErr := harness.GetResourcesByName("repositories", repoName)
+				Expect(getErr).ToNot(HaveOccurred(), "Viewer should be able to get a repository on quadlet")
+
+				By("Testing that viewer can list and get enrollment requests")
+				err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests"}, true)
+				Expect(err).ToNot(HaveOccurred())
+				_, getErr = harness.GetResourcesByName("enrollmentrequests", erName)
+				Expect(getErr).ToNot(HaveOccurred(), "Viewer should be able to get an enrollment request on quadlet")
+
+				By("Testing that viewer can list events")
+				err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"events"}, true)
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				By("Testing that viewer cannot list or get repositories on OCP")
+				expectReadOnlyListForbidden(harness, "repositories")
+				out, getErr := harness.GetResourcesByName("repositories", repoName)
+				Expect(getErr).To(HaveOccurred(), "Viewer should not be able to get a repository on OCP")
+				Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for viewer repository get")
+
+				By("Testing that viewer cannot list or get enrollment requests on OCP")
+				expectReadOnlyListForbidden(harness, "enrollmentrequests")
+				out, getErr = harness.GetResourcesByName("enrollmentrequests", erName)
+				Expect(getErr).To(HaveOccurred(), "Viewer should not be able to get an enrollment request on OCP")
+				Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for viewer enrollment request get")
+
+				By("Testing that viewer cannot list events on OCP")
+				expectReadOnlyListForbidden(harness, "events")
+			}
+
+			By("Testing that viewer cannot approve an enrollment request")
+			status, approveErr := harness.ApproveEnrollmentRequestWithLabels(erName, nil)
+			Expect(approveErr).To(HaveOccurred(), "Viewer should not be able to approve an enrollment request")
+			Expect(status).To(Equal(http.StatusForbidden), "Expected 403 Forbidden for viewer enrollment approval")
+		})
+
+		It("should enforce device console access by role", Label("89607", "agent"), func() {
+			testID := harness.GetTestIDFromContext()
+			deferOrgSimulatorConfig(harness, users)
+
+			By("Creating a device via simulator as admin")
+			err := loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			setupSharedOrgSimulatorConfig(harness)
+
+			simCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "console-rbac", 0, 1, false)
+			Expect(simErr).ToNot(HaveOccurred())
+			simulatorCmds = append(simulatorCmds, simCmd)
+
+			deviceName, err := harness.WaitForLabeledSimulatorDevice(testID, 0, deviceEnrollTimeout, deviceEnrollPolling)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Device for console RBAC test: %s\n", deviceName)
+
+			for _, tc := range []struct {
+				role    string
+				user    userCred
+				allowed bool
+			}{
+				{"admin", users.admin, true},
+				{"operator", users.operator, true},
+				{"viewer", users.viewer, false},
+				{"installer", users.installer, false},
+			} {
+				By(fmt.Sprintf("Testing console access as %s", tc.role))
+				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
+				Expect(err).ToNot(HaveOccurred())
+				assertConsoleAccess(harness, deviceName, tc.allowed)
+			}
 		})
 
 		DescribeTable("decommission access control",
 			func(user, password string, shouldSucceed bool) {
+				deferOrgSimulatorConfig(harness, users)
+
 				By("Creating devices via simulator as admin")
+				err := loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				Expect(err).ToNot(HaveOccurred())
+				setupSharedOrgSimulatorConfig(harness)
+
 				loginFn := makeLoginFunc(users.admin.name, users.admin.password)
-				deviceName, cmd, err := harness.EnrollDeviceForDecommissionTest(loginFn, devicesPerUser, deviceEnrollTimeout)
+				deviceName, cmd, err := harness.EnrollDeviceForDecommissionTest(loginFn, 1, deviceEnrollTimeout)
 				Expect(err).ToNot(HaveOccurred())
 				simulatorCmds = append(simulatorCmds, cmd)
+				deferDecommissionTestCleanup(harness, users, deviceName)
 				GinkgoWriter.Printf("Device for decommission test: %s\n", deviceName)
 
 				By(fmt.Sprintf("Logging in as %s and attempting to decommission", user))
@@ -260,8 +452,11 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Entry("installer cannot decommission a device", Label("88367"), installerUserCred().name, installerUserCred().password, false),
 		)
 
-		It("installer can read enrollment requests but cannot create devices or fleets", Label("88366"), func() {
+		It("installer should read enrollment requests and be denied device, fleet, repository, and events access", Label("88366"), func() {
 			suiteCtx := e2e.GetWorkerContext()
+			testID := harness.GetTestIDFromContext()
+			var erName string
+			deferOrgSimulatorConfig(harness, users)
 
 			By("Logging in as installer")
 			err := loginAndSetOrg(harness, users.installer.name, users.installer.password)
@@ -270,6 +465,15 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			By("Testing that installer can read enrollment requests")
 			err = e2e.ExecuteReadOnlyResourceOperations(harness, []string{"enrollmentrequests"}, true)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that installer cannot list fleets")
+			expectReadOnlyListForbidden(harness, util.Fleet)
+
+			By("Testing that installer cannot list repositories")
+			expectReadOnlyListForbidden(harness, "repositories")
+
+			By("Testing that installer cannot list events")
+			expectReadOnlyListForbidden(harness, "events")
 
 			installerLabels := &map[string]string{"test": "multiorg-installer"}
 
@@ -284,6 +488,61 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				[]string{util.Fleet},
 				false, installerLabels, flightCtlNs, []string{e2e.OperationCreate})
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating devices and fleets as admin so installer can attempt to update them")
+			err = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, deviceName, deviceData, deviceCreateErr := harness.CreateResource(util.Device)
+			Expect(deviceCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a device for installer RBAC test")
+			DeferCleanup(func() {
+				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				_, _ = harness.CleanUpResource(util.Device, deviceName)
+			})
+
+			_, fleetName, fleetData, fleetCreateErr := harness.CreateResource(util.Fleet)
+			Expect(fleetCreateErr).ToNot(HaveOccurred(), "Admin should be able to create a fleet for installer RBAC test")
+			DeferCleanup(func() {
+				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				_, _ = harness.CleanUpResource(util.Fleet, fleetName)
+			})
+
+			setupSharedOrgSimulatorConfig(harness)
+
+			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "installer-er-rbac", 0, 1, true)
+			Expect(simErr).ToNot(HaveOccurred())
+			simulatorCmds = append(simulatorCmds, erSimCmd)
+
+			Eventually(func() error {
+				var waitErr error
+				erName, waitErr = harness.WaitForSimulatorEnrollmentRequest(
+					testID, e2e.DeviceSimulatorAgentAlias(0), deviceEnrollTimeout, deviceEnrollPolling)
+				return waitErr
+			}, deviceEnrollTimeout, deviceEnrollPolling).Should(Succeed(),
+				"Expected an enrollment request from the simulator")
+
+			By("Switching back to installer for update and approve tests")
+			err = loginAndSetOrg(harness, users.installer.name, users.installer.password)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Testing that installer cannot update a device")
+			updatedDeviceYAML, updateErr := harness.AddLabelsToYAML(string(deviceData), *installerLabels)
+			Expect(updateErr).ToNot(HaveOccurred())
+			out, applyErr := harness.CLIWithStdin(updatedDeviceYAML, "apply", "-f", "-")
+			Expect(applyErr).To(HaveOccurred(), "Installer should not be able to update a device")
+			Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for installer device update")
+
+			By("Testing that installer cannot update a fleet")
+			updatedFleetYAML, updateErr := harness.AddLabelsToYAML(string(fleetData), *installerLabels)
+			Expect(updateErr).ToNot(HaveOccurred())
+			out, applyErr = harness.CLIWithStdin(updatedFleetYAML, "apply", "-f", "-")
+			Expect(applyErr).To(HaveOccurred(), "Installer should not be able to update a fleet")
+			Expect(out).To(ContainSubstring(http403Substring), "Expected 403 Forbidden for installer fleet update")
+
+			By("Testing that installer can approve an enrollment request")
+			status, approveErr := harness.ApproveEnrollmentRequestWithLabels(erName, nil)
+			Expect(approveErr).ToNot(HaveOccurred(), "Installer should be able to approve an enrollment request")
+			Expect(status).To(Equal(http.StatusOK), "Expected 200 OK for installer enrollment approval")
 		})
 	})
 })
@@ -324,6 +583,79 @@ func operatorUserCred() userCred  { return testUserCreds()[1] }
 func viewerUserCred() userCred    { return testUserCreds()[2] }
 func installerUserCred() userCred { return testUserCreds()[3] }
 
+// expectReadOnlyListForbidden asserts listing resource types is denied with HTTP 403.
+func expectReadOnlyListForbidden(harness *e2e.Harness, resourceTypes ...string) {
+	for _, resourceType := range resourceTypes {
+		out, err := harness.GetResourcesByName(resourceType)
+		Expect(err).To(HaveOccurred(), "listing %s should fail for this role", resourceType)
+		Expect(out).To(Or(
+			ContainSubstring(http403Substring),
+			ContainSubstring(forbiddenSubstring),
+		), "Expected RBAC denial (403/Forbidden) when listing %s", resourceType)
+	}
+}
+
+// deferDecommissionTestCleanup deletes the decommission test device and enrollment request
+// by name. Decommission clears device labels, so label-based AfterEach cleanup can miss them.
+func deferDecommissionTestCleanup(harness *e2e.Harness, users testUserSet, deviceName string) {
+	GinkgoHelper()
+	DeferCleanup(func() {
+		if deviceName == "" {
+			return
+		}
+		_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+		_, _ = harness.CleanUpResource(util.EnrollmentRequest, deviceName)
+		_ = harness.DeleteDeviceIgnoreNotFound(deviceName)
+	})
+}
+
+// setupSharedOrgSimulatorConfig regenerates ~/.flightctl/agent.yaml for the shared multiorg org.
+func setupSharedOrgSimulatorConfig(harness *e2e.Harness) {
+	GinkgoHelper()
+	_, err := harness.SetupDeviceSimulatorAgentConfig(0, 0)
+	Expect(err).ToNot(HaveOccurred(), "Failed to setup simulator agent config for shared org")
+}
+
+// deferOrgSimulatorConfig registers cleanup that resets CLI org to the system
+// default and regenerates ~/.flightctl/agent.yaml after tests that change simulator config.
+func deferOrgSimulatorConfig(harness *e2e.Harness, users testUserSet) {
+	GinkgoHelper()
+	DeferCleanup(func() {
+		if err := revertDefaultOrgSimulatorConfig(harness, users); err != nil {
+			GinkgoWriter.Printf("Warning: failed to restore default org and device simulator config: %v\n", err)
+		}
+	})
+}
+
+func revertDefaultOrgSimulatorConfig(harness *e2e.Harness, users testUserSet) error {
+	if infra.DetectEnvironment() == infra.EnvironmentOCP {
+		kubeadminPass := os.Getenv("KUBEADMIN_PASS")
+		if kubeadminPass == "" {
+			return fmt.Errorf("KUBEADMIN_PASS not set")
+		}
+		if err := login.Login(harness, "kubeadmin", kubeadminPass); err != nil {
+			return fmt.Errorf("login kubeadmin: %w", err)
+		}
+	} else if err := loginAndSetOrg(harness, users.admin.name, users.admin.password); err != nil {
+		return fmt.Errorf("login admin for revert: %w", err)
+	}
+
+	if err := harness.SetCurrentOrganization(org.DefaultID.String()); err != nil {
+		return fmt.Errorf("set default organization: %w", err)
+	}
+	if _, err := harness.SetupDeviceSimulatorAgentConfig(0, 0); err != nil {
+		return fmt.Errorf("regenerate device simulator agent config: %w", err)
+	}
+	GinkgoWriter.Printf("Restored default organization %s and device simulator config\n", org.DefaultID)
+	return nil
+}
+
+func makeLoginFunc(user, password string) e2e.LoginFunc {
+	return func(h *e2e.Harness) error {
+		return loginAndSetOrg(h, user, password)
+	}
+}
+
 // loginAndSetOrg logs in and ensures the user operates in the shared test org.
 // On quadlet, cluster-admin users default to the system org, so we explicitly
 // switch to the shared org. On OCP this is a no-op.
@@ -335,12 +667,6 @@ func loginAndSetOrg(harness *e2e.Harness, user, password string) error {
 		return harness.SetCurrentOrganization(quadletSharedOrgID)
 	}
 	return nil
-}
-
-func makeLoginFunc(user, password string) e2e.LoginFunc {
-	return func(h *e2e.Harness) error {
-		return loginAndSetOrg(h, user, password)
-	}
 }
 
 func collectOrgIDs(harness *e2e.Harness, users []userCred) (map[string]string, error) {
@@ -371,4 +697,21 @@ func loginAndGetOrgID(harness *e2e.Harness, user, password string) (string, erro
 		return "", fmt.Errorf("getting org for %s: %w", user, err)
 	}
 	return orgID, nil
+}
+
+// assertConsoleAccess verifies devices/console RBAC via flightctl console.
+func assertConsoleAccess(harness *e2e.Harness, deviceName string, allowed bool) {
+	GinkgoHelper()
+	const consoleMarker = "multiorg-console-ok"
+	out, err := harness.RunConsoleCommand(deviceName, []string{"--notty"}, "echo", consoleMarker)
+	if allowed {
+		Expect(err).ToNot(HaveOccurred(), "Console command should succeed for authorized role")
+		Expect(out).To(ContainSubstring(consoleMarker), "Console should execute remote command successfully")
+		return
+	}
+	Expect(err).To(HaveOccurred(), "Console should fail for unauthorized role")
+	Expect(out).To(Or(
+		ContainSubstring(http403Substring),
+		ContainSubstring(forbiddenSubstring),
+	), "Expected 403 Forbidden for console access")
 }

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -1039,10 +1039,15 @@ func (h *Harness) CleanUpTestResources(resourceTypes ...string) error {
 
 // cleanUpEnrollmentRequests handles the special case for enrollment requests
 // Since enrollment requests don't support labels, we need to:
-// 1. Get devices with the test label
-// 2. Delete enrollment requests with the same names as those devices
+// 1. Delete pending ERs whose spec.labels include the test-id (simulator skip-auto-approve path)
+// 2. Get devices with the test label
+// 3. Delete enrollment requests with the same names as those devices
 func (h *Harness) cleanUpEnrollmentRequests(testID string) error {
 	logrus.Debugf("Cleaning up enrollment requests for test-id: %s", testID)
+
+	if err := h.deleteEnrollmentRequestsBySpecTestID(testID); err != nil {
+		return fmt.Errorf("deleting enrollment requests by spec test-id: %w", err)
+	}
 
 	// Get devices with the test label
 	devices, err := h.CLI("get", util.Device, "-l", fmt.Sprintf("test-id=%s", testID), "-o", "name")

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/flightctl/flightctl/test/util"
 	ginkgo "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
 
@@ -301,8 +301,9 @@ func (h *Harness) ValidateFleetYAMLDevicesPerFleet(yamlContent string, expectedD
 type LoginFunc func(h *Harness) error
 
 // StartLabeledSimulator starts a device simulator with the given test-id label, user prefix,
-// initial device index, and device count. Returns the running command.
-func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix string, initialIndex, deviceCount int) (*exec.Cmd, error) {
+// initial device index, and device count. When skipAutoApprove is true, agents submit enrollment
+// requests and wait for manual approval instead of auto-approving via the simulator client.
+func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix string, initialIndex, deviceCount int, skipAutoApprove bool) (*exec.Cmd, error) {
 	if testID == "" {
 		return nil, fmt.Errorf("testID is empty")
 	}
@@ -315,7 +316,96 @@ func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix 
 		"--label", fmt.Sprintf("test-id=%s", testID),
 		"--label", fmt.Sprintf("user=%s", userPrefix),
 	}
+	if skipAutoApprove {
+		args = append(args, "--skip-auto-approve")
+	}
 	return h.RunDeviceSimulator(ctx, args...)
+}
+
+// DeviceSimulatorAgentAlias returns the agent alias label for a simulator device index.
+func DeviceSimulatorAgentAlias(initialDeviceIndex int) string {
+	return fmt.Sprintf("device-%05d", initialDeviceIndex)
+}
+
+// WaitForSimulatorEnrollmentRequest polls until an enrollment request exists whose
+// spec.labels match the given test-id and alias (from devicesimulator --label flags).
+func (h *Harness) WaitForSimulatorEnrollmentRequest(testID, alias string, timeout, polling time.Duration) (string, error) {
+	if strings.TrimSpace(testID) == "" {
+		return "", fmt.Errorf("testID is empty")
+	}
+	if strings.TrimSpace(alias) == "" {
+		return "", fmt.Errorf("alias is empty")
+	}
+	return pollUntil(timeout.String(), polling.String(),
+		fmt.Sprintf("enrollment request with test-id=%s and alias=%s", testID, alias),
+		func() (string, bool, error) {
+			name, found, err := h.findEnrollmentRequestBySpecLabels(testID, alias)
+			if err != nil || !found {
+				return "", false, err
+			}
+			return name, true, nil
+		})
+}
+
+// findEnrollmentRequestBySpecLabels finds an enrollment request by its test-id and alias labels.
+func (h *Harness) findEnrollmentRequestBySpecLabels(testID, alias string) (string, bool, error) {
+	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if resp == nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode()
+		}
+		return "", false, fmt.Errorf("list enrollment requests: status %d", status)
+	}
+	for _, er := range resp.JSON200.Items {
+		if er.Metadata.Name == nil {
+			continue
+		}
+		if er.Spec.Labels == nil {
+			continue
+		}
+		labels := *er.Spec.Labels
+		if labels["test-id"] == testID && labels["alias"] == alias {
+			return *er.Metadata.Name, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// deleteEnrollmentRequestsBySpecTestID deletes pending enrollment requests whose
+// spec.labels include the given test-id (e.g. from devicesimulator --skip-auto-approve).
+func (h *Harness) deleteEnrollmentRequestsBySpecTestID(testID string) error {
+	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, nil)
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode()
+		}
+		return fmt.Errorf("list enrollment requests: status %d", status)
+	}
+
+	for _, er := range resp.JSON200.Items {
+		if er.Metadata.Name == nil || er.Spec.Labels == nil {
+			continue
+		}
+		if (*er.Spec.Labels)["test-id"] != testID {
+			continue
+		}
+		name := *er.Metadata.Name
+		_, err := h.CLI("delete", util.EnrollmentRequest, name)
+		if err != nil {
+			logrus.Debugf("Error deleting enrollment request %s: %v (might already be deleted)", name, err)
+			continue
+		}
+		logrus.Debugf("Successfully deleted enrollment request: %s", name)
+	}
+	return nil
 }
 
 // StopAllSimulators stops all running simulator commands, logging warnings on failure.
@@ -343,6 +433,27 @@ func (h *Harness) CountDevicesByLabel(testID string) int {
 	return len(lines)
 }
 
+// WaitForLabeledSimulatorDevice polls until the simulator device for the given test-id and
+// device index has enrolled and returns its name (the enrollment / device ID).
+func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceIndex int, timeout, polling time.Duration) (string, error) {
+	alias := DeviceSimulatorAgentAlias(initialDeviceIndex)
+	return pollUntil(timeout.String(), polling.String(),
+		fmt.Sprintf("simulator device with test-id=%s and alias=%s", testID, alias),
+		func() (string, bool, error) {
+			name, found, err := h.findEnrollmentRequestBySpecLabels(testID, alias)
+			if err != nil {
+				return "", false, err
+			}
+			if !found {
+				return "", false, nil
+			}
+			if _, err := h.GetDevice(name); err != nil {
+				return "", false, nil
+			}
+			return name, true, nil
+		})
+}
+
 // EnrollDeviceForDecommissionTest starts a labeled simulator as the given user, waits for
 // at least one device to enroll, and returns the name of the first enrolled device.
 func (h *Harness) EnrollDeviceForDecommissionTest(loginFn LoginFunc, deviceCount int, enrollTimeout time.Duration) (string, *exec.Cmd, error) {
@@ -355,30 +466,14 @@ func (h *Harness) EnrollDeviceForDecommissionTest(loginFn LoginFunc, deviceCount
 
 	testID := h.GetTestIDFromContext()
 
-	cmd, err := h.StartLabeledSimulator(h.Context, testID, "decommission-test", 0, deviceCount)
+	cmd, err := h.StartLabeledSimulator(h.Context, testID, "decommission-test", 0, deviceCount, false)
 	if err != nil {
 		return "", nil, fmt.Errorf("starting simulator: %w", err)
 	}
 
-	Eventually(func() int {
-		return h.CountDevicesByLabel(testID)
-	}, enrollTimeout, 2*time.Second).Should(BeNumerically(">=", 1),
-		fmt.Sprintf("Expected at least 1 device to enroll within %s", enrollTimeout))
-
-	out, err := h.CLI("get", "devices", "-l", fmt.Sprintf("test-id=%s", testID), "-o", "name")
+	deviceName, err := h.WaitForLabeledSimulatorDevice(testID, 0, enrollTimeout, 2*time.Second)
 	if err != nil {
-		return "", cmd, fmt.Errorf("listing devices: %w", err)
-	}
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) == 0 || lines[0] == "" {
-		return "", cmd, fmt.Errorf("no devices found after enrollment")
-	}
-	parts := strings.SplitN(lines[0], "/", 2)
-	var deviceName string
-	if len(parts) == 2 {
-		deviceName = parts[1]
-	} else {
-		deviceName = parts[0]
+		return "", cmd, fmt.Errorf("waiting for device enrollment: %w", err)
 	}
 	return deviceName, cmd, nil
 }


### PR DESCRIPTION
- Add quadlet vs OCP splits for operator and viewer enrollment request
and events access.
- Extend operator (88361) and viewer (88362) tests with repository checks, update/delete denials, and enrollment approve
deny (403)
- Add installer test (88366) for ER list/approve allow and deny fleet, repository, events, and device/fleet mutations.
- Add device console RBAC test (89607).
- Add devicesimulator --skip-auto-approve for pending enrollment fixtures,apply simulator labels on enrollment spec, and wait for the matching ER
by test-id and alias in the harness.

Note: After https://redhat.atlassian.net/browse/EDM-4376 is fixed a change will be needed to the tests