### PR TITLE
EDM-4099: [DEV] Agent lifecycle reconciliation — CLI support

### DIFF
--- a/cmd/flightctl/main.go
+++ b/cmd/flightctl/main.go
@@ -43,6 +43,9 @@ func NewFlightCtlCommand() *cobra.Command {
 	cmd.AddCommand(cli.NewCmdCertificate())
 	cmd.AddCommand(cli.NewCmdDownload())
 	cmd.AddCommand(cli.NewCmdLogs())
+	cmd.AddCommand(cli.NewCmdStop())
+	cmd.AddCommand(cli.NewCmdStart())
+	cmd.AddCommand(cli.NewCmdRestartApplication())
 
 	return cmd
 }

--- a/cmd/flightctl/main.go
+++ b/cmd/flightctl/main.go
@@ -45,7 +45,7 @@ func NewFlightCtlCommand() *cobra.Command {
 	cmd.AddCommand(cli.NewCmdLogs())
 	cmd.AddCommand(cli.NewCmdStop())
 	cmd.AddCommand(cli.NewCmdStart())
-	cmd.AddCommand(cli.NewCmdRestartApplication())
+	cmd.AddCommand(cli.NewCmdRestart())
 
 	return cmd
 }

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -1185,7 +1185,7 @@ func TestManagerResolveConsole(t *testing.T) {
 }
 
 func mockExecPodmanComposeStop(mockExec *executer.MockExecuter, name string) *gomock.Call {
-	workDir := fmt.Sprintf("/etc/compose/manifests/%s", name)
+	workDir := fmt.Sprintf("%s/%s", lifecycle.ComposeAppPath, name)
 	id := lifecycle.GenerateAppID(name, v1beta1.CurrentProcessUsername)
 	args := []string{"compose", "-p", id, "stop"}
 	return mockExec.EXPECT().ExecuteWithContextFromDir(gomock.Any(), workDir, "podman", args).Return("", "", 0)

--- a/internal/cli/app_lifecycle.go
+++ b/internal/cli/app_lifecycle.go
@@ -90,7 +90,10 @@ func confirm(prompt string, skip bool) error {
 	reader := bufio.NewReader(os.Stdin)
 	response, err := reader.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("failed to read confirmation from stdin: %w; use --yes to skip the prompt", err)
+		if response == "" {
+			return fmt.Errorf("failed to read confirmation from stdin: %w; use --yes to skip the prompt", err)
+		}
+		// Partial read (e.g. "y" without trailing newline); proceed to check the response.
 	}
 	response = strings.TrimSpace(strings.ToLower(response))
 	if response != "y" && response != "yes" {

--- a/internal/cli/app_lifecycle.go
+++ b/internal/cli/app_lifecycle.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// AppLifecycleOptions holds the options shared by the stop/start/restart application commands.
+type AppLifecycleOptions struct {
+	GlobalOptions
+	AppName string
+	Yes     bool
+}
+
+func DefaultAppLifecycleOptions() *AppLifecycleOptions {
+	return &AppLifecycleOptions{
+		GlobalOptions: DefaultGlobalOptions(),
+	}
+}
+
+func (o *AppLifecycleOptions) Bind(fs *pflag.FlagSet) {
+	o.GlobalOptions.Bind(fs)
+	fs.StringVar(&o.AppName, "app", o.AppName, "Application name to control (required)")
+	fs.BoolVarP(&o.Yes, "yes", "y", o.Yes, "Skip the confirmation prompt")
+}
+
+func (o *AppLifecycleOptions) Complete(cmd *cobra.Command, args []string) error {
+	return o.GlobalOptions.Complete(cmd, args)
+}
+
+// resolveDeviceName validates the positional args and required flags shared by the
+// device-only restart command, returning the target device name.
+func (o *AppLifecycleOptions) resolveDeviceName(args []string) (string, error) {
+	kind, name, err := parseAndValidateKindNameFromArgsSingle(args)
+	if err != nil {
+		return "", err
+	}
+	if kind != DeviceKind {
+		return "", fmt.Errorf("kind must be Device")
+	}
+	if len(name) == 0 {
+		return "", fmt.Errorf("device name is required")
+	}
+	if o.AppName == "" {
+		return "", fmt.Errorf("--app is required")
+	}
+	return name, nil
+}
+
+// resolveTarget validates the positional args and required flags shared by the stop/start
+// application commands, returning the target's kind (Device or Fleet) and name. Stopping or
+// starting on a fleet sets a fleet-wide default applied to every device owned by the fleet,
+// still overridable per device (see StopFleetApplication/StartFleetApplication).
+func (o *AppLifecycleOptions) resolveTarget(args []string) (ResourceKind, string, error) {
+	kind, name, err := parseAndValidateKindNameFromArgsSingle(args)
+	if err != nil {
+		return "", "", err
+	}
+	if kind != DeviceKind && kind != FleetKind {
+		return "", "", fmt.Errorf("kind must be Device or Fleet")
+	}
+	if len(name) == 0 {
+		return "", "", fmt.Errorf("%s name is required", kind)
+	}
+	if o.AppName == "" {
+		return "", "", fmt.Errorf("--app is required")
+	}
+	return kind, name, nil
+}
+
+// confirm prompts the user for confirmation on stderr, returning an error if they decline.
+// Skipped entirely when skip is true (--yes).
+func confirm(prompt string, skip bool) error {
+	if skip {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "%s (y/N): ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read user input: %w", err)
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response != "y" && response != "yes" {
+		return fmt.Errorf("cancelled")
+	}
+	return nil
+}
+
+func NewCmdStop() *cobra.Command {
+	o := DefaultAppLifecycleOptions()
+	cmd := &cobra.Command{
+		Use:   "stop (device/NAME | fleet/NAME) --app APP",
+		Short: "Stop an application running on a device, or on every device owned by a fleet.",
+		Long: "Stop an application running on a device, or on every device owned by a fleet.\n\n" +
+			"Stopping on a fleet sets a fleet-wide default: it applies to every device currently " +
+			"owned by the fleet, as well as any device that joins the fleet later, but a device's " +
+			"own stop/start command still takes precedence over the fleet-wide default for that " +
+			"device.",
+		Example: `  # Stop an application on a single device
+  flightctl stop device/my-device --app my-app
+
+  # Stop an application on every device in a fleet
+  flightctl stop fleet/my-fleet --app my-app`,
+		Args: cobra.MinimumNArgs(1),
+		ValidArgsFunction: KindNameAutocomplete{
+			Options:            o,
+			AllowMultipleNames: false,
+			AllowedKinds:       []ResourceKind{DeviceKind, FleetKind},
+		}.ValidArgsFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			kind, name, err := o.resolveTarget(args)
+			if err != nil {
+				return err
+			}
+			if err := confirm(stopStartConfirmPrompt("Stop", o.AppName, kind, name), o.Yes); err != nil {
+				return err
+			}
+			ctx, cancel := o.WithTimeout(cmd.Context())
+			defer cancel()
+			c, err := o.BuildClient()
+			if err != nil {
+				return fmt.Errorf("creating client: %w", err)
+			}
+			c.Start(ctx)
+			defer c.Stop()
+			if kind == FleetKind {
+				return runStopFleet(ctx, c.ClientWithResponses, name, o.AppName)
+			}
+			return runStop(ctx, c.ClientWithResponses, name, o.AppName)
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+func NewCmdStart() *cobra.Command {
+	o := DefaultAppLifecycleOptions()
+	cmd := &cobra.Command{
+		Use:   "start (device/NAME | fleet/NAME) --app APP",
+		Short: "Start an application running on a device, or on every device owned by a fleet.",
+		Long: "Start an application running on a device, or on every device owned by a fleet.\n\n" +
+			"Starting on a fleet sets a fleet-wide default: it applies to every device currently " +
+			"owned by the fleet, as well as any device that joins the fleet later, but a device's " +
+			"own stop/start command still takes precedence over the fleet-wide default for that " +
+			"device.",
+		Example: `  # Start an application on a single device
+  flightctl start device/my-device --app my-app
+
+  # Start an application on every device in a fleet
+  flightctl start fleet/my-fleet --app my-app`,
+		Args: cobra.MinimumNArgs(1),
+		ValidArgsFunction: KindNameAutocomplete{
+			Options:            o,
+			AllowMultipleNames: false,
+			AllowedKinds:       []ResourceKind{DeviceKind, FleetKind},
+		}.ValidArgsFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			kind, name, err := o.resolveTarget(args)
+			if err != nil {
+				return err
+			}
+			if err := confirm(stopStartConfirmPrompt("Start", o.AppName, kind, name), o.Yes); err != nil {
+				return err
+			}
+			ctx, cancel := o.WithTimeout(cmd.Context())
+			defer cancel()
+			c, err := o.BuildClient()
+			if err != nil {
+				return fmt.Errorf("creating client: %w", err)
+			}
+			c.Start(ctx)
+			defer c.Stop()
+			if kind == FleetKind {
+				return runStartFleet(ctx, c.ClientWithResponses, name, o.AppName)
+			}
+			return runStart(ctx, c.ClientWithResponses, name, o.AppName)
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+// stopStartConfirmPrompt builds the confirmation prompt for the stop/start commands, calling
+// out the fleet-wide blast radius when the target is a fleet rather than a single device.
+func stopStartConfirmPrompt(verb, appName string, kind ResourceKind, name string) string {
+	if kind == FleetKind {
+		return fmt.Sprintf("%s application %q on every device in fleet %q?", verb, appName, name)
+	}
+	return fmt.Sprintf("%s application %q on device %q?", verb, appName, name)
+}
+
+func NewCmdRestartApplication() *cobra.Command {
+	o := DefaultAppLifecycleOptions()
+	cmd := &cobra.Command{
+		Use:   "restart device/NAME --app APP",
+		Short: "Restart an application running on a device.",
+		Args:  cobra.MinimumNArgs(1),
+		ValidArgsFunction: KindNameAutocomplete{
+			Options:            o,
+			AllowMultipleNames: false,
+			AllowedKinds:       []ResourceKind{DeviceKind},
+		}.ValidArgsFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(cmd, args); err != nil {
+				return err
+			}
+			deviceName, err := o.resolveDeviceName(args)
+			if err != nil {
+				return err
+			}
+			if err := confirm(fmt.Sprintf("Restart application %q on device %q?", o.AppName, deviceName), o.Yes); err != nil {
+				return err
+			}
+			ctx, cancel := o.WithTimeout(cmd.Context())
+			defer cancel()
+			c, err := o.BuildClient()
+			if err != nil {
+				return fmt.Errorf("creating client: %w", err)
+			}
+			c.Start(ctx)
+			defer c.Stop()
+			return runRestart(ctx, c.ClientWithResponses, deviceName, o.AppName)
+		},
+		SilenceUsage: true,
+	}
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+func runStop(ctx context.Context, c *apiclient.ClientWithResponses, deviceName, appName string) error {
+	response, err := c.StopDeviceApplicationWithResponse(ctx, deviceName, appName)
+	if err != nil {
+		return fmt.Errorf("stopping application %s on device %s: %w", appName, deviceName, err)
+	}
+	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "stopping", appName, "device", deviceName); err != nil {
+		return err
+	}
+	fmt.Printf("Application %q on device %q stopped\n", appName, deviceName)
+	return nil
+}
+
+func runStart(ctx context.Context, c *apiclient.ClientWithResponses, deviceName, appName string) error {
+	response, err := c.StartDeviceApplicationWithResponse(ctx, deviceName, appName)
+	if err != nil {
+		return fmt.Errorf("starting application %s on device %s: %w", appName, deviceName, err)
+	}
+	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "starting", appName, "device", deviceName); err != nil {
+		return err
+	}
+	fmt.Printf("Application %q on device %q started\n", appName, deviceName)
+	return nil
+}
+
+func runRestart(ctx context.Context, c *apiclient.ClientWithResponses, deviceName, appName string) error {
+	response, err := c.RestartDeviceApplicationWithResponse(ctx, deviceName, appName)
+	if err != nil {
+		return fmt.Errorf("restarting application %s on device %s: %w", appName, deviceName, err)
+	}
+	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "restarting", appName, "device", deviceName); err != nil {
+		return err
+	}
+	fmt.Printf("Application %q on device %q restarted\n", appName, deviceName)
+	return nil
+}
+
+func runStopFleet(ctx context.Context, c *apiclient.ClientWithResponses, fleetName, appName string) error {
+	response, err := c.StopFleetApplicationWithResponse(ctx, fleetName, appName)
+	if err != nil {
+		return fmt.Errorf("stopping application %s on fleet %s: %w", appName, fleetName, err)
+	}
+	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "stopping", appName, "fleet", fleetName); err != nil {
+		return err
+	}
+	fmt.Printf("Application %q stopped on every device in fleet %q\n", appName, fleetName)
+	return nil
+}
+
+func runStartFleet(ctx context.Context, c *apiclient.ClientWithResponses, fleetName, appName string) error {
+	response, err := c.StartFleetApplicationWithResponse(ctx, fleetName, appName)
+	if err != nil {
+		return fmt.Errorf("starting application %s on fleet %s: %w", appName, fleetName, err)
+	}
+	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "starting", appName, "fleet", fleetName); err != nil {
+		return err
+	}
+	fmt.Printf("Application %q started on every device in fleet %q\n", appName, fleetName)
+	return nil
+}
+
+// checkLifecycleResponse returns a CLIError if the HTTP response status is not 200 OK.
+func checkLifecycleResponse(resp *http.Response, body []byte, verbGerund, appName, targetKind, targetName string) error {
+	if resp != nil && resp.StatusCode != http.StatusOK {
+		return &CLIError{
+			Context: fmt.Sprintf("%s application %s on %s %s: failed", verbGerund, appName, targetKind, targetName),
+			Err:     &APIError{Status: ParseStatusFromBody(body)},
+		}
+	}
+	return nil
+}

--- a/internal/cli/app_lifecycle.go
+++ b/internal/cli/app_lifecycle.go
@@ -56,9 +56,7 @@ func (o *AppLifecycleOptions) resolveDeviceName(args []string) (string, error) {
 }
 
 // resolveTarget validates the positional args and required flags shared by the stop/start
-// application commands, returning the target's kind (Device or Fleet) and name. Stopping or
-// starting on a fleet sets a fleet-wide default applied to every device owned by the fleet,
-// still overridable per device (see StopFleetApplication/StartFleetApplication).
+// application commands, returning the target's kind (Device or Fleet) and name.
 func (o *AppLifecycleOptions) resolveTarget(args []string) (ResourceKind, string, error) {
 	kind, name, err := parseAndValidateKindNameFromArgsSingle(args)
 	if err != nil {

--- a/internal/cli/app_lifecycle.go
+++ b/internal/cli/app_lifecycle.go
@@ -32,6 +32,12 @@ func (o *AppLifecycleOptions) Bind(fs *pflag.FlagSet) {
 	fs.BoolVarP(&o.Yes, "yes", "y", o.Yes, "Skip the confirmation prompt")
 }
 
+// markAppFlagRequired declares --app required on cmd so cobra rejects a missing
+// value immediately and documents the requirement in --help.
+func markAppFlagRequired(cmd *cobra.Command) {
+	_ = cmd.MarkFlagRequired("app")
+}
+
 func (o *AppLifecycleOptions) Complete(cmd *cobra.Command, args []string) error {
 	return o.GlobalOptions.Complete(cmd, args)
 }
@@ -84,7 +90,7 @@ func confirm(prompt string, skip bool) error {
 	reader := bufio.NewReader(os.Stdin)
 	response, err := reader.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("failed to read user input: %w", err)
+		return fmt.Errorf("failed to read confirmation from stdin: %w; use --yes to skip the prompt", err)
 	}
 	response = strings.TrimSpace(strings.ToLower(response))
 	if response != "y" && response != "yes" {
@@ -141,6 +147,7 @@ func NewCmdStop() *cobra.Command {
 		SilenceUsage: true,
 	}
 	o.Bind(cmd.Flags())
+	markAppFlagRequired(cmd)
 	return cmd
 }
 
@@ -192,6 +199,7 @@ func NewCmdStart() *cobra.Command {
 		SilenceUsage: true,
 	}
 	o.Bind(cmd.Flags())
+	markAppFlagRequired(cmd)
 	return cmd
 }
 
@@ -239,6 +247,7 @@ func NewCmdRestartApplication() *cobra.Command {
 		SilenceUsage: true,
 	}
 	o.Bind(cmd.Flags())
+	markAppFlagRequired(cmd)
 	return cmd
 }
 

--- a/internal/cli/app_lifecycle.go
+++ b/internal/cli/app_lifecycle.go
@@ -215,7 +215,7 @@ func stopStartConfirmPrompt(verb, appName string, kind ResourceKind, name string
 	return fmt.Sprintf("%s application %q on device %q?", verb, appName, name)
 }
 
-func NewCmdRestartApplication() *cobra.Command {
+func NewCmdRestart() *cobra.Command {
 	o := DefaultAppLifecycleOptions()
 	cmd := &cobra.Command{
 		Use:   "restart device/NAME --app APP",
@@ -262,7 +262,7 @@ func runStop(ctx context.Context, c *apiclient.ClientWithResponses, deviceName, 
 	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "stopping", appName, "device", deviceName); err != nil {
 		return err
 	}
-	fmt.Printf("Application %q on device %q stopped\n", appName, deviceName)
+	fmt.Printf("Requested stop of application %q on device %q\n", appName, deviceName)
 	return nil
 }
 
@@ -274,7 +274,7 @@ func runStart(ctx context.Context, c *apiclient.ClientWithResponses, deviceName,
 	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "starting", appName, "device", deviceName); err != nil {
 		return err
 	}
-	fmt.Printf("Application %q on device %q started\n", appName, deviceName)
+	fmt.Printf("Requested start of application %q on device %q\n", appName, deviceName)
 	return nil
 }
 
@@ -286,7 +286,7 @@ func runRestart(ctx context.Context, c *apiclient.ClientWithResponses, deviceNam
 	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "restarting", appName, "device", deviceName); err != nil {
 		return err
 	}
-	fmt.Printf("Application %q on device %q restarted\n", appName, deviceName)
+	fmt.Printf("Requested restart of application %q on device %q\n", appName, deviceName)
 	return nil
 }
 
@@ -298,7 +298,7 @@ func runStopFleet(ctx context.Context, c *apiclient.ClientWithResponses, fleetNa
 	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "stopping", appName, "fleet", fleetName); err != nil {
 		return err
 	}
-	fmt.Printf("Application %q stopped on every device in fleet %q\n", appName, fleetName)
+	fmt.Printf("Requested stop of application %q on every device in fleet %q\n", appName, fleetName)
 	return nil
 }
 
