### PR TITLE
EDM-4161/EDM-4101: user documentation for VM applications and remote-…

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -484,6 +484,7 @@ v3.4
 VNC
 VirtIO
 Hyper-V
+enlightenments
 hostDisk
 RDP
 ISO

--- a/.spelling
+++ b/.spelling
@@ -415,6 +415,10 @@ CRI-O
  ImageContentSourcePolicy
  walkthrough
  arg
+ - docs/user/references/cli-commands.md
+VNC
+stdin
+stdout
  - docs/user/references/api-resources.md
 CertificateSigningRequest
 AuthConfig
@@ -474,8 +478,16 @@ setgid
 setuid
 TargetRevision
 undeploy
+undeploying
 unpackaged
 v3.4
+VNC
+VirtIO
+Hyper-V
+hostDisk
+RDP
+ISO
+ISOs
 WorkDir
 10s
  - docs/user/using/managing-fleets.md

--- a/.spelling
+++ b/.spelling
@@ -65,6 +65,7 @@ JSONL
 JWT
 Keycloak
 Klusterlet
+KubeVirt
 Kubernetes
 kustomize
 KVM
@@ -356,6 +357,9 @@ Issuer
 air-gapped
 vCPU
 vRAM
+WebSocket
+gRPC
+Proxy
 vDisk
 resolution
 Fedora

--- a/docs/user/installing/configuring-auth/auth-aap.md
+++ b/docs/user/installing/configuring-auth/auth-aap.md
@@ -18,7 +18,7 @@ Flight Control uses the following standard roles for authorization:
 - **`flightctl-admin`** - Full access to all resources within an organization
   - **Note:** This role cannot be set directly. Users automatically receive this role when they are set as AAP super admin
 - **`flightctl-org-admin`** - Full access to all resources within a specific organization
-- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
+- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; application lifecycle (start/stop/restart); device and application console; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
 - **`flightctl-viewer`** - Read-only access to all resources; imagebuilds and imageexports (including logs, but no download)
 - **`flightctl-installer`** - Access to get and approve enrollmentrequests, manage certificate signing requests; view imagebuilds and imageexports; download imageexports
 

--- a/docs/user/installing/configuring-auth/auth-kubernetes.md
+++ b/docs/user/installing/configuring-auth/auth-kubernetes.md
@@ -17,7 +17,7 @@ Flight Control API server validates Kubernetes service account tokens by:
 Flight Control provides the following standard ClusterRoles out-of-the-box:
 
 - **`flightctl-admin-<namespace>`** - Full access to all Flight Control resources
-- **`flightctl-operator-<namespace>`** - CRUD operations on devices, fleets, resourcesyncs, repositories; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
+- **`flightctl-operator-<namespace>`** - CRUD operations on devices, fleets, resourcesyncs, repositories; application lifecycle (start/stop/restart); device and application console; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
 - **`flightctl-viewer-<namespace>`** - Read-only access to devices, fleets, resourcesyncs, organizations; imagebuilds and imageexports (including logs, but no download)
 - **`flightctl-installer-<namespace>`** - Access to enrollmentrequests, certificate signing requests; view imagebuilds and imageexports; download imageexports
 

--- a/docs/user/installing/configuring-auth/auth-oauth2.md
+++ b/docs/user/installing/configuring-auth/auth-oauth2.md
@@ -85,7 +85,7 @@ Flight Control currently recognizes the following roles with defined permissions
 
 - **`flightctl-admin`** - Full access to all resources (super admin)
 - **`flightctl-org-admin`** - Full access to all resources within assigned organization
-- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
+- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; application lifecycle (start/stop/restart); device and application console; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
 - **`flightctl-viewer`** - Read-only access to devices, fleets, resourcesyncs, organizations; imagebuilds and imageexports (including logs, but no download)
 - **`flightctl-installer`** - Access to get and approve enrollmentrequests, manage certificate signing requests; view imagebuilds and imageexports; download imageexports
 

--- a/docs/user/installing/configuring-auth/auth-oidc.md
+++ b/docs/user/installing/configuring-auth/auth-oidc.md
@@ -82,7 +82,7 @@ Flight Control currently recognizes the following roles with defined permissions
 
 - **`flightctl-admin`** - Full access to all resources (super admin)
 - **`flightctl-org-admin`** - Full access to all resources within assigned organization
-- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
+- **`flightctl-operator`** - CRUD operations on devices, fleets, resourcesyncs, repositories; application lifecycle (start/stop/restart); device and application console; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
 - **`flightctl-viewer`** - Read-only access to devices, fleets, resourcesyncs, organizations; imagebuilds and imageexports (including logs, but no download)
 - **`flightctl-installer`** - Access to get and approve enrollmentrequests, manage certificate signing requests; view imagebuilds and imageexports; download imageexports
 

--- a/docs/user/installing/configuring-auth/auth-openshift.md
+++ b/docs/user/installing/configuring-auth/auth-openshift.md
@@ -16,7 +16,7 @@ Flight Control API server integrates with OpenShift OAuth by:
 Flight Control provides the following standard ClusterRoles out-of-the-box:
 
 - **`flightctl-admin-<namespace>`** - Full access to all Flight Control resources
