### PR TITLE
EDM-3530: Fix OIDC/OAuth2 auth provider URL normalization across all paths

### DIFF
--- a/api/core/v1beta1/authprovider_validation_test.go
+++ b/api/core/v1beta1/authprovider_validation_test.go
@@ -1,0 +1,283 @@
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildValidPerUserOrgAssignment returns an AuthOrganizationAssignment in the PerUser form.
+func buildValidPerUserOrgAssignment() AuthOrganizationAssignment {
+	a := AuthOrganizationAssignment{}
+	_ = a.FromAuthPerUserOrganizationAssignment(AuthPerUserOrganizationAssignment{
+		Type: PerUser,
+	})
+	return a
+}
+
+// buildValidDynamicRoleAssignment returns an AuthRoleAssignment in the Dynamic form.
+func buildValidDynamicRoleAssignment() AuthRoleAssignment {
+	r := AuthRoleAssignment{}
+	_ = r.FromAuthDynamicRoleAssignment(AuthDynamicRoleAssignment{
+		Type:      AuthDynamicRoleAssignmentTypeDynamic,
+		ClaimPath: []string{"groups"},
+	})
+	return r
+}
+
+// validOIDCSpec builds a minimal OIDC spec that passes validation under a super-admin ctx.
+func validOIDCSpec(issuer string) OIDCProviderSpec {
+	return OIDCProviderSpec{
+		ProviderType:           Oidc,
+		Issuer:                 issuer,
+		ClientId:               "my-client",
+		OrganizationAssignment: buildValidPerUserOrgAssignment(),
+		RoleAssignment:         buildValidDynamicRoleAssignment(),
+	}
+}
+
+func TestValidateHTTPSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+	}{
+		{"When valid HTTPS URL it should pass", "https://example.com", false},
+		{"When valid HTTP URL it should pass", "http://example.com", false},
+		{"When URL with path it should pass", "https://example.com/realm/master", false},
+		{"When URL with port it should pass", "https://example.com:8443", false},
+		{"When URL missing scheme it should fail", "example.com", true},
+		{"When URL missing host it should fail", "https://", true},
+		{"When relative path it should fail", "/just/a/path", true},
+		{"When empty string it should fail", "", true},
+		{"When plain word it should fail", "notaurl", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPSURL("field", tt.value)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOIDCProviderSpec_Validate_URLFields(t *testing.T) {
+	ctx := contextWithSuperAdmin(context.Background())
+
+	tests := []struct {
+		name        string
+		spec        OIDCProviderSpec
+		wantErrMsgs []string
+	}{
+		{
+			name: "When valid spec it should pass",
+			spec: validOIDCSpec("https://idp.example.com"),
+		},
+		{
+			name:        "When issuer is empty it should fail",
+			spec:        validOIDCSpec(""),
+			wantErrMsgs: []string{"issuer is required"},
+		},
+		{
+			name:        "When issuer has no scheme it should fail",
+			spec:        validOIDCSpec("idp.example.com"),
+			wantErrMsgs: []string{"issuer must be a valid URL"},
+		},
+		{
+			name:        "When issuer has no host it should fail",
+			spec:        validOIDCSpec("https://"),
+			wantErrMsgs: []string{"issuer must be a valid URL"},
+		},
+		{
+			name:        "When issuer is a bare word it should fail",
+			spec:        validOIDCSpec("not-a-url"),
+			wantErrMsgs: []string{"issuer must be a valid URL"},
+		},
+		{
+			name: "When clientId is empty it should fail",
+			spec: OIDCProviderSpec{
+				ProviderType:           Oidc,
+				Issuer:                 "https://idp.example.com",
+				OrganizationAssignment: buildValidPerUserOrgAssignment(),
+				RoleAssignment:         buildValidDynamicRoleAssignment(),
+			},
+			wantErrMsgs: []string{"clientId is required"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.spec.Validate(ctx, false)
+			allErrs := ""
+			for _, e := range errs {
+				allErrs += e.Error() + "; "
+			}
+			if len(tt.wantErrMsgs) == 0 {
+				assert.Empty(t, errs, "unexpected errors: %s", allErrs)
+				return
+			}
+			for _, want := range tt.wantErrMsgs {
+				assert.Contains(t, allErrs, want)
+			}
+		})
+	}
+}
+
+func TestOAuth2ProviderSpec_Validate_URLFields(t *testing.T) {
+	ctx := contextWithSuperAdmin(context.Background())
+
+	validRfc7662Introspection := func() *OAuth2Introspection {
+		i := &OAuth2Introspection{}
+		require.NoError(t, i.FromRfc7662IntrospectionSpec(Rfc7662IntrospectionSpec{
+			Type: Rfc7662,
+			Url:  "https://idp.example.com/introspect",
+		}))
+		return i
+	}
+
+	baseSpec := func() OAuth2ProviderSpec {
+		return OAuth2ProviderSpec{
+			ProviderType:           Oauth2,
+			AuthorizationUrl:       "https://idp.example.com/authorize",
+			TokenUrl:               "https://idp.example.com/token",
+			UserinfoUrl:            "https://idp.example.com/userinfo",
+			ClientId:               "my-client",
+			Introspection:          validRfc7662Introspection(),
+			OrganizationAssignment: buildValidPerUserOrgAssignment(),
+			RoleAssignment:         buildValidDynamicRoleAssignment(),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		mutate      func(s *OAuth2ProviderSpec)
+		wantErrMsgs []string
+	}{
+		{
+			name:   "When valid spec it should pass",
+			mutate: func(s *OAuth2ProviderSpec) {},
+		},
+		{
+			name:        "When authorizationUrl is empty it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.AuthorizationUrl = "" },
+			wantErrMsgs: []string{"authorizationUrl is required"},
+		},
+		{
+			name:        "When authorizationUrl has no scheme it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.AuthorizationUrl = "idp.example.com/authorize" },
+			wantErrMsgs: []string{"authorizationUrl must be a valid URL"},
+		},
+		{
+			name:        "When tokenUrl has no scheme it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.TokenUrl = "idp.example.com/token" },
+			wantErrMsgs: []string{"tokenUrl must be a valid URL"},
+		},
+		{
+			name:        "When userinfoUrl has no scheme it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.UserinfoUrl = "idp.example.com/userinfo" },
+			wantErrMsgs: []string{"userinfoUrl must be a valid URL"},
+		},
+		{
+			name:        "When optional issuer is set to invalid URL it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.Issuer = lo.ToPtr("not-a-url") },
+			wantErrMsgs: []string{"issuer must be a valid URL"},
+		},
+		{
+			name:        "When introspection is nil it should fail",
+			mutate:      func(s *OAuth2ProviderSpec) { s.Introspection = nil },
+			wantErrMsgs: []string{"introspection field is required"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := baseSpec()
+			tt.mutate(&spec)
+			errs := spec.Validate(ctx, false)
+			allErrs := ""
+			for _, e := range errs {
+				allErrs += e.Error() + "; "
+			}
+			if len(tt.wantErrMsgs) == 0 {
+				assert.Empty(t, errs, "unexpected errors: %s", allErrs)
+				return
+			}
+			for _, want := range tt.wantErrMsgs {
+				assert.Contains(t, allErrs, want)
+			}
+		})
+	}
+}
+
+func TestAuthProviderSpec_Validate_ConfigOnlyTypes(t *testing.T) {
+	ctx := contextWithSuperAdmin(context.Background())
+
+	t.Run("When K8s provider type it should be rejected via API", func(t *testing.T) {
+		spec := AuthProviderSpec{}
+		_ = spec.FromK8sProviderSpec(K8sProviderSpec{ProviderType: K8s, ApiUrl: "https://k8s.example.com"})
+		errs := spec.Validate(ctx, false)
+		require.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), "configuration")
+	})
+
+	t.Run("When AAP provider type it should be rejected via API", func(t *testing.T) {
+		spec := AuthProviderSpec{}
+		_ = spec.FromAapProviderSpec(AapProviderSpec{
+			ProviderType:     Aap,
+			ApiUrl:           "https://aap.example.com",
+			AuthorizationUrl: "https://aap.example.com/authorize",
+			TokenUrl:         "https://aap.example.com/token",
+			ClientId:         "client",
+			ClientSecret:     "secret",
+			Scopes:           []string{"api"},
+		})
+		errs := spec.Validate(ctx, false)
+		require.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), "configuration")
+	})
+}
+
+func TestAuthProvider_Validate_E2E(t *testing.T) {
+	ctx := contextWithSuperAdmin(context.Background())
+
+	t.Run("When valid OIDC AuthProvider it should pass", func(t *testing.T) {
+		spec := AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(validOIDCSpec("https://idp.example.com"))
+		ap := AuthProvider{
+			Metadata: ObjectMeta{Name: lo.ToPtr("my-oidc")},
+			Spec:     spec,
+		}
+		errs := ap.Validate(ctx)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("When OIDC AuthProvider with invalid issuer URL it should fail", func(t *testing.T) {
+		spec := AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(validOIDCSpec("not-a-url"))
+		ap := AuthProvider{
+			Metadata: ObjectMeta{Name: lo.ToPtr("my-oidc")},
+			Spec:     spec,
+		}
+		errs := ap.Validate(ctx)
+		require.NotEmpty(t, errs)
+		allErrs := ""
+		for _, e := range errs {
+			allErrs += e.Error() + "; "
+		}
+		assert.Contains(t, allErrs, "issuer must be a valid URL")
+	})
+
+	t.Run("When OIDC AuthProvider with missing name it should fail", func(t *testing.T) {
+		spec := AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(validOIDCSpec("https://idp.example.com"))
+		ap := AuthProvider{
+			Spec: spec,
+		}
+		errs := ap.Validate(ctx)
+		require.NotEmpty(t, errs)
+	})
+}

--- a/api/core/v1beta1/authprovider_validation_test.go
+++ b/api/core/v1beta1/authprovider_validation_test.go
@@ -39,7 +39,7 @@ func validOIDCSpec(issuer string) OIDCProviderSpec {
 	}
 }
 
-func TestValidateHTTPSURL(t *testing.T) {
+func TestValidateAbsoluteURL(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     string
@@ -57,7 +57,7 @@ func TestValidateHTTPSURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateHTTPSURL("field", tt.value)
+			err := validateAbsoluteURL("field", tt.value)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"slices"
@@ -1760,11 +1761,22 @@ func (a *AuthProvider) ValidateUpdate(ctx context.Context, oldObj *AuthProvider)
 	return allErrs
 }
 
+// validateHTTPSURL returns an error if the value is not a valid URL with a scheme and host.
+func validateHTTPSURL(fieldName, value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be a valid URL with scheme and host", fieldName)
+	}
+	return nil
+}
+
 func (o *OIDCProviderSpec) Validate(ctx context.Context, isUpdate bool) []error {
 	allErrs := []error{}
 
 	if o.Issuer == "" {
 		allErrs = append(allErrs, ErrIssuerRequired)
+	} else if err := validateHTTPSURL("issuer", o.Issuer); err != nil {
+		allErrs = append(allErrs, err)
 	}
 	if o.ClientId == "" {
 		allErrs = append(allErrs, ErrClientIdRequired)
@@ -1784,15 +1796,26 @@ func (o *OAuth2ProviderSpec) Validate(ctx context.Context, isUpdate bool) []erro
 
 	if o.AuthorizationUrl == "" {
 		allErrs = append(allErrs, ErrAuthorizationUrlRequired)
+	} else if err := validateHTTPSURL("authorizationUrl", o.AuthorizationUrl); err != nil {
+		allErrs = append(allErrs, err)
 	}
 	if o.TokenUrl == "" {
 		allErrs = append(allErrs, ErrTokenUrlRequired)
+	} else if err := validateHTTPSURL("tokenUrl", o.TokenUrl); err != nil {
+		allErrs = append(allErrs, err)
 	}
 	if o.UserinfoUrl == "" {
 		allErrs = append(allErrs, ErrUserinfoUrlRequired)
+	} else if err := validateHTTPSURL("userinfoUrl", o.UserinfoUrl); err != nil {
+		allErrs = append(allErrs, err)
 	}
 	if o.ClientId == "" {
 		allErrs = append(allErrs, ErrClientIdRequired)
+	}
+	if o.Issuer != nil && *o.Issuer != "" {
+		if err := validateHTTPSURL("issuer", *o.Issuer); err != nil {
+			allErrs = append(allErrs, err)
+		}
 	}
 
 	// Validate introspection field is present

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -1761,8 +1761,8 @@ func (a *AuthProvider) ValidateUpdate(ctx context.Context, oldObj *AuthProvider)
 	return allErrs
 }
 
-// validateHTTPSURL returns an error if the value is not a valid URL with a scheme and host.
-func validateHTTPSURL(fieldName, value string) error {
+// validateAbsoluteURL returns an error if the value is not a valid absolute URL with a scheme and host.
+func validateAbsoluteURL(fieldName, value string) error {
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return fmt.Errorf("%s must be a valid URL with scheme and host", fieldName)
@@ -1775,7 +1775,7 @@ func (o *OIDCProviderSpec) Validate(ctx context.Context, isUpdate bool) []error 
 
 	if o.Issuer == "" {
 		allErrs = append(allErrs, ErrIssuerRequired)
-	} else if err := validateHTTPSURL("issuer", o.Issuer); err != nil {
+	} else if err := validateAbsoluteURL("issuer", o.Issuer); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if o.ClientId == "" {
@@ -1796,24 +1796,24 @@ func (o *OAuth2ProviderSpec) Validate(ctx context.Context, isUpdate bool) []erro
 
 	if o.AuthorizationUrl == "" {
 		allErrs = append(allErrs, ErrAuthorizationUrlRequired)
-	} else if err := validateHTTPSURL("authorizationUrl", o.AuthorizationUrl); err != nil {
+	} else if err := validateAbsoluteURL("authorizationUrl", o.AuthorizationUrl); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if o.TokenUrl == "" {
 		allErrs = append(allErrs, ErrTokenUrlRequired)
-	} else if err := validateHTTPSURL("tokenUrl", o.TokenUrl); err != nil {
+	} else if err := validateAbsoluteURL("tokenUrl", o.TokenUrl); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if o.UserinfoUrl == "" {
 		allErrs = append(allErrs, ErrUserinfoUrlRequired)
-	} else if err := validateHTTPSURL("userinfoUrl", o.UserinfoUrl); err != nil {
+	} else if err := validateAbsoluteURL("userinfoUrl", o.UserinfoUrl); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if o.ClientId == "" {
 		allErrs = append(allErrs, ErrClientIdRequired)
 	}
 	if o.Issuer != nil && *o.Issuer != "" {
-		if err := validateHTTPSURL("issuer", *o.Issuer); err != nil {
+		if err := validateAbsoluteURL("issuer", *o.Issuer); err != nil {
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -85,8 +85,11 @@ func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMid
 	return authNProvider, nil
 }
 func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
-	oidcUrl := strings.TrimSuffix(cfg.Auth.OIDC.Issuer, "/")
-	log.Infof("OIDC auth enabled: %s", oidcUrl)
+	normalizedIssuer, err := authprovider.NormalizeIssuerURL(cfg.Auth.OIDC.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OIDC issuer URL: %w", err)
+	}
+	log.Infof("OIDC auth enabled: %s", normalizedIssuer)
 
 	providerName := "oidc"
 	metadata := api.ObjectMeta{
@@ -96,7 +99,9 @@ func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddl
 		},
 	}
 
-	authNProvider, err := authn.NewOIDCAuth(metadata, *cfg.Auth.OIDC, getTlsConfig(cfg), log)
+	spec := *cfg.Auth.OIDC
+	spec.Issuer = normalizedIssuer
+	authNProvider, err := authn.NewOIDCAuth(metadata, spec, getTlsConfig(cfg), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC AuthN: %w", err)
 	}
@@ -112,7 +117,9 @@ func initAAPAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddle
 		Name: &providerName,
 	}
 
-	authNProvider, err := authn.NewAapGatewayAuth(metadata, *cfg.Auth.AAP, getTlsConfig(cfg))
+	spec := *cfg.Auth.AAP
+	spec.ApiUrl = gatewayUrl
+	authNProvider, err := authn.NewAapGatewayAuth(metadata, spec, getTlsConfig(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AAP Gateway AuthN: %w", err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"strings"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/authn"
@@ -70,11 +69,11 @@ func getTlsConfig(cfg *config.Config) *tls.Config {
 }
 
 func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
-	normalizedAuthzURL, err := authprovider.NormalizeIssuerURL(cfg.Auth.OAuth2.AuthorizationUrl)
-	if err != nil {
-		return nil, fmt.Errorf("invalid OAuth2 AuthorizationUrl: %w", err)
+	spec := *cfg.Auth.OAuth2
+	if err := authprovider.NormalizeOAuth2ProviderSpecURLs(&spec); err != nil {
+		return nil, err
 	}
-	log.Infof("OAuth2 auth enabled: %s", normalizedAuthzURL)
+	log.Infof("OAuth2 auth enabled: %s", spec.AuthorizationUrl)
 
 	providerName := "oauth2"
 	metadata := api.ObjectMeta{
@@ -84,16 +83,6 @@ func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMid
 		},
 	}
 
-	spec := *cfg.Auth.OAuth2
-	spec.AuthorizationUrl = normalizedAuthzURL
-	if spec.Issuer != nil && *spec.Issuer != "" {
-		normalizedIssuer, err := authprovider.NormalizeIssuerURL(*spec.Issuer)
-		if err != nil {
-			return nil, fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
-		}
-		spec.Issuer = &normalizedIssuer
-	}
-
 	authNProvider, err := authn.NewOAuth2Auth(metadata, spec, getTlsConfig(cfg), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OAuth2 AuthN: %w", err)
@@ -101,11 +90,11 @@ func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMid
 	return authNProvider, nil
 }
 func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
-	normalizedIssuer, err := authprovider.NormalizeIssuerURL(cfg.Auth.OIDC.Issuer)
-	if err != nil {
-		return nil, fmt.Errorf("invalid OIDC issuer URL: %w", err)
+	spec := *cfg.Auth.OIDC
+	if err := authprovider.NormalizeOIDCProviderSpecURLs(&spec); err != nil {
+		return nil, err
 	}
-	log.Infof("OIDC auth enabled: %s", normalizedIssuer)
+	log.Infof("OIDC auth enabled: %s", spec.Issuer)
 
 	providerName := "oidc"
 	metadata := api.ObjectMeta{
@@ -115,8 +104,6 @@ func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddl
 		},
 	}
 
-	spec := *cfg.Auth.OIDC
-	spec.Issuer = normalizedIssuer
 	authNProvider, err := authn.NewOIDCAuth(metadata, spec, getTlsConfig(cfg), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC AuthN: %w", err)
@@ -125,7 +112,12 @@ func initOIDCAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddl
 }
 
 func initAAPAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
-	gatewayUrl := strings.TrimSuffix(cfg.Auth.AAP.ApiUrl, "/")
+	spec := *cfg.Auth.AAP
+	gatewayUrl, err := authprovider.NormalizeIssuerURL(spec.ApiUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid AAP ApiUrl: %w", err)
+	}
+	spec.ApiUrl = gatewayUrl
 	log.Infof("AAP Gateway auth enabled: %s", gatewayUrl)
 
 	providerName := "aap"
@@ -133,8 +125,6 @@ func initAAPAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddle
 		Name: &providerName,
 	}
 
-	spec := *cfg.Auth.AAP
-	spec.ApiUrl = gatewayUrl
 	authNProvider, err := authn.NewAapGatewayAuth(metadata, spec, getTlsConfig(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AAP Gateway AuthN: %w", err)
@@ -143,11 +133,15 @@ func initAAPAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddle
 }
 
 func initK8sAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
-	apiUrl := strings.TrimSuffix(cfg.Auth.K8s.ApiUrl, "/")
+	spec := *cfg.Auth.K8s
+	apiUrl, err := authprovider.NormalizeIssuerURL(spec.ApiUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid K8s ApiUrl: %w", err)
+	}
+	spec.ApiUrl = apiUrl
 	log.Infof("k8s auth enabled: %s", apiUrl)
 
 	var k8sClient k8sclient.K8SClient
-	var err error
 	if apiUrl == k8sApiService {
 		k8sClient, err = k8sclient.NewK8SClient()
 	} else {
@@ -162,7 +156,7 @@ func initK8sAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddle
 		Name: &providerName,
 	}
 
-	authNProvider, err := authn.NewK8sAuthN(metadata, *cfg.Auth.K8s, k8sClient)
+	authNProvider, err := authn.NewK8sAuthN(metadata, spec, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s AuthN: %w", err)
 	}
@@ -180,11 +174,22 @@ func initOpenShiftAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthN
 		return nil, errors.New("OpenShift ClusterControlPlaneUrl cannot be empty")
 	}
 
-	apiUrl := strings.TrimSuffix(*cfg.Auth.OpenShift.ClusterControlPlaneUrl, "/")
+	spec := *cfg.Auth.OpenShift
+	apiUrl, err := authprovider.NormalizeIssuerURL(*spec.ClusterControlPlaneUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OpenShift ClusterControlPlaneUrl: %w", err)
+	}
+	spec.ClusterControlPlaneUrl = &apiUrl
+	if spec.AuthorizationUrl != nil && *spec.AuthorizationUrl != "" {
+		authzURL, normErr := authprovider.NormalizeIssuerURL(*spec.AuthorizationUrl)
+		if normErr != nil {
+			return nil, fmt.Errorf("invalid OpenShift AuthorizationUrl: %w", normErr)
+		}
+		spec.AuthorizationUrl = &authzURL
+	}
 	log.Infof("OpenShift auth enabled: %s", apiUrl)
 
 	var k8sClient k8sclient.K8SClient
-	var err error
 	if apiUrl == k8sApiService {
 		k8sClient, err = k8sclient.NewK8SClient()
 	} else {
@@ -199,7 +204,7 @@ func initOpenShiftAuth(cfg *config.Config, log logrus.FieldLogger) (common.AuthN
 		Name: &providerName,
 	}
 
-	authNProvider, err := authn.NewOpenShiftAuth(metadata, *cfg.Auth.OpenShift, k8sClient, getTlsConfig(cfg), log)
+	authNProvider, err := authn.NewOpenShiftAuth(metadata, spec, k8sClient, getTlsConfig(cfg), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OpenShift AuthN: %w", err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -70,6 +70,12 @@ func getTlsConfig(cfg *config.Config) *tls.Config {
 }
 
 func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMiddleware, error) {
+	normalizedAuthzURL, err := authprovider.NormalizeIssuerURL(cfg.Auth.OAuth2.AuthorizationUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OAuth2 AuthorizationUrl: %w", err)
+	}
+	log.Infof("OAuth2 auth enabled: %s", normalizedAuthzURL)
+
 	providerName := "oauth2"
 	metadata := api.ObjectMeta{
 		Name: &providerName,
@@ -78,7 +84,17 @@ func initOAuth2Auth(cfg *config.Config, log logrus.FieldLogger) (common.AuthNMid
 		},
 	}
 
-	authNProvider, err := authn.NewOAuth2Auth(metadata, *cfg.Auth.OAuth2, getTlsConfig(cfg), log)
+	spec := *cfg.Auth.OAuth2
+	spec.AuthorizationUrl = normalizedAuthzURL
+	if spec.Issuer != nil && *spec.Issuer != "" {
+		normalizedIssuer, err := authprovider.NormalizeIssuerURL(*spec.Issuer)
+		if err != nil {
+			return nil, fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
+		}
+		spec.Issuer = &normalizedIssuer
+	}
+
+	authNProvider, err := authn.NewOAuth2Auth(metadata, spec, getTlsConfig(cfg), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OAuth2 AuthN: %w", err)
 	}

--- a/internal/auth/authn/create_provider_normalize_test.go
+++ b/internal/auth/authn/create_provider_normalize_test.go
@@ -28,7 +28,7 @@ func TestCreateOIDCAuthFromProvider_NormalizesIssuer(t *testing.T) {
 	require.NoError(t, err)
 	oidcAuth, ok := authN.(*OIDCAuth)
 	require.True(t, ok)
-	assert.Equal(t, "https://idp.example.com/realm", oidcAuth.GetOIDCSpec().Issuer)
+	assert.Equal(t, "https://idp.example.com/Realm", oidcAuth.GetOIDCSpec().Issuer)
 }
 
 func TestCreateOAuth2AuthFromProvider_NormalizesURLs(t *testing.T) {

--- a/internal/auth/authn/create_provider_normalize_test.go
+++ b/internal/auth/authn/create_provider_normalize_test.go
@@ -1,0 +1,83 @@
+package authn
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOIDCAuthFromProvider_NormalizesIssuer(t *testing.T) {
+	name := "mixed-case-oidc"
+	enabled := true
+	provider := &api.AuthProvider{
+		Metadata: api.ObjectMeta{Name: &name},
+	}
+	require.NoError(t, provider.Spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
+		ProviderType: api.Oidc,
+		Issuer:       "HTTPS://IdP.Example.COM/Realm/",
+		ClientId:     "client",
+		Enabled:      &enabled,
+	}))
+
+	authN, err := createOIDCAuthFromProvider(provider, nil, logrus.New())
+	require.NoError(t, err)
+	oidcAuth, ok := authN.(*OIDCAuth)
+	require.True(t, ok)
+	assert.Equal(t, "https://idp.example.com/realm", oidcAuth.GetOIDCSpec().Issuer)
+}
+
+func TestCreateOAuth2AuthFromProvider_NormalizesURLs(t *testing.T) {
+	name := "mixed-case-oauth2"
+	enabled := true
+	introspection := &api.OAuth2Introspection{}
+	require.NoError(t, introspection.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+		Type: api.Rfc7662,
+		Url:  "https://idp.example.com/introspect",
+	}))
+	provider := &api.AuthProvider{
+		Metadata: api.ObjectMeta{Name: &name},
+	}
+	require.NoError(t, provider.Spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+		ProviderType:     api.Oauth2,
+		AuthorizationUrl: "HTTPS://IdP.Example.COM/oauth2/authorize/",
+		TokenUrl:         "HTTPS://IdP.Example.COM/token/",
+		UserinfoUrl:      "HTTPS://IdP.Example.COM/userinfo/",
+		Issuer:           lo.ToPtr("HTTPS://IdP.Example.COM/"),
+		ClientId:         "client",
+		ClientSecret:     "secret",
+		Enabled:          &enabled,
+		Introspection:    introspection,
+	}))
+
+	authN, err := createOAuth2AuthFromProvider(context.Background(), provider, nil, logrus.New())
+	require.NoError(t, err)
+	oauth2Auth, ok := authN.(*OAuth2Auth)
+	require.True(t, ok)
+	got := oauth2Auth.GetOAuth2Spec()
+	assert.Equal(t, "https://idp.example.com/oauth2/authorize", got.AuthorizationUrl)
+	assert.Equal(t, "https://idp.example.com/token", got.TokenUrl)
+	assert.Equal(t, "https://idp.example.com/userinfo", got.UserinfoUrl)
+	require.NotNil(t, got.Issuer)
+	assert.Equal(t, "https://idp.example.com", *got.Issuer)
+}
+
+func TestCreateOIDCAuthFromProvider_WhenIssuerInvalidItShouldFail(t *testing.T) {
+	name := "bad-oidc"
+	provider := &api.AuthProvider{
+		Metadata: api.ObjectMeta{Name: &name},
+	}
+	require.NoError(t, provider.Spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
+		ProviderType: api.Oidc,
+		Issuer:       "not-a-url",
+		ClientId:     "client",
+	}))
+
+	_, err := createOIDCAuthFromProvider(provider, nil, logrus.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to normalize OIDC provider URLs")
+}

--- a/internal/auth/authn/has_provider_changed_test.go
+++ b/internal/auth/authn/has_provider_changed_test.go
@@ -1,0 +1,95 @@
+package authn
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubOAuth2Middleware struct {
+	MockAuthNMiddleware
+	spec api.OAuth2ProviderSpec
+}
+
+func (s *stubOAuth2Middleware) GetOAuth2Spec() api.OAuth2ProviderSpec {
+	return s.spec
+}
+
+func oauth2SpecForChangeCompare(t *testing.T, authorizationURL, tokenURL, userinfoURL string) api.OAuth2ProviderSpec {
+	t.Helper()
+
+	introspection := &api.OAuth2Introspection{}
+	require.NoError(t, introspection.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+		Type: api.Rfc7662,
+		Url:  "https://idp.example.com/introspect",
+	}))
+
+	orgAssignment := api.AuthOrganizationAssignment{}
+	require.NoError(t, orgAssignment.FromAuthStaticOrganizationAssignment(api.AuthStaticOrganizationAssignment{
+		Type:             api.AuthStaticOrganizationAssignmentTypeStatic,
+		OrganizationName: "test-org",
+	}))
+
+	roleAssignment := api.AuthRoleAssignment{}
+	require.NoError(t, roleAssignment.FromAuthStaticRoleAssignment(api.AuthStaticRoleAssignment{
+		Type:  api.AuthStaticRoleAssignmentTypeStatic,
+		Roles: []string{"viewer"},
+	}))
+
+	return api.OAuth2ProviderSpec{
+		ProviderType:           api.Oauth2,
+		AuthorizationUrl:       authorizationURL,
+		TokenUrl:               tokenURL,
+		UserinfoUrl:            userinfoURL,
+		ClientId:               "client",
+		ClientSecret:           "secret",
+		Introspection:          introspection,
+		OrganizationAssignment: orgAssignment,
+		RoleAssignment:         roleAssignment,
+	}
+}
+
+func TestHasProviderChanged_OAuth2URLNormalizationEquivalence(t *testing.T) {
+	existing := oauth2SpecForChangeCompare(t,
+		"https://idp.example.com/authorize",
+		"https://idp.example.com/token",
+		"https://idp.example.com/userinfo",
+	)
+	incoming := oauth2SpecForChangeCompare(t,
+		"HTTPS://IdP.Example.COM/authorize/",
+		"HTTPS://IdP.Example.COM/token/",
+		"HTTPS://IdP.Example.COM/userinfo/",
+	)
+
+	provider := &api.AuthProvider{}
+	require.NoError(t, provider.Spec.FromOAuth2ProviderSpec(incoming))
+
+	m := NewMultiAuth(nil, nil, logrus.New())
+	changed, err := m.hasProviderChanged(&stubOAuth2Middleware{spec: existing}, provider, "oauth2")
+	require.NoError(t, err)
+	assert.False(t, changed, "host case and trailing-slash variants should not count as a provider change")
+}
+
+func TestHasProviderChanged_OAuth2TokenURLPathCaseIsSignificant(t *testing.T) {
+	existing := oauth2SpecForChangeCompare(t,
+		"https://idp.example.com/authorize",
+		"https://idp.example.com/token",
+		"https://idp.example.com/userinfo",
+	)
+	incoming := oauth2SpecForChangeCompare(t,
+		"https://idp.example.com/authorize",
+		"https://idp.example.com/TOKEN",
+		"https://idp.example.com/userinfo",
+	)
+
+	provider := &api.AuthProvider{}
+	require.NoError(t, provider.Spec.FromOAuth2ProviderSpec(incoming))
+
+	m := NewMultiAuth(nil, nil, logrus.New())
+	changed, err := m.hasProviderChanged(&stubOAuth2Middleware{spec: existing}, provider, "oauth2")
+	require.NoError(t, err)
+	assert.True(t, changed, "tokenUrl path case differences should count as a provider change")
+}

