### PR TITLE
EDM-3400: Create RHEM HAProxy e2e automation

### DIFF
--- a/test/e2e/agent/agent_haproxy_test.go
+++ b/test/e2e/agent/agent_haproxy_test.go
@@ -1,0 +1,377 @@
+package agent_test
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	agentcfg "github.com/flightctl/flightctl/internal/agent/config"
+	clientcfg "github.com/flightctl/flightctl/internal/client"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	rhemHAProxyLocalPort        = 8443
+	rhemHAProxyIdleTimeout      = 5 * time.Second
+	rhemHAProxyWaitAfterIdle    = 15 * time.Second
+	rhemHAProxyAvailableMessage = "haproxy_available"
+	rhemHAProxyReadyMessage     = "haproxy_ready"
+	rhemHAProxyServiceName      = "flightctl-agent-haproxy.service"
+	rhemHAProxyConfigPath       = "/etc/flightctl/haproxy-agent-api.cfg"
+	rhemHAProxySystemdUnitPath  = "/etc/systemd/system/" + rhemHAProxyServiceName
+	rhemHAProxyMarkerConfigName = "rhem-haproxy-long-poll"
+	rhemHAProxyMarkerPath       = "/etc/flightctl-rhem-haproxy-marker"
+	rhemHAProxyMarkerContent    = "rendered through haproxy after idle timeout"
+)
+
+// This regression covers Edge Manager deployments where agent long-poll requests
+// traverse a load balancer with an idle timeout shorter than the server poll.
+var _ = Describe("VM Agent behavior behind HAProxy", func() {
+	It("keeps syncing rendered specs in RHEM behind HAProxy idle timeouts", Label("89640", "sanity", "agent"), func() {
+		harness := e2e.GetWorkerHarness()
+
+		By("Verifying this is an OCP environment")
+		err := verifyRHEMOCPEnvironment()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Ensuring HAProxy is available on the agent VM")
+		availabilityOutput, err := ensureRHEMHAProxyAvailableOnVM(harness)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(availabilityOutput).ToNot(BeEmpty(), "HAProxy availability output should not be empty")
+		Expect(availabilityOutput).To(ContainSubstring(rhemHAProxyAvailableMessage), "haproxy must be available on the agent VM")
+
+		By("Enrolling the VM agent before placing HAProxy in the management path")
+		deviceID, _ := harness.EnrollAndWaitForOnlineStatus()
+		Expect(deviceID).ToNot(BeEmpty(), "enrolled device id should not be empty")
+		Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(deviceID).
+			Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+
+		By("Starting HAProxy on the VM with an idle timeout shorter than the rendered-spec long-poll")
+		originalConfig, err := harness.GetAgentConfig()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(originalConfig).ToNot(BeNil())
+		registerRHEMHAProxyCleanup(harness, originalConfig)
+
+		proxyURL, err := configureAgentManagementThroughHAProxy(harness, originalConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(proxyURL).To(ContainSubstring(strconv.Itoa(rhemHAProxyLocalPort)))
+
+		By("Waiting for the agent to reconnect through HAProxy")
+		Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(deviceID).
+			Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+
+		By("Waiting beyond the HAProxy idle timeout while the agent continues polling")
+		Consistently(harness.GetDeviceWithStatusSummary, rhemHAProxyWaitAfterIdle, POLLING).WithArguments(deviceID).
+			Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+
+		By("Applying a device spec update that must be delivered through HAProxy")
+		nextRenderedVersion, err := harness.PrepareNextDeviceVersion(deviceID)
+		Expect(err).ToNot(HaveOccurred())
+		configSpec, err := buildRHEMHAProxyMarkerConfig()
+		Expect(err).ToNot(HaveOccurred())
+		err = harness.UpdateDeviceConfigWithRetries(deviceID, []v1beta1.ConfigProviderSpec{configSpec}, nextRenderedVersion)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the VM applied the rendered config from the proxied sync")
+		out, err := harness.VM.RunSSH([]string{"sudo", "cat", rhemHAProxyMarkerPath}, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(BeNil(), "marker file command output should not be nil")
+		Expect(out.String()).ToNot(BeEmpty(), "marker file content should not be empty")
+		Expect(out.String()).To(ContainSubstring(rhemHAProxyMarkerContent))
+		Eventually(harness.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(deviceID).
+			Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+	})
+})
+
+// verifyRHEMOCPEnvironment confirms the e2e run targets OCP.
+func verifyRHEMOCPEnvironment() error {
+	providers := setup.GetDefaultProviders()
+	if providers == nil {
+		return fmt.Errorf("default providers are not initialized")
+	}
+	if providers.Infra == nil {
+		return fmt.Errorf("infra provider is nil")
+	}
+	envType := providers.Infra.GetEnvironmentType()
+	GinkgoWriter.Printf("RHEM HAProxy environment type: %s\n", envType)
+	if envType != infra.EnvironmentOCP {
+		Skip(fmt.Sprintf("RHEM HAProxy regression is OCP-only, got %q", envType))
+	}
+	return nil
+}
+
+// configureAgentManagementThroughHAProxy starts a TCP HAProxy on the VM and points management traffic at it.
+func configureAgentManagementThroughHAProxy(harness *e2e.Harness, originalConfig *agentcfg.Config) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if harness.VM == nil {
+		return "", fmt.Errorf("harness VM is nil")
+	}
+	if originalConfig == nil {
+		return "", fmt.Errorf("original agent config is nil")
+	}
+	managementURL := getRHEMHAProxyManagementURL(originalConfig)
+	if managementURL == "" {
+		return "", fmt.Errorf("management and enrollment service server URLs are empty")
+	}
+	parsed, err := url.Parse(managementURL)
+	if err != nil {
+		return "", fmt.Errorf("parse management service URL %q: %w", managementURL, err)
+	}
+	backendHost := parsed.Hostname()
+	if backendHost == "" {
+		return "", fmt.Errorf("management service URL %q has empty hostname", managementURL)
+	}
+	backendPort := parsed.Port()
+	if backendPort == "" {
+		backendPort = "443"
+	}
+
+	output, err := startRHEMHAProxyOnVM(harness, backendHost, backendPort)
+	if err != nil {
+		return "", err
+	}
+	if !strings.Contains(output, rhemHAProxyReadyMessage) {
+		return "", fmt.Errorf("HAProxy readiness output missing %q: %s", rhemHAProxyReadyMessage, output)
+	}
+
+	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", parsed.Scheme, rhemHAProxyLocalPort)
+	originalTLSServerName := getRHEMHAProxyTLSServerName(originalConfig)
+	originalTrustService := getRHEMHAProxyTrustService(originalConfig)
+	if err := harness.UpdateAgentConfigWith(func(cfg *agentcfg.Config) {
+		cfg.ManagementService.Service.Server = proxyURL
+		copyRHEMHAProxyServiceTrust(&cfg.ManagementService.Service, originalTrustService)
+		if strings.TrimSpace(cfg.ManagementService.Service.TLSServerName) == "" {
+			cfg.ManagementService.Service.TLSServerName = originalTLSServerName
+			if cfg.ManagementService.Service.TLSServerName == "" {
+				cfg.ManagementService.Service.TLSServerName = backendHost
+			}
+		}
+	}); err != nil {
+		return "", fmt.Errorf("point agent management service at HAProxy: %w", err)
+	}
+	return proxyURL, nil
+}
+
+// getRHEMHAProxyManagementURL returns the effective management endpoint from the agent config.
+func getRHEMHAProxyManagementURL(cfg *agentcfg.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if server := strings.TrimSpace(cfg.ManagementService.Service.Server); server != "" {
+		return server
+	}
+	return strings.TrimSpace(cfg.EnrollmentService.Service.Server)
+}
+
+// getRHEMHAProxyTLSServerName returns the effective TLS server name from the agent config.
+func getRHEMHAProxyTLSServerName(cfg *agentcfg.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if serverName := strings.TrimSpace(cfg.ManagementService.Service.TLSServerName); serverName != "" {
+		return serverName
+	}
+	return strings.TrimSpace(cfg.EnrollmentService.Service.TLSServerName)
+}
+
+// getRHEMHAProxyTrustService returns the service config with the effective TLS trust settings.
+func getRHEMHAProxyTrustService(cfg *agentcfg.Config) *clientcfg.Service {
+	if cfg == nil {
+		return nil
+	}
+	if hasRHEMHAProxyServiceTrust(&cfg.ManagementService.Service) {
+		return &cfg.ManagementService.Service
+	}
+	return &cfg.EnrollmentService.Service
+}
+
+// hasRHEMHAProxyServiceTrust returns true when the service carries explicit TLS trust settings.
+func hasRHEMHAProxyServiceTrust(service *clientcfg.Service) bool {
+	if service == nil {
+		return false
+	}
+	return strings.TrimSpace(service.CertificateAuthority) != "" ||
+		len(service.CertificateAuthorityData) > 0 ||
+		service.InsecureSkipVerify
+}
+
+// copyRHEMHAProxyServiceTrust copies TLS trust settings without sharing CA data backing storage.
+func copyRHEMHAProxyServiceTrust(dst, src *clientcfg.Service) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.CertificateAuthority = src.CertificateAuthority
+	dst.CertificateAuthorityData = append([]byte(nil), src.CertificateAuthorityData...)
+	dst.InsecureSkipVerify = src.InsecureSkipVerify
+}
+
+// ensureRHEMHAProxyAvailableOnVM installs HAProxy on the VM when missing and verifies it is usable.
+func ensureRHEMHAProxyAvailableOnVM(harness *e2e.Harness) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if harness.VM == nil {
+		return "", fmt.Errorf("harness VM is nil")
+	}
+
+	output, err := runRHEMHAProxyScriptOnVM(harness, "ensure HAProxy availability on VM", fmt.Sprintf(`set -e
+if ! command -v haproxy >/dev/null 2>&1; then
+  if command -v dnf >/dev/null 2>&1; then
+    dnf install -y --transient haproxy || dnf install -y haproxy
+  elif command -v microdnf >/dev/null 2>&1; then
+    microdnf install -y haproxy
+  else
+    echo "no supported package manager found for installing haproxy" >&2
+    exit 127
+  fi
+fi
+command -v haproxy >/dev/null 2>&1
+haproxy -v
+echo %[1]s
+`, rhemHAProxyAvailableMessage))
+	if err != nil {
+		return output, err
+	}
+	GinkgoWriter.Printf("RHEM HAProxy availability output: %s\n", strings.TrimSpace(output))
+	return output, nil
+}
+
+// startRHEMHAProxyOnVM starts a TCP HAProxy service on the VM.
+func startRHEMHAProxyOnVM(harness *e2e.Harness, backendHost, backendPort string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if strings.TrimSpace(backendHost) == "" || strings.TrimSpace(backendPort) == "" {
+		return "", fmt.Errorf("backend host and port must be non-empty")
+	}
+
+	script := fmt.Sprintf(`set -euo pipefail
+install -d /etc/flightctl
+cat >%[1]s <<'EOF'
+global
+  log stdout format raw local0
+
+defaults
+  mode tcp
+  timeout connect %[2]s
+  timeout client %[2]s
+  timeout server %[2]s
+
+frontend agent_api
+  bind 127.0.0.1:%[3]d
+  default_backend flightctl_agent_api
+
+backend flightctl_agent_api
+  server api %[4]s:%[5]s check
+EOF
+cat >%[6]s <<'EOF'
+[Unit]
+Description=Flight Control e2e HAProxy for agent API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/haproxy -Ws -f %[1]s
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl restart %[7]s
+systemctl is-active --quiet %[7]s
+echo %[8]s
+`,
+		strconv.Quote(rhemHAProxyConfigPath),
+		rhemHAProxyIdleTimeout.String(),
+		rhemHAProxyLocalPort,
+		backendHost,
+		backendPort,
+		strconv.Quote(rhemHAProxySystemdUnitPath),
+		rhemHAProxyServiceName,
+		rhemHAProxyReadyMessage,
+	)
+
+	return runRHEMHAProxyScriptOnVM(harness, "start HAProxy on VM", script)
+}
+
+// runRHEMHAProxyScriptOnVM executes a VM script and returns non-nil output with contextual errors.
+func runRHEMHAProxyScriptOnVM(harness *e2e.Harness, description, script string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("%s: harness is nil", description)
+	}
+	if harness.VM == nil {
+		return "", fmt.Errorf("%s: harness VM is nil", description)
+	}
+	if strings.TrimSpace(description) == "" {
+		return "", fmt.Errorf("script description is empty")
+	}
+	if strings.TrimSpace(script) == "" {
+		return "", fmt.Errorf("%s: script is empty", description)
+	}
+	out, err := harness.RunScriptOnVM(script)
+	output := ""
+	if out != nil {
+		output = out.String()
+	}
+	if err != nil {
+		return output, fmt.Errorf("%s: %w: %s", description, err, output)
+	}
+	return output, nil
+}
+
+// buildRHEMHAProxyMarkerConfig returns the marker config applied through the proxied long-poll path.
+func buildRHEMHAProxyMarkerConfig() (v1beta1.ConfigProviderSpec, error) {
+	configSpec, err := util.BuildInlineConfigSpec(rhemHAProxyMarkerConfigName, rhemHAProxyMarkerPath, rhemHAProxyMarkerContent, "")
+	if err != nil {
+		return v1beta1.ConfigProviderSpec{}, fmt.Errorf("build RHEM HAProxy marker config: %w", err)
+	}
+	return configSpec, nil
+}
+
+// registerRHEMHAProxyCleanup restores the original agent config and stops the test HAProxy service.
+func registerRHEMHAProxyCleanup(harness *e2e.Harness, originalConfig *agentcfg.Config) {
+	DeferCleanup(func() error {
+		if harness == nil {
+			return fmt.Errorf("RHEM HAProxy cleanup: harness is nil")
+		}
+		var cleanupErr error
+		if originalConfig != nil {
+			if err := harness.SetAgentConfig(originalConfig); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore agent config: %w", err))
+			} else if err := harness.RestartFlightCtlAgent(); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restart agent after restoring config: %w", err))
+			}
+		}
+		if _, err := harness.RunScriptOnVM(fmt.Sprintf(`set -euo pipefail
+	if systemctl cat %[1]s >/dev/null 2>&1; then
+	  systemctl stop %[1]s
+	  if systemctl is-enabled --quiet %[1]s; then
+	    systemctl disable %[1]s
+	  else
+	    echo "%[1]s is not enabled; skipping disable"
+	  fi
+	else
+	  echo "%[1]s is not installed; skipping stop/disable"
+	fi
+	rm -f %[2]s %[3]s %[4]s
+	systemctl daemon-reload
+	`, strconv.Quote(rhemHAProxyServiceName), strconv.Quote(rhemHAProxyConfigPath), strconv.Quote(rhemHAProxySystemdUnitPath), strconv.Quote(rhemHAProxyMarkerPath))); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove HAProxy artifacts: %w", err))
+		}
+		return cleanupErr
+	})
+}

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -93,7 +93,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			By(fmt.Sprintf("Starting 3 device simulators (%d devices each) as admin", devicesPerUser))
 			for i := 0; i < 3; i++ {
 				initialIndex := i * devicesPerUser
-				cmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, users.admin.name, initialIndex, devicesPerUser, false)
+				// Use default auto-approval for bulk enrollment.
+				cmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, users.admin.name, initialIndex, devicesPerUser)
 				Expect(simErr).ToNot(HaveOccurred(), fmt.Sprintf("Failed to start simulator batch %d", i))
 				simulatorCmds = append(simulatorCmds, cmd)
 				GinkgoWriter.Printf("Simulator batch %d started (devices %d-%d)\n",
@@ -196,7 +197,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 
 			setupSharedOrgSimulatorConfig(harness)
 
-			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "operator-er-rbac", 0, 1, true)
+			// Keep the enrollment request pending for RBAC approval checks.
+			erSimCmd, simErr := harness.StartLabeledSimulatorWithOptions(harness.Context, testID, "operator-er-rbac", 0, 1, e2e.StartLabeledSimulatorOptions{SkipAutoApprove: true})
 			Expect(simErr).ToNot(HaveOccurred())
 			simulatorCmds = append(simulatorCmds, erSimCmd)
 
