### PR TITLE
EDM-4742: Add VM app status diagnostics to e2e test

### DIFF
--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -1,9 +1,12 @@
 package vm_test
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -11,8 +14,14 @@ import (
 )
 
 const (
-	vmAppName      = "test-vm"
-	defaultVMImage = "quay.io/containerdisks/fedora:40"
+	vmAppName                    = "test-vm"
+	defaultVMImage               = "quay.io/containerdisks/fedora:40"
+	vmAppTargetUnitSuffix        = "flightctl-quadlet-app.target"
+	vmAppComputeServiceFmt       = "%s-virt-launcher-%s-compute.service"
+	systemdSubStateActive        = "active"
+	systemdSubStateRunning       = "running"
+	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
+	systemdActiveStateActive     = string(v1beta1.SystemdActiveStateActive)
 )
 
 func getVMImage() string {
@@ -50,12 +59,115 @@ var _ = Describe("VM Applications", Ordered, func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying the VM application reaches Running status")
+		By("Verifying the VM application reports Running status")
 		err = harness.WaitForApplicationStatus(deviceID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppName)
+		}
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying the applications summary is Healthy")
 		err = harness.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppName)
+		}
 		Expect(err).ToNot(HaveOccurred())
 	})
 })
+
+// logVMApplicationUnitStatus logs generated systemd unit state when product-level VM app status checks fail.
+func logVMApplicationUnitStatus(h *e2e.Harness, appName string) {
+	if appName == "" {
+		GinkgoWriter.Println("VM application unit diagnostics skipped: app name is empty")
+		return
+	}
+	units, err := vmApplicationUnitStatus(h, appName)
+	if err != nil {
+		GinkgoWriter.Printf("VM application %s unit diagnostics failed: %v\n", appName, err)
+		return
+	}
+	if len(units) == 0 {
+		GinkgoWriter.Printf("VM application %s unit diagnostics found no matching systemd units\n", appName)
+		return
+	}
+	running, details := vmApplicationUnitsRunningStatus(units, appName)
+	GinkgoWriter.Printf("VM application %s unit readiness=%t: %s\n", appName, running, details)
+}
+
+// vmApplicationUnitPatterns returns the generated systemd unit patterns for a VM app.
+func vmApplicationUnitPatterns(appName string) []string {
+	if appName == "" {
+		return nil
+	}
+	return []string{
+		vmApplicationTargetUnitName(appName),
+		vmApplicationComputeServiceName(appName),
+	}
+}
+
+// vmApplicationUnitStatus returns the live systemd units generated for a VM app.
+func vmApplicationUnitStatus(h *e2e.Harness, appName string) ([]e2e.SystemdUnitState, error) {
+	patterns := vmApplicationUnitPatterns(appName)
+	if len(patterns) == 0 {
+		return nil, fmt.Errorf("VM application unit patterns are empty for app %q", appName)
+	}
+	units, _, err := h.ListSystemdUnitsOnVM(patterns...)
+	if err != nil {
+		return nil, err
+	}
+	return units, nil
+}
+
+// vmApplicationUnitsRunning reports whether the VM app target is active and the compute service is running.
+func vmApplicationUnitsRunning(units []e2e.SystemdUnitState, appName string) bool {
+	running, _ := vmApplicationUnitsRunningStatus(units, appName)
+	return running
+}
+
+// vmApplicationUnitsRunningStatus reports VM app readiness and explains missing or mismatched unit state.
+func vmApplicationUnitsRunningStatus(units []e2e.SystemdUnitState, appName string) (bool, string) {
+	targetRunning, targetDetails := vmApplicationUnitHasState(units, vmApplicationTargetUnitName(appName), systemdLoadStateLoadedString, systemdActiveStateActive, systemdSubStateActive)
+	computeRunning, computeDetails := vmApplicationUnitHasState(units, vmApplicationComputeServiceName(appName), systemdLoadStateLoadedString, systemdActiveStateActive, systemdSubStateRunning)
+	if targetRunning && computeRunning {
+		return true, "target and compute service have required states"
+	}
+	return false, fmt.Sprintf("%s; %s; matching units: %s", targetDetails, computeDetails, vmApplicationFormatUnits(units))
+}
+
+// vmApplicationUnitHasState reports whether a named unit has the expected load, active, and sub states.
+func vmApplicationUnitHasState(units []e2e.SystemdUnitState, unitName string, loadState string, activeState string, subState string) (bool, string) {
+	for _, unit := range units {
+		if unit.Unit != unitName {
+			continue
+		}
+		if unit.LoadState == loadState &&
+			unit.ActiveState == activeState &&
+			unit.SubState == subState {
+			return true, fmt.Sprintf("%s has required state", unitName)
+		}
+		return false, fmt.Sprintf("%s has load=%q active=%q sub=%q, want load=%q active=%q sub=%q", unitName, unit.LoadState, unit.ActiveState, unit.SubState, loadState, activeState, subState)
+	}
+	return false, fmt.Sprintf("%s is missing, want load=%q active=%q sub=%q", unitName, loadState, activeState, subState)
+}
+
+// vmApplicationFormatUnits returns compact diagnostic text for matching systemd units.
+func vmApplicationFormatUnits(units []e2e.SystemdUnitState) string {
+	if len(units) == 0 {
+		return "none"
+	}
+	formatted := make([]string, 0, len(units))
+	for _, unit := range units {
+		formatted = append(formatted, fmt.Sprintf("%s(load=%s active=%s sub=%s)", unit.Unit, unit.LoadState, unit.ActiveState, unit.SubState))
+	}
+	return strings.Join(formatted, ", ")
+}
+
+// vmApplicationTargetUnitName returns the exact generated Flight Control target unit name for a VM app.
+func vmApplicationTargetUnitName(appName string) string {
+	return fmt.Sprintf("%s-%s", lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername), vmAppTargetUnitSuffix)
+}
+
+// vmApplicationComputeServiceName returns the generated virt-launcher compute service name for a VM app.
+func vmApplicationComputeServiceName(appName string) string {
+	return fmt.Sprintf(vmAppComputeServiceFmt, lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername), appName)
+}

