### PR TITLE
NO-ISSUE: fix TestListenForEvents race with pipe lifecycle and mock expectations

### DIFF
--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -265,6 +265,11 @@ func TestListenForEvents(t *testing.T) {
 					}
 				}
 			}()
+			defer func() {
+				writer.Close()
+				<-writeDone
+				reader.Close()
+			}()
 
 			timeoutDuration := 5 * time.Second
 			retryDuration := 100 * time.Millisecond
@@ -307,11 +312,6 @@ func TestListenForEvents(t *testing.T) {
 					return true
 				}, timeoutDuration, retryDuration, "data was not processed in time")
 			}
-
-			// ensure the writer goroutine exits before test cleanup
-			writer.Close()
-			<-writeDone
-			reader.Close()
 		})
 	}
 }

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -212,20 +212,16 @@ func TestListenForEvents(t *testing.T) {
 
 			// create a pipe to simulate events being written to the monitor
 			reader, writer := io.Pipe()
-			defer reader.Close()
-			defer writer.Close()
 
-			// testify v1.11 changed Eventually to check the condition immediately
-			// rather than waiting for the first tick. This causes false positives
-			// when initial state matches expected final state (e.g. "app start
-			// then removed" where 0 workloads = Unknown before and after events).
-			// Track inspect calls to ensure all events are processed first.
+			// Track inspect calls to ensure all events are processed before
+			// asserting state (avoids false positives when initial state matches
+			// expected final state, e.g. "app start then removed").
 			var inspectCount atomic.Int32
 			execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "inspect", gomock.Any()).
 				DoAndReturn(func(_ context.Context, _ string, _ ...string) (string, string, int) {
 					inspectCount.Add(1)
 					return string(inspectBytes), "", 0
-				}).Times(len(tc.events))
+				}).AnyTimes()
 			podmanEventsCommandMock(execMock).Return(streamDataToStdout(t, reader))
 
 			podman := client.NewPodman(log, execMock, rw, util.NewPollConfig())
@@ -259,11 +255,13 @@ func TestListenForEvents(t *testing.T) {
 			err = podmanMonitor.ExecuteActions(t.Context())
 			require.NoError(err)
 
+			writeDone := make(chan struct{})
 			go func() {
+				defer close(writeDone)
 				for i := range tc.events {
 					event := tc.events[i]
 					if err := writeEvent(writer, &event); err != nil {
-						t.Errorf("failed to write event: %v", err)
+						return
 					}
 				}
 			}()
@@ -309,6 +307,11 @@ func TestListenForEvents(t *testing.T) {
 					return true
 				}, timeoutDuration, retryDuration, "data was not processed in time")
 			}
+
+			// ensure the writer goroutine exits before test cleanup
+			writer.Close()
+			<-writeDone
+			reader.Close()
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Fix latent race conditions in `TestListenForEvents` that will trigger once `stretchr/testify` is upgraded to v1.11+ (already manifesting on release-1.0 and release-1.1 via the CVE-2026-33186 grpc dependency bump)
- Use `AnyTimes()` for the inspect mock instead of strict `Times(len(tc.events))` — the `inspectCount` atomic gate and Eventually assertions already validate behavior
- Ensure writer goroutine exits before test cleanup to prevent `t.Errorf` panics from a completed test's goroutine

## Test plan

- [x] `TestListenForEvents` passes 5/5 runs locally
- [x] Full unit test suite passes (4729 tests, 0 failures)

Assisted-by: Claude <noreply@anthropic.com>