### PR TITLE
EDM-4104: Remote access scaffold

### DIFF
--- a/.github/workflows/pr-helm-upgrade-testing.yaml
+++ b/.github/workflows/pr-helm-upgrade-testing.yaml
@@ -222,7 +222,7 @@ jobs:
           CHART_FILE="artifacts-pr/flightctl-chart.tgz"
           helm diff upgrade flightctl "${CHART_FILE}" \
             --namespace flightctl-external \
-            --reuse-values \
+            --reset-then-reuse-values \
             --dry-run=server \
             --output=dyff \
             --debug
@@ -233,7 +233,7 @@ jobs:
           # Use values files with image overrides
           helm upgrade flightctl "${CHART_FILE}" \
             --namespace flightctl-external \
-            --reuse-values \
+            --reset-then-reuse-values \
             --debug --wait # for the deployment complete (including readiness probes passing)
 
       - name: "[HEAD] Wait for API readiness after upgrade"
@@ -305,7 +305,7 @@ jobs:
 
           helm upgrade flightctl "${CHART_FILE}" \
             --namespace flightctl-external \
-            --reuse-values \
+            --reset-then-reuse-values \
             --debug --wait
 
       - name: "[HEAD] Wait for API readiness after same-version upgrade"

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ build: bin build-cli build-pam-issuer
 		./cmd/flightctl-agent \
 		./cmd/flightctl-api \
 		./cmd/flightctl-periodic \
+		./cmd/flightctl-remote-access \
 		./cmd/flightctl-worker \
 		./cmd/flightctl-alert-exporter \
 		./cmd/flightctl-alertmanager-proxy \
@@ -222,6 +223,9 @@ build-imagebuilder-api: bin
 
 build-imagebuilder-worker: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-imagebuilder-worker
+
+build-remote-access: bin
+	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-remote-access
 
 build-devicesimulator: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/devicesimulator
@@ -318,7 +322,14 @@ flightctl-imagebuilder-worker-container: packaging/images/$(OS)/Containerfile.im
 		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
 		-f packaging/images/$(OS)/Containerfile.imagebuilder-worker -t flightctl-imagebuilder-worker-$(OS):latest -t quay.io/flightctl/flightctl-imagebuilder-worker-$(OS):$(SOURCE_GIT_TAG) .
 
-.PHONY: flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container
+flightctl-remote-access-container: packaging/images/$(OS)/Containerfile.remote-access go.mod go.sum $(GO_FILES)
+	podman build $(call CACHE_FLAGS_FOR_IMAGE,flightctl-remote-access) \
+		--build-arg SOURCE_GIT_TAG=${SOURCE_GIT_TAG} \
+		--build-arg SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
+		--build-arg SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} \
+		-f packaging/images/$(OS)/Containerfile.remote-access -t flightctl-remote-access-$(OS):latest -t quay.io/flightctl/flightctl-remote-access-$(OS):$(SOURCE_GIT_TAG) .
+
+.PHONY: flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container flightctl-remote-access-container
 
 # --- Registry Operations ---
 # The login target expects REGISTRY_USER via environment variable and
@@ -358,7 +369,7 @@ rebuild-containers: clean-containers build-containers
 clean-containers:
 	- podman images --filter "reference=flightctl-*-$(OS):latest" --format "{{.Repository}}:{{.Tag}}" | xargs -r podman rmi || true
 
-build-containers: flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container
+build-containers: flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-multiarch-cli-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container flightctl-remote-access-container
 
 bundle-containers:
 	test/scripts/agent-images/scripts/bundle.sh \
