### PR TITLE
NO-ISSUE: refactor Exporter interface to return StatusContribution

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -340,6 +340,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	statusManager.RegisterStatusExporter(osManager)
 	statusManager.RegisterStatusExporter(specManager)
 	statusManager.RegisterStatusExporter(systemInfoManager)
+	if len(a.config.Warnings) > 0 {
+		statusManager.RegisterStatusExporter(&configWarningExporter{warnings: a.config.Warnings})
+	}
 
 	// create config controller
 	configController := config.NewController(
@@ -367,17 +370,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	// bootstrap
 	if err := bootstrap.Initialize(ctx); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
-	}
-
-	if len(a.config.Warnings) > 0 {
-		msg := strings.Join(a.config.Warnings, "; ")
-		_, updateErr := statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
-			Status: v1beta1.DeviceSummaryStatusDegraded,
-			Info:   &msg,
-		}))
-		if updateErr != nil {
-			a.log.Warnf("Failed to report config warnings to status: %v", updateErr)
-		}
 	}
 
 	// Initialize certificate manager
@@ -539,5 +531,23 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 	}
 
 	log.Info("Successfully wiped certificate and restarted flightctl-agent service")
+	return nil
+}
+
+// configWarningExporter surfaces config loading warnings (e.g. skipped drop-ins)
+// in the device summary on every status collection cycle.
+type configWarningExporter struct {
+	warnings []string
+}
+
+func (e *configWarningExporter) Status(_ context.Context, s *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
+	if len(e.warnings) == 0 {
+		return nil
+	}
+	msg := log.Truncate(strings.Join(e.warnings, "; "), status.MaxMessageLength)
+	if s.Summary.Status == v1beta1.DeviceSummaryStatusOnline {
+		s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
+	}
+	s.Summary.Info = &msg
 	return nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -309,9 +308,19 @@ func (a *Agent) Run(ctx context.Context) error {
 	)
 
 	// create status manager
+	statusExporters := []status.Exporter{
+		applicationsManager,
+		rootSystemdManager,
+		resourceManager,
+		osManager,
+		specManager,
+		systemInfoManager,
+	}
 	statusManager := status.NewManager(
 		deviceName,
 		a.log,
+		statusExporters,
+		a.config.Warnings,
 	)
 
 	// create lifecycle manager
@@ -332,17 +341,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		backoff,
 		a.log,
 	)
-
-	// register status exporters
-	statusManager.RegisterStatusExporter(applicationsManager)
-	statusManager.RegisterStatusExporter(rootSystemdManager)
-	statusManager.RegisterStatusExporter(resourceManager)
-	statusManager.RegisterStatusExporter(osManager)
-	statusManager.RegisterStatusExporter(specManager)
-	statusManager.RegisterStatusExporter(systemInfoManager)
-	if len(a.config.Warnings) > 0 {
-		statusManager.RegisterStatusExporter(newConfigWarningExporter(a.config.Warnings))
-	}
 
 	// create config controller
 	configController := config.NewController(
@@ -534,23 +532,3 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 	return nil
 }
 
-// configWarningExporter surfaces config loading warnings (e.g. skipped drop-ins)
-// in the device summary on every status collection cycle.
-type configWarningExporter struct {
-	msg string
-}
-
-func newConfigWarningExporter(warnings []string) *configWarningExporter {
-	return &configWarningExporter{
-		msg: log.Truncate(strings.Join(warnings, "; "), status.MaxMessageLength),
-	}
-}
-
-func (e *configWarningExporter) Status(_ context.Context, s *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
-	if s.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
-		return nil
-	}
-	s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
-	s.Summary.Info = &e.msg
-	return nil
-}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -341,7 +341,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	statusManager.RegisterStatusExporter(specManager)
 	statusManager.RegisterStatusExporter(systemInfoManager)
 	if len(a.config.Warnings) > 0 {
-		statusManager.RegisterStatusExporter(&configWarningExporter{warnings: a.config.Warnings})
+		statusManager.RegisterStatusExporter(newConfigWarningExporter(a.config.Warnings))
 	}
 
 	// create config controller
@@ -537,17 +537,20 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 // configWarningExporter surfaces config loading warnings (e.g. skipped drop-ins)
 // in the device summary on every status collection cycle.
 type configWarningExporter struct {
-	warnings []string
+	msg string
+}
+
+func newConfigWarningExporter(warnings []string) *configWarningExporter {
+	return &configWarningExporter{
+		msg: log.Truncate(strings.Join(warnings, "; "), status.MaxMessageLength),
+	}
 }
 
 func (e *configWarningExporter) Status(_ context.Context, s *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
-	if len(e.warnings) == 0 {
+	if s.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
 		return nil
 	}
-	msg := log.Truncate(strings.Join(e.warnings, "; "), status.MaxMessageLength)
-	if s.Summary.Status == v1beta1.DeviceSummaryStatusOnline {
-		s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
-	}
-	s.Summary.Info = &msg
+	s.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
+	s.Summary.Info = &e.msg
 	return nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -366,6 +367,17 @@ func (a *Agent) Run(ctx context.Context) error {
 	// bootstrap
 	if err := bootstrap.Initialize(ctx); err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)
+	}
+
+	if len(a.config.Warnings) > 0 {
+		msg := strings.Join(a.config.Warnings, "; ")
+		_, updateErr := statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
+			Status: v1beta1.DeviceSummaryStatusDegraded,
+			Info:   &msg,
+		}))
+		if updateErr != nil {
+			a.log.Warnf("Failed to report config warnings to status: %v", updateErr)
+		}
 	}
 
 	// Initialize certificate manager

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -531,4 +531,3 @@ func wipeCertificateAndRestart(ctx context.Context, identityProvider identity.Pr
 	log.Info("Successfully wiped certificate and restarted flightctl-agent service")
 	return nil
 }
-

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -156,6 +156,10 @@ type Config struct {
 	// ImagePruning holds all image/artifact pruning-related configuration
 	ImagePruning ImagePruning `json:"image-pruning,omitempty"`
 
+	// Warnings collects non-fatal issues encountered during config loading
+	// (e.g., skipped drop-ins) so they can be surfaced in device status.
+	Warnings []string `json:"-"`
+
 	readWriter fileio.ReadWriter
 }
 
@@ -440,11 +444,15 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
-			logrus.Warnf("Skipping unreadable override config %s: %v", overridePath, err)
+			msg := fmt.Sprintf("Skipping unreadable override config %s: %v", overridePath, err)
+			logrus.Warn(msg)
+			cfg.Warnings = append(cfg.Warnings, msg)
 			continue
 		}
 		if err := yaml.Unmarshal(contents, overrideCfg); err != nil {
-			logrus.Warnf("Skipping invalid override config %s: %v", overridePath, err)
+			msg := fmt.Sprintf("Skipping invalid override config %s: %v", overridePath, err)
+			logrus.Warn(msg)
+			cfg.Warnings = append(cfg.Warnings, msg)
 			continue
 		}
 		mergeConfigs(cfg, overrideCfg)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -432,16 +432,20 @@ func (cfg *Config) LoadWithOverrides(configFile string) error {
 	}
 	sort.Strings(yamlFiles)
 
