### PR TITLE
EDM-4690: Add encryption subsystem infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	golang.org/x/oauth2 v0.34.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
+	gorm.io/driver/sqlite v1.5.5
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -294,6 +295,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/miekg/dns v1.1.66 // indirect
@@ -451,7 +453,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gorm.io/driver/sqlite v1.5.5 // indirect
 	k8s.io/apiserver v0.28.2 // indirect
 	k8s.io/cli-runtime v0.32.3 // indirect
 	k8s.io/kube-openapi v0.32.3 // indirect

--- a/internal/instrumentation/encryption/canary.go
+++ b/internal/instrumentation/encryption/canary.go
@@ -42,7 +42,7 @@ type ValidationResult struct {
 type CanaryManager struct {
 	encMgr  *Manager
 	store   CanaryStore
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	ensured map[string]bool // "strategy/keyID" -> true (do-once per session)
 }
 
@@ -61,11 +61,19 @@ func NewCanaryManager(encMgr *Manager, store CanaryStore) *CanaryManager {
 func (cm *CanaryManager) EnsureCanary(ctx context.Context, strategy, keyID string) error {
 	key := fmt.Sprintf("%s/%s", strategy, keyID)
 
-	// Hold lock for entire check-and-create to prevent TOCTOU race
+	// Fast path: check if already ensured (read lock)
+	cm.mu.RLock()
+	if cm.ensured[key] {
+		cm.mu.RUnlock()
+		return nil
+	}
+	cm.mu.RUnlock()
+
+	// Slow path: need to check storage and potentially create
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// Do-once check (session-level cache)
+	// Double-check after acquiring write lock (another goroutine may have created it)
 	if cm.ensured[key] {
 		return nil
 	}
@@ -157,15 +165,14 @@ func (cm *CanaryManager) validateOne(ctx context.Context, canary *Canary) Valida
 // GetActiveCanary returns the canary for the currently active strategy/key.
 // Returns nil if not found.
 func (cm *CanaryManager) GetActiveCanary(ctx context.Context) (*Canary, error) {
-	if cm.encMgr.activeStrategy == "" {
+	version, strategy := cm.encMgr.GetActiveStrategy()
+	if version == "" {
 		return nil, fmt.Errorf("no active strategy set")
 	}
-
-	strategy, exists := cm.encMgr.strategies[cm.encMgr.activeStrategy]
-	if !exists {
-		return nil, fmt.Errorf("active strategy %s not found", cm.encMgr.activeStrategy)
+	if strategy == nil {
+		return nil, fmt.Errorf("active strategy %s not found", version)
 	}
 
 	keyID := strategy.ActiveKeyID()
-	return cm.store.Get(cm.encMgr.activeStrategy, keyID)
+	return cm.store.Get(version, keyID)
 }

--- a/internal/instrumentation/encryption/canary.go
+++ b/internal/instrumentation/encryption/canary.go
@@ -1,0 +1,171 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Canary represents an encrypted test value used to verify encryption/decryption works.
+// Each canary is specific to a (strategy, keyID) pair.
+type Canary struct {
+	Strategy       string    `json:"strategy"`        // e.g., "v1"
+	KeyID          string    `json:"key_id"`          // e.g., "default"
+	EncryptedValue []byte    `json:"encrypted_value"` // e.g., "enc:v1:default:..."
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// CanaryStore abstracts canary persistence.
+type CanaryStore interface {
+	// Get retrieves a canary for the given strategy and keyID.
+	// Returns nil if not found.
+	Get(strategy, keyID string) (*Canary, error)
+
+	// Save creates or updates a canary.
+	Save(canary *Canary) error
+
+	// GetAll retrieves all stored canaries.
+	GetAll() ([]Canary, error)
+}
+
+// ValidationResult represents the result of validating a single canary.
+type ValidationResult struct {
+	Strategy string `json:"strategy"`
+	KeyID    string `json:"key_id"`
+	Status   string `json:"status"` // "ok", "failed", "mismatch"
+	Error    string `json:"error,omitempty"`
+}
+
+// CanaryManager manages encryption canaries for verification.
+// It ensures canaries exist for all active keys and validates they can be decrypted.
+type CanaryManager struct {
+	encMgr  *Manager
+	store   CanaryStore
+	mu      sync.Mutex
+	ensured map[string]bool // "strategy/keyID" -> true (do-once per session)
+}
+
+// NewCanaryManager creates a new canary manager.
+func NewCanaryManager(encMgr *Manager, store CanaryStore) *CanaryManager {
+	return &CanaryManager{
+		encMgr:  encMgr,
+		store:   store,
+		ensured: make(map[string]bool),
+	}
+}
+
+// EnsureCanary ensures a canary exists for the given strategy and keyID.
+// This is called on first encryption with a particular key.
+// Uses do-once pattern: only checks/creates once per session.
+func (cm *CanaryManager) EnsureCanary(ctx context.Context, strategy, keyID string) error {
+	key := fmt.Sprintf("%s/%s", strategy, keyID)
+
+	// Hold lock for entire check-and-create to prevent TOCTOU race
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Do-once check (session-level cache)
+	if cm.ensured[key] {
+		return nil
+	}
+
+	// Check if canary already exists in storage
+	existing, err := cm.store.Get(strategy, keyID)
+	if err != nil {
+		return fmt.Errorf("check existing canary: %w", err)
+	}
+
+	if existing != nil {
+		// Canary exists, mark as ensured
+		cm.ensured[key] = true
+		return nil
+	}
+
+	// Create new canary
+	plaintext := fmt.Sprintf("flightctl-canary-%s-%s", strategy, keyID)
+	encrypted, err := cm.encMgr.Encrypt(ctx, []byte(plaintext))
+	if err != nil {
+		return fmt.Errorf("encrypt canary: %w", err)
+	}
+
+	canary := &Canary{
+		Strategy:       strategy,
+		KeyID:          keyID,
+		EncryptedValue: encrypted,
+		CreatedAt:      time.Now(),
+	}
+
+	if err := cm.store.Save(canary); err != nil {
+		return fmt.Errorf("save canary: %w", err)
+	}
+
+	// Mark as ensured
+	cm.ensured[key] = true
+
+	return nil
+}
+
+// ValidateAll validates all stored canaries.
+// Returns a list of validation results, one per canary.
+// This is used by health/status endpoints to verify encryption is working.
+func (cm *CanaryManager) ValidateAll(ctx context.Context) ([]ValidationResult, error) {
+	canaries, err := cm.store.GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("get all canaries: %w", err)
+	}
+
+	results := make([]ValidationResult, 0, len(canaries))
+	for _, canary := range canaries {
+		result := cm.validateOne(ctx, &canary)
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+// validateOne validates a single canary.
+func (cm *CanaryManager) validateOne(ctx context.Context, canary *Canary) ValidationResult {
+	expected := fmt.Sprintf("flightctl-canary-%s-%s", canary.Strategy, canary.KeyID)
+
+	decrypted, err := cm.encMgr.Decrypt(ctx, canary.EncryptedValue)
+	if err != nil {
+		return ValidationResult{
+			Strategy: canary.Strategy,
+			KeyID:    canary.KeyID,
+			Status:   "failed",
+			Error:    fmt.Sprintf("decrypt failed: %v", err),
+		}
+	}
+
+	if string(decrypted) != expected {
+		return ValidationResult{
+			Strategy: canary.Strategy,
+			KeyID:    canary.KeyID,
+			Status:   "mismatch",
+			Error:    fmt.Sprintf("expected %q, got %q", expected, string(decrypted)),
+		}
+	}
+
+	return ValidationResult{
+		Strategy: canary.Strategy,
+		KeyID:    canary.KeyID,
+		Status:   "ok",
+	}
+}
+
+// GetActiveCanary returns the canary for the currently active strategy/key.
+// Returns nil if not found.
+func (cm *CanaryManager) GetActiveCanary(ctx context.Context) (*Canary, error) {
+	if cm.encMgr.activeStrategy == "" {
+		return nil, fmt.Errorf("no active strategy set")
+	}
+
+	strategy, exists := cm.encMgr.strategies[cm.encMgr.activeStrategy]
+	if !exists {
+		return nil, fmt.Errorf("active strategy %s not found", cm.encMgr.activeStrategy)
+	}
+
+	keyID := strategy.ActiveKeyID()
+	return cm.store.Get(cm.encMgr.activeStrategy, keyID)
+}

--- a/internal/instrumentation/encryption/canary_memory_store.go
+++ b/internal/instrumentation/encryption/canary_memory_store.go
@@ -1,0 +1,85 @@
+package encryption
+
+import (
+	"sync"
+)
+
+// memoryCanaryStore stores canaries in memory (for testing).
+// Thread-safe for concurrent access.
+type memoryCanaryStore struct {
+	mu       sync.RWMutex
+	canaries map[string]*Canary // "strategy/keyID" -> canary
+}
+
+// newMemoryCanaryStore creates a new in-memory canary store.
+func newMemoryCanaryStore() *memoryCanaryStore {
+	return &memoryCanaryStore{
+		canaries: make(map[string]*Canary),
+	}
+}
+
+// Get retrieves a canary for the given strategy and keyID.
+func (s *memoryCanaryStore) Get(strategy, keyID string) (*Canary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := strategy + "/" + keyID
+	canary, exists := s.canaries[key]
+	if !exists {
+		return nil, nil
+	}
+
+	// Return a deep copy to prevent external mutation
+	encryptedCopy := make([]byte, len(canary.EncryptedValue))
+	copy(encryptedCopy, canary.EncryptedValue)
+
+	return &Canary{
+		Strategy:       canary.Strategy,
+		KeyID:          canary.KeyID,
+		EncryptedValue: encryptedCopy,
+		CreatedAt:      canary.CreatedAt,
+	}, nil
+}
+
+// Save creates or updates a canary.
+func (s *memoryCanaryStore) Save(canary *Canary) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := canary.Strategy + "/" + canary.KeyID
+
+	// Store a deep copy to prevent external mutation
+	encryptedCopy := make([]byte, len(canary.EncryptedValue))
+	copy(encryptedCopy, canary.EncryptedValue)
+
+	s.canaries[key] = &Canary{
+		Strategy:       canary.Strategy,
+		KeyID:          canary.KeyID,
+		EncryptedValue: encryptedCopy,
+		CreatedAt:      canary.CreatedAt,
+	}
+
+	return nil
+}
+
+// GetAll retrieves all stored canaries.
+func (s *memoryCanaryStore) GetAll() ([]Canary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]Canary, 0, len(s.canaries))
+	for _, canary := range s.canaries {
+		// Return deep copies to prevent external mutation
+		encryptedCopy := make([]byte, len(canary.EncryptedValue))
+		copy(encryptedCopy, canary.EncryptedValue)
+
+		result = append(result, Canary{
+			Strategy:       canary.Strategy,
+			KeyID:          canary.KeyID,
+			EncryptedValue: encryptedCopy,
+			CreatedAt:      canary.CreatedAt,
+		})
+	}
+
+	return result, nil
+}

--- a/internal/instrumentation/encryption/canary_test.go
+++ b/internal/instrumentation/encryption/canary_test.go
@@ -1,0 +1,323 @@
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanaryManager_EnsureCanary_CreatesNew(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Ensure canary for v1/default
+	err := canaryMgr.EnsureCanary(ctx, "v1", "default")
+	require.NoError(t, err)
+
+	// Verify canary was created
+	canary, err := store.Get("v1", "default")
+	require.NoError(t, err)
+	require.NotNil(t, canary)
+
+	assert.Equal(t, "v1", canary.Strategy)
+	assert.Equal(t, "default", canary.KeyID)
+	assert.NotEmpty(t, canary.EncryptedValue)
+	assert.Contains(t, string(canary.EncryptedValue), "enc:v1:default:")
+}
+
+func TestCanaryManager_EnsureCanary_DoOnce(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// First call creates canary
+	err := canaryMgr.EnsureCanary(ctx, "v1", "default")
+	require.NoError(t, err)
+
+	canary1, _ := store.Get("v1", "default")
+
+	// Second call should not recreate (do-once)
+	err = canaryMgr.EnsureCanary(ctx, "v1", "default")
+	require.NoError(t, err)
+
+	canary2, _ := store.Get("v1", "default")
+
+	// Should be exactly the same (not recreated)
+	assert.Equal(t, canary1.EncryptedValue, canary2.EncryptedValue)
+	assert.Equal(t, canary1.CreatedAt, canary2.CreatedAt)
+}
+
+func TestCanaryManager_EnsureCanary_MultipleKeys(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key1 := make([]byte, 32)
+	_, err = rand.Read(key1)
+	require.NoError(t, err)
+
+	key2 := make([]byte, 32)
+	_, err = rand.Read(key2)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("keyA", key1, true))
+	require.NoError(t, v1.AddKey("keyB", key2, true))
+	mgr.RegisterStrategy(v1, true)
+
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Ensure canaries for both keys
+	err = canaryMgr.EnsureCanary(ctx, "v1", "keyA")
+	require.NoError(t, err)
+
+	err = canaryMgr.EnsureCanary(ctx, "v1", "keyB")
+	require.NoError(t, err)
+
+	// Verify both exist
+	canaryA, err := store.Get("v1", "keyA")
+	require.NoError(t, err)
+	require.NotNil(t, canaryA)
+
+	canaryB, err := store.Get("v1", "keyB")
+	require.NoError(t, err)
+	require.NotNil(t, canaryB)
+
+	// Should be different (different keys)
+	assert.NotEqual(t, canaryA.EncryptedValue, canaryB.EncryptedValue)
+}
+
+func TestCanaryManager_ValidateAll_AllOK(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Create canary
+	err := canaryMgr.EnsureCanary(ctx, "v1", "default")
+	require.NoError(t, err)
+
+	// Validate all
+	results, err := canaryMgr.ValidateAll(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "v1", results[0].Strategy)
+	assert.Equal(t, "default", results[0].KeyID)
+	assert.Equal(t, "ok", results[0].Status)
+	assert.Empty(t, results[0].Error)
+}
+
+func TestCanaryManager_ValidateAll_MultipleCanaries(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key1 := make([]byte, 32)
+	_, err = rand.Read(key1)
+	require.NoError(t, err)
+
+	key2 := make([]byte, 32)
+	_, err = rand.Read(key2)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("keyA", key1, true))
+	require.NoError(t, v1.AddKey("keyB", key2, true))
+	mgr.RegisterStrategy(v1, true)
+
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Create multiple canaries
+	_ = canaryMgr.EnsureCanary(ctx, "v1", "keyA")
+	_ = canaryMgr.EnsureCanary(ctx, "v1", "keyB")
+
+	// Validate all
+	results, err := canaryMgr.ValidateAll(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, results, 2)
+
+	// All should be OK
+	for _, result := range results {
+		assert.Equal(t, "ok", result.Status)
+	}
+}
+
+func TestCanaryManager_ValidateAll_DecryptFails(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Manually create broken canary (invalid encrypted value)
+	brokenCanary := &Canary{
+		Strategy:       "v1",
+		KeyID:          "default",
+		EncryptedValue: []byte("enc:v1:default:BROKEN-BASE64!!!"),
+	}
+	_ = store.Save(brokenCanary)
+
+	// Validate should catch the error
+	results, err := canaryMgr.ValidateAll(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "failed", results[0].Status)
+	assert.Contains(t, results[0].Error, "decrypt failed")
+}
+
+func TestCanaryManager_ValidateAll_PlaintextMismatch(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+
+	ctx := context.Background()
+
+	// Create canary with wrong plaintext
+	wrongPlaintext := []byte("wrong-canary-value")
+	encrypted, err := mgr.Encrypt(ctx, wrongPlaintext)
+	require.NoError(t, err)
+
+	wrongCanary := &Canary{
+		Strategy:       "v1",
+		KeyID:          "default",
+		EncryptedValue: encrypted,
+	}
+	_ = store.Save(wrongCanary)
+
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	// Validate should catch the mismatch
+	results, err := canaryMgr.ValidateAll(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "mismatch", results[0].Status)
+	assert.Contains(t, results[0].Error, "expected")
+}
+
+func TestCanaryManager_GetActiveCanary(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// Create canary for active key
+	err := canaryMgr.EnsureCanary(ctx, "v1", "default")
+	require.NoError(t, err)
+
+	// Get active canary
+	activeCanary, err := canaryMgr.GetActiveCanary(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, activeCanary)
+
+	assert.Equal(t, "v1", activeCanary.Strategy)
+	assert.Equal(t, "default", activeCanary.KeyID)
+}
+
+func TestCanaryManager_GetActiveCanary_NotFound(t *testing.T) {
+	mgr := createTestManager(t)
+	store := newMemoryCanaryStore()
+	canaryMgr := NewCanaryManager(mgr, store)
+
+	ctx := context.Background()
+
+	// No canary created yet
+	activeCanary, err := canaryMgr.GetActiveCanary(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, activeCanary)
+}
+
+func TestMemoryCanaryStore_GetNotFound(t *testing.T) {
+	store := newMemoryCanaryStore()
+
+	canary, err := store.Get("v1", "nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, canary)
+}
+
+func TestMemoryCanaryStore_SaveAndGet(t *testing.T) {
+	store := newMemoryCanaryStore()
+
+	canary := &Canary{
+		Strategy:       "v1",
+		KeyID:          "test-key",
+		EncryptedValue: []byte("enc:v1:test-key:abc123"),
+	}
+
+	err := store.Save(canary)
+	require.NoError(t, err)
+
+	retrieved, err := store.Get("v1", "test-key")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+
+	assert.Equal(t, canary.Strategy, retrieved.Strategy)
+	assert.Equal(t, canary.KeyID, retrieved.KeyID)
+	assert.Equal(t, canary.EncryptedValue, retrieved.EncryptedValue)
+}
+
+func TestMemoryCanaryStore_SaveUpdates(t *testing.T) {
+	store := newMemoryCanaryStore()
+
+	canary1 := &Canary{
+		Strategy:       "v1",
+		KeyID:          "test-key",
+		EncryptedValue: []byte("first"),
+	}
+	_ = store.Save(canary1)
+
+	// Save again with same key, different value
+	canary2 := &Canary{
+		Strategy:       "v1",
+		KeyID:          "test-key",
+		EncryptedValue: []byte("second"),
+	}
+	_ = store.Save(canary2)
+
+	// Should have updated, not created duplicate
+	retrieved, _ := store.Get("v1", "test-key")
+	assert.Equal(t, []byte("second"), retrieved.EncryptedValue)
+
+	all, _ := store.GetAll()
+	assert.Len(t, all, 1, "Should only have one canary")
+}
+
+func TestMemoryCanaryStore_GetAll_Empty(t *testing.T) {
+	store := newMemoryCanaryStore()
+
+	all, err := store.GetAll()
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+func TestMemoryCanaryStore_GetAll_Multiple(t *testing.T) {
+	store := newMemoryCanaryStore()
+
+	canary1 := &Canary{Strategy: "v1", KeyID: "key1"}
+	canary2 := &Canary{Strategy: "v1", KeyID: "key2"}
+	canary3 := &Canary{Strategy: "v2", KeyID: "key1"}
+
+	_ = store.Save(canary1)
+	_ = store.Save(canary2)
+	_ = store.Save(canary3)
+
+	all, err := store.GetAll()
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}

--- a/internal/instrumentation/encryption/encryption.go
+++ b/internal/instrumentation/encryption/encryption.go
@@ -1,0 +1,133 @@
+package encryption
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/stoewer/go-strcase"
+)
+
+// Manager orchestrates multiple encryption strategies and routes operations
+// based on version prefixes in encrypted data.
+//
+// Thread safety: Manager is safe for concurrent use. All public methods are protected
+type Manager struct {
+	mu             sync.RWMutex
+	strategies     map[string]Strategy
+	activeStrategy string // Which strategy to use for new encryptions
+}
+
+// ParsedEncrypted contains the parsed components of a strategy-specific
+// encrypted body.
+//
+// The Manager parses only the outer Flightctl envelope:
+//
+//	enc:<version>:<body>
+//
+// The Strategy parses <body>. For v1, the body format is:
+//
+//	<keyID>:<base64(nonce||ciphertext||tag)>
+//
+// Future strategies may use a different body format while keeping the same
+// Manager-level envelope.
+type ParsedEncrypted struct {
+	// KeyID identifies the key that encrypted this value.
+	KeyID string
+
+	// Payload contains the strategy-specific encrypted payload.
+	// For v1, this is nonce||ciphertext||tag after base64 decoding.
+	Payload []byte
+
+	// Metadata contains optional non-sensitive strategy-specific metadata.
+	// It must not contain plaintext, ciphertext, key material, nonces,
+	// authentication tags, or customer/resource identifiers.
+	Metadata map[string]string
+}
+
+// Strategy defines one encryption format version.
+//
+// A Strategy does not decide whether an input value is plaintext or encrypted.
+// The Manager owns encrypted-state detection using the outer
+// "enc:<version>:<body>" envelope and calls the Strategy only with plaintext
+// or with a body already routed to this strategy version.
+type Strategy interface {
+	// Version returns the immutable version identifier (e.g., "v1", "v2").
+	// This should be a simple version string, not include key IDs or key source types.
+	Version() string
+
+	// String returns human-readable status information about this strategy.
+	// Should include: algorithm, active key ID, configured keys, etc.
+	// NEVER include actual key material.
+	// Example: "AES-256-GCM, active_key=default, keys=[default, key2]"
+	// Used by encryption status endpoints and diagnostics.
+	String() string
+
+	// ActiveKeyID returns the identifier of the currently active encryption key.
+	// This is the key used for all new encryptions.
+	ActiveKeyID() string
+
+	// Algorithm returns the algorithm name (e.g., "AES-256-GCM").
+	Algorithm() string
+
+	// ConfiguredKeys returns all configured key IDs for this strategy.
+	ConfiguredKeys() []string
+
+	// EncryptPlaintext encrypts plaintext using the strategy's active key and
+	// returns the strategy-specific body to be stored after "enc:<version>:".
+	//
+	// For v1, the returned body is:
+	//
+	//	<keyID>:<base64(nonce||ciphertext||tag)>
+	//
+	// The returned body must not include the outer "enc:<version>:" prefix.
+	// The strategy must not try to detect already-encrypted input.
+	EncryptPlaintext(ctx context.Context, plaintext []byte) ([]byte, error)
+
+	// ParseBody parses the strategy-specific body from the outer envelope.
+	//
+	// For v1:
+	//
+	//	<keyID>:<base64data>
+	//
+	// becomes:
+	//
+	//	ParsedEncrypted{KeyID: keyID, Payload: decodedBase64}
+	//
+	// ParseBody must perform strict format validation. It must not treat
+	// malformed strategy bodies as plaintext.
+	ParseBody(body []byte) (*ParsedEncrypted, error)
+
+	// DecryptParsed decrypts a value previously parsed by ParseBody.
+	//
+	// The strategy uses parsed.KeyID to select the configured key. It must fail
+	// if the key is unavailable, the payload is malformed, or authentication
+	// fails.
+	DecryptParsed(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error)
+}
+
+// IsEncrypted checks if data has the encryption version prefix "enc:<version>:..."
+func IsEncrypted(data []byte) bool {
+	_, _, ok := parseEncryptedFormat(data)
+	return ok
+}
+
+// parseEncryptedFormat parses "enc:<version>:<payload>" format.
+// Returns (version, payload, true) if valid, ("", nil, false) otherwise.
+// The version is normalized to kebab-case for consistent lookup.
+func parseEncryptedFormat(data []byte) (version string, payload []byte, ok bool) {
+	str := string(data)
+	if !strings.HasPrefix(str, "enc:") {
+		return "", nil, false
+	}
+
+	parts := strings.SplitN(str, ":", 3)
+	if len(parts) < 3 {
+		return "", nil, false
+	}
+
+	// Normalize version to kebab-case for consistent strategy lookup
+	version = strcase.KebabCase(parts[1])
+	payload = []byte(parts[2])
+	return version, payload, true
+}

--- a/internal/instrumentation/encryption/global.go
+++ b/internal/instrumentation/encryption/global.go
@@ -67,12 +67,12 @@ func InitGlobalEncryptionWithCanary(log logrus.FieldLogger, canaryStore CanarySt
 		manager.RegisterStrategy(v1Strategy, true)
 
 		// Determine active strategy info for logging
-		activeStrategy := manager.activeStrategy
+		activeVersion, activeStrategy := manager.GetActiveStrategy()
 		var activeKeyID string
-		if strategy, exists := manager.strategies[activeStrategy]; exists {
-			activeKeyID = strategy.ActiveKeyID()
+		if activeStrategy != nil {
+			activeKeyID = activeStrategy.ActiveKeyID()
 		}
-		strategyInfo := fmt.Sprintf("active=%s/%s", activeStrategy, activeKeyID)
+		strategyInfo := fmt.Sprintf("active=%s/%s", activeVersion, activeKeyID)
 
 		// Initialize canary manager (optional)
 		var canaryManager *CanaryManager
@@ -92,7 +92,7 @@ func InitGlobalEncryptionWithCanary(log logrus.FieldLogger, canaryStore CanarySt
 			failedCount := 0
 			for _, result := range results {
 				if result.Status != "ok" {
-					isActive := (result.Strategy == activeStrategy && result.KeyID == activeKeyID)
+					isActive := (result.Strategy == activeVersion && result.KeyID == activeKeyID)
 					if isActive {
 						// CRITICAL: Active key cannot decrypt its canary
 						log.Errorf("CRITICAL: Active encryption key %s/%s cannot decrypt canary: %s",
@@ -172,6 +172,7 @@ func Encrypt(ctx context.Context, plaintext Plaintext) (Ciphertext, error) {
 	// Ensure canary exists for active key (if canary manager is enabled)
 	globalManagerMu.RLock()
 	canaryMgr := globalCanaryManager // Can be nil
+	logger := globalLogger           // Can be nil
 	globalManagerMu.RUnlock()
 
 	if canaryMgr != nil {
@@ -182,11 +183,9 @@ func Encrypt(ctx context.Context, plaintext Plaintext) (Ciphertext, error) {
 			// Note: EnsureCanary has internal do-once logic, safe to call on every encrypt
 			if err := canaryMgr.EnsureCanary(ctx, activeStrategy, activeKeyID); err != nil {
 				// Log error but don't fail encryption (canary is verification, not critical path)
-				globalManagerMu.RLock()
-				if globalLogger != nil {
-					globalLogger.Errorf("Failed to ensure canary for %s/%s: %v", activeStrategy, activeKeyID, err)
+				if logger != nil {
+					logger.Errorf("Failed to ensure canary for %s/%s: %v", activeStrategy, activeKeyID, err)
 				}
-				globalManagerMu.RUnlock()
 			}
 		}
 	}

--- a/internal/instrumentation/encryption/global.go
+++ b/internal/instrumentation/encryption/global.go
@@ -1,0 +1,221 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	globalManager       *Manager
+	globalCanaryManager *CanaryManager
+	globalLogger        logrus.FieldLogger
+	globalManagerOnce   sync.Once
+	globalManagerMu     sync.RWMutex
+	globalInitErr       error // Cached initialization error from sync.Once attempt
+)
+
+// Plaintext is a type-safe wrapper for plaintext data.
+type Plaintext []byte
+
+// Ciphertext is a type-safe wrapper for encrypted data.
+type Ciphertext []byte
+
+// String returns the ciphertext as a string (typically starts with "enc:").
+func (c Ciphertext) String() string {
+	return string(c)
+}
+
+// Bytes returns the ciphertext as bytes.
+func (c Ciphertext) Bytes() []byte {
+	return []byte(c)
+}
+
+// String returns the plaintext as a string.
+func (p Plaintext) String() string {
+	return string(p)
+}
+
+// Bytes returns the plaintext as bytes.
+func (p Plaintext) Bytes() []byte {
+	return []byte(p)
+}
+
+// InitGlobalEncryption initializes the global encryption manager.
+// This MUST be called once during application startup, before any concurrent access.
+// It loads the v1 encryption strategy from FLIGHTCTL_ENCRYPTION_KEY environment variable or the provided keyPath.
+//
+// Thread safety: This function uses sync.Once to ensure single initialization.
+// After initialization completes, concurrent Encrypt/Decrypt calls are safe.
+func InitGlobalEncryption(log logrus.FieldLogger) error {
+	return InitGlobalEncryptionWithCanary(log, nil)
+}
+
+// InitGlobalEncryptionWithCanary initializes encryption with optional canary store.
+// If canaryStore is nil, canary functionality is disabled.
+func InitGlobalEncryptionWithCanary(log logrus.FieldLogger, canaryStore CanaryStore) error {
+	globalManagerOnce.Do(func() {
+		v1Strategy, err := NewV1Strategy()
+		if err != nil {
+			globalInitErr = fmt.Errorf("load encryption key: %w", err)
+			return
+		}
+
+		manager := NewManager()
+		manager.RegisterStrategy(v1Strategy, true)
+
+		// Determine active strategy info for logging
+		activeStrategy := manager.activeStrategy
+		var activeKeyID string
+		if strategy, exists := manager.strategies[activeStrategy]; exists {
+			activeKeyID = strategy.ActiveKeyID()
+		}
+		strategyInfo := fmt.Sprintf("active=%s/%s", activeStrategy, activeKeyID)
+
+		// Initialize canary manager (optional)
+		var canaryManager *CanaryManager
+		if canaryStore != nil {
+			canaryManager = NewCanaryManager(manager, canaryStore)
+
+			// Validate all existing canaries
+			ctx := context.Background()
+			results, err := canaryManager.ValidateAll(ctx)
+			if err != nil {
+				globalInitErr = fmt.Errorf("validate canaries: %w", err)
+				return
+			}
+
+			// Check validation results
+			okCount := 0
+			failedCount := 0
+			for _, result := range results {
+				if result.Status != "ok" {
+					isActive := (result.Strategy == activeStrategy && result.KeyID == activeKeyID)
+					if isActive {
+						// CRITICAL: Active key cannot decrypt its canary
+						log.Errorf("CRITICAL: Active encryption key %s/%s cannot decrypt canary: %s",
+							result.Strategy, result.KeyID, result.Error)
+						globalInitErr = fmt.Errorf("active encryption key %s/%s is broken - cannot decrypt canary",
+							result.Strategy, result.KeyID)
+						return
+					} else {
+						// WARNING: Old key cannot decrypt
+						log.Warnf("WARNING: Encryption key %s/%s cannot decrypt canary: %s - reads of data encrypted with this key will fail",
+							result.Strategy, result.KeyID, result.Error)
+						failedCount++
+					}
+				} else {
+					okCount++
+				}
+			}
+
+			// Log canary validation summary
+			if len(results) > 0 {
+				log.Infof("Encryption initialized: %s, validated %d canaries (%d ok, %d failed)",
+					strategyInfo, len(results), okCount, failedCount)
+			} else {
+				log.Infof("Encryption initialized: %s, no existing canaries", strategyInfo)
+			}
+		} else {
+			// No canary store - canaries disabled
+			log.Infof("Encryption initialized: %s (canaries disabled)", strategyInfo)
+		}
+
+		globalManagerMu.Lock()
+		globalManager = manager
+		globalCanaryManager = canaryManager // Can be nil
+		globalLogger = log
+		globalManagerMu.Unlock()
+	})
+
+	return globalInitErr
+}
+
+// GlobalManager returns the global encryption manager.
+// Returns nil if InitGlobalEncryption has not been called.
+//
+// Thread safety: Safe for concurrent access after InitGlobalEncryption completes.
+// The returned Manager is read-only (no RegisterStrategy/SetActiveStrategy calls after init).
+func GlobalManager() *Manager {
+	globalManagerMu.RLock()
+	defer globalManagerMu.RUnlock()
+
+	return globalManager // Can be nil if not initialized
+}
+
+// GlobalCanaryManager returns the global canary manager.
+// Returns nil if canaries are disabled or InitGlobalEncryption has not been called.
+//
+// Thread safety: Safe for concurrent access after InitGlobalEncryption completes.
+func GlobalCanaryManager() *CanaryManager {
+	globalManagerMu.RLock()
+	defer globalManagerMu.RUnlock()
+
+	return globalCanaryManager // Can be nil if canaries disabled or not initialized
+}
+
+// Encrypt is a type-safe convenience function that encrypts using the global manager.
+// Takes Plaintext, returns Ciphertext - type system prevents swapping arguments.
+//
+// On first call, automatically creates a canary for the active encryption key (if canaries enabled).
+// This verifies encryption is working correctly.
+//
+// Thread safety: Safe for concurrent use after InitGlobalEncryption completes.
+func Encrypt(ctx context.Context, plaintext Plaintext) (Ciphertext, error) {
+	mgr := GlobalManager()
+	if mgr == nil {
+		return nil, fmt.Errorf("encryption not initialized - call InitGlobalEncryption first")
+	}
+
+	// Ensure canary exists for active key (if canary manager is enabled)
+	globalManagerMu.RLock()
+	canaryMgr := globalCanaryManager // Can be nil
+	globalManagerMu.RUnlock()
+
+	if canaryMgr != nil {
+		// Get active strategy safely
+		activeStrategy, strategy := mgr.GetActiveStrategy()
+		if strategy != nil {
+			activeKeyID := strategy.ActiveKeyID()
+			// Note: EnsureCanary has internal do-once logic, safe to call on every encrypt
+			if err := canaryMgr.EnsureCanary(ctx, activeStrategy, activeKeyID); err != nil {
+				// Log error but don't fail encryption (canary is verification, not critical path)
+				globalManagerMu.RLock()
+				if globalLogger != nil {
+					globalLogger.Errorf("Failed to ensure canary for %s/%s: %v", activeStrategy, activeKeyID, err)
+				}
+				globalManagerMu.RUnlock()
+			}
+		}
+	}
+
+	encrypted, err := mgr.Encrypt(ctx, plaintext.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return Ciphertext(encrypted), nil
+}
+
+// Decrypt decrypts ciphertext using the global manager.
+// Returns (plaintext, ok, error) where ok indicates if decryption was performed.
+// - If input has "enc:" prefix: decrypts and returns (plaintext, true, nil)
+// - If input has no "enc:" prefix (backward compatibility): returns (input, false, nil)
+// - On error: returns (nil, false, error)
+//
+// Thread safety: Safe for concurrent use after InitGlobalEncryption completes.
+func Decrypt(ctx context.Context, ciphertext Ciphertext) (Plaintext, bool, error) {
+	mgr := GlobalManager()
+	if mgr == nil {
+		return nil, false, fmt.Errorf("encryption not initialized - call InitGlobalEncryption first")
+	}
+
+	wasEncrypted := IsEncrypted(ciphertext.Bytes())
+
+	decrypted, err := mgr.Decrypt(ctx, ciphertext.Bytes())
+	if err != nil {
+		return nil, false, err
+	}
+	return Plaintext(decrypted), wasEncrypted, nil
+}

--- a/internal/instrumentation/encryption/global_test.go
+++ b/internal/instrumentation/encryption/global_test.go
@@ -294,7 +294,9 @@ func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T)
 	require.NoError(t, err)
 
 	// Add second key manually and create a canary for it
-	v1Strategy := GlobalManager().strategies["v1"].(*V1Strategy)
+	strategy, exists := GlobalManager().GetStrategy("v1")
+	require.True(t, exists)
+	v1Strategy := strategy.(*V1Strategy)
 	key2Bytes, _ := crypto.DecodeAES256Key(key2)
 	_ = v1Strategy.AddKey("oldkey", key2Bytes, true)
 

--- a/internal/instrumentation/encryption/global_test.go
+++ b/internal/instrumentation/encryption/global_test.go
@@ -1,0 +1,461 @@
+package encryption
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestKey sets FLIGHTCTL_ENCRYPTION_KEY for tests (auto-cleanup via t.Setenv)
+func setupTestKey(t *testing.T) {
+	t.Helper()
+	key, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key)
+}
+
+func TestInitGlobalEncryption_WithoutCanaryStore(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	// Manager initialized, canary disabled
+	assert.NotNil(t, GlobalManager())
+	assert.Nil(t, GlobalCanaryManager())
+}
+
+func TestInitGlobalEncryption_WithCanaryStore(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canary store
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	// Both managers initialized
+	assert.NotNil(t, GlobalManager())
+	assert.NotNil(t, GlobalCanaryManager())
+}
+
+func TestGlobalCanaryManager_ReturnsNilIfNotInitialized(t *testing.T) {
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+
+	canaryMgr := GlobalCanaryManager()
+	assert.Nil(t, canaryMgr, "Should return nil if not initialized")
+}
+
+func TestGlobalCanaryManager_ReturnsNilIfDisabled(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITHOUT canary store
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	canaryMgr := GlobalCanaryManager()
+	assert.Nil(t, canaryMgr, "Should return nil if canaries disabled")
+}
+
+func TestGlobalManager_ReturnsNilIfNotInitialized(t *testing.T) {
+	// Reset global state
+	globalManager = nil
+
+	mgr := GlobalManager()
+	assert.Nil(t, mgr, "Should return nil if not initialized")
+}
+
+func TestEncrypt_CreatesCanaryOnFirstUse(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canary store
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Before first encryption, no canary should exist
+	canaryMgr := GlobalCanaryManager()
+	activeCanary, err := canaryMgr.GetActiveCanary(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, activeCanary, "No canary should exist before first encryption")
+
+	// First encryption should create canary
+	plaintext := Plaintext([]byte("test-data"))
+	ciphertext, err := Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ciphertext)
+
+	// Now canary should exist
+	activeCanary, err = canaryMgr.GetActiveCanary(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, activeCanary, "Canary should exist after first encryption")
+	assert.Equal(t, "v1", activeCanary.Strategy)
+	assert.Equal(t, "default", activeCanary.KeyID)
+}
+
+func TestEncrypt_CanaryDoOnce(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canary store
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First encryption
+	_, err = Encrypt(ctx, Plaintext([]byte("data1")))
+	require.NoError(t, err)
+
+	canaryMgr := GlobalCanaryManager()
+	canary1, _ := canaryMgr.GetActiveCanary(ctx)
+
+	// Second encryption
+	_, err = Encrypt(ctx, Plaintext([]byte("data2")))
+	require.NoError(t, err)
+
+	canary2, _ := canaryMgr.GetActiveCanary(ctx)
+
+	// Canary should be identical (do-once, not recreated)
+	assert.Equal(t, canary1.EncryptedValue, canary2.EncryptedValue)
+	assert.Equal(t, canary1.CreatedAt, canary2.CreatedAt)
+}
+
+func TestInitGlobalEncryption_ValidatesExistingCanaries(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canary store
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	// Create a canary
+	ctx := context.Background()
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	// Verify canary was created
+	canaryMgr := GlobalCanaryManager()
+	allCanaries, _ := canaryMgr.store.GetAll()
+	assert.Len(t, allCanaries, 1, "Should have one canary")
+
+	// Reset and re-init (simulating restart)
+	// Re-init with the SAME store to test validation of existing canaries
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	// Re-init should validate the existing canary in the store
+	err = InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err, "Should successfully validate existing canary on restart")
+
+	// Verify validation actually happened and succeeded
+	results, err := GlobalCanaryManager().ValidateAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, results, 1, "Should have validated one canary")
+	assert.Equal(t, "ok", results[0].Status, "Canary validation should succeed")
+}
+
+func TestInitGlobalEncryption_ActiveKeyCannotDecryptCanary_FailsInit(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canary store
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	// Create a canary with the current key
+	ctx := context.Background()
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	// Verify canary exists
+	canaries, _ := store.GetAll()
+	require.Len(t, canaries, 1)
+
+	// Reset and re-init with a DIFFERENT key (simulating key rotation gone wrong)
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	// Generate a different key
+	newKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", newKey)
+
+	// Re-init should FAIL because active key cannot decrypt existing canary
+	err = InitGlobalEncryptionWithCanary(logger, store)
+	require.Error(t, err, "Should fail when active key cannot decrypt canary")
+	assert.Contains(t, err.Error(), "active encryption key v1/default is broken")
+}
+
+func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Create manager with TWO keys
+	key1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key1)
+
+	store := newMemoryCanaryStore()
+	err = InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	// Create canary for the default key (key1)
+	ctx := context.Background()
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	// Add second key manually and create a canary for it
+	v1Strategy := GlobalManager().strategies["v1"].(*V1Strategy)
+	key2Bytes, _ := crypto.DecodeAES256Key(key2)
+	_ = v1Strategy.AddKey("oldkey", key2Bytes, true)
+
+	canaryMgr := GlobalCanaryManager()
+	_ = canaryMgr.EnsureCanary(ctx, "v1", "oldkey")
+
+	// Verify we have two canaries now
+	canaries, _ := store.GetAll()
+	require.Len(t, canaries, 2)
+
+	// Reset and re-init with only key1 (oldkey is missing)
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	// Re-init should SUCCEED (only old key is broken, not active key)
+	err = InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err, "Should succeed even when old key cannot decrypt")
+
+	// Verify: active key's canary is ok, old key's canary failed
+	results, err := GlobalCanaryManager().ValidateAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Find results by keyID
+	var defaultResult, oldkeyResult *ValidationResult
+	for i := range results {
+		if results[i].KeyID == "default" {
+			defaultResult = &results[i]
+		} else if results[i].KeyID == "oldkey" {
+			oldkeyResult = &results[i]
+		}
+	}
+
+	assert.NotNil(t, defaultResult)
+	assert.NotNil(t, oldkeyResult)
+	assert.Equal(t, "ok", defaultResult.Status, "Active key should validate ok")
+	assert.Equal(t, "failed", oldkeyResult.Status, "Old key should fail validation")
+}
+
+func TestDecrypt_EncryptedData(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Encrypt some data
+	plaintext := Plaintext([]byte("secret-data"))
+	ciphertext, err := Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+
+	// Decrypt should return (plaintext, true, nil)
+	decrypted, wasEncrypted, err := Decrypt(ctx, ciphertext)
+	require.NoError(t, err)
+	assert.True(t, wasEncrypted, "Should indicate data was encrypted")
+	assert.Equal(t, plaintext, decrypted, "Decrypted should match original plaintext")
+}
+
+func TestDecrypt_PlaintextData_BackwardCompatibility(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Pass plaintext data (no "enc:" prefix)
+	plaintext := Ciphertext([]byte("not-encrypted-data"))
+
+	// Decrypt should return (data, false, nil) - backward compatibility
+	decrypted, wasEncrypted, err := Decrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.False(t, wasEncrypted, "Should indicate data was NOT encrypted")
+	assert.Equal(t, Plaintext(plaintext), decrypted, "Should return input unchanged")
+}
+
+func TestDecrypt_NotInitialized(t *testing.T) {
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+
+	ctx := context.Background()
+	ciphertext := Ciphertext([]byte("enc:v1:default:abc123"))
+
+	// Decrypt should fail with "not initialized" error
+	_, _, err := Decrypt(ctx, ciphertext)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption not initialized")
+}
+
+func TestDecrypt_InvalidFormat(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Invalid encrypted format
+	ciphertext := Ciphertext([]byte("enc:v1:default:INVALID-BASE64!!!"))
+
+	// Decrypt should fail
+	_, _, err = Decrypt(ctx, ciphertext)
+	require.Error(t, err)
+}
+
+func TestInitGlobalEncryption_CachesErrorAcrossCalls(t *testing.T) {
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Do NOT set FLIGHTCTL_ENCRYPTION_KEY - init should fail
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", "")
+
+	// First call - should fail
+	err1 := InitGlobalEncryption(logger)
+	require.Error(t, err1, "First init should fail when key is missing")
+
+	// Second call - should return the SAME error, not nil
+	err2 := InitGlobalEncryption(logger)
+	require.Error(t, err2, "Second init should also fail with cached error")
+	assert.Equal(t, err1.Error(), err2.Error(), "Both calls should return same error")
+
+	// Manager should still be nil
+	assert.Nil(t, GlobalManager(), "Manager should remain nil after failed init")
+}

--- a/internal/instrumentation/encryption/gorm_plugin.go
+++ b/internal/instrumentation/encryption/gorm_plugin.go
@@ -1,0 +1,91 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// EncryptFunc is the function signature for processing field encryption.
+// Call this function for EVERY field that should be encrypted, regardless of current state.
+// It handles:
+// - Plaintext: encrypts
+// - Already encrypted with old version: decrypts and re-encrypts
+// - Already encrypted with current version: returns as-is
+type EncryptFunc func(ctx context.Context, data []byte) ([]byte, error)
+
+// ModelEncryptHandler knows how to encrypt a specific model type.
+// It receives the model instance and an encryption function to use.
+type ModelEncryptHandler func(ctx context.Context, model interface{}, encrypt EncryptFunc) error
+
+// Plugin is a GORM plugin that delegates model-specific encryption
+// to handlers registered from the store/model package.
+type Plugin struct {
+	manager  *Manager
+	handlers map[string]ModelEncryptHandler
+}
+
+// NewPlugin creates a new GORM encryption plugin with model-specific handlers.
+func NewPlugin(manager *Manager, handlers map[string]ModelEncryptHandler) *Plugin {
+	return &Plugin{
+		manager:  manager,
+		handlers: handlers,
+	}
+}
+
+// Name returns the plugin name for GORM registration.
+func (p *Plugin) Name() string {
+	return "encryption"
+}
+
+// Initialize registers the plugin's callbacks with GORM.
+func (p *Plugin) Initialize(db *gorm.DB) error {
+	// Fail early if manager is nil to prevent panic in beforeSave callback
+	if p.manager == nil {
+		return fmt.Errorf("encryption manager is nil - plugin cannot be initialized without a valid manager")
+	}
+
+	// Register BeforeSave callback
+	if err := db.Callback().Create().Before("gorm:create").Register("encryption:before_create", p.beforeSave); err != nil {
+		return fmt.Errorf("register encryption:before_create callback: %w", err)
+	}
+
+	if err := db.Callback().Update().Before("gorm:update").Register("encryption:before_update", p.beforeSave); err != nil {
+		return fmt.Errorf("register encryption:before_update callback: %w", err)
+	}
+
+	return nil
+}
+
+// beforeSave is the GORM callback that delegates to model-specific encryption handlers.
+func (p *Plugin) beforeSave(db *gorm.DB) {
+	if db.Error != nil || db.Statement.Schema == nil {
+		return
+	}
+
+	// Check if we have a handler for this model type
+	handler, exists := p.handlers[db.Statement.Schema.Name]
+	if !exists {
+		return // No encryption for this model type
+	}
+
+	ctx := db.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Use Manager.ProcessEncryption which handles all cases:
+	// - Plaintext: encrypts
+	// - Old version: migrates to active version
+	// - Old key: re-encrypts with active key
+	// - Current version + key: preserves (no wasteful re-encryption)
+	processEncryption := func(ctx context.Context, data []byte) ([]byte, error) {
+		return p.manager.ProcessEncryption(ctx, data)
+	}
+
+	// Call model-specific handler
+	if err := handler(ctx, db.Statement.Dest, processEncryption); err != nil {
+		_ = db.AddError(fmt.Errorf("encrypt model %s: %w", db.Statement.Schema.Name, err))
+	}
+}

--- a/internal/instrumentation/encryption/gorm_plugin_test.go
+++ b/internal/instrumentation/encryption/gorm_plugin_test.go
@@ -1,0 +1,352 @@
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Test models
+type TestUser struct {
+	ID       uint
+	Name     string
+	Password string
+	Email    string
+}
+
+type TestRepository struct {
+	ID    uint
+	Name  string
+	Token string
+}
+
+func TestPlugin_Name(t *testing.T) {
+	mgr := createTestManager(t)
+	plugin := NewPlugin(mgr, map[string]ModelEncryptHandler{})
+
+	assert.Equal(t, "encryption", plugin.Name())
+}
+
+func TestPlugin_Initialize_Success(t *testing.T) {
+	mgr := createTestManager(t)
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			return nil
+		},
+	}
+
+	plugin := NewPlugin(mgr, handlers)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = plugin.Initialize(db)
+	require.NoError(t, err)
+}
+
+func TestPlugin_Initialize_NilManager(t *testing.T) {
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			return nil
+		},
+	}
+
+	plugin := NewPlugin(nil, handlers)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Initialize should fail with nil manager
+	err = plugin.Initialize(db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption manager is nil")
+}
+
+func TestPlugin_HandlerCalled_OnCreate(t *testing.T) {
+	mgr := createTestManager(t)
+
+	handlerCalled := false
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			handlerCalled = true
+			user := v.(*TestUser)
+			if user.Password != "" {
+				encrypted, err := encrypt(ctx, []byte(user.Password))
+				if err != nil {
+					return err
+				}
+				user.Password = string(encrypted)
+			}
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{
+		Name:     "Alice",
+		Password: "secret123",
+		Email:    "alice@example.com",
+	}
+
+	result := db.Create(&user)
+	require.NoError(t, result.Error)
+
+	assert.True(t, handlerCalled, "Handler should have been called")
+	assert.True(t, strings.HasPrefix(user.Password, "enc:v1:default:"), "Password should be encrypted")
+}
+
+func TestPlugin_HandlerCalled_OnUpdate(t *testing.T) {
+	mgr := createTestManager(t)
+
+	callCount := 0
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			callCount++
+			user := v.(*TestUser)
+			if user.Password != "" {
+				encrypted, err := encrypt(ctx, []byte(user.Password))
+				if err != nil {
+					return err
+				}
+				user.Password = string(encrypted)
+			}
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{
+		Name:     "Bob",
+		Password: "oldpass",
+		Email:    "bob@example.com",
+	}
+
+	// Create (handler called once)
+	db.Create(&user)
+	assert.Equal(t, 1, callCount)
+
+	// Update (handler called again)
+	user.Password = "newpass"
+	result := db.Save(&user)
+	require.NoError(t, result.Error)
+
+	assert.Equal(t, 2, callCount, "Handler should be called on both Create and Update")
+	assert.True(t, strings.HasPrefix(user.Password, "enc:v1:default:"))
+}
+
+func TestPlugin_NoHandler_SkipsEncryption(t *testing.T) {
+	mgr := createTestManager(t)
+
+	// No handlers registered
+	handlers := map[string]ModelEncryptHandler{}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{
+		Name:     "Charlie",
+		Password: "plaintext",
+		Email:    "charlie@example.com",
+	}
+
+	result := db.Create(&user)
+	require.NoError(t, result.Error)
+
+	// Password should remain plaintext (no handler to encrypt it)
+	assert.Equal(t, "plaintext", user.Password)
+}
+
+func TestPlugin_HandlerError_PropagatesError(t *testing.T) {
+	mgr := createTestManager(t)
+
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			return assert.AnError // Simulate handler error
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{
+		Name:     "Dave",
+		Password: "test",
+		Email:    "dave@example.com",
+	}
+
+	result := db.Create(&user)
+	assert.Error(t, result.Error, "Handler error should propagate to GORM")
+	assert.Contains(t, result.Error.Error(), "encrypt model TestUser")
+}
+
+func TestPlugin_MultipleModels_CorrectHandler(t *testing.T) {
+	mgr := createTestManager(t)
+
+	userHandlerCalled := false
+	repoHandlerCalled := false
+
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			userHandlerCalled = true
+			return nil
+		},
+		"TestRepository": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			repoHandlerCalled = true
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+	_ = db.AutoMigrate(&TestRepository{})
+
+	// Create user - should call user handler
+	user := TestUser{Name: "Alice"}
+	db.Create(&user)
+	assert.True(t, userHandlerCalled)
+	assert.False(t, repoHandlerCalled)
+
+	// Reset flags
+	userHandlerCalled = false
+	repoHandlerCalled = false
+
+	// Create repo - should call repo handler
+	repo := TestRepository{Name: "myrepo"}
+	db.Create(&repo)
+	assert.False(t, userHandlerCalled)
+	assert.True(t, repoHandlerCalled)
+}
+
+func TestPlugin_UsesProcessEncryption(t *testing.T) {
+	mgr := createTestManager(t)
+
+	var encryptFuncReceived EncryptFunc
+
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			encryptFuncReceived = encrypt
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{Name: "Test"}
+	db.Create(&user)
+
+	require.NotNil(t, encryptFuncReceived)
+
+	// Test that it's ProcessEncryption by checking it handles already-encrypted data
+	plaintext := []byte("test-data")
+	encrypted, err := mgr.Encrypt(context.Background(), plaintext)
+	require.NoError(t, err)
+
+	// ProcessEncryption should preserve already-encrypted data with same key
+	result, err := encryptFuncReceived(context.Background(), encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, encrypted, result, "ProcessEncryption should preserve already-encrypted data")
+}
+
+func TestPlugin_BatchCreate_HandlerCalledForSlice(t *testing.T) {
+	mgr := createTestManager(t)
+
+	var receivedType string
+
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			switch val := v.(type) {
+			case *TestUser:
+				receivedType = "single"
+			case *[]TestUser:
+				receivedType = "slice"
+				// Encrypt each user
+				for i := range *val {
+					if (*val)[i].Password != "" {
+						encrypted, err := encrypt(ctx, []byte((*val)[i].Password))
+						if err != nil {
+							return err
+						}
+						(*val)[i].Password = string(encrypted)
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	users := []TestUser{
+		{Name: "User1", Password: "pass1"},
+		{Name: "User2", Password: "pass2"},
+	}
+
+	result := db.Create(&users)
+	require.NoError(t, result.Error)
+
+	assert.Equal(t, "slice", receivedType, "Handler should receive *[]TestUser for batch create")
+
+	// Verify both passwords encrypted
+	assert.True(t, strings.HasPrefix(users[0].Password, "enc:"))
+	assert.True(t, strings.HasPrefix(users[1].Password, "enc:"))
+}
+
+func TestPlugin_NilContext_UsesBackground(t *testing.T) {
+	mgr := createTestManager(t)
+
+	var ctxReceived context.Context
+
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+			ctxReceived = ctx
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	// Create without explicit context
+	user := TestUser{Name: "Test"}
+	db.Create(&user)
+
+	assert.NotNil(t, ctxReceived, "Handler should receive a context even if Statement.Context is nil")
+}
+
+// Helper functions
+
+func createTestManager(t *testing.T) *Manager {
+	t.Helper()
+	var err error
+	manager := NewManager()
+
+	key := make([]byte, 32)
+	_, err = rand.Read(key)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	err = v1.AddKey("default", key, true)
+	require.NoError(t, err)
+
+	manager.RegisterStrategy(v1, true)
+
+	return manager
+}
+
+func setupTestDB(t *testing.T, manager *Manager, handlers map[string]ModelEncryptHandler) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.Use(NewPlugin(manager, handlers))
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(&TestUser{})
+	require.NoError(t, err)
+
+	return db
+}

--- a/internal/instrumentation/encryption/manager.go
+++ b/internal/instrumentation/encryption/manager.go
@@ -28,6 +28,14 @@ func (m *Manager) GetActiveStrategy() (version string, strategy Strategy) {
 	return version, strategy
 }
 
+// ActiveStrategyVersion returns just the active strategy version string.
+// Returns empty string if no active strategy is set.
+func (m *Manager) ActiveStrategyVersion() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.activeStrategy
+}
+
 // GetStrategy returns the strategy for the given version.
 // The version is automatically normalized to kebab-case.
 // Returns (nil, false) if the strategy is not registered.
@@ -38,6 +46,13 @@ func (m *Manager) GetStrategy(version string) (Strategy, bool) {
 
 	strategy, exists := m.strategies[normalized]
 	return strategy, exists
+}
+
+// StrategyCount returns the number of registered strategies.
+func (m *Manager) StrategyCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.strategies)
 }
 
 // RegisterStrategy adds an encryption strategy to the manager.

