### PR TITLE
EDM-4694: Fix backup and restore issues on standalone

### DIFF
--- a/internal/restore/archive.go
+++ b/internal/restore/archive.go
@@ -16,6 +16,45 @@ import (
 	"github.com/flightctl/flightctl/internal/backup"
 )
 
+// parseMajorMinor extracts the major and minor components from a version
+// string such as "v1.2.3", "1.2.0-dirty", or "v1.2.0-rc1". It strips a
+// leading "v", discards everything after a hyphen (pre-release/build
+// metadata), and splits on ".".
+func parseMajorMinor(ver string) (major, minor string, err error) {
+	ver = strings.TrimPrefix(ver, "v")
+	if idx := strings.IndexByte(ver, '-'); idx != -1 {
+		ver = ver[:idx]
+	}
+	parts := strings.Split(ver, ".")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot parse major.minor from version %q", ver)
+	}
+	return parts[0], parts[1], nil
+}
+
+// ValidateVersion checks that the archive's recorded version is compatible
+// with currentVersion. Compatibility means major and minor components match;
+// patch-level differences are allowed. Returns a descriptive error on
+// mismatch naming both versions.
+func ValidateVersion(metadata *backup.BackupMetadata, currentVersion string) error {
+	archMajor, archMinor, err := parseMajorMinor(metadata.Version)
+	if err != nil {
+		return fmt.Errorf("version mismatch: archive version %q is not parseable: %w", metadata.Version, err)
+	}
+	curMajor, curMinor, err := parseMajorMinor(currentVersion)
+	if err != nil {
+		return fmt.Errorf("version mismatch: current version %q is not parseable: %w", currentVersion, err)
+	}
+	if archMajor != curMajor || archMinor != curMinor {
+		return fmt.Errorf(
+			"version mismatch: archive was created by version %q but the current version is %q; restore requires matching major.minor versions",
+			metadata.Version,
+			currentVersion,
+		)
+	}
+	return nil
+}
+
 // verifyChecksum reads the SHA256 checksum file at archivePath+".sha256",
 // computes the SHA256 digest of the archive file, and returns an error if the
 // checksum file is missing, unreadable, malformed, or the digest does not match.

--- a/internal/restore/archive_test.go
+++ b/internal/restore/archive_test.go
@@ -451,6 +451,98 @@ func TestReadMetadata(t *testing.T) {
 	}
 }
 
+// TestValidateVersion validates the behavioral contract of ValidateVersion.
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		archiveVersion string
+		currentVersion string
+		wantErr        bool
+		errContains    string
+	}{
+		{
+			name:           "When versions are identical it should return nil",
+			archiveVersion: "v1.2.3",
+			currentVersion: "v1.2.3",
+		},
+		{
+			name:           "When only patch differs it should return nil",
+			archiveVersion: "v1.2.0",
+			currentVersion: "v1.2.3",
+		},
+		{
+			name:           "When minor differs it should return version mismatch error",
+			archiveVersion: "v1.1.0",
+			currentVersion: "v1.2.0",
+			wantErr:        true,
+			errContains:    "version mismatch",
+		},
+		{
+			name:           "When major differs it should return version mismatch error",
+			archiveVersion: "v2.0.0",
+			currentVersion: "v1.0.0",
+			wantErr:        true,
+			errContains:    "version mismatch",
+		},
+		{
+			name:           "When archive version has dirty suffix it should compare correctly",
+			archiveVersion: "v1.2.3-dirty",
+			currentVersion: "v1.2.0",
+		},
+		{
+			name:           "When current version has dirty suffix it should compare correctly",
+			archiveVersion: "v1.2.0",
+			currentVersion: "v1.2.3-dirty",
+		},
+		{
+			name:           "When archive version has rc suffix it should compare correctly",
+			archiveVersion: "v1.2.0-rc1",
+			currentVersion: "v1.2.3",
+		},
+		{
+			name:           "When archive version is unparseable it should return error",
+			archiveVersion: "not-a-version",
+			currentVersion: "v1.2.0",
+			wantErr:        true,
+			errContains:    "version",
+		},
+		{
+			name:           "When current version is unparseable it should return error",
+			archiveVersion: "v1.2.0",
+			currentVersion: "unknown",
+			wantErr:        true,
+			errContains:    "version",
+		},
+		{
+			name:           "When versions have no v prefix it should compare correctly",
+			archiveVersion: "1.2.0",
+			currentVersion: "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &backup.BackupMetadata{
+				Timestamp:      time.Now(),
+				Version:        tt.archiveVersion,
+				DeploymentType: backup.DeploymentTypePodman,
+			}
+
+			err := ValidateVersion(metadata, tt.currentVersion)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestValidateDeploymentType validates the behavioral contract of ValidateDeploymentType.
 func TestValidateDeploymentType(t *testing.T) {
 	tests := []struct {

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/pkg/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -66,6 +67,11 @@ func Restore(
 
 	log.Info("Validating deployment type compatibility")
 	if err := ValidateDeploymentType(metadata, deployer.Type()); err != nil {
+		return err
+	}
+
+	log.Info("Validating version compatibility")
+	if err := ValidateVersion(metadata, version.Get().String()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add version validation to flightctl-restore so it rejects archives created by a different major.minor version. This was missing — the restore binary logged the archive version but never checked it, causing E2E test 89196 to fail.

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
