### PR TITLE
EDM-4743: Initialize encryption-at-rest across control plane components

### DIFF
--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flightctl/flightctl/internal/alert_exporter"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/org/cache"
@@ -41,6 +42,10 @@ func main() {
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)

--- a/cmd/flightctl-alertmanager-proxy/main.go
+++ b/cmd/flightctl-alertmanager-proxy/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/flightctl/flightctl/internal/auth"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/org/cache"
 	"github.com/flightctl/flightctl/internal/service"
@@ -191,6 +192,10 @@ func main() {
 			logger.Fatalf("Failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(logger, cfg); err != nil {
+		logger.Fatalf("initializing encryption: %v", err)
+	}
 
 	// Initialize data store
 	db, err := store.InitDB(cfg, logger)

--- a/cmd/flightctl-api/main.go
+++ b/cmd/flightctl-api/main.go
@@ -15,8 +15,10 @@ import (
 	"github.com/flightctl/flightctl/internal/api_server/middleware"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/domain"
+	encmetrics "github.com/flightctl/flightctl/internal/instrumentation/metrics/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/system"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
@@ -60,6 +62,10 @@ func main() {
 			log.Fatalf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)
@@ -177,6 +183,12 @@ func main() {
 					}
 				}()
 			}
+		}
+
+		if encMgr := encryption.GlobalManager(); encMgr != nil {
+			encCollector := encmetrics.NewEncryptionCollector(encMgr)
+			encMgr.SetMetricsRecorder(encCollector)
+			collectors = append(collectors, encCollector)
 		}
 
 		go func() {

--- a/cmd/flightctl-imagebuilder-api/main.go
+++ b/cmd/flightctl-imagebuilder-api/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api"
 	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/store"
@@ -38,6 +39,10 @@ func main() {
 			log.Fatalf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)

--- a/cmd/flightctl-imagebuilder-worker/main.go
+++ b/cmd/flightctl-imagebuilder-worker/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/crypto"
 	imagebuilderstore "github.com/flightctl/flightctl/internal/imagebuilder_api/store"
 	imagebuilderworker "github.com/flightctl/flightctl/internal/imagebuilder_worker"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/store"
@@ -40,6 +41,10 @@ func main() {
 			log.Errorf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)

--- a/cmd/flightctl-periodic/main.go
+++ b/cmd/flightctl-periodic/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	periodic "github.com/flightctl/flightctl/internal/periodic_checker"
 	"github.com/flightctl/flightctl/internal/store"
@@ -28,6 +29,10 @@ func main() {
 			log.Fatalf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)

--- a/cmd/flightctl-remote-access/main.go
+++ b/cmd/flightctl-remote-access/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	remoteaccessserver "github.com/flightctl/flightctl/internal/remote_access_server"
@@ -56,6 +57,10 @@ func main() {
 			log.Errorf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)

--- a/cmd/flightctl-worker/main.go
+++ b/cmd/flightctl-worker/main.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/consts"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	encmetrics "github.com/flightctl/flightctl/internal/instrumentation/metrics/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/system"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/worker"
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
@@ -43,6 +45,10 @@ func main() {
 			log.Fatalf("failed to shut down tracer: %v", err)
 		}
 	}()