-	// Apply drop-ins in order (later files override earlier ones)
+	// Apply drop-ins in order (later files override earlier ones).
+	// Invalid drop-ins are skipped with a warning so the agent can still
+	// start and perform spec rollback if needed.
 	for _, filename := range yamlFiles {
 		overrideCfg := &Config{}
 		overridePath := filepath.Join(confSubdir, filename)
 		contents, err := cfg.readWriter.ReadFile(overridePath)
 		if err != nil {
-			return fmt.Errorf("reading override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping unreadable override config %s: %v", overridePath, err)
+			continue
 		}
 		if err := yaml.Unmarshal(contents, overrideCfg); err != nil {
-			return fmt.Errorf("unmarshalling override config %s: %w", overridePath, err)
+			logrus.Warnf("Skipping invalid override config %s: %v", overridePath, err)
+			continue
 		}
 		mergeConfigs(cfg, overrideCfg)
 	}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -271,3 +271,104 @@ image-pruning:
 	require.NotNil(cfg.ImagePruning.Enabled, "Enabled should not be nil when dropin enables pruning")
 	require.True(*cfg.ImagePruning.Enabled, "pruning dropin should override config setting")
 }
+
+func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// Invalid YAML dropin (tab character breaks YAML parsing)
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "01-bad.yaml"),
+		[]byte("image-pruning:\n\t enabled: true\n"),
+		0o600,
+	))
+
+	// Valid dropin applied after the invalid one
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-good.yaml"),
+		[]byte("log-level: debug\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "invalid dropin should be skipped, not cause an error")
+
+	// Valid dropin should still be applied
+	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
+}
+
+func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte("invalid: yaml: [\n"), 0o600))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.Error(err, "invalid base config should still return an error")
+}
+
+func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// All dropins are invalid
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "01-bad.yaml"),
+		[]byte("image-pruning:\n\t enabled: true\n"),
+		0o600,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-also-bad.yaml"),
+		[]byte("{{{not yaml at all\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "all invalid dropins should be skipped, agent should still start")
+
+	// Base config values should be intact
+	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
+}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -272,152 +272,122 @@ image-pruning:
 	require.True(*cfg.ImagePruning.Enabled, "pruning dropin should override config setting")
 }
 
-func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+func TestLoadWithOverrides_DropinErrorHandling(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseConfig       string
+		setupDropins     func(t *testing.T, dropinDir string)
+		wantErr          bool
+		skipOnRoot       bool
+		expectedLogLevel string
+		expectedWarnings int
+		warningContains  string
+	}{
+		{
+			name:       "When an invalid dropin exists it should skip it and apply valid ones",
+			baseConfig: yamlConfig,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-bad.yaml"),
+					[]byte("image-pruning:\n\t enabled: true\n"),
+					0o600,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-good.yaml"),
+					[]byte("log-level: debug\n"),
+					0o600,
+				))
+			},
+			expectedLogLevel: "debug",
+			expectedWarnings: 1,
+			warningContains:  "01-bad.yaml",
+		},
+		{
+			name:       "When the base config is invalid it should return an error",
+			baseConfig: "invalid: yaml: [\n",
+			wantErr:    true,
+		},
+		{
+			name:       "When only invalid dropins exist it should still succeed with base config",
+			baseConfig: yamlConfig,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-bad.yaml"),
+					[]byte("image-pruning:\n\t enabled: true\n"),
+					0o600,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-also-bad.yaml"),
+					[]byte("{{{not yaml at all\n"),
+					0o600,
+				))
+			},
+			expectedWarnings: 2,
+		},
+		{
+			name:       "When an unreadable dropin exists it should skip it and apply valid ones",
+			baseConfig: yamlConfig,
+			skipOnRoot: true,
+			setupDropins: func(t *testing.T, dropinDir string) {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "01-unreadable.yaml"),
+					[]byte("log-level: debug\n"),
+					0o000,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dropinDir, "02-good.yaml"),
+					[]byte("log-level: warn\n"),
+					0o600,
+				))
+			},
+			expectedLogLevel: "warn",
+			expectedWarnings: 1,
+			warningContains:  "01-unreadable.yaml",
+		},
+	}
 
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipOnRoot && os.Getuid() == 0 {
+				t.Skip("permission test is not meaningful when running as root")
+			}
 
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+			require := require.New(t)
+			tmpDir := t.TempDir()
+			configDir := filepath.Join(tmpDir, "etc", "flightctl")
+			dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
 
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+			require.NoError(os.MkdirAll(configDir, 0o755))
+			require.NoError(os.MkdirAll(dataDir, 0o755))
 
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
+			cfg := NewDefault()
+			cfg.ConfigDir = configDir
+			cfg.DataDir = dataDir
+			cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
 
-	// Invalid YAML dropin (tab character breaks YAML parsing)
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "01-bad.yaml"),
-		[]byte("image-pruning:\n\t enabled: true\n"),
-		0o600,
-	))
+			configFile := filepath.Join(configDir, "config.yaml")
+			require.NoError(os.WriteFile(configFile, []byte(tt.baseConfig), 0o600))
 
-	// Valid dropin applied after the invalid one
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-good.yaml"),
-		[]byte("log-level: debug\n"),
-		0o600,
-	))
+			if tt.setupDropins != nil {
+				dropinDir := filepath.Join(configDir, "conf.d")
+				require.NoError(os.MkdirAll(dropinDir, 0o755))
+				tt.setupDropins(t, dropinDir)
+			}
 
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "invalid dropin should be skipped, not cause an error")
+			err := cfg.LoadWithOverrides(configFile)
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
 
