### PR TITLE
NO-ISSUE: overlap E2E aux service setup with VM boot, stream image bundle via skopeo

### DIFF
--- a/test/e2e/agent/agent_suite_test.go
+++ b/test/e2e/agent/agent_suite_test.go
@@ -48,9 +48,10 @@ func TestAgent(t *testing.T) {
 var auxSvcs *auxiliary.Services
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/applications/containers/containers_suite_test.go
+++ b/test/e2e/applications/containers/containers_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/util"
@@ -18,9 +17,10 @@ func TestContainers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/applications/helm/helm_suite_test.go
+++ b/test/e2e/applications/helm/helm_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,8 +16,9 @@ func TestHelm(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	_, _, err := e2e.SetupWorkerHarness()
+	auxFuture.Wait()
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/test/e2e/backup_restore/backup_restore_suite_test.go
+++ b/test/e2e/backup_restore/backup_restore_suite_test.go
@@ -37,10 +37,11 @@ func TestBackupRestore(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	// Most specs only exercise backup/restore binaries against the cluster; VM pool is started on demand for needvm specs.
 	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	auxSvcs = auxFuture.Wait()
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/test/e2e/basic_operations/basic_operations_suite_test.go
+++ b/test/e2e/basic_operations/basic_operations_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -18,9 +17,10 @@ func TestBasicOperations(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/certificate_rotation/certificate_rotation_suite_test.go
+++ b/test/e2e/certificate_rotation/certificate_rotation_suite_test.go
@@ -30,7 +30,7 @@ func TestCertificateRotation(t *testing.T) {
 var auxSvcs *auxiliary.Services
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 
 	// Configure the API server to issue short-lived management certificates
@@ -40,6 +40,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/cli/cli_suite_test.go
+++ b/test/e2e/cli/cli_suite_test.go
@@ -31,9 +31,10 @@ func init() {
 var auxSvcs *auxiliary.Services
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/configuration/configuration_suite_test.go
+++ b/test/e2e/configuration/configuration_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -22,10 +21,11 @@ func TestConfiguration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	// Setup VM and harness for this worker
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/decommission/decommission_suite_test.go
+++ b/test/e2e/decommission/decommission_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -33,9 +32,10 @@ func TestCLIDecommission(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/field_selectors/field_selectors_suite_test.go
+++ b/test/e2e/field_selectors/field_selectors_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -18,10 +17,11 @@ func TestFieldSelector(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	// Setup VM and harness for this worker
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/hooks/hooks_suite_test.go
+++ b/test/e2e/hooks/hooks_suite_test.go
@@ -24,9 +24,10 @@ func TestHooks(t *testing.T) {
 var auxSvcs *auxiliary.Services
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/infra/auxiliary/images.go
+++ b/test/e2e/infra/auxiliary/images.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 )
@@ -18,6 +19,12 @@ import (
 const (
 	agentBundlePattern = "agent-images-bundle-*.tar"
 	appBundleName      = "app-images-bundle.tar"
+
+	// uploadConcurrency bounds how many images are copied out of a bundle at once.
+	// This is I/O-bound work (reading tar offsets, pushing to a local registry), so
+	// running several in parallel overlaps their I/O wait without oversubscribing the
+	// runner's CPU.
+	uploadConcurrency = 4
 )
 
 // UploadImages uploads all image bundles to the registry.
@@ -57,28 +64,17 @@ func (s *Services) findImageBundles(projectRoot string) []string {
 	return bundles
 }
 
-func getImageDigest(imageRef string, tlsVerify bool) string {
-	tlsArg := fmt.Sprintf("--tls-verify=%v", tlsVerify)
-	cmd := exec.Command("skopeo", "inspect", tlsArg, "--format", "{{.Digest}}", imageRef)
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(output))
-}
-
-func (s *Services) imageNeedsPush(localRef, registryRef string) bool {
-	localDigest := getImageDigest("containers-storage:"+localRef, false)
-	if localDigest == "" {
-		return true
-	}
-	registryDigest := getImageDigest("docker://"+registryRef, false)
-	if registryDigest == "" {
-		return true
-	}
-	return localDigest != registryDigest
-}
-
+// uploadBundle copies every image in the bundle straight from the archive to the
+// registry via "skopeo copy docker-archive:...", in parallel across images. This is
+// only called when the registry container was just created (see StartServices), so
+// the registry is always empty here - there's no digest check to skip redundant
+// pushes because every image needs pushing.
+//
+// This intentionally skips "podman load": loading a bundle of bootc images means
+// extracting a full OS root filesystem (many small files) into local containers
+// storage just to immediately read it back out for push. skopeo streams the already
+// packaged layer blobs directly from the tar to the registry without ever touching
+// local storage.
 func (s *Services) uploadBundle(bundlePath string) error {
 	refs, err := extractImageRefs(bundlePath)
 	if err != nil {
@@ -87,34 +83,42 @@ func (s *Services) uploadBundle(bundlePath string) error {
 	if len(refs) == 0 {
 		return nil
 	}
-	loadCmd := exec.Command("podman", "load", "-i", bundlePath)
-	if output, err := loadCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("podman load -i %s failed: %w, output: %s", bundlePath, err, string(output))
-	}
-	var needsPush []string
+
+	sem := make(chan struct{}, uploadConcurrency)
+	errCh := make(chan error, len(refs))
+	var wg sync.WaitGroup
 	for _, ref := range refs {
-		path := ref
-		if idx := strings.Index(ref, "/"); idx != -1 {
-			path = ref[idx+1:]
-		}
-		registryRef := fmt.Sprintf("%s/%s", s.Registry.URL, path)
-		if s.imageNeedsPush(ref, registryRef) {
-			needsPush = append(needsPush, ref)
+		wg.Add(1)
+		go func(ref string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			errCh <- s.copyImageFromBundle(bundlePath, ref)
+		}(ref)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			return err
 		}
 	}
-	if len(needsPush) == 0 {
-		return nil
+	return nil
+}
+
+// copyImageFromBundle copies a single image reference out of a multi-image
+// docker-archive bundle directly to the registry.
+func (s *Services) copyImageFromBundle(bundlePath, ref string) error {
+	path := ref
+	if idx := strings.Index(ref, "/"); idx != -1 {
+		path = ref[idx+1:]
 	}
-	for _, ref := range needsPush {
-		path := ref
-		if idx := strings.Index(ref, "/"); idx != -1 {
-			path = ref[idx+1:]
-		}
-		dst := fmt.Sprintf("%s/%s", s.Registry.URL, path)
-		pushCmd := exec.Command("podman", "push", "--tls-verify=false", ref, dst)
-		if output, err := pushCmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("podman push failed for %s: %w, output: %s", ref, err, string(output))
-		}
+	src := fmt.Sprintf("docker-archive:%s:%s", bundlePath, ref)
+	dst := fmt.Sprintf("docker://%s/%s", s.Registry.URL, path)
+	copyCmd := exec.Command("skopeo", "copy", "--dest-tls-verify=false", src, dst)
+	if output, err := copyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("skopeo copy failed for %s: %w, output: %s", ref, err, string(output))
 	}
 	return nil
 }

--- a/test/e2e/label_selectors/label_selectors_suite_test.go
+++ b/test/e2e/label_selectors/label_selectors_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
@@ -18,10 +17,11 @@ func TestLabelSelectors(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	// Setup VM and harness for this worker
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_suite_test.go
+++ b/test/e2e/microshift_acm_enrollment/microshift_acm_enrollment_suite_test.go
@@ -24,9 +24,10 @@ func TestMicroshift(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/observability/observability_suite_test.go
+++ b/test/e2e/observability/observability_suite_test.go
@@ -28,9 +28,10 @@ func TestObservability(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxSvcs = auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/parametrisable_templates/parametrisable_templates_suite_test.go
+++ b/test/e2e/parametrisable_templates/parametrisable_templates_suite_test.go
@@ -25,14 +25,15 @@ func TestParametrisableTemplates(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx := context.Background()
-	auxSvcs = auxiliary.Get(ctx)
-
-	fileServerSvcs, err := auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceFileServer})
-	Expect(err).ToNot(HaveOccurred(), "failed to start file server")
-	auxSvcs.FileServer = fileServerSvcs.FileServer
+	auxFuture := e2e.StartAuxServicesAsync(ctx)
 
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+
+	auxSvcs = auxFuture.Wait()
+	fileServerSvcs, err := auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceFileServer})
+	Expect(err).ToNot(HaveOccurred(), "failed to start file server")
+	auxSvcs.FileServer = fileServerSvcs.FileServer
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/quadlets/quadlets_suite_test.go
+++ b/test/e2e/quadlets/quadlets_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
@@ -30,9 +29,10 @@ func TestQuadlets(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/rbac/rbac_suite_test.go
+++ b/test/e2e/rbac/rbac_suite_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
@@ -24,9 +23,10 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 
 	// Check if ACM is installed before running any tests
 	isAcmInstalled, _, err := util.IsAcmInstalled()

--- a/test/e2e/selectors/selectors_suite_test.go
+++ b/test/e2e/selectors/selectors_suite_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/util"
@@ -33,10 +32,11 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	// Setup VM and harness for this worker
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/tpm/tpm_suite_test.go
+++ b/test/e2e/tpm/tpm_suite_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	. "github.com/onsi/ginkgo/v2"
@@ -34,9 +33,10 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 
 	suiteCtx := e2e.GetWorkerContext()
 

--- a/test/e2e/vm/vm_suite_test.go
+++ b/test/e2e/vm/vm_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/util"
@@ -19,9 +18,10 @@ func TestVM(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	auxiliary.Get(context.Background())
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
 	e2e.SetupWorkerHarnessOrAbort()
+	auxFuture.Wait()
 })
 
 var _ = BeforeEach(func() {

--- a/test/harness/e2e/worker_utils.go
+++ b/test/harness/e2e/worker_utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
 )
@@ -90,6 +91,32 @@ func SetupWorkerHarnessWithoutVM() (*Harness, context.Context, error) {
 
 	logrus.Infof("✅ [SetupWorkerHarnessWithoutVM] Worker %d: Harness setup completed (no VM)", workerID)
 	return harness, suiteCtx, nil
+}
+
+// AuxServicesFuture represents an in-flight auxiliary.Get call. Aux service setup
+// (registry, image bundle upload, git server, prometheus) and VM/harness setup are
+// independent of each other (aux uses podman networking, VM setup uses libvirt), so
+// starting aux in the background and waiting on it after VM setup overlaps the two
+// instead of paying both latencies sequentially. On the first package to run in a
+// shard, aux setup is dominated by the agent image bundle upload (~100s).
+type AuxServicesFuture struct {
+	result chan *auxiliary.Services
+}
+
+// StartAuxServicesAsync starts auxiliary.Get(ctx) in the background and returns
+// immediately. Call Wait on the returned future once aux services are needed
+// (typically right after VM/harness setup in BeforeSuite).
+func StartAuxServicesAsync(ctx context.Context) *AuxServicesFuture {
+	future := &AuxServicesFuture{result: make(chan *auxiliary.Services, 1)}
+	go func() {
+		future.result <- auxiliary.Get(ctx)
+	}()
+	return future
+}
+
+// Wait blocks until aux service setup completes and returns the services.
+func (f *AuxServicesFuture) Wait() *auxiliary.Services {
+	return <-f.result
 }
 
 // GetWorkerHarness retrieves the harness for the current worker.


### PR DESCRIPTION
## Summary

Two independent optimizations to the one-time E2E shard setup cost, found while investigating why E2E wall time didn't drop as much as expected after the buildah cache fix (#3186 / #3212).

Traced raw BeforeSuite timestamps from real runs and found that the ~4.3-4.4 min "cold start" tax paid once per shard splits almost 50/50 between two things that were previously lumped together as "VM management overhead":

- **Aux service setup** (registry, agent image bundle upload, git server, prometheus): ~145-150s, dominated by uploading a 3.24GB/6-image bootc bundle into the local registry (~96-100s).
- **VM cold boot + first pristine snapshot**: ~110-115s (boot+SSH ~40s, greenboot wait ~60s, snapshot create ~10s).

Both fixes are behavioral no-ops for test correctness; only the setup mechanics change.

### Commit 1 — overlap aux setup with VM boot

Every suite's `BeforeSuite` called `auxiliary.Get(ctx)` and then `SetupWorkerHarness*()` sequentially, even though the two are independent (aux uses podman networking, VM setup uses libvirt/qemu). Added a `StartAuxServicesAsync`/`AuxServicesFuture` helper that kicks off aux setup in the background, and switched ~20 VM-based suites to `Wait()` on it right after VM/harness setup instead of before.

Since every shard's first package pays this tax exactly once, and ~15 shards run in parallel, this overlaps ~100-110s of independent work per shard.

`dependency_sync_suite_test.go` is intentionally left alone — it uses `SynchronizedBeforeSuite`, where Ginkgo blocks the per-process phase on the return value of the controller phase, so the two phases can't overlap there.

### Commit 2 — stream image bundle directly to registry via skopeo

`uploadBundle` ran `podman load -i bundle.tar` (extracting every image's full layers into local containers storage) and then looped over each tag doing a digest-check plus `podman push` from storage.

`uploadBundle` is only invoked when the registry container was just created (see `StartServices`' `Reused` check), so the registry is always empty and every image always needs pushing — the local/registry digest comparison never actually skipped anything, it just cost two `skopeo inspect` calls per tag.

Replaced `podman load`+push with `skopeo copy docker-archive:bundle:<ref> docker://...`, run concurrently (bounded to 4 at a time) across image refs. This streams layer blobs straight from the tar to the registry without ever extracting a full OS root filesystem to local storage just to immediately read it back out for push.

Verified locally end-to-end: built a multi-image docker-archive from real images, copied every ref through the new code path into a throwaway registry, and confirmed each pushed image's config digest and image ID match the source exactly after pulling it back down.

## Test plan

- [x] `go build ./...` and `go vet ./test/e2e/... ./test/harness/...` pass clean
- [x] Manually verified `skopeo copy docker-archive:path:<ref>` correctly disambiguates distinct images in a multi-image archive (digest-verified)
- [x] Manually verified end-to-end upload correctness: pushed images pulled back down match source image ID and config digest exactly
- [ ] Watch the next few merge-queue E2E runs / weekly health report to confirm the real-world wall-time delta (couldn't reproduce the ~100s CI bottleneck locally; this sandbox's disk is too fast for a representative before/after timing)

Made with [Cursor](https://cursor.com)