### PR TITLE
NO-ISSUE: Fix fleet rollout skipping re-render when renderedTemplateVersion is stale

### DIFF
--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -264,10 +264,13 @@ func (f FleetRolloutsLogic) RolloutDevice(ctx context.Context) error {
 
 func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, device *domain.Device, templateVersion *domain.TemplateVersion, delayDeviceRender bool) ([]model.DependencyRef, error) {
 	currentVersion := ""
+	currentRenderedVersion := ""
 	if device.Metadata.Annotations != nil {
-		v, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationTemplateVersion]
-		if ok {
+		if v, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationTemplateVersion]; ok {
 			currentVersion = v
+		}
+		if v, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationRenderedTemplateVersion]; ok {
+			currentRenderedVersion = v
 		}
 	}
 	errs := []error{}
@@ -313,7 +316,7 @@ func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, dev
 		return nil, fmt.Errorf("failed validating device spec for %s/%s: %w", f.orgId, *device.Metadata.Name, errors.Join(errs...))
 	}
 
-	if currentVersion == *templateVersion.Metadata.Name && domain.DeviceSpecsAreEqual(newDeviceSpec, *device.Spec) {
+	if currentVersion == *templateVersion.Metadata.Name && currentRenderedVersion == *templateVersion.Metadata.Name && domain.DeviceSpecsAreEqual(newDeviceSpec, *device.Spec) {
 		f.log.Debugf("Not rolling out device %s/%s because it is already at templateVersion %s", f.orgId, *device.Metadata.Name, *templateVersion.Metadata.Name)
 		return depRefs, nil
 	}

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -395,6 +395,99 @@ func createTestDeviceWithLabels(name string, owner string, labels map[string]str
 	}
 }
 
+func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_SkipCondition(t *testing.T) {
+	const tvName = "v1"
+	const image = "test-image:latest"
+
+	tests := []struct {
+		name                string
+		templateVersion     string
+		renderedVersion     string
+		deviceImage         string
+		expectReplaceDevice bool
+		description         string
+	}{
+		{
+			name:                "WhenVersionAndRenderedVersionAndSpecMatch",
+			templateVersion:     tvName,
+			renderedVersion:     tvName,
+			deviceImage:         image,
+			expectReplaceDevice: false,
+			description:         "When templateVersion, renderedTemplateVersion, and spec all match fleet, rollout should be skipped",
+		},
+		{
+			name:                "WhenRenderedVersionDiffersFromFleetVersion",
+			templateVersion:     tvName,
+			renderedVersion:     "v2",
+			deviceImage:         image,
+			expectReplaceDevice: true,
+			description:         "When renderedTemplateVersion differs from fleet templateVersion, rollout must not be skipped even if spec is unchanged",
+		},
+		{
+			name:                "WhenTemplateVersionDiffersFromFleetVersion",
+			templateVersion:     "v2",
+			renderedVersion:     "v2",
+			deviceImage:         image,
+			expectReplaceDevice: true,
+			description:         "When templateVersion differs from fleet templateVersion, rollout must not be skipped",
+		},
+		{
+			name:                "WhenSpecDiffersFromFleetSpec",
+			templateVersion:     tvName,
+			renderedVersion:     tvName,
+			deviceImage:         "old-image:latest",
+			expectReplaceDevice: true,
+			description:         "When spec differs from fleet spec, rollout must not be skipped even if versions match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			orgId := uuid.New()
+			log := logrus.New()
+			fleetName := "test-fleet"
+			event := domain.Event{
+				InvolvedObject: domain.ObjectReference{Kind: domain.FleetKind, Name: fleetName},
+			}
+			mockService := service.NewMockService(ctrl)
+			logic := NewFleetRolloutsLogic(log, mockService, orgId, event)
+			logic.owner = lo.FromPtr(util.SetResourceOwner(domain.FleetKind, fleetName))
+
+			annotations := map[string]string{
+				domain.DeviceAnnotationTemplateVersion:         tt.templateVersion,
+				domain.DeviceAnnotationRenderedTemplateVersion: tt.renderedVersion,
+			}
+			deviceName := "test-device"
+			ownerStr := logic.owner
+			device := &domain.Device{
+				Metadata: domain.ObjectMeta{
+					Name:        &deviceName,
+					Owner:       &ownerStr,
+					Annotations: &annotations,
+				},
+				Spec: &domain.DeviceSpec{
+					Os: &domain.DeviceOsSpec{Image: tt.deviceImage},
+				},
+				Status: &domain.DeviceStatus{},
+			}
+
+			tv := createTestTemplateVersion(tvName)
+			tv.Status.Os = &domain.DeviceOsSpec{Image: image}
+
+			if tt.expectReplaceDevice {
+				mockService.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, domain.Status{Code: http.StatusOK})
+				mockService.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(domain.Status{Code: http.StatusOK})
+			}
+
+			_, err := logic.updateDeviceToFleetTemplate(context.Background(), device, tv, false)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestFleetRolloutsLogic_ReplaceComposeImageApplicationParameters(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
… Fixes #3141

# Release target (required before merge to `main`)

- [ ] `release-1.2`
- [ ] `release-1.3`

**Fix**

Add `renderedTemplateVersion` to the skip condition. A rollout is skipped only when all three agree:

```
if currentVersion == *templateVersion.Metadata.Name &&
    currentRenderedVersion == *templateVersion.Metadata.Name &&
    domain.DeviceSpecsAreEqual(newDeviceSpec, *device.Spec) {
    return depRefs, nil
}
```

When `renderedTemplateVersion` is stale, the rollout proceeds, `ReplaceDevice` is called, device-render re-runs and updates `renderedTemplateVersion` to the correct value.

**Testing**

- Added table-driven unit test TestFleetRolloutsLogic_updateDeviceToFleetTemplate_SkipCondition covering:
  - Skip when templateVersion, renderedTemplateVersion, and spec all match
  - No skip when renderedTemplateVersion differs (stale) — new case
  - No skip when templateVersion differs
  - No skip when spec differs
