### PR TITLE
EDM-4752: Split flightctl-greenboot RPM subpackage

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -47,12 +47,23 @@ flightctl is the CLI for controlling the Flight Control service.
 Summary: Flight Control management agent
 
 Requires: flightctl-selinux = %{version}
-Requires: greenboot
+Recommends: flightctl-greenboot
 Requires: jq
 Requires: sudo
 
 %description agent
 The flightctl-agent package provides the management agent for the Flight Control fleet management service.
+
+# greenboot sub-package
+%package greenboot
+Summary: Greenboot integration for the Flight Control agent
+Requires: greenboot
+Requires: flightctl-agent = %{version}
+
+%description greenboot
+The flightctl-greenboot package provides greenboot health checks, bootc timer
+masking, and greenboot configuration for the Flight Control agent on
+image-mode (bootc) systems.
 
 # selinux sub-package
 %package selinux
@@ -485,6 +496,11 @@ fi
     /usr/lib/systemd/system/flightctl-agent.service
     /usr/lib/tmpfiles.d/flightctl.conf
     /usr/lib/tmpfiles.d/centos-buildinfo.conf
+    /usr/share/sosreport/flightctl.py
+    %{_sysusersdir}/flightctl.conf
+    /etc/sudoers.d/*
+
+%files greenboot
     /usr/share/flightctl/functions/greenboot.sh
     /usr/lib/greenboot/check/required.d/20_check_flightctl_agent.sh
     /usr/lib/greenboot/red.d/40_flightctl_agent_pre_rollback.sh
@@ -492,24 +508,8 @@ fi
     /usr/libexec/flightctl/mask-bootc-timer.sh
     /usr/lib/systemd/system/flightctl-configure-greenboot.service
     /usr/lib/systemd/system/flightctl-mask-bootc-timer.service
-    /usr/share/sosreport/flightctl.py
-    %{_sysusersdir}/flightctl.conf
-    /etc/sudoers.d/*
 
 %post agent
-# Enable greenboot-healthcheck if present (not enabled by default in greenboot-rs 0.16.x).
-# Must be unconditional: greenboot's own %%systemd_post preset removes greenboot-success.target
-# (renamed from greenboot-set-success.target) due to a CentOS preset mismatch. Re-running
-# `systemctl enable` recreates it via the Also= directive.
-# See: https://github.com/fedora-iot/greenboot-rs/issues/171
-# See: https://github.com/openshift/microshift/pull/5530
-systemctl enable --quiet greenboot-healthcheck 2>/dev/null || :
-# Enable the greenboot configuration service (runs before greenboot-healthcheck.service)
-# This ensures only flightctl health checks can trigger OS rollback
-systemctl enable flightctl-configure-greenboot.service >/dev/null 2>&1 || :
-# Mask bootc auto-update timer on first boot (bootc/composefs); also run from %post below.
-systemctl enable flightctl-mask-bootc-timer.service >/dev/null 2>&1 || :
-
 # Ensure /var/lib/flightctl exists immediately for environments where systemd-tmpfiles succeeds or via fallback
 # Try systemd-tmpfiles first, fall back to manual creation if it fails
 /usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/flightctl.conf || {
@@ -540,18 +540,36 @@ mkdir -p ~flightctl/.config/{containers/systemd,systemd/user}
 mkdir -p ~flightctl/.local
 chown -R flightctl:flightctl ~flightctl/{.config,.local}
 
+%post greenboot
+# Enable greenboot-healthcheck if present (not enabled by default in greenboot-rs 0.16.x).
+# Must be unconditional: greenboot's own %%systemd_post preset removes greenboot-success.target
+# (renamed from greenboot-set-success.target) due to a CentOS preset mismatch. Re-running
+# `systemctl enable` recreates it via the Also= directive.
+# See: https://github.com/fedora-iot/greenboot-rs/issues/171
+# See: https://github.com/openshift/microshift/pull/5530
+systemctl enable --quiet greenboot-healthcheck 2>/dev/null || :
+# Enable the greenboot configuration service (runs before greenboot-healthcheck.service)
+# This ensures only flightctl health checks can trigger OS rollback
+systemctl enable flightctl-configure-greenboot.service >/dev/null 2>&1 || :
+# Mask bootc auto-update timer on first boot (bootc/composefs); the script
+# is also run directly below for immediate effect during RPM install.
+systemctl enable flightctl-mask-bootc-timer.service >/dev/null 2>&1 || :
 # Disable bootc automatic updates on bootc systems (flightctl manages updates).
 # mask-bootc-timer.sh applies the mask; flightctl-mask-bootc-timer.service re-runs on
 # boot when image-build %post changes do not persist on bootc/composefs disks.
 /usr/libexec/flightctl/mask-bootc-timer.sh 2>/dev/null || true
 
 %postun agent
+if [ "$1" -eq 0 ]; then
+    loginctl disable-linger flightctl || :
+fi
+
+%postun greenboot
 # Restore bootc automatic-update timer only on full removal (not upgrade)
 if [ "$1" -eq 0 ]; then
     systemctl disable flightctl-mask-bootc-timer.service 2>/dev/null || true
     systemctl unmask bootc-fetch-apply-updates.timer 2>/dev/null || true
     systemctl start bootc-fetch-apply-updates.timer 2>/dev/null || true
-    loginctl disable-linger flightctl || :
 fi
 
 %files selinux

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -564,10 +564,12 @@ if [ "$1" -eq 0 ]; then
     loginctl disable-linger flightctl || :
 fi
 
+%preun greenboot
+%systemd_preun flightctl-configure-greenboot.service flightctl-mask-bootc-timer.service
+
 %postun greenboot
 # Restore bootc automatic-update timer only on full removal (not upgrade)
 if [ "$1" -eq 0 ]; then
-    systemctl disable flightctl-mask-bootc-timer.service 2>/dev/null || true
     systemctl unmask bootc-fetch-apply-updates.timer 2>/dev/null || true
     systemctl start bootc-fetch-apply-updates.timer 2>/dev/null || true
 fi

--- a/test/scripts/agent-images/containerfiles/cs10-bootc/Containerfile
+++ b/test/scripts/agent-images/containerfiles/cs10-bootc/Containerfile
@@ -119,6 +119,7 @@ RUN --mount=type=bind,from=project-bin,source=.,target=/build-context \
       else \
         echo "Installing local RPMs from ${RPM_DIR}"; \
         cp /build-context/${RPM_DIR}/flightctl-agent-*.rpm \
+           /build-context/${RPM_DIR}/flightctl-greenboot-*.rpm \
            /build-context/${RPM_DIR}/flightctl-selinux-*.rpm /tmp/rpms/; \
         ls -l /tmp/rpms; \
         dnf install -y /tmp/rpms/*.rpm; \

--- a/test/scripts/agent-images/containerfiles/cs9-bootc/Containerfile
+++ b/test/scripts/agent-images/containerfiles/cs9-bootc/Containerfile
@@ -109,6 +109,7 @@ RUN --mount=type=bind,from=project-bin,source=.,target=/build-context \
       else \
         echo "Installing local RPMs from ${RPM_DIR}"; \
         cp /build-context/${RPM_DIR}/flightctl-agent-*.rpm \
+           /build-context/${RPM_DIR}/flightctl-greenboot-*.rpm \
            /build-context/${RPM_DIR}/flightctl-selinux-*.rpm /tmp/rpms/; \
         ls -l /tmp/rpms; \
         dnf install -y /tmp/rpms/*.rpm; \


### PR DESCRIPTION
## EDM-4752: Split flightctl-greenboot RPM subpackage

**Jira:** [EDM-4752](https://redhat.atlassian.net/browse/EDM-4752)
**Story type:** [DEV]
**Design:** [§4.1.2 RPM Packaging Restructuring](https://github.com/flightctl/design-docs/pull/23)

### Summary

Splits greenboot and bootc-specific dependencies out of the `flightctl-agent` RPM into a new `flightctl-greenboot` subpackage, following MicroShift's subpackage pattern. This enables clean agent installation on package-mode hosts where greenboot is unavailable (`dnf install --setopt=install_weak_deps=False flightctl-agent`). Image-mode installations are unaffected — `Recommends:` pulls in `flightctl-greenboot` (and transitively `greenboot`) by default.

### Changes

**`packaging/rpm/flightctl.spec`:**

- **New `%package greenboot`** — contains greenboot health checks, bootc timer masking, configure-greenboot service. `Requires: greenboot` and `Requires: flightctl-agent = %{version}`.
- **`flightctl-agent` dependency change** — `Requires: greenboot` → `Recommends: flightctl-greenboot`.
- **`%files` split** — 7 greenboot/bootc-related files moved from `%files agent` to `%files greenboot`: greenboot scripts, shared functions, mask-bootc-timer script/service, configure-greenboot service.
- **`%post` split** — greenboot service enablement and bootc timer masking moved from `%post agent` to `%post greenboot`. Core agent setup (tmpfiles, SOS plugin, user creation, lingering) stays in `%post agent`.
- **`%postun` split** — bootc timer restoration moved from `%postun agent` to `%postun greenboot`. Linger cleanup stays in `%postun agent`.

### Testing

- **`make rpmlint`:** 0 errors, 1 pre-existing warning (improved from 2)
- **Manual verification:** RPM build and install verification in mock environment (not automated)

### Acceptance Criteria

- [x] AC-1: New `flightctl-greenboot` subpackage contains greenboot scripts, bootc timer masking, configure-greenboot service
- [x] AC-2: `flightctl-agent` no longer hard-requires greenboot; uses `Recommends: flightctl-greenboot`
- [x] AC-3: Greenboot/bootc `%post` and `%postun` scriptlets moved to `flightctl-greenboot`
- [x] AC-4: Core agent scriptlets (user creation, tmpfiles, SOS plugin, lingering) remain in `flightctl-agent`
- [x] AC-5: RPM spec passes `make rpmlint`