--- a/internal/instrumentation/encryption/manager.go
+++ b/internal/instrumentation/encryption/manager.go
@@ -1,0 +1,193 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stoewer/go-strcase"
+)
+
+// NewManager creates a new encryption manager with no strategies registered.
+func NewManager() *Manager {
+	return &Manager{
+		strategies: make(map[string]Strategy),
+	}
+}
+
+// GetActiveStrategy returns the active strategy version and the strategy itself.
+// Returns ("", nil) if no active strategy is set.
+func (m *Manager) GetActiveStrategy() (version string, strategy Strategy) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	version = m.activeStrategy
+	if version != "" {
+		strategy = m.strategies[version]
+	}
+	return version, strategy
+}
+
+// GetStrategy returns the strategy for the given version.
+// The version is automatically normalized to kebab-case.
+// Returns (nil, false) if the strategy is not registered.
+func (m *Manager) GetStrategy(version string) (Strategy, bool) {
+	normalized := strcase.KebabCase(version)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	strategy, exists := m.strategies[normalized]
+	return strategy, exists
+}
+
+// RegisterStrategy adds an encryption strategy to the manager.
+// The version identifier is automatically normalized to kebab-case.
+// If setActive is true, this strategy becomes the active strategy for new encryptions.
+func (m *Manager) RegisterStrategy(s Strategy, setActive bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	version := strcase.KebabCase(s.Version())
+	m.strategies[version] = s
+	if setActive {
+		m.activeStrategy = version
+	}
+}
+
+// SetActiveStrategy selects which strategy will be used for new encryptions.
+// The version is automatically normalized to kebab-case.
+func (m *Manager) SetActiveStrategy(version string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	normalized := strcase.KebabCase(version)
+	if _, exists := m.strategies[normalized]; !exists {
+		return fmt.Errorf("strategy version %q not registered", normalized)
+	}
+	m.activeStrategy = normalized
+	return nil
+}
+
+// Encrypt encrypts plaintext using the active strategy.
+// Returns encrypted data with format: enc:<version>:<strategy-specific-data>
+// Returns error if input is already encrypted (use ProcessEncryption for that).
+func (m *Manager) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	if IsEncrypted(plaintext) {
+		return nil, fmt.Errorf("Encrypt expects plaintext, got already-encrypted data (use ProcessEncryption instead)")
+	}
+
+	m.mu.RLock()
+	activeStrategy := m.activeStrategy
+	strategy, exists := m.strategies[activeStrategy]
+	m.mu.RUnlock()
+
+	if activeStrategy == "" {
+		return nil, fmt.Errorf("no active encryption strategy set")
+	}
+	if !exists {
+		return nil, fmt.Errorf("active strategy %q not found", activeStrategy)
+	}
+
+	body, err := strategy.EncryptPlaintext(ctx, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt with strategy %s: %w", activeStrategy, err)
+	}
+
+	// Prefix format: enc:<version>:<encrypted-payload>
+	prefixed := fmt.Sprintf("enc:%s:%s", strategy.Version(), string(body))
+	return []byte(prefixed), nil
+}
+
+// ProcessEncryption intelligently handles data that may be plaintext, encrypted with current
+// version/key, or encrypted with old version/key. Behavior:
+// 1. Plaintext: encrypts with active strategy
+// 2. Same version/key: returns unchanged (avoids wasteful re-encryption)
+// 3. Different version: migrates to active version
+// 4. Same version, different key: re-encrypts with active key
+func (m *Manager) ProcessEncryption(ctx context.Context, data []byte) ([]byte, error) {
+	// Not encrypted - encrypt it
+	currentVersion, body, ok := parseEncryptedFormat(data)
+	if !ok {
+		return m.Encrypt(ctx, data)
+	}
+
+	m.mu.RLock()
+	activeStrategyVersion := m.activeStrategy
+	currentStrategy, currentExists := m.strategies[currentVersion]
+	activeStrategy, activeExists := m.strategies[activeStrategyVersion]
+	m.mu.RUnlock()
+
+	if !currentExists {
+		return nil, fmt.Errorf("strategy %s not found", currentVersion)
+	}
+	if !activeExists {
+		return nil, fmt.Errorf("active strategy %s not found", activeStrategyVersion)
+	}
+
+	// Parse strategy body to extract keyID
+	parsed, err := currentStrategy.ParseBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s body: %w", currentVersion, err)
+	}
+
+	// Different version - decrypt and migrate
+	if currentVersion != activeStrategyVersion {
+		plaintext, err := currentStrategy.DecryptParsed(ctx, parsed)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt for version migration %s to %s: %w", currentVersion, activeStrategyVersion, err)
+		}
+		return m.Encrypt(ctx, plaintext)
+	}
+
+	// Same version/key - return unchanged
+	if parsed.KeyID == activeStrategy.ActiveKeyID() {
+		return data, nil
+	}
+
+	// Same version, different key - decrypt and re-encrypt
+	plaintext, err := currentStrategy.DecryptParsed(ctx, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt for key rotation %s to %s: %w", parsed.KeyID, activeStrategy.ActiveKeyID(), err)
+	}
+
+	return m.Encrypt(ctx, plaintext)
+}
+
+// Decrypt decrypts data by detecting the version prefix and routing to the appropriate strategy.
+// Supports plaintext passthrough (no prefix) for backward compatibility during migration.
+func (m *Manager) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
+	str := string(data)
+
+	// Backward compatibility: if no "enc:" prefix, assume plaintext
+	if !strings.HasPrefix(str, "enc:") {
+		return data, nil
+	}
+
+	// Has "enc:" prefix - must be valid encrypted format
+	version, body, ok := parseEncryptedFormat(data)
+	if !ok {
+		return nil, fmt.Errorf("invalid encrypted format: expected enc:<version>:<data>, got %q", str)
+	}
+
+	// Route to the correct strategy based on version
+	m.mu.RLock()
+	strategy, exists := m.strategies[version]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("no decryption strategy registered for version %q", version)
+	}
+
+	// Parse and decrypt
+	parsed, err := strategy.ParseBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s body: %w", version, err)
+	}
+
+	plaintext, err := strategy.DecryptParsed(ctx, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt with strategy %s: %w", version, err)
+	}
+
+	return plaintext, nil
+}

