### PR TITLE
EDM-4773: Add encryption key backup and restore support

### DIFF
--- a/docs/user/installing/backup-restore.md
+++ b/docs/user/installing/backup-restore.md
@@ -4,16 +4,16 @@ This document describes how to back up and restore Flight Control server state u
 
 ## Overview
 
-Flight Control provides CLI commands for backing up and restoring server state (database, PKI materials, and service configuration), enabling disaster recovery without device re-enrollment.
+Flight Control provides CLI commands for backing up and restoring server state (database, PKI materials, encryption keys, and service configuration), enabling disaster recovery without device re-enrollment.
 
 Supports Podman and Kubernetes with Helm deployments.
 Works with cron or Kubernetes CronJob schedulers.
 
-⚠️ **Warning**: Backup archives contain sensitive materials including database content, CA private keys, TLS certificates, and database credentials. Store backup archives on encrypted storage with restricted access and use encrypted channels when transporting archives.
+⚠️ **Warning**: Backup archives contain sensitive materials including database content, CA private keys, TLS certificates, encryption keys, and database credentials. Store backup archives on encrypted storage with restricted access and use encrypted channels when transporting archives.
 
 **Key capabilities:**
 
-- Back up database, PKI materials, and service configuration to timestamped archives
+- Back up database, PKI materials, encryption keys, and service configuration to timestamped archives
 - Restore from backup archives with automatic integrity verification
 - Podman and Kubernetes with Helm deployments
 - Cron and Kubernetes CronJob automation
@@ -77,6 +77,7 @@ Backup archives contain the following:
 
 - `db/dump.sql` — PostgreSQL database dump (internal database only; omitted for external databases)
 - `pki/` — CA keys and TLS certificates (Podman: directory tree, Kubernetes: Secret YAML exports)
+- `encryption/` — Encryption keys (Podman: key files, Kubernetes: Secret YAML export)
 - `config/` — Service configuration files
 - `volumes/` — Podman volumes (PAM Issuer user database, if present)
 - `metadata.json` — Backup metadata (timestamp, Flight Control version, deployment type)
@@ -178,9 +179,10 @@ The restore process performs the following steps:
 3. Stops Flight Control services
 4. Restores the database (if `db/dump.sql` is present in the archive)
 5. Restores PKI materials
