### PR TITLE
EDM-4688: Separate temporary and permanent spec rendering errors

### DIFF
--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -407,7 +407,7 @@ func (t *DeviceRenderLogic) renderConfigItem(ctx context.Context, configItem *do
 func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec, vmConverter VmConverterFn, kvStore kvstore.KVStore) (*string, *domain.ApplicationProviderSpec, error) {
 	appType, err := (*app).GetAppType()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get app type: %w", err)
+		return nil, nil, fmt.Errorf("%w: failed to get app type: %w", ErrUnknownApplicationType, err)
 	}
 
 	switch appType {
@@ -422,7 +422,7 @@ func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec,
 	case domain.AppTypeVm:
 		vmApp, parseErr := (*app).AsVmApplication()
 		if parseErr != nil {
-			return nil, nil, fmt.Errorf("failed to parse application spec for type %s: %w", appType, parseErr)
+			return nil, nil, fmt.Errorf("%w: failed to parse application spec for type %s: %w", ErrUnknownApplicationType, appType, parseErr)
 		}
 		appName := vmApp.Name
 		converted, renderErr := renderVmApplication(ctx, vmApp, vmConverter, kvStore)
@@ -434,11 +434,11 @@ func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec,
 		return nil, nil, fmt.Errorf("%w: unsupported application type: %q", ErrUnknownApplicationType, appType)
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse application spec for type %s: %w", appType, err)
+		return nil, nil, fmt.Errorf("%w: failed to parse application spec for type %s: %w", ErrUnknownApplicationType, appType, err)
 	}
 	appName, err := (*app).GetName()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get app name: %w", err)
+		return nil, nil, fmt.Errorf("%w: failed to get app name: %w", ErrUnknownApplicationType, err)
 	}
 	return appName, app, nil
 }

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -209,11 +209,17 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	}
 
 	if renderErr != nil {
+		if !isRetryableRenderError(renderErr) {
+			t.markPermanentRenderFailure(ctx, specHash)
+		}
 		return t.setStatus(ctx, renderErr)
 	}
 
 	renderedApplications, err := t.renderApplications(ctx)
 	if err != nil {
+		if !isRetryableRenderError(err) {
+			t.markPermanentRenderFailure(ctx, specHash)
+		}
 		return t.setStatus(ctx, err)
 	}
 
@@ -230,6 +236,20 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	// even though specHash is unchanged (see bypassHashCheck above).
 	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(renderedConfig), string(renderedApplications), specHash, syncRefs, bypassHashCheck)
 	return t.setStatus(ctx, common.ApiStatusToErr(status))
