### PR TITLE
EDM-4380: support quadlet deployments in dependency sync e2e tests

### DIFF
--- a/test/e2e/dependency_sync/dependency_sync_suite_test.go
+++ b/test/e2e/dependency_sync/dependency_sync_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/quadlet"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,17 +24,82 @@ const (
 	EVENTTIMEOUT  = "4m"
 
 	fastPollInterval = 30 * time.Second
+
+	// periodicTemplatePath is the host path for the periodic service's config template.
+	// ExecStartPre renders this template on every service start/restart.
+	periodicTemplatePath = "/usr/share/flightctl/flightctl-periodic/config.yaml.template"
+
+	// dependenciesSyncTemplateBlock is a Go template block appended to the periodic
+	// config template so that ExecStartPre renders dependenciesSync from service-config.yaml.
+	dependenciesSyncTemplateBlock = `{{- if .dependenciesSync}}
+dependenciesSync:
+  pollInterval: {{if .dependenciesSync.pollInterval}}{{.dependenciesSync.pollInterval}}{{else}}15m{{end}}
+{{- end}}
+`
 )
 
 var (
-	auxSvcs            *auxiliary.Services
-	originalConfigYAML string
+	auxSvcs                 *auxiliary.Services
+	originalConfigYAML      string
+	originalTemplateContent string
 )
 
 func TestDependencySync(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Dependency Sync E2E Suite")
 }
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	ctx := context.Background()
+	auxSvcs = auxiliary.Get(ctx)
+
+	fileServerSvcs, err := auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceFileServer})
+	Expect(err).ToNot(HaveOccurred(), "failed to start file server")
+	auxSvcs.FileServer = fileServerSvcs.FileServer
+
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+
+	// On quadlets, the periodic config template does not include a dependenciesSync
+	// section, so ExecStartPre (which re-renders the template on every restart)
+	// would drop the patched poll interval. Patch the template before restarting.
+	providers := setup.GetDefaultProviders()
+	if providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		Expect(managePeriodicTemplate(providers, true)).To(Succeed(), "patch periodic template for quadlet")
+	}
+
+	originalConfigYAML, err = patchPollInterval(fastPollInterval)
+	Expect(err).ToNot(HaveOccurred(), "patchPollInterval must succeed; tests assume a 30s poll interval")
+	GinkgoWriter.Printf("Lowered dependency sync poll interval to %v\n", fastPollInterval)
+	return []byte(originalConfigYAML)
+}, func(data []byte) {
+	originalConfigYAML = string(data)
+	e2e.SetupWorkerHarnessOrAbort()
+})
+
+var _ = SynchronizedAfterSuite(func() {
+}, func() {
+	// Restore the original periodic template on quadlets first, before
+	// restorePollInterval which restarts the service. If restore runs after
+	// and fails (e.g. restart timeout), the patched template stays on the
+	// host permanently — every future periodic restart would render a
+	// dependenciesSync section that was never part of the original deployment.
+	providers := setup.GetDefaultProviders()
+	if providers != nil && providers.Infra.GetEnvironmentType() == infra.EnvironmentQuadlet {
+		if err := managePeriodicTemplate(providers, false); err != nil {
+			GinkgoWriter.Printf("WARNING: failed to restore periodic template: %v\n", err)
+		}
+	}
+
+	err := restorePollInterval(originalConfigYAML)
+	if err != nil {
+		GinkgoWriter.Printf("WARNING: restorePollInterval failed: %v\n", err)
+	}
+
+	_ = auxiliary.StopServices([]auxiliary.Service{auxiliary.ServiceFileServer})
+	if auxSvcs != nil {
+		auxSvcs.Cleanup(context.Background())
+	}
+})
 
 // patchPollInterval lowers the dependency-sync poll interval for fast E2E testing.
 func patchPollInterval(interval time.Duration) (originalConfig string, err error) {
@@ -103,33 +169,54 @@ func restorePollInterval(original string) error {
 	return nil
 }
 
-var _ = SynchronizedBeforeSuite(func() []byte {
-	ctx := context.Background()
-	auxSvcs = auxiliary.Get(ctx)
+// managePeriodicTemplate patches or restores the periodic config template on the
+// quadlet host. When patch is true, it appends a dependenciesSync block to the
+// template so ExecStartPre renders it from service-config.yaml. When patch is
+// false, it restores the original template and removes the stale dependenciesSync
+// key from service-config.yaml.
+func managePeriodicTemplate(providers *infra.Providers, patch bool) error {
+	quadletInfra, ok := providers.Infra.(*quadlet.InfraProvider)
+	if !ok {
+		return fmt.Errorf("expected quadlet infra provider")
+	}
 
-	fileServerSvcs, err := auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceFileServer})
-	Expect(err).ToNot(HaveOccurred(), "failed to start file server")
-	auxSvcs.FileServer = fileServerSvcs.FileServer
+	if patch {
+		content, err := quadletInfra.ReadHostFile(periodicTemplatePath)
+		if err != nil {
+			return fmt.Errorf("read periodic template: %w", err)
+		}
+		originalTemplateContent = content
 
-	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+		return quadletInfra.WriteHostFile(periodicTemplatePath, []byte(content+dependenciesSyncTemplateBlock))
+	}
 
-	originalConfigYAML, err = patchPollInterval(fastPollInterval)
-	Expect(err).ToNot(HaveOccurred(), "patchPollInterval must succeed; tests assume a 30s poll interval")
-	GinkgoWriter.Printf("Lowered dependency sync poll interval to %v\n", fastPollInterval)
-	return []byte(originalConfigYAML)
-}, func(data []byte) {
-	originalConfigYAML = string(data)
-	e2e.SetupWorkerHarnessOrAbort()
-})
+	// Restore the original template.
+	if originalTemplateContent == "" {
+		return nil
+	}
+	if err := quadletInfra.WriteHostFile(periodicTemplatePath, []byte(originalTemplateContent)); err != nil {
+		return fmt.Errorf("restore periodic template: %w", err)
+	}
 
