### PR TITLE
EDM-3778: VM Agent Helm Application Tests SSH fix

### DIFF
--- a/test/e2e/applications/helm/helm_application_test.go
+++ b/test/e2e/applications/helm/helm_application_test.go
@@ -545,6 +545,20 @@ image-pruning:
 			})
 			Expect(err).ToNot(HaveOccurred())
 
+			By("Trigger an additional prune cycle to handle CRI images that failed removal while pods were terminating")
+			time.Sleep(util.SPECK_UPDATE_DELAY)
+			pruneRetryConfig, err := e2e.NewInlineConfigSpec("prune-retry", []v1beta1.FileSpec{
+				{
+					Content: "# triggers an additional reconciliation and prune cycle\n",
+					Path:    "/etc/flightctl/conf.d/prune-retry-trigger",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+				device.Spec.Config = &[]v1beta1.ConfigProviderSpec{pruningConfig, pruneRetryConfig}
+			})
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Verify shared image is pruned after all apps are removed")
 			Eventually(func() bool {
 				exists, err := harness.CrictlImageExists(sharedImage)

--- a/test/harness/e2e/vm/vm_linux.go
+++ b/test/harness/e2e/vm/vm_linux.go
@@ -661,6 +661,16 @@ func (v *VMInLibvirt) performRevertCore(name string) error {
 
 // performRevertOperation performs a single revert operation attempt
 func (v *VMInLibvirt) performRevertOperation(name string) error {
+	// Wait for SSH to be ready before attempting verification data creation.
+	// Uses a shorter timeout than the full WaitForSSHToBeReady since this runs
+	// inside a retry loop with exponential backoff.
+	origTimeout := v.TestVM.SSHWaitTimeout
+	v.TestVM.SSHWaitTimeout = 30 * time.Second
+	defer func() { v.TestVM.SSHWaitTimeout = origTimeout }()
+	if err := v.TestVM.WaitForSSHToBeReady(); err != nil {
+		return fmt.Errorf("SSH not ready before revert verification: %w", err)
+	}
+
 	err := v.createRevertVerificationData()
 	if err != nil {
 		return fmt.Errorf("failed to create revert verification data: %w", err)


### PR DESCRIPTION
The fix adds an SSH readiness check (30s timeout) at the start of each performRevertOperation attempt, before the createRevertVerificationData() call that was failing. If SSH isn't available, the attempt fails gracefully and the outer RevertToSnapshot retry loop (with exponential backoff) retries. This prevents the immediate "Connection reset by peer" failures that exhausted all 5 attempts in ~11 seconds.