### PR TITLE
EDM-4741: Fix edit no-args e2e expectation

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -979,7 +979,7 @@ var _ = Describe("cli login", func() {
 		By("failing when no arguments are provided")
 		out, err = harness.CLI("edit")
 		Expect(err).To(HaveOccurred())
-		Expect(out).To(ContainSubstring("Error: accepts between 1 and 2 arg(s), received 0"))
+		Expect(out).To(ContainSubstring("Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)"))
 
 		By("failing on invalid resource kind (numeric)")
 		out, err = harness.CLI("edit", "1234")


### PR DESCRIPTION
Changed one e2e test expectation in test/e2e/cli/cli_test.go.

**Why** 
flightctl edit with no args now returns its custom validation error:
`Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)`
The test was still expecting Cobra’s generic arg-count error:
`Error: accepts between 1 and 2 arg(s), received 0`

**How**: 
Updated only that assertion to match the actual edit command behavior. No production code or other failures were changed.

## Release target
Target release: release-1.3