-6. Restores service configuration
-7. Prepares devices (clears KV store, updates device annotations)
-8. Starts Flight Control services
+6. Restores encryption keys (if `encryption/` is present in the archive)
+7. Restores service configuration
+8. Prepares devices (clears KV store, updates device annotations)
+9. Starts Flight Control services
 
 **Note**: Services are automatically started even if the restore fails, ensuring the system is not left in a stopped state.
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -259,9 +259,10 @@ func CreateArchive(ctx context.Context, stagingDir string, outputDir string, met
 //  2. Create staging directory
 //  3. Backup database (if internal)
 //  4. Backup PKI materials
-//  5. Backup config (stub)
-//  6. Create timestamped archive with checksum
-//  7. Clean up staging directory
+//  5. Backup encryption keys (if present)
+//  6. Backup config (stub)
+//  7. Create timestamped archive with checksum
+//  8. Clean up staging directory
 //
 // Returns path to created archive on success.
 func PerformBackup(ctx context.Context, deployer Deployer, outputDir string, log logrus.FieldLogger) (archivePath string, err error) {
@@ -311,6 +312,18 @@ func PerformBackup(ctx context.Context, deployer Deployer, outputDir string, log
 		return "", fmt.Errorf("PKI backup failed: %w", err)
 	}
 	log.Infof("PKI backup completed")
+
+	// Check for context cancellation
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("backup cancelled: %w", ctx.Err())
+	default:
+	}
+
+	// Backup encryption keys (optional — may not exist in pre-encryption deployments)
+	if err := deployer.BackupEncryptionKeys(ctx, stagingDir); err != nil {
+		return "", fmt.Errorf("encryption keys backup failed: %w", err)
+	}
 
 	// Check for context cancellation
 	select {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -478,13 +478,15 @@ func TestCreateArchive(t *testing.T) {
 
 // mockDeployer is a test implementation of the Deployer interface
 type mockDeployer struct {
-	deploymentType     DeploymentType
-	backupDBError      error
-	backupPKIError     error
-	backupConfigError  error
-	backupDBCalled     bool
-	backupPKICalled    bool
-	backupConfigCalled bool
+	deploymentType             DeploymentType
+	backupDBError              error
+	backupPKIError             error
+	backupEncryptionKeysError  error
+	backupConfigError          error
+	backupDBCalled             bool
+	backupPKICalled            bool
+	backupEncryptionKeysCalled bool
+	backupConfigCalled         bool
 }
 
 func (m *mockDeployer) Type() DeploymentType {
@@ -517,6 +519,19 @@ func (m *mockDeployer) BackupPKI(ctx context.Context, outputDir string) error {
 	return os.WriteFile(filepath.Join(pkiDir, "ca.crt"), []byte("mock cert"), 0600)
 }
 
+func (m *mockDeployer) BackupEncryptionKeys(ctx context.Context, outputDir string) error {
+	m.backupEncryptionKeysCalled = true
+	if m.backupEncryptionKeysError != nil {
+		return m.backupEncryptionKeysError
+	}
+	// Create mock encryption key backup
+	encDir := filepath.Join(outputDir, "encryption")
+	if err := os.MkdirAll(encDir, 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(encDir, "flightctl-encryption-key.yaml"), []byte("mock encryption key"), 0600)
+}
+
 func (m *mockDeployer) BackupConfig(ctx context.Context, outputDir string) error {
 	m.backupConfigCalled = true
 	if m.backupConfigError != nil {
@@ -547,6 +562,7 @@ func TestPerformBackup(t *testing.T) {
 				// Verify all deployer methods were called
 				require.True(t, deployer.backupDBCalled, "BackupDatabase should be called")
 				require.True(t, deployer.backupPKICalled, "BackupPKI should be called")
+				require.True(t, deployer.backupEncryptionKeysCalled, "BackupEncryptionKeys should be called")
 				require.True(t, deployer.backupConfigCalled, "BackupConfig should be called")
 
 				// Verify archive was created
@@ -559,6 +575,7 @@ func TestPerformBackup(t *testing.T) {
 				require.FileExists(t, filepath.Join(extractDir, "metadata.json"))
 				require.FileExists(t, filepath.Join(extractDir, "db", "dump.sql"))
 				require.FileExists(t, filepath.Join(extractDir, "pki", "ca.crt"))
+				require.FileExists(t, filepath.Join(extractDir, "encryption", "flightctl-encryption-key.yaml"))
 
 				// Verify metadata includes database
 				metadataBytes, err := os.ReadFile(filepath.Join(extractDir, "metadata.json"))
@@ -627,6 +644,25 @@ func TestPerformBackup(t *testing.T) {
 			wantErr: true,
 			validate: func(t *testing.T, deployer *mockDeployer, archivePath string) {
 				require.Equal(t, "", archivePath)
+			},
+		},
+		{
+			name: "When BackupEncryptionKeys fails it should return error and skip config",
+			setup: func(t *testing.T) (*mockDeployer, string) {
+				deployer := &mockDeployer{
+					deploymentType:            DeploymentTypeKubernetes,
+					backupEncryptionKeysError: errors.New("encryption key access denied"),
+				}
+				outputDir := t.TempDir()
+				return deployer, outputDir
+			},
+			wantErr: true,
+			validate: func(t *testing.T, deployer *mockDeployer, archivePath string) {
+				require.Equal(t, "", archivePath)
+				require.True(t, deployer.backupDBCalled, "BackupDatabase should be called before encryption keys")
+				require.True(t, deployer.backupPKICalled, "BackupPKI should be called before encryption keys")
+				require.True(t, deployer.backupEncryptionKeysCalled, "BackupEncryptionKeys should be called")
+				require.False(t, deployer.backupConfigCalled, "BackupConfig should NOT be called after encryption key failure")
 			},
 		},
 	}

--- a/internal/backup/deployer.go
+++ b/internal/backup/deployer.go
@@ -26,17 +26,15 @@ const (
 	DeploymentTypeUnknown    DeploymentType = "unknown"
 )
 
-// PKI backup permission modes
+// Backup permission modes for sensitive material (PKI, encryption keys, config).
 const (
-	// pkiDirMode is the permission mode for PKI backup output directories.
-	// 0700 (owner-only access) ensures PKI materials are only accessible
-	// to the backup process owner.
-	pkiDirMode os.FileMode = 0700
+	// sensitiveDataDirMode is the permission mode for backup output directories
+	// containing sensitive data. 0700 (owner-only access).
+	sensitiveDataDirMode os.FileMode = 0700
 
-	// pkiFileMode is the permission mode for sensitive PKI files in backups.
-	// 0600 (owner-only read/write) protects private keys and certificates
-	// from unauthorized access.
-	pkiFileMode os.FileMode = 0600
+	// sensitiveDataFileMode is the permission mode for sensitive files in backups
+	// (private keys, encryption keys, credentials). 0600 (owner-only read/write).
+	sensitiveDataFileMode os.FileMode = 0600
 )
 
 // Deployer interface for backup operations across deployment types
@@ -44,6 +42,7 @@ type Deployer interface {
 	Type() DeploymentType
 	BackupDatabase(ctx context.Context, outputDir string) error
 	BackupPKI(ctx context.Context, outputDir string) error
+	BackupEncryptionKeys(ctx context.Context, outputDir string) error
 	BackupConfig(ctx context.Context, outputDir string) error
 }
 
@@ -82,8 +81,8 @@ func (d *Detector) Detect() (DeploymentType, error) {
 
 	if podmanActive && kubeconfigPresent {
 		return DeploymentTypeUnknown, fmt.Errorf(
-			"conflicting deployment indicators detected: "+
-				"Podman (flightctl-api.service is active) and Kubernetes (kubeconfig present); "+
+			"conflicting deployment indicators detected: " +
+				"Podman (flightctl-api.service is active) and Kubernetes (kubeconfig present); " +
 				"use --deployment-type to specify explicitly",
 		)
 	}
@@ -138,7 +137,6 @@ func ValidateDeploymentType(s string) error {
 	}
 }
 
-
 // serviceConfigDB holds the db section parsed from a raw service-config.yaml.
 // The service-config.yaml uses the top-level key "db" (not "database"), which
 // does not map to config.Config.Database (JSON tag "database").
@@ -160,7 +158,6 @@ func parseServiceConfigDB(data []byte, log logrus.FieldLogger) serviceConfigDB {
 	log.Debugf("Parsed db section from service-config.yaml: type=%q name=%q", root.DB.Type, root.DB.Name)
 	return root.DB
 }
-
 
 // podmanServiceIsActive returns true if the FlightCtl Podman service is running.
 // Tries systemctl directly, then falls back to sudo systemctl — matching the

--- a/internal/backup/kubernetes_deployer.go
+++ b/internal/backup/kubernetes_deployer.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,6 +30,8 @@ const (
 	// dbDefaultName and dbDefaultPort are the well-known values used by the FlightCtl Helm chart.
 	dbDefaultName = "flightctl"
 	dbDefaultPort = 5432
+	// encryptionKeySecretName is the Kubernetes Secret containing the data-at-rest encryption key.
+	encryptionKeySecretName = "flightctl-encryption-key"
 )
 
 // requiredPKISecretNames lists PKI/TLS Secrets that must exist in every deployment.
@@ -322,7 +325,7 @@ func (k *KubernetesDeployer) BackupDatabase(ctx context.Context, outputDir strin
 
 // BackupPKI backs up PKI materials by exporting all PKI/TLS Secrets to YAML files.
 // Writes one YAML file per Secret to <outputDir>/pki/<secretName>.yaml.
-// All YAML files are created with pkiFileMode permissions (contain sensitive data).
+// All YAML files are created with sensitiveDataFileMode permissions (contain sensitive data).
 func (k *KubernetesDeployer) BackupPKI(ctx context.Context, outputDir string) error {
 	namespace := k.namespace
 	k.log.Infof("Starting PKI backup from namespace %s...", namespace)
@@ -340,7 +343,7 @@ func (k *KubernetesDeployer) BackupPKI(ctx context.Context, outputDir string) er
 
 	pkiDir := filepath.Join(outputDir, "pki")
 
-	if err := os.MkdirAll(pkiDir, pkiDirMode); err != nil {
+	if err := os.MkdirAll(pkiDir, sensitiveDataDirMode); err != nil {
 		return fmt.Errorf("failed to create PKI output directory: %w", err)
 	}
 
@@ -375,7 +378,7 @@ func (k *KubernetesDeployer) BackupPKI(ctx context.Context, outputDir string) er
 		}
 
 		yamlPath := filepath.Join(pkiDir, secretName+".yaml")
-		if err := os.WriteFile(yamlPath, yamlBytes, pkiFileMode); err != nil {
+		if err := os.WriteFile(yamlPath, yamlBytes, sensitiveDataFileMode); err != nil {
 			return fmt.Errorf("failed to write Secret YAML %s: %w", secretName, err)
 		}
 		backedUp++
@@ -395,6 +398,57 @@ func (k *KubernetesDeployer) BackupPKI(ctx context.Context, outputDir string) er
 
 	k.log.Infof("PKI backup completed. Backed up %d Secrets to %s", backedUp, pkiDir)
 
+	success = true
+	return nil
+}
+
+// BackupEncryptionKeys backs up the data-at-rest encryption key Secret.
+// Writes the Secret as YAML to <outputDir>/encryption/flightctl-encryption-key.yaml.
+// A missing Secret is logged as a warning and does not return an error,
+// so the operator knows encrypted fields will be unrecoverable from this backup.
+func (k *KubernetesDeployer) BackupEncryptionKeys(ctx context.Context, outputDir string) (retErr error) {
+	namespace := k.namespace
+	k.log.Infof("Starting encryption key backup from namespace %s...", namespace)
+
+	clientset, err := k.resolveClientset()
+	if err != nil {
+		return err
+	}
+
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, encryptionKeySecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		k.log.Warnf("Encryption key Secret %q not found — skipping. If this deployment uses data-at-rest encryption, encrypted database fields will be unrecoverable from this backup.", encryptionKeySecretName)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get encryption key Secret %q from namespace %s: %w", encryptionKeySecretName, namespace, err)
+	}
+
+	encDir := filepath.Join(outputDir, "encryption")
+	if err := os.MkdirAll(encDir, sensitiveDataDirMode); err != nil {
+		return fmt.Errorf("failed to create encryption output directory: %w", err)
+	}
+
+	// Clean up encryption directory on error to avoid leaving partial sensitive data on disk.
+	success := false
+	defer func() {
+		if !success {
+			if cleanupErr := os.RemoveAll(encDir); cleanupErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("failed to clean up partial encryption backup at %s: %w", encDir, cleanupErr))
+			}
+		}
+	}()
+
+	yamlBytes, err := yaml.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("failed to marshal encryption key Secret to YAML: %w", err)
+	}
+
+	yamlPath := filepath.Join(encDir, encryptionKeySecretName+".yaml")
+	if err := os.WriteFile(yamlPath, yamlBytes, sensitiveDataFileMode); err != nil {
+		return fmt.Errorf("failed to write encryption key Secret YAML: %w", err)
+	}
+
+	k.log.Infof("Encryption key backup completed: %s", yamlPath)
 	success = true
 	return nil
 }
@@ -420,7 +474,7 @@ func (k *KubernetesDeployer) BackupPKI(ctx context.Context, outputDir string) er
 // Returns error if no Helm release Secrets are found or if multiple are found without an explicit release name.
 func (k *KubernetesDeployer) BackupConfig(ctx context.Context, outputDir string) error {
 	configDir := filepath.Join(outputDir, "config")
-	if err := os.MkdirAll(configDir, pkiDirMode); err != nil {
+	if err := os.MkdirAll(configDir, sensitiveDataDirMode); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -449,7 +503,7 @@ func (k *KubernetesDeployer) BackupConfig(ctx context.Context, outputDir string)
 	}
 
 	helmSecretPath := filepath.Join(configDir, fmt.Sprintf("helm-release-%s.yaml", releaseName))
-	if err := os.WriteFile(helmSecretPath, yamlBytes, pkiFileMode); err != nil {
+	if err := os.WriteFile(helmSecretPath, yamlBytes, sensitiveDataFileMode); err != nil {
 		return fmt.Errorf("failed to write Helm Secret YAML %s: %w", helmSecretPath, err)
 	}
 

--- a/internal/backup/kubernetes_deployer_test.go
+++ b/internal/backup/kubernetes_deployer_test.go
@@ -7,12 +7,16 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // dbAppSecret creates a fake flightctl-db-app-secret for use in tests.
@@ -416,4 +420,131 @@ func TestKubernetesDeployer_BackupConfig_LabelFiltering(t *testing.T) {
 
 	otherPath := filepath.Join(outputDir, "config", "helm-release-other-app.yaml")
 	require.NoFileExists(t, otherPath)
+}
+
+func TestKubernetesDeployer_BackupEncryptionKeys_MissingSecret(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	fakeClient := fake.NewSimpleClientset()
+	deployer := NewKubernetesDeployer(log, WithNamespace("flightctl"), WithClientset(fakeClient))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+
+	require.NoError(t, err, "missing encryption key should not be an error")
+
+	encDir := filepath.Join(outputDir, "encryption")
+	_, statErr := os.Stat(encDir)
+	require.True(t, os.IsNotExist(statErr), "encryption directory should not be created when secret is missing")
+}
+
+func TestKubernetesDeployer_BackupEncryptionKeys_Success(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	encSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encryptionKeySecretName,
+			Namespace: "flightctl",
+		},
+		Data: map[string][]byte{
+			"encryption-key": []byte("supersecretkey"),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(encSecret)
+	deployer := NewKubernetesDeployer(log, WithNamespace("flightctl"), WithClientset(fakeClient))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+	require.NoError(t, err)
+
+	yamlPath := filepath.Join(outputDir, "encryption", encryptionKeySecretName+".yaml")
+	require.FileExists(t, yamlPath)
+
+	stat, err := os.Stat(yamlPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), stat.Mode().Perm(), "encryption key YAML should have 0600 permissions")
+
+	content, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), encryptionKeySecretName)
+}
+
+func TestKubernetesDeployer_BackupEncryptionKeys_DirectoryPermissions(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	encSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encryptionKeySecretName,
+			Namespace: "flightctl",
+		},
+		Data: map[string][]byte{
+			"encryption-key": []byte("key"),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(encSecret)
+	deployer := NewKubernetesDeployer(log, WithNamespace("flightctl"), WithClientset(fakeClient))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	require.NoError(t, deployer.BackupEncryptionKeys(ctx, outputDir))
+
+	encDir := filepath.Join(outputDir, "encryption")
+	stat, err := os.Stat(encDir)
+	require.NoError(t, err)
+	require.True(t, stat.IsDir())
+	require.Equal(t, os.FileMode(0700), stat.Mode().Perm(), "encryption directory should have 0700 permissions")
+}
+
+func TestKubernetesDeployer_BackupEncryptionKeys_CleanupOnError(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	encSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encryptionKeySecretName,
+			Namespace: "flightctl",
+		},
+		Data: map[string][]byte{
+			"encryption-key": []byte("key"),
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(encSecret)
+	deployer := NewKubernetesDeployer(log, WithNamespace("flightctl"), WithClientset(fakeClient))
+	ctx := context.Background()
+
+	outputDir := t.TempDir()
+	encDir := filepath.Join(outputDir, "encryption")
+	require.NoError(t, os.MkdirAll(encDir, 0700))
+	yamlPath := filepath.Join(encDir, encryptionKeySecretName+".yaml")
+	require.NoError(t, os.MkdirAll(yamlPath, 0700))
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+	require.Error(t, err, "should fail when YAML path is a directory")
+
+	_, statErr := os.Stat(encDir)
+	require.True(t, os.IsNotExist(statErr), "encryption directory should be cleaned up on error")
+}
+
+func TestKubernetesDeployer_BackupEncryptionKeys_APIErrorReturned(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("API server unavailable")
+	})
+
+	deployer := NewKubernetesDeployer(log, WithNamespace("flightctl"), WithClientset(fakeClient))
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(context.Background(), outputDir)
+	require.Error(t, err, "non-NotFound API errors must be returned, not swallowed")
+	require.ErrorContains(t, err, "API server unavailable")
+
+	encDir := filepath.Join(outputDir, "encryption")
+	_, statErr := os.Stat(encDir)
+	require.True(t, os.IsNotExist(statErr), "encryption directory should not be created on API error")
 }

--- a/internal/backup/kubernetes_deployer_test.go
+++ b/internal/backup/kubernetes_deployer_test.go
@@ -448,7 +448,7 @@ func TestKubernetesDeployer_BackupEncryptionKeys_Success(t *testing.T) {
 			Namespace: "flightctl",
 		},
 		Data: map[string][]byte{
-			"encryption-key": []byte("supersecretkey"),
+			"key": []byte("supersecretkey"),
 		},
 	}
 
@@ -481,7 +481,7 @@ func TestKubernetesDeployer_BackupEncryptionKeys_DirectoryPermissions(t *testing
 			Namespace: "flightctl",
 		},
 		Data: map[string][]byte{
-			"encryption-key": []byte("key"),
+			"key": []byte("key"),
 		},
 	}
 
