### PR TITLE
EDM-4009: fix confusing error message in edit command

### DIFF
--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -75,7 +75,12 @@ that contains your unapplied changes. The most common error when updating a reso
 is another editor changing the resource on the server. When this occurs, you will have
 to apply your changes to the newer version of the resource, or update your temporary
 saved copy to include the latest resource version.`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 || len(args) > 2 {
+				return fmt.Errorf("you must specify a resource to edit (TYPE NAME or TYPE/NAME)")
+			}
+			return nil
+		},
 		ValidArgsFunction: KindNameAutocomplete{
 			Options:            o,
 			AllowMultipleNames: false,


### PR DESCRIPTION
# PR Description — EDM-4009

## Title

**EDM-4009: fix confusing error message in edit command**

## Description

Improves the error message when users run `flightctl edit` without specifying a resource argument.

### Problem

When users ran `flightctl edit --org <org-id>` without specifying a resource, they received a confusing generic error:
```
Error: accepts between 1 and 2 arg(s), received 0
```

This error didn't explain what was missing or how to fix it.

### Root Cause

Cobra's `RangeArgs(1, 2)` validator executes before the command's custom validation logic, intercepting execution with a generic error message. The custom `Validate()` function (which has a better error message) never runs.

### Solution

Replaced `Args: cobra.RangeArgs(1, 2)` with a custom validator function that provides a clear, actionable error message:
```go
Args: func(cmd *cobra.Command, args []string) error {
    if len(args) < 1 || len(args) > 2 {
        return fmt.Errorf("you must specify a resource to edit (TYPE NAME or TYPE/NAME)")
    }
    return nil
},
```

### Before/After

**Before:**
```bash
$ flightctl edit --org 00000000-0000-0000-0000-000000000000
Error: accepts between 1 and 2 arg(s), received 0
```

**After:**
```bash
$ flightctl edit --org 00000000-0000-0000-0000-000000000000
Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)
```

### Testing

**Automated:**
- ✅ All existing unit tests pass
- ✅ Lint passes with no errors
- ✅ Autocomplete functionality preserved

**Manual test cases:**
1. `flightctl edit --org <org-id>` → Clear error message ✅
2. `flightctl edit` → Clear error message ✅
3. `flightctl edit device` → Existing validation still works ✅
4. `flightctl edit device/test --org <org-id>` → Normal operation ✅

### Review Notes

**For reviewers:**
- This is a minimal UX improvement (5 lines changed)
- No behavior changes, only error message improvement
- No breaking changes
- Backward compatible

**Manual testing:**
Run `flightctl edit --org <any-id>` and verify the error message is clear.

### Files Changed

- `internal/cli/edit.go` — Replaced Cobra validator with custom function (lines 78-83)