--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/device/applications/lifecycle"
+	"github.com/flightctl/flightctl/internal/quadlet"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	testutil "github.com/flightctl/flightctl/test/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -16,8 +17,6 @@ import (
 const (
 	vmAppName                    = "test-vm"
 	defaultVMImage               = "quay.io/containerdisks/fedora:40"
-	vmAppTargetUnitSuffix        = "flightctl-quadlet-app.target"
-	vmAppComputeServiceFmt       = "%s-virt-launcher-%s-compute.service"
 	systemdSubStateActive        = "active"
 	systemdSubStateRunning       = "running"
 	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
@@ -164,10 +163,15 @@ func vmApplicationFormatUnits(units []e2e.SystemdUnitState) string {
 
 // vmApplicationTargetUnitName returns the exact generated Flight Control target unit name for a VM app.
 func vmApplicationTargetUnitName(appName string) string {
-	return fmt.Sprintf("%s-%s", lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername), vmAppTargetUnitSuffix)
+	return quadlet.NamespaceResource(vmApplicationID(appName), lifecycle.QuadletTargetName)
 }
 
 // vmApplicationComputeServiceName returns the generated virt-launcher compute service name for a VM app.
 func vmApplicationComputeServiceName(appName string) string {
-	return fmt.Sprintf(vmAppComputeServiceFmt, lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername), appName)
+	return quadlet.NamespaceResource(vmApplicationID(appName), fmt.Sprintf("virt-launcher-%s-compute.service", appName))
+}
+
+// vmApplicationID returns the production app ID used to namespace generated VM units.
+func vmApplicationID(appName string) string {
+	return lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername)
 }