-var _ = SynchronizedAfterSuite(func() {
-}, func() {
-	err := restorePollInterval(originalConfigYAML)
+	// Remove stale dependenciesSync from service-config.yaml. The mapping
+	// leaves it behind because the original config doesn't contain the key.
+	raw, err := quadletInfra.GetStandaloneServiceConfig()
 	if err != nil {
-		GinkgoWriter.Printf("WARNING: restorePollInterval failed: %v\n", err)
+		return fmt.Errorf("read service-config.yaml for cleanup: %w", err)
 	}
-	_ = auxiliary.StopServices([]auxiliary.Service{auxiliary.ServiceFileServer})
-	if auxSvcs != nil {
-		auxSvcs.Cleanup(context.Background())
+	var svcCfg map[string]interface{}
+	if err := yaml.Unmarshal([]byte(raw), &svcCfg); err != nil {
+		return fmt.Errorf("parse service-config.yaml for cleanup: %w", err)
 	}
-})
+	if _, exists := svcCfg["dependenciesSync"]; exists {
+		delete(svcCfg, "dependenciesSync")
+		out, err := yaml.Marshal(svcCfg)
+		if err != nil {
+			return fmt.Errorf("marshal service-config.yaml after cleanup: %w", err)
+		}
+		if err := quadletInfra.SetStandaloneServiceConfig(string(out)); err != nil {
+			return fmt.Errorf("write cleaned service-config.yaml: %w", err)
+		}
+	}
+	return nil
+}

