### PR TITLE
NO-ISSUE: Sync air-gap embed after flightctl-greenboot Requires agent

### DIFF
--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -109,6 +109,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -214,6 +215,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -315,6 +317,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",
@@ -416,6 +419,7 @@ var embeddedBuildManifest = []byte(`
       "rpms": [
         "bash",
         "container-selinux",
+        "flightctl-agent",
         "flightctl-selinux",
         "flightctl-services",
         "greenboot",


### PR DESCRIPTION

## Summary

- Regenerates `scripts/air-gap/mirror-images/embedded_data_generated.go` via `make generate-mirror-embed`
- Adds `flightctl-agent` to each variant's RPM list

## Why

`generate-embed` builds the air-gap RPM list from bare `Requires:` lines in `packaging/rpm/flightctl.spec`. After the `flightctl-greenboot` subpackage split, the spec includes `Requires: flightctl-agent`, but the embedded manifest was not regenerated. This syncs generated output with the current spec.

Spotted while working on EDM-4755; kept out of that PR as unrelated scope.

## Test plan

- [x] Confirmed diff is only the four `flightctl-agent` RPM entries
- [ ] CI passes


Made with [Cursor](https://cursor.com)