@@ -310,7 +310,7 @@ func runStartFleet(ctx context.Context, c *apiclient.ClientWithResponses, fleetN
 	if err := checkLifecycleResponse(response.HTTPResponse, response.Body, "starting", appName, "fleet", fleetName); err != nil {
 		return err
 	}
-	fmt.Printf("Application %q started on every device in fleet %q\n", appName, fleetName)
+	fmt.Printf("Requested start of application %q on every device in fleet %q\n", appName, fleetName)
 	return nil
 }
 

--- a/internal/cli/app_lifecycle_test.go
+++ b/internal/cli/app_lifecycle_test.go
@@ -350,20 +350,69 @@ func TestRunStopFleet(t *testing.T) {
 }
 
 func TestRunStartFleet(t *testing.T) {
-	response := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(bytes.NewReader([]byte(`{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`))),
+	tests := []struct {
+		name           string
+		httpStatus     int
+		responseBody   string
+		expectError    bool
+		errorContains  string
+		expectOutput   string
+		expectAPIError bool
+	}{
+		{
+			name:         "successful start",
+			httpStatus:   http.StatusOK,
+			responseBody: `{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`,
+			expectOutput: `Application "app-1" started on every device in fleet "fleet-1"`,
+		},
+		{
+			name:           "fleet not found",
+			httpStatus:     http.StatusNotFound,
+			responseBody:   `{"message":"fleet not found"}`,
+			expectError:    true,
+			errorContains:  "starting application app-1 on fleet fleet-1: failed",
+			expectAPIError: true,
+		},
 	}
-	client, _ := newTestClient(t, response)
 
-	output := captureStdout(t, func() {
-		if err := runStartFleet(context.Background(), client, "fleet-1", "app-1"); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{
+				StatusCode: tt.httpStatus,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.responseBody))),
+			}
+			client, _ := newTestClient(t, response)
 
