### PR TITLE
EDM-4727: fix console trigger to avoid bumping renderedVersion

### DIFF
--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -223,7 +223,7 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 		n.log.Infof("New spec version received: %s -> %s", n.lastKnownVersion, newVersion)
 		n.lastKnownVersion = newVersion
 	} else {
-		n.log.Warnf("Received spec version %s is not greater than last known version %s, skipping...", newVersion, n.lastKnownVersion)
+		n.log.Debugf("Received rendered device with unchanged version %s (last known: %s)", newVersion, n.lastKnownVersion)
 	}
 
 	// notify all watchers of the new device spec

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/flightctl/flightctl/internal/console"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/rendered"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/store"
 	transportv1alpha1 "github.com/flightctl/flightctl/internal/transport/v1alpha1"
@@ -360,7 +361,7 @@ func (s *Server) Run(ctx context.Context) error {
 			RateLimitScopeGeneral,
 		)
 
-		consoleSessionManager := console.NewConsoleSessionManager(serviceHandler, s.log, s.consoleEndpointReg)
+		consoleSessionManager := console.NewConsoleSessionManager(serviceHandler, s.log, s.consoleEndpointReg, rendered.Bus.Instance())
 		ws := transportv1beta1.NewWebsocketHandler(s.ca, s.log, consoleSessionManager)
 		ws.RegisterRoutes(r)
 	})

--- a/internal/console/app_console.go
+++ b/internal/console/app_console.go
@@ -41,10 +41,11 @@ type AppConsoleSessionRegistration interface {
 	CloseSession(session *AppConsoleSession) error
 }
 
