### PR TITLE
NO-ISSUE: fix prune-ci-caches gh cache commands with no git checkout

### DIFF
--- a/.github/workflows/prune-ci-caches.yaml
+++ b/.github/workflows/prune-ci-caches.yaml
@@ -63,6 +63,11 @@ jobs:
       - name: Prune old caches for ${{ matrix.prefix }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no actions/checkout step (nothing here needs repo files),
+          # so gh has no local .git to infer the target repo from - it errors with
+          # "failed to run git: fatal: not a git repository". GH_REPO tells gh
+          # which repo to target directly, without needing a git checkout.
+          GH_REPO: ${{ github.repository }}
           PREFIX: ${{ matrix.prefix }}
         run: |
           # Keep only the most recently created entry for this prefix; delete the rest.


### PR DESCRIPTION
## Summary

- The `prune-ci-caches` workflow added in #3214 failed on its very first run after merging: `failed to run git: fatal: not a git repository (or any of the parent directories): .git` ([job log](https://github.com/flightctl/flightctl/actions/runs/29190692500/job/86644728214)).
- Root cause: this job has no `actions/checkout` step (it only calls `gh cache list`/`gh cache delete`, no repo files needed), so `gh` had no local `.git` to infer the target repository from.
- Fix: set `GH_REPO: ${{ github.repository }}` in the step's env so `gh` targets the repo directly instead of trying to auto-detect it via git.
- Verified locally: the identical `gh cache list` command fails from a directory with no `.git` and succeeds once `GH_REPO` is set - confirmed this is the actual root cause, and confirmed the fixed command correctly resolves the current 3 duplicate `Linux-buildah-*` caches down to keeping just the newest.
- `update-test-timings.yaml`'s equivalent prune step is unaffected - it already runs after `actions/checkout`, which gives `gh` a valid git remote to detect the repo from (also verified locally).

## Test plan

- [x] Reproduced the exact failure locally (`gh cache list` from a directory with no `.git`).
- [x] Verified the fix resolves it (`gh cache list` with `GH_REPO` set, from the same non-git directory).
- [x] Dry-ran the full list+jq pipeline against the live repo's current `Linux-buildah-*` caches to confirm it identifies the correct 2 duplicates to prune, keeping the newest.
- [ ] Next scheduled/event-driven run after merge is the real end-to-end validation.

Made with Cursor

Made with [Cursor](https://cursor.com)