+
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing encryption: %v", err)
+	}
 
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)
@@ -86,6 +92,12 @@ func main() {
 			if systemMetricsCollector := system.NewSystemCollector(ctx, cfg); systemMetricsCollector != nil {
 				collectors = append(collectors, systemMetricsCollector)
 			}
+		}
+
+		if encMgr := encryption.GlobalManager(); encMgr != nil {
+			encCollector := encmetrics.NewEncryptionCollector(encMgr)
+			encMgr.SetMetricsRecorder(encCollector)
+			collectors = append(collectors, encCollector)
 		}
 
 		if len(collectors) > 0 {

--- a/deploy/helm/flightctl/scripts/generate-encryption-key.sh
+++ b/deploy/helm/flightctl/scripts/generate-encryption-key.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -euo pipefail
+
+ENCRYPTION_DIR=""
+CREATE_K8S_SECRETS="false"
+NAMESPACE=""
+INTERNAL_NAMESPACE=""
+
+usage() {
+    cat <<EOF
+Usage: $0 --encryption-dir <directory> [options]
+
+Generates an AES-256 encryption key for Flight Control data-at-rest encryption.
+
+Required:
+  --encryption-dir <dir>        Directory to store the encryption key
+
+Optional:
+  --create-k8s-secrets          Create Kubernetes secret using oc/kubectl
+  --namespace <ns>              Kubernetes namespace (required if --create-k8s-secrets is set)
+  --internal-namespace <ns>     Internal namespace to copy encryption key secret to (optional)
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --encryption-dir)
+            [[ $# -ge 2 ]] || { echo "Error: --encryption-dir requires a value" >&2; usage; }
+            ENCRYPTION_DIR="$2"
+            shift 2
+            ;;
+        --create-k8s-secrets)
+            CREATE_K8S_SECRETS="true"
+            shift
+            ;;
+        --namespace)
+            [[ $# -ge 2 ]] || { echo "Error: --namespace requires a value" >&2; usage; }
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        --internal-namespace)
+            [[ $# -ge 2 ]] || { echo "Error: --internal-namespace requires a value" >&2; usage; }
+            INTERNAL_NAMESPACE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$ENCRYPTION_DIR" ]]; then
+    echo "Error: --encryption-dir is required"
+    usage
+fi
+
+if [[ "$CREATE_K8S_SECRETS" == "true" ]] && [[ -z "$NAMESPACE" ]]; then
+    echo "Error: --namespace is required when --create-k8s-secrets is set"
+    usage
+fi
+
+# Detect K8s CLI early (needed for restoring existing secrets before generation)
+K8S_CLI=""
+if [[ "$CREATE_K8S_SECRETS" == "true" ]]; then
+    if command -v oc &> /dev/null; then
+        K8S_CLI="oc"
+    elif command -v kubectl &> /dev/null; then
+        K8S_CLI="kubectl"
+    else
+        echo "Error: Neither 'oc' nor 'kubectl' found in PATH"
+        exit 1
+    fi
+fi
+
+# Restore existing encryption key from K8s secret (upgrade scenario)
+if [[ "$CREATE_K8S_SECRETS" == "true" ]]; then
+    # --ignore-not-found returns exit 0 with empty output when the secret
+    # does not exist, and a non-zero exit code on transient errors (RBAC,
+    # timeout, connectivity).
+    secret_name=""
+    if ! secret_name=$("$K8S_CLI" get secret "flightctl-encryption-key" -n "$NAMESPACE" \
+            --ignore-not-found -o name 2>&1); then
+        echo "Error: failed to look up existing encryption key secret. Aborting to avoid overwriting an existing key."
+        echo "  Detail: $secret_name"
+        exit 1
+    fi
+    if [[ -n "$secret_name" ]]; then
+        echo "=== Restoring existing encryption key from K8s secret ==="
+        enc_key_data=$("$K8S_CLI" get secret "flightctl-encryption-key" -n "$NAMESPACE" \
+            -o jsonpath='{.data.key}')
+        if [[ -z "${enc_key_data:-}" ]]; then
+            echo "Error: secret flightctl-encryption-key exists but has no .data.key field. Aborting to avoid overwriting the existing secret."
+            exit 1
+        fi
+        mkdir -p "$ENCRYPTION_DIR"
+        (umask 077; echo "$enc_key_data" | base64 -d > "$ENCRYPTION_DIR/key")
+        chmod 600 "$ENCRYPTION_DIR/key"
+        echo "  Restored: flightctl-encryption-key"
+        echo "=== Secret restoration complete ==="
+        echo ""
+    fi
+fi
+
+echo "=== Generating Flight Control Encryption Key in $ENCRYPTION_DIR ==="
+
+# Generate encryption key (AES-256, base64-encoded)
+ENCRYPTION_KEY_FILE="$ENCRYPTION_DIR/key"
+mkdir -p "$ENCRYPTION_DIR"
+
+if [[ -f "$ENCRYPTION_KEY_FILE" ]]; then
+    # Validate existing key: must decode to exactly 32 bytes (AES-256)
+    decoded_len=$(base64 -d < "$ENCRYPTION_KEY_FILE" 2>/dev/null | wc -c || true)
+    if [[ "$decoded_len" -ne 32 ]]; then
+        echo "Error: existing key file $ENCRYPTION_KEY_FILE is invalid (expected 32 decoded bytes, got $decoded_len). Remove it to regenerate."
+        exit 1
+    fi
+    chmod 600 "$ENCRYPTION_KEY_FILE"
+    echo "Skipped generation of encryption key (already exists)"
+else
+    tmp_key=$(mktemp "${ENCRYPTION_DIR}/key.XXXXXX")
+    trap 'rm -f "$tmp_key"' EXIT
+    openssl rand -base64 32 > "$tmp_key"
+    chmod 600 "$tmp_key"
+    mv "$tmp_key" "$ENCRYPTION_KEY_FILE"
+    trap - EXIT
+    echo "Generated encryption key (AES-256)"
+fi
+
+echo ""
+echo "=== Encryption Key Generation Complete ==="
+echo ""
+
+# Create Kubernetes secrets if requested
+if [[ "$CREATE_K8S_SECRETS" == "true" ]]; then
+    echo "=== Creating Kubernetes Secrets ==="
+    echo "Using CLI: $K8S_CLI"
+    echo "Namespace: $NAMESPACE"
+    echo ""
+
+    echo "Creating secret: flightctl-encryption-key"
+    $K8S_CLI create secret generic flightctl-encryption-key \
+        --namespace="$NAMESPACE" \
+        --from-file=key="$ENCRYPTION_KEY_FILE" \
+        --dry-run=client -o yaml | $K8S_CLI apply -f -
+
+    # Copy encryption key secret to internal namespace if different from release namespace
+    if [[ -n "$INTERNAL_NAMESPACE" ]] && [[ "$INTERNAL_NAMESPACE" != "$NAMESPACE" ]]; then
+        echo ""
+        echo "=== Copying encryption key secret to internal namespace: $INTERNAL_NAMESPACE ==="
+        echo "Creating secret: flightctl-encryption-key"
+        $K8S_CLI create secret generic flightctl-encryption-key \
+            --namespace="$INTERNAL_NAMESPACE" \
+            --from-file=key="$ENCRYPTION_KEY_FILE" \
+            --dry-run=client -o yaml | $K8S_CLI apply -f -
+        echo "Encryption key secret copied successfully to $INTERNAL_NAMESPACE"
+    fi
+
+    echo ""
+    echo "=== Kubernetes Secret Creation Complete ==="
+fi

--- a/deploy/helm/flightctl/scripts/generate_encryption_key_test.go
+++ b/deploy/helm/flightctl/scripts/generate_encryption_key_test.go
@@ -1,0 +1,96 @@
+package scripts_test
+
+import (
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEncryptionKeyGeneration(t *testing.T) {
+	scriptPath := encryptionKeyScriptPath()
+
+	t.Run("When generating encryption key it should create a valid AES-256 key", func(t *testing.T) {
+		encDir := t.TempDir()
+
+		cmd := exec.Command("bash", scriptPath,
+			"--encryption-dir", encDir,
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Script failed: %v\nOutput: %s", err, output)
+		}
+
+		encKeyFile := filepath.Join(encDir, "key")
+		keyData, err := os.ReadFile(encKeyFile)
+		if err != nil {
+			t.Fatalf("Encryption key file was not created: %v", err)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(keyData)))
+		if err != nil {
+			t.Fatalf("Encryption key is not valid base64: %v", err)
+		}
+
+		if len(decoded) != 32 {
+			t.Errorf("Encryption key should be 32 bytes (AES-256), got %d", len(decoded))
+		}
+	})
+
+	t.Run("When --encryption-dir is missing it should exit with an error", func(t *testing.T) {
+		cmd := exec.Command("bash", scriptPath)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("Script should have failed without --encryption-dir, output: %s", output)
+		}
+		if !strings.Contains(string(output), "--encryption-dir is required") {
+			t.Errorf("Expected missing-arg error message, got: %s", output)
+		}
+	})
+
+	t.Run("When encryption key exists it should skip regeneration", func(t *testing.T) {
+		encDir := t.TempDir()
+
+		cmd := exec.Command("bash", scriptPath,
+			"--encryption-dir", encDir,
+		)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("First run failed: %v\nOutput: %s", err, output)
+		}
+
+		encKeyFile := filepath.Join(encDir, "key")
+		origKey, err := os.ReadFile(encKeyFile)
+		if err != nil {
+			t.Fatalf("Failed to read encryption key: %v", err)
+		}
+
+		cmd = exec.Command("bash", scriptPath,
+			"--encryption-dir", encDir,
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Second run failed: %v\nOutput: %s", err, output)
+		}
+
+		newKey, err := os.ReadFile(encKeyFile)
+		if err != nil {
+			t.Fatalf("Failed to read encryption key after second run: %v", err)
+		}
+
+		if string(origKey) != string(newKey) {
+			t.Error("Encryption key was regenerated when it should have been preserved")
+		}
+
+		if !strings.Contains(string(output), "already exists") {
+			t.Error("Second run should indicate key already exists")
+		}
+	})
+}
+
+func encryptionKeyScriptPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "generate-encryption-key.sh")
+}

--- a/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-deployment.yaml
+++ b/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-deployment.yaml
@@ -81,6 +81,9 @@ spec:
             - mountPath: /root/.flightctl
               name: flightctl-alert-exporter-config
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
           livenessProbe:
             httpGet:
@@ -103,5 +106,9 @@ spec:
         - name: flightctl-alert-exporter-config
           configMap:
             name: flightctl-alert-exporter-config
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-deployment.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-deployment.yaml
@@ -95,6 +95,9 @@ spec:
               name: flightctl-alertmanager-proxy-server-tls
               subPath: tls.key
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
           livenessProbe:
             httpGet:
@@ -154,5 +157,9 @@ spec:
         - name: flightctl-alertmanager-proxy-server-tls
           secret:
             secretName: {{ default "flightctl-alertmanager-proxy-server-tls" .Values.alertmanagerProxy.baseDomainTlsSecretName }}
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/api/flightctl-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-deployment.yaml
@@ -123,6 +123,9 @@ spec:
               name: flightctl-ca-bundle
               subPath: ca-bundle.crt
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
 
       restartPolicy: Always
@@ -149,4 +152,8 @@ spec:
         - name: flightctl-ca-bundle
           secret:
             secretName: flightctl-ca-bundle
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}