@@ -508,7 +508,7 @@ func TestKubernetesDeployer_BackupEncryptionKeys_CleanupOnError(t *testing.T) {
 			Namespace: "flightctl",
 		},
 		Data: map[string][]byte{
-			"encryption-key": []byte("key"),
+			"key": []byte("key"),
 		},
 	}
 

--- a/internal/backup/podman_deployer.go
+++ b/internal/backup/podman_deployer.go
@@ -228,7 +228,7 @@ func copyDirPreservePerms(src, dst string, ctx context.Context, log logrus.Field
 
 		// Reject symlinks to prevent path traversal attacks and undefined behavior
 		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("symlinks not supported in PKI directory: %s", relPath)
+			return fmt.Errorf("symlinks not supported in backup directory: %s", relPath)
 		}
 
 		// Handle directories

--- a/internal/backup/podman_deployer.go
+++ b/internal/backup/podman_deployer.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 type PodmanDeployer struct {
 	log               logrus.FieldLogger
 	pkiPath           string // Optional: if empty, defaults to "/etc/flightctl/pki"
+	encryptionPath    string // Optional: if empty, defaults to "/etc/flightctl/encryption"
 	serviceConfigPath string // Optional: if empty, defaults to "/etc/flightctl/service-config.yaml"
 	dbContainerName   string
 	dbName            string
@@ -31,6 +33,13 @@ type PodmanDeployerOption func(*PodmanDeployer)
 func WithPKIPath(path string) PodmanDeployerOption {
 	return func(d *PodmanDeployer) {
 		d.pkiPath = path
+	}
+}
+
+// WithEncryptionPath sets the encryption key source directory path.
+func WithEncryptionPath(path string) PodmanDeployerOption {
+	return func(d *PodmanDeployer) {
+		d.encryptionPath = path
 	}
 }
 
@@ -98,6 +107,9 @@ func NewPodmanDeployer(log logrus.FieldLogger, opts ...PodmanDeployerOption) *Po
 	}
 	if d.pkiPath == "" {
 		d.pkiPath = "/etc/flightctl/pki"
+	}
+	if d.encryptionPath == "" {
+		d.encryptionPath = "/etc/flightctl/encryption"
 	}
 	if d.serviceConfigPath == "" {
 		d.serviceConfigPath = "/etc/flightctl/service-config.yaml"
@@ -276,7 +288,7 @@ func (p *PodmanDeployer) BackupPKI(ctx context.Context, outputDir string) error 
 	p.log.Infof("Starting PKI backup from %s...", pkiSrcDir)
 
 	// Create destination directory
-	if err := os.MkdirAll(pkiDstDir, pkiDirMode); err != nil {
+	if err := os.MkdirAll(pkiDstDir, sensitiveDataDirMode); err != nil {
 		return fmt.Errorf("failed to create PKI output directory: %w", err)
 	}
 
@@ -300,6 +312,47 @@ func (p *PodmanDeployer) BackupPKI(ctx context.Context, outputDir string) error 
 	return nil
 }
 
+// BackupEncryptionKeys backs up the data-at-rest encryption key directory.
+// Copies <encryptionPath>/ to <outputDir>/encryption/, preserving file permissions.
+// Never returns an error for a missing encryption directory — a warning is logged
+// so the operator knows encrypted fields will be unrecoverable from this backup.
+func (p *PodmanDeployer) BackupEncryptionKeys(ctx context.Context, outputDir string) (retErr error) {
+	encSrcDir := p.encryptionPath
+
+	if _, err := os.Stat(encSrcDir); os.IsNotExist(err) {
+		p.log.Warnf("Encryption key directory not found at %s — skipping. If this deployment uses data-at-rest encryption, encrypted database fields will be unrecoverable from this backup.", encSrcDir)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to access encryption key directory %s: %w", encSrcDir, err)
+	}
+
+	p.log.Infof("Starting encryption key backup from %s...", encSrcDir)
+
+	encDstDir := filepath.Join(outputDir, "encryption")
+	if err := os.MkdirAll(encDstDir, sensitiveDataDirMode); err != nil {
+		return fmt.Errorf("failed to create encryption output directory: %w", err)
+	}
+
+	// Clean up encryption directory on error to avoid leaving partial sensitive data on disk.
+	success := false
+	defer func() {
+		if !success {
+			if cleanupErr := os.RemoveAll(encDstDir); cleanupErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("failed to clean up partial encryption backup at %s: %w", encDstDir, cleanupErr))
+			}
+		}
+	}()
+
+	fileCount, err := copyDirPreservePerms(encSrcDir, encDstDir, ctx, p.log)
+	if err != nil {
+		return fmt.Errorf("failed to copy encryption directory: %w", err)
+	}
+
+	p.log.Infof("Encryption key backup completed. Backed up %d files from %s", fileCount, encSrcDir)
+	success = true
+	return nil
+}
+
 // BackupConfig backs up service configuration files for Podman deployments.
 // Copies /etc/flightctl/service-config.yaml to <outputDir>/config/service-config.yaml.
 // Exports PAM Issuer volume to <outputDir>/volumes/pam-issuer-etc.tar.
