### PR TITLE
EDM-4180: Fix AAP role-assignment lookups to use ansible_id (Controller API)

### DIFF
--- a/internal/auth/authn/aapgateway.go
+++ b/internal/auth/authn/aapgateway.go
@@ -28,6 +28,7 @@ type AAPIdentity struct {
 	common.BaseIdentity
 	superUser       bool
 	platformAuditor bool
+	ansibleID       string
 }
 
 // Ensure AAPIdentity implements AAPGatewayUserIdentity
@@ -131,6 +132,7 @@ func (a *AapGatewayAuth) loadUserInfo(ctx context.Context, token string) (*AAPId
 		BaseIdentity:    *common.NewBaseIdentityWithIssuer(aapUserInfo.Username, strconv.Itoa(aapUserInfo.ID), []common.ReportedOrganization{}, identity.NewIssuer(identity.AuthTypeAAP, a.spec.ApiUrl)),
 		superUser:       aapUserInfo.IsSuperuser,
 		platformAuditor: aapUserInfo.IsPlatformAuditor,
+		ansibleID:       aapUserInfo.SummaryFields.Resource.AnsibleID,
 	}
 
 	return userInfo, nil
@@ -205,7 +207,7 @@ func (a *AapGatewayAuth) GetIdentity(ctx context.Context, token string) (common.
 		orgRoles["*"] = globalRoles
 	}
 
-	roleAssignments, err := a.getUserRoleAssignments(ctx, token, userInfo.GetUID())
+	roleAssignments, err := a.getUserRoleAssignments(ctx, token, userInfo.ansibleID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role assignments: %w", err)
 	}
@@ -310,8 +312,8 @@ func (a *AapGatewayAuth) getUserScopedOrganizations(ctx context.Context, token s
 }
 
 // getUserRoleAssignments gets role assignments for a specific user from AAP
