### PR TITLE
EDM-3677: Surface fleet rollout errors in device status

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -247,25 +247,7 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 			device.Status.Updated.Info = lo.ToPtr("Device was updated to the fleet's latest device spec.")
 		} else {
 			device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
-
-			var errorMessage string
-			baseMessage := "Device could not be updated to the fleet's latest device spec"
-			if device.Metadata.Annotations != nil {
-				if lastRolloutError, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationLastRolloutError]; ok && lastRolloutError != "" {
-					errorMessage = fmt.Sprintf("%s: %s", baseMessage, lastRolloutError)
-				}
-			}
-			if errorMessage == "" {
-				if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
-					if updateCondition.Reason == string(domain.UpdateStateError) {
-						errorMessage = fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
-					}
-				}
-			}
-			if errorMessage == "" {
-				errorMessage = domain.DeviceOutOfSyncWithFleetText
-			}
-			device.Status.Updated.Info = lo.ToPtr(errorMessage)
+			device.Status.Updated.Info = lo.ToPtr(managedDeviceOutOfDateMessage(device))
 		}
 	} else {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusUpToDate
@@ -281,6 +263,21 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 	}
 
 	return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
+}
+
+func managedDeviceOutOfDateMessage(device *domain.Device) string {
+	baseMessage := "Device could not be updated to the fleet's latest device spec"
+	if device.Metadata.Annotations != nil {
+		if lastRolloutError, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationLastRolloutError]; ok && lastRolloutError != "" {
+			return fmt.Sprintf("%s: %s", baseMessage, lastRolloutError)
+		}
+	}
+	if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
+		if updateCondition.Reason == string(domain.UpdateStateError) {
+			return fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
+		}
+	}
+	return domain.DeviceOutOfSyncWithFleetText
 }
 
 func updateServerSideApplicationStatus(device *domain.Device) bool {

--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -196,11 +196,10 @@ func updateServerSideLifecycleStatus(device *domain.Device) bool {
 
 func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Context, fleetStore fleetstore.Store, log logrus.FieldLogger, orgId uuid.UUID) bool {
 	lastUpdateStatus := device.Status.Updated.Status
-	lastUpdateInfo := lo.FromPtr(device.Status.Updated.Info)
 	if device.IsDisconnected(domain.DeviceDisconnectedTimeout) && device.Status != nil && device.Status.LastSeen != nil && !device.Status.LastSeen.IsZero() {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusUnknown
 		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device is disconnected (last seen more than %s).", humanize.Time(time.Now().Add(-domain.DeviceDisconnectedTimeout))))
-		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
+		return device.Status.Updated.Status != lastUpdateStatus
 	}
 	if device.IsUpdating() {
 		var agentInfoMessage string
@@ -209,27 +208,25 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		}
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusUpdating
 		device.Status.Updated.Info = lo.ToPtr(util.DefaultString(agentInfoMessage, "Device is updating to the latest device spec."))
-		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
+		return device.Status.Updated.Status != lastUpdateStatus
 	}
 	if !device.IsManaged() && !device.IsUpdatedToDeviceSpec() {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
 		baseMessage := domain.DeviceOutOfDateText
 		var errorMessage string
 
-		// Prefer update condition error if available
 		if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
 			if updateCondition.Reason == string(domain.UpdateStateError) && updateCondition.Message != "" {
 				errorMessage = fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
 			}
 		}
 
-		// Final fallback to base message (skip rollout error check since unmanaged devices don't have rollout errors)
 		if errorMessage == "" {
 			errorMessage = baseMessage + "."
 		}
 
 		device.Status.Updated.Info = lo.ToPtr(errorMessage)
-		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
+		return device.Status.Updated.Status != lastUpdateStatus
 	}
 	if device.IsManaged() {
 		_, fleetName, err := util.GetResourceOwner(device.Metadata.Owner)
@@ -262,7 +259,7 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device OS image mismatch: running %q, expected %q.", device.Status.Os.Image, device.Spec.Os.Image))
 	}
 