--- a/test/e2e/vm/vm_unit_test.go
+++ b/test/e2e/vm/vm_unit_test.go
@@ -1,0 +1,72 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVMApplicationUnitsRunning verifies VM readiness requires both target and compute units.
+func TestVMApplicationUnitsRunning(t *testing.T) {
+	targetUnitName := vmApplicationTargetUnitName(vmAppName)
+	computeServiceName := vmApplicationComputeServiceName(vmAppName)
+	targetUnit := e2e.SystemdUnitState{
+		Unit:        targetUnitName,
+		LoadState:   systemdLoadStateLoadedString,
+		ActiveState: systemdActiveStateActive,
+		SubState:    systemdSubStateActive,
+	}
+	computeUnit := e2e.SystemdUnitState{
+		Unit:        computeServiceName,
+		LoadState:   systemdLoadStateLoadedString,
+		ActiveState: systemdActiveStateActive,
+		SubState:    systemdSubStateRunning,
+	}
+	collisionComputeUnit := e2e.SystemdUnitState{
+		Unit:        "other-" + computeServiceName,
+		LoadState:   systemdLoadStateLoadedString,
+		ActiveState: systemdActiveStateActive,
+		SubState:    systemdSubStateRunning,
+	}
+
+	tests := []struct {
+		name  string
+		units []e2e.SystemdUnitState
+		want  bool
+	}{
+		{
+			name:  "running state",
+			units: []e2e.SystemdUnitState{targetUnit, computeUnit},
+			want:  true,
+		},
+		{
+			name:  "target-only state",
+			units: []e2e.SystemdUnitState{targetUnit},
+			want:  false,
+		},
+		{
+			name:  "compute-only state",
+			units: []e2e.SystemdUnitState{computeUnit},
+			want:  false,
+		},
+		{
+			name:  "compute service collision",
+			units: []e2e.SystemdUnitState{targetUnit, collisionComputeUnit},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.want, vmApplicationUnitsRunning(tt.units, vmAppName), tt.name)
+	}
+}
+
+// TestVMApplicationUnitPatternsUseExactTarget verifies systemd unit lookups use exact VM unit names.
+func TestVMApplicationUnitPatternsUseExactTarget(t *testing.T) {
+	patterns := vmApplicationUnitPatterns(vmAppName)
+
+	require.Len(t, patterns, 2)
+	require.Equal(t, vmApplicationTargetUnitName(vmAppName), patterns[0])
+	require.Equal(t, vmApplicationComputeServiceName(vmAppName), patterns[1])
+}

