### PR TITLE
EDM-4056: Add --skip-auto-enrollment flag to device simulator

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -78,6 +78,7 @@ func main() {
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
+	skipAutoEnrollment := pflag.Bool("skip-auto-enrollment", false, "skip automatic enrollment approval of simulated devices")
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
 	pflag.Usage = printUsage
@@ -199,13 +200,14 @@ func main() {
 	}
 
 	launchParams := agentLaunchParams{
-		agents:          agents,
-		agentFolders:    agentsFolders,
-		log:             log,
-		serviceClient:   serviceClient.ClientWithResponses,
-		formattedLabels: formattedLables,
-		sem:             sem,
-		jitterDuration:  jitterDuration,
+		agents:             agents,
+		agentFolders:       agentsFolders,
+		log:                log,
+		serviceClient:      serviceClient.ClientWithResponses,
+		formattedLabels:    formattedLables,
+		sem:                sem,
+		jitterDuration:     jitterDuration,
+		skipAutoEnrollment: *skipAutoEnrollment,
 	}
 	for i := range *numDevices {
 		if err := sem.Acquire(ctx, 1); err != nil {
@@ -237,7 +239,9 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 	// leave the agent process running in the background
 	// when the agent is approved, we return and release the semaphore to allow other agents to onboard
 	go startAgent(ctx, params.agents[i], params.log, i)
-	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+	if !params.skipAutoEnrollment {
+		approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+	}
 }
 
 func reportVersion(versionFormat *string) error {
@@ -339,13 +343,14 @@ type createAgentsConfig struct {
 }
 
 type agentLaunchParams struct {
-	agents          []*agent.Agent
-	agentFolders    []string
-	log             *logrus.Logger
-	serviceClient   *apiClient.ClientWithResponses
-	formattedLabels *map[string]string
-	sem             *semaphore.Weighted
-	jitterDuration  time.Duration
+	agents             []*agent.Agent
+	agentFolders       []string
+	log                *logrus.Logger
+	serviceClient      *apiClient.ClientWithResponses
+	formattedLabels    *map[string]string
+	sem                *semaphore.Weighted
+	jitterDuration     time.Duration
+	skipAutoEnrollment bool
 }
 
 func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {

--- a/test/e2e/devicesimulator/devicesimulator_suite_test.go
+++ b/test/e2e/devicesimulator/devicesimulator_suite_test.go
@@ -1,0 +1,49 @@
+package devicesimulator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeviceSimulator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Device Simulator E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
+
+	auxiliary.Get(context.Background())
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+})
+
+var _ = BeforeEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	_, err := harness.SetupDeviceSimulatorAgentConfig(0, 0)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	harness.CaptureDeploymentLogsIfFailed()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+
+	harness.SetTestContext(suiteCtx)
+})

