### PR TITLE
NO-ISSUE: fix import.sh including failed images from BundleImages

### DIFF
--- a/scripts/air-gap/mirror-images/bundle.go
+++ b/scripts/air-gap/mirror-images/bundle.go
@@ -29,11 +29,17 @@ import (
 //
 // This approach preserves namespaces — unlike skopeo sync --src yaml --dest dir
 // which strips namespace prefixes from directory names.
-func BundleImages(ctx context.Context, pairs []ImagePair, bundleDir string, exec executer.Executer) error {
+// BundleImages copies each image in pairs into bundleDir/images/ using skopeo.
+// It returns the subset of pairs that were successfully bundled alongside any
+// error describing which images failed.  Callers must use the returned slice
+// (not the original pairs) when generating the import script, so that the
+// script only references images that are actually present in the bundle.
+func BundleImages(ctx context.Context, pairs []ImagePair, bundleDir string, exec executer.Executer) ([]ImagePair, error) {
 	imagesDir := filepath.Join(bundleDir, "images")
 	logInfo("Bundling %d images to %s...", len(pairs), imagesDir)
 
 	var failed []string
+	var bundled []ImagePair
 	for i, p := range pairs {
 		// Strip the source registry host to get the namespace/name:tag path.
 		// "quay.io/flightctl/flightctl-api-el9:latest" → "flightctl/flightctl-api-el9:latest"
@@ -59,13 +65,15 @@ func BundleImages(ctx context.Context, pairs []ImagePair, bundleDir string, exec
 		if exitCode != 0 {
 			logError("skopeo copy failed for %s: %s — continuing", p.Source, strings.TrimSpace(stderr))
 			failed = append(failed, p.Source)
+			continue
 		}
+		bundled = append(bundled, p)
 	}
 
 	if len(failed) > 0 {
-		return fmt.Errorf("%d image(s) failed to bundle: %s", len(failed), strings.Join(failed, ", "))
+		return bundled, fmt.Errorf("%d image(s) failed to bundle: %s", len(failed), strings.Join(failed, ", "))
 	}
-	return nil
+	return bundled, nil
 }
 
 // DownloadRPMs fetches RPMs into bundleDir/rpms/ using one of two strategies:

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -205,10 +205,11 @@ func runBundleMode(ctx context.Context, unique []ImagePair, bundle, variant stri
 		Dest:   destRegistry + "/library/registry:2",
 	})
 
-	if err := BundleImages(ctx, bundleImages, tmpDir, exec); err != nil {
+	bundled, err := BundleImages(ctx, bundleImages, tmpDir, exec)
+	if err != nil {
 		logWarn("Some images failed to bundle: %v", err)
 	}
-	if err := WriteImportScript(tmpDir, bundleImages, variant); err != nil {
+	if err := WriteImportScript(tmpDir, bundled, variant); err != nil {
 		return fmt.Errorf("write import script: %w", err)
 	}
 	if bundleRPMs {


### PR DESCRIPTION
## Summary

- `BundleImages` returned an error for failed images but the caller passed the full original pair list to `WriteImportScript`, so `import.sh` referenced images never written to the bundle directory.
- Changed `BundleImages` signature from `error` to `([]ImagePair, error)`, returning only the successfully bundled pairs. The caller now passes this subset to `WriteImportScript`.

## Root Cause

`flightctl-remote-access-el9:1.2.0-rc3` was never published to quay.io. This caused `BundleImages` to fail for that image while silently including it in `import.sh` anyway, resulting in a broken bundle that referenced a non-existent local image path.

## Test plan

- [ ] Run `flightctl-mirror-images --bundle` against a variant that includes an image known to be missing or unreachable
- [ ] Verify `import.sh` in the resulting bundle does **not** reference the failed image
- [ ] Verify the warning for the failed image is still printed to stderr
- [ ] Verify all successfully bundled images are still present in `import.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)