-	return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
+	return device.Status.Updated.Status != lastUpdateStatus
 }
 
 func managedDeviceOutOfDateMessage(device *domain.Device) string {
@@ -273,7 +270,7 @@ func managedDeviceOutOfDateMessage(device *domain.Device) string {
 		}
 	}
 	if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
-		if updateCondition.Reason == string(domain.UpdateStateError) {
+		if updateCondition.Reason == string(domain.UpdateStateError) && updateCondition.Message != "" {
 			return fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
 		}
 	}

--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -196,10 +196,11 @@ func updateServerSideLifecycleStatus(device *domain.Device) bool {
 
 func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Context, fleetStore fleetstore.Store, log logrus.FieldLogger, orgId uuid.UUID) bool {
 	lastUpdateStatus := device.Status.Updated.Status
+	lastUpdateInfo := lo.FromPtr(device.Status.Updated.Info)
 	if device.IsDisconnected(domain.DeviceDisconnectedTimeout) && device.Status != nil && device.Status.LastSeen != nil && !device.Status.LastSeen.IsZero() {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusUnknown
 		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device is disconnected (last seen more than %s).", humanize.Time(time.Now().Add(-domain.DeviceDisconnectedTimeout))))
-		return device.Status.Updated.Status != lastUpdateStatus
+		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
 	}
 	if device.IsUpdating() {
 		var agentInfoMessage string
@@ -208,7 +209,7 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		}
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusUpdating
 		device.Status.Updated.Info = lo.ToPtr(util.DefaultString(agentInfoMessage, "Device is updating to the latest device spec."))
-		return device.Status.Updated.Status != lastUpdateStatus
+		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
 	}
 	if !device.IsManaged() && !device.IsUpdatedToDeviceSpec() {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
@@ -228,7 +229,7 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		}
 
 		device.Status.Updated.Info = lo.ToPtr(errorMessage)
-		return device.Status.Updated.Status != lastUpdateStatus
+		return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
 	}
 	if device.IsManaged() {
 		_, fleetName, err := util.GetResourceOwner(device.Metadata.Owner)
@@ -249,13 +250,16 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 
 			var errorMessage string
 			baseMessage := "Device could not be updated to the fleet's latest device spec"
-			if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
-				if updateCondition.Reason == string(domain.UpdateStateError) {
-					errorMessage = fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
-				}
-			} else if device.Metadata.Annotations != nil {
+			if device.Metadata.Annotations != nil {
 				if lastRolloutError, ok := (*device.Metadata.Annotations)[domain.DeviceAnnotationLastRolloutError]; ok && lastRolloutError != "" {
 					errorMessage = fmt.Sprintf("%s: %s", baseMessage, lastRolloutError)
+				}
+			}
+			if errorMessage == "" {
+				if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
+					if updateCondition.Reason == string(domain.UpdateStateError) {
+						errorMessage = fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
+					}
 				}
 			}
 			if errorMessage == "" {
@@ -276,7 +280,7 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device OS image mismatch: running %q, expected %q.", device.Status.Os.Image, device.Spec.Os.Image))
 	}
 