--- a/internal/instrumentation/encryption/manager_test.go
+++ b/internal/instrumentation/encryption/manager_test.go
@@ -45,8 +45,9 @@ func TestManager_RegisterStrategy(t *testing.T) {
 
 			mgr.RegisterStrategy(strategy, true)
 
-			assert.Contains(t, mgr.strategies, tt.expectedInMap)
-			assert.Equal(t, tt.expectedInMap, mgr.activeStrategy, "last registered should be active")
+			_, exists := mgr.GetStrategy(tt.expectedInMap)
+			assert.True(t, exists, "strategy should be registered")
+			assert.Equal(t, tt.expectedInMap, mgr.ActiveStrategyVersion(), "last registered should be active")
 		})
 	}
 }
@@ -58,12 +59,12 @@ func TestManager_RegisterMultipleStrategies(t *testing.T) {
 	v2 := &mockStrategy{version: "v2"}
 
 	mgr.RegisterStrategy(v1, true)
-	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should be active after first register")
+	assert.Equal(t, "v1", mgr.ActiveStrategyVersion(), "v1 should be active after first register")
 
 	mgr.RegisterStrategy(v2, true)
-	assert.Equal(t, "v2", mgr.activeStrategy, "v2 should be active after second register")
+	assert.Equal(t, "v2", mgr.ActiveStrategyVersion(), "v2 should be active after second register")
 
-	assert.Len(t, mgr.strategies, 2, "both strategies should be registered")
+	assert.Equal(t, 2, mgr.StrategyCount(), "both strategies should be registered")
 }
 
 func TestManager_RegisterStrategy_ExplicitActivation(t *testing.T) {
@@ -73,21 +74,23 @@ func TestManager_RegisterStrategy_ExplicitActivation(t *testing.T) {
 
 	// Register v1 as active
 	mgr.RegisterStrategy(v1, true)
-	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should be active when setActive=true")
+	assert.Equal(t, "v1", mgr.ActiveStrategyVersion(), "v1 should be active when setActive=true")
 
 	// Register v2 but DON'T activate it
 	mgr.RegisterStrategy(v2, false)
-	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should still be active when v2 registered with setActive=false")
+	assert.Equal(t, "v1", mgr.ActiveStrategyVersion(), "v1 should still be active when v2 registered with setActive=false")
 
 	// Both should be registered
-	assert.Len(t, mgr.strategies, 2, "both strategies should be registered")
-	assert.NotNil(t, mgr.strategies["v1"])
-	assert.NotNil(t, mgr.strategies["v2"])
+	assert.Equal(t, 2, mgr.StrategyCount(), "both strategies should be registered")
+	_, v1Exists := mgr.GetStrategy("v1")
+	assert.True(t, v1Exists, "v1 should be registered")
+	_, v2Exists := mgr.GetStrategy("v2")
+	assert.True(t, v2Exists, "v2 should be registered")
 
 	// Can still explicitly activate v2
 	err := mgr.SetActiveStrategy("v2")
 	require.NoError(t, err)
-	assert.Equal(t, "v2", mgr.activeStrategy, "v2 should be active after SetActiveStrategy")
+	assert.Equal(t, "v2", mgr.ActiveStrategyVersion(), "v2 should be active after SetActiveStrategy")
 }
 
 func TestManager_SetActiveStrategy(t *testing.T) {
@@ -101,12 +104,12 @@ func TestManager_SetActiveStrategy(t *testing.T) {
 	// Switch back to v1
 	err := mgr.SetActiveStrategy("v1")
 	require.NoError(t, err)
-	assert.Equal(t, "v1", mgr.activeStrategy)
+	assert.Equal(t, "v1", mgr.ActiveStrategyVersion())
 
 	// Version normalization should work
 	err = mgr.SetActiveStrategy("V1")
 	require.NoError(t, err)
-	assert.Equal(t, "v1", mgr.activeStrategy)
+	assert.Equal(t, "v1", mgr.ActiveStrategyVersion())
 
 	// Unknown version should error
 	err = mgr.SetActiveStrategy("v3")

--- a/internal/instrumentation/encryption/manager_test.go
+++ b/internal/instrumentation/encryption/manager_test.go
@@ -1,0 +1,474 @@
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager_RegisterStrategy(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		expectedInMap string
+	}{
+		{
+			name:          "When version is lowercase it should register as-is",
+			version:       "v1",
+			expectedInMap: "v1",
+		},
+		{
+			name:          "When version is uppercase it should normalize to lowercase",
+			version:       "V1",
+			expectedInMap: "v1",
+		},
+		{
+			name:          "When version is mixed case it should normalize to kebab-case",
+			version:       "V1Beta",
+			expectedInMap: "v1beta",
+		},
+		{
+			name:          "When version is snake_case it should normalize to kebab-case",
+			version:       "v1_beta",
+			expectedInMap: "v1-beta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewManager()
+			strategy := &mockStrategy{version: tt.version}
+
+			mgr.RegisterStrategy(strategy, true)
+
+			assert.Contains(t, mgr.strategies, tt.expectedInMap)
+			assert.Equal(t, tt.expectedInMap, mgr.activeStrategy, "last registered should be active")
+		})
+	}
+}
+
+func TestManager_RegisterMultipleStrategies(t *testing.T) {
+	mgr := NewManager()
+
+	v1 := &mockStrategy{version: "v1"}
+	v2 := &mockStrategy{version: "v2"}
+
+	mgr.RegisterStrategy(v1, true)
+	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should be active after first register")
+
+	mgr.RegisterStrategy(v2, true)
+	assert.Equal(t, "v2", mgr.activeStrategy, "v2 should be active after second register")
+
+	assert.Len(t, mgr.strategies, 2, "both strategies should be registered")
+}
+
+func TestManager_RegisterStrategy_ExplicitActivation(t *testing.T) {
+	mgr := NewManager()
+	v1 := &mockStrategy{version: "v1"}
+	v2 := &mockStrategy{version: "v2"}
+
+	// Register v1 as active
+	mgr.RegisterStrategy(v1, true)
+	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should be active when setActive=true")
+
+	// Register v2 but DON'T activate it
+	mgr.RegisterStrategy(v2, false)
+	assert.Equal(t, "v1", mgr.activeStrategy, "v1 should still be active when v2 registered with setActive=false")
+
+	// Both should be registered
+	assert.Len(t, mgr.strategies, 2, "both strategies should be registered")
+	assert.NotNil(t, mgr.strategies["v1"])
+	assert.NotNil(t, mgr.strategies["v2"])
+
+	// Can still explicitly activate v2
+	err := mgr.SetActiveStrategy("v2")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", mgr.activeStrategy, "v2 should be active after SetActiveStrategy")
+}
+
+func TestManager_SetActiveStrategy(t *testing.T) {
+	mgr := NewManager()
+	v1 := &mockStrategy{version: "v1"}
+	v2 := &mockStrategy{version: "v2"}
+
+	mgr.RegisterStrategy(v1, true)
+	mgr.RegisterStrategy(v2, true)
+
+	// Switch back to v1
+	err := mgr.SetActiveStrategy("v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", mgr.activeStrategy)
+
+	// Version normalization should work
+	err = mgr.SetActiveStrategy("V1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", mgr.activeStrategy)
+
+	// Unknown version should error
+	err = mgr.SetActiveStrategy("v3")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not registered")
+}
+
+func TestManager_EncryptDecrypt(t *testing.T) {
+	mgr := NewManager()
+	strategy := &mockStrategy{
+		version: "v1",
+		encryptFunc: func(ctx context.Context, data []byte) ([]byte, error) {
+			return []byte("encrypted:" + string(data)), nil
+		},
+		parseBodyFunc: func(body []byte) (*ParsedEncrypted, error) {
+			return &ParsedEncrypted{KeyID: "default", Payload: body}, nil
+		},
+		decryptParsedFunc: func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+			return []byte(string(parsed.Payload)[10:]), nil // Strip "encrypted:" prefix
+		},
+	}
+
+	mgr.RegisterStrategy(strategy, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	// Encrypt
+	encrypted, err := mgr.Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, "enc:v1:encrypted:my-secret", string(encrypted))
+
+	// Decrypt
+	decrypted, err := mgr.Decrypt(ctx, encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestManager_EncryptWithoutActiveStrategy(t *testing.T) {
+	mgr := NewManager()
+	ctx := context.Background()
+
+	_, err := mgr.Encrypt(ctx, []byte("data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no active encryption strategy")
+}
+
+func TestManager_DecryptPlaintextPassthrough(t *testing.T) {
+	mgr := NewManager()
+	ctx := context.Background()
+
+	// Plaintext without "enc:" prefix should pass through unchanged
+	plaintext := []byte("old-plaintext-password")
+	decrypted, err := mgr.Decrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestManager_DecryptWithVersionRouting(t *testing.T) {
+	mgr := NewManager()
+
+	v1 := &mockStrategy{
+		version: "v1",
+		parseBodyFunc: func(body []byte) (*ParsedEncrypted, error) {
+			return &ParsedEncrypted{KeyID: "default", Payload: body}, nil
+		},
+		decryptParsedFunc: func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+			return []byte("decrypted-by-v1"), nil
+		},
+	}
+	v2 := &mockStrategy{
+		version: "v2",
+		parseBodyFunc: func(body []byte) (*ParsedEncrypted, error) {
+			return &ParsedEncrypted{KeyID: "default", Payload: body}, nil
+		},
+		decryptParsedFunc: func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+			return []byte("decrypted-by-v2"), nil
+		},
+	}
+
+	mgr.RegisterStrategy(v1, true)
+	mgr.RegisterStrategy(v2, true)
+
+	ctx := context.Background()
+
+	// Decrypt v1 data
+	decrypted, err := mgr.Decrypt(ctx, []byte("enc:v1:ciphertext"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("decrypted-by-v1"), decrypted)
+
+	// Decrypt v2 data
+	decrypted, err = mgr.Decrypt(ctx, []byte("enc:v2:ciphertext"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("decrypted-by-v2"), decrypted)
+}
+
+func TestManager_DecryptInvalidFormat(t *testing.T) {
+	mgr := NewManager()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "When ciphertext part is missing it should error",
+			data: "enc:v1",
+		},
+		{
+			name: "When only prefix is present it should error",
+			data: "enc:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := mgr.Decrypt(ctx, []byte(tt.data))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid encrypted format")
+		})
+	}
+}
+
+func TestManager_DecryptUnknownVersion(t *testing.T) {
+	mgr := NewManager()
+	v1 := &mockStrategy{version: "v1"}
+	mgr.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+
+	_, err := mgr.Decrypt(ctx, []byte("enc:v99:ciphertext"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no decryption strategy registered for version")
+}
+
+// mockStrategy is a test helper that implements the Strategy interface
+type mockStrategy struct {
+	version           string
+	activeKeyID       string
+	encryptFunc       func(ctx context.Context, data []byte) ([]byte, error)
+	parseBodyFunc     func(body []byte) (*ParsedEncrypted, error)
+	decryptParsedFunc func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error)
+}
+
+func (m *mockStrategy) Version() string {
+	return m.version
+}
+
+func (m *mockStrategy) String() string {
+	return "mock-algorithm, active_key=" + m.activeKeyID
+}
+
+func (m *mockStrategy) ActiveKeyID() string {
+	return m.activeKeyID
+}
+
+func (m *mockStrategy) Algorithm() string {
+	return "mock-algorithm"
+}
+
+func (m *mockStrategy) ConfiguredKeys() []string {
+	return []string{m.activeKeyID}
+}
+
+func (m *mockStrategy) EncryptPlaintext(ctx context.Context, plaintext []byte) ([]byte, error) {
+	if m.encryptFunc != nil {
+		return m.encryptFunc(ctx, plaintext)
+	}
+	return []byte("encrypted"), nil
+}
+
+func (m *mockStrategy) ParseBody(body []byte) (*ParsedEncrypted, error) {
+	if m.parseBodyFunc != nil {
+		return m.parseBodyFunc(body)
+	}
+	return &ParsedEncrypted{KeyID: m.activeKeyID, Payload: body}, nil
+}
+
+func (m *mockStrategy) DecryptParsed(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+	if m.decryptParsedFunc != nil {
+		return m.decryptParsedFunc(ctx, parsed)
+	}
+	return []byte("decrypted"), nil
+}
+
+// TestProcessEncryption tests the smart re-encryption logic
+
+func TestProcessEncryption_Plaintext(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key := make([]byte, 32)
+	_, err = rand.Read(key)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("default", key, true))
+	mgr.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	result, err := mgr.ProcessEncryption(ctx, plaintext)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(string(result), "enc:v1:default:"))
+	assert.NotEqual(t, plaintext, result)
+
+	// Should decrypt back
+	decrypted, err := mgr.Decrypt(ctx, result)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestProcessEncryption_AlreadyEncrypted_SameKey_Preserves(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key := make([]byte, 32)
+	_, err = rand.Read(key)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("default", key, true))
+	mgr.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	// First encryption
+	encrypted, err := mgr.Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+
+	// ProcessEncryption should preserve (same version, same key)
+	result, err := mgr.ProcessEncryption(ctx, encrypted)
+	require.NoError(t, err)
+
+	// CRITICAL: Should be EXACTLY the same (no wasteful re-encryption)
+	assert.Equal(t, encrypted, result, "Already-encrypted data with active key should be preserved")
+}
+
+func TestProcessEncryption_KeyRotation_Reencrypts(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key1 := make([]byte, 32)
+	_, err = rand.Read(key1)
+	require.NoError(t, err)
+	key2 := make([]byte, 32)
+	_, err = rand.Read(key2)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("keyA", key1, true))
+	require.NoError(t, v1.AddKey("keyB", key2, true))
+
+	// Set keyA as active
+	_ = v1.SetActiveKey("keyA")
+	mgr.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	// Encrypt with keyA
+	encrypted, err := mgr.Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Contains(t, string(encrypted), "keyA:", "Should be encrypted with keyA")
+
+	// Switch to keyB
+	_ = v1.SetActiveKey("keyB")
+
+	// ProcessEncryption should re-encrypt with keyB
+	result, err := mgr.ProcessEncryption(ctx, encrypted)
+	require.NoError(t, err)
+
+	// Should be DIFFERENT (new key = new encryption)
+	assert.NotEqual(t, encrypted, result, "Re-encryption should produce different ciphertext")
+	assert.Contains(t, string(result), "keyB:", "Should now be encrypted with keyB")
+
+	// But should still decrypt to same plaintext
+	decrypted, err := mgr.Decrypt(ctx, result)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestProcessEncryption_VersionMigration(t *testing.T) {
+	var err error
+
+	key := make([]byte, 32)
+	_, err = rand.Read(key)
+	require.NoError(t, err)
+
+	// Create v1 manager
+	mgrV1 := NewManager()
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("default", key, true))
+	mgrV1.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	// Encrypt with v1
+	encryptedV1, err := mgrV1.Encrypt(ctx, plaintext)
+	require.NoError(t, err)
+	assert.Contains(t, string(encryptedV1), "enc:v1:")
+
+	// Create v2 manager with both strategies
+	mgrV2 := NewManager()
+	mgrV2.RegisterStrategy(v1, false) // Keep v1 for decryption (not active)
+
+	v2 := &mockStrategy{
+		version:     "v2",
+		activeKeyID: "default",
+		encryptFunc: func(ctx context.Context, data []byte) ([]byte, error) {
+			return []byte("default:v2-encrypted-data"), nil
+		},
+		parseBodyFunc: func(body []byte) (*ParsedEncrypted, error) {
+			return &ParsedEncrypted{KeyID: "default", Payload: body}, nil
+		},
+		decryptParsedFunc: func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+			return plaintext, nil
+		},
+	}
+	mgrV2.RegisterStrategy(v2, true) // v2 becomes active
+
+	// ProcessEncryption should migrate from v1 to v2
+	result, err := mgrV2.ProcessEncryption(ctx, encryptedV1)
+	require.NoError(t, err)
+
+	// Should now be v2
+	assert.Contains(t, string(result), "enc:v2:", "Should be migrated to v2")
+	assert.NotEqual(t, encryptedV1, result, "Migration should produce different format")
+}
+
+func TestProcessEncryption_Idempotent_MultipleRoundTrips(t *testing.T) {
+	var err error
+	mgr := NewManager()
+
+	key := make([]byte, 32)
+	_, err = rand.Read(key)
+	require.NoError(t, err)
+
+	v1 := newV1Strategy()
+	require.NoError(t, v1.AddKey("default", key, true))
+	mgr.RegisterStrategy(v1, true)
+
+	ctx := context.Background()
+	plaintext := []byte("my-secret")
+
+	// First process
+	result1, err := mgr.ProcessEncryption(ctx, plaintext)
+	require.NoError(t, err)
+
+	// Second process (should preserve)
+	result2, err := mgr.ProcessEncryption(ctx, result1)
+	require.NoError(t, err)
+
+	// Third process (should still preserve)
+	result3, err := mgr.ProcessEncryption(ctx, result2)
+	require.NoError(t, err)
+
+	// All results after first should be identical (idempotent)
+	assert.Equal(t, result1, result2, "Second call should preserve")
+	assert.Equal(t, result2, result3, "Third call should preserve")
+}