+}
+
+func (t *DeviceRenderLogic) markPermanentRenderFailure(ctx context.Context, specHash string) {
+	annotations := map[string]string{
+		domain.DeviceAnnotationRenderedSpecHash: specHash,
+	}
+	if t.templateVersion != nil {
+		annotations[domain.DeviceAnnotationRenderedTemplateVersion] = *t.templateVersion
+	}
+
+	status := t.deviceSvc.UpdateDeviceAnnotations(ctx, t.orgId, t.event.InvolvedObject.Name, annotations, nil)
+	if status.Code != http.StatusOK {
+		t.log.Errorf("Failed writing render-failure annotations for device %s/%s: %s", t.orgId, t.event.InvolvedObject.Name, status.Message)
+	}
 }
 
 func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -209,7 +209,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	}
 
 	if renderErr != nil {
-		if !isRetryableRenderError(renderErr) {
+		if isPermanentRenderError(renderErr) {
 			t.markPermanentRenderFailure(ctx, specHash)
 		}
 		return t.setStatus(ctx, renderErr)
@@ -217,7 +217,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 
 	renderedApplications, err := t.renderApplications(ctx)
 	if err != nil {
-		if !isRetryableRenderError(err) {
+		if isPermanentRenderError(err) {
 			t.markPermanentRenderFailure(ctx, specHash)
 		}
 		return t.setStatus(ctx, err)

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -878,7 +878,7 @@ func TestRenderDevice_ExternalError_FleetOwned_NoAnnotations(t *testing.T) {
 	assert.Contains(t, err.Error(), "kubernetes API is not available")
 }
 
-func TestRenderDevice_NonPermanentAppError(t *testing.T) {
+func TestRenderDevice_PermanentAppError(t *testing.T) {
 	const deviceName = "app-error-device"
 	orgId := uuid.New()
 	ctrl := gomock.NewController(t)
@@ -897,6 +897,16 @@ func TestRenderDevice_NonPermanentAppError(t *testing.T) {
 	mockSvc := deviceservice.NewMockService(ctrl)
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+
+	specHash := hashRenderedWithSpec(device.Spec)
+	mockSvc.EXPECT().UpdateDeviceAnnotations(
+		gomock.Any(), orgId, deviceName,
+		map[string]string{
+			domain.DeviceAnnotationRenderedSpecHash: specHash,
+		},
+		gomock.Nil(),
+	).Return(statusOK)
+
 	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
 	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
 
@@ -905,7 +915,7 @@ func TestRenderDevice_NonPermanentAppError(t *testing.T) {
 
 	err := logic.RenderDevice(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid application")
+	assert.ErrorIs(t, err, ErrUnknownApplicationType)
 }
 
 func makeK8sSecretConfigItem(configName, namespace, name, mountPath string) domain.ConfigProviderSpec {

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/google/uuid"
@@ -689,6 +691,183 @@ func TestRenderApplication_PreservesLifecycleFields(t *testing.T) {
 		assert.Equal(t, domain.ApplicationDesiredStateStopped, rendered.GetDesiredState())
 		assert.Equal(t, 2, rendered.GetRestartGeneration())
 	})
+}
+
+func TestRenderDevice_PermanentError(t *testing.T) {
+	const (
+		deviceName      = "test-device"
+		fleet           = "my-fleet"
+		templateVersion = "tv-1"
+	)
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	invalidConfig := []domain.ConfigProviderSpec{{}}
+	ownerStr := fmt.Sprintf("Fleet/%s", fleet)
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name:  lo.ToPtr(deviceName),
+			Owner: &ownerStr,
+			Annotations: &map[string]string{
+				domain.DeviceAnnotationTemplateVersion: templateVersion,
+			},
+		},
+		Spec: &domain.DeviceSpec{
+			Config: &invalidConfig,
+		},
+	}
+
+	mockSvc := deviceservice.NewMockService(ctrl)
+
+	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+
+	specHash := hashRenderedWithSpec(device.Spec)
+	mockSvc.EXPECT().UpdateDeviceAnnotations(
+		gomock.Any(), orgId, deviceName,
+		map[string]string{
+			domain.DeviceAnnotationRenderedSpecHash:        specHash,
+			domain.DeviceAnnotationRenderedTemplateVersion: templateVersion,
+		},
+		gomock.Nil(),
+	).Return(statusOK)
+
+	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ string, conditions []domain.Condition) domain.Status {
+			require.Len(t, conditions, 1)
+			assert.Equal(t, domain.ConditionStatusFalse, conditions[0].Status)
+			assert.Equal(t, "Invalid", conditions[0].Reason)
+			return statusOK
+		})
+	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonFleetRolloutDeviceSelected, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockSvc, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+
+	err := logic.RenderDevice(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownConfigName)
+}
+
+func TestRenderDevice_RetryableError(t *testing.T) {
+	const (
+		deviceName = "test-device"
+		namespace  = "default"
+		secretName = "my-secret"
+		mountPath  = "/etc/secret"
+	)
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sConfigItem := makeK8sSecretConfigItem("k8s-cfg", namespace, secretName, mountPath)
+	configItems := []domain.ConfigProviderSpec{k8sConfigItem}
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name: lo.ToPtr(deviceName),
+		},
+		Spec: &domain.DeviceSpec{
+			Config: &configItems,
+		},
+	}
+
+	mockDeviceSvc := deviceservice.NewMockService(ctrl)
+	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+
+	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+	mockDeviceSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	mockK8S := k8sclient.NewMockK8SClient(ctrl)
+	mockK8S.EXPECT().GetSecret(gomock.Any(), namespace, secretName).Return(nil, fmt.Errorf("connection to apiserver: %w", io.EOF))
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, mockK8S, newTestKVStore(), &config.Config{}, orgId, event)
+
+	err := logic.RenderDevice(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EOF")
+}
+
+func TestRenderDevice_PermanentError_StandaloneDevice(t *testing.T) {
+	const deviceName = "standalone-device"
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	invalidConfig := []domain.ConfigProviderSpec{{}}
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name: lo.ToPtr(deviceName),
+		},
+		Spec: &domain.DeviceSpec{
+			Config: &invalidConfig,
+		},
+	}
+
+	mockSvc := deviceservice.NewMockService(ctrl)
+	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+
+	specHash := hashRenderedWithSpec(device.Spec)
+	mockSvc.EXPECT().UpdateDeviceAnnotations(
+		gomock.Any(), orgId, deviceName,
+		map[string]string{
+			domain.DeviceAnnotationRenderedSpecHash: specHash,
+		},
+		gomock.Nil(),
+	).Return(statusOK)
+
+	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
+	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockSvc, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+
+	err := logic.RenderDevice(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownConfigName)
+}
+
+func TestRenderDevice_PermanentAppError(t *testing.T) {
+	const deviceName = "app-error-device"
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	invalidApp := []domain.ApplicationProviderSpec{{}}
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name: lo.ToPtr(deviceName),
+		},
+		Spec: &domain.DeviceSpec{
+			Applications: &invalidApp,
+		},
+	}
+
+	mockSvc := deviceservice.NewMockService(ctrl)
+	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+
+	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+
+	specHash := hashRenderedWithSpec(device.Spec)
+	mockSvc.EXPECT().UpdateDeviceAnnotations(
+		gomock.Any(), orgId, deviceName,
+		map[string]string{
+			domain.DeviceAnnotationRenderedSpecHash: specHash,
+		},
+		gomock.Nil(),
+	).Return(statusOK)
+
+	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
+	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockSvc, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+
+	err := logic.RenderDevice(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid application")
 }
 
 func makeK8sSecretConfigItem(configName, namespace, name, mountPath string) domain.ConfigProviderSpec {

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -829,7 +829,56 @@ func TestRenderDevice_PermanentError_StandaloneDevice(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnknownConfigName)
 }
 
