### PR TITLE
NO-ISSUE: Run backend image builds on flightctl-ci-runner

### DIFF
--- a/.github/workflows/build-images-and-charts.yaml
+++ b/.github/workflows/build-images-and-charts.yaml
@@ -27,7 +27,10 @@ on:
 
 jobs:
   build-backend-containers:
-    runs-on: ubuntu-24.04
+    # Larger self-hosted runners: parallel container builds (make -j4) exhaust
+    # disk on GitHub-hosted ubuntu-24.04 (ENOSPC pulling kubevirt / writing CLI bins).
+    # Match e2e (run-e2e-tests.yaml) which already uses flightctl-ci-runner.
+    runs-on: flightctl-ci-runner
     outputs:
       git_tag: ${{ steps.compute-tag.outputs.git_tag }}
     steps:


### PR DESCRIPTION
## Summary
- Move `build-backend-containers` in `build-images-and-charts.yaml` from `ubuntu-24.04` to `flightctl-ci-runner` (same label as e2e in `run-e2e-tests.yaml`).
- Avoids intermittent `no space left on device` failures during parallel `make -j4 build-containers` (kubevirt Go module cache / writing `flightctl-backup` and related bins).

## Test plan
- [ ] Confirm `build-backend-containers` schedules on `flightctl-ci-runner`
- [ ] Confirm image build completes without ENOSPC
- [ ] Re-run / merge-queue a PR that previously failed on disk (e.g. #3233) after this lands


Made with [Cursor](https://cursor.com)