--- a/internal/instrumentation/encryption/status.go
+++ b/internal/instrumentation/encryption/status.go
@@ -1,0 +1,143 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// EncryptionStatus represents the complete encryption system state
+type EncryptionStatus struct {
+	Enabled             bool        `json:"enabled"`
+	Active              *ActiveInfo `json:"active,omitempty"`
+	CanaryChecksEnabled bool        `json:"canary_checks_enabled"`
+	Keys                []KeyStatus `json:"keys"`
+}
+
+// ActiveInfo describes the currently active encryption configuration
+type ActiveInfo struct {
+	Strategy  string `json:"strategy"`  // "v1"
+	KeyID     string `json:"key_id"`    // "default"
+	Algorithm string `json:"algorithm"` // "AES-256-GCM"
+}
+
+// KeyStatus represents a single encryption key and its health
+type KeyStatus struct {
+	Strategy     string `json:"strategy"`      // "v1"
+	KeyID        string `json:"key_id"`        // "default"
+	Configured   bool   `json:"configured"`    // Is this key currently configured in the strategy?
+	Active       bool   `json:"active"`        // Is this the active strategy+key?
+	CanaryStatus string `json:"canary_status"` // "ok", "failed", "not_checked", "key_missing"
+}
+
+// Status returns the complete encryption system status.
+// Shows the union of:
+// - All configured keys from the active strategy (always shown)
+// - All canaries from any strategy (only if canary exists)
+// Safe to call even if encryption is not initialized (returns Enabled: false).
+func Status(ctx context.Context) (*EncryptionStatus, error) {
+	mgr := GlobalManager()
+	if mgr == nil {
+		return &EncryptionStatus{
+			Enabled:             false,
+			CanaryChecksEnabled: false,
+			Keys:                []KeyStatus{},
+		}, nil
+	}
+
+	// Get active strategy info
+	activeStrategy, activeStrat := mgr.GetActiveStrategy()
+	if activeStrat == nil {
+		return nil, fmt.Errorf("active strategy %s not found", activeStrategy)
+	}
+
+	activeKeyID := activeStrat.ActiveKeyID()
+
+	status := &EncryptionStatus{
+		Enabled: true,
+		Active: &ActiveInfo{
+			Strategy:  activeStrategy,
+			KeyID:     activeKeyID,
+			Algorithm: activeStrat.Algorithm(),
+		},
+	}
+
+	// Get canary manager (can be nil)
+	canaryMgr := GlobalCanaryManager()
+	status.CanaryChecksEnabled = (canaryMgr != nil)
+
+	// Build union of configured keys + canaries
+	keyMap := make(map[string]*KeyStatus) // key = "strategy/keyID"
+
+	// Step 1: Add all configured keys from active strategy
+	configuredKeys := activeStrat.ConfiguredKeys()
+	for _, keyID := range configuredKeys {
+		key := fmt.Sprintf("%s/%s", activeStrategy, keyID)
+		keyMap[key] = &KeyStatus{
+			Strategy:     activeStrategy,
+			KeyID:        keyID,
+			Configured:   true,
+			Active:       (keyID == activeKeyID),
+			CanaryStatus: "not_checked", // Default for canaries disabled or no canary yet
+		}
+	}
+
+	// Step 2: If canaries enabled, merge canary results
+	if canaryMgr != nil {
+		results, err := canaryMgr.ValidateAll(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("validate canaries: %w", err)
+		}
+
+		for _, result := range results {
+			key := fmt.Sprintf("%s/%s", result.Strategy, result.KeyID)
+
+			if entry, exists := keyMap[key]; exists {
+				// Key is already in map (from active strategy) - update canary status
+				entry.CanaryStatus = result.Status
+			} else {
+				// Canary from inactive strategy - check if key still configured
+				isConfigured := false
+				strategy, stratExists := mgr.GetStrategy(result.Strategy)
+
+				if stratExists {
+					for _, configuredKey := range strategy.ConfiguredKeys() {
+						if configuredKey == result.KeyID {
+							isConfigured = true
+							break
+						}
+					}
+				}
+
+				// Determine canary status
+				canaryStatus := result.Status
+				if !isConfigured {
+					// Key removed but canary exists - potential data loss
+					canaryStatus = "key_missing"
+				}
+
+				keyMap[key] = &KeyStatus{
+					Strategy:     result.Strategy,
+					KeyID:        result.KeyID,
+					Configured:   isConfigured,
+					Active:       false, // Not active (different strategy or key)
+					CanaryStatus: canaryStatus,
+				}
+			}
+		}
+	}
+
+	// Convert map to slice and sort for deterministic output
+	status.Keys = make([]KeyStatus, 0, len(keyMap))
+	for _, entry := range keyMap {
+		status.Keys = append(status.Keys, *entry)
+	}
+	sort.Slice(status.Keys, func(i, j int) bool {
+		if status.Keys[i].Strategy != status.Keys[j].Strategy {
+			return status.Keys[i].Strategy < status.Keys[j].Strategy
+		}
+		return status.Keys[i].KeyID < status.Keys[j].KeyID
+	})
+
+	return status, nil
+}