@@ -308,7 +361,7 @@ func (p *PodmanDeployer) BackupPKI(ctx context.Context, outputDir string) error 
 func (p *PodmanDeployer) BackupConfig(ctx context.Context, outputDir string) error {
 	// Create config directory
 	configDir := filepath.Join(outputDir, "config")
-	if err := os.MkdirAll(configDir, pkiDirMode); err != nil {
+	if err := os.MkdirAll(configDir, sensitiveDataDirMode); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -334,7 +387,7 @@ func (p *PodmanDeployer) BackupConfig(ctx context.Context, outputDir string) err
 
 	// Backup PAM Issuer volume (optional component)
 	volumesDir := filepath.Join(outputDir, "volumes")
-	if err := os.MkdirAll(volumesDir, pkiDirMode); err != nil {
+	if err := os.MkdirAll(volumesDir, sensitiveDataDirMode); err != nil {
 		return fmt.Errorf("failed to create volumes directory: %w", err)
 	}
 

--- a/internal/backup/podman_deployer_test.go
+++ b/internal/backup/podman_deployer_test.go
@@ -304,3 +304,111 @@ func TestPodmanDeployer_BackupConfig_DirectoryPermissions(t *testing.T) {
 	require.True(t, stat.IsDir(), "config should be a directory")
 	require.Equal(t, os.FileMode(0700), stat.Mode().Perm(), "config directory should have 0700 permissions")
 }
+
+func TestPodmanDeployer_BackupEncryptionKeys_MissingDirectory(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	nonExistentPath := filepath.Join(t.TempDir(), "does-not-exist")
+	deployer := NewPodmanDeployer(log, WithEncryptionPath(nonExistentPath))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+
+	require.NoError(t, err, "missing encryption directory should not be an error")
+
+	encDir := filepath.Join(outputDir, "encryption")
+	_, statErr := os.Stat(encDir)
+	require.True(t, os.IsNotExist(statErr), "encryption output directory should not be created when source is missing")
+}
+
+func TestPodmanDeployer_BackupEncryptionKeys_Success(t *testing.T) {
+	tmpRoot := t.TempDir()
+	encSrc := filepath.Join(tmpRoot, "encryption")
+	require.NoError(t, os.MkdirAll(encSrc, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(encSrc, "encryption.key"), []byte("secret-key"), 0600))
+
+	log, _ := test.NewNullLogger()
+	log.SetLevel(logrus.InfoLevel)
+
+	deployer := NewPodmanDeployer(log, WithEncryptionPath(encSrc))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+	require.NoError(t, err)
+
+	encDst := filepath.Join(outputDir, "encryption")
+	require.FileExists(t, filepath.Join(encDst, "encryption.key"))
+
+	data, err := os.ReadFile(filepath.Join(encDst, "encryption.key"))
+	require.NoError(t, err)
+	require.Equal(t, "secret-key", string(data))
+
+	info, err := os.Stat(filepath.Join(encDst, "encryption.key"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestPodmanDeployer_BackupEncryptionKeys_DirectoryPermissions(t *testing.T) {
+	tmpRoot := t.TempDir()
+	encSrc := filepath.Join(tmpRoot, "encryption")
+	require.NoError(t, os.MkdirAll(encSrc, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(encSrc, "key.dat"), []byte("k"), 0600))
+
+	log, _ := test.NewNullLogger()
+	deployer := NewPodmanDeployer(log, WithEncryptionPath(encSrc))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	require.NoError(t, deployer.BackupEncryptionKeys(ctx, outputDir))
+
+	encDst := filepath.Join(outputDir, "encryption")
+	stat, err := os.Stat(encDst)
+	require.NoError(t, err)
+	require.True(t, stat.IsDir())
+	require.Equal(t, os.FileMode(0700), stat.Mode().Perm(), "encryption directory should have 0700 permissions")
+}
+
+func TestPodmanDeployer_BackupEncryptionKeys_CleanupOnError(t *testing.T) {
+	tmpRoot := t.TempDir()
+	encSrc := filepath.Join(tmpRoot, "encryption")
+	require.NoError(t, os.MkdirAll(encSrc, 0755))
+	require.NoError(t, os.Symlink("/dev/null", filepath.Join(encSrc, "badlink")))
+
+	log, _ := test.NewNullLogger()
+	deployer := NewPodmanDeployer(log, WithEncryptionPath(encSrc))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	err := deployer.BackupEncryptionKeys(ctx, outputDir)
+	require.Error(t, err, "should fail when encountering a symlink")
+
+	encDst := filepath.Join(outputDir, "encryption")
+	_, statErr := os.Stat(encDst)
+	require.True(t, os.IsNotExist(statErr), "encryption directory should be cleaned up on error")
+}
+
+func TestPodmanDeployer_BackupEncryptionKeys_PreservesPermissions(t *testing.T) {
+	tmpRoot := t.TempDir()
+	encSrc := filepath.Join(tmpRoot, "encryption")
+	subDir := filepath.Join(encSrc, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "nested.key"), []byte("nested"), 0640))
+
+	log, _ := test.NewNullLogger()
+	deployer := NewPodmanDeployer(log, WithEncryptionPath(encSrc))
+	ctx := context.Background()
+	outputDir := t.TempDir()
+
+	require.NoError(t, deployer.BackupEncryptionKeys(ctx, outputDir))
+
+	encDst := filepath.Join(outputDir, "encryption")
+	dirInfo, err := os.Stat(filepath.Join(encDst, "subdir"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0750), dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(filepath.Join(encDst, "subdir", "nested.key"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0640), fileInfo.Mode().Perm())
+}

--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -734,6 +735,50 @@ func parseContainerHostPort(output string) (host string, port int, ok bool) {
 	return hostRaw, int(p64), true
 }
 
+// copyDirSecure recursively copies srcDir to dstDir, preserving file permissions.
+// It rejects symlinks and any non-regular, non-directory entries to prevent path
+// traversal attacks. Returns the number of regular files copied.
+func copyDirSecure(ctx context.Context, srcDir, dstDir string, log logrus.FieldLogger) (int, error) {
+	count := 0
+	err := filepath.Walk(srcDir, func(srcPath string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("error walking source directory: %w", walkErr)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		relPath, err := filepath.Rel(srcDir, srcPath)
+		if err != nil {
+			return fmt.Errorf("computing relative path for %s: %w", srcPath, err)
+		}
+		dstPath := filepath.Join(dstDir, relPath)
+
+		if info.IsDir() {
+			if relPath == "." {
+				return nil
+			}
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing non-regular entry %s (mode %s)", relPath, info.Mode())
+		}
+
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", relPath, err)
+		}
+		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
+			return fmt.Errorf("failed to write file %s: %w", relPath, err)
+		}
+		log.Debugf("Restored file: %s", relPath)
+		count++
+		return nil
+	})
+	return count, err
+}
+
 // RestorePKI copies the pki/ directory from the extracted archive into the configured
 // PKI destination, preserving each file's mode. Returns an error if pki/ is absent.
 func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir string) error {
@@ -748,43 +793,7 @@ func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir strin
 		return fmt.Errorf("failed to create PKI destination directory %s: %w", p.pkiDestPath, err)
 	}
 
-	count := 0
-	err := filepath.Walk(pkiSrcDir, func(srcPath string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return fmt.Errorf("error walking PKI source directory: %w", walkErr)
-		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		relPath, err := filepath.Rel(pkiSrcDir, srcPath)
-		if err != nil {
-			return fmt.Errorf("computing relative path for %s: %w", srcPath, err)
-		}
-		dstPath := filepath.Join(p.pkiDestPath, relPath)
-
-		if info.IsDir() {
-			if relPath == "." {
-				return nil
-			}
-			return os.MkdirAll(dstPath, info.Mode())
-		}
-
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("refusing non-regular PKI entry %s (mode %s)", relPath, info.Mode())
-		}
-
-		data, err := os.ReadFile(srcPath)
-		if err != nil {
-			return fmt.Errorf("failed to read PKI file %s: %w", relPath, err)
-		}
-		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
-			return fmt.Errorf("failed to write PKI file %s: %w", relPath, err)
-		}
-		p.log.Debugf("Restored PKI file: %s", relPath)
-		count++
-		return nil
-	})
+	count, err := copyDirSecure(ctx, pkiSrcDir, p.pkiDestPath, p.log)
 	if err != nil {
 		return fmt.Errorf("PKI restore failed: %w", err)
 	}
@@ -797,7 +806,7 @@ func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir strin
 // Copies <extractDir>/encryption/ to <encryptionDestPath>, preserving file permissions.
 // Logs a warning and skips if the encryption directory is absent from the archive
 // (backwards compatible with pre-encryption backups).
-func (p *PodmanRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extractDir string) error {
+func (p *PodmanRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extractDir string) (retErr error) {
 	encSrcDir := filepath.Join(extractDir, "encryption")
 
 	if _, err := os.Stat(encSrcDir); os.IsNotExist(err) {
@@ -816,45 +825,13 @@ func (p *PodmanRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extra
 	if err != nil {
 		return fmt.Errorf("failed to create staging directory: %w", err)
 	}
-	defer os.RemoveAll(stagingDir) // clean up on any error path
+	defer func() {
+		if cleanupErr := os.RemoveAll(stagingDir); cleanupErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("failed to clean up staging directory %s: %w", stagingDir, cleanupErr))
+		}
+	}()
 
-	count := 0
-	err = filepath.Walk(encSrcDir, func(srcPath string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return fmt.Errorf("error walking encryption source directory: %w", walkErr)
-		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		relPath, err := filepath.Rel(encSrcDir, srcPath)
-		if err != nil {
-			return fmt.Errorf("computing relative path for %s: %w", srcPath, err)
-		}
-		dstPath := filepath.Join(stagingDir, relPath)
-
-		if info.IsDir() {
-			if relPath == "." {
-				return nil
-			}
-			return os.MkdirAll(dstPath, info.Mode())
-		}
-
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("refusing non-regular encryption entry %s (mode %s)", relPath, info.Mode())
-		}
-
-		data, err := os.ReadFile(srcPath)
-		if err != nil {
-			return fmt.Errorf("failed to read encryption file %s: %w", relPath, err)
-		}
-		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
-			return fmt.Errorf("failed to write encryption file %s: %w", relPath, err)
-		}
-		p.log.Debugf("Restored encryption file: %s", relPath)
-		count++
-		return nil
-	})
+	count, err := copyDirSecure(ctx, encSrcDir, stagingDir, p.log)
 	if err != nil {
 		return fmt.Errorf("encryption key restore failed: %w", err)
 	}