-	// Valid dropin should still be applied
-	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
-
-	// Warning should be recorded for the invalid dropin
-	require.Len(cfg.Warnings, 1, "one warning should be recorded for the invalid dropin")
-	require.Contains(cfg.Warnings[0], "01-bad.yaml")
-}
-
-func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte("invalid: yaml: [\n"), 0o600))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.Error(err, "invalid base config should still return an error")
-}
-
-func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
-
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
-
-	// All dropins are invalid
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "01-bad.yaml"),
-		[]byte("image-pruning:\n\t enabled: true\n"),
-		0o600,
-	))
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-also-bad.yaml"),
-		[]byte("{{{not yaml at all\n"),
-		0o600,
-	))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "all invalid dropins should be skipped, agent should still start")
-
-	// Base config values should be intact
-	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
-
-	// Warnings should be recorded for both invalid dropins
-	require.Len(cfg.Warnings, 2, "warnings should be recorded for each invalid dropin")
-}
-
-func TestLoadWithOverrides_UnreadableDropinIsSkipped(t *testing.T) {
-	require := require.New(t)
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "etc", "flightctl")
-	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
-
-	require.NoError(os.MkdirAll(configDir, 0o755))
-	require.NoError(os.MkdirAll(dataDir, 0o755))
-
-	cfg := NewDefault()
-	cfg.ConfigDir = configDir
-	cfg.DataDir = dataDir
-	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
-
-	configFile := filepath.Join(configDir, "config.yaml")
-	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
-
-	dropinDir := filepath.Join(configDir, "conf.d")
-	require.NoError(os.MkdirAll(dropinDir, 0o755))
-
-	// Create a dropin file with no read permissions
-	unreadablePath := filepath.Join(dropinDir, "01-unreadable.yaml")
-	require.NoError(os.WriteFile(unreadablePath, []byte("log-level: debug\n"), 0o000))
-
-	// Valid dropin applied after the unreadable one
-	require.NoError(os.WriteFile(
-		filepath.Join(dropinDir, "02-good.yaml"),
-		[]byte("log-level: warn\n"),
-		0o600,
-	))
-
-	err := cfg.LoadWithOverrides(configFile)
-	require.NoError(err, "unreadable dropin should be skipped, not cause an error")
-
-	// Valid dropin should still be applied
-	require.Equal("warn", cfg.LogLevel, "valid dropin after unreadable one should still be applied")
-
-	// Warning should be recorded for the unreadable dropin
-	require.Len(cfg.Warnings, 1, "one warning should be recorded for the unreadable dropin")
-	require.Contains(cfg.Warnings[0], "01-unreadable.yaml")
+			if tt.expectedLogLevel != "" {
+				require.Equal(tt.expectedLogLevel, cfg.LogLevel)
+			}
+			require.Len(cfg.Warnings, tt.expectedWarnings)
+			if tt.warningContains != "" {
+				require.Contains(cfg.Warnings[0], tt.warningContains)
+			}
+		})
+	}
 }

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -311,6 +311,10 @@ func TestLoadWithOverrides_InvalidDropinIsSkipped(t *testing.T) {
 
 	// Valid dropin should still be applied
 	require.Equal("debug", cfg.LogLevel, "valid dropin after invalid one should still be applied")
+
+	// Warning should be recorded for the invalid dropin
+	require.Len(cfg.Warnings, 1, "one warning should be recorded for the invalid dropin")
+	require.Contains(cfg.Warnings[0], "01-bad.yaml")
 }
 
 func TestLoadWithOverrides_InvalidBaseConfigStillFails(t *testing.T) {
@@ -371,4 +375,49 @@ func TestLoadWithOverrides_OnlyInvalidDropinsStillSucceeds(t *testing.T) {
 
 	// Base config values should be intact
 	require.Equal("https://enrollment.endpoint", cfg.EnrollmentService.Service.Server)
+
+	// Warnings should be recorded for both invalid dropins
+	require.Len(cfg.Warnings, 2, "warnings should be recorded for each invalid dropin")
+}
+
+func TestLoadWithOverrides_UnreadableDropinIsSkipped(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "etc", "flightctl")
+	dataDir := filepath.Join(tmpDir, "var", "lib", "flightctl")
+
+	require.NoError(os.MkdirAll(configDir, 0o755))
+	require.NoError(os.MkdirAll(dataDir, 0o755))
+
+	cfg := NewDefault()
+	cfg.ConfigDir = configDir
+	cfg.DataDir = dataDir
+	cfg.readWriter = fileio.NewReadWriter(fileio.NewReader(), fileio.NewWriter())
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	require.NoError(os.WriteFile(configFile, []byte(yamlConfig), 0o600))
+
+	dropinDir := filepath.Join(configDir, "conf.d")
+	require.NoError(os.MkdirAll(dropinDir, 0o755))
+
+	// Create a dropin file with no read permissions
+	unreadablePath := filepath.Join(dropinDir, "01-unreadable.yaml")
+	require.NoError(os.WriteFile(unreadablePath, []byte("log-level: debug\n"), 0o000))
+
+	// Valid dropin applied after the unreadable one
+	require.NoError(os.WriteFile(
+		filepath.Join(dropinDir, "02-good.yaml"),
+		[]byte("log-level: warn\n"),
+		0o600,
+	))
+
+	err := cfg.LoadWithOverrides(configFile)
+	require.NoError(err, "unreadable dropin should be skipped, not cause an error")
+
+	// Valid dropin should still be applied
+	require.Equal("warn", cfg.LogLevel, "valid dropin after unreadable one should still be applied")
+
+	// Warning should be recorded for the unreadable dropin
+	require.Len(cfg.Warnings, 1, "one warning should be recorded for the unreadable dropin")
+	require.Contains(cfg.Warnings[0], "01-unreadable.yaml")
 }

--- a/internal/agent/device/applications/manager.go
+++ b/internal/agent/device/applications/manager.go
@@ -219,25 +219,26 @@ func (m *manager) clearAppDataCache() {
 	m.appDataCache = provider.NewAppDataCache()
 }
 