--- a/test/e2e/vm/vm_unit_test.go
+++ b/test/e2e/vm/vm_unit_test.go
@@ -7,7 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestVMApplicationUnitsRunning verifies VM readiness requires both target and compute units.
+const (
+	expectedVMAppTargetUnitName     = "test-vm-425604-flightctl-quadlet-app.target"
+	expectedVMAppComputeServiceName = "test-vm-425604-virt-launcher-test-vm-compute.service"
+)
+
+// TestVMApplicationUnitsRunning verifies VM readiness requires exact target and compute unit states.
 func TestVMApplicationUnitsRunning(t *testing.T) {
 	targetUnitName := vmApplicationTargetUnitName(vmAppName)
 	computeServiceName := vmApplicationComputeServiceName(vmAppName)
@@ -28,6 +33,12 @@ func TestVMApplicationUnitsRunning(t *testing.T) {
 		LoadState:   systemdLoadStateLoadedString,
 		ActiveState: systemdActiveStateActive,
 		SubState:    systemdSubStateRunning,
+	}
+	wrongStateComputeUnit := e2e.SystemdUnitState{
+		Unit:        computeServiceName,
+		LoadState:   systemdLoadStateLoadedString,
+		ActiveState: systemdActiveStateActive,
+		SubState:    systemdSubStateActive,
 	}
 
 	tests := []struct {
@@ -55,6 +66,11 @@ func TestVMApplicationUnitsRunning(t *testing.T) {
 			units: []e2e.SystemdUnitState{targetUnit, collisionComputeUnit},
 			want:  false,
 		},
+		{
+			name:  "compute service wrong state",
+			units: []e2e.SystemdUnitState{targetUnit, wrongStateComputeUnit},
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -62,11 +78,11 @@ func TestVMApplicationUnitsRunning(t *testing.T) {
 	}
 }
 
-// TestVMApplicationUnitPatternsUseExactTarget verifies systemd unit lookups use exact VM unit names.
-func TestVMApplicationUnitPatternsUseExactTarget(t *testing.T) {
+// TestVMApplicationUnitPatternsUseProductionNames pins generated unit names used for VM diagnostics.
+func TestVMApplicationUnitPatternsUseProductionNames(t *testing.T) {
 	patterns := vmApplicationUnitPatterns(vmAppName)
 
 	require.Len(t, patterns, 2)
-	require.Equal(t, vmApplicationTargetUnitName(vmAppName), patterns[0])
-	require.Equal(t, vmApplicationComputeServiceName(vmAppName), patterns[1])
+	require.Equal(t, expectedVMAppTargetUnitName, patterns[0])
+	require.Equal(t, expectedVMAppComputeServiceName, patterns[1])
 }

--- a/test/harness/e2e/harness_systemd.go
+++ b/test/harness/e2e/harness_systemd.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -11,6 +13,16 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 )
+
+const systemdListUnitsProbeTimeout = 30 * time.Second
+
+// SystemdUnitState is one row from `systemctl list-units` on the test VM.
+type SystemdUnitState struct {
+	Unit        string
+	LoadState   string
+	ActiveState string
+	SubState    string
+}
 
 func CreateFailingServiceOnDevice(h *Harness, serviceName string) error {
 	GinkgoWriter.Printf("creating failing systemd service %s on device VM\n", serviceName)
@@ -98,6 +110,100 @@ func RestoreServiceOnDevice(h *Harness, serviceName string) error {
 		GinkgoWriter.Printf("systemctl restart %s failed: %v, stdout: %s\n", serviceName, err, outStr)
 	}
 	return err
+}
+
+// ListSystemdUnitsOnVM lists live systemd units on the harness VM that match the provided patterns.
+func (h *Harness) ListSystemdUnitsOnVM(patterns ...string) ([]SystemdUnitState, string, error) {
+	return h.ListSystemdUnitsOnVMWithTimeout(systemdListUnitsProbeTimeout, patterns...)
+}
+
+// ListSystemdUnitsOnVMContext lists live systemd units on the harness VM using the provided context.
+func (h *Harness) ListSystemdUnitsOnVMContext(ctx context.Context, patterns ...string) ([]SystemdUnitState, string, error) {
+	if err := h.validateSystemdUnitListing(); err != nil {
+		return nil, "", err
+	}
+	if len(patterns) == 0 {
+		return nil, "", fmt.Errorf("at least one systemd unit pattern is required")
+	}
+
+	args := append([]string{
+		"sudo",
+		"systemctl",
+		"list-units",
+		"--all",
+		"--no-legend",
+		"--plain",
+	}, patterns...)
+
+	output, err := h.VM.RunSSHContext(ctx, args, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("listing systemd units on VM: %w", err)
+	}
+	if output == nil {
+		return nil, "", fmt.Errorf("listing systemd units on VM returned nil output")
+	}
+
+	rawOutput := output.String()
+	if strings.TrimSpace(rawOutput) == "" {
+		GinkgoWriter.Printf("systemctl list-units returned no matches for patterns: %v\n", patterns)
+	}
+	return ParseSystemdListUnits(rawOutput), rawOutput, nil
+}
+
+// ListSystemdUnitsOnVMWithTimeout lists live systemd units on the harness VM with a per-call timeout.
+func (h *Harness) ListSystemdUnitsOnVMWithTimeout(timeout time.Duration, patterns ...string) ([]SystemdUnitState, string, error) {
+	if err := h.validateSystemdUnitListing(); err != nil {
+		return nil, "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return h.ListSystemdUnitsOnVMContext(ctx, patterns...)
+}
+
+// validateSystemdUnitListing checks that the harness can run systemd unit probes on a VM.
+func (h *Harness) validateSystemdUnitListing() error {
+	if h == nil {
+		return fmt.Errorf("harness is nil")
+	}
+	if h.VM == nil {
+		return fmt.Errorf("harness VM is nil")
+	}
+	return nil
+}
+
+// ParseSystemdListUnits parses the stable columns emitted by `systemctl list-units --plain`.
+func ParseSystemdListUnits(output string) []SystemdUnitState {
+	units := []SystemdUnitState{}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		units = append(units, SystemdUnitState{
+			Unit:        fields[0],
+			LoadState:   fields[1],
+			ActiveState: fields[2],
+			SubState:    fields[3],
+		})
+	}
+	return units
+}
+
+// SystemdUnitsContainState reports whether any parsed unit name matches exactly or with a dash-delimited suffix and has the expected state.
+func SystemdUnitsContainState(units []SystemdUnitState, unitName string, loadState string, activeState string, subState string) bool {
+	return slices.ContainsFunc(units, func(unit SystemdUnitState) bool {
+		return systemdUnitNameMatches(unit.Unit, unitName) &&
+			unit.LoadState == loadState &&
+			unit.ActiveState == activeState &&
+			unit.SubState == subState
+	})
+}
+
+// systemdUnitNameMatches reports whether unitName is exact or namespaced with a dash delimiter.
+func systemdUnitNameMatches(unitName string, expectedName string) bool {
+	return unitName == expectedName || strings.HasSuffix(unitName, "-"+expectedName)
 }
 
 // RemoveSystemdService disables and removes a systemd unit file on the device and reloads systemd.

--- a/test/harness/e2e/harness_systemd.go
+++ b/test/harness/e2e/harness_systemd.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -189,21 +188,6 @@ func ParseSystemdListUnits(output string) []SystemdUnitState {
 		})
 	}
 	return units
