### PR TITLE
Add flightctl telemetry gateway network policy

### DIFF
--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.alertManager .Values.alertManager.enabled }}
+{{ if and (eq (include "flightctl.enableMulticlusterExtensions" .) "false") (eq (include "flightctl.getServiceExposeMethod" .) "route") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-alertmanager-proxy-from-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-alertmanager-proxy
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-alertmanager-proxy
+  policyTypes:
+  - Ingress
+{{ end }}
+{{- end }}

--- a/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/cli-artifacts/flightctl-cli-artifacts-networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.cliArtifacts .Values.cliArtifacts.enabled }}
+{{ if and (eq (include "flightctl.enableMulticlusterExtensions" .) "false") (eq (include "flightctl.getServiceExposeMethod" .) "route") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-cli-artifacts-from-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-cli-artifacts
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-cli-artifacts
+  policyTypes:
+  - Ingress
+{{ end }}
+{{- end }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.remoteAccess .Values.remoteAccess.enabled }}
+{{ if and (eq (include "flightctl.enableMulticlusterExtensions" .) "false") (eq (include "flightctl.getServiceExposeMethod" .) "route") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-remote-access-from-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-remote-access
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-remote-access
+  policyTypes:
+  - Ingress
+{{ end }}
+{{- end }}

--- a/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-networkpolicy.yaml
+++ b/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{ if and (eq (include "flightctl.enableMulticlusterExtensions" .) "false") (eq (include "flightctl.getServiceExposeMethod" .) "route") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-telemetry-gateway-from-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flightctl.standardLabels" . | nindent 4 }}
+    flightctl.service: flightctl-telemetry-gateway
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector:
+    matchLabels:
+      flightctl.service: flightctl-telemetry-gateway
+  policyTypes:
+  - Ingress
+{{ end }}


### PR DESCRIPTION
Add a policy to telemetry gateway otherwise a device can't reach the telemetry unless NP is configured
Also add network policies for:
- flightctl-remote-access-networkpolicy
- flightctl-cli-artifacts-networkpolicy
- flightctl-alertmanager-proxy-networkpolicy