@@ -862,12 +839,32 @@ func (p *PodmanRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extra
 		return fmt.Errorf("encryption archive directory is empty — refusing to overwrite live key material")
 	}
 
-	// Atomic swap: remove existing destination and rename staging dir into place.
-	if err := os.RemoveAll(p.encryptionDestPath); err != nil {
-		return fmt.Errorf("failed to remove existing encryption directory: %w", err)
+	// Atomic swap: rename the existing destination aside, then rename staging
+	// into place. If the final rename fails, roll back by restoring the backup
+	// so live key material is never lost.
+	backupDir := p.encryptionDestPath + ".bak"
+	if _, statErr := os.Stat(p.encryptionDestPath); statErr == nil {
+		if err := os.RemoveAll(backupDir); err != nil {
+			p.log.Warnf("Failed to clean up stale encryption key backup at %s: %v", backupDir, err)
+		}
+		if err := os.Rename(p.encryptionDestPath, backupDir); err != nil {
+			return fmt.Errorf("failed to move existing encryption directory aside: %w", err)
+		}
+	} else if _, bakErr := os.Stat(backupDir); bakErr == nil {
+		p.log.Warnf("Destination %s is missing but backup %s exists — likely an interrupted prior restore; preserving it for recovery", p.encryptionDestPath, backupDir)
 	}
 	if err := os.Rename(stagingDir, p.encryptionDestPath); err != nil {
+		// Roll back: restore the original directory so keys are not lost.
+		if rbErr := os.Rename(backupDir, p.encryptionDestPath); rbErr != nil {
+			return errors.Join(
+				fmt.Errorf("failed to move staged encryption keys to destination: %w", err),
+				fmt.Errorf("rollback also failed: %w", rbErr),
+			)
+		}
 		return fmt.Errorf("failed to move staged encryption keys to destination: %w", err)
+	}
+	if err := os.RemoveAll(backupDir); err != nil {
+		p.log.Warnf("Failed to clean up old encryption key backup at %s: %v", backupDir, err)
 	}
 
 	p.log.Infof("Encryption key restore completed. Restored %d files to %s", count, p.encryptionDestPath)
@@ -1533,7 +1530,7 @@ func (k *KubernetesRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, e
 		return fmt.Errorf("unexpected Secret name %q in encryption key archive (expected %q)", secret.Name, expectedSecretName)
 	}
 	if len(secret.Data) == 0 {
-		return fmt.Errorf("encryption key Secret %q has no data — refusing to overwrite live key material with an empty Secret", expectedSecretName)
+		return fmt.Errorf("encryption key Secret %q has no data — refusing to overwrite live key material", expectedSecretName)
 	}
 
 	clientset, err := k.resolveClientset()

--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -161,6 +161,14 @@ type Deployer interface {
 	// Returns an error if the pki/ subdirectory is absent from the archive.
 	// StopServices must be called before RestorePKI.
 	RestorePKI(ctx context.Context, extractDir string) error
+	// RestoreEncryptionKeys restores data-at-rest encryption keys from the archive.
+	// For Podman, copies <extractDir>/encryption/ to the configured encryption
+	// destination (default: /etc/flightctl/encryption/), preserving file permissions.
+	// For Kubernetes, applies <extractDir>/encryption/flightctl-encryption-key.yaml
+	// as a Secret and duplicates it to the internal namespace if different.
+	// Silently skips if the encryption directory is absent from the archive
+	// (backwards compatible with pre-encryption backups).
+	RestoreEncryptionKeys(ctx context.Context, extractDir string) error
 	// RestoreConfig restores service configuration from the extracted archive directory.
 	// For Podman: copies <extractDir>/config/service-config.yaml to the configured service
 	// config path and imports the PAM Issuer volume from <extractDir>/volumes/pam-issuer-etc.tar
@@ -187,6 +195,7 @@ type PodmanRestoreDeployer struct {
 	dbName              string
 	kvContainerName     string
 	pkiDestPath         string
+	encryptionDestPath  string
 	pamIssuerVolumeName string
 	keepOldDB           bool
 	cachedCfg           *config.Config
@@ -256,6 +265,14 @@ func WithPKIDestPath(path string) PodmanRestoreOption {
 	}
 }
 
+// WithEncryptionDestPath sets the destination directory for encryption keys restoration.
+// Defaults to /etc/flightctl/encryption.
+func WithEncryptionDestPath(path string) PodmanRestoreOption {
+	return func(d *PodmanRestoreDeployer) {
+		d.encryptionDestPath = path
+	}
+}
+
 // WithPodmanKeepOldDB controls whether the pre-restore database is dropped after
 // a successful swap (false, default) or preserved under <dbname>_old_<timestamp> (true).
 func WithPodmanKeepOldDB(keep bool) PodmanRestoreOption {
@@ -320,6 +337,9 @@ func NewPodmanRestoreDeployer(
 	}
 	if d.pkiDestPath == "" {
 		d.pkiDestPath = "/etc/flightctl/pki"
+	}
+	if d.encryptionDestPath == "" {
+		d.encryptionDestPath = "/etc/flightctl/encryption"
 	}
 	if d.pamIssuerVolumeName == "" {
 		d.pamIssuerVolumeName = "flightctl-pam-issuer-etc"
@@ -770,6 +790,87 @@ func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir strin
 	}
 
 	p.log.Infof("PKI restore completed. Restored %d files to %s", count, p.pkiDestPath)
+	return nil
+}
+
+// RestoreEncryptionKeys restores the data-at-rest encryption key directory from the archive.
+// Copies <extractDir>/encryption/ to <encryptionDestPath>, preserving file permissions.
+// Logs a warning and skips if the encryption directory is absent from the archive
+// (backwards compatible with pre-encryption backups).
+func (p *PodmanRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extractDir string) error {
+	encSrcDir := filepath.Join(extractDir, "encryption")
+
+	if _, err := os.Stat(encSrcDir); os.IsNotExist(err) {
+		p.log.Warnf("No encryption key directory in archive, skipping encryption key restore. If this deployment uses data-at-rest encryption, encrypted database fields will be unrecoverable.")
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to access encryption directory in archive: %w", err)
+	}
+
+	p.log.Infof("Starting encryption key restore to %s...", p.encryptionDestPath)
+
+	// Stage into a temp directory next to the destination so that a failure
+	// mid-walk (e.g. symlink rejection) does not leave a partially written
+	// destination. On success the staging dir is renamed atomically.
+	stagingDir, err := os.MkdirTemp(filepath.Dir(p.encryptionDestPath), ".enc-restore-*")
+	if err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+	defer os.RemoveAll(stagingDir) // clean up on any error path
+
+	count := 0
+	err = filepath.Walk(encSrcDir, func(srcPath string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("error walking encryption source directory: %w", walkErr)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		relPath, err := filepath.Rel(encSrcDir, srcPath)
+		if err != nil {
+			return fmt.Errorf("computing relative path for %s: %w", srcPath, err)
+		}
+		dstPath := filepath.Join(stagingDir, relPath)
+
+		if info.IsDir() {
+			if relPath == "." {
+				return nil
+			}
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing non-regular encryption entry %s (mode %s)", relPath, info.Mode())
+		}
+
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed to read encryption file %s: %w", relPath, err)
+		}
+		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
+			return fmt.Errorf("failed to write encryption file %s: %w", relPath, err)
+		}
+		p.log.Debugf("Restored encryption file: %s", relPath)
+		count++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("encryption key restore failed: %w", err)
+	}
+	if count == 0 {
+		return fmt.Errorf("encryption archive directory is empty — refusing to overwrite live key material")
+	}
+
+	// Atomic swap: remove existing destination and rename staging dir into place.
+	if err := os.RemoveAll(p.encryptionDestPath); err != nil {
+		return fmt.Errorf("failed to remove existing encryption directory: %w", err)
+	}
+	if err := os.Rename(stagingDir, p.encryptionDestPath); err != nil {
+		return fmt.Errorf("failed to move staged encryption keys to destination: %w", err)
+	}
+
+	p.log.Infof("Encryption key restore completed. Restored %d files to %s", count, p.encryptionDestPath)
 	return nil
 }
 
@@ -1403,11 +1504,63 @@ func (k *KubernetesRestoreDeployer) RestorePKI(ctx context.Context, extractDir s
 	return nil
 }
 
+// RestoreEncryptionKeys restores the data-at-rest encryption key Secret from the archive.
+// Applies <extractDir>/encryption/flightctl-encryption-key.yaml to the release namespace,
+// and duplicates it to the internal namespace if different.
+// Logs a warning and skips if the encryption directory is absent (backwards compatible
+// with pre-encryption backups).
+func (k *KubernetesRestoreDeployer) RestoreEncryptionKeys(ctx context.Context, extractDir string) error {
+	const expectedSecretName = "flightctl-encryption-key"
+
+	encKeyPath := filepath.Join(extractDir, "encryption", expectedSecretName+".yaml")
+
+	if _, err := os.Stat(encKeyPath); os.IsNotExist(err) {
+		k.log.Warnf("No encryption key in archive, skipping encryption key restore. If this deployment uses data-at-rest encryption, encrypted database fields will be unrecoverable.")
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to access encryption key in archive: %w", err)
+	}
+
+	data, err := os.ReadFile(encKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read encryption key Secret: %w", err)
+	}
+	var secret corev1.Secret
+	if err := yaml.Unmarshal(data, &secret); err != nil {
+		return fmt.Errorf("failed to unmarshal encryption key Secret: %w", err)
+	}
+	if secret.Name != expectedSecretName {
+		return fmt.Errorf("unexpected Secret name %q in encryption key archive (expected %q)", secret.Name, expectedSecretName)
+	}
+	if len(secret.Data) == 0 {
+		return fmt.Errorf("encryption key Secret %q has no data — refusing to overwrite live key material with an empty Secret", expectedSecretName)
+	}
+
+	clientset, err := k.resolveClientset()
+	if err != nil {
+		return fmt.Errorf("failed to resolve Kubernetes clientset for encryption key restore: %w", err)
+	}
+
+	if err := k.applySecret(ctx, clientset, &secret, k.namespace); err != nil {
+		return fmt.Errorf("failed to apply encryption key Secret: %w", err)
+	}
+	k.log.Infof("Restored encryption key Secret to namespace %s", k.namespace)
+
+	// Duplicate to internal namespace if it differs from release namespace.
+	// The Helm hook creates the encryption key in both namespaces; restore must do the same.
+	if k.internalNamespace != "" && k.internalNamespace != k.namespace {
+		if err := k.applySecret(ctx, clientset, &secret, k.internalNamespace); err != nil {
+			return fmt.Errorf("failed to apply encryption key Secret to internal namespace %s: %w", k.internalNamespace, err)
+		}
+		k.log.Infof("Duplicated encryption key Secret to internal namespace %s", k.internalNamespace)
+	}
+
+	return nil
+}
+
 // applySecretFromFile reads a Secret YAML file, unmarshals it, and creates or
 // updates the Secret in the cluster. The namespace is taken from the YAML
 // metadata; if absent it falls back to k.namespace.
-// Server-assigned fields (ResourceVersion, UID, ManagedFields) are cleared so
-// that create and update both work regardless of prior cluster state.
 func (k *KubernetesRestoreDeployer) applySecretFromFile(ctx context.Context, clientset kubernetes.Interface, yamlPath string) error {
 	data, err := os.ReadFile(yamlPath)
 	if err != nil {
@@ -1424,14 +1577,20 @@ func (k *KubernetesRestoreDeployer) applySecretFromFile(ctx context.Context, cli
 		ns = k.namespace
 	}
 
-	// Clear server-assigned fields so the object can be created or updated
-	// without conflicts from stale metadata recorded at backup time.
+	return k.applySecret(ctx, clientset, &secret, ns)
+}
+
+// applySecret creates or updates a Secret in the given namespace.
+// Server-assigned fields (ResourceVersion, UID, ManagedFields) are cleared so
+// that create and update both work regardless of prior cluster state.
+func (k *KubernetesRestoreDeployer) applySecret(ctx context.Context, clientset kubernetes.Interface, secret *corev1.Secret, ns string) error {
+	secret.Namespace = ns
 	secret.ResourceVersion = ""
 	secret.UID = ""
 	secret.Generation = 0
 	secret.ManagedFields = nil
 
-	_, err = clientset.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
 	if err == nil {
 		return nil
 	}
@@ -1445,7 +1604,7 @@ func (k *KubernetesRestoreDeployer) applySecretFromFile(ctx context.Context, cli
 		return fmt.Errorf("failed to get existing Secret %s/%s: %w", ns, secret.Name, err)
 	}
 	secret.ResourceVersion = existing.ResourceVersion
-	if _, err := clientset.CoreV1().Secrets(ns).Update(ctx, &secret, metav1.UpdateOptions{}); err != nil {
+	if _, err := clientset.CoreV1().Secrets(ns).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update Secret %s/%s: %w", ns, secret.Name, err)
 	}
 	return nil
@@ -1651,8 +1810,9 @@ func getFreePort() (int, error) {
 // the temp file paths. Returns a cleanup function to delete the temp files when done.
 //
 // Based on Helm values structure:
-//   db.external.tlsConfigMapName: postgres-ca-cert (CA certificate in ca-cert.pem key)
-//   db.external.tlsSecretName: postgres-client-certs (client cert/key in tls.crt and tls.key)
+//
+//	db.external.tlsConfigMapName: postgres-ca-cert (CA certificate in ca-cert.pem key)
+//	db.external.tlsSecretName: postgres-client-certs (client cert/key in tls.crt and tls.key)
 //
 // This is a Kubernetes-specific implementation detail, not part of the Deployer interface.
 func (k *KubernetesRestoreDeployer) SetupExternalDBCerts(ctx context.Context, cfg *config.Config) (cleanup func(), err error) {

--- a/internal/restore/deployer_test.go
+++ b/internal/restore/deployer_test.go
@@ -18,9 +18,11 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
 )
 
@@ -861,4 +863,455 @@ kv:
 	require.Equal(t, uint(dbInternalPort), cfg.Database.Port)
 	require.Equal(t, "flightctl-kv", cfg.KV.Hostname)
 	require.Equal(t, uint(kvInternalPort), cfg.KV.Port)
+}
+
+// buildExtractDirWithEncryption creates an extract directory containing an encryption/
+// subdirectory with the given files (filename → content). Returns the extract directory path.
+func buildExtractDirWithEncryption(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	encDir := filepath.Join(dir, "encryption")
+	require.NoError(t, os.MkdirAll(encDir, 0700))
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(encDir, name), []byte(content), 0600))
+	}
+	return dir
+}
+
+// buildExtractDirWithEncryptionSecret creates an extract directory with an encryption/
+// subdirectory containing a Secret YAML file. Returns the extract directory and a fresh
+// fake clientset for verifying post-restore cluster state.
+func buildExtractDirWithEncryptionSecret(t *testing.T, secret *corev1.Secret) (string, kubernetes.Interface) {
+	t.Helper()
+	dir := t.TempDir()
+	encDir := filepath.Join(dir, "encryption")
+	require.NoError(t, os.MkdirAll(encDir, 0700))
+	data, err := json.Marshal(secret)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(encDir, secret.Name+".yaml"), data, 0600))
+	return dir, fake.NewSimpleClientset()
+}
+
+// TestPodmanRestoreDeployer_RestoreEncryptionKeys validates the behavioral contracts
+// of PodmanRestoreDeployer.RestoreEncryptionKeys.
+func TestPodmanRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupDir    func(t *testing.T) string
+		setupDest   func(t *testing.T, destDir string)
+		wantErr     bool
+		errContains string
+		verify      func(t *testing.T, destDir string)
+	}{
+		{
+			name: "When encryption dir is absent from archive it should skip silently",
+			setupDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			verify: func(t *testing.T, destDir string) {
+				entries, err := os.ReadDir(destDir)
+				require.NoError(t, err)
+				require.Empty(t, entries, "destination should remain empty")
+			},
+		},
+		{
+			name: "When encryption dir exists it should copy all files to destination",
+			setupDir: func(t *testing.T) string {
+				return buildExtractDirWithEncryption(t, map[string]string{
+					"encryption.key": "secret-key-data",
+				})
+			},
+			verify: func(t *testing.T, destDir string) {
+				require.FileExists(t, filepath.Join(destDir, "encryption.key"))
+				data, err := os.ReadFile(filepath.Join(destDir, "encryption.key"))
+				require.NoError(t, err)
+				require.Equal(t, "secret-key-data", string(data))
+			},
+		},
+		{
+			name: "When encryption dir exists it should preserve file permissions",
+			setupDir: func(t *testing.T) string {
+				return buildExtractDirWithEncryption(t, map[string]string{
+					"encryption.key": "key-data",
+				})
+			},
+			verify: func(t *testing.T, destDir string) {
+				info, err := os.Stat(filepath.Join(destDir, "encryption.key"))
+				require.NoError(t, err)
+				require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+			},
+		},
+		{
+			name: "When encryption dir contains a symlink it should return an error and leave destination unchanged",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				encDir := filepath.Join(dir, "encryption")
+				require.NoError(t, os.MkdirAll(encDir, 0700))
+				target := filepath.Join(encDir, "encryption.key")
+				require.NoError(t, os.WriteFile(target, []byte("key"), 0600))
+				require.NoError(t, os.Symlink(target, filepath.Join(encDir, "key-link")))
+				return dir
+			},
+			wantErr:     true,
+			errContains: "non-regular",
+			verify: func(t *testing.T, destDir string) {
+				entries, err := os.ReadDir(destDir)
+				require.NoError(t, err)
+				require.Empty(t, entries, "destination should remain unchanged after failed restore")
+			},
+		},
+		{
+			name: "When encryption dir contains a symlink it should preserve existing destination files",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				encDir := filepath.Join(dir, "encryption")
+				require.NoError(t, os.MkdirAll(encDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(encDir, "good.key"), []byte("new-key"), 0600))
+				require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(encDir, "evil-link")))
+				return dir
+			},
+			setupDest: func(t *testing.T, destDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(destDir, "existing.key"), []byte("original-key"), 0600))
+			},
+			wantErr:     true,
+			errContains: "non-regular",
+			verify: func(t *testing.T, destDir string) {
+				data, err := os.ReadFile(filepath.Join(destDir, "existing.key"))
+				require.NoError(t, err, "pre-existing file should survive failed restore")
+				require.Equal(t, "original-key", string(data))
+			},
+		},
+		{
+			name: "When encryption dir is empty it should return an error and leave destination unchanged",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "encryption"), 0700))
+				return dir
+			},
+			setupDest: func(t *testing.T, destDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(destDir, "existing.key"), []byte("live-key"), 0600))
+			},
+			wantErr:     true,
+			errContains: "empty",
+			verify: func(t *testing.T, destDir string) {
+				data, err := os.ReadFile(filepath.Join(destDir, "existing.key"))
+				require.NoError(t, err, "pre-existing key should survive failed restore of empty archive")
+				require.Equal(t, "live-key", string(data))
+			},
+		},
+		{
+			name: "When encryption dir contains subdirectories it should create them and copy nested files",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				subDir := filepath.Join(dir, "encryption", "sub")
+				require.NoError(t, os.MkdirAll(subDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(subDir, "nested.key"), []byte("nested-key"), 0600))
+				return dir
+			},
+			verify: func(t *testing.T, destDir string) {
+				data, err := os.ReadFile(filepath.Join(destDir, "sub", "nested.key"))
+				require.NoError(t, err)
+				require.Equal(t, "nested-key", string(data))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, _ := test.NewNullLogger()
+			destDir := t.TempDir()
+			if tt.setupDest != nil {
+				tt.setupDest(t, destDir)
+			}
+			d := NewPodmanRestoreDeployer(log, WithEncryptionDestPath(destDir))
+			err := d.RestoreEncryptionKeys(context.Background(), tt.setupDir(t))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.verify != nil {
+				tt.verify(t, destDir)
+			}
+		})
+	}
+}
+
+// TestKubernetesRestoreDeployer_RestoreEncryptionKeys validates the behavioral contracts
+// of KubernetesRestoreDeployer.RestoreEncryptionKeys.
+func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
+	const ns = "flightctl"
+
+	t.Run("When encryption dir is absent from archive it should skip silently", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestoreEncryptionKeys(context.Background(), t.TempDir())
+		require.NoError(t, err)
+	})
+
+	t.Run("When encryption key yaml exists it should create the Secret in the cluster", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("supersecret")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("supersecret"), got.Data["encryption-key"])
+	})
+
+	t.Run("When internal namespace differs it should duplicate the Secret", func(t *testing.T) {
+		const internalNS = "flightctl-internal"
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("dualns")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreInternalNamespace(internalNS),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		gotRelease, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("dualns"), gotRelease.Data["encryption-key"])
+
+		gotInternal, err := cs.CoreV1().Secrets(internalNS).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("dualns"), gotInternal.Data["encryption-key"])
+	})
+
+	t.Run("When internal namespace apply fails it should return an error after release namespace succeeds", func(t *testing.T) {
+		const internalNS = "flightctl-internal"
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("partial-fail")},
+		}
+
+		dir := t.TempDir()
+		encDir := filepath.Join(dir, "encryption")
+		require.NoError(t, os.MkdirAll(encDir, 0700))
+		data, err := json.Marshal(secret)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(encDir, "flightctl-encryption-key.yaml"), data, 0600))
+
+		cs := fake.NewSimpleClientset()
+		cs.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() == internalNS {
+				return true, nil, fmt.Errorf("simulated internal namespace failure")
+			}
+			return false, nil, nil
+		})
+		cs.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() == internalNS {
+				return true, nil, fmt.Errorf("simulated internal namespace failure")
+			}
+			return false, nil, nil
+		})
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreInternalNamespace(internalNS),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err = d.RestoreEncryptionKeys(context.Background(), dir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to apply encryption key Secret to internal namespace")
+
+		gotRelease, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err, "Release namespace Secret should have been created before the failure")
+		require.Equal(t, []byte("partial-fail"), gotRelease.Data["encryption-key"])
+	})
+
+	t.Run("When internal namespace equals release namespace it should not duplicate", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("singlelns")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreInternalNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("singlelns"), got.Data["encryption-key"])
+	})
+
+	t.Run("When encryption yaml has no namespace it should use the deployer namespace", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key"},
+			Data:       map[string][]byte{"encryption-key": []byte("no-ns-key")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "flightctl-encryption-key", got.Name)
+	})
+
+	t.Run("When encryption yaml contains invalid content it should return an error", func(t *testing.T) {
+		dir := t.TempDir()
+		encDir := filepath.Join(dir, "encryption")
+		require.NoError(t, os.MkdirAll(encDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(encDir, "flightctl-encryption-key.yaml"), []byte("{not: valid: yaml: ["), 0600))
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestoreEncryptionKeys(context.Background(), dir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to unmarshal encryption key Secret")
+	})
+
+	t.Run("When encryption yaml has unexpected secret name it should return an error", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-secret-name", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("some-key")},
+		}
+		dir := t.TempDir()
+		encDir := filepath.Join(dir, "encryption")
+		require.NoError(t, os.MkdirAll(encDir, 0700))
+		data, err := yaml.Marshal(secret)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(encDir, "flightctl-encryption-key.yaml"), data, 0600))
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err = d.RestoreEncryptionKeys(context.Background(), dir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unexpected Secret name")
+	})
+
+	t.Run("When encryption yaml has empty data it should return an error", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+		}
+		dir := t.TempDir()
+		encDir := filepath.Join(dir, "encryption")
+		require.NoError(t, os.MkdirAll(encDir, 0700))
+		data, err := yaml.Marshal(secret)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(encDir, "flightctl-encryption-key.yaml"), data, 0600))
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err = d.RestoreEncryptionKeys(context.Background(), dir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "has no data")
+	})
+
+	t.Run("When encryption yaml has a different namespace it should apply to the deployer namespace", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: "other-namespace"},
+			Data:       map[string][]byte{"encryption-key": []byte("forced-ns-key")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("forced-ns-key"), got.Data["encryption-key"])
+
+		_, err = cs.CoreV1().Secrets("other-namespace").Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.Error(t, err, "Secret should NOT be created in the archived namespace")
+	})
+
+	t.Run("When existing secret exists it should update it", func(t *testing.T) {
+		existing := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("old-key")},
+		}
+		updated := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
+			Data:       map[string][]byte{"encryption-key": []byte("new-key")},
+		}
+		extractDir, cs := buildExtractDirWithEncryptionSecret(t, updated)
+		_, err := cs.CoreV1().Secrets(ns).Create(context.Background(), existing, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestoreEncryptionKeys(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("new-key"), got.Data["encryption-key"])
+	})
 }

