### PR TITLE
NO-ISSUE: exclude no-op runs from e2e health report timing averages

### DIFF
--- a/test/scripts/analyze_e2e_health/compute.go
+++ b/test/scripts/analyze_e2e_health/compute.go
@@ -24,6 +24,14 @@ type pipelineAgg struct {
 	phases      map[string][]float64
 	shardCounts map[string][]int
 	wallTimes   []float64
+	// noOpRuns holds runs that concluded "success" but never actually ran the
+	// e2e suite — e.g. a push that didn't touch any path matched by the
+	// workflow's changed-files filter, so every substantive job shows as
+	// GitHub-conclusion "skipped" while a trivial gate job still passes in
+	// seconds. These are excluded from wallTimes/phases (see aggregateRawJobs)
+	// and from JUnit-based accounting (see computeReport) since they carry no
+	// signal about real pipeline performance.
+	noOpRuns []runRef
 }
 
 // junitAgg is the in-memory result of aggregating raw JUnit run data.
@@ -45,8 +53,21 @@ type specResult struct {
 	GinkgoLabel     string `json:"ginkgo_label,omitempty"`
 }
 
+// hasPositiveDuration reports whether any key containing substr has a
+// positive duration in durByKey.
+func hasPositiveDuration(durByKey map[string]float64, substr string) bool {
+	for key, dur := range durByKey {
+		if dur > 0 && strings.Contains(key, substr) {
+			return true
+		}
+	}
+	return false
+}
+
 // aggregateRawJobs converts raw per-run job data into pipeline timing observations.
 // Only successful runs contribute — failed runs abort early and skew averages.
+// Runs that concluded "success" without actually running the e2e suite (see
+// pipelineAgg.noOpRuns) are also excluded from timing observations.
 func aggregateRawJobs(rawRuns []rawRunEntry) pipelineAgg {
 	agg := pipelineAgg{
 		phases:      make(map[string][]float64),
@@ -103,6 +124,18 @@ func aggregateRawJobs(rawRuns []rawRunEntry) pipelineAgg {
 					stepMaxDur[stepKey] = step.DurationSec
 				}
 			}
+		}
+
+		// A run whose changed-files filter matched nothing has every
+		// substantive job show up as GitHub-conclusion "skipped" (start ==
+		// end, so jobDur <= 0 above filters them out of jobMaxDur), while a
+		// trivial gate job still lets the run conclude "success" in seconds.
+		// Such a run carries no signal about real pipeline duration — treat
+		// it as a no-op rather than let its near-zero wall time drag down
+		// the average.
+		if !hasPositiveDuration(jobMaxDur, "e2e-test") {
+			agg.noOpRuns = append(agg.noOpRuns, runRef{RunID: run.RunID, RunURL: run.RunURL, Date: run.Date})
+			continue
 		}
 
 		// Wall time = max(job.CompletedAt) - run.StartedAt, matching what