-func (m *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, opts ...status.CollectorOpt) error {
+func (m *manager) Status(ctx context.Context, opts ...status.CollectorOpt) (*status.StatusContribution, error) {
 	var allResults []AppStatusResult
 
 	podmanResults, err := m.podmanMonitor.Status()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	allResults = append(allResults, podmanResults...)
 
 	k8sResults, err := m.kubernetesMonitor.Status()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	allResults = append(allResults, k8sResults...)
 
 	statuses, summary := aggregateAppStatuses(allResults)
-	status.ApplicationsSummary = summary
-	status.Applications = statuses
-	return nil
+	return &status.StatusContribution{
+		Applications:        statuses,
+		ApplicationsSummary: &summary,
+	}, nil
 }
 
 func aggregateAppStatuses(results []AppStatusResult) ([]v1beta1.DeviceApplicationStatus, v1beta1.DeviceApplicationsSummaryStatus) {

--- a/internal/agent/device/applications/mock_applications.go
+++ b/internal/agent/device/applications/mock_applications.go
@@ -190,21 +190,22 @@ func (mr *MockManagerMockRecorder) Shutdown(ctx, state any) *gomock.Call {
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }
 

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -404,7 +404,7 @@ func TestSync(t *testing.T) {
 			}
 			consoleManager := console.NewManager(mockRouterService, deviceName, "root", mockExec, mockWatcher, log)
 			appController := applications.NewController(podmanFactory, nil, mockAppManager, rwFactory, log, "2025-01-01T00:00:00Z")
-			statusManager := status.NewManager(deviceName, log)
+			statusManager := status.NewManager(deviceName, log, nil, nil)
 			statusManager.SetClient(mockManagementClient)
 			configController := config.NewController(readWriter, log)
 
@@ -526,7 +526,7 @@ func TestRollbackDevice(t *testing.T) {
 			dataDir := filepath.Join(tmpDir, "data")
 
 			policyManager := policy.NewManager(log)
-			statusManager := status.NewManager(deviceName, log)
+			statusManager := status.NewManager(deviceName, log, nil, nil)
 			statusManager.SetClient(mockManagementClient)
 			mockAuditLogger := audit.NewMockLogger(ctrl)
 			mockAuditLogger.EXPECT().Close().Return(nil).AnyTimes()
@@ -719,7 +719,7 @@ func TestOSRollback(t *testing.T) {
 
 			log := log.NewPrefixLogger("test")
 			log.SetLevel(logrus.DebugLevel)
-			statusManager := status.NewManager(deviceName, log)
+			statusManager := status.NewManager(deviceName, log, nil, nil)
 			statusManager.SetClient(mockManagementClient)
 
 			agent := Agent{

--- a/internal/agent/device/os/mock_os.go
+++ b/internal/agent/device/os/mock_os.go
@@ -199,20 +199,21 @@ func (mr *MockManagerMockRecorder) Rollback(ctx, desired any) *gomock.Call {
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -65,15 +65,18 @@ type manager struct {
 	log                *log.PrefixLogger
 }
 
-func (m *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
+func (m *manager) Status(ctx context.Context, _ ...status.CollectorOpt) (*status.StatusContribution, error) {
 	bootcInfo, err := m.client.Status(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	status.Os.Image = bootcInfo.GetBootedImage()
-	status.Os.ImageDigest = bootcInfo.GetBootedImageDigest()
-	return nil
+	return &status.StatusContribution{
+		Os: &v1beta1.DeviceOsStatus{
+			Image:       bootcInfo.GetBootedImage(),
+			ImageDigest: bootcInfo.GetBootedImageDigest(),
+		},
+	}, nil
 }
 
 func (m *manager) BeforeUpdate(ctx context.Context, current, desired *v1beta1.DeviceSpec) error {

--- a/internal/agent/device/resource/mock_resource.go
+++ b/internal/agent/device/resource/mock_resource.go
@@ -110,21 +110,22 @@ func (mr *MockManagerMockRecorder) Run(ctx any) *gomock.Call {
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }
 

--- a/internal/agent/device/resource/resource.go
+++ b/internal/agent/device/resource/resource.go
@@ -150,43 +150,30 @@ func (m *ResourceManager) ResetAlertDefaults() error {
 	return nil
 }
 
-// Status returns the device status based on the resource monitors and for the device summary.
-func (m *ResourceManager) Status(ctx context.Context, status *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
+// Status returns the device resource status and a summary contribution reflecting resource alerts.
+func (m *ResourceManager) Status(ctx context.Context, _ ...status.CollectorOpt) (*status.StatusContribution, error) {
 	alerts := m.Alerts()
 
+	var resources v1beta1.DeviceResourceStatus
 	hasCriticalOrErrorResource := false
 	hasDegradedResource := false
 	criticalResourceTypes := []string{}
 	degradedResourceTypes := []string{}
 
-	// define monitor types and alerts
-	resourceMonitors := map[string]struct {
+	type monitorDef struct {
+		monitorType string
 		alerts      []v1beta1.ResourceAlertRule
-		setStatusFn func(v1beta1.DeviceResourceStatusType)
-	}{
-		DiskMonitorType: {
-			alerts: alerts.DiskUsage,
-			setStatusFn: func(resourceStatus v1beta1.DeviceResourceStatusType) {
-				status.Resources.Disk = resourceStatus
-			},
-		},
-		CPUMonitorType: {
-			alerts: alerts.CPUUsage,
-			setStatusFn: func(resourceStatus v1beta1.DeviceResourceStatusType) {
-				status.Resources.Cpu = resourceStatus
-			},
-		},
-		MemoryMonitorType: {
-			alerts: alerts.MemoryUsage,
-			setStatusFn: func(resourceStatus v1beta1.DeviceResourceStatusType) {
-				status.Resources.Memory = resourceStatus
-			},
-		},
+		setFn       func(v1beta1.DeviceResourceStatusType)
 	}
 
-	// set the status for each monitor type
-	for monitorType, monitor := range resourceMonitors {
-		resourceStatus, alertMsg := getHighestSeverityResourceStatusFromAlerts(monitorType, monitor.alerts)
+	monitors := []monitorDef{
+		{DiskMonitorType, alerts.DiskUsage, func(s v1beta1.DeviceResourceStatusType) { resources.Disk = s }},
+		{CPUMonitorType, alerts.CPUUsage, func(s v1beta1.DeviceResourceStatusType) { resources.Cpu = s }},
+		{MemoryMonitorType, alerts.MemoryUsage, func(s v1beta1.DeviceResourceStatusType) { resources.Memory = s }},
+	}
+
+	for _, mon := range monitors {
+		resourceStatus, alertMsg := getHighestSeverityResourceStatusFromAlerts(mon.monitorType, mon.alerts)
 		if alertMsg != "" {
 			m.log.Warn(alertMsg)
 		}
@@ -194,28 +181,36 @@ func (m *ResourceManager) Status(ctx context.Context, status *v1beta1.DeviceStat
 		switch resourceStatus {
 		case v1beta1.DeviceResourceStatusCritical, v1beta1.DeviceResourceStatusError:
 			hasCriticalOrErrorResource = true
-			criticalResourceTypes = append(criticalResourceTypes, monitorType)
+			criticalResourceTypes = append(criticalResourceTypes, mon.monitorType)
 		case v1beta1.DeviceResourceStatusWarning:
 			hasDegradedResource = true
-			degradedResourceTypes = append(degradedResourceTypes, monitorType)
+			degradedResourceTypes = append(degradedResourceTypes, mon.monitorType)
 		}
 
-		monitor.setStatusFn(resourceStatus)
+		mon.setFn(resourceStatus)
 	}
 
-	// ensure status proper reflects in the device summary
+	contribution := &status.StatusContribution{
+		Resources: &resources,
+	}
+
 	if hasCriticalOrErrorResource {
-		status.Summary.Status = v1beta1.DeviceSummaryStatusError
-		status.Summary.Info = lo.ToPtr(fmt.Sprintf("Critical resource alert: %s", strings.Join(criticalResourceTypes, ", ")))
+		contribution.SummaryContribution = &status.SummaryContribution{
+			Status: v1beta1.DeviceSummaryStatusError,
+			Info:   lo.ToPtr(fmt.Sprintf("Critical resource alert: %s", strings.Join(criticalResourceTypes, ", "))),
+		}
 	} else if hasDegradedResource {
-		status.Summary.Status = v1beta1.DeviceSummaryStatusDegraded
-		status.Summary.Info = lo.ToPtr(fmt.Sprintf("Degraded resource alert: %s", strings.Join(degradedResourceTypes, ", ")))
+		contribution.SummaryContribution = &status.SummaryContribution{
+			Status: v1beta1.DeviceSummaryStatusDegraded,
+			Info:   lo.ToPtr(fmt.Sprintf("Degraded resource alert: %s", strings.Join(degradedResourceTypes, ", "))),
+		}
 	} else {
-		status.Summary.Status = v1beta1.DeviceSummaryStatusOnline
-		status.Summary.Info = nil
+		contribution.SummaryContribution = &status.SummaryContribution{
+			Status: v1beta1.DeviceSummaryStatusOnline,
+		}
 	}
 
-	return nil
+	return contribution, nil
 }
 
 func (m *ResourceManager) Alerts() *Alerts {

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -562,9 +562,12 @@ func (s *manager) CheckOsReconciliation(ctx context.Context) (string, bool, erro
 	return bootedOSImage, desired.Spec.Os.Image == osStatus.GetBootedImage(), nil
 }
 
-func (s *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
-	status.Config.RenderedVersion = s.cache.getRenderedVersion(Current)
-	return nil
+func (s *manager) Status(ctx context.Context, _ ...status.CollectorOpt) (*status.StatusContribution, error) {
+	return &status.StatusContribution{
+		Config: &v1beta1.DeviceConfigStatus{
+			RenderedVersion: s.cache.getRenderedVersion(Current),
+		},
+	}, nil
 }
 
 func (s *manager) CheckPolicy(ctx context.Context, policyType policy.Type, version string) error {

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -361,21 +361,22 @@ func (mr *MockManagerMockRecorder) SetUpgradeFailed(version, specHash any) *gomo
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }
 

--- a/internal/agent/device/status/mock_status.go
+++ b/internal/agent/device/status/mock_status.go
@@ -42,21 +42,22 @@ func (m *MockExporter) EXPECT() *MockExporterMockRecorder {
 }
 
 // Status mocks base method.
-func (m *MockExporter) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...CollectorOpt) error {
+func (m *MockExporter) Status(arg0 context.Context, arg1 ...CollectorOpt) (*StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockExporterMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockExporterMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockExporter)(nil).Status), varargs...)
 }
 
@@ -163,18 +164,6 @@ func (m *MockManager) InvalidateLastStatus() {
 func (mr *MockManagerMockRecorder) InvalidateLastStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateLastStatus", reflect.TypeOf((*MockManager)(nil).InvalidateLastStatus))
-}
-
-// RegisterStatusExporter mocks base method.
-func (m *MockManager) RegisterStatusExporter(arg0 Exporter) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterStatusExporter", arg0)
-}
-
-// RegisterStatusExporter indicates an expected call of RegisterStatusExporter.
-func (mr *MockManagerMockRecorder) RegisterStatusExporter(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterStatusExporter", reflect.TypeOf((*MockManager)(nil).RegisterStatusExporter), arg0)
 }
 
 // SetClient mocks base method.

--- a/internal/agent/device/status/status.go
+++ b/internal/agent/device/status/status.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,10 +24,47 @@ const (
 
 var _ Manager = (*StatusManager)(nil)
 
+// StatusContribution holds the status data returned by an exporter.
+// Each exporter populates only the fields it owns; nil fields are ignored
+// during merge.
+//
+// If an exporter returns both a non-nil StatusContribution and a non-nil
+// error, the contribution is still merged (the exporter did its best) and
+// the error is aggregated with other exporter errors.
+type StatusContribution struct {
+	Applications        []v1beta1.DeviceApplicationStatus
+	ApplicationsSummary *v1beta1.DeviceApplicationsSummaryStatus
+	Systemd             *[]v1beta1.SystemdUnitStatus
+	Resources           *v1beta1.DeviceResourceStatus
+	Os                  *v1beta1.DeviceOsStatus
+	Config              *v1beta1.DeviceConfigStatus
+	SystemInfo          *v1beta1.DeviceSystemInfo
+	// SummaryContribution lets an exporter influence the device summary
+	// without setting it directly. The manager picks highest severity.
+	SummaryContribution *SummaryContribution
+}
+
+// SummaryContribution carries an exporter's desired summary severity.
+type SummaryContribution struct {
+	Status v1beta1.DeviceSummaryStatusType
+	Info   *string
+}
+
+// summaryPriority defines the ordering for picking the highest-severity summary.
+var summaryPriority = map[v1beta1.DeviceSummaryStatusType]int{
+	v1beta1.DeviceSummaryStatusUnknown:   0,
+	v1beta1.DeviceSummaryStatusOnline:    1,
+	v1beta1.DeviceSummaryStatusDegraded:  2,
+	v1beta1.DeviceSummaryStatusRebooting: 3,
+	v1beta1.DeviceSummaryStatusError:     4,
+}
+
 // NewManager creates a new device status manager.
 func NewManager(
 	deviceName string,
 	log *log.PrefixLogger,
+	exporters []Exporter,
+	configWarnings []string,
 ) *StatusManager {
 	status := v1beta1.NewDeviceStatus()
 	return &StatusManager{
@@ -39,40 +77,43 @@ func NewManager(
 			},
 			Status: &status,
 		},
-		log: log,
+		exporters:      exporters,
+		configWarnings: configWarnings,
+		log:            log,
 	}
 }
 
-// Collector aggregates device status from various exporters.
+// StatusManager aggregates device status from various exporters.
 type StatusManager struct {
 	mu               sync.Mutex
 	deviceName       string
 	managementClient client.Management
 	exporters        []Exporter
+	configWarnings   []string
 	device           *v1beta1.Device
 	lastStatus       *v1beta1.DeviceStatus
 
 	log *log.PrefixLogger
 }
 
+// Exporter returns a StatusContribution describing the exporter's owned fields.
 type Exporter interface {
-	// Status collects status information and updates the device status.
-	Status(context.Context, *v1beta1.DeviceStatus, ...CollectorOpt) error
+	Status(context.Context, ...CollectorOpt) (*StatusContribution, error)
 }
 
+// Getter provides read access to the device status.
 type Getter interface {
 	// Get returns the device status and is safe to call without a management client.
 	Get(context.Context) *v1beta1.DeviceStatus
 }
 
+// Manager is the consumer-facing interface for device status operations.
 type Manager interface {
 	Getter
 	// Sync collects status information from all exporters and updates the device status.
 	Sync(context.Context) error
 	// Collect gathers status information from all exporters and is safe to call without a management client.
 	Collect(context.Context, ...CollectorOpt) error
-	// RegisterStatusExporter registers an exporter to be called when collecting status.
-	RegisterStatusExporter(Exporter)
 	// Update updates the device status with the given update functions.
 	Update(ctx context.Context, updateFuncs ...UpdateStatusFn) (*v1beta1.DeviceStatus, error)
 	// UpdateCondition updates the device status with the given condition.
@@ -104,15 +145,10 @@ func (m *StatusManager) Get(ctx context.Context) *v1beta1.DeviceStatus {
 	return &statusCopy
 }
 
-// reset assumes the lock is held
+// reset assumes the lock is held — only Applications is zeroed; other fields
+// carry forward from the previous cycle.
 func (m *StatusManager) reset() {
 	m.device.Status.Applications = m.device.Status.Applications[:0]
-}
-
-func (m *StatusManager) RegisterStatusExporter(exporter Exporter) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.exporters = append(m.exporters, exporter)
 }
 
 func (m *StatusManager) Collect(ctx context.Context, opts ...CollectorOpt) error {
@@ -126,21 +162,108 @@ func (m *StatusManager) Collect(ctx context.Context, opts ...CollectorOpt) error
 func (m *StatusManager) collect(ctx context.Context, opts ...CollectorOpt) error {
 	m.reset()
 
-	errs := []error{}
+	var errs []error
+	var summaryContributions []*SummaryContribution
+
 	for _, export := range m.exporters {
-		if err := export.Status(ctx, m.device.Status, opts...); err != nil {
+		contribution, err := export.Status(ctx, opts...)
+		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
 			}
 			errs = append(errs, err)
 		}
+		if contribution != nil {
+			mergeContribution(m.device.Status, contribution)
+			if contribution.SummaryContribution != nil {
+				summaryContributions = append(summaryContributions, contribution.SummaryContribution)
+			}
+		}
 	}
+
+	m.device.Status.Summary = calculateSummary(summaryContributions, m.configWarnings)
 
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 
 	return nil
+}
+
+// mergeContribution applies non-nil fields from a StatusContribution onto
+// the existing DeviceStatus. Nil fields are left untouched (carry-forward).
+func mergeContribution(s *v1beta1.DeviceStatus, c *StatusContribution) {
+	if c == nil {
+		return
+	}
+	if c.Applications != nil {
+		s.Applications = append(s.Applications, c.Applications...)
+	}
+	if c.ApplicationsSummary != nil {
+		s.ApplicationsSummary = *c.ApplicationsSummary
+	}
+	if c.Systemd != nil {
+		if *c.Systemd == nil {
+			s.Systemd = nil
+		} else {
+			s.Systemd = c.Systemd
+		}
+	}
+	if c.Resources != nil {
+		s.Resources = *c.Resources
+	}
+	if c.Os != nil {
+		s.Os = *c.Os
+	}
+	if c.Config != nil {
+		s.Config = *c.Config
+	}
+	if c.SystemInfo != nil {
+		s.SystemInfo = *c.SystemInfo
+	}
+}
+
+// calculateSummary picks the highest-severity SummaryContribution using
+// summaryPriority ordering. If configWarnings are present and no higher
+// severity exists, returns Degraded with the joined warning message.
+// If no contributions exist, returns Online with nil Info.
+func calculateSummary(contributions []*SummaryContribution, configWarnings []string) v1beta1.DeviceSummaryStatus {
+	var best *SummaryContribution
+	bestPriority := -1
+
+	for _, c := range contributions {
+		if c == nil {
+			continue
+		}
+		p := summaryPriority[c.Status]
+		if p >= bestPriority {
+			bestPriority = p
+			best = c
+		}
+	}
+
+	// Config warnings contribute Degraded if no higher severity exists
+	if len(configWarnings) > 0 {
+		degradedPriority := summaryPriority[v1beta1.DeviceSummaryStatusDegraded]
+		if bestPriority < degradedPriority {
+			msg := log.Truncate(strings.Join(configWarnings, "; "), MaxMessageLength)
+			return v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusDegraded,
+				Info:   &msg,
+			}
+		}
+	}
+
+	if best == nil {
+		return v1beta1.DeviceSummaryStatus{
+			Status: v1beta1.DeviceSummaryStatusOnline,
+		}
+	}
+
+	return v1beta1.DeviceSummaryStatus{
+		Status: best.Status,
+		Info:   best.Info,
+	}
 }
 
 // ReloadCollect collects status information from all exporters in the case that

--- a/internal/agent/device/status/status_test.go
+++ b/internal/agent/device/status/status_test.go
@@ -2,19 +2,426 @@ package status
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
-// TestInvalidateLastStatus_CausesNextSyncToPush verifies that when InvalidateLastStatus is called,
-// the next Sync pushes status again (UpdateDeviceStatus called twice total). We call InvalidateLastStatus
-// ourselves here because this test is about the StatusManager's behavior. The condition under which
-// it gets called (GetRenderedDevice returns 200 with ConflictPaused) is tested in spec/publisher_test.go
-// (TestDevicePublisher_ConflictPausedCallback).
+func TestMergeContribution(t *testing.T) {
+	testCases := []struct {
+		name     string
+		initial  func() *v1beta1.DeviceStatus
+		contrib  *StatusContribution
+		validate func(*testing.T, *v1beta1.DeviceStatus)
+	}{
+		{
+			name: "When contribution is nil it should be a no-op",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: nil,
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				expected := v1beta1.NewDeviceStatus()
+				require.Equal(t, &expected, s)
+			},
+		},
+		{
+			name: "When all fields are nil it should preserve existing values",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				s.Os.Image = "existing-image"
+				s.Config.RenderedVersion = "v1"
+				return &s
+			},
+			contrib: &StatusContribution{},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, "existing-image", s.Os.Image)
+				require.Equal(t, "v1", s.Config.RenderedVersion)
+			},
+		},
+		{
+			name: "When Applications is set it should append to existing",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				s.Applications = []v1beta1.DeviceApplicationStatus{{Name: "existing"}}
+				return &s
+			},
+			contrib: &StatusContribution{
+				Applications: []v1beta1.DeviceApplicationStatus{{Name: "new-app"}},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Len(t, s.Applications, 2)
+				require.Equal(t, "existing", s.Applications[0].Name)
+				require.Equal(t, "new-app", s.Applications[1].Name)
+			},
+		},
+		{
+			name: "When ApplicationsSummary is set it should overwrite",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: &StatusContribution{
+				ApplicationsSummary: &v1beta1.DeviceApplicationsSummaryStatus{
+					Status: v1beta1.ApplicationsSummaryStatusHealthy,
+				},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, v1beta1.ApplicationsSummaryStatusHealthy, s.ApplicationsSummary.Status)
+			},
+		},
+		{
+			name: "When Systemd is set with non-nil slice it should set field",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: &StatusContribution{
+				Systemd: lo.ToPtr([]v1beta1.SystemdUnitStatus{{Unit: "foo.service"}}),
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.NotNil(t, s.Systemd)
+				require.Len(t, *s.Systemd, 1)
+				require.Equal(t, "foo.service", (*s.Systemd)[0].Unit)
+			},
+		},
+		{
+			name: "When Systemd points to nil slice it should clear field to nil",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				s.Systemd = lo.ToPtr([]v1beta1.SystemdUnitStatus{{Unit: "old.service"}})
+				return &s
+			},
+			contrib: func() *StatusContribution {
+				var nilSlice []v1beta1.SystemdUnitStatus
+				return &StatusContribution{Systemd: &nilSlice}
+			}(),
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Nil(t, s.Systemd)
+			},
+		},
+		{
+			name: "When Resources is set it should overwrite",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: &StatusContribution{
+				Resources: &v1beta1.DeviceResourceStatus{
+					Cpu:    v1beta1.DeviceResourceStatusWarning,
+					Disk:   v1beta1.DeviceResourceStatusHealthy,
+					Memory: v1beta1.DeviceResourceStatusHealthy,
+				},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, v1beta1.DeviceResourceStatusWarning, s.Resources.Cpu)
+			},
+		},
+		{
+			name: "When Os is set it should overwrite",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				s.Os.Image = "old-image"
+				return &s
+			},
+			contrib: &StatusContribution{
+				Os: &v1beta1.DeviceOsStatus{
+					Image:       "new-image",
+					ImageDigest: "sha256:abc",
+				},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, "new-image", s.Os.Image)
+				require.Equal(t, "sha256:abc", s.Os.ImageDigest)
+			},
+		},
+		{
+			name: "When Config is set it should overwrite",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: &StatusContribution{
+				Config: &v1beta1.DeviceConfigStatus{RenderedVersion: "v5"},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, "v5", s.Config.RenderedVersion)
+			},
+		},
+		{
+			name: "When SystemInfo is set it should overwrite",
+			initial: func() *v1beta1.DeviceStatus {
+				s := v1beta1.NewDeviceStatus()
+				return &s
+			},
+			contrib: &StatusContribution{
+				SystemInfo: &v1beta1.DeviceSystemInfo{
+					Architecture: "amd64",
+					BootID:       "boot-123",
+				},
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus) {
+				require.Equal(t, "amd64", s.SystemInfo.Architecture)
+				require.Equal(t, "boot-123", s.SystemInfo.BootID)
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.initial()
+			mergeContribution(s, tt.contrib)
+			tt.validate(t, s)
+		})
+	}
+}
+
+func TestCalculateSummary(t *testing.T) {
+	testCases := []struct {
+		name           string
+		contributions  []*SummaryContribution
+		configWarnings []string
+		expected       v1beta1.DeviceSummaryStatus
+	}{
+		{
+			name:          "When no contributions and no warnings it should default to Online",
+			contributions: nil,
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusOnline,
+			},
+		},
+		{
+			name: "When single Online contribution it should return Online",
+			contributions: []*SummaryContribution{
+				{Status: v1beta1.DeviceSummaryStatusOnline},
+			},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusOnline,
+			},
+		},
+		{
+			name: "When Error and Degraded it should pick Error (highest severity)",
+			contributions: []*SummaryContribution{
+				{Status: v1beta1.DeviceSummaryStatusDegraded, Info: lo.ToPtr("degraded reason")},
+				{Status: v1beta1.DeviceSummaryStatusError, Info: lo.ToPtr("error reason")},
+			},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusError,
+				Info:   lo.ToPtr("error reason"),
+			},
+		},
+		{
+			name: "When Rebooting and Online it should pick Rebooting",
+			contributions: []*SummaryContribution{
+				{Status: v1beta1.DeviceSummaryStatusOnline},
+				{Status: v1beta1.DeviceSummaryStatusRebooting, Info: lo.ToPtr("rebooting")},
+			},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusRebooting,
+				Info:   lo.ToPtr("rebooting"),
+			},
+		},
+		{
+			name: "When tied severity it should pick the last one",
+			contributions: []*SummaryContribution{
+				{Status: v1beta1.DeviceSummaryStatusDegraded, Info: lo.ToPtr("first")},
+				{Status: v1beta1.DeviceSummaryStatusDegraded, Info: lo.ToPtr("second")},
+			},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusDegraded,
+				Info:   lo.ToPtr("second"),
+			},
+		},
+		{
+			name:           "When config warnings present and no higher severity it should return Degraded",
+			contributions:  []*SummaryContribution{{Status: v1beta1.DeviceSummaryStatusOnline}},
+			configWarnings: []string{"bad config", "another warning"},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusDegraded,
+				Info:   lo.ToPtr("bad config; another warning"),
+			},
+		},
+		{
+			name: "When config warnings present but Error severity exists it should keep Error",
+			contributions: []*SummaryContribution{
+				{Status: v1beta1.DeviceSummaryStatusError, Info: lo.ToPtr("critical")},
+			},
+			configWarnings: []string{"config issue"},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusError,
+				Info:   lo.ToPtr("critical"),
+			},
+		},
+		{
+			name:           "When config warnings and no contributions it should return Degraded",
+			contributions:  nil,
+			configWarnings: []string{"some warning"},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusDegraded,
+				Info:   lo.ToPtr("some warning"),
+			},
+		},
+		{
+			name: "When nil contribution entries it should ignore them",
+			contributions: []*SummaryContribution{
+				nil,
+				{Status: v1beta1.DeviceSummaryStatusDegraded, Info: lo.ToPtr("valid")},
+				nil,
+			},
+			expected: v1beta1.DeviceSummaryStatus{
+				Status: v1beta1.DeviceSummaryStatusDegraded,
+				Info:   lo.ToPtr("valid"),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			result := calculateSummary(tt.contributions, tt.configWarnings)
+			require.Equal(tt.expected.Status, result.Status)
+			if tt.expected.Info == nil {
+				require.Nil(result.Info)
+			} else {
+				require.NotNil(result.Info)
+				require.Equal(*tt.expected.Info, *result.Info)
+			}
+		})
+	}
+}
+
+func TestCollect(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setupMocks func(*MockExporter, *MockExporter)
+		validate   func(*testing.T, *v1beta1.DeviceStatus, error)
+	}{
+		{
+			name: "When multiple exporters succeed it should merge all contributions",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					Os: &v1beta1.DeviceOsStatus{Image: "image-1"},
+				}, nil)
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					Config: &v1beta1.DeviceConfigStatus{RenderedVersion: "v3"},
+				}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.NoError(err)
+				require.Equal("image-1", s.Os.Image)
+				require.Equal("v3", s.Config.RenderedVersion)
+			},
+		},
+		{
+			name: "When exporter returns contribution and error it should merge contribution and aggregate error",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					Os: &v1beta1.DeviceOsStatus{Image: "partial-image"},
+				}, fmt.Errorf("partial failure"))
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					Config: &v1beta1.DeviceConfigStatus{RenderedVersion: "v2"},
+				}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.Error(err)
+				require.Contains(err.Error(), "partial failure")
+				require.Equal("partial-image", s.Os.Image)
+				require.Equal("v2", s.Config.RenderedVersion)
+			},
+		},
+		{
+			name: "When exporter returns nil contribution and error it should still continue",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(nil, fmt.Errorf("total failure"))
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					Config: &v1beta1.DeviceConfigStatus{RenderedVersion: "v4"},
+				}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.Error(err)
+				require.Contains(err.Error(), "total failure")
+				require.Equal("v4", s.Config.RenderedVersion)
+			},
+		},
+		{
+			name: "When collect is called it should carry forward prior status fields",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(&StatusContribution{}, nil)
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.NoError(err)
+				require.Equal("pre-existing-image", s.Os.Image)
+			},
+		},
+		{
+			name: "When collect is called it should reset Applications to empty",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(&StatusContribution{}, nil)
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.NoError(err)
+				require.Empty(s.Applications)
+			},
+		},
+		{
+			name: "When exporter provides SummaryContribution it should calculate summary",
+			setupMocks: func(exp1, exp2 *MockExporter) {
+				exp1.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					SummaryContribution: &SummaryContribution{
+						Status: v1beta1.DeviceSummaryStatusError,
+						Info:   lo.ToPtr("resource critical"),
+					},
+				}, nil)
+				exp2.EXPECT().Status(gomock.Any()).Return(&StatusContribution{
+					SummaryContribution: &SummaryContribution{
+						Status: v1beta1.DeviceSummaryStatusOnline,
+					},
+				}, nil)
+			},
+			validate: func(t *testing.T, s *v1beta1.DeviceStatus, err error) {
+				require := require.New(t)
+				require.NoError(err)
+				require.Equal(v1beta1.DeviceSummaryStatusError, s.Summary.Status)
+				require.NotNil(s.Summary.Info)
+				require.Equal("resource critical", *s.Summary.Info)
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			exp1 := NewMockExporter(ctrl)
+			exp2 := NewMockExporter(ctrl)
+			tt.setupMocks(exp1, exp2)
+
+			mgr := NewManager("test-device", log.NewPrefixLogger(""), []Exporter{exp1, exp2}, nil)
+			// Set pre-existing status to verify carry-forward
+			mgr.device.Status.Os.Image = "pre-existing-image"
+			mgr.device.Status.Applications = []v1beta1.DeviceApplicationStatus{{Name: "old-app"}}
+
+			err := mgr.Collect(context.Background())
+			tt.validate(t, mgr.device.Status, err)
+		})
+	}
+}
+
 func TestInvalidateLastStatus_CausesNextSyncToPush(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
@@ -25,11 +432,10 @@ func TestInvalidateLastStatus_CausesNextSyncToPush(t *testing.T) {
 	mockClient := client.NewMockManagement(ctrl)
 	mockExporter := NewMockExporter(ctrl)
 
-	mgr := NewManager(deviceName, log.NewPrefixLogger(""))
+	mgr := NewManager(deviceName, log.NewPrefixLogger(""), []Exporter{mockExporter}, nil)
 	mgr.SetClient(mockClient)
-	mgr.RegisterStatusExporter(mockExporter)
 
-	mockExporter.EXPECT().Status(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	mockExporter.EXPECT().Status(gomock.Any()).Return(&StatusContribution{}, nil).Times(2)
 	mockClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).Times(2)
 
 	require.NoError(mgr.Sync(ctx))

--- a/internal/agent/device/systemd/mock_systemd.go
+++ b/internal/agent/device/systemd/mock_systemd.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
 	client "github.com/flightctl/flightctl/internal/agent/client"
 	status "github.com/flightctl/flightctl/internal/agent/device/status"
 	gomock "go.uber.org/mock/gomock"
@@ -211,21 +210,22 @@ func (mr *MockManagerMockRecorder) Start(ctx any, units ...any) *gomock.Call {
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }
 

--- a/internal/agent/device/systemd/systemd.go
+++ b/internal/agent/device/systemd/systemd.go
@@ -154,15 +154,17 @@ func (m *manager) normalizeActiveStateValue(val v1beta1.SystemdActiveStateType) 
 	return val
 }
 
-func (m *manager) Status(ctx context.Context, device *v1beta1.DeviceStatus, _ ...status.CollectorOpt) error {
+func (m *manager) Status(ctx context.Context, _ ...status.CollectorOpt) (*status.StatusContribution, error) {
 	if len(m.patterns) == 0 {
-		device.Systemd = nil
-		return nil
+		var nilSlice []v1beta1.SystemdUnitStatus
+		return &status.StatusContribution{
+			Systemd: &nilSlice,
+		}, nil
 	}
 
 	units, err := m.client.ShowByMatchPattern(ctx, m.patterns)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	systemdUnits := make([]v1beta1.SystemdUnitStatus, 0, len(units))
@@ -181,8 +183,9 @@ func (m *manager) Status(ctx context.Context, device *v1beta1.DeviceStatus, _ ..
 			SubState:    unit["SubState"],
 		})
 	}
-	device.Systemd = lo.ToPtr(systemdUnits)
-	return nil
+	return &status.StatusContribution{
+		Systemd: lo.ToPtr(systemdUnits),
+	}, nil
 }
 
 func validatePatterns(patterns []string) error {

--- a/internal/agent/device/systemd/systemd_test.go
+++ b/internal/agent/device/systemd/systemd_test.go
@@ -312,14 +312,19 @@ UnitFileState=enabled
 				m.AddExclusions(tt.exclusions...)
 			}
 
