### PR TITLE
NO-ISSUE: pin wildcard-DNS hostnames for schemathesis to avoid nip.io flakiness

### DIFF
--- a/test/api/run_tests.sh
+++ b/test/api/run_tests.sh
@@ -29,6 +29,36 @@ extract_server_url() {
     ' "$CLIENT_CONFIG"
 }
 
+url_host() {
+    local url="${1#*://}"
+    url="${url%%/*}"
+    echo "${url%%:*}"
+}
+
+# resolve_wildcard_dns_ip prints the IP address embedded in a nip.io/sslip.io
+# hostname (e.g. "api.10.1.0.5.nip.io" -> "10.1.0.5"), or nothing if the host
+# isn't one of these synthetic wildcard-DNS names (see test/scripts/functions,
+# which mints them from the runner's own IP). Resolving them for real still
+# means a live query to a third-party nameserver for an answer already known
+# locally, and a transient failure there ("NameResolutionError") has broken
+# otherwise-healthy schemathesis runs mid-fuzzing.
+resolve_wildcard_dns_ip() {
+    local host="$1"
+    if [[ "$host" =~ ^.+\.([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\.nip\.io$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    if [[ "$host" =~ ^.+\.([0-9a-fA-F-]+)\.sslip\.io$ ]]; then
+        echo "${BASH_REMATCH[1]//-/:}"
+        return 0
+    fi
+    # Not a wildcard-DNS hostname (e.g. a real domain in a non-CI environment) -
+    # leave it to normal DNS. Explicit 0: under "set -e", the caller's
+    # "ip=$(resolve_wildcard_dns_ip ...)" assignment would otherwise abort the
+    # whole script on the first non-matching host.
+    return 0
+}
+
 run_schemathesis() {
     local service="$1" version="$2" server_url="$3" core_url="$4"
     local service_name="${service%%/*}"
@@ -52,6 +82,23 @@ run_schemathesis() {
 
     local -a podman_args=(--rm --init --security-opt label=disable --network=host)
     [ -z "${CI:-}" ] && podman_args+=(-t)
+
+    # Pin any wildcard-DNS hostnames (base_url and core_url may name different
+    # services, e.g. imagebuilder-api.* vs api.*) so the container resolves them
+    # locally instead of over the network. --network=host shares the host's
+    # network namespace but not its /etc/hosts, so this container would otherwise
+    # still make a live DNS query per hostname.
+    local -A pinned_hosts=()
+    local url host ip
+    for url in "$base_url" "$core_url"; do
+        host=$(url_host "$url")
+        [ -n "${pinned_hosts[$host]:-}" ] && continue
+        ip=$(resolve_wildcard_dns_ip "$host")
+        [ -z "$ip" ] && continue
+        podman_args+=(--add-host "${host}:${ip}")
+        pinned_hosts[$host]=1
+    done
+
     local -a volumes=(
         -v "${ROOT_DIR}/api:/app/specs:ro"
         -v "${SCRIPT_DIR}:/app/config:ro"


### PR DESCRIPTION
## Summary

`api-tests` (`.github/workflows/run-api-tests.yaml` → `make test-api` / Schemathesis) intermittently fails with a **transient `nip.io` DNS resolution error**, not an API or schema bug.

```
urllib3.exceptions.NameResolutionError: HTTPSConnection(host='api.<ip>.nip.io', port=3443):
Failed to resolve 'api.<ip>.nip.io' ([Errno -3] Try again)
```

Schemathesis reports this as a **Network Error**; a single blip fails the whole job even after hundreds of passing cases.

### Why

`BASE_URL` / `CORE_URL` use `api.<runner-ip>.nip.io`-style hostnames minted from the CI runner IP (`test/scripts/functions`) so the ephemeral kind gateway can do hostname-based routing (`api`, `agent-api`, `imagebuilder-api` on one IP:port) without real DNS records. Resolving those names still requires a live query to nip.io's public nameservers for an answer already embedded in the hostname. A resolver hiccup (`EAI_AGAIN`) ~8–9 minutes into an otherwise-healthy run is enough to go red.

`--network=host` shares the host network namespace but **not** `/etc/hosts`, so the Schemathesis container still does live DNS per hostname.

### Confirmed occurrences (same signature)

| When | Run | Host |
|------|-----|------|
| 2026-07-06 (`main` push) | https://github.com/flightctl/flightctl/actions/runs/28785519173 | `api.10.1.1.100.nip.io` |
| 2026-07-09 (**merge queue**) | https://github.com/flightctl/flightctl/actions/runs/29040334007 | `api.10.1.0.5.nip.io` |
| 2026-08-05 | https://github.com/flightctl/flightctl/actions/runs/31001543631 | `api.10.1.0.57.nip.io` |
| 2026-08-09 (`main` push) | https://github.com/flightctl/flightctl/actions/runs/31312041748 | `api.10.1.0.138.nip.io` |

Still reproduces after this PR opened (Jul 12); can block the merge queue, not only PR checks.

### Out of scope (other `api-tests` reds)

This PR only removes the nip.io DNS dependency. Separate failure modes seen recently:

- **Python 3.14t free-threading import races** (`_DeadlockError` / `HookError` loading hooks) — tooling/runtime flake
- **CI setup infra** (`curl` 503 downloading crun during `setup-dependencies`) — never reaches Schemathesis

## Fix

Pin any `nip.io` / `sslip.io` wildcard-DNS hostname found in `BASE_URL` / `CORE_URL` to its embedded IP via `podman run --add-host`, so the Schemathesis container never needs a live DNS query for them.

- Same hostnames, same TLS SNI / cert-SAN routing — only resolution changes (local lookup vs network round-trip).
- Real domains (non-CI) do not match the wildcard-DNS pattern and fall through untouched.
- Handles `nip.io` (IPv4) and `sslip.io` (dashed IPv6), matching `test/scripts/functions` `DNS_IP` construction.

## Test plan

- [x] Verified `url_host` / `resolve_wildcard_dns_ip` against `nip.io`, `sslip.io`, and real-domain inputs (correct extraction; safe no-op for non-wildcard hosts).
- [x] Confirmed the "no match" path returns exit 0 so `set -euo pipefail` does not abort on the first non-`nip.io` host.
- [ ] Rebase onto current `main` (branch is behind) and re-run `api-tests` / e2e as needed.

## Release target

- Target: **release-1.4** (label `release-1.4`)