--- a/internal/restore/deployer_test.go
+++ b/internal/restore/deployer_test.go
@@ -273,6 +273,95 @@ func buildExtractDirWithPKI(t *testing.T, files map[string]os.FileMode) string {
 	return dir
 }
 
+func TestCopyDirSecure(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	t.Run("When source has regular files it should copy them to destination", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaa"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "b.txt"), []byte("bbb"), 0600))
+
+		count, err := copyDirSecure(context.Background(), src, dst, log)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+
+		data, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "aaa", string(data))
+
+		data, err = os.ReadFile(filepath.Join(dst, "b.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "bbb", string(data))
+	})
+
+	t.Run("When source has files it should preserve their permissions", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "secret.key"), []byte("key"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "public.crt"), []byte("cert"), 0644))
+
+		_, err := copyDirSecure(context.Background(), src, dst, log)
+		require.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(dst, "secret.key"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+		info, err = os.Stat(filepath.Join(dst, "public.crt"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0644), info.Mode().Perm())
+	})
+
+	t.Run("When source has subdirectories it should recreate them with contents", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		subDir := filepath.Join(src, "sub", "nested")
+		require.NoError(t, os.MkdirAll(subDir, 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(subDir, "deep.txt"), []byte("deep"), 0600))
+
+		count, err := copyDirSecure(context.Background(), src, dst, log)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		data, err := os.ReadFile(filepath.Join(dst, "sub", "nested", "deep.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "deep", string(data))
+	})
+
+	t.Run("When source contains a symlink it should return an error", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "real.txt"), []byte("real"), 0600))
+		require.NoError(t, os.Symlink(filepath.Join(src, "real.txt"), filepath.Join(src, "link.txt")))
+
+		_, err := copyDirSecure(context.Background(), src, dst, log)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "non-regular")
+	})
+
+	t.Run("When context is cancelled it should return early", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "file.txt"), []byte("data"), 0600))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := copyDirSecure(ctx, src, dst, log)
+		require.Error(t, err)
+	})
+
+	t.Run("When source is empty it should return zero count", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		count, err := copyDirSecure(context.Background(), src, dst, log)
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+	})
+}
+
 // TestPodmanRestoreDeployer_RestorePKI validates the behavioral contracts
 // of PodmanRestoreDeployer.RestorePKI.
 func TestPodmanRestoreDeployer_RestorePKI(t *testing.T) {
@@ -1005,6 +1094,26 @@ func TestPodmanRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 			},
 		},
 		{
+			name: "When existing destination has files it should replace them and leave no backup behind",
+			setupDir: func(t *testing.T) string {
+				return buildExtractDirWithEncryption(t, map[string]string{
+					"new.key": "new-key-data",
+				})
+			},
+			setupDest: func(t *testing.T, destDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(destDir, "old.key"), []byte("old-key-data"), 0600))
+			},
+			verify: func(t *testing.T, destDir string) {
+				data, err := os.ReadFile(filepath.Join(destDir, "new.key"))
+				require.NoError(t, err)
+				require.Equal(t, "new-key-data", string(data))
+				require.NoFileExists(t, filepath.Join(destDir, "old.key"), "old files should not survive the swap")
+				_, err = os.Stat(destDir + ".bak")
+				require.True(t, os.IsNotExist(err), ".bak directory should be cleaned up after successful swap")
+			},
+		},
+		{
 			name: "When encryption dir contains subdirectories it should create them and copy nested files",
 			setupDir: func(t *testing.T) string {
 				t.Helper()
@@ -1067,7 +1176,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("supersecret")},
+			Data:       map[string][]byte{"key": []byte("supersecret")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
 
@@ -1081,7 +1190,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("supersecret"), got.Data["encryption-key"])
+		require.Equal(t, []byte("supersecret"), got.Data["key"])
 	})
 
 	t.Run("When internal namespace differs it should duplicate the Secret", func(t *testing.T) {
@@ -1089,7 +1198,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("dualns")},
+			Data:       map[string][]byte{"key": []byte("dualns")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
 
@@ -1104,11 +1213,11 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		gotRelease, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("dualns"), gotRelease.Data["encryption-key"])
+		require.Equal(t, []byte("dualns"), gotRelease.Data["key"])
 
 		gotInternal, err := cs.CoreV1().Secrets(internalNS).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("dualns"), gotInternal.Data["encryption-key"])
