### PR TITLE
EDM-4774: Implement encryption-at-rest handlers for Repository and Au…

### DIFF
--- a/internal/auth/authn/oauth2_auth.go
+++ b/internal/auth/authn/oauth2_auth.go
@@ -18,6 +18,7 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/identity"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -60,6 +61,12 @@ func NewOAuth2Auth(metadata api.ObjectMeta, spec api.OAuth2ProviderSpec, tlsConf
 	if spec.ClientSecret == "" {
 		return nil, fmt.Errorf("clientSecret is required")
 	}
+
+	decryptedSecret, _, err := encryption.Decrypt(context.Background(), encryption.Ciphertext(spec.ClientSecret))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt clientSecret: %w", err)
+	}
+	spec.ClientSecret = string(decryptedSecret)
 
 	// Convert organization assignment to org config
 	orgConfig := convertOrganizationAssignmentToOrgConfig(spec.OrganizationAssignment)

--- a/internal/auth/authn/oauth2_auth.go
+++ b/internal/auth/authn/oauth2_auth.go
@@ -62,12 +62,6 @@ func NewOAuth2Auth(metadata api.ObjectMeta, spec api.OAuth2ProviderSpec, tlsConf
 		return nil, fmt.Errorf("clientSecret is required")
 	}
 
-	decryptedSecret, _, err := encryption.Decrypt(context.Background(), encryption.Ciphertext(spec.ClientSecret))
-	if err != nil {
-		return nil, fmt.Errorf("decrypt clientSecret: %w", err)
-	}
-	spec.ClientSecret = string(decryptedSecret)
-
 	// Convert organization assignment to org config
 	orgConfig := convertOrganizationAssignmentToOrgConfig(spec.OrganizationAssignment)
 
@@ -136,6 +130,14 @@ func NewOAuth2Auth(metadata api.ObjectMeta, spec api.OAuth2ProviderSpec, tlsConf
 	}
 
 	return oauth2Auth, nil
