### PR TITLE
NO-ISSUE: publish e2e health report to flightctl-reports gh-pages

### DIFF
--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -51,13 +51,18 @@ jobs:
           REPORTS_DEPLOY_KEY: ${{ secrets.REPORTS_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "REPORTS_DEPLOY_KEY not set, skipping."; exit 0; }
+          [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "::error::REPORTS_DEPLOY_KEY not set"; exit 1; }
           REPORT_SRC="test/scripts/e2e-health/e2e-health-report.html"
-          [ ! -f "$REPORT_SRC" ] && { echo "Report file not found, skipping publish."; exit 0; }
+          [ ! -f "$REPORT_SRC" ] && { echo "::error::Report file not found: $REPORT_SRC"; exit 1; }
           install -d -m 700 ~/.ssh
           echo "$REPORTS_DEPLOY_KEY" > ~/.ssh/reports_deploy_key
           chmod 600 ~/.ssh/reports_deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          # Use GitHub's pinned host keys instead of trust-on-first-use ssh-keyscan
+          cat >> ~/.ssh/known_hosts <<'EOF'
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SoTKygFR7H6H+TuK4P8PCAP2iBNt89f6MkLjGXS8kWw/Ps2V4+S5FBl7GITMHJXoOGLidnxFWGwkOmSe5e36PBo/tUyLwopZe2aiBBlvOhVs2nOE4blnP8qMIxY3L6n6CbMKcgO91PJXJL3HHF6L5WjMuEpocLHO+3t9D2IFLe2rHq3l0Yf16r3CAnH/2vlvG/6RrCNcsBq8Ai4C7zCAAvAAAAADAQAB
+github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+EOF
           GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" \
             git clone --depth=1 git@github.com:flightctl/flightctl-reports.git /tmp/flightctl-reports
           DATE="$(date -u +%Y-%m-%d)"

--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -58,11 +58,11 @@ jobs:
           echo "$REPORTS_DEPLOY_KEY" > ~/.ssh/reports_deploy_key
           chmod 600 ~/.ssh/reports_deploy_key
           # Use GitHub's pinned host keys instead of trust-on-first-use ssh-keyscan
-          cat >> ~/.ssh/known_hosts <<'EOF'
-github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SoTKygFR7H6H+TuK4P8PCAP2iBNt89f6MkLjGXS8kWw/Ps2V4+S5FBl7GITMHJXoOGLidnxFWGwkOmSe5e36PBo/tUyLwopZe2aiBBlvOhVs2nOE4blnP8qMIxY3L6n6CbMKcgO91PJXJL3HHF6L5WjMuEpocLHO+3t9D2IFLe2rHq3l0Yf16r3CAnH/2vlvG/6RrCNcsBq8Ai4C7zCAAvAAAAADAQAB
-github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
-github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-EOF
+          {
+            echo 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl'
+            echo 'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg='
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk='
+          } >> ~/.ssh/known_hosts
           GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" \
             git clone --depth=1 git@github.com:flightctl/flightctl-reports.git /tmp/flightctl-reports
           DATE="$(date -u +%Y-%m-%d)"

--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -18,6 +18,7 @@ concurrency:
 permissions:
   contents: read
   actions: read  # jobs API + artifact download
+  # publish step uses REPORTS_DEPLOY_KEY (SSH deploy key) to write to flightctl/flightctl-reports
 
 jobs:
   report:
@@ -44,31 +45,29 @@ jobs:
             test/scripts/e2e-health/e2e-health-report.html
             test/scripts/e2e-health/e2e-health-summary.json
 
-      - name: Notify Slack
-        if: always()
+      - name: Publish report to flightctl-reports
+        if: always() && github.event_name != 'pull_request'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPORTS_DEPLOY_KEY: ${{ secrets.REPORTS_DEPLOY_KEY }}
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          SUMMARY_FILE="test/scripts/e2e-health/e2e-health-summary.json"
-          if [ -f "$SUMMARY_FILE" ]; then
-            MSG=$(jq -r '
-              def mins: (. / 60 + 0.5 | floor | tostring) + "m";
-              "E2E Health Report  (\(.analyzed_runs) runs, \(.inferred_shards) shards)\n" +
-              "• Pipeline:  wall \(.wall_time_seconds | mins)  =  prepare \(.prepare_time_seconds | mins)  +  tests \(.testing_time_seconds | mins)\n" +
-              "• Specs:  \(.total_specs_tracked) tracked  ·  \(.flaky_tests) flaky  ·  \(.consistently_failing) always failing  ·  \(.never_failed) clean" +
-              (if .infra_instability_events > 0 then "  (\(.infra_instability_events) infra events excluded)" else "" end) +
-              (if .optimization_savings_seconds > 60 then
-                "\n• Potential saving: \(.optimization_savings_seconds | mins)" else "" end)
-            ' "$SUMMARY_FILE")
-          else
-            MSG="E2E Health Report — report generation failed; see run for details."
-          fi
-          [ -z "$SLACK_WEBHOOK_URL" ] && { echo "SLACK_WEBHOOK_URL not set, skipping."; exit 0; }
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n \
-              --arg text "$MSG" \
-              --arg url "$RUN_URL" \
-              '{text: ($text + "\nFull report: <" + $url + "|view run artifacts>")}')"
+          [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "REPORTS_DEPLOY_KEY not set, skipping."; exit 0; }
+          REPORT_SRC="test/scripts/e2e-health/e2e-health-report.html"
+          [ ! -f "$REPORT_SRC" ] && { echo "Report file not found, skipping publish."; exit 0; }
+          install -d -m 700 ~/.ssh
+          echo "$REPORTS_DEPLOY_KEY" > ~/.ssh/reports_deploy_key
+          chmod 600 ~/.ssh/reports_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" \
+            git clone --depth=1 git@github.com:flightctl/flightctl-reports.git /tmp/flightctl-reports
+          DATE="$(date -u +%Y-%m-%d)"
+          mkdir -p /tmp/flightctl-reports/e2e-health-report
+          cp "$REPORT_SRC" /tmp/flightctl-reports/e2e-health-report/index.html
+          cp "$REPORT_SRC" "/tmp/flightctl-reports/e2e-health-report/${DATE}.html"
+          cd /tmp/flightctl-reports
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add e2e-health-report/
+          git diff --cached --quiet && { echo "No changes to publish."; exit 0; }
+          git commit -m "e2e-health-report: publish ${DATE} report"
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" git push
         shell: bash

--- a/.github/workflows/e2e-health-report.yml
+++ b/.github/workflows/e2e-health-report.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           REPORTS_DEPLOY_KEY: ${{ secrets.REPORTS_DEPLOY_KEY }}
         run: |
+          set -euo pipefail
           [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "REPORTS_DEPLOY_KEY not set, skipping."; exit 0; }
           REPORT_SRC="test/scripts/e2e-health/e2e-health-report.html"
           [ ! -f "$REPORT_SRC" ] && { echo "Report file not found, skipping publish."; exit 0; }


### PR DESCRIPTION
## Summary

- Removes the Slack notification step from the weekly E2E health report workflow
- Adds a publish step that pushes `e2e-health-report.html` to [flightctl/flightctl-reports](https://github.com/flightctl/flightctl-reports) via an SSH deploy key
- Both `index.html` (latest) and a dated archive (`YYYY-MM-DD.html`) are written under `e2e-health-report/`
- The publish step is **skipped on `pull_request` events** so generation can be validated in CI without writing to the reports repo

## Setup required

Add a deploy key to `flightctl/flightctl-reports` (with write access) and store the corresponding private key as secret `REPORTS_DEPLOY_KEY` in this repo.

```bash
ssh-keygen -t ed25519 -C "flightctl e2e-health-report CI" -f reports_deploy_key -N ""
# Add reports_deploy_key.pub → flightctl-reports → Settings → Deploy keys (write access)
# Add reports_deploy_key     → flightctl         → Settings → Secrets → REPORTS_DEPLOY_KEY
```

## Test plan

- [ ] Verify the workflow runs on this PR and the publish step is skipped (logged as "REPORTS_DEPLOY_KEY not set, skipping" or the `if:` condition skips it)
- [ ] After secret is configured, trigger via `workflow_dispatch` on this branch and confirm `e2e-health-report/index.html` is updated in flightctl-reports

Made with [Cursor](https://cursor.com)