-	return device.Status.Updated.Status != lastUpdateStatus
+	return device.Status.Updated.Status != lastUpdateStatus || lo.FromPtr(device.Status.Updated.Info) != lastUpdateInfo
 }
 
 func updateServerSideApplicationStatus(device *domain.Device) bool {

--- a/internal/service/common/device_test.go
+++ b/internal/service/common/device_test.go
@@ -6,11 +6,21 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+type stubFleetStore struct {
+	fleetstore.Store
+	fleet *domain.Fleet
+}
+
+func (s *stubFleetStore) Get(_ context.Context, _ uuid.UUID, _ string, _ ...fleetstore.GetOption) (*domain.Fleet, error) {
+	return s.fleet, nil
+}
 
 func TestComputeDeviceStatusChanges_DeviceUpdateFailed(t *testing.T) {
 	ctx := context.Background()
@@ -466,6 +476,102 @@ func TestUpdateServerSideDeviceUpdatedStatus_OsImageMismatch(t *testing.T) {
 			if tt.expectMismatch {
 				assert.Contains(t, *device.Status.Updated.Info, "OS image mismatch")
 			}
+		})
+	}
+}
+
+func TestUpdateServerSideDeviceUpdatedStatus_ManagedDeviceErrorPriority(t *testing.T) {
+	ctx := context.Background()
+	orgId := uuid.New()
+	log := logrus.NewEntry(logrus.StandardLogger())
+
+	fleetName := "test-fleet"
+	fleetTV := "v2"
+	fleet := &domain.Fleet{
+		Metadata: domain.ObjectMeta{
+			Name:        &fleetName,
+			Annotations: &map[string]string{domain.FleetAnnotationTemplateVersion: fleetTV},
+		},
+	}
+	fs := &stubFleetStore{fleet: fleet}
+	owner := "Fleet/test-fleet"
+
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		conditions      []domain.Condition
+		expectedContain string
+	}{
+		{
+			name: "When only lastRolloutError is present it should show the rollout error",
+			annotations: map[string]string{
+				domain.DeviceAnnotationTemplateVersion: "v1",
+				domain.DeviceAnnotationLastRolloutError: "failed replacing parameters in env var DNS_SERVER_DOMAIN",
+			},
+			conditions:      nil,
+			expectedContain: "failed replacing parameters in env var DNS_SERVER_DOMAIN",
+		},
+		{
+			name: "When both lastRolloutError and DeviceUpdating error exist it should prefer rollout error",
+			annotations: map[string]string{
+				domain.DeviceAnnotationTemplateVersion: "v1",
+				domain.DeviceAnnotationLastRolloutError: "template rendering failure",
+			},
+			conditions: []domain.Condition{
+				{
+					Type:    domain.ConditionTypeDeviceUpdating,
+					Status:  domain.ConditionStatusFalse,
+					Reason:  string(domain.UpdateStateError),
+					Message: "old agent update error",
+				},
+			},
+			expectedContain: "template rendering failure",
+		},
+		{
+			name: "When only DeviceUpdating error is present it should show the agent error",
+			annotations: map[string]string{
+				domain.DeviceAnnotationTemplateVersion: "v1",
+			},
+			conditions: []domain.Condition{
+				{
+					Type:    domain.ConditionTypeDeviceUpdating,
+					Status:  domain.ConditionStatusFalse,
+					Reason:  string(domain.UpdateStateError),
+					Message: "agent update failed",
+				},
+			},
+			expectedContain: "agent update failed",
+		},
+		{
+			name: "When neither error source is present it should show generic out-of-sync message",
+			annotations: map[string]string{
+				domain.DeviceAnnotationTemplateVersion: "v1",
+			},
+			conditions:      nil,
+			expectedContain: domain.DeviceOutOfSyncWithFleetText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			device := &domain.Device{
+				Metadata: domain.ObjectMeta{
+					Name:        lo.ToPtr("test-device"),
+					Owner:       &owner,
+					Annotations: &tt.annotations,
+				},
+				Spec: &domain.DeviceSpec{},
+				Status: &domain.DeviceStatus{
+					LastSeen:   lo.ToPtr(time.Now()),
+					Updated:    domain.DeviceUpdatedStatus{Status: domain.DeviceUpdatedStatusOutOfDate},
+					Conditions: tt.conditions,
+				},
+			}
+
+			updateServerSideDeviceUpdatedStatus(device, ctx, fs, log, orgId)
+
+			assert.Equal(t, domain.DeviceUpdatedStatusOutOfDate, device.Status.Updated.Status)
+			assert.Contains(t, *device.Status.Updated.Info, tt.expectedContain)
 		})
 	}
 }

--- a/internal/service/common/device_test.go
+++ b/internal/service/common/device_test.go
@@ -568,8 +568,9 @@ func TestUpdateServerSideDeviceUpdatedStatus_ManagedDeviceErrorPriority(t *testi
 				},
 			}
 
