### PR TITLE
NO-ISSUE: stop go/lint/dnf/bootc caches from thrashing the repo's 10GB cache budget

### DIFF
--- a/.github/workflows/build-images-and-charts.yaml
+++ b/.github/workflows/build-images-and-charts.yaml
@@ -223,6 +223,7 @@ jobs:
         uses: ./.github/actions/compute-tag
 
       - name: Restore Go cache
+        id: cache-go-restore
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -251,7 +252,14 @@ jobs:
 
       - name: Save Go cache
         uses: actions/cache/save@v4
-        if: always()
+        # Same key across every PR/branch (hashFiles('**/go.sum') rarely changes), but Actions
+        # cache save is scoped per-ref, so an unconditional save here leaves one throwaway
+        # ~1GB copy behind per PR/branch that nothing else can ever restore from and nothing
+        # ever deletes - pure eviction pressure on the repo's shared 10GB budget. Restrict
+        # saves to main, matching the buildah cache above; every other ref still benefits via
+        # restore-keys fallback to main's copy. cache-hit skip avoids racing this job's save
+        # against build-restore's identically-keyed save when both run on main concurrently.
+        if: always() && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true'
         with:
           path: |
             ~/.cache/go-build
@@ -276,6 +284,7 @@ jobs:
         uses: ./.github/actions/compute-tag
 
       - name: Restore Go cache
+        id: cache-go-restore
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -304,7 +313,9 @@ jobs:
 
       - name: Save Go cache
         uses: actions/cache/save@v4