+		require.Equal(t, []byte("dualns"), gotInternal.Data["key"])
 	})
 
 	t.Run("When internal namespace apply fails it should return an error after release namespace succeeds", func(t *testing.T) {
@@ -1116,7 +1225,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("partial-fail")},
+			Data:       map[string][]byte{"key": []byte("partial-fail")},
 		}
 
 		dir := t.TempDir()
@@ -1153,14 +1262,14 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		gotRelease, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err, "Release namespace Secret should have been created before the failure")
-		require.Equal(t, []byte("partial-fail"), gotRelease.Data["encryption-key"])
+		require.Equal(t, []byte("partial-fail"), gotRelease.Data["key"])
 	})
 
 	t.Run("When internal namespace equals release namespace it should not duplicate", func(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("singlelns")},
+			Data:       map[string][]byte{"key": []byte("singlelns")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
 
@@ -1175,14 +1284,14 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("singlelns"), got.Data["encryption-key"])
+		require.Equal(t, []byte("singlelns"), got.Data["key"])
 	})
 
 	t.Run("When encryption yaml has no namespace it should use the deployer namespace", func(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key"},
-			Data:       map[string][]byte{"encryption-key": []byte("no-ns-key")},
+			Data:       map[string][]byte{"key": []byte("no-ns-key")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
 
@@ -1220,7 +1329,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "wrong-secret-name", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("some-key")},
+			Data:       map[string][]byte{"key": []byte("some-key")},
 		}
 		dir := t.TempDir()
 		encDir := filepath.Join(dir, "encryption")
@@ -1240,7 +1349,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		require.ErrorContains(t, err, "unexpected Secret name")
 	})
 
