### PR TITLE
NO-ISSUE: fix flaky E2E helm tests timing out in merge queue

### DIFF
--- a/test/e2e/applications/helm/helm_application_test.go
+++ b/test/e2e/applications/helm/helm_application_test.go
@@ -263,7 +263,7 @@ var _ = Describe("VM Agent Helm Application Tests", Ordered, func() {
 			err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
 				device.Spec.Os = microshiftOs
 				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{helmAppSpec}
-			})
+			}, e2e.EXTENDEDTIMEOUT)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify application initially reaches healthy status while failing pod sleeps")
@@ -447,7 +447,7 @@ var _ = Describe("VM Agent Helm Application Tests", Ordered, func() {
 				device.Spec.Os = microshiftOs
 				device.Spec.Config = &[]v1beta1.ConfigProviderSpec{helmAuth}
 				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{helmAppSpec}
-			})
+			}, e2e.EXTENDEDTIMEOUT)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = harness.WaitForApplicationStatus(deviceId, helmAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -90,10 +90,11 @@ const fiveSecondTimeout = 5 * time.Second
 const setupSnapshotRestoreTimeout = 10 * time.Minute
 
 const (
-	POLLING     = "250ms"
-	POLLINGLONG = "1s"
-	TIMEOUT     = "5m"
-	LONGTIMEOUT = "10m"
+	POLLING         = "250ms"
+	POLLINGLONG     = "1s"
+	TIMEOUT         = "5m"
+	LONGTIMEOUT     = "10m"
+	EXTENDEDTIMEOUT = "20m"
 )
 
 // Service name constants for flightctl deployment components.

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -506,13 +506,18 @@ func (h *Harness) PrepareNextDeviceVersionFromCurrentStatus(deviceID string) (in
 	return cur + 1, nil
 }
 
-func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVersionInt int) (err error) {
+func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVersionInt int, timeout ...string) (err error) {
+	t := LONGTIMEOUT
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+
 	// Check that the device was already approved
 	Eventually(func() v1beta1.DeviceSummaryStatusType {
 		res, err := h.GetDeviceWithStatusSummary(deviceId)
 		Expect(err).ToNot(HaveOccurred())
 		return res
-	}, LONGTIMEOUT, POLLING).ShouldNot(BeEmpty())
+	}, t, POLLING).ShouldNot(BeEmpty())
 	logrus.Infof("The device %s was approved", deviceId)
 
 	// Wait for the device to pickup the new config and report measurements on device status.
@@ -557,7 +562,7 @@ func (h *Harness) WaitForDeviceNewRenderedVersion(deviceId string, newRenderedVe
 			}
 
 			return false
-		}, LONGTIMEOUT)
+		}, t)
 
 	return nil
 }
@@ -640,7 +645,7 @@ func (h *Harness) WaitForDeviceNewRenderedVersionWithReboot(deviceId string, new
 }
 
 // UpdateDeviceAndWaitForVersion updates the device and waits for the new rendered version
-func (h *Harness) UpdateDeviceAndWaitForVersion(deviceID string, updateFunc func(device *v1beta1.Device)) error {
+func (h *Harness) UpdateDeviceAndWaitForVersion(deviceID string, updateFunc func(device *v1beta1.Device), timeout ...string) error {
 	newRenderedVersion, err := h.PrepareNextDeviceVersion(deviceID)
 	if err != nil {
 		return fmt.Errorf("failed to prepare next device version: %w", err)
@@ -652,7 +657,7 @@ func (h *Harness) UpdateDeviceAndWaitForVersion(deviceID string, updateFunc func
 	}
 
 	GinkgoWriter.Printf("Waiting for device to pick up config version %d\n", newRenderedVersion)
-	err = h.WaitForDeviceNewRenderedVersion(deviceID, newRenderedVersion)
+	err = h.WaitForDeviceNewRenderedVersion(deviceID, newRenderedVersion, timeout...)
 	if err != nil {
 		return fmt.Errorf("failed to wait for new rendered version: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Tests 87531 and 88004 consistently time out after 600s in the merge queue, ejecting PRs (e.g. #3166)
- Root cause: both tests combine OS change to microshift with helm app deployment in a single `UpdateDeviceAndWaitForVersion` call — the agent must reboot, start microshift (3-5 min), pull charts, and deploy apps within one 10-minute `LONGTIMEOUT`, which isn't enough under CI load
- Fix: add an optional timeout parameter to `UpdateDeviceAndWaitForVersion` and `WaitForDeviceNewRenderedVersion`, and use `EXTENDEDTIMEOUT` (20m) for the combined OS+app updates in these two tests
- The test logic is preserved — both tests still validate the v1 (no microshift) → v2 (microshift + apps) path in a single update

## Test plan

- [ ] Merge queue E2E tests pass — tests 87531 and 88004 no longer time out with the extended 20-minute budget for combined OS+app updates

Assisted-by: Claude <noreply@anthropic.com>