@@ -387,7 +398,7 @@ bin/.rpm: $(shell find $(ROOT_DIR)/ -name "*.go" -not -path "$(ROOT_DIR)/packagi
 
 rpm: bin/.rpm
 
-.PHONY: rpm build build-api build-pam-issuer build-periodic build-worker build-alert-exporter build-alertmanager-proxy build-userinfo-proxy build-standalone build-imagebuilder-api build-imagebuilder-worker build-mirror-images
+.PHONY: rpm build build-api build-pam-issuer build-periodic build-worker build-alert-exporter build-alertmanager-proxy build-userinfo-proxy build-standalone build-imagebuilder-api build-imagebuilder-worker build-remote-access build-mirror-images
 
 # cross-building for deb pkg
 bin/amd64:
@@ -436,7 +447,7 @@ clean-quadlets:
 	sudo deploy/scripts/clean_quadlets.sh
 
 
-.PHONY: tools flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container
+.PHONY: tools flightctl-api-container flightctl-pam-issuer-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-userinfo-proxy-container flightctl-telemetry-gateway-container flightctl-remote-access-container
 
 # Use custom golangci-lint container with libvirt support
 LINT_IMAGE := flightctl-lint:latest

--- a/cmd/flightctl-remote-access/main.go
+++ b/cmd/flightctl-remote-access/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
+	remoteaccessserver "github.com/flightctl/flightctl/internal/remote_access_server"
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+func main() {
+	ctx := context.Background()
+
+	cfg, err := config.LoadOrGenerate(config.ConfigFile())
+	if err != nil {
+		log.InitLogs().Fatalf("reading configuration: %v", err)
+	}
+
+	log := log.InitLogs(cfg.Service.LogLevel)
+	log.Println("Starting remote-access service")
+	defer log.Println("Remote-access service stopped")
+	log.Printf("Using config: %s", cfg)
+
+	ca, err := crypto.LoadInternalCA(cfg.CA)
+	if err != nil {
+		log.Fatalf("loading CA certificates: %v", err)
+	}
+	caClient := crypto.NewCAClient(cfg.CA, ca)
+
+	serverCerts, err := config.LoadServerCertificates(cfg, log)
+	if err != nil {
+		log.Fatalf("loading server certificates: %v", err)
+	}
+
+	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-remote-access")
+	defer func() {
+		if err := tracerShutdown(ctx); err != nil {
+			log.Fatalf("failed to shut down tracer: %v", err)
+		}
+	}()
+
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+	defer cancel()
+
+	server, err := remoteaccessserver.New(log, cfg, caClient, serverCerts)
+	if err != nil {
+		log.Fatalf("initializing remote-access server: %v", err)
+	}
+
+	if err := server.Run(ctx); err != nil {
+		log.Fatalf("Error running remote-access server: %v", err)
+	}
+}

--- a/cmd/flightctl-remote-access/main.go
+++ b/cmd/flightctl-remote-access/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
@@ -39,8 +40,10 @@ func main() {
 
 	tracerShutdown := tracing.InitTracer(log, cfg, "flightctl-remote-access")
 	defer func() {
-		if err := tracerShutdown(ctx); err != nil {
-			log.Fatalf("failed to shut down tracer: %v", err)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := tracerShutdown(shutdownCtx); err != nil {
+			log.Errorf("failed to shut down tracer: %v", err)
 		}
 	}()
 

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -51,7 +51,7 @@ redeploy-imagebuilder-api: flightctl-imagebuilder-api-container
 
 
 ifndef SKIP_BUILD
-deploy-helm: flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container flightctl-multiarch-cli-container flightctl-telemetry-gateway-container
+deploy-helm: flightctl-api-container flightctl-db-setup-container flightctl-worker-container flightctl-periodic-container flightctl-alert-exporter-container flightctl-alertmanager-proxy-container flightctl-imagebuilder-api-container flightctl-imagebuilder-worker-container flightctl-multiarch-cli-container flightctl-telemetry-gateway-container flightctl-remote-access-container
 endif
 deploy-helm:
 	kubectl config set-context kind-kind

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -393,11 +393,13 @@ For more detailed configuration options, see the [Values](#values) section below
 | periodic.metrics | object | `{"address":":15690","enabled":true}` | Metrics configuration for flightctl-periodic |
 | periodic.metrics.address | string | `":15690"` | Address for the metrics HTTP server |
 | periodic.metrics.enabled | bool | `true` | Enable Prometheus metrics endpoint |
-| remoteAccess | object | `{"env":{},"image":{"image":"quay.io/flightctl/flightctl-remote-access-el9","pullPolicy":"","tag":""}}` | Remote Access Configuration |
+| remoteAccess | object | `{"enabled":true,"env":{},"image":{"image":"quay.io/flightctl/flightctl-remote-access-el9","pullPolicy":"","tag":""},"resources":{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}}` | Remote Access Configuration |
+| remoteAccess.enabled | bool | `true` | Enable remote access service |
 | remoteAccess.env | object | `{}` | Additional environment variables for the remote access container |
 | remoteAccess.image.image | string | `"quay.io/flightctl/flightctl-remote-access-el9"` | Remote access container image |
 | remoteAccess.image.pullPolicy | string | `""` | Image pull policy for remote access container |
 | remoteAccess.image.tag | string | `""` | Remote access image tag (leave empty to use chart appVersion) |
+| remoteAccess.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits for the remote access container |
 | telemetryGateway.additionalRouteLabels | string | `nil` |  |
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -393,6 +393,11 @@ For more detailed configuration options, see the [Values](#values) section below
 | periodic.metrics | object | `{"address":":15690","enabled":true}` | Metrics configuration for flightctl-periodic |
 | periodic.metrics.address | string | `":15690"` | Address for the metrics HTTP server |
 | periodic.metrics.enabled | bool | `true` | Enable Prometheus metrics endpoint |
+| remoteAccess | object | `{"env":{},"image":{"image":"quay.io/flightctl/flightctl-remote-access-el9","pullPolicy":"","tag":""}}` | Remote Access Configuration |
+| remoteAccess.env | object | `{}` | Additional environment variables for the remote access container |
+| remoteAccess.image.image | string | `"quay.io/flightctl/flightctl-remote-access-el9"` | Remote access container image |
+| remoteAccess.image.pullPolicy | string | `""` | Image pull policy for remote access container |
+| remoteAccess.image.tag | string | `""` | Remote access image tag (leave empty to use chart appVersion) |
 | telemetryGateway.additionalRouteLabels | string | `nil` |  |
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |

--- a/deploy/helm/flightctl/scripts/generate-certificates.sh
+++ b/deploy/helm/flightctl/scripts/generate-certificates.sh
@@ -14,6 +14,7 @@ IMAGEBUILDER_API_SANS=()
 PROMETHEUS_SANS=()
 GRAFANA_SANS=()
 USERINFO_PROXY_SANS=()
+REMOTE_ACCESS_SANS=()
 NAMESPACE=""
 INTERNAL_NAMESPACE=""
 CREATE_K8S_SECRETS="false"
@@ -38,6 +39,7 @@ Optional:
   --prometheus-san <dns>        DNS SAN for flightctl-prometheus (can be specified multiple times)
   --grafana-san <dns>           DNS SAN for flightctl-grafana (can be specified multiple times)
   --userinfo-proxy-san <dns>    DNS SAN for flightctl-userinfo-proxy (can be specified multiple times)
+  --remote-access-san <dns>     DNS SAN for flightctl-remote-access (can be specified multiple times)
   --create-k8s-secrets          Create Kubernetes secrets using oc/kubectl
   --namespace <ns>              Kubernetes namespace (required if --create-k8s-secrets is set)
   --internal-namespace <ns>      Internal namespace to copy CA secrets to (optional)
@@ -94,6 +96,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --userinfo-proxy-san)
             USERINFO_PROXY_SANS+=("$2")
+            shift 2
+            ;;
+        --remote-access-san)
+            REMOTE_ACCESS_SANS+=("$2")
             shift 2
             ;;
         --create-k8s-secrets)
@@ -330,6 +336,8 @@ if [[ "$CREATE_K8S_SECRETS" == "true" ]]; then
         "$CERT_DIR/flightctl-ui/server.crt" "$CERT_DIR/flightctl-ui/server.key"
     restore_tls_secret "flightctl-cli-artifacts-server-tls" \
         "$CERT_DIR/flightctl-cli-artifacts/server.crt" "$CERT_DIR/flightctl-cli-artifacts/server.key"
+    restore_tls_secret "flightctl-remote-access-server-tls" \
+        "$CERT_DIR/flightctl-remote-access/server.crt" "$CERT_DIR/flightctl-remote-access/server.key"
 
     # Restore CA bundle (generic secret, not TLS)
     if $K8S_CLI get secret "flightctl-ca-bundle" -n "$NAMESPACE" &>/dev/null; then
@@ -607,6 +615,26 @@ else
     echo "Skipped generation of UserInfo Proxy TLS certificate (no SANs specified)"
 fi
 
+# Remote Access TLS certificate
+if [[ ${#REMOTE_ACCESS_SANS[@]} -gt 0 ]]; then
+    mkdir -p "$CERT_DIR/flightctl-remote-access"
+
+    REMOTE_ACCESS_KEY="$CERT_DIR/flightctl-remote-access/server.key"
+    REMOTE_ACCESS_CERT="$CERT_DIR/flightctl-remote-access/server.crt"
+
+    if [[ -f "$REMOTE_ACCESS_CERT" ]] && [[ -f "$REMOTE_ACCESS_KEY" ]] && cert_has_expected_sans "$REMOTE_ACCESS_CERT" "${REMOTE_ACCESS_SANS[@]}"; then
+        echo "Skipped generation of Remote Access TLS certificate (already exists with correct SANs)"
+    else
+        generate_server_cert "flightctl-remote-access" \
+            "$REMOTE_ACCESS_KEY" "$REMOTE_ACCESS_CERT" \
+            "$FLIGHTCTL_CA_CERT" "$FLIGHTCTL_CA_KEY" \
+            "${REMOTE_ACCESS_SANS[@]}"
+        echo "Generated Remote Access TLS certificate (2 years, ECDSA P-256)"
+    fi
+else
+    echo "Skipped generation of Remote Access TLS certificate (no SANs specified)"
+fi
+
 # CA Bundle
 CA_BUNDLE="$CERT_DIR/ca-bundle.crt"
 
@@ -702,6 +730,16 @@ if [[ "$CREATE_K8S_SECRETS" == "true" ]]; then
             --namespace="$NAMESPACE" \
             --cert="$CLI_ARTIFACTS_CERT" \
             --key="$CLI_ARTIFACTS_KEY" \
+            --dry-run=client -o yaml | $K8S_CLI apply -f -
+    fi
+
+    # Create flightctl-remote-access-server-tls secret (only if certificate was generated)
+    if [[ ${#REMOTE_ACCESS_SANS[@]} -gt 0 ]]; then
+        echo "Creating secret: flightctl-remote-access-server-tls"
+        $K8S_CLI create secret tls flightctl-remote-access-server-tls \
+            --namespace="$NAMESPACE" \
+            --cert="$REMOTE_ACCESS_CERT" \
+            --key="$REMOTE_ACCESS_KEY" \
             --dry-run=client -o yaml | $K8S_CLI apply -f -
     fi
 

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -729,6 +729,23 @@ Usage: {{- $result := include "flightctl.getImagebuilderApiDNSSans" . | fromJson
 {{- end }}
 
 {{- /*
+Get DNS SANs for remote-access agent server certificate
+Usage: {{- $result := include "flightctl.getRemoteAccessDNSSans" . | fromJson }}{{ $remoteAccessDNSSans := $result.sans }}
+*/}}
+{{- define "flightctl.getRemoteAccessDNSSans" }}
+  {{- $sans := list }}
+  {{- $baseDomain := include "flightctl.getBaseDomain" . }}
+  {{- $sans = append $sans (printf "agent-remote-access.%s" $baseDomain) }}
+  {{- $sans = append $sans "flightctl-remote-access" }}
+  {{- $sans = append $sans "flightctl-remote-access-agent" }}
+  {{- $sans = append $sans (printf "flightctl-remote-access.%s" .Release.Namespace) }}
+  {{- $sans = append $sans (printf "flightctl-remote-access-agent.%s" .Release.Namespace) }}
+  {{- $sans = append $sans (printf "flightctl-remote-access.%s.svc.cluster.local" .Release.Namespace) }}
+  {{- $sans = append $sans (printf "flightctl-remote-access-agent.%s.svc.cluster.local" .Release.Namespace) }}
+  {{- dict "sans" $sans | toJson -}}
+{{- end }}
+
+{{- /*
 Auth configuration block helper.
 Outputs the auth configuration section for service config files.
 Usage: {{- include "flightctl.authConfig" . | nindent 4 }}

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -735,6 +735,7 @@ Usage: {{- $result := include "flightctl.getRemoteAccessDNSSans" . | fromJson }}
 {{- define "flightctl.getRemoteAccessDNSSans" }}
   {{- $sans := list }}
   {{- $baseDomain := include "flightctl.getBaseDomain" . }}
+  {{- $sans = append $sans (printf "remote-access.%s" $baseDomain) }}
   {{- $sans = append $sans (printf "agent-remote-access.%s" $baseDomain) }}
   {{- $sans = append $sans "flightctl-remote-access" }}
   {{- $sans = append $sans "flightctl-remote-access-agent" }}

--- a/deploy/helm/flightctl/templates/certs/flightctl-certs-from-certmanager.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-certs-from-certmanager.yaml
@@ -201,6 +201,37 @@ spec:
     kind: Issuer
     group: cert-manager.io
 
+---
+# Remote Access Server TLS Certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: flightctl-remote-access-server-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+spec:
+  secretName: flightctl-remote-access-server-tls
+  commonName: flightctl-remote-access
+  duration: 17520h  # 2 years
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  dnsNames:
+    {{- $remoteAccessDNSSansResult := include "flightctl.getRemoteAccessDNSSans" . | fromJson }}
+    {{- range $remoteAccessDNSSansResult.sans }}
+    - {{ . }}
+    {{- end }}
+  issuerRef:
+    name: flightctl-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+
 {{- if .Values.cliArtifacts.enabled }}
 ---
 # CLI Artifacts Server TLS Certificate

--- a/deploy/helm/flightctl/templates/certs/flightctl-certs-from-certmanager.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-certs-from-certmanager.yaml
@@ -201,6 +201,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 
+{{- if .Values.remoteAccess.enabled }}
 ---
 # Remote Access Server TLS Certificate
 apiVersion: cert-manager.io/v1
@@ -231,6 +232,7 @@ spec:
     name: flightctl-ca-issuer
     kind: Issuer
     group: cert-manager.io
+{{- end }}
 
 {{- if .Values.cliArtifacts.enabled }}
 ---

--- a/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
@@ -14,6 +14,8 @@
 {{- $cliArtifactsDNSSans := $cliArtifactsDNSSansResult.sans -}}
 {{- $imagebuilderApiDNSSansResult := include "flightctl.getImagebuilderApiDNSSans" . | fromJson -}}
 {{- $imagebuilderApiDNSSans := $imagebuilderApiDNSSansResult.sans -}}
+{{- $remoteAccessDNSSansResult := include "flightctl.getRemoteAccessDNSSans" . | fromJson -}}
+{{- $remoteAccessDNSSans := $remoteAccessDNSSansResult.sans -}}
 
 ---
 # ConfigMap containing the certificate generation script
@@ -79,6 +81,10 @@ spec:
         {{- end }}
         {{- range $imagebuilderApiDNSSans }}
         - --imagebuilder-api-san
+        - {{ . }}
+        {{- end }}
+        {{- range $remoteAccessDNSSans }}
+        - --remote-access-san
         - {{ . }}
         {{- end }}
         {{- if and .Values.ui.enabled (eq (include "flightctl.enableMulticlusterExtensions" .) "false") }}

--- a/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-certs-from-openssl.yaml
@@ -83,9 +83,11 @@ spec:
         - --imagebuilder-api-san
         - {{ . }}
         {{- end }}
+        {{- if .Values.remoteAccess.enabled }}
         {{- range $remoteAccessDNSSans }}
         - --remote-access-san
         - {{ . }}
+        {{- end }}
         {{- end }}
         {{- if and .Values.ui.enabled (eq (include "flightctl.enableMulticlusterExtensions" .) "false") }}
         {{- range $uiDNSSans }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flightctl-remote-access-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-remote-access
+data:
+  config.yaml: |-
+    service:
+        address: :3444
+        agentEndpointAddress: :7444
+    {{ if (default dict .Values.dev).tracing }}
+    tracing:
+        enabled: true
+        endpoint: {{ .Values.dev.tracing.endpoint }}
+        insecure: {{ .Values.dev.tracing.insecure }}
+    {{ end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.remoteAccess.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,3 +18,4 @@ data:
         endpoint: {{ .Values.dev.tracing.endpoint }}
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
+{{- end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    flightctl.service: flightctl-remote-access
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+  name: flightctl-remote-access
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      flightctl.service: flightctl-remote-access
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        flightctl.service: flightctl-remote-access
+        {{- include "flightctl.standardLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.global.imagePullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
+      containers:
+        - name: flightctl-remote-access
+          image: {{ include "flightctl.ensureOsQualifiedImage" (dict "root" . "imageName" .Values.remoteAccess.image.image) }}:{{ default .Chart.AppVersion .Values.remoteAccess.image.tag }}
+          imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.remoteAccess.image.pullPolicy }}
+          ports:
+            - containerPort: 3444
+              name: service-api
+              protocol: TCP
+            - containerPort: 7444
+              name: agent-api
+              protocol: TCP
+          env:
+            - name: HOME
+              value: "/root"
+            {{- if .Values.remoteAccess.env }}
+            {{- range $key, $value := .Values.remoteAccess.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /root/.flightctl/config.yaml
+              name: flightctl-remote-access-config
+              subPath: config.yaml
+              readOnly: true
+            - mountPath: /root/.flightctl/certs/client-signer.crt
+              name: flightctl-client-signer
+              subPath: tls.crt
+              readOnly: true
+            - mountPath: /root/.flightctl/certs/client-signer.key
+              name: flightctl-client-signer
+              subPath: tls.key
+              readOnly: true
+            - mountPath: /root/.flightctl/certs/server.crt
+              name: flightctl-remote-access-server-tls
+              subPath: tls.crt
+              readOnly: true
+            - mountPath: /root/.flightctl/certs/server.key
+              name: flightctl-remote-access-server-tls
+              subPath: tls.key
+              readOnly: true
+            - mountPath: /root/.flightctl/certs/ca-bundle.crt
+              name: flightctl-ca-bundle
+              subPath: ca-bundle.crt
+              readOnly: true
+      restartPolicy: Always
+      volumes:
+        - name: flightctl-remote-access-config
+          configMap:
+            name: flightctl-remote-access-config
+        - name: flightctl-client-signer
+          secret:
+            secretName: flightctl-client-signer-ca
+        - name: flightctl-remote-access-server-tls
+          secret:
+            secretName: flightctl-remote-access-server-tls
+        - name: flightctl-ca-bundle
+          secret:
+            secretName: flightctl-ca-bundle

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.remoteAccess.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,7 @@ spec:
         flightctl.service: flightctl-remote-access
         {{- include "flightctl.standardLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecretName }}
@@ -27,6 +29,13 @@ spec:
         - name: flightctl-remote-access
           image: {{ include "flightctl.ensureOsQualifiedImage" (dict "root" . "imageName" .Values.remoteAccess.image.image) }}:{{ default .Chart.AppVersion .Values.remoteAccess.image.tag }}
           imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.remoteAccess.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3444
               name: service-api
@@ -34,6 +43,22 @@ spec:
             - containerPort: 7444
               name: agent-api
               protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: agent-api
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            tcpSocket:
+              port: service-api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.remoteAccess.resources | nindent 12 }}
           env:
             - name: HOME
               value: "/root"
@@ -82,3 +107,4 @@ spec:
         - name: flightctl-ca-bundle
           secret:
             secretName: flightctl-ca-bundle
+{{- end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-gateway-route-agent.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-gateway-route-agent.yaml
@@ -1,0 +1,20 @@
+{{ if eq (include "flightctl.getServiceExposeMethod" .) "gateway" }}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: flightctl-remote-access-route-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-remote-access
+spec:
+  parentRefs:
+    - name: flightctl-gateway
+      sectionName: api
+  hostnames:
+    - agent-remote-access.{{ include "flightctl.getBaseDomain" . }}
+  rules:
+    - backendRefs:
+      - name: flightctl-remote-access-agent
+        port: 7444
+{{ end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-gateway-route.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-gateway-route.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
-  name: flightctl-remote-access-route-agent
+  name: flightctl-remote-access-route
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flightctl.standardLabels" . | nindent 4 }}
@@ -12,9 +12,9 @@ spec:
     - name: flightctl-gateway
       sectionName: api
   hostnames:
-    - agent-remote-access.{{ include "flightctl.getBaseDomain" . }}
+    - remote-access.{{ include "flightctl.getBaseDomain" . }}
   rules:
     - backendRefs:
-      - name: flightctl-remote-access-agent
-        port: 7444
+      - name: flightctl-remote-access
+        port: 3444
 {{ end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-route-agent.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-route-agent.yaml
@@ -1,0 +1,25 @@
+{{ if eq (include "flightctl.getServiceExposeMethod" .) "route" }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    {{- with .Values.global.additionalRouteLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-remote-access
+  name: flightctl-remote-access-agent
+  namespace: {{ .Release.Namespace }}
+spec:
+  host: agent-remote-access.{{ include "flightctl.getBaseDomain" . }}
+  port:
+    targetPort: 7444
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+  to:
+    kind: Service
+    name: flightctl-remote-access-agent
+    weight: 100
+  wildcardPolicy: None
+{{ end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-route.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-route.yaml
@@ -8,18 +8,18 @@ metadata:
     {{- end }}
     {{- include "flightctl.standardLabels" . | nindent 4 }}
     flightctl.service: flightctl-remote-access
-  name: flightctl-remote-access-agent
+  name: flightctl-remote-access
   namespace: {{ .Release.Namespace }}
 spec:
-  host: agent-remote-access.{{ include "flightctl.getBaseDomain" . }}
+  host: remote-access.{{ include "flightctl.getBaseDomain" . }}
   port:
-    targetPort: 7444
+    targetPort: 3444
   tls:
     termination: passthrough
     insecureEdgeTerminationPolicy: None
   to:
     kind: Service
-    name: flightctl-remote-access-agent
+    name: flightctl-remote-access
     weight: 100
   wildcardPolicy: None
 {{ end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service-agent.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service-agent.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    flightctl.service: flightctl-remote-access
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+  name: flightctl-remote-access-agent
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: "agent-api"
+      port: 7444
+      targetPort: 7444
+  selector:
+    flightctl.service: flightctl-remote-access

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service-agent.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service-agent.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.remoteAccess.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       targetPort: 7444
   selector:
     flightctl.service: flightctl-remote-access
+{{- end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    flightctl.service: flightctl-remote-access
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+  name: flightctl-remote-access
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: "service-api"
+      port: 3444
+      targetPort: 3444
+  selector:
+    flightctl.service: flightctl-remote-access

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.remoteAccess.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       targetPort: 3444
   selector:
     flightctl.service: flightctl-remote-access
+{{- end }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -528,6 +528,26 @@
         }
       }
     },
+    "remoteAccess": {
+      "type": "object",
+      "description": "Remote access service configuration",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "image": { "type": "string", "description": "Remote access container image" },
+            "tag": { "type": "string", "description": "Remote access image tag" },
+            "pullPolicy": { "type": "string", "description": "Image pull policy for remote access container" }
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
     "alertExporter": {
       "type": "object",
       "description": "Alert exporter configuration",

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -533,6 +533,7 @@
       "description": "Remote access service configuration",
       "additionalProperties": false,
       "properties": {
+        "enabled": { "type": "boolean", "description": "Enable remote access service" },
         "image": {
           "type": "object",
           "additionalProperties": false,
@@ -545,6 +546,29 @@
         "env": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for the remote access container",
+          "additionalProperties": false,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            }
+          }
         }
       }
     },

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -322,6 +322,18 @@ periodic:
     # -- Address for the metrics HTTP server
     address: ":15690"
 
+# -- Remote Access Configuration
+remoteAccess:
+  image:
+    # -- Remote access container image
+    image: quay.io/flightctl/flightctl-remote-access-el9
+    # -- Remote access image tag (leave empty to use chart appVersion)
+    tag: ""
+    # -- Image pull policy for remote access container
+    pullPolicy: ""
+  # -- Additional environment variables for the remote access container
+  env: {}
+
 # -- Alert Exporter Configuration
 alertExporter:
   # -- Enable alert exporter service

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -324,6 +324,8 @@ periodic:
 
 # -- Remote Access Configuration
 remoteAccess:
+  # -- Enable remote access service
+  enabled: true
   image:
     # -- Remote access container image
     image: quay.io/flightctl/flightctl-remote-access-el9
@@ -333,6 +335,14 @@ remoteAccess:
     pullPolicy: ""
   # -- Additional environment variables for the remote access container
   env: {}
+  # -- Resource requests and limits for the remote access container
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
 
 # -- Alert Exporter Configuration
 alertExporter:

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -324,6 +324,8 @@ periodic:
 
 # -- Remote Access Configuration
 remoteAccess:
+  # -- Enable remote access service
+  enabled: true
   image:
     # -- Remote access container image
     image: {{ .Images.remoteAccess.Image }}
@@ -333,6 +335,14 @@ remoteAccess:
     pullPolicy: ""
   # -- Additional environment variables for the remote access container
   env: {}
+  # -- Resource requests and limits for the remote access container
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
 
 # -- Alert Exporter Configuration
 alertExporter:

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -322,6 +322,18 @@ periodic:
     # -- Address for the metrics HTTP server
     address: ":15690"
 
+# -- Remote Access Configuration
+remoteAccess:
+  image:
+    # -- Remote access container image
+    image: {{ .Images.remoteAccess.Image }}
+    # -- Remote access image tag (leave empty to use chart appVersion)
+    tag: ""
+    # -- Image pull policy for remote access container
+    pullPolicy: ""
+  # -- Additional environment variables for the remote access container
+  env: {}
+
 # -- Alert Exporter Configuration
 alertExporter:
   # -- Enable alert exporter service

--- a/deploy/helm/helm-chart-opts.yaml
+++ b/deploy/helm/helm-chart-opts.yaml
@@ -44,6 +44,8 @@ community-el9:
       image: quay.io/flightctl/flightctl-db-setup-el9
     telemetryGateway:
       image: quay.io/flightctl/flightctl-telemetry-gateway-el9
+    remoteAccess:
+      image: quay.io/flightctl/flightctl-remote-access-el9
     ubiMinimal:
       image: registry.access.redhat.com/ubi9/ubi-minimal
       tag: "9.7-1763362218"
@@ -96,6 +98,8 @@ rhem-el9:
       image: registry.redhat.io/rhem/flightctl-db-setup-rhel9
     telemetryGateway:
       image: registry.redhat.io/rhem/flightctl-telemetry-gateway-rhel9
+    remoteAccess:
+      image: registry.redhat.io/rhem/flightctl-remote-access-rhel9
     ubiMinimal:
       image: registry.redhat.io/ubi9/ubi-minimal
       tag: "9.7-1763362218"
@@ -145,6 +149,8 @@ community-el10:
       image: quay.io/flightctl/flightctl-db-setup-el10
     telemetryGateway:
       image: quay.io/flightctl/flightctl-telemetry-gateway-el10
+    remoteAccess:
+      image: quay.io/flightctl/flightctl-remote-access-el10
     ubiMinimal:
       image: registry.access.redhat.com/ubi10/ubi-minimal
       tag: "10.1-1769677092"
@@ -197,6 +203,8 @@ rhem-el10:
       image: registry.redhat.io/rhem/flightctl-db-setup-rhel10
     telemetryGateway:
       image: registry.redhat.io/rhem/flightctl-telemetry-gateway-rhel10
+    remoteAccess:
+      image: registry.redhat.io/rhem/flightctl-remote-access-rhel10
     ubiMinimal:
       image: registry.redhat.io/ubi10/ubi-minimal
       tag: "10.1-1769677092"

--- a/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
@@ -143,4 +143,12 @@ stream {
 
     proxy_pass flightctl-telemetry-gateway:4317;
   }
+
+  # Passthrough to the Remote Access Agent service
+  server {
+    listen 7444;
+    listen [::]:7444 ipv6only=on;
+
+    proxy_pass flightctl-remote-access:7444;
+  }
 }

--- a/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
@@ -66,6 +66,14 @@ http {
       proxy_pass http://flightctl-imagebuilder-api:8445/;
     }
 
+    location /_/remote-access/ {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_pass http://flightctl-remote-access:3444/;
+    }
+
     # Everything else goes to the UI service for the frontend.
     location / {
       # This is a convenience so that users can point to the base URL of the deployment when doing the
@@ -144,7 +152,7 @@ stream {
     proxy_pass flightctl-telemetry-gateway:4317;
   }
 
-  # Passthrough to the Remote Access Agent service
+  # Passthrough to the Remote Access Agent service (gRPC — agents)
   server {
     listen 7444;
     listen [::]:7444 ipv6only=on;

--- a/deploy/podman/flightctl-gateway/flightctl-gateway.container
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Flight Control Gateway service
-After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
-Requires=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service
+After=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service flightctl-remote-access.service
+Requires=flightctl-certs-init.service flightctl-api.service flightctl-telemetry-gateway.service flightctl-ui.service flightctl-pam-issuer.service flightctl-alertmanager-proxy.service flightctl-cli-artifacts.service flightctl-remote-access.service
 PartOf=flightctl.target
 
 [Container]
@@ -24,6 +24,7 @@ PublishPort=443:8443
 # These are published unconditionally; nginx controls whether they are served based on suppressOldPorts.
 PublishPort=3443:3443
 PublishPort=7443:7443
+PublishPort=7444:7444
 PublishPort=8445:8445
 PublishPort=4317:4317
 

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
@@ -1,0 +1,3 @@
+service:
+  address: :3444
+  agentEndpointAddress: :7444

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
@@ -1,3 +1,4 @@
 service:
   address: :3444
   agentEndpointAddress: :7444
+  disableTLS: true

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
@@ -1,0 +1,29 @@
+[Unit]
+Description=Flight Control Remote Access service
+PartOf=flightctl.target
+After=flightctl-certs-init.service
+Wants=flightctl-certs-init.service
+
+[Container]
+ContainerName=flightctl-remote-access
+Image={{ .RemoteAccess.Image }}:{{ .RemoteAccess.Tag }}
+Pull=missing
+Network=flightctl.network
+AddHost=%H:host-gateway
+Environment=HOME=/root
+
+Volume=/etc/flightctl/pki/flightctl-remote-access/server.crt:/root/.flightctl/certs/server.crt:ro,z
+Volume=/etc/flightctl/pki/flightctl-remote-access/server.key:/root/.flightctl/certs/server.key:ro,z
+Volume=/etc/flightctl/pki/flightctl-remote-access/client-signer.crt:/root/.flightctl/certs/client-signer.crt:ro,z
+Volume=/etc/flightctl/pki/flightctl-remote-access/client-signer.key:/root/.flightctl/certs/client-signer.key:ro,z
+Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
+Volume=/etc/flightctl/flightctl-remote-access/config.yaml:/root/.flightctl/config.yaml:ro,z
+
+[Service]
+Restart=always
+RestartSec=30
+
+ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-remote-access/config.yaml.template --output-file /etc/flightctl/flightctl-remote-access/config.yaml
+
+[Install]
+WantedBy=flightctl.target

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
@@ -10,6 +10,7 @@ Image={{ .RemoteAccess.Image }}:{{ .RemoteAccess.Tag }}
 Pull=missing
 Network=flightctl.network
 AddHost=%H:host-gateway
+User=1001
 Environment=HOME=/root
 
 Volume=/etc/flightctl/pki/flightctl-remote-access/server.crt:/root/.flightctl/certs/server.crt:ro,z

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -457,7 +457,7 @@ Apply:
 
 ```bash
 helm upgrade flightctl flightctl-chart.tgz \
-    --reuse-values \
+    --reset-then-reuse-values \
     -f disconnected-values.yaml
 ```
 

--- a/docs/user/installing/deploying-observability-kubernetes.md
+++ b/docs/user/installing/deploying-observability-kubernetes.md
@@ -422,10 +422,10 @@ Procedure:
 
    ```console
    helm upgrade flightctl oci://quay.io/flightctl/charts/flightctl:${FC_VERSION} \
-     -n flightctl -f values.yaml --reuse-values
+     -n flightctl -f values.yaml --reset-then-reuse-values
    ```
 
-   The `--reuse-values` flag preserves all existing configuration and only updates the values specified in `values.yaml`.
+   The `--reset-then-reuse-values` flag applies new chart defaults first, then merges existing configuration on top, ensuring new chart values are not lost on upgrade.
 
 Verification:
 

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -75,6 +75,10 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-imagebuilder-worker.container"), Template: true, Mode: RegularFileMode},
 		{Action: ActionCopyDir, Source: "deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "flightctl-imagebuilder-worker/"), Template: false, Mode: RegularFileMode},
 
+		// Remote Access service
+		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-remote-access/flightctl-remote-access.container", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-remote-access.container"), Template: true, Mode: RegularFileMode},
+		{Action: ActionCopyDir, Source: "deploy/podman/flightctl-remote-access/flightctl-remote-access-config/", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "flightctl-remote-access/"), Template: false, Mode: RegularFileMode},
+
 		// Telemetry Gateway service
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway.container", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl-telemetry-gateway.container"), Template: true, Mode: RegularFileMode},
 		{Action: ActionCopyDir, Source: "deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway-config/", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "flightctl-telemetry-gateway/"), Template: false, Mode: RegularFileMode},
@@ -144,6 +148,8 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-db-migrate"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-imagebuilder-api"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-imagebuilder-worker"), Mode: ExecutableFileMode},
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-remote-access"), Mode: ExecutableFileMode},
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "pki", "flightctl-remote-access"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarTmpOutputDir, "flightctl-builds"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.VarTmpOutputDir, "flightctl-exports"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "flightctl-telemetry-gateway"), Mode: ExecutableFileMode},

--- a/internal/quadlet/renderer/renderer.go
+++ b/internal/quadlet/renderer/renderer.go
@@ -101,6 +101,7 @@ type RendererConfig struct {
 	TelemetryGateway   ImageConfig `mapstructure:"telemetry-gateway"`
 	UserinfoProxy      ImageConfig `mapstructure:"userinfo-proxy"`
 	Gateway            ImageConfig `mapstructure:"gateway"`
+	RemoteAccess       ImageConfig `mapstructure:"remote-access"`
 }
 
 func NewRendererConfig() *RendererConfig {
@@ -315,6 +316,8 @@ func (config *RendererConfig) ApplyFlightctlServicesTagOverride(log logrus.Field
 	config.ImagebuilderWorker.Tag = tag
 	config.TelemetryGateway.Tag = tag
 	config.UserinfoProxy.Tag = tag
+
+	config.RemoteAccess.Tag = tag
 
 	if config.FlightctlUiTagOverride {
 		// For release builds, UI tag must be overridden

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -1,0 +1,151 @@
+package remote_access_server
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	pb "github.com/flightctl/flightctl/api/grpc/v1"
+	apiserver "github.com/flightctl/flightctl/internal/api_server"
+	"github.com/flightctl/flightctl/internal/api_server/middleware"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/crypto"
+	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+// Server provides the flightctl-remote-access service: an HTTP 501 stub and
+// a gRPC RouterService stub that accepts and immediately closes streams.
+// Future stories will replace the stubs with real console-bridging logic.
+type Server struct {
+	pb.UnimplementedRouterServiceServer
+	log            logrus.FieldLogger
+	cfg            *config.Config
+	grpcServer     *grpc.Server
+	httpListener   net.Listener
+	agentListener  net.Listener
+	agentTLSConfig *tls.Config
+}
+
+// New creates a Server with a TLS HTTP listener at cfg.Service.Address and
+// an mTLS gRPC+HTTP mux listener at cfg.Service.AgentEndpointAddress.
+func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, serverCerts *crypto.TLSCertificateConfig) (*Server, error) {
+	tlsConfig, agentTLSConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
+	if err != nil {
+		return nil, err
+	}
+
+	httpListener, err := middleware.NewTLSListener(cfg.Service.Address, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Plain TCP listener — ServeTLS is called in Run() so that Go's net/http
+	// stack configures HTTP/2 (ALPN "h2") automatically, which gRPC requires.
+	agentListener, err := net.Listen("tcp", cfg.Service.AgentEndpointAddress)
+	if err != nil {
+		_ = httpListener.Close()
+		return nil, err
+	}
+
+	grpcServer := grpc.NewServer(
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.ChainStreamInterceptor(grpcAuth.StreamServerInterceptor(middleware.GrpcAuthMiddleware)),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 15 * time.Minute,
+			Time:              2 * time.Minute,
+			Timeout:           20 * time.Second,
+		}),
+	)
+
+	s := &Server{
+		log:            log,
+		cfg:            cfg,
+		grpcServer:     grpcServer,
+		httpListener:   httpListener,
+		agentListener:  agentListener,
+		agentTLSConfig: agentTLSConfig,
+	}
+	pb.RegisterRouterServiceServer(grpcServer, s)
+	return s, nil
+}
+
+// Run starts both listeners concurrently and blocks until ctx is cancelled.
+func (s *Server) Run(ctx context.Context) error {
+	agentSrv := middleware.NewHTTPServerWithTLSContext(
+		grpcMuxHandlerFunc(s.grpcServer, stubHandler(), s.log),
+		s.log,
+		s.cfg.Service.AgentEndpointAddress,
+		s.cfg,
+	)
+
+	httpSrv := middleware.NewHTTPServer(stubHandler(), s.log, s.cfg.Service.Address, s.cfg)
+
+	go func() {
+		s.log.Printf("Remote-access agent listener on %s", s.agentListener.Addr())
+		agentSrv.TLSConfig = s.agentTLSConfig
+		if err := agentSrv.ServeTLS(s.agentListener, "", ""); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
+			s.log.Errorf("agent listener error: %v", err)
+		}
+	}()
+
+	go func() {
+		s.log.Printf("Remote-access HTTP stub listener on %s", s.httpListener.Addr())
+		if err := httpSrv.Serve(s.httpListener); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
+			s.log.Errorf("HTTP stub listener error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	s.log.Println("Shutdown signal received:", ctx.Err())
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), apiserver.GracefulShutdownTimeout)
+	defer cancel()
+	_ = agentSrv.Shutdown(ctxTimeout)
+	_ = httpSrv.Shutdown(ctxTimeout)
+	return nil
+}
+
+// Stream implements pb.RouterServiceServer — accepts the incoming agent gRPC
+// stream and immediately closes it (stub).
+func (s *Server) Stream(_ pb.RouterService_StreamServer) error {
+	return nil
+}
+
+// stubHandler returns HTTP 501 Not Implemented for every request.
+func stubHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
+	})
+}
+
+// grpcMuxHandlerFunc routes incoming requests to grpcServer (gRPC) or
+// httpHandler (HTTP) based on the Content-Type header.
+func grpcMuxHandlerFunc(grpcServer *grpc.Server, httpHandler http.Handler, log logrus.FieldLogger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && r.Header.Get("Content-Type") == "application/grpc" {
+			type rwTimeoutSetter interface {
+				SetReadDeadline(time.Time) error
+				SetWriteDeadline(time.Time) error
+			}
+			if rtw, ok := w.(rwTimeoutSetter); ok {
+				if err := rtw.SetReadDeadline(time.Time{}); err != nil {
+					log.Errorf("setting gRPC read deadline: %v", err)
+				}
+				if err := rtw.SetWriteDeadline(time.Time{}); err != nil {
+					log.Errorf("setting gRPC write deadline: %v", err)
+				}
+			} else {
+				log.Error("cannot set gRPC deadline")
+			}
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpHandler.ServeHTTP(w, r)
+		}
+	})
+}

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	pb "github.com/flightctl/flightctl/api/grpc/v1"
@@ -17,7 +19,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 )
 
 // Server provides the flightctl-remote-access service: an HTTP 501 stub and
@@ -33,17 +37,21 @@ type Server struct {
 	agentTLSConfig *tls.Config
 }
 
-// New creates a Server with a TLS HTTP listener at cfg.Service.Address and
-// an mTLS gRPC+HTTP mux listener at cfg.Service.AgentEndpointAddress.
+// New creates a Server with an HTTP listener at cfg.Service.Address (TLS
+// terminated at the service when cfg.Service.DisableTLS is false, or plain HTTP
+// when DisableTLS is true for deployments where TLS is handled upstream) and an
+// mTLS gRPC+HTTP mux listener at cfg.Service.AgentEndpointAddress.
 func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, serverCerts *crypto.TLSCertificateConfig) (*Server, error) {
-	tlsConfig, agentTLSConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
+	_, agentTLSConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building agent TLS config: %w", err)
 	}
 
-	httpListener, err := middleware.NewTLSListener(cfg.Service.Address, tlsConfig)
+	// Plain TCP listener; ServeTLS is called in Run() when DisableTLS is false
+	// so the service terminates TLS itself (e.g. OCP/Helm passthrough route).
+	httpListener, err := net.Listen("tcp", cfg.Service.Address)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listening on service address %q: %w", cfg.Service.Address, err)
 	}
 
 	// Plain TCP listener — ServeTLS is called in Run() so that Go's net/http
@@ -51,7 +59,7 @@ func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, server
 	agentListener, err := net.Listen("tcp", cfg.Service.AgentEndpointAddress)
 	if err != nil {
 		_ = httpListener.Close()
-		return nil, err
+		return nil, fmt.Errorf("listening on agent endpoint address %q: %w", cfg.Service.AgentEndpointAddress, err)
 	}
 
 	grpcServer := grpc.NewServer(
@@ -76,7 +84,8 @@ func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, server
 	return s, nil
 }
 
-// Run starts both listeners concurrently and blocks until ctx is cancelled.
+// Run starts both listeners concurrently and blocks until ctx is cancelled or a
+// listener exits unexpectedly.
 func (s *Server) Run(ctx context.Context) error {
 	agentSrv := middleware.NewHTTPServerWithTLSContext(
 		grpcMuxHandlerFunc(s.grpcServer, stubHandler(), s.log),
@@ -87,34 +96,61 @@ func (s *Server) Run(ctx context.Context) error {
 
 	httpSrv := middleware.NewHTTPServer(stubHandler(), s.log, s.cfg.Service.Address, s.cfg)
 
+	serveErrCh := make(chan error, 2)
+
 	go func() {
 		s.log.Printf("Remote-access agent listener on %s", s.agentListener.Addr())
 		agentSrv.TLSConfig = s.agentTLSConfig
 		if err := agentSrv.ServeTLS(s.agentListener, "", ""); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
-			s.log.Errorf("agent listener error: %v", err)
+			serveErrCh <- err
 		}
 	}()
 
 	go func() {
-		s.log.Printf("Remote-access HTTP stub listener on %s", s.httpListener.Addr())
-		if err := httpSrv.Serve(s.httpListener); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
-			s.log.Errorf("HTTP stub listener error: %v", err)
+		s.log.Printf("Remote-access HTTP listener on %s (disableTLS=%v)", s.httpListener.Addr(), s.cfg.Service.DisableTLS)
+		var err error
+		if s.cfg.Service.DisableTLS {
+			err = httpSrv.Serve(s.httpListener)
+		} else {
+			httpSrv.TLSConfig = s.agentTLSConfig
+			err = httpSrv.ServeTLS(s.httpListener, "", "")
+		}
+		if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {
+			serveErrCh <- err
 		}
 	}()
 
-	<-ctx.Done()
-	s.log.Println("Shutdown signal received:", ctx.Err())
+	var runErr error
+	select {
+	case <-ctx.Done():
+		s.log.Println("Shutdown signal received:", ctx.Err())
+	case runErr = <-serveErrCh:
+		s.log.Errorf("listener exited unexpectedly: %v", runErr)
+	}
+
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), apiserver.GracefulShutdownTimeout)
 	defer cancel()
 	_ = agentSrv.Shutdown(ctxTimeout)
 	_ = httpSrv.Shutdown(ctxTimeout)
-	return nil
+
+	grpcStopCh := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(grpcStopCh)
+	}()
+	select {
+	case <-grpcStopCh:
+	case <-ctxTimeout.Done():
+		s.grpcServer.Stop()
+	}
+
+	return runErr
 }
 
-// Stream implements pb.RouterServiceServer — accepts the incoming agent gRPC
-// stream and immediately closes it (stub).
+// Stream implements pb.RouterServiceServer — rejects the stream with Unavailable
+// until real console-bridging logic is added in a future story.
 func (s *Server) Stream(_ pb.RouterService_StreamServer) error {
-	return nil
+	return status.Error(codes.Unavailable, "service not yet implemented")
 }
 
 // stubHandler returns HTTP 501 Not Implemented for every request.
@@ -128,7 +164,7 @@ func stubHandler() http.Handler {
 // httpHandler (HTTP) based on the Content-Type header.
 func grpcMuxHandlerFunc(grpcServer *grpc.Server, httpHandler http.Handler, log logrus.FieldLogger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.ProtoMajor == 2 && r.Header.Get("Content-Type") == "application/grpc" {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
 			type rwTimeoutSetter interface {
 				SetReadDeadline(time.Time) error
 				SetWriteDeadline(time.Time) error

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -29,11 +29,11 @@ import (
 // Future stories will replace the stubs with real console-bridging logic.
 type Server struct {
 	pb.UnimplementedRouterServiceServer
-	log            logrus.FieldLogger
-	cfg            *config.Config
-	grpcServer     *grpc.Server
-	httpListener   net.Listener
-	agentListener  net.Listener
+	log             logrus.FieldLogger
+	cfg             *config.Config
+	grpcServer      *grpc.Server
+	httpListener    net.Listener
+	agentListener   net.Listener
 	serverTLSConfig *tls.Config
 	agentTLSConfig  *tls.Config
 }

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -34,7 +34,8 @@ type Server struct {
 	grpcServer     *grpc.Server
 	httpListener   net.Listener
 	agentListener  net.Listener
-	agentTLSConfig *tls.Config
+	serverTLSConfig *tls.Config
+	agentTLSConfig  *tls.Config
 }
 
 // New creates a Server with an HTTP listener at cfg.Service.Address (TLS
@@ -42,7 +43,7 @@ type Server struct {
 // when DisableTLS is true for deployments where TLS is handled upstream) and an
 // mTLS gRPC+HTTP mux listener at cfg.Service.AgentEndpointAddress.
 func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, serverCerts *crypto.TLSCertificateConfig) (*Server, error) {
-	_, agentTLSConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
+	serverTLSConfig, agentTLSConfig, err := crypto.TLSConfigForServer(ca.GetCABundleX509(), serverCerts)
 	if err != nil {
 		return nil, fmt.Errorf("building agent TLS config: %w", err)
 	}
@@ -73,12 +74,13 @@ func New(log logrus.FieldLogger, cfg *config.Config, ca *crypto.CAClient, server
 	)
 
 	s := &Server{
-		log:            log,
-		cfg:            cfg,
-		grpcServer:     grpcServer,
-		httpListener:   httpListener,
-		agentListener:  agentListener,
-		agentTLSConfig: agentTLSConfig,
+		log:             log,
+		cfg:             cfg,
+		grpcServer:      grpcServer,
+		httpListener:    httpListener,
+		agentListener:   agentListener,
+		serverTLSConfig: serverTLSConfig,
+		agentTLSConfig:  agentTLSConfig,
 	}
 	pb.RegisterRouterServiceServer(grpcServer, s)
 	return s, nil
@@ -112,7 +114,7 @@ func (s *Server) Run(ctx context.Context) error {
 		if s.cfg.Service.DisableTLS {
 			err = httpSrv.Serve(s.httpListener)
 		} else {
-			httpSrv.TLSConfig = s.agentTLSConfig
+			httpSrv.TLSConfig = s.serverTLSConfig
 			err = httpSrv.ServeTLS(s.httpListener, "", "")
 		}
 		if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, http.ErrServerClosed) {

--- a/internal/remote_access_server/server_test.go
+++ b/internal/remote_access_server/server_test.go
@@ -1,0 +1,67 @@
+package remote_access_server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pb "github.com/flightctl/flightctl/api/grpc/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// stubStreamServer is a hand-written stub for pb.RouterService_StreamServer.
+type stubStreamServer struct {
+	grpc.ServerStream
+}
+
+func (s *stubStreamServer) Send(*pb.StreamResponse) error    { return nil }
+func (s *stubStreamServer) Recv() (*pb.StreamRequest, error) { return nil, nil }
+func (s *stubStreamServer) Context() context.Context         { return context.Background() }
+func (s *stubStreamServer) SendMsg(interface{}) error        { return nil }
+func (s *stubStreamServer) RecvMsg(interface{}) error        { return nil }
+func (s *stubStreamServer) SetHeader(metadata.MD) error      { return nil }
+func (s *stubStreamServer) SendHeader(metadata.MD) error     { return nil }
+func (s *stubStreamServer) SetTrailer(metadata.MD)           {}
+
+func TestStubHandler(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "GET root", method: http.MethodGet, path: "/"},
+		{name: "POST api path", method: http.MethodPost, path: "/api/v1/something"},
+		{name: "PUT arbitrary path", method: http.MethodPut, path: "/ws/v1/devices/foo/console"},
+		{name: "DELETE", method: http.MethodDelete, path: "/any"},
+	}
+
+	handler := stubHandler()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotImplemented {
+				t.Errorf("When %s %s it should return 501, got %d", tc.method, tc.path, rec.Code)
+			}
+		})
+	}
+}
+
+func TestServerStream(t *testing.T) {
+	t.Parallel()
+	srv := &Server{}
+	stream := &stubStreamServer{}
+
+	err := srv.Stream(stream)
+	if err != nil {
+		t.Errorf("When Stream is called it should return nil, got %v", err)
+	}
+}

--- a/internal/remote_access_server/server_test.go
+++ b/internal/remote_access_server/server_test.go
@@ -2,13 +2,17 @@ package remote_access_server
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	pb "github.com/flightctl/flightctl/api/grpc/v1"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // stubStreamServer is a hand-written stub for pb.RouterService_StreamServer.
@@ -17,7 +21,7 @@ type stubStreamServer struct {
 }
 
 func (s *stubStreamServer) Send(*pb.StreamResponse) error    { return nil }
-func (s *stubStreamServer) Recv() (*pb.StreamRequest, error) { return nil, nil }
+func (s *stubStreamServer) Recv() (*pb.StreamRequest, error) { return nil, io.EOF }
 func (s *stubStreamServer) Context() context.Context         { return context.Background() }
 func (s *stubStreamServer) SendMsg(interface{}) error        { return nil }
 func (s *stubStreamServer) RecvMsg(interface{}) error        { return nil }
@@ -55,13 +59,62 @@ func TestStubHandler(t *testing.T) {
 	}
 }
 
+func TestGrpcMuxHandlerFunc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		contentType     string
+		proto           int
+		expectHTTPRoute bool
+	}{
+		{name: "When gRPC exact content-type it should not route to HTTP stub", contentType: "application/grpc", proto: 2, expectHTTPRoute: false},
+		{name: "When application/grpc+proto it should not route to HTTP stub", contentType: "application/grpc+proto", proto: 2, expectHTTPRoute: false},
+		{name: "When application/grpc with params it should not route to HTTP stub", contentType: "application/grpc; charset=utf-8", proto: 2, expectHTTPRoute: false},
+		{name: "When HTTP/1 with gRPC content-type it should route to HTTP stub", contentType: "application/grpc", proto: 1, expectHTTPRoute: true},
+		{name: "When non-gRPC content-type it should route to HTTP stub", contentType: "application/json", proto: 2, expectHTTPRoute: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var httpHit bool
+			sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				httpHit = true
+				w.WriteHeader(http.StatusNotImplemented)
+			})
+
+			log := logrus.New()
+			handler := grpcMuxHandlerFunc(grpc.NewServer(), sentinel, log)
+
+			req := httptest.NewRequest(http.MethodPost, "/api.RouterService/Stream", nil)
+			req.ProtoMajor = tc.proto
+			req.Header.Set("Content-Type", tc.contentType)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if tc.expectHTTPRoute && !httpHit {
+				t.Errorf("expected HTTP stub to be called for Content-Type %q HTTP/%d", tc.contentType, tc.proto)
+			}
+			if !tc.expectHTTPRoute && httpHit {
+				t.Errorf("expected gRPC routing for Content-Type %q HTTP/%d, but HTTP stub was called", tc.contentType, tc.proto)
+			}
+		})
+	}
+}
+
 func TestServerStream(t *testing.T) {
 	t.Parallel()
 	srv := &Server{}
 	stream := &stubStreamServer{}
 
 	err := srv.Stream(stream)
-	if err != nil {
-		t.Errorf("When Stream is called it should return nil, got %v", err)
+	if err == nil {
+		t.Fatal("When Stream is called it should return an error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Errorf("When Stream is called it should return codes.Unavailable, got %v", code)
 	}
 }

--- a/packaging/images/el10/Containerfile.remote-access
+++ b/packaging/images/el10/Containerfile.remote-access
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as build
 WORKDIR /app
 
 # Switch to root for build operations
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
     --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
     make build-remote-access
 
-FROM quay.io/flightctl/flightctl-base:9.7-1762965531
+FROM quay.io/flightctl/flightctl-base:10.1-1769518576
 WORKDIR /app
 LABEL \
   com.redhat.component="flightctl-remote-access-container" \

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -67,3 +67,6 @@ telemetry-gateway:
 userinfo-proxy:
   image: quay.io/flightctl/flightctl-userinfo-proxy-el10
   tag: latest
+remote-access:
+  image: quay.io/flightctl/flightctl-remote-access-el10
+  tag: latest

--- a/packaging/images/el10/local-images.yaml
+++ b/packaging/images/el10/local-images.yaml
@@ -60,3 +60,6 @@ telemetry-gateway:
 userinfo-proxy:
   image: flightctl-userinfo-proxy-el10
   tag: latest
+remote-access:
+  image: flightctl-remote-access-el10
+  tag: latest

--- a/packaging/images/el9/Containerfile.remote-access
+++ b/packaging/images/el9/Containerfile.remote-access
@@ -1,0 +1,51 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as build
+WORKDIR /app
+
+# Switch to root for build operations
+USER 0
+
+# Copy dependencies first (most stable)
+COPY go.mod go.sum ./
+
+# Download dependencies (cached layer)
+RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    go mod download
+
+# Copy build tools and configs
+COPY Makefile .
+
+# Copy source code directories
+COPY ./api ./api
+COPY ./cmd ./cmd
+COPY ./deploy ./deploy
+COPY ./hack ./hack
+COPY ./internal ./internal
+COPY ./pkg ./pkg
+COPY ./test ./test
+
+# Define version info ARGs right before build
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_TREE_STATE
+ARG SOURCE_GIT_COMMIT
+
+# Convert ARGs to ENV so make can use them
+ENV SOURCE_GIT_TAG=${SOURCE_GIT_TAG}
+ENV SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE}
+ENV SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}
+
+# Use BuildKit cache mounts for Go caching
+RUN --mount=type=cache,target=/opt/app-root/src/.cache/go-build \
+    --mount=type=cache,target=/opt/app-root/src/go/pkg/mod \
+    make build-remote-access
+
+FROM quay.io/flightctl/flightctl-base:9.7-1762965531
+WORKDIR /app
+LABEL \
+  com.redhat.component="flightctl-remote-access-container" \
+  description="Flight Control Edge management service, remote access gateway" \
+  io.k8s.description="Flight Control Edge management service, remote access gateway" \
+  io.k8s.display-name="Flight Control Remote Access Gateway" \
+  name="flightctl-remote-access" \
+  summary="Flight Control Edge management service, remote access gateway"
+COPY --from=build /app/bin/flightctl-remote-access .
+CMD ["./flightctl-remote-access"]

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -65,3 +65,6 @@ telemetry-gateway:
 userinfo-proxy:
   image: quay.io/flightctl/flightctl-userinfo-proxy-el9
   tag: latest
+remote-access:
+  image: quay.io/flightctl/flightctl-remote-access-el9
+  tag: latest

--- a/packaging/images/el9/local-images.yaml
+++ b/packaging/images/el9/local-images.yaml
@@ -56,3 +56,6 @@ telemetry-gateway:
 userinfo-proxy:
   image: flightctl-userinfo-proxy-el9
   tag: latest
+remote-access:
+  image: flightctl-remote-access-el9
+  tag: latest

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -565,6 +565,7 @@ fi
     %dir %{_sysconfdir}/flightctl/pki/flightctl-pam-issuer
     %dir %{_sysconfdir}/flightctl/pki/flightctl-gateway
     %dir %{_sysconfdir}/flightctl/pki/flightctl-imagebuilder-api
+    %dir %{_sysconfdir}/flightctl/pki/flightctl-remote-access
     %dir %{_sysconfdir}/flightctl/pki/flightctl-telemetry-gateway
     %dir %{_sysconfdir}/flightctl/pki/db
     %dir %{_sysconfdir}/flightctl/flightctl-alert-exporter
@@ -576,6 +577,7 @@ fi
     %dir %{_sysconfdir}/flightctl/flightctl-gateway
     %dir %{_sysconfdir}/flightctl/flightctl-imagebuilder-api
     %dir %{_sysconfdir}/flightctl/flightctl-imagebuilder-worker
+    %dir %{_sysconfdir}/flightctl/flightctl-remote-access
     %dir %{_sysconfdir}/flightctl/flightctl-pam-issuer
     %dir %{_sysconfdir}/flightctl/flightctl-periodic
     %dir %{_sysconfdir}/flightctl/flightctl-ui
@@ -605,6 +607,7 @@ fi
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db-migrate
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-imagebuilder-api
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-imagebuilder-worker
+    %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-remote-access
     %dir %attr(0755,root,root) %{_datadir}/flightctl/flightctl-telemetry-gateway
     %dir %attr(0755,root,root) %{_var}/tmp/flightctl-builds
     %dir %attr(0755,root,root) %{_var}/tmp/flightctl-exports
@@ -631,6 +634,7 @@ fi
     %{_datadir}/flightctl/flightctl-db-migrate/config.yaml.template
     %{_datadir}/flightctl/flightctl-imagebuilder-api/config.yaml.template
     %{_datadir}/flightctl/flightctl-imagebuilder-worker/config.yaml.template
+    %{_datadir}/flightctl/flightctl-remote-access/config.yaml.template
     %{_datadir}/flightctl/flightctl-telemetry-gateway/config.yaml.template
 
     # Quadlet files (excluding observability components which are in separate packages)
@@ -649,6 +653,7 @@ fi
     %{_datadir}/containers/systemd/flightctl-ui*.container
     %{_datadir}/containers/systemd/flightctl-ui-certs.volume
     %{_datadir}/containers/systemd/flightctl-imagebuilder*.container
+    %{_datadir}/containers/systemd/flightctl-remote-access.container
     %{_datadir}/containers/systemd/flightctl-alertmanager.volume
     %{_datadir}/containers/systemd/flightctl-telemetry-gateway.container
     %{_datadir}/containers/systemd/flightctl.network

--- a/test/api/README.md
+++ b/test/api/README.md
@@ -21,7 +21,7 @@ Run the curl command to reproduce the failure and read the response body for det
 - To apply API test overrides (rate limits, rendered spec poll timeout) to the running deployment:
 
   ```bash
-  helm upgrade flightctl ./deploy/helm/flightctl/ -n flightctl-external --reuse-values --values test/api/values.api-tests.yaml
+  helm upgrade flightctl ./deploy/helm/flightctl/ -n flightctl-external --reset-then-reuse-values --values test/api/values.api-tests.yaml
   ```
 
 - `make test-api` builds the schemathesis container image and runs `test/api/run_tests.sh`.

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -98,7 +98,7 @@ kubectl create namespace flightctl-e2e      --context kind-kind 2>/dev/null || t
 # if we are only deploying the database, we don't need inject the server container
 if [ -z "$ONLY_DB" ]; then
 
-  for suffix in periodic api worker alert-exporter alertmanager-proxy cli-artifacts db-setup telemetry-gateway imagebuilder-api imagebuilder-worker ; do
+  for suffix in periodic api worker alert-exporter alertmanager-proxy cli-artifacts db-setup telemetry-gateway imagebuilder-api imagebuilder-worker remote-access ; do
     kind_load_image localhost/flightctl-${suffix}-el9:latest
   done
 


### PR DESCRIPTION
adds boilerplate for a new service - flightctl-remote-access service,
fixes the upgrade process to use the --reset-then-reuse flag as discussed multiple times already , the issue mostly resurfaces for new services requiring to add boiler plate templating , this fixes it