### PR TITLE
EDM-4696: add NetworkPolicy to allow OCP Router access to cli-artifacts

### DIFF
--- a/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{ if and (.Values.cliArtifacts.enabled) (eq (include "flightctl.enableMulticlusterExtensions" .) "false") (eq (include "flightctl.getServiceExposeMethod" .) "route") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-cli-artifacts-from-ingress
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-cli-artifacts
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-cli-artifacts
+  policyTypes:
+  - Ingress
+{{ end }}


### PR DESCRIPTION
## Summary

- The Helm chart deploys a `allow-from-flightctl` NetworkPolicy that blocks all external ingress to every pod in the `flightctl` namespace.
- All other services with an OpenShift Route (e.g. `flightctl-api`, `flightctl-ui`) have a corresponding NetworkPolicy that explicitly allows ingress from the `openshift-ingress` namespace (OCP Router).
- `flightctl-cli-artifacts` was missing this policy, so the OCP Router's requests were silently dropped by OVN-Kubernetes, returning HTTP 503 for all CLI artifact downloads in standalone OCP deployments.

## Fix

Add `flightctl-cli-artifacts-networkpolicy.yaml` — modeled on the existing `flightctl-api-networkpolicy.yaml` — which allows ingress from the `openshift-ingress` namespace to pods labelled `flightctl.service=flightctl-cli-artifacts`. The policy is gated on the same conditions as the Route itself (`enableMulticlusterExtensions=false` and `exposeServicesMethod=route`).

## Verification

Manually applied the policy to `ocp-edge124` (cluster `ocp3m0w-ic4s20`). CLI artifact URLs that previously returned 503 now return HTTP 200.

Fixes: [EDM-4696](https://redhat.atlassian.net/browse/EDM-4696)
Related: [EDM-3771](https://redhat.atlassian.net/browse/EDM-3771)

## Test plan

- [ ] Deploy to a standalone OCP cluster with `exposeServicesMethod=route`.
- [ ] Confirm that all CLI artifact download URLs are accessible from outside the cluster (HTTP 200).
- [ ] Confirm that ACM/multicluster deployments (`enableMulticlusterExtensions=true`) are not affected (policy not rendered).