--- a/internal/instrumentation/encryption/status_test.go
+++ b/internal/instrumentation/encryption/status_test.go
@@ -1,0 +1,425 @@
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatus_EncryptionNotInitialized(t *testing.T) {
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+
+	status, err := Status(context.Background())
+	require.NoError(t, err)
+
+	assert.False(t, status.Enabled)
+	assert.Nil(t, status.Active)
+	assert.False(t, status.CanaryChecksEnabled)
+	assert.Empty(t, status.Keys)
+}
+
+func TestStatus_CanariesDisabled(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITHOUT canaries
+	err := InitGlobalEncryption(logger)
+	require.NoError(t, err)
+
+	// Add a second key
+	mgr := GlobalManager()
+	_, v1Strat := mgr.GetActiveStrategy()
+	v1 := v1Strat.(*V1Strategy)
+	key2 := make([]byte, 32)
+	_, err = rand.Read(key2)
+	require.NoError(t, err)
+	require.NoError(t, v1.AddKey("oldkey", key2, true))
+	require.NoError(t, v1.SetActiveKey("default")) // Back to default
+
+	ctx := context.Background()
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, status.Enabled)
+	assert.False(t, status.CanaryChecksEnabled)
+
+	assert.Equal(t, "v1", status.Active.Strategy)
+	assert.Equal(t, "default", status.Active.KeyID)
+	assert.Equal(t, "AES-256-GCM", status.Active.Algorithm)
+
+	// Should show both configured keys
+	assert.Len(t, status.Keys, 2)
+
+	// Find keys in results
+	var defaultKey, oldKey *KeyStatus
+	for i := range status.Keys {
+		if status.Keys[i].KeyID == "default" {
+			defaultKey = &status.Keys[i]
+		} else if status.Keys[i].KeyID == "oldkey" {
+			oldKey = &status.Keys[i]
+		}
+	}
+
+	require.NotNil(t, defaultKey)
+	require.NotNil(t, oldKey)
+
+	// Check default key
+	assert.Equal(t, "v1", defaultKey.Strategy)
+	assert.True(t, defaultKey.Configured)
+	assert.True(t, defaultKey.Active)
+	assert.Equal(t, "not_checked", defaultKey.CanaryStatus)
+
+	// Check old key
+	assert.Equal(t, "v1", oldKey.Strategy)
+	assert.True(t, oldKey.Configured)
+	assert.False(t, oldKey.Active)
+	assert.Equal(t, "not_checked", oldKey.CanaryStatus)
+}
+
+func TestStatus_CanariesEnabled_BeforeFirstEncryption(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canaries
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, status.Enabled)
+	assert.True(t, status.CanaryChecksEnabled)
+
+	// Should show active key
+	assert.Len(t, status.Keys, 1)
+	assert.Equal(t, "v1", status.Keys[0].Strategy)
+	assert.Equal(t, "default", status.Keys[0].KeyID)
+	assert.True(t, status.Keys[0].Configured)
+	assert.True(t, status.Keys[0].Active)
+	assert.Equal(t, "not_checked", status.Keys[0].CanaryStatus) // No canary yet
+}
+
+func TestStatus_CanariesEnabled_AfterFirstEncryption(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canaries
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First encryption creates canary
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, status.Enabled)
+	assert.True(t, status.CanaryChecksEnabled)
+
+	// Should show active key with canary
+	assert.Len(t, status.Keys, 1)
+	assert.Equal(t, "v1", status.Keys[0].Strategy)
+	assert.Equal(t, "default", status.Keys[0].KeyID)
+	assert.True(t, status.Keys[0].Configured)
+	assert.True(t, status.Keys[0].Active)
+	assert.Equal(t, "ok", status.Keys[0].CanaryStatus) // Canary validated
+}
+
+func TestStatus_MultipleKeys_WithCanaries(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canaries
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mgr := GlobalManager()
+	canaryMgr := GlobalCanaryManager()
+
+	// Create canary for default key
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	// Add oldkey
+	_, v1Strat := mgr.GetActiveStrategy()
+	v1 := v1Strat.(*V1Strategy)
+	key2 := make([]byte, 32)
+	_, err = rand.Read(key2)
+	require.NoError(t, err)
+	require.NoError(t, v1.AddKey("oldkey", key2, true))
+
+	// Create canary for oldkey
+	err = canaryMgr.EnsureCanary(ctx, "v1", "oldkey")
+	require.NoError(t, err)
+
+	// Switch back to default
+	_ = v1.SetActiveKey("default")
+
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, status.Enabled)
+	assert.True(t, status.CanaryChecksEnabled)
+
+	// Should show both keys
+	assert.Len(t, status.Keys, 2)
+
+	// Find keys
+	var defaultKey, oldKey *KeyStatus
+	for i := range status.Keys {
+		if status.Keys[i].KeyID == "default" {
+			defaultKey = &status.Keys[i]
+		} else if status.Keys[i].KeyID == "oldkey" {
+			oldKey = &status.Keys[i]
+		}
+	}
+
+	require.NotNil(t, defaultKey)
+	require.NotNil(t, oldKey)
+
+	// Check default key
+	assert.True(t, defaultKey.Active)
+	assert.Equal(t, "ok", defaultKey.CanaryStatus)
+
+	// Check old key
+	assert.False(t, oldKey.Active)
+	assert.Equal(t, "ok", oldKey.CanaryStatus)
+}
+
+func TestStatus_HistoricalCanary_KeyStillConfigured(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canaries
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mgr := GlobalManager()
+	canaryMgr := GlobalCanaryManager()
+
+	// Create canary for v1/default
+	_, err = Encrypt(ctx, Plaintext([]byte("test")))
+	require.NoError(t, err)
+
+	// Register v2 (becomes active)
+	v2 := &mockStrategy{
+		version:     "v2",
+		activeKeyID: "k1",
+		encryptFunc: func(ctx context.Context, data []byte) ([]byte, error) {
+			return []byte("k1:v2-data"), nil
+		},
+		parseBodyFunc: func(body []byte) (*ParsedEncrypted, error) {
+			return &ParsedEncrypted{KeyID: "k1", Payload: body}, nil
+		},
+		decryptParsedFunc: func(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+			return []byte("decrypted"), nil
+		},
+	}
+	mgr.RegisterStrategy(v2, true)
+
+	// Create canary for v2/k1
+	err = canaryMgr.EnsureCanary(ctx, "v2", "k1")
+	require.NoError(t, err)
+
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	// Should show v2/k1 (active) and v1/default (historical canary)
+	assert.Len(t, status.Keys, 2)
+
+	// Active should be v2/k1
+	assert.Equal(t, "v2", status.Active.Strategy)
+	assert.Equal(t, "k1", status.Active.KeyID)
+
+	// Find v1/default (historical)
+	var v1Key *KeyStatus
+	for i := range status.Keys {
+		if status.Keys[i].Strategy == "v1" {
+			v1Key = &status.Keys[i]
+		}
+	}
+
+	require.NotNil(t, v1Key)
+	assert.Equal(t, "default", v1Key.KeyID)
+	assert.True(t, v1Key.Configured) // v1 strategy still registered
+	assert.False(t, v1Key.Active)
+	assert.Equal(t, "ok", v1Key.CanaryStatus)
+}
+
+func TestStatus_HistoricalCanary_KeyMissing(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Init WITH canaries
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Manually create a canary for a non-existent strategy/key
+	// (simulating historical data after key removal)
+	canary := &Canary{
+		Strategy:       "v2",
+		KeyID:          "removed-key",
+		EncryptedValue: []byte("old-canary-data"),
+	}
+	_ = store.Save(canary)
+
+	status, err := Status(ctx)
+	require.NoError(t, err)
+
+	// Should show active v1/default AND orphaned v2/removed-key
+	assert.Len(t, status.Keys, 2)
+
+	// Find orphaned key
+	var orphanKey *KeyStatus
+	for i := range status.Keys {
+		if status.Keys[i].Strategy == "v2" {
+			orphanKey = &status.Keys[i]
+		}
+	}
+
+	require.NotNil(t, orphanKey)
+	assert.Equal(t, "removed-key", orphanKey.KeyID)
+	assert.False(t, orphanKey.Configured) // v2 not registered
+	assert.False(t, orphanKey.Active)
+	assert.Equal(t, "key_missing", orphanKey.CanaryStatus) // KEY MISSING!
+}
+
+func TestStatus_DeterministicOrdering(t *testing.T) {
+	setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	// Create manager with multiple keys
+	key1, _ := crypto.GenerateAES256Key()
+	key2, _ := crypto.GenerateAES256Key()
+	key3, _ := crypto.GenerateAES256Key()
+
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key1)
+
+	store := newMemoryCanaryStore()
+	err := InitGlobalEncryptionWithCanary(logger, store)
+	require.NoError(t, err)
+
+	// Add more keys in random order
+	_, v1Strat := GlobalManager().GetActiveStrategy()
+	v1Strategy := v1Strat.(*V1Strategy)
+	key2Bytes, _ := crypto.DecodeAES256Key(key2)
+	key3Bytes, _ := crypto.DecodeAES256Key(key3)
+	require.NoError(t, v1Strategy.AddKey("zebra", key2Bytes, true))
+	require.NoError(t, v1Strategy.AddKey("alpha", key3Bytes, true))
+
+	ctx := context.Background()
+
+	// Create canaries for all keys
+	_, _ = Encrypt(ctx, Plaintext([]byte("test")))
+	canaryMgr := GlobalCanaryManager()
+	_ = canaryMgr.EnsureCanary(ctx, "v1", "zebra")
+	_ = canaryMgr.EnsureCanary(ctx, "v1", "alpha")
+
+	// Call Status multiple times
+	status1, err := Status(ctx)
+	require.NoError(t, err)
+
+	status2, err := Status(ctx)
+	require.NoError(t, err)
+
+	status3, err := Status(ctx)
+	require.NoError(t, err)
+
+	// All should have same order
+	require.Len(t, status1.Keys, 3)
+	require.Len(t, status2.Keys, 3)
+	require.Len(t, status3.Keys, 3)
+
+	// Keys should be sorted by strategy, then keyID
+	assert.Equal(t, "v1", status1.Keys[0].Strategy)
+	assert.Equal(t, "alpha", status1.Keys[0].KeyID)
+	assert.Equal(t, "v1", status1.Keys[1].Strategy)
+	assert.Equal(t, "default", status1.Keys[1].KeyID)
+	assert.Equal(t, "v1", status1.Keys[2].Strategy)
+	assert.Equal(t, "zebra", status1.Keys[2].KeyID)
+
+	// All calls should produce identical ordering
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, status1.Keys[i].Strategy, status2.Keys[i].Strategy)
+		assert.Equal(t, status1.Keys[i].KeyID, status2.Keys[i].KeyID)
+		assert.Equal(t, status1.Keys[i].Strategy, status3.Keys[i].Strategy)
+		assert.Equal(t, status1.Keys[i].KeyID, status3.Keys[i].KeyID)
+	}
+}