@@ -355,12 +388,15 @@ type reportData struct {
 	EstimatedWallTimeSecs float64
 	BaselineShardSecs     float64 // LPT slowest-shard estimate at current node count
 	PipelineOverviewReady bool    // true when overhead+shard breakdown is valid
+	PipelineSampleCount   int     // runs actually contributing to EstimatedWallTimeSecs (excludes no-op runs)
 
 	// Section 2: Flaky tests.
 	FlakeEntries             []flakeEntry
 	InfraInstabilityCount    int
 	PreTestFailureCount      int
 	PreTestFailureRefs       []runRef
+	NoOpRunCount             int // runs that concluded "success" without running the e2e suite at all
+	NoOpRunRefs              []runRef
 	TotalAnalyzedSpecs       int
 	FlakyCount               int
 	ConsistentlyFailingCount int
@@ -595,15 +631,26 @@ func computeShardDistrib(rawRuns []rawRunEntry, discoverySpecs []e2etestutils.Sp
 }
 
 func computeReport(jobsFile rawJobsFile, junitFiles []rawJUnitFile, discoverySpecs []e2etestutils.SpecInfo, topN int) *reportData {
+	pagg := aggregateRawJobs(jobsFile.Runs)
+
+	noOpRunIDs := make(map[int64]bool, len(pagg.noOpRuns))
+	for _, ref := range pagg.noOpRuns {
+		noOpRunIDs[ref.RunID] = true
+	}
+
 	// All run references come from jobsFile.Runs — every collected run has an
 	// entry there, including failed runs (with empty Jobs). This is the
-	// single source of truth for "what runs were analyzed".
+	// single source of truth for "what runs were analyzed", excluding no-op
+	// runs (pagg.noOpRuns) so they aren't miscounted as pre-test failures —
+	// they never ran, they didn't fail before running.
 	allRunRefs := make([]runRef, 0, len(jobsFile.Runs))
 	for _, jr := range jobsFile.Runs {
+		if noOpRunIDs[jr.RunID] {
+			continue
+		}
 		allRunRefs = append(allRunRefs, runRef{RunID: jr.RunID, RunURL: jr.RunURL, Date: jr.Date})
 	}
 
-	pagg := aggregateRawJobs(jobsFile.Runs)
 	jagg := aggregateJUnit(junitFiles, allRunRefs)
 	timings := computeTimings(junitFiles, allRunRefs)
 
@@ -614,10 +661,13 @@ func computeReport(jobsFile rawJobsFile, junitFiles []rawJUnitFile, discoverySpe
 		InfraInstabilityCount: len(jagg.infraRuns),
 		PreTestFailureCount:   len(jagg.noJUnit),
 		PreTestFailureRefs:    jagg.noJUnit,
+		NoOpRunCount:          len(pagg.noOpRuns),
+		NoOpRunRefs:           pagg.noOpRuns,
 	}
 
 	r.PipelinePhases = buildPipelinePhases(pagg)
 	r.EstimatedWallTimeSecs = estimateWallTime(pagg)
+	r.PipelineSampleCount = len(pagg.wallTimes)
 
 	r.FlakeEntries, r.TotalAnalyzedSpecs, r.FlakyCount, r.ConsistentlyFailingCount, r.CleanCount = computeFlakes(jagg)
 
@@ -808,7 +858,6 @@ func computeSlowest(timings map[string]specTiming, topN int) []specEntry {
 	}
 	return specs
 }
-
 
 // lptSimulate runs the LPT algorithm with the given timings and returns the
 // estimated total workflow time (pipeline overhead + max shard duration).
@@ -1077,4 +1126,3 @@ func inferShardCount(agg pipelineAgg) int {
 	}
 	return 10
 }
-

--- a/test/scripts/analyze_e2e_health/main_test.go
+++ b/test/scripts/analyze_e2e_health/main_test.go
@@ -499,6 +499,105 @@ func TestBuildPipelinePhases(t *testing.T) {
 	})
 }
 