--- a/deploy/helm/flightctl/templates/certs/flightctl-encryption-key-from-openssl.yaml
+++ b/deploy/helm/flightctl/templates/certs/flightctl-encryption-key-from-openssl.yaml
@@ -1,0 +1,178 @@
+---
+# ServiceAccount for the encryption key generator Job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flightctl-encryption-key-generator
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+
+---
+# Role with minimal permissions for encryption key secret management
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flightctl-encryption-key-generator
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["flightctl-encryption-key"]
+    verbs: ["patch", "update"]
+
+---
+# RoleBinding to grant permissions to the ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flightctl-encryption-key-generator
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: flightctl-encryption-key-generator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flightctl-encryption-key-generator
+
+{{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
+---
+# Role with permissions for encryption key secret in internal namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flightctl-encryption-key-generator
+  namespace: {{ .Values.global.internalNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["flightctl-encryption-key"]
+    verbs: ["patch", "update"]
+
+---
+# RoleBinding to grant permissions to the ServiceAccount in internal namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flightctl-encryption-key-generator
+  namespace: {{ .Values.global.internalNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: flightctl-encryption-key-generator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: flightctl-encryption-key-generator
+{{- end }}
+
+---
+# ConfigMap containing the encryption key generation script
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flightctl-encryption-key-generator-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  generate-encryption-key.sh: |
+{{ .Files.Get "scripts/generate-encryption-key.sh" | nindent 4 }}
+
+---
+# Job to generate encryption key and create Kubernetes secret
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flightctl-encryption-key-generator-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-encryption-key-generator
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "flightctl.standardLabels" . | nindent 8 }}
+        flightctl.service: flightctl-encryption-key-generator
+    spec:
+      serviceAccountName: flightctl-encryption-key-generator
+      restartPolicy: Never
+      containers:
+      - name: encryption-key-generator
+        image: "{{ .Values.clusterCli.image.image }}:{{ .Values.clusterCli.image.tag }}"
+        imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.clusterCli.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - /scripts/generate-encryption-key.sh
+        - --encryption-dir
+        - /tmp/encryption
+        - --namespace
+        - {{ .Release.Namespace }}
+        {{- if and .Values.global.internalNamespace (ne .Values.global.internalNamespace .Release.Namespace) }}
+        - --internal-namespace
+        - {{ .Values.global.internalNamespace }}
+        {{- end }}
+        - --create-k8s-secrets
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+          readOnly: true
+        - name: encryption-workdir
+          mountPath: /tmp/encryption
+      volumes:
+      - name: scripts
+        configMap:
+          name: flightctl-encryption-key-generator-script
+          defaultMode: 0755
+      - name: encryption-workdir
+        emptyDir: {}
+      {{- if .Values.global.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}

--- a/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-deployment.yaml
@@ -71,6 +71,9 @@ spec:
               name: flightctl-ca-bundle
               subPath: ca-bundle.crt
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
           livenessProbe:
             httpGet:
@@ -97,5 +100,9 @@ spec:
         - name: flightctl-ca-bundle
           secret:
             secretName: flightctl-ca-bundle
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-deployment.yaml
@@ -82,6 +82,9 @@ spec:
               name: flightctl-ca-bundle
               subPath: ca-bundle.crt
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             - mountPath: /var/tmp/flightctl-builds
               name: flightctl-builds
               readOnly: false
@@ -158,6 +161,10 @@ spec:
         - name: flightctl-ca-bundle
           secret:
             secretName: flightctl-ca-bundle
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         - name: flightctl-builds
           hostPath:
             path: /var/tmp/flightctl-builds

--- a/deploy/helm/flightctl/templates/periodic/flightctl-periodic-deployment.yaml
+++ b/deploy/helm/flightctl/templates/periodic/flightctl-periodic-deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - mountPath: /etc/flightctl/ssh
               name: flightctl-ssh-known-hosts
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
 
       restartPolicy: Always
@@ -95,4 +98,8 @@ spec:
             items:
               - key: known_hosts
                 path: known_hosts
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-deployment.yaml
@@ -97,6 +97,9 @@ spec:
               name: flightctl-ca-bundle
               subPath: ca-bundle.crt
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
       restartPolicy: Always
       volumes:
@@ -109,5 +112,9 @@ spec:
         - name: flightctl-ca-bundle
           secret:
             secretName: flightctl-ca-bundle
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-deployment.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-deployment.yaml
@@ -67,6 +67,9 @@ spec:
             - mountPath: /etc/flightctl/ssh
               name: flightctl-ssh-known-hosts
               readOnly: true
+            - mountPath: /root/.flightctl/encryption
+              name: flightctl-encryption-key
+              readOnly: true
             {{- include "flightctl.dbSslVolumeMounts" . | nindent 12 }}
       restartPolicy: Always
       volumes:
@@ -79,4 +82,8 @@ spec:
             items:
               - key: known_hosts
                 path: known_hosts
+        - name: flightctl-encryption-key
+          secret:
+            secretName: flightctl-encryption-key
+            defaultMode: 0400
         {{- include "flightctl.dbSslVolumes" . | nindent 8 }}

--- a/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
+++ b/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Flight Control Alert Exporter service
 PartOf=flightctl.target
-After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-alertmanager.service
-Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-alertmanager.service
+After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-alertmanager.service flightctl-certs-init.service
+Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-alertmanager.service flightctl-certs-init.service
 
 [Container]
 ContainerName=flightctl-alert-exporter
@@ -15,6 +15,7 @@ Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
 Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
 Environment=DB_USER=flightctl_app
 Volume=/etc/flightctl/flightctl-alert-exporter/config.yaml:/root/.flightctl/config.yaml:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 [Service]

--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy.container
@@ -12,6 +12,7 @@ Network=flightctl.network
 AddHost=%H:host-gateway
 EnvironmentFile=/etc/flightctl/flightctl-alertmanager-proxy/env
 Volume=/etc/flightctl/flightctl-alertmanager-proxy/config.yaml:/root/.flightctl/config.yaml:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Secret=flightctl-postgresql-user-password,type=env,target=DB_PASSWORD
 Environment=DB_USER=flightctl_app

--- a/deploy/podman/flightctl-api/flightctl-api.container
+++ b/deploy/podman/flightctl-api/flightctl-api.container
@@ -23,6 +23,7 @@ Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,
 Volume=/etc/flightctl/flightctl-api/config.yaml:/root/.flightctl/config.yaml:ro,z
 # TPM CA PEMs for enrollment (paths in service.tpmCAPaths must exist inside the container)
 Volume=/etc/flightctl/tpm-cas:/etc/flightctl/tpm-cas:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Volume=flightctl-listeners:/var/run/flightctl-listeners/:z
 

--- a/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
+++ b/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api.container
@@ -16,6 +16,7 @@ Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
 Environment=DB_USER=flightctl_app
 Volume=/etc/flightctl/flightctl-imagebuilder-api/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 [Service]

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
@@ -18,6 +18,7 @@ Volume=/etc/flightctl/flightctl-imagebuilder-worker/config.yaml:/root/.flightctl
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.crt:/root/.flightctl/certs/client-signer.crt:ro,z
 Volume=/etc/flightctl/pki/flightctl-api/client-signer.key:/root/.flightctl/certs/client-signer.key:ro,z
 Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Volume=/var/tmp/flightctl-builds:/var/tmp/flightctl-builds:rw,z
 Volume=/var/tmp/flightctl-exports:/var/tmp/flightctl-exports:rw,z

--- a/deploy/podman/flightctl-periodic/flightctl-periodic.container
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Flight Control Periodic service
 PartOf=flightctl.target
-After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service
-Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service
+After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-certs-init.service
+Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-certs-init.service
 
 [Container]
 ContainerName=flightctl-periodic
@@ -16,6 +16,7 @@ Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
 Environment=DB_USER=flightctl_app
 Volume=/etc/flightctl/flightctl-periodic/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/ssh:/etc/flightctl/ssh:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 [Service]

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access.container
@@ -20,6 +20,7 @@ Volume=/etc/flightctl/pki/flightctl-remote-access/server.crt:/root/.flightctl/ce
 Volume=/etc/flightctl/pki/flightctl-remote-access/server.key:/root/.flightctl/certs/server.key:ro,z
 Volume=/etc/flightctl/pki/ca-bundle.crt:/root/.flightctl/certs/ca-bundle.crt:ro,z
 Volume=/etc/flightctl/flightctl-remote-access/config.yaml:/root/.flightctl/config.yaml:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 [Service]

--- a/deploy/podman/flightctl-worker/flightctl-worker.container
+++ b/deploy/podman/flightctl-worker/flightctl-worker.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Flight Control Worker service
 PartOf=flightctl.target
-After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service
-Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service
+After=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-certs-init.service
+Wants=flightctl-db-wait.service flightctl-db-migrate.service flightctl-kv.service flightctl-certs-init.service
 
 [Container]
 ContainerName=flightctl-worker
@@ -16,6 +16,7 @@ Secret=flightctl-kv-password,type=env,target=KV_PASSWORD
 Environment=DB_USER=flightctl_app
 Volume=/etc/flightctl/flightctl-worker/config.yaml:/root/.flightctl/config.yaml:ro,z
 Volume=/etc/flightctl/ssh:/etc/flightctl/ssh:ro,z
+Volume=/etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 
 [Service]

--- a/deploy/scripts/init_certs.sh
+++ b/deploy/scripts/init_certs.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 CONFIG_FILE="/etc/flightctl/service-config.yaml"
 CERT_DIR="/etc/flightctl/pki"
+ENCRYPTION_DIR="/etc/flightctl/encryption"
 YAML_HELPER="/usr/share/flightctl/yaml_helpers.py"
+
+# Generate encryption key unconditionally (independent of certificate method)
+/usr/share/flightctl/generate-encryption-key.sh --encryption-dir "$ENCRYPTION_DIR"
 
 CERT_METHOD=$(python3 "$YAML_HELPER" extract .global.generateCertificates "$CONFIG_FILE")
 if [ "$CERT_METHOD" = "builtin" ]; then

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	TelemetryGateway       *telemetryGatewayConfig    `json:"telemetrygateway,omitempty"`
 	VulnerabilityReporting *VulnerabilityConfig       `json:"vulnerabilityReporting,omitempty"`
 	DependenciesSync       *DependenciesSyncConfig    `json:"dependenciesSync,omitempty"`
+	Encryption             *EncryptionConfig          `json:"encryption,omitempty"`
 }
 
 // CryptoPolicyConfig contains cryptographic policy configuration for all protocols.
@@ -723,6 +724,20 @@ type telemetryGatewayForwardTLS struct {
 	KeyFile               string `json:"keyFile,omitempty"`
 }
 
+// EncryptionKeyConfig defines a single encryption key with its identifier and file path.
+type EncryptionKeyConfig struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+// EncryptionConfig holds encryption-at-rest key configuration.
+// Keys lists all available keys (for rotation support); ActiveKeyID selects which
+// key is used for new encryptions. Old keys remain available for decryption.
+type EncryptionConfig struct {
+	Keys        []EncryptionKeyConfig `json:"keys"`
+	ActiveKeyID string                `json:"activeKeyID"`
+}
+
 type ConfigOption func(*Config)
 
 func WithTracingEnabled() ConfigOption {
@@ -816,6 +831,10 @@ func ClientConfigFile() string {
 
 func CertificateDir() string {
 	return filepath.Join(ConfigDir(), "certs")
+}
+
+func EncryptionDir() string {
+	return filepath.Join(ConfigDir(), "encryption")
 }
 
 func NewDefault(opts ...ConfigOption) *Config {
@@ -933,6 +952,15 @@ func NewDefault(opts ...ConfigOption) *Config {
 		},
 		Auth: &authConfig{
 			DynamicProviderCacheTTL: util.Duration(5 * time.Second),
+		},
+		Encryption: &EncryptionConfig{
+			Keys: []EncryptionKeyConfig{
+				{
+					ID:   "default",
+					Path: filepath.Join(EncryptionDir(), "key"),
+				},
+			},
+			ActiveKeyID: "default",
 		},
 	}
 	c.CA = ca.NewDefault(CertificateDir())

--- a/internal/instrumentation/encryption/global.go
+++ b/internal/instrumentation/encryption/global.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,28 +44,24 @@ func (p Plaintext) Bytes() []byte {
 	return []byte(p)
 }
 
-// InitGlobalEncryption initializes the global encryption manager.
-// This MUST be called once during application startup, before any concurrent access.
-// It loads the v1 encryption strategy from FLIGHTCTL_ENCRYPTION_KEY environment variable or the provided keyPath.
-//
-// Thread safety: This function uses sync.Once to ensure single initialization.
-// After initialization completes, concurrent Encrypt/Decrypt calls are safe.
-func InitGlobalEncryption(log logrus.FieldLogger) error {
-	return InitGlobalEncryptionFull(log, nil, nil)
+// InitGlobalEncryption initializes the global encryption manager from the
+// application config (cfg.Encryption). Must be called once at startup before
+// any concurrent access. Uses sync.Once internally.
+func InitGlobalEncryption(log logrus.FieldLogger, cfg *config.Config) error {
+	return InitGlobalEncryptionFull(log, cfg, nil, nil)
 }
 
-// InitGlobalEncryptionWithCanary initializes encryption with optional canary store.
-// If canaryStore is nil, canary functionality is disabled.
-func InitGlobalEncryptionWithCanary(log logrus.FieldLogger, canaryStore CanaryStore) error {
-	return InitGlobalEncryptionFull(log, canaryStore, nil)
+// InitGlobalEncryptionWithCanary initializes encryption from the application
+// config with an optional canary store for key-health verification.
+func InitGlobalEncryptionWithCanary(log logrus.FieldLogger, cfg *config.Config, canaryStore CanaryStore) error {
+	return InitGlobalEncryptionFull(log, cfg, canaryStore, nil)
 }
 
-// InitGlobalEncryptionFull initializes encryption with optional canary store and metrics.
-// If canaryStore is nil, canary functionality is disabled.
-// If metrics is nil, metrics recording is disabled.
-func InitGlobalEncryptionFull(log logrus.FieldLogger, canaryStore CanaryStore, metrics MetricsRecorder) error {
+// InitGlobalEncryptionFull initializes encryption from the application config
+// with optional canary store and metrics recorder.
+func InitGlobalEncryptionFull(log logrus.FieldLogger, cfg *config.Config, canaryStore CanaryStore, metrics MetricsRecorder) error {
 	globalManagerOnce.Do(func() {
-		v1Strategy, err := NewV1Strategy()
+		v1Strategy, err := NewV1Strategy(cfg)
 		if err != nil {
 			globalInitErr = fmt.Errorf("load encryption key: %w", err)
 			return

--- a/internal/instrumentation/encryption/global_test.go
+++ b/internal/instrumentation/encryption/global_test.go
@@ -2,25 +2,42 @@ package encryption
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// setupTestKey sets FLIGHTCTL_ENCRYPTION_KEY for tests (auto-cleanup via t.Setenv)
-func setupTestKey(t *testing.T) {
+// setupTestKey writes a random AES-256 key to a temp file and returns a Config.
+func setupTestKey(t *testing.T) *config.Config {
 	t.Helper()
 	key, err := crypto.GenerateAES256Key()
 	require.NoError(t, err)
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key)
+	return writeTestKey(t, key, "default")
+}
+
+// writeTestKey writes a key string to a temp file and returns a Config.
+func writeTestKey(t *testing.T, key, keyID string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+	return &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: keyID, Path: keyPath}},
+			ActiveKeyID: keyID,
+		},
+	}
 }
 
 func TestInitGlobalEncryption_WithoutCanaryStore(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -31,7 +48,7 @@ func TestInitGlobalEncryption_WithoutCanaryStore(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	// Manager initialized, canary disabled
@@ -40,7 +57,7 @@ func TestInitGlobalEncryption_WithoutCanaryStore(t *testing.T) {
 }
 
 func TestInitGlobalEncryption_WithCanaryStore(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -53,7 +70,7 @@ func TestInitGlobalEncryption_WithCanaryStore(t *testing.T) {
 
 	// Init WITH canary store
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	// Both managers initialized
@@ -71,7 +88,7 @@ func TestGlobalCanaryManager_ReturnsNilIfNotInitialized(t *testing.T) {
 }
 
 func TestGlobalCanaryManager_ReturnsNilIfDisabled(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -83,7 +100,7 @@ func TestGlobalCanaryManager_ReturnsNilIfDisabled(t *testing.T) {
 	logger.SetLevel(logrus.FatalLevel)
 
 	// Init WITHOUT canary store
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	canaryMgr := GlobalCanaryManager()
@@ -99,7 +116,7 @@ func TestGlobalManager_ReturnsNilIfNotInitialized(t *testing.T) {
 }
 
 func TestEncrypt_CreatesCanaryOnFirstUse(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -112,7 +129,7 @@ func TestEncrypt_CreatesCanaryOnFirstUse(t *testing.T) {
 
 	// Init WITH canary store
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -138,7 +155,7 @@ func TestEncrypt_CreatesCanaryOnFirstUse(t *testing.T) {
 }
 
 func TestEncrypt_CanaryDoOnce(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -151,7 +168,7 @@ func TestEncrypt_CanaryDoOnce(t *testing.T) {
 
 	// Init WITH canary store
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -175,7 +192,7 @@ func TestEncrypt_CanaryDoOnce(t *testing.T) {
 }
 
 func TestInitGlobalEncryption_ValidatesExistingCanaries(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -188,7 +205,7 @@ func TestInitGlobalEncryption_ValidatesExistingCanaries(t *testing.T) {
 
 	// Init WITH canary store
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	// Create a canary
@@ -210,7 +227,7 @@ func TestInitGlobalEncryption_ValidatesExistingCanaries(t *testing.T) {
 	globalInitErr = nil
 
 	// Re-init should validate the existing canary in the store
-	err = InitGlobalEncryptionWithCanary(logger, store)
+	err = InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err, "Should successfully validate existing canary on restart")
 
 	// Verify validation actually happened and succeeded
@@ -221,7 +238,7 @@ func TestInitGlobalEncryption_ValidatesExistingCanaries(t *testing.T) {
 }
 
 func TestInitGlobalEncryption_ActiveKeyCannotDecryptCanary_FailsInit(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -234,7 +251,7 @@ func TestInitGlobalEncryption_ActiveKeyCannotDecryptCanary_FailsInit(t *testing.
 
 	// Init WITH canary store
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	// Create a canary with the current key
@@ -256,16 +273,15 @@ func TestInitGlobalEncryption_ActiveKeyCannotDecryptCanary_FailsInit(t *testing.
 	// Generate a different key
 	newKey, err := crypto.GenerateAES256Key()
 	require.NoError(t, err)
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", newKey)
+	newEncCfg := writeTestKey(t, newKey, "default")
 
 	// Re-init should FAIL because active key cannot decrypt existing canary
-	err = InitGlobalEncryptionWithCanary(logger, store)
+	err = InitGlobalEncryptionWithCanary(logger, newEncCfg, store)
 	require.Error(t, err, "Should fail when active key cannot decrypt canary")
 	assert.Contains(t, err.Error(), "active encryption key v1/default is broken")
 }
 
 func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T) {
-	setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -282,10 +298,10 @@ func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T)
 	key2, err := crypto.GenerateAES256Key()
 	require.NoError(t, err)
 
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key1)
+	encCfg := writeTestKey(t, key1, "default")
 
 	store := newMemoryCanaryStore()
-	err = InitGlobalEncryptionWithCanary(logger, store)
+	err = InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	// Create canary for the default key (key1)
@@ -315,7 +331,7 @@ func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T)
 	globalInitErr = nil
 
 	// Re-init should SUCCEED (only old key is broken, not active key)
-	err = InitGlobalEncryptionWithCanary(logger, store)
+	err = InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err, "Should succeed even when old key cannot decrypt")
 
 	// Verify: active key's canary is ok, old key's canary failed
@@ -326,9 +342,10 @@ func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T)
 	// Find results by keyID
 	var defaultResult, oldkeyResult *ValidationResult
 	for i := range results {
-		if results[i].KeyID == "default" {
+		switch results[i].KeyID {
+		case "default":
 			defaultResult = &results[i]
-		} else if results[i].KeyID == "oldkey" {
+		case "oldkey":
 			oldkeyResult = &results[i]
 		}
 	}
@@ -340,7 +357,7 @@ func TestInitGlobalEncryption_OldKeyCannotDecrypt_WarnsButSucceeds(t *testing.T)
 }
 
 func TestDecrypt_EncryptedData(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -351,7 +368,7 @@ func TestDecrypt_EncryptedData(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -369,7 +386,7 @@ func TestDecrypt_EncryptedData(t *testing.T) {
 }
 
 func TestDecrypt_PlaintextData_BackwardCompatibility(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -380,7 +397,7 @@ func TestDecrypt_PlaintextData_BackwardCompatibility(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -411,7 +428,7 @@ func TestDecrypt_NotInitialized(t *testing.T) {
 }
 
 func TestDecrypt_InvalidFormat(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -422,7 +439,7 @@ func TestDecrypt_InvalidFormat(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -446,18 +463,88 @@ func TestInitGlobalEncryption_CachesErrorAcrossCalls(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	// Do NOT set FLIGHTCTL_ENCRYPTION_KEY - init should fail
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", "")
+	// Config with nonexistent key path - init should fail
+	badCfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: filepath.Join(t.TempDir(), "missing-key")}},
+			ActiveKeyID: "default",
+		},
+	}
 
 	// First call - should fail
-	err1 := InitGlobalEncryption(logger)
+	err1 := InitGlobalEncryption(logger, badCfg)
 	require.Error(t, err1, "First init should fail when key is missing")
 
 	// Second call - should return the SAME error, not nil
-	err2 := InitGlobalEncryption(logger)
+	err2 := InitGlobalEncryption(logger, badCfg)
 	require.Error(t, err2, "Second init should also fail with cached error")
 	assert.Equal(t, err1.Error(), err2.Error(), "Both calls should return same error")
 
 	// Manager should still be nil
 	assert.Nil(t, GlobalManager(), "Manager should remain nil after failed init")
+}
+
+func TestKeyRotation_AddNewKeyAndReencrypt(t *testing.T) {
+	encCfg := setupTestKey(t)
+	// Reset global state
+	globalManager = nil
+	globalCanaryManager = nil
+	globalLogger = nil
+	globalManagerOnce = *new(sync.Once)
+	globalInitErr = nil
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err := InitGlobalEncryption(logger, encCfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mgr := GlobalManager()
+
+	// Encrypt data with the original key
+	plaintext := []byte("rotate-me-secret")
+	ciphertext, err := Encrypt(ctx, Plaintext(plaintext))
+	require.NoError(t, err)
+	assert.Contains(t, string(ciphertext), "enc:v1:default:")
+
+	// Add a new key and make it active (simulating key rotation)
+	_, v1Strat := mgr.GetActiveStrategy()
+	v1 := v1Strat.(*V1Strategy)
+
+	newKey, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	newKeyBytes, err := crypto.DecodeAES256Key(newKey)
+	require.NoError(t, err)
+	require.NoError(t, v1.AddKey("2025-07", newKeyBytes, true))
+
+	assert.Equal(t, "2025-07", v1.ActiveKeyID())
+
+	// Old ciphertext still decrypts (old key is retained)
+	decrypted, wasEncrypted, err := Decrypt(ctx, ciphertext)
+	require.NoError(t, err)
+	assert.True(t, wasEncrypted)
+	assert.Equal(t, plaintext, decrypted.Bytes())
+
+	// ProcessEncryption re-encrypts with the new active key
+	reencrypted, err := mgr.ProcessEncryption(ctx, ciphertext.Bytes())
+	require.NoError(t, err)
+	assert.Contains(t, string(reencrypted), "enc:v1:2025-07:", "Should be re-encrypted with new key")
+	assert.NotEqual(t, ciphertext.Bytes(), reencrypted, "Re-encrypted ciphertext should differ")
+
+	// Re-encrypted data decrypts to the same plaintext
+	decrypted2, wasEncrypted2, err := Decrypt(ctx, Ciphertext(reencrypted))
+	require.NoError(t, err)
+	assert.True(t, wasEncrypted2)
+	assert.Equal(t, plaintext, decrypted2.Bytes())
+
+	// ProcessEncryption on already-rotated data is idempotent
+	reencrypted2, err := mgr.ProcessEncryption(ctx, reencrypted)
+	require.NoError(t, err)
+	assert.Equal(t, reencrypted, reencrypted2, "Same key should not re-encrypt again")
+
+	// New encryptions use the new key
+	newCiphertext, err := Encrypt(ctx, Plaintext([]byte("new-secret")))
+	require.NoError(t, err)
+	assert.Contains(t, string(newCiphertext), "enc:v1:2025-07:")
 }

--- a/internal/instrumentation/encryption/status_test.go
+++ b/internal/instrumentation/encryption/status_test.go
@@ -27,7 +27,7 @@ func TestStatus_EncryptionNotInitialized(t *testing.T) {
 }
 
 func TestStatus_CanariesDisabled(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -39,7 +39,7 @@ func TestStatus_CanariesDisabled(t *testing.T) {
 	logger.SetLevel(logrus.FatalLevel)
 
 	// Init WITHOUT canaries
-	err := InitGlobalEncryption(logger)
+	err := InitGlobalEncryption(logger, encCfg)
 	require.NoError(t, err)
 
 	// Add a second key
@@ -93,7 +93,7 @@ func TestStatus_CanariesDisabled(t *testing.T) {
 }
 
 func TestStatus_CanariesEnabled_BeforeFirstEncryption(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -106,7 +106,7 @@ func TestStatus_CanariesEnabled_BeforeFirstEncryption(t *testing.T) {
 
 	// Init WITH canaries
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -126,7 +126,7 @@ func TestStatus_CanariesEnabled_BeforeFirstEncryption(t *testing.T) {
 }
 
 func TestStatus_CanariesEnabled_AfterFirstEncryption(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -139,7 +139,7 @@ func TestStatus_CanariesEnabled_AfterFirstEncryption(t *testing.T) {
 
 	// Init WITH canaries
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -164,7 +164,7 @@ func TestStatus_CanariesEnabled_AfterFirstEncryption(t *testing.T) {
 }
 
 func TestStatus_MultipleKeys_WithCanaries(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -177,7 +177,7 @@ func TestStatus_MultipleKeys_WithCanaries(t *testing.T) {
 
 	// Init WITH canaries
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -235,7 +235,7 @@ func TestStatus_MultipleKeys_WithCanaries(t *testing.T) {
 }
 
 func TestStatus_HistoricalCanary_KeyStillConfigured(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -248,7 +248,7 @@ func TestStatus_HistoricalCanary_KeyStillConfigured(t *testing.T) {
 
 	// Init WITH canaries
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -305,7 +305,7 @@ func TestStatus_HistoricalCanary_KeyStillConfigured(t *testing.T) {
 }
 
 func TestStatus_HistoricalCanary_KeyMissing(t *testing.T) {
-	setupTestKey(t)
+	encCfg := setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -318,7 +318,7 @@ func TestStatus_HistoricalCanary_KeyMissing(t *testing.T) {
 
 	// Init WITH canaries
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -354,7 +354,6 @@ func TestStatus_HistoricalCanary_KeyMissing(t *testing.T) {
 }
 
 func TestStatus_DeterministicOrdering(t *testing.T) {
-	setupTestKey(t)
 	// Reset global state
 	globalManager = nil
 	globalCanaryManager = nil
@@ -370,10 +369,10 @@ func TestStatus_DeterministicOrdering(t *testing.T) {
 	key2, _ := crypto.GenerateAES256Key()
 	key3, _ := crypto.GenerateAES256Key()
 
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key1)
+	encCfg := writeTestKey(t, key1, "default")
 
 	store := newMemoryCanaryStore()
-	err := InitGlobalEncryptionWithCanary(logger, store)
+	err := InitGlobalEncryptionWithCanary(logger, encCfg, store)
 	require.NoError(t, err)
 
 	// Add more keys in random order

--- a/internal/instrumentation/encryption/v1_strategy.go
+++ b/internal/instrumentation/encryption/v1_strategy.go
@@ -10,19 +10,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/pkg/crypto"
 )
-
-// defaultKeyFile returns the default path for the v1 encryption key file.
-// This is $HOME/.flightctl/encryption/key (e.g., /root/.flightctl/encryption/key).
-func defaultKeyFile() string {
-	return filepath.Join(config.ConfigDir(), "encryption", "key")
-}
 
 // V1Strategy implements AES-256-GCM encryption.
 // Format: keyID:base64(nonce||ciphertext||tag)
@@ -43,34 +36,42 @@ func newV1Strategy() *V1Strategy {
 	}
 }
 
-// NewV1Strategy loads a single encryption key from environment variable or file.
-// Priority: FLIGHTCTL_ENCRYPTION_KEY env var > defaultKeyFile()
-// The key is registered with keyID "default".
-func NewV1Strategy() (*V1Strategy, error) {
+// NewV1Strategy creates a V1 (AES-256-GCM) strategy from the application config.
+// Keys are loaded from cfg.Encryption; ActiveKeyID selects the key for new
+// encryptions while the rest remain available for decryption (rotation).
+func NewV1Strategy(cfg *config.Config) (*V1Strategy, error) {
+	if cfg == nil || cfg.Encryption == nil || len(cfg.Encryption.Keys) == 0 {
+		return nil, fmt.Errorf("no encryption keys configured")
+	}
+
+	encCfg := cfg.Encryption
+
 	strategy := newV1Strategy()
 
-	var encodedKey string
-	keyPath := defaultKeyFile()
-
-	// Try environment variable first
-	if envKey := os.Getenv("FLIGHTCTL_ENCRYPTION_KEY"); envKey != "" {
-		encodedKey = strings.TrimSpace(envKey)
-	} else {
-		// Try default key file
-		keyBytes, err := os.ReadFile(keyPath)
-		if err != nil {
-			return nil, fmt.Errorf("read key file %s: %w", keyPath, err)
+	seen := make(map[string]bool, len(encCfg.Keys))
+	for _, keyCfg := range encCfg.Keys {
+		if seen[keyCfg.ID] {
+			return nil, fmt.Errorf("duplicate encryption key ID %q in config", keyCfg.ID)
 		}
-		encodedKey = strings.TrimSpace(string(keyBytes))
+		seen[keyCfg.ID] = true
+		keyBytes, err := os.ReadFile(keyCfg.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read key file %s for key %s: %w", keyCfg.Path, keyCfg.ID, err)
+		}
+
+		key, err := crypto.DecodeAES256Key(strings.TrimSpace(string(keyBytes)))
+		if err != nil {
+			return nil, fmt.Errorf("decode encryption key %s: %w", keyCfg.ID, err)
+		}
+
+		isActive := keyCfg.ID == encCfg.ActiveKeyID
+		if err := strategy.AddKey(keyCfg.ID, key, isActive); err != nil {
+			return nil, err
+		}
 	}
 
-	key, err := crypto.DecodeAES256Key(encodedKey)
-	if err != nil {
-		return nil, fmt.Errorf("decode encryption key: %w", err)
-	}
-
-	if err := strategy.AddKey("default", key, true); err != nil {
-		return nil, err
+	if strategy.activeKey == "" {
+		return nil, fmt.Errorf("activeKeyID %q does not match any configured key", encCfg.ActiveKeyID)
 	}
 
 	return strategy, nil

--- a/internal/instrumentation/encryption/v1_strategy_test.go
+++ b/internal/instrumentation/encryption/v1_strategy_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,8 +20,7 @@ func TestNewV1Strategy_EmptyConstructor(t *testing.T) {
 	strategy := newV1Strategy()
 
 	assert.NotNil(t, strategy)
-	assert.Empty(t, strategy.keys)
-	assert.Empty(t, strategy.gcms)
+	assert.Empty(t, strategy.ConfiguredKeys())
 	assert.Empty(t, strategy.ActiveKeyID())
 }
 
@@ -33,8 +34,7 @@ func TestV1Strategy_AddKey(t *testing.T) {
 
 	require.NoError(t, strategy.AddKey("my-key", key, true))
 
-	assert.Contains(t, strategy.keys, "my-key")
-	assert.Contains(t, strategy.gcms, "my-key")
+	assert.Contains(t, strategy.ConfiguredKeys(), "my-key")
 	assert.Equal(t, "my-key", strategy.ActiveKeyID(), "newly added key should be active")
 }
 
@@ -81,7 +81,7 @@ func TestV1Strategy_AddMultipleKeys(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "2024-06", strategy.ActiveKeyID(), "last added key should be active")
 
-	assert.Len(t, strategy.keys, 2, "both keys should be registered")
+	assert.Len(t, strategy.ConfiguredKeys(), 2, "both keys should be registered")
 }
 
 func TestV1Strategy_SetActiveKey(t *testing.T) {
@@ -353,46 +353,162 @@ func TestV1Strategy_UniqueNonces(t *testing.T) {
 	assert.Equal(t, plaintext, decrypted2)
 }
 
-func TestNewV1Strategy_EnvVar(t *testing.T) {
+func TestNewV1Strategy_FromConfig(t *testing.T) {
 	encodedKey, err := crypto.GenerateAES256Key()
 	require.NoError(t, err)
 
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", encodedKey)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(encodedKey), 0600))
 
-	strategy, err := NewV1Strategy()
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "default",
+		},
+	}
+
+	strategy, err := NewV1Strategy(cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, strategy)
 	assert.Equal(t, "default", strategy.ActiveKeyID())
-	assert.Contains(t, strategy.keys, "default")
+}
+
+func TestNewV1Strategy_FromConfig_MultipleKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	key1, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key1Path := filepath.Join(dir, "key1")
+	require.NoError(t, os.WriteFile(key1Path, []byte(key1), 0600))
+
+	key2, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	key2Path := filepath.Join(dir, "key2")
+	require.NoError(t, os.WriteFile(key2Path, []byte(key2), 0600))
+
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys: []config.EncryptionKeyConfig{
+				{ID: "2024-01", Path: key1Path},
+				{ID: "2025-07", Path: key2Path},
+			},
+			ActiveKeyID: "2025-07",
+		},
+	}
+
+	strategy, err := NewV1Strategy(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2025-07", strategy.ActiveKeyID(), "ActiveKeyID from config should be selected")
+	assert.ElementsMatch(t, []string{"2024-01", "2025-07"}, strategy.ConfiguredKeys())
+
+	ctx := context.Background()
+
+	// Encrypt with the active key
+	encrypted, err := strategy.EncryptPlaintext(ctx, []byte("secret"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(encrypted), "2025-07:"))
+
+	// Switch active to old key and encrypt again
+	require.NoError(t, strategy.SetActiveKey("2024-01"))
+	encrypted2, err := strategy.EncryptPlaintext(ctx, []byte("secret2"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(encrypted2), "2024-01:"))
+
+	// Both decrypt correctly regardless of which key is active
+	decrypted, err := testDecrypt(t, strategy, ctx, encrypted)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret"), decrypted)
+
+	decrypted2, err := testDecrypt(t, strategy, ctx, encrypted2)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret2"), decrypted2)
+}
+
+func TestNewV1Strategy_FromConfig_InvalidActiveKeyID(t *testing.T) {
+	dir := t.TempDir()
+	key, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "nonexistent",
+		},
+	}
+
+	_, err = NewV1Strategy(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "activeKeyID")
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestNewV1Strategy_FromConfig_DuplicateKeyID(t *testing.T) {
+	dir := t.TempDir()
+	key, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys: []config.EncryptionKeyConfig{
+				{ID: "default", Path: keyPath},
+				{ID: "default", Path: keyPath},
+			},
+			ActiveKeyID: "default",
+		},
+	}
+
+	_, err = NewV1Strategy(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate encryption key ID")
 }
 
 func TestNewV1Strategy_NoKeyProvided(t *testing.T) {
-	os.Unsetenv("FLIGHTCTL_ENCRYPTION_KEY")
-
-	_, err := NewV1Strategy()
+	_, err := NewV1Strategy(nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "read key file")
+	assert.Contains(t, err.Error(), "no encryption keys configured")
 }
 
 func TestNewV1Strategy_InvalidBase64(t *testing.T) {
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", "not-valid-base64!!!")
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte("not-valid-base64!!!"), 0600))
 
-	_, err := NewV1Strategy()
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "default",
+		},
+	}
+
+	_, err := NewV1Strategy(cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "decode")
 }
 
 func TestNewV1Strategy_KeyTooShort(t *testing.T) {
-	var err error
-
 	shortKey := make([]byte, 16) // Only 16 bytes, need 32
-	_, err = rand.Read(shortKey)
+	_, err := rand.Read(shortKey)
 	require.NoError(t, err)
 	encodedKey := base64.StdEncoding.EncodeToString(shortKey)
 
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", encodedKey)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(encodedKey), 0600))
 
-	_, err = NewV1Strategy()
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "default",
+		},
+	}
+
+	_, err = NewV1Strategy(cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "32 bytes")
 }

--- a/internal/instrumentation/metrics/encryption/collector_test.go
+++ b/internal/instrumentation/metrics/encryption/collector_test.go
@@ -2,9 +2,12 @@ package encryption
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/config"
 	enc "github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -116,17 +119,24 @@ func TestEncryptionCollector_Integration_WithManager(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(collector.operationsTotal.WithLabelValues("decrypt", "v1", "default", "success")))
 }
 
-// Helper function to create a test manager
 func createTestManager(t *testing.T) *enc.Manager {
 	t.Helper()
 
-	// Generate and set test key via environment variable
 	key, err := crypto.GenerateAES256Key()
 	require.NoError(t, err)
-	t.Setenv("FLIGHTCTL_ENCRYPTION_KEY", key)
 
-	// Create strategy
-	strategy, err := enc.NewV1Strategy()
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+
+	cfg := &config.Config{
+		Encryption: &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "default",
+		},
+	}
+
+	strategy, err := enc.NewV1Strategy(cfg)
 	require.NoError(t, err)
 
 	mgr := enc.NewManager()

--- a/internal/quadlet/renderer/manifest.go
+++ b/internal/quadlet/renderer/manifest.go
@@ -102,6 +102,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		// Certs init service
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl-certs-init.service", Destination: filepath.Join(config.SystemdUnitOutputDir, "flightctl-certs-init.service"), Template: false, Mode: RegularFileMode},
 		{Action: ActionCopyFile, Source: "deploy/helm/flightctl/scripts/generate-certificates.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "generate-certificates.sh"), Template: false, Mode: ExecutableFileMode},
+		{Action: ActionCopyFile, Source: "deploy/helm/flightctl/scripts/generate-encryption-key.sh", Destination: filepath.Join(config.ReadOnlyConfigOutputDir, "generate-encryption-key.sh"), Template: false, Mode: ExecutableFileMode},
 
 		// Shared files
 		{Action: ActionCopyFile, Source: "deploy/podman/flightctl.network", Destination: filepath.Join(config.QuadletFilesOutputDir, "flightctl.network"), Template: false, Mode: RegularFileMode},
@@ -125,6 +126,7 @@ func servicesManifest(config *RendererConfig) []InstallAction {
 		{Action: ActionCreateEmptyFile, Destination: filepath.Join(config.WriteableConfigOutputDir, "ssh", "known_hosts"), Mode: RegularFileMode},
 
 		// Empty directories
+		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "encryption"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "pki"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "pki", "flightctl-api"), Mode: ExecutableFileMode},
 		{Action: ActionCreateEmptyDir, Destination: filepath.Join(config.WriteableConfigOutputDir, "pki", "flightctl-alertmanager-proxy"), Mode: ExecutableFileMode},

--- a/internal/store/gorm.go
+++ b/internal/store/gorm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
@@ -124,6 +125,15 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 		sqlDB.Close()
 		log.Errorf("failed to register OpenTelemetry GORM plugin: %v", err)
 		return nil, fmt.Errorf("failed to register OpenTelemetry GORM plugin: %w", err)
+	}
+
+	// Register encryption plugin if encryption is initialized
+	if encryption.GlobalManager() != nil {
+		if err = newDB.Use(encryption.NewPlugin(encryption.GlobalManager(), map[string]encryption.ModelEncryptHandler{})); err != nil {
+			sqlDB.Close()
+			log.Errorf("failed to register encryption plugin: %v", err)
+			return nil, fmt.Errorf("failed to register encryption plugin: %w", err)
+		}
 	}
 
 	return newDB, nil

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -77,6 +77,7 @@ The flightctl-selinux package provides the SELinux policy modules required by th
 %package services
 Summary: Flight Control services
 Requires: bash
+Requires: openssl
 Requires: podman
 Requires: python3-pyyaml
 BuildRequires: systemd-rpm-macros
@@ -392,9 +393,10 @@ fi
     # Copy services must gather script
     cp packaging/must-gather/flightctl-services-must-gather %{buildroot}%{_bindir}
 
-    # Copy generate-certificates.sh script
+    # Copy certificate and encryption key generation scripts
     mkdir -p %{buildroot}%{_datadir}/flightctl
     install -m 0755 deploy/helm/flightctl/scripts/generate-certificates.sh %{buildroot}%{_datadir}/flightctl/generate-certificates.sh
+    install -m 0755 deploy/helm/flightctl/scripts/generate-encryption-key.sh %{buildroot}%{_datadir}/flightctl/generate-encryption-key.sh
 
     # Copy sos report flightctl plugin
     mkdir -p %{buildroot}/usr/share/sosreport
@@ -559,6 +561,7 @@ fi
     %defattr(0644,root,root,-)
     # Files mounted to system config
     %dir %{_sysconfdir}/flightctl
+    %dir %{_sysconfdir}/flightctl/encryption
     %dir %{_sysconfdir}/flightctl/pki
     %dir %{_sysconfdir}/flightctl/pki/flightctl-api
     %dir %{_sysconfdir}/flightctl/pki/flightctl-alertmanager-proxy
@@ -667,6 +670,7 @@ fi
     %attr(0755,root,root) %{_datadir}/flightctl/secrets.sh
     %attr(0755,root,root) %{_datadir}/flightctl/yaml_helpers.py
     %attr(0755,root,root) %{_datadir}/flightctl/generate-certificates.sh
+    %attr(0755,root,root) %{_datadir}/flightctl/generate-encryption-key.sh
 
     # flightctl-services pre upgrade checks
     %dir %{_libexecdir}/flightctl

--- a/test/integration/integrationstack/stack.go
+++ b/test/integration/integrationstack/stack.go
@@ -14,18 +14,23 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/migration"
 	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/flightctl/flightctl/test/harness/containers"
 	"github.com/sirupsen/logrus"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+var ensureTestEncryptionOnce sync.Once
 
 // Container names for integration stack services.
 // Note: Redis is NOT part of the shared stack - each test suite creates its own ephemeral Redis.
@@ -237,10 +242,44 @@ func integrationStackCredentialMismatch(ctx context.Context, postgresMaster stri
 // If credentials differ from running containers, removes them so init SQL applies.
 // Note: Redis is NOT started here - each test suite creates its own ephemeral Redis via testdb.CreateTestRedis().
 func EnsureRunning(ctx context.Context) error {
+	EnsureTestEncryption(logrus.StandardLogger())
 	if err := ensureContainersRunning(ctx); err != nil {
 		return err
 	}
 	return RunMigrationsWithLock(ctx)
+}
+
+// EnsureTestEncryption generates a random AES-256 key in a process-local temp
+// directory and initializes the global encryption manager. Each process gets its
+// own key, avoiding cross-process races on a shared file path.
+// Safe to call multiple times (runs once per process).
+func EnsureTestEncryption(log *logrus.Logger) {
+	ensureTestEncryptionOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "flightctl-test-encryption-*")
+		if err != nil {
+			log.Fatalf("creating temp encryption dir: %v", err)
+		}
+
+		keyPath := filepath.Join(dir, "key")
+		key, err := crypto.GenerateAES256Key()
+		if err != nil {
+			log.Fatalf("generating test encryption key: %v", err)
+		}
+
+		if err := os.WriteFile(keyPath, []byte(key), 0600); err != nil {
+			log.Fatalf("writing test encryption key to %s: %v", keyPath, err)
+		}
+		log.Infof("Test encryption key written to %s", keyPath)
+
+		cfg := config.NewDefault()
+		cfg.Encryption = &config.EncryptionConfig{
+			Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+			ActiveKeyID: "default",
+		}
+		if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+			log.Fatalf("initializing test encryption: %v", err)
+		}
+	})
 }
 
 // EnsureContainersOnly starts containers without running migrations.


### PR DESCRIPTION
#### Summary

This PR wires the encryption-at-rest foundation across the control plane, deployment, and test infrastructure as part of EDM-3460.

Changes include:

- Add config-based encryption key management:
  - introduce encryption config types
  - load encryption keys from files on disk instead of `FLIGHTCTL_ENCRYPTION_KEY`
  - support multiple configured keys and an active key ID as a foundation for key rotation
  - add an `EncryptionDir()` helper with a default encryption key path under the Flightctl config directory

- Initialize `InitGlobalEncryption` in all control plane binaries that access the store:
  - `flightctl-api`
  - `flightctl-worker`
  - `flightctl-periodic`
  - `flightctl-alertmanager-proxy`
  - `flightctl-alert-exporter`
  - `flightctl-remote-access`
  - `flightctl-imagebuilder-api`
  - `flightctl-imagebuilder-worker`

- Initialize encryption after store creation, so the encryption manager can use a database-backed canary store in follow-up work.

- Register the GORM encryption plugin during store initialization.
  - The plugin is registered on the write path.
  - The encryption handler map is currently empty, so this PR does not yet encrypt model fields.
  - Field-level encryption handlers will be added in follow-up work.

- Register the encryption metrics collector for components that expose Prometheus metrics:
  - `flightctl-api`
  - `flightctl-worker`

- Add deployment-time encryption key provisioning:
  - Helm OpenSSL-based encryption key generation job
  - `generate-encryption-key.sh` script and tests
  - encryption key Secret and volume mounts for all relevant Helm deployments
  - Podman/quadlet encryption directory generation and bind mounts
  - RPM packaging updates for the encryption directory

- Update encryption unit tests to use config-based key setup instead of environment variables.

- Add test coverage for multi-key configuration and rotation foundation:
  - adding a new key and re-encrypting with the active key
  - loading multiple keys from config
  - rejecting invalid active key configuration

- Add `EnsureTestEncryption()` to the integration test infrastructure so integration tests run with encryption initialized from config.

- Initialize test encryption from the shared integration stack entry point, following the same pattern as certificate setup.

#### Notes

This PR initializes and wires the encryption-at-rest infrastructure, but it does not yet enable field-level encryption for model data. The GORM encryption plugin is registered, but the encryption handler map is currently empty. Follow-up work will add the model-specific encryption handlers for protected fields.