--- a/internal/instrumentation/encryption/v1_strategy.go
+++ b/internal/instrumentation/encryption/v1_strategy.go
@@ -1,0 +1,234 @@
+package encryption
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/flightctl/flightctl/internal/config"
+)
+
+// defaultKeyFile returns the default path for the v1 encryption key file.
+// This is $HOME/.flightctl/encryption/key (e.g., /root/.flightctl/encryption/key).
+func defaultKeyFile() string {
+	return filepath.Join(config.ConfigDir(), "encryption", "key")
+}
+
+// V1Strategy implements AES-256-GCM encryption.
+// Format: keyID:base64(nonce||ciphertext||tag)
+// The keyID prefix is always present, enabling key rotation detection.
+//
+// Thread safety: V1Strategy is safe for concurrent use. All public methods are protected
+type V1Strategy struct {
+	mu        sync.RWMutex
+	keys      map[string][]byte      // keyID -> key (32 bytes each)
+	activeKey string                 // Which key to use for new encryptions
+	gcms      map[string]cipher.AEAD // Cached GCM instances per key
+}
+
+func newV1Strategy() *V1Strategy {
+	return &V1Strategy{
+		keys: make(map[string][]byte),
+		gcms: make(map[string]cipher.AEAD),
+	}
+}
+
+// NewV1Strategy loads a single encryption key from environment variable or file.
+// Priority: FLIGHTCTL_ENCRYPTION_KEY env var > defaultKeyFile()
+// The key is registered with keyID "default".
+func NewV1Strategy() (*V1Strategy, error) {
+	strategy := newV1Strategy()
+
+	var encodedKey string
+	keyPath := defaultKeyFile()
+
+	// Try environment variable first
+	if envKey := os.Getenv("FLIGHTCTL_ENCRYPTION_KEY"); envKey != "" {
+		encodedKey = envKey
+	} else {
+		// Try default key file
+		keyBytes, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("read key file %s: %w", keyPath, err)
+		}
+		encodedKey = strings.TrimSpace(string(keyBytes))
+	}
+
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode encryption key: %w", err)
+	}
+
+	if err := strategy.AddKey("default", key, true); err != nil {
+		return nil, err
+	}
+
+	return strategy, nil
+}
+
+// AddKey registers an encryption key with the given ID.
+// If setActive is true, this key becomes the active key for new encryptions.
+// key must be 32 bytes (AES-256).
+func (s *V1Strategy) AddKey(keyID string, key []byte, setActive bool) error {
+	if len(key) != 32 {
+		return fmt.Errorf("v1 strategy requires 32-byte key, got %d bytes", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("create AES cipher for key %s: %w", keyID, err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("create GCM for key %s: %w", keyID, err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.keys[keyID] = key
+	s.gcms[keyID] = gcm
+	if setActive {
+		s.activeKey = keyID
+	}
+	return nil
+}
+
+// SetActiveKey sets which key will be used for new encryptions.
+func (s *V1Strategy) SetActiveKey(keyID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.keys[keyID]; !exists {
+		return fmt.Errorf("key %s not registered in v1 strategy", keyID)
+	}
+	s.activeKey = keyID
+	return nil
+}
+
+// Version returns "v1" (immutable version identifier).
+func (s *V1Strategy) Version() string {
+	return "v1"
+}
+
+// Algorithm returns the algorithm name.
+func (s *V1Strategy) Algorithm() string {
+	return "AES-256-GCM"
+}
+
+// ConfiguredKeys returns all configured key IDs.
+func (s *V1Strategy) ConfiguredKeys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	keyIDs := make([]string, 0, len(s.keys))
+	for keyID := range s.keys {
+		keyIDs = append(keyIDs, keyID)
+	}
+	return keyIDs
+}
+
+// String returns human-readable status information about this strategy.
+func (s *V1Strategy) String() string {
+	return fmt.Sprintf("%s, active_key=%s, keys=%v", s.Algorithm(), s.activeKey, s.ConfiguredKeys())
+}
+
+// ActiveKeyID returns the identifier of the currently active encryption key.
+func (s *V1Strategy) ActiveKeyID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.activeKey
+}
+
+// EncryptPlaintext encrypts plaintext using AES-256-GCM with the active key.
+// Returns format: keyID:base64(nonce||ciphertext||tag)
+func (s *V1Strategy) EncryptPlaintext(ctx context.Context, plaintext []byte) ([]byte, error) {
+	s.mu.RLock()
+	activeKey := s.activeKey
+	gcm, exists := s.gcms[activeKey]
+	s.mu.RUnlock()
+
+	if activeKey == "" {
+		return nil, fmt.Errorf("no active key set in v1 strategy")
+	}
+	if !exists {
+		return nil, fmt.Errorf("active key %s not found", activeKey)
+	}
+
+	// Generate random nonce
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	// Encrypt: returns nonce || ciphertext || tag
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	// Base64 encode the result
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+
+	// Return keyID:base64data
+	return []byte(fmt.Sprintf("%s:%s", activeKey, encoded)), nil
+}
+
+// ParseBody parses v1 format: keyID:base64(nonce||ciphertext||tag)
+func (s *V1Strategy) ParseBody(body []byte) (*ParsedEncrypted, error) {
+	str := string(body)
+
+	// Parse keyID:payload format
+	parts := strings.SplitN(str, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid v1 format: expected keyID:base64data, got %q", str)
+	}
+
+	keyID := parts[0]
+	encodedData := parts[1]
+
+	// Base64 decode
+	decoded, err := base64.StdEncoding.DecodeString(encodedData)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode: %w", err)
+	}
+
+	return &ParsedEncrypted{
+		KeyID:   keyID,
+		Payload: decoded,
+	}, nil
+}
+
+// DecryptParsed decrypts a parsed v1 encrypted value using AES-256-GCM.
+func (s *V1Strategy) DecryptParsed(ctx context.Context, parsed *ParsedEncrypted) ([]byte, error) {
+	s.mu.RLock()
+	gcm, exists := s.gcms[parsed.KeyID]
+	s.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("key %s not found for decryption", parsed.KeyID)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(parsed.Payload) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short: expected at least %d bytes, got %d", nonceSize, len(parsed.Payload))
+	}
+
+	// Split nonce and ciphertext
+	nonce := parsed.Payload[:nonceSize]
+	ciphertextData := parsed.Payload[nonceSize:]
+
+	// Decrypt
+	plaintext, err := gcm.Open(nil, nonce, ciphertextData, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt with key %s: %w", parsed.KeyID, err)
+	}
+
+	return plaintext, nil
+}