--- a/internal/auth/authn/multiauth.go
+++ b/internal/auth/authn/multiauth.go
@@ -383,9 +383,10 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 		}
 
 		// Compare all fields including client secret
-		existingNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(existingOidcSpec.Issuer)
-		newNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(newOidcSpec.Issuer)
-		if existingNormalizedIssuer != newNormalizedIssuer {
+		// If normalization fails for either URL (malformed), treat as changed — safer than silently skipping a real change.
+		existingNormalizedIssuer, existingNormErr := authprovider.NormalizeIssuerURL(existingOidcSpec.Issuer)
+		newNormalizedIssuer, newNormErr := authprovider.NormalizeIssuerURL(newOidcSpec.Issuer)
+		if existingNormErr != nil || newNormErr != nil || existingNormalizedIssuer != newNormalizedIssuer {
 			m.log.Debugf("Provider %s: changed (OIDC Issuer: existing=%q, new=%q)", providerName, existingOidcSpec.Issuer, newOidcSpec.Issuer)
 			return true, nil
 		}
@@ -459,15 +460,17 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 			return true, nil
 		}
 		if existingOauth2Spec.Issuer != nil && newOauth2Spec.Issuer != nil {
-			existingNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(*existingOauth2Spec.Issuer)
-			newNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(*newOauth2Spec.Issuer)
-			if existingNormalizedIssuer != newNormalizedIssuer {
+			// If normalization fails for either URL (malformed), treat as changed — safer than missing a real change.
+			existingNormalizedIssuer, existingNormErr := authprovider.NormalizeIssuerURL(*existingOauth2Spec.Issuer)
+			newNormalizedIssuer, newNormErr := authprovider.NormalizeIssuerURL(*newOauth2Spec.Issuer)
+			if existingNormErr != nil || newNormErr != nil || existingNormalizedIssuer != newNormalizedIssuer {
 				return true, nil
 			}
 		}
-		existingNormalizedAuthzURL, _ := authprovider.NormalizeIssuerURL(existingOauth2Spec.AuthorizationUrl)
-		newNormalizedAuthzURL, _ := authprovider.NormalizeIssuerURL(newOauth2Spec.AuthorizationUrl)
-		if existingNormalizedAuthzURL != newNormalizedAuthzURL {
+		// If normalization fails for either URL (malformed), treat as changed.
+		existingNormalizedAuthzURL, existingAuthzNormErr := authprovider.NormalizeIssuerURL(existingOauth2Spec.AuthorizationUrl)
+		newNormalizedAuthzURL, newAuthzNormErr := authprovider.NormalizeIssuerURL(newOauth2Spec.AuthorizationUrl)
+		if existingAuthzNormErr != nil || newAuthzNormErr != nil || existingNormalizedAuthzURL != newNormalizedAuthzURL {
 			m.log.Debugf("Provider %s: changed (OAuth2 AuthorizationUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.AuthorizationUrl, newOauth2Spec.AuthorizationUrl)
 			return true, nil
 		}

--- a/internal/auth/authn/multiauth.go
+++ b/internal/auth/authn/multiauth.go
@@ -474,11 +474,16 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 			m.log.Debugf("Provider %s: changed (OAuth2 AuthorizationUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.AuthorizationUrl, newOauth2Spec.AuthorizationUrl)
 			return true, nil
 		}
-		if existingOauth2Spec.TokenUrl != newOauth2Spec.TokenUrl {
+		// If normalization fails for either URL (malformed), treat as changed.
+		existingNormalizedTokenURL, existingTokenNormErr := authprovider.NormalizeIssuerURL(existingOauth2Spec.TokenUrl)
+		newNormalizedTokenURL, newTokenNormErr := authprovider.NormalizeIssuerURL(newOauth2Spec.TokenUrl)
+		if existingTokenNormErr != nil || newTokenNormErr != nil || existingNormalizedTokenURL != newNormalizedTokenURL {
 			m.log.Debugf("Provider %s: changed (OAuth2 TokenUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.TokenUrl, newOauth2Spec.TokenUrl)
 			return true, nil
 		}
-		if existingOauth2Spec.UserinfoUrl != newOauth2Spec.UserinfoUrl {
+		existingNormalizedUserinfoURL, existingUserinfoNormErr := authprovider.NormalizeIssuerURL(existingOauth2Spec.UserinfoUrl)
+		newNormalizedUserinfoURL, newUserinfoNormErr := authprovider.NormalizeIssuerURL(newOauth2Spec.UserinfoUrl)
+		if existingUserinfoNormErr != nil || newUserinfoNormErr != nil || existingNormalizedUserinfoURL != newNormalizedUserinfoURL {
 			m.log.Debugf("Provider %s: changed (OAuth2 UserinfoUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.UserinfoUrl, newOauth2Spec.UserinfoUrl)
 			return true, nil
 		}

--- a/internal/auth/authn/multiauth.go
+++ b/internal/auth/authn/multiauth.go
@@ -1154,6 +1154,10 @@ func createOIDCAuthFromProvider(provider *api.AuthProvider, tlsConfig *tls.Confi
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse OIDC provider spec: %w", err)
 	}
+	if err := authprovider.NormalizeOIDCProviderSpecURLs(&oidcSpec); err != nil {
+		return nil, fmt.Errorf("failed to normalize OIDC provider URLs for %s: %w",
+			lo.FromPtr(provider.Metadata.Name), err)
+	}
 
 	// Create OIDCAuth instance for this specific provider
 	oidcAuth, err := NewOIDCAuth(provider.Metadata, oidcSpec, tlsConfig, log)
@@ -1170,6 +1174,10 @@ func createOAuth2AuthFromProvider(ctx context.Context, provider *api.AuthProvide
 	oauth2Spec, err := provider.Spec.AsOAuth2ProviderSpec()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse OAuth2 provider spec: %w", err)
+	}
+	if err := authprovider.NormalizeOAuth2ProviderSpecURLs(&oauth2Spec); err != nil {
+		return nil, fmt.Errorf("failed to normalize OAuth2 provider URLs for %s: %w",
+			lo.FromPtr(provider.Metadata.Name), err)
 	}
 
 	// Create OAuth2Auth instance for this specific provider

--- a/internal/auth/authn/multiauth.go
+++ b/internal/auth/authn/multiauth.go
@@ -383,7 +383,9 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 		}
 
 		// Compare all fields including client secret
-		if existingOidcSpec.Issuer != newOidcSpec.Issuer {
+		existingNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(existingOidcSpec.Issuer)
+		newNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(newOidcSpec.Issuer)
+		if existingNormalizedIssuer != newNormalizedIssuer {
 			m.log.Debugf("Provider %s: changed (OIDC Issuer: existing=%q, new=%q)", providerName, existingOidcSpec.Issuer, newOidcSpec.Issuer)
 			return true, nil
 		}
@@ -456,10 +458,16 @@ func (m *MultiAuth) hasProviderChanged(existingMiddleware common.AuthNMiddleware
 		if (existingOauth2Spec.Issuer == nil) != (newOauth2Spec.Issuer == nil) {
 			return true, nil
 		}
-		if existingOauth2Spec.Issuer != nil && newOauth2Spec.Issuer != nil && *existingOauth2Spec.Issuer != *newOauth2Spec.Issuer {
-			return true, nil
+		if existingOauth2Spec.Issuer != nil && newOauth2Spec.Issuer != nil {
+			existingNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(*existingOauth2Spec.Issuer)
+			newNormalizedIssuer, _ := authprovider.NormalizeIssuerURL(*newOauth2Spec.Issuer)
+			if existingNormalizedIssuer != newNormalizedIssuer {
+				return true, nil
+			}
 		}
-		if existingOauth2Spec.AuthorizationUrl != newOauth2Spec.AuthorizationUrl {
+		existingNormalizedAuthzURL, _ := authprovider.NormalizeIssuerURL(existingOauth2Spec.AuthorizationUrl)
+		newNormalizedAuthzURL, _ := authprovider.NormalizeIssuerURL(newOauth2Spec.AuthorizationUrl)
+		if existingNormalizedAuthzURL != newNormalizedAuthzURL {
 			m.log.Debugf("Provider %s: changed (OAuth2 AuthorizationUrl: existing=%q, new=%q)", providerName, existingOauth2Spec.AuthorizationUrl, newOauth2Spec.AuthorizationUrl)
 			return true, nil
 		}

--- a/internal/auth/authn/oauth2_auth.go
+++ b/internal/auth/authn/oauth2_auth.go
@@ -17,6 +17,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/common"
+	authprovider "github.com/flightctl/flightctl/internal/auth/provider"
 	"github.com/flightctl/flightctl/internal/identity"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -527,16 +528,29 @@ func (o *OAuth2Auth) introspectJWT(ctx context.Context, token string, spec api.J
 		return fmt.Errorf("failed to validate JWT token: %w", err)
 	}
 
-	// Validate issuer if specified, otherwise use OAuth2ProviderSpec issuer
-	expectedIssuer := ""
+	// Validate issuer if specified, otherwise use OAuth2ProviderSpec issuer.
+	// Both sides are normalized so that a trailing-slash difference (e.g. the IdP
+	// mints tokens with "https://issuer.com/realm/" but the config stores
+	// "https://issuer.com/realm") does not cause spurious authentication failures.
+	rawExpectedIssuer := ""
 	if spec.Issuer != nil && *spec.Issuer != "" {
-		expectedIssuer = *spec.Issuer
+		rawExpectedIssuer = *spec.Issuer
 	} else if o.spec.Issuer != nil && *o.spec.Issuer != "" {
-		expectedIssuer = *o.spec.Issuer
+		rawExpectedIssuer = *o.spec.Issuer
 	}
 
-	if expectedIssuer != "" && parsedToken.Issuer() != expectedIssuer {
-		return fmt.Errorf("token issuer '%s' does not match expected issuer '%s'", parsedToken.Issuer(), expectedIssuer)
+	if rawExpectedIssuer != "" {
+		normalizedExpected, err := authprovider.NormalizeIssuerURL(rawExpectedIssuer)
+		if err != nil {
+			return fmt.Errorf("invalid configured issuer URL %q: %w", rawExpectedIssuer, err)
+		}
+		normalizedActual, err := authprovider.NormalizeIssuerURL(parsedToken.Issuer())
+		if err != nil {
+			return fmt.Errorf("invalid token issuer URL %q: %w", parsedToken.Issuer(), err)
+		}
+		if normalizedActual != normalizedExpected {
+			return fmt.Errorf("token issuer '%s' does not match expected issuer '%s'", parsedToken.Issuer(), rawExpectedIssuer)
+		}
 	}
 
 	// Validate audience if specified, otherwise use OAuth2ProviderSpec clientId

--- a/internal/auth/authn/oauth2_auth_test.go
+++ b/internal/auth/authn/oauth2_auth_test.go
@@ -1031,3 +1031,112 @@ func TestOAuth2Auth_TLSConfig(t *testing.T) {
 	assert.NotNil(t, oauth2Auth.tlsConfig)
 	assert.True(t, oauth2Auth.tlsConfig.InsecureSkipVerify)
 }
+
+// TestOAuth2Auth_introspectJWT_IssuerNormalization verifies that the JWT issuer comparison
+// normalizes both sides so that a trailing slash difference between the configured issuer
+// and the JWT iss claim does not cause authentication to fail.
+func TestOAuth2Auth_introspectJWT_IssuerNormalization(t *testing.T) {
+	testKey, err := jwk.FromRaw([]byte("test-secret-key-that-is-at-least-32-bytes-long"))
+	require.NoError(t, err)
+	require.NoError(t, testKey.Set(jwk.KeyIDKey, "test-key-id"))
+	require.NoError(t, testKey.Set(jwk.AlgorithmKey, jwa.HS256))
+
+	testKeySet := jwk.NewSet()
+	require.NoError(t, testKeySet.AddKey(testKey))
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwksBytes, _ := json.Marshal(testKeySet)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBytes)
+	}))
+	defer jwksServer.Close()
+
+	buildToken := func(issuer string) string {
+		now := time.Now()
+		tok, err := jwt.NewBuilder().
+			Issuer(issuer).
+			Subject("test-user").
+			Audience([]string{"test-client-id"}).
+			IssuedAt(now).
+			Expiration(now.Add(time.Hour)).
+			Build()
+		require.NoError(t, err)
+		signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256, testKey))
+		require.NoError(t, err)
+		return string(signed)
+	}
+
+	tests := []struct {
+		name            string
+		configIssuer    string
+		tokenIssuer     string
+		wantErr         bool
+	}{
+		{
+			name:         "When config and token issuer are identical it should pass",
+			configIssuer: "https://test-issuer.com",
+			tokenIssuer:  "https://test-issuer.com",
+			wantErr:      false,
+		},
+		{
+			name:         "When config has no trailing slash but token iss does it should pass",
+			configIssuer: "https://test-issuer.com",
+			tokenIssuer:  "https://test-issuer.com/",
+			wantErr:      false,
+		},
+		{
+			name:         "When config has trailing slash but token iss does not it should pass",
+			configIssuer: "https://test-issuer.com/",
+			tokenIssuer:  "https://test-issuer.com",
+			wantErr:      false,
+		},
+		{
+			name:         "When both have trailing slash it should pass",
+			configIssuer: "https://test-issuer.com/",
+			tokenIssuer:  "https://test-issuer.com/",
+			wantErr:      false,
+		},
+		{
+			name:         "When config has path with trailing slash but token iss does not it should pass",
+			configIssuer: "https://test-issuer.com/realms/myrealm/",
+			tokenIssuer:  "https://test-issuer.com/realms/myrealm",
+			wantErr:      false,
+		},
+		{
+			name:         "When config has path without trailing slash but token iss has it it should pass",
+			configIssuer: "https://test-issuer.com/realms/myrealm",
+			tokenIssuer:  "https://test-issuer.com/realms/myrealm/",
+			wantErr:      false,
+		},
+		{
+			name:         "When issuers are genuinely different it should fail",
+			configIssuer: "https://test-issuer.com",
+			tokenIssuer:  "https://other-issuer.com",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := createBasicOAuth2Spec()
+			spec.Issuer = lo.ToPtr(tt.configIssuer)
+			introspection := &api.OAuth2Introspection{}
+			jwtSpec := api.JwtIntrospectionSpec{
+				Type:    api.Jwt,
+				JwksUrl: jwksServer.URL,
+			}
+			require.NoError(t, introspection.FromJwtIntrospectionSpec(jwtSpec))
+			spec.Introspection = introspection
+
+			oauth2Auth := createTestOAuth2Auth(t, spec)
+			defer oauth2Auth.Stop()
+
+			err := oauth2Auth.ValidateToken(context.Background(), buildToken(tt.tokenIssuer))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err, "issuer comparison should ignore trailing slash difference")
+			}
+		})
+	}
+}

--- a/internal/auth/authn/oauth2_auth_test.go
+++ b/internal/auth/authn/oauth2_auth_test.go
@@ -42,7 +42,9 @@ func createTestOAuth2Auth(t *testing.T, spec api.OAuth2ProviderSpec) *OAuth2Auth
 }
 
 // Helper function to create a basic OAuth2ProviderSpec
-func createBasicOAuth2Spec() api.OAuth2ProviderSpec {
+func createBasicOAuth2Spec(t *testing.T) api.OAuth2ProviderSpec {
+	t.Helper()
+
 	assignment := api.AuthOrganizationAssignment{}
 	staticAssignment := api.AuthStaticOrganizationAssignment{
 		Type:             api.AuthStaticOrganizationAssignmentTypeStatic,
@@ -88,14 +90,14 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 		{
 			name:        "valid OAuth2 spec",
 			metadata:    api.ObjectMeta{Name: lo.ToPtr("test-provider")},
-			spec:        createBasicOAuth2Spec(),
+			spec:        createBasicOAuth2Spec(t),
 			expectError: false,
 		},
 		{
 			name:     "missing authorizationUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.AuthorizationUrl = ""
 				return spec
 			}(),
@@ -106,7 +108,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing tokenUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.TokenUrl = ""
 				return spec
 			}(),
@@ -117,7 +119,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing userinfoUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.UserinfoUrl = ""
 				return spec
 			}(),
@@ -128,7 +130,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing clientId",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.ClientId = ""
 				return spec
 			}(),
@@ -139,7 +141,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing clientSecret",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.ClientSecret = ""
 				return spec
 			}(),