-}
-
-// SystemdUnitsContainState reports whether any parsed unit name matches exactly or with a dash-delimited suffix and has the expected state.
-func SystemdUnitsContainState(units []SystemdUnitState, unitName string, loadState string, activeState string, subState string) bool {
-	return slices.ContainsFunc(units, func(unit SystemdUnitState) bool {
-		return systemdUnitNameMatches(unit.Unit, unitName) &&
-			unit.LoadState == loadState &&
-			unit.ActiveState == activeState &&
-			unit.SubState == subState
-	})
-}
-
-// systemdUnitNameMatches reports whether unitName is exact or namespaced with a dash delimiter.
-func systemdUnitNameMatches(unitName string, expectedName string) bool {
-	return unitName == expectedName || strings.HasSuffix(unitName, "-"+expectedName)
 }
 
 // RemoveSystemdService disables and removes a systemd unit file on the device and reloads systemd.

--- a/test/harness/e2e/harness_systemd_test.go
+++ b/test/harness/e2e/harness_systemd_test.go
@@ -1,0 +1,47 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	systemdTestLoadedState     = "loaded"
+	systemdTestActiveState     = "active"
+	systemdTestRunningSubState = "running"
+	systemdTestActiveSubState  = "active"
+	systemdTestTargetUnit      = "flightctl-quadlet-app.target"
+	systemdTestComputeUnit     = "virt-launcher-test-vm-compute.service"
+	systemdTestSubstringOnly   = "launcher-test-vm-compute"
+	systemdTestMissingUnit     = "missing.service"
+	systemdTestHarnessUnit     = "unit.service"
+	systemdTestListUnitsOutput = `test-vm-425604-flightctl-quadlet-app.target loaded active active test-vm target
+test-vm-425604-virt-launcher-test-vm-compute.service loaded active running Container compute for pod virt-launcher-test-vm
+malformed
+`
+	systemdTestHarnessNilError = "harness is nil"
+	systemdTestVMNilError      = "harness VM is nil"
+)
+
+// TestParseSystemdListUnits verifies parsing and tightened unit-name matching for systemd list output.
+func TestParseSystemdListUnits(t *testing.T) {
+	units := ParseSystemdListUnits(systemdTestListUnitsOutput)
+
+	require.Len(t, units, 2)
+	require.True(t, SystemdUnitsContainState(units, systemdTestTargetUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestActiveSubState))
+	require.True(t, SystemdUnitsContainState(units, systemdTestComputeUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
+	require.False(t, SystemdUnitsContainState(units, systemdTestSubstringOnly, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
+	require.False(t, SystemdUnitsContainState(units, systemdTestMissingUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
+}
+
+// TestListSystemdUnitsOnVMWithTimeoutValidatesHarness verifies harness validation happens before VM probing.
+func TestListSystemdUnitsOnVMWithTimeoutValidatesHarness(t *testing.T) {
+	var nilHarness *Harness
+	_, _, err := nilHarness.ListSystemdUnitsOnVMWithTimeout(time.Second, systemdTestHarnessUnit)
+	require.ErrorContains(t, err, systemdTestHarnessNilError)
+
+	_, _, err = (&Harness{}).ListSystemdUnitsOnVMWithTimeout(time.Second, systemdTestHarnessUnit)
+	require.ErrorContains(t, err, systemdTestVMNilError)
+}

--- a/test/harness/e2e/harness_systemd_test.go
+++ b/test/harness/e2e/harness_systemd_test.go
@@ -8,14 +8,12 @@ import (
 )
 
 const (
+	systemdTestTargetUnitName  = "test-vm-425604-flightctl-quadlet-app.target"
+	systemdTestComputeUnitName = "test-vm-425604-virt-launcher-test-vm-compute.service"
 	systemdTestLoadedState     = "loaded"
 	systemdTestActiveState     = "active"
 	systemdTestRunningSubState = "running"
 	systemdTestActiveSubState  = "active"
-	systemdTestTargetUnit      = "flightctl-quadlet-app.target"
-	systemdTestComputeUnit     = "virt-launcher-test-vm-compute.service"
-	systemdTestSubstringOnly   = "launcher-test-vm-compute"
-	systemdTestMissingUnit     = "missing.service"
 	systemdTestHarnessUnit     = "unit.service"
 	systemdTestListUnitsOutput = `test-vm-425604-flightctl-quadlet-app.target loaded active active test-vm target
 test-vm-425604-virt-launcher-test-vm-compute.service loaded active running Container compute for pod virt-launcher-test-vm
@@ -25,15 +23,19 @@ malformed
 	systemdTestVMNilError      = "harness VM is nil"
 )
 
-// TestParseSystemdListUnits verifies parsing and tightened unit-name matching for systemd list output.
+// TestParseSystemdListUnits verifies parsing stable fields from systemd list output.
 func TestParseSystemdListUnits(t *testing.T) {
 	units := ParseSystemdListUnits(systemdTestListUnitsOutput)
 
 	require.Len(t, units, 2)
-	require.True(t, SystemdUnitsContainState(units, systemdTestTargetUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestActiveSubState))
-	require.True(t, SystemdUnitsContainState(units, systemdTestComputeUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
-	require.False(t, SystemdUnitsContainState(units, systemdTestSubstringOnly, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
-	require.False(t, SystemdUnitsContainState(units, systemdTestMissingUnit, systemdTestLoadedState, systemdTestActiveState, systemdTestRunningSubState))
+	require.Equal(t, systemdTestTargetUnitName, units[0].Unit)
+	require.Equal(t, systemdTestLoadedState, units[0].LoadState)
+	require.Equal(t, systemdTestActiveState, units[0].ActiveState)
+	require.Equal(t, systemdTestActiveSubState, units[0].SubState)
+	require.Equal(t, systemdTestComputeUnitName, units[1].Unit)
+	require.Equal(t, systemdTestLoadedState, units[1].LoadState)
+	require.Equal(t, systemdTestActiveState, units[1].ActiveState)
+	require.Equal(t, systemdTestRunningSubState, units[1].SubState)
 }
 
 // TestListSystemdUnitsOnVMWithTimeoutValidatesHarness verifies harness validation happens before VM probing.

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -59,6 +59,7 @@ type TestVMInterface interface {
 	SSHCommand(inputArgs []string) *exec.Cmd
 	SSHCommandWithUser(nputArgs []string, user string) *exec.Cmd
 	RunSSH(inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer, error)
+	RunSSHContext(ctx context.Context, inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer, error)
 	RunSSHWithUser(inputArgs []string, stdin *bytes.Buffer, user string) (*bytes.Buffer, error)
 	Exists() (bool, error)
 	GetConsoleOutput() string
@@ -191,6 +192,11 @@ func (v *TestVM) RunSSH(inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer,
 
 	stdout, err := v.RunSSHWithUser(inputArgs, stdin, v.VMUser)
 	return stdout, err
+}
+
+// RunSSHContext runs a command over SSH using the VM's default user and the provided context.
+func (v *TestVM) RunSSHContext(ctx context.Context, inputArgs []string, stdin *bytes.Buffer) (*bytes.Buffer, error) {
+	return v.runSSHWithUserContext(ctx, inputArgs, stdin, v.VMUser)
 }
 
 func (v *TestVM) JournalLogs(opts JournalOpts) (string, error) {


### PR DESCRIPTION
Keep the VM application e2e test asserting the existing product behavior: Flight Control must report the app as Running and the applications summary as Healthy.

## Why
The CI timeout only showed that the app did not reach Running, but not whether the VM workload itself failed or whether Flight Control status reporting did not update.

## How
This PR adds failure-only diagnostics around the existing status checks. When the Running/Healthy wait fails, the test logs the generated VM app target and virt-launcher compute service states from `systemctl list-units` over SSH.

## Release target
Target release: release-1.3
