### PR TITLE
NO-ISSUE: Fix flaky TestVMVNCSession initial-CR test

### DIFF
--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -667,8 +667,17 @@ func TestVMVNCSession(t *testing.T) {
 		}
 		readDone := make(chan readResult, 1)
 		go func() {
+			// require/t.FailNow must only be called from the test's main goroutine, so
+			// errors here are reported via readDone instead of require calls.
 			buf := make([]byte, 1)
-			require.NoError(serverConn.SetDeadline(time.Now().Add(100 * time.Millisecond)))
+			if err := serverConn.SetDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+				// Run()'s teardown may have already closed the other end of the pipe
+				// (clientConn), which net.Pipe surfaces here too. That race is fine: it
+				// still proves zero bytes were written before teardown.
+				readDone <- readResult{n: 0, err: err}
+				serverConn.Close()
+				return
+			}
 			n, err := serverConn.Read(buf)
 			readDone <- readResult{n: n, err: err}
 			serverConn.Close()


### PR DESCRIPTION
## Summary
- `TestVMVNCSession/When_a_VNC_session_starts_it_should_not_send_an_initial_CR` intermittently failed in CI with `io: read/write on closed pipe` followed by `timed out waiting for serverConn.Read to complete`.
- Root cause: a background goroutine called `require.NoError(serverConn.SetDeadline(...))`. `Run()`'s teardown (via `bridgeConn`) closes the other end of the `net.Pipe()` almost immediately once the mocked `Recv()` returns `io.EOF`, and `net.Pipe.SetDeadline` returns `io.ErrClosedPipe` if *either* end is closed. When that race won, `SetDeadline` failed and `require.NoError` invoked `t.FailNow()` from a non-test goroutine — invalid per Go's testing docs — which silently exited the goroutine without sending to the result channel, causing the main goroutine's `select` to time out.
- Fix: route the `SetDeadline` error through the existing `readDone` channel instead of asserting in the goroutine, consistent with the test's own documented reasoning that a closed pipe there still proves no bytes were written.

## Test plan
- [x] Reverted the fix and reproduced the exact CI failure locally (~1000 runs without `-race`).
- [x] Re-applied the fix and ran the test 500x with `-race -v`: all pass.
- [x] Ran the full `internal/agent/device/applications/console` package 20x with `-race`: all pass.
- [x] `go vet` and `gofmt` clean on the changed file.

Made with [Cursor](https://cursor.com)