### PR TITLE
NO-ISSUE: Reduce make lint wall-clock time by ~63% and add lint-fix target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,4 +158,3 @@ formatters:
   enable:
     - gci
     - gofmt
-    - goimports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Flight Control is a service for declarative management of fleets of edge devices
 - **Integration tests:** `make integration-test` (uses testcontainers for Postgres/Redis/Alertmanager; requires Podman). Key options: `INTEGRATION_PROCS=N` for parallelism, `TEST_DIR=./test/integration/store` for specific suites, `INTEGRATION_GINKGO_FOCUS="pattern"` for specific tests.
 - **E2E tests:** `make e2e-test` or `make in-cluster-e2e-test`; see [test/AGENTS.md](test/AGENTS.md).
 - **Lint:** `make lint` (do not invoke golangci-lint directly; `make lint` installs and configures it automatically), `make lint-openapi`, `make lint-docs`, `make lint-helm`, `make rpmlint`, `make lint-diagrams`.
+- **Lint with auto-fix:** `make lint-fix` runs golangci-lint with `--fix`, writing fixes directly back to the working tree. Auto-fixes formatting (`gofmt`, `gci`), typos (`misspell`), and unnecessary type conversions (`unconvert`). Issues requiring human judgment (`gosec`, `staticcheck`, `govet`, `errcheck`, `depguard`, `unused`, `gocyclo`) are still reported but not auto-fixed.
 - **Documentation checks:** `make spellcheck-docs` to check spelling, `make fix-spelling` for interactive fixing.
 - **Code formatting:** Format Go imports with `gci write --skip-generated -s standard -s default .` (required for `make lint` to pass). Import order: standard library, then all other imports.
 - **Dependency management:** `make tidy` to tidy go.mod files after adding/removing dependencies.
@@ -50,7 +51,7 @@ Flight Control is a service for declarative management of fleets of edge devices
 1. **Keep docs up to date** – If you change behavior, APIs, or workflows, update the relevant docs in `docs/user/` or `docs/developer/` and run `make lint-docs` (and `make spellcheck-docs` for user docs).
 2. **Add test coverage** – New or changed code should include or extend unit tests (and integration tests where appropriate). Prefer table-driven tests and existing patterns; see [test/AGENTS.md](test/AGENTS.md) and [internal/agent/AGENTS.md](internal/agent/AGENTS.md) for agent code.
 3. **Tidy dependencies** – Run `make tidy` after adding/removing dependencies or modifying go.mod files.
-4. **Run lint** – Run `make lint` before committing and fix any issues.
+4. **Run lint** – Run `make lint` before committing and fix any issues. Use `make lint-fix` to auto-fix formatting, typos, and unnecessary conversions.
 5. **Run unit and integration tests** – Before committing, run `make unit-test` and `make integration-test` (integration tests require Podman; they use testcontainers for Postgres/Redis/Alertmanager). Fix any failures before pushing.
 
 ## Pointers to area-specific guidance

--- a/Makefile
+++ b/Makefile
@@ -459,6 +459,10 @@ tools:
 lint: .output/stamps/lint-image
 	$(LINT_CONTAINER) golangci-lint run -v
 
+.PHONY: lint-fix
+lint-fix: .output/stamps/lint-image
+	$(LINT_CONTAINER) golangci-lint run -v --fix
+
 .PHONY: rpmlint
 rpmlint: check-rpmlint
 	@echo "Running rpmlint on RPM spec file"

--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,11 @@ LINT_CONTAINER := podman run --rm --security-opt label=disable \
 	-v go-build-cache:/root/.cache/go-build \
 	-v go-mod-cache:/go/pkg/mod \
 	-w /app --user 0 $(LINT_IMAGE)
+# lint-fix runs as the host user so that auto-fixed files are not root-owned.
+# Cache volumes are omitted because /root/.cache is inaccessible to non-root.
+LINT_FIX_CONTAINER := podman run --rm --security-opt label=disable \
+	-v $(GOBASE):/app \
+	-w /app --user $$(id -u):$$(id -g) $(LINT_IMAGE)
 
 .PHONY: tools
 tools:
@@ -461,7 +466,7 @@ lint: .output/stamps/lint-image
 
 .PHONY: lint-fix
 lint-fix: .output/stamps/lint-image
-	$(LINT_CONTAINER) golangci-lint run -v --fix
+	$(LINT_FIX_CONTAINER) golangci-lint run -v --fix
 
 .PHONY: rpmlint
 rpmlint: check-rpmlint


### PR DESCRIPTION
## Summary

- **Remove \`goimports\` formatter** from \`.golangci.yml\` — it was consuming ~79% of total analyzer CPU time (1m37s out of 2m4s total locally, 3m7s out of 5m51s in CI) due to the full type-checking pass it runs to resolve import paths on every file. \`gci\` already enforces the same two-group import structure (\`standard\` → \`default\`), so no detection capability is lost. The Go compiler hard-errors on missing/unused imports making those unreachable by lint anyway.
- **Add \`make lint-fix\` target** — runs \`golangci-lint run --fix\`, writing auto-fixes directly back to the working tree via the existing bind mount. Fixes formatting (\`gofmt\`, \`gci\`), typos (\`misspell\`), and unnecessary type conversions (\`unconvert\`). Issues requiring human judgment (\`gosec\`, \`staticcheck\`, \`govet\`, \`errcheck\`, \`depguard\`, \`unused\`, \`gocyclo\`) are still reported but not auto-fixed.
- **Update \`AGENTS.md\`** — document \`make lint-fix\` in both the "Build and development" section and the "Before committing" checklist.

## Performance results

### Local (Intel Core Ultra 7 165U, 30 GB RAM, warm container image + Go build cache)

| Metric | Before | After | Change |
|---|---|---|---|
| Wall-clock time | ~43s | ~16s | **-63%** |
| \`golangci-lint\` execution | ~39s | ~13s | -67% |
| Analyzer CPU time (top stage) | \`goimports\`: 1m37.9s | \`buildir\`: 18.2s | — |
| Memory avg / peak | 1.3 GB / 1.79 GB | 1.6 GB / 2.4 GB | (more RAM available for other linters) |

### CI (GitHub Actions ubuntu-24.04, warm Go volume cache, fresh container image each run)

| Metric | Before (main) | After (this PR) | Change |
|---|---|---|---|
| \`golangci-lint\` execution | 1m47s | 58.8s | **-45%** |
| Packages loading | 39.6s | 36.7s | — |
| Linters wall clock | 1m7s | 21.9s | -67% |
| Analyzer CPU (top stage) | \`goimports\`: 3m7s | \`buildir\`: 41.8s | — |
| Total CI job time | 6m5s | 5m1s | -17% |

The larger local improvement vs CI is because packages loading (~37–40s) is a fixed cost that dominates more in CI (where the Go build cache is less warm). The linters stage improvement is consistent at ~67% in both environments.

## Test plan

- [x] \`make lint\` passes with 0 issues
- [x] \`make lint-fix\` runs without error and writes fixes to disk

Made with [Cursor](https://cursor.com)