### PR TITLE
NO-ISSUE: fixes a case where e2e are faked pass by failed build steps

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -263,11 +263,14 @@ jobs:
           fi
           E2E_RESULT="${{ needs.e2e-tests.result }}"
           API_RESULT="${{ needs.api-tests.result }}"
-          if [[ "$E2E_RESULT" == "success" || "$E2E_RESULT" == "skipped" ]] && \
+          # At this point we are past the early-exit guards, so tests were expected to run.
+          # "skipped" here means an upstream dependency (e.g. image build) failed and caused
+          # e2e-tests to be skipped by GitHub Actions — that must be treated as a failure.
+          if [[ "$E2E_RESULT" == "success" ]] && \
              [[ "$API_RESULT" == "success" || "$API_RESULT" == "skipped" ]]; then
-            echo "All tests passed or were skipped (e2e: $E2E_RESULT, api: $API_RESULT)"
+            echo "All tests passed (e2e: $E2E_RESULT, api: $API_RESULT)"
             exit 0
           else
-            echo "Tests failed or were cancelled (e2e: $E2E_RESULT, api: $API_RESULT)"
+            echo "Tests failed, were cancelled, or were skipped due to a dependency failure (e2e: $E2E_RESULT, api: $API_RESULT)"
             exit 1
           fi

--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -276,7 +276,7 @@ var _ = Describe("CLI - device console", func() {
 		Expect(out).To(
 			And(
 				ContainSubstring("Usage:"),
-				ContainSubstring("flightctl console device/NAME [-- COMMAND [ARG...]]"),
+				ContainSubstring("flightctl console device/NAME [--app APP --remote-type TYPE] [-- COMMAND [ARG...]]"),
 			),
 		)
 

--- a/test/scripts/agent-images/containerfiles/cs10-bootc/Containerfile
+++ b/test/scripts/agent-images/containerfiles/cs10-bootc/Containerfile
@@ -27,7 +27,13 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     dnf install -y greenboot greenboot-default-health-checks podman-compose && \
-    dnf install -y firewalld && \
+    # install_weak_deps=False prevents iptables-nft (a Recommends: of firewalld) from being
+    # installed. On CS10 kernel 6.12.0-243+, xtables modules were dropped from the default
+    # kernel set, so iptables-nft's kmod(xt_nat) requirement resolves to kernel-debug-modules
+    # → kernel-debug-core, adding a second directory under usr/lib/modules and breaking
+    # bootc install-to-filesystem. CS10 e2e tests use the nftables backend so iptables-nft
+    # is not needed.
+    dnf install -y --setopt=install_weak_deps=False firewalld && \
     systemctl enable firewalld.service && \
     systemctl enable podman.service
 


### PR DESCRIPTION
fixes an issue where a PR skips the E2E inside the merge queue due to failed images , 
example:

https://github.com/flightctl/flightctl/actions/runs/28734939005/attempts/1