-// RenderedVersionPublisher stores and broadcasts rendered version change notifications so that
-// waiting GetRenderedDevice long-polls on the API server see the change immediately.
-type RenderedVersionPublisher interface {
-	StoreAndNotify(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error
+// ConsoleEventNotifier signals the device agent that a console session needs handling.
+// It is deliberately decoupled from rendered-spec versioning.
+type ConsoleEventNotifier interface {
+	NotifyConsole(ctx context.Context, orgId uuid.UUID, name string) error
+	ClearConsoleNotification(ctx context.Context, orgId uuid.UUID, name string) error
 }
 
 // AppConsoleSessionManager manages application console sessions using device annotations.
@@ -54,20 +55,20 @@ type AppConsoleSessionManager struct {
 	svc                 AppConsoleDeviceService
 	log                 logrus.FieldLogger
 	sessionRegistration AppConsoleSessionRegistration
-	publisher           RenderedVersionPublisher
+	notifier            ConsoleEventNotifier
 }
 
 func NewAppConsoleSessionManager(
 	svc AppConsoleDeviceService,
 	log logrus.FieldLogger,
 	reg AppConsoleSessionRegistration,
-	publisher RenderedVersionPublisher,
+	notifier ConsoleEventNotifier,
 ) *AppConsoleSessionManager {
 	return &AppConsoleSessionManager{
 		svc:                 svc,
 		log:                 log,
 		sessionRegistration: reg,
-		publisher:           publisher,
+		notifier:            notifier,
 	}
 }
 
@@ -77,9 +78,8 @@ func NewAppConsoleSessionManager(
 // for cleanup/rollback paths so they are never blocked by device state changes.
 func (m *AppConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId uuid.UUID, deviceName string, enforceSessionStartGuards bool, updater func(string) (string, error)) domain.Status {
 	var (
-		err                 error
-		newValue            string
-		nextRenderedVersion string
+		err      error
+		newValue string
 	)
 	for i := 0; i != 10; i++ {
 		device, status := m.svc.GetDevice(ctx, orgId, deviceName)
@@ -118,20 +118,10 @@ func (m *AppConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId 
 		} else {
 			(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = newValue
 		}
-		nextRenderedVersion, err = domain.GetNextDeviceRenderedVersion(*device.Metadata.Annotations, device.Status)
-		if err != nil {
-			return domain.StatusInternalServerError(err.Error())
-		}
-		(*device.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion] = nextRenderedVersion
 		m.log.Debugf("updating remote-session annotations for device %s", deviceName)
 		_, err = m.svc.UpdateDevice(context.WithValue(ctx, consts.InternalRequestCtxKey, true), orgId, deviceName, *device, nil)
 		if !errors.Is(err, flterrors.ErrResourceVersionConflict) {
 			break
-		}
-	}
-	if err == nil {
-		if pubErr := m.publisher.StoreAndNotify(ctx, orgId, deviceName, nextRenderedVersion); pubErr != nil {
-			m.log.WithError(pubErr).Errorf("annotation for device %s persisted but rendered-version notification failed", deviceName)
 		}
 	}
 	if err != nil {
@@ -280,6 +270,11 @@ func (m *AppConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.
 		}
 		return nil, domain.StatusInternalServerError(err.Error())
 	}
+
+	if err := m.notifier.NotifyConsole(ctx, orgId, deviceName); err != nil {
+		m.log.Warnf("StartSession: failed to notify device %s: %v", deviceName, err)
+	}
+
 	return session, domain.StatusOK()
 }
 

--- a/internal/console/app_console_test.go
+++ b/internal/console/app_console_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // mockAppDeviceService is a hand-written testify mock for AppConsoleDeviceService.
@@ -46,17 +47,22 @@ func (m *mockAppSessionRegistration) CloseSession(session *AppConsoleSession) er
 	return args.Error(0)
 }
 
-// mockRenderedPublisher is a hand-written testify mock for RenderedVersionPublisher.
-type mockRenderedPublisher struct {
+// mockConsoleEventNotifier is a hand-written testify mock for ConsoleEventNotifier.
+type mockConsoleEventNotifier struct {
 	mock.Mock
 }
 
-func (m *mockRenderedPublisher) StoreAndNotify(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error {
-	args := m.Called(ctx, orgId, name, renderedVersion)
+func (m *mockConsoleEventNotifier) NotifyConsole(ctx context.Context, orgId uuid.UUID, name string) error {
+	args := m.Called(ctx, orgId, name)
 	return args.Error(0)
 }
 
-func newTestAppManager(svc *mockAppDeviceService, reg *mockAppSessionRegistration, pub *mockRenderedPublisher) *AppConsoleSessionManager {
+func (m *mockConsoleEventNotifier) ClearConsoleNotification(ctx context.Context, orgId uuid.UUID, name string) error {
+	args := m.Called(ctx, orgId, name)
+	return args.Error(0)
+}
+
+func newTestAppManager(svc *mockAppDeviceService, reg *mockAppSessionRegistration, pub *mockConsoleEventNotifier) *AppConsoleSessionManager {
 	return NewAppConsoleSessionManager(svc, logrus.NewEntry(logrus.New()), reg, pub)
 }
 
@@ -73,7 +79,7 @@ func makeTestDevice(name string) *domain.Device {
 func TestAppConsoleSessionManager_StartSession_EmptyAppName(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	session, status := mgr.StartSession(context.Background(), uuid.New(), "device1", "", "serial")
@@ -87,7 +93,7 @@ func TestAppConsoleSessionManager_StartSession_EmptyAppName(t *testing.T) {
 func TestAppConsoleSessionManager_StartSession_InvalidConsoleType(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	session, status := mgr.StartSession(context.Background(), uuid.New(), "device1", "app1", "invalid")
@@ -101,7 +107,7 @@ func TestAppConsoleSessionManager_StartSession_InvalidConsoleType(t *testing.T) 
 func TestAppConsoleSessionManager_StartSession_DeviceNotFound(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -121,7 +127,7 @@ func TestAppConsoleSessionManager_StartSession_DeviceNotFound(t *testing.T) {
 func TestAppConsoleSessionManager_StartSession_DecommissionedDevice(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -141,7 +147,7 @@ func TestAppConsoleSessionManager_StartSession_DecommissionedDevice(t *testing.T
 func TestAppConsoleSessionManager_StartSession_DuplicateAppName(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -162,7 +168,7 @@ func TestAppConsoleSessionManager_StartSession_DuplicateAppName(t *testing.T) {
 func TestAppConsoleSessionManager_CloseSession_RemovesAnnotation(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -189,7 +195,6 @@ func TestAppConsoleSessionManager_CloseSession_RemovesAnnotation(t *testing.T) {
 			capturedDevice = args.Get(3).(domain.Device)
 		}).
 		Return(device, nil)
-	pub.On("StoreAndNotify", mock.Anything, orgId, "device1", mock.Anything).Return(nil)
 
 	status := mgr.CloseSession(ctx, session)
 
@@ -205,7 +210,7 @@ func TestAppConsoleSessionManager_CloseSession_RemovesAnnotation(t *testing.T) {
 func TestAppConsoleSessionManager_CloseSession_AnnotationFailure_DoesNotUnregister(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -236,7 +241,7 @@ func TestAppConsoleSessionManager_CloseSession_AnnotationFailure_DoesNotUnregist
 func TestAppConsoleSessionManager_StartSession_RollsBackOnRegistrationFailure(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -246,7 +251,7 @@ func TestAppConsoleSessionManager_StartSession_RollsBackOnRegistrationFailure(t 
 	// GetDevice called multiple times: fast-path check, addAppSession loop, removeAppSession rollback loop
 	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
 	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).Return(device, nil)
-	pub.On("StoreAndNotify", mock.Anything, orgId, "device1", mock.Anything).Return(nil)
+	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(nil)
 	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(fmt.Errorf("registration failed"))
 
 	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "serial")
@@ -260,7 +265,7 @@ func TestAppConsoleSessionManager_StartSession_RollsBackOnRegistrationFailure(t 
 func TestAppConsoleSessionManager_StartSession_ProceedsWhenPublishFails(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
-	pub := &mockRenderedPublisher{}
+	pub := &mockConsoleEventNotifier{}
 	mgr := newTestAppManager(svc, reg, pub)
 
 	ctx := context.Background()
@@ -269,8 +274,8 @@ func TestAppConsoleSessionManager_StartSession_ProceedsWhenPublishFails(t *testi
 
 	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
 	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).Return(device, nil)
-	// StoreAndNotify fails — publish failure is non-fatal after a successful UpdateDevice.
-	pub.On("StoreAndNotify", mock.Anything, orgId, "device1", mock.Anything).Return(fmt.Errorf("redis unavailable")).Once()
+	// NotifyConsole failure is non-fatal — the session still starts.
+	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(fmt.Errorf("redis unavailable")).Once()
 	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(nil)
 
 	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "serial")
@@ -303,4 +308,70 @@ func TestRemoveAppSession_LastSession_ReturnsEmpty(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+func TestAppConsoleSessionManager_StartSession_DoesNotBumpDeviceAnnotationRenderedVersion(t *testing.T) {
+	svc := &mockAppDeviceService{}
+	reg := &mockAppSessionRegistration{}
+	pub := &mockConsoleEventNotifier{}
+	mgr := newTestAppManager(svc, reg, pub)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	device := makeTestDevice("device1")
+	// Seed an existing rendered version that must survive the console start.
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion] = "99"
+
+	var capturedDevice domain.Device
+	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
+	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			capturedDevice = args.Get(3).(domain.Device)
+		}).
+		Return(device, nil)
+	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(nil)
+	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(nil)
+
+	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "serial")
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	assert.NotNil(t, session)
+	pub.AssertExpectations(t)
+
+	// DeviceAnnotationRenderedVersion must remain exactly as before — console start must not bump it.
+	require.NotNil(t, capturedDevice.Metadata.Annotations)
+	v, exists := (*capturedDevice.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion]
+	assert.True(t, exists, "DeviceAnnotationRenderedVersion should still be present in the saved device")
+	assert.Equal(t, "99", v, "DeviceAnnotationRenderedVersion must not be changed by console start")
+}
+
+func TestAppConsoleSessionManager_CloseSession_DoesNotCallNotifier(t *testing.T) {
+	svc := &mockAppDeviceService{}
+	reg := &mockAppSessionRegistration{}
+	pub := &mockConsoleEventNotifier{} // no expectations — must not be called
+	mgr := newTestAppManager(svc, reg, pub)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	sessionID := uuid.New().String()
+
+	session := &AppConsoleSession{
+		UUID:       sessionID,
+		OrgId:      orgId,
+		DeviceName: "device1",
+		AppName:    "app1",
+	}
+
+	device := makeTestDevice("device1")
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"` + sessionID + `","appName":"app1"}]`
+
+	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
+	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).Return(device, nil)
+	reg.On("CloseSession", session).Return(nil)
+
+	status := mgr.CloseSession(ctx, session)
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	pub.AssertNotCalled(t, "NotifyConsole")
+	pub.AssertNotCalled(t, "ClearConsoleNotification")
 }

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
-	"github.com/flightctl/flightctl/internal/rendered"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
@@ -39,24 +38,25 @@ type InternalSessionRegistration interface {
 type ConsoleSessionManager struct {
 	serviceHandler service.Service
 	log            logrus.FieldLogger
+	notifier       ConsoleEventNotifier
 	// This one is the gRPC Handler of the agent for now, in the next iteration
 	// this should be split so we funnel traffic through a queue in redis/valkey
 	sessionRegistration InternalSessionRegistration
 }
 
-func NewConsoleSessionManager(serviceHandler service.Service, log logrus.FieldLogger, sessionRegistration InternalSessionRegistration) *ConsoleSessionManager {
+func NewConsoleSessionManager(serviceHandler service.Service, log logrus.FieldLogger, sessionRegistration InternalSessionRegistration, notifier ConsoleEventNotifier) *ConsoleSessionManager {
 	return &ConsoleSessionManager{
 		serviceHandler:      serviceHandler,
 		log:                 log,
+		notifier:            notifier,
 		sessionRegistration: sessionRegistration,
 	}
 }
 
 func (m *ConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId uuid.UUID, deviceName string, updater func(value string) (string, error)) domain.Status {
 	var (
-		err                 error
-		newValue            string
-		nextRenderedVersion string
+		err      error
+		newValue string
 	)
 	for i := 0; i != 10; i++ {
 		device, status := m.serviceHandler.GetDevice(ctx, orgId, deviceName)
@@ -83,19 +83,11 @@ func (m *ConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId uui
 			return domain.StatusInternalServerError(err.Error())
 		}
 		(*device.Metadata.Annotations)[domain.DeviceAnnotationConsole] = newValue
-		nextRenderedVersion, err = domain.GetNextDeviceRenderedVersion(*device.Metadata.Annotations, device.Status)
-		if err != nil {
-			return domain.StatusInternalServerError(err.Error())
-		}
-		(*device.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion] = nextRenderedVersion
 		m.log.Infof("About to save annotations %+v", *device.Metadata.Annotations)
 		_, err = m.serviceHandler.UpdateDevice(context.WithValue(ctx, consts.InternalRequestCtxKey, true), orgId, deviceName, *device, nil)
 		if !errors.Is(err, flterrors.ErrResourceVersionConflict) {
 			break
 		}
-	}
-	if err == nil {
-		err = rendered.Bus.Instance().StoreAndNotify(ctx, orgId, deviceName, nextRenderedVersion)
 	}
 	if err != nil {
 		return domain.StatusInternalServerError(err.Error())
@@ -200,6 +192,11 @@ func (m *ConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.UUI
 		}
 		return nil, domain.StatusInternalServerError(err.Error())
 	}
+
+	if err := m.notifier.NotifyConsole(ctx, orgId, deviceName); err != nil {
+		m.log.Warnf("StartSession: failed to notify device %s: %v", deviceName, err)
+	}
+
 	return session, domain.StatusOK()
 }
 

--- a/internal/console/console_test.go
+++ b/internal/console/console_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/service"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -29,6 +30,21 @@ func (m *MockSessionRegistration) CloseSession(session *ConsoleSession) error {
 	return args.Error(0)
 }
 
+// MockConsoleEventNotifier is a simple mock for ConsoleEventNotifier.
+type MockConsoleEventNotifier struct {
+	mock.Mock
+}
+
+func (m *MockConsoleEventNotifier) NotifyConsole(ctx context.Context, orgId uuid.UUID, name string) error {
+	args := m.Called(ctx, orgId, name)
+	return args.Error(0)
+}
+
+func (m *MockConsoleEventNotifier) ClearConsoleNotification(ctx context.Context, orgId uuid.UUID, name string) error {
+	args := m.Called(ctx, orgId, name)
+	return args.Error(0)
+}
+
 func TestConsoleSessionManager_StartSession_DeviceNotFound(t *testing.T) {
 	// This test specifically addresses EDM-3084: ensure nonexistent devices return 404, not 500
 
@@ -37,9 +53,10 @@ func TestConsoleSessionManager_StartSession_DeviceNotFound(t *testing.T) {
 
 	mockService := service.NewMockService(ctrl)
 	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
 	logger := logrus.NewEntry(logrus.New())
 
-	manager := NewConsoleSessionManager(mockService, logger, mockRegistration)
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
 
 	ctx := context.Background()
 	orgId := uuid.New()
@@ -70,9 +87,10 @@ func TestConsoleSessionManager_StartSession_DecommissionedDevice(t *testing.T) {
 
 	mockService := service.NewMockService(ctrl)
 	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
 	logger := logrus.NewEntry(logrus.New())
 
-	manager := NewConsoleSessionManager(mockService, logger, mockRegistration)
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
 
 	ctx := context.Background()
 	orgId := uuid.New()
@@ -108,9 +126,10 @@ func TestConsoleSessionManager_StartSession_MissingMetadata(t *testing.T) {
 
 	mockService := service.NewMockService(ctrl)
 	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
 	logger := logrus.NewEntry(logrus.New())
 
-	manager := NewConsoleSessionManager(mockService, logger, mockRegistration)
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
 
 	ctx := context.Background()
 	orgId := uuid.New()
@@ -127,4 +146,148 @@ func TestConsoleSessionManager_StartSession_MissingMetadata(t *testing.T) {
 
 	// Verify that no service calls were made (guard pattern prevents them)
 	mockRegistration.AssertNotCalled(t, "StartSession")
+}
+
+// makeHealthyDevice returns a domain.Device in a state that passes all session-start guards.
+func makeHealthyDevice(name string) *domain.Device {
+	return &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name:        lo.ToPtr(name),
+			Annotations: lo.ToPtr(map[string]string{}),
+		},
+		Spec: &domain.DeviceSpec{},
+	}
+}
+
+func TestConsoleSessionManager_StartSession_DoesNotBumpDeviceAnnotationRenderedVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := service.NewMockService(ctrl)
+	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
+	logger := logrus.NewEntry(logrus.New())
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	deviceName := "my-device"
+
+	device := makeHealthyDevice(deviceName)
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion] = "42"
+
+	// GetDevice is called once for the initial guard check and once inside modifyAnnotations.
+	mockService.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, domain.StatusOK()).AnyTimes()
+
+	var captured domain.Device
+	mockService.EXPECT().
+		UpdateDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ string, d domain.Device, _ []string) (*domain.Device, error) {
+			captured = d
+			return device, nil
+		}).AnyTimes()
+
+	mockNotifier.On("NotifyConsole", mock.Anything, orgId, deviceName).Return(nil)
+	mockRegistration.On("StartSession", mock.AnythingOfType("*console.ConsoleSession")).Return(nil)
+
+	session, status := manager.StartSession(ctx, orgId, deviceName, `{"tty":true}`)
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	assert.NotNil(t, session)
+	mockNotifier.AssertExpectations(t)
+
+	// DeviceAnnotationRenderedVersion must not be changed by console operations.
+	if captured.Metadata.Annotations != nil {
+		v, exists := (*captured.Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion]
+		assert.True(t, exists, "DeviceAnnotationRenderedVersion should still be present")
+		assert.Equal(t, "42", v, "DeviceAnnotationRenderedVersion must not be bumped by console start")
+	}
+}
+
+func TestConsoleSessionManager_StartSession_CallsNotifyConsoleOnSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := service.NewMockService(ctrl)
+	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
+	logger := logrus.NewEntry(logrus.New())
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	deviceName := "my-device"
+	device := makeHealthyDevice(deviceName)
+
+	mockService.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, domain.StatusOK()).AnyTimes()
+	mockService.EXPECT().UpdateDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, nil).AnyTimes()
+	mockNotifier.On("NotifyConsole", mock.Anything, orgId, deviceName).Return(nil).Once()
+	mockRegistration.On("StartSession", mock.AnythingOfType("*console.ConsoleSession")).Return(nil)
+
+	session, status := manager.StartSession(ctx, orgId, deviceName, `{"tty":true}`)
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	assert.NotNil(t, session)
+	mockNotifier.AssertCalled(t, "NotifyConsole", mock.Anything, orgId, deviceName)
+}
+
+func TestConsoleSessionManager_StartSession_ProceedsWhenNotifyConsoleFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := service.NewMockService(ctrl)
+	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{}
+	logger := logrus.NewEntry(logrus.New())
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	deviceName := "my-device"
+	device := makeHealthyDevice(deviceName)
+
+	mockService.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, domain.StatusOK()).AnyTimes()
+	mockService.EXPECT().UpdateDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, nil).AnyTimes()
+	mockNotifier.On("NotifyConsole", mock.Anything, orgId, deviceName).Return(assert.AnError).Once()
+	mockRegistration.On("StartSession", mock.AnythingOfType("*console.ConsoleSession")).Return(nil)
+
+	// NotifyConsole failure must be non-fatal — session is still returned.
+	session, status := manager.StartSession(ctx, orgId, deviceName, `{"tty":true}`)
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	assert.NotNil(t, session)
+}
+
+func TestConsoleSessionManager_CloseSession_DoesNotCallNotifier(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := service.NewMockService(ctrl)
+	mockRegistration := &MockSessionRegistration{}
+	mockNotifier := &MockConsoleEventNotifier{} // no expectations — must not be called
+	logger := logrus.NewEntry(logrus.New())
+	manager := NewConsoleSessionManager(mockService, logger, mockRegistration, mockNotifier)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	deviceName := "my-device"
+	sessionID := uuid.New().String()
+
+	device := makeHealthyDevice(deviceName)
+
+	mockService.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, domain.StatusOK()).AnyTimes()
+	mockService.EXPECT().UpdateDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, nil).AnyTimes()
+	mockRegistration.On("CloseSession", mock.Anything).Return(nil)
+
+	session := &ConsoleSession{
+		UUID:       sessionID,
+		OrgId:      orgId,
+		DeviceName: deviceName,
+	}
+
+	status := manager.CloseSession(ctx, session)
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	// mockNotifier has no expectations set — testify/mock will panic on unexpected calls.
+	mockNotifier.AssertNotCalled(t, "NotifyConsole")
+	mockNotifier.AssertNotCalled(t, "ClearConsoleNotification")
 }

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -40,7 +40,7 @@ type Server struct {
 	caBundleCerts  []*x509.Certificate
 	serverCerts    *crypto.TLSCertificateConfig
 	dataStore      store.Store
-	publisher      console.RenderedVersionPublisher
+	notifier       console.ConsoleEventNotifier
 	pendingStreams *sync.Map
 }
 
@@ -66,7 +66,7 @@ func New(
 	caBundleCerts []*x509.Certificate,
 	serverCerts *crypto.TLSCertificateConfig,
 	dataStore store.Store,
-	publisher console.RenderedVersionPublisher,
+	notifier console.ConsoleEventNotifier,
 ) (*Server, error) {
 	if cfg.RemoteAccessService == nil {
 		return nil, fmt.Errorf("remoteAccessService config section is required")
@@ -77,7 +77,7 @@ func New(
 		caBundleCerts:  caBundleCerts,
 		serverCerts:    serverCerts,
 		dataStore:      dataStore,
-		publisher:      publisher,
+		notifier:       notifier,
 		pendingStreams: &sync.Map{},
 	}, nil
 }
@@ -157,7 +157,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// App console.
 	svc := &storeAppConsoleService{deviceStore: s.dataStore.Device()}
-	appConsoleMgr := console.NewAppConsoleSessionManager(svc, s.log, s, s.publisher)
+	appConsoleMgr := console.NewAppConsoleSessionManager(svc, s.log, s, s.notifier)
 	appConsoleHandler := NewAppConsoleHandler(s.log, appConsoleMgr)
 
 	// HTTP router — mirrors flightctl-api: AuthN → IdentityMapping → OrgExtraction → AuthZ.

--- a/internal/rendered/manager.go
+++ b/internal/rendered/manager.go
@@ -73,7 +73,11 @@ func (m *VersionManager) key(orgId uuid.UUID, name string) string {
 	return fmt.Sprintf("v1/%s/device/%s/rendered", orgId.String(), name)
 }
 
-func (m *VersionManager) subscribe(orgId uuid.UUID, name string, notifier chan string) {
+func (m *VersionManager) consolePendingKey(orgId uuid.UUID, name string) string {
+	return fmt.Sprintf("v1/%s/device/%s/console-pending", orgId.String(), name)
+}
+
+func (m *VersionManager) subscribe(orgId uuid.UUID, name string, notifier chan Notification) {
 	m.subscribers.Store(m.key(orgId, name), notifier)
 }
 
@@ -81,30 +85,42 @@ func (m *VersionManager) unsubscribe(orgId uuid.UUID, name string) {
 	m.subscribers.Delete(m.key(orgId, name))
 }
 
-func (m *VersionManager) WaitForNewVersion(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion string) (bool, string, error) {
-	ch := make(chan string, 1)
+// WaitForNotification blocks until a Notification occurs, then returns it.
+// Returns (Notification{}, false, nil) on timeout — caller should return 204.
+func (m *VersionManager) WaitForNotification(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion string) (Notification, bool, error) {
+	ch := make(chan Notification, 1)
 	m.subscribe(orgId, name, ch)
 	defer m.unsubscribe(orgId, name)
+
 	b, err := m.kvStore.Get(ctx, m.key(orgId, name))
 	if err != nil {
-		return false, "", fmt.Errorf("failed to get rendered version from kvstore: %v", err)
+		return Notification{}, false, fmt.Errorf("failed to get rendered version from kvstore: %v", err)
 	}
 	var currentRenderedVersion string
 	if b != nil {
 		currentRenderedVersion = string(b)
 	}
-	if currentRenderedVersion == knownRenderedVersion {
-		timeout := time.NewTimer(m.renderedWaitTimeout)
-		defer timeout.Stop()
-		select {
-		case <-ctx.Done():
-			return false, currentRenderedVersion, ctx.Err()
-		case <-timeout.C:
-			return false, currentRenderedVersion, nil
-		case currentRenderedVersion = <-ch:
-		}
+	if currentRenderedVersion != knownRenderedVersion {
+		return Notification{Type: NotificationTypeSpecUpdated, RenderedVersion: currentRenderedVersion}, true, nil
 	}
-	return true, currentRenderedVersion, nil
+
+	pending, err := m.kvStore.Get(ctx, m.consolePendingKey(orgId, name))
+	if err != nil {
+		m.log.Warnf("WaitForNotification: failed to check console notification for %s/%s: %v", orgId, name, err)
+	} else if pending != nil {
+		return Notification{Type: NotificationTypeConsole}, true, nil
+	}
+
+	timeout := time.NewTimer(m.renderedWaitTimeout)
+	defer timeout.Stop()
+	select {
+	case <-ctx.Done():
+		return Notification{}, false, ctx.Err()
+	case <-timeout.C:
+		return Notification{}, false, nil
+	case n := <-ch:
+		return n, true, nil
+	}
 }
 
 func (m *VersionManager) StoreAndNotify(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error {
@@ -126,25 +142,39 @@ func (m *VersionManager) StoreAndNotify(ctx context.Context, orgId uuid.UUID, na
 		return fmt.Errorf("failed to store rendered version: %w", err)
 	}
 	if valueSet {
-		if err := m.broadcaster.Publish(ctx, orgId, name, renderedVersion); err != nil {
+		if err := m.broadcaster.Publish(ctx, orgId, name, Notification{Type: NotificationTypeSpecUpdated, RenderedVersion: renderedVersion}); err != nil {
 			return fmt.Errorf("failed to broadcast rendered version: %w", err)
 		}
 	}
 	return nil
 }
 
-func (m *VersionManager) consumeHandler(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error {
+// NotifyConsole sets the console-pending KV flag and publishes a console notification
+// so that a waiting GetRenderedDevice long-poll is unblocked immediately.
+func (m *VersionManager) NotifyConsole(ctx context.Context, orgId uuid.UUID, name string) error {
+	if _, err := m.kvStore.SetNX(ctx, m.consolePendingKey(orgId, name), []byte("1")); err != nil {
+		return fmt.Errorf("failed to set console notification: %w", err)
+	}
+	return m.broadcaster.Publish(ctx, orgId, name, Notification{Type: NotificationTypeConsole})
+}
+
+// ClearConsoleNotification removes the console-pending KV flag after the agent has been woken.
+func (m *VersionManager) ClearConsoleNotification(ctx context.Context, orgId uuid.UUID, name string) error {
+	return m.kvStore.Delete(ctx, m.consolePendingKey(orgId, name))
+}
+
+func (m *VersionManager) consumeHandler(ctx context.Context, orgId uuid.UUID, name string, n Notification) error {
 	notifier, ok := m.subscribers.Load(m.key(orgId, name))
 	if !ok {
 		return nil
 	}
-	ch, isChan := notifier.(chan string)
+	ch, isChan := notifier.(chan Notification)
 	if !isChan {
 		m.log.Errorf("GetRenderedDevice: notifier for %s/%s is not a channel, skipping notification", orgId, name)
 		return nil
 	}
 	select {
-	case ch <- renderedVersion:
+	case ch <- n:
 	default:
 		m.log.Warnf("GetRenderedDevice: channel for %s/%s is full, skipping notification", orgId, name)
 	}

--- a/internal/rendered/manager_test.go
+++ b/internal/rendered/manager_test.go
@@ -1,0 +1,394 @@
+package rendered
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKVStore is a minimal in-memory KVStore for unit testing.
+type fakeKVStore struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newFakeKVStore() *fakeKVStore {
+	return &fakeKVStore{data: make(map[string][]byte)}
+}
+
+func (f *fakeKVStore) preset(key string, value []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key] = value
+}
+
+func (f *fakeKVStore) has(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.data[key]
+	return ok
+}
+
+func (f *fakeKVStore) Close() {}
+
+func (f *fakeKVStore) Get(_ context.Context, key string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.data[key]
+	if !ok {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (f *fakeKVStore) SetNX(_ context.Context, key string, value []byte) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, exists := f.data[key]; exists {
+		return false, nil
+	}
+	f.data[key] = value
+	return true, nil
+}
+
+func (f *fakeKVStore) SetIfGreater(_ context.Context, key string, newVal int64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if existing, ok := f.data[key]; ok {
+		cur, err := strconv.ParseInt(string(existing), 10, 64)
+		if err == nil && cur >= newVal {
+			return false, nil
+		}
+	}
+	f.data[key] = []byte(fmt.Sprintf("%d", newVal))
+	return true, nil
+}
+
+func (f *fakeKVStore) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, key)
+	return nil
+}
+
+func (f *fakeKVStore) GetOrSetNX(_ context.Context, key string, value []byte) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if v, ok := f.data[key]; ok {
+		return v, nil
+	}
+	f.data[key] = value
+	return value, nil
+}
+
+func (f *fakeKVStore) DeleteKeysForTemplateVersion(_ context.Context, _ string) error { return nil }
+func (f *fakeKVStore) DeleteAllKeys(_ context.Context) error                          { return nil }
+func (f *fakeKVStore) PrintAllKeys(_ context.Context)                                 {}
+func (f *fakeKVStore) StreamAdd(_ context.Context, _ string, _ []byte) (string, error) {
+	return "", nil
+}
+func (f *fakeKVStore) StreamRange(_ context.Context, _, _, _ string) ([]kvstore.StreamEntry, error) {
+	return nil, nil
+}
+func (f *fakeKVStore) StreamRead(_ context.Context, _ string, _ string, _ time.Duration, _ int64) ([]kvstore.StreamEntry, error) {
+	return nil, nil
+}
+func (f *fakeKVStore) SetExpire(_ context.Context, _ string, _ time.Duration) error { return nil }
+
+// recordingPublisher records the last Publish call.
+type recordingPublisher struct {
+	mu   sync.Mutex
+	last *Notification
+}
+
+func (r *recordingPublisher) Publish(_ context.Context, _ uuid.UUID, _ string, n Notification) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := n
+	r.last = &cp
+	return nil
+}
+
+func (r *recordingPublisher) lastNotification() *Notification {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.last == nil {
+		return nil
+	}
+	cp := *r.last
+	return &cp
+}
+
+// noopSubscriber satisfies the Subscriber interface but does nothing.
+type noopSubscriber struct{}
+
+func (noopSubscriber) Subscribe(_ context.Context, _ func(context.Context, uuid.UUID, string, Notification) error) error {
+	return nil
+}
+
+// newTestVersionManager builds a VersionManager with fake dependencies.
+func newTestVersionManager(kv *fakeKVStore, pub *recordingPublisher) *VersionManager {
+	return &VersionManager{
+		kvStore:             kv,
+		broadcaster:         pub,
+		subscriber:          noopSubscriber{},
+		renderedWaitTimeout: 50 * time.Millisecond,
+		log:                 logrus.NewEntry(logrus.New()),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// WaitForNotification tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestWaitForNotification_ReturnsSpecUpdatedWhenKVHasNewerVersion(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("2"))
+
+	n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "1")
+
+	require.NoError(t, err)
+	assert.True(t, got)
+	assert.Equal(t, NotificationTypeSpecUpdated, n.Type)
+	assert.Equal(t, "2", n.RenderedVersion)
+}
+
+func TestWaitForNotification_ReturnsConsoleWhenKVFlagSet(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("5"))
+	kv.preset(vm.consolePendingKey(orgId, "dev"), []byte("1"))
+
+	// knownRenderedVersion matches KV — spec is unchanged, so console path fires.
+	n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "5")
+
+	require.NoError(t, err)
+	assert.True(t, got)
+	assert.Equal(t, NotificationTypeConsole, n.Type)
+	assert.Empty(t, n.RenderedVersion, "console notification carries no rendered version")
+}
+
+func TestWaitForNotification_SpecHasPriorityOverConsolePendingKey(t *testing.T) {
+	// When both spec version and console-pending are set, SpecUpdated is returned first.
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("2"))
+	kv.preset(vm.consolePendingKey(orgId, "dev"), []byte("1"))
+
+	n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "1")
+
+	require.NoError(t, err)
+	assert.True(t, got)
+	assert.Equal(t, NotificationTypeSpecUpdated, n.Type)
+	assert.Equal(t, "2", n.RenderedVersion)
+}
+
+func TestWaitForNotification_UnblocksViaConsumeHandlerConsole(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("3"))
+
+	type result struct {
+		n   Notification
+		got bool
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "3")
+		ch <- result{n, got, err}
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	// Simulate pub/sub delivery of a console notification via consumeHandler.
+	_ = vm.consumeHandler(context.Background(), orgId, "dev", Notification{Type: NotificationTypeConsole})
+
+	r := <-ch
+	require.NoError(t, r.err)
+	assert.True(t, r.got)
+	assert.Equal(t, NotificationTypeConsole, r.n.Type)
+}
+
+func TestWaitForNotification_UnblocksViaConsumeHandlerSpecUpdated(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("3"))
+
+	type result struct {
+		n   Notification
+		got bool
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "3")
+		ch <- result{n, got, err}
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	_ = vm.consumeHandler(context.Background(), orgId, "dev", Notification{Type: NotificationTypeSpecUpdated, RenderedVersion: "4"})
+
+	r := <-ch
+	require.NoError(t, r.err)
+	assert.True(t, r.got)
+	assert.Equal(t, NotificationTypeSpecUpdated, r.n.Type)
+	assert.Equal(t, "4", r.n.RenderedVersion)
+}
+
+func TestWaitForNotification_ReturnsTimeoutWhenNoEvent(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("5"))
+
+	n, got, err := vm.WaitForNotification(context.Background(), orgId, "dev", "5")
+
+	require.NoError(t, err)
+	assert.False(t, got)
+	assert.Empty(t, n.Type)
+}
+
+func TestWaitForNotification_ReturnsErrorOnContextCancel(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.key(orgId, "dev"), []byte("5"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := vm.WaitForNotification(ctx, orgId, "dev", "5")
+		errCh <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+
+	err := <-errCh
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// NotifyConsole tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestNotifyConsole_SetsKVFlagAndPublishesConsoleNotification(t *testing.T) {
+	kv := newFakeKVStore()
+	pub := &recordingPublisher{}
+	vm := newTestVersionManager(kv, pub)
+
+	orgId := uuid.New()
+	err := vm.NotifyConsole(context.Background(), orgId, "dev")
+
+	require.NoError(t, err)
+	assert.True(t, kv.has(vm.consolePendingKey(orgId, "dev")), "console-pending KV flag should be set")
+
+	last := pub.lastNotification()
+	require.NotNil(t, last)
+	assert.Equal(t, NotificationTypeConsole, last.Type)
+	assert.Empty(t, last.RenderedVersion)
+}
+
+func TestNotifyConsole_SetNXIsIdempotent(t *testing.T) {
+	// Calling NotifyConsole twice should not fail; SetNX is a no-op on the second call.
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	require.NoError(t, vm.NotifyConsole(context.Background(), orgId, "dev"))
+	require.NoError(t, vm.NotifyConsole(context.Background(), orgId, "dev"))
+	assert.True(t, kv.has(vm.consolePendingKey(orgId, "dev")))
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ClearConsoleNotification tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestClearConsoleNotification_DeletesKVFlag(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	kv.preset(vm.consolePendingKey(orgId, "dev"), []byte("1"))
+
+	require.NoError(t, vm.ClearConsoleNotification(context.Background(), orgId, "dev"))
+	assert.False(t, kv.has(vm.consolePendingKey(orgId, "dev")), "console-pending KV flag should be deleted")
+}
+
+func TestClearConsoleNotification_NoopWhenFlagAbsent(t *testing.T) {
+	kv := newFakeKVStore()
+	vm := newTestVersionManager(kv, &recordingPublisher{})
+
+	orgId := uuid.New()
+	err := vm.ClearConsoleNotification(context.Background(), orgId, "dev")
+	require.NoError(t, err)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// StoreAndNotify tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestStoreAndNotify_PublishesSpecUpdatedNotification(t *testing.T) {
+	kv := newFakeKVStore()
+	pub := &recordingPublisher{}
+	vm := newTestVersionManager(kv, pub)
+
+	orgId := uuid.New()
+	require.NoError(t, vm.StoreAndNotify(context.Background(), orgId, "dev", "7"))
+
+	last := pub.lastNotification()
+	require.NotNil(t, last)
+	assert.Equal(t, NotificationTypeSpecUpdated, last.Type)
+	assert.Equal(t, "7", last.RenderedVersion)
+}
+
+func TestStoreAndNotify_DoesNotPublishWhenVersionNotGreater(t *testing.T) {
+	kv := newFakeKVStore()
+	pub := &recordingPublisher{}
+	vm := newTestVersionManager(kv, pub)
+
+	orgId := uuid.New()
+	require.NoError(t, vm.StoreAndNotify(context.Background(), orgId, "dev", "10"))
+	pub.mu.Lock()
+	pub.last = nil
+	pub.mu.Unlock()
+
+	// Try to store a lower version — SetIfGreater returns false, no publish.
+	require.NoError(t, vm.StoreAndNotify(context.Background(), orgId, "dev", "5"))
+	assert.Nil(t, pub.lastNotification(), "should not publish when new version is not greater than existing")
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// consolePendingKey format
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestConsolePendingKey_Format(t *testing.T) {
+	vm := &VersionManager{}
+	orgId := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	assert.Equal(t,
+		"v1/00000000-0000-0000-0000-000000000001/device/my-device/console-pending",
+		vm.consolePendingKey(orgId, "my-device"),
+	)
+}

--- a/internal/rendered/pubsub.go
+++ b/internal/rendered/pubsub.go
@@ -11,12 +11,29 @@ import (
 
 const queueName = "rendered_version_notifier"
 
+// NotificationType distinguishes between different kinds of notifications that wake
+// a device agent's long-poll. It is intentionally decoupled from the persisted
+// auditing Event system (api/core/v1beta1).
+type NotificationType string
+
+const (
+	NotificationTypeSpecUpdated NotificationType = "spec-updated"
+	NotificationTypeConsole     NotificationType = "console"
+)
+
+// Notification is the internal signal sent over the pub/sub channel to unblock
+// a waiting GetRenderedDevice long-poll on the API server.
+type Notification struct {
+	Type            NotificationType
+	RenderedVersion string // only populated for NotificationTypeSpecUpdated
+}
+
 type Publisher interface {
-	Publish(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error
+	Publish(ctx context.Context, orgId uuid.UUID, name string, n Notification) error
 }
 
 type Subscriber interface {
-	Subscribe(ctx context.Context, handler func(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error) error
+	Subscribe(ctx context.Context, handler func(ctx context.Context, orgId uuid.UUID, name string, n Notification) error) error
 }
 
 func NewBroadcaster(ctx context.Context, queuesProvider queues.Provider) (Publisher, error) {
@@ -40,19 +57,22 @@ func NewSubscriber(ctx context.Context, queuesProvider queues.Provider) (Subscri
 }
 
 type serializedResourceId struct {
-	OrgId         uuid.UUID `json:"org_id"`
-	Name          string    `json:"name"`
-	RenderVersion string    `json:"render_version,omitempty"`
+	OrgId         uuid.UUID        `json:"org_id"`
+	Name          string           `json:"name"`
+	RenderVersion string           `json:"render_version,omitempty"`
+	Type          NotificationType `json:"type,omitempty"`
 }
+
 type publisher struct {
 	broadcaster queues.PubSubPublisher
 }
 
-func (p *publisher) Publish(ctx context.Context, orgId uuid.UUID, name string, renderVersion string) error {
+func (p *publisher) Publish(ctx context.Context, orgId uuid.UUID, name string, n Notification) error {
 	s := serializedResourceId{
 		OrgId:         orgId,
 		Name:          name,
-		RenderVersion: renderVersion,
+		RenderVersion: n.RenderedVersion,
+		Type:          n.Type,
 	}
 	b, err := json.Marshal(s)
 	if err != nil {
@@ -66,14 +86,17 @@ type consumer struct {
 	subscriptions []queues.Subscription
 }
 
-func (c *consumer) Subscribe(ctx context.Context, handler func(ctx context.Context, orgId uuid.UUID, name string, renderedVersion string) error) error {
+func (c *consumer) Subscribe(ctx context.Context, handler func(ctx context.Context, orgId uuid.UUID, name string, n Notification) error) error {
 	queuesHandler := func(ctx context.Context, payload []byte, log logrus.FieldLogger) error {
 		var s serializedResourceId
 		if err := json.Unmarshal(payload, &s); err != nil {
 			log.WithError(err).Error("failed to unmarshal payload")
 			return err
 		}
-		return handler(ctx, s.OrgId, s.Name, s.RenderVersion)
+		return handler(ctx, s.OrgId, s.Name, Notification{
+			Type:            s.Type,
+			RenderedVersion: s.RenderVersion,
+		})
 	}
 
 	if _, err := c.subscriber.Subscribe(ctx, queuesHandler); err != nil {

--- a/internal/service/device.go
+++ b/internal/service/device.go
@@ -331,7 +331,6 @@ func (h *ServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid.UUID,
 
 func (h *ServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, params domain.GetRenderedDeviceParams) (*domain.Device, domain.Status) {
 	var (
-		isNew                   bool
 		kvRenderedVersion       string
 		err                     error
 		isAgent                 bool
@@ -349,16 +348,24 @@ func (h *ServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid.UUID,
 	}
 
 	if params.KnownRenderedVersion != nil && !processedAwaitReconnect {
-		isNew, kvRenderedVersion, err = rendered.Bus.Instance().WaitForNewVersion(ctx, orgId, name, *params.KnownRenderedVersion)
+		n, gotNotification, err := rendered.Bus.Instance().WaitForNotification(ctx, orgId, name, *params.KnownRenderedVersion)
 		if err != nil {
-			h.log.Errorf("GetRenderedDevice %s/%s: failed to wait for new rendered version: %v", orgId, name, err)
-			return nil, domain.StatusInternalServerError(fmt.Sprintf("failed to wait for new rendered version: %v", err))
+			h.log.Errorf("GetRenderedDevice %s/%s: failed to wait for notification: %v", orgId, name, err)
+			return nil, domain.StatusInternalServerError(fmt.Sprintf("failed to wait for notification: %v", err))
 		}
-		if !isNew {
+		if !gotNotification {
 			return nil, domain.StatusNoContent()
 		}
+		switch n.Type {
+		case rendered.NotificationTypeSpecUpdated:
+			kvRenderedVersion = n.RenderedVersion
+		case rendered.NotificationTypeConsole:
+			if err := rendered.Bus.Instance().ClearConsoleNotification(ctx, orgId, name); err != nil {
+				h.log.Warnf("GetRenderedDevice %s/%s: failed to clear console notification: %v", orgId, name, err)
+			}
+		}
 	}
-	// When processedAwaitReconnect we skip WaitForNewVersion and return the current device (200)
+	// When processedAwaitReconnect we skip WaitForNotification and return the current device (200)
 	// so the agent sees the updated state and re-pushes its status.
 
 	if isAgent {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1684,6 +1685,238 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			}
 
 			Expect(foundDevice).To(BeFalse(), "Device with nil lastSeen should not be found in lastSeen> filter")
+		})
+	})
+
+	Context("Console notification via GetRenderedDevice", func() {
+		var (
+			suite          *ServiceTestSuite
+			testKvStore    kvstore.KVStore
+			queuesProvider queues.Provider
+		)
+
+		BeforeEach(func() {
+			suite = NewServiceTestSuite()
+			suite.Setup()
+
+			healthchecker.HealthChecks.Initialize(suite.Ctx, suite.Store, suite.Log)
+
+			var err error
+			if testKvStore == nil {
+				testKvStore, err = kvstore.NewKVStore(suite.Ctx, suite.Log, redisHost, redisPort, redisPassword)
+				Expect(err).ToNot(HaveOccurred())
+				processID := fmt.Sprintf("console-notification-test-%s", uuid.New().String())
+				queuesProvider, err = queues.NewRedisProvider(suite.Ctx, suite.Log, processID, redisHost, redisPort, redisPassword, queues.DefaultRetryConfig())
+				Expect(err).ToNot(HaveOccurred())
+				err = rendered.Bus.Initialize(suite.Ctx, testKvStore, queuesProvider, 10*time.Second, suite.Log)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			suite.Teardown()
+		})
+
+		buildRenderedConfig := func(contents string) string {
+			provider := api.ConfigProviderSpec{}
+			files := []api.FileSpec{{Content: contents}}
+			Expect(provider.FromInlineConfigProviderSpec(api.InlineConfigProviderSpec{Inline: files})).To(Succeed())
+			b, err := json.Marshal(&[]api.ConfigProviderSpec{provider})
+			Expect(err).ToNot(HaveOccurred())
+			return string(b)
+		}
+
+		It("returns 200 immediately when console-pending KV flag is set and spec is unchanged", func() {
+			deviceName := "console-notification-test-wakeup"
+			knownVersion := "3"
+
+			_, status := suite.Handler.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, err := suite.Store.Device().UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash1", nil, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Prime the KV rendered-version to match what the agent reports.
+			renderedKey := fmt.Sprintf("v1/%s/device/%s/rendered", suite.OrgID, deviceName)
+			_, err = testKvStore.GetOrSetNX(suite.Ctx, renderedKey, []byte(knownVersion))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set the console-pending flag as the console manager would do.
+			consolePendingKey := fmt.Sprintf("v1/%s/device/%s/console-pending", suite.OrgID, deviceName)
+			_, err = testKvStore.SetNX(suite.Ctx, consolePendingKey, []byte("1"))
+			Expect(err).ToNot(HaveOccurred())
+
+			agentCtx := context.WithValue(suite.Ctx, consts.AgentCtxKey, deviceName)
+			params := domain.GetRenderedDeviceParams{KnownRenderedVersion: lo.ToPtr(knownVersion)}
+			result, status := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
+
+			// Even though the spec version hasn't changed, the console-pending flag causes a 200.
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result).ToNot(BeNil())
+		})
+
+		It("clears the console-pending KV flag after returning 200", func() {
+			deviceName := "console-notification-test-clear"
+			knownVersion := "5"
+
+			_, status := suite.Handler.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, err := suite.Store.Device().UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash2", nil, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			renderedKey := fmt.Sprintf("v1/%s/device/%s/rendered", suite.OrgID, deviceName)
+			_, err = testKvStore.GetOrSetNX(suite.Ctx, renderedKey, []byte(knownVersion))
+			Expect(err).ToNot(HaveOccurred())
+
+			consolePendingKey := fmt.Sprintf("v1/%s/device/%s/console-pending", suite.OrgID, deviceName)
+			_, err = testKvStore.SetNX(suite.Ctx, consolePendingKey, []byte("1"))
+			Expect(err).ToNot(HaveOccurred())
+
+			agentCtx := context.WithValue(suite.Ctx, consts.AgentCtxKey, deviceName)
+			params := domain.GetRenderedDeviceParams{KnownRenderedVersion: lo.ToPtr(knownVersion)}
+
+			// First call wakes up and clears the flag.
+			result, status := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result).ToNot(BeNil())
+
+			// Verify the flag was cleared.
+			flagVal, err := testKvStore.Get(suite.Ctx, consolePendingKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(flagVal).To(BeNil(), "console-pending KV flag should be cleared after GetRenderedDevice returns 200")
+
+			// Second call with unchanged spec must return 204 (no busy-loop).
+			result2, status2 := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
+			Expect(status2.Code).To(Equal(int32(204)))
+			Expect(result2).To(BeNil())
+		})
+
+		It("does not bump DeviceAnnotationRenderedVersion when console notification is processed", func() {
+			deviceName := "console-notification-test-no-version-bump"
+			knownVersion := "7"
+
+			_, status := suite.Handler.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, err := suite.Store.Device().UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash3", nil, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Pin the DeviceAnnotationRenderedVersion annotation to a known value.
+			err = suite.Store.Device().UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
+				api.DeviceAnnotationRenderedVersion: knownVersion,
+			}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			renderedKey := fmt.Sprintf("v1/%s/device/%s/rendered", suite.OrgID, deviceName)
+			_, err = testKvStore.GetOrSetNX(suite.Ctx, renderedKey, []byte(knownVersion))
+			Expect(err).ToNot(HaveOccurred())
+
+			consolePendingKey := fmt.Sprintf("v1/%s/device/%s/console-pending", suite.OrgID, deviceName)
+			_, err = testKvStore.SetNX(suite.Ctx, consolePendingKey, []byte("1"))
+			Expect(err).ToNot(HaveOccurred())
+
+			agentCtx := context.WithValue(suite.Ctx, consts.AgentCtxKey, deviceName)
+			params := domain.GetRenderedDeviceParams{KnownRenderedVersion: lo.ToPtr(knownVersion)}
+			result, status := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result).ToNot(BeNil())
+
+			// DeviceAnnotationRenderedVersion must be unchanged — the console event must not
+			// cause a rendered-version bump in the database.
+			device, devStatus := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(devStatus.Code).To(Equal(int32(200)))
+			Expect(device).ToNot(BeNil())
+			Expect(device.Metadata.Annotations).ToNot(BeNil())
+			Expect((*device.Metadata.Annotations)[api.DeviceAnnotationRenderedVersion]).To(Equal(knownVersion),
+				"DeviceAnnotationRenderedVersion must not be bumped by a console notification")
+		})
+
+		It("returns 200 on fresh connect even when console-pending flag is absent (backward compat)", func() {
+			// No knownRenderedVersion → agent is reconnecting for the first time.
+			// GetRenderedDevice should always return 200 with the current spec.
+			deviceName := "console-notification-test-fresh-connect"
+
+			_, status := suite.Handler.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, err := suite.Store.Device().UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash4", nil, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set console annotation to simulate an open console session.
+			err = suite.Store.Device().UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
+				api.DeviceAnnotationConsole: `[{"sessionID":"sess-1","sessionMetadata":"{\"tty\":true}"}]`,
+			}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			agentCtx := context.WithValue(suite.Ctx, consts.AgentCtxKey, deviceName)
+			// No KnownRenderedVersion → fresh connect path.
+			params := domain.GetRenderedDeviceParams{}
+			result, status := suite.Handler.GetRenderedDevice(agentCtx, suite.OrgID, deviceName, params)
+
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result).ToNot(BeNil())
+			// Console annotation should be present in the returned spec.
+			Expect(result.Metadata.Annotations).ToNot(BeNil())
+			Expect(*result.Metadata.Annotations).To(HaveKey(api.DeviceAnnotationConsole))
+		})
+
+		It("does not bump resource version more than once during a console open cycle", func() {
+			deviceName := "console-notification-test-resource-version"
+			knownVersion := "1"
+
+			_, status := suite.Handler.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, err := suite.Store.Device().UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash5", nil, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = suite.Store.Device().UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
+				api.DeviceAnnotationRenderedVersion: knownVersion,
+			}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Capture the resource version before the console open.
+			deviceBefore, devStatus := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(devStatus.Code).To(Equal(int32(200)))
+			rvBefore := lo.FromPtr(deviceBefore.Metadata.ResourceVersion)
+
+			// Simulate adding a single console session annotation (as the console manager would).
+			err = suite.Store.Device().UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
+				api.DeviceAnnotationConsole: `[{"sessionID":"sess-open","sessionMetadata":"{\"tty\":true}"}]`,
+			}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceAfterOpen, devStatus := suite.Handler.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(devStatus.Code).To(Equal(int32(200)))
+			rvAfterOpen := lo.FromPtr(deviceAfterOpen.Metadata.ResourceVersion)
+
+			// Convert resource versions to integers for comparison.
+			rvBeforeInt, err := strconv.Atoi(rvBefore)
+			Expect(err).ToNot(HaveOccurred())
+			rvAfterOpenInt, err := strconv.Atoi(rvAfterOpen)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Console annotation addition is exactly one UpdateAnnotations call → resource version +1.
+			Expect(rvAfterOpenInt).To(BeNumerically(">", rvBeforeInt),
+				"resource version should increase when the console annotation is added")
+			Expect(rvAfterOpenInt-rvBeforeInt).To(Equal(1),
+				"exactly one resource-version bump is expected when opening a console session")
 		})
 	})
 })


### PR DESCRIPTION
Depends on: #3187

## Summary

Opening a console session (device or VM app) previously triggered a rendered-version bump (via `GetNextDeviceRenderedVersion` + annotation update) purely to wake up the agent's long-polling `GetRenderedDevice` call. This conflated two unrelated concerns — "the device spec changed" and "the agent should reconnect for a console session" — and caused an unnecessary rendered-version increment (and downstream spec reconciliation) on every console open.

This decouples the two by introducing a separate, dedicated notification channel:

- **`internal/rendered` (`pubsub.go`, `manager.go`)** — replace the `string` rendered-version pub/sub payload with a typed `Notification{Type, RenderedVersion}` (`NotificationTypeSpecUpdated` / `NotificationTypeConsole`). Add a `console-pending` KV flag (`NotifyConsole` / `ClearConsoleNotification`) so a console wake-up survives even if no long-poll is currently subscribed. `WaitForNotification` (renamed from `WaitForNewVersion`) now returns whichever notification type fires first.
- **`internal/service/device.go`** — `GetRenderedDevice` switches on the notification type: `SpecUpdated` updates `kvRenderedVersion` as before; `Console` just clears the pending flag and returns the current device, without incrementing anything.
- **`internal/console/{console.go,app_console.go}`** — `modifyAnnotations` no longer computes/persists a next rendered version on session start/stop; `StartSession` now calls the new `ConsoleEventNotifier.NotifyConsole` directly instead of going through `RenderedVersionPublisher.StoreAndNotify`.
- **`internal/remote_access_server/server.go`, `internal/api_server/server.go`** — wire the renamed `ConsoleEventNotifier` (backed by `rendered.Bus.Instance()`) into both session managers.

## Test plan

- `make unit-test` — all tests pass
- `make lint` — 0 issues

Made with [Cursor](https://cursor.com)