-	t.Run("When encryption yaml has empty data it should return an error", func(t *testing.T) {
+	t.Run("When encryption yaml has no data it should return an error", func(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
@@ -1267,7 +1376,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		secret := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: "other-namespace"},
-			Data:       map[string][]byte{"encryption-key": []byte("forced-ns-key")},
+			Data:       map[string][]byte{"key": []byte("forced-ns-key")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, secret)
 
@@ -1281,7 +1390,7 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("forced-ns-key"), got.Data["encryption-key"])
+		require.Equal(t, []byte("forced-ns-key"), got.Data["key"])
 
 		_, err = cs.CoreV1().Secrets("other-namespace").Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.Error(t, err, "Secret should NOT be created in the archived namespace")
@@ -1291,12 +1400,12 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 		existing := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("old-key")},
+			Data:       map[string][]byte{"key": []byte("old-key")},
 		}
 		updated := &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-encryption-key", Namespace: ns},
-			Data:       map[string][]byte{"encryption-key": []byte("new-key")},
+			Data:       map[string][]byte{"key": []byte("new-key")},
 		}
 		extractDir, cs := buildExtractDirWithEncryptionSecret(t, updated)
 		_, err := cs.CoreV1().Secrets(ns).Create(context.Background(), existing, metav1.CreateOptions{})
@@ -1312,6 +1421,6 @@ func TestKubernetesRestoreDeployer_RestoreEncryptionKeys(t *testing.T) {
 
 		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-encryption-key", metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, []byte("new-key"), got.Data["encryption-key"])
+		require.Equal(t, []byte("new-key"), got.Data["key"])
 	})
 }

--- a/internal/restore/mock_deployer.go
+++ b/internal/restore/mock_deployer.go
@@ -152,6 +152,20 @@ func (mr *MockDeployerMockRecorder) RestoreDatabase(ctx, extractDir any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreDatabase", reflect.TypeOf((*MockDeployer)(nil).RestoreDatabase), ctx, extractDir)
 }
 
+// RestoreEncryptionKeys mocks base method.
+func (m *MockDeployer) RestoreEncryptionKeys(ctx context.Context, extractDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreEncryptionKeys", ctx, extractDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreEncryptionKeys indicates an expected call of RestoreEncryptionKeys.
+func (mr *MockDeployerMockRecorder) RestoreEncryptionKeys(ctx, extractDir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreEncryptionKeys", reflect.TypeOf((*MockDeployer)(nil).RestoreEncryptionKeys), ctx, extractDir)
+}
+
 // RestorePKI mocks base method.
 func (m *MockDeployer) RestorePKI(ctx context.Context, extractDir string) error {
 	m.ctrl.T.Helper()

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -23,11 +23,12 @@ const startServicesTimeout = 2 * time.Minute
 //  5. Stops FlightCtl services (deployer.StopServices)
 //  6. Imports the database (deployer.RestoreDatabase)
 //  7. Restores PKI materials (deployer.RestorePKI)
-//  8. Restores service configuration (deployer.RestoreConfig)
-//  9. Retrieves service credentials via deployer.GetConfig
-//  10. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
-//  11. Runs post-restoration device preparation (PrepareDevices)
-//  12. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
+//  8. Restores encryption keys (deployer.RestoreEncryptionKeys)
+//  9. Restores service configuration (deployer.RestoreConfig)
+//  10. Retrieves service credentials via deployer.GetConfig
+//  11. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
+//  12. Runs post-restoration device preparation (PrepareDevices)
+//  13. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
 //
 // The deployer encapsulates all deployment-specific operations and credential extraction.
 // The temporary extraction directory is always cleaned up before Restore returns.
@@ -107,6 +108,12 @@ func Restore(
 		return fmt.Errorf("PKI restore failed: %w", err)
 	}
 	log.Info("PKI restore completed")
+
+	log.Info("Restoring encryption keys")
+	if err := deployer.RestoreEncryptionKeys(ctx, extractDir); err != nil {
+		return fmt.Errorf("encryption keys restore failed: %w", err)
+	}
+	log.Info("Encryption keys restore completed")
 
 	log.Info("Restoring service configuration")
 	if err := deployer.RestoreConfig(ctx, extractDir); err != nil {


### PR DESCRIPTION
Add BackupEncryptionKeys/RestoreEncryptionKeys to the backup/restore Deployer interface with implementations for both Kubernetes and Podman. Missing encryption keys are logged as warnings, not errors, for backwards compatibility with pre-encryption deployments.