-func (a *AapGatewayAuth) getUserRoleAssignments(ctx context.Context, token string, userID string) ([]*aap.AAPRoleUserAssignment, error) {
-	roleAssignments, err := a.aapClient.ListUserRoleAssignments(ctx, token, userID)
+func (a *AapGatewayAuth) getUserRoleAssignments(ctx context.Context, token string, ansibleID string) ([]*aap.AAPRoleUserAssignment, error) {
+	roleAssignments, err := a.aapClient.ListUserRoleAssignments(ctx, token, ansibleID)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +351,10 @@ func (a *AapGatewayAuth) mapRoleAssignmentsToOrgRoles(roleAssignments []*aap.AAP
 	return orgRoles
 }
 
-// getTeamRoleAssignments fetches role assignments for all teams the user belongs to
+// getTeamRoleAssignments fetches role assignments for all teams the user belongs to.
+// ListUserTeams is a Gateway-to-Gateway lookup so the Gateway numeric userID is safe to use there,
+// but each team's role assignments are then looked up via the Controller API by ansible_id (see
+// ListTeamRoleAssignments), since a team's Gateway and Controller numeric IDs are not guaranteed to match.
 func (a *AapGatewayAuth) getTeamRoleAssignments(ctx context.Context, token string, userID string) ([]*aap.AAPRoleTeamAssignment, error) {
 	teams, err := a.aapClient.ListUserTeams(ctx, token, userID)
 	if err != nil {
@@ -358,7 +363,7 @@ func (a *AapGatewayAuth) getTeamRoleAssignments(ctx context.Context, token strin
 
 	var allAssignments []*aap.AAPRoleTeamAssignment
 	for _, team := range teams {
-		assignments, err := a.aapClient.ListTeamRoleAssignments(ctx, token, strconv.Itoa(team.ID))
+		assignments, err := a.aapClient.ListTeamRoleAssignments(ctx, token, team.SummaryFields.Resource.AnsibleID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/aap/roles.go
+++ b/pkg/aap/roles.go
@@ -71,11 +71,15 @@ type AAPRoleTeamAssignment struct {
 	Team           int                                `json:"team"`
 }
 
-// GET /api/controller/v2/role_user_assignments/?user__id={user_id}
-func (a *AAPGatewayClient) ListUserRoleAssignments(ctx context.Context, token string, userID string) ([]*AAPRoleUserAssignment, error) {
-	// Build query parameters using url.Values
+// GET /api/controller/v2/role_user_assignments/?user__resource__ansible_id={ansible_id}
+//
+// Filters by ansible_id rather than the Gateway numeric user ID: a user's numeric ID is not
+// guaranteed to be the same between the Gateway and Controller components, but ansible_id is.
+// Custom role definitions (e.g. flightctl-org-admin) are only visible through the Controller
+// API today, not the Gateway's role_user_assignments endpoint.
+func (a *AAPGatewayClient) ListUserRoleAssignments(ctx context.Context, token string, ansibleID string) ([]*AAPRoleUserAssignment, error) {
 	query := url.Values{}
-	query.Set("user__id", userID)
+	query.Set("user__resource__ansible_id", ansibleID)
 	if a.maxPageSize != nil {
 		query.Set("page_size", strconv.Itoa(*a.maxPageSize))
 	}
@@ -84,10 +88,12 @@ func (a *AAPGatewayClient) ListUserRoleAssignments(ctx context.Context, token st
 	return getWithPagination[AAPRoleUserAssignment](a, ctx, endpoint, token)
 }
 
-// GET /api/controller/v2/role_team_assignments/?team__id={team_id}
-func (a *AAPGatewayClient) ListTeamRoleAssignments(ctx context.Context, token string, teamID string) ([]*AAPRoleTeamAssignment, error) {
+// GET /api/controller/v2/role_team_assignments/?team__resource__ansible_id={ansible_id}
+//
+// See ListUserRoleAssignments for why this filters by ansible_id and uses the Controller API.
+func (a *AAPGatewayClient) ListTeamRoleAssignments(ctx context.Context, token string, ansibleID string) ([]*AAPRoleTeamAssignment, error) {
 	query := url.Values{}
-	query.Set("team__id", teamID)
+	query.Set("team__resource__ansible_id", ansibleID)
 	if a.maxPageSize != nil {
 		query.Set("page_size", strconv.Itoa(*a.maxPageSize))
 	}

--- a/pkg/aap/teams.go
+++ b/pkg/aap/teams.go
@@ -7,7 +7,8 @@ import (
 )
 
 type AAPTeamSummaryFields struct {
-	Organization AAPOrganization `json:"organization"`
+	Organization AAPOrganization    `json:"organization"`
+	Resource     AAPResourceSummary `json:"resource"`
 }
 
 type AAPTeam struct {

--- a/pkg/aap/user.go
+++ b/pkg/aap/user.go
@@ -5,11 +5,23 @@ import (
 	"fmt"
 )
 
+// AAPResourceSummary is the "resource" summary field shared across AAP objects (users, teams, ...),
+// carrying the ansible_id that stays stable across AAP components (Gateway, Controller, ...).
+type AAPResourceSummary struct {
+	AnsibleID    string `json:"ansible_id"`
+	ResourceType string `json:"resource_type"`
+}
+
+type AAPUserSummaryFields struct {
+	Resource AAPResourceSummary `json:"resource"`
+}
+
 type AAPUser struct {
-	ID                int    `json:"id,omitempty"`
-	Username          string `json:"username,omitempty"`
-	IsSuperuser       bool   `json:"is_superuser,omitempty"`
-	IsPlatformAuditor bool   `json:"is_platform_auditor,omitempty"`
+	ID                int                  `json:"id,omitempty"`
+	Username          string               `json:"username,omitempty"`
+	IsSuperuser       bool                 `json:"is_superuser,omitempty"`
+	IsPlatformAuditor bool                 `json:"is_platform_auditor,omitempty"`
+	SummaryFields     AAPUserSummaryFields `json:"summary_fields,omitempty"`
 }
 
 type AAPUsersResponse = AAPPaginatedResponse[AAPUser]


### PR DESCRIPTION
## Summary
- **Update:** the first commit in this PR switched role-assignment lookups from the Controller API to the Gateway API per initial AAP team guidance. Live testing against a real AAP 2.5 environment showed this breaks custom-role-based RBAC entirely: custom role definitions (e.g. `flightctl-org-admin`) only exist in the Controller's role registry and are invisible through the Gateway's `role_user_assignments`/`role_team_assignments` endpoints (confirmed live: Gateway only returns AAP's 5 built-in managed roles; Gateway's `role_definitions` endpoint doesn't even support creating custom roles).
- The second commit reverts those two lookups back to the Controller API, and separately fixes a real (if latent) bug along the way: the code was assuming the Gateway numeric user/team ID is the same as the Controller's numeric ID for the same resource. That's not guaranteed. Lookups now filter by `ansible_id` (`user__resource__ansible_id` / `team__resource__ansible_id`), which is meant to stay stable across AAP components.
- Confirmed live against a real AAP instance: filtering by `ansible_id` returns the same (correct) set of role assignments as the old numeric-ID filter, including the custom `flightctl-org-admin` assignment that the Gateway-only endpoint was silently dropping.

## Test plan
- [x] `go build ./pkg/aap/... ./internal/auth/...`
- [x] `go test ./pkg/aap/... ./internal/auth/...`
- [x] Verified live against a real AAP 2.5 instance: `GET /api/controller/v2/role_user_assignments/?user__resource__ansible_id=<id>` returns both the custom `flightctl-org-admin` assignment and the built-in `Organization Member` assignment for a test user, matching what the numeric-ID filter returned
- [ ] Team-role-assignment path (`team__resource__ansible_id`) implemented symmetrically but not live-tested — the test AAP environment has no teams configured