### PR TITLE
NO-ISSUE: add unit and integration test health reports

### DIFF
--- a/.github/workflows/integration-health-report.yml
+++ b/.github/workflows/integration-health-report.yml
@@ -1,0 +1,83 @@
+name: Weekly Integration Test Health Report
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/integration-health-report.yml'
+      - '.github/actions/setup-dependencies/**'
+      - 'test/scripts/analyze_test_health/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read  # jobs API + artifact download
+  # publish step uses REPORTS_DEPLOY_KEY (SSH deploy key) to write to flightctl/flightctl-reports
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Generate health report
+        working-directory: test/scripts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./analyze_test_health \
+            --workflow integration-tests.yaml \
+            --artifact-name junit-integration-test \
+            --title "Integration Test Health" \
+            --out-dir integration-health
+
+      - name: Upload HTML report and JSON summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-health-report
+          path: |
+            test/scripts/integration-health/integration-health-report.html
+            test/scripts/integration-health/integration-health-summary.json
+
+      - name: Publish report to flightctl-reports
+        if: always() && github.event_name != 'pull_request'
+        env:
+          REPORTS_DEPLOY_KEY: ${{ secrets.REPORTS_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "::error::REPORTS_DEPLOY_KEY not set"; exit 1; }
+          REPORT_SRC="test/scripts/integration-health/integration-health-report.html"
+          [ ! -f "$REPORT_SRC" ] && { echo "::error::Report file not found: $REPORT_SRC"; exit 1; }
+          install -d -m 700 ~/.ssh
+          echo "$REPORTS_DEPLOY_KEY" > ~/.ssh/reports_deploy_key
+          chmod 600 ~/.ssh/reports_deploy_key
+          # Use GitHub's pinned host keys instead of trust-on-first-use ssh-keyscan
+          {
+            echo 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl'
+            echo 'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg='
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk='
+          } >> ~/.ssh/known_hosts
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" \
+            git clone --depth=1 git@github.com:flightctl/flightctl-reports.git /tmp/flightctl-reports
+          DATE="$(date -u +%Y-%m-%d)"
+          mkdir -p /tmp/flightctl-reports/integration-health-report
+          cp "$REPORT_SRC" /tmp/flightctl-reports/integration-health-report/index.html
+          cp "$REPORT_SRC" "/tmp/flightctl-reports/integration-health-report/${DATE}.html"
+          cd /tmp/flightctl-reports
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add integration-health-report/
+          git diff --cached --quiet && { echo "No changes to publish."; exit 0; }
+          git commit -m "integration-health-report: publish ${DATE} report"
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" git push
+        shell: bash

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -68,6 +68,14 @@ jobs:
         env:
           DISABLE_FIPS: true
 
+      - name: Upload JUnit results
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-integration-test
+          path: reports/junit_integration_test.xml
+          if-no-files-found: ignore
+
       - name: Detect baseline for compatibility testing
         if: ${{ steps.changed-files.outputs.any_changed == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         id: detect_baseline

--- a/.github/workflows/unit-health-report.yml
+++ b/.github/workflows/unit-health-report.yml
@@ -1,0 +1,83 @@
+name: Weekly Unit Test Health Report
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/unit-health-report.yml'
+      - '.github/actions/setup-dependencies/**'
+      - 'test/scripts/analyze_test_health/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read  # jobs API + artifact download
+  # publish step uses REPORTS_DEPLOY_KEY (SSH deploy key) to write to flightctl/flightctl-reports
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Generate health report
+        working-directory: test/scripts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./analyze_test_health \
+            --workflow unit-tests.yaml \
+            --artifact-name junit-unit-test \
+            --title "Unit Test Health" \
+            --out-dir unit-health
+
+      - name: Upload HTML report and JSON summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-health-report
+          path: |
+            test/scripts/unit-health/unit-health-report.html
+            test/scripts/unit-health/unit-health-summary.json
+
+      - name: Publish report to flightctl-reports
+        if: always() && github.event_name != 'pull_request'
+        env:
+          REPORTS_DEPLOY_KEY: ${{ secrets.REPORTS_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          [ -z "$REPORTS_DEPLOY_KEY" ] && { echo "::error::REPORTS_DEPLOY_KEY not set"; exit 1; }
+          REPORT_SRC="test/scripts/unit-health/unit-health-report.html"
+          [ ! -f "$REPORT_SRC" ] && { echo "::error::Report file not found: $REPORT_SRC"; exit 1; }
+          install -d -m 700 ~/.ssh
+          echo "$REPORTS_DEPLOY_KEY" > ~/.ssh/reports_deploy_key
+          chmod 600 ~/.ssh/reports_deploy_key
+          # Use GitHub's pinned host keys instead of trust-on-first-use ssh-keyscan
+          {
+            echo 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl'
+            echo 'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg='
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk='
+          } >> ~/.ssh/known_hosts
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" \
+            git clone --depth=1 git@github.com:flightctl/flightctl-reports.git /tmp/flightctl-reports
+          DATE="$(date -u +%Y-%m-%d)"
+          mkdir -p /tmp/flightctl-reports/unit-health-report
+          cp "$REPORT_SRC" /tmp/flightctl-reports/unit-health-report/index.html
+          cp "$REPORT_SRC" "/tmp/flightctl-reports/unit-health-report/${DATE}.html"
+          cd /tmp/flightctl-reports
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add unit-health-report/
+          git diff --cached --quiet && { echo "No changes to publish."; exit 0; }
+          git commit -m "unit-health-report: publish ${DATE} report"
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/reports_deploy_key -o IdentitiesOnly=yes" git push
+        shell: bash

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,3 +49,11 @@ jobs:
         run: make unit-test
         env:
           DISABLE_FIPS: "true"
+
+      - name: Upload JUnit results
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-unit-test
+          path: reports/junit_unit_test.xml
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ __pycache__/
 .mcp.json
 test/scripts/test-timings.json
 test/scripts/e2e-health/
+test/scripts/unit-health/
+test/scripts/integration-health/

--- a/test/scripts/.gitignore
+++ b/test/scripts/.gitignore
@@ -5,3 +5,4 @@ e2e-health/
 *.json
 *.html
 !*/testdata/**
+!*/template.html

--- a/test/scripts/analyze_test_health/collect.go
+++ b/test/scripts/analyze_test_health/collect.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v72/github"
+)
+
+type junitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	TestSuites []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestSuite struct {
+	Name      string          `xml:"name,attr"`
+	TestCases []junitTestCase `xml:"testcase"`
+}
+
+type junitTestCase struct {
+	Name      string     `xml:"name,attr"`
+	ClassName string     `xml:"classname,attr"`
+	Time      float64    `xml:"time,attr"`
+	Skipped   []struct{} `xml:"skipped"`
+	Failure   []struct {
+		Message string `xml:"message,attr"`
+		Body    string `xml:",chardata"`
+	} `xml:"failure"`
+}
+
+// junitResult holds the parsed data we need from a single test case.
+type junitResult struct {
+	SpecName    string
+	Passed      bool
+	Skipped     bool
+	DurationSec float64
+	FailureMsg  string
+}
+
+// runSummary is a lightweight run descriptor used during collection.
+type runSummary struct {
+	id         int64
+	url        string
+	date       string
+	conclusion string
+	startedAt  time.Time
+}
+
+func collectHealthData(ctx context.Context, client *github.Client, owner, repo, workflow, artifactName, title string, nRuns int) (rawFile, error) {
+	meta := collectMeta{
+		Branch:       defaultBranch,
+		Workflow:     workflow,
+		ArtifactName: artifactName,
+		Title:        title,
+		RepoURL:      buildRepoURL(owner, repo),
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	runs, err := listCompletedRuns(ctx, client, owner, repo, workflow, nRuns)
+	if err != nil {
+		return rawFile{}, fmt.Errorf("list runs: %w", err)
+	}
+	if len(runs) == 0 {
+		fmt.Println("No completed runs found.")
+		meta.AnalyzedRuns = 0
+		return rawFile{Meta: meta}, nil
+	}
+	fmt.Printf("Found %d completed run(s)\n", len(runs))
+
+	var runData []rawRunData
+	for _, run := range runs {
+		fmt.Printf("  Processing run %d (%s, %s)...\n", run.id, run.conclusion, run.date)
+		specs, err := processRun(ctx, client, owner, repo, run, artifactName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "    Warning: %v\n", err)
+		}
+		runData = append(runData, rawRunData{
+			RunID:      run.id,
+			RunURL:     run.url,
+			Date:       run.date,
+			Conclusion: run.conclusion,
+			Specs:      specs,
+		})
+	}
+	meta.AnalyzedRuns = len(runs)
+	return rawFile{Meta: meta, Runs: runData}, nil
+}
+
+func listCompletedRuns(ctx context.Context, client *github.Client, owner, repo, workflow string, limit int) ([]runSummary, error) {
+	// The GitHub REST API does not support multiple status values in one request,
+	// so fetch successes and failures separately and merge by recency.
+	var result []runSummary
+	for _, conclusion := range []string{"success", "failure"} {
+		opts := &github.ListWorkflowRunsOptions{
+			Branch:      defaultBranch,
+			Status:      conclusion,
+			ListOptions: github.ListOptions{PerPage: limit},
+		}
+		runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflow, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list workflow runs (%s): %w", conclusion, err)
+		}
+		for _, r := range runs.WorkflowRuns {
+			result = append(result, runSummary{
+				id:         r.GetID(),
+				url:        r.GetHTMLURL(),
+				date:       r.GetCreatedAt().Format("2006-01-02"),
+				conclusion: conclusion,
+				startedAt:  r.GetRunStartedAt().Time,
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].startedAt.After(result[j].startedAt)
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+// processRun downloads the named JUnit artifact for one workflow run and
+// returns the parsed spec results. Returns nil specs (not an error) when no
+// matching artifact exists (tests were skipped or run failed before tests ran).
+func processRun(ctx context.Context, client *github.Client, owner, repo string, run runSummary, artifactName string) (map[string]rawSpecResult, error) {
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("test-health-%d-*", run.id))
+	if err != nil {
+		return nil, fmt.Errorf("mktemp: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	found, err := downloadArtifact(ctx, client, owner, repo, run.id, artifactName, tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("download artifact: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+
+	// Parse all XML files found in the artifact (usually just one).
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("read temp dir: %w", err)
+	}
+
+	merged := make(map[string]rawSpecResult)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".xml") {
+			continue
+		}
+		results, err := parseJUnitFile(filepath.Join(tmpDir, e.Name()))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "    Warning: parse %s: %v\n", e.Name(), err)
+			continue
+		}
+		for _, r := range results {
+			existing, seen := merged[r.SpecName]
+			if !seen {
+				merged[r.SpecName] = rawSpecResult{
+					Passed:      r.Passed,
+					Skipped:     r.Skipped,
+					DurationSec: r.DurationSec,
+					FailureMsg:  truncateMsg(r.FailureMsg, 200),
+				}
+				continue
+			}
+			// Failure always wins over pass or skip.
+			if !r.Passed && !r.Skipped {
+				existing.Passed = false
+				existing.Skipped = false
+				if r.DurationSec > 0 && existing.DurationSec == 0 {
+					existing.DurationSec = r.DurationSec
+				}
+				if r.FailureMsg != "" && existing.FailureMsg == "" {
+					existing.FailureMsg = truncateMsg(r.FailureMsg, 200)
+				}
+				merged[r.SpecName] = existing
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil, nil
+	}
+	return merged, nil
+}
+
+// downloadArtifact fetches the artifact with the exact given name for runID,
+// extracts its contents to destDir, and reports whether a matching artifact was found.
+func downloadArtifact(ctx context.Context, client *github.Client, owner, repo string, runID int64, artifactName, destDir string) (bool, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		page, resp, err := client.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, opts)
+		if err != nil {
+			return false, fmt.Errorf("list artifacts: %w", err)
+		}
+		for _, a := range page.Artifacts {
+			if a.GetName() == artifactName {
+				if err := downloadAndExtract(ctx, client, owner, repo, a.GetID(), destDir); err != nil {
+					return true, fmt.Errorf("extract artifact: %w", err)
+				}
+				return true, nil
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return false, nil
+}
+
+func downloadAndExtract(ctx context.Context, client *github.Client, owner, repo string, artifactID int64, destDir string) error {
+	redirectURL, _, err := client.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 1)
+	if err != nil {
+		return fmt.Errorf("get download URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirectURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	tmp, err := os.CreateTemp("", "artifact-*.zip")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	size, err := io.Copy(tmp, resp.Body)
+	if err != nil {
+		return fmt.Errorf("write zip: %w", err)
+	}
+	zr, err := zip.NewReader(tmp, size)
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, ".xml") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(destDir, fmt.Sprintf("%d_%s", artifactID, filepath.Base(f.Name)))
+		out, err := os.Create(dest)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		_, copyErr := io.Copy(out, rc)
+		rc.Close()
+		out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+	return nil
+}
+
+func parseJUnitFile(path string) ([]junitResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var suites junitTestSuites
+	if err := xml.Unmarshal(data, &suites); err != nil {
+		return nil, fmt.Errorf("parse xml: %w", err)
+	}
+	var results []junitResult
+	for _, suite := range suites.TestSuites {
+		suiteName := suite.Name
+		if suiteName == "" && len(suite.TestCases) > 0 {
+			suiteName = suite.TestCases[0].ClassName
+		}
+
+		for _, tc := range suite.TestCases {
+			// Skip BeforeSuite overhead entries — they are not test specs.
+			if tc.Name == "[BeforeSuite]" || tc.Name == "[AfterSuite]" {
+				continue
+			}
+
+			specName := specNameFromCase(tc, suiteName)
+			if specName == "" {
+				continue
+			}
+			r := junitResult{
+				SpecName:    specName,
+				Skipped:     len(tc.Skipped) > 0,
+				Passed:      len(tc.Failure) == 0 && len(tc.Skipped) == 0,
+				DurationSec: tc.Time,
+			}
+			if len(tc.Failure) > 0 {
+				msg := tc.Failure[0].Message
+				if msg == "" {
+					msg = strings.TrimSpace(tc.Failure[0].Body)
+				}
+				r.FailureMsg = msg
+			}
+			results = append(results, r)
+		}
+	}
+	return results, nil
+}
+
+// specNameFromCase derives a stable, human-readable spec key from a JUnit test case.
+//
+// Ginkgo format:   "[It] Suite Spec [labels]" → "Suite Spec"
+// Go test format:  classname="pkg/path", name="TestFoo/sub" → "pkg/path/TestFoo/sub"
+//
+// For Go tests the full module prefix (e.g. "github.com/flightctl/flightctl/") is
+// stripped so keys are reasonably short while still unique within the repo.
+func specNameFromCase(tc junitTestCase, suiteName string) string {
+	const itPrefix = "[It] "
+	if strings.HasPrefix(tc.Name, itPrefix) {
+		name := strings.TrimPrefix(tc.Name, itPrefix)
+		// Strip trailing Ginkgo label group " [label, label]".
+		if idx := strings.LastIndex(name, " ["); idx > 0 && strings.HasSuffix(name, "]") {
+			name = name[:idx]
+		}
+		return name
+	}
+
+	// Standard Go test: build "short/pkg/TestFoo/subtest".
+	cn := tc.ClassName
+	if cn == "" {
+		cn = suiteName
+	}
+	// Strip the module path prefix so display names are concise.
+	if idx := strings.Index(cn, "/"); idx >= 0 {
+		// Drop everything up to the first path segment that looks like a
+		// Go source directory (heuristic: find "internal/", "pkg/", "api/", "cmd/").
+		for _, anchor := range []string{"/internal/", "/pkg/", "/api/", "/cmd/"} {
+			if i := strings.Index(cn, anchor); i >= 0 {
+				cn = cn[i+1:]
+				break
+			}
+		}
+	}
+	if cn != "" {
+		return cn + "/" + tc.Name
+	}
+	return tc.Name
+}
+
+func truncateMsg(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func avgStddev(values []float64) (avg, stddev float64) {
+	if len(values) == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	avg = sum / float64(len(values))
+	if len(values) < 2 {
+		return avg, 0
+	}
+	var variance float64
+	for _, v := range values {
+		d := v - avg
+		variance += d * d
+	}
+	return avg, math.Sqrt(variance / float64(len(values)))
+}

--- a/test/scripts/analyze_test_health/collect.go
+++ b/test/scripts/analyze_test_health/collect.go
@@ -81,44 +81,42 @@ func collectHealthData(ctx context.Context, client *github.Client, owner, repo, 
 	for _, run := range runs {
 		fmt.Printf("  Processing run %d (%s, %s)...\n", run.id, run.conclusion, run.date)
 		specs, err := processRun(ctx, client, owner, repo, run, artifactName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "    Warning: %v\n", err)
-		}
-		runData = append(runData, rawRunData{
+		rd := rawRunData{
 			RunID:      run.id,
 			RunURL:     run.url,
 			Date:       run.date,
 			Conclusion: run.conclusion,
 			Specs:      specs,
-		})
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "    ERROR: run %d: %v\n", run.id, err)
+			rd.CollectError = err.Error()
+		}
+		runData = append(runData, rd)
 	}
 	meta.AnalyzedRuns = len(runs)
 	return rawFile{Meta: meta, Runs: runData}, nil
 }
 
 func listCompletedRuns(ctx context.Context, client *github.Client, owner, repo, workflow string, limit int) ([]runSummary, error) {
-	// The GitHub REST API does not support multiple status values in one request,
-	// so fetch successes and failures separately and merge by recency.
+	opts := &github.ListWorkflowRunsOptions{
+		Branch:      defaultBranch,
+		Status:      "completed",
+		ListOptions: github.ListOptions{PerPage: limit},
+	}
+	runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflow, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list workflow runs: %w", err)
+	}
 	var result []runSummary
-	for _, conclusion := range []string{"success", "failure"} {
-		opts := &github.ListWorkflowRunsOptions{
-			Branch:      defaultBranch,
-			Status:      conclusion,
-			ListOptions: github.ListOptions{PerPage: limit},
-		}
-		runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflow, opts)
-		if err != nil {
-			return nil, fmt.Errorf("list workflow runs (%s): %w", conclusion, err)
-		}
-		for _, r := range runs.WorkflowRuns {
-			result = append(result, runSummary{
-				id:         r.GetID(),
-				url:        r.GetHTMLURL(),
-				date:       r.GetCreatedAt().Format("2006-01-02"),
-				conclusion: conclusion,
-				startedAt:  r.GetRunStartedAt().Time,
-			})
-		}
+	for _, r := range runs.WorkflowRuns {
+		result = append(result, runSummary{
+			id:         r.GetID(),
+			url:        r.GetHTMLURL(),
+			date:       r.GetCreatedAt().Format("2006-01-02"),
+			conclusion: r.GetConclusion(),
+			startedAt:  r.GetRunStartedAt().Time,
+		})
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].startedAt.After(result[j].startedAt)

--- a/test/scripts/analyze_test_health/compute.go
+++ b/test/scripts/analyze_test_health/compute.go
@@ -37,6 +37,10 @@ func aggregateRuns(runs []rawRunData) junitAgg {
 	// Runs are stored newest-first from collect; process in that order so
 	// LastFailedURL records the most recent failure URL for each spec.
 	for _, run := range runs {
+		// Collection failures are excluded entirely; they are not "no JUnit".
+		if run.CollectError != "" {
+			continue
+		}
 		ref := runRef{RunID: run.RunID, RunURL: run.RunURL, Date: run.Date}
 
 		if len(run.Specs) == 0 {
@@ -143,6 +147,7 @@ type reportData struct {
 	FlakeEntries             []flakeEntry
 	InfraInstabilityCount    int
 	NoJUnitCount             int
+	CollectErrorCount        int
 	TotalAnalyzedSpecs       int
 	FlakyCount               int
 	ConsistentlyFailingCount int
@@ -245,9 +250,22 @@ func computeSlowest(timings map[string]specTiming, topN int) []specEntry {
 	return entries
 }
 
+func computeCollectErrors(runs []rawRunData) int {
+	n := 0
+	for _, run := range runs {
+		if run.CollectError != "" {
+			n++
+		}
+	}
+	return n
+}
+
 func computeTrend(runs []rawRunData) []trendEntry {
 	trend := make([]trendEntry, 0, len(runs))
 	for _, run := range runs {
+		if run.CollectError != "" {
+			continue
+		}
 		entry := trendEntry{
 			RunID:      run.RunID,
 			RunURL:     run.RunURL,
@@ -281,6 +299,7 @@ func computeReport(raw rawFile, title string, topN int) *reportData {
 	flakes, totalSpecs, flakyCount, consistentCount, cleanCount := computeFlakes(agg, topN)
 	slowest := computeSlowest(timings, topN)
 	trend := computeTrend(raw.Runs)
+	collectErrors := computeCollectErrors(raw.Runs)
 
 	generatedAt := raw.Meta.GeneratedAt
 	if generatedAt == "" {
@@ -296,6 +315,7 @@ func computeReport(raw rawFile, title string, topN int) *reportData {
 		FlakeEntries:             flakes,
 		InfraInstabilityCount:    len(agg.infraRuns),
 		NoJUnitCount:             len(agg.noJUnit),
+		CollectErrorCount:        collectErrors,
 		TotalAnalyzedSpecs:       totalSpecs,
 		FlakyCount:               flakyCount,
 		ConsistentlyFailingCount: consistentCount,

--- a/test/scripts/analyze_test_health/compute.go
+++ b/test/scripts/analyze_test_health/compute.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"sort"
+	"time"
+)
+
+// junitAgg is the in-memory result of aggregating raw run data.
+// It is always computed from raw-junit.json and never persisted.
+type junitAgg struct {
+	specs     map[string]specResult
+	noJUnit   []runRef
+	infraRuns []runRef
+}
+
+// specResult tracks aggregate pass/fail counts across analyzed runs.
+type specResult struct {
+	PassCount       int
+	FailCount       int
+	SkipCount       int
+	LastFailedRunID int64
+	LastFailedURL   string
+	FailureMsg      string
+}
+
+// aggregateRuns builds per-spec pass/fail counts, detects infra instability
+// runs, and records runs that produced no JUnit output.
+//
+// Infra instability detection: if >infraInstabilityThreshold of the executed
+// specs fail in a single run, the entire run is excluded from per-spec counts.
+// This prevents environment failures from inflating individual spec flake rates.
+func aggregateRuns(runs []rawRunData) junitAgg {
+	agg := junitAgg{
+		specs: make(map[string]specResult),
+	}
+
+	// Runs are stored newest-first from collect; process in that order so
+	// LastFailedURL records the most recent failure URL for each spec.
+	for _, run := range runs {
+		ref := runRef{RunID: run.RunID, RunURL: run.RunURL, Date: run.Date}
+
+		if len(run.Specs) == 0 {
+			agg.noJUnit = append(agg.noJUnit, ref)
+			continue
+		}
+
+		// Infra instability check: only count executed (non-skipped) specs.
+		executed := 0
+		failures := 0
+		for _, s := range run.Specs {
+			if s.Skipped {
+				continue
+			}
+			executed++
+			if !s.Passed {
+				failures++
+			}
+		}
+		if executed > 0 && float64(failures)/float64(executed) > infraInstabilityThreshold {
+			agg.infraRuns = append(agg.infraRuns, ref)
+			continue
+		}
+
+		for name, s := range run.Specs {
+			existing := agg.specs[name]
+			switch {
+			case s.Skipped:
+				existing.SkipCount++
+			case s.Passed:
+				existing.PassCount++
+			default:
+				existing.FailCount++
+				if existing.LastFailedRunID == 0 {
+					existing.LastFailedRunID = run.RunID
+					existing.LastFailedURL = run.RunURL
+				}
+				if s.FailureMsg != "" && existing.FailureMsg == "" {
+					existing.FailureMsg = s.FailureMsg
+				}
+			}
+			agg.specs[name] = existing
+		}
+	}
+	return agg
+}
+
+// computeTimings derives per-spec avg duration and stddev from raw run data.
+// Infra instability runs are excluded. Skipped specs and zero-duration entries
+// are ignored.
+func computeTimings(runs []rawRunData) map[string]specTiming {
+	allObs := make(map[string][]float64)
+	for _, run := range runs {
+		if len(run.Specs) == 0 {
+			continue
+		}
+		// Skip infra instability runs.
+		executed := 0
+		failures := 0
+		for _, s := range run.Specs {
+			if s.Skipped {
+				continue
+			}
+			executed++
+			if !s.Passed {
+				failures++
+			}
+		}
+		if executed > 0 && float64(failures)/float64(executed) > infraInstabilityThreshold {
+			continue
+		}
+		for name, s := range run.Specs {
+			if s.Skipped || s.DurationSec <= 0 {
+				continue
+			}
+			allObs[name] = append(allObs[name], s.DurationSec)
+		}
+	}
+	timings := make(map[string]specTiming, len(allObs))
+	for name, obs := range allObs {
+		avg, std := avgStddev(obs)
+		timings[name] = specTiming{Avg: avg, StdDev: std}
+	}
+	return timings
+}
+
+// specTiming holds the average and standard deviation of a spec's duration.
+type specTiming struct {
+	Avg    float64
+	StdDev float64
+}
+
+// reportData is the output of computeReport. It contains only plain Go values
+// — no template.HTML, no SVG. The render layer wraps it in a renderContext to
+// add the generated charts before executing the HTML template.
+type reportData struct {
+	Title        string
+	GeneratedAt  string
+	RepoURL      string
+	Workflow     string
+	AnalyzedRuns int
+
+	// Section: Flaky tests.
+	FlakeEntries             []flakeEntry
+	InfraInstabilityCount    int
+	NoJUnitCount             int
+	TotalAnalyzedSpecs       int
+	FlakyCount               int
+	ConsistentlyFailingCount int
+	CleanCount               int
+
+	// Section: Slowest tests.
+	SlowestTests []specEntry
+
+	// Section: Per-run trend.
+	TrendEntries []trendEntry
+}
+
+// flakeEntry is one row in the flaky tests table.
+type flakeEntry struct {
+	SpecName   string
+	FailRate   float64
+	FailCount  int
+	TotalRuns  int
+	Class      string // "Flaky" or "Consistently failing"
+	LastRunURL string
+	FailureMsg string
+}
+
+// specEntry is one row in the slowest-tests table.
+type specEntry struct {
+	Name    string
+	AvgSecs float64
+	StdDev  float64
+}
+
+// trendEntry is one row in the per-run trend table.
+type trendEntry struct {
+	RunID      int64
+	RunURL     string
+	Date       string
+	Conclusion string
+	Passed     int
+	Failed     int
+	Skipped    int
+	Total      int
+}
+
+func computeFlakes(agg junitAgg, topN int) (flakes []flakeEntry, totalSpecs, flakyCount, consistentCount, cleanCount int) {
+	// Classify each spec that appeared at least once (pass or fail; skip-only excluded).
+	for name, sr := range agg.specs {
+		total := sr.PassCount + sr.FailCount
+		if total == 0 {
+			// Only ever skipped — not interesting.
+			continue
+		}
+		totalSpecs++
+		if sr.FailCount == 0 {
+			cleanCount++
+			continue
+		}
+		failRate := float64(sr.FailCount) / float64(total)
+		class := "Flaky"
+		if sr.PassCount == 0 {
+			class = "Consistently failing"
+			consistentCount++
+		} else {
+			flakyCount++
+		}
+		flakes = append(flakes, flakeEntry{
+			SpecName:   name,
+			FailRate:   failRate,
+			FailCount:  sr.FailCount,
+			TotalRuns:  total,
+			Class:      class,
+			LastRunURL: sr.LastFailedURL,
+			FailureMsg: sr.FailureMsg,
+		})
+	}
+	// Sort: consistently failing first, then by fail rate descending.
+	sort.Slice(flakes, func(i, j int) bool {
+		ci := flakes[i].Class == "Consistently failing"
+		cj := flakes[j].Class == "Consistently failing"
+		if ci != cj {
+			return ci
+		}
+		return flakes[i].FailRate > flakes[j].FailRate
+	})
+	if topN > 0 && len(flakes) > topN {
+		flakes = flakes[:topN]
+	}
+	return flakes, totalSpecs, flakyCount, consistentCount, cleanCount
+}
+
+func computeSlowest(timings map[string]specTiming, topN int) []specEntry {
+	entries := make([]specEntry, 0, len(timings))
+	for name, t := range timings {
+		entries = append(entries, specEntry{Name: name, AvgSecs: t.Avg, StdDev: t.StdDev})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].AvgSecs > entries[j].AvgSecs
+	})
+	if topN > 0 && len(entries) > topN {
+		entries = entries[:topN]
+	}
+	return entries
+}
+
+func computeTrend(runs []rawRunData) []trendEntry {
+	trend := make([]trendEntry, 0, len(runs))
+	for _, run := range runs {
+		entry := trendEntry{
+			RunID:      run.RunID,
+			RunURL:     run.RunURL,
+			Date:       run.Date,
+			Conclusion: run.Conclusion,
+		}
+		for _, s := range run.Specs {
+			switch {
+			case s.Skipped:
+				entry.Skipped++
+			case s.Passed:
+				entry.Passed++
+			default:
+				entry.Failed++
+			}
+		}
+		entry.Total = entry.Passed + entry.Failed + entry.Skipped
+		trend = append(trend, entry)
+	}
+	// Reverse to chronological order (oldest first) for the chart.
+	for i, j := 0, len(trend)-1; i < j; i, j = i+1, j-1 {
+		trend[i], trend[j] = trend[j], trend[i]
+	}
+	return trend
+}
+
+func computeReport(raw rawFile, title string, topN int) *reportData {
+	agg := aggregateRuns(raw.Runs)
+	timings := computeTimings(raw.Runs)
+
+	flakes, totalSpecs, flakyCount, consistentCount, cleanCount := computeFlakes(agg, topN)
+	slowest := computeSlowest(timings, topN)
+	trend := computeTrend(raw.Runs)
+
+	generatedAt := raw.Meta.GeneratedAt
+	if generatedAt == "" {
+		generatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	return &reportData{
+		Title:                    title,
+		GeneratedAt:              generatedAt,
+		RepoURL:                  raw.Meta.RepoURL,
+		Workflow:                 raw.Meta.Workflow,
+		AnalyzedRuns:             raw.Meta.AnalyzedRuns,
+		FlakeEntries:             flakes,
+		InfraInstabilityCount:    len(agg.infraRuns),
+		NoJUnitCount:             len(agg.noJUnit),
+		TotalAnalyzedSpecs:       totalSpecs,
+		FlakyCount:               flakyCount,
+		ConsistentlyFailingCount: consistentCount,
+		CleanCount:               cleanCount,
+		SlowestTests:             slowest,
+		TrendEntries:             trend,
+	}
+}

--- a/test/scripts/analyze_test_health/main.go
+++ b/test/scripts/analyze_test_health/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v72/github"
 	"github.com/spf13/cobra"
@@ -57,13 +58,15 @@ type rawFile struct {
 
 // rawRunData is one workflow run's parsed JUnit data.
 // Specs is nil when the run produced no JUnit artifact (tests skipped or
-// run failed before tests could run).
+// run failed before tests could run). CollectError is set when the artifact
+// download or parse failed; these runs are excluded from all aggregation.
 type rawRunData struct {
-	RunID      int64                    `json:"run_id"`
-	RunURL     string                   `json:"run_url"`
-	Date       string                   `json:"date"`
-	Conclusion string                   `json:"conclusion"`
-	Specs      map[string]rawSpecResult `json:"specs,omitempty"`
+	RunID        int64                    `json:"run_id"`
+	RunURL       string                   `json:"run_url"`
+	Date         string                   `json:"date"`
+	Conclusion   string                   `json:"conclusion"`
+	CollectError string                   `json:"collect_error,omitempty"`
+	Specs        map[string]rawSpecResult `json:"specs,omitempty"`
 }
 
 // rawSpecResult is the outcome of one test case in a run's JUnit XML output.
@@ -185,8 +188,10 @@ Requires GH_TOKEN (or GITHUB_TOKEN) and GITHUB_REPOSITORY when collecting.`,
 				reportData = filepath.Join(outDirFlag, prefix+"-report-data.json")
 			}
 
-			if err := os.MkdirAll(filepath.Dir(rawJunitPath), 0o755); err != nil {
-				return fmt.Errorf("create output dir: %w", err)
+			for _, p := range []string{rawJunitPath, outputHTML, summaryJSON, reportData} {
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					return fmt.Errorf("create output dir for %s: %w", p, err)
+				}
 			}
 
 			var raw rawFile
@@ -215,12 +220,13 @@ Requires GH_TOKEN (or GITHUB_TOKEN) and GITHUB_REPOSITORY when collecting.`,
 					return err
 				}
 
-				ctx := context.Background()
-				client := github.NewClient(nil).WithAuthToken(token)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+			defer cancel()
+			client := github.NewClient(nil).WithAuthToken(token)
 
-				fmt.Printf("Collecting health data for %s/%s (last %d runs of %s)...\n", owner, repo, nRuns, workflow)
-				var err2 error
-				raw, err2 = collectHealthData(ctx, client, owner, repo, workflow, artifactName, title, nRuns)
+			fmt.Printf("Collecting health data for %s/%s (last %d runs of %s)...\n", owner, repo, nRuns, workflow)
+			var err2 error
+			raw, err2 = collectHealthData(ctx, client, owner, repo, workflow, artifactName, title, nRuns)
 				if err2 != nil {
 					return fmt.Errorf("collect: %w", err2)
 				}

--- a/test/scripts/analyze_test_health/main.go
+++ b/test/scripts/analyze_test_health/main.go
@@ -1,0 +1,287 @@
+// Command analyze_test_health produces a unified weekly HTML health report for
+// a CI test workflow (unit or integration), covering flaky tests, slowest tests,
+// and a per-run pass-rate trend.
+//
+// Data flow:
+//
+//  1. Collect – hits GitHub API; writes one raw file:
+//     • <out-dir>/raw-junit.json – per-run per-spec pass/fail/skip results
+//  2. Compute – reads the raw file; aggregates and produces reportData.
+//  3. Render  – generates HTML, Slack JSON, and step summary.
+//
+// Step 1 is automatically skipped when <out-dir>/raw-junit.json already exists.
+// Delete it to trigger a fresh collect.
+// All output files are written to <out-dir>/ (gitignored).
+// Requires GH_TOKEN (or GITHUB_TOKEN) and GITHUB_REPOSITORY when collecting.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/v72/github"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultBranch = "main"
+	defaultRuns   = 14
+	defaultTopN   = 10
+
+	// infraInstabilityThreshold: fraction of specs that must fail in a single
+	// run for it to be classified as an infra instability event (excluded from
+	// per-spec flake counts).
+	infraInstabilityThreshold = 0.30
+)
+
+// collectMeta holds the collection context saved alongside the raw file.
+type collectMeta struct {
+	Branch       string `json:"branch"`
+	Workflow     string `json:"workflow"`
+	ArtifactName string `json:"artifact_name"`
+	Title        string `json:"title"`
+	RepoURL      string `json:"repo_url"`
+	GeneratedAt  string `json:"generated_at"`
+	AnalyzedRuns int    `json:"analyzed_runs"`
+}
+
+// rawFile is the top-level structure of raw-junit.json.
+type rawFile struct {
+	Meta collectMeta  `json:"meta"`
+	Runs []rawRunData `json:"runs"`
+}
+
+// rawRunData is one workflow run's parsed JUnit data.
+// Specs is nil when the run produced no JUnit artifact (tests skipped or
+// run failed before tests could run).
+type rawRunData struct {
+	RunID      int64                    `json:"run_id"`
+	RunURL     string                   `json:"run_url"`
+	Date       string                   `json:"date"`
+	Conclusion string                   `json:"conclusion"`
+	Specs      map[string]rawSpecResult `json:"specs,omitempty"`
+}
+
+// rawSpecResult is the outcome of one test case in a run's JUnit XML output.
+type rawSpecResult struct {
+	Passed      bool    `json:"passed"`
+	Skipped     bool    `json:"skipped"`
+	DurationSec float64 `json:"duration_sec,omitempty"`
+	FailureMsg  string  `json:"failure_msg,omitempty"`
+}
+
+// runRef is a lightweight run reference used in reportData.
+type runRef struct {
+	RunID  int64  `json:"run_id"`
+	RunURL string `json:"run_url"`
+	Date   string `json:"date"`
+}
+
+func githubToken() string {
+	if t := os.Getenv("GH_TOKEN"); t != "" {
+		return t
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}
+
+func repoFromFlag(flag string) (owner, repo string, err error) {
+	parts := strings.SplitN(flag, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("--repo must be in owner/repo format, got %q", flag)
+	}
+	return parts[0], parts[1], nil
+}
+
+func repoFromEnv() (owner, repo string, err error) {
+	v := os.Getenv("GITHUB_REPOSITORY")
+	parts := strings.SplitN(v, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("GITHUB_REPOSITORY not set or invalid (expected owner/repo)")
+	}
+	return parts[0], parts[1], nil
+}
+
+func buildRepoURL(owner, repo string) string {
+	return fmt.Sprintf("https://github.com/%s/%s", owner, repo)
+}
+
+func loadJSON[T any](path string, dest *T) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, dest); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+func writeJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+func newRootCmd() *cobra.Command {
+	var (
+		repoFlag     string
+		workflow     string
+		artifactName string
+		title        string
+		nRuns        int
+		topN         int
+		outDirFlag   string
+		rawJunitPath string
+		outputHTML   string
+		summaryJSON  string
+		reportData   string
+	)
+
+	perFileFlags := []string{"raw-junit", "output", "json-summary", "report-data"}
+
+	cmd := &cobra.Command{
+		Use:   "analyze_test_health",
+		Short: "Generate a unified weekly HTML health report for a CI test workflow",
+		Long: `Collects JUnit XML artifacts from GitHub Actions and renders a self-contained
+HTML report covering flaky tests, slowest tests, and a per-run pass-rate trend.
+
+All output is written to the <out-dir>/ directory (gitignored):
+  <out-dir>/raw-junit.json        – per-run per-spec pass/fail/skip results
+  <out-dir>/<prefix>-report.html  – self-contained HTML report
+  <out-dir>/<prefix>-summary.json – Slack notification payload
+
+All aggregation is performed from the raw file at report time; changing
+compute or render logic never requires re-fetching from the API.
+
+If raw-junit.json already exists on disk the collect step is skipped. Delete
+it to trigger a fresh collect.
+
+Requires GH_TOKEN (or GITHUB_TOKEN) and GITHUB_REPOSITORY when collecting.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if workflow == "" {
+				return fmt.Errorf("--workflow is required")
+			}
+			if artifactName == "" {
+				return fmt.Errorf("--artifact-name is required")
+			}
+
+			// --out-dir is mutually exclusive with individual path flags.
+			if outDirFlag != "" {
+				for _, f := range perFileFlags {
+					if cmd.Flags().Changed(f) {
+						return fmt.Errorf("--out-dir cannot be combined with --%s", f)
+					}
+				}
+				prefix := strings.TrimSuffix(filepath.Base(outDirFlag), "/")
+				rawJunitPath = filepath.Join(outDirFlag, "raw-junit.json")
+				outputHTML = filepath.Join(outDirFlag, prefix+"-report.html")
+				summaryJSON = filepath.Join(outDirFlag, prefix+"-summary.json")
+				reportData = filepath.Join(outDirFlag, prefix+"-report-data.json")
+			}
+
+			if err := os.MkdirAll(filepath.Dir(rawJunitPath), 0o755); err != nil {
+				return fmt.Errorf("create output dir: %w", err)
+			}
+
+			var raw rawFile
+
+			if _, err := os.Stat(rawJunitPath); err == nil {
+				// Raw file exists — skip the GitHub API fetch.
+				fmt.Printf("Found %s — skipping collect, loading from disk...\n", rawJunitPath)
+				if err := loadJSON(rawJunitPath, &raw); err != nil {
+					return fmt.Errorf("load raw junit: %w", err)
+				}
+				fmt.Printf("Loaded: workflow=%s, %d runs\n", raw.Meta.Workflow, len(raw.Runs))
+			} else {
+				token := githubToken()
+				if token == "" {
+					return fmt.Errorf("GH_TOKEN or GITHUB_TOKEN environment variable is not set")
+				}
+
+				var owner, repo string
+				var err error
+				if repoFlag != "" {
+					owner, repo, err = repoFromFlag(repoFlag)
+				} else {
+					owner, repo, err = repoFromEnv()
+				}
+				if err != nil {
+					return err
+				}
+
+				ctx := context.Background()
+				client := github.NewClient(nil).WithAuthToken(token)
+
+				fmt.Printf("Collecting health data for %s/%s (last %d runs of %s)...\n", owner, repo, nRuns, workflow)
+				var err2 error
+				raw, err2 = collectHealthData(ctx, client, owner, repo, workflow, artifactName, title, nRuns)
+				if err2 != nil {
+					return fmt.Errorf("collect: %w", err2)
+				}
+				if err2 = writeJSON(rawJunitPath, raw); err2 != nil {
+					return fmt.Errorf("write raw junit: %w", err2)
+				}
+				fmt.Printf("Collect complete: %d runs, wrote %s\n", raw.Meta.AnalyzedRuns, rawJunitPath)
+			}
+
+			// If title was not set via flag but we loaded from disk, use meta title.
+			if title == "" {
+				title = raw.Meta.Title
+			}
+			if title == "" {
+				title = "Test Health Report"
+			}
+
+			fmt.Println("Computing and rendering HTML report...")
+			report := computeReport(raw, title, topN)
+
+			if err := writeJSON(reportData, report); err != nil {
+				return fmt.Errorf("write report data: %w", err)
+			}
+			fmt.Printf("Wrote %s\n", reportData)
+
+			if err := renderHTML(report, outputHTML); err != nil {
+				return fmt.Errorf("render HTML: %w", err)
+			}
+			fmt.Printf("Wrote %s\n", outputHTML)
+
+			if err := renderSlackSummary(report, summaryJSON); err != nil {
+				return fmt.Errorf("render slack summary: %w", err)
+			}
+			fmt.Printf("Wrote %s\n", summaryJSON)
+
+			if err := appendStepSummary(report); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not write step summary: %v\n", err)
+			}
+			return nil
+		},
+	}
+
+	defaultOutDir := "test-health"
+
+	cmd.Flags().StringVar(&repoFlag, "repo", "", "GitHub repository owner/repo (default: $GITHUB_REPOSITORY)")
+	cmd.Flags().StringVar(&workflow, "workflow", "", "Workflow filename to analyze (required)")
+	cmd.Flags().StringVar(&artifactName, "artifact-name", "", "Exact artifact name containing JUnit XML (required)")
+	cmd.Flags().StringVar(&title, "title", "Test Health Report", "Report title")
+	cmd.Flags().IntVar(&nRuns, "runs", defaultRuns, "Number of recent completed runs to analyze")
+	cmd.Flags().IntVar(&topN, "top", defaultTopN, "Entries to show per ranking table")
+	cmd.Flags().StringVar(&outDirFlag, "out-dir", "", "Directory for all output files (mutually exclusive with individual path flags; default: "+defaultOutDir+")")
+	cmd.Flags().StringVar(&rawJunitPath, "raw-junit", defaultOutDir+"/raw-junit.json", "Path to raw-junit.json (conflicts with --out-dir)")
+	cmd.Flags().StringVar(&outputHTML, "output", defaultOutDir+"/test-health-report.html", "Path for HTML report output (conflicts with --out-dir)")
+	cmd.Flags().StringVar(&summaryJSON, "json-summary", defaultOutDir+"/test-health-summary.json", "Path for Slack JSON summary (conflicts with --out-dir)")
+	cmd.Flags().StringVar(&reportData, "report-data", defaultOutDir+"/test-health-report-data.json", "Path for computed report data JSON (conflicts with --out-dir)")
+
+	return cmd
+}
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/test/scripts/analyze_test_health/main_test.go
+++ b/test/scripts/analyze_test_health/main_test.go
@@ -1,0 +1,691 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// loadFixture reads a file from the testdata directory.
+func loadFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return string(data)
+}
+
+// makeRun is a helper that builds a rawRunData with the given specs and N
+// additional passing specs as padding to avoid tripping the infra instability
+// threshold unless the test deliberately wants to do that.
+func makeRun(id int64, url, date, conclusion string, extraPassing int, specs map[string]rawSpecResult) rawRunData {
+	merged := make(map[string]rawSpecResult, len(specs)+extraPassing)
+	for k, v := range specs {
+		merged[k] = v
+	}
+	for i := 0; i < extraPassing; i++ {
+		merged[fmt.Sprintf("Pad %s %d", date, i)] = rawSpecResult{Passed: true, DurationSec: 0.1}
+	}
+	return rawRunData{
+		RunID:      id,
+		RunURL:     url,
+		Date:       date,
+		Conclusion: conclusion,
+		Specs:      merged,
+	}
+}
+
+// --------------------------------------------------------------------------
+// specNameFromCase
+// --------------------------------------------------------------------------
+
+// TestSpecNameFromCase covers both Ginkgo and standard Go test name extraction.
+func TestSpecNameFromCase(t *testing.T) {
+	tests := []struct {
+		name      string
+		tc        junitTestCase
+		suiteName string
+		want      string
+	}{
+		{
+			name:  "When name has [It] prefix and labels it should strip both",
+			tc:    junitTestCase{Name: "[It] Store Suite should create a device [12345, integration]", ClassName: "Store Suite"},
+			want:  "Store Suite should create a device",
+		},
+		{
+			name:  "When name has [It] prefix but no labels it should strip only the prefix",
+			tc:    junitTestCase{Name: "[It] Simple spec", ClassName: "Suite"},
+			want:  "Simple spec",
+		},
+		{
+			name:      "When name is a standard Go test with classname it should return classname/TestName",
+			tc:        junitTestCase{Name: "TestCreate", ClassName: "github.com/flightctl/flightctl/internal/store"},
+			suiteName: "",
+			want:      "internal/store/TestCreate",
+		},
+		{
+			name:      "When name is a standard Go test with a subtest it should include the subtest",
+			tc:        junitTestCase{Name: "TestCreate/with_valid_input", ClassName: "github.com/flightctl/flightctl/internal/store"},
+			want:      "internal/store/TestCreate/with_valid_input",
+		},
+		{
+			name:      "When classname is empty it should fall back to suiteName",
+			tc:        junitTestCase{Name: "TestFoo", ClassName: ""},
+			suiteName: "github.com/flightctl/flightctl/pkg/util",
+			want:      "pkg/util/TestFoo",
+		},
+		{
+			name:      "When classname is empty and suiteName is also empty it should return the raw name",
+			tc:        junitTestCase{Name: "TestFoo", ClassName: ""},
+			suiteName: "",
+			want:      "TestFoo",
+		},
+		{
+			name:  "When name contains a pkg path anchor it should strip the module prefix",
+			tc:    junitTestCase{Name: "TestList", ClassName: "github.com/flightctl/flightctl/pkg/version"},
+			want:  "pkg/version/TestList",
+		},
+		{
+			name:  "When name contains a cmd path anchor it should strip the module prefix",
+			tc:    junitTestCase{Name: "TestRun", ClassName: "github.com/flightctl/flightctl/cmd/flightctl"},
+			want:  "cmd/flightctl/TestRun",
+		},
+		{
+			name:  "When name contains an api path anchor it should strip the module prefix",
+			tc:    junitTestCase{Name: "TestValidate", ClassName: "github.com/flightctl/flightctl/api/v1beta1"},
+			want:  "api/v1beta1/TestValidate",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, specNameFromCase(tt.tc, tt.suiteName))
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// aggregateRuns
+// --------------------------------------------------------------------------
+
+// TestAggregateRuns covers pass/fail accumulation, infra instability exclusion,
+// and handling of runs with no JUnit output.
+func TestAggregateRuns(t *testing.T) {
+	t.Run("When a run has more than 30 percent of specs failing it should be excluded as infra instability", func(t *testing.T) {
+		// 5 specs, 4 failing = 80% > threshold
+		run := rawRunData{
+			RunID: 1, RunURL: "u1", Date: "d", Conclusion: "failure",
+			Specs: map[string]rawSpecResult{
+				"Spec A": {Passed: false},
+				"Spec B": {Passed: false},
+				"Spec C": {Passed: false},
+				"Spec D": {Passed: false},
+				"Spec E": {Passed: true},
+			},
+		}
+		agg := aggregateRuns([]rawRunData{run})
+		require.Empty(t, agg.specs)
+		require.Len(t, agg.infraRuns, 1)
+	})
+
+	t.Run("When a run has no specs it should be recorded in noJUnit", func(t *testing.T) {
+		run := rawRunData{RunID: 2, RunURL: "u2", Date: "d", Conclusion: "failure", Specs: nil}
+		agg := aggregateRuns([]rawRunData{run})
+		require.Len(t, agg.noJUnit, 1)
+		require.Empty(t, agg.specs)
+	})
+
+	t.Run("When a spec passes across runs it should accumulate pass counts", func(t *testing.T) {
+		runs := []rawRunData{
+			makeRun(1, "u1", "d1", "success", 9, map[string]rawSpecResult{"Spec A": {Passed: true}}),
+			makeRun(2, "u2", "d2", "success", 9, map[string]rawSpecResult{"Spec A": {Passed: true}}),
+		}
+		agg := aggregateRuns(runs)
+		require.Equal(t, 2, agg.specs["Spec A"].PassCount)
+		require.Equal(t, 0, agg.specs["Spec A"].FailCount)
+	})
+
+	t.Run("When a spec fails in some runs it should accumulate fail counts and record the last URL", func(t *testing.T) {
+		failURL := "https://github.com/org/repo/actions/runs/999"
+		runs := []rawRunData{
+			// Newest first (as collect returns them)
+			makeRun(3, failURL, "d3", "success", 9, map[string]rawSpecResult{"Spec A": {Passed: false, FailureMsg: "timeout"}}),
+			makeRun(2, "u2", "d2", "success", 9, map[string]rawSpecResult{"Spec A": {Passed: true}}),
+		}
+		agg := aggregateRuns(runs)
+		require.Equal(t, 1, agg.specs["Spec A"].FailCount)
+		require.Equal(t, failURL, agg.specs["Spec A"].LastFailedURL)
+		require.Equal(t, "timeout", agg.specs["Spec A"].FailureMsg)
+	})
+
+	t.Run("When a spec is skipped it should increment skip count and not count as pass or fail", func(t *testing.T) {
+		run := makeRun(1, "u1", "d1", "success", 9, map[string]rawSpecResult{"Spec A": {Skipped: true}})
+		agg := aggregateRuns([]rawRunData{run})
+		require.Equal(t, 1, agg.specs["Spec A"].SkipCount)
+		require.Equal(t, 0, agg.specs["Spec A"].PassCount)
+		require.Equal(t, 0, agg.specs["Spec A"].FailCount)
+	})
+}
+
+// --------------------------------------------------------------------------
+// computeFlakes
+// --------------------------------------------------------------------------
+
+// TestComputeFlakes covers classification, sorting, and metadata propagation.
+func TestComputeFlakes(t *testing.T) {
+	t.Run("When a spec fails some runs but also passes it should be classified as Flaky", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 10, FailCount: 4},
+		}}
+		entries, _, flakyCount, consistentCount, _ := computeFlakes(agg, 10)
+		require.Len(t, entries, 1)
+		require.Equal(t, "Flaky", entries[0].Class)
+		require.Equal(t, 1, flakyCount)
+		require.Equal(t, 0, consistentCount)
+	})
+
+	t.Run("When a spec never passes it should be classified as Consistently failing", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 0, FailCount: 8},
+		}}
+		entries, _, flakyCount, consistentCount, _ := computeFlakes(agg, 10)
+		require.Len(t, entries, 1)
+		require.Equal(t, "Consistently failing", entries[0].Class)
+		require.Equal(t, 0, flakyCount)
+		require.Equal(t, 1, consistentCount)
+	})
+
+	t.Run("When a spec never fails it should be counted as clean and not appear in flake entries", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 14, FailCount: 0},
+		}}
+		entries, totalSpecs, _, _, cleanCount := computeFlakes(agg, 10)
+		require.Empty(t, entries)
+		require.Equal(t, 1, totalSpecs)
+		require.Equal(t, 1, cleanCount)
+	})
+
+	t.Run("When a spec is only ever skipped it should not be counted in totalSpecs", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {SkipCount: 5},
+		}}
+		_, totalSpecs, _, _, _ := computeFlakes(agg, 10)
+		require.Equal(t, 0, totalSpecs)
+	})
+
+	t.Run("When multiple specs have failures they should be sorted by fail rate descending", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Low flake":  {PassCount: 9, FailCount: 1},
+			"High flake": {PassCount: 2, FailCount: 8},
+		}}
+		entries, _, _, _, _ := computeFlakes(agg, 10)
+		require.Len(t, entries, 2)
+		require.Greater(t, entries[0].FailRate, entries[1].FailRate)
+	})
+
+	t.Run("When topN is smaller than flake count it should truncate to topN entries", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 1, FailCount: 9},
+			"Spec B": {PassCount: 2, FailCount: 8},
+			"Spec C": {PassCount: 3, FailCount: 7},
+		}}
+		entries, _, _, _, _ := computeFlakes(agg, 2)
+		require.Len(t, entries, 2)
+	})
+
+	t.Run("When consistently failing entries are present they should appear before flaky ones", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Flaky":      {PassCount: 5, FailCount: 5},
+			"Consistent": {PassCount: 0, FailCount: 5},
+		}}
+		entries, _, _, _, _ := computeFlakes(agg, 10)
+		require.Len(t, entries, 2)
+		require.Equal(t, "Consistently failing", entries[0].Class)
+	})
+
+	t.Run("When a flake entry is generated it should record the last failed run URL", func(t *testing.T) {
+		failURL := "https://github.com/org/repo/actions/runs/42"
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 5, FailCount: 2, LastFailedURL: failURL},
+		}}
+		entries, _, _, _, _ := computeFlakes(agg, 10)
+		require.Len(t, entries, 1)
+		require.Equal(t, failURL, entries[0].LastRunURL)
+	})
+
+	t.Run("When a flake entry has a failure message it should propagate to the entry", func(t *testing.T) {
+		agg := junitAgg{specs: map[string]specResult{
+			"Spec A": {PassCount: 5, FailCount: 2, FailureMsg: "connection refused"},
+		}}
+		entries, _, _, _, _ := computeFlakes(agg, 10)
+		require.Equal(t, "connection refused", entries[0].FailureMsg)
+	})
+}
+
+// --------------------------------------------------------------------------
+// computeTimings
+// --------------------------------------------------------------------------
+
+// TestComputeTimings verifies per-spec avg/stddev derived from raw run data.
+func TestComputeTimings(t *testing.T) {
+	t.Run("When two runs have the same spec it should average the durations", func(t *testing.T) {
+		runs := []rawRunData{
+			makeRun(1, "u1", "d1", "success", 0, map[string]rawSpecResult{"Spec A": {Passed: true, DurationSec: 100}}),
+			makeRun(2, "u2", "d2", "success", 0, map[string]rawSpecResult{"Spec A": {Passed: true, DurationSec: 200}}),
+		}
+		timings := computeTimings(runs)
+		require.InDelta(t, 150.0, timings["Spec A"].Avg, 0.001)
+	})
+
+	t.Run("When a spec has zero duration it should be excluded from timings", func(t *testing.T) {
+		runs := []rawRunData{
+			makeRun(1, "u1", "d1", "success", 0, map[string]rawSpecResult{"Spec A": {Passed: true, DurationSec: 0}}),
+		}
+		timings := computeTimings(runs)
+		_, exists := timings["Spec A"]
+		require.False(t, exists)
+	})
+
+	t.Run("When a spec is skipped it should be excluded from timings", func(t *testing.T) {
+		runs := []rawRunData{
+			makeRun(1, "u1", "d1", "success", 0, map[string]rawSpecResult{"Spec A": {Skipped: true, DurationSec: 10}}),
+		}
+		timings := computeTimings(runs)
+		_, exists := timings["Spec A"]
+		require.False(t, exists)
+	})
+
+	t.Run("When a run exceeds the infra instability threshold it should be excluded from timings", func(t *testing.T) {
+		// 5 specs all failing = 100% > threshold
+		specs := map[string]rawSpecResult{
+			"Spec A": {Passed: false, DurationSec: 99},
+			"Spec B": {Passed: false, DurationSec: 50},
+			"Spec C": {Passed: false, DurationSec: 60},
+			"Spec D": {Passed: false, DurationSec: 70},
+			"Spec E": {Passed: false, DurationSec: 80},
+		}
+		run := rawRunData{RunID: 1, RunURL: "u1", Date: "d1", Conclusion: "failure", Specs: specs}
+		timings := computeTimings([]rawRunData{run})
+		require.Empty(t, timings)
+	})
+}
+
+// --------------------------------------------------------------------------
+// computeSlowest
+// --------------------------------------------------------------------------
+
+// TestComputeSlowest verifies descending order and top-N truncation.
+func TestComputeSlowest(t *testing.T) {
+	timings := map[string]specTiming{
+		"fast":      {Avg: 10.0},
+		"medium":    {Avg: 50.0},
+		"slow":      {Avg: 200.0},
+		"very slow": {Avg: 300.0},
+	}
+
+	t.Run("When specs are ranked by avg it should return the top N in descending order", func(t *testing.T) {
+		result := computeSlowest(timings, 3)
+		require.Len(t, result, 3)
+		require.Equal(t, "very slow", result[0].Name)
+		require.Equal(t, "slow", result[1].Name)
+		require.Equal(t, "medium", result[2].Name)
+	})
+
+	t.Run("When topN exceeds available specs it should return all specs", func(t *testing.T) {
+		result := computeSlowest(timings, 20)
+		require.Len(t, result, 4)
+	})
+
+	t.Run("When topN is zero it should return all specs", func(t *testing.T) {
+		result := computeSlowest(timings, 0)
+		require.Len(t, result, 4)
+	})
+}
+
+// --------------------------------------------------------------------------
+// computeTrend
+// --------------------------------------------------------------------------
+
+// TestComputeTrend verifies per-run pass/fail/skip counts and ordering.
+func TestComputeTrend(t *testing.T) {
+	t.Run("When runs are in newest-first order trend should be reversed to oldest-first", func(t *testing.T) {
+		runs := []rawRunData{
+			{RunID: 3, Date: "2026-01-06", Conclusion: "success", Specs: map[string]rawSpecResult{"Spec A": {Passed: true}}},
+			{RunID: 2, Date: "2026-01-05", Conclusion: "success", Specs: map[string]rawSpecResult{"Spec A": {Passed: true}}},
+			{RunID: 1, Date: "2026-01-04", Conclusion: "success", Specs: map[string]rawSpecResult{"Spec A": {Passed: true}}},
+		}
+		trend := computeTrend(runs)
+		require.Len(t, trend, 3)
+		require.Equal(t, int64(1), trend[0].RunID)
+		require.Equal(t, int64(3), trend[2].RunID)
+	})
+
+	t.Run("When a run has passed failed and skipped specs it should count each correctly", func(t *testing.T) {
+		run := rawRunData{
+			RunID: 1, Date: "d", Conclusion: "success",
+			Specs: map[string]rawSpecResult{
+				"Spec P1": {Passed: true},
+				"Spec P2": {Passed: true},
+				"Spec F1": {Passed: false},
+				"Spec S1": {Skipped: true},
+			},
+		}
+		trend := computeTrend([]rawRunData{run})
+		require.Len(t, trend, 1)
+		require.Equal(t, 2, trend[0].Passed)
+		require.Equal(t, 1, trend[0].Failed)
+		require.Equal(t, 1, trend[0].Skipped)
+		require.Equal(t, 4, trend[0].Total)
+	})
+
+	t.Run("When a run has no specs the trend entry should have zero counts", func(t *testing.T) {
+		run := rawRunData{RunID: 1, Date: "d", Conclusion: "failure", Specs: nil}
+		trend := computeTrend([]rawRunData{run})
+		require.Len(t, trend, 1)
+		require.Equal(t, 0, trend[0].Total)
+	})
+}
+
+// --------------------------------------------------------------------------
+// avgStddev
+// --------------------------------------------------------------------------
+
+// TestAvgStddev covers the statistics helper.
+func TestAvgStddev(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      []float64
+		wantAvg    float64
+		wantStddev float64
+	}{
+		{
+			name:       "When step durations are provided it should compute avg and stddev correctly",
+			input:      []float64{100, 200, 300},
+			wantAvg:    200,
+			wantStddev: 81.65,
+		},
+		{
+			name:       "When a single value is provided stddev should be zero",
+			input:      []float64{50},
+			wantAvg:    50,
+			wantStddev: 0,
+		},
+		{
+			name:       "When slice is empty both should be zero",
+			input:      []float64{},
+			wantAvg:    0,
+			wantStddev: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			avg, std := avgStddev(tt.input)
+			require.InDelta(t, tt.wantAvg, avg, 0.01)
+			require.InDelta(t, tt.wantStddev, std, 0.01)
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// formatDuration
+// --------------------------------------------------------------------------
+
+// TestFormatDuration covers the human-readable duration formatter.
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		secs float64
+		want string
+	}{
+		{"When duration is zero it should return 0s", 0, "0s"},
+		{"When duration is sub-minute it should show seconds", 45, "45s"},
+		{"When duration is exact minutes it should omit seconds", 120, "2m"},
+		{"When duration has minutes and seconds it should show both", 125, "2m 5s"},
+		{"When duration is negative it should return 0s", -10, "0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatDuration(tt.secs))
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// truncateMsg
+// --------------------------------------------------------------------------
+
+// TestTruncateMsg covers message truncation and whitespace normalization.
+func TestTruncateMsg(t *testing.T) {
+	t.Run("When message is within the limit it should be returned unchanged", func(t *testing.T) {
+		require.Equal(t, "short msg", truncateMsg("short msg", 200))
+	})
+	t.Run("When message exceeds the limit it should be truncated with ellipsis", func(t *testing.T) {
+		buf := make([]byte, 300)
+		for i := range buf {
+			buf[i] = 'a'
+		}
+		result := truncateMsg(string(buf), 200)
+		require.Len(t, []rune(result), 201)
+		require.True(t, len(result) > 200)
+	})
+	t.Run("When message contains newlines they should be normalized to spaces", func(t *testing.T) {
+		result := truncateMsg("line1\nline2\nline3", 200)
+		require.Equal(t, "line1 line2 line3", result)
+	})
+}
+
+// --------------------------------------------------------------------------
+// renderHTML / renderSlackSummary / appendStepSummary (fixture-based)
+// --------------------------------------------------------------------------
+
+// TestRenderHTML exercises the full compute+render path using the testdata fixture.
+func TestRenderHTML(t *testing.T) {
+	var raw rawFile
+	require.NoError(t, loadJSON("testdata/raw-junit.json", &raw))
+
+	report := computeReport(raw, "Integration Test Health", 10)
+
+	outPath := filepath.Join(t.TempDir(), "report.html")
+	require.NoError(t, renderHTML(report, outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	html := string(content)
+
+	t.Run("When all sections have data it should produce a valid HTML file with all sections", func(t *testing.T) {
+		require.Contains(t, html, `id="trend"`)
+		require.Contains(t, html, `id="flakes"`)
+		require.Contains(t, html, `id="slowest"`)
+	})
+
+	t.Run("When the HTML file is parsed it should contain SVG elements for the charts", func(t *testing.T) {
+		require.Contains(t, html, "<svg ")
+		require.Contains(t, html, "<rect ")
+	})
+
+	t.Run("When the title is set it should appear in the HTML", func(t *testing.T) {
+		require.Contains(t, html, "Integration Test Health")
+	})
+}
+
+// TestRenderSlackSummary verifies the JSON summary fields.
+func TestRenderSlackSummary(t *testing.T) {
+	var raw rawFile
+	require.NoError(t, loadJSON("testdata/raw-junit.json", &raw))
+
+	report := computeReport(raw, "Integration Test Health", 10)
+
+	path := filepath.Join(t.TempDir(), "summary.json")
+	require.NoError(t, renderSlackSummary(report, path))
+
+	t.Run("When the JSON summary is written it should contain the required fields", func(t *testing.T) {
+		var s slackSummary
+		require.NoError(t, loadJSON(path, &s))
+		require.Equal(t, "Integration Test Health", s.Title)
+		require.GreaterOrEqual(t, s.AnalyzedRuns, 0)
+		require.GreaterOrEqual(t, s.TotalSpecsTracked, 0)
+		require.GreaterOrEqual(t, s.ConsistentlyFailing, 0)
+		require.GreaterOrEqual(t, s.FlakyTests, 0)
+		require.GreaterOrEqual(t, s.NeverFailed, 0)
+		require.GreaterOrEqual(t, s.InfraInstabilityEvents, 0)
+	})
+}
+
+// TestStepSummaryNoScriptTags verifies the step summary is plain HTML.
+func TestStepSummaryNoScriptTags(t *testing.T) {
+	var raw rawFile
+	require.NoError(t, loadJSON("testdata/raw-junit.json", &raw))
+
+	report := computeReport(raw, "Integration Test Health", 10)
+
+	summaryPath := filepath.Join(t.TempDir(), "summary.html")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	require.NoError(t, appendStepSummary(report))
+
+	content, err := os.ReadFile(summaryPath)
+	require.NoError(t, err)
+	html := string(content)
+
+	t.Run("When the step summary is written it should contain only HTML with no script or svg tags", func(t *testing.T) {
+		require.NotContains(t, html, "<script")
+		require.NotContains(t, html, "<svg")
+		require.Contains(t, html, "<table")
+		require.Contains(t, html, "<h2>")
+	})
+}
+
+// --------------------------------------------------------------------------
+// computeReport (end-to-end)
+// --------------------------------------------------------------------------
+
+// TestComputeReportFromFixture verifies the end-to-end compute pipeline.
+func TestComputeReportFromFixture(t *testing.T) {
+	var raw rawFile
+	require.NoError(t, loadJSON("testdata/raw-junit.json", &raw))
+
+	report := computeReport(raw, "Integration Test Health", 10)
+
+	t.Run("When fixture data is loaded it should produce non-empty report fields", func(t *testing.T) {
+		require.Equal(t, "Integration Test Health", report.Title)
+		require.Equal(t, raw.Meta.AnalyzedRuns, report.AnalyzedRuns)
+		require.Greater(t, report.TotalAnalyzedSpecs, 0)
+		require.NotEmpty(t, report.TrendEntries)
+		require.NotEmpty(t, report.SlowestTests)
+	})
+
+	t.Run("When fixture has 3 runs the trend should have 3 entries in chronological order", func(t *testing.T) {
+		require.Len(t, report.TrendEntries, 3)
+		require.Equal(t, "2026-01-04", report.TrendEntries[0].Date)
+		require.Equal(t, "2026-01-06", report.TrendEntries[2].Date)
+	})
+
+	t.Run("When clean and flaky counts are summed they should equal total specs tracked", func(t *testing.T) {
+		total := report.CleanCount + report.FlakyCount + report.ConsistentlyFailingCount
+		require.Equal(t, report.TotalAnalyzedSpecs, total)
+	})
+
+	t.Run("When a spec is flaky it should appear in FlakeEntries", func(t *testing.T) {
+		require.NotEmpty(t, report.FlakeEntries)
+	})
+}
+
+// --------------------------------------------------------------------------
+// Fixture loading sanity check
+// --------------------------------------------------------------------------
+
+// TestLoadFixture verifies the testdata file parses correctly.
+func TestLoadFixture(t *testing.T) {
+	t.Run("raw-junit.json should parse as rawFile", func(t *testing.T) {
+		var raw rawFile
+		require.NoError(t, loadJSON("testdata/raw-junit.json", &raw))
+		require.NotEmpty(t, raw.Meta.Workflow)
+		require.NotEmpty(t, raw.Runs)
+	})
+
+	t.Run("raw-junit.json fixture helper should return content string", func(t *testing.T) {
+		content := loadFixture(t, "raw-junit.json")
+		require.Contains(t, content, "runs")
+	})
+}
+
+// TestParseJUnitFile verifies XML parsing for both Ginkgo and Go test formats.
+func TestParseJUnitFile(t *testing.T) {
+	t.Run("When JUnit XML has Ginkgo format it should extract the spec name correctly", func(t *testing.T) {
+		xml := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Store Suite">
+    <testcase name="[It] Store Suite should create a device [12345, integration]" classname="Store Suite" time="1.5"/>
+    <testcase name="[It] Store Suite should fail [67890, integration]" classname="Store Suite" time="2.0">
+      <failure message="database error">detail here</failure>
+    </testcase>
+    <testcase name="[BeforeSuite]" classname="Store Suite" time="0.3"/>
+  </testsuite>
+</testsuites>`
+		path := filepath.Join(t.TempDir(), "junit.xml")
+		require.NoError(t, os.WriteFile(path, []byte(xml), 0o644))
+
+		results, err := parseJUnitFile(path)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		var passing, failing *junitResult
+		for i := range results {
+			if results[i].Passed {
+				passing = &results[i]
+			} else {
+				failing = &results[i]
+			}
+		}
+		require.NotNil(t, passing)
+		require.Equal(t, "Store Suite should create a device", passing.SpecName)
+		require.InDelta(t, 1.5, passing.DurationSec, 0.001)
+
+		require.NotNil(t, failing)
+		require.Equal(t, "Store Suite should fail", failing.SpecName)
+		require.Equal(t, "database error", failing.FailureMsg)
+	})
+
+	t.Run("When JUnit XML has standard Go test format it should build classname/TestName keys", func(t *testing.T) {
+		xml := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="github.com/flightctl/flightctl/internal/store">
+    <testcase name="TestCreateDevice" classname="github.com/flightctl/flightctl/internal/store" time="0.05"/>
+    <testcase name="TestCreateDevice/valid_input" classname="github.com/flightctl/flightctl/internal/store" time="0.02"/>
+  </testsuite>
+</testsuites>`
+		path := filepath.Join(t.TempDir(), "junit.xml")
+		require.NoError(t, os.WriteFile(path, []byte(xml), 0o644))
+
+		results, err := parseJUnitFile(path)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.SpecName] = true
+		}
+		require.True(t, names["internal/store/TestCreateDevice"])
+		require.True(t, names["internal/store/TestCreateDevice/valid_input"])
+	})
+
+	t.Run("When JUnit XML has a skipped test case it should be marked as skipped", func(t *testing.T) {
+		xml := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Suite">
+    <testcase name="TestSkipped" classname="pkg/foo" time="0">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>`
+		path := filepath.Join(t.TempDir(), "junit.xml")
+		require.NoError(t, os.WriteFile(path, []byte(xml), 0o644))
+
+		results, err := parseJUnitFile(path)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results[0].Skipped)
+		require.False(t, results[0].Passed)
+	})
+}

--- a/test/scripts/analyze_test_health/render.go
+++ b/test/scripts/analyze_test_health/render.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"math"
+	"os"
+	"strings"
+)
+
+//go:embed template.html
+var htmlReportTemplate string
+
+// renderContext wraps the computed reportData and adds pre-generated SVG
+// charts. The HTML template receives a *renderContext so it can access both
+// the plain data fields (promoted from the embedded *reportData) and the
+// chart SVGs in a single pass.
+type renderContext struct {
+	*reportData
+	FlakeDonutSVG   template.HTML
+	SlowestChartSVG template.HTML
+	TrendChartSVG   template.HTML
+}
+
+type slackSummary struct {
+	Title                   string  `json:"title"`
+	Workflow                string  `json:"workflow"`
+	AnalyzedRuns            int     `json:"analyzed_runs"`
+	TotalSpecsTracked       int     `json:"total_specs_tracked"`
+	ConsistentlyFailing     int     `json:"consistently_failing"`
+	FlakyTests              int     `json:"flaky_tests"`
+	NeverFailed             int     `json:"never_failed"`
+	InfraInstabilityEvents  int     `json:"infra_instability_events"`
+}
+
+// renderHTML generates all SVG charts, builds a renderContext, and executes
+// the embedded HTML template, writing the result to path.
+func renderHTML(data *reportData, path string) error {
+	ctx := &renderContext{
+		reportData: data,
+		FlakeDonutSVG: svgDonut([]donutSegment{
+			{Label: "Clean", Value: float64(data.CleanCount), Color: "#22c55e"},
+			{Label: "Flaky", Value: float64(data.FlakyCount), Color: "#f59e0b"},
+			{Label: "Consistently failing", Value: float64(data.ConsistentlyFailingCount), Color: "#ef4444"},
+		}, 260),
+		SlowestChartSVG: svgSpecBars(data.SlowestTests, "#f59e0b"),
+		TrendChartSVG:   svgTrendBars(data.TrendEntries),
+	}
+
+	funcMap := template.FuncMap{
+		"FormatDuration": formatDuration,
+		"FailPct":        func(rate float64) string { return fmt.Sprintf("%.0f%%", rate*100) },
+		"Abs":            math.Abs,
+		"Sub":            func(a, b float64) float64 { return a - b },
+		"IntSub":         func(a, b int) int { return a - b },
+	}
+	tmpl, err := template.New("report").Funcs(funcMap).Parse(htmlReportTemplate)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	defer f.Close()
+	return tmpl.Execute(f, ctx)
+}
+
+func renderSlackSummary(r *reportData, path string) error {
+	s := slackSummary{
+		Title:                  r.Title,
+		Workflow:               r.Workflow,
+		AnalyzedRuns:           r.AnalyzedRuns,
+		TotalSpecsTracked:      r.TotalAnalyzedSpecs,
+		ConsistentlyFailing:    r.ConsistentlyFailingCount,
+		FlakyTests:             r.FlakyCount,
+		NeverFailed:            r.CleanCount,
+		InfraInstabilityEvents: r.InfraInstabilityCount,
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+func appendStepSummary(r *reportData) error {
+	summaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "<h1>%s</h1>\n", htmlEsc(r.Title))
+	fmt.Fprintf(&b, "<p>Generated: %s &nbsp;·&nbsp; %d runs analyzed</p>\n", r.GeneratedAt, r.AnalyzedRuns)
+
+	fmt.Fprintf(&b, "<h2>Test Health</h2>\n")
+	fmt.Fprintf(&b, "<p>%d specs — %d flaky, %d consistently failing, %d clean",
+		r.TotalAnalyzedSpecs, r.FlakyCount, r.ConsistentlyFailingCount, r.CleanCount)
+	if r.InfraInstabilityCount > 0 {
+		fmt.Fprintf(&b, " (%d infra instability runs excluded)", r.InfraInstabilityCount)
+	}
+	fmt.Fprintf(&b, "</p>\n")
+
+	if len(r.FlakeEntries) > 0 {
+		fmt.Fprintf(&b, "<table><thead><tr><th>Rate</th><th>Class</th><th>Last Failed</th><th>Test</th></tr></thead><tbody>\n")
+		for _, fe := range r.FlakeEntries {
+			fmt.Fprintf(&b, "<tr><td>%.0f%% (%d/%d)</td><td>%s</td><td><a href=%q>run</a></td><td>%s</td></tr>\n",
+				fe.FailRate*100, fe.FailCount, fe.TotalRuns, htmlEsc(fe.Class), fe.LastRunURL, htmlEsc(fe.SpecName))
+		}
+		fmt.Fprintf(&b, "</tbody></table>\n")
+	}
+
+	if len(r.SlowestTests) > 0 {
+		fmt.Fprintf(&b, "<h2>Slowest Tests</h2>\n")
+		fmt.Fprintf(&b, "<table><thead><tr><th>Avg</th><th>±StdDev</th><th>Test</th></tr></thead><tbody>\n")
+		for _, s := range r.SlowestTests {
+			fmt.Fprintf(&b, "<tr><td>%s</td><td>±%s</td><td>%s</td></tr>\n",
+				formatDuration(s.AvgSecs), formatDuration(s.StdDev), htmlEsc(s.Name))
+		}
+		fmt.Fprintf(&b, "</tbody></table>\n")
+	}
+
+	_, err = f.WriteString(b.String())
+	return err
+}
+
+// formatDuration converts seconds to a human-readable string.
+func formatDuration(secs float64) string {
+	if secs <= 0 {
+		return "0s"
+	}
+	if secs < 60 {
+		return fmt.Sprintf("%.0fs", secs)
+	}
+	m := int(secs) / 60
+	s := int(secs) % 60
+	if s == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dm %ds", m, s)
+}
+
+func htmlEsc(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, `"`, "&#34;")
+	return s
+}
+
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+// SVG chart generators
+
+type donutSegment struct {
+	Label string
+	Value float64
+	Color string
+}
+
+// svgDonut generates a self-contained SVG donut chart.
+func svgDonut(segments []donutSegment, size int) template.HTML {
+	var total float64
+	for _, s := range segments {
+		total += s.Value
+	}
+	if total == 0 {
+		return ""
+	}
+	cx, cy := float64(size)/2, float64(size)/2
+	outerR := cx * 0.72
+	innerR := outerR * 0.56
+	legendX := size + 14
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="100%%" style="max-width:%dpx">`, size+190, size, size+190)
+
+	startAngle := -math.Pi / 2
+	for i, seg := range segments {
+		if seg.Value == 0 {
+			continue
+		}
+		sweep := seg.Value / total * 2 * math.Pi
+		endAngle := startAngle + sweep
+
+		x1 := cx + outerR*math.Cos(startAngle)
+		y1 := cy + outerR*math.Sin(startAngle)
+		x2 := cx + outerR*math.Cos(endAngle)
+		y2 := cy + outerR*math.Sin(endAngle)
+		x3 := cx + innerR*math.Cos(endAngle)
+		y3 := cy + innerR*math.Sin(endAngle)
+		x4 := cx + innerR*math.Cos(startAngle)
+		y4 := cy + innerR*math.Sin(startAngle)
+
+		largeArc := 0
+		if sweep > math.Pi {
+			largeArc = 1
+		}
+		fmt.Fprintf(&buf,
+			`<path d="M %.2f %.2f A %.2f %.2f 0 %d 1 %.2f %.2f L %.2f %.2f A %.2f %.2f 0 %d 0 %.2f %.2f Z" fill="%s"/>`,
+			x1, y1, outerR, outerR, largeArc, x2, y2, x3, y3, innerR, innerR, largeArc, x4, y4, seg.Color)
+
+		ly := float64(20 + i*26)
+		fmt.Fprintf(&buf, `<rect x="%d" y="%.0f" width="14" height="14" rx="2" fill="%s"/>`, legendX, ly, seg.Color)
+		fmt.Fprintf(&buf,
+			`<text x="%d" y="%.0f" font-size="12" style="fill:var(--text)" font-family="system-ui,sans-serif">%.0f%% %s (%.0f)</text>`,
+			legendX+18, ly+11, seg.Value/total*100, htmlEsc(seg.Label), seg.Value)
+
+		startAngle = endAngle
+	}
+
+	fmt.Fprintf(&buf,
+		`<text x="%.0f" y="%.0f" font-size="16" font-weight="700" text-anchor="middle" style="fill:var(--text)" font-family="system-ui,sans-serif">%.0f</text>`,
+		cx, cy+6, total)
+
+	buf.WriteString("</svg>")
+	return template.HTML(buf.String()) //nolint:gosec
+}
+
+// svgBars renders a horizontal bar chart from parallel slices.
+func svgBars(labels []string, values []float64, stddevs []float64, colors []string, svgWidth, rowH int) template.HTML {
+	if len(labels) == 0 {
+		return ""
+	}
+	const labelW = 260
+	const valW = 100
+	const gap = 6
+	barW := svgWidth - labelW - valW - 12
+
+	maxVal := 0.0
+	for _, v := range values {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	if maxVal == 0 {
+		maxVal = 1
+	}
+
+	var buf bytes.Buffer
+	svgH := len(labels)*(rowH+gap) + 12
+	fmt.Fprintf(&buf, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="100%%" style="max-width:%dpx">`, svgWidth, svgH, svgWidth)
+
+	for i, label := range labels {
+		y := i*(rowH+gap) + 6
+		midY := y + rowH/2 + 4
+		barPx := int(values[i] / maxVal * float64(barW))
+
+		color := "#3b82f6"
+		if i < len(colors) && colors[i] != "" {
+			color = colors[i]
+		}
+
+		fmt.Fprintf(&buf,
+			`<text x="4" y="%d" font-size="12" text-anchor="start" style="fill:var(--text)" font-family="system-ui,sans-serif">%s</text>`,
+			midY, htmlEsc(truncateStr(label, 38)))
+		fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" rx="2" style="fill:var(--bar-bg)"/>`, labelW, y, barW, rowH)
+		if barPx > 0 {
+			fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" rx="2" fill="%s"/>`, labelW, y, barPx, rowH, color)
+		}
+		valLabel := formatDuration(values[i])
+		if i < len(stddevs) && stddevs[i] > 0 {
+			valLabel += " ±" + formatDuration(stddevs[i])
+		}
+		fmt.Fprintf(&buf,
+			`<text x="%d" y="%d" font-size="11" style="fill:var(--muted)" font-family="system-ui,sans-serif">%s</text>`,
+			labelW+barW+4, midY, valLabel)
+	}
+
+	buf.WriteString("</svg>")
+	return template.HTML(buf.String()) //nolint:gosec
+}
+
+func svgSpecBars(specs []specEntry, color string) template.HTML {
+	labels := make([]string, len(specs))
+	values := make([]float64, len(specs))
+	stddevs := make([]float64, len(specs))
+	colors := make([]string, len(specs))
+	for i, s := range specs {
+		labels[i] = s.Name
+		values[i] = s.AvgSecs
+		stddevs[i] = s.StdDev
+		colors[i] = color
+	}
+	return svgBars(labels, values, stddevs, colors, 560, 22)
+}
+
+// svgTrendBars renders a stacked vertical bar chart showing per-run pass/fail counts.
+func svgTrendBars(trend []trendEntry) template.HTML {
+	if len(trend) == 0 {
+		return ""
+	}
+
+	const (
+		barW    = 32
+		barGap  = 6
+		maxBarH = 120
+		labelH  = 32
+		svgPad  = 10
+	)
+
+	// Find the max total to scale bars.
+	maxTotal := 0
+	for _, t := range trend {
+		if t.Total > maxTotal {
+			maxTotal = t.Total
+		}
+	}
+	if maxTotal == 0 {
+		maxTotal = 1
+	}
+
+	svgW := len(trend)*(barW+barGap) + svgPad*2
+	svgH := maxBarH + labelH + svgPad
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="100%%" style="max-width:%dpx">`, svgW, svgH, svgW)
+
+	for i, t := range trend {
+		x := svgPad + i*(barW+barGap)
+		if t.Total == 0 {
+			// No JUnit data for this run — draw a gray placeholder.
+			fmt.Fprintf(&buf,
+				`<rect x="%d" y="%d" width="%d" height="%d" rx="2" fill="#d1d5db" opacity="0.4"/>`,
+				x, svgPad+maxBarH/2, barW, maxBarH/2)
+		} else {
+			totalH := int(float64(t.Total) / float64(maxTotal) * float64(maxBarH))
+			if totalH < 2 {
+				totalH = 2
+			}
+			passH := int(float64(t.Passed) / float64(t.Total) * float64(totalH))
+			failH := int(float64(t.Failed) / float64(t.Total) * float64(totalH))
+			skipH := totalH - passH - failH
+			if skipH < 0 {
+				skipH = 0
+			}
+
+			yTop := svgPad + maxBarH - totalH
+			// Draw fail (red), skip (gray), pass (green) — bottom up.
+			yPass := yTop
+			if passH > 0 {
+				fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" rx="0" fill="#22c55e"/>`, x, yPass, barW, passH)
+			}
+			ySkip := yPass + passH
+			if skipH > 0 {
+				fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" rx="0" fill="#d1d5db"/>`, x, ySkip, barW, skipH)
+			}
+			yFail := ySkip + skipH
+			if failH > 0 {
+				fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="%d" height="%d" rx="0" fill="#ef4444"/>`, x, yFail, barW, failH)
+			}
+		}
+
+		// Date label, rotated.
+		labelY := svgPad + maxBarH + 4
+		dateShort := t.Date
+		if len(dateShort) >= 10 {
+			dateShort = dateShort[5:] // "MM-DD"
+		}
+		linkOpen := ""
+		linkClose := ""
+		if t.RunURL != "" {
+			linkOpen = fmt.Sprintf(`<a href="%s" target="_blank">`, htmlEsc(t.RunURL))
+			linkClose = `</a>`
+		}
+		fmt.Fprintf(&buf,
+			`%s<text x="%d" y="%d" font-size="9" text-anchor="end" transform="rotate(-55,%d,%d)" style="fill:var(--muted)" font-family="system-ui,sans-serif">%s</text>%s`,
+			linkOpen, x+barW/2, labelY, x+barW/2, labelY, htmlEsc(dateShort), linkClose)
+	}
+
+	// Legend
+	legendY := svgH - 4
+	fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="10" height="10" fill="#22c55e"/>`, svgPad, legendY-10)
+	fmt.Fprintf(&buf, `<text x="%d" y="%d" font-size="10" style="fill:var(--muted)" font-family="system-ui,sans-serif">Pass</text>`, svgPad+13, legendY)
+	fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="10" height="10" fill="#ef4444"/>`, svgPad+50, legendY-10)
+	fmt.Fprintf(&buf, `<text x="%d" y="%d" font-size="10" style="fill:var(--muted)" font-family="system-ui,sans-serif">Fail</text>`, svgPad+63, legendY)
+	fmt.Fprintf(&buf, `<rect x="%d" y="%d" width="10" height="10" fill="#d1d5db"/>`, svgPad+100, legendY-10)
+	fmt.Fprintf(&buf, `<text x="%d" y="%d" font-size="10" style="fill:var(--muted)" font-family="system-ui,sans-serif">Skip/missing</text>`, svgPad+113, legendY)
+
+	buf.WriteString("</svg>")
+	return template.HTML(buf.String()) //nolint:gosec
+}

--- a/test/scripts/analyze_test_health/template.html
+++ b/test/scripts/analyze_test_health/template.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{.Title}}</title>
+<style>
+:root{
+  --bg:#f9fafb;--card:#fff;--border:#e5e7eb;--text:#111827;--muted:#6b7280;
+  --green:#22c55e;--amber:#f59e0b;--red:#ef4444;--blue:#3b82f6;
+  --bar-bg:#f3f4f6;
+  --badge-amber-bg:#fef3c7;--badge-amber-fg:#92400e;
+  --badge-red-bg:#fee2e2;--badge-red-fg:#991b1b;
+  --badge-green-bg:#dcfce7;--badge-green-fg:#166534;
+  --badge-blue-bg:#dbeafe;--badge-blue-fg:#1e40af;
+  --highlight-bg:#fffbeb;
+}
+@media(prefers-color-scheme:dark){
+  :root{
+    --bg:#0f172a;--card:#1e293b;--border:#334155;--text:#f1f5f9;--muted:#94a3b8;
+    --bar-bg:#334155;
+    --badge-amber-bg:#3d1f00;--badge-amber-fg:#fbbf24;
+    --badge-red-bg:#3b0a0a;--badge-red-fg:#fca5a5;
+    --badge-green-bg:#052e16;--badge-green-fg:#4ade80;
+    --badge-blue-bg:#172554;--badge-blue-fg:#93c5fd;
+    --highlight-bg:#1c1a07;
+  }
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.5}
+a{color:var(--blue);text-decoration:none}
+a:hover{text-decoration:underline}
+.container{max-width:1140px;margin:0 auto;padding:24px 16px}
+header{border-bottom:1px solid var(--border);padding-bottom:16px;margin-bottom:20px}
+h1{font-size:22px;font-weight:700}
+h2{font-size:17px;font-weight:600;margin-bottom:12px}
+h3{font-size:12px;font-weight:600;margin-bottom:8px;color:var(--muted);text-transform:uppercase;letter-spacing:.05em}
+.meta{color:var(--muted);font-size:13px;margin-top:4px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:20px;margin-bottom:20px}
+.badge{display:inline-block;padding:2px 7px;border-radius:10px;font-size:11px;font-weight:600}
+.badge-amber{background:var(--badge-amber-bg);color:var(--badge-amber-fg)}
+.badge-red{background:var(--badge-red-bg);color:var(--badge-red-fg)}
+.badge-green{background:var(--badge-green-bg);color:var(--badge-green-fg)}
+.badge-blue{background:var(--badge-blue-bg);color:var(--badge-blue-fg)}
+.stats-row{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:16px;justify-content:center}
+.stat{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:10px 16px;min-width:110px;text-align:center}
+.stat-value{font-size:26px;font-weight:700}
+.stat-label{font-size:11px;color:var(--muted);margin-top:2px}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;padding:7px 10px;border-bottom:2px solid var(--border);color:var(--muted);font-weight:600;white-space:nowrap}
+td{padding:7px 10px;border-bottom:1px solid var(--border);vertical-align:top}
+tr:last-child td{border-bottom:none}
+.spec-name{font-family:ui-monospace,monospace;font-size:12px;word-break:break-all}
+.failure-msg{font-family:ui-monospace,monospace;font-size:11px;color:var(--muted);margin-top:4px;white-space:pre-wrap;word-break:break-word}
+details summary{cursor:pointer;color:var(--blue);font-size:12px;user-select:none}
+.chart-wrap{margin:12px 0;min-width:0}
+.cols-2{display:grid;grid-template-columns:1fr 1fr;gap:20px;min-width:0;align-items:start}
+.cols-2>*{min-width:0}
+.cols-2.equal-height{align-items:stretch}
+.cols-2.equal-height .card{overflow-y:auto;max-height:680px}
+.cols-2.equal-height .card h2{position:sticky;top:0;background:var(--card);z-index:1;padding-bottom:6px;margin-bottom:6px;border-bottom:1px solid var(--border)}
+@media(max-width:700px){.cols-2{grid-template-columns:1fr}}
+nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}
+nav a{font-size:13px;padding:4px 10px;border:1px solid var(--border);border-radius:4px;background:var(--card)}
+nav a:hover{background:var(--bg);text-decoration:none}
+.highlight{background:var(--highlight-bg);border-left:3px solid var(--amber);padding:10px 14px;border-radius:0 4px 4px 0;margin:12px 0;font-size:13px}
+.warn-box{display:flex;align-items:flex-start;gap:10px;background:var(--highlight-bg);border:1px solid var(--amber);border-radius:6px;padding:10px 14px;margin:12px 0;font-size:13px}
+.warn-icon{flex-shrink:0;font-size:16px;line-height:1.4}
+.warn-body{flex:1;min-width:0}
+.warn-title{font-weight:600;color:var(--text)}
+/* scrollbar styling */
+.cols-2.equal-height .card{scrollbar-width:thin;scrollbar-color:var(--border) transparent}
+.cols-2.equal-height .card::-webkit-scrollbar{width:6px}
+.cols-2.equal-height .card::-webkit-scrollbar-track{background:transparent}
+.cols-2.equal-height .card::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+.cols-2.equal-height .card::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+</style>
+</head>
+<body>
+<div class="container">
+<header>
+  <h1>{{.Title}}</h1>
+  <div class="meta">Generated {{.GeneratedAt}} &nbsp;·&nbsp; <a href="{{.RepoURL}}" target="_blank">{{.RepoURL}}</a> &nbsp;·&nbsp; {{.AnalyzedRuns}} runs analyzed (workflow: <code>{{.Workflow}}</code>)</div>
+</header>
+
+<nav>
+  <a href="#trend">Run Trend</a>
+  <a href="#flakes">Flaky Tests</a>
+  <a href="#slowest">Slowest Tests</a>
+</nav>
+
+<!-- Summary stats -->
+<div class="card" style="margin-bottom:20px">
+  <div class="stats-row" style="margin-bottom:0">
+    <div class="stat"><div class="stat-value">{{.AnalyzedRuns}}</div><div class="stat-label">Runs analyzed</div></div>
+    <div class="stat"><div class="stat-value">{{.TotalAnalyzedSpecs}}</div><div class="stat-label">Specs tracked</div></div>
+    <div class="stat"><div class="stat-value" style="color:var(--red)">{{.ConsistentlyFailingCount}}</div><div class="stat-label">Always failing</div></div>
+    <div class="stat"><div class="stat-value" style="color:var(--amber)">{{.FlakyCount}}</div><div class="stat-label">Flaky</div></div>
+    <div class="stat"><div class="stat-value" style="color:var(--green)">{{.CleanCount}}</div><div class="stat-label">Never failed</div></div>
+    {{if .InfraInstabilityCount}}
+    <div class="stat"><div class="stat-value" style="color:var(--muted)">{{.InfraInstabilityCount}}</div><div class="stat-label">Infra events excluded</div></div>
+    {{end}}
+  </div>
+</div>
+
+<!-- Section: Run Trend -->
+<section id="trend">
+<div class="card">
+  <h2>Run Trend</h2>
+  <div class="meta" style="margin-bottom:12px">Pass/fail/skip breakdown per analyzed run (oldest → newest). Gray bars indicate runs with no JUnit output (tests skipped or pre-test failure).</div>
+  {{if .TrendEntries}}
+  <div class="chart-wrap" style="overflow-x:auto">{{.TrendChartSVG}}</div>
+  {{else}}
+  <p class="meta">No run data available.</p>
+  {{end}}
+  {{if gt .NoJUnitCount 0}}
+  <p class="meta" style="margin-top:8px">{{.NoJUnitCount}} run(s) produced no JUnit output (tests skipped because no relevant files changed, or pre-test failure).</p>
+  {{end}}
+</div>
+</section>
+
+<!-- Section: Flaky Tests -->
+<section id="flakes">
+<div class="card">
+  <h2>Flaky Tests</h2>
+  {{if .InfraInstabilityCount}}<p class="meta" style="margin-bottom:12px">{{.InfraInstabilityCount}} infra instability event(s) excluded from per-spec counts</p>{{end}}
+  {{if or (gt .FlakyCount 0) (gt .ConsistentlyFailingCount 0)}}
+  <div class="cols-2">
+    <div class="chart-wrap">{{.FlakeDonutSVG}}</div>
+    <div>
+      <table>
+        <thead><tr><th>Rate</th><th>Class</th><th>Last Failed</th><th>Test</th></tr></thead>
+        <tbody>
+        {{range .FlakeEntries}}
+        <tr>
+          <td><strong>{{FailPct .FailRate}}</strong><br><span class="meta">{{.FailCount}}/{{.TotalRuns}} runs</span></td>
+          <td>{{if eq .Class "Flaky"}}<span class="badge badge-amber">Flaky</span>{{else}}<span class="badge badge-red">Consistent</span>{{end}}</td>
+          <td>{{if .LastRunURL}}<a href="{{.LastRunURL}}" target="_blank">view run</a>{{end}}</td>
+          <td>
+            <div class="spec-name">{{.SpecName}}</div>
+            {{if .FailureMsg}}<details><summary>failure detail</summary><div class="failure-msg">{{.FailureMsg}}</div></details>{{end}}
+          </td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {{else}}
+  <p style="color:var(--green);font-weight:600">&#10003; No flakes detected in the analyzed runs.</p>
+  {{end}}
+</div>
+</section>
+
+<!-- Section: Slowest Tests -->
+<section id="slowest">
+<div class="card">
+  <h2>Slowest Tests</h2>
+  <div class="meta" style="margin-bottom:12px">Average wall-clock duration per spec across analyzed runs (±1σ shown). Infra instability runs are excluded.</div>
+  {{if .SlowestTests}}
+  <div class="cols-2">
+    <div class="chart-wrap">{{.SlowestChartSVG}}</div>
+    <div style="overflow-y:auto;max-height:400px">
+      <table>
+        <thead><tr><th>Avg</th><th>±StdDev</th><th>Test</th></tr></thead>
+        <tbody>
+        {{range .SlowestTests}}
+        <tr>
+          <td style="white-space:nowrap">{{FormatDuration .AvgSecs}}</td>
+          <td style="white-space:nowrap;color:var(--muted)">±{{FormatDuration .StdDev}}</td>
+          <td><div class="spec-name">{{.Name}}</div></td>
+        </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {{else}}
+  <p class="meta">No timing data available for this period.</p>
+  {{end}}
+</div>
+</section>
+
+</div>
+</body>
+</html>

--- a/test/scripts/analyze_test_health/template.html
+++ b/test/scripts/analyze_test_health/template.html
@@ -116,6 +116,9 @@ nav a:hover{background:var(--bg);text-decoration:none}
   {{if gt .NoJUnitCount 0}}
   <p class="meta" style="margin-top:8px">{{.NoJUnitCount}} run(s) produced no JUnit output (tests skipped because no relevant files changed, or pre-test failure).</p>
   {{end}}
+  {{if gt .CollectErrorCount 0}}
+  <p class="meta" style="margin-top:8px;color:#e05252">{{.CollectErrorCount}} run(s) could not be collected (artifact download or parse error); excluded from all aggregation.</p>
+  {{end}}
 </div>
 </section>
 

--- a/test/scripts/analyze_test_health/testdata/raw-junit.json
+++ b/test/scripts/analyze_test_health/testdata/raw-junit.json
@@ -1,0 +1,67 @@
+{
+  "meta": {
+    "branch": "main",
+    "workflow": "integration-tests.yaml",
+    "artifact_name": "junit-integration-test",
+    "title": "Integration Test Health",
+    "repo_url": "https://github.com/flightctl/flightctl",
+    "generated_at": "2026-01-07T09:00:00Z",
+    "analyzed_runs": 3
+  },
+  "runs": [
+    {
+      "run_id": 2001,
+      "run_url": "https://github.com/flightctl/flightctl/actions/runs/2001",
+      "date": "2026-01-06",
+      "conclusion": "success",
+      "specs": {
+        "Store Suite should create a device":              {"passed": true,  "duration_sec": 1.2},
+        "Store Suite should list devices with filters":   {"passed": true,  "duration_sec": 0.8},
+        "Store Suite should delete a device":             {"passed": true,  "duration_sec": 0.5},
+        "Store Suite should handle concurrent writes":    {"passed": false, "duration_sec": 2.1, "failure_msg": "deadlock detected"},
+        "Service Suite enrollment request is accepted":   {"passed": true,  "duration_sec": 3.5},
+        "Service Suite status update is persisted":       {"passed": true,  "duration_sec": 2.8},
+        "Service Suite expired token is rejected":        {"passed": true,  "duration_sec": 1.1},
+        "Rollout Suite fleet rolls out sequentially":     {"passed": true,  "duration_sec": 8.4},
+        "Rollout Suite rollback on failure":              {"passed": true,  "duration_sec": 7.2},
+        "Rollout Suite disruption budget is respected":   {"passed": true,  "duration_sec": 6.1}
+      }
+    },
+    {
+      "run_id": 2002,
+      "run_url": "https://github.com/flightctl/flightctl/actions/runs/2002",
+      "date": "2026-01-05",
+      "conclusion": "success",
+      "specs": {
+        "Store Suite should create a device":              {"passed": true,  "duration_sec": 1.1},
+        "Store Suite should list devices with filters":   {"passed": true,  "duration_sec": 0.9},
+        "Store Suite should delete a device":             {"passed": true,  "duration_sec": 0.6},
+        "Store Suite should handle concurrent writes":    {"passed": true,  "duration_sec": 2.0},
+        "Service Suite enrollment request is accepted":   {"passed": true,  "duration_sec": 3.6},
+        "Service Suite status update is persisted":       {"passed": true,  "duration_sec": 2.9},
+        "Service Suite expired token is rejected":        {"passed": true,  "duration_sec": 1.0},
+        "Rollout Suite fleet rolls out sequentially":     {"passed": true,  "duration_sec": 8.2},
+        "Rollout Suite rollback on failure":              {"passed": false, "duration_sec": 7.5, "failure_msg": "agent did not roll back in time"},
+        "Rollout Suite disruption budget is respected":   {"passed": true,  "duration_sec": 6.3}
+      }
+    },
+    {
+      "run_id": 2003,
+      "run_url": "https://github.com/flightctl/flightctl/actions/runs/2003",
+      "date": "2026-01-04",
+      "conclusion": "failure",
+      "specs": {
+        "Store Suite should create a device":              {"passed": true,  "duration_sec": 1.3},
+        "Store Suite should list devices with filters":   {"passed": true,  "duration_sec": 0.7},
+        "Store Suite should delete a device":             {"passed": true,  "duration_sec": 0.5},
+        "Store Suite should handle concurrent writes":    {"passed": true,  "duration_sec": 2.2},
+        "Service Suite enrollment request is accepted":   {"passed": true,  "duration_sec": 3.4},
+        "Service Suite status update is persisted":       {"passed": true,  "duration_sec": 2.7},
+        "Service Suite expired token is rejected":        {"passed": true,  "duration_sec": 1.2},
+        "Rollout Suite fleet rolls out sequentially":     {"passed": true,  "duration_sec": 8.6},
+        "Rollout Suite rollback on failure":              {"passed": false, "duration_sec": 7.1, "failure_msg": "agent did not roll back in time"},
+        "Rollout Suite disruption budget is respected":   {"passed": true,  "duration_sec": 6.0}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a shared Go program `test/scripts/analyze_test_health/` that generates weekly HTML health reports for the unit and integration test CI workflows, analogous to the existing `analyze_e2e_health` tool. Uses the same 3-phase collect → compute → render architecture and handles both Ginkgo `[It]` (integration tests) and standard Go test formats (unit tests).
- Uploads JUnit artifacts (`junit-unit-test` / `junit-integration-test`) from each CI run in `unit-tests.yaml` and `integration-tests.yaml` so the reporter can download and aggregate them.
- Adds two weekly GitHub Actions workflows (`unit-health-report.yml` and `integration-health-report.yml`) that run every Monday 09:00 UTC, upload the HTML report as a CI artifact, and publish to `flightctl/flightctl-reports`.

## Report sections

Each report covers three sections:
1. **Run Trend** — stacked bar chart showing pass/fail/skip breakdown per CI run (oldest → newest).
2. **Flaky Tests** — donut chart + table with fail rate, classification (Flaky / Consistently failing), last failed run link, and failure detail.
3. **Slowest Tests** — bar chart + table with avg duration and ±stddev across runs.

Infra instability detection (>30% of specs failing in a run) is inherited from the e2e report and excludes environment-failure runs from per-spec flake counts.

## Test plan

- [ ] Unit tests for all layers pass: `cd test/scripts && go test ./analyze_test_health/...` (57 tests)
- [ ] Report builds locally: `cd test/scripts && go run ./analyze_test_health --workflow unit-tests.yaml --artifact-name junit-unit-test --title "Unit Test Health" --out-dir unit-health` (requires `GH_TOKEN` and `GITHUB_REPOSITORY` env vars once JUnit artifacts are present in CI)
- [ ] The weekly workflows trigger via `workflow_dispatch` after merging to validate artifact upload → collect → render end-to-end.


Made with [Cursor](https://cursor.com)