### PR TITLE
EDM-4772: Remove unnecessary VM setup from selector and RBAC e2e suites

### DIFF
--- a/test/e2e/field_selectors/field_selectors_suite_test.go
+++ b/test/e2e/field_selectors/field_selectors_suite_test.go
@@ -19,8 +19,8 @@ func TestFieldSelector(t *testing.T) {
 var _ = BeforeSuite(func() {
 	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
-	// Setup VM and harness for this worker
-	e2e.SetupWorkerHarnessOrAbort()
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
 	auxFuture.Wait()
 })
 
@@ -30,17 +30,13 @@ var _ = BeforeEach(func() {
 	harness := e2e.GetWorkerHarness()
 	suiteCtx := e2e.GetWorkerContext()
 
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test\n", workerID)
 
 	// Create test-specific context for proper tracing
 	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
 
 	// Set the test context in the harness
 	harness.SetTestContext(ctx)
-
-	// Setup VM from pool, revert to pristine snapshot, and start agent
-	err := harness.SetupVMFromPoolAndStartAgent(workerID)
-	Expect(err).ToNot(HaveOccurred())
 
 	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
 })

--- a/test/e2e/label_selectors/label_selectors_suite_test.go
+++ b/test/e2e/label_selectors/label_selectors_suite_test.go
@@ -19,8 +19,8 @@ func TestLabelSelectors(t *testing.T) {
 var _ = BeforeSuite(func() {
 	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
-	// Setup VM and harness for this worker
-	e2e.SetupWorkerHarnessOrAbort()
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
 	auxFuture.Wait()
 })
 
@@ -30,17 +30,13 @@ var _ = BeforeEach(func() {
 	harness := e2e.GetWorkerHarness()
 	suiteCtx := e2e.GetWorkerContext()
 
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test\n", workerID)
 
 	// Create test-specific context for proper tracing
 	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
 
 	// Set the test context in the harness
 	harness.SetTestContext(ctx)
-
-	// Setup VM from pool, revert to pristine snapshot, and start agent
-	err := harness.SetupVMFromPoolAndStartAgent(workerID)
-	Expect(err).ToNot(HaveOccurred())
 
 	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
 })

--- a/test/e2e/label_selectors/label_selectors_test.go
+++ b/test/e2e/label_selectors/label_selectors_test.go
@@ -114,9 +114,10 @@ func createDevicesWithAddedUniqueLabelToLabels(harness *e2e.Harness, count int, 
 		deviceName := uuid.NewString()
 		labels[labelKey] = uuid.NewString()
 		device, err := resources.CreateDevice(harness, deviceName, &labels)
-		if err == nil {
-			*expectedDevices = append(*expectedDevices, device)
+		if err != nil {
+			return fmt.Errorf("failed to create device %q: %w", deviceName, err)
 		}
+		*expectedDevices = append(*expectedDevices, device)
 	}
 	return nil
 }

--- a/test/e2e/rbac/rbac_suite_test.go
+++ b/test/e2e/rbac/rbac_suite_test.go
@@ -25,7 +25,8 @@ var (
 var _ = BeforeSuite(func() {
 	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
-	e2e.SetupWorkerHarnessOrAbort()
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
 	auxFuture.Wait()
 
 	// Check if ACM is installed before running any tests
@@ -40,20 +41,12 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	flightCtlNs = os.Getenv("FLIGHTCTL_NS")
-	if flightCtlNs == "" {
-		Skip("FLIGHTCTL_NS environment variable should be set")
-	}
-
 	// Get the harness and context directly - no package-level variables
 	workerID := GinkgoParallelProcess()
 	harness := e2e.GetWorkerHarness()
 	suiteCtx := e2e.GetWorkerContext()
 
-	_, err := login.LoginToAPIWithToken(harness)
-	Expect(err).ToNot(HaveOccurred())
-
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test\n", workerID)
 
 	// Create test-specific context for proper tracing
 	ctx := util.StartSpecTracerForGinkgo(suiteCtx)
@@ -61,8 +54,12 @@ var _ = BeforeEach(func() {
 	// Set the test context in the harness
 	harness.SetTestContext(ctx)
 
-	// Setup VM from pool, revert to pristine snapshot, and start agent
-	err = harness.SetupVMFromPoolAndStartAgent(workerID)
+	flightCtlNs = os.Getenv("FLIGHTCTL_NS")
+	if flightCtlNs == "" {
+		Skip("FLIGHTCTL_NS environment variable should be set")
+	}
+
+	_, err := login.LoginToAPIWithToken(harness)
 	Expect(err).ToNot(HaveOccurred())
 
 	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)

--- a/test/e2e/selectors/selectors_suite_test.go
+++ b/test/e2e/selectors/selectors_suite_test.go
@@ -34,8 +34,8 @@ func init() {
 var _ = BeforeSuite(func() {
 	auxFuture := e2e.StartAuxServicesAsync(context.Background())
 	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
-	// Setup VM and harness for this worker
-	e2e.SetupWorkerHarnessOrAbort()
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
 	auxFuture.Wait()
 })
 
@@ -45,17 +45,13 @@ var _ = BeforeEach(func() {
 	harness := e2e.GetWorkerHarness()
 	suiteCtx := e2e.GetWorkerContext()
 
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test\n", workerID)
 
 	// Create test-specific context for proper tracing
 	ctx := util.StartSpecTracerForGinkgo(suiteCtx)
 
 	// Set the test context in the harness
 	harness.SetTestContext(ctx)
-
-	// Setup VM from pool, revert to pristine snapshot, and start agent
-	err := harness.SetupVMFromPoolAndStartAgent(workerID)
-	Expect(err).ToNot(HaveOccurred())
 
 	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
 })

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -90,6 +90,15 @@ const fiveSecondTimeout = 5 * time.Second
 const setupSnapshotRestoreTimeout = 10 * time.Minute
 
 const (
+	cliRateLimitRetryAttempts       = 8
+	cliRateLimitRetryDelay          = 2 * time.Second
+	cliRateLimitResponseStatus      = "response status: 429"
+	cliRateLimitServerReturned      = "server returned 429"
+	cliRateLimitExceeded            = "rate limit exceeded"
+	cliLoginRateLimitExceededOutput = "Login rate limit exceeded, please try again later"
+)
+
+const (
 	POLLING     = "250ms"
 	POLLINGLONG = "1s"
 	TIMEOUT     = "5m"
@@ -764,18 +773,36 @@ func (h *Harness) CLIWithStdin(stdin string, args ...string) (string, error) {
 
 // SHWithStdin runs a command with stdin. Set redactStdin to true to suppress stdin from logs (e.g. secrets).
 func (h *Harness) SHWithStdin(stdin, command string, redactStdin bool, args ...string) (string, error) {
-	cmd := exec.Command(command)
-
-	cmd.Stdin = strings.NewReader(stdin)
-
-	h.setArgsInCmd(cmd, args...)
-
 	stdinLog := stdin
 	if redactStdin {
 		stdinLog = "<redacted>"
 	}
-	logrus.Infof("running: %s with stdin: %s", strings.Join(cmd.Args, " "), stdinLog)
-	output, err := cmd.CombinedOutput()
+
+	var output []byte
+	var err error
+	var cmd *exec.Cmd
+	ctx := h.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for attempt := 1; attempt <= cliRateLimitRetryAttempts; attempt++ {
+		cmd = exec.CommandContext(ctx, command)
+		cmd.Stdin = strings.NewReader(stdin)
+		h.setArgsInCmd(cmd, args...)
+
+		logrus.Infof("running: %s with stdin: %s", strings.Join(cmd.Args, " "), stdinLog)
+		output, err = cmd.CombinedOutput()
+		if err == nil || !isCLIRateLimitOutput(string(output)) || attempt == cliRateLimitRetryAttempts {
+			break
+		}
+		logrus.Warnf("%s hit API rate limit, retrying attempt %d/%d in %s", cmd.Args[0], attempt+1, cliRateLimitRetryAttempts, cliRateLimitRetryDelay)
+		select {
+		case <-ctx.Done():
+			return string(output), ctx.Err()
+		case <-time.After(cliRateLimitRetryDelay):
+		}
+	}
+
 	if err != nil {
 		logrus.Errorf("executing cli: %s", err)
 		// keeping standard error output for debugging, otherwise log output
@@ -784,6 +811,14 @@ func (h *Harness) SHWithStdin(stdin, command string, redactStdin bool, args ...s
 	}
 
 	return string(output), err
+}
+
+// isCLIRateLimitOutput reports whether CLI output indicates an API rate limit.
+func isCLIRateLimitOutput(output string) bool {
+	normalizedOutput := strings.ToLower(output)
+	return strings.Contains(output, cliRateLimitResponseStatus) ||
+		strings.Contains(output, cliRateLimitServerReturned) ||
+		strings.Contains(normalizedOutput, cliRateLimitExceeded)
 }
 
 func flightctlPath() string {
@@ -1014,7 +1049,7 @@ func (h *Harness) CleanUpTestResources(resourceTypes ...string) error {
 			if line == "" {
 				continue
 			}
-			resourceNames = append(resourceNames, line)
+			resourceNames = append(resourceNames, resourceNameFromCLIOutput(line))
 		}
 
 		if len(resourceNames) == 0 {
@@ -1022,12 +1057,18 @@ func (h *Harness) CleanUpTestResources(resourceTypes ...string) error {
 			continue
 		}
 
-		// Delete the resources by name
-		deleteArgs := append([]string{"delete", resourceType}, resourceNames...)
-		_, err = h.CLI(deleteArgs...)
-		if err != nil {
-			logrus.Infof("Error deleting %s resources with test-id %s: %v", resourceType, testID, err)
-			return err
+		// Delete resources individually. Bulk deletes can partially succeed before
+		// a rate-limit response, which makes retries fail on already-deleted names.
+		for _, resourceName := range resourceNames {
+			output, err := h.CLI("delete", resourceType, resourceName)
+			if err != nil {
+				if isCLINotFoundOutput(output) {
+					logrus.Debugf("%s resource %s was already deleted during cleanup for test-id %s", resourceType, resourceName, testID)
+					continue
+				}
+				logrus.Infof("Error deleting %s resource %s with test-id %s: %v", resourceType, resourceName, testID, err)
+				return fmt.Errorf("deleting %s resource %s: %w", resourceType, resourceName, err)
+			}
 		}
 
 		logrus.Infof("Successfully deleted %d %s resources with test-id %s: %v", len(resourceNames), resourceType, testID, resourceNames)
@@ -1035,6 +1076,23 @@ func (h *Harness) CleanUpTestResources(resourceTypes ...string) error {
 
 	logrus.Infof("Successfully cleaned up all test resources with test-id %s", testID)
 	return nil
+}
+
+// resourceNameFromCLIOutput extracts the resource name from CLI "-o name" output.
+func resourceNameFromCLIOutput(resource string) string {
+	if !strings.Contains(resource, "/") {
+		return resource
+	}
+	parts := strings.Split(resource, "/")
+	return parts[len(parts)-1]
+}
+
+// isCLINotFoundOutput reports whether CLI output describes a missing resource.
+func isCLINotFoundOutput(output string) bool {
+	output = strings.ToLower(output)
+	return strings.Contains(output, "not found") ||
+		strings.Contains(output, "response status: 404") ||
+		strings.Contains(output, "server returned 404")
 }
 
 // cleanUpEnrollmentRequests handles the special case for enrollment requests

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/test/util"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
@@ -360,7 +361,7 @@ func (h *Harness) WaitForSimulatorEnrollmentRequest(testID, alias string, timeou
 
 // findEnrollmentRequestBySpecLabels finds an enrollment request by its test-id and alias labels.
 func (h *Harness) findEnrollmentRequestBySpecLabels(testID, alias string) (string, bool, error) {
-	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, nil)
+	resp, err := h.listEnrollmentRequestsWithRetry()
 	if err != nil {
 		return "", false, err
 	}
@@ -389,7 +390,7 @@ func (h *Harness) findEnrollmentRequestBySpecLabels(testID, alias string) (strin
 // deleteEnrollmentRequestsBySpecTestID deletes pending enrollment requests whose
 // spec.labels include the given test-id (e.g. from devicesimulator --skip-auto-approve).
 func (h *Harness) deleteEnrollmentRequestsBySpecTestID(testID string) error {
-	resp, err := h.Client.ListEnrollmentRequestsWithResponse(h.Context, nil)
+	resp, err := h.listEnrollmentRequestsWithRetry()
 	if err != nil {
 		return err
 	}
@@ -417,6 +418,30 @@ func (h *Harness) deleteEnrollmentRequestsBySpecTestID(testID string) error {
 		logrus.Debugf("Successfully deleted enrollment request: %s", name)
 	}
 	return nil
+}
+
+// listEnrollmentRequestsWithRetry lists enrollment requests with bounded 429 retries.
+func (h *Harness) listEnrollmentRequestsWithRetry() (*apiclient.ListEnrollmentRequestsResponse, error) {
+	ctx := h.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var resp *apiclient.ListEnrollmentRequestsResponse
+	var err error
+	for attempt := 1; attempt <= cliRateLimitRetryAttempts; attempt++ {
+		resp, err = h.Client.ListEnrollmentRequestsWithResponse(ctx, nil)
+		if err != nil || resp == nil || resp.StatusCode() != http.StatusTooManyRequests || attempt == cliRateLimitRetryAttempts {
+			return resp, err
+		}
+		logrus.Warnf("ListEnrollmentRequests hit API rate limit, retrying attempt %d/%d in %s", attempt+1, cliRateLimitRetryAttempts, cliRateLimitRetryDelay)
+		select {
+		case <-ctx.Done():
+			return resp, ctx.Err()
+		case <-time.After(cliRateLimitRetryDelay):
+		}
+	}
+	return resp, err
 }
 
 // StopAllSimulators stops all running simulator commands, logging warnings on failure.

--- a/test/harness/e2e/harness_test.go
+++ b/test/harness/e2e/harness_test.go
@@ -1,0 +1,24 @@
+package e2e
+
+import "testing"
+
+// TestIsCLIRateLimitOutputDetectsLoginRateLimit verifies auth rate-limit output is retried.
+func TestIsCLIRateLimitOutputDetectsLoginRateLimit(t *testing.T) {
+	if !isCLIRateLimitOutput(cliLoginRateLimitExceededOutput) {
+		t.Fatalf("expected login rate-limit output to be classified as rate-limited")
+	}
+}
+
+// TestIsCLIRateLimitOutputPreservesExisting429Checks verifies existing 429 retry detection.
+func TestIsCLIRateLimitOutputPreservesExisting429Checks(t *testing.T) {
+	cases := []string{
+		cliRateLimitResponseStatus,
+		cliRateLimitServerReturned,
+	}
+
+	for _, output := range cases {
+		if !isCLIRateLimitOutput(output) {
+			t.Fatalf("expected %q to be classified as rate-limited", output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- switch selectors, label_selectors, field_selectors, and rbac suites to SetupWorkerHarnessWithoutVM
- remove per-spec SetupVMFromPoolAndStartAgent calls from those suites
- keep per-spec tracing, cleanup, provider setup, and RBAC login/context handling intact

## Why
These suites create and validate API resources directly and do not require a live agent VM for their assertions. Removing the VM setup avoids expensive neutral-device provisioning while preserving per-test cleanup labels and contexts.

The main change was removing VM setup from suites that only validate API-created resources and do not need a live agent. That made the suites much faster, but it also removed the natural delay that VM restore/start used to add between tests.

Once the tests became API-only, resource creation and cleanup happened much more densely. That exposed transient API 429 Rate limit exceeded responses during cleanup, which caused new branch-only AfterEach failures even though the test assertions themselves were unchanged.

The additional harness changes are there to preserve the same result profile as main:
**retry transient CLI/API 429 responses instead of failing cleanup immediately
make cleanup more robust when bulk deletes partially succeed
keep cleanup tied to the per-test test-id
add a focused unit test for the new rate-limit detection behavior
After those fixes, the branch has the same results as main, but the runtime drops from about 36m13s to 11m22s.**

## Release target
Target release: release-1.3