--- a/test/e2e/dependency_sync/dependency_sync_test.go
+++ b/test/e2e/dependency_sync/dependency_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
@@ -89,7 +90,6 @@ var _ = Describe("Dependency Sync", Label("dependency-sync"), func() {
 		p := setup.GetDefaultProviders()
 		Expect(p).ToNot(BeNil(), "infra providers must be initialized")
 		releaseNamespace = p.Infra.GetExternalNamespace()
-		Expect(releaseNamespace).ToNot(BeEmpty(), "could not resolve release namespace")
 		secretNamespace = p.Infra.GetInternalNamespace()
 		if secretNamespace == "" {
 			secretNamespace = releaseNamespace
@@ -351,6 +351,7 @@ var _ = Describe("Dependency Sync", Label("dependency-sync"), func() {
 		})
 
 		It("should create a new TV and update device fingerprint when a K8s secret is updated", Label("89094", "sanity", "agent"), func() {
+			infra.SkipIfNotK8s("K8s secret sync requires Kubernetes")
 			fleetName := fmt.Sprintf("dep-sync-secret-fleet-%s", testID)
 			secretName := fmt.Sprintf("dep-sync-secret-%s", testID)
 
@@ -405,6 +406,7 @@ var _ = Describe("Dependency Sync", Label("dependency-sync"), func() {
 		})
 
 		It("should re-render a standalone device when a K8s secret is updated", Label("89321", "sanity", "agent"), func() {
+			infra.SkipIfNotK8s("K8s secret sync requires Kubernetes")
 			secretName := fmt.Sprintf("ds-secret-sa-%s", testID)
 
 			By("creating a K8s secret for the test")

--- a/test/e2e/infra/quadlet/service_config_mapping.go
+++ b/test/e2e/infra/quadlet/service_config_mapping.go
@@ -64,6 +64,11 @@ var serviceConfigSectionMappings = map[infra.ServiceName][]SectionMapping{
 			ServiceConfigKey: "vulnerabilityReporting",
 			Transform:        nil,
 		},
+		{
+			RenderedKey:      "dependenciesSync",
+			ServiceConfigKey: "dependenciesSync",
+			Transform:        nil,
+		},
 	},
 }
 

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -320,6 +320,54 @@ vulnerabilityReporting:
 	}
 }
 
+// TestApplyServiceConfigMappings_DependenciesSync verifies that the dependenciesSync
+// section is correctly extracted from per-service config into service-config.yaml updates.
+// Equivalent to TestApplyServiceConfigMappings_VulnerabilityReporting for the dependenciesSync mapping.
+func TestApplyServiceConfigMappings_DependenciesSync(t *testing.T) {
+	configYAML := `
+dependenciesSync:
+  pollInterval: 30s
+`
+	updates, err := applyServiceConfigMappings(infra.ServicePeriodic, configYAML)
+	require.NoError(t, err)
+	require.NotNil(t, updates)
+
+	section, ok := updates["dependenciesSync"].(map[string]interface{})
+	require.True(t, ok, "updates should contain dependenciesSync")
+	assert.Equal(t, "30s", section["pollInterval"])
+}
+
+// TestApplyServiceConfigMappings_DependenciesSyncDeletion verifies that an explicit null
+// for dependenciesSync signals deletion from service-config.yaml.
+// Equivalent to TestApplyServiceConfigMappings_VulnerabilityReportingDeletion for the dependenciesSync mapping.
+func TestApplyServiceConfigMappings_DependenciesSyncDeletion(t *testing.T) {
+	configYAML := `
+dependenciesSync: null
+`
+	updates, err := applyServiceConfigMappings(infra.ServicePeriodic, configYAML)
+	require.NoError(t, err)
+	require.NotNil(t, updates, "should return updates map")
+
+	value, exists := updates["dependenciesSync"]
+	require.True(t, exists, "updates should contain dependenciesSync key")
+	assert.Nil(t, value, "value should be nil to signal deletion")
+}
+
+// TestApplyServiceConfigMappings_DependenciesSyncMissing verifies that a missing
+// dependenciesSync key does not appear in updates, leaving the existing value unchanged.
+// Equivalent to TestApplyServiceConfigMappings_VulnerabilityReportingMissing for the dependenciesSync mapping.
+func TestApplyServiceConfigMappings_DependenciesSyncMissing(t *testing.T) {
+	configYAML := `
+database: {}
+`
+	updates, err := applyServiceConfigMappings(infra.ServicePeriodic, configYAML)
+	require.NoError(t, err)
+	require.NotNil(t, updates, "should return updates map (possibly empty)")
+
+	_, exists := updates["dependenciesSync"]
+	assert.False(t, exists, "missing key should not be in updates")
+}
+
 func TestApplyServiceConfigMappings_VulnerabilityReportingDeletion(t *testing.T) {
 	// When vulnerabilityReporting key is explicitly set to null, the mapping
 	// should return nil for that key to signal deletion from service-config.yaml.


### PR DESCRIPTION
Remove the hard assertion on releaseNamespace in BeforeEach so non-secret tests can run on quadlet deployments where no Helm release namespace exists.
Skip the two K8s secret tests (89094, 89321) on non-K8s environments with infra.SkipIfNotK8s.

## Release target

Target release: release-1.3