-			status := v1beta1.NewDeviceStatus()
-			err := m.Status(context.Background(), &status)
+			contribution, err := m.Status(context.Background())
 
 			if tt.expectError {
 				require.Error(err)
 			} else {
 				require.NoError(err)
-				require.Equal(tt.expected, status.Systemd)
+				require.NotNil(contribution)
+				require.NotNil(contribution.Systemd)
+				if tt.expected == nil {
+					require.Nil(*contribution.Systemd)
+				} else {
+					require.Equal(*tt.expected, *contribution.Systemd)
+				}
 			}
 		})
 	}

--- a/internal/agent/device/systeminfo/manager.go
+++ b/internal/agent/device/systeminfo/manager.go
@@ -200,7 +200,7 @@ func (m *manager) BootTime() string {
 	return m.bootTime
 }
 
-func (m *manager) Status(ctx context.Context, deviceStatus *v1beta1.DeviceStatus, opts ...status.CollectorOpt) error {
+func (m *manager) Status(ctx context.Context, opts ...status.CollectorOpt) (*status.StatusContribution, error) {
 	collectorOpts := status.CollectorOpts{}
 	for _, opt := range opts {
 		opt(&collectorOpts)
@@ -209,7 +209,7 @@ func (m *manager) Status(ctx context.Context, deviceStatus *v1beta1.DeviceStatus
 
 	if m.collected && !collectorOpts.Force {
 		m.mu.Unlock()
-		return nil
+		return &status.StatusContribution{}, nil
 	}
 
 	// set collected to true even if there is an error this is to prevent
@@ -244,12 +244,10 @@ func (m *manager) Status(ctx context.Context, deviceStatus *v1beta1.DeviceStatus
 	)
 
 	if err != nil {
-		deviceStatus.SystemInfo = m.defaultSystemInfo()
-		return err
+		defaultInfo := m.defaultSystemInfo()
+		return &status.StatusContribution{SystemInfo: &defaultInfo}, err
 	}
-	deviceStatus.SystemInfo = systemInfo
-
-	return nil
+	return &status.StatusContribution{SystemInfo: &systemInfo}, nil
 }
 
 // defaultSystemInfo returns the default system info.

--- a/internal/agent/device/systeminfo/mock_system_info.go
+++ b/internal/agent/device/systeminfo/mock_system_info.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
 	status "github.com/flightctl/flightctl/internal/agent/device/status"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -96,20 +95,21 @@ func (mr *MockManagerMockRecorder) RegisterCollector(ctx, key, fn any) *gomock.C
 }
 
 // Status mocks base method.
-func (m *MockManager) Status(arg0 context.Context, arg1 *v1beta1.DeviceStatus, arg2 ...status.CollectorOpt) error {
+func (m *MockManager) Status(arg0 context.Context, arg1 ...status.CollectorOpt) (*status.StatusContribution, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Status", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*status.StatusContribution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockManagerMockRecorder) Status(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Status(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockManager)(nil).Status), varargs...)
 }


### PR DESCRIPTION
# Release target (required before merge to `main`)

- [x] **`release-X.Y`**

## Summary

Refactors the status `Exporter` interface so each exporter returns a `StatusContribution` struct instead of mutating a shared `*DeviceStatus`. The `StatusManager` now merges contributions and calculates the aggregate device summary, eliminating order-dependent mutations and making the data flow explicit.

Follow-up to [#2823](https://github.com/flightctl/flightctl/pull/2823) — addresses review feedback about architectural separation of concerns in the status pipeline.

## Motivation

The previous design had each exporter receive a `*DeviceStatus` pointer and write directly into it. This created implicit coupling between exporters and made the aggregation order-dependent. Moving to a return-value pattern makes each exporter's ownership explicit and lets the manager control aggregation.

## Changes

**New types (`internal/agent/device/status/status.go`):**
- `StatusContribution` — each exporter populates only the fields it owns; nil fields are ignored during merge
- `SummaryContribution` — exporters declare a desired summary severity; manager picks highest
- `summaryPriority` map for severity ordering (Unknown < Online < Degraded < Rebooting < Error)
- `mergeContribution()` — applies non-nil fields from a contribution onto existing status
- `calculateSummary()` — picks highest-severity summary contribution

**Updated exporters (all return `*StatusContribution`):**
- Applications, Systemd, Resource, OS, Spec, SystemInfo

**Wiring (`internal/agent/agent.go`):**
- Removed `configWarningExporter` — config warnings now passed to `NewManager` constructor
- Exporters passed to `NewManager` instead of registered after construction

**Tests (`status_test.go`):**
- `TestMergeContribution` — 10 subtests covering nil/non-nil field merge
- `TestCalculateSummary` — 9 subtests covering severity ordering, config warnings, defaults
- `TestCollect` — 6 subtests covering multi-exporter merge, partial-error, carry-forward

## Testing

- **Unit tests:** 26 new subtests across 3 test functions, all passing
- **Coverage:** `mergeContribution` 100%, `calculateSummary` 100%, `collect` 94.1%
- **Full suite:** 4592 tests passed (2 pre-existing PAM build failures unrelated)
- **Lint:** clean