-			updateServerSideDeviceUpdatedStatus(device, ctx, fs, log, orgId)
+			changed := updateServerSideDeviceUpdatedStatus(device, ctx, fs, log, orgId)
 
+			assert.False(t, changed, "status enum did not change so changed must be false")
 			assert.Equal(t, domain.DeviceUpdatedStatusOutOfDate, device.Status.Updated.Status)
 			assert.Contains(t, *device.Status.Updated.Info, tt.expectedContain)
 		})

--- a/internal/service/common/device_test.go
+++ b/internal/service/common/device_test.go
@@ -505,7 +505,7 @@ func TestUpdateServerSideDeviceUpdatedStatus_ManagedDeviceErrorPriority(t *testi
 		{
 			name: "When only lastRolloutError is present it should show the rollout error",
 			annotations: map[string]string{
-				domain.DeviceAnnotationTemplateVersion: "v1",
+				domain.DeviceAnnotationTemplateVersion:  "v1",
 				domain.DeviceAnnotationLastRolloutError: "failed replacing parameters in env var DNS_SERVER_DOMAIN",
 			},
 			conditions:      nil,
@@ -514,7 +514,7 @@ func TestUpdateServerSideDeviceUpdatedStatus_ManagedDeviceErrorPriority(t *testi
 		{
 			name: "When both lastRolloutError and DeviceUpdating error exist it should prefer rollout error",
 			annotations: map[string]string{
-				domain.DeviceAnnotationTemplateVersion: "v1",
+				domain.DeviceAnnotationTemplateVersion:  "v1",
 				domain.DeviceAnnotationLastRolloutError: "template rendering failure",
 			},
 			conditions: []domain.Condition{

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -487,6 +487,20 @@ func (h *DeviceServiceHandler) UpdateServerSideDeviceStatus(ctx context.Context,
 	return nil
 }
 
+func (h *DeviceServiceHandler) ForceUpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) error {
+	device, err := h.deviceStore.GetWithTimestamp(ctx, orgId, name)
+	if err != nil {
+		return err
+	}
+	common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log)
+	_, err = h.deviceStore.UpdateStatus(ctx, orgId, device, h.callbackDeviceUpdated)
+	if err != nil {
+		h.log.WithError(err).Errorf("failed to update status for device %s/%s", orgId, name)
+		return err
+	}
+	return nil
+}
+
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
 	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, name, decom, h.callbackDeviceDecommission)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)

--- a/internal/service/device/mock.go
+++ b/internal/service/device/mock.go
@@ -118,6 +118,20 @@ func (mr *MockServiceMockRecorder) DeleteDevice(ctx, orgId, name any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDevice", reflect.TypeOf((*MockService)(nil).DeleteDevice), ctx, orgId, name)
 }
 
+// ForceUpdateServerSideDeviceStatus mocks base method.
+func (m *MockService) ForceUpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceUpdateServerSideDeviceStatus", ctx, orgId, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceUpdateServerSideDeviceStatus indicates an expected call of ForceUpdateServerSideDeviceStatus.
+func (mr *MockServiceMockRecorder) ForceUpdateServerSideDeviceStatus(ctx, orgId, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceUpdateServerSideDeviceStatus", reflect.TypeOf((*MockService)(nil).ForceUpdateServerSideDeviceStatus), ctx, orgId, name)
+}
+
 // GetDevice mocks base method.
 func (m *MockService) GetDevice(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()

--- a/internal/service/device/service.go
+++ b/internal/service/device/service.go
@@ -43,6 +43,7 @@ type Service interface {
 	UpdateServiceSideDeviceStatus(ctx context.Context, orgId uuid.UUID, device domain.Device) bool
 	SetOutOfDate(ctx context.Context, orgId uuid.UUID, owner string) error
 	UpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) error
+	ForceUpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) error
 	ListConnectivityChangedDevices(ctx context.Context, orgId uuid.UUID, params domain.ListDevicesParams, cutoffTime time.Time) (*domain.DeviceList, domain.Status)
 	ListLabels(ctx context.Context, orgId uuid.UUID, params domain.ListLabelsParams) (*domain.LabelList, domain.Status)
 }