+}
+
+func (o *OAuth2Auth) decryptClientSecret(ctx context.Context) (string, error) {
+	plaintext, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(o.spec.ClientSecret))
+	if err != nil {
+		return "", fmt.Errorf("decrypt clientSecret: %w", err)
+	}
+	return string(plaintext), nil
 }
 
 func (o *OAuth2Auth) IsEnabled() bool {
@@ -431,7 +433,11 @@ func (o *OAuth2Auth) introspectRFC7662(ctx context.Context, token string, spec a
 	}
 
 	// RFC 7662 requires client authentication via Basic Auth
-	req.SetBasicAuth(o.spec.ClientId, o.spec.ClientSecret)
+	plainSecret, err := o.decryptClientSecret(ctx)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(o.spec.ClientId, plainSecret)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
@@ -485,7 +491,11 @@ func (o *OAuth2Auth) introspectGitHub(ctx context.Context, token string, spec ap
 	}
 
 	// GitHub requires Basic Auth with client ID and secret
-	req.SetBasicAuth(o.spec.ClientId, o.spec.ClientSecret)
+	plainSecret, err := o.decryptClientSecret(ctx)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(o.spec.ClientId, plainSecret)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/vnd.github+json")
 

--- a/internal/auth/authn/oauth2_auth_test.go
+++ b/internal/auth/authn/oauth2_auth_test.go
@@ -6,11 +6,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -19,6 +24,39 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "authn-test")
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := crypto.GenerateAES256Key()
+	if err != nil {
+		panic(err)
+	}
+	keyPath := filepath.Join(dir, "key")
+	if err := os.WriteFile(keyPath, []byte(key), 0600); err != nil {
+		panic(err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Encryption = &config.EncryptionConfig{
+		Keys:        []config.EncryptionKeyConfig{{ID: "test", Path: keyPath}},
+		ActiveKeyID: "test",
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	if err := encryption.InitGlobalEncryption(logger, cfg); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 // Helper function to create a test OAuth2Auth instance
 func createTestOAuth2Auth(t *testing.T, spec api.OAuth2ProviderSpec) *OAuth2Auth {
@@ -42,7 +80,9 @@ func createTestOAuth2Auth(t *testing.T, spec api.OAuth2ProviderSpec) *OAuth2Auth
 }
 
 // Helper function to create a basic OAuth2ProviderSpec
-func createBasicOAuth2Spec() api.OAuth2ProviderSpec {
+func createBasicOAuth2Spec(t *testing.T) api.OAuth2ProviderSpec {
+	t.Helper()
+
 	assignment := api.AuthOrganizationAssignment{}
 	staticAssignment := api.AuthStaticOrganizationAssignment{
 		Type:             api.AuthStaticOrganizationAssignmentTypeStatic,
@@ -57,13 +97,16 @@ func createBasicOAuth2Spec() api.OAuth2ProviderSpec {
 	}
 	_ = roleAssignment.FromAuthStaticRoleAssignment(staticRoleAssignment)
 
+	encryptedSecret, err := encryption.Encrypt(t.Context(), []byte("test-client-secret"))
+	require.NoError(t, err)
+
 	spec := api.OAuth2ProviderSpec{
 		ProviderType:           api.Oauth2,
 		AuthorizationUrl:       "https://oauth2.example.com/authorize",
 		TokenUrl:               "https://oauth2.example.com/token",
 		UserinfoUrl:            "https://oauth2.example.com/userinfo",
 		ClientId:               "test-client-id",
-		ClientSecret:           "test-client-secret",
+		ClientSecret:           string(encryptedSecret),
 		Enabled:                lo.ToPtr(true),
 		OrganizationAssignment: assignment,
 		RoleAssignment:         roleAssignment,
@@ -88,14 +131,14 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 		{
 			name:        "valid OAuth2 spec",
 			metadata:    api.ObjectMeta{Name: lo.ToPtr("test-provider")},
-			spec:        createBasicOAuth2Spec(),
+			spec:        createBasicOAuth2Spec(t),
 			expectError: false,
 		},
 		{
 			name:     "missing authorizationUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.AuthorizationUrl = ""
 				return spec
 			}(),
@@ -106,7 +149,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing tokenUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.TokenUrl = ""
 				return spec
 			}(),
@@ -117,7 +160,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing userinfoUrl",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.UserinfoUrl = ""
 				return spec
 			}(),
@@ -128,7 +171,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing clientId",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.ClientId = ""
 				return spec
 			}(),
@@ -139,7 +182,7 @@ func TestOAuth2Auth_NewOAuth2Auth(t *testing.T) {
 			name:     "missing clientSecret",
 			metadata: api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 			spec: func() api.OAuth2ProviderSpec {
-				spec := createBasicOAuth2Spec()
+				spec := createBasicOAuth2Spec(t)
 				spec.ClientSecret = ""
 				return spec
 			}(),
@@ -198,7 +241,7 @@ func TestOAuth2Auth_IntrospectRFC7662(t *testing.T) {
 	defer server.Close()
 
 	// Create OAuth2Auth with RFC 7662 introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	rfc7662Spec := api.Rfc7662IntrospectionSpec{
 		Type: api.Rfc7662,
@@ -283,7 +326,7 @@ func TestOAuth2Auth_IntrospectGitHub(t *testing.T) {
 	defer server.Close()
 
 	// Create OAuth2Auth with GitHub introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	githubSpec := api.GitHubIntrospectionSpec{
 		Type: api.Github,
@@ -345,7 +388,7 @@ func TestOAuth2Auth_IntrospectJWT(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -480,7 +523,7 @@ func TestOAuth2Auth_IntrospectJWT_CustomIssuerAndAudience(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection with custom issuer and audience
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
 		Type:     api.Jwt,
@@ -538,7 +581,7 @@ func TestOAuth2Auth_GetIdentity(t *testing.T) {
 	defer userinfoServer.Close()
 
 	// Create OAuth2Auth
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.UserinfoUrl = userinfoServer.URL
 
 	oauth2Auth := createTestOAuth2Auth(t, spec)
@@ -634,13 +677,16 @@ func TestOAuth2Auth_GetIdentity_FiltersFlightctlAdmin_NotCreatedBySuperAdmin(t *
 	}
 	_ = roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
 
+	encryptedSecret, err := encryption.Encrypt(t.Context(), []byte("test-client-secret"))
+	require.NoError(t, err)
+
 	spec := api.OAuth2ProviderSpec{
 		ProviderType:           api.Oauth2,
 		AuthorizationUrl:       "https://oauth2.example.com/authorize",
 		TokenUrl:               "https://oauth2.example.com/token",
 		UserinfoUrl:            userinfoServer.URL,
 		ClientId:               "test-client-id",
-		ClientSecret:           "test-client-secret",
+		ClientSecret:           string(encryptedSecret),
 		Enabled:                lo.ToPtr(true),
 		OrganizationAssignment: assignment,
 		RoleAssignment:         roleAssignment,
@@ -726,13 +772,16 @@ func TestOAuth2Auth_GetIdentity_AllowsFlightctlAdmin_CreatedBySuperAdmin(t *test
 	}
 	_ = roleAssignment.FromAuthDynamicRoleAssignment(dynamicRoleAssignment)
 
+	encryptedSecret, err := encryption.Encrypt(t.Context(), []byte("test-client-secret"))
+	require.NoError(t, err)
+
 	spec := api.OAuth2ProviderSpec{
 		ProviderType:           api.Oauth2,
 		AuthorizationUrl:       "https://oauth2.example.com/authorize",
 		TokenUrl:               "https://oauth2.example.com/token",
 		UserinfoUrl:            userinfoServer.URL,
 		ClientId:               "test-client-id",
-		ClientSecret:           "test-client-secret",
+		ClientSecret:           string(encryptedSecret),
 		Enabled:                lo.ToPtr(true),
 		OrganizationAssignment: assignment,
 		RoleAssignment:         roleAssignment,
@@ -794,7 +843,7 @@ func TestOAuth2Auth_IntrospectJWT_CacheLifecycle(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -854,7 +903,7 @@ func TestOAuth2Auth_IntrospectJWT_ProviderContextUsed(t *testing.T) {
 	defer jwksServer.Close()
 
 	// Create OAuth2Auth with JWT introspection
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 	introspection := &api.OAuth2Introspection{}
 	jwtSpec := api.JwtIntrospectionSpec{
@@ -899,7 +948,7 @@ func TestOAuth2Auth_IntrospectJWT_ProviderContextUsed(t *testing.T) {
 }
 
 func TestOAuth2Auth_StartStop(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 
@@ -930,7 +979,7 @@ func TestOAuth2Auth_StartStop(t *testing.T) {
 }
 
 func TestOAuth2Auth_GetAuthToken(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	oauth2Auth := createTestOAuth2Auth(t, spec)
 	defer oauth2Auth.Stop()
 
@@ -983,7 +1032,7 @@ func TestOAuth2Auth_GetAuthToken(t *testing.T) {
 }
 
 func TestOAuth2Auth_GetAuthConfig(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	spec.Issuer = lo.ToPtr("https://test-issuer.com")
 
 	oauth2Auth := createTestOAuth2Auth(t, spec)
@@ -1011,7 +1060,7 @@ func TestOAuth2Auth_GetAuthConfig(t *testing.T) {
 }
 
 func TestOAuth2Auth_TLSConfig(t *testing.T) {
-	spec := createBasicOAuth2Spec()
+	spec := createBasicOAuth2Spec(t)
 	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 

--- a/internal/auth/authn/openshift_auth.go
+++ b/internal/auth/authn/openshift_auth.go
@@ -14,7 +14,6 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/identity"
-	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/samber/lo"
@@ -51,13 +50,6 @@ func NewOpenShiftAuth(metadata api.ObjectMeta, spec api.OpenShiftProviderSpec, k
 	if spec.ClientSecret == nil || *spec.ClientSecret == "" {
 		return nil, fmt.Errorf("clientSecret is required")
 	}
-
-	decryptedSecret, _, err := encryption.Decrypt(context.Background(), encryption.Ciphertext(*spec.ClientSecret))
-	if err != nil {
-		return nil, fmt.Errorf("decrypt clientSecret: %w", err)
-	}
-	decryptedStr := string(decryptedSecret)
-	spec.ClientSecret = &decryptedStr
 
 	if spec.ClusterControlPlaneUrl == nil || *spec.ClusterControlPlaneUrl == "" {
 		return nil, fmt.Errorf("clusterControlPlaneUrl is required")

--- a/internal/auth/authn/openshift_auth.go
+++ b/internal/auth/authn/openshift_auth.go
@@ -14,6 +14,7 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/flightctl/flightctl/internal/identity"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/samber/lo"
@@ -50,6 +51,14 @@ func NewOpenShiftAuth(metadata api.ObjectMeta, spec api.OpenShiftProviderSpec, k
 	if spec.ClientSecret == nil || *spec.ClientSecret == "" {
 		return nil, fmt.Errorf("clientSecret is required")
 	}
+
+	decryptedSecret, _, err := encryption.Decrypt(context.Background(), encryption.Ciphertext(*spec.ClientSecret))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt clientSecret: %w", err)
+	}
+	decryptedStr := string(decryptedSecret)
+	spec.ClientSecret = &decryptedStr
+
 	if spec.ClusterControlPlaneUrl == nil || *spec.ClusterControlPlaneUrl == "" {
 		return nil, fmt.Errorf("clusterControlPlaneUrl is required")
 	}

--- a/internal/auth/authn/openshift_auth_test.go
+++ b/internal/auth/authn/openshift_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,10 @@ import (
 
 func newTestOpenShiftAuth(t *testing.T, k8sClient k8sclient.K8SClient) *OpenShiftAuth {
 	t.Helper()
+	encryptedSecret, err := encryption.Encrypt(t.Context(), []byte("secret"))
+	require.NoError(t, err)
+	encryptedStr := string(encryptedSecret)
+
 	auth, err := NewOpenShiftAuth(
 		api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 		api.OpenShiftProviderSpec{
@@ -24,7 +29,7 @@ func newTestOpenShiftAuth(t *testing.T, k8sClient k8sclient.K8SClient) *OpenShif
 			AuthorizationUrl:       lo.ToPtr("https://oauth.example.com/authorize"),
 			TokenUrl:               lo.ToPtr("https://oauth.example.com/token"),
 			ClientId:               lo.ToPtr("flightctl"),
-			ClientSecret:           lo.ToPtr("secret"),
+			ClientSecret:           &encryptedStr,
 			ClusterControlPlaneUrl: lo.ToPtr("https://api.example.com:6443"),
 			Issuer:                 lo.ToPtr("https://oauth.example.com"),
 			RoleSuffix:             lo.ToPtr("flightctl"),
@@ -72,6 +77,10 @@ func projectListJSON(names ...string) []byte {
 
 func newTestOpenShiftAuthWithPrefix(t *testing.T, k8sClient k8sclient.K8SClient, prefix string) *OpenShiftAuth {
 	t.Helper()
+	encryptedSecret, err := encryption.Encrypt(t.Context(), []byte("secret"))
+	require.NoError(t, err)
+	encryptedStr := string(encryptedSecret)
+
 	auth, err := NewOpenShiftAuth(
 		api.ObjectMeta{Name: lo.ToPtr("test-provider")},
 		api.OpenShiftProviderSpec{
@@ -79,7 +88,7 @@ func newTestOpenShiftAuthWithPrefix(t *testing.T, k8sClient k8sclient.K8SClient,
 			AuthorizationUrl:       lo.ToPtr("https://oauth.example.com/authorize"),
 			TokenUrl:               lo.ToPtr("https://oauth.example.com/token"),
 			ClientId:               lo.ToPtr("flightctl"),
-			ClientSecret:           lo.ToPtr("secret"),
+			ClientSecret:           &encryptedStr,
 			ClusterControlPlaneUrl: lo.ToPtr("https://api.example.com:6443"),
 			Issuer:                 lo.ToPtr("https://oauth.example.com"),
 			RoleSuffix:             lo.ToPtr("flightctl"),

--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
 	"github.com/flightctl/flightctl/internal/imagebuilder_api/store"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/service/events"
@@ -579,9 +580,13 @@ func (s *imageExportService) setupRepositoryReference(ctx context.Context, ociSp
 	if ociSpec.OciAuth != nil {
 		dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
 		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
+			decryptedPassword, _, decErr := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+			if decErr != nil {
+				return nil, "", "", fmt.Errorf("failed to decrypt OCI password: %w", decErr)
+			}
 			authClient.Credential = auth.StaticCredential(registryHostname, auth.Credential{
 				Username: dockerAuth.Username,
-				Password: dockerAuth.Password,
+				Password: string(decryptedPassword),
 			})
 			log.WithFields(logrus.Fields{"registryHostname": registryHostname, "username": dockerAuth.Username}).Debug("Configured authentication for repository")
 		}
@@ -706,8 +711,13 @@ func (s *imageExportService) addAuthenticationToRequest(ctx context.Context, req
 		return nil
 	}
 
+	decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+	if err != nil {
+		return fmt.Errorf("failed to decrypt OCI password: %w", err)
+	}
+
 	log.WithFields(logrus.Fields{"registryHostname": registryHostname, "repoName": repoName}).Debug("Getting registry token for authentication")
-	token, err := s.getRegistryToken(ctx, client, scheme, registryHostname, repoName, dockerAuth.Username, dockerAuth.Password)
+	token, err := s.getRegistryToken(ctx, client, scheme, registryHostname, repoName, dockerAuth.Username, string(decryptedPassword))
 	if err != nil {
 		log.WithError(err).WithField("registryHostname", registryHostname).Error("Failed to get registry token from external service")
 		return fmt.Errorf("%w: failed to get registry token: %w", ErrExternalServiceUnavailable, err)

--- a/internal/imagebuilder_worker/tasks/imagebuild.go
+++ b/internal/imagebuilder_worker/tasks/imagebuild.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
 	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
 	imagebuilderservice "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/service"
 	repositorystore "github.com/flightctl/flightctl/internal/store/repository"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
@@ -1074,7 +1075,11 @@ func (c *Consumer) buildImageWithPodman(
 	if ociSpec.OciAuth != nil {
 		dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
 		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
-			if err := c.loginToRegistry(ctx, podmanWorker, sourceRegistryHostname, dockerAuth.Username, dockerAuth.Password, ociSpec, log); err != nil {
+			decryptedPassword, _, decErr := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+			if decErr != nil {
+				return fmt.Errorf("failed to decrypt OCI password: %w", decErr)
+			}
+			if err := c.loginToRegistry(ctx, podmanWorker, sourceRegistryHostname, dockerAuth.Username, string(decryptedPassword), ociSpec, log); err != nil {
 				return fmt.Errorf("failed to login to source registry: %w", err)
 			}
 		}
@@ -1186,7 +1191,11 @@ func (c *Consumer) pushImageWithPodman(
 	if ociSpec.OciAuth != nil {
 		dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
 		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
-			if err := c.loginToRegistry(ctx, podmanWorker, destRegistryHostname, dockerAuth.Username, dockerAuth.Password, ociSpec, log); err != nil {
+			decryptedPassword, _, decErr := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+			if decErr != nil {
+				return "", "", fmt.Errorf("failed to decrypt OCI password: %w", decErr)
+			}
+			if err := c.loginToRegistry(ctx, podmanWorker, destRegistryHostname, dockerAuth.Username, string(decryptedPassword), ociSpec, log); err != nil {
 				return "", "", fmt.Errorf("failed to login to destination registry: %w", err)
 			}
 		}

--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
 	imagebuilderapi "github.com/flightctl/flightctl/internal/imagebuilder_api/service"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/oci"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/google/uuid"
@@ -405,7 +406,11 @@ func (c *Consumer) executeExport(
 	if exportSource.OciRepoSpec.OciAuth != nil {
 		dockerAuth, err := exportSource.OciRepoSpec.OciAuth.AsDockerAuth()
 		if err == nil && dockerAuth.Username != "" && dockerAuth.Password != "" {
-			if err := c.loginToRegistryForExport(ctx, worker, registryHostname, dockerAuth.Username, dockerAuth.Password, exportSource.OciRepoSpec, log); err != nil {
+			decryptedPassword, _, decErr := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+			if decErr != nil {
+				return "", cleanup, fmt.Errorf("failed to decrypt OCI password: %w", decErr)
+			}
+			if err := c.loginToRegistryForExport(ctx, worker, registryHostname, dockerAuth.Username, string(decryptedPassword), exportSource.OciRepoSpec, log); err != nil {
 				return "", cleanup, fmt.Errorf("failed to login to registry: %w", err)
 			}
 		}
@@ -1122,7 +1127,7 @@ func (c *Consumer) pushArtifact(
 	statusUpdater.reportOutput([]byte("Starting artifact push to destination registry\n"))
 
 	// Create repository reference (no tag needed - referrer will be discoverable via referrers API)
-	repoRef, err := oci.BuildOciRepoRef(&ociSpec, destRef)
+	repoRef, err := oci.BuildOciRepoRef(ctx, &ociSpec, destRef)
 	if err != nil {
 		return fmt.Errorf("failed to configure OCI repository reference: %w", err)
 	}

--- a/internal/imagebuilder_worker/tasks/sbom.go
+++ b/internal/imagebuilder_worker/tasks/sbom.go
@@ -213,7 +213,7 @@ func (c *Consumer) pushSBOMAsReferrer(
 	}
 	report([]byte("Starting SBOM push to destination registry\n"))
 
-	repoRef, err := oci.BuildOciRepoRef(ociSpec, destRef)
+	repoRef, err := oci.BuildOciRepoRef(ctx, ociSpec, destRef)
 	if err != nil {
 		return fmt.Errorf("failed to configure OCI repository reference: %w", err)
 	}

--- a/internal/instrumentation/encryption/gorm_plugin.go
+++ b/internal/instrumentation/encryption/gorm_plugin.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"gorm.io/gorm"
 )
@@ -17,7 +18,7 @@ type EncryptFunc func(ctx context.Context, data []byte) ([]byte, error)
 
 // ModelEncryptHandler knows how to encrypt a specific model type.
 // It receives the model instance and an encryption function to use.
-type ModelEncryptHandler func(ctx context.Context, model interface{}, encrypt EncryptFunc) error
+type ModelEncryptHandler func(ctx context.Context, model any, encrypt EncryptFunc) error
 
 // Plugin is a GORM plugin that delegates model-specific encryption
 // to handlers registered from the store/model package.
@@ -59,33 +60,55 @@ func (p *Plugin) Initialize(db *gorm.DB) error {
 }
 
 // beforeSave is the GORM callback that delegates to model-specific encryption handlers.
-func (p *Plugin) beforeSave(db *gorm.DB) {
-	if db.Error != nil || db.Statement.Schema == nil {
+func (p *Plugin) beforeSave(tx *gorm.DB) {
+	if tx.Error != nil || tx.Statement.Schema == nil {
 		return
 	}
 
 	// Check if we have a handler for this model type
-	handler, exists := p.handlers[db.Statement.Schema.Name]
+	handler, exists := p.handlers[tx.Statement.Schema.Name]
 	if !exists {
 		return // No encryption for this model type
 	}
 
-	ctx := db.Statement.Context
+	ctx := tx.Statement.Context
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	// Use Manager.ProcessEncryption which handles all cases:
-	// - Plaintext: encrypts
-	// - Old version: migrates to active version
-	// - Old key: re-encrypts with active key
-	// - Current version + key: preserves (no wasteful re-encryption)
-	processEncryption := func(ctx context.Context, data []byte) ([]byte, error) {
-		return p.manager.ProcessEncryption(ctx, data)
+	dest := tx.Statement.Dest
+	val := reflect.ValueOf(dest)
+
+	// Dereference pointer if needed (GORM passes *[]T for batch creates).
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
 	}
 
-	// Call model-specific handler
-	if err := handler(ctx, db.Statement.Dest, processEncryption); err != nil {
-		_ = db.AddError(fmt.Errorf("encrypt model %s: %w", db.Statement.Schema.Name, err))
+	// Batch operations: GORM may pass []T or []*T — encrypt each element.
+	if val.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			elem := val.Index(i)
+			// For []T (non-pointer elements), take address so handler gets *T.
+			if elem.Kind() != reflect.Ptr && elem.CanAddr() {
+				elem = elem.Addr()
+			}
+			if err := handler(ctx, elem.Interface(), p.manager.ProcessEncryption); err != nil {
+				tx.Logger.Error(ctx, err.Error())
+				_ = tx.AddError(fmt.Errorf("encrypt model %s: %w", tx.Statement.Schema.Name, err))
+				return
+			}
+		}
+		return
+	}
+
+	// Partial updates (map[string]interface{}, etc.) don't carry the full model.
+	// Only encrypt pointer-to-struct, the normal single-model create/update path.
+	if val.Kind() != reflect.Struct {
+		return
+	}
+
+	if err := handler(ctx, dest, p.manager.ProcessEncryption); err != nil {
+		tx.Logger.Error(ctx, err.Error())
+		_ = tx.AddError(fmt.Errorf("encrypt model %s: %w", tx.Statement.Schema.Name, err))
 	}
 }

--- a/internal/instrumentation/encryption/gorm_plugin_test.go
+++ b/internal/instrumentation/encryption/gorm_plugin_test.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -255,25 +256,21 @@ func TestPlugin_UsesProcessEncryption(t *testing.T) {
 func TestPlugin_BatchCreate_HandlerCalledForSlice(t *testing.T) {
 	mgr := createTestManager(t)
 
-	var receivedType string
+	var callCount int
 
 	handlers := map[string]ModelEncryptHandler{
 		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
-			switch val := v.(type) {
-			case *TestUser:
-				receivedType = "single"
-			case *[]TestUser:
-				receivedType = "slice"
-				// Encrypt each user
-				for i := range *val {
-					if (*val)[i].Password != "" {
-						encrypted, err := encrypt(ctx, []byte((*val)[i].Password))
-						if err != nil {
-							return err
-						}
-						(*val)[i].Password = string(encrypted)
-					}
+			user, ok := v.(*TestUser)
+			if !ok {
+				return fmt.Errorf("expected *TestUser, got %T", v)
+			}
+			callCount++
+			if user.Password != "" {
+				encrypted, err := encrypt(ctx, []byte(user.Password))
+				if err != nil {
+					return err
 				}
+				user.Password = string(encrypted)
 			}
 			return nil
 		},
@@ -289,7 +286,7 @@ func TestPlugin_BatchCreate_HandlerCalledForSlice(t *testing.T) {
 	result := db.Create(&users)
 	require.NoError(t, result.Error)
 
-	assert.Equal(t, "slice", receivedType, "Handler should receive *[]TestUser for batch create")
+	assert.Equal(t, 2, callCount, "Handler should be called once per element in batch create")
 
 	// Verify both passwords encrypted
 	assert.True(t, strings.HasPrefix(users[0].Password, "enc:"))

--- a/internal/oci/reporef.go
+++ b/internal/oci/reporef.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
@@ -16,13 +18,13 @@ import (
 // and a full reference string (e.g. "registry.example.com/my-image").
 // It sets up TLS, credentials, and HTTP scheme based on the spec.
 // Callers that push artifacts should also set repoRef.SkipReferrersGC = true.
-func BuildOciRepoRef(ociSpec *domain.OciRepoSpec, ref string) (*remote.Repository, error) {
+func BuildOciRepoRef(ctx context.Context, ociSpec *domain.OciRepoSpec, ref string) (*remote.Repository, error) {
 	repoRef, err := remote.NewRepository(ref)
 	if err != nil {
 		return nil, fmt.Errorf("create repository reference: %w", err)
 	}
 
-	authClient, err := newOCIAuthClient(ociSpec)
+	authClient, err := newOCIAuthClient(ctx, ociSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +67,7 @@ func BuildOciTLSConfig(ociSpec *domain.OciRepoSpec) (*tls.Config, error) {
 // newOCIAuthClient builds an auth.Client from an OciRepoSpec.
 // A custom HTTP transport is only attached when TLS settings are non-default,
 // so callers that do not configure TLS options get the default transport.
-func newOCIAuthClient(ociSpec *domain.OciRepoSpec) (*auth.Client, error) {
+func newOCIAuthClient(ctx context.Context, ociSpec *domain.OciRepoSpec) (*auth.Client, error) {
 	authClient := &auth.Client{}
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
@@ -104,9 +106,13 @@ func newOCIAuthClient(ociSpec *domain.OciRepoSpec) (*auth.Client, error) {
 			return nil, fmt.Errorf("failed to parse OCI authentication: %w", err)
 		}
 		if dockerAuth.Username != "" && dockerAuth.Password != "" {
+			decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+			if err != nil {
+				return nil, fmt.Errorf("failed to decrypt OCI password: %w", err)
+			}
 			authClient.Credential = auth.StaticCredential(ociSpec.Registry, auth.Credential{
 				Username: dockerAuth.Username,
-				Password: dockerAuth.Password,
+				Password: string(decryptedPassword),
 			})
 		}
 	}

--- a/internal/oci/reporef_test.go
+++ b/internal/oci/reporef_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -11,15 +12,50 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
 	coredomain "github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/pkg/crypto"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
+
+func TestMain(m *testing.M) {
+	log := logrus.StandardLogger()
+	dir, err := os.MkdirTemp("", "oci-test-encryption-*")
+	if err != nil {
+		log.Fatalf("creating temp encryption dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	keyPath := filepath.Join(dir, "key")
+	key, err := crypto.GenerateAES256Key()
+	if err != nil {
+		log.Fatalf("generating test encryption key: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte(key), 0600); err != nil {
+		log.Fatalf("writing test encryption key: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Encryption = &config.EncryptionConfig{
+		Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+		ActiveKeyID: "default",
+	}
+	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
+		log.Fatalf("initializing test encryption: %v", err)
+	}
+
+	os.Exit(m.Run())
+}
 
 func generateTestCACertPEM(t *testing.T) string {
 	t.Helper()
@@ -44,7 +80,7 @@ func generateTestCACertPEM(t *testing.T) string {
 // authClientFrom extracts the *auth.Client from a BuildOciRepoRef result.
 func authClientFrom(t *testing.T, ociSpec *coredomain.OciRepoSpec) *auth.Client {
 	t.Helper()
-	repoRef, err := BuildOciRepoRef(ociSpec, ociSpec.Registry+"/test-image")
+	repoRef, err := BuildOciRepoRef(context.Background(), ociSpec, ociSpec.Registry+"/test-image")
 	require.NoError(t, err)
 	client, ok := repoRef.Client.(*auth.Client)
 	require.True(t, ok, "repoRef.Client must be *auth.Client")
@@ -148,7 +184,7 @@ func TestBuildOciRepoRef_InvalidBase64CaCrt(t *testing.T) {
 		CaCrt:    &invalid,
 	}
 
-	_, err := BuildOciRepoRef(ociSpec, ociSpec.Registry+"/test-image")
+	_, err := BuildOciRepoRef(context.Background(), ociSpec, ociSpec.Registry+"/test-image")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decode CA certificate")
 }
@@ -171,7 +207,7 @@ func TestBuildOciRepoRef_PlainHTTP(t *testing.T) {
 		Scheme:   lo.ToPtr(coredomain.OciRepoSchemeHttp),
 	}
 
-	repoRef, err := BuildOciRepoRef(ociSpec, ociSpec.Registry+"/test-image")
+	repoRef, err := BuildOciRepoRef(context.Background(), ociSpec, ociSpec.Registry+"/test-image")
 	require.NoError(t, err)
 	require.True(t, repoRef.PlainHTTP)
 }

--- a/internal/service/auth_token_proxy.go
+++ b/internal/service/auth_token_proxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flightctl/flightctl/internal/auth/authn"
 	authprovider "github.com/flightctl/flightctl/internal/auth/provider"
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 )
 
 // cacheEntry holds a cached token endpoint with its expiration time
@@ -284,6 +285,14 @@ func (p *AuthTokenProxy) discoverTokenEndpoint(issuer string) (string, error) {
 
 // proxyTokenRequest makes an HTTP request to the provider's token endpoint
 func (p *AuthTokenProxy) proxyTokenRequest(ctx context.Context, providerConfig *ProviderConfig, clientId string, clientSecret string, tokenReq *domain.TokenRequest) (*ProxyResult, error) {
+	if clientSecret != "" {
+		plaintext, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(clientSecret))
+		if err != nil {
+			return nil, fmt.Errorf("decrypt clientSecret: %w", err)
+		}
+		clientSecret = string(plaintext)
+	}
+
 	// Prepare form data
 	formData := url.Values{}
 	formData.Set("grant_type", string(tokenReq.GrantType))

--- a/internal/service/repository/handler.go
+++ b/internal/service/repository/handler.go
@@ -324,7 +324,7 @@ func (h *ServiceHandler) resolveOciRepoRef(ctx context.Context, orgId uuid.UUID,
 	ociSpec := &ociSpecVal
 
 	fullRef := strings.TrimRight(ociSpec.Registry, "/") + "/" + strings.TrimLeft(imageName, "/")
-	repoRef, err := oci.BuildOciRepoRef(ociSpec, fullRef)
+	repoRef, err := oci.BuildOciRepoRef(ctx, ociSpec, fullRef)
 	if err != nil {
 		return nil, domain.StatusBadRequest(fmt.Sprintf("invalid repository reference %q: %v", fullRef, err))
 	}

--- a/internal/store/gorm.go
+++ b/internal/store/gorm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
@@ -160,7 +161,7 @@ func initDBWithUser(cfg *config.Config, log *logrus.Logger, user string, passwor
 
 	// Register encryption plugin if encryption is initialized
 	if encryption.GlobalManager() != nil {
-		if err = newDB.Use(encryption.NewPlugin(encryption.GlobalManager(), map[string]encryption.ModelEncryptHandler{})); err != nil {
+		if err = newDB.Use(encryption.NewPlugin(encryption.GlobalManager(), model.EncryptionHandlers())); err != nil {
 			sqlDB.Close()
 			log.Errorf("failed to register encryption plugin: %v", err)
 			return nil, fmt.Errorf("failed to register encryption plugin: %w", err)

--- a/internal/store/model/encryption.go
+++ b/internal/store/model/encryption.go
@@ -13,14 +13,13 @@ import (
 // This registry is used by the GORM encryption plugin to know how to encrypt each model.
 func EncryptionHandlers() map[string]encryption.ModelEncryptHandler {
 	return map[string]encryption.ModelEncryptHandler{
-		"Repository":   encryptRepository,
-		"AuthProvider": encryptAuthProvider,
+		domain.RepositoryKind:   encryptRepository,
+		domain.AuthProviderKind: encryptAuthProvider,
 	}
 }
 
 // repositoryEncryptPaths lists the sensitive fields in the Repository Spec JSONB
-// that must be encrypted at rest. These match the fields redacted by HideSensitiveData
-// in api/core/v1beta1/util.go.
+// that must be encrypted at rest.
 // Each entry is a slice of JSON key segments (e.g. {"httpConfig", "tls.key"}).
 var repositoryEncryptPaths = [][]string{
 	{"httpConfig", "password"},

--- a/internal/store/model/encryption.go
+++ b/internal/store/model/encryption.go
@@ -1,0 +1,149 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+)
+
+// EncryptionHandlers maps model type name to its encryption handler.
+// This registry is used by the GORM encryption plugin to know how to encrypt each model.
+func EncryptionHandlers() map[string]encryption.ModelEncryptHandler {
+	return map[string]encryption.ModelEncryptHandler{
+		"Repository":   encryptRepository,
+		"AuthProvider": encryptAuthProvider,
+	}
+}
+
+// repositoryEncryptPaths lists the sensitive fields in the Repository Spec JSONB
+// that must be encrypted at rest. These match the fields redacted by HideSensitiveData
+// in api/core/v1beta1/util.go.
+// Each entry is a slice of JSON key segments (e.g. {"httpConfig", "tls.key"}).
+var repositoryEncryptPaths = [][]string{
+	{"httpConfig", "password"},
+	{"httpConfig", "token"},
+	{"httpConfig", "tls.key"},
+	{"httpConfig", "tls.crt"},
+	{"sshConfig", "sshPrivateKey"},
+	{"sshConfig", "privateKeyPassphrase"},
+	{"ociAuth", "password"},
+}
+
+// authProviderEncryptPaths lists the sensitive fields in the AuthProvider Spec JSONB.
+// clientSecret appears at the top level of all provider type variants (OIDC, OAuth2,
+// OpenShift, AAP).
+var authProviderEncryptPaths = [][]string{
+	{"clientSecret"},
+}
+
+func encryptRepository(ctx context.Context, v interface{}, encrypt encryption.EncryptFunc) error {
+	repo, ok := v.(*Repository)
+	if !ok {
+		return fmt.Errorf("expected *Repository, got %T", v)
+	}
+
+	if repo.Spec == nil {
+		return nil
+	}
+
+	return encryptJSONField(ctx, &repo.Spec.Data, repositoryEncryptPaths, encrypt)
+}
+
+func encryptAuthProvider(ctx context.Context, v interface{}, encrypt encryption.EncryptFunc) error {
+	ap, ok := v.(*AuthProvider)
+	if !ok {
+		return fmt.Errorf("expected *AuthProvider, got %T", v)
+	}
+
+	if ap.Spec == nil {
+		return nil
+	}
+
+	return encryptJSONField(ctx, &ap.Spec.Data, authProviderEncryptPaths, encrypt)
+}
+
+// encryptJSONField encrypts string values at the given paths within a JSONB field.
+// It marshals the data to a generic map, encrypts matching paths, and unmarshals back.
+func encryptJSONField(ctx context.Context, data any, paths [][]string, encrypt encryption.EncryptFunc) error {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal spec: %w", err)
+	}
+
+	var jsonData map[string]any
+	if err := json.Unmarshal(jsonBytes, &jsonData); err != nil {
+		return fmt.Errorf("unmarshal spec to map: %w", err)
+	}
+
+	modified := false
+	for _, path := range paths {
+		encrypted, err := encryptJSONPath(ctx, jsonData, path, encrypt)
+		if err != nil {
+			return fmt.Errorf("encrypt field %v: %w", path, err)
+		}
+		if encrypted {
+			modified = true
+		}
+	}
+
+	if !modified {
+		return nil
+	}
+
+	updatedJSON, err := json.Marshal(jsonData)
+	if err != nil {
+		return fmt.Errorf("marshal updated spec: %w", err)
+	}
+
+	if err := json.Unmarshal(updatedJSON, data); err != nil {
+		return fmt.Errorf("unmarshal to spec: %w", err)
+	}
+
+	return nil
+}
+
+// encryptJSONPath encrypts a string value at the given path segments in a JSON map.
+// Returns true if encryption was performed, false if the path doesn't exist or the
+// value was already encrypted with the current key.
+func encryptJSONPath(ctx context.Context, data map[string]any, path []string, encrypt encryption.EncryptFunc) (bool, error) {
+	current := data
+	for i := 0; i < len(path)-1; i++ {
+		val, exists := current[path[i]]
+		if !exists {
+			return false, nil
+		}
+
+		nestedMap, ok := val.(map[string]any)
+		if !ok {
+			return false, nil
+		}
+
+		current = nestedMap
+	}
+
+	lastPart := path[len(path)-1]
+	val, exists := current[lastPart]
+	if !exists {
+		return false, nil
+	}
+
+	strVal, ok := val.(string)
+	if !ok || strVal == "" {
+		return false, nil
+	}
+
+	encrypted, err := encrypt(ctx, []byte(strVal))
+	if err != nil {
+		return false, fmt.Errorf("encrypt path %s: %w", path, err)
+	}
+
+	newValue := string(encrypted)
+	if newValue == strVal {
+		return false, nil
+	}
+
+	current[lastPart] = newValue
+	return true, nil
+}

--- a/internal/store/model/encryption.go
+++ b/internal/store/model/encryption.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 )
 
@@ -48,7 +49,20 @@ func encryptRepository(ctx context.Context, v interface{}, encrypt encryption.En
 		return nil
 	}
 
-	return encryptJSONField(ctx, &repo.Spec.Data, repositoryEncryptPaths, encrypt)
+	updated, err := encryptJSONField(ctx, repo.Spec.Data, repositoryEncryptPaths, encrypt)
+	if err != nil {
+		return err
+	}
+	// Unmarshal into a new object — Spec.Data shares a pointer with the API
+	// resource, and mutating in-place corrupts its json.RawMessage on retry.
+	if updated != nil {
+		var newSpec domain.RepositorySpec
+		if err := json.Unmarshal(updated, &newSpec); err != nil {
+			return fmt.Errorf("unmarshal encrypted repo spec: %w", err)
+		}
+		repo.Spec.Data = newSpec
+	}
+	return nil
 }
 
 func encryptAuthProvider(ctx context.Context, v interface{}, encrypt encryption.EncryptFunc) error {
@@ -61,27 +75,41 @@ func encryptAuthProvider(ctx context.Context, v interface{}, encrypt encryption.
 		return nil
 	}
 
-	return encryptJSONField(ctx, &ap.Spec.Data, authProviderEncryptPaths, encrypt)
+	updated, err := encryptJSONField(ctx, ap.Spec.Data, authProviderEncryptPaths, encrypt)
+	if err != nil {
+		return err
+	}
+	// See comment in encryptRepository for why we unmarshal into a new object.
+	if updated != nil {
+		var newSpec domain.AuthProviderSpec
+		if err := json.Unmarshal(updated, &newSpec); err != nil {
+			return fmt.Errorf("unmarshal encrypted auth provider spec: %w", err)
+		}
+		ap.Spec.Data = newSpec
+	}
+	return nil
 }
 
 // encryptJSONField encrypts string values at the given paths within a JSONB field.
-// It marshals the data to a generic map, encrypts matching paths, and unmarshals back.
-func encryptJSONField(ctx context.Context, data any, paths [][]string, encrypt encryption.EncryptFunc) error {
+// It marshals the data to a generic map, encrypts matching paths, and returns the
+// updated JSON bytes. Returns nil if no fields were modified. The caller is
+// responsible for unmarshaling into a new object to avoid corrupting shared pointers.
+func encryptJSONField(ctx context.Context, data any, paths [][]string, encrypt encryption.EncryptFunc) ([]byte, error) {
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("marshal spec: %w", err)
+		return nil, fmt.Errorf("marshal spec: %w", err)
 	}
 
 	var jsonData map[string]any
 	if err := json.Unmarshal(jsonBytes, &jsonData); err != nil {
-		return fmt.Errorf("unmarshal spec to map: %w", err)
+		return nil, fmt.Errorf("unmarshal spec to map: %w", err)
 	}
 
 	modified := false
 	for _, path := range paths {
 		encrypted, err := encryptJSONPath(ctx, jsonData, path, encrypt)
 		if err != nil {
-			return fmt.Errorf("encrypt field %v: %w", path, err)
+			return nil, fmt.Errorf("encrypt field %v: %w", path, err)
 		}
 		if encrypted {
 			modified = true
@@ -89,19 +117,15 @@ func encryptJSONField(ctx context.Context, data any, paths [][]string, encrypt e
 	}
 
 	if !modified {
-		return nil
+		return nil, nil
 	}
 
 	updatedJSON, err := json.Marshal(jsonData)
 	if err != nil {
-		return fmt.Errorf("marshal updated spec: %w", err)
+		return nil, fmt.Errorf("marshal updated spec: %w", err)
 	}
 
-	if err := json.Unmarshal(updatedJSON, data); err != nil {
-		return fmt.Errorf("unmarshal to spec: %w", err)
-	}
-
-	return nil
+	return updatedJSON, nil
 }
 
 // encryptJSONPath encrypts a string value at the given path segments in a JSON map.

--- a/internal/store/model/encryption_test.go
+++ b/internal/store/model/encryption_test.go
@@ -1,0 +1,466 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestEncryption(t *testing.T) *encryption.Manager {
+	t.Helper()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "key")
+
+	key, err := crypto.GenerateAES256Key()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+
+	cfg := config.NewDefault()
+	cfg.Encryption = &config.EncryptionConfig{
+		Keys:        []config.EncryptionKeyConfig{{ID: "default", Path: keyPath}},
+		ActiveKeyID: "default",
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	err = encryption.InitGlobalEncryption(logger, cfg)
+	require.NoError(t, err)
+
+	mgr := encryption.GlobalManager()
+	require.NotNil(t, mgr)
+	return mgr
+}
+
+func TestEncryptionHandlersRegistry(t *testing.T) {
+	mgr := setupTestEncryption(t)
+
+	mockEncryptFunc := func(ctx context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+	_ = mgr
+
+	for modelName, handler := range EncryptionHandlers() {
+		t.Run(modelName, func(t *testing.T) {
+			require.NotNil(t, handler, "Encryption handler for %s is nil", modelName)
+
+			var model any
+			switch modelName {
+			case "Repository":
+				model = &Repository{}
+			case "AuthProvider":
+				model = &AuthProvider{}
+			default:
+				t.Fatalf("Unknown model type in registry: %s - add a case for it in this test", modelName)
+			}
+
+			err := handler(context.Background(), model, mockEncryptFunc)
+			if err != nil {
+				t.Logf("Handler %s returned error (expected for empty model): %v", modelName, err)
+			}
+		})
+	}
+}
+
+func TestEncryptionFormatStability(t *testing.T) {
+	mgr := setupTestEncryption(t)
+
+	plaintext := []byte("test-secret")
+	encrypted, err := mgr.Encrypt(context.Background(), plaintext)
+	require.NoError(t, err)
+
+	encryptedStr := string(encrypted)
+	require.True(t, encryption.IsEncrypted(encrypted), "Should be recognized as encrypted")
+	require.Contains(t, encryptedStr, "enc:v1:", "Should have enc:v1: prefix")
+	require.Contains(t, encryptedStr, "default:", "Should have keyID 'default'")
+
+	decrypted, err := mgr.Decrypt(context.Background(), encrypted)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted, "Decrypted value should match plaintext")
+}
+
+func TestRepositoryEncryptionEndToEnd(t *testing.T) {
+	mgr := setupTestEncryption(t)
+
+	testCases := []struct {
+		name        string
+		apiRepo     *domain.Repository
+		checkValues []string
+	}{
+		{
+			name: "When encrypting GitRepoSpec with httpConfig it should encrypt password and token",
+			apiRepo: &domain.Repository{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-http")},
+				Spec: func() domain.RepositorySpec {
+					var spec domain.RepositorySpec
+					_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+						HttpConfig: &domain.HttpConfig{
+							Username: strPtr("testuser"),
+							Password: strPtr("testpass"),
+							Token:    strPtr("testtoken"),
+						},
+					})
+					return spec
+				}(),
+			},
+			checkValues: []string{"testpass", "testtoken"},
+		},
+		{
+			name: "When encrypting GitRepoSpec with httpConfig it should encrypt TLS key and cert",
+			apiRepo: &domain.Repository{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-tls")},
+				Spec: func() domain.RepositorySpec {
+					var spec domain.RepositorySpec
+					_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+						HttpConfig: &domain.HttpConfig{
+							TlsKey: strPtr("base64-encoded-private-key"),
+							TlsCrt: strPtr("base64-encoded-certificate"),
+						},
+					})
+					return spec
+				}(),
+			},
+			checkValues: []string{"base64-encoded-private-key", "base64-encoded-certificate"},
+		},
+		{
+			name: "When encrypting GitRepoSpec with sshConfig it should encrypt private key and passphrase",
+			apiRepo: &domain.Repository{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-ssh")},
+				Spec: func() domain.RepositorySpec {
+					var spec domain.RepositorySpec
+					_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+						SshConfig: &domain.SshConfig{
+							SshPrivateKey:        strPtr("ssh-key-content"),
+							PrivateKeyPassphrase: strPtr("ssh-passphrase"),
+						},
+					})
+					return spec
+				}(),
+			},
+			checkValues: []string{"ssh-key-content", "ssh-passphrase"},
+		},
+		{
+			name: "When encrypting OciRepoSpec with ociAuth it should encrypt password",
+			apiRepo: &domain.Repository{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-oci")},
+				Spec: func() domain.RepositorySpec {
+					var ociAuth domain.OciAuth
+					_ = ociAuth.FromDockerAuth(domain.DockerAuth{
+						AuthType: domain.OciAuthTypeDocker,
+						Username: "ociuser",
+						Password: "ocipass",
+					})
+					var spec domain.RepositorySpec
+					_ = spec.FromOciRepoSpec(domain.OciRepoSpec{
+						OciAuth: &ociAuth,
+					})
+					return spec
+				}(),
+			},
+			checkValues: []string{"ocipass"},
+		},
+		{
+			name: "When encrypting HttpRepoSpec with httpConfig it should encrypt password and token",
+			apiRepo: &domain.Repository{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-http-repo")},
+				Spec: func() domain.RepositorySpec {
+					var spec domain.RepositorySpec
+					_ = spec.FromHttpRepoSpec(domain.HttpRepoSpec{
+						HttpConfig: &domain.HttpConfig{
+							Password: strPtr("http-repo-pass"),
+							Token:    strPtr("http-repo-token"),
+						},
+					})
+					return spec
+				}(),
+			},
+			checkValues: []string{"http-repo-pass", "http-repo-token"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelRepo, err := NewRepositoryFromApiResource(tc.apiRepo)
+			require.NoError(t, err)
+
+			handler := EncryptionHandlers()["Repository"]
+			err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+			require.NoError(t, err)
+
+			specJSON, err := json.Marshal(modelRepo.Spec.Data)
+			require.NoError(t, err)
+			specStr := string(specJSON)
+
+			for _, plaintext := range tc.checkValues {
+				require.NotContains(t, specStr, plaintext,
+					"Plaintext '%s' found in spec after encryption", plaintext)
+			}
+
+			require.Contains(t, specStr, "enc:v1:default:",
+				"Spec should contain encrypted values with proper format")
+		})
+	}
+}
+
+func TestRepositoryEncryption_UsernameNotEncrypted(t *testing.T) {
+	mgr := setupTestEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-username")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Username: strPtr("testuser"),
+					Password: strPtr("testpass"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()["Repository"]
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.Contains(t, specStr, "testuser",
+		"Username should NOT be encrypted - it is not a sensitive field")
+	require.NotContains(t, specStr, "testpass",
+		"Password should be encrypted")
+}
+
+func staticOrgAssignment() domain.AuthOrganizationAssignment {
+	var oa domain.AuthOrganizationAssignment
+	_ = oa.FromAuthStaticOrganizationAssignment(domain.AuthStaticOrganizationAssignment{
+		Type: domain.AuthStaticOrganizationAssignmentTypeStatic,
+	})
+	return oa
+}
+
+func TestAuthProviderEncryptionEndToEnd(t *testing.T) {
+	mgr := setupTestEncryption(t)
+
+	testCases := []struct {
+		name    string
+		apiProv *domain.AuthProvider
+		secret  string
+	}{
+		{
+			name: "When encrypting OIDC provider it should encrypt clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-oidc")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+						ClientId:               "my-client",
+						ClientSecret:           "oidc-secret-value",
+						Issuer:                 "https://issuer.example.com",
+						ProviderType:           domain.Oidc,
+						OrganizationAssignment: staticOrgAssignment(),
+					})
+					return spec
+				}(),
+			},
+			secret: "oidc-secret-value",
+		},
+		{
+			name: "When encrypting OAuth2 provider it should encrypt clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-oauth2")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromOAuth2ProviderSpec(domain.OAuth2ProviderSpec{
+						ClientId:               "my-client",
+						ClientSecret:           "oauth2-secret-value",
+						AuthorizationUrl:       "https://auth.example.com/authorize",
+						TokenUrl:               "https://auth.example.com/token",
+						UserinfoUrl:            "https://auth.example.com/userinfo",
+						ProviderType:           domain.Oauth2,
+						OrganizationAssignment: staticOrgAssignment(),
+					})
+					return spec
+				}(),
+			},
+			secret: "oauth2-secret-value",
+		},
+		{
+			name: "When encrypting OpenShift provider it should encrypt clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-openshift")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromOpenShiftProviderSpec(domain.OpenShiftProviderSpec{
+						ClientSecret:           strPtr("openshift-secret-value"),
+						ClusterControlPlaneUrl: strPtr("https://api.cluster.example.com:6443"),
+						ProviderType:           domain.Openshift,
+					})
+					return spec
+				}(),
+			},
+			secret: "openshift-secret-value",
+		},
+		{
+			name: "When encrypting AAP provider it should encrypt clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-aap")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromAapProviderSpec(domain.AapProviderSpec{
+						ClientId:         "my-client",
+						ClientSecret:     "aap-secret-value",
+						ApiUrl:           "https://aap.example.com/api",
+						AuthorizationUrl: "https://aap.example.com/authorize",
+						TokenUrl:         "https://aap.example.com/token",
+						ProviderType:     domain.Aap,
+					})
+					return spec
+				}(),
+			},
+			secret: "aap-secret-value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelAP, err := NewAuthProviderFromApiResource(tc.apiProv)
+			require.NoError(t, err)
+
+			handler := EncryptionHandlers()["AuthProvider"]
+			err = handler(context.Background(), modelAP, mgr.ProcessEncryption)
+			require.NoError(t, err)
+
+			specJSON, err := json.Marshal(modelAP.Spec.Data)
+			require.NoError(t, err)
+			specStr := string(specJSON)
+
+			require.NotContains(t, specStr, tc.secret,
+				"Plaintext clientSecret '%s' found in spec after encryption", tc.secret)
+			require.Contains(t, specStr, "enc:v1:default:",
+				"Spec should contain encrypted clientSecret with proper format")
+
+			// Verify decrypt round-trip: extract the encrypted clientSecret from
+			// the spec JSON and decrypt it back to the original value.
+			var specMap map[string]any
+			require.NoError(t, json.Unmarshal(specJSON, &specMap))
+
+			encryptedSecret := extractClientSecret(t, specMap)
+			require.True(t, encryption.IsEncrypted([]byte(encryptedSecret)),
+				"clientSecret should be encrypted in spec")
+
+			decrypted, err := mgr.Decrypt(context.Background(), []byte(encryptedSecret))
+			require.NoError(t, err)
+			require.Equal(t, tc.secret, string(decrypted),
+				"Decrypted clientSecret should match original plaintext")
+		})
+	}
+}
+
+func extractClientSecret(t *testing.T, specMap map[string]any) string {
+	t.Helper()
+	val, ok := specMap["clientSecret"]
+	if ok {
+		s, ok := val.(string)
+		require.True(t, ok, "clientSecret should be a string")
+		return s
+	}
+	t.Fatal("clientSecret not found in spec map")
+	return ""
+}
+
+func TestRepositoryEncryption_FailClosed(t *testing.T) {
+	_ = setupTestEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-fail-closed")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Password: strPtr("secret-password"),
+					Token:    strPtr("secret-token"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	originalSpec, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	errEncrypt := fmt.Errorf("KMS unavailable")
+	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errEncrypt
+	}
+
+	handler := EncryptionHandlers()["Repository"]
+	err = handler(context.Background(), modelRepo, failingEncrypt)
+	require.ErrorIs(t, err, errEncrypt)
+
+	afterSpec, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalSpec), string(afterSpec),
+		"spec must remain unmodified after encryption failure")
+}
+
+func TestAuthProviderEncryption_FailClosed(t *testing.T) {
+	_ = setupTestEncryption(t)
+
+	apiProv := &domain.AuthProvider{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-fail-closed")},
+		Spec: func() domain.AuthProviderSpec {
+			var spec domain.AuthProviderSpec
+			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				Issuer:       "https://issuer.example.com",
+				ClientId:     "client-id",
+				ClientSecret: "top-secret",
+				ProviderType: domain.Oidc,
+			})
+			return spec
+		}(),
+	}
+
+	modelAP, err := NewAuthProviderFromApiResource(apiProv)
+	require.NoError(t, err)
+
+	originalSpec, err := json.Marshal(modelAP.Spec.Data)
+	require.NoError(t, err)
+
+	errEncrypt := fmt.Errorf("KMS unavailable")
+	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errEncrypt
+	}
+
+	handler := EncryptionHandlers()["AuthProvider"]
+	err = handler(context.Background(), modelAP, failingEncrypt)
+	require.ErrorIs(t, err, errEncrypt)
+
+	afterSpec, err := json.Marshal(modelAP.Spec.Data)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalSpec), string(afterSpec),
+		"spec must remain unmodified after encryption failure")
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/tasks/dependency_sync_git.go
+++ b/internal/tasks/dependency_sync_git.go
@@ -131,7 +131,7 @@ func (d *DependencySyncGit) probeRepo(ctx context.Context,
 	}
 
 	repo := &domain.Repository{Spec: spec}
-	auth, err := GetAuth(repo, d.cfg)
+	auth, err := GetAuth(ctx, repo, d.cfg)
 	if err != nil {
 		d.log.WithError(err).Warnf("failed getting auth for repository %s", repoName)
 		return nil

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -439,7 +439,7 @@ func (t *DeviceRenderLogic) renderGitConfig(ctx context.Context, configItem *dom
 
 	if t.ownerFleet == nil {
 		var hash string
-		ignition, hash, err = CloneGitRepoToIgnition(repo, gitSpec.GitRef.TargetRevision, gitSpec.GitRef.Path, t.cfg)
+		ignition, hash, err = CloneGitRepoToIgnition(ctx, repo, gitSpec.GitRef.TargetRevision, gitSpec.GitRef.Path, t.cfg)
 		if err != nil {
 			return &gitSpec.Name, &gitSpec.GitRef.Repository, nil, fmt.Errorf("failed cloning specified git repository %s/%s: %w", t.orgId, gitSpec.GitRef.Repository, err)
 		}
@@ -700,7 +700,7 @@ func (t *DeviceRenderLogic) renderHttpProviderConfig(ctx context.Context, config
 	}
 
 	if httpData == nil {
-		httpData, err = sendHTTPrequest(repo.Spec, repoURL)
+		httpData, err = sendHTTPrequest(ctx, repo.Spec, repoURL)
 		if err != nil {
 			return &httpConfigProviderSpec.Name, nil, nil, fmt.Errorf("failed fetching data: %w", err)
 		}
@@ -846,7 +846,7 @@ func (t *DeviceRenderLogic) cloneCachedGitRepoToIgnition(ctx context.Context, re
 		revisionToClone = string(frozenHashBytes)
 	}
 
-	ign, hash, err := CloneGitRepoToIgnition(repo, revisionToClone, path, t.cfg)
+	ign, hash, err := CloneGitRepoToIgnition(ctx, repo, revisionToClone, path, t.cfg)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed cloning git: %w", err)
 	}

--- a/internal/tasks/git_helpers.go
+++ b/internal/tasks/git_helpers.go
@@ -17,6 +17,7 @@ import (
 	config_latest_types "github.com/coreos/ignition/v2/config/v3_4/types"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	sshcrypto "github.com/flightctl/flightctl/internal/ssh"
 	"github.com/flightctl/flightctl/pkg/ignition"
 	"github.com/go-git/go-billy/v5"
@@ -37,9 +38,9 @@ import (
 var scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5}):)?(?P<path>[^\\].*)$`)
 
 // a function to clone a git repo, for mockable unit testing
-type cloneGitRepoFunc func(repo *domain.Repository, revision *string, depth *int, cfg *config.Config) (billy.Filesystem, string, error)
+type cloneGitRepoFunc func(ctx context.Context, repo *domain.Repository, revision *string, depth *int, cfg *config.Config) (billy.Filesystem, string, error)
 
-func CloneGitRepo(repo *domain.Repository, revision *string, depth *int, cfg *config.Config) (billy.Filesystem, string, error) {
+func CloneGitRepo(ctx context.Context, repo *domain.Repository, revision *string, depth *int, cfg *config.Config) (billy.Filesystem, string, error) {
 	storage := gitmemory.NewStorage()
 	mfs := memfs.New()
 	repoURL, err := repo.Spec.GetRepoURL()
@@ -52,7 +53,7 @@ func CloneGitRepo(repo *domain.Repository, revision *string, depth *int, cfg *co
 	if depth != nil {
 		opts.Depth = *depth
 	}
-	auth, err := GetAuth(repo, cfg)
+	auth, err := GetAuth(ctx, repo, cfg)
 	if err != nil {
 		return nil, "", err
 	}
@@ -66,7 +67,7 @@ func CloneGitRepo(repo *domain.Repository, revision *string, depth *int, cfg *co
 			hash = *revision
 		}
 	}
-	gitRepo, err := git.Clone(storage, mfs, opts)
+	gitRepo, err := git.CloneContext(ctx, storage, mfs, opts)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed cloning git repo: %w", err)
 	}
@@ -224,7 +225,7 @@ func wrapAuthWithCryptoSettings(auth transport.AuthMethod, settings sshcrypto.SS
 
 // Read repository's ssh/http config and create transport.AuthMethod.
 // If no ssh/http config is defined a nil is returned.
-func GetAuth(repository *domain.Repository, cfg *config.Config) (transport.AuthMethod, error) {
+func GetAuth(ctx context.Context, repository *domain.Repository, cfg *config.Config) (transport.AuthMethod, error) {
 	gitSpec, err := repository.Spec.AsGitRepoSpec()
 	if err != nil {
 		// Not a Git repo spec, no auth
@@ -235,14 +236,25 @@ func GetAuth(repository *domain.Repository, cfg *config.Config) (transport.AuthM
 	if gitSpec.SshConfig != nil {
 		var auth *gitssh.PublicKeys
 		if gitSpec.SshConfig.SshPrivateKey != nil {
-			sshPrivateKey, err := base64.StdEncoding.DecodeString(*gitSpec.SshConfig.SshPrivateKey)
+			// Decrypt SSH private key (passthrough if plaintext for BC)
+			decryptedKey, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*gitSpec.SshConfig.SshPrivateKey))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("decrypt SSH private key: %w", err)
+			}
+
+			sshPrivateKey, err := base64.StdEncoding.DecodeString(string(decryptedKey))
+			if err != nil {
+				return nil, fmt.Errorf("decode SSH private key: %w", err)
 			}
 
 			password := ""
 			if gitSpec.SshConfig.PrivateKeyPassphrase != nil {
-				password = *gitSpec.SshConfig.PrivateKeyPassphrase
+				// Decrypt passphrase (passthrough if plaintext for BC)
+				decryptedPassphrase, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*gitSpec.SshConfig.PrivateKeyPassphrase))
+				if err != nil {
+					return nil, fmt.Errorf("decrypt SSH passphrase: %w", err)
+				}
+				password = string(decryptedPassphrase)
 			}
 			user := ""
 			repoSubmatch := scpLikeUrlRegExp.FindStringSubmatch(gitSpec.Url)
@@ -291,21 +303,31 @@ func GetAuth(repository *domain.Repository, cfg *config.Config) (transport.AuthM
 	// Handle HTTP authentication
 	if gitSpec.HttpConfig != nil {
 		if strings.HasPrefix(gitSpec.Url, "https") {
-			err := configureRepoHTTPSClient(*gitSpec.HttpConfig)
+			err := configureRepoHTTPSClient(ctx, *gitSpec.HttpConfig)
 			if err != nil {
 				return nil, err
 			}
 		}
 		if gitSpec.HttpConfig.Token != nil {
+			// Decrypt token (passthrough if plaintext for BC)
+			decryptedToken, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*gitSpec.HttpConfig.Token))
+			if err != nil {
+				return nil, fmt.Errorf("decrypt HTTP token: %w", err)
+			}
 			auth := &githttp.TokenAuth{
-				Token: *gitSpec.HttpConfig.Token,
+				Token: string(decryptedToken),
 			}
 			return auth, nil
 		}
 		if gitSpec.HttpConfig.Username != nil && gitSpec.HttpConfig.Password != nil {
+			// Decrypt password (passthrough if plaintext for BC)
+			decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*gitSpec.HttpConfig.Password))
+			if err != nil {
+				return nil, fmt.Errorf("decrypt HTTP password: %w", err)
+			}
 			auth := &githttp.BasicAuth{
 				Username: *gitSpec.HttpConfig.Username,
-				Password: *gitSpec.HttpConfig.Password,
+				Password: string(decryptedPassword),
 			}
 			return auth, nil
 		}
@@ -315,21 +337,29 @@ func GetAuth(repository *domain.Repository, cfg *config.Config) (transport.AuthM
 	return nil, nil
 }
 
-func configureRepoHTTPSClient(httpConfig domain.HttpConfig) error {
+func configureRepoHTTPSClient(ctx context.Context, httpConfig domain.HttpConfig) error {
 	tlsConfig := tls.Config{} //nolint:gosec
 	if httpConfig.SkipServerVerification != nil {
 		tlsConfig.InsecureSkipVerify = *httpConfig.SkipServerVerification //nolint:gosec
 	}
 
 	if httpConfig.TlsCrt != nil && httpConfig.TlsKey != nil {
-		cert, err := base64.StdEncoding.DecodeString(*httpConfig.TlsCrt)
+		decryptedCrt, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*httpConfig.TlsCrt))
 		if err != nil {
-			return err
+			return fmt.Errorf("decrypt TLS cert: %w", err)
+		}
+		cert, err := base64.StdEncoding.DecodeString(string(decryptedCrt))
+		if err != nil {
+			return fmt.Errorf("decode TLS cert: %w", err)
 		}
 
-		key, err := base64.StdEncoding.DecodeString(*httpConfig.TlsKey)
+		decryptedKey, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*httpConfig.TlsKey))
 		if err != nil {
-			return err
+			return fmt.Errorf("decrypt TLS key: %w", err)
+		}
+		key, err := base64.StdEncoding.DecodeString(string(decryptedKey))
+		if err != nil {
+			return fmt.Errorf("decode TLS key: %w", err)
 		}
 
 		tlsPair, err := tls.X509KeyPair(cert, key)
@@ -411,8 +441,8 @@ func ConvertFileSystemToIgnition(mfs billy.Filesystem, path string) (*config_lat
 	return &ignition, nil
 }
 
-func CloneGitRepoToIgnition(repo *domain.Repository, revision string, path string, cfg *config.Config) (*config_latest_types.Config, string, error) {
-	mfs, hash, err := CloneGitRepo(repo, &revision, nil, cfg)
+func CloneGitRepoToIgnition(ctx context.Context, repo *domain.Repository, revision string, path string, cfg *config.Config) (*config_latest_types.Config, string, error) {
+	mfs, hash, err := CloneGitRepo(ctx, repo, &revision, nil, cfg)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/tasks/http_helpers.go
+++ b/internal/tasks/http_helpers.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -9,10 +10,11 @@ import (
 	"net/http"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 )
 
-func sendHTTPrequest(repoSpec domain.RepositorySpec, repoURL string) ([]byte, error) {
-	req, err := http.NewRequest("GET", repoURL, nil)
+func sendHTTPrequest(ctx context.Context, repoSpec domain.RepositorySpec, repoURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", repoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -46,6 +48,7 @@ func sendHTTPrequest(repoSpec domain.RepositorySpec, repoURL string) ([]byte, er
 }
 
 func buildHttpRepoRequestAuth(repoHttpSpec domain.HttpRepoSpec, req *http.Request) (*http.Request, *tls.Config, error) {
+	ctx := req.Context()
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
@@ -56,18 +59,34 @@ func buildHttpRepoRequestAuth(repoHttpSpec domain.HttpRepoSpec, req *http.Reques
 	}
 
 	if repoHttpSpec.HttpConfig.Username != nil && repoHttpSpec.HttpConfig.Password != nil {
-		req.SetBasicAuth(*repoHttpSpec.HttpConfig.Username, *repoHttpSpec.HttpConfig.Password)
+		decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*repoHttpSpec.HttpConfig.Password))
+		if err != nil {
+			return nil, tlsConfig, fmt.Errorf("decrypt HTTP password: %w", err)
+		}
+		req.SetBasicAuth(*repoHttpSpec.HttpConfig.Username, string(decryptedPassword))
 	}
 	if repoHttpSpec.HttpConfig.Token != nil {
-		req.Header.Set("Authorization", "Bearer "+*repoHttpSpec.HttpConfig.Token)
+		decryptedToken, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*repoHttpSpec.HttpConfig.Token))
+		if err != nil {
+			return nil, tlsConfig, fmt.Errorf("decrypt HTTP token: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+string(decryptedToken))
 	}
 	if repoHttpSpec.HttpConfig.TlsCrt != nil && repoHttpSpec.HttpConfig.TlsKey != nil {
-		cert, err := base64.StdEncoding.DecodeString(*repoHttpSpec.HttpConfig.TlsCrt)
+		decryptedCrt, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*repoHttpSpec.HttpConfig.TlsCrt))
+		if err != nil {
+			return nil, tlsConfig, fmt.Errorf("decrypt TLS cert: %w", err)
+		}
+		cert, err := base64.StdEncoding.DecodeString(string(decryptedCrt))
 		if err != nil {
 			return nil, tlsConfig, err
 		}
 
-		key, err := base64.StdEncoding.DecodeString(*repoHttpSpec.HttpConfig.TlsKey)
+		decryptedKey, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(*repoHttpSpec.HttpConfig.TlsKey))
+		if err != nil {
+			return nil, tlsConfig, fmt.Errorf("decrypt TLS key: %w", err)
+		}
+		key, err := base64.StdEncoding.DecodeString(string(decryptedKey))
 		if err != nil {
 			return nil, tlsConfig, err
 		}

--- a/internal/tasks/http_helpers_test.go
+++ b/internal/tasks/http_helpers_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -13,9 +14,18 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func encryptString(s string) string {
+	encrypted, err := encryption.Encrypt(context.Background(), []byte(s))
+	if err != nil {
+		panic(err)
+	}
+	return string(encrypted)
+}
 
 func generateDummyX509KeyPair() ([]byte, []byte, error) {
 	// Generate a private key
@@ -53,11 +63,32 @@ func generateDummyX509KeyPair() ([]byte, []byte, error) {
 }
 
 var _ = Describe("buildHttpRepoRequestAuth", func() {
+	When("only basic auth credentials are provided", func() {
+		It("sets basic auth header with decrypted password", func() {
+			username := "user"
+			password := encryptString("pass")
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			repoHttpSpec := domain.HttpRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Username: &username,
+					Password: &password,
+				},
+			}
+			req, tlsConfig, err := buildHttpRepoRequestAuth(repoHttpSpec, req)
+			Expect(err).ToNot(HaveOccurred())
+			u, p, ok := req.BasicAuth()
+			Expect(ok).To(BeTrue())
+			Expect(u).To(Equal("user"))
+			Expect(p).To(Equal("pass"))
+			Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		})
+	})
+
 	When("all authentication details are provided", func() {
 		It("sets basic auth and bearer token headers", func() {
 			username := "user"
-			password := "pass"
-			token := "token"
+			password := encryptString("pass")
+			token := encryptString("token")
 			req, _ := http.NewRequest("GET", "http://example.com", nil)
 			repoHttpSpec := domain.HttpRepoSpec{
 				HttpConfig: &domain.HttpConfig{
@@ -77,8 +108,8 @@ var _ = Describe("buildHttpRepoRequestAuth", func() {
 		It("sets the TLS certificates", func() {
 			tlsCrt, tlsKey, err := generateDummyX509KeyPair()
 			Expect(err).ToNot(HaveOccurred())
-			tlsCrtEncoded := base64.StdEncoding.EncodeToString(tlsCrt)
-			tlsKeyEncoded := base64.StdEncoding.EncodeToString(tlsKey)
+			tlsCrtEncoded := encryptString(base64.StdEncoding.EncodeToString(tlsCrt))
+			tlsKeyEncoded := encryptString(base64.StdEncoding.EncodeToString(tlsKey))
 			req, _ := http.NewRequest("GET", "http://example.com", nil)
 			repoHttpSpec := domain.HttpRepoSpec{
 				HttpConfig: &domain.HttpConfig{

--- a/internal/tasks/repotester.go
+++ b/internal/tasks/repotester.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/service/common"
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	"github.com/flightctl/flightctl/pkg/log"
@@ -129,14 +130,14 @@ func (r *RepoTester) SetAccessCondition(ctx context.Context, orgId uuid.UUID, re
 
 func (r *RepoTester) testRepository(ctx context.Context, orgId uuid.UUID, repository domain.Repository, tester TypeSpecificRepoTester) {
 	repoName := *repository.Metadata.Name
-	accessErr := tester.TestAccess(&repository)
+	accessErr := tester.TestAccess(ctx, &repository)
 	if err := r.SetAccessCondition(ctx, orgId, &repository, accessErr); err != nil {
 		r.log.Errorf("Failed to update repository status for %s: %v", repoName, err)
 	}
 }
 
 type TypeSpecificRepoTester interface {
-	TestAccess(repository *domain.Repository) error
+	TestAccess(ctx context.Context, repository *domain.Repository) error
 }
 
 type GitRepoTester struct {
@@ -148,7 +149,7 @@ type HttpRepoTester struct {
 type OciRepoTester struct {
 }
 
-func (r *GitRepoTester) TestAccess(repository *domain.Repository) error {
+func (r *GitRepoTester) TestAccess(ctx context.Context, repository *domain.Repository) error {
 	repoURL, err := repository.Spec.GetRepoURL()
 	if err != nil {
 		return err
@@ -160,13 +161,13 @@ func (r *GitRepoTester) TestAccess(repository *domain.Repository) error {
 	})
 
 	listOps := &git.ListOptions{}
-	auth, err := GetAuth(repository, nil) // nil config for test
+	auth, err := GetAuth(ctx, repository, nil) // nil config for test
 	if err != nil {
 		return err
 	}
 
 	listOps.Auth = auth
-	_, err = remote.List(listOps)
+	_, err = remote.ListContext(ctx, listOps)
 	if err != nil {
 		// Extract the root cause from go-git wrapped errors
 		// Format is often "authentication required: <actual error>"
@@ -182,7 +183,7 @@ func (r *GitRepoTester) TestAccess(repository *domain.Repository) error {
 	return nil
 }
 
-func (r *HttpRepoTester) TestAccess(repository *domain.Repository) error {
+func (r *HttpRepoTester) TestAccess(ctx context.Context, repository *domain.Repository) error {
 	repoHttpSpec, err := repository.Spec.AsHttpRepoSpec()
 	if err != nil {
 		return fmt.Errorf("failed to get HTTP repo spec: %w", err)
@@ -195,11 +196,11 @@ func (r *HttpRepoTester) TestAccess(repository *domain.Repository) error {
 	}
 
 	repoSpec := repository.Spec
-	_, err = sendHTTPrequest(repoSpec, repoURL)
+	_, err = sendHTTPrequest(ctx, repoSpec, repoURL)
 	return err
 }
 
-func (r *OciRepoTester) TestAccess(repository *domain.Repository) error {
+func (r *OciRepoTester) TestAccess(ctx context.Context, repository *domain.Repository) error {
 	ociSpec, err := repository.Spec.AsOciRepoSpec()
 	if err != nil {
 		return fmt.Errorf("failed to get OCI repo spec: %w", err)
@@ -245,7 +246,11 @@ func (r *OciRepoTester) TestAccess(repository *domain.Repository) error {
 	}
 
 	// Step 1: Call /v2/ without auth (OCI Distribution Spec)
-	resp, err := client.Get(v2URL)
+	req, err := http.NewRequestWithContext(ctx, "GET", v2URL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to connect to registry: %w", err)
 	}
@@ -264,20 +269,20 @@ func (r *OciRepoTester) TestAccess(repository *domain.Repository) error {
 		}
 		switch domain.OciAuthType(authType) {
 		case domain.Docker:
-			return r.authenticateDocker(client, v2URL, resp, ociSpec.OciAuth)
+			return r.authenticateDocker(ctx, client, v2URL, resp, ociSpec.OciAuth)
 		default:
 			return fmt.Errorf("unsupported OCI auth type: %s", authType)
 		}
 	}
 
 	// No auth configured - try anonymous access with Docker protocol
-	return r.authenticateDocker(client, v2URL, resp, nil)
+	return r.authenticateDocker(ctx, client, v2URL, resp, nil)
 }
 
 // authenticateDocker performs OCI registry authentication. It detects whether
 // the registry challenges with HTTP Basic or Bearer (Docker token) auth from the
 // Www-Authenticate header and dispatches accordingly.
-func (r *OciRepoTester) authenticateDocker(client *http.Client, v2URL string, initialResp *http.Response, ociAuth *domain.OciAuth) error {
+func (r *OciRepoTester) authenticateDocker(ctx context.Context, client *http.Client, v2URL string, initialResp *http.Response, ociAuth *domain.OciAuth) error {
 	if initialResp.StatusCode != http.StatusUnauthorized {
 		return fmt.Errorf("unexpected status code: %d", initialResp.StatusCode)
 	}
@@ -286,7 +291,7 @@ func (r *OciRepoTester) authenticateDocker(client *http.Client, v2URL string, in
 
 	// RFC 7235: auth scheme names are case-insensitive.
 	if strings.HasPrefix(strings.ToLower(wwwAuth), "basic ") {
-		return r.authenticateBasic(client, v2URL, ociAuth)
+		return r.authenticateBasic(ctx, client, v2URL, ociAuth)
 	}
 
 	// Parse www-authenticate header to get realm and service
@@ -302,18 +307,23 @@ func (r *OciRepoTester) authenticateDocker(client *http.Client, v2URL string, in
 		if err != nil {
 			return fmt.Errorf("failed to parse docker auth config: %w", err)
 		}
+		decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt OCI password: %w", err)
+		}
+		pw := string(decryptedPassword)
 		username = &dockerAuth.Username
-		password = &dockerAuth.Password
+		password = &pw
 	}
 
 	// Get token from auth endpoint
-	token, err := r.getToken(client, realm, service, username, password)
+	token, err := r.getToken(ctx, client, realm, service, username, password)
 	if err != nil {
 		return err
 	}
 
 	// Call /v2/ with bearer token
-	req, err := http.NewRequest("GET", v2URL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", v2URL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -333,7 +343,7 @@ func (r *OciRepoTester) authenticateDocker(client *http.Client, v2URL string, in
 }
 
 // authenticateBasic performs HTTP Basic authentication against the OCI /v2/ endpoint.
-func (r *OciRepoTester) authenticateBasic(client *http.Client, v2URL string, ociAuth *domain.OciAuth) error {
+func (r *OciRepoTester) authenticateBasic(ctx context.Context, client *http.Client, v2URL string, ociAuth *domain.OciAuth) error {
 	if ociAuth == nil {
 		return fmt.Errorf("registry requires Basic authentication but no credentials are configured")
 	}
@@ -347,11 +357,16 @@ func (r *OciRepoTester) authenticateBasic(client *http.Client, v2URL string, oci
 		return fmt.Errorf("registry requires Basic authentication but credentials are incomplete")
 	}
 
-	req, err := http.NewRequest("GET", v2URL, nil)
+	decryptedPassword, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(dockerAuth.Password))
+	if err != nil {
+		return fmt.Errorf("failed to decrypt OCI password: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", v2URL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-	req.SetBasicAuth(dockerAuth.Username, dockerAuth.Password)
+	req.SetBasicAuth(dockerAuth.Username, string(decryptedPassword))
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -393,7 +408,7 @@ func parseWwwAuthenticate(header string) (realm, service string, err error) {
 }
 
 // getToken gets an auth token from the registry's auth endpoint
-func (r *OciRepoTester) getToken(client *http.Client, realm, service string, username, password *string) (string, error) {
+func (r *OciRepoTester) getToken(ctx context.Context, client *http.Client, realm, service string, username, password *string) (string, error) {
 	// Parse the realm URL
 	authURL, err := url.Parse(realm)
 	if err != nil {
@@ -409,7 +424,7 @@ func (r *OciRepoTester) getToken(client *http.Client, realm, service string, use
 	query.Set("scope", "repository:"+uuid.New().String()+":pull")
 	authURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequest("GET", authURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", authURL.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create auth request: %w", err)
 	}

--- a/internal/tasks/repotester_test.go
+++ b/internal/tasks/repotester_test.go
@@ -1,16 +1,56 @@
 package tasks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/pkg/crypto"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "repotester-test")
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := crypto.GenerateAES256Key()
+	if err != nil {
+		panic(err)
+	}
+	keyPath := filepath.Join(dir, "key")
+	if err := os.WriteFile(keyPath, []byte(key), 0600); err != nil {
+		panic(err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Encryption = &config.EncryptionConfig{
+		Keys:        []config.EncryptionKeyConfig{{ID: "test", Path: keyPath}},
+		ActiveKeyID: "test",
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+
+	if err := encryption.InitGlobalEncryption(logger, cfg); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 // makeTestOciRepo builds a Repository pointing at a test HTTP server.
 func makeTestOciRepo(t *testing.T, server *httptest.Server, auth *domain.OciAuth) *domain.Repository {
@@ -28,13 +68,18 @@ func makeTestOciRepo(t *testing.T, server *httptest.Server, auth *domain.OciAuth
 	return &domain.Repository{Spec: spec}
 }
 
-// makeDockerOciAuth creates an OciAuth with docker (username/password) credentials.
+// makeDockerOciAuth creates an OciAuth with docker credentials.
+// The password is encrypted to match what the GORM plugin produces on save.
 func makeDockerOciAuth(username, password string) *domain.OciAuth {
+	encrypted, err := encryption.Encrypt(context.Background(), []byte(password))
+	if err != nil {
+		panic(fmt.Sprintf("makeDockerOciAuth encrypt: %v", err))
+	}
 	auth := &domain.OciAuth{}
-	err := auth.FromDockerAuth(domain.DockerAuth{
+	err = auth.FromDockerAuth(domain.DockerAuth{
 		AuthType: domain.Docker,
 		Username: username,
-		Password: password,
+		Password: string(encrypted),
 	})
 	if err != nil {
 		panic(fmt.Sprintf("makeDockerOciAuth: %v", err))
@@ -66,7 +111,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, nil)
-		require.NoError(t, tester.TestAccess(repo))
+		require.NoError(t, tester.TestAccess(t.Context(), repo))
 	})
 
 	t.Run("When registry returns 401 with Basic challenge and valid credentials it returns nil", func(t *testing.T) {
@@ -74,7 +119,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, makeDockerOciAuth("user", "pass"))
-		require.NoError(t, tester.TestAccess(repo))
+		require.NoError(t, tester.TestAccess(t.Context(), repo))
 	})
 
 	t.Run("When registry returns 401 with Basic challenge and wrong credentials it returns an auth error", func(t *testing.T) {
@@ -82,7 +127,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, makeDockerOciAuth("user", "wrong"))
-		err := tester.TestAccess(repo)
+		err := tester.TestAccess(t.Context(), repo)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "authentication failed")
 	})
@@ -92,7 +137,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, nil)
-		err := tester.TestAccess(repo)
+		err := tester.TestAccess(t.Context(), repo)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no credentials")
 	})
@@ -120,7 +165,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, makeDockerOciAuth("user", "pass"))
-		require.NoError(t, tester.TestAccess(repo))
+		require.NoError(t, tester.TestAccess(t.Context(), repo))
 	})
 
 	t.Run("When registry returns 401 with an unsupported auth scheme it returns an error", func(t *testing.T) {
@@ -131,7 +176,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, nil)
-		err := tester.TestAccess(repo)
+		err := tester.TestAccess(t.Context(), repo)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported auth type")
 	})
@@ -141,7 +186,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, makeDockerOciAuth("", ""))
-		err := tester.TestAccess(repo)
+		err := tester.TestAccess(t.Context(), repo)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "credentials are incomplete")
 	})
@@ -158,7 +203,7 @@ func TestOciRepoTester_TestAccess(t *testing.T) {
 		defer server.Close()
 
 		repo := makeTestOciRepo(t, server, makeDockerOciAuth("user", "pass"))
-		err := tester.TestAccess(repo)
+		err := tester.TestAccess(t.Context(), repo)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "authentication failed")
 	})

--- a/internal/tasks/resourcesync.go
+++ b/internal/tasks/resourcesync.go
@@ -100,7 +100,7 @@ func (r *ResourceSync) run(ctx context.Context, log logrus.FieldLogger, orgId uu
 	}
 
 	// Parse and validate resources
-	resources, err := r.parseAndValidateResources(rs, repo, CloneGitRepo)
+	resources, err := r.parseAndValidateResources(ctx, rs, repo, CloneGitRepo)
 	if err != nil {
 		log.Errorf("resourcesync/%s: parsing failed. error: %s", *rs.Metadata.Name, err.Error())
 		return err
@@ -403,10 +403,10 @@ func NeedsSyncToHash(rs *domain.ResourceSync, hash string) bool {
 	return hash != prevHash || observedGen != *rs.Metadata.Generation
 }
 
-func (r *ResourceSync) parseAndValidateResources(rs *domain.ResourceSync, repo *domain.Repository, gitCloneRepo cloneGitRepoFunc) ([]GenericResourceMap, error) {
+func (r *ResourceSync) parseAndValidateResources(ctx context.Context, rs *domain.ResourceSync, repo *domain.Repository, gitCloneRepo cloneGitRepoFunc) ([]GenericResourceMap, error) {
 	path := rs.Spec.Path
 	revision := rs.Spec.TargetRevision
-	mfs, hash, err := gitCloneRepo(repo, &revision, lo.ToPtr(1), r.cfg)
+	mfs, hash, err := gitCloneRepo(ctx, repo, &revision, lo.ToPtr(1), r.cfg)
 	domain.SetStatusConditionByError(&rs.Status.Conditions, domain.ConditionTypeResourceSyncAccessible, "accessible", "failed to clone repository", err)
 	if err != nil {
 		return nil, err

--- a/test/integration/git_ssh_fips_test.go
+++ b/test/integration/git_ssh_fips_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -117,7 +118,7 @@ func TestGitSSHCloneWithFIPS(t *testing.T) {
 
 	// Attempt to clone the repository
 	// In FIPS mode WITH the fix, this should succeed by using FIPS-compliant algorithms
-	_, _, err = tasks.CloneGitRepo(repo, nil, nil, nil)
+	_, _, err = tasks.CloneGitRepo(context.Background(), repo, nil, nil, nil)
 
 	// With the fix implemented, SSH clone should succeed in FIPS mode
 	// The fix applies FIPS-compliant algorithms (ecdh-sha2-nistp*, diffie-hellman-group*-sha256)
@@ -185,7 +186,7 @@ func TestGitSSHCloneNonFIPS(t *testing.T) {
 	}
 
 	// In non-FIPS mode, this should work with default algorithms
-	_, _, err = tasks.CloneGitRepo(repo, nil, nil, nil)
+	_, _, err = tasks.CloneGitRepo(context.Background(), repo, nil, nil, nil)
 
 	// Note: This might still fail because we're using a minimal SSH server
 	// The important part is that it should NOT fail due to FIPS restrictions

--- a/test/integration/store/repository_test.go
+++ b/test/integration/store/repository_test.go
@@ -7,6 +7,7 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/store"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
@@ -24,6 +25,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
+
+// decryptString decrypts an encrypted string field value and asserts it was actually encrypted.
+func decryptString(val string) string {
+	plaintext, wasEncrypted, err := encryption.Decrypt(context.Background(), encryption.Ciphertext(val))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(wasEncrypted).To(BeTrue(), "expected value to be encrypted but got plaintext: %s", val)
+	return string(plaintext)
+}
 
 func newOciAuth(username, password string) *api.OciAuth {
 	auth := &api.OciAuth{}
@@ -390,7 +399,7 @@ var _ = Describe("RepositoryStore create", func() {
 			dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dockerAuth.Username).To(Equal("myuser"))
-			Expect(dockerAuth.Password).To(Equal("mypassword"))
+			Expect(decryptString(dockerAuth.Password)).To(Equal("mypassword"))
 		})
 
 		It("Create OCI repository without credentials (public registry)", func() {
@@ -530,7 +539,7 @@ var _ = Describe("RepositoryStore create", func() {
 			dockerAuth, err := ociSpec.OciAuth.AsDockerAuth()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dockerAuth.Username).To(Equal("testuser"))
-			Expect(dockerAuth.Password).To(Equal("testpass"))
+			Expect(decryptString(dockerAuth.Password)).To(Equal("testpass"))
 		})
 
 		It("List OCI repositories with combined type and accessMode FieldSelector", func() {
@@ -667,9 +676,9 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(gitSpec.Url).To(Equal("git@github.com:flightctl/flightctl.git"))
 			Expect(gitSpec.Type).To(Equal(api.GitRepoSpecTypeGit))
 			Expect(gitSpec.SshConfig.SshPrivateKey).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.SshPrivateKey).To(Equal(privateKey))
+			Expect(decryptString(*gitSpec.SshConfig.SshPrivateKey)).To(Equal(privateKey))
 			Expect(gitSpec.SshConfig.PrivateKeyPassphrase).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.PrivateKeyPassphrase).To(Equal(passphrase))
+			Expect(decryptString(*gitSpec.SshConfig.PrivateKeyPassphrase)).To(Equal(passphrase))
 		})
 
 		It("Create SSH repository without passphrase", func() {
@@ -702,7 +711,7 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(gitSpec.Url).To(Equal("git@gitlab.com:myorg/myrepo.git"))
 			Expect(gitSpec.SshConfig.SshPrivateKey).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.SshPrivateKey).To(Equal(privateKey))
+			Expect(decryptString(*gitSpec.SshConfig.SshPrivateKey)).To(Equal(privateKey))
 			Expect(gitSpec.SshConfig.PrivateKeyPassphrase).To(BeNil())
 		})
 
@@ -740,9 +749,9 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(gitSpec.Url).To(Equal("git@github.com:testorg/testrepo.git"))
 			Expect(gitSpec.Type).To(Equal(api.GitRepoSpecTypeGit))
 			Expect(gitSpec.SshConfig.SshPrivateKey).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.SshPrivateKey).To(Equal(privateKey))
+			Expect(decryptString(*gitSpec.SshConfig.SshPrivateKey)).To(Equal(privateKey))
 			Expect(gitSpec.SshConfig.PrivateKeyPassphrase).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.PrivateKeyPassphrase).To(Equal(passphrase))
+			Expect(decryptString(*gitSpec.SshConfig.PrivateKeyPassphrase)).To(Equal(passphrase))
 		})
 
 		It("Update SSH repository", func() {
@@ -791,9 +800,9 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(gitSpec.Url).To(Equal("git@github.com:updated/repo.git"))
 			Expect(gitSpec.SshConfig.SshPrivateKey).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.SshPrivateKey).To(Equal(newPrivateKey))
+			Expect(decryptString(*gitSpec.SshConfig.SshPrivateKey)).To(Equal(newPrivateKey))
 			Expect(gitSpec.SshConfig.PrivateKeyPassphrase).ToNot(BeNil())
-			Expect(*gitSpec.SshConfig.PrivateKeyPassphrase).To(Equal(newPassphrase))
+			Expect(decryptString(*gitSpec.SshConfig.PrivateKeyPassphrase)).To(Equal(newPassphrase))
 		})
 
 		It("Delete SSH repository", func() {
@@ -872,7 +881,7 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(httpSpec.HttpConfig.Username).ToNot(BeNil())
 			Expect(*httpSpec.HttpConfig.Username).To(Equal(username))
 			Expect(httpSpec.HttpConfig.Password).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.Password).To(Equal(password))
+			Expect(decryptString(*httpSpec.HttpConfig.Password)).To(Equal(password))
 		})
 
 		It("Create HTTP repository with token", func() {
@@ -905,7 +914,7 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(httpSpec.Url).To(Equal("https://github.com/flightctl/flightctl.git"))
 			Expect(httpSpec.HttpConfig.Token).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.Token).To(Equal(token))
+			Expect(decryptString(*httpSpec.HttpConfig.Token)).To(Equal(token))
 			Expect(httpSpec.HttpConfig.Username).To(BeNil())
 			Expect(httpSpec.HttpConfig.Password).To(BeNil())
 		})
@@ -946,9 +955,9 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(httpSpec.HttpConfig.CaCrt).ToNot(BeNil())
 			Expect(*httpSpec.HttpConfig.CaCrt).To(Equal(caCrt))
 			Expect(httpSpec.HttpConfig.TlsCrt).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.TlsCrt).To(Equal(tlsCrt))
+			Expect(decryptString(*httpSpec.HttpConfig.TlsCrt)).To(Equal(tlsCrt))
 			Expect(httpSpec.HttpConfig.TlsKey).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.TlsKey).To(Equal(tlsKey))
+			Expect(decryptString(*httpSpec.HttpConfig.TlsKey)).To(Equal(tlsKey))
 		})
 
 		It("Create HTTP repository with skipServerVerification", func() {
@@ -1024,7 +1033,7 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(httpSpec.HttpConfig.Username).ToNot(BeNil())
 			Expect(*httpSpec.HttpConfig.Username).To(Equal(username))
 			Expect(httpSpec.HttpConfig.Password).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.Password).To(Equal(password))
+			Expect(decryptString(*httpSpec.HttpConfig.Password)).To(Equal(password))
 		})
 
 		It("Update HTTP repository", func() {
@@ -1071,7 +1080,7 @@ var _ = Describe("RepositoryStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(httpSpec.Url).To(Equal("https://github.com/updated/repo.git"))
 			Expect(httpSpec.HttpConfig.Token).ToNot(BeNil())
-			Expect(*httpSpec.HttpConfig.Token).To(Equal(newToken))
+			Expect(decryptString(*httpSpec.HttpConfig.Token)).To(Equal(newToken))
 		})
 
 		It("Delete HTTP repository", func() {

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -34,7 +34,7 @@ import (
 type MockRepoTester struct {
 }
 
-func (r *MockRepoTester) TestAccess(repository *api.Repository) error {
+func (r *MockRepoTester) TestAccess(_ context.Context, repository *api.Repository) error {
 	if repository.Metadata.Labels == nil {
 		return errors.New("fail")
 	}

--- a/test/integration/tasks/repotester_test.go
+++ b/test/integration/tasks/repotester_test.go
@@ -175,7 +175,7 @@ var _ = Describe("RepoTester", func() {
 				}})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("name")}, Spec: spec})
+			err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("name")}, Spec: spec})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -211,7 +211,7 @@ var _ = Describe("RepoTester", func() {
 				}})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("name")}, Spec: spec})
+			err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("name")}, Spec: spec})
 			Expect(err).NotTo(HaveOccurred())
 
 			select {
@@ -241,7 +241,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -270,7 +270,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -299,7 +299,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid credentials"))
 			})
@@ -327,7 +327,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -358,7 +358,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Test without credentials - should get anonymous token via scope
@@ -370,7 +370,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo-anon")}, Spec: specAnon})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo-anon")}, Spec: specAnon})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Test with invalid credentials - should fail even though anonymous access is available
@@ -383,7 +383,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo-invalid")}, Spec: specInvalid})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo-invalid")}, Spec: specInvalid})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid credentials"))
 			})
@@ -400,7 +400,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-repo")}, Spec: spec})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to connect"))
 			})
@@ -423,7 +423,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-tls")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-tls")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -453,7 +453,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-tls-auth")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-tls-auth")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -475,7 +475,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-insecure")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-insecure")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -496,7 +496,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-no-ca")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-no-ca")}, Spec: spec})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to connect"))
 			})
@@ -524,7 +524,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -551,7 +551,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-invalid")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-invalid")}, Spec: spec})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("authentication failed"))
 			})
@@ -576,7 +576,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-no-creds")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-no-creds")}, Spec: spec})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("no credentials"))
 			})
@@ -605,7 +605,7 @@ var _ = Describe("RepoTester", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = repotester.TestAccess(&api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-tls")}, Spec: spec})
+				err = repotester.TestAccess(context.Background(), &api.Repository{Metadata: api.ObjectMeta{Name: lo.ToPtr("test-oci-basic-auth-tls")}, Spec: spec})
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
…thProvider fields

Register GORM beforeSave encryption handlers for Repository and AuthProvider models so sensitive fields are encrypted before being persisted to PostgreSQL.

Repository handler encrypts: httpConfig.password, httpConfig.token, httpConfig.tls.key, httpConfig.tls.crt, sshConfig.sshPrivateKey, sshConfig.privateKeyPassphrase, ociAuth.password.

AuthProvider handler encrypts: clientSecret (OIDC, OAuth2, OpenShift, AAP).