-	if !containsString(output, `Application "app-1" started on every device in fleet "fleet-1"`) {
-		t.Errorf("unexpected output: %q", output)
+			output := captureStdout(t, func() {
+				err := runStartFleet(context.Background(), client, "fleet-1", "app-1")
+				if tt.expectError {
+					if err == nil {
+						t.Fatalf("expected error but got none")
+					}
+					if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+						t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+					}
+					if tt.expectAPIError {
+						var cliErr *CLIError
+						if !errors.As(err, &cliErr) {
+							t.Errorf("expected error to unwrap to *CLIError, got %T", err)
+						}
+						var apiErr *APIError
+						if !errors.As(err, &apiErr) {
+							t.Errorf("expected error to unwrap to *APIError, got %T", err)
+						}
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			if !tt.expectError && !containsString(output, tt.expectOutput) {
+				t.Errorf("expected output to contain %q, got %q", tt.expectOutput, output)
+			}
+		})
 	}
 }

--- a/internal/cli/app_lifecycle_test.go
+++ b/internal/cli/app_lifecycle_test.go
@@ -189,7 +189,7 @@ func TestRunStop(t *testing.T) {
 			name:         "successful stop",
 			httpStatus:   http.StatusOK,
 			responseBody: `{"kind":"Device","apiVersion":"v1beta1","metadata":{"name":"dev-1"}}`,
-			expectOutput: `Application "app-1" on device "dev-1" stopped`,
+			expectOutput: `Requested stop of application "app-1" on device "dev-1"`,
 		},
 		{
 			name:           "device not found",
@@ -257,7 +257,7 @@ func TestRunStart(t *testing.T) {
 		}
 	})
 