+// TestHasPositiveDuration covers the substring/positive-duration lookup used
+// to detect no-op runs.
+func TestHasPositiveDuration(t *testing.T) {
+	t.Run("When a matching key has a positive duration it should return true", func(t *testing.T) {
+		require.True(t, hasPositiveDuration(map[string]float64{"e2e-tests_cs10": 120, "build-rpms": 0}, "e2e-test"))
+	})
+
+	t.Run("When no key matches the substring it should return false", func(t *testing.T) {
+		require.False(t, hasPositiveDuration(map[string]float64{"build-rpms": 90}, "e2e-test"))
+	})
+
+	t.Run("When the matching key has a zero duration it should return false", func(t *testing.T) {
+		require.False(t, hasPositiveDuration(map[string]float64{"e2e-tests_cs10": 0}, "e2e-test"))
+	})
+}
+
+// TestAggregateRawJobsExcludesNoOpRuns verifies that a run which concluded
+// "success" without ever running the e2e suite — e.g. a push whose
+// changed-files filter matched nothing, so every substantive job shows as
+// GitHub-conclusion "skipped" (identical start/end timestamps) while a
+// trivial gate job still passes in seconds — is excluded from wall time and
+// tracked separately instead of polluting the average with a near-zero
+// duration.
+func TestAggregateRawJobsExcludesNoOpRuns(t *testing.T) {
+	genuineRun := rawRunEntry{
+		RunID:      1,
+		RunURL:     "https://github.com/flightctl/flightctl/actions/runs/1",
+		Date:       "2026-01-01",
+		StartedAt:  "2026-01-01T08:00:00Z",
+		Conclusion: "success",
+		Jobs: []rawJobEntry{
+			{Name: "build-images-and-charts", StartedAt: "2026-01-01T08:00:00Z", CompletedAt: "2026-01-01T08:10:00Z"},
+			{Name: "e2e-tests (cs10, 1)", StartedAt: "2026-01-01T08:10:00Z", CompletedAt: "2026-01-01T08:40:00Z"},
+		},
+	}
+	noOpRun := rawRunEntry{
+		RunID:      2,
+		RunURL:     "https://github.com/flightctl/flightctl/actions/runs/2",
+		Date:       "2026-01-02",
+		StartedAt:  "2026-01-02T09:00:00Z",
+		Conclusion: "success",
+		Jobs: []rawJobEntry{
+			{Name: "compute-tag", StartedAt: "2026-01-02T09:00:00Z", CompletedAt: "2026-01-02T09:00:05Z"},
+			{Name: "e2e-tests", StartedAt: "2026-01-02T09:00:08Z", CompletedAt: "2026-01-02T09:00:08Z"},
+			{Name: "e2e", StartedAt: "2026-01-02T09:00:19Z", CompletedAt: "2026-01-02T09:00:21Z"},
+		},
+	}
+
+	agg := aggregateRawJobs([]rawRunEntry{genuineRun, noOpRun})
+
+	t.Run("When a run never executed the e2e suite it should be excluded from wall times", func(t *testing.T) {
+		require.Len(t, agg.wallTimes, 1, "only the genuine run should contribute a wall time")
+	})
+
+	t.Run("When a run never executed the e2e suite it should be tracked as a no-op run", func(t *testing.T) {
+		require.Len(t, agg.noOpRuns, 1)
+		require.Equal(t, int64(2), agg.noOpRuns[0].RunID)
+	})
+}
+
+// TestComputeReportExcludesNoOpRunsFromPreTestFailures verifies that no-op
+// runs are not double-counted as "pre-test failures" — they never ran, they
+// didn't fail before running.
+func TestComputeReportExcludesNoOpRunsFromPreTestFailures(t *testing.T) {
+	jobsFile := rawJobsFile{
+		Meta: collectMeta{AnalyzedRuns: 2},
+		Runs: []rawRunEntry{
+			{
+				RunID:      1,
+				RunURL:     "https://github.com/flightctl/flightctl/actions/runs/1",
+				Date:       "2026-01-01",
+				StartedAt:  "2026-01-01T08:00:00Z",
+				Conclusion: "success",
+				Jobs: []rawJobEntry{
+					{Name: "e2e-tests (cs10, 1)", StartedAt: "2026-01-01T08:00:00Z", CompletedAt: "2026-01-01T08:30:00Z"},
+				},
+			},
+			{
+				RunID:      2,
+				RunURL:     "https://github.com/flightctl/flightctl/actions/runs/2",
+				Date:       "2026-01-02",
+				StartedAt:  "2026-01-02T09:00:00Z",
+				Conclusion: "success",
+				Jobs: []rawJobEntry{
+					{Name: "e2e-tests", StartedAt: "2026-01-02T09:00:08Z", CompletedAt: "2026-01-02T09:00:08Z"},
+				},
+			},
+		},
+	}
+	// Neither run has JUnit artifacts in this fixture; only run 1 (genuine)
+	// should end up flagged as a pre-test failure.
+	report := computeReport(jobsFile, nil, nil, 10)
+
+	require.Equal(t, 1, report.NoOpRunCount)
+	require.Equal(t, int64(2), report.NoOpRunRefs[0].RunID)
+	require.Equal(t, 1, report.PreTestFailureCount)
+	require.Equal(t, int64(1), report.PreTestFailureRefs[0].RunID)
+}
+
 // TestRenderHTML exercises the render path using fixture raw files.
 func TestRenderHTML(t *testing.T) {
 	var jobsFile rawJobsFile

--- a/test/scripts/analyze_e2e_health/render.go
+++ b/test/scripts/analyze_e2e_health/render.go
@@ -27,18 +27,19 @@ type renderContext struct {
 
 type slackSummary struct {
 	// Pipeline timing (mirrors overview row 1)
-	WallTimeSecs            float64 `json:"wall_time_seconds"`
-	PrepareTimeSecs         float64 `json:"prepare_time_seconds"`
-	TestingTimeSecs         float64 `json:"testing_time_seconds"`
-	InferredShards          int     `json:"inferred_shards"`
-	AnalyzedRuns            int     `json:"analyzed_runs"`
+	WallTimeSecs    float64 `json:"wall_time_seconds"`
+	PrepareTimeSecs float64 `json:"prepare_time_seconds"`
+	TestingTimeSecs float64 `json:"testing_time_seconds"`
+	InferredShards  int     `json:"inferred_shards"`
+	AnalyzedRuns    int     `json:"analyzed_runs"`
 	// Test health (mirrors overview row 2)
-	TotalSpecsTracked       int     `json:"total_specs_tracked"`
-	ConsistentlyFailing     int     `json:"consistently_failing"`
-	FlakyTests              int     `json:"flaky_tests"`
-	NeverFailed             int     `json:"never_failed"`
+	TotalSpecsTracked   int `json:"total_specs_tracked"`
+	ConsistentlyFailing int `json:"consistently_failing"`
+	FlakyTests          int `json:"flaky_tests"`
+	NeverFailed         int `json:"never_failed"`
 	// Extra context
 	InfraInstabilityEvents  int     `json:"infra_instability_events"`
+	NoOpRunsExcluded        int     `json:"no_op_runs_excluded"`
 	OptimizationSavingsSecs float64 `json:"optimization_savings_seconds"`
 }
 
@@ -87,6 +88,7 @@ func renderSlackSummary(r *reportData, path string) error {
 		FlakyTests:              r.FlakyCount,
 		NeverFailed:             r.CleanCount,
 		InfraInstabilityEvents:  r.InfraInstabilityCount,
+		NoOpRunsExcluded:        r.NoOpRunCount,
 		OptimizationSavingsSecs: r.OptimBaselineWorkflowSecs - r.OptimBestWorkflowSecs,
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -109,7 +111,11 @@ func appendStepSummary(r *reportData) error {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "<h1>E2E Health Report</h1>\n")
-	fmt.Fprintf(&b, "<p>Generated: %s &nbsp;·&nbsp; %d runs analyzed</p>\n", r.GeneratedAt, r.AnalyzedRuns)
+	fmt.Fprintf(&b, "<p>Generated: %s &nbsp;·&nbsp; %d runs analyzed", r.GeneratedAt, r.AnalyzedRuns)
+	if r.NoOpRunCount > 0 {
+		fmt.Fprintf(&b, " (%d skipped the e2e suite entirely, excluded from timing)", r.NoOpRunCount)
+	}
+	fmt.Fprintf(&b, "</p>\n")
 
 	fmt.Fprintf(&b, "<h2>Pipeline Timing</h2>\n")
 	fmt.Fprintf(&b, "<table><thead><tr><th>Phase</th><th>Avg</th><th>±StdDev</th></tr></thead><tbody>\n")

--- a/test/scripts/analyze_e2e_health/template.html
+++ b/test/scripts/analyze_e2e_health/template.html
@@ -132,10 +132,22 @@ dialog.lpt-debug::backdrop{background:rgba(0,0,0,.5)}
   </div>
 </div>
 
+{{if gt .NoOpRunCount 0}}
+<div class="warn-box" style="border-color:var(--blue)">
+  <span class="warn-icon" style="color:var(--blue)">&#9432;</span>
+  <div class="warn-body">
+    <div class="warn-title">{{.NoOpRunCount}} run(s) skipped the e2e suite entirely (no matching file changes) — excluded from timing averages</div>
+    <div class="warn-links">
+      {{range .NoOpRunRefs}}<a href="{{.RunURL}}" target="_blank" style="border-color:var(--blue);color:var(--blue)">{{.Date}}</a>{{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
 <section id="pipeline">
 <div class="card">
   <h2>Pipeline Timing</h2>
-  <div class="meta">Average wall-clock durations over {{.AnalyzedRuns}} analyzed runs (±1σ shown next to each value)</div>
+  <div class="meta">Average wall-clock durations over {{.PipelineSampleCount}} analyzed runs (±1σ shown next to each value)</div>
   {{if .PipelinePhases}}
   <div class="chart-wrap" style="max-height:420px;overflow-y:auto">{{.PipelineChartSVG}}</div>
   <p class="meta" style="margin-top:4px">* slowest shard across parallel matrix jobs</p>


### PR DESCRIPTION
## Summary

- The e2e health report's wall-time average was being skewed by "no-op" runs: pushes whose changed-files filter matched nothing still conclude `success`, but every substantive job (build, `e2e-tests`, etc.) shows as GitHub-conclusion `skipped` with near-zero duration.
- These runs were silently blended into the wall-time average and also miscounted as "pre-test failures" (no JUnit artifacts, since the suite never ran).
- Concretely, this is what produced the misleading **44m 45s** average in an earlier report: 9 genuine full runs averaging **64.5 min** were diluted by 4 near-instant skip runs averaging **0.4 min**, blending down to 44.8 min — a number that was never a real pipeline duration.
- Detect these runs (`hasPositiveDuration` on job durations containing `e2e-test`) and exclude them from `wallTimes`/`phases` and from the pre-test-failure count, instead surfacing them in their own report callout (`NoOpRunCount`/`NoOpRunRefs`) so the exclusion is transparent rather than silent.
- Report now shows the sample count actually contributing to timing (`PipelineSampleCount`) rather than the raw analyzed-run count, and the Slack summary includes a `no_op_runs_excluded` field.

## Test plan

- [x] Added unit tests: `TestHasPositiveDuration`, `TestAggregateRawJobsExcludesNoOpRuns`, `TestComputeReportExcludesNoOpRunsFromPreTestFailures`.
- [x] `go test ./test/scripts/analyze_e2e_health/...` passes.
- [x] Manually verified against the fixture/report data that no-op runs (skip due to path filters) no longer drag down the reported average or inflate the pre-test-failure count.

Made with [Cursor](https://cursor.com)