--- a/test/e2e/devicesimulator/devicesimulator_test.go
+++ b/test/e2e/devicesimulator/devicesimulator_test.go
@@ -1,0 +1,109 @@
+package devicesimulator_test
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	deviceCount          = 3
+	enrollTimeout        = 120 * time.Second
+	enrollPolling        = 2 * time.Second
+	simulatorStopTimeout = 10 * time.Second
+)
+
+var _ = Describe("Device Simulator E2E Tests", Label("devicesimulator", "e2e"), func() {
+	var (
+		harness *e2e.Harness
+	)
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+	})
+
+	Context("When using --skip-auto-enrollment", func() {
+		var simulatorCmd *exec.Cmd
+
+		AfterEach(func() {
+			if simulatorCmd != nil {
+				_ = harness.StopDeviceSimulator(simulatorCmd, simulatorStopTimeout)
+				simulatorCmd = nil
+			}
+		})
+
+		It("should create enrollment requests that remain unapproved until manually approved", func() {
+			By("Starting the device simulator with --skip-auto-enrollment")
+			var err error
+			simulatorCmd, err = harness.RunDeviceSimulator(harness.Context,
+				"--count", fmt.Sprintf("%d", deviceCount),
+				"--skip-auto-enrollment",
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("Waiting for %d enrollment requests to appear", deviceCount))
+			var enrollmentRequests []v1beta1.EnrollmentRequest
+			Eventually(func() int {
+				resp, listErr := harness.Client.ListEnrollmentRequestsWithResponse(harness.Context, &v1beta1.ListEnrollmentRequestsParams{})
+				if listErr != nil || resp.JSON200 == nil {
+					return 0
+				}
+				enrollmentRequests = resp.JSON200.Items
+				return len(enrollmentRequests)
+			}, enrollTimeout, enrollPolling).Should(BeNumerically(">=", deviceCount),
+				fmt.Sprintf("expected at least %d enrollment requests", deviceCount))
+
+			By("Verifying all enrollment requests are NOT approved")
+			for _, er := range enrollmentRequests {
+				isApproved := er.Status != nil && er.Status.Approval != nil && er.Status.Approval.Approved
+				Expect(isApproved).To(BeFalse(),
+					fmt.Sprintf("enrollment request %s should not be approved", safeNameStr(er.Metadata.Name)))
+			}
+
+			By("Verifying no devices exist from the simulator")
+			for _, er := range enrollmentRequests {
+				name := safeNameStr(er.Metadata.Name)
+				resp, getErr := harness.Client.GetDeviceWithResponse(harness.Context, name)
+				Expect(getErr).ToNot(HaveOccurred())
+				Expect(resp.JSON200).To(BeNil(),
+					fmt.Sprintf("device %s should not exist before approval", name))
+			}
+
+			firstER := enrollmentRequests[0]
+			firstName := safeNameStr(firstER.Metadata.Name)
+
+			By(fmt.Sprintf("Manually approving enrollment request %s", firstName))
+			harness.ApproveEnrollment(firstName, harness.TestEnrollmentApproval())
+
+			By("Verifying the approved device appears")
+			Eventually(func() bool {
+				resp, getErr := harness.Client.GetDeviceWithResponse(harness.Context, firstName)
+				return getErr == nil && resp != nil && resp.JSON200 != nil
+			}, enrollTimeout, enrollPolling).Should(BeTrue(),
+				fmt.Sprintf("device %s should exist after approval", firstName))
+
+			By("Verifying the remaining enrollment requests are still unapproved")
+			for _, er := range enrollmentRequests[1:] {
+				name := safeNameStr(er.Metadata.Name)
+				resp, getErr := harness.Client.GetEnrollmentRequestWithResponse(harness.Context, name)
+				Expect(getErr).ToNot(HaveOccurred())
+				Expect(resp.JSON200).ToNot(BeNil())
+				isApproved := resp.JSON200.Status != nil && resp.JSON200.Status.Approval != nil && resp.JSON200.Status.Approval.Approved
+				Expect(isApproved).To(BeFalse(),
+					fmt.Sprintf("enrollment request %s should still not be approved", name))
+			}
+		})
+	})
+})
+
+func safeNameStr(name *string) string {
+	if name == nil {
+		return "<nil>"
+	}
+	return *name
+}

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/test/util"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -381,4 +382,42 @@ func (h *Harness) EnrollDeviceForDecommissionTest(loginFn LoginFunc, deviceCount
 		deviceName = parts[0]
 	}
 	return deviceName, cmd, nil
+}
+
+// CountEnrollmentRequestsByLabel returns the number of enrollment requests matching the given test-id label.
+func (h *Harness) CountEnrollmentRequestsByLabel(testID string) int {
+	if testID == "" {
+		return 0
+	}
+	labelSelector := fmt.Sprintf("test-id=%s", testID)
+	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, &v1beta1.ListEnrollmentRequestsParams{
+		LabelSelector: &labelSelector,
+	})
+	if err != nil || resp.JSON200 == nil {
+		return 0
+	}
+	return len(resp.JSON200.Items)
+}
+
+// GetUnapprovedEnrollmentRequests returns the names of enrollment requests that have not been approved.
+func (h *Harness) GetUnapprovedEnrollmentRequests(testID string) []string {
+	if testID == "" {
+		return nil
+	}
+	labelSelector := fmt.Sprintf("test-id=%s", testID)
+	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, &v1beta1.ListEnrollmentRequestsParams{
+		LabelSelector: &labelSelector,
+	})
+	if err != nil || resp.JSON200 == nil {
+		return nil
+	}
+	var unapproved []string
+	for _, er := range resp.JSON200.Items {
+		if er.Status == nil || er.Status.Approval == nil || !er.Status.Approval.Approved {
+			if er.Metadata.Name != nil {
+				unapproved = append(unapproved, *er.Metadata.Name)
+			}
+		}
+	}
+	return unapproved
 }


### PR DESCRIPTION
cmd/devicesimulator/main.go — added --skip-auto-enrollment flag, threaded into agentLaunchParams, guarded approveAgent() call