-	if !containsString(output, `Application "app-1" on device "dev-1" started`) {
+	if !containsString(output, `Requested start of application "app-1" on device "dev-1"`) {
 		t.Errorf("unexpected output: %q", output)
 	}
 }
@@ -276,7 +276,7 @@ func TestRunRestart(t *testing.T) {
 		}
 	})
 
-	if !containsString(output, `Application "app-1" on device "dev-1" restarted`) {
+	if !containsString(output, `Requested restart of application "app-1" on device "dev-1"`) {
 		t.Errorf("unexpected output: %q", output)
 	}
 }
@@ -295,7 +295,7 @@ func TestRunStopFleet(t *testing.T) {
 			name:         "successful stop",
 			httpStatus:   http.StatusOK,
 			responseBody: `{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`,
-			expectOutput: `Application "app-1" stopped on every device in fleet "fleet-1"`,
+			expectOutput: `Requested stop of application "app-1" on every device in fleet "fleet-1"`,
 		},
 		{
 			name:           "fleet not found",
@@ -363,7 +363,7 @@ func TestRunStartFleet(t *testing.T) {
 			name:         "successful start",
 			httpStatus:   http.StatusOK,
 			responseBody: `{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`,
-			expectOutput: `Application "app-1" started on every device in fleet "fleet-1"`,
+			expectOutput: `Requested start of application "app-1" on every device in fleet "fleet-1"`,
 		},
 		{
 			name:           "fleet not found",

--- a/internal/cli/app_lifecycle_test.go
+++ b/internal/cli/app_lifecycle_test.go
@@ -1,0 +1,369 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestAppLifecycleOptions_resolveDeviceName(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		appName       string
+		expectError   bool
+		errorContains string
+		expectDevice  string
+	}{
+		{
+			name:         "valid device and app",
+			args:         []string{"device/my-device"},
+			appName:      "my-app",
+			expectDevice: "my-device",
+		},
+		{
+			name:          "missing app name",
+			args:          []string{"device/my-device"},
+			appName:       "",
+			expectError:   true,
+			errorContains: "--app is required",
+		},
+		{
+			name:          "wrong kind",
+			args:          []string{"fleet/my-fleet"},
+			appName:       "my-app",
+			expectError:   true,
+			errorContains: "kind must be Device",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &AppLifecycleOptions{AppName: tt.appName}
+			name, err := o.resolveDeviceName(tt.args)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tt.expectDevice {
+				t.Errorf("expected device name %q, got %q", tt.expectDevice, name)
+			}
+		})
+	}
+}
+
+func TestAppLifecycleOptions_resolveTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		appName       string
+		expectError   bool
+		errorContains string
+		expectKind    ResourceKind
+		expectName    string
+	}{
+		{
+			name:       "valid device and app",
+			args:       []string{"device/my-device"},
+			appName:    "my-app",
+			expectKind: DeviceKind,
+			expectName: "my-device",
+		},
+		{
+			name:       "valid fleet and app",
+			args:       []string{"fleet/my-fleet"},
+			appName:    "my-app",
+			expectKind: FleetKind,
+			expectName: "my-fleet",
+		},
+		{
+			name:          "missing app name",
+			args:          []string{"device/my-device"},
+			appName:       "",
+			expectError:   true,
+			errorContains: "--app is required",
+		},
+		{
+			name:          "unsupported kind",
+			args:          []string{"repository/my-repo"},
+			appName:       "my-app",
+			expectError:   true,
+			errorContains: "kind must be Device or Fleet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &AppLifecycleOptions{AppName: tt.appName}
+			kind, name, err := o.resolveTarget(tt.args)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if kind != tt.expectKind {
+				t.Errorf("expected kind %q, got %q", tt.expectKind, kind)
+			}
+			if name != tt.expectName {
+				t.Errorf("expected name %q, got %q", tt.expectName, name)
+			}
+		})
+	}
+}
+
+func TestStopStartConfirmPrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		verb     string
+		appName  string
+		kind     ResourceKind
+		target   string
+		expected string
+	}{
+		{
+			name:     "device target",
+			verb:     "Stop",
+			appName:  "my-app",
+			kind:     DeviceKind,
+			target:   "my-device",
+			expected: `Stop application "my-app" on device "my-device"?`,
+		},
+		{
+			name:     "fleet target",
+			verb:     "Start",
+			appName:  "my-app",
+			kind:     FleetKind,
+			target:   "my-fleet",
+			expected: `Start application "my-app" on every device in fleet "my-fleet"?`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stopStartConfirmPrompt(tt.verb, tt.appName, tt.kind, tt.target)
+			if got != tt.expected {
+				t.Errorf("expected prompt %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestConfirm(t *testing.T) {
+	// skip=true never touches stdin and always succeeds.
+	if err := confirm("prompt", true); err != nil {
+		t.Errorf("expected no error when skip is true, got %v", err)
+	}
+}
+
+func TestRunStop(t *testing.T) {
+	tests := []struct {
+		name           string
+		httpStatus     int
+		responseBody   string
+		expectError    bool
+		errorContains  string
+		expectOutput   string
+		expectAPIError bool
+	}{
+		{
+			name:         "successful stop",
+			httpStatus:   http.StatusOK,
+			responseBody: `{"kind":"Device","apiVersion":"v1beta1","metadata":{"name":"dev-1"}}`,
+			expectOutput: `Application "app-1" on device "dev-1" stopped`,
+		},
+		{
+			name:           "device not found",
+			httpStatus:     http.StatusNotFound,
+			responseBody:   `{"message":"device not found"}`,
+			expectError:    true,
+			errorContains:  "stopping application app-1 on device dev-1: failed",
+			expectAPIError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{
+				StatusCode: tt.httpStatus,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.responseBody))),
+			}
+			client, _ := newTestClient(t, response)
+
+			output := captureStdout(t, func() {
+				err := runStop(context.Background(), client, "dev-1", "app-1")
+				if tt.expectError {
+					if err == nil {
+						t.Fatalf("expected error but got none")
+					}
+					if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+						t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+					}
+					if tt.expectAPIError {
+						var cliErr *CLIError
+						if !errors.As(err, &cliErr) {
+							t.Errorf("expected error to unwrap to *CLIError, got %T", err)
+						}
+						var apiErr *APIError
+						if !errors.As(err, &apiErr) {
+							t.Errorf("expected error to unwrap to *APIError, got %T", err)
+						}
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			if !tt.expectError && !containsString(output, tt.expectOutput) {
+				t.Errorf("expected output to contain %q, got %q", tt.expectOutput, output)
+			}
+		})
+	}
+}
+
+func TestRunStart(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"kind":"Device","apiVersion":"v1beta1","metadata":{"name":"dev-1"}}`))),
+	}
+	client, _ := newTestClient(t, response)
+
+	output := captureStdout(t, func() {
+		if err := runStart(context.Background(), client, "dev-1", "app-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !containsString(output, `Application "app-1" on device "dev-1" started`) {
+		t.Errorf("unexpected output: %q", output)
+	}
+}
+
+func TestRunRestart(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"kind":"Device","apiVersion":"v1beta1","metadata":{"name":"dev-1"}}`))),
+	}
+	client, _ := newTestClient(t, response)
+
+	output := captureStdout(t, func() {
+		if err := runRestart(context.Background(), client, "dev-1", "app-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !containsString(output, `Application "app-1" on device "dev-1" restarted`) {
+		t.Errorf("unexpected output: %q", output)
+	}
+}
+
+func TestRunStopFleet(t *testing.T) {
+	tests := []struct {
+		name           string
+		httpStatus     int
+		responseBody   string
+		expectError    bool
+		errorContains  string
+		expectOutput   string
+		expectAPIError bool
+	}{
+		{
+			name:         "successful stop",
+			httpStatus:   http.StatusOK,
+			responseBody: `{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`,
+			expectOutput: `Application "app-1" stopped on every device in fleet "fleet-1"`,
+		},
+		{
+			name:           "fleet not found",
+			httpStatus:     http.StatusNotFound,
+			responseBody:   `{"message":"fleet not found"}`,
+			expectError:    true,
+			errorContains:  "stopping application app-1 on fleet fleet-1: failed",
+			expectAPIError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{
+				StatusCode: tt.httpStatus,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.responseBody))),
+			}
+			client, _ := newTestClient(t, response)
+
+			output := captureStdout(t, func() {
+				err := runStopFleet(context.Background(), client, "fleet-1", "app-1")
+				if tt.expectError {
+					if err == nil {
+						t.Fatalf("expected error but got none")
+					}
+					if tt.errorContains != "" && !containsString(err.Error(), tt.errorContains) {
+						t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+					}
+					if tt.expectAPIError {
+						var cliErr *CLIError
+						if !errors.As(err, &cliErr) {
+							t.Errorf("expected error to unwrap to *CLIError, got %T", err)
+						}
+						var apiErr *APIError
+						if !errors.As(err, &apiErr) {
+							t.Errorf("expected error to unwrap to *APIError, got %T", err)
+						}
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			if !tt.expectError && !containsString(output, tt.expectOutput) {
+				t.Errorf("expected output to contain %q, got %q", tt.expectOutput, output)
+			}
+		})
+	}
+}
+
+func TestRunStartFleet(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"kind":"Fleet","apiVersion":"v1beta1","metadata":{"name":"fleet-1"}}`))),
+	}
+	client, _ := newTestClient(t, response)
+
+	output := captureStdout(t, func() {
+		if err := runStartFleet(context.Background(), client, "fleet-1", "app-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !containsString(output, `Application "app-1" started on every device in fleet "fleet-1"`) {
+		t.Errorf("unexpected output: %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds CLI support for device application lifecycle control: `flightctl stop|start|restart device/NAME --app APP`
- `stop`/`start` call `StopDeviceApplication`/`StartDeviceApplication` to set the application's desired state to `stopped`/`running`
- `restart` calls `RestartDeviceApplication` to increment `restartGeneration`
- Each command prompts for confirmation before acting, with `-y`/`--yes` to skip the prompt for scripting

Note: this branch is based on EDM-4098 (#3117) and EDM-4102 (#3198), so it includes their commits until those PRs merge into `main`; the diff will shrink to just the CLI commit once they land.

## Test plan
- [ ] `go build ./...`
- [ ] `flightctl stop device/NAME --app APP` / `start` / `restart` against a running dev environment

Made with [Cursor](https://cursor.com)