### PR TITLE
NO_ISSUE: Fix remote console access not working for UI in quadlets

### DIFF
--- a/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
+++ b/deploy/podman/flightctl-gateway/flightctl-gateway-config/nginx.conf.template
@@ -81,7 +81,7 @@ http {
       rewrite ^(/api/v1/.*)$ /_/flightctl$1 last;
       rewrite ^(/ws/v1/.*)$ /_/flightctl$1 last;
 
-      location /api/terminal/ {
+      location ~ ^/api/(terminal|app-terminal)/ {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
+++ b/deploy/podman/flightctl-ui/flightctl-ui-config/env.template
@@ -1,6 +1,7 @@
 API_PORT=8080
 BASE_UI_URL=https://{{.global.baseDomain}}
 FLIGHTCTL_SERVER=http://flightctl-api:3080/
+FLIGHTCTL_REMOTE_ACCESS_SERVER=http://flightctl-remote-access:3444
 FLIGHTCTL_SERVER_EXTERNAL=https://{{.global.baseDomain}}/_/flightctl/
 FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY=true
 FLIGHTCTL_CLI_ARTIFACTS_SERVER=https://{{.global.baseDomain}}/_/cli-artifacts/


### PR DESCRIPTION
Adds the necessary changes for the UI to be able to work in the quadlets deployment.

- Add rule to nginx server so that Websocket connection is upgraded.
- Define FLIGHTCTL_REMOTE_ACCESS_SERVER

Made-with: Cursor