-func TestRenderDevice_PermanentAppError(t *testing.T) {
+func TestRenderDevice_ExternalError_FleetOwned_NoAnnotations(t *testing.T) {
+	const (
+		deviceName      = "fleet-ext-err-device"
+		fleet           = "my-fleet"
+		templateVersion = "tv-1"
+		namespace       = "default"
+		secretName      = "my-secret"
+		mountPath       = "/etc/secret"
+	)
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sConfigItem := makeK8sSecretConfigItem("k8s-cfg", namespace, secretName, mountPath)
+	configItems := []domain.ConfigProviderSpec{k8sConfigItem}
+	ownerStr := fmt.Sprintf("Fleet/%s", fleet)
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name:  lo.ToPtr(deviceName),
+			Owner: &ownerStr,
+			Annotations: &map[string]string{
+				domain.DeviceAnnotationTemplateVersion: templateVersion,
+			},
+		},
+		Spec: &domain.DeviceSpec{
+			Config: &configItems,
+		},
+	}
+
+	mockSvc := deviceservice.NewMockService(ctrl)
+	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+
+	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, _ string, conditions []domain.Condition) domain.Status {
+			require.Len(t, conditions, 1)
+			assert.Equal(t, domain.ConditionStatusFalse, conditions[0].Status)
+			assert.Contains(t, conditions[0].Message, "kubernetes API is not available")
+			return statusOK
+		})
+	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonFleetRolloutDeviceSelected, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockSvc, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+
+	err := logic.RenderDevice(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kubernetes API is not available")
+}
+
+func TestRenderDevice_NonPermanentAppError(t *testing.T) {
 	const deviceName = "app-error-device"
 	orgId := uuid.New()
 	ctrl := gomock.NewController(t)
@@ -847,18 +896,7 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 
 	mockSvc := deviceservice.NewMockService(ctrl)
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
-
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
-
-	specHash := hashRenderedWithSpec(device.Spec)
-	mockSvc.EXPECT().UpdateDeviceAnnotations(
-		gomock.Any(), orgId, deviceName,
-		map[string]string{
-			domain.DeviceAnnotationRenderedSpecHash: specHash,
-		},
-		gomock.Nil(),
-	).Return(statusOK)
-
 	mockSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
 	mockSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
 

--- a/internal/tasks/render_errors.go
+++ b/internal/tasks/render_errors.go
@@ -1,53 +1,23 @@
 package tasks
 
 import (
-	"context"
 	"errors"
-	"io"
-	"net"
-	"strings"
-	"syscall"
+
+	"github.com/flightctl/flightctl/internal/util/validation"
 )
 
-func isRetryableRenderError(err error) bool {
+func isPermanentRenderError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return dnsErr.Temporary() //nolint:staticcheck
-	}
-
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-
 	switch {
-	case errors.Is(err, syscall.ECONNRESET),
-		errors.Is(err, syscall.ETIMEDOUT):
+	case errors.Is(err, ErrUnknownConfigName):
 		return true
-
-	case errors.Is(err, io.EOF),
-		errors.Is(err, io.ErrUnexpectedEOF):
+	case errors.Is(err, ErrUnknownApplicationType):
 		return true
-
-	case errors.Is(err, context.DeadlineExceeded),
-		errors.Is(err, context.Canceled):
+	case errors.Is(err, validation.ErrForbiddenDevicePath):
 		return true
-	}
-
-	msg := err.Error()
-	for _, substr := range []string{
-		"connection refused",
-		"connection reset",
-		"i/o timeout",
-		"unexpected EOF",
-	} {
-		if strings.Contains(msg, substr) {
-			return true
-		}
 	}
 
 	return false

--- a/internal/tasks/render_errors.go
+++ b/internal/tasks/render_errors.go
@@ -1,0 +1,54 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+)
+
+func isRetryableRenderError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.Temporary() //nolint:staticcheck
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	switch {
+	case errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.ETIMEDOUT):
+		return true
+
+	case errors.Is(err, io.EOF),
+		errors.Is(err, io.ErrUnexpectedEOF):
+		return true
+
+	case errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled):
+		return true
+	}
+
+	msg := err.Error()
+	for _, substr := range []string{
+		"connection refused",
+		"connection reset",
+		"i/o timeout",
+		"unexpected EOF",
+	} {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/tasks/render_errors_test.go
+++ b/internal/tasks/render_errors_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestIsPermanentRenderError(t *testing.T) {
-	require := require.New(t)
-
 	tests := []struct {
 		name     string
 		err      error
@@ -54,6 +52,11 @@ func TestIsPermanentRenderError(t *testing.T) {
 		{
 			name:     "When error wraps ErrForbiddenDevicePath it should return true",
 			err:      fmt.Errorf("invalid path from git config: %w", validation.ErrForbiddenDevicePath),
+			expected: true,
+		},
+		{
+			name:     "When error is a relative-path rejection from DenyForbiddenDevicePath it should return true",
+			err:      fmt.Errorf("invalid path from git config: %w", validation.DenyForbiddenDevicePath("relative/path")),
 			expected: true,
 		},
 		{
@@ -130,6 +133,7 @@ func TestIsPermanentRenderError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
 			result := isPermanentRenderError(tt.err)
 			require.Equal(tt.expected, result)
 		})

--- a/internal/tasks/render_errors_test.go
+++ b/internal/tasks/render_errors_test.go
@@ -1,0 +1,147 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryableRenderError(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil it should return false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "When error is a temporary DNS error it should return true",
+			err:      &net.DNSError{Err: "temporary", IsTemporary: true},
+			expected: true,
+		},
+		{
+			name:     "When error is a non-temporary DNS error it should return false",
+			err:      &net.DNSError{Err: "no such host", IsNotFound: true},
+			expected: false,
+		},
+		{
+			name:     "When error is a timeout net.Error it should return true",
+			err:      &timeoutNetError{},
+			expected: true,
+		},
+		{
+			name:     "When error is ECONNRESET it should return true",
+			err:      syscall.ECONNRESET,
+			expected: true,
+		},
+		{
+			name:     "When error is ETIMEDOUT it should return true",
+			err:      syscall.ETIMEDOUT,
+			expected: true,
+		},
+		{
+			name:     "When error is io.EOF it should return true",
+			err:      io.EOF,
+			expected: true,
+		},
+		{
+			name:     "When error is io.ErrUnexpectedEOF it should return true",
+			err:      io.ErrUnexpectedEOF,
+			expected: true,
+		},
+		{
+			name:     "When error is context.DeadlineExceeded it should return true",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "When error is context.Canceled it should return true",
+			err:      context.Canceled,
+			expected: true,
+		},
+		{
+			name:     "When error wraps a transient error it should return true",
+			err:      fmt.Errorf("failed cloning git repo: %w", &net.DNSError{Err: "temporary", IsTemporary: true}),
+			expected: true,
+		},
+		{
+			name:     "When error wraps ECONNRESET it should return true",
+			err:      fmt.Errorf("failed fetching data: %w", syscall.ECONNRESET),
+			expected: true,
+		},
+		{
+			name:     "When error wraps io.EOF it should return true",
+			err:      fmt.Errorf("failed reading response: %w", io.EOF),
+			expected: true,
+		},
+		{
+			name:     "When error contains 'connection refused' it should return true",
+			err:      errors.New("dial tcp 10.0.0.1:443: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "When error contains 'connection reset' it should return true",
+			err:      errors.New("read tcp: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "When error contains 'i/o timeout' it should return true",
+			err:      errors.New("dial tcp: i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "When error contains 'unexpected EOF' it should return true",
+			err:      errors.New("http: unexpected EOF reading trailer"),
+			expected: true,
+		},
+		{
+			name:     "When error is a config validation error it should return false",
+			err:      fmt.Errorf("invalid path from git config: %w", errors.New("forbidden device path")),
+			expected: false,
+		},
+		{
+			name:     "When error is ErrUnknownConfigName it should return false",
+			err:      fmt.Errorf("bad config: %w", ErrUnknownConfigName),
+			expected: false,
+		},
+		{
+			name:     "When error is ErrUnknownApplicationType it should return false",
+			err:      fmt.Errorf("bad app: %w", ErrUnknownApplicationType),
+			expected: false,
+		},
+		{
+			name:     "When error is a generic error it should return false",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+		{
+			name:     "When error is a repo not found error it should return false",
+			err:      fmt.Errorf("failed fetching specified Repository definition org/repo: not found"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableRenderError(tt.err)
+			require.Equal(tt.expected, result)
+		})
+	}
+}
+
+type timeoutNetError struct{}
+
+func (e *timeoutNetError) Error() string   { return "timeout" }
+func (e *timeoutNetError) Timeout() bool   { return true }
+func (e *timeoutNetError) Temporary() bool { return true }

--- a/internal/tasks/render_errors_test.go
+++ b/internal/tasks/render_errors_test.go
@@ -9,10 +9,11 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsRetryableRenderError(t *testing.T) {
+func TestIsPermanentRenderError(t *testing.T) {
 	require := require.New(t)
 
 	tests := []struct {
@@ -26,9 +27,39 @@ func TestIsRetryableRenderError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a temporary DNS error it should return true",
-			err:      &net.DNSError{Err: "temporary", IsTemporary: true},
+			name:     "When error is ErrUnknownConfigName it should return true",
+			err:      ErrUnknownConfigName,
 			expected: true,
+		},
+		{
+			name:     "When error wraps ErrUnknownConfigName it should return true",
+			err:      fmt.Errorf("bad config: %w", ErrUnknownConfigName),
+			expected: true,
+		},
+		{
+			name:     "When error is ErrUnknownApplicationType it should return true",
+			err:      ErrUnknownApplicationType,
+			expected: true,
+		},
+		{
+			name:     "When error wraps ErrUnknownApplicationType it should return true",
+			err:      fmt.Errorf("bad app: %w", ErrUnknownApplicationType),
+			expected: true,
+		},
+		{
+			name:     "When error is ErrForbiddenDevicePath it should return true",
+			err:      validation.ErrForbiddenDevicePath,
+			expected: true,
+		},
+		{
+			name:     "When error wraps ErrForbiddenDevicePath it should return true",
+			err:      fmt.Errorf("invalid path from git config: %w", validation.ErrForbiddenDevicePath),
+			expected: true,
+		},
+		{
+			name:     "When error is a temporary DNS error it should return false",
+			err:      &net.DNSError{Err: "temporary", IsTemporary: true},
+			expected: false,
 		},
 		{
 			name:     "When error is a non-temporary DNS error it should return false",
@@ -36,88 +67,23 @@ func TestIsRetryableRenderError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "When error is a timeout net.Error it should return true",
-			err:      &timeoutNetError{},
-			expected: true,
-		},
-		{
-			name:     "When error is ECONNRESET it should return true",
+			name:     "When error is ECONNRESET it should return false",
 			err:      syscall.ECONNRESET,
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "When error is ETIMEDOUT it should return true",
-			err:      syscall.ETIMEDOUT,
-			expected: true,
-		},
-		{
-			name:     "When error is io.EOF it should return true",
+			name:     "When error is io.EOF it should return false",
 			err:      io.EOF,
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "When error is io.ErrUnexpectedEOF it should return true",
-			err:      io.ErrUnexpectedEOF,
-			expected: true,
-		},
-		{
-			name:     "When error is context.DeadlineExceeded it should return true",
+			name:     "When error is context.DeadlineExceeded it should return false",
 			err:      context.DeadlineExceeded,
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "When error is context.Canceled it should return true",
+			name:     "When error is context.Canceled it should return false",
 			err:      context.Canceled,
-			expected: true,
-		},
-		{
-			name:     "When error wraps a transient error it should return true",
-			err:      fmt.Errorf("failed cloning git repo: %w", &net.DNSError{Err: "temporary", IsTemporary: true}),
-			expected: true,
-		},
-		{
-			name:     "When error wraps ECONNRESET it should return true",
-			err:      fmt.Errorf("failed fetching data: %w", syscall.ECONNRESET),
-			expected: true,
-		},
-		{
-			name:     "When error wraps io.EOF it should return true",
-			err:      fmt.Errorf("failed reading response: %w", io.EOF),
-			expected: true,
-		},
-		{
-			name:     "When error contains 'connection refused' it should return true",
-			err:      errors.New("dial tcp 10.0.0.1:443: connection refused"),
-			expected: true,
-		},
-		{
-			name:     "When error contains 'connection reset' it should return true",
-			err:      errors.New("read tcp: connection reset by peer"),
-			expected: true,
-		},
-		{
-			name:     "When error contains 'i/o timeout' it should return true",
-			err:      errors.New("dial tcp: i/o timeout"),
-			expected: true,
-		},
-		{
-			name:     "When error contains 'unexpected EOF' it should return true",
-			err:      errors.New("http: unexpected EOF reading trailer"),
-			expected: true,
-		},
-		{
-			name:     "When error is a config validation error it should return false",
-			err:      fmt.Errorf("invalid path from git config: %w", errors.New("forbidden device path")),
-			expected: false,
-		},
-		{
-			name:     "When error is ErrUnknownConfigName it should return false",
-			err:      fmt.Errorf("bad config: %w", ErrUnknownConfigName),
-			expected: false,
-		},
-		{
-			name:     "When error is ErrUnknownApplicationType it should return false",
-			err:      fmt.Errorf("bad app: %w", ErrUnknownApplicationType),
 			expected: false,
 		},
 		{
@@ -130,18 +96,42 @@ func TestIsRetryableRenderError(t *testing.T) {
 			err:      fmt.Errorf("failed fetching specified Repository definition org/repo: not found"),
 			expected: false,
 		},
+		{
+			name:     "When error is HTTP unexpected status code it should return false",
+			err:      fmt.Errorf("unexpected status code 503"),
+			expected: false,
+		},
+		{
+			name:     "When error is secret NotFound it should return false",
+			err:      fmt.Errorf("failed getting secret default/my-secret: not found"),
+			expected: false,
+		},
+		{
+			name:     "When error is kubernetes API unavailable it should return false",
+			err:      fmt.Errorf("kubernetes API is not available"),
+			expected: false,
+		},
+		{
+			name:     "When error wraps a network error it should return false",
+			err:      fmt.Errorf("failed cloning git repo: %w", &net.DNSError{Err: "temporary", IsTemporary: true}),
+			expected: false,
+		},
+		{
+			name:     "When error wraps io.EOF it should return false",
+			err:      fmt.Errorf("failed reading response: %w", io.EOF),
+			expected: false,
+		},
+		{
+			name:     "When error contains connection refused it should return false",
+			err:      errors.New("dial tcp 10.0.0.1:443: connection refused"),
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isRetryableRenderError(tt.err)
+			result := isPermanentRenderError(tt.err)
 			require.Equal(tt.expected, result)
 		})
 	}
 }
-
-type timeoutNetError struct{}
-
-func (e *timeoutNetError) Error() string   { return "timeout" }
-func (e *timeoutNetError) Timeout() bool   { return true }
-func (e *timeoutNetError) Temporary() bool { return true }

--- a/internal/util/validation/validation.go
+++ b/internal/util/validation/validation.go
@@ -261,11 +261,11 @@ func ValidateFileOrDirectoryPath(s *string, path string) []error {
 func DenyForbiddenDevicePath(p string) error {
 	// Only single absolute Linux paths are allowed in rendered configs
 	if p == "" || !filepath.IsAbs(p) {
-		return fmt.Errorf("invalid device path (must be absolute): %q", p)
+		return fmt.Errorf("%w: path must be absolute: %q", ErrForbiddenDevicePath, p)
 	}
 	// Reject PATH-like lists which could alter semantics downstream
 	if strings.ContainsRune(p, ':') {
-		return fmt.Errorf("invalid device path (must not contain ':'): %q", p)
+		return fmt.Errorf("%w: path must not contain ':': %q", ErrForbiddenDevicePath, p)
 	}
 	clean := filepath.Clean(p)
 

--- a/internal/util/validation/validation_test.go
+++ b/internal/util/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -105,6 +106,7 @@ func TestDenyForbiddenDevicePath(t *testing.T) {
 			err := DenyForbiddenDevicePath(tt.path)
 			if tt.wantErr {
 				require.Error(t, err)
+				require.True(t, errors.Is(err, ErrForbiddenDevicePath), "all rejections must wrap ErrForbiddenDevicePath")
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
## Problem

After PR #3142, devices with permanent render errors (bad git path, forbidden config path, unknown config type) get re-rendered indefinitely. The fleet rollout skip condition at `fleet_rollout.go:356` requires `renderedTemplateVersion` to match, but this annotation is only written on successful render via `UpdateRenderedDevice`. Failed renders leave it empty, so the skip condition never fires and the device is re-processed every rollout cycle.

## Root Cause

`renderedSpecHash` and `renderedTemplateVersion` annotations are only written inside `UpdateRenderedDevice` (`store/device/store.go`), which only runs on **successful** render. When render fails permanently, these annotations stay empty/stale, causing:

1. Fleet rollout skip condition fails (`"" != "v3"`) → device re-rolled-out
2. `FleetRolloutDeviceSelected` events bypass the spec-hash guard → forced re-render
3. Same permanent error repeats indefinitely

## Fix

Classify render errors as **permanent vs retryable** using an allowlist-based classifier. On permanent failure, write `renderedSpecHash` and `renderedTemplateVersion` annotations via `UpdateDeviceAnnotations` to stop re-processing.

- **`isPermanentRenderError`** — defaults to **retryable** (non-permanent), only whitelists known immutable validation errors as permanent:
  - `ErrUnknownConfigName` — unsupported or unparseable config type
  - `ErrUnknownApplicationType` — unsupported or unparseable app type / malformed app shape
  - `ErrForbiddenDevicePath` — forbidden device paths (all `DenyForbiddenDevicePath` rejections: denied roots, agent config files, relative paths, colon-containing paths)
- **External/infrastructure errors remain retryable** — DNS, connection reset, EOF, context cancellation, repo not found, K8s API unavailable, HTTP 5xx, secret NotFound. These do NOT write annotations, so repository-update recovery and retry continue working.
- **`markPermanentRenderFailure`** — writes hash/version annotations on permanent failure via `UpdateDeviceAnnotations` (no agent notification, no event emission).
- **Both error paths covered** — config render error and app render error in `RenderDevice`.
- **App-shape sentinel wrapping** — `renderApplication` now wraps `GetAppType`, `As*Application` parse, and `GetName` failures with `ErrUnknownApplicationType` (matching the config-side pattern). VM infra/conversion errors are intentionally not wrapped.
- **Path validation sentinel wrapping** — `DenyForbiddenDevicePath` early rejects (empty, relative, colon-containing paths) now wrap `ErrForbiddenDevicePath`, matching the denied-root and agent-config branches.
- **Recovery**: when user fixes fleet template → new template version → new hash → hash guard passes → render succeeds.

## Testing

- 23 unit tests for `isPermanentRenderError` covering all error types including relative-path rejection
- 5 `RenderDevice` tests for permanent/retryable behavior:
  - Fleet-owned device + permanent config error → both annotations written
  - Standalone device + permanent config error → only specHash written
  - Retryable error (K8s EOF) → no annotations written
  - External error (K8s unavailable, fleet-owned) → no annotations written
  - Permanent app error (empty app spec) → annotations written, `ErrorIs(ErrUnknownApplicationType)`
- `DenyForbiddenDevicePath` tests verify all rejections wrap `ErrForbiddenDevicePath`
- Regression validated: reverting fix causes permanent error tests to fail

## Confidence

High (95%) — minimal change, well-tested, no side effects on existing code paths.

## Risk Assessment

Low — only adds annotation writes on a previously-unhandled failure path. No changes to fleet rollout, store layer, or agent notification.

## Rollback

Revert the commit. Devices with permanent errors will resume the retry loop (pre-existing behavior).