@@ -297,7 +299,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 
 			setupSharedOrgSimulatorConfig(harness)
 
-			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "viewer-er-rbac", 0, 1, true)
+			// Keep the enrollment request pending for RBAC approval checks.
+			erSimCmd, simErr := harness.StartLabeledSimulatorWithOptions(harness.Context, testID, "viewer-er-rbac", 0, 1, e2e.StartLabeledSimulatorOptions{SkipAutoApprove: true})
 			Expect(simErr).ToNot(HaveOccurred())
 			simulatorCmds = append(simulatorCmds, erSimCmd)
 
@@ -392,7 +395,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 
 			setupSharedOrgSimulatorConfig(harness)
 
-			simCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "console-rbac", 0, 1, false)
+			// Use default auto-approval for console RBAC device checks.
+			simCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "console-rbac", 0, 1)
 			Expect(simErr).ToNot(HaveOccurred())
 			simulatorCmds = append(simulatorCmds, simCmd)
 
@@ -509,7 +513,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 
 			setupSharedOrgSimulatorConfig(harness)
 
-			erSimCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "installer-er-rbac", 0, 1, true)
+			// Keep the enrollment request pending for RBAC approval checks.
+			erSimCmd, simErr := harness.StartLabeledSimulatorWithOptions(harness.Context, testID, "installer-er-rbac", 0, 1, e2e.StartLabeledSimulatorOptions{SkipAutoApprove: true})
 			Expect(simErr).ToNot(HaveOccurred())
 			simulatorCmds = append(simulatorCmds, erSimCmd)
 

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -300,10 +300,21 @@ func (h *Harness) ValidateFleetYAMLDevicesPerFleet(yamlContent string, expectedD
 // LoginFunc is a function that logs in a user on the given harness.
 type LoginFunc func(h *Harness) error
 
+// StartLabeledSimulatorOptions configures StartLabeledSimulatorWithOptions.
+type StartLabeledSimulatorOptions struct {
+	SkipAutoApprove bool
+}
+
 // StartLabeledSimulator starts a device simulator with the given test-id label, user prefix,
-// initial device index, and device count. When skipAutoApprove is true, agents submit enrollment
-// requests and wait for manual approval instead of auto-approving via the simulator client.
-func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix string, initialIndex, deviceCount int, skipAutoApprove bool) (*exec.Cmd, error) {
+// initial device index, and device count.
+func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix string, initialIndex, deviceCount int) (*exec.Cmd, error) {
+	return h.StartLabeledSimulatorWithOptions(ctx, testID, userPrefix, initialIndex, deviceCount, StartLabeledSimulatorOptions{})
+}
+
+// StartLabeledSimulatorWithOptions starts a labeled device simulator with optional behavior.
+// When SkipAutoApprove is true, agents submit enrollment requests and wait for manual approval
+// instead of auto-approving via the simulator client.
+func (h *Harness) StartLabeledSimulatorWithOptions(ctx context.Context, testID, userPrefix string, initialIndex, deviceCount int, opts StartLabeledSimulatorOptions) (*exec.Cmd, error) {
 	if testID == "" {
 		return nil, fmt.Errorf("testID is empty")
 	}
@@ -316,7 +327,7 @@ func (h *Harness) StartLabeledSimulator(ctx context.Context, testID, userPrefix 
 		"--label", fmt.Sprintf("test-id=%s", testID),
 		"--label", fmt.Sprintf("user=%s", userPrefix),
 	}
-	if skipAutoApprove {
+	if opts.SkipAutoApprove {
 		args = append(args, "--skip-auto-approve")
 	}
 	return h.RunDeviceSimulator(ctx, args...)
@@ -466,7 +477,7 @@ func (h *Harness) EnrollDeviceForDecommissionTest(loginFn LoginFunc, deviceCount
 
 	testID := h.GetTestIDFromContext()
 
-	cmd, err := h.StartLabeledSimulator(h.Context, testID, "decommission-test", 0, deviceCount, false)
+	cmd, err := h.StartLabeledSimulator(h.Context, testID, "decommission-test", 0, deviceCount)
 	if err != nil {
 		return "", nil, fmt.Errorf("starting simulator: %w", err)
 	}


### PR DESCRIPTION
Adds an e2e regression test for RHEM on OCP where the agent syncs through a local HAProxy with a shorter idle timeout than the server long-poll.

The test verifies the agent stays online and still applies a rendered config update through the proxied management path, covering the load balancer idle-connection failure scenario.

## Release target

Target release: release-1.3

Label guidance: this PR is targeted for the release-1.3 stream and should keep the `release-1.3` label.