-- **`flightctl-operator-<namespace>`** - CRUD operations on devices, fleets, resourcesyncs, repositories; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
+- **`flightctl-operator-<namespace>`** - CRUD operations on devices, fleets, resourcesyncs, repositories; application lifecycle (start/stop/restart); device and application console; imagebuilds (including cancel and logs); imageexports (including cancel, download, and logs)
 - **`flightctl-viewer-<namespace>`** - Read-only access to devices, fleets, resourcesyncs, organizations; imagebuilds and imageexports (including logs, but no download)
 - **`flightctl-installer-<namespace>`** - Access to enrollmentrequests, certificate signing requests; view imagebuilds and imageexports; download imageexports
 

--- a/docs/user/installing/configuring-auth/auth-pam.md
+++ b/docs/user/installing/configuring-auth/auth-pam.md
@@ -285,7 +285,7 @@ Flight Control supports the following external role names:
 |-----------|-------------|---------------|
 | `flightctl-admin` | Full administrative access | **Must be global** |
 | `flightctl-org-admin` | Organization administrator | Can be org-scoped or global |
-| `flightctl-operator` | Manage devices, fleets; imagebuilds (cancel, logs); imageexports (cancel, download, logs) | Can be org-scoped or global |
+| `flightctl-operator` | Manage devices, fleets; application lifecycle (start/stop/restart); device and application console; imagebuilds (cancel, logs); imageexports (cancel, download, logs) | Can be org-scoped or global |
 | `flightctl-viewer` | Read-only access; imagebuilds/imageexports with logs (no download) | Can be org-scoped or global |
 | `flightctl-installer` | Device provisioning; view imagebuilds/imageexports; download imageexports | Can be org-scoped or global |
 

--- a/docs/user/references/auth-resources.md
+++ b/docs/user/references/auth-resources.md
@@ -24,6 +24,7 @@ The table below contains the routes, names, resource names, and verbs for Flight
 |`GET /api/v1/devices/{name}/lastseen`|`GetDeviceLastSeen`|`devices/lastseen`|`get`|
 |`PUT /api/v1/devices/{name}/decommission`|`DecommissionDevice`|`devices/decommission`|`update`|
 |`GET /ws/v1/devices/{name}/console`|`DeviceConsole`|`devices/console`|`get`|
+|`GET /ws/v1/devices/{name}/applications/{appname}/console`|`GetDeviceApplicationConsole`|`devices/applications/console`|`get`|
 |`POST /api/v1/enrollmentrequests`|`CreateEnrollmentRequest`|`enrollmentrequests`|`create`|
 |`GET /api/v1/enrollmentrequests`|`ListEnrollmentRequests`|`enrollmentrequests`|`list`|
 |`GET /api/v1/enrollmentrequests/{name}`|`ReadEnrollmentRequest`|`enrollmentrequests`|`get`|

--- a/docs/user/references/auth-resources.md
+++ b/docs/user/references/auth-resources.md
@@ -25,6 +25,9 @@ The table below contains the routes, names, resource names, and verbs for Flight
 |`PUT /api/v1/devices/{name}/decommission`|`DecommissionDevice`|`devices/decommission`|`update`|
 |`GET /ws/v1/devices/{name}/console`|`DeviceConsole`|`devices/console`|`get`|
 |`GET /ws/v1/devices/{name}/applications/{appname}/console`|`GetDeviceApplicationConsole`|`devices/applications/console`|`get`|
+|`POST /api/v1/devices/{name}/applications/{appname}/actions/stop`|`StopDeviceApplication`|`devices/applications/lifecycle`|`update`|
+|`POST /api/v1/devices/{name}/applications/{appname}/actions/start`|`StartDeviceApplication`|`devices/applications/lifecycle`|`update`|
+|`POST /api/v1/devices/{name}/applications/{appname}/actions/restart`|`RestartDeviceApplication`|`devices/applications/lifecycle`|`update`|
 |`POST /api/v1/enrollmentrequests`|`CreateEnrollmentRequest`|`enrollmentrequests`|`create`|
 |`GET /api/v1/enrollmentrequests`|`ListEnrollmentRequests`|`enrollmentrequests`|`list`|
 |`GET /api/v1/enrollmentrequests/{name}`|`ReadEnrollmentRequest`|`enrollmentrequests`|`get`|
@@ -41,6 +44,8 @@ The table below contains the routes, names, resource names, and verbs for Flight
 |`DELETE /api/v1/fleets/{name}`|`DeleteFleet`|`fleets`|`delete`|
 |`GET /api/v1/fleets/{name}/status`|`ReadFleetStatus`|`fleets/status`|`get`|
 |`PUT /api/v1/fleets/{name}/status`|`ReplaceFleetStatus`|`fleets/status`|`update`|
+|`POST /api/v1/fleets/{name}/applications/{appname}/actions/stop`|`StopFleetApplication`|`fleets/applications/lifecycle`|`update`|
+|`POST /api/v1/fleets/{name}/applications/{appname}/actions/start`|`StartFleetApplication`|`fleets/applications/lifecycle`|`update`|
 |`POST /api/v1/repositories`|`CreateRepository`|`repositories`|`create`|
 |`GET /api/v1/repositories`|`ListRepositories`|`repositories`|`list`|
 |`PUT /api/v1/repositories/{name}`|`ReplaceRepository`|`repositories`|`update`|

