### PR TITLE
NO-ISSUE: add buildah cache for smoke test container builds

### DIFF
--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -95,6 +95,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bootc-cache-smoke-
 
+      - name: Set buildah cache path
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        run: echo "BUILDAH_CACHE_PATH=${TMPDIR:-/var/tmp}/buildah-cache-$(id -u)" >> "$GITHUB_ENV"
+
+      - name: Restore buildah cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.BUILDAH_CACHE_PATH }}
+          key: ${{ runner.os }}-buildah-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-buildah-
+
       - name: Create cluster
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make cluster
@@ -102,6 +115,13 @@ jobs:
       - name: Deploy
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: DISABLE_FIPS="true" make deploy
+
+      - name: Save buildah cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.BUILDAH_CACHE_PATH }}
+          key: ${{ runner.os }}-buildah-${{ github.run_id }}
 
       - name: Check
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}


### PR DESCRIPTION
## Summary
- The smoke test workflow's `make deploy` step builds all backend containers via podman with `--mount=type=cache` buildah cache mounts, but the workflow only cached the host's `~/.cache/go-build`/`~/go/pkg/mod` via `actions/cache`, which podman container builds never use (same issue fixed for `build-images-and-charts.yaml` in #3186).
- Add Restore/Save buildah cache steps targeting `${TMPDIR:-/var/tmp}/buildah-cache-<uid>`, saved only on `main` to avoid cache thrashing across concurrent PRs.
- Since the key prefix (`${{ runner.os }}-buildah-`) and underlying Containerfiles are identical to `build-images-and-charts.yaml`, this workflow shares a warm cache with it rather than maintaining an independent cold one.
- Kept the existing Go modules cache as-is, since this job's single step also runs native `go build` (via `build-cli`/`build-devicesimulator`) which does benefit from it — only the container build step needed the buildah cache fix.

## Test plan
- [ ] Confirm the `Smoke tests` workflow passes on this PR
- [ ] After merging, confirm a subsequent `main` push saves a `Linux-buildah-*` cache entry
- [ ] Confirm the next smoke test run (PR or main) restores that cache and shows a warm `make deploy` container build

Made with [Cursor](https://cursor.com)