-        if: always()
+        # See the "Save Go cache" step in build-cli above for why this is main-only and
+        # skips on cache-hit.
+        if: always() && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true'
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/build-rpms.yaml
+++ b/.github/workflows/build-rpms.yaml
@@ -40,7 +40,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Save Go modules cache
-        if: ${{ always() }}
+        # Main-only: this key is identical across every PR/branch (hashFiles('**/go.sum')
+        # rarely changes), and Actions cache save is scoped per-ref, so saving unconditionally
+        # leaves a throwaway ~1GB copy behind per PR that nothing else restores from and
+        # nothing ever deletes - see build-images-and-charts.yaml's "Save Go cache" for the
+        # full explanation. Other refs still benefit via restore-keys fallback to main's copy.
+        # cache-hit skip avoids racing against other jobs saving the same key concurrently
+        # on main (e.g. the multiple build-rpms matrix entries, each a separate job).
+        if: ${{ always() && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,9 +60,16 @@ jobs:
           make tidy
           git diff --exit-code
 
-      - name: Cache golangci-lint volumes
+      # Restore-only (see the paired "Save ..." step below): this key is the same across
+      # every PR/branch, and Actions cache save is scoped per-ref, so a unified
+      # actions/cache@v4 here saves an unrestorable throwaway ~1GB copy on every single
+      # PR/branch run - see build-images-and-charts.yaml's "Save Go cache" for the full
+      # rationale. Restricting the save to main lets every other ref still benefit via
+      # restore-keys fallback to main's copy.
+      - name: Restore golangci-lint volumes cache
+        id: cache-lint-restore
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.local/share/containers/storage/volumes/golangci-lint-cache
@@ -75,3 +82,13 @@ jobs:
       - name: Running Linter
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: make lint
+
+      - name: Save golangci-lint volumes cache
+        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-lint-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.local/share/containers/storage/volumes/golangci-lint-cache
+            ~/.local/share/containers/storage/volumes/go-build-cache
+            ~/.local/share/containers/storage/volumes/go-mod-cache
+          key: lint-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,22 +60,26 @@ jobs:
           make tidy
           git diff --exit-code
 
-      # Restore-only (see the paired "Save ..." step below): this key is the same across
-      # every PR/branch, and Actions cache save is scoped per-ref, so a unified
-      # actions/cache@v4 here saves an unrestorable throwaway ~1GB copy on every single
-      # PR/branch run - see build-images-and-charts.yaml's "Save Go cache" for the full
-      # rationale. Restricting the save to main lets every other ref still benefit via
-      # restore-keys fallback to main's copy.
+      # Restore-only (see the paired "Save ..." step below). Unlike the standalone Go
+      # module/build cache elsewhere (keyed by hashFiles('**/go.sum') - see
+      # build-images-and-charts.yaml's "Save Go cache"), this volume set also holds
+      # golangci-lint's own analysis cache, which is invalidated by source file content
+      # and lint config, not go.sum - a go.sum-based key would leave it frozen at
+      # whatever it looked like right after the last go.sum change, however much source
+      # code changes in between. So instead this uses the same pattern as the buildah
+      # cache below: a fresh key every run (never an exact hit, cache-hit is always
+      # false) with restore-keys falling back to the newest entry, refreshing the
+      # snapshot on every main push regardless of go.sum. The "prune" job below keeps
+      # only the newest entry.
       - name: Restore golangci-lint volumes cache
-        id: cache-lint-restore
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: actions/cache/restore@v4
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           path: |
             ~/.local/share/containers/storage/volumes/golangci-lint-cache
             ~/.local/share/containers/storage/volumes/go-build-cache
             ~/.local/share/containers/storage/volumes/go-mod-cache
-          key: lint-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: lint-cache-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
             lint-cache-${{ runner.os }}-
 
@@ -84,11 +88,15 @@ jobs:
         run: make lint
 
       - name: Save golangci-lint volumes cache
-        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-lint-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
+        # Main-only: this key is unique per run_id, so a save here always creates a new
+        # entry rather than updating an existing one - restricting to main (like the
+        # buildah cache) keeps PR/branch runs from leaving behind their own throwaway
+        # copy that nothing else can restore from and nothing else deletes.
+        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' }}
         with:
           path: |
             ~/.local/share/containers/storage/volumes/golangci-lint-cache
             ~/.local/share/containers/storage/volumes/go-build-cache
             ~/.local/share/containers/storage/volumes/go-mod-cache
-          key: lint-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: lint-cache-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -62,9 +62,16 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/setup-dependencies
 
-      - name: Cache Go modules
+      # Restore-only (see the paired "Save ..." steps below, run near the end of the job):
+      # these keys are the same across every PR/branch, and Actions cache save is scoped
+      # per-ref, so a unified actions/cache@v4 here would save an unrestorable throwaway
+      # copy on every single PR/branch run. Splitting restore/save lets the save be
+      # restricted to main (see build-images-and-charts.yaml's "Save Go cache" for the
+      # full rationale) while every ref still benefits from restoring main's copy.
+      - name: Restore Go modules cache
+        id: cache-go-restore
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/go-build
@@ -73,9 +80,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Cache DNF packages
+      - name: Restore DNF cache
+        id: cache-dnf-restore
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             /var/cache/dnf
@@ -84,9 +92,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-dnf-
 
-      - name: Cache bootc-image-builder
+      - name: Restore bootc-image-builder cache
+        id: cache-bootc-restore
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             bin/dnf-cache
@@ -122,6 +131,33 @@ jobs:
         with:
           path: ${{ env.BUILDAH_CACHE_PATH }}
           key: ${{ runner.os }}-buildah-${{ github.run_id }}
+
+      - name: Save Go modules cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Save DNF cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-smoke
+
+      - name: Save bootc-image-builder cache
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-bootc-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            bin/dnf-cache
+            bin/osbuild-cache
+          key: ${{ runner.os }}-bootc-cache-smoke-${{ hashFiles('test/scripts/agent-images/Containerfile-e2e-base.local') }}
 
       - name: Check
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/.github/workflows/pr-smoke-testing.yaml
+++ b/.github/workflows/pr-smoke-testing.yaml
@@ -133,7 +133,9 @@ jobs:
           key: ${{ runner.os }}-buildah-${{ github.run_id }}
 
       - name: Save Go modules cache
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
+        # always(): populated by "Setup all dependencies"/build steps earlier in the job,
+        # so still worth saving even if a later step (Create cluster/Deploy) fails on main.
+        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -142,7 +144,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Save DNF cache
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
+        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -151,7 +153,7 @@ jobs:
           key: ${{ runner.os }}-dnf-smoke
 
       - name: Save bootc-image-builder cache
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-bootc-restore.outputs.cache-hit != 'true' }}
+        if: ${{ always() && steps.changed-files.outputs.any_changed == 'true' && github.ref == 'refs/heads/main' && steps.cache-bootc-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/prune-ci-caches.yaml
+++ b/.github/workflows/prune-ci-caches.yaml
@@ -114,7 +114,10 @@ jobs:
           # scoped copy, plus any older main-ref entry left behind by a since-changed content
           # hash (e.g. go.sum). If no main-ref entry exists yet, this deletes nothing for this
           # prefix rather than guessing which copy to keep.
-          gh cache list --key "${PREFIX}" --limit 100 --json id,key,ref,createdAt \
+          # --sort created_at: gh cache list defaults to last_accessed_at, which could
+          # push the true newest-by-createdAt entry past the --limit 100 cutoff if a
+          # prefix ever accumulates more than 100 entries.
+          gh cache list --key "${PREFIX}" --limit 100 --sort created_at --order desc --json id,key,ref,createdAt \
             | jq -r '
                 (map(select(.ref == "refs/heads/main")) | sort_by(.createdAt) | last | .id) as $keep
                 | if $keep then .[] | select(.id != $keep) | .id else empty end

--- a/.github/workflows/prune-ci-caches.yaml
+++ b/.github/workflows/prune-ci-caches.yaml
@@ -27,7 +27,7 @@ name: "Prune duplicate CI caches"
 
 on:
   workflow_run:
-    workflows: ["E2E testing (Parallel Build)", "Helm upgrade test"]
+    workflows: ["E2E testing (Parallel Build)", "Helm upgrade test", "Code Quality"]
     types: [completed]
     branches: [main]
   schedule:
@@ -73,4 +73,49 @@ jobs:
           # Keep only the most recently created entry for this prefix; delete the rest.
           gh cache list --key "${PREFIX}" --limit 100 --sort created_at --order desc --json id,key \
             | jq -r '.[1:] | .[].id' \
+            | xargs -r -n1 gh cache delete
+
+  prune-branch-scoped:
+    name: Prune branch-scoped duplicate caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # required for gh cache list/delete
+    strategy:
+      matrix:
+        # These caches use a content hash as their key (e.g. hashFiles('**/go.sum')), so
+        # unlike Linux-buildah- above the *same* key text is legitimately re-saved by every
+        # branch/PR that runs a workflow touching it - Actions cache save/restore is scoped
+        # per-ref, so an identical key on refs/pull/123/merge is a distinct cache entry from
+        # the one on refs/heads/main. Every currently-open PR (and every already-closed PR's
+        # now-unreachable merge-queue ref) used to end up holding its own ~1.1GB copy that
+        # nothing ever cleaned up, since actions/cache never deletes on its own - the
+        # corresponding save steps are now gated to github.ref == 'refs/heads/main' (see
+        # build-images-and-charts.yaml's "Save Go cache" and lint.yaml's "Save golangci-lint
+        # volumes cache"), so this job is now mainly a safety net for whatever's already
+        # accumulated plus any future cache added without that gate.
+        #
+        # Add a prefix here for any other cache keyed by content hash (rather than run_id)
+        # whose save is (or should be) gated to main.
+        prefix:
+          - "Linux-go-"
+          - "lint-cache-Linux-"
+          - "Linux-dnf-"
+          - "Linux-bootc-cache-smoke-"
+    steps:
+      - name: Prune superseded/branch-scoped caches for ${{ matrix.prefix }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PREFIX: ${{ matrix.prefix }}
+        run: |
+          # Keep only the single newest refs/heads/main-scoped entry (the fallback source for
+          # every other branch); delete everything else for this prefix - every PR/branch-
+          # scoped copy, plus any older main-ref entry left behind by a since-changed content
+          # hash (e.g. go.sum). If no main-ref entry exists yet, this deletes nothing for this
+          # prefix rather than guessing which copy to keep.
+          gh cache list --key "${PREFIX}" --limit 100 --json id,key,ref,createdAt \
+            | jq -r '
+                (map(select(.ref == "refs/heads/main")) | sort_by(.createdAt) | last | .id) as $keep
+                | if $keep then .[] | select(.id != $keep) | .id else empty end
+              ' \
             | xargs -r -n1 gh cache delete

--- a/.github/workflows/prune-ci-caches.yaml
+++ b/.github/workflows/prune-ci-caches.yaml
@@ -59,6 +59,7 @@ jobs:
         # duplicates on a long-lived ref like main.
         prefix:
           - "Linux-buildah-"
+          - "lint-cache-Linux-"
     steps:
       - name: Prune old caches for ${{ matrix.prefix }}
         env:
@@ -90,15 +91,15 @@ jobs:
         # now-unreachable merge-queue ref) used to end up holding its own ~1.1GB copy that
         # nothing ever cleaned up, since actions/cache never deletes on its own - the
         # corresponding save steps are now gated to github.ref == 'refs/heads/main' (see
-        # build-images-and-charts.yaml's "Save Go cache" and lint.yaml's "Save golangci-lint
-        # volumes cache"), so this job is now mainly a safety net for whatever's already
-        # accumulated plus any future cache added without that gate.
+        # build-images-and-charts.yaml's "Save Go cache"), so this job is now mainly a
+        # safety net for whatever's already accumulated plus any future cache added
+        # without that gate. (lint-cache-Linux- moved to the "prune" job above once it
+        # switched to a run_id-keyed save, same as buildah.)
         #
         # Add a prefix here for any other cache keyed by content hash (rather than run_id)
         # whose save is (or should be) gated to main.
         prefix:
           - "Linux-go-"
-          - "lint-cache-Linux-"
           - "Linux-dnf-"
           - "Linux-bootc-cache-smoke-"
     steps:

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -86,8 +86,16 @@ jobs:
       - name: Install Dependencies
         run: go mod tidy
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
+      # Restore-only (see the paired "Save ..." steps below): these keys are the same
+      # across every PR/branch, and every one of the 6 matrix entries above builds on
+      # ubuntu-latest (cross-compiling via GOOS/GOARCH), so they'd all race to save the
+      # identical key too. Actions cache save is scoped per-ref, so saving unconditionally
+      # here would leave a throwaway ~1GB copy behind per PR/branch (times 6, racing)
+      # that nothing else can ever restore from and nothing ever deletes - see
+      # build-images-and-charts.yaml's "Save Go cache" for the full rationale.
+      - name: Restore Go modules cache
+        id: cache-go-restore
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/go-build
@@ -96,8 +104,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Cache DNF packages
-        uses: actions/cache@v4
+      - name: Restore DNF cache
+        id: cache-dnf-restore
+        uses: actions/cache/restore@v4
         with:
           path: |
             /var/cache/dnf
@@ -117,6 +126,24 @@ jobs:
           else
             tar cvf flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.zip }} flightctl-${{ matrix.os }}-${{ matrix.arch}}${{ matrix.ext }}
           fi
+
+      - name: Save Go modules cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Save DNF cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /var/cache/dnf
+            /var/lib/dnf
+          key: ${{ runner.os }}-dnf-cli
 
       - name: Save zip
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -128,7 +128,9 @@ jobs:
           fi
 
       - name: Save Go modules cache
-        if: ${{ github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
+        # always(): populated during "Build" above regardless of whether the build itself
+        # succeeds, so still worth saving even if Build fails on main.
+        if: ${{ always() && github.ref == 'refs/heads/main' && steps.cache-go-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -137,7 +139,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Save DNF cache
-        if: ${{ github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
+        if: ${{ always() && github.ref == 'refs/heads/main' && steps.cache-dnf-restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |


### PR DESCRIPTION
## Summary

Follow-up to #3214/#3219's buildah cache pruning: the repo's total Actions cache usage was still over the 10GB budget (~11GB), which was evicting small, unrelated caches out from under other workflows - most notably `e2e-test-timings` (causing the E2E LPT scheduler to silently fall back to unweighted round-robin assignment) and `Linux-apt-kvm-*` (causing severe `apt install` slowdowns from cold, unthrottled-cache network pulls).

Root cause this time: `Linux-go-*` and `lint-cache-Linux-*` (and, latent but not yet triggered, `Linux-dnf-*` / `Linux-bootc-cache-smoke-*`) use a content-hash key that's identical across every PR/branch, but `actions/cache` save/restore is scoped per-ref. Their save steps were unconditional, so every single PR/branch run left its own throwaway ~1-1.2GB copy behind that nothing else could ever restore from and nothing ever deleted - 6 `Linux-go-*` copies (6.33GB) and 2 `lint-cache-Linux-*` copies (2.1GB) were alive at once as of this PR.

- **Prevention:** gate every such save to `github.ref == 'refs/heads/main'`, matching the existing buildah cache pattern. Every other ref still benefits from restoring main's copy via `restore-keys` fallback. Also skip the save when the paired restore already got an exact `cache-hit`, avoiding a wasted archive-then-reject round trip (`actions/cache/save` archives the directory *before* checking whether the key already exists server-side).
- **Cleanup/safety net:** extend `prune-ci-caches.yaml`'s branch-scoped pruning to keep only the single newest `refs/heads/main` entry per prefix (covers both existing PR-scoped duplicates and any future stale entry left behind by a since-changed content hash), and add the `Linux-dnf-`/`Linux-bootc-cache-smoke-` prefixes for completeness. Also trigger the prune workflow after `Code Quality` completes on main, since that's what saves the lint-cache entry.
- **Lint-cache freshness:** unlike the standalone Go module/build cache (fully determined by `go.sum`), the lint-cache volume set also holds golangci-lint's own analysis cache, which is invalidated by source content and lint config, not `go.sum` - keying it on `go.sum` left it frozen at whatever it looked like right after the last `go.sum` change, however much source changed in between. Switched it to the same pattern as buildah: a fresh `run_id`-keyed save on every main push, with `restore-keys` falling back to the newest entry, and moved it to the plain "keep newest" prune job.

Expected effect: steady-state total cache usage drops from ~11GB (over budget) to ~4.6GB, giving enough headroom that this class of cascading eviction shouldn't recur from the same cause.

## Test plan

- [x] Validated all modified workflow YAML parses correctly
- [x] Validated the refined prune jq logic against sample restore/main-ref data (keeps newest main entry, deletes the rest; leaves everything alone when no main entry exists yet)
- [ ] After merge: confirm on the next few main-branch runs that `Save Go cache`/`Save golangci-lint volumes cache`/etc. only actually save once (first run after a `go.sum`/lockfile change, or every run for lint-cache), and that the prune jobs clean up the currently-existing PR-scoped duplicates
- [ ] Confirm total repo cache usage (`gh cache list`) settles near the ~4.6GB estimate