--- a/internal/service/device/traced.gen.go
+++ b/internal/service/device/traced.gen.go
@@ -87,6 +87,18 @@ func (_d *TracedDeviceService) DeleteDevice(ctx context.Context, orgId uuid.UUID
 	return s1
 }
 
+func (_d *TracedDeviceService) ForceUpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) (err error) {
+	ctx, span := startSpan(ctx, "ForceUpdateServerSideDeviceStatus")
+
+	err = _d.inner.ForceUpdateServerSideDeviceStatus(ctx, orgId, name)
+	st := domain.StatusOK()
+	if err != nil {
+		st = domain.StatusInternalServerError(err.Error())
+	}
+	endSpan(span, st)
+	return err
+}
+
 func (_d *TracedDeviceService) GetDevice(ctx context.Context, orgId uuid.UUID, name string) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "GetDevice")
 

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -333,7 +333,7 @@ func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, dev
 		if status.Code != http.StatusOK {
 			errs = append(errs, common.ApiStatusToErr(status))
 		}
-		if err := f.deviceSvc.UpdateServerSideDeviceStatus(ctx, f.orgId, *device.Metadata.Name); err != nil {
+		if err := f.deviceSvc.ForceUpdateServerSideDeviceStatus(ctx, f.orgId, *device.Metadata.Name); err != nil {
 			f.log.Errorf("failed to update server-side status for device %s/%s after rollout error: %v", f.orgId, *device.Metadata.Name, err)
 		}
 		return nil, fmt.Errorf("failed generating device spec for %s/%s: %w", f.orgId, *device.Metadata.Name, errors.Join(errs...))

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -333,6 +333,9 @@ func (f FleetRolloutsLogic) updateDeviceToFleetTemplate(ctx context.Context, dev
 		if status.Code != http.StatusOK {
 			errs = append(errs, common.ApiStatusToErr(status))
 		}
+		if err := f.deviceSvc.UpdateServerSideDeviceStatus(ctx, f.orgId, *device.Metadata.Name); err != nil {
+			f.log.Errorf("failed to update server-side status for device %s/%s after rollout error: %v", f.orgId, *device.Metadata.Name, err)
+		}
 		return nil, fmt.Errorf("failed generating device spec for %s/%s: %w", f.orgId, *device.Metadata.Name, errors.Join(errs...))
 	}
 

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -444,8 +444,8 @@ func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_TemplateRenderingFailure
 			return domain.Status{Code: http.StatusOK}
 		})
 
-		// Expect UpdateServerSideDeviceStatus to be called to recompute device status
-		mockDeviceSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+		// Expect ForceUpdateServerSideDeviceStatus to be called to recompute and persist device status
+		mockDeviceSvc.EXPECT().ForceUpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
 
 		_, err := logic.updateDeviceToFleetTemplate(context.Background(), device, tv, false)
 		require.Error(t, err)

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -404,6 +404,55 @@ func createTestDeviceWithLabels(name string, owner string, labels map[string]str
 	}
 }
 