--- a/docs/user/references/certificate-architecture.md
+++ b/docs/user/references/certificate-architecture.md
@@ -27,6 +27,7 @@ For TPM attestation certificates, see [Configuring Device Attestation](../instal
 | [Device Management](../../../internal/crypto/signer/signer_device_management.go)             | Device operations        | 1 year   | Client-Signer CA         |
 | [Device Management Renewal](../../../internal/crypto/signer/signer_device_management_renewal.go)             | Device operations        | 1 year   | Client-Signer CA         |
 | [Device Services](../../../internal/crypto/signer/signer_device_svc_client.go)    | Device services    | 1 year   | Client-Signer CA |
+| Remote Access Server *        | Application console TLS  | 2 years  | Root CA                  |
 | UI Server *                   | UI TLS                   | 2 years  | Root CA                  |
 | CLI Artifacts Server *        | CLI Artifacts TLS        | 2 years  | Root CA                  |
 | PAM Issuer Token Signer CA *  | Signs JWT tokens         | 10 years | Root CA                  |
@@ -60,6 +61,8 @@ Generation controlled by `global.generateCertificates` in Helm `values.yaml`: `a
 | `/etc/flightctl/pki/flightctl-api/client-signer.key`    | Client-Signer CA key            |
 | `/etc/flightctl/pki/flightctl-api/server.crt`           | API server cert                 |
 | `/etc/flightctl/pki/flightctl-api/server.key`           | API server key                  |
+| `/etc/flightctl/pki/flightctl-remote-access/server.crt` | Remote access server cert       |
+| `/etc/flightctl/pki/flightctl-remote-access/server.key` | Remote access server key        |
 | `/etc/flightctl/pki/flightctl-ui/server.crt`            | UI server cert                  |
 | `/etc/flightctl/pki/flightctl-ui/server.key`            | UI server key                   |
 | `/etc/flightctl/pki/flightctl-cli-artifacts/server.crt` | CLI Artifacts server cert       |

--- a/docs/user/references/cli-commands.md
+++ b/docs/user/references/cli-commands.md
@@ -317,9 +317,190 @@ flightctl get devices --cve-id CVE-2023-44487 --selector region=us-west
 
 ---
 
+## flightctl app start
+
+Start an application running on a device, or on every device owned by a fleet.
+
+### Synopsis
+
+```shell
+flightctl app start (device/NAME | fleet/NAME) --name APP [flags]
+```
+
+### Arguments
+
+* `device/NAME` or `fleet/NAME` - Target device or fleet
+
+### Flags
+
+* `--name <app_name>` - Application name to control (required)
+* `-y, --yes` - Skip the confirmation prompt
+
+### Description
+
+Starting an application on a fleet sets a fleet-wide default that is applied on top of the rendered application spec of every device currently owned by the fleet, and is automatically inherited by devices that join the fleet later. If a specific device also has its own override for the same application, from a previous `flightctl app start` or `flightctl app stop` issued directly against that device, whichever of the two actions was issued most recently takes effect for that device.
+
+### Examples
+
+```shell
+# Start an application on a single device
+flightctl app start device/my-device --name my-app
+
+# Start an application on every device in a fleet
+flightctl app start fleet/my-fleet --name my-app
+
+# Skip the confirmation prompt
+flightctl app start device/my-device --name my-app --yes
+```
+
+### Exit Status
+
+* `0` - Success
+* Non-zero - Error
+
+---
+
+## flightctl app stop
+
+Stop an application running on a device, or on every device owned by a fleet.
+
+### Synopsis
+
+```shell
+flightctl app stop (device/NAME | fleet/NAME) --name APP [flags]
+```
+
+### Arguments
+
+* `device/NAME` or `fleet/NAME` - Target device or fleet
+
+### Flags
+
+* `--name <app_name>` - Application name to control (required)
+* `-y, --yes` - Skip the confirmation prompt
+
+### Description
+
+Stopping an application on a fleet sets a fleet-wide default that is applied on top of the rendered application spec of every device currently owned by the fleet, and is automatically inherited by devices that join the fleet later. If a specific device also has its own override for the same application, from a previous `flightctl app start` or `flightctl app stop` issued directly against that device, whichever of the two actions was issued most recently takes effect for that device.
+
+### Examples
+
+```shell
+# Stop an application on a single device
+flightctl app stop device/my-device --name my-app
+
+# Stop an application on every device in a fleet
+flightctl app stop fleet/my-fleet --name my-app
+
+# Skip the confirmation prompt
+flightctl app stop device/my-device --name my-app --yes
+```
+
+### Exit Status
+
+* `0` - Success
+* Non-zero - Error
+
+---
+
+## flightctl app restart
+
+Restart an application running on a device.
+
+### Synopsis
+
+```shell
+flightctl app restart device/NAME --name APP [flags]
+```
+
+### Arguments
+
+* `device/NAME` - Target device
+
+### Flags
+
+* `--name <app_name>` - Application name to control (required)
+* `-y, --yes` - Skip the confirmation prompt
+
+### Description
+
+Restarting an application is only supported on individual devices; fleets are not supported.
+
+### Examples
+
+```shell
+# Restart an application on a device
+flightctl app restart device/my-device --name my-app
+```
+
+### Exit Status
+
+* `0` - Success
+* Non-zero - Error
+
+---
+
+## flightctl app console
+
+Connect a console to a VM application running on a device through the server.
+
+### Synopsis
+
+```shell
+flightctl app console device/NAME --name APP --type serial|vnc [flags]
+```
+
+### Arguments
+
+* `device/NAME` - Target device
+
+### Flags
+
+* `--name <app_name>` - Application name to open a console for (required)
+* `--type <serial|vnc>` - Console type (required)
+* `--tty` - Allocate a remote pseudo terminal
+* `--notty` - Don't allocate a remote pseudo terminal (mutually exclusive with `--tty`)
+* `--exposed-port <port>` - Local TCP port for the VNC port-forward (`0` = random ephemeral port; only valid with `--type vnc`)
+* `--force` - Take over an already-active console session for the same `--name`, disconnecting it
+
+### Description
+
+Only devices can be targeted; fleets are not supported. Requires a remote access service configured in the client config, which is set automatically by `flightctl login`.
+
+A `serial` console bridges stdin/stdout over a WebSocket connection to the device's agent, the same way as `flightctl console`; use `~.` to disconnect.
+
+A `vnc` console opens a local TCP listener and bridges a single VNC viewer connection through the agent to the application's VNC server. The session ends once that viewer disconnects; run the command again to start a new session.
+
+Only one console session — serial or VNC — is allowed per application at a time. If a console session for the same application is already active, regardless of its type, the command fails with a conflict error unless `--force` is passed, which disconnects the existing session.
+
+### Examples
+
+```shell
+# Connect to an application's serial console
+flightctl app console device/my-device --name my-app --type serial
+
+# Connect to an application's VNC console
+flightctl app console device/my-device --name my-app --type vnc
+
+# Request a specific local port for the VNC port-forward
+flightctl app console device/my-device --name my-app --type vnc --exposed-port 5900
+
+# Take over an already-active console session
+flightctl app console device/my-device --name my-app --type serial --force
+```
+
+### Exit Status
+
+* `0` - Success
+* Non-zero - Error
+
+---
+
 ## See Also
 
 * [Using the CLI](../using/cli/overview.md)
 * [Logging in to the Service](../using/cli/logging-in.md)
+* [Managing Application Lifecycle](../using/managing-devices.md#managing-application-lifecycle)
+* [Accessing a VM Application Console](../using/managing-devices.md#accessing-a-vm-application-console)
 * [Managing Image Builds and Exports](../using/managing-image-builds.md)
 * [Viewing Vulnerabilities](../using/viewing-vulnerabilities.md)

--- a/docs/user/references/cli-commands.md
+++ b/docs/user/references/cli-commands.md
@@ -338,7 +338,9 @@ flightctl app start (device/NAME | fleet/NAME) --name APP [flags]
 
 ### Description
 
-Starting an application on a fleet sets a fleet-wide default that is applied on top of the rendered application spec of every device currently owned by the fleet, and is automatically inherited by devices that join the fleet later. If a specific device also has its own override for the same application, from a previous `flightctl app start` or `flightctl app stop` issued directly against that device, whichever of the two actions was issued most recently takes effect for that device.
+Requests that the named application be started on the target device, or on every device owned by the target fleet.
+
+If the application is already started, the request still succeeds; the application stays running and no restart is performed. Starting on a fleet applies to every current member device and to devices that join the fleet later. A later start or stop issued directly against a device takes precedence for that device over the fleet-wide setting.
 
 ### Examples
 
@@ -381,7 +383,9 @@ flightctl app stop (device/NAME | fleet/NAME) --name APP [flags]
 
 ### Description
 
-Stopping an application on a fleet sets a fleet-wide default that is applied on top of the rendered application spec of every device currently owned by the fleet, and is automatically inherited by devices that join the fleet later. If a specific device also has its own override for the same application, from a previous `flightctl app start` or `flightctl app stop` issued directly against that device, whichever of the two actions was issued most recently takes effect for that device.
+Requests that the named application be stopped on the target device, or on every device owned by the target fleet.
+
+If the application is already stopped, the request still succeeds; the application stays stopped. Stopping on a fleet applies to every current member device and to devices that join the fleet later. A later start or stop issued directly against a device takes precedence for that device over the fleet-wide setting.
 
 ### Examples
 
@@ -424,7 +428,9 @@ flightctl app restart device/NAME --name APP [flags]
 
 ### Description
 
-Restarting an application is only supported on individual devices; fleets are not supported.
+Requests that the named application be restarted on the target device. Restart is only supported on individual devices; fleets are not supported.
+
+The command can be issued whether or not the application is currently running. A restart only takes effect while the application is supposed to be running; if the application has been stopped, the request still succeeds but no restart is performed.
 
 ### Examples
 

--- a/docs/user/references/components.md
+++ b/docs/user/references/components.md
@@ -58,6 +58,18 @@ A scheduler service that runs periodic maintenance tasks against the database. R
 
 **Dependencies:** PostgreSQL
 
+### flightctl-remote-access
+
+A service that brokers interactive console sessions between CLI clients and device-side applications. It provides the WebSocket endpoint for application console access and relays traffic to the agent over a gRPC channel.
+
+**Overview:**
+
+- Brokering application console WebSocket sessions (`/ws/v1/devices/{name}/applications/{appname}/console`)
+- Relaying console traffic to the agent via gRPC
+- Rate limiting console WebSocket connections
+
+**Dependencies:** PostgreSQL, Redis
+
 ### flightctl-agent
 
 The device side agent that runs on each managed device. It handles the full device lifecycle from enrollment through ongoing configuration and application management.
@@ -193,6 +205,7 @@ graph TD
         API[flightctl-api]
         Worker[flightctl-worker]
         Periodic[flightctl-periodic]
+        RA[flightctl-remote-access]
     end
 
     subgraph Observability
@@ -218,7 +231,12 @@ graph TD
     AlertProxy --> PG
     AlertProxy --> AM
 
+    RA --> PG
+    RA --> Redis
+
     UI --> API
     CLI --> API
+    CLI --> RA
     Agent --> API
+    Agent --> RA
 ```

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -656,11 +656,20 @@ The following table shows the application runtimes and formats supported by Flig
 |-------------------------------------------------------------------------------|-----------|-------------------|
 | Helm chart (via [Helm](https://helm.sh/))                                     | OCI Image | OCI registry      |
 
+### Runtime: **Virtual machine** (KVM)
+
+| Specification              | Format            | Source / Delivery              |
+|----------------------------|-------------------|--------------------------------|
+| Virtual machine definition | Unpackaged inline | Inline in device specification |
+
 > [!NOTE]
 > Compose applications require `podman-compose` to be installed on the device.
 
 > [!NOTE]
-> `quadlet` and `container` applications require podman version 5.0 or above.
+> `quadlet`, `container`, and `vm` applications require podman version 5.0 or above.
+
+> [!NOTE]
+> `vm` applications require the `/dev/kvm` device node to be present on the device. This requires CPU virtualization extensions (Intel VT-x or AMD-V) and the `kvm` kernel module to be loaded.
 
 > [!NOTE]
 > Image downloads adhere to the `pull-timeout` [configuration](../installing/installing-agent.md#agent-configuration).
@@ -674,7 +683,7 @@ To deploy an application to a device, create a new entry in the "applications" s
 |-----------|---------------------------------------------------------------------------------------------------------------------------------|
 | Name      | A user-defined name for the application. This will be used when the web UI and CLI list applications.                           |
 | Image     | A reference to an application package in an OCI registry.                                                                       |
-| AppType   | The application format type. Currently supported types: `compose`, `quadlet`, `container`, `helm`.                              |
+| AppType   | The application format type. Currently supported types: `compose`, `quadlet`, `container`, `helm`, `vm`.                       |
 | EnvVars   | (Optional) A list of key/value-pairs that will be passed to the deployment tool as environment variables or command line flags. |
 
 For each application in the "applications" section of the device's specification, there exist a corresponding device status information that contains the following information:
@@ -712,6 +721,95 @@ spec:
       WORDPRESS_DB_PASSWORD: "password"
 [...]
 ```
+
+### VM applications
+
+VM applications deploy virtual machines on the device. You define the VM using an inline manifest file; Flight Control handles the conversion and deployment automatically.
+
+#### Device requirements
+
+The device must have hardware virtualization support:
+
+| Requirement | Description |
+|-------------|-------------|
+| `/dev/kvm`  | Hardware virtualization device node. Requires CPU virtualization extensions (Intel VT-x or AMD-V) and the `kvm` kernel module to be loaded. |
+
+The VM runtime is included in the device OS image. You do not need to install it separately.
+
+> [!NOTE]
+> When an OS update is pending, the agent defers validation. This allows you to deploy VM applications alongside an OS image that includes the VM runtime. The agent applies the OS update and reboots first, then validates and deploys applications.
+
+#### VM application specification
+
+To deploy a VM application, add an entry to the `applications` section of the device specification with `appType: vm`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Required. Application name. Must match `metadata.name` inside the `vm.yaml` file. |
+| `appType` | Must be `vm` for VM applications. |
+| `inline` | Required. Exactly one file named `vm.yaml`. The file must be a KubeVirt `VirtualMachine` manifest with `apiVersion: kubevirt.io/v1`, `kind: VirtualMachine`, and `metadata.name` matching the application name. |
+| `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
+
+> [!NOTE]
+> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly.
+
+#### Example: VM application
+
+```yaml
+apiVersion: flightctl.io/v1beta1
+kind: Device
+metadata:
+  name: edge-device-001
+spec:
+  applications:
+    - name: my-vm
+      appType: vm
+      publishPorts:
+        - "2222:22"
+      inline:
+        - path: vm.yaml
+          content: |
+            apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: my-vm
+            spec:
+              running: true
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: containerdisk
+                          disk:
+                            bus: virtio
+                    resources:
+                      requests:
+                        memory: 1Gi
+                  volumes:
+                    - name: containerdisk
+                      containerDisk:
+                        image: quay.io/myorg/my-vm-image:v1.0.0
+```
+
+#### VM application status
+
+The agent reports the following status values for a VM application:
+
+| Status Field | Description |
+| ------------ |-------------|
+| Preparing | The agent is pulling OCI images required by the VM before starting it. |
+| Starting | The VM has been submitted to the system and is initializing. |
+| Running | The virtual machine is running and accepting workloads. |
+| Error | The VM failed to start or terminated with an error. Check the device events for details. |
+| Unknown | The VM was submitted but no running state has been observed yet. |
+| Completed | The VM exited cleanly. This is expected only if `spec.running` is set to `false`. |
+
+#### VM restart behavior
+
+When `spec.running: true` is set in the VM manifest, the agent automatically restarts the virtual machine if it crashes or is stopped unexpectedly. This matches the restart-on-failure policy applied to other Quadlet-based applications.
+
+To stop a VM without triggering a restart, set `spec.running: false` and apply the updated device specification.
 
 ### Helm Applications
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -726,7 +726,7 @@ spec:
 
 ### Managing Application Lifecycle
 
-In addition to deploying, updating, or undeploying applications through the device specification, you can start, stop, or restart a deployed application on demand, without changing the specification. This is useful for temporarily taking an application out of service, or for triggering a restart to recover from an issue. A user with the appropriate authorization (`update` permission on the `devices/applications/lifecycle` or `fleets/applications/lifecycle` resource) can issue these actions.
+In addition to deploying, updating, or undeploying applications through the device specification, you can start, stop, or restart a deployed application on demand, without changing the specification. This is useful for temporarily taking an application out of service, or for triggering a restart to recover from an issue.
 
 Use the `flightctl app stop`, `flightctl app start`, and `flightctl app restart` commands to control an application without changing the device or fleet specification. See the [`flightctl app start`](../references/cli-commands.md#flightctl-app-start), [`flightctl app stop`](../references/cli-commands.md#flightctl-app-stop), and [`flightctl app restart`](../references/cli-commands.md#flightctl-app-restart) CLI reference pages for command syntax, flags, and examples.
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -726,7 +726,7 @@ spec:
 
 ### Managing Application Lifecycle
 
-In addition to deploying, updating, or undeploying applications through the device specification, you can start, stop, or restart a deployed application on demand, without changing the specification. This is useful for temporarily taking an application out of service, or for triggering a restart to recover from an issue.
+In addition to deploying, updating, or undeploying applications through the device specification, you can start, stop, or restart a deployed application on demand, without changing the specification. This is useful for temporarily taking an application out of service, or for triggering a restart to recover from an issue. A user with the appropriate authorization (`update` permission on the `devices/applications/lifecycle` or `fleets/applications/lifecycle` resource) can issue these actions.
 
 Use the `flightctl app stop`, `flightctl app start`, and `flightctl app restart` commands to control an application without changing the device or fleet specification. See the [`flightctl app start`](../references/cli-commands.md#flightctl-app-start), [`flightctl app stop`](../references/cli-commands.md#flightctl-app-stop), and [`flightctl app restart`](../references/cli-commands.md#flightctl-app-restart) CLI reference pages for command syntax, flags, and examples.
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -818,7 +818,9 @@ spec:
 
 ##### Windows
 
-This example installs a Windows guest from ISOs staged on the device (`hostDisk`), with a blank root disk, VirtIO drivers media, UEFI firmware, Hyper-V features, and a TPM. You can also supply those ISOs from an OCI registry (for example as a `containerDisk`) instead; this example uses `hostDisk` for illustration. The `hostDisk` paths must already exist on the target device before applying the specification, and RDP is published on host port `3389`:
+This example installs a Windows guest from ISOs staged on the device (`hostDisk`), with a blank root disk, VirtIO drivers media, UEFI firmware, Hyper-V enlightenments, and a TPM. The Hyper-V settings in the manifest are guest enlightenments exposed for Windows compatibility and performance; the VM still runs on KubeVirt/KVM on the device, not on Microsoft Hyper-V, and they do not enable nested virtualization.
+
+Because each `hostDisk` path must already exist on every target device, this `hostDisk` layout is mainly for manual or illustrative setups. For production or larger-scale deployments, pull the ISOs from an OCI registry (for example as a `containerDisk`) instead. RDP is published on host port `3389`:
 
 ```yaml
 apiVersion: flightctl.io/v1beta1

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -770,6 +770,9 @@ To deploy a VM application, add an entry to the `applications` section of the de
 > [!NOTE]
 > The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly.
 
+> [!NOTE]
+> The `spec.running` field in `vm.yaml` is ignored. Use [application lifecycle](#managing-application-lifecycle) commands (`flightctl app start` / `stop` / `restart`) to control whether the VM is running.
+
 #### Examples
 
 ##### Fedora
@@ -946,18 +949,15 @@ The agent reports the following status values for a VM application:
 | Running | The virtual machine is running and accepting workloads. |
 | Error | The VM failed to start or terminated with an error. Check the device events for details. |
 | Unknown | The VM was submitted but no running state has been observed yet. |
-| Completed | The VM exited cleanly. This is expected only if `spec.running` is set to `false`. |
+| Completed | The VM exited cleanly. |
 | Stopping | The VM was stopped with `flightctl app stop` and is shutting down. |
 | Stopped | The VM was stopped with `flightctl app stop` and is no longer running. |
 
 #### VM restart behavior
 
-When `spec.running: true` is set in the VM manifest, the agent automatically restarts the virtual machine if it crashes or is stopped unexpectedly. This matches the restart-on-failure policy applied to other Quadlet-based applications.
+The `spec.running` field in the KubeVirt `VirtualMachine` manifest is ignored. Flight Control controls whether the VM is running through application lifecycle actions instead.
 
-To stop a VM without triggering a restart, set `spec.running: false` and apply the updated device specification.
-
-> [!TIP]
-> You can also stop, start, or restart a VM application on demand, without editing the device specification, using `flightctl app stop`, `flightctl app start`, and `flightctl app restart`. See [Managing Application Lifecycle](#managing-application-lifecycle).
+By default, a deployed VM application is kept running and is automatically restarted if it crashes or is stopped unexpectedly. To stop, start, or restart a VM application on demand, use `flightctl app stop`, `flightctl app start`, and `flightctl app restart`. See [Managing Application Lifecycle](#managing-application-lifecycle).
 
 #### Accessing a VM Application Console
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -696,6 +696,8 @@ For each application in the "applications" section of the device's specification
 | Error       | All containers failed. |
 | Unknown     | Application started, no containers observed. |
 | Completed   | All containers have completed successfully. |
+| Stopping    | The application was stopped and is shutting down its containers. |
+| Stopped     | The application was stopped and has no running containers. |
 
 ### Managing Applications on the Web UI
 
@@ -722,9 +724,24 @@ spec:
 [...]
 ```
 
+### Managing Application Lifecycle
+
+In addition to deploying, updating, or undeploying applications through the device specification, you can start, stop, or restart a deployed application on demand, without changing the specification. This is useful for temporarily taking an application out of service, or for triggering a restart to recover from an issue.
+
+Use the `flightctl app stop`, `flightctl app start`, and `flightctl app restart` commands to control an application without changing the device or fleet specification. See the [`flightctl app start`](../references/cli-commands.md#flightctl-app-start), [`flightctl app stop`](../references/cli-commands.md#flightctl-app-stop), and [`flightctl app restart`](../references/cli-commands.md#flightctl-app-restart) CLI reference pages for command syntax, flags, and examples.
+
+> [!NOTE]
+> Restarting an application is only supported on individual devices, not on fleets.
+
+Stopping or starting an application on a fleet sets a fleet-wide default that applies to every device currently in the fleet, and to any device that joins the fleet later. If you separately stop or start the same application directly on one of those devices, that device-level action takes precedence over the fleet-wide default for that device, until you issue another fleet-level action.
+
+While an application is stopped, its status is reported as `Stopped`. Starting it again returns it to the normal `Preparing`/`Starting`/`Running` progression.
+
 ### VM applications
 
 VM applications deploy virtual machines on the device. You define the VM using an inline manifest file; Flight Control handles the conversion and deployment automatically.
+
+Flight Control manages the lifecycle of a VM application — deploying, starting, stopping, and restarting the virtual machine — but does not manage anything running inside the VM. Managing the VM's content and workloads is left to you, using whatever tooling you would otherwise use for that, for example Ansible Automation Platform (AAP), or by connecting to the VM directly.
 
 #### Device requirements
 
@@ -753,7 +770,11 @@ To deploy a VM application, add an entry to the `applications` section of the de
 > [!NOTE]
 > The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly.
 
-#### Example: VM application
+#### Examples
+
+##### Fedora
+
+This example deploys a Fedora guest from a public container disk image and publishes SSH on host port `2222`:
 
 ```yaml
 apiVersion: flightctl.io/v1beta1
@@ -762,7 +783,7 @@ metadata:
   name: edge-device-001
 spec:
   applications:
-    - name: my-vm
+    - name: fedora-vm
       appType: vm
       publishPorts:
         - "2222:22"
@@ -772,7 +793,7 @@ spec:
             apiVersion: kubevirt.io/v1
             kind: VirtualMachine
             metadata:
-              name: my-vm
+              name: fedora-vm
             spec:
               running: true
               template:
@@ -789,8 +810,130 @@ spec:
                   volumes:
                     - name: containerdisk
                       containerDisk:
-                        image: quay.io/myorg/my-vm-image:v1.0.0
+                        image: quay.io/containerdisks/fedora:40
 ```
+
+##### Windows
+
+This example installs a Windows guest from ISOs staged on the device (`hostDisk`), with a blank root disk, VirtIO drivers media, UEFI firmware, Hyper-V features, and a TPM. You can also supply those ISOs from an OCI registry (for example as a `containerDisk`) instead; this example uses `hostDisk` for illustration. The `hostDisk` paths must already exist on the target device before applying the specification, and RDP is published on host port `3389`:
+
+```yaml
+apiVersion: flightctl.io/v1beta1
+kind: Device
+metadata:
+  name: edge-device-001
+spec:
+  applications:
+    - name: windows-vm
+      appType: vm
+      publishPorts:
+        - "3389:3389"
+      inline:
+        - path: vm.yaml
+          content: |
+            apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: windows-vm
+            spec:
+              running: true
+              dataVolumeTemplates:
+              - metadata:
+                  name: rootdisk
+                spec:
+                  source:
+                    blank: {}
+                  storage:
+                    resources:
+                      requests:
+                        storage: 60Gi
+              template:
+                spec:
+                  domain:
+                    firmware:
+                      bootloader:
+                        efi:
+                          secureBoot: false
+                    cpu:
+                      cores: 2
+                      sockets: 1
+                      threads: 1
+                    features:
+                      acpi:
+                        enabled: true
+                      apic:
+                        enabled: true
+                      hyperv:
+                        relaxed:    { enabled: true }
+                        vapic:      { enabled: true }
+                        spinlocks:  { enabled: true, spinlocks: 8191 }
+                        vpindex:    { enabled: true }
+                        runtime:    { enabled: true }
+                        synic:      { enabled: true }
+                        synictimer: { enabled: true, direct: { enabled: true } }
+                        reset:      { enabled: true }
+                        frequencies: { enabled: true }
+                        tlbflush:   { enabled: true }
+                        ipi:        { enabled: true }
+                        stimer:     { enabled: true }
+                    clock:
+                      utc: {}
+                      timer:
+                        hpet: { present: false }
+                        pit: { tickPolicy: delay }
+                        rtc: { tickPolicy: catchup }
+                        hyperv: { present: true }
+                    devices:
+                      autoattachMemBalloon: false
+                      disks:
+                      - disk:
+                          bus: virtio
+                        cache: writeback
+                        dedicatedIOThread: true
+                        name: rootdisk
+                        bootOrder: 2
+                      - cdrom:
+                          bus: sata
+                          readonly: true
+                        name: windows-iso
+                        bootOrder: 1
+                      - cdrom:
+                          bus: sata
+                          readonly: true
+                        name: virtio-drivers
+                      interfaces:
+                      - masquerade: {}
+                        name: default
+                        model: virtio
+                        ports:
+                        - port: 3389
+                      inputs:
+                      - type: tablet
+                        bus: usb
+                        name: tablet
+                      tpm: {}
+                    memory:
+                      guest: 4Gi
+                    resources: {}
+                  networks:
+                  - name: default
+                    pod: {}
+                  volumes:
+                  - name: rootdisk
+                    dataVolume:
+                      name: rootdisk
+                  - name: windows-iso
+                    hostDisk:
+                      path: /path/to/Win11.iso
+                      type: DiskOrFail
+                  - name: virtio-drivers
+                    hostDisk:
+                      path: /path/to/virtio-win.iso
+                      type: DiskOrFail
+```
+
+> [!NOTE]
+> In this example the Windows installation ISO and VirtIO drivers ISO are referenced via `hostDisk` paths on the device. Replace `/path/to/...` with the locations where you have staged those files, or change the volumes to pull the ISOs from an OCI registry instead.
 
 #### VM application status
 
@@ -804,12 +947,28 @@ The agent reports the following status values for a VM application:
 | Error | The VM failed to start or terminated with an error. Check the device events for details. |
 | Unknown | The VM was submitted but no running state has been observed yet. |
 | Completed | The VM exited cleanly. This is expected only if `spec.running` is set to `false`. |
+| Stopping | The VM was stopped with `flightctl app stop` and is shutting down. |
+| Stopped | The VM was stopped with `flightctl app stop` and is no longer running. |
 
 #### VM restart behavior
 
 When `spec.running: true` is set in the VM manifest, the agent automatically restarts the virtual machine if it crashes or is stopped unexpectedly. This matches the restart-on-failure policy applied to other Quadlet-based applications.
 
 To stop a VM without triggering a restart, set `spec.running: false` and apply the updated device specification.
+
+> [!TIP]
+> You can also stop, start, or restart a VM application on demand, without editing the device specification, using `flightctl app stop`, `flightctl app start`, and `flightctl app restart`. See [Managing Application Lifecycle](#managing-application-lifecycle).
+
+#### Accessing a VM Application Console
+
+A VM application is not otherwise reachable over the network, so a user with the appropriate authorization (`get` permission on the `devices/applications/console` resource) can connect to its serial or VNC console through the agent. This works even if the device is behind a NAT or has a dynamic IP address.
+
+Use the `flightctl app console` command to open a serial or VNC console to a VM application. See the [`flightctl app console`](../references/cli-commands.md#flightctl-app-console) CLI reference page for command syntax, flags, and examples.
+
+Only one console session — serial or VNC — is allowed per application at a time. If you attempt to connect while another session is already active, the command fails unless you pass `--force`, which takes over the existing session and disconnects it.
+
+> [!NOTE]
+> A VNC console session additionally supports only one connected viewer. The command exits once that viewer disconnects; run it again to start a new session.
 
 ### Helm Applications
 


### PR DESCRIPTION
## Summary

User-facing documentation for VM applications and related day-2 operations:

* **VM applications** in `managing-devices.md`: requirements (`/dev/kvm`, Podman 5.0), specification parameters, Fedora and Windows examples, status values (including `Stopped`/`Stopping`), restart behavior, and a clear boundary that Flight Control manages VM lifecycle but not content inside the guest.
* **Application lifecycle**: document `flightctl app start` / `stop` / `restart` (device and fleet where applicable), with fleet-vs-device precedence, and CLI reference entries that the procedural docs link to.
* **VM application console**: document `flightctl app console` (serial/VNC, `--force`, single session per app) under the VM applications section, with a full CLI reference entry.
* **References**: `flightctl-remote-access` in the components diagram, remote-access cert paths, and the `devices/applications/console` auth resource.

## Test plan

- [x] `make lint-docs`
- [x] `make spellcheck-docs`
- [ ] Spot-check rendered docs / anchors from `README.md` and cross-links between `managing-devices.md` and `cli-commands.md`