@@ -198,7 +200,7 @@ func TestOAuth2Auth_IntrospectRFC7662(t *testing.T) {
 	defer server.Close()
 
 	// Create OAuth2Auth with RFC 7662 introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	rfc7662Spec := api.Rfc7662IntrospectionSpec{
 		Type: api.Rfc7662,
@@ -283,7 +285,7 @@ func TestOAuth2Auth_IntrospectGitHub(t *testing.T) {
 	defer server.Close()
 
 	// Create OAuth2Auth with GitHub introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	githubSpec := api.GitHubIntrospectionSpec{
 		Type: api.Github,
@@ -345,7 +347,7 @@ func TestOAuth2Auth_IntrospectJWT(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -480,7 +482,7 @@ func TestOAuth2Auth_IntrospectJWT_CustomIssuerAndAudience(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection with custom issuer and audience
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
 		Type:     api.Jwt,
@@ -538,7 +540,7 @@ func TestOAuth2Auth_GetIdentity(t *testing.T) {
 	defer userinfoServer.Close()
 
 	// Create OAuth2Auth
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.UserinfoUrl = userinfoServer.URL
 
 	oauth2Auth := createTestOAuth2Auth(t, spec)
@@ -794,7 +796,7 @@ func TestOAuth2Auth_IntrospectJWT_CacheLifecycle(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -854,7 +856,7 @@ func TestOAuth2Auth_IntrospectJWT_ProviderContextUsed(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -899,7 +901,7 @@ func TestOAuth2Auth_IntrospectJWT_ProviderContextUsed(t *testing.T) {
 }
 
 func TestOAuth2Auth_StartStop(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 
@@ -930,7 +932,7 @@ func TestOAuth2Auth_StartStop(t *testing.T) {
 }
 
 func TestOAuth2Auth_GetAuthToken(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	oauth2Auth := createTestOAuth2Auth(t, spec)
 	defer oauth2Auth.Stop()
 
@@ -983,7 +985,7 @@ func TestOAuth2Auth_GetAuthToken(t *testing.T) {
 }
 
 func TestOAuth2Auth_GetAuthConfig(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 
 	oauth2Auth := createTestOAuth2Auth(t, spec)
@@ -1011,7 +1013,7 @@ func TestOAuth2Auth_GetAuthConfig(t *testing.T) {
 }
 
 func TestOAuth2Auth_TLSConfig(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 
@@ -1118,7 +1120,7 @@ func TestOAuth2Auth_introspectJWT_IssuerNormalization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := createBasicOAuth2Spec()
+			spec := createBasicOAuth2Spec(t)
 			spec.Issuer = lo.ToPtr(tt.configIssuer)
 			introspection := &api.OAuth2Introspection{}
 			jwtSpec := api.JwtIntrospectionSpec{

--- a/internal/auth/authn/oauth2_auth_test.go
+++ b/internal/auth/authn/oauth2_auth_test.go
@@ -1067,10 +1067,10 @@ func TestOAuth2Auth_introspectJWT_IssuerNormalization(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		configIssuer    string
-		tokenIssuer     string
-		wantErr         bool
+		name         string
+		configIssuer string
+		tokenIssuer  string
+		wantErr      bool
 	}{
 		{
 			name:         "When config and token issuer are identical it should pass",

--- a/internal/auth/authn/oidc_auth_test.go
+++ b/internal/auth/authn/oidc_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -301,4 +302,87 @@ func TestOIDCAuth_extractOrganizations(t *testing.T) {
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s
+}
+
+// TestOIDCAuth_ensureDiscovery_TrailingSlash verifies that ensureDiscovery correctly builds
+// the OIDC discovery URL when the configured issuer has a trailing slash.
+// The server-side fix uses provider.DiscoveryURL which normalizes the issuer, so these
+// tests must all pass. They document the expected correct behavior.
+func TestOIDCAuth_ensureDiscovery_TrailingSlash(t *testing.T) {
+	tests := []struct {
+		name         string
+		issuerSuffix string
+		validPath    string
+	}{
+		{
+			name:         "When issuer has no trailing slash it should fetch the correct discovery endpoint",
+			issuerSuffix: "",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a trailing slash it should fetch the correct discovery endpoint without double slash",
+			issuerSuffix: "/",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a realm path with trailing slash it should fetch the correct discovery endpoint",
+			issuerSuffix: "/realms/myrealm/",
+			validPath:    "/realms/myrealm/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a realm path without trailing slash it should fetch the correct discovery endpoint",
+			issuerSuffix: "/realms/myrealm",
+			validPath:    "/realms/myrealm/.well-known/openid-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var requestedPaths []string
+
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				requestedPaths = append(requestedPaths, r.URL.Path)
+				mu.Unlock()
+
+				if r.URL.Path != tt.validPath {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				response := OIDCServerResponse{
+					JwksUri: server.URL + "/jwks",
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			issuer := server.URL + tt.issuerSuffix
+			spec := api.OIDCProviderSpec{
+				Issuer:   issuer,
+				ClientId: "test-client",
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			oidcAuth, err := NewOIDCAuth(api.ObjectMeta{}, spec, nil, log)
+			require.NoError(t, err)
+
+			err = oidcAuth.ensureDiscovery(context.Background())
+			require.NoError(t, err, "ensureDiscovery should succeed for issuer %q", issuer)
+
+			mu.Lock()
+			paths := append([]string{}, requestedPaths...)
+			mu.Unlock()
+
+			require.NotEmpty(t, paths, "Expected at least one request to the discovery server")
+			for _, path := range paths {
+				assert.NotContains(t, path, "//",
+					"Discovery request path must not contain double slash (issuer: %q, path: %q)", issuer, path)
+			}
+		})
+	}
 }

--- a/internal/auth/init_normalize_test.go
+++ b/internal/auth/init_normalize_test.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/auth/authn"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitOIDCAuth_NormalizesIssuer(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithOIDCAuth("HTTPS://IdP.Example.COM/Realm/", "client", true)(cfg)
+
+	authN, err := initOIDCAuth(cfg, logrus.New())
+	require.NoError(t, err)
+	oidcAuth, ok := authN.(*authn.OIDCAuth)
+	require.True(t, ok)
+	assert.Equal(t, "https://idp.example.com/realm", oidcAuth.GetOIDCSpec().Issuer)
+}
+
+func TestInitOAuth2Auth_NormalizesURLs(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithOAuth2Auth(
+		"HTTPS://IdP.Example.COM/authorize/",
+		"HTTPS://IdP.Example.COM/token/",
+		"HTTPS://IdP.Example.COM/userinfo/",
+		"HTTPS://IdP.Example.COM/",
+		"client",
+		true,
+	)(cfg)
+	cfg.Auth.OAuth2.ClientSecret = "secret"
+	introspection := &api.OAuth2Introspection{}
+	require.NoError(t, introspection.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+		Type: api.Rfc7662,
+		Url:  "https://idp.example.com/introspect",
+	}))
+	cfg.Auth.OAuth2.Introspection = introspection
+
+	authN, err := initOAuth2Auth(cfg, logrus.New())
+	require.NoError(t, err)
+	oauth2Auth, ok := authN.(*authn.OAuth2Auth)
+	require.True(t, ok)
+	got := oauth2Auth.GetOAuth2Spec()
+	assert.Equal(t, "https://idp.example.com/authorize", got.AuthorizationUrl)
+	assert.Equal(t, "https://idp.example.com/token", got.TokenUrl)
+	assert.Equal(t, "https://idp.example.com/userinfo", got.UserinfoUrl)
+	require.NotNil(t, got.Issuer)
+	assert.Equal(t, "https://idp.example.com", *got.Issuer)
+}
+
+func TestInitAAPAuth_NormalizesApiUrl(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithAAPAuth("HTTPS://Gateway.Example.COM/", "")(cfg)
+
+	authN, err := initAAPAuth(cfg, logrus.New())
+	require.NoError(t, err)
+	aapAuth, ok := authN.(*authn.AapGatewayAuth)
+	require.True(t, ok)
+	assert.Equal(t, "https://gateway.example.com", aapAuth.GetAapSpec().ApiUrl)
+}
+
+func TestInitK8sAuth_WhenApiUrlInvalidItShouldFailBeforeClientCreate(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithK8sAuth("not-a-url", "default")(cfg)
+
+	_, err := initK8sAuth(cfg, logrus.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid K8s ApiUrl")
+}
+
+func TestInitOpenShiftAuth_WhenControlPlaneURLInvalidItShouldFailBeforeClientCreate(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithOIDCAuth("https://unused.example.com", "unused", false)(cfg)
+	cfg.Auth.OIDC = nil
+	cfg.Auth.OpenShift = &api.OpenShiftProviderSpec{
+		ProviderType:           api.Openshift,
+		ClusterControlPlaneUrl: lo.ToPtr("not-a-url"),
+		AuthorizationUrl:       lo.ToPtr("https://oauth.example.com/oauth/authorize"),
+		ClientId:               lo.ToPtr("console"),
+		Enabled:                lo.ToPtr(true),
+	}
+
+	_, err := initOpenShiftAuth(cfg, logrus.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid OpenShift ClusterControlPlaneUrl")
+}
+
+func TestInitOpenShiftAuth_WhenAuthorizationURLInvalidItShouldFail(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithOIDCAuth("https://unused.example.com", "unused", false)(cfg)
+	cfg.Auth.OIDC = nil
+	cfg.Auth.OpenShift = &api.OpenShiftProviderSpec{
+		ProviderType:           api.Openshift,
+		ClusterControlPlaneUrl: lo.ToPtr("https://api.example.com:6443"),
+		AuthorizationUrl:       lo.ToPtr("not-a-url"),
+		ClientId:               lo.ToPtr("console"),
+		Enabled:                lo.ToPtr(true),
+	}
+
+	_, err := initOpenShiftAuth(cfg, logrus.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid OpenShift AuthorizationUrl")
+}
+
+func TestInitAAPAuth_WhenApiUrlInvalidItShouldFail(t *testing.T) {
+	cfg := config.NewDefault()
+	config.WithAAPAuth("not-a-url", "")(cfg)
+
+	_, err := initAAPAuth(cfg, logrus.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid AAP ApiUrl")
+}

--- a/internal/auth/init_normalize_test.go
+++ b/internal/auth/init_normalize_test.go
@@ -20,7 +20,7 @@ func TestInitOIDCAuth_NormalizesIssuer(t *testing.T) {
 	require.NoError(t, err)
 	oidcAuth, ok := authN.(*authn.OIDCAuth)
 	require.True(t, ok)
-	assert.Equal(t, "https://idp.example.com/realm", oidcAuth.GetOIDCSpec().Issuer)
+	assert.Equal(t, "https://idp.example.com/Realm", oidcAuth.GetOIDCSpec().Issuer)
 }
 
 func TestInitOAuth2Auth_NormalizesURLs(t *testing.T) {

--- a/internal/auth/provider/introspection.go
+++ b/internal/auth/provider/introspection.go
@@ -112,7 +112,8 @@ func buildIntrospectionURL(baseURL string) string {
 }
 
 // NormalizeIssuerURL parses an issuer URL and returns a canonical form:
-// scheme/host/path/query/fragment lowercased, and no trailing slash on path.
+// scheme and host lowercased, and no trailing slash on path.
+// Path, query, and fragment case are preserved (OIDC issuer paths are case-sensitive).
 // Requires scheme and host. Used so discovery, token verification, unique indexes,
 // and cache keys share one form.
 func NormalizeIssuerURL(issuer string) (string, error) {
@@ -128,10 +129,8 @@ func NormalizeIssuerURL(issuer string) (string, error) {
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	parsed.Host = strings.ToLower(parsed.Host)
-	parsed.Path = strings.ToLower(strings.TrimSuffix(parsed.Path, "/"))
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
 	parsed.RawPath = ""
-	parsed.RawQuery = strings.ToLower(parsed.RawQuery)
-	parsed.Fragment = strings.ToLower(parsed.Fragment)
 	return parsed.String(), nil
 }
 

--- a/internal/auth/provider/introspection.go
+++ b/internal/auth/provider/introspection.go
@@ -111,10 +111,10 @@ func buildIntrospectionURL(baseURL string) string {
 	return parsedURL.String()
 }
 
-// NormalizeIssuerURL parses an issuer URL and returns a canonical form (no trailing slash on path).
-// Requires scheme and host. Host letter-case and other RFC 3986 equivalence classes are left
-// unchanged — uniqueness and lookups are exact-string after this trailing-slash strip only.
-// Used so discovery, token verification, and cache keys share one form.
+// NormalizeIssuerURL parses an issuer URL and returns a canonical form:
+// scheme/host/path/query/fragment lowercased, and no trailing slash on path.
+// Requires scheme and host. Used so discovery, token verification, unique indexes,
+// and cache keys share one form.
 func NormalizeIssuerURL(issuer string) (string, error) {
 	if issuer == "" {
 		return "", errors.New("issuer URL is empty")
@@ -126,7 +126,12 @@ func NormalizeIssuerURL(issuer string) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", errors.New("issuer URL must have scheme and host")
 	}
-	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.ToLower(strings.TrimSuffix(parsed.Path, "/"))
+	parsed.RawPath = ""
+	parsed.RawQuery = strings.ToLower(parsed.RawQuery)
+	parsed.Fragment = strings.ToLower(parsed.Fragment)
 	return parsed.String(), nil
 }
 

--- a/internal/auth/provider/introspection.go
+++ b/internal/auth/provider/introspection.go
@@ -112,7 +112,9 @@ func buildIntrospectionURL(baseURL string) string {
 }
 
 // NormalizeIssuerURL parses an issuer URL and returns a canonical form (no trailing slash on path).
-// Requires scheme and host. Used so discovery, token verification, and cache keys share one form.
+// Requires scheme and host. Host letter-case and other RFC 3986 equivalence classes are left
+// unchanged — uniqueness and lookups are exact-string after this trailing-slash strip only.
+// Used so discovery, token verification, and cache keys share one form.
 func NormalizeIssuerURL(issuer string) (string, error) {
 	if issuer == "" {
 		return "", errors.New("issuer URL is empty")

--- a/internal/auth/provider/introspection_test.go
+++ b/internal/auth/provider/introspection_test.go
@@ -1,0 +1,210 @@
+package provider
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIntrospectionURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "When token URL is provided it should append /introspect",
+			baseURL: "https://idp.example.com/oauth2/token",
+			want:    "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name:    "When base URL without /token it should append /introspect",
+			baseURL: "https://idp.example.com/oauth2",
+			want:    "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name:    "When base URL has trailing slash it should strip and append /introspect",
+			baseURL: "https://idp.example.com/oauth2/token/",
+			want:    "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name:    "When URL has query parameters they should be preserved",
+			baseURL: "https://idp.example.com/oauth2/token?realm=master",
+			want:    "https://idp.example.com/oauth2/introspect?realm=master",
+		},
+		{
+			name:    "When URL has port it should be preserved",
+			baseURL: "https://idp.example.com:8080/oauth2/token",
+			want:    "https://idp.example.com:8080/oauth2/introspect",
+		},
+		{
+			name:    "When URL has no scheme or host it should return empty string",
+			baseURL: "not-a-url",
+			want:    "",
+		},
+		{
+			name:    "When empty string it should return empty string",
+			baseURL: "",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildIntrospectionURL(tt.baseURL)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractGitHubEnterpriseBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		authURL string
+		want    string
+	}{
+		{
+			name:    "When GHE authorization URL it should return API base URL",
+			authURL: "https://github.enterprise.com/login/oauth/authorize",
+			want:    "https://github.enterprise.com/api/v3",
+		},
+		{
+			name:    "When URL has no path it should return empty string",
+			authURL: "https://github.enterprise.com",
+			want:    "",
+		},
+		{
+			name:    "When URL has no scheme it should return empty string",
+			authURL: "github.enterprise.com/login/oauth/authorize",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractGitHubEnterpriseBaseURL(tt.authURL)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInferOAuth2IntrospectionConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		spec            api.OAuth2ProviderSpec
+		wantType        string
+		wantErrContains string
+	}{
+		{
+			name: "When GitHub.com URLs it should infer GitHub introspection without custom URL",
+			spec: api.OAuth2ProviderSpec{
+				AuthorizationUrl: "https://github.com/login/oauth/authorize",
+				TokenUrl:         "https://github.com/login/oauth/access_token",
+				UserinfoUrl:      "https://api.github.com/user",
+				ClientId:         "client-id",
+			},
+			wantType: string(api.Github),
+		},
+		{
+			name: "When GitHub Enterprise URLs it should infer GitHub introspection with custom URL",
+			spec: api.OAuth2ProviderSpec{
+				AuthorizationUrl: "https://github.enterprise.com/login/oauth/authorize",
+				TokenUrl:         "https://github.enterprise.com/login/oauth/access_token",
+				UserinfoUrl:      "https://github.enterprise.com/api/v3/user",
+				ClientId:         "client-id",
+			},
+			wantType: string(api.Github),
+		},
+		{
+			name: "When token URL ends with /token it should infer RFC 7662 with /introspect sibling",
+			spec: api.OAuth2ProviderSpec{
+				AuthorizationUrl: "https://idp.example.com/oauth2/authorize",
+				TokenUrl:         "https://idp.example.com/oauth2/token",
+				UserinfoUrl:      "https://idp.example.com/oauth2/userinfo",
+				ClientId:         "client-id",
+			},
+			wantType: string(api.Rfc7662),
+		},
+		{
+			name: "When token URL has no /token suffix it should infer RFC 7662 by appending /introspect",
+			spec: api.OAuth2ProviderSpec{
+				AuthorizationUrl: "https://idp.example.com/authorize",
+				TokenUrl:         "https://idp.example.com/oauth2",
+				UserinfoUrl:      "https://idp.example.com/userinfo",
+				ClientId:         "client-id",
+			},
+			wantType: string(api.Rfc7662),
+		},
+		{
+			name: "When token URL is invalid it should fail to infer and return error",
+			spec: api.OAuth2ProviderSpec{
+				AuthorizationUrl: "not-a-url",
+				TokenUrl:         "not-a-url-either",
+				UserinfoUrl:      "https://idp.example.com/userinfo",
+				ClientId:         "client-id",
+			},
+			wantErrContains: "could not infer introspection",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InferOAuth2IntrospectionConfig(tt.spec)
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			discriminator, err := got.Discriminator()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, discriminator)
+		})
+	}
+}
+
+func TestInferRFC7662IntrospectionURL(t *testing.T) {
+	tests := []struct {
+		name string
+		spec api.OAuth2ProviderSpec
+		want string
+	}{
+		{
+			name: "When token URL provided it should derive introspection from token URL",
+			spec: api.OAuth2ProviderSpec{
+				TokenUrl: "https://idp.example.com/oauth2/token",
+			},
+			want: "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name: "When only issuer provided it should derive introspection from issuer",
+			spec: api.OAuth2ProviderSpec{
+				Issuer: lo.ToPtr("https://idp.example.com/oauth2"),
+			},
+			want: "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name: "When token URL is invalid and issuer is valid it should fall back to issuer",
+			spec: api.OAuth2ProviderSpec{
+				TokenUrl: "not-a-url",
+				Issuer:   lo.ToPtr("https://idp.example.com/oauth2"),
+			},
+			want: "https://idp.example.com/oauth2/introspect",
+		},
+		{
+			name: "When both token URL and issuer are invalid it should return empty string",
+			spec: api.OAuth2ProviderSpec{
+				TokenUrl: "not-a-url",
+				Issuer:   lo.ToPtr("also-not-a-url"),
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferRFC7662IntrospectionURL(tt.spec)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/auth/provider/normalize_urls.go
+++ b/internal/auth/provider/normalize_urls.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"fmt"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+)
+
+// NormalizeOIDCProviderSpecURLs canonicalizes issuer-identity URL fields on an OIDC spec
+// by stripping a trailing path slash. Host case and other RFC 3986 variations are left unchanged.
+func NormalizeOIDCProviderSpecURLs(spec *api.OIDCProviderSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if spec.Issuer == "" {
+		return nil
+	}
+	normalized, err := NormalizeIssuerURL(spec.Issuer)
+	if err != nil {
+		return fmt.Errorf("invalid OIDC issuer URL: %w", err)
+	}
+	spec.Issuer = normalized
+	return nil
+}
+
+// NormalizeOAuth2ProviderSpecURLs canonicalizes OAuth2 URL fields used for identity and
+// uniqueness (authorizationUrl, issuer, tokenUrl, userinfoUrl) by stripping a trailing path slash.
+func NormalizeOAuth2ProviderSpecURLs(spec *api.OAuth2ProviderSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if spec.AuthorizationUrl != "" {
+		normalized, err := NormalizeIssuerURL(spec.AuthorizationUrl)
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 authorizationUrl: %w", err)
+		}
+		spec.AuthorizationUrl = normalized
+	}
+	if spec.Issuer != nil && *spec.Issuer != "" {
+		normalized, err := NormalizeIssuerURL(*spec.Issuer)
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
+		}
+		spec.Issuer = &normalized
+	}
+	if spec.TokenUrl != "" {
+		normalized, err := NormalizeIssuerURL(spec.TokenUrl)
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 tokenUrl: %w", err)
+		}
+		spec.TokenUrl = normalized
+	}
+	if spec.UserinfoUrl != "" {
+		normalized, err := NormalizeIssuerURL(spec.UserinfoUrl)
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 userinfoUrl: %w", err)
+		}
+		spec.UserinfoUrl = normalized
+	}
+	return nil
+}
+
+// NormalizeAuthProviderSpecURLs normalizes URL fields in auth provider specs before storing
+// or constructing auth middleware. Unknown/malformed provider types are skipped so callers
+// can surface validation errors separately.
+func NormalizeAuthProviderSpecURLs(spec *api.AuthProviderSpec) error {
+	if spec == nil {
+		return nil
+	}
+	discriminator, err := spec.Discriminator()
+	if err != nil {
+		return nil
+	}
+
+	switch discriminator {
+	case string(api.Oidc):
+		oidcSpec, err := spec.AsOIDCProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OIDC provider spec: %w", err)
+		}
+		if err := NormalizeOIDCProviderSpecURLs(&oidcSpec); err != nil {
+			return err
+		}
+		if mergeErr := spec.MergeOIDCProviderSpec(oidcSpec); mergeErr != nil {
+			return fmt.Errorf("failed to update OIDC provider spec: %w", mergeErr)
+		}
+
+	case string(api.Oauth2):
+		oauth2Spec, err := spec.AsOAuth2ProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 provider spec: %w", err)
+		}
+		if err := NormalizeOAuth2ProviderSpecURLs(&oauth2Spec); err != nil {
+			return err
+		}
+		if mergeErr := spec.MergeOAuth2ProviderSpec(oauth2Spec); mergeErr != nil {
+			return fmt.Errorf("failed to update OAuth2 provider spec: %w", mergeErr)
+		}
+	}
+
+	return nil
+}

--- a/internal/auth/provider/normalize_urls.go
+++ b/internal/auth/provider/normalize_urls.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NormalizeOIDCProviderSpecURLs canonicalizes issuer-identity URL fields on an OIDC spec
-// by stripping a trailing path slash. Host case and other RFC 3986 variations are left unchanged.
+// via NormalizeIssuerURL (lowercase + trailing-slash strip).
 func NormalizeOIDCProviderSpecURLs(spec *api.OIDCProviderSpec) error {
 	if spec == nil {
 		return nil
@@ -24,7 +24,7 @@ func NormalizeOIDCProviderSpecURLs(spec *api.OIDCProviderSpec) error {
 }
 
 // NormalizeOAuth2ProviderSpecURLs canonicalizes OAuth2 URL fields used for identity and
-// uniqueness (authorizationUrl, issuer, tokenUrl, userinfoUrl) by stripping a trailing path slash.
+// uniqueness (authorizationUrl, issuer, tokenUrl, userinfoUrl) via NormalizeIssuerURL.
 func NormalizeOAuth2ProviderSpecURLs(spec *api.OAuth2ProviderSpec) error {
 	if spec == nil {
 		return nil

--- a/internal/auth/provider/normalize_urls_test.go
+++ b/internal/auth/provider/normalize_urls_test.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeOIDCProviderSpecURLs(t *testing.T) {
+	t.Run("When issuer has mixed case and trailing slash it should canonicalize", func(t *testing.T) {
+		spec := api.OIDCProviderSpec{
+			ProviderType: api.Oidc,
+			Issuer:       "HTTPS://IdP.Example.COM/Realm/",
+			ClientId:     "client",
+		}
+		require.NoError(t, NormalizeOIDCProviderSpecURLs(&spec))
+		assert.Equal(t, "https://idp.example.com/realm", spec.Issuer)
+	})
+
+	t.Run("When issuer is empty it should be a no-op", func(t *testing.T) {
+		spec := api.OIDCProviderSpec{ProviderType: api.Oidc, ClientId: "client"}
+		require.NoError(t, NormalizeOIDCProviderSpecURLs(&spec))
+		assert.Empty(t, spec.Issuer)
+	})
+
+	t.Run("When issuer is invalid it should fail", func(t *testing.T) {
+		spec := api.OIDCProviderSpec{ProviderType: api.Oidc, Issuer: "not-a-url", ClientId: "client"}
+		err := NormalizeOIDCProviderSpecURLs(&spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid OIDC issuer URL")
+	})
+}
+
+func TestNormalizeOAuth2ProviderSpecURLs(t *testing.T) {
+	t.Run("When URL fields have mixed case and trailing slashes they should canonicalize", func(t *testing.T) {
+		spec := api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "HTTPS://IdP.Example.COM/oauth2/authorize/",
+			TokenUrl:         "HTTPS://IdP.Example.COM/token/",
+			UserinfoUrl:      "HTTPS://IdP.Example.COM/userinfo/",
+			Issuer:           lo.ToPtr("HTTPS://IdP.Example.COM/"),
+			ClientId:         "client",
+		}
+		require.NoError(t, NormalizeOAuth2ProviderSpecURLs(&spec))
+		assert.Equal(t, "https://idp.example.com/oauth2/authorize", spec.AuthorizationUrl)
+		assert.Equal(t, "https://idp.example.com/token", spec.TokenUrl)
+		assert.Equal(t, "https://idp.example.com/userinfo", spec.UserinfoUrl)
+		require.NotNil(t, spec.Issuer)
+		assert.Equal(t, "https://idp.example.com", *spec.Issuer)
+	})
+
+	t.Run("When userinfoUrl is invalid it should fail", func(t *testing.T) {
+		spec := api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "https://idp.example.com/authorize",
+			TokenUrl:         "https://idp.example.com/token",
+			UserinfoUrl:      "not-a-url",
+			ClientId:         "client",
+		}
+		err := NormalizeOAuth2ProviderSpecURLs(&spec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid OAuth2 userinfoUrl")
+	})
+}
+
+func TestNormalizeAuthProviderSpecURLs(t *testing.T) {
+	t.Run("When OIDC union it should normalize issuer", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		require.NoError(t, spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
+			ProviderType: api.Oidc,
+			Issuer:       "HTTPS://IdP.Example.COM/",
+			ClientId:     "client",
+		}))
+		require.NoError(t, NormalizeAuthProviderSpecURLs(&spec))
+		got, err := spec.AsOIDCProviderSpec()
+		require.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com", got.Issuer)
+	})
+
+	t.Run("When OAuth2 union it should normalize uniqueness fields", func(t *testing.T) {
+		introspection := &api.OAuth2Introspection{}
+		require.NoError(t, introspection.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+			Type: api.Rfc7662,
+			Url:  "https://idp.example.com/introspect",
+		}))
+		spec := api.AuthProviderSpec{}
+		require.NoError(t, spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "HTTPS://IdP.Example.COM/authorize/",
+			TokenUrl:         "HTTPS://IdP.Example.COM/token/",
+			UserinfoUrl:      "HTTPS://IdP.Example.COM/userinfo/",
+			ClientId:         "client",
+			Introspection:    introspection,
+		}))
+		require.NoError(t, NormalizeAuthProviderSpecURLs(&spec))
+		got, err := spec.AsOAuth2ProviderSpec()
+		require.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com/authorize", got.AuthorizationUrl)
+		assert.Equal(t, "https://idp.example.com/token", got.TokenUrl)
+		assert.Equal(t, "https://idp.example.com/userinfo", got.UserinfoUrl)
+	})
+
+	t.Run("When AAP union it should leave ApiUrl unchanged", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		require.NoError(t, spec.FromAapProviderSpec(api.AapProviderSpec{
+			ProviderType:     api.Aap,
+			ApiUrl:           "HTTPS://AAP.Example.COM/",
+			AuthorizationUrl: "https://aap.example.com/authorize",
+			TokenUrl:         "https://aap.example.com/token",
+			ClientId:         "client",
+			ClientSecret:     "secret",
+			Scopes:           []string{"api"},
+		}))
+		require.NoError(t, NormalizeAuthProviderSpecURLs(&spec))
+		got, err := spec.AsAapProviderSpec()
+		require.NoError(t, err)
+		assert.Equal(t, "HTTPS://AAP.Example.COM/", got.ApiUrl)
+	})
+}

--- a/internal/auth/provider/normalize_urls_test.go
+++ b/internal/auth/provider/normalize_urls_test.go
@@ -17,7 +17,7 @@ func TestNormalizeOIDCProviderSpecURLs(t *testing.T) {
 			ClientId:     "client",
 		}
 		require.NoError(t, NormalizeOIDCProviderSpecURLs(&spec))
-		assert.Equal(t, "https://idp.example.com/realm", spec.Issuer)
+		assert.Equal(t, "https://idp.example.com/Realm", spec.Issuer)
 	})
 
 	t.Run("When issuer is empty it should be a no-op", func(t *testing.T) {

--- a/internal/auth/provider/url_test.go
+++ b/internal/auth/provider/url_test.go
@@ -15,8 +15,9 @@ func TestNormalizeIssuerURL(t *testing.T) {
 		{"trailing slash", "https://example.com/", "https://example.com", false},
 		{"with path", "https://example.com/oidc", "https://example.com/oidc", false},
 		{"with path and trailing slash", "https://example.com/oidc/", "https://example.com/oidc", false},
-		{"upper host and scheme", "HTTPS://IdP.Example.COM/Realm/", "https://idp.example.com/realm", false},
-		{"mixed case path", "https://example.com/OIDC/Master/", "https://example.com/oidc/master", false},
+		{"upper host and scheme", "HTTPS://IdP.Example.COM/Realm/", "https://idp.example.com/Realm", false},
+		{"mixed case path preserved", "https://example.com/OIDC/Master/", "https://example.com/OIDC/Master", false},
+		{"query and fragment case preserved", "https://Example.COM/path?Realm=MyRealm#Frag", "https://example.com/path?Realm=MyRealm#Frag", false},
 		{"empty", "", "", true},
 		{"invalid no scheme", "example.com", "", true},
 		{"invalid no host", "https://", "", true},
@@ -46,7 +47,7 @@ func TestDiscoveryURL(t *testing.T) {
 		{"no trailing slash", "https://example.com", "https://example.com/.well-known/openid-configuration", false},
 		{"trailing slash no double slash", "https://example.com/", "https://example.com/.well-known/openid-configuration", false},
 		{"with path", "https://example.com/oidc", "https://example.com/oidc/.well-known/openid-configuration", false},
-		{"mixed case issuer", "HTTPS://IdP.Example.COM/OIDC/", "https://idp.example.com/oidc/.well-known/openid-configuration", false},
+		{"mixed case issuer", "HTTPS://IdP.Example.COM/OIDC/", "https://idp.example.com/OIDC/.well-known/openid-configuration", false},
 		{"empty", "", "", true},
 	}
 	for _, tt := range tests {

--- a/internal/auth/provider/url_test.go
+++ b/internal/auth/provider/url_test.go
@@ -46,6 +46,7 @@ func TestDiscoveryURL(t *testing.T) {
 		{"no trailing slash", "https://example.com", "https://example.com/.well-known/openid-configuration", false},
 		{"trailing slash no double slash", "https://example.com/", "https://example.com/.well-known/openid-configuration", false},
 		{"with path", "https://example.com/oidc", "https://example.com/oidc/.well-known/openid-configuration", false},
+		{"mixed case issuer", "HTTPS://IdP.Example.COM/OIDC/", "https://idp.example.com/oidc/.well-known/openid-configuration", false},
 		{"empty", "", "", true},
 	}
 	for _, tt := range tests {

--- a/internal/auth/provider/url_test.go
+++ b/internal/auth/provider/url_test.go
@@ -15,6 +15,8 @@ func TestNormalizeIssuerURL(t *testing.T) {
 		{"trailing slash", "https://example.com/", "https://example.com", false},
 		{"with path", "https://example.com/oidc", "https://example.com/oidc", false},
 		{"with path and trailing slash", "https://example.com/oidc/", "https://example.com/oidc", false},
+		{"upper host and scheme", "HTTPS://IdP.Example.COM/Realm/", "https://idp.example.com/realm", false},
+		{"mixed case path", "https://example.com/OIDC/Master/", "https://example.com/oidc/master", false},
 		{"empty", "", "", true},
 		{"invalid no scheme", "example.com", "", true},
 		{"invalid no host", "https://", "", true},

--- a/internal/cli/login/aap.go
+++ b/internal/cli/login/aap.go
@@ -68,7 +68,10 @@ func (o *AAPOAuth) getOAuth2Client(callback string) (*osincli.Client, error) {
 	if o.Metadata.Name == nil {
 		return nil, fmt.Errorf("provider name is required")
 	}
-	tokenProxyURL := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	tokenProxyURL, err := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &osincli.ClientConfig{
 		ClientId:                 o.Spec.ClientId,

--- a/internal/cli/login/common.go
+++ b/internal/cli/login/common.go
@@ -76,8 +76,11 @@ type ValidateArgs struct {
 // for the given provider name. Returns an error if apiServerURL is not a valid URL.
 func getTokenProxyURL(apiServerURL, providerName string) (string, error) {
 	u, err := url.Parse(apiServerURL)
-	if err != nil || u.Scheme == "" || u.Host == "" {
+	if err != nil {
 		return "", fmt.Errorf("invalid API server URL %q: %w", apiServerURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid API server URL %q: missing scheme or host", apiServerURL)
 	}
 	return u.JoinPath("api", "v1", "auth", providerName, "token").String(), nil
 }

--- a/internal/cli/login/common.go
+++ b/internal/cli/login/common.go
@@ -3,6 +3,7 @@ package login
 import (
 	"crypto/tls"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -72,9 +73,13 @@ type ValidateArgs struct {
 }
 
 // getTokenProxyURL returns the Flight Control API server's token proxy endpoint
-// for the given provider name
-func getTokenProxyURL(apiServerURL, providerName string) string {
-	return fmt.Sprintf("%s/api/v1/auth/%s/token", apiServerURL, providerName)
+// for the given provider name. Returns an error if apiServerURL is not a valid URL.
+func getTokenProxyURL(apiServerURL, providerName string) (string, error) {
+	u, err := url.Parse(apiServerURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid API server URL %q: %w", apiServerURL, err)
+	}
+	return u.JoinPath("api", "v1", "auth", providerName, "token").String(), nil
 }
 
 type AuthProvider interface {

--- a/internal/cli/login/common_test.go
+++ b/internal/cli/login/common_test.go
@@ -1,0 +1,73 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTokenProxyURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiServerURL string
+		providerName string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "When API server URL has no trailing slash it should produce the correct token proxy URL",
+			apiServerURL: "https://api.example.com",
+			providerName: "keycloak-oidc",
+			want:         "https://api.example.com/api/v1/auth/keycloak-oidc/token",
+		},
+		{
+			name:         "When API server URL has a trailing slash it should produce the correct token proxy URL without double slash",
+			apiServerURL: "https://api.example.com/",
+			providerName: "keycloak-oidc",
+			want:         "https://api.example.com/api/v1/auth/keycloak-oidc/token",
+		},
+		{
+			name:         "When API server URL has a port it should be preserved",
+			apiServerURL: "https://api.example.com:8443",
+			providerName: "my-provider",
+			want:         "https://api.example.com:8443/api/v1/auth/my-provider/token",
+		},
+		{
+			name:         "When API server URL has a port and trailing slash it should produce the correct token proxy URL",
+			apiServerURL: "https://api.example.com:8443/",
+			providerName: "my-provider",
+			want:         "https://api.example.com:8443/api/v1/auth/my-provider/token",
+		},
+		{
+			name:         "When API server URL uses http it should be preserved",
+			apiServerURL: "http://192.168.1.100:9100",
+			providerName: "keycloak",
+			want:         "http://192.168.1.100:9100/api/v1/auth/keycloak/token",
+		},
+		{
+			name:         "When API server URL is empty it should return an error",
+			apiServerURL: "",
+			providerName: "provider",
+			wantErr:      true,
+		},
+		{
+			name:         "When API server URL has no scheme it should return an error",
+			apiServerURL: "api.example.com",
+			providerName: "provider",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getTokenProxyURL(tt.apiServerURL, tt.providerName)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cli/login/oauth2.go
+++ b/internal/cli/login/oauth2.go
@@ -51,7 +51,10 @@ func (o *OAuth2) getOAuth2Client(callback string) (*osincli.Client, error) {
 	if o.Metadata.Name == nil {
 		return nil, fmt.Errorf("provider name is required")
 	}
-	tokenProxyURL := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	tokenProxyURL, err := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &osincli.ClientConfig{
 		ClientId:                 o.Spec.ClientId,

--- a/internal/cli/login/oidc.go
+++ b/internal/cli/login/oidc.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	authprovider "github.com/flightctl/flightctl/internal/auth/provider"
 	"github.com/openshift/osincli"
 )
 
@@ -49,7 +50,10 @@ func (o *OIDC) SetInsecureSkipVerify(insecureSkipVerify bool) {
 }
 
 func (o *OIDC) getOIDCClient(callback string) (*osincli.Client, error) {
-	discoveryUrl := fmt.Sprintf("%s/.well-known/openid-configuration", o.Spec.Issuer)
+	discoveryUrl, err := authprovider.DiscoveryURL(o.Spec.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OIDC issuer URL: %w", err)
+	}
 	oidcDiscovery, err := getOIDCDiscoveryConfig(discoveryUrl, o.CAFile, o.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
@@ -63,7 +67,10 @@ func (o *OIDC) getOIDCClient(callback string) (*osincli.Client, error) {
 	if o.Metadata.Name == nil {
 		return nil, fmt.Errorf("provider name is required")
 	}
-	tokenProxyURL := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	tokenProxyURL, err := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &osincli.ClientConfig{
 		ClientId:                 o.Spec.ClientId,
@@ -114,7 +121,10 @@ func (o *OIDC) Auth() (AuthInfo, error) {
 }
 
 func (o *OIDC) authPasswordFlow() (AuthInfo, error) {
-	discoveryUrl := fmt.Sprintf("%s/.well-known/openid-configuration", o.Spec.Issuer)
+	discoveryUrl, err := authprovider.DiscoveryURL(o.Spec.Issuer)
+	if err != nil {
+		return AuthInfo{}, fmt.Errorf("invalid OIDC issuer URL: %w", err)
+	}
 	oidcDiscovery, err := getOIDCDiscoveryConfig(discoveryUrl, o.CAFile, o.InsecureSkipVerify)
 	if err != nil {
 		return AuthInfo{}, err

--- a/internal/cli/login/oidc_test.go
+++ b/internal/cli/login/oidc_test.go
@@ -35,7 +35,7 @@ func setupOIDCDiscoveryServer(t *testing.T, validPaths map[string]bool) (server 
 				JwksUri:                          server.URL + "/jwks",
 				SubjectTypesSupported:            []string{"public"},
 				ResponseTypesSupported:           []string{"code"},
-				IdTokenSigningAlgValuesSupported:  []string{"RS256"},
+				IdTokenSigningAlgValuesSupported: []string{"RS256"},
 			}
 			_ = json.NewEncoder(w).Encode(discovery)
 		} else {

--- a/internal/cli/login/oidc_test.go
+++ b/internal/cli/login/oidc_test.go
@@ -1,0 +1,181 @@
+package login
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupOIDCDiscoveryServer creates a test HTTP server that serves a minimal OIDC discovery
+// document. It records every path that was requested so tests can assert on it.
+func setupOIDCDiscoveryServer(t *testing.T, validPaths map[string]bool) (server *httptest.Server, requestedPaths *[]string, mu *sync.Mutex) {
+	t.Helper()
+	paths := []string{}
+	var m sync.Mutex
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.Lock()
+		paths = append(paths, r.URL.Path)
+		m.Unlock()
+
+		if validPaths[r.URL.Path] {
+			w.Header().Set("Content-Type", "application/json")
+			discovery := OIDCDiscoveryResponse{
+				Issuer:                           server.URL,
+				AuthorizationEndpoint:            server.URL + "/authorize",
+				TokenEndpoint:                    server.URL + "/token",
+				JwksUri:                          server.URL + "/jwks",
+				SubjectTypesSupported:            []string{"public"},
+				ResponseTypesSupported:           []string{"code"},
+				IdTokenSigningAlgValuesSupported:  []string{"RS256"},
+			}
+			_ = json.NewEncoder(w).Encode(discovery)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &paths, &m
+}
+
+// TestOIDC_getOIDCClient_DiscoveryURL verifies that getOIDCClient builds the OIDC discovery
+// URL without a double slash regardless of whether the issuer has a trailing slash.
+func TestOIDC_getOIDCClient_DiscoveryURL(t *testing.T) {
+	scopes := []string{"openid"}
+	tests := []struct {
+		name         string
+		issuerSuffix string
+		validPath    string
+	}{
+		{
+			name:         "When issuer has no trailing slash it should reach the correct discovery endpoint",
+			issuerSuffix: "",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a trailing slash it should reach the correct discovery endpoint without double slash",
+			issuerSuffix: "/",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a realm path with trailing slash it should reach the correct discovery endpoint",
+			issuerSuffix: "/realms/myrealm/",
+			validPath:    "/realms/myrealm/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a realm path without trailing slash it should reach the correct discovery endpoint",
+			issuerSuffix: "/realms/myrealm",
+			validPath:    "/realms/myrealm/.well-known/openid-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, requestedPaths, mu := setupOIDCDiscoveryServer(t, map[string]bool{tt.validPath: true})
+
+			issuer := server.URL + tt.issuerSuffix
+
+			o := &OIDC{
+				Metadata: api.ObjectMeta{
+					Name: lo.ToPtr("test-provider"),
+				},
+				Spec: api.OIDCProviderSpec{
+					Issuer:   issuer,
+					ClientId: "test-client",
+					Scopes:   &scopes,
+				},
+				ApiServerURL:       server.URL,
+				InsecureSkipVerify: true,
+			}
+
+			_, err := o.getOIDCClient("http://localhost:8080/callback")
+			require.NoError(t, err, fmt.Sprintf("getOIDCClient should succeed when issuer is %q", issuer))
+
+			mu.Lock()
+			paths := append([]string{}, *requestedPaths...)
+			mu.Unlock()
+
+			require.NotEmpty(t, paths, "Expected at least one request to discovery server")
+			for _, path := range paths {
+				assert.NotContains(t, path, "//",
+					"Discovery request path must not contain double slash (issuer: %q, got path: %q)", issuer, path)
+			}
+		})
+	}
+}
+
+// TestOIDC_authPasswordFlow_DiscoveryURL verifies that authPasswordFlow builds the OIDC
+// discovery URL without a double slash regardless of trailing slash in the issuer.
+func TestOIDC_authPasswordFlow_DiscoveryURL(t *testing.T) {
+	scopes := []string{"openid"}
+	tests := []struct {
+		name         string
+		issuerSuffix string
+		validPath    string
+	}{
+		{
+			name:         "When issuer has no trailing slash it should reach the correct discovery endpoint",
+			issuerSuffix: "",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a trailing slash it should reach the correct discovery endpoint without double slash",
+			issuerSuffix: "/",
+			validPath:    "/.well-known/openid-configuration",
+		},
+		{
+			name:         "When issuer has a realm path with trailing slash it should reach the correct discovery endpoint",
+			issuerSuffix: "/realms/myrealm/",
+			validPath:    "/realms/myrealm/.well-known/openid-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The token endpoint returned by discovery will be called by the password flow,
+			// so we need to serve that too (return an error from it — we only care that
+			// discovery itself succeeds with the correct URL).
+			validPaths := map[string]bool{
+				tt.validPath: true,
+			}
+			server, requestedPaths, mu := setupOIDCDiscoveryServer(t, validPaths)
+
+			issuer := server.URL + tt.issuerSuffix
+
+			o := &OIDC{
+				Spec: api.OIDCProviderSpec{
+					Issuer:   issuer,
+					ClientId: "test-client",
+					Scopes:   &scopes,
+				},
+				Username:           "user",
+				Password:           "pass",
+				InsecureSkipVerify: true,
+			}
+
+			// authPasswordFlow will fail at the token exchange step (our mock server
+			// doesn't implement the token endpoint), but we only care that the discovery
+			// request itself was sent to the correct path.
+			_, _ = o.authPasswordFlow()
+
+			mu.Lock()
+			paths := append([]string{}, *requestedPaths...)
+			mu.Unlock()
+
+			require.NotEmpty(t, paths, "Expected at least one request to discovery server")
+			for _, path := range paths {
+				assert.NotContains(t, path, "//",
+					"Discovery request path must not contain double slash (issuer: %q, got path: %q)", issuer, path)
+			}
+		})
+	}
+}

--- a/internal/cli/login/openshift.go
+++ b/internal/cli/login/openshift.go
@@ -47,7 +47,10 @@ func (o *OpenShift) getOAuth2Client(callback string) (*osincli.Client, error) {
 	}
 
 	// Use the API server's token proxy endpoint instead of the OpenShift provider's token endpoint
-	tokenProxyURL := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	tokenProxyURL, err := getTokenProxyURL(o.ApiServerURL, *o.Metadata.Name)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &osincli.ClientConfig{
 		ClientId:                 *o.Spec.ClientId,

--- a/internal/cli/login/providers_url_test.go
+++ b/internal/cli/login/providers_url_test.go
@@ -1,0 +1,274 @@
+package login
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTokenProxyServer creates a test server that records every path requested.
+// It always returns 200 so that client creation can complete past the token proxy step.
+func setupTokenProxyServer(t *testing.T) (server *httptest.Server, requestedPaths *[]string, mu *sync.Mutex) {
+	t.Helper()
+	paths := []string{}
+	var m sync.Mutex
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.Lock()
+		paths = append(paths, r.URL.Path)
+		m.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	return server, &paths, &m
+}
+
+// assertNoDoubleSlash asserts that none of the captured request paths contain "//".
+func assertNoDoubleSlash(t *testing.T, paths []string, label string) {
+	t.Helper()
+	for _, p := range paths {
+		assert.NotContains(t, p, "//", "%s: request path must not contain double slash, got: %q", label, p)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OAuth2
+// ---------------------------------------------------------------------------
+
+// TestOAuth2_getOAuth2Client_TokenProxyURL verifies that getOAuth2Client builds the
+// token-proxy URL without a double slash regardless of trailing slash in the API server URL.
+func TestOAuth2_getOAuth2Client_TokenProxyURL(t *testing.T) {
+	scopes := []string{"openid"}
+	tests := []struct {
+		name             string
+		apiServerSuffix  string
+	}{
+		{
+			name:            "When API server URL has no trailing slash it should produce the correct token proxy URL",
+			apiServerSuffix: "",
+		},
+		{
+			name:            "When API server URL has a trailing slash it should produce the correct token proxy URL without double slash",
+			apiServerSuffix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, requestedPaths, mu := setupTokenProxyServer(t)
+			apiServerURL := server.URL + tt.apiServerSuffix
+
+			o := &OAuth2{
+				Metadata: api.ObjectMeta{
+					Name: lo.ToPtr("test-oauth2"),
+				},
+				Spec: api.OAuth2ProviderSpec{
+					AuthorizationUrl: server.URL + "/authorize",
+					TokenUrl:         server.URL + "/token",
+					UserinfoUrl:      server.URL + "/userinfo",
+					ClientId:         "test-client",
+					Scopes:           &scopes,
+				},
+				ApiServerURL:       apiServerURL,
+				InsecureSkipVerify: true,
+			}
+
+			_, err := o.getOAuth2Client("http://localhost:8080/callback")
+			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
+
+			mu.Lock()
+			paths := append([]string{}, *requestedPaths...)
+			mu.Unlock()
+
+			assertNoDoubleSlash(t, paths, "OAuth2 token proxy URL")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OpenShift
+// ---------------------------------------------------------------------------
+
+// TestOpenShift_getOAuth2Client_TokenProxyURL verifies that the OpenShift provider builds the
+// token-proxy URL without a double slash regardless of trailing slash in the API server URL.
+func TestOpenShift_getOAuth2Client_TokenProxyURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		apiServerSuffix string
+	}{
+		{
+			name:            "When API server URL has no trailing slash it should produce the correct token proxy URL",
+			apiServerSuffix: "",
+		},
+		{
+			name:            "When API server URL has a trailing slash it should produce the correct token proxy URL without double slash",
+			apiServerSuffix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, requestedPaths, mu := setupTokenProxyServer(t)
+			apiServerURL := server.URL + tt.apiServerSuffix
+
+			o := &OpenShift{
+				Metadata: api.ObjectMeta{
+					Name: lo.ToPtr("test-openshift"),
+				},
+				Spec: api.OpenShiftProviderSpec{
+					AuthorizationUrl: lo.ToPtr(server.URL + "/oauth/authorize"),
+					ClientId:         lo.ToPtr("test-client"),
+				},
+				ApiServerURL:       apiServerURL,
+				InsecureSkipVerify: true,
+			}
+
+			_, err := o.getOAuth2Client("http://localhost:8080/callback")
+			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
+
+			mu.Lock()
+			paths := append([]string{}, *requestedPaths...)
+			mu.Unlock()
+
+			assertNoDoubleSlash(t, paths, "OpenShift token proxy URL")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AAP
+// ---------------------------------------------------------------------------
+
+// TestAAPOAuth_getOAuth2Client_TokenProxyURL verifies that the AAP provider builds the
+// token-proxy URL without a double slash regardless of trailing slash in the API server URL.
+func TestAAPOAuth_getOAuth2Client_TokenProxyURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		apiServerSuffix string
+	}{
+		{
+			name:            "When API server URL has no trailing slash it should produce the correct token proxy URL",
+			apiServerSuffix: "",
+		},
+		{
+			name:            "When API server URL has a trailing slash it should produce the correct token proxy URL without double slash",
+			apiServerSuffix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, requestedPaths, mu := setupTokenProxyServer(t)
+			apiServerURL := server.URL + tt.apiServerSuffix
+
+			o := &AAPOAuth{
+				Metadata: api.ObjectMeta{
+					Name: lo.ToPtr("test-aap"),
+				},
+				Spec: api.AapProviderSpec{
+					AuthorizationUrl: server.URL + "/o/authorize",
+					TokenUrl:         server.URL + "/o/token",
+					ClientId:         "test-client",
+					Scopes:           []string{"read"},
+				},
+				ApiServerURL:       apiServerURL,
+				InsecureSkipVerify: true,
+			}
+
+			_, err := o.getOAuth2Client("http://localhost:8080/callback")
+			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
+
+			mu.Lock()
+			paths := append([]string{}, *requestedPaths...)
+			mu.Unlock()
+
+			assertNoDoubleSlash(t, paths, "AAP token proxy URL")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OIDC — token proxy URL (complement to the discovery URL tests in oidc_test.go)
+// ---------------------------------------------------------------------------
+
+// TestOIDC_getOIDCClient_TokenProxyURL verifies that the OIDC provider builds the
+// token-proxy URL without a double slash regardless of trailing slash in the API server URL.
+func TestOIDC_getOIDCClient_TokenProxyURL(t *testing.T) {
+	scopes := []string{"openid"}
+	tests := []struct {
+		name            string
+		apiServerSuffix string
+	}{
+		{
+			name:            "When API server URL has no trailing slash it should produce the correct token proxy URL",
+			apiServerSuffix: "",
+		},
+		{
+			name:            "When API server URL has a trailing slash it should produce the correct token proxy URL without double slash",
+			apiServerSuffix: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We need both: a valid OIDC discovery endpoint AND a token proxy endpoint.
+			// Use one server for both, serving the discovery doc on /.well-known/openid-configuration.
+			var mu sync.Mutex
+			var requestedPaths []string
+
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				requestedPaths = append(requestedPaths, r.URL.Path)
+				mu.Unlock()
+
+				if r.URL.Path == "/.well-known/openid-configuration" {
+					w.Header().Set("Content-Type", "application/json")
+					discovery := OIDCDiscoveryResponse{
+						Issuer:                          server.URL,
+						AuthorizationEndpoint:           server.URL + "/authorize",
+						TokenEndpoint:                   server.URL + "/token",
+						JwksUri:                         server.URL + "/jwks",
+						SubjectTypesSupported:           []string{"public"},
+						ResponseTypesSupported:          []string{"code"},
+						IdTokenSigningAlgValuesSupported: []string{"RS256"},
+					}
+					_ = json.NewEncoder(w).Encode(discovery)
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			apiServerURL := server.URL + tt.apiServerSuffix
+
+			o := &OIDC{
+				Metadata: api.ObjectMeta{
+					Name: lo.ToPtr("test-provider"),
+				},
+				Spec: api.OIDCProviderSpec{
+					Issuer:   server.URL,
+					ClientId: "test-client",
+					Scopes:   &scopes,
+				},
+				ApiServerURL:       apiServerURL,
+				InsecureSkipVerify: true,
+			}
+
+			_, err := o.getOIDCClient("http://localhost:8080/callback")
+			require.NoError(t, err, "getOIDCClient should succeed for API server URL %q", apiServerURL)
+
+			mu.Lock()
+			paths := append([]string{}, requestedPaths...)
+			mu.Unlock()
+
+			assertNoDoubleSlash(t, paths, "OIDC token proxy URL")
+		})
+	}
+}

--- a/internal/cli/login/providers_url_test.go
+++ b/internal/cli/login/providers_url_test.go
@@ -46,8 +46,8 @@ func assertNoDoubleSlash(t *testing.T, paths []string, label string) {
 func TestOAuth2_getOAuth2Client_TokenProxyURL(t *testing.T) {
 	scopes := []string{"openid"}
 	tests := []struct {
-		name             string
-		apiServerSuffix  string
+		name            string
+		apiServerSuffix string
 	}{
 		{
 			name:            "When API server URL has no trailing slash it should produce the correct token proxy URL",
@@ -231,12 +231,12 @@ func TestOIDC_getOIDCClient_TokenProxyURL(t *testing.T) {
 				if r.URL.Path == "/.well-known/openid-configuration" {
 					w.Header().Set("Content-Type", "application/json")
 					discovery := OIDCDiscoveryResponse{
-						Issuer:                          server.URL,
-						AuthorizationEndpoint:           server.URL + "/authorize",
-						TokenEndpoint:                   server.URL + "/token",
-						JwksUri:                         server.URL + "/jwks",
-						SubjectTypesSupported:           []string{"public"},
-						ResponseTypesSupported:          []string{"code"},
+						Issuer:                           server.URL,
+						AuthorizationEndpoint:            server.URL + "/authorize",
+						TokenEndpoint:                    server.URL + "/token",
+						JwksUri:                          server.URL + "/jwks",
+						SubjectTypesSupported:            []string{"public"},
+						ResponseTypesSupported:           []string{"code"},
 						IdTokenSigningAlgValuesSupported: []string{"RS256"},
 					}
 					_ = json.NewEncoder(w).Encode(discovery)

--- a/internal/cli/login/providers_url_test.go
+++ b/internal/cli/login/providers_url_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -12,30 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// setupTokenProxyServer creates a test server that records every path requested.
-// It always returns 200 so that client creation can complete past the token proxy step.
-func setupTokenProxyServer(t *testing.T) (server *httptest.Server, requestedPaths *[]string, mu *sync.Mutex) {
-	t.Helper()
-	paths := []string{}
-	var m sync.Mutex
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		m.Lock()
-		paths = append(paths, r.URL.Path)
-		m.Unlock()
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(server.Close)
-	return server, &paths, &m
-}
-
-// assertNoDoubleSlash asserts that none of the captured request paths contain "//".
-func assertNoDoubleSlash(t *testing.T, paths []string, label string) {
-	t.Helper()
-	for _, p := range paths {
-		assert.NotContains(t, p, "//", "%s: request path must not contain double slash, got: %q", label, p)
-	}
-}
 
 // ---------------------------------------------------------------------------
 // OAuth2
@@ -61,7 +38,10 @@ func TestOAuth2_getOAuth2Client_TokenProxyURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server, requestedPaths, mu := setupTokenProxyServer(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(server.Close)
 			apiServerURL := server.URL + tt.apiServerSuffix
 
 			o := &OAuth2{
@@ -82,11 +62,12 @@ func TestOAuth2_getOAuth2Client_TokenProxyURL(t *testing.T) {
 			_, err := o.getOAuth2Client("http://localhost:8080/callback")
 			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
 
-			mu.Lock()
-			paths := append([]string{}, *requestedPaths...)
-			mu.Unlock()
-
-			assertNoDoubleSlash(t, paths, "OAuth2 token proxy URL")
+			// Directly verify that the token proxy URL path computed for this provider contains no double slashes.
+			tokenURL, err := getTokenProxyURL(apiServerURL, *o.Metadata.Name)
+			require.NoError(t, err)
+			parsed, err := url.Parse(tokenURL)
+			require.NoError(t, err)
+			assert.NotContains(t, parsed.Path, "//", "OAuth2 token proxy URL path must not contain double slash, got: %q", tokenURL)
 		})
 	}
 }
@@ -114,7 +95,10 @@ func TestOpenShift_getOAuth2Client_TokenProxyURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server, requestedPaths, mu := setupTokenProxyServer(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(server.Close)
 			apiServerURL := server.URL + tt.apiServerSuffix
 
 			o := &OpenShift{
@@ -132,11 +116,12 @@ func TestOpenShift_getOAuth2Client_TokenProxyURL(t *testing.T) {
 			_, err := o.getOAuth2Client("http://localhost:8080/callback")
 			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
 
-			mu.Lock()
-			paths := append([]string{}, *requestedPaths...)
-			mu.Unlock()
-
-			assertNoDoubleSlash(t, paths, "OpenShift token proxy URL")
+			// Directly verify that the token proxy URL path computed for this provider contains no double slashes.
+			tokenURL, err := getTokenProxyURL(apiServerURL, *o.Metadata.Name)
+			require.NoError(t, err)
+			parsed, err := url.Parse(tokenURL)
+			require.NoError(t, err)
+			assert.NotContains(t, parsed.Path, "//", "OpenShift token proxy URL path must not contain double slash, got: %q", tokenURL)
 		})
 	}
 }
@@ -164,7 +149,10 @@ func TestAAPOAuth_getOAuth2Client_TokenProxyURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server, requestedPaths, mu := setupTokenProxyServer(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(server.Close)
 			apiServerURL := server.URL + tt.apiServerSuffix
 
 			o := &AAPOAuth{
@@ -184,11 +172,12 @@ func TestAAPOAuth_getOAuth2Client_TokenProxyURL(t *testing.T) {
 			_, err := o.getOAuth2Client("http://localhost:8080/callback")
 			require.NoError(t, err, "getOAuth2Client should succeed for API server URL %q", apiServerURL)
 
-			mu.Lock()
-			paths := append([]string{}, *requestedPaths...)
-			mu.Unlock()
-
-			assertNoDoubleSlash(t, paths, "AAP token proxy URL")
+			// Directly verify that the token proxy URL path computed for this provider contains no double slashes.
+			tokenURL, err := getTokenProxyURL(apiServerURL, *o.Metadata.Name)
+			require.NoError(t, err)
+			parsed, err := url.Parse(tokenURL)
+			require.NoError(t, err)
+			assert.NotContains(t, parsed.Path, "//", "AAP token proxy URL path must not contain double slash, got: %q", tokenURL)
 		})
 	}
 }
@@ -217,8 +206,6 @@ func TestOIDC_getOIDCClient_TokenProxyURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// We need both: a valid OIDC discovery endpoint AND a token proxy endpoint.
-			// Use one server for both, serving the discovery doc on /.well-known/openid-configuration.
 			var mu sync.Mutex
 			var requestedPaths []string
 
@@ -264,11 +251,20 @@ func TestOIDC_getOIDCClient_TokenProxyURL(t *testing.T) {
 			_, err := o.getOIDCClient("http://localhost:8080/callback")
 			require.NoError(t, err, "getOIDCClient should succeed for API server URL %q", apiServerURL)
 
+			// Verify the OIDC discovery request paths have no double slashes.
 			mu.Lock()
 			paths := append([]string{}, requestedPaths...)
 			mu.Unlock()
+			for _, p := range paths {
+				assert.NotContains(t, p, "//", "OIDC discovery request path must not contain double slash, got: %q", p)
+			}
 
-			assertNoDoubleSlash(t, paths, "OIDC token proxy URL")
+			// Directly verify that the token proxy URL path computed for this provider contains no double slashes.
+			tokenURL, err := getTokenProxyURL(apiServerURL, *o.Metadata.Name)
+			require.NoError(t, err)
+			parsed, err := url.Parse(tokenURL)
+			require.NoError(t, err)
+			assert.NotContains(t, parsed.Path, "//", "OIDC token proxy URL path must not contain double slash, got: %q", tokenURL)
 		})
 	}
 }

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -137,7 +137,10 @@ func customizeMigration(ctx context.Context, tx *gorm.DB) error {
 		}
 	}
 
-	return backfillDefaultCatalogs(ctx, tx)
+	if err := backfillDefaultCatalogs(ctx, tx); err != nil {
+		return err
+	}
+	return normalizeAuthProviderURLs(ctx, tx)
 }
 
 // backfillDefaultCatalogs creates a default catalog for every organization that has no

--- a/internal/migration/normalize_auth_provider_urls.go
+++ b/internal/migration/normalize_auth_provider_urls.go
@@ -28,11 +28,11 @@ type oauth2UniquenessKey struct {
 }
 
 // normalizeAuthProviderURLs rewrites stored OIDC/OAuth2 auth provider URL fields to the
-// canonical form (lowercase + trailing-slash strip) so unique indexes and runtime lookups
-// match write-path normalization. Runs once via schema_migrations.
+// canonical form (lowercase scheme/host + trailing-slash strip) so unique indexes and
+// runtime lookups match write-path normalization. Runs once via schema_migrations.
 //
 // If two existing rows would collide after normalization (e.g. issuer with/without a
-// trailing slash, or differing only by letter case, for the same clientId), the migration
+// trailing slash, or differing only by host case, for the same clientId), the migration
 // fails so an admin can resolve the duplicate before upgrade completes.
 func normalizeAuthProviderURLs(ctx context.Context, tx *gorm.DB) error {
 	return tx.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/internal/migration/normalize_auth_provider_urls.go
+++ b/internal/migration/normalize_auth_provider_urls.go
@@ -1,0 +1,133 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	authprovider "github.com/flightctl/flightctl/internal/auth/provider"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const normalizeAuthProviderURLsMigrationKey = "normalize_auth_provider_urls_v1"
+
+type oidcUniquenessKey struct {
+	issuer   string
+	clientID string
+}
+
+type oauth2UniquenessKey struct {
+	userinfoURL string
+	clientID    string
+}
+
+// normalizeAuthProviderURLs rewrites stored OIDC/OAuth2 auth provider URL fields to the
+// canonical trailing-slash-stripped form so unique indexes and runtime lookups match
+// write-path normalization. Runs once via schema_migrations.
+//
+// If two existing rows would collide after normalization (e.g. issuer with and without a
+// trailing slash for the same clientId), the migration fails so an admin can resolve the
+// duplicate before upgrade completes.
+func normalizeAuthProviderURLs(ctx context.Context, tx *gorm.DB) error {
+	return tx.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Clauses(clause.OnConflict{DoNothing: true}).
+			Create(&model.SchemaMigration{Key: normalizeAuthProviderURLsMigrationKey, AppliedAt: time.Now()})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
+
+		var rows []model.AuthProvider
+		if err := tx.Find(&rows).Error; err != nil {
+			return fmt.Errorf("list auth providers for URL normalization: %w", err)
+		}
+
+		seenOIDC := make(map[oidcUniquenessKey]string)
+		seenOAuth2 := make(map[oauth2UniquenessKey]string)
+
+		for i := range rows {
+			row := &rows[i]
+			if row.Spec == nil {
+				continue
+			}
+			before := row.Spec.Data
+			after, err := cloneAuthProviderSpec(before)
+			if err != nil {
+				return fmt.Errorf("clone auth provider %q for URL normalization: %w", row.Name, err)
+			}
+			if err := authprovider.NormalizeAuthProviderSpecURLs(&after); err != nil {
+				return fmt.Errorf("normalize auth provider %q (org %s): %w", row.Name, row.OrgID, err)
+			}
+
+			if err := recordNormalizedAuthProviderKey(row.Name, after, seenOIDC, seenOAuth2); err != nil {
+				return err
+			}
+
+			if reflect.DeepEqual(before, after) {
+				continue
+			}
+			if err := tx.Model(&model.AuthProvider{}).
+				Where("org_id = ? AND name = ?", row.OrgID, row.Name).
+				Update("spec", model.MakeJSONField(after)).Error; err != nil {
+				return fmt.Errorf("update auth provider %q after URL normalization: %w", row.Name, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func recordNormalizedAuthProviderKey(
+	name string,
+	spec domain.AuthProviderSpec,
+	seenOIDC map[oidcUniquenessKey]string,
+	seenOAuth2 map[oauth2UniquenessKey]string,
+) error {
+	discriminator, err := spec.Discriminator()
+	if err != nil {
+		return nil
+	}
+	switch discriminator {
+	case string(api.Oidc):
+		oidcSpec, err := spec.AsOIDCProviderSpec()
+		if err != nil {
+			return fmt.Errorf("parse OIDC auth provider %q after normalize: %w", name, err)
+		}
+		key := oidcUniquenessKey{issuer: oidcSpec.Issuer, clientID: oidcSpec.ClientId}
+		if existing, ok := seenOIDC[key]; ok {
+			return fmt.Errorf("cannot normalize auth provider URLs: OIDC providers %q and %q would share issuer %q and clientId %q after trailing-slash normalization; resolve the duplicate and re-run migration", existing, name, key.issuer, key.clientID)
+		}
+		seenOIDC[key] = name
+	case string(api.Oauth2):
+		oauth2Spec, err := spec.AsOAuth2ProviderSpec()
+		if err != nil {
+			return fmt.Errorf("parse OAuth2 auth provider %q after normalize: %w", name, err)
+		}
+		key := oauth2UniquenessKey{userinfoURL: oauth2Spec.UserinfoUrl, clientID: oauth2Spec.ClientId}
+		if existing, ok := seenOAuth2[key]; ok {
+			return fmt.Errorf("cannot normalize auth provider URLs: OAuth2 providers %q and %q would share userinfoUrl %q and clientId %q after trailing-slash normalization; resolve the duplicate and re-run migration", existing, name, key.userinfoURL, key.clientID)
+		}
+		seenOAuth2[key] = name
+	}
+	return nil
+}
+
+func cloneAuthProviderSpec(spec domain.AuthProviderSpec) (domain.AuthProviderSpec, error) {
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return domain.AuthProviderSpec{}, err
+	}
+	var cloned domain.AuthProviderSpec
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		return domain.AuthProviderSpec{}, err
+	}
+	return cloned, nil
+}

--- a/internal/migration/normalize_auth_provider_urls.go
+++ b/internal/migration/normalize_auth_provider_urls.go
@@ -28,12 +28,12 @@ type oauth2UniquenessKey struct {
 }
 
 // normalizeAuthProviderURLs rewrites stored OIDC/OAuth2 auth provider URL fields to the
-// canonical trailing-slash-stripped form so unique indexes and runtime lookups match
-// write-path normalization. Runs once via schema_migrations.
+// canonical form (lowercase + trailing-slash strip) so unique indexes and runtime lookups
+// match write-path normalization. Runs once via schema_migrations.
 //
-// If two existing rows would collide after normalization (e.g. issuer with and without a
-// trailing slash for the same clientId), the migration fails so an admin can resolve the
-// duplicate before upgrade completes.
+// If two existing rows would collide after normalization (e.g. issuer with/without a
+// trailing slash, or differing only by letter case, for the same clientId), the migration
+// fails so an admin can resolve the duplicate before upgrade completes.
 func normalizeAuthProviderURLs(ctx context.Context, tx *gorm.DB) error {
 	return tx.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		result := tx.Clauses(clause.OnConflict{DoNothing: true}).
@@ -103,7 +103,7 @@ func recordNormalizedAuthProviderKey(
 		}
 		key := oidcUniquenessKey{issuer: oidcSpec.Issuer, clientID: oidcSpec.ClientId}
 		if existing, ok := seenOIDC[key]; ok {
-			return fmt.Errorf("cannot normalize auth provider URLs: OIDC providers %q and %q would share issuer %q and clientId %q after trailing-slash normalization; resolve the duplicate and re-run migration", existing, name, key.issuer, key.clientID)
+			return fmt.Errorf("cannot normalize auth provider URLs: OIDC providers %q and %q would share issuer %q and clientId %q after URL normalization; resolve the duplicate and re-run migration", existing, name, key.issuer, key.clientID)
 		}
 		seenOIDC[key] = name
 	case string(api.Oauth2):
@@ -113,7 +113,7 @@ func recordNormalizedAuthProviderKey(
 		}
 		key := oauth2UniquenessKey{userinfoURL: oauth2Spec.UserinfoUrl, clientID: oauth2Spec.ClientId}
 		if existing, ok := seenOAuth2[key]; ok {
-			return fmt.Errorf("cannot normalize auth provider URLs: OAuth2 providers %q and %q would share userinfoUrl %q and clientId %q after trailing-slash normalization; resolve the duplicate and re-run migration", existing, name, key.userinfoURL, key.clientID)
+			return fmt.Errorf("cannot normalize auth provider URLs: OAuth2 providers %q and %q would share userinfoUrl %q and clientId %q after URL normalization; resolve the duplicate and re-run migration", existing, name, key.userinfoURL, key.clientID)
 		}
 		seenOAuth2[key] = name
 	}

--- a/internal/migration/normalize_auth_provider_urls_test.go
+++ b/internal/migration/normalize_auth_provider_urls_test.go
@@ -1,0 +1,91 @@
+package migration
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordNormalizedAuthProviderKey_DetectsOIDCCollision(t *testing.T) {
+	seenOIDC := make(map[oidcUniquenessKey]string)
+	seenOAuth2 := make(map[oauth2UniquenessKey]string)
+
+	specA := domain.AuthProviderSpec{}
+	require.NoError(t, specA.FromOIDCProviderSpec(api.OIDCProviderSpec{
+		ProviderType: api.Oidc,
+		Issuer:       "https://idp.example.com",
+		ClientId:     "client",
+	}))
+	require.NoError(t, recordNormalizedAuthProviderKey("provider-a", specA, seenOIDC, seenOAuth2))
+
+	specB := domain.AuthProviderSpec{}
+	require.NoError(t, specB.FromOIDCProviderSpec(api.OIDCProviderSpec{
+		ProviderType: api.Oidc,
+		Issuer:       "https://idp.example.com",
+		ClientId:     "client",
+	}))
+	err := recordNormalizedAuthProviderKey("provider-b", specB, seenOIDC, seenOAuth2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would share issuer")
+	assert.Contains(t, err.Error(), "provider-a")
+	assert.Contains(t, err.Error(), "provider-b")
+}
+
+func TestRecordNormalizedAuthProviderKey_DetectsOAuth2Collision(t *testing.T) {
+	seenOIDC := make(map[oidcUniquenessKey]string)
+	seenOAuth2 := make(map[oauth2UniquenessKey]string)
+
+	introspection := &api.OAuth2Introspection{}
+	require.NoError(t, introspection.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+		Type: api.Rfc7662,
+		Url:  "https://idp.example.com/introspect",
+	}))
+
+	specA := domain.AuthProviderSpec{}
+	require.NoError(t, specA.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+		ProviderType:     api.Oauth2,
+		AuthorizationUrl: "https://idp.example.com/authorize",
+		TokenUrl:         "https://idp.example.com/token",
+		UserinfoUrl:      "https://idp.example.com/userinfo",
+		ClientId:         "client",
+		Introspection:    introspection,
+	}))
+	require.NoError(t, recordNormalizedAuthProviderKey("oauth2-a", specA, seenOIDC, seenOAuth2))
+
+	specB := domain.AuthProviderSpec{}
+	require.NoError(t, specB.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+		ProviderType:     api.Oauth2,
+		AuthorizationUrl: "https://other.example.com/authorize",
+		TokenUrl:         "https://other.example.com/token",
+		UserinfoUrl:      "https://idp.example.com/userinfo",
+		ClientId:         "client",
+		Introspection:    introspection,
+	}))
+	err := recordNormalizedAuthProviderKey("oauth2-b", specB, seenOIDC, seenOAuth2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would share userinfoUrl")
+}
+
+func TestCloneAuthProviderSpec_IsIndependent(t *testing.T) {
+	original := domain.AuthProviderSpec{}
+	require.NoError(t, original.FromOIDCProviderSpec(api.OIDCProviderSpec{
+		ProviderType: api.Oidc,
+		Issuer:       "https://idp.example.com/",
+		ClientId:     "client",
+	}))
+
+	cloned, err := cloneAuthProviderSpec(original)
+	require.NoError(t, err)
+
+	oidc, err := cloned.AsOIDCProviderSpec()
+	require.NoError(t, err)
+	oidc.Issuer = "https://changed.example.com"
+	require.NoError(t, cloned.MergeOIDCProviderSpec(oidc))
+
+	origOIDC, err := original.AsOIDCProviderSpec()
+	require.NoError(t, err)
+	assert.Equal(t, "https://idp.example.com/", origOIDC.Issuer)
+}

--- a/internal/service/auth_token_proxy_test.go
+++ b/internal/service/auth_token_proxy_test.go
@@ -27,9 +27,9 @@ func newTestAuthTokenProxy(discoveryClient *http.Client) *AuthTokenProxy {
 // slash in the issuer never produces a double-slash path.
 func TestAuthTokenProxy_discoverTokenEndpoint_TrailingSlash(t *testing.T) {
 	tests := []struct {
-		name         string
-		issuerSuffix string
-		validPath    string
+		name          string
+		issuerSuffix  string
+		validPath     string
 		tokenEndpoint string
 	}{
 		{

--- a/internal/service/auth_token_proxy_test.go
+++ b/internal/service/auth_token_proxy_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestAuthTokenProxy builds a minimal AuthTokenProxy suitable for unit-testing
+// discoverTokenEndpoint. Only the fields used by that method are populated.
+func newTestAuthTokenProxy(discoveryClient *http.Client) *AuthTokenProxy {
+	return &AuthTokenProxy{
+		tokenEndpointCache:    make(map[string]*cacheEntry),
+		tokenEndpointCacheTTL: 5 * time.Minute,
+		discoveryClient:       discoveryClient,
+	}
+}
+
+// TestAuthTokenProxy_discoverTokenEndpoint_TrailingSlash verifies that discoverTokenEndpoint
+// correctly normalizes the issuer URL before building the discovery URL, so a trailing
+// slash in the issuer never produces a double-slash path.
+func TestAuthTokenProxy_discoverTokenEndpoint_TrailingSlash(t *testing.T) {
+	tests := []struct {
+		name         string
+		issuerSuffix string
+		validPath    string
+		tokenEndpoint string
+	}{
+		{
+			name:          "When issuer has no trailing slash it should discover the token endpoint",
+			issuerSuffix:  "",
+			validPath:     "/.well-known/openid-configuration",
+			tokenEndpoint: "/token",
+		},
+		{
+			name:          "When issuer has a trailing slash it should discover the token endpoint without double slash",
+			issuerSuffix:  "/",
+			validPath:     "/.well-known/openid-configuration",
+			tokenEndpoint: "/token",
+		},
+		{
+			name:          "When issuer has a realm path with trailing slash it should discover the token endpoint",
+			issuerSuffix:  "/realms/myrealm/",
+			validPath:     "/realms/myrealm/.well-known/openid-configuration",
+			tokenEndpoint: "/realms/myrealm/token",
+		},
+		{
+			name:          "When issuer has a realm path without trailing slash it should discover the token endpoint",
+			issuerSuffix:  "/realms/myrealm",
+			validPath:     "/realms/myrealm/.well-known/openid-configuration",
+			tokenEndpoint: "/realms/myrealm/token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var requestedPaths []string
+
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				requestedPaths = append(requestedPaths, r.URL.Path)
+				mu.Unlock()
+
+				if r.URL.Path != tt.validPath {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				doc := struct {
+					TokenEndpoint string `json:"token_endpoint"`
+				}{
+					TokenEndpoint: server.URL + tt.tokenEndpoint,
+				}
+				_ = json.NewEncoder(w).Encode(doc)
+			}))
+			defer server.Close()
+
+			issuer := server.URL + tt.issuerSuffix
+			proxy := newTestAuthTokenProxy(server.Client())
+
+			endpoint, err := proxy.discoverTokenEndpoint(issuer)
+			require.NoError(t, err, "discoverTokenEndpoint should succeed for issuer %q", issuer)
+			assert.Equal(t, server.URL+tt.tokenEndpoint, endpoint)
+
+			mu.Lock()
+			paths := append([]string{}, requestedPaths...)
+			mu.Unlock()
+
+			require.NotEmpty(t, paths, "Expected at least one request to the discovery server")
+			for _, path := range paths {
+				assert.NotContains(t, path, "//",
+					"Discovery request path must not contain double slash (issuer: %q, path: %q)", issuer, path)
+			}
+		})
+	}
+}
+
+// TestAuthTokenProxy_discoverTokenEndpoint_Caching verifies that repeated calls with the
+// same issuer are served from cache (only one HTTP round-trip is made).
+func TestAuthTokenProxy_discoverTokenEndpoint_Caching(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		doc := struct {
+			TokenEndpoint string `json:"token_endpoint"`
+		}{
+			TokenEndpoint: server.URL + "/token",
+		}
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
+	defer server.Close()
+
+	proxy := newTestAuthTokenProxy(server.Client())
+
+	for i := 0; i < 5; i++ {
+		endpoint, err := proxy.discoverTokenEndpoint(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, server.URL+"/token", endpoint)
+	}
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+	assert.Equal(t, 1, count, "Expected exactly one HTTP call to the discovery server (cache should serve the rest)")
+}
+
+// TestAuthTokenProxy_discoverTokenEndpoint_InvalidIssuer verifies that an invalid issuer
+// URL returns an error without making any HTTP requests.
+func TestAuthTokenProxy_discoverTokenEndpoint_InvalidIssuer(t *testing.T) {
+	tests := []struct {
+		name   string
+		issuer string
+	}{
+		{
+			name:   "When issuer is empty it should return an error",
+			issuer: "",
+		},
+		{
+			name:   "When issuer has no scheme it should return an error",
+			issuer: "example.com/realms/myrealm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := newTestAuthTokenProxy(&http.Client{})
+			_, err := proxy.discoverTokenEndpoint(tt.issuer)
+			assert.Error(t, err, "Expected error for invalid issuer %q", tt.issuer)
+		})
+	}
+}

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -50,56 +50,7 @@ func sanitizeSchemaError(err error) string {
 // normalizeAuthProviderURLs normalizes URL fields in auth provider specs before storing.
 // This ensures consistent URL representation (e.g. no trailing slashes on issuer identifiers).
 func normalizeAuthProviderURLs(spec *domain.AuthProviderSpec) error {
-	discriminator, err := spec.Discriminator()
-	if err != nil {
-		// Unknown or malformed provider type — skip normalization. Validation (called after this)
-		// will reject the spec with a descriptive error, so surfacing the discriminator error here
-		// would only add noise.
-		return nil
-	}
-
-	switch discriminator {
-	case string(domain.Oidc):
-		oidcSpec, err := spec.AsOIDCProviderSpec()
-		if err != nil {
-			return fmt.Errorf("invalid OIDC provider spec: %w", err)
-		}
-		if oidcSpec.Issuer != "" {
-			normalized, err := provider.NormalizeIssuerURL(oidcSpec.Issuer)
-			if err != nil {
-				return fmt.Errorf("invalid OIDC issuer URL: %w", err)
-			}
-			oidcSpec.Issuer = normalized
-		}
-		if mergeErr := spec.MergeOIDCProviderSpec(oidcSpec); mergeErr != nil {
-			return fmt.Errorf("failed to update OIDC provider spec: %w", mergeErr)
-		}
-
-	case string(domain.Oauth2):
-		oauth2Spec, err := spec.AsOAuth2ProviderSpec()
-		if err != nil {
-			return fmt.Errorf("invalid OAuth2 provider spec: %w", err)
-		}
-		if oauth2Spec.AuthorizationUrl != "" {
-			normalized, err := provider.NormalizeIssuerURL(oauth2Spec.AuthorizationUrl)
-			if err != nil {
-				return fmt.Errorf("invalid OAuth2 authorizationUrl: %w", err)
-			}
-			oauth2Spec.AuthorizationUrl = normalized
-		}
-		if oauth2Spec.Issuer != nil && *oauth2Spec.Issuer != "" {
-			normalized, err := provider.NormalizeIssuerURL(*oauth2Spec.Issuer)
-			if err != nil {
-				return fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
-			}
-			oauth2Spec.Issuer = &normalized
-		}
-		if mergeErr := spec.MergeOAuth2ProviderSpec(oauth2Spec); mergeErr != nil {
-			return fmt.Errorf("failed to update OAuth2 provider spec: %w", mergeErr)
-		}
-	}
-
-	return nil
+	return provider.NormalizeAuthProviderSpecURLs(spec)
 }
 
 // applyAuthProviderDefaults applies default values to auth provider specs during creation.

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -52,7 +52,10 @@ func sanitizeSchemaError(err error) string {
 func normalizeAuthProviderURLs(spec *domain.AuthProviderSpec) error {
 	discriminator, err := spec.Discriminator()
 	if err != nil {
-		return nil // Not a valid provider, nothing to do
+		// Unknown or malformed provider type — skip normalization. Validation (called after this)
+		// will reject the spec with a descriptive error, so surfacing the discriminator error here
+		// would only add noise.
+		return nil
 	}
 
 	switch discriminator {
@@ -274,7 +277,10 @@ func (h *ServiceHandler) ReplaceAuthProvider(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
-	// Normalize URL fields before validation
+	// Normalize URL fields before validation.
+	// Note: if the resource does not exist, this delegates to CreateAuthProvider which also calls
+	// normalizeAuthProviderURLs. The function is idempotent (normalizing an already-normalized URL
+	// is a no-op), so the double call is safe.
 	if err := normalizeAuthProviderURLs(&authProvider.Spec); err != nil {
 		return nil, domain.StatusBadRequest(sanitizeSchemaError(err))
 	}

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -47,6 +47,58 @@ func sanitizeSchemaError(err error) string {
 	return errMsg
 }
 
+// normalizeAuthProviderURLs normalizes URL fields in auth provider specs before storing.
+// This ensures consistent URL representation (e.g. no trailing slashes on issuer identifiers).
+func normalizeAuthProviderURLs(spec *domain.AuthProviderSpec) error {
+	discriminator, err := spec.Discriminator()
+	if err != nil {
+		return nil // Not a valid provider, nothing to do
+	}
+
+	switch discriminator {
+	case string(domain.Oidc):
+		oidcSpec, err := spec.AsOIDCProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OIDC provider spec: %w", err)
+		}
+		if oidcSpec.Issuer != "" {
+			normalized, err := authprovider.NormalizeIssuerURL(oidcSpec.Issuer)
+			if err != nil {
+				return fmt.Errorf("invalid OIDC issuer URL: %w", err)
+			}
+			oidcSpec.Issuer = normalized
+		}
+		if mergeErr := spec.MergeOIDCProviderSpec(oidcSpec); mergeErr != nil {
+			return fmt.Errorf("failed to update OIDC provider spec: %w", mergeErr)
+		}
+
+	case string(domain.Oauth2):
+		oauth2Spec, err := spec.AsOAuth2ProviderSpec()
+		if err != nil {
+			return fmt.Errorf("invalid OAuth2 provider spec: %w", err)
+		}
+		if oauth2Spec.AuthorizationUrl != "" {
+			normalized, err := authprovider.NormalizeIssuerURL(oauth2Spec.AuthorizationUrl)
+			if err != nil {
+				return fmt.Errorf("invalid OAuth2 authorizationUrl: %w", err)
+			}
+			oauth2Spec.AuthorizationUrl = normalized
+		}
+		if oauth2Spec.Issuer != nil && *oauth2Spec.Issuer != "" {
+			normalized, err := authprovider.NormalizeIssuerURL(*oauth2Spec.Issuer)
+			if err != nil {
+				return fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
+			}
+			oauth2Spec.Issuer = &normalized
+		}
+		if mergeErr := spec.MergeOAuth2ProviderSpec(oauth2Spec); mergeErr != nil {
+			return fmt.Errorf("failed to update OAuth2 provider spec: %w", mergeErr)
+		}
+	}
+
+	return nil
+}
+
 // applyAuthProviderDefaults applies default values to auth provider specs during creation.
 // This includes setting UsernameClaim for OIDC and OAuth2 providers, Issuer for OAuth2,
 // and inferring Introspection for OAuth2 if not provided.
@@ -128,6 +180,11 @@ func (h *ServiceHandler) CreateAuthProvider(ctx context.Context, orgId uuid.UUID
 
 	// don't set fields that are managed by the service
 	common.NilOutManagedObjectMetaProperties(&authProvider.Metadata)
+
+	// Normalize URL fields before applying defaults so defaults inherit the normalized form
+	if err := normalizeAuthProviderURLs(&authProvider.Spec); err != nil {
+		return nil, domain.StatusBadRequest(sanitizeSchemaError(err))
+	}
 
 	// Apply defaults for auth providers (only during creation)
 	if err := applyAuthProviderDefaults(&authProvider.Spec); err != nil {
@@ -217,6 +274,11 @@ func (h *ServiceHandler) ReplaceAuthProvider(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
+	// Normalize URL fields before validation
+	if err := normalizeAuthProviderURLs(&authProvider.Spec); err != nil {
+		return nil, domain.StatusBadRequest(sanitizeSchemaError(err))
+	}
+
 	// Get the existing resource to perform update validation
 	currentObj, err := h.store.Get(ctx, orgId, name)
 	if err == nil {
@@ -254,6 +316,11 @@ func (h *ServiceHandler) PatchAuthProvider(ctx context.Context, orgId uuid.UUID,
 	// Forbid changing metadata.name via PATCH
 	if currentObj.Metadata.Name != nil && newObj.Metadata.Name != nil && *currentObj.Metadata.Name != *newObj.Metadata.Name {
 		return nil, domain.StatusBadRequest("metadata.name cannot be changed")
+	}
+
+	// Normalize URL fields before validation
+	if err := normalizeAuthProviderURLs(&newObj.Spec); err != nil {
+		return nil, domain.StatusBadRequest(sanitizeSchemaError(err))
 	}
 
 	// Use ValidateUpdate to prevent deletion of required fields

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -65,7 +65,7 @@ func normalizeAuthProviderURLs(spec *domain.AuthProviderSpec) error {
 			return fmt.Errorf("invalid OIDC provider spec: %w", err)
 		}
 		if oidcSpec.Issuer != "" {
-			normalized, err := authprovider.NormalizeIssuerURL(oidcSpec.Issuer)
+			normalized, err := provider.NormalizeIssuerURL(oidcSpec.Issuer)
 			if err != nil {
 				return fmt.Errorf("invalid OIDC issuer URL: %w", err)
 			}
@@ -81,14 +81,14 @@ func normalizeAuthProviderURLs(spec *domain.AuthProviderSpec) error {
 			return fmt.Errorf("invalid OAuth2 provider spec: %w", err)
 		}
 		if oauth2Spec.AuthorizationUrl != "" {
-			normalized, err := authprovider.NormalizeIssuerURL(oauth2Spec.AuthorizationUrl)
+			normalized, err := provider.NormalizeIssuerURL(oauth2Spec.AuthorizationUrl)
 			if err != nil {
 				return fmt.Errorf("invalid OAuth2 authorizationUrl: %w", err)
 			}
 			oauth2Spec.AuthorizationUrl = normalized
 		}
 		if oauth2Spec.Issuer != nil && *oauth2Spec.Issuer != "" {
-			normalized, err := authprovider.NormalizeIssuerURL(*oauth2Spec.Issuer)
+			normalized, err := provider.NormalizeIssuerURL(*oauth2Spec.Issuer)
 			if err != nil {
 				return fmt.Errorf("invalid OAuth2 issuer URL: %w", err)
 			}

--- a/internal/service/authprovider/normalize_test.go
+++ b/internal/service/authprovider/normalize_test.go
@@ -38,9 +38,9 @@ func TestNormalizeAuthProviderURLs_OIDC(t *testing.T) {
 			wantIssuer: "https://idp.example.com:8443",
 		},
 		{
-			name:       "When OIDC issuer has mixed case it should be lowercased",
+			name:       "When OIDC issuer has mixed case host it should lowercase host and preserve path case",
 			issuer:     "HTTPS://IdP.Example.COM/Realm/Master/",
-			wantIssuer: "https://idp.example.com/realm/master",
+			wantIssuer: "https://idp.example.com/Realm/Master",
 		},
 		{
 			name:        "When OIDC issuer has no scheme it should fail",

--- a/internal/service/authprovider/normalize_test.go
+++ b/internal/service/authprovider/normalize_test.go
@@ -38,6 +38,11 @@ func TestNormalizeAuthProviderURLs_OIDC(t *testing.T) {
 			wantIssuer: "https://idp.example.com:8443",
 		},
 		{
+			name:       "When OIDC issuer has mixed case it should be lowercased",
+			issuer:     "HTTPS://IdP.Example.COM/Realm/Master/",
+			wantIssuer: "https://idp.example.com/realm/master",
+		},
+		{
 			name:        "When OIDC issuer has no scheme it should fail",
 			issuer:      "idp.example.com",
 			wantErr:     true,

--- a/internal/service/authprovider/normalize_test.go
+++ b/internal/service/authprovider/normalize_test.go
@@ -78,33 +78,51 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 		name             string
 		authorizationUrl string
 		issuer           *string
+		tokenUrl         string
+		userinfoUrl      string
 		wantAuthzURL     string
 		wantIssuer       *string
+		wantTokenURL     string
+		wantUserinfoURL  string
 		wantErr          bool
 		errContains      string
 	}{
 		{
 			name:             "When authorizationUrl has trailing slash it should be stripped",
 			authorizationUrl: "https://idp.example.com/oauth2/authorize/",
+			tokenUrl:         "https://idp.example.com/token",
+			userinfoUrl:      "https://idp.example.com/userinfo",
 			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
+			wantTokenURL:     "https://idp.example.com/token",
+			wantUserinfoURL:  "https://idp.example.com/userinfo",
 		},
 		{
 			name:             "When both authorizationUrl and issuer have trailing slashes they should both be stripped",
 			authorizationUrl: "https://idp.example.com/oauth2/authorize/",
 			issuer:           lo.ToPtr("https://idp.example.com/"),
+			tokenUrl:         "https://idp.example.com/token/",
+			userinfoUrl:      "https://idp.example.com/userinfo/",
 			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
 			wantIssuer:       lo.ToPtr("https://idp.example.com"),
+			wantTokenURL:     "https://idp.example.com/token",
+			wantUserinfoURL:  "https://idp.example.com/userinfo",
 		},
 		{
 			name:             "When issuer is nil it should be left nil",
 			authorizationUrl: "https://idp.example.com/oauth2/authorize",
 			issuer:           nil,
+			tokenUrl:         "https://idp.example.com/token",
+			userinfoUrl:      "https://idp.example.com/userinfo",
 			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
 			wantIssuer:       nil,
+			wantTokenURL:     "https://idp.example.com/token",
+			wantUserinfoURL:  "https://idp.example.com/userinfo",
 		},
 		{
 			name:             "When authorizationUrl is invalid it should fail",
 			authorizationUrl: "not-a-url",
+			tokenUrl:         "https://idp.example.com/token",
+			userinfoUrl:      "https://idp.example.com/userinfo",
 			wantErr:          true,
 			errContains:      "invalid OAuth2 authorizationUrl",
 		},
@@ -112,8 +130,18 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 			name:             "When issuer is invalid it should fail",
 			authorizationUrl: "https://idp.example.com/authorize",
 			issuer:           lo.ToPtr("not-a-url"),
+			tokenUrl:         "https://idp.example.com/token",
+			userinfoUrl:      "https://idp.example.com/userinfo",
 			wantErr:          true,
 			errContains:      "invalid OAuth2 issuer URL",
+		},
+		{
+			name:             "When userinfoUrl is invalid it should fail",
+			authorizationUrl: "https://idp.example.com/authorize",
+			tokenUrl:         "https://idp.example.com/token",
+			userinfoUrl:      "not-a-url",
+			wantErr:          true,
+			errContains:      "invalid OAuth2 userinfoUrl",
 		},
 	}
 	for _, tt := range tests {
@@ -127,8 +155,8 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 			oauth2Spec := domain.OAuth2ProviderSpec{
 				ProviderType:     domain.Oauth2,
 				AuthorizationUrl: tt.authorizationUrl,
-				TokenUrl:         "https://idp.example.com/token",
-				UserinfoUrl:      "https://idp.example.com/userinfo",
+				TokenUrl:         tt.tokenUrl,
+				UserinfoUrl:      tt.userinfoUrl,
 				ClientId:         "test-client",
 				Issuer:           tt.issuer,
 				Introspection:    rfc7662,
@@ -145,6 +173,8 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 			got, err := spec.AsOAuth2ProviderSpec()
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantAuthzURL, got.AuthorizationUrl)
+			assert.Equal(t, tt.wantTokenURL, got.TokenUrl)
+			assert.Equal(t, tt.wantUserinfoURL, got.UserinfoUrl)
 			if tt.wantIssuer == nil {
 				assert.Nil(t, got.Issuer)
 			} else {

--- a/internal/service/authprovider/normalize_test.go
+++ b/internal/service/authprovider/normalize_test.go
@@ -1,4 +1,4 @@
-package service
+package authprovider
 
 import (
 	"testing"

--- a/internal/service/authprovider_test.go
+++ b/internal/service/authprovider_test.go
@@ -158,7 +158,7 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
 	t.Run("When AAP provider type it should be a no-op", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromAapProviderSpec(domain.AapProviderSpec{
+		require.NoError(t, spec.FromAapProviderSpec(domain.AapProviderSpec{
 			ProviderType:     domain.Aap,
 			ApiUrl:           "https://aap.example.com/",
 			AuthorizationUrl: "https://aap.example.com/authorize",
@@ -166,7 +166,7 @@ func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
 			ClientId:         "client",
 			ClientSecret:     "secret",
 			Scopes:           []string{"api"},
-		})
+		}))
 		err := normalizeAuthProviderURLs(&spec)
 		require.NoError(t, err)
 		got, err := spec.AsAapProviderSpec()
@@ -179,11 +179,11 @@ func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
 func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 	t.Run("When UsernameClaim is nil it should default to preferred_username", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
 			ProviderType: domain.Oidc,
 			Issuer:       "https://idp.example.com",
 			ClientId:     "test-client",
-		})
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOIDCProviderSpec()
 		require.NoError(t, err)
@@ -193,12 +193,12 @@ func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 
 	t.Run("When UsernameClaim is already set it should not be overwritten", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
 			ProviderType:  domain.Oidc,
 			Issuer:        "https://idp.example.com",
 			ClientId:      "test-client",
 			UsernameClaim: lo.ToPtr([]string{"email"}),
-		})
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOIDCProviderSpec()
 		require.NoError(t, err)
@@ -208,25 +208,25 @@ func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 }
 
 func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
-	rfc7662 := func() *domain.OAuth2Introspection {
+	rfc7662 := func(t *testing.T) *domain.OAuth2Introspection {
 		i := &domain.OAuth2Introspection{}
-		_ = i.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
+		require.NoError(t, i.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
 			Type: domain.IntrospectionTypeRfc7662,
 			Url:  "https://idp.example.com/introspect",
-		})
+		}))
 		return i
 	}
 
 	t.Run("When Issuer is nil it should be set to AuthorizationUrl", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+		require.NoError(t, spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
 			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
 			ClientId:         "test-client",
-			Introspection:    rfc7662(),
-		})
+			Introspection:    rfc7662(t),
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOAuth2ProviderSpec()
 		require.NoError(t, err)
@@ -237,15 +237,15 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 	t.Run("When Issuer is already set it should not be overwritten", func(t *testing.T) {
 		explicitIssuer := "https://idp.example.com"
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+		require.NoError(t, spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
 			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
 			ClientId:         "test-client",
 			Issuer:           &explicitIssuer,
-			Introspection:    rfc7662(),
-		})
+			Introspection:    rfc7662(t),
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOAuth2ProviderSpec()
 		require.NoError(t, err)
@@ -255,13 +255,13 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 
 	t.Run("When Introspection is nil and token URL is a GitHub URL it should infer GitHub introspection", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+		require.NoError(t, spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
 			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://github.com/login/oauth/authorize",
 			TokenUrl:         "https://github.com/login/oauth/access_token",
 			UserinfoUrl:      "https://api.github.com/user",
 			ClientId:         "test-client",
-		})
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOAuth2ProviderSpec()
 		require.NoError(t, err)
@@ -273,13 +273,13 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 
 	t.Run("When Introspection is nil and token URL is a standard URL it should infer RFC 7662 introspection", func(t *testing.T) {
 		spec := domain.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+		require.NoError(t, spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
 			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/oauth2/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
 			ClientId:         "test-client",
-		})
+		}))
 		require.NoError(t, applyAuthProviderDefaults(&spec))
 		got, err := spec.AsOAuth2ProviderSpec()
 		require.NoError(t, err)

--- a/internal/service/authprovider_test.go
+++ b/internal/service/authprovider_test.go
@@ -1,0 +1,316 @@
+package service
+
+import (
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAuthProviderURLs_OIDC(t *testing.T) {
+	tests := []struct {
+		name        string
+		issuer      string
+		wantIssuer  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "When OIDC issuer has no trailing slash it should stay unchanged",
+			issuer:     "https://idp.example.com",
+			wantIssuer: "https://idp.example.com",
+		},
+		{
+			name:       "When OIDC issuer has trailing slash it should be stripped",
+			issuer:     "https://idp.example.com/",
+			wantIssuer: "https://idp.example.com",
+		},
+		{
+			name:       "When OIDC issuer has path and trailing slash it should strip only trailing slash",
+			issuer:     "https://idp.example.com/realm/master/",
+			wantIssuer: "https://idp.example.com/realm/master",
+		},
+		{
+			name:       "When OIDC issuer has port it should be preserved",
+			issuer:     "https://idp.example.com:8443/",
+			wantIssuer: "https://idp.example.com:8443",
+		},
+		{
+			name:        "When OIDC issuer has no scheme it should fail",
+			issuer:      "idp.example.com",
+			wantErr:     true,
+			errContains: "invalid OIDC issuer URL",
+		},
+		{
+			name:       "When OIDC issuer is empty it should be a no-op (validation catches it separately)",
+			issuer:     "",
+			wantIssuer: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := api.AuthProviderSpec{}
+			oidcSpec := api.OIDCProviderSpec{
+				ProviderType: api.Oidc,
+				Issuer:       tt.issuer,
+				ClientId:     "test-client",
+			}
+			require.NoError(t, spec.FromOIDCProviderSpec(oidcSpec))
+
+			err := normalizeAuthProviderURLs(&spec)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			got, err := spec.AsOIDCProviderSpec()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIssuer, got.Issuer)
+		})
+	}
+}
+
+func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
+	tests := []struct {
+		name             string
+		authorizationUrl string
+		issuer           *string
+		wantAuthzURL     string
+		wantIssuer       *string
+		wantErr          bool
+		errContains      string
+	}{
+		{
+			name:             "When authorizationUrl has trailing slash it should be stripped",
+			authorizationUrl: "https://idp.example.com/oauth2/authorize/",
+			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
+		},
+		{
+			name:             "When both authorizationUrl and issuer have trailing slashes they should both be stripped",
+			authorizationUrl: "https://idp.example.com/oauth2/authorize/",
+			issuer:           lo.ToPtr("https://idp.example.com/"),
+			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
+			wantIssuer:       lo.ToPtr("https://idp.example.com"),
+		},
+		{
+			name:             "When issuer is nil it should be left nil",
+			authorizationUrl: "https://idp.example.com/oauth2/authorize",
+			issuer:           nil,
+			wantAuthzURL:     "https://idp.example.com/oauth2/authorize",
+			wantIssuer:       nil,
+		},
+		{
+			name:             "When authorizationUrl is invalid it should fail",
+			authorizationUrl: "not-a-url",
+			wantErr:          true,
+			errContains:      "invalid OAuth2 authorizationUrl",
+		},
+		{
+			name:             "When issuer is invalid it should fail",
+			authorizationUrl: "https://idp.example.com/authorize",
+			issuer:           lo.ToPtr("not-a-url"),
+			wantErr:          true,
+			errContains:      "invalid OAuth2 issuer URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rfc7662 := &api.OAuth2Introspection{}
+			require.NoError(t, rfc7662.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+				Type: api.Rfc7662,
+				Url:  "https://idp.example.com/introspect",
+			}))
+			spec := api.AuthProviderSpec{}
+			oauth2Spec := api.OAuth2ProviderSpec{
+				ProviderType:     api.Oauth2,
+				AuthorizationUrl: tt.authorizationUrl,
+				TokenUrl:         "https://idp.example.com/token",
+				UserinfoUrl:      "https://idp.example.com/userinfo",
+				ClientId:         "test-client",
+				Issuer:           tt.issuer,
+				Introspection:    rfc7662,
+			}
+			require.NoError(t, spec.FromOAuth2ProviderSpec(oauth2Spec))
+
+			err := normalizeAuthProviderURLs(&spec)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			got, err := spec.AsOAuth2ProviderSpec()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuthzURL, got.AuthorizationUrl)
+			if tt.wantIssuer == nil {
+				assert.Nil(t, got.Issuer)
+			} else {
+				require.NotNil(t, got.Issuer)
+				assert.Equal(t, *tt.wantIssuer, *got.Issuer)
+			}
+		})
+	}
+}
+
+func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
+	t.Run("When AAP provider type it should be a no-op", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromAapProviderSpec(api.AapProviderSpec{
+			ProviderType:     api.Aap,
+			ApiUrl:           "https://aap.example.com/",
+			AuthorizationUrl: "https://aap.example.com/authorize",
+			TokenUrl:         "https://aap.example.com/token",
+			ClientId:         "client",
+			ClientSecret:     "secret",
+			Scopes:           []string{"api"},
+		})
+		err := normalizeAuthProviderURLs(&spec)
+		require.NoError(t, err)
+		got, err := spec.AsAapProviderSpec()
+		require.NoError(t, err)
+		// AAP ApiUrl is not touched by normalizeAuthProviderURLs
+		assert.Equal(t, "https://aap.example.com/", got.ApiUrl)
+	})
+}
+
+func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
+	t.Run("When UsernameClaim is nil it should default to preferred_username", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
+			ProviderType: api.Oidc,
+			Issuer:       "https://idp.example.com",
+			ClientId:     "test-client",
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOIDCProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.UsernameClaim)
+		assert.Equal(t, []string{"preferred_username"}, *got.UsernameClaim)
+	})
+
+	t.Run("When UsernameClaim is already set it should not be overwritten", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
+			ProviderType:  api.Oidc,
+			Issuer:        "https://idp.example.com",
+			ClientId:      "test-client",
+			UsernameClaim: lo.ToPtr([]string{"email"}),
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOIDCProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.UsernameClaim)
+		assert.Equal(t, []string{"email"}, *got.UsernameClaim)
+	})
+}
+
+func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
+	rfc7662 := func() *api.OAuth2Introspection {
+		i := &api.OAuth2Introspection{}
+		_ = i.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
+			Type: api.Rfc7662,
+			Url:  "https://idp.example.com/introspect",
+		})
+		return i
+	}
+
+	t.Run("When Issuer is nil it should be set to AuthorizationUrl", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "https://idp.example.com/authorize",
+			TokenUrl:         "https://idp.example.com/token",
+			UserinfoUrl:      "https://idp.example.com/userinfo",
+			ClientId:         "test-client",
+			Introspection:    rfc7662(),
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOAuth2ProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.Issuer)
+		assert.Equal(t, "https://idp.example.com/authorize", *got.Issuer)
+	})
+
+	t.Run("When Issuer is already set it should not be overwritten", func(t *testing.T) {
+		explicitIssuer := "https://idp.example.com"
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "https://idp.example.com/authorize",
+			TokenUrl:         "https://idp.example.com/token",
+			UserinfoUrl:      "https://idp.example.com/userinfo",
+			ClientId:         "test-client",
+			Issuer:           &explicitIssuer,
+			Introspection:    rfc7662(),
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOAuth2ProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.Issuer)
+		assert.Equal(t, explicitIssuer, *got.Issuer)
+	})
+
+	t.Run("When Introspection is nil and token URL is a GitHub URL it should infer GitHub introspection", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "https://github.com/login/oauth/authorize",
+			TokenUrl:         "https://github.com/login/oauth/access_token",
+			UserinfoUrl:      "https://api.github.com/user",
+			ClientId:         "test-client",
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOAuth2ProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.Introspection)
+		discriminator, err := got.Introspection.Discriminator()
+		require.NoError(t, err)
+		assert.Equal(t, string(api.Github), discriminator)
+	})
+
+	t.Run("When Introspection is nil and token URL is a standard URL it should infer RFC 7662 introspection", func(t *testing.T) {
+		spec := api.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
+			ProviderType:     api.Oauth2,
+			AuthorizationUrl: "https://idp.example.com/authorize",
+			TokenUrl:         "https://idp.example.com/oauth2/token",
+			UserinfoUrl:      "https://idp.example.com/userinfo",
+			ClientId:         "test-client",
+		})
+		require.NoError(t, applyAuthProviderDefaults(&spec))
+		got, err := spec.AsOAuth2ProviderSpec()
+		require.NoError(t, err)
+		require.NotNil(t, got.Introspection)
+		discriminator, err := got.Introspection.Discriminator()
+		require.NoError(t, err)
+		assert.Equal(t, string(api.Rfc7662), discriminator)
+	})
+}
+
+func TestSanitizeSchemaError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "When nil error it should return empty string",
+			err:     nil,
+			wantMsg: "",
+		},
+		{
+			name:    "When non-sensitive error it should return original message",
+			err:     assert.AnError,
+			wantMsg: assert.AnError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSchemaError(tt.err)
+			assert.Equal(t, tt.wantMsg, got)
+		})
+	}
+}

--- a/internal/service/authprovider_test.go
+++ b/internal/service/authprovider_test.go
@@ -209,6 +209,7 @@ func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 
 func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 	rfc7662 := func(t *testing.T) *domain.OAuth2Introspection {
+		t.Helper()
 		i := &domain.OAuth2Introspection{}
 		require.NoError(t, i.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
 			Type: domain.IntrospectionTypeRfc7662,

--- a/internal/service/authprovider_test.go
+++ b/internal/service/authprovider_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"testing"
 
-	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,9 +51,9 @@ func TestNormalizeAuthProviderURLs_OIDC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := api.AuthProviderSpec{}
-			oidcSpec := api.OIDCProviderSpec{
-				ProviderType: api.Oidc,
+			spec := domain.AuthProviderSpec{}
+			oidcSpec := domain.OIDCProviderSpec{
+				ProviderType: domain.Oidc,
 				Issuer:       tt.issuer,
 				ClientId:     "test-client",
 			}
@@ -118,14 +118,14 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rfc7662 := &api.OAuth2Introspection{}
-			require.NoError(t, rfc7662.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
-				Type: api.Rfc7662,
+			rfc7662 := &domain.OAuth2Introspection{}
+			require.NoError(t, rfc7662.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
+				Type: domain.IntrospectionTypeRfc7662,
 				Url:  "https://idp.example.com/introspect",
 			}))
-			spec := api.AuthProviderSpec{}
-			oauth2Spec := api.OAuth2ProviderSpec{
-				ProviderType:     api.Oauth2,
+			spec := domain.AuthProviderSpec{}
+			oauth2Spec := domain.OAuth2ProviderSpec{
+				ProviderType:     domain.Oauth2,
 				AuthorizationUrl: tt.authorizationUrl,
 				TokenUrl:         "https://idp.example.com/token",
 				UserinfoUrl:      "https://idp.example.com/userinfo",
@@ -157,9 +157,9 @@ func TestNormalizeAuthProviderURLs_OAuth2(t *testing.T) {
 
 func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
 	t.Run("When AAP provider type it should be a no-op", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromAapProviderSpec(api.AapProviderSpec{
-			ProviderType:     api.Aap,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromAapProviderSpec(domain.AapProviderSpec{
+			ProviderType:     domain.Aap,
 			ApiUrl:           "https://aap.example.com/",
 			AuthorizationUrl: "https://aap.example.com/authorize",
 			TokenUrl:         "https://aap.example.com/token",
@@ -178,9 +178,9 @@ func TestNormalizeAuthProviderURLs_NonURLTypes(t *testing.T) {
 
 func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 	t.Run("When UsernameClaim is nil it should default to preferred_username", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
-			ProviderType: api.Oidc,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+			ProviderType: domain.Oidc,
 			Issuer:       "https://idp.example.com",
 			ClientId:     "test-client",
 		})
@@ -192,9 +192,9 @@ func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 	})
 
 	t.Run("When UsernameClaim is already set it should not be overwritten", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOIDCProviderSpec(api.OIDCProviderSpec{
-			ProviderType:  api.Oidc,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+			ProviderType:  domain.Oidc,
 			Issuer:        "https://idp.example.com",
 			ClientId:      "test-client",
 			UsernameClaim: lo.ToPtr([]string{"email"}),
@@ -208,19 +208,19 @@ func TestApplyAuthProviderDefaults_OIDC(t *testing.T) {
 }
 
 func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
-	rfc7662 := func() *api.OAuth2Introspection {
-		i := &api.OAuth2Introspection{}
-		_ = i.FromRfc7662IntrospectionSpec(api.Rfc7662IntrospectionSpec{
-			Type: api.Rfc7662,
+	rfc7662 := func() *domain.OAuth2Introspection {
+		i := &domain.OAuth2Introspection{}
+		_ = i.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
+			Type: domain.IntrospectionTypeRfc7662,
 			Url:  "https://idp.example.com/introspect",
 		})
 		return i
 	}
 
 	t.Run("When Issuer is nil it should be set to AuthorizationUrl", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
-			ProviderType:     api.Oauth2,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
@@ -236,9 +236,9 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 
 	t.Run("When Issuer is already set it should not be overwritten", func(t *testing.T) {
 		explicitIssuer := "https://idp.example.com"
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
-			ProviderType:     api.Oauth2,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
@@ -254,9 +254,9 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 	})
 
 	t.Run("When Introspection is nil and token URL is a GitHub URL it should infer GitHub introspection", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
-			ProviderType:     api.Oauth2,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://github.com/login/oauth/authorize",
 			TokenUrl:         "https://github.com/login/oauth/access_token",
 			UserinfoUrl:      "https://api.github.com/user",
@@ -268,13 +268,13 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 		require.NotNil(t, got.Introspection)
 		discriminator, err := got.Introspection.Discriminator()
 		require.NoError(t, err)
-		assert.Equal(t, string(api.Github), discriminator)
+		assert.Equal(t, string(domain.IntrospectionTypeGithub), discriminator)
 	})
 
 	t.Run("When Introspection is nil and token URL is a standard URL it should infer RFC 7662 introspection", func(t *testing.T) {
-		spec := api.AuthProviderSpec{}
-		_ = spec.FromOAuth2ProviderSpec(api.OAuth2ProviderSpec{
-			ProviderType:     api.Oauth2,
+		spec := domain.AuthProviderSpec{}
+		_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+			ProviderType:     domain.Oauth2,
 			AuthorizationUrl: "https://idp.example.com/authorize",
 			TokenUrl:         "https://idp.example.com/oauth2/token",
 			UserinfoUrl:      "https://idp.example.com/userinfo",
@@ -286,7 +286,7 @@ func TestApplyAuthProviderDefaults_OAuth2(t *testing.T) {
 		require.NotNil(t, got.Introspection)
 		discriminator, err := got.Introspection.Discriminator()
 		require.NoError(t, err)
-		assert.Equal(t, string(api.Rfc7662), discriminator)
+		assert.Equal(t, string(domain.IntrospectionTypeRfc7662), discriminator)
 	})
 }
 

--- a/test/integration/store/store_test.go
+++ b/test/integration/store/store_test.go
@@ -178,4 +178,107 @@ var _ = Describe("DataStore Migration Tests", func() {
 			Expect(err).To(HaveOccurred(), "default catalog deleted by user must not be recreated on restart")
 		})
 	})
+
+	Context("Auth provider URL normalization", func() {
+		It("When upgrading, it should strip trailing slashes from stored OIDC and OAuth2 URL fields", func() {
+			freshCtx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+			freshLog := flightlog.InitLogs()
+
+			orgID := uuid.New()
+			freshCfg, freshDbName, freshGormDb := createFreshDBWithOrgs(freshCtx, freshLog, []uuid.UUID{orgID})
+			defer func() {
+				Expect(testdb.DeleteTestDB(freshCtx, freshLog, freshCfg, freshGormDb, freshDbName)).To(Succeed())
+			}()
+
+			Expect(migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)).To(Succeed())
+
+			db := freshGormDb.WithContext(freshCtx)
+			Expect(db.Where("key = ?", "normalize_auth_provider_urls_v1").Delete(&model.SchemaMigration{}).Error).To(Succeed())
+
+			oidcSpec := domain.AuthProviderSpec{}
+			Expect(oidcSpec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				ProviderType: domain.Oidc,
+				Issuer:       "https://idp.example.com/realm/master/",
+				ClientId:     "oidc-client",
+			})).To(Succeed())
+			Expect(db.Create(&model.AuthProvider{
+				Resource: model.Resource{OrgID: orgID, Name: "legacy-oidc"},
+				Spec:     model.MakeJSONField(oidcSpec),
+			}).Error).To(Succeed())
+
+			oauth2Introspection := &domain.OAuth2Introspection{}
+			Expect(oauth2Introspection.FromRfc7662IntrospectionSpec(domain.Rfc7662IntrospectionSpec{
+				Type: domain.IntrospectionTypeRfc7662,
+				Url:  "https://idp.example.com/introspect",
+			})).To(Succeed())
+			oauth2Spec := domain.AuthProviderSpec{}
+			Expect(oauth2Spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+				ProviderType:     domain.Oauth2,
+				AuthorizationUrl: "https://idp.example.com/oauth2/authorize/",
+				TokenUrl:         "https://idp.example.com/token/",
+				UserinfoUrl:      "https://idp.example.com/userinfo/",
+				ClientId:         "oauth2-client",
+				Introspection:    oauth2Introspection,
+			})).To(Succeed())
+			Expect(db.Create(&model.AuthProvider{
+				Resource: model.Resource{OrgID: orgID, Name: "legacy-oauth2"},
+				Spec:     model.MakeJSONField(oauth2Spec),
+			}).Error).To(Succeed())
+
+			Expect(migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)).To(Succeed())
+
+			var oidcRow model.AuthProvider
+			Expect(db.Where("org_id = ? AND name = ?", orgID, "legacy-oidc").First(&oidcRow).Error).To(Succeed())
+			gotOIDC, err := oidcRow.Spec.Data.AsOIDCProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotOIDC.Issuer).To(Equal("https://idp.example.com/realm/master"))
+
+			var oauth2Row model.AuthProvider
+			Expect(db.Where("org_id = ? AND name = ?", orgID, "legacy-oauth2").First(&oauth2Row).Error).To(Succeed())
+			gotOAuth2, err := oauth2Row.Spec.Data.AsOAuth2ProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotOAuth2.AuthorizationUrl).To(Equal("https://idp.example.com/oauth2/authorize"))
+			Expect(gotOAuth2.TokenUrl).To(Equal("https://idp.example.com/token"))
+			Expect(gotOAuth2.UserinfoUrl).To(Equal("https://idp.example.com/userinfo"))
+		})
+
+		It("When two providers would collide after normalization, migration should fail", func() {
+			freshCtx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+			freshLog := flightlog.InitLogs()
+
+			orgID := uuid.New()
+			freshCfg, freshDbName, freshGormDb := createFreshDBWithOrgs(freshCtx, freshLog, []uuid.UUID{orgID})
+			defer func() {
+				Expect(testdb.DeleteTestDB(freshCtx, freshLog, freshCfg, freshGormDb, freshDbName)).To(Succeed())
+			}()
+
+			Expect(migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)).To(Succeed())
+
+			db := freshGormDb.WithContext(freshCtx)
+			Expect(db.Where("key = ?", "normalize_auth_provider_urls_v1").Delete(&model.SchemaMigration{}).Error).To(Succeed())
+
+			for _, nameIssuer := range []struct {
+				name   string
+				issuer string
+			}{
+				{name: "oidc-a", issuer: "https://idp.example.com"},
+				{name: "oidc-b", issuer: "https://idp.example.com/"},
+			} {
+				spec := domain.AuthProviderSpec{}
+				Expect(spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+					ProviderType: domain.Oidc,
+					Issuer:       nameIssuer.issuer,
+					ClientId:     "same-client",
+				})).To(Succeed())
+				Expect(db.Create(&model.AuthProvider{
+					Resource: model.Resource{OrgID: orgID, Name: nameIssuer.name},
+					Spec:     model.MakeJSONField(spec),
+				}).Error).To(Succeed())
+			}
+
+			err := migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("would share issuer"))
+		})
+	})
 })

--- a/test/integration/store/store_test.go
+++ b/test/integration/store/store_test.go
@@ -231,7 +231,7 @@ var _ = Describe("DataStore Migration Tests", func() {
 			Expect(db.Where("org_id = ? AND name = ?", orgID, "legacy-oidc").First(&oidcRow).Error).To(Succeed())
 			gotOIDC, err := oidcRow.Spec.Data.AsOIDCProviderSpec()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(gotOIDC.Issuer).To(Equal("https://idp.example.com/realm/master"))
+			Expect(gotOIDC.Issuer).To(Equal("https://idp.example.com/Realm/Master"))
 
 			var oauth2Row model.AuthProvider
 			Expect(db.Where("org_id = ? AND name = ?", orgID, "legacy-oauth2").First(&oauth2Row).Error).To(Succeed())

--- a/test/integration/store/store_test.go
+++ b/test/integration/store/store_test.go
@@ -198,7 +198,7 @@ var _ = Describe("DataStore Migration Tests", func() {
 			oidcSpec := domain.AuthProviderSpec{}
 			Expect(oidcSpec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
 				ProviderType: domain.Oidc,
-				Issuer:       "https://idp.example.com/realm/master/",
+				Issuer:       "HTTPS://IdP.Example.COM/Realm/Master/",
 				ClientId:     "oidc-client",
 			})).To(Succeed())
 			Expect(db.Create(&model.AuthProvider{
@@ -214,9 +214,9 @@ var _ = Describe("DataStore Migration Tests", func() {
 			oauth2Spec := domain.AuthProviderSpec{}
 			Expect(oauth2Spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
 				ProviderType:     domain.Oauth2,
-				AuthorizationUrl: "https://idp.example.com/oauth2/authorize/",
-				TokenUrl:         "https://idp.example.com/token/",
-				UserinfoUrl:      "https://idp.example.com/userinfo/",
+				AuthorizationUrl: "HTTPS://IdP.Example.COM/oauth2/authorize/",
+				TokenUrl:         "HTTPS://IdP.Example.COM/token/",
+				UserinfoUrl:      "HTTPS://IdP.Example.COM/userinfo/",
 				ClientId:         "oauth2-client",
 				Introspection:    oauth2Introspection,
 			})).To(Succeed())
@@ -262,7 +262,7 @@ var _ = Describe("DataStore Migration Tests", func() {
 				issuer string
 			}{
 				{name: "oidc-a", issuer: "https://idp.example.com"},
-				{name: "oidc-b", issuer: "https://idp.example.com/"},
+				{name: "oidc-b", issuer: "HTTPS://IdP.Example.COM/"},
 			} {
 				spec := domain.AuthProviderSpec{}
 				Expect(spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{

--- a/test/integration/store/store_test.go
+++ b/test/integration/store/store_test.go
@@ -280,5 +280,44 @@ var _ = Describe("DataStore Migration Tests", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("would share issuer"))
 		})
+
+		It("When two providers differ only by host case, migration should fail on collision", func() {
+			freshCtx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+			freshLog := flightlog.InitLogs()
+
+			orgID := uuid.New()
+			freshCfg, freshDbName, freshGormDb := createFreshDBWithOrgs(freshCtx, freshLog, []uuid.UUID{orgID})
+			defer func() {
+				Expect(testdb.DeleteTestDB(freshCtx, freshLog, freshCfg, freshGormDb, freshDbName)).To(Succeed())
+			}()
+
+			Expect(migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)).To(Succeed())
+
+			db := freshGormDb.WithContext(freshCtx)
+			Expect(db.Where("key = ?", "normalize_auth_provider_urls_v1").Delete(&model.SchemaMigration{}).Error).To(Succeed())
+
+			for _, nameIssuer := range []struct {
+				name   string
+				issuer string
+			}{
+				{name: "oidc-lower", issuer: "https://idp.example.com"},
+				{name: "oidc-upper", issuer: "https://IdP.Example.COM"},
+			} {
+				spec := domain.AuthProviderSpec{}
+				Expect(spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+					ProviderType: domain.Oidc,
+					Issuer:       nameIssuer.issuer,
+					ClientId:     "same-client",
+				})).To(Succeed())
+				Expect(db.Create(&model.AuthProvider{
+					Resource: model.Resource{OrgID: orgID, Name: nameIssuer.name},
+					Spec:     model.MakeJSONField(spec),
+				}).Error).To(Succeed())
+			}
+
+			err := migration.Run(freshCtx, freshGormDb, freshLog.WithField("pkg", "store"), false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("would share issuer"))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- **Root cause (EDM-3530)**: CLI OIDC login used `fmt.Sprintf` to build the discovery URL, producing double-slash paths (`https://idp.example.com//.well-known/...`) when the configured issuer had a trailing slash. Server-side code already used the correct `authprovider.DiscoveryURL` helper.
- **Additional normalization gaps** found during audit and fixed end-to-end:
  - `getTokenProxyURL` (all CLI providers) was using `fmt.Sprintf` for URL construction — replaced with `url.JoinPath` + error return
  - `introspectJWT` compared JWT issuer claims without normalizing either side — could reject valid tokens
  - `initOIDCAuth`/`initAAPAuth` computed a trimmed URL for logging but passed the raw spec (with trailing slash) to the auth constructor — dead code fixed
  - Dynamic AP resource write paths (`Create`, `Replace`, `Patch`) stored URL fields raw — trailing slashes in issuer would produce duplicate DB entries for the same IdP and confuse the DB unique index
  - `hasProviderChanged` compared raw issuer strings — a cosmetically different trailing slash caused unnecessary provider teardown/restart

## Changes

| Area | Change |
|---|---|
| `internal/cli/login/oidc.go` | Use `authprovider.DiscoveryURL` instead of `fmt.Sprintf` |
| `internal/cli/login/common.go` | `getTokenProxyURL` uses `url.JoinPath`, returns error |
| `internal/cli/login/{aap,oauth2,openshift}.go` | Handle new error from `getTokenProxyURL` |
| `internal/auth/authn/oauth2_auth.go` | Normalize both sides of JWT issuer comparison |
| `internal/auth/auth.go` | Apply `NormalizeIssuerURL`/`TrimSuffix` to spec copy before passing to constructors |
| `internal/service/authprovider.go` | Add `normalizeAuthProviderURLs`; call from all write paths |
| `api/core/v1beta1/validation.go` | Add `validateHTTPSURL`; validate URL fields in OIDC/OAuth2 `Validate()` |
| `internal/auth/authn/multiauth.go` | Normalize both sides of issuer comparison in `hasProviderChanged` |

## Test plan

- [x] `make unit-test` passes (2 pre-existing unrelated failures in console/Redis)
- [x] `internal/auth/provider` coverage: 26% → 96% (new `introspection_test.go`)
- [x] New tests: CLI login URL construction for all providers, server-side OIDC/OAuth2 auth, token proxy discovery, introspection config inference, AP validation
- [x] Existing tests: no regressions in `internal/auth/...`, `internal/service/...`, `api/core/v1beta1/...`

Made with [Cursor](https://cursor.com)