### PR TITLE
EDM-2054: inject mirror registry config into QCOW for MicroShift

### DIFF
--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -27,6 +27,7 @@ REGISTRY_ADDRESS="${REGISTRY_ADDRESS:-}"
 REGISTRY_HOSTNAME="${REGISTRY_HOSTNAME:-e2e-registry}"
 E2E_CA="${E2E_CA:-bin/e2e-certs/pki/CA/ca.crt}"
 SOURCE_REPO="quay.io/flightctl"
+MIRROR_REGISTRY="${MIRROR_REGISTRY:-}"
 
 log()   { echo "[info] $*"; }
 dbg()   { echo "[debug] $*"; }
@@ -82,6 +83,13 @@ if [[ "$SOURCE_REPO" != */* ]]; then
 fi
 SOURCE_REPO_PATH="${SOURCE_REPO#*/}"
 
+# Auto-detect mirror registry from OCP ImageTagMirrorSet if not explicitly set
+if [[ -z "$MIRROR_REGISTRY" ]] && command -v oc &>/dev/null; then
+  MIRROR_REGISTRY=$(oc get imagetagmirrorset -o \
+    jsonpath='{range .items[*].spec.imageTagMirrors[*]}{.source}{" "}{.mirrors[0]}{"\n"}{end}' 2>/dev/null \
+    | awk '$1 == "quay.io" || index($1, "quay.io/") == 1 {print $2; exit}') || true
+fi
+
 log "QCOW=$QCOW"
 log "AGENT_DIR=$AGENT_DIR"
 log "MOUNT_DIR=$MOUNT_DIR"
@@ -91,6 +99,7 @@ log "REG_TLS_HOSTPORT=$REG_TLS_HOSTPORT"
 log "IPV6_ONLY=${IPV6_ONLY:-false}"
 log "E2E_CA=$E2E_CA"
 log "SOURCE_REPO=$SOURCE_REPO"
+log "MIRROR_REGISTRY=${MIRROR_REGISTRY:-<not set>}"
 
 sudo modprobe nbd max_part=16 || true
 
@@ -257,6 +266,57 @@ EOF
   sudo chown root:root "$remap_file"
 }
 
+write_mirror_registry() {
+  local base="$1"
+  if [[ -z "${MIRROR_REGISTRY:-}" ]]; then
+    log "No mirror registry configured - skipping"
+    return
+  fi
+  local config_dir="$base/containers/registries.conf.d"
+  local mirror_file="$config_dir/100-mirror-registry.conf"
+  log "Configuring mirror registry remap: quay.io -> $MIRROR_REGISTRY"
+  sudo install -d "$config_dir"
+  sudo tee "$mirror_file" >/dev/null <<EOF
+[[registry]]
+prefix = "quay.io:443"
+location = "${MIRROR_REGISTRY}"
+insecure = true
+
+[[registry]]
+prefix = "quay.io"
+location = "${MIRROR_REGISTRY}"
+insecure = true
+
+[[registry]]
+prefix = "registry.redhat.io"
+location = "${MIRROR_REGISTRY}"
+insecure = true
+
+[[registry]]
+prefix = "registry.access.redhat.com"
+location = "${MIRROR_REGISTRY}"
+insecure = true
+EOF
+  sudo chown root:root "$mirror_file"
+
+  local policy_file="$base/containers/policy.json"
+  log "Writing permissive policy.json for mirror registry"
+  sudo tee "$policy_file" >/dev/null <<EOF
+{
+  "default": [{"type": "insecureAcceptAnything"}],
+  "transports": {
+    "docker": {
+      "${MIRROR_REGISTRY}": [{"type": "insecureAcceptAnything"}]
+    },
+    "docker-daemon": {
+      "": [{"type": "insecureAcceptAnything"}]
+    }
+  }
+}
+EOF
+  sudo chown root:root "$policy_file"
+}
+
 # Inject /etc/hosts entry so VM can resolve the host's hostname
 inject_hosts_entry() {
   local base="$1"
@@ -331,6 +391,7 @@ EOF
 copy_into "$DEPLOY_ETC"
 inject_registry_ca "$DEPLOY_ETC"
 write_registry_remap "$DEPLOY_ETC"
+write_mirror_registry "$DEPLOY_ETC"
 inject_hosts_entry "$DEPLOY_ETC"
 
 # Also mirror to on-disk etc so it shows under guest /sysroot/etc
@@ -338,6 +399,7 @@ if [[ "$SYSROOT_ETC" != "$DEPLOY_ETC" ]]; then
   copy_into "$SYSROOT_ETC"
   inject_registry_ca "$SYSROOT_ETC"
   write_registry_remap "$SYSROOT_ETC"
+  write_mirror_registry "$SYSROOT_ETC"
   inject_hosts_entry "$SYSROOT_ETC"
 fi
 


### PR DESCRIPTION
## Summary
- Auto-detect quay.io mirror from OCP `ImageTagMirrorSet` at QCOW injection time
- Inject `registries.conf.d` + `policy.json` into the QCOW image so MicroShift can pull images from the mirror
- Files persist across bootc image switches via ostree `/etc` 


