### PR TITLE
EDM-4842: Fix edit argument validation e2e assertions

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -25,6 +25,7 @@ var (
 	unspecifiedResource  = "Error: name must be specified when deleting"
 	resourceCreated      = `(200 OK|201 Created)`
 	invalidResource      = "invalid resource kind"
+	editResourceRequired = "Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)"
 	strictfipsruntimeTag = "X:strictfipsruntime"
 	applyOperation       = "apply"
 )
@@ -979,7 +980,7 @@ var _ = Describe("cli login", func() {
 		By("failing when no arguments are provided")
 		out, err = harness.CLI("edit")
 		Expect(err).To(HaveOccurred())
-		Expect(out).To(ContainSubstring("Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)"))
+		Expect(out).To(ContainSubstring(editResourceRequired))
 
 		By("failing on invalid resource kind (numeric)")
 		out, err = harness.CLI("edit", "1234")
@@ -994,7 +995,7 @@ var _ = Describe("cli login", func() {
 		By("failing when too many arguments are provided")
 		out, err = harness.CLI("edit", "1", "2", "3", "4")
 		Expect(err).To(HaveOccurred())
-		Expect(out).To(ContainSubstring("Error: accepts between 1 and 2 arg(s), received 4"))
+		Expect(out).To(ContainSubstring(editResourceRequired))
 	})
 
 	It("generates completion and can be sourced for each supported shell (harness.CLI only for flightctl calls)", Label("85470", "client"), func() {


### PR DESCRIPTION
## Summary
- reuse the edit command-specific validation error in the CLI e2e test
- update the too-many-arguments edit assertion to match current edit command behavior

## Why
`flightctl edit` uses a custom Args validator for both missing and excessive arguments, so both cases return `Error: you must specify a resource to edit (TYPE NAME or TYPE/NAME)`. The logs from the failing profiles show the stale Cobra arg-count expectation only on the too-many-args edit check after the no-args assertion passes.


This time we fixed the full edit arg-count case, not just the first failure.
Before, we only updated the no-args assertion. The test then moved forward and failed on the too-many-args assertion.
Now we added one shared expected error for flightctl edit and use it for both:
flightctl edit
flightctl edit 1 2 3 4
That matches the actual edit command code, where both cases return the same custom validation error.


## Release target
Target release: release-1.3

## AI attribution
This change was assisted by OpenAI Codex and reviewed by Eldar Weiss.