### PR TITLE
EDM-4753: Add fieldSelector support for status.capabilities.osMode

### DIFF
--- a/internal/store/model/selectors.go
+++ b/internal/store/model/selectors.go
@@ -19,6 +19,7 @@ var (
 		selector.NewSelectorName("status.applicationsSummary.status"): selector.String,
 		selector.NewSelectorName("status.updated.status"):             selector.String,
 		selector.NewSelectorName("status.lifecycle.status"):           selector.String,
+		selector.NewSelectorName("status.capabilities.osMode"):        selector.String,
 	}
 	fleetSpecSelectors = selectorToTypeMap{
 		selector.NewSelectorName("spec.template.spec.os.image"): selector.String,

--- a/internal/store/model/selectors_test.go
+++ b/internal/store/model/selectors_test.go
@@ -36,6 +36,30 @@ func TestModelSchemaSelectors(t *testing.T) {
 	}
 }
 
+func TestDeviceOsModeSelector(t *testing.T) {
+	name := selector.NewSelectorName("status.capabilities.osMode")
+	var device Device
+
+	field, err := device.ResolveSelector(name)
+	if err != nil {
+		t.Fatalf("ResolveSelector(%q) returned error: %v", name, err)
+	}
+	if field.Type != selector.String {
+		t.Errorf("Type = %v, want String", field.Type)
+	}
+	if field.FieldType != "jsonb" {
+		t.Errorf("FieldType = %q, want jsonb", field.FieldType)
+	}
+	wantFieldName := "status -> 'capabilities' ->> 'osMode'"
+	if field.FieldName != wantFieldName {
+		t.Errorf("FieldName = %q, want %q", field.FieldName, wantFieldName)
+	}
+
+	if !device.ListSelectors().Contains(name) {
+		t.Errorf("ListSelectors() missing %q", name)
+	}
+}
+
 func verifySchema(schemaName string, apischema any, selectors selectorToTypeMap) error {
 	schema := scanAPISchema(schemaName, apischema)
 	for s, typ := range selectors {

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -302,6 +302,55 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(len(devices.Items)).To(Equal(3))
 		})
 
+		It("List with status.capabilities.osMode field filter", func() {
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-package", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-image", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-absent", nil, nil, nil)
+
+			setOsMode := func(name string, mode *api.OsModeType) {
+				status := api.NewDeviceStatus()
+				if mode != nil {
+					status.Capabilities = &api.DeviceCapabilities{OsMode: mode}
+				}
+				device := api.Device{
+					Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
+					Status:   &status,
+				}
+				_, err := devStore.UpdateStatus(ctx, orgId, &device, nil)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			setOsMode("osmode-package", lo.ToPtr(api.OsModePackage))
+			setOsMode("osmode-image", lo.ToPtr(api.OsModeImage))
+			setOsMode("osmode-absent", nil)
+
+			deviceNames := func(items []api.Device) []string {
+				names := make([]string, 0, len(items))
+				for _, d := range items {
+					names = append(names, *d.Metadata.Name)
+				}
+				return names
+			}
+
+			packageList, err := devStore.List(ctx, orgId, store.DeviceListParams{
+				ListParams: store.ListParams{
+					Limit:         1000,
+					FieldSelector: selector.NewFieldSelectorOrDie("status.capabilities.osMode=package", selector.WithPrivateSelectors()),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceNames(packageList.Items)).To(ConsistOf("osmode-package"))
+
+			imageList, err := devStore.List(ctx, orgId, store.DeviceListParams{
+				ListParams: store.ListParams{
+					Limit:         1000,
+					FieldSelector: selector.NewFieldSelectorOrDie("status.capabilities.osMode=image", selector.WithPrivateSelectors()),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deviceNames(imageList.Items)).To(ConsistOf("osmode-image"))
+		})
+
 		It("List with owner selector", func() {
 			testutil.CreateTestDevice(ctx, devStore, orgId, "fleet-a-device", lo.ToPtr("Fleet/fleet-a"), nil, nil)
 			testutil.CreateTestDevice(ctx, devStore, orgId, "fleet-b-device", lo.ToPtr("Fleet/fleet-b"), nil, nil)


### PR DESCRIPTION
### Summary

Registers `status.capabilities.osMode` as a Device JSONB String fieldSelector, enabling API consumers to filter devices by OS management mode (`image` or `package`) via `GET /api/v1beta1/devices?fieldSelector=status.capabilities.osMode=package`. This is the API/store prerequisite for the console package-mode filter (EDM-4763).

### Changes

- **`internal/store/model/selectors.go`** — Add `status.capabilities.osMode` → `selector.String` entry to `deviceStatusSelectors` map. Produces SQL expression `status -> 'capabilities' ->> 'osMode'`.
- **`internal/store/model/selectors_test.go`** — Add `TestDeviceOsModeSelector` verifying `ResolveSelector` returns the correct JSONB field name, type, and field type; and `ListSelectors` includes the new selector name.
- **`test/integration/store/device_test.go`** — Add `"List with status.capabilities.osMode field filter"` test: creates devices with `osMode=package`, `osMode=image`, and absent `osMode`; asserts equality filters return only matching devices and exclude absent-mode devices.

### Testing

- **Unit tests:** `TestDeviceOsModeSelector` — verifies selector resolution (type, JSONB expression, discoverability via `ListSelectors`). `TestModelSchemaSelectors` auto-validates the new path exists on `DeviceStatus`.
- **Integration tests:** End-to-end store filtering for `=package` and `=image` selectors with absent-mode exclusion.
- **Coverage:** All behavioral paths of the new code are exercised through public interfaces.

### Acceptance Criteria

- [x] AC-1: `fieldSelector=status.capabilities.osMode=package` returns only package-mode devices
- [x] AC-2: `fieldSelector=status.capabilities.osMode=image` works symmetrically
- [x] AC-3: Invalid/unknown fieldSelector values return appropriate API errors (existing engine behavior; new selector is included in `ListSelectors` discovery)
- [x] AC-4: Devices without `capabilities.osMode` are excluded from mode-specific filters