+func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_TemplateRenderingFailure(t *testing.T) {
+	t.Run("When template rendering fails it should set lastRolloutError and recompute device status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		orgId := uuid.New()
+		log := logrus.New()
+		fleetName := "test-fleet"
+		event := domain.Event{
+			InvolvedObject: domain.ObjectReference{Kind: domain.FleetKind, Name: fleetName},
+		}
+		mockDeviceSvc := deviceservice.NewMockService(ctrl)
+		logic := NewFleetRolloutsLogic(log, nil, nil, mockDeviceSvc, nil, orgId, event)
+		logic.owner = lo.FromPtr(util.SetResourceOwner(domain.FleetKind, fleetName))
+
+		deviceName := "test-device"
+		ownerStr := logic.owner
+		device := &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:  &deviceName,
+				Owner: &ownerStr,
+			},
+			Spec:   &domain.DeviceSpec{},
+			Status: &domain.DeviceStatus{},
+		}
+
+		// Template references a label that doesn't exist on the device
+		tv := createTestTemplateVersion("v1")
+		tv.Status.Os = &domain.DeviceOsSpec{Image: "{{ .metadata.labels.domainname }}"}
+
+		// Expect the lastRolloutError annotation to be written
+		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(
+			gomock.Any(), orgId, deviceName,
+			gomock.AssignableToTypeOf(map[string]string{}),
+			gomock.Nil(),
+		).DoAndReturn(func(_ context.Context, _ uuid.UUID, _ string, annotations map[string]string, _ []string) domain.Status {
+			assert.Contains(t, annotations[domain.DeviceAnnotationLastRolloutError], "cannot apply parameters")
+			return domain.Status{Code: http.StatusOK}
+		})
+
+		// Expect UpdateServerSideDeviceStatus to be called to recompute device status
+		mockDeviceSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+		_, err := logic.updateDeviceToFleetTemplate(context.Background(), device, tv, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed generating device spec")
+	})
+}
+
 func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_SkipCondition(t *testing.T) {
 	const tvName = "v1"
 	const image = "test-image:latest"


### PR DESCRIPTION
## Problem

When a fleet template references a device label that doesn't exist (e.g. `{{ .metadata.labels.domainname }}`), the template rendering error is stored in the `fleet-controller/lastRolloutError` annotation but `status.updated.info` shows a generic "Device has not yet been scheduled for update to the fleet's latest spec." message instead of the actual error.

## Root Cause

Three issues combined to hide the error:

1. **Missing status recomputation:** After writing the `lastRolloutError` annotation in `fleet_rollout.go`, `UpdateServerSideDeviceStatus` was never called, so `status.updated.info` was not recomputed.

2. **Wrong error priority:** In `updateServerSideDeviceUpdatedStatus`, the `DeviceUpdating` condition (agent-side) was checked first via an `else if` chain, shadowing the `lastRolloutError` annotation (server-side). Any existing `DeviceUpdating` condition — even a stale or non-error one — prevented the rollout error from being shown.

3. **Info-only changes not detected:** `updateServerSideDeviceUpdatedStatus` only checked whether `status.updated.status` changed (e.g. `UpToDate` → `OutOfDate`). When the status stayed `OutOfDate` but the info message changed from generic to specific, the function returned `false` and the update was never persisted.

## Fix

- **`fleet_rollout.go`:** Call `UpdateServerSideDeviceStatus` after writing the `lastRolloutError` annotation so the error is immediately visible in device status.
- **`device.go`:** Check `lastRolloutError` annotation before the `DeviceUpdating` condition so server-side rollout errors take priority over stale agent-side errors.
- **`device.go`:** Track `lastUpdateInfo` alongside `lastUpdateStatus` and include info changes in all return value comparisons so info-only updates are persisted.

## Testing

- **`fleet_rollout_test.go`:** Added `TestFleetRolloutsLogic_updateDeviceToFleetTemplate_TemplateRenderingFailure` — verifies the annotation is written and `UpdateServerSideDeviceStatus` is called after a template rendering failure.
- **`device_test.go`:** Added `TestUpdateServerSideDeviceUpdatedStatus_ManagedDeviceErrorPriority` — verifies error priority with 4 cases: rollout error only, both errors (rollout wins), agent error only, neither (generic fallback).
- Locally verified with `make deploy-quadlets` using a fleet with `{{ .metadata.labels.domainname }}` and a device missing the label. Confirmed `status.updated.info` now shows the actual template rendering error.

## Confidence

High — the fix is minimal and well-scoped. All three changes are in the server-side status computation path and do not affect agent behavior.

## Risk Assessment

Low — changes only affect the display of error messages in `status.updated.info` for devices with rollout failures. No changes to rollout logic, device specs, or agent communication.