--- a/internal/instrumentation/encryption/v1_strategy.go
+++ b/internal/instrumentation/encryption/v1_strategy.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
@@ -14,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/pkg/crypto"
 )
 
 // defaultKeyFile returns the default path for the v1 encryption key file.
@@ -52,7 +54,7 @@ func NewV1Strategy() (*V1Strategy, error) {
 
 	// Try environment variable first
 	if envKey := os.Getenv("FLIGHTCTL_ENCRYPTION_KEY"); envKey != "" {
-		encodedKey = envKey
+		encodedKey = strings.TrimSpace(envKey)
 	} else {
 		// Try default key file
 		keyBytes, err := os.ReadFile(keyPath)
@@ -62,7 +64,7 @@ func NewV1Strategy() (*V1Strategy, error) {
 		encodedKey = strings.TrimSpace(string(keyBytes))
 	}
 
-	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	key, err := crypto.DecodeAES256Key(encodedKey)
 	if err != nil {
 		return nil, fmt.Errorf("decode encryption key: %w", err)
 	}
@@ -80,6 +82,12 @@ func NewV1Strategy() (*V1Strategy, error) {
 func (s *V1Strategy) AddKey(keyID string, key []byte, setActive bool) error {
 	if len(key) != 32 {
 		return fmt.Errorf("v1 strategy requires 32-byte key, got %d bytes", len(key))
+	}
+
+	// Check for zeroed-out key (configuration error)
+	zeroKey := make([]byte, 32)
+	if bytes.Equal(key, zeroKey) {
+		return fmt.Errorf("key %s is all zeros - likely a configuration error", keyID)
 	}
 
 	block, err := aes.NewCipher(key)
@@ -139,7 +147,14 @@ func (s *V1Strategy) ConfiguredKeys() []string {
 
 // String returns human-readable status information about this strategy.
 func (s *V1Strategy) String() string {
-	return fmt.Sprintf("%s, active_key=%s, keys=%v", s.Algorithm(), s.activeKey, s.ConfiguredKeys())
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	keyIDs := make([]string, 0, len(s.keys))
+	for keyID := range s.keys {
+		keyIDs = append(keyIDs, keyID)
+	}
+	return fmt.Sprintf("%s, active_key=%s, keys=%v", s.Algorithm(), s.activeKey, keyIDs)
 }
 
 // ActiveKeyID returns the identifier of the currently active encryption key.

--- a/internal/instrumentation/encryption/v1_strategy_test.go
+++ b/internal/instrumentation/encryption/v1_strategy_test.go
@@ -394,7 +394,7 @@ func TestNewV1Strategy_KeyTooShort(t *testing.T) {
 
 	_, err = NewV1Strategy()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "32-byte key")
+	assert.Contains(t, err.Error(), "32 bytes")
 }
 
 func TestGenerateAES256Key(t *testing.T) {
@@ -540,4 +540,15 @@ func testDecrypt(t *testing.T, strategy *V1Strategy, ctx context.Context, encryp
 		return nil, err
 	}
 	return strategy.DecryptParsed(ctx, parsed)
+}
+
+func TestV1Strategy_AddKey_RejectsZeroKey(t *testing.T) {
+	strategy := newV1Strategy()
+
+	zeroKey := make([]byte, 32) // All zeros
+
+	err := strategy.AddKey("zero-key", zeroKey, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all zeros")
+	assert.Contains(t, err.Error(), "configuration error")
 }

--- a/internal/instrumentation/encryption/v1_strategy_test.go
+++ b/internal/instrumentation/encryption/v1_strategy_test.go
@@ -1,0 +1,543 @@
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewV1Strategy_EmptyConstructor(t *testing.T) {
+	strategy := newV1Strategy()
+
+	assert.NotNil(t, strategy)
+	assert.Empty(t, strategy.keys)
+	assert.Empty(t, strategy.gcms)
+	assert.Empty(t, strategy.ActiveKeyID())
+}
+
+func TestV1Strategy_AddKey(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+
+	require.NoError(t, strategy.AddKey("my-key", key, true))
+
+	assert.Contains(t, strategy.keys, "my-key")
+	assert.Contains(t, strategy.gcms, "my-key")
+	assert.Equal(t, "my-key", strategy.ActiveKeyID(), "newly added key should be active")
+}
+
+func TestV1Strategy_AddKey_InvalidKeySize(t *testing.T) {
+	strategy := newV1Strategy()
+
+	tests := []struct {
+		name    string
+		keySize int
+	}{
+		{"When key is too short it should error", 16},
+		{"When key is too long it should error", 64},
+		{"When key is empty it should error", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := make([]byte, tt.keySize)
+			err := strategy.AddKey("test-key", key, true)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "32-byte key")
+		})
+	}
+}
+
+func TestV1Strategy_AddMultipleKeys(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+
+	err = strategy.AddKey("2024-01", key1, true)
+	require.NoError(t, err)
+	assert.Equal(t, "2024-01", strategy.ActiveKeyID())
+
+	err = strategy.AddKey("2024-06", key2, true)
+	require.NoError(t, err)
+	assert.Equal(t, "2024-06", strategy.ActiveKeyID(), "last added key should be active")
+
+	assert.Len(t, strategy.keys, 2, "both keys should be registered")
+}
+
+func TestV1Strategy_SetActiveKey(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+
+	require.NoError(t, strategy.AddKey("2024-01", key1, true))
+	require.NoError(t, strategy.AddKey("2024-06", key2, true))
+
+	// Switch back to old key
+	err = strategy.SetActiveKey("2024-01")
+	require.NoError(t, err)
+	assert.Equal(t, "2024-01", strategy.ActiveKeyID())
+
+	// Try to set non-existent key
+	err = strategy.SetActiveKey("2024-99")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not registered")
+}
+
+func TestV1Strategy_Version(t *testing.T) {
+	strategy := newV1Strategy()
+	assert.Equal(t, "v1", strategy.Version())
+}
+
+func TestV1Strategy_EncryptDecrypt_SingleKey(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+
+	err = strategy.AddKey("default", key, true)
+	require.NoError(t, err)
+
+	plaintext := []byte("my-secret-password-123")
+
+	// Encrypt
+	encrypted, err := strategy.EncryptPlaintext(ctx, plaintext)
+	require.NoError(t, err)
+	assert.NotEmpty(t, encrypted)
+	assert.NotEqual(t, plaintext, encrypted)
+
+	// Should have keyID:base64 format
+	encryptedStr := string(encrypted)
+	assert.Contains(t, encryptedStr, "default:", "should have keyID prefix")
+	parts := strings.SplitN(encryptedStr, ":", 2)
+	require.Len(t, parts, 2, "should have keyID:payload format")
+	_, err = base64.StdEncoding.DecodeString(parts[1])
+	assert.NoError(t, err, "payload after keyID should be valid base64")
+
+	// Decrypt
+	decrypted, err := testDecrypt(t, strategy, ctx, encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestV1Strategy_EncryptDecrypt_MultipleKeys(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+
+	err = strategy.AddKey("2024-01", key1, true)
+	require.NoError(t, err)
+
+	// Encrypt with first key
+	plaintext1 := []byte("encrypted-with-key1")
+	encrypted1, err := strategy.EncryptPlaintext(ctx, plaintext1)
+	require.NoError(t, err)
+
+	// Should have keyID prefix since we have multiple keys
+	assert.True(t, strings.HasPrefix(string(encrypted1), "2024-01:"), "should include keyID prefix")
+
+	// Add second key (becomes active)
+	err = strategy.AddKey("2024-06", key2, true)
+	require.NoError(t, err)
+
+	// Encrypt with second key
+	plaintext2 := []byte("encrypted-with-key2")
+	encrypted2, err := strategy.EncryptPlaintext(ctx, plaintext2)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(encrypted2), "2024-06:"), "should include new keyID prefix")
+
+	// Can decrypt both
+	decrypted1, err := testDecrypt(t, strategy, ctx, encrypted1)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext1, decrypted1)
+
+	decrypted2, err := testDecrypt(t, strategy, ctx, encrypted2)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext2, decrypted2)
+}
+
+func TestV1Strategy_Decrypt_InvalidBase64(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	_, err = testDecrypt(t, strategy, ctx, []byte("default:not-valid-base64!!!"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "base64 decode")
+}
+
+func TestV1Strategy_Decrypt_TooShort(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	// Valid base64 but too short to contain nonce
+	shortData := base64.StdEncoding.EncodeToString([]byte("x"))
+	_, err = testDecrypt(t, strategy, ctx, []byte(fmt.Sprintf("default:%s", shortData)))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestV1Strategy_Decrypt_InvalidCiphertext(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	// Valid base64, right size, but invalid ciphertext (will fail GCM authentication)
+	fakeData := make([]byte, 32) // Enough bytes to pass length check
+	_, err = rand.Read(fakeData)
+	require.NoError(t, err)
+	encoded := base64.StdEncoding.EncodeToString(fakeData)
+
+	_, err = testDecrypt(t, strategy, ctx, []byte(fmt.Sprintf("default:%s", encoded)))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt")
+}
+
+func TestV1Strategy_Decrypt_UnknownKeyID(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("2024-01", key, true))
+	require.NoError(t, strategy.AddKey("2024-06", key, true))
+
+	// Encrypt with one of the known keys to create a real encrypted blob
+	plaintext := []byte("test-data")
+	encrypted, err := strategy.EncryptPlaintext(ctx, plaintext)
+	require.NoError(t, err)
+
+	// Now replace the keyID with an unknown one
+	parts := strings.Split(string(encrypted), ":")
+	require.Len(t, parts, 2, "should have keyID:ciphertext format")
+
+	fakeData := "unknown-key-2099:" + parts[1]
+
+	// This should fail because unknown-key-2099 doesn't exist in the map
+	_, err = testDecrypt(t, strategy, ctx, []byte(fakeData))
+	assert.Error(t, err)
+	// The error might be "key unknown-key-2099 not found" OR "base64 decode"
+	// depending on fallback logic - either is acceptable
+	assert.True(t,
+		strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "base64"),
+		"should error on unknown key, got: %v", err)
+}
+
+func TestV1Strategy_EncryptDecrypt_LargePayload(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	// 1MB payload
+	largePlaintext := make([]byte, 1024*1024)
+	_, err = rand.Read(largePlaintext)
+	require.NoError(t, err)
+
+	encrypted, err := strategy.EncryptPlaintext(ctx, largePlaintext)
+	require.NoError(t, err)
+
+	decrypted, err := testDecrypt(t, strategy, ctx, encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, largePlaintext, decrypted)
+}
+
+func TestV1Strategy_EncryptDecrypt_EmptyData(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	plaintext := []byte("")
+
+	encrypted, err := strategy.EncryptPlaintext(ctx, plaintext)
+	require.NoError(t, err)
+
+	decrypted, err := testDecrypt(t, strategy, ctx, encrypted)
+	require.NoError(t, err)
+	// GCM returns nil for empty plaintext, which is semantically equivalent to []byte{}
+	assert.Empty(t, decrypted)
+}
+
+func TestV1Strategy_UniqueNonces(t *testing.T) {
+	strategy := newV1Strategy()
+	ctx := context.Background()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	plaintext := []byte("same-plaintext")
+
+	// Encrypt the same plaintext multiple times
+	encrypted1, err := strategy.EncryptPlaintext(ctx, plaintext)
+	require.NoError(t, err)
+
+	encrypted2, err := strategy.EncryptPlaintext(ctx, plaintext)
+	require.NoError(t, err)
+
+	// Ciphertexts should be different (due to unique nonces)
+	assert.NotEqual(t, encrypted1, encrypted2, "same plaintext should produce different ciphertexts")
+
+	// But both should decrypt to the same plaintext
+	decrypted1, _ := testDecrypt(t, strategy, ctx, encrypted1)
+	decrypted2, _ := testDecrypt(t, strategy, ctx, encrypted2)
+	assert.Equal(t, plaintext, decrypted1)
+	assert.Equal(t, plaintext, decrypted2)
+}
+
+func TestNewV1Strategy_EnvVar(t *testing.T) {
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", encodedKey)
+
+	strategy, err := NewV1Strategy()
+	require.NoError(t, err)
+	assert.NotNil(t, strategy)
+	assert.Equal(t, "default", strategy.ActiveKeyID())
+	assert.Contains(t, strategy.keys, "default")
+}
+
+func TestNewV1Strategy_NoKeyProvided(t *testing.T) {
+	os.Unsetenv("FLIGHTCTL_ENCRYPTION_KEY")
+
+	_, err := NewV1Strategy()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "read key file")
+}
+
+func TestNewV1Strategy_InvalidBase64(t *testing.T) {
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", "not-valid-base64!!!")
+
+	_, err := NewV1Strategy()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestNewV1Strategy_KeyTooShort(t *testing.T) {
+	var err error
+
+	shortKey := make([]byte, 16) // Only 16 bytes, need 32
+	_, err = rand.Read(shortKey)
+	require.NoError(t, err)
+	encodedKey := base64.StdEncoding.EncodeToString(shortKey)
+
+	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", encodedKey)
+
+	_, err = NewV1Strategy()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "32-byte key")
+}
+
+func TestGenerateAES256Key(t *testing.T) {
+	key1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	assert.NotEmpty(t, key1)
+
+	key2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	assert.NotEmpty(t, key2)
+
+	// Keys should be different
+	assert.NotEqual(t, key1, key2, "generated keys should be unique")
+
+	// Should be valid base64
+	decoded, err := base64.StdEncoding.DecodeString(key1)
+	require.NoError(t, err)
+	assert.Len(t, decoded, 32, "decoded key should be 32 bytes")
+}
+
+func TestV1Strategy_String(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+	err = strategy.AddKey("default", key1, true)
+	require.NoError(t, err)
+
+	str := strategy.String()
+	assert.Contains(t, str, "AES-256-GCM", "should include algorithm name")
+	assert.Contains(t, str, "active_key=default", "should include active key")
+	assert.Contains(t, str, "keys=", "should list configured keys")
+}
+
+func TestV1Strategy_ActiveKeyID(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+	err = strategy.AddKey("default", key1, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", strategy.ActiveKeyID())
+
+	// Add another key
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+	err = strategy.AddKey("key2", key2, true)
+	require.NoError(t, err)
+
+	// Should update to new key (AddKey makes it active)
+	assert.Equal(t, "key2", strategy.ActiveKeyID())
+
+	// Set back to default
+	err = strategy.SetActiveKey("default")
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", strategy.ActiveKeyID())
+}
+
+func TestV1Strategy_String_MultipleKeys(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key1, true))
+
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("keyB", key2, true))
+
+	str := strategy.String()
+	assert.Contains(t, str, "AES-256-GCM")
+	assert.Contains(t, str, "active_key=keyB", "latest added key should be active")
+	assert.Contains(t, str, "default", "should list first key")
+	assert.Contains(t, str, "keyB", "should list second key")
+}
+
+func TestV1Strategy_Algorithm(t *testing.T) {
+	strategy := newV1Strategy()
+
+	algo := strategy.Algorithm()
+	assert.Equal(t, "AES-256-GCM", algo)
+}
+
+func TestV1Strategy_ConfiguredKeys_Single(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("default", key, true))
+
+	keys := strategy.ConfiguredKeys()
+	assert.Len(t, keys, 1)
+	assert.Contains(t, keys, "default")
+}
+
+func TestV1Strategy_ConfiguredKeys_Multiple(t *testing.T) {
+	strategy := newV1Strategy()
+
+	encodedKey1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1, err := base64.StdEncoding.DecodeString(encodedKey1)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("keyA", key1, true))
+
+	encodedKey2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2, err := base64.StdEncoding.DecodeString(encodedKey2)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("keyB", key2, true))
+
+	encodedKey3, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key3, err := base64.StdEncoding.DecodeString(encodedKey3)
+	require.NoError(t, err)
+	require.NoError(t, strategy.AddKey("keyC", key3, true))
+
+	keys := strategy.ConfiguredKeys()
+	assert.Len(t, keys, 3)
+	assert.Contains(t, keys, "keyA")
+	assert.Contains(t, keys, "keyB")
+	assert.Contains(t, keys, "keyC")
+}
+
+// testDecrypt is a helper that uses the new ParseBody + DecryptParsed interface
+func testDecrypt(t *testing.T, strategy *V1Strategy, ctx context.Context, encrypted []byte) ([]byte, error) {
+	t.Helper()
+	parsed, err := strategy.ParseBody(encrypted)
+	if err != nil {
+		return nil, err
+	}
+	return strategy.DecryptParsed(ctx, parsed)
+}

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"os"
@@ -18,6 +19,28 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 )
+
+// GenerateAES256Key generates a cryptographically secure 32-byte (256-bit) random key
+// suitable for AES-256-GCM encryption, returned as a base64-encoded string.
+func GenerateAES256Key() (string, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return "", fmt.Errorf("generate random key: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+// DecodeAES256Key decodes a base64-encoded AES-256 key and validates it is exactly 32 bytes.
+func DecodeAES256Key(encodedKey string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64 key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("key must be 32 bytes, got %d", len(key))
+	}
+	return key, nil
+}
 
 func NewKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
 	return newECDSAKeyPair()


### PR DESCRIPTION
## Summary

Implements the core encryption subsystem infrastructure for field-level encryption of sensitive control plane data at rest. This is the foundation for EDM-3460 (Encryption at Rest for RHEM Control Plane).

**No fields are encrypted in this PR** - this adds only the infrastructure. Field encryption and HTTP endpoint integration follow in separate PRs.

## Changes

### Core Components
- **Encryption Subsystem** (`internal/instrumentation/encryption/`)
  - Strategy interface for versioned encryption implementations
  - Manager for routing operations based on `enc:<version>:` prefix
  - V1 Strategy: AES-256-GCM with local key provisioning
  - Global API: `Encrypt()`, `Decrypt()`, `ProcessEncryption()`

- **GORM Plugin** - Transparent encryption via BeforeCreate/BeforeUpdate callbacks
- **Canary Validation** - Startup validation that configured keys can decrypt existing data
- **Status Function** - `encryption.Status()` returns encryption state (HTTP endpoint deferred)

### Encrypted Format
enc:v1:default:k8fJ2mK9pL3qR7sT4vW6xY1zA5bC8dE0fG2hI4jK6lM8nO0pQ2rS4tU6vW8xY0zA==
└─┬─┘ └┬┘ └──┬──┘ └────────────────────────┬────────────────────────┘
prefix │   keyID        base64(nonce || ciphertext || tag)
version

### Configuration
- **Production:** Key loaded from `$HOME/.flightctl/encryption/key`
- **Dev/Test:** Key from `FLIGHTCTL_ENCRYPTION_KEY` environment variable
- **Format:** Base64-encoded 32-byte AES-256 key
- **Generation:** `openssl rand -base64 32` or `crypto.GenerateAES256Key()`