### PR TITLE
NO-ISSUE: Fix duplicate systemd unit path in deb package

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -25,5 +25,4 @@ override_dh_auto_install:
 
 	dh_install
 
-	install -D -m 644 debian/flightctl-agent.service debian/flightctl-agent/lib/systemd/system/flightctl-agent.service
 	install -d -m 755 debian/flightctl-agent/etc/issues.d


### PR DESCRIPTION
Remove the manual lib/systemd install so dh_installsystemd is the sole source of the unit file, fixing dpkg install failures on merged-usr systems.

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
