### PR TITLE
EDM-4755: Detect OS mode and report status.capabilities.osMode

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	stdexec "os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -168,6 +169,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	// create os client
 	osClient := os.NewClient(a.log, exec)
 
+	osMode := os.DetectMode(stdexec.LookPath)
+	a.log.Infof("OS mode detected: %s", osMode)
+
 	// create podman client
 	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory)
 	rootPodmanClient, err := podmanClientFactory("")
@@ -255,6 +259,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		policyManager,
 		rootReadWriter,
 		osClient,
+		osMode,
 		pollBackoff,
 		deviceNotFoundHandler,
 		auditLogger,
@@ -294,7 +299,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	shutdownManager.Register("applications", applicationsManager.Shutdown)
 
 	// create os manager
-	osManager := os.NewManager(a.log, osClient, rootReadWriter, rootPodmanClient, pullConfigResolver)
+	osManager := os.NewManager(a.log, osClient, osMode, rootReadWriter, rootPodmanClient, pullConfigResolver)
 
 	// create prefetch manager
 	prefetchManager := dependency.NewPrefetchManager(

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -537,6 +537,7 @@ func TestRollbackDevice(t *testing.T) {
 				policyManager,
 				readWriter,
 				mockOSClient,
+				v1beta1.OsModeImage,
 				poll.NewConfig(time.Second, 1.5),
 				func() error { return nil },
 				mockAuditLogger,

--- a/internal/agent/device/os/client.go
+++ b/internal/agent/device/os/client.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"os/exec"
 
+	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent/client"
 	"github.com/flightctl/flightctl/internal/container"
 	"github.com/flightctl/flightctl/pkg/executer"
 	"github.com/flightctl/flightctl/pkg/log"
 )
+
+// DetectMode determines the OS management mode by checking for image
+// management binaries on PATH. If bootc or rpm-ostree is available, the
+// mode is "image"; otherwise it is "package".
+//
+// lookPath should be exec.LookPath in production. Accepting it as a
+// parameter enables deterministic unit testing without PATH manipulation.
+//
+// DetectMode and NewClient both check binary availability but via separate
+// mechanisms — DetectMode uses the caller-supplied lookPath while NewClient
+// uses isBinaryAvailable (os/exec.LookPath directly). Both run sequentially
+// at startup in agent.go, so PATH cannot change between the two calls.
+func DetectMode(lookPath func(string) (string, error)) v1beta1.OsModeType {
+	if _, err := lookPath("bootc"); err == nil {
+		return v1beta1.OsModeImage
+	}
+	if _, err := lookPath("rpm-ostree"); err == nil {
+		return v1beta1.OsModeImage
+	}
+	return v1beta1.OsModePackage
+}
 
 func NewClient(log *log.PrefixLogger, exec executer.Executer) Client {
 	switch {
@@ -105,16 +127,16 @@ func (d *dummy) Status(ctx context.Context) (*Status, error) {
 }
 
 func (d *dummy) Switch(ctx context.Context, image string) error {
-	d.log.Warnf("Ignoring switch to image %s from dummy client for unsupported OS", image)
+	d.log.Debugf("Ignoring switch to image %s from dummy client for unsupported OS", image)
 	return nil
 }
 
 func (d *dummy) Rollback(ctx context.Context) error {
-	d.log.Warnf("Ignoring rollback and reboot from dummy client for unsupported OS")
+	d.log.Debugf("Ignoring rollback and reboot from dummy client for unsupported OS")
 	return nil
 }
 
 func (d *dummy) Apply(ctx context.Context) error {
-	d.log.Warnf("Ignoring apply from dummy client for unsupported OS")
+	d.log.Debugf("Ignoring apply from dummy client for unsupported OS")
 	return nil
 }

--- a/internal/agent/device/os/client_test.go
+++ b/internal/agent/device/os/client_test.go
@@ -1,0 +1,68 @@
+package os
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectMode(t *testing.T) {
+	require := require.New(t)
+
+	testCases := []struct {
+		name     string
+		lookPath func(string) (string, error)
+		expected v1beta1.OsModeType
+	}{
+		{
+			name: "When bootc is available it should return image mode",
+			lookPath: func(name string) (string, error) {
+				if name == "bootc" {
+					return "/usr/bin/bootc", nil
+				}
+				return "", fmt.Errorf("not found: %s", name)
+			},
+			expected: v1beta1.OsModeImage,
+		},
+		{
+			name: "When rpm-ostree is available without bootc it should return image mode",
+			lookPath: func(name string) (string, error) {
+				if name == "rpm-ostree" {
+					return "/usr/bin/rpm-ostree", nil
+				}
+				return "", fmt.Errorf("not found: %s", name)
+			},
+			expected: v1beta1.OsModeImage,
+		},
+		{
+			name: "When both bootc and rpm-ostree are available it should return image mode",
+			lookPath: func(name string) (string, error) {
+				switch name {
+				case "bootc":
+					return "/usr/bin/bootc", nil
+				case "rpm-ostree":
+					return "/usr/bin/rpm-ostree", nil
+				default:
+					return "", fmt.Errorf("not found: %s", name)
+				}
+			},
+			expected: v1beta1.OsModeImage,
+		},
+		{
+			name: "When neither bootc nor rpm-ostree is available it should return package mode",
+			lookPath: func(name string) (string, error) {
+				return "", fmt.Errorf("not found: %s", name)
+			},
+			expected: v1beta1.OsModePackage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode := DetectMode(tc.lookPath)
+			require.Equal(tc.expected, mode)
+		})
+	}
+}

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -40,16 +40,18 @@ type Manager interface {
 	status.Exporter
 }
 
-// NewManager creates a new OS manager
+// NewManager creates a new OS manager.
 func NewManager(
 	log *log.PrefixLogger,
 	client Client,
+	osMode v1beta1.OsModeType,
 	readWriter fileio.ReadWriter,
 	podmanClient *client.Podman,
 	pullConfigResolver dependency.PullConfigResolver,
 ) Manager {
 	return &manager{
 		client:             client,
+		osMode:             osMode,
 		podmanClient:       podmanClient,
 		readWriter:         readWriter,
 		pullConfigResolver: pullConfigResolver,
@@ -59,6 +61,7 @@ func NewManager(
 
 type manager struct {
 	client             Client
+	osMode             v1beta1.OsModeType
 	podmanClient       *client.Podman
 	readWriter         fileio.ReadWriter
 	pullConfigResolver dependency.PullConfigResolver
@@ -73,6 +76,7 @@ func (m *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, _ ..
 
 	status.Os.Image = bootcInfo.GetBootedImage()
 	status.Os.ImageDigest = bootcInfo.GetBootedImageDigest()
+	status.Capabilities = &v1beta1.DeviceCapabilities{OsMode: &m.osMode}
 	return nil
 }
 

--- a/internal/agent/device/os/os.go
+++ b/internal/agent/device/os/os.go
@@ -76,7 +76,8 @@ func (m *manager) Status(ctx context.Context, status *v1beta1.DeviceStatus, _ ..
 
 	status.Os.Image = bootcInfo.GetBootedImage()
 	status.Os.ImageDigest = bootcInfo.GetBootedImageDigest()
-	status.Capabilities = &v1beta1.DeviceCapabilities{OsMode: &m.osMode}
+	osMode := m.osMode
+	status.Capabilities = &v1beta1.DeviceCapabilities{OsMode: &osMode}
 	return nil
 }
 

--- a/internal/agent/device/os/os_test.go
+++ b/internal/agent/device/os/os_test.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -69,4 +70,24 @@ func TestManagerStatus(t *testing.T) {
 			require.Equal(tc.osMode, *status.Capabilities.OsMode)
 		})
 	}
+}
+
+func TestManagerStatusWhenClientFails(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := NewMockClient(ctrl)
+	clientErr := errors.New("status unavailable")
+	mockClient.EXPECT().Status(gomock.Any()).Return(nil, clientErr)
+
+	m := &manager{
+		client: mockClient,
+		osMode: v1beta1.OsModePackage,
+	}
+
+	status := &v1beta1.DeviceStatus{}
+	err := m.Status(context.Background(), status)
+	require.ErrorIs(err, clientErr)
+	require.Nil(status.Capabilities)
 }

--- a/internal/agent/device/os/os_test.go
+++ b/internal/agent/device/os/os_test.go
@@ -1,0 +1,72 @@
+package os
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/container"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestManagerStatus(t *testing.T) {
+	require := require.New(t)
+
+	testCases := []struct {
+		name              string
+		osMode            v1beta1.OsModeType
+		bootedImage       string
+		bootedImageDigest string
+		expectedImage     string
+		expectedDigest    string
+	}{
+		{
+			name:              "When image mode it should populate os fields and capabilities",
+			osMode:            v1beta1.OsModeImage,
+			bootedImage:       "quay.io/centos-bootc/centos-bootc:stream9",
+			bootedImageDigest: "sha256:a0b1c2d3",
+			expectedImage:     "quay.io/centos-bootc/centos-bootc:stream9",
+			expectedDigest:    "sha256:a0b1c2d3",
+		},
+		{
+			name:              "When package mode it should report empty os fields and package capabilities",
+			osMode:            v1beta1.OsModePackage,
+			bootedImage:       "",
+			bootedImageDigest: "",
+			expectedImage:     "",
+			expectedDigest:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := NewMockClient(ctrl)
+
+			bootcHost := container.BootcHost{}
+			bootcHost.Status.Booted.Image.Image.Image = tc.bootedImage
+			bootcHost.Status.Booted.Image.ImageDigest = tc.bootedImageDigest
+
+			mockClient.EXPECT().Status(gomock.Any()).Return(&Status{BootcHost: bootcHost}, nil)
+
+			m := &manager{
+				client: mockClient,
+				osMode: tc.osMode,
+			}
+
+			ctx := context.Background()
+			status := &v1beta1.DeviceStatus{}
+
+			err := m.Status(ctx, status)
+			require.NoError(err)
+			require.Equal(tc.expectedImage, status.Os.Image)
+			require.Equal(tc.expectedDigest, status.Os.ImageDigest)
+			require.NotNil(status.Capabilities)
+			require.NotNil(status.Capabilities.OsMode)
+			require.Equal(tc.osMode, *status.Capabilities.OsMode)
+		})
+	}
+}

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -40,6 +40,7 @@ type manager struct {
 	deviceName       string
 	deviceReadWriter fileio.ReadWriter
 	osClient         os.Client
+	osMode           v1beta1.OsModeType
 	publisher        Publisher
 	watcher          Watcher
 	cache            *cache
@@ -61,6 +62,7 @@ func NewManager(
 	policyManager policy.Manager,
 	deviceReadWriter fileio.ReadWriter,
 	osClient os.Client,
+	osMode v1beta1.OsModeType,
 	pollConfig poll.Config,
 	deviceNotFoundHandler func() error,
 	auditLogger audit.Logger,
@@ -83,6 +85,7 @@ func NewManager(
 		deviceName:       deviceName,
 		deviceReadWriter: deviceReadWriter,
 		osClient:         osClient,
+		osMode:           osMode,
 		cache:            cache,
 		policyManager:    policyManager,
 		auditLogger:      auditLogger,

--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -109,7 +109,6 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
-        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -215,7 +214,6 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
-        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -317,7 +315,6 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
-        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -419,7 +416,6 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
-        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",

--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -109,6 +109,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -214,6 +215,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -315,6 +317,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -416,6 +419,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",


### PR DESCRIPTION
## EDM-4755: Detect OS mode and report status.capabilities.osMode

**Jira:** https://redhat.atlassian.net/browse/EDM-4755
**Story type:** [DEV]
**Epic:** EDM-4747 — Package-Mode Agent Runtime

### Summary

Adds agent-side OS mode detection at startup (`DetectMode`) and reports it via `status.capabilities.osMode` on every status export. Mode is resolved once from the bootc → rpm-ostree → package fallback, logged at info level, and wired into the OS manager and spec manager constructors. The OS `Client` interface is unchanged.

### Changes

- **`internal/agent/device/os/client.go`:** Add `DetectMode(lookPath)`; downgrade dummy client Switch/Rollback/Apply logs from warn to debug
- **`internal/agent/device/os/os.go`:** Accept `osMode` in `NewManager`; populate `status.Capabilities.OsMode` in `Status()`
- **`internal/agent/device/spec/manager.go`:** Accept and store `osMode` (forward wiring for EDM-4759)
- **`internal/agent/agent.go`:** Call `DetectMode` once at startup, log mode, pass to both managers
- **Tests:** New unit tests for `DetectMode` and OS manager `Status` (image/package/error paths)

### Testing

- **Unit tests:** `DetectMode` (4 PATH fallback cases); OS manager `Status` (image, package, client error)
- **Integration tests:** N/A for this story (no new component interactions)
- **Coverage:** `DetectMode` 100%; OS manager `Status` 100%

### Acceptance Criteria

- [x] AC-1: `DetectMode()` returns `"image"` or `"package"` via bootc → rpm-ostree → package fallback
- [x] AC-2: Mode resolved once at agent startup and passed to spec manager and OS manager constructors
- [x] AC-3: OS manager `Status()` populates `status.capabilities.osMode`; package-mode reports empty `status.os.image` / `imageDigest`
- [x] AC-4: Info-level log at startup: `"OS mode detected: image"` or `"OS mode detected: package"`
- [x] AC-5: OS `Client` interface unchanged — no mode accessor on client
