### PR TITLE
EDM-2822: Improve expired OAuth2 token error message

### DIFF
--- a/internal/client/authorization.go
+++ b/internal/client/authorization.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -113,6 +115,13 @@ func (r *AccessTokenRefresher) shouldRefresh(expireTime time.Time) bool {
 	return time.Now().Add(5 * time.Second).After(expireTime)
 }
 
+func isExpiredTokenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "invalid_grant")
+}
+
 func (r *AccessTokenRefresher) refresh() error {
 	if r.config.AuthInfo.RefreshToken == "" {
 		return fmt.Errorf("no refresh token found")
@@ -159,7 +168,11 @@ func (r *AccessTokenRefresher) refreshLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := r.refresh(); err != nil {
-				r.log.Errorf("failed to renew token: %v", err)
+				if isExpiredTokenError(err) {
+					fmt.Fprintln(os.Stderr, "Error: Your session has expired. Please log in again using: flightctl login <server>")
+				} else {
+					r.log.Errorf("failed to renew token: %v", err)
+				}
 				return
 			}
 			r.log.Info("renewed access token")
@@ -186,7 +199,11 @@ func (r *AccessTokenRefresher) Start(ctx context.Context) {
 		expireTime, err := r.parseExpireTime()
 		if err != nil || r.shouldRefresh(expireTime) {
 			if err := r.refresh(); err != nil {
-				r.log.WithError(err).Error("failed to refresh access token")
+				if isExpiredTokenError(err) {
+					fmt.Fprintln(os.Stderr, "Error: Your session has expired. Please log in again using: flightctl login <server>")
+				} else {
+					r.log.WithError(err).Error("failed to refresh access token")
+				}
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
Improve the error message when OAuth2 refresh tokens expire to provide a clear, actionable message instead of technical logging output.

## Problem
When OAuth2/OIDC refresh tokens expire, users see confusing technical error messages with file paths, line numbers, and function names:
```
ERRO[0000]/home/user/flightctl/internal/client/authorization.go:189
github.com/flightctl/flightctl/internal/client.(*AccessTokenRefresher).Start.func1()
failed to refresh access token
error="failed to renew token: OAuth2 error: invalid_grant - Invalid refresh token"
```

## Solution
Detect expired token errors (OAuth2 `invalid_grant` error code) and display a user-friendly message:
```
Error: Your session has expired. Please log in again using: flightctl login <server>
```

## Changes
- Add `isExpiredTokenError()` function to detect OAuth2 `invalid_grant` errors
- Update `refreshLoop()` and `Start()` methods to show user-friendly message for expired tokens
- Preserve technical logging for other error types (network errors, etc.)

## Testing
Tested in real environment with:
- OAuth2 provider (Keycloak)
- Real refresh tokens
- Simulated token expiration

**Before (old code):**
```
ERRO[0000]/home/user/flightctl/internal/client/authorization.go:189 
github.com/flightctl/flightctl/internal/client.(*AccessTokenRefresher).Start.func1() 
failed to refresh access token
error="failed to renew token: OAuth2 error: invalid_grant - Invalid refresh token"
```

**After (with fix):**
```
Error: Your session has expired. Please log in again using: flightctl login <server>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)