### PR TITLE
EDM-4826: Fleet and catalog ownership on Replace/Patch

### DIFF
--- a/cmd/flightctl-alert-exporter/main.go
+++ b/cmd/flightctl-alert-exporter/main.go
@@ -47,7 +47,6 @@ func main() {
 
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-alert-exporter")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-alert-exporter")
-	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 
 	if err := encryption.InitGlobalEncryption(log, cfg); err != nil {
 		log.Fatalf("initializing encryption: %v", err)

--- a/cmd/flightctl-imagebuilder-worker/main.go
+++ b/cmd/flightctl-imagebuilder-worker/main.go
@@ -59,8 +59,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
 	defer cancel()
 
-	// Set internal request context values for worker operations
-	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
+	// Set context values for worker operations
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-imagebuilder-worker")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-imagebuilder-worker")
 

--- a/cmd/flightctl-worker/main.go
+++ b/cmd/flightctl-worker/main.go
@@ -63,7 +63,6 @@ func main() {
 	}()
 
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
-	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-worker")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-worker")
 

--- a/internal/alert_exporter/event_processor.go
+++ b/internal/alert_exporter/event_processor.go
@@ -51,7 +51,7 @@ func (e *EventProcessor) ProcessLatestEvents(ctx context.Context, oldCheckpoint 
 	})
 
 	// Get all organizations
-	orgs, status := e.organizationSvc.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	orgs, status := e.organizationSvc.ListAllOrganizations(ctx, domain.ListOrganizationsParams{})
 	if status.Code != http.StatusOK {
 		logger.WithFields(logrus.Fields{
 			"status_code": status.Code,

--- a/internal/console/app_console.go
+++ b/internal/console/app_console.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/util"
@@ -126,7 +125,7 @@ func (m *AppConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId 
 			(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = newValue
 		}
 		m.log.Debugf("updating remote-session annotations for device %s", deviceName)
-		_, err = m.svc.UpdateDevice(context.WithValue(ctx, consts.InternalRequestCtxKey, true), orgId, deviceName, *device, nil)
+		_, err = m.svc.UpdateDevice(ctx, orgId, deviceName, *device, nil)
 		if !errors.Is(err, flterrors.ErrResourceVersionConflict) {
 			break
 		}

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
@@ -84,7 +83,7 @@ func (m *ConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId uui
 		}
 		(*device.Metadata.Annotations)[domain.DeviceAnnotationConsole] = newValue
 		m.log.Infof("About to save annotations %+v", *device.Metadata.Annotations)
-		_, err = m.deviceSvc.UpdateDevice(context.WithValue(ctx, consts.InternalRequestCtxKey, true), orgId, deviceName, *device, nil)
+		_, err = m.deviceSvc.UpdateDevice(ctx, orgId, deviceName, *device, nil)
 		if !errors.Is(err, flterrors.ErrResourceVersionConflict) {
 			break
 		}

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -69,8 +69,6 @@ const (
 	CheckpointKeyGlobal              = "global_checkpoint"
 
 	// Ctx
-	InternalRequestCtxKey      ctxKey = "internal-request"
-	ResourceSyncRequestCtxKey  ctxKey = "resource-sync-request"
 	DelayDeviceRenderCtxKey    ctxKey = "delay-device-render"
 	EventSourceComponentCtxKey ctxKey = "event-source"
 	EventActorCtxKey           ctxKey = "event-actor"

--- a/internal/imagebuilder_worker/tasks/imagepromotion.go
+++ b/internal/imagebuilder_worker/tasks/imagepromotion.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	coredomain "github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
@@ -210,7 +209,6 @@ func (c *Consumer) transitionToPublishing(ctx context.Context, orgID uuid.UUID, 
 		baseURI = extractBaseURIWorker(imageBuild.Status.ImageReference)
 	}
 
-	internalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	discriminator, _ := promotion.Spec.Target.Discriminator()
 	var publishErr error
 
@@ -220,13 +218,13 @@ func (c *Consumer) transitionToPublishing(ctx context.Context, orgID uuid.UUID, 
 		if err != nil {
 			return c.transitionToFailed(ctx, orgID, promotion, domain.ImagePromotionConditionReasonFailed, "invalid target: "+err.Error())
 		}
-		publishErr = c.createNewCatalogItem(internalCtx, orgID, target, references, baseURI)
+		publishErr = c.createNewCatalogItem(ctx, orgID, target, references, baseURI)
 	case string(domain.ImagePromotionTargetTypeExistingCatalogItem):
 		target, err := promotion.Spec.Target.AsExistingCatalogItemTarget()
 		if err != nil {
 			return c.transitionToFailed(ctx, orgID, promotion, domain.ImagePromotionConditionReasonFailed, "invalid target: "+err.Error())
 		}
-		publishErr = c.appendVersionToCatalogItem(internalCtx, orgID, target, references, baseURI)
+		publishErr = c.appendVersionToCatalogItem(ctx, orgID, target, references, baseURI)
 	default:
 		publishErr = fmt.Errorf("unknown target type: %s", discriminator)
 	}
@@ -270,7 +268,6 @@ func (c *Consumer) executeAmendmentPublish(ctx context.Context, orgID uuid.UUID,
 		baseURI = extractBaseURIWorker(imageBuild.Status.ImageReference)
 	}
 
-	internalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	discriminator, _ := promotion.Spec.Target.Discriminator()
 
 	var catalogName, itemName, version string
@@ -291,7 +288,7 @@ func (c *Consumer) executeAmendmentPublish(ctx context.Context, orgID uuid.UUID,
 		return c.transitionToAmendmentFailed(ctx, orgID, promotion, fmt.Sprintf("unknown target type: %s", discriminator))
 	}
 
-	if err := c.patchCatalogItemVersion(internalCtx, orgID, catalogName, itemName, version, newReferences, baseURI); err != nil {
+	if err := c.patchCatalogItemVersion(ctx, orgID, catalogName, itemName, version, newReferences, baseURI); err != nil {
 		return c.transitionToAmendmentFailed(ctx, orgID, promotion, err.Error())
 	}
 

--- a/internal/periodic_checker/publisher.go
+++ b/internal/periodic_checker/publisher.go
@@ -60,7 +60,7 @@ func NewTaskHeap() *TaskHeap {
 }
 
 type OrganizationService interface {
-	ListOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status)
+	ListAllOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status)
 }
 
 type TaskChannelManager interface {
@@ -310,7 +310,7 @@ func (p *PeriodicTaskPublisher) organizationSyncLoop(ctx context.Context) {
 func (p *PeriodicTaskPublisher) syncOrganizations(ctx context.Context) {
 	p.log.Info("Syncing organizations")
 
-	orgList, status := p.orgService.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	orgList, status := p.orgService.ListAllOrganizations(ctx, domain.ListOrganizationsParams{})
 	if status.Code < 200 || status.Code >= 300 {
 		p.log.Errorf("Failed to list organizations: %v", status)
 		return

--- a/internal/periodic_checker/publisher_test.go
+++ b/internal/periodic_checker/publisher_test.go
@@ -82,7 +82,7 @@ type mockOrganizationService struct {
 	callCount     int
 }
 
-func (m *mockOrganizationService) ListOrganizations(ctx context.Context, _ domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
+func (m *mockOrganizationService) ListAllOrganizations(ctx context.Context, _ domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
 	m.callCount++
 	return m.organizations, m.status
 }

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -74,7 +74,6 @@ func (s *Server) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-periodic")
 	ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-periodic")
-	ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 	defer cancel()
 
 	processID := fmt.Sprintf("periodic-%s-%s", util.GetHostname(), uuid.New().String())

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -31,6 +31,27 @@ func NewServiceHandler(store authproviderstore.Store, events events.Service, log
 
 var _ Service = (*ServiceHandler)(nil)
 
+// SanitizeAuthProvider clears managed metadata from an untrusted auth provider document
+// (HTTP body).
+func SanitizeAuthProvider(authProvider *domain.AuthProvider) {
+	if authProvider == nil {
+		return
+	}
+	common.NilOutManagedObjectMetaProperties(&authProvider.Metadata)
+}
+
+// CreateAuthProviderFromUntrusted sanitizes an untrusted auth provider document, then creates it.
+func CreateAuthProviderFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, authProvider domain.AuthProvider) (*domain.AuthProvider, domain.Status) {
+	SanitizeAuthProvider(&authProvider)
+	return svc.CreateAuthProvider(ctx, orgId, authProvider)
+}
+
+// ReplaceAuthProviderFromUntrusted sanitizes an untrusted auth provider document, then replaces it.
+func ReplaceAuthProviderFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, authProvider domain.AuthProvider) (*domain.AuthProvider, domain.Status) {
+	SanitizeAuthProvider(&authProvider)
+	return svc.ReplaceAuthProvider(ctx, orgId, name, authProvider)
+}
+
 // sanitizeSchemaError inspects the error and redacts sensitive fields
 func sanitizeSchemaError(err error) string {
 	if err == nil {
@@ -126,9 +147,6 @@ func (h *ServiceHandler) handleSuperAdminAnnotation(ctx context.Context, authPro
 
 func (h *ServiceHandler) CreateAuthProvider(ctx context.Context, orgId uuid.UUID, authProvider domain.AuthProvider) (*domain.AuthProvider, domain.Status) {
 
-	// don't set fields that are managed by the service
-	common.NilOutManagedObjectMetaProperties(&authProvider.Metadata)
-
 	// Apply defaults for auth providers (only during creation)
 	if err := applyAuthProviderDefaults(&authProvider.Spec); err != nil {
 		return nil, domain.StatusBadRequest(sanitizeSchemaError(err))
@@ -203,11 +221,6 @@ func (h *ServiceHandler) GetAuthProvider(ctx context.Context, orgId uuid.UUID, n
 }
 
 func (h *ServiceHandler) ReplaceAuthProvider(ctx context.Context, orgId uuid.UUID, name string, authProvider domain.AuthProvider) (*domain.AuthProvider, domain.Status) {
-
-	// don't overwrite fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		common.NilOutManagedObjectMetaProperties(&authProvider.Metadata)
-	}
 
 	// Validate name early for both create and update paths
 	if authProvider.Metadata.Name == nil {

--- a/internal/service/authprovider/handler_test.go
+++ b/internal/service/authprovider/handler_test.go
@@ -251,16 +251,28 @@ func TestCreateAuthProvider(t *testing.T) {
 		require.Nil(t, stored.Metadata.Annotations)
 	})
 
-	t.Run("When managed metadata fields are set by the caller it should clear them before creation", func(t *testing.T) {
+	t.Run("When managed metadata fields are set by the caller CreateAuthProviderFromUntrusted should clear them before creation", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		provider := testutil.ReturnTestAuthProvider(uuid.Nil, "p3", "", nil)
 		provider.Metadata.Owner = lo.ToPtr("someone")
 		provider.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := h.CreateAuthProvider(adminCtx(), uuid.New(), provider)
+		_, status := CreateAuthProviderFromUntrusted(adminCtx(), h, uuid.New(), provider)
 		require.Equal(t, int32(201), status.Code)
 		require.Nil(t, fakeStore.providers["p3"].Metadata.Owner)
 		require.Nil(t, fakeStore.providers["p3"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateAuthProvider (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		provider := testutil.ReturnTestAuthProvider(uuid.Nil, "p3-trusted", "", nil)
+		provider.Metadata.Owner = lo.ToPtr("someone")
+		provider.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateAuthProvider(memberCtx(), uuid.New(), provider)
+		require.Equal(t, int32(201), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.providers["p3-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.providers["p3-trusted"].Metadata.Generation))
 	})
 
 	t.Run("When creating an OAuth2 provider it should default the issuer to the authorization URL and infer introspection", func(t *testing.T) {
@@ -415,6 +427,30 @@ func TestReplaceAuthProvider(t *testing.T) {
 		// data leaves generation/labels/owner unchanged, so no further event is emitted.
 		require.Len(t, fakeEvents.created, 1)
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceAuthProviderFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		provider := testutil.ReturnTestAuthProvider(uuid.Nil, "replace-untrusted", "", nil)
+		provider.Metadata.Owner = lo.ToPtr("someone")
+		provider.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceAuthProviderFromUntrusted(memberCtx(), h, uuid.New(), "replace-untrusted", provider)
+		require.Equal(t, int32(201), status.Code)
+		require.Nil(t, fakeStore.providers["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, fakeStore.providers["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceAuthProvider (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		provider := testutil.ReturnTestAuthProvider(uuid.Nil, "replace-trusted", "", nil)
+		provider.Metadata.Owner = lo.ToPtr("someone")
+		provider.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceAuthProvider(memberCtx(), uuid.New(), "replace-trusted", provider)
+		require.Equal(t, int32(201), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.providers["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.providers["replace-trusted"].Metadata.Generation))
 	})
 }
 

--- a/internal/service/catalog/handler.go
+++ b/internal/service/catalog/handler.go
@@ -30,10 +30,10 @@ func NewServiceHandler(store catalogstore.Store, events events.Service, log logr
 
 var _ Service = (*ServiceHandler)(nil)
 
-// nilOutManagedCatalogItemMetaProperties clears the CatalogItemMeta fields that are managed
+// NilOutManagedCatalogItemMetaProperties clears the CatalogItemMeta fields that are managed
 // by the service and must not be set by API callers. Catalog-specific; deliberately left
 // un-relocated to internal/service/common (no other resource needs it).
-func nilOutManagedCatalogItemMetaProperties(om *domain.CatalogItemMeta) {
+func NilOutManagedCatalogItemMetaProperties(om *domain.CatalogItemMeta) {
 	if om == nil {
 		return
 	}
@@ -44,11 +44,49 @@ func nilOutManagedCatalogItemMetaProperties(om *domain.CatalogItemMeta) {
 	om.DeletionTimestamp = nil
 }
 
-func (h *ServiceHandler) CreateCatalog(ctx context.Context, orgId uuid.UUID, catalog domain.Catalog) (*domain.Catalog, domain.Status) {
-	// don't set fields that are managed by the service
+// SanitizeCatalog clears status and managed metadata from an untrusted catalog document
+// (HTTP body or ResourceSync YAML). Callers that must set Owner must not use this.
+func SanitizeCatalog(catalog *domain.Catalog) {
+	if catalog == nil {
+		return
+	}
 	catalog.Status = nil
 	common.NilOutManagedObjectMetaProperties(&catalog.Metadata)
+}
 
+// SanitizeCatalogItem clears managed metadata from an untrusted catalog item document.
+func SanitizeCatalogItem(item *domain.CatalogItem) {
+	if item == nil {
+		return
+	}
+	NilOutManagedCatalogItemMetaProperties(&item.Metadata)
+}
+
+// CreateCatalogFromUntrusted sanitizes an untrusted catalog document, then creates it.
+func CreateCatalogFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, catalog domain.Catalog) (*domain.Catalog, domain.Status) {
+	SanitizeCatalog(&catalog)
+	return svc.CreateCatalog(ctx, orgId, catalog)
+}
+
+// ReplaceCatalogFromUntrusted sanitizes an untrusted catalog document, then replaces it.
+func ReplaceCatalogFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, catalog domain.Catalog, enforceOwnership bool) (*domain.Catalog, domain.Status) {
+	SanitizeCatalog(&catalog)
+	return svc.ReplaceCatalog(ctx, orgId, name, catalog, enforceOwnership)
+}
+
+// CreateCatalogItemFromUntrusted sanitizes an untrusted catalog item document, then creates it.
+func CreateCatalogItemFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, catalogName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status) {
+	SanitizeCatalogItem(&item)
+	return svc.CreateCatalogItem(ctx, orgId, catalogName, item)
+}
+
+// ReplaceCatalogItemFromUntrusted sanitizes an untrusted catalog item document, then replaces it.
+func ReplaceCatalogItemFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, catalogName, itemName string, item domain.CatalogItem, enforceOwnership bool) (*domain.CatalogItem, domain.Status) {
+	SanitizeCatalogItem(&item)
+	return svc.ReplaceCatalogItem(ctx, orgId, catalogName, itemName, item, enforceOwnership)
+}
+
+func (h *ServiceHandler) CreateCatalog(ctx context.Context, orgId uuid.UUID, catalog domain.Catalog) (*domain.Catalog, domain.Status) {
 	if errs := catalog.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -83,13 +121,7 @@ func (h *ServiceHandler) GetCatalog(ctx context.Context, orgId uuid.UUID, name s
 	return result, common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
 }
 
-func (h *ServiceHandler) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog) (*domain.Catalog, domain.Status) {
-	// don't overwrite fields that are managed by the service
-	isInternal := common.IsInternalRequest(ctx)
-	if !isInternal {
-		catalog.Status = nil
-		common.NilOutManagedObjectMetaProperties(&catalog.Metadata)
-	}
+func (h *ServiceHandler) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog, enforceOwnership bool) (*domain.Catalog, domain.Status) {
 	if errs := catalog.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -97,26 +129,23 @@ func (h *ServiceHandler) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, na
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
-	// External updates of owned catalogs cannot change spec (ResourceSync may).
-	// Internal requests skip this check (store fromAPI=false path).
-	if !isInternal {
+	if enforceOwnership {
 		existing, getErr := h.store.Get(ctx, orgId, name)
 		if getErr != nil {
 			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
 				return nil, common.StoreErrorToApiStatus(getErr, false, domain.CatalogKind, &name)
 			}
 		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 &&
-			!common.IsResourceSyncRequest(ctx) &&
 			!reflect.DeepEqual(existing.Spec, catalog.Spec) {
 			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogKind, &name)
 		}
 	}
 
-	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &catalog, !isInternal, h.callbackCatalogUpdated)
+	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &catalog, false, h.callbackCatalogUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.CatalogKind, &name)
 }
 
-func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
+func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status {
 	c, err := h.store.Get(ctx, orgId, name)
 	if err != nil {
 		if errors.Is(err, flterrors.ErrResourceNotFound) {
@@ -125,7 +154,7 @@ func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, nam
 		return common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
 	}
 
-	if c.Metadata.Owner != nil && !common.IsResourceSyncRequest(ctx) {
+	if enforceOwnership && len(lo.FromPtr(c.Metadata.Owner)) != 0 {
 		return domain.StatusConflict(flterrors.ErrDeletingResourceWithOwnerNotAllowed.Error())
 	}
 
@@ -140,7 +169,7 @@ func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, nam
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.
-func (h *ServiceHandler) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Catalog, domain.Status) {
+func (h *ServiceHandler) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Catalog, domain.Status) {
 	currentObj, err := h.store.Get(ctx, orgId, name)
 	if err != nil {
 		return nil, common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
@@ -162,9 +191,8 @@ func (h *ServiceHandler) PatchCatalog(ctx context.Context, orgId uuid.UUID, name
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	// Owned catalogs cannot change spec via patch (ResourceSync may).
-	if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 &&
-		!common.IsResourceSyncRequest(ctx) &&
+	if enforceOwnership &&
+		len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 &&
 		!reflect.DeepEqual(currentObj.Spec, newObj.Spec) {
 		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogKind, &name)
 	}
@@ -264,8 +292,6 @@ func (h *ServiceHandler) GetCatalogItem(ctx context.Context, orgId uuid.UUID, ca
 }
 
 func (h *ServiceHandler) CreateCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status) {
-	nilOutManagedCatalogItemMetaProperties(&item.Metadata)
-
 	if errs := item.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -277,17 +303,24 @@ func (h *ServiceHandler) CreateCatalogItem(ctx context.Context, orgId uuid.UUID,
 	return result, common.StoreErrorToApiStatus(err, true, domain.CatalogItemKind, item.Metadata.Name)
 }
 
-func (h *ServiceHandler) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status) {
-	isInternal := common.IsInternalRequest(ctx)
-	if !isInternal {
-		nilOutManagedCatalogItemMetaProperties(&item.Metadata)
-	}
-
+func (h *ServiceHandler) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem, enforceOwnership bool) (*domain.CatalogItem, domain.Status) {
 	if errs := item.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
 	if itemName != *item.Metadata.Name {
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
+	}
+
+	if enforceOwnership {
+		existing, getErr := h.store.GetItem(ctx, orgId, catalogName, itemName)
+		if getErr != nil {
+			if !errors.Is(getErr, flterrors.ErrResourceNotFound) && !errors.Is(getErr, flterrors.ErrParentResourceNotFound) {
+				return nil, common.StoreErrorToApiStatus(getErr, false, domain.CatalogItemKind, &itemName)
+			}
+		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 &&
+			!reflect.DeepEqual(existing.Spec, item.Spec) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogItemKind, &itemName)
+		}
 	}
 
 	result, created, err := h.store.CreateOrUpdateItem(ctx, orgId, catalogName, &item)
@@ -297,7 +330,7 @@ func (h *ServiceHandler) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID
 	return result, common.StoreErrorToApiStatus(err, created, domain.CatalogItemKind, &itemName)
 }
 
-func (h *ServiceHandler) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest) (*domain.CatalogItem, domain.Status) {
+func (h *ServiceHandler) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest, enforceOwnership bool) (*domain.CatalogItem, domain.Status) {
 	currentObj, err := h.store.GetItem(ctx, orgId, catalogName, itemName)
 	if err != nil {
 		if errors.Is(err, flterrors.ErrParentResourceNotFound) {
@@ -320,8 +353,14 @@ func (h *ServiceHandler) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, 
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
 
-	nilOutManagedCatalogItemMetaProperties(&newObj.Metadata)
+	NilOutManagedCatalogItemMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
+
+	if enforceOwnership &&
+		len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 &&
+		!reflect.DeepEqual(currentObj.Spec, newObj.Spec) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogItemKind, &itemName)
+	}
 
 	result, err := h.store.UpdateItem(ctx, orgId, catalogName, newObj)
 	if errors.Is(err, flterrors.ErrParentResourceNotFound) {
@@ -330,7 +369,7 @@ func (h *ServiceHandler) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, 
 	return result, common.StoreErrorToApiStatus(err, false, domain.CatalogItemKind, &itemName)
 }
 
-func (h *ServiceHandler) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) domain.Status {
+func (h *ServiceHandler) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, enforceOwnership bool) domain.Status {
 	existing, err := h.store.GetItem(ctx, orgId, catalogName, itemName)
 	if err != nil {
 		if errors.Is(err, flterrors.ErrResourceNotFound) || errors.Is(err, flterrors.ErrParentResourceNotFound) {
@@ -339,7 +378,7 @@ func (h *ServiceHandler) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID,
 		return common.StoreErrorToApiStatus(err, false, domain.CatalogItemKind, &itemName)
 	}
 
-	if existing.Metadata.Owner != nil && !common.IsResourceSyncRequest(ctx) {
+	if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
 		return domain.StatusConflict(flterrors.ErrDeletingResourceWithOwnerNotAllowed.Error())
 	}
 

--- a/internal/service/catalog/handler.go
+++ b/internal/service/catalog/handler.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
@@ -11,6 +12,7 @@ import (
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -95,6 +97,21 @@ func (h *ServiceHandler) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, na
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
+	// External updates of owned catalogs cannot change spec (ResourceSync may).
+	// Internal requests skip this check (store fromAPI=false path).
+	if !isInternal {
+		existing, getErr := h.store.Get(ctx, orgId, name)
+		if getErr != nil {
+			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+				return nil, common.StoreErrorToApiStatus(getErr, false, domain.CatalogKind, &name)
+			}
+		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 &&
+			!common.IsResourceSyncRequest(ctx) &&
+			!reflect.DeepEqual(existing.Spec, catalog.Spec) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogKind, &name)
+		}
+	}
+
 	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &catalog, !isInternal, h.callbackCatalogUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.CatalogKind, &name)
 }
@@ -144,6 +161,14 @@ func (h *ServiceHandler) PatchCatalog(ctx context.Context, orgId uuid.UUID, name
 
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
+
+	// Owned catalogs cannot change spec via patch (ResourceSync may).
+	if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 &&
+		!common.IsResourceSyncRequest(ctx) &&
+		!reflect.DeepEqual(currentObj.Spec, newObj.Spec) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.CatalogKind, &name)
+	}
+
 	result, err := h.store.Update(ctx, orgId, newObj, h.callbackCatalogUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -407,6 +407,116 @@ func TestReplaceCatalog(t *testing.T) {
 	})
 }
 
+func TestReplaceCatalogOwnership(t *testing.T) {
+	owner := "ResourceSync/my-resourcesync"
+
+	t.Run("When replacing an owned catalog with a changed spec it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		updated := createTestCatalog("owned-catalog", nil)
+		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
+
+		_, status := h.ReplaceCatalog(context.Background(), orgId, "owned-catalog", updated)
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+	})
+
+	t.Run("When ResourceSync replaces an owned catalog it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		updated := createTestCatalog("owned-catalog", nil)
+		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
+		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
+
+		result, status := h.ReplaceCatalog(ctx, orgId, "owned-catalog", updated)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
+	})
+
+	t.Run("When an internal request replaces an owned catalog it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		updated := createTestCatalog("owned-catalog", nil)
+		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
+		ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
+
+		result, status := h.ReplaceCatalog(ctx, orgId, "owned-catalog", updated)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
+	})
+
+	t.Run("When replacing an unowned catalog with a changed spec it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestCatalog("unowned-catalog", nil)
+		fakeStore.catalogs["unowned-catalog"] = &existing
+
+		updated := createTestCatalog("unowned-catalog", nil)
+		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
+
+		result, status := h.ReplaceCatalog(context.Background(), orgId, "unowned-catalog", updated)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["unowned-catalog"].Spec.DisplayName))
+	})
+}
+
+func TestPatchCatalogOwnership(t *testing.T) {
+	owner := "ResourceSync/my-resourcesync"
+
+	t.Run("When patching an owned catalog spec it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		var valueIface interface{} = "Changed Name"
+		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
+
+		_, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch)
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+	})
+
+	t.Run("When ResourceSync patches an owned catalog it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		var valueIface interface{} = "Changed Name"
+		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
+		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
+
+		result, status := h.PatchCatalog(ctx, uuid.New(), "owned-catalog", patch)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
+	})
+
+	t.Run("When patching an owned catalog labels it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestCatalog("owned-catalog", &owner)
+		fakeStore.catalogs["owned-catalog"] = &existing
+
+		var valueIface interface{} = map[string]string{"env": "prod"}
+		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &valueIface}}
+
+		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result)
+	})
+}
+
 func TestDeleteCatalog(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/service/events"
@@ -310,24 +309,36 @@ func TestCreateCatalog(t *testing.T) {
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
 	})
 
-	t.Run("When managed metadata fields are set by the caller it should clear them before creation", func(t *testing.T) {
-		h, fakeStore, _ := newTestHandler()
-		catalog := createTestCatalog("c2", nil)
-		catalog.Metadata.Owner = lo.ToPtr("someone")
-		catalog.Metadata.Generation = lo.ToPtr(int64(5))
-
-		_, status := h.CreateCatalog(context.Background(), uuid.New(), catalog)
-		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Nil(t, fakeStore.catalogs["c2"].Metadata.Owner)
-		require.Nil(t, fakeStore.catalogs["c2"].Metadata.Generation)
-	})
-
 	t.Run("When the store errors it should return an internal-server-error status", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		fakeStore.err = errors.New("db down")
 
 		_, status := h.CreateCatalog(context.Background(), uuid.New(), createTestCatalog("c3", nil))
 		require.Equal(t, int32(http.StatusInternalServerError), status.Code)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateCatalogFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		catalog := createTestCatalog("c4", nil)
+		catalog.Metadata.Owner = lo.ToPtr("someone")
+		catalog.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := CreateCatalogFromUntrusted(context.Background(), h, uuid.New(), catalog)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, fakeStore.catalogs["c4"].Metadata.Owner)
+		require.Nil(t, fakeStore.catalogs["c4"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateCatalog (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		catalog := createTestCatalog("c4-trusted", nil)
+		catalog.Metadata.Owner = lo.ToPtr("someone")
+		catalog.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateCatalog(context.Background(), uuid.New(), catalog)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs["c4-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs["c4-trusted"].Metadata.Generation))
 	})
 }
 
@@ -375,7 +386,7 @@ func TestReplaceCatalog(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		catalog := createTestCatalog("new-catalog", nil)
 
-		result, status := h.ReplaceCatalog(context.Background(), uuid.New(), "new-catalog", catalog)
+		result, status := h.ReplaceCatalog(context.Background(), uuid.New(), "new-catalog", catalog, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
 		require.Contains(t, fakeStore.catalogs, "new-catalog")
@@ -385,7 +396,7 @@ func TestReplaceCatalog(t *testing.T) {
 		h, _, _ := newTestHandler()
 		catalog := createTestCatalog("c1", nil)
 
-		_, status := h.ReplaceCatalog(context.Background(), uuid.New(), "different-name", catalog)
+		_, status := h.ReplaceCatalog(context.Background(), uuid.New(), "different-name", catalog, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -396,7 +407,7 @@ func TestReplaceCatalog(t *testing.T) {
 		_, status := h.CreateCatalog(context.Background(), orgId, catalog)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 
-		result, status := h.ReplaceCatalog(context.Background(), orgId, "c1", catalog)
+		result, status := h.ReplaceCatalog(context.Background(), orgId, "c1", catalog, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Contains(t, fakeStore.catalogs, "c1")
@@ -404,6 +415,32 @@ func TestReplaceCatalog(t *testing.T) {
 		// metadata (no generation/labels/owner change) emits nothing further.
 		require.Len(t, fakeEvents.created, 1)
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCatalogFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("replace-untrusted", nil)
+		catalog.Metadata.Owner = lo.ToPtr("someone")
+		catalog.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceCatalogFromUntrusted(context.Background(), h, orgId, "replace-untrusted", catalog, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, fakeStore.catalogs["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, fakeStore.catalogs["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCatalog (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("replace-trusted", nil)
+		catalog.Metadata.Owner = lo.ToPtr("someone")
+		catalog.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceCatalog(context.Background(), orgId, "replace-trusted", catalog, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs["replace-trusted"].Metadata.Generation))
 	})
 }
 
@@ -419,12 +456,12 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		updated := createTestCatalog("owned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
 
-		_, status := h.ReplaceCatalog(context.Background(), orgId, "owned-catalog", updated)
+		_, status := h.ReplaceCatalog(context.Background(), orgId, "owned-catalog", updated, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 	})
 
-	t.Run("When ResourceSync replaces an owned catalog it should allow the update", func(t *testing.T) {
+	t.Run("When enforceOwnership is false it should allow updating an owned catalog", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
@@ -432,25 +469,8 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 
 		updated := createTestCatalog("owned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
-		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
 
-		result, status := h.ReplaceCatalog(ctx, orgId, "owned-catalog", updated)
-		require.Equal(t, int32(http.StatusOK), status.Code)
-		require.NotNil(t, result)
-		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
-	})
-
-	t.Run("When an internal request replaces an owned catalog it should allow the update", func(t *testing.T) {
-		h, fakeStore, _ := newTestHandler()
-		orgId := uuid.New()
-		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
-
-		updated := createTestCatalog("owned-catalog", nil)
-		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
-		ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
-
-		result, status := h.ReplaceCatalog(ctx, orgId, "owned-catalog", updated)
+		result, status := h.ReplaceCatalog(context.Background(), orgId, "owned-catalog", updated, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
@@ -465,7 +485,7 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		updated := createTestCatalog("unowned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
 
-		result, status := h.ReplaceCatalog(context.Background(), orgId, "unowned-catalog", updated)
+		result, status := h.ReplaceCatalog(context.Background(), orgId, "unowned-catalog", updated, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["unowned-catalog"].Spec.DisplayName))
@@ -483,21 +503,20 @@ func TestPatchCatalogOwnership(t *testing.T) {
 		var valueIface interface{} = "Changed Name"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
 
-		_, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch)
+		_, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 	})
 
-	t.Run("When ResourceSync patches an owned catalog it should allow the update", func(t *testing.T) {
+	t.Run("When enforceOwnership is false it should allow patching an owned catalog", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		existing := createTestCatalog("owned-catalog", &owner)
 		fakeStore.catalogs["owned-catalog"] = &existing
 
 		var valueIface interface{} = "Changed Name"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
-		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
 
-		result, status := h.PatchCatalog(ctx, uuid.New(), "owned-catalog", patch)
+		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
@@ -511,7 +530,7 @@ func TestPatchCatalogOwnership(t *testing.T) {
 		var valueIface interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &valueIface}}
 
-		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch)
+		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 	})
@@ -521,20 +540,21 @@ func TestDeleteCatalog(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 
 	tests := []struct {
-		name                  string
-		catalogName           string
-		catalogOwner          *string
-		createCatalog         bool
-		isResourceSyncRequest bool
-		expectedStatusCode    int32
-		expectedError         error
-		expectCatalogDeleted  bool
+		name                 string
+		catalogName          string
+		catalogOwner         *string
+		createCatalog        bool
+		enforceOwnership     bool
+		expectedStatusCode   int32
+		expectedError        error
+		expectCatalogDeleted bool
 	}{
 		{
 			name:                 "delete catalog without owner succeeds",
 			catalogName:          "test-catalog",
 			catalogOwner:         nil,
 			createCatalog:        true,
+			enforceOwnership:     true,
 			expectedStatusCode:   int32(http.StatusOK),
 			expectCatalogDeleted: true,
 		},
@@ -542,6 +562,7 @@ func TestDeleteCatalog(t *testing.T) {
 			name:                 "delete non-existent catalog returns OK (idempotent)",
 			catalogName:          "nonexistent-catalog",
 			createCatalog:        false,
+			enforceOwnership:     true,
 			expectedStatusCode:   int32(http.StatusOK),
 			expectCatalogDeleted: true,
 		},
@@ -550,18 +571,19 @@ func TestDeleteCatalog(t *testing.T) {
 			catalogName:          "owned-catalog",
 			catalogOwner:         &owner,
 			createCatalog:        true,
+			enforceOwnership:     true,
 			expectedStatusCode:   int32(http.StatusConflict),
 			expectedError:        flterrors.ErrDeletingResourceWithOwnerNotAllowed,
 			expectCatalogDeleted: false,
 		},
 		{
-			name:                  "resourceSync can delete catalogs it owns",
-			catalogName:           "resourcesync-owned-catalog",
-			catalogOwner:          &owner,
-			createCatalog:         true,
-			isResourceSyncRequest: true,
-			expectedStatusCode:    int32(http.StatusOK),
-			expectCatalogDeleted:  true,
+			name:                 "delete owned catalog succeeds when enforceOwnership is false",
+			catalogName:          "resourcesync-owned-catalog",
+			catalogOwner:         &owner,
+			createCatalog:        true,
+			enforceOwnership:     false,
+			expectedStatusCode:   int32(http.StatusOK),
+			expectCatalogDeleted: true,
 		},
 	}
 
@@ -576,12 +598,7 @@ func TestDeleteCatalog(t *testing.T) {
 				fakeStore.catalogs[tt.catalogName] = &catalog
 			}
 
-			deleteCtx := ctx
-			if tt.isResourceSyncRequest {
-				deleteCtx = context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
-			}
-
-			status := h.DeleteCatalog(deleteCtx, testOrgId, tt.catalogName)
+			status := h.DeleteCatalog(ctx, testOrgId, tt.catalogName, tt.enforceOwnership)
 			require.Equal(t, tt.expectedStatusCode, status.Code)
 
 			if tt.expectedError != nil {
@@ -609,7 +626,7 @@ func TestPatchCatalog(t *testing.T) {
 		var value interface{} = "value"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels/k", Value: &value}}
 
-		_, status := h.PatchCatalog(context.Background(), uuid.New(), "missing", patch)
+		_, status := h.PatchCatalog(context.Background(), uuid.New(), "missing", patch, true)
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 	})
 
@@ -621,7 +638,7 @@ func TestPatchCatalog(t *testing.T) {
 		var value interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &value}}
 
-		result, status := h.PatchCatalog(context.Background(), uuid.New(), "c1", patch)
+		result, status := h.PatchCatalog(context.Background(), uuid.New(), "c1", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Len(t, fakeEvents.created, 1)
@@ -766,6 +783,34 @@ func TestCreateCatalogItem(t *testing.T) {
 		_, status := h.CreateCatalogItem(context.Background(), uuid.New(), "missing", item)
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 	})
+
+	t.Run("When managed metadata fields are set by the caller CreateCatalogItemFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		catalog := createTestCatalog("c1", nil)
+		fakeStore.catalogs["c1"] = &catalog
+		item := createTestCatalogItem("c1", "i2", nil)
+		item.Metadata.Owner = lo.ToPtr("someone")
+		item.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := CreateCatalogItemFromUntrusted(context.Background(), h, uuid.New(), "c1", item)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, fakeStore.items[itemKey("c1", "i2")].Metadata.Owner)
+		require.Nil(t, fakeStore.items[itemKey("c1", "i2")].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateCatalogItem (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		catalog := createTestCatalog("c1", nil)
+		fakeStore.catalogs["c1"] = &catalog
+		item := createTestCatalogItem("c1", "i3", nil)
+		item.Metadata.Owner = lo.ToPtr("someone")
+		item.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateCatalogItem(context.Background(), uuid.New(), "c1", item)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey("c1", "i3")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey("c1", "i3")].Metadata.Generation))
+	})
 }
 
 func TestReplaceCatalogItem(t *testing.T) {
@@ -779,7 +824,7 @@ func TestReplaceCatalogItem(t *testing.T) {
 		fakeStore.catalogs[catalogName] = &catalog
 
 		item := createTestCatalogItem(catalogName, itemName, nil)
-		result, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), catalogName, itemName, item)
+		result, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), catalogName, itemName, item, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
 	})
@@ -790,8 +835,38 @@ func TestReplaceCatalogItem(t *testing.T) {
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 
-		_, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "different-item", item)
+		_, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "different-item", item, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCatalogItemFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("c1", nil)
+		fakeStore.catalogs["c1"] = &catalog
+		item := createTestCatalogItem("c1", "replace-untrusted", nil)
+		item.Metadata.Owner = lo.ToPtr("someone")
+		item.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceCatalogItemFromUntrusted(context.Background(), h, orgId, "c1", "replace-untrusted", item, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, fakeStore.items[itemKey("c1", "replace-untrusted")].Metadata.Owner)
+		require.Nil(t, fakeStore.items[itemKey("c1", "replace-untrusted")].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCatalogItem (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("c1", nil)
+		fakeStore.catalogs["c1"] = &catalog
+		item := createTestCatalogItem("c1", "replace-trusted", nil)
+		item.Metadata.Owner = lo.ToPtr("someone")
+		item.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "replace-trusted", item, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey("c1", "replace-trusted")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey("c1", "replace-trusted")].Metadata.Generation))
 	})
 }
 
@@ -801,7 +876,7 @@ func TestPatchCatalogItem(t *testing.T) {
 		var value interface{} = "value"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels/k", Value: &value}}
 
-		_, status := h.PatchCatalogItem(context.Background(), uuid.New(), "missing", "i1", patch)
+		_, status := h.PatchCatalogItem(context.Background(), uuid.New(), "missing", "i1", patch, true)
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 	})
 
@@ -815,7 +890,7 @@ func TestPatchCatalogItem(t *testing.T) {
 		var value interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &value}}
 
-		result, status := h.PatchCatalogItem(context.Background(), uuid.New(), "c1", "i1", patch)
+		result, status := h.PatchCatalogItem(context.Background(), uuid.New(), "c1", "i1", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 	})
@@ -825,15 +900,15 @@ func TestDeleteCatalogItem(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 
 	tests := []struct {
-		name                  string
-		catalogName           string
-		itemName              string
-		itemOwner             *string
-		createItem            bool
-		isResourceSyncRequest bool
-		expectedStatusCode    int32
-		expectedError         error
-		expectItemDeleted     bool
+		name               string
+		catalogName        string
+		itemName           string
+		itemOwner          *string
+		createItem         bool
+		enforceOwnership   bool
+		expectedStatusCode int32
+		expectedError      error
+		expectItemDeleted  bool
 	}{
 		{
 			name:               "delete item without owner succeeds",
@@ -841,6 +916,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 			itemName:           "test-item",
 			itemOwner:          nil,
 			createItem:         true,
+			enforceOwnership:   true,
 			expectedStatusCode: int32(http.StatusOK),
 			expectItemDeleted:  true,
 		},
@@ -849,6 +925,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 			catalogName:        "test-catalog",
 			itemName:           "nonexistent-item",
 			createItem:         false,
+			enforceOwnership:   true,
 			expectedStatusCode: int32(http.StatusOK),
 			expectItemDeleted:  true,
 		},
@@ -858,19 +935,20 @@ func TestDeleteCatalogItem(t *testing.T) {
 			itemName:           "owned-item",
 			itemOwner:          &owner,
 			createItem:         true,
+			enforceOwnership:   true,
 			expectedStatusCode: int32(http.StatusConflict),
 			expectedError:      flterrors.ErrDeletingResourceWithOwnerNotAllowed,
 			expectItemDeleted:  false,
 		},
 		{
-			name:                  "resourceSync can delete items it owns",
-			catalogName:           "test-catalog",
-			itemName:              "rs-owned-item",
-			itemOwner:             &owner,
-			createItem:            true,
-			isResourceSyncRequest: true,
-			expectedStatusCode:    int32(http.StatusOK),
-			expectItemDeleted:     true,
+			name:               "delete owned item succeeds when enforceOwnership is false",
+			catalogName:        "test-catalog",
+			itemName:           "rs-owned-item",
+			itemOwner:          &owner,
+			createItem:         true,
+			enforceOwnership:   false,
+			expectedStatusCode: int32(http.StatusOK),
+			expectItemDeleted:  true,
 		},
 	}
 
@@ -888,12 +966,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 				fakeStore.items[itemKey(tt.catalogName, tt.itemName)] = &item
 			}
 
-			deleteCtx := ctx
-			if tt.isResourceSyncRequest {
-				deleteCtx = context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
-			}
-
-			status := h.DeleteCatalogItem(deleteCtx, testOrgId, tt.catalogName, tt.itemName)
+			status := h.DeleteCatalogItem(ctx, testOrgId, tt.catalogName, tt.itemName, tt.enforceOwnership)
 			require.Equal(t, tt.expectedStatusCode, status.Code)
 
 			if tt.expectedError != nil {

--- a/internal/service/catalog/mock.go
+++ b/internal/service/catalog/mock.go
@@ -72,31 +72,31 @@ func (mr *MockServiceMockRecorder) CreateCatalogItem(ctx, orgId, catalogName, it
 }
 
 // DeleteCatalog mocks base method.
-func (m *MockService) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
+func (m *MockService) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCatalog", ctx, orgId, name)
+	ret := m.ctrl.Call(m, "DeleteCatalog", ctx, orgId, name, enforceOwnership)
 	ret0, _ := ret[0].(domain.Status)
 	return ret0
 }
 
 // DeleteCatalog indicates an expected call of DeleteCatalog.
-func (mr *MockServiceMockRecorder) DeleteCatalog(ctx, orgId, name any) *gomock.Call {
+func (mr *MockServiceMockRecorder) DeleteCatalog(ctx, orgId, name, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCatalog", reflect.TypeOf((*MockService)(nil).DeleteCatalog), ctx, orgId, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCatalog", reflect.TypeOf((*MockService)(nil).DeleteCatalog), ctx, orgId, name, enforceOwnership)
 }
 
 // DeleteCatalogItem mocks base method.
-func (m *MockService) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string) domain.Status {
+func (m *MockService) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string, enforceOwnership bool) domain.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCatalogItem", ctx, orgId, catalogName, itemName)
+	ret := m.ctrl.Call(m, "DeleteCatalogItem", ctx, orgId, catalogName, itemName, enforceOwnership)
 	ret0, _ := ret[0].(domain.Status)
 	return ret0
 }
 
 // DeleteCatalogItem indicates an expected call of DeleteCatalogItem.
-func (mr *MockServiceMockRecorder) DeleteCatalogItem(ctx, orgId, catalogName, itemName any) *gomock.Call {
+func (mr *MockServiceMockRecorder) DeleteCatalogItem(ctx, orgId, catalogName, itemName, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCatalogItem", reflect.TypeOf((*MockService)(nil).DeleteCatalogItem), ctx, orgId, catalogName, itemName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCatalogItem", reflect.TypeOf((*MockService)(nil).DeleteCatalogItem), ctx, orgId, catalogName, itemName, enforceOwnership)
 }
 
 // GetCatalog mocks base method.
@@ -190,33 +190,33 @@ func (mr *MockServiceMockRecorder) ListCatalogs(ctx, orgId, params any) *gomock.
 }
 
 // PatchCatalog mocks base method.
-func (m *MockService) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Catalog, domain.Status) {
+func (m *MockService) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Catalog, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchCatalog", ctx, orgId, name, patch)
+	ret := m.ctrl.Call(m, "PatchCatalog", ctx, orgId, name, patch, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Catalog)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // PatchCatalog indicates an expected call of PatchCatalog.
-func (mr *MockServiceMockRecorder) PatchCatalog(ctx, orgId, name, patch any) *gomock.Call {
+func (mr *MockServiceMockRecorder) PatchCatalog(ctx, orgId, name, patch, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchCatalog", reflect.TypeOf((*MockService)(nil).PatchCatalog), ctx, orgId, name, patch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchCatalog", reflect.TypeOf((*MockService)(nil).PatchCatalog), ctx, orgId, name, patch, enforceOwnership)
 }
 
 // PatchCatalogItem mocks base method.
-func (m *MockService) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string, patch domain.PatchRequest) (*domain.CatalogItem, domain.Status) {
+func (m *MockService) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string, patch domain.PatchRequest, enforceOwnership bool) (*domain.CatalogItem, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchCatalogItem", ctx, orgId, catalogName, itemName, patch)
+	ret := m.ctrl.Call(m, "PatchCatalogItem", ctx, orgId, catalogName, itemName, patch, enforceOwnership)
 	ret0, _ := ret[0].(*domain.CatalogItem)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // PatchCatalogItem indicates an expected call of PatchCatalogItem.
-func (mr *MockServiceMockRecorder) PatchCatalogItem(ctx, orgId, catalogName, itemName, patch any) *gomock.Call {
+func (mr *MockServiceMockRecorder) PatchCatalogItem(ctx, orgId, catalogName, itemName, patch, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchCatalogItem", reflect.TypeOf((*MockService)(nil).PatchCatalogItem), ctx, orgId, catalogName, itemName, patch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchCatalogItem", reflect.TypeOf((*MockService)(nil).PatchCatalogItem), ctx, orgId, catalogName, itemName, patch, enforceOwnership)
 }
 
 // PatchCatalogStatus mocks base method.
@@ -235,33 +235,33 @@ func (mr *MockServiceMockRecorder) PatchCatalogStatus(ctx, orgId, name, patch an
 }
 
 // ReplaceCatalog mocks base method.
-func (m *MockService) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog) (*domain.Catalog, domain.Status) {
+func (m *MockService) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog, enforceOwnership bool) (*domain.Catalog, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceCatalog", ctx, orgId, name, catalog)
+	ret := m.ctrl.Call(m, "ReplaceCatalog", ctx, orgId, name, catalog, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Catalog)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceCatalog indicates an expected call of ReplaceCatalog.
-func (mr *MockServiceMockRecorder) ReplaceCatalog(ctx, orgId, name, catalog any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceCatalog(ctx, orgId, name, catalog, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceCatalog", reflect.TypeOf((*MockService)(nil).ReplaceCatalog), ctx, orgId, name, catalog)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceCatalog", reflect.TypeOf((*MockService)(nil).ReplaceCatalog), ctx, orgId, name, catalog, enforceOwnership)
 }
 
 // ReplaceCatalogItem mocks base method.
-func (m *MockService) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status) {
+func (m *MockService) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName, itemName string, item domain.CatalogItem, enforceOwnership bool) (*domain.CatalogItem, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceCatalogItem", ctx, orgId, catalogName, itemName, item)
+	ret := m.ctrl.Call(m, "ReplaceCatalogItem", ctx, orgId, catalogName, itemName, item, enforceOwnership)
 	ret0, _ := ret[0].(*domain.CatalogItem)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceCatalogItem indicates an expected call of ReplaceCatalogItem.
-func (mr *MockServiceMockRecorder) ReplaceCatalogItem(ctx, orgId, catalogName, itemName, item any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceCatalogItem(ctx, orgId, catalogName, itemName, item, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceCatalogItem", reflect.TypeOf((*MockService)(nil).ReplaceCatalogItem), ctx, orgId, catalogName, itemName, item)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceCatalogItem", reflect.TypeOf((*MockService)(nil).ReplaceCatalogItem), ctx, orgId, catalogName, itemName, item, enforceOwnership)
 }
 
 // ReplaceCatalogStatus mocks base method.

--- a/internal/service/catalog/service.go
+++ b/internal/service/catalog/service.go
@@ -11,9 +11,9 @@ type Service interface {
 	CreateCatalog(ctx context.Context, orgId uuid.UUID, catalog domain.Catalog) (*domain.Catalog, domain.Status)
 	ListCatalogs(ctx context.Context, orgId uuid.UUID, params domain.ListCatalogsParams) (*domain.CatalogList, domain.Status)
 	GetCatalog(ctx context.Context, orgId uuid.UUID, name string) (*domain.Catalog, domain.Status)
-	ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog) (*domain.Catalog, domain.Status)
-	DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string) domain.Status
-	PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Catalog, domain.Status)
+	ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog, enforceOwnership bool) (*domain.Catalog, domain.Status)
+	DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status
+	PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Catalog, domain.Status)
 	GetCatalogStatus(ctx context.Context, orgId uuid.UUID, name string) (*domain.Catalog, domain.Status)
 	ReplaceCatalogStatus(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog) (*domain.Catalog, domain.Status)
 	PatchCatalogStatus(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Catalog, domain.Status)
@@ -21,7 +21,7 @@ type Service interface {
 	ListCatalogItems(ctx context.Context, orgId uuid.UUID, catalogName string, params domain.ListCatalogItemsParams) (*domain.CatalogItemList, domain.Status)
 	GetCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) (*domain.CatalogItem, domain.Status)
 	CreateCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status)
-	ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status)
-	PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest) (*domain.CatalogItem, domain.Status)
-	DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) domain.Status
+	ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem, enforceOwnership bool) (*domain.CatalogItem, domain.Status)
+	PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest, enforceOwnership bool) (*domain.CatalogItem, domain.Status)
+	DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, enforceOwnership bool) domain.Status
 }

--- a/internal/service/catalog/traced.gen.go
+++ b/internal/service/catalog/traced.gen.go
@@ -60,18 +60,18 @@ func (_d *TracedService) CreateCatalogItem(ctx context.Context, orgId uuid.UUID,
 	return cp1, s1
 }
 
-func (_d *TracedService) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string) (s1 domain.Status) {
+func (_d *TracedService) DeleteCatalog(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) (s1 domain.Status) {
 	ctx, span := startSpan(ctx, "DeleteCatalog")
 
-	s1 = _d.inner.DeleteCatalog(ctx, orgId, name)
+	s1 = _d.inner.DeleteCatalog(ctx, orgId, name, enforceOwnership)
 	endSpan(span, s1)
 	return s1
 }
 
-func (_d *TracedService) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) (s1 domain.Status) {
+func (_d *TracedService) DeleteCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, enforceOwnership bool) (s1 domain.Status) {
 	ctx, span := startSpan(ctx, "DeleteCatalogItem")
 
-	s1 = _d.inner.DeleteCatalogItem(ctx, orgId, catalogName, itemName)
+	s1 = _d.inner.DeleteCatalogItem(ctx, orgId, catalogName, itemName, enforceOwnership)
 	endSpan(span, s1)
 	return s1
 }
@@ -124,18 +124,18 @@ func (_d *TracedService) ListCatalogs(ctx context.Context, orgId uuid.UUID, para
 	return cp1, s1
 }
 
-func (_d *TracedService) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (cp1 *domain.Catalog, s1 domain.Status) {
+func (_d *TracedService) PatchCatalog(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (cp1 *domain.Catalog, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "PatchCatalog")
 
-	cp1, s1 = _d.inner.PatchCatalog(ctx, orgId, name, patch)
+	cp1, s1 = _d.inner.PatchCatalog(ctx, orgId, name, patch, enforceOwnership)
 	endSpan(span, s1)
 	return cp1, s1
 }
 
-func (_d *TracedService) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest) (cp1 *domain.CatalogItem, s1 domain.Status) {
+func (_d *TracedService) PatchCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, patch domain.PatchRequest, enforceOwnership bool) (cp1 *domain.CatalogItem, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "PatchCatalogItem")
 
-	cp1, s1 = _d.inner.PatchCatalogItem(ctx, orgId, catalogName, itemName, patch)
+	cp1, s1 = _d.inner.PatchCatalogItem(ctx, orgId, catalogName, itemName, patch, enforceOwnership)
 	endSpan(span, s1)
 	return cp1, s1
 }
@@ -148,18 +148,18 @@ func (_d *TracedService) PatchCatalogStatus(ctx context.Context, orgId uuid.UUID
 	return cp1, s1
 }
 
-func (_d *TracedService) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog) (cp1 *domain.Catalog, s1 domain.Status) {
+func (_d *TracedService) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, name string, catalog domain.Catalog, enforceOwnership bool) (cp1 *domain.Catalog, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceCatalog")
 
-	cp1, s1 = _d.inner.ReplaceCatalog(ctx, orgId, name, catalog)
+	cp1, s1 = _d.inner.ReplaceCatalog(ctx, orgId, name, catalog, enforceOwnership)
 	endSpan(span, s1)
 	return cp1, s1
 }
 
-func (_d *TracedService) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem) (cp1 *domain.CatalogItem, s1 domain.Status) {
+func (_d *TracedService) ReplaceCatalogItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string, item domain.CatalogItem, enforceOwnership bool) (cp1 *domain.CatalogItem, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceCatalogItem")
 
-	cp1, s1 = _d.inner.ReplaceCatalogItem(ctx, orgId, catalogName, itemName, item)
+	cp1, s1 = _d.inner.ReplaceCatalogItem(ctx, orgId, catalogName, itemName, item, enforceOwnership)
 	endSpan(span, s1)
 	return cp1, s1
 }

--- a/internal/service/certificatesigningrequest/enrollment_credential.go
+++ b/internal/service/certificatesigningrequest/enrollment_credential.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/crypto"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/util"
@@ -80,12 +79,11 @@ func (h *ServiceHandler) GenerateEnrollmentCredential(ctx context.Context, orgId
 		},
 	}
 
-	// Submit CSR through the service with internal request context
-	// This ensures the Owner field is preserved (not nil'd out)
+	// Submit the CSR directly through the service (bypassing sanitization, which is a
+	// transport-adapter concern): Owner is set above and must be preserved.
 	// Also add orgId to context so WithOrgIDExtension can inject it into the certificate
-	internalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, true)
-	internalCtx = util.WithOrganizationID(internalCtx, orgId)
-	result, status := h.CreateCertificateSigningRequest(internalCtx, orgId, csrResource)
+	ctx = util.WithOrganizationID(ctx, orgId)
+	result, status := h.CreateCertificateSigningRequest(ctx, orgId, csrResource)
 	if status.Code != 201 && status.Code != 200 {
 		return nil, status
 	}

--- a/internal/service/certificatesigningrequest/handler.go
+++ b/internal/service/certificatesigningrequest/handler.go
@@ -44,6 +44,29 @@ func NewServiceHandler(store certificatesigningrequeststore.Store, enrollmentReq
 
 var _ Service = (*ServiceHandler)(nil)
 
+// SanitizeCertificateSigningRequest clears status and managed metadata from an untrusted CSR
+// document (HTTP body). Callers that must set Owner (e.g. the agent creating its own device CSR)
+// must not use this.
+func SanitizeCertificateSigningRequest(csr *domain.CertificateSigningRequest) {
+	if csr == nil {
+		return
+	}
+	csr.Status = nil
+	common.NilOutManagedObjectMetaProperties(&csr.Metadata)
+}
+
+// CreateCertificateSigningRequestFromUntrusted sanitizes an untrusted CSR document, then creates it.
+func CreateCertificateSigningRequestFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status) {
+	SanitizeCertificateSigningRequest(&csr)
+	return svc.CreateCertificateSigningRequest(ctx, orgId, csr)
+}
+
+// ReplaceCertificateSigningRequestFromUntrusted sanitizes an untrusted CSR document, then replaces it.
+func ReplaceCertificateSigningRequestFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status) {
+	SanitizeCertificateSigningRequest(&csr)
+	return svc.ReplaceCertificateSigningRequest(ctx, orgId, name, csr)
+}
+
 func (h *ServiceHandler) autoApprove(ctx context.Context, orgId uuid.UUID, csr *domain.CertificateSigningRequest) {
 	if domain.IsStatusConditionTrue(csr.Status.Conditions, domain.ConditionTypeCertificateSigningRequestApproved) || domain.IsStatusConditionTrue(csr.Status.Conditions, domain.ConditionTypeCertificateSigningRequestDenied) {
 		return
@@ -176,12 +199,6 @@ func (h *ServiceHandler) verifyTPMCSRRequest(ctx context.Context, orgId uuid.UUI
 }
 
 func (h *ServiceHandler) CreateCertificateSigningRequest(ctx context.Context, orgId uuid.UUID, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status) {
-	// don't set fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		csr.Status = nil
-		common.NilOutManagedObjectMetaProperties(&csr.Metadata)
-	}
-
 	// Support legacy shorthand "enrollment" by replacing it with the configured signer name
 	if csr.Spec.SignerName == "enrollment" {
 		csr.Spec.SignerName = h.ca.Cfg.DeviceEnrollmentSignerName
@@ -301,12 +318,6 @@ func (h *ServiceHandler) PatchCertificateSigningRequest(ctx context.Context, org
 }
 
 func (h *ServiceHandler) ReplaceCertificateSigningRequest(ctx context.Context, orgId uuid.UUID, name string, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status) {
-	// don't set fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		csr.Status = nil
-		common.NilOutManagedObjectMetaProperties(&csr.Metadata)
-	}
-
 	if name != *csr.Metadata.Name {
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}

--- a/internal/service/certificatesigningrequest/handler_test.go
+++ b/internal/service/certificatesigningrequest/handler_test.go
@@ -348,6 +348,42 @@ func TestCreateCertificateSigningRequest(t *testing.T) {
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
 	})
 
+	t.Run("When managed metadata fields are set by the caller CreateCertificateSigningRequestFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		cn := "untrusted-csr"
+		csr := domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.CertificateSigningRequestSpec{SignerName: "enrollment", Request: csrPEM(t, cn), Usages: validUsages()},
+		}
+
+		_, status := CreateCertificateSigningRequestFromUntrusted(context.Background(), h, uuid.New(), csr)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.items[cn].Metadata.Owner)
+		require.Nil(t, fakeStore.items[cn].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateCertificateSigningRequest (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		cn := "trusted-csr"
+		csr := domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.CertificateSigningRequestSpec{SignerName: "enrollment", Request: csrPEM(t, cn), Usages: validUsages()},
+		}
+
+		_, status := h.CreateCertificateSigningRequest(context.Background(), uuid.New(), csr)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[cn].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[cn].Metadata.Generation))
+	})
+
 	t.Run("When the device-management signer is used it should be rejected", func(t *testing.T) {
 		h, _, _, _, cfg := newTestHandler(t)
 		cn := "test-csr-rejected"
@@ -443,6 +479,46 @@ func TestReplaceCertificateSigningRequest(t *testing.T) {
 	result, status := h.ReplaceCertificateSigningRequest(context.Background(), uuid.New(), cn, csr)
 	require.Equal(t, statusSuccessCode, status.Code)
 	require.NotNil(t, result)
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCertificateSigningRequestFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		orgId := uuid.New()
+		cn := "replace-untrusted"
+		csr := domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.CertificateSigningRequestSpec{SignerName: "enrollment", Request: csrPEM(t, cn), Usages: validUsages()},
+		}
+		fakeStore.items[cn] = &csr
+
+		_, status := ReplaceCertificateSigningRequestFromUntrusted(context.Background(), h, orgId, cn, csr)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.Nil(t, fakeStore.items[cn].Metadata.Owner)
+		require.Nil(t, fakeStore.items[cn].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceCertificateSigningRequest (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		orgId := uuid.New()
+		cn := "replace-trusted"
+		csr := domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.CertificateSigningRequestSpec{SignerName: "enrollment", Request: csrPEM(t, cn), Usages: validUsages()},
+		}
+		fakeStore.items[cn] = &csr
+
+		_, status := h.ReplaceCertificateSigningRequest(context.Background(), orgId, cn, csr)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[cn].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[cn].Metadata.Generation))
+	})
 }
 
 func TestUpdateCertificateSigningRequestApproval(t *testing.T) {

--- a/internal/service/common/http.go
+++ b/internal/service/common/http.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
@@ -32,24 +31,6 @@ const MaxRecordsPerListRequest = 1000
 // MaxConcurrentAgents bounds the number of concurrent agent-originated requests a resource's
 // ServiceHandler will process at once via its own semaphore.Weighted gate.
 const MaxConcurrentAgents = 15
-
-// IsInternalRequest reports whether ctx marks the current request as internal
-// (i.e. originating from within the service, not from an external API caller).
-func IsInternalRequest(ctx context.Context) bool {
-	if internal, ok := ctx.Value(consts.InternalRequestCtxKey).(bool); ok && internal {
-		return true
-	}
-	return false
-}
-
-// IsResourceSyncRequest reports whether ctx marks the current request as originating
-// from the ResourceSync controller.
-func IsResourceSyncRequest(ctx context.Context) bool {
-	if rs, ok := ctx.Value(consts.ResourceSyncRequestCtxKey).(bool); ok && rs {
-		return true
-	}
-	return false
-}
 
 // NilOutManagedObjectMetaProperties clears the ObjectMeta fields that are managed by the
 // service and must not be set by API callers.

--- a/internal/service/common/http_test.go
+++ b/internal/service/common/http_test.go
@@ -6,64 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/stretchr/testify/require"
 )
-
-func TestIsInternalRequest(t *testing.T) {
-	tests := []struct {
-		name     string
-		ctx      context.Context
-		expected bool
-	}{
-		{
-			name:     "When the context has no internal-request value it should return false",
-			ctx:      context.Background(),
-			expected: false,
-		},
-		{
-			name:     "When the context has internal-request set to true it should return true",
-			ctx:      context.WithValue(context.Background(), consts.InternalRequestCtxKey, true),
-			expected: true,
-		},
-		{
-			name:     "When the context has internal-request set to false it should return false",
-			ctx:      context.WithValue(context.Background(), consts.InternalRequestCtxKey, false),
-			expected: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, IsInternalRequest(tt.ctx))
-		})
-	}
-}
-
-func TestIsResourceSyncRequest(t *testing.T) {
-	tests := []struct {
-		name     string
-		ctx      context.Context
-		expected bool
-	}{
-		{
-			name:     "When the context has no resource-sync-request value it should return false",
-			ctx:      context.Background(),
-			expected: false,
-		},
-		{
-			name:     "When the context has resource-sync-request set to true it should return true",
-			ctx:      context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true),
-			expected: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, IsResourceSyncRequest(tt.ctx))
-		})
-	}
-}
 
 func TestNilOutManagedObjectMetaProperties(t *testing.T) {
 	t.Run("When om is nil it should not panic", func(t *testing.T) {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -61,15 +61,33 @@ func NewDeviceServiceHandler(
 
 var _ Service = (*DeviceServiceHandler)(nil)
 
+// SanitizeDevice clears status and managed metadata from an untrusted device document
+// (HTTP body). Trusted callers that must preserve Owner/annotations must not use this.
+func SanitizeDevice(device *domain.Device) {
+	if device == nil {
+		return
+	}
+	device.Status = nil
+	common.NilOutManagedObjectMetaProperties(&device.Metadata)
+}
+
+// CreateDeviceFromUntrusted sanitizes an untrusted device document, then creates it.
+func CreateDeviceFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, device domain.Device) (*domain.Device, domain.Status) {
+	SanitizeDevice(&device)
+	return svc.CreateDevice(ctx, orgId, device)
+}
+
+// ReplaceDeviceFromUntrusted sanitizes an untrusted device document, then replaces it.
+func ReplaceDeviceFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+	SanitizeDevice(&device)
+	return svc.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
+}
+
 func (h *DeviceServiceHandler) CreateDevice(ctx context.Context, orgId uuid.UUID, device domain.Device) (*domain.Device, domain.Status) {
 	if device.Spec != nil && device.Spec.Decommissioning != nil {
 		h.log.WithError(flterrors.ErrDecommission).Error("attempt to create decommissioned device")
 		return nil, domain.StatusBadRequest(flterrors.ErrDecommission.Error())
 	}
-
-	// don't set fields that are managed by the service
-	device.Status = nil
-	common.NilOutManagedObjectMetaProperties(&device.Metadata)
 
 	if errs := device.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
@@ -204,17 +222,10 @@ func DeviceVerificationCallback(ctx context.Context, before, after *domain.Devic
 	return nil
 }
 
-func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, domain.Status) {
+func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
 	if device.Spec != nil && device.Spec.Decommissioning != nil {
 		h.log.WithError(flterrors.ErrDecommission).Error("attempt to set decommissioned status when replacing device, or to replace decommissioned device")
 		return nil, domain.StatusBadRequest(flterrors.ErrDecommission.Error())
-	}
-
-	// don't overwrite fields that are managed by the service for external requests
-	isNotInternal := !common.IsInternalRequest(ctx)
-	if isNotInternal {
-		device.Status = nil
-		common.NilOutManagedObjectMetaProperties(&device.Metadata)
 	}
 
 	if errs := device.Validate(); len(errs) > 0 {
@@ -224,9 +235,22 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
+	if enforceOwnership {
+		existing, getErr := h.deviceStore.Get(ctx, orgId, name)
+		if getErr != nil {
+			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
+			}
+		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
+			if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+			}
+		}
+	}
+
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
-	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, isNotInternal, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.DeviceKind, &name)
 }
 
@@ -234,12 +258,6 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 	if device.Spec != nil && device.Spec.Decommissioning != nil {
 		h.log.WithError(flterrors.ErrDecommission).Error("attempt to set decommissioned status when replacing device, or to replace decommissioned device")
 		return nil, flterrors.ErrDecommission
-	}
-
-	// don't overwrite fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		device.Status = nil
-		common.NilOutManagedObjectMetaProperties(&device.Metadata)
 	}
 
 	if errs := device.Validate(); len(errs) > 0 {
@@ -251,6 +269,7 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
+	// Ownership is never enforced on UpdateDevice (agent/console trusted path).
 	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
 }
 
@@ -286,7 +305,7 @@ func validateDeviceStatus(d *domain.Device) []error {
 	return allErrs
 }
 
-func (h *DeviceServiceHandler) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, incomingDevice domain.Device) (*domain.Device, domain.Status) {
+func (h *DeviceServiceHandler) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, incomingDevice domain.Device, refreshLastSeen bool) (*domain.Device, domain.Status) {
 	if errs := validateDeviceStatus(&incomingDevice); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -299,8 +318,7 @@ func (h *DeviceServiceHandler) ReplaceDeviceStatus(ctx context.Context, orgId uu
 	if incomingDevice.Status == nil {
 		return nil, domain.StatusBadRequest("device status is required")
 	}
-	isNotInternal := !common.IsInternalRequest(ctx)
-	if isNotInternal {
+	if refreshLastSeen {
 		if h.agentGate.Acquire(ctx, 1) == nil {
 			defer h.agentGate.Release(1)
 		}
@@ -362,7 +380,7 @@ func (h *DeviceServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, true, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
@@ -428,7 +446,7 @@ func (h *DeviceServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.
-func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Device, domain.Status) {
+func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status) {
 	currentObj, err := h.deviceStore.Get(ctx, orgId, name)
 	if err != nil {
 		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
@@ -462,9 +480,15 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
+	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
+		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+		}
+	}
+
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, true, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/util"
@@ -53,6 +52,44 @@ func TestCreateDevice(t *testing.T) {
 		_, status := svc.CreateDevice(ctx, orgId, device)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
+
+	t.Run("When managed metadata fields are set by the caller CreateDeviceFromUntrusted should clear them before creation", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr("untrusted"),
+				Owner:      lo.ToPtr("Fleet/f1"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: &domain.DeviceSpec{},
+		}
+
+		_, status := CreateDeviceFromUntrusted(ctx, svc, orgId, device)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, st.device.devices["untrusted"].Metadata.Owner)
+		require.Nil(t, st.device.devices["untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateDevice (trusted) should preserve them", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr("trusted"),
+				Owner:      lo.ToPtr("Fleet/f1"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: &domain.DeviceSpec{},
+		}
+
+		_, status := svc.CreateDevice(ctx, orgId, device)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "Fleet/f1", lo.FromPtr(st.device.devices["trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(st.device.devices["trusted"].Metadata.Generation))
+	})
 }
 
 func TestGetDevice(t *testing.T) {
@@ -85,7 +122,7 @@ func TestReplaceDevice(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Spec:     &domain.DeviceSpec{},
 		}
-		_, status := svc.ReplaceDevice(ctx, orgId, "bar", device, nil)
+		_, status := svc.ReplaceDevice(ctx, orgId, "bar", device, nil, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -97,9 +134,47 @@ func TestReplaceDevice(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Spec:     &domain.DeviceSpec{},
 		}
-		result, status := svc.ReplaceDevice(ctx, orgId, "foo", device, nil)
+		result, status := svc.ReplaceDevice(ctx, orgId, "foo", device, nil, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.Equal(t, "foo", lo.FromPtr(result.Metadata.Name))
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceDeviceFromUntrusted should clear them before replacing", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr("replace-untrusted"),
+				Owner:      lo.ToPtr("Fleet/f1"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: &domain.DeviceSpec{},
+		}
+
+		_, status := ReplaceDeviceFromUntrusted(ctx, svc, orgId, "replace-untrusted", device, nil, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Nil(t, st.device.devices["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, st.device.devices["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceDevice (trusted) should preserve them", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr("replace-trusted"),
+				Owner:      lo.ToPtr("Fleet/f1"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: &domain.DeviceSpec{},
+		}
+
+		_, status := svc.ReplaceDevice(ctx, orgId, "replace-trusted", device, nil, true)
+		require.Equal(t, int32(http.StatusCreated), status.Code)
+		require.Equal(t, "Fleet/f1", lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Generation))
 	})
 }
 
@@ -148,7 +223,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/spec/os/image", Value: &value},
 		}
-		result, status := svc.PatchDevice(context.Background(), orgId, "foo", patch)
+		result, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.Equal(t, "newimg", result.Spec.Os.Image)
 	})
@@ -159,7 +234,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/metadata/name", Value: &value},
 		}
-		_, status := svc.PatchDevice(context.Background(), orgId, "foo", patch)
+		_, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -169,7 +244,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/metadata/labels/labelKey", Value: &value},
 		}
-		_, status := svc.PatchDevice(context.Background(), orgId, "bar", patch)
+		_, status := svc.PatchDevice(context.Background(), orgId, "bar", patch, true)
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 		require.Equal(t, domain.StatusResourceNotFound("Device", "bar"), status)
 	})
@@ -515,7 +590,6 @@ func TestUpdateDevice(t *testing.T) {
 		orgId := uuid.New()
 		_, err := st.device.Create(ctx, orgId, &domain.Device{Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")}, Spec: &domain.DeviceSpec{}}, nil)
 		require.NoError(t, err)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		device := domain.Device{
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img"}},
@@ -589,7 +663,7 @@ func TestReplaceDeviceStatus(t *testing.T) {
 	t.Run("When device status is missing it should return bad request", func(t *testing.T) {
 		_, _, svc := newTestHandler()
 		device := domain.Device{Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")}}
-		_, status := svc.ReplaceDeviceStatus(context.Background(), uuid.New(), "foo", device)
+		_, status := svc.ReplaceDeviceStatus(context.Background(), uuid.New(), "foo", device, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -608,8 +682,7 @@ func TestReplaceDeviceStatus(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Status:   lo.ToPtr(domain.NewDeviceStatus()),
 		}
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
-		result, status := svc.ReplaceDeviceStatus(ctx, orgId, "foo", incoming)
+		result, status := svc.ReplaceDeviceStatus(ctx, orgId, "foo", incoming, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 	})

--- a/internal/service/device/mock.go
+++ b/internal/service/device/mock.go
@@ -317,18 +317,18 @@ func (mr *MockServiceMockRecorder) OverwriteDeviceRepositoryRefs(ctx, orgId, nam
 }
 
 // PatchDevice mocks base method.
-func (m *MockService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Device, domain.Status) {
+func (m *MockService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchDevice", ctx, orgId, name, patch)
+	ret := m.ctrl.Call(m, "PatchDevice", ctx, orgId, name, patch, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Device)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // PatchDevice indicates an expected call of PatchDevice.
-func (mr *MockServiceMockRecorder) PatchDevice(ctx, orgId, name, patch any) *gomock.Call {
+func (mr *MockServiceMockRecorder) PatchDevice(ctx, orgId, name, patch, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDevice", reflect.TypeOf((*MockService)(nil).PatchDevice), ctx, orgId, name, patch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDevice", reflect.TypeOf((*MockService)(nil).PatchDevice), ctx, orgId, name, patch, enforceOwnership)
 }
 
 // PatchDeviceStatus mocks base method.
@@ -347,33 +347,33 @@ func (mr *MockServiceMockRecorder) PatchDeviceStatus(ctx, orgId, name, patch any
 }
 
 // ReplaceDevice mocks base method.
-func (m *MockService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, domain.Status) {
+func (m *MockService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceDevice", ctx, orgId, name, device, fieldsToUnset)
+	ret := m.ctrl.Call(m, "ReplaceDevice", ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Device)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceDevice indicates an expected call of ReplaceDevice.
-func (mr *MockServiceMockRecorder) ReplaceDevice(ctx, orgId, name, device, fieldsToUnset any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDevice", reflect.TypeOf((*MockService)(nil).ReplaceDevice), ctx, orgId, name, device, fieldsToUnset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDevice", reflect.TypeOf((*MockService)(nil).ReplaceDevice), ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
 }
 
 // ReplaceDeviceStatus mocks base method.
-func (m *MockService) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device) (*domain.Device, domain.Status) {
+func (m *MockService) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, refreshLastSeen bool) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceDeviceStatus", ctx, orgId, name, device)
+	ret := m.ctrl.Call(m, "ReplaceDeviceStatus", ctx, orgId, name, device, refreshLastSeen)
 	ret0, _ := ret[0].(*domain.Device)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceDeviceStatus indicates an expected call of ReplaceDeviceStatus.
-func (mr *MockServiceMockRecorder) ReplaceDeviceStatus(ctx, orgId, name, device any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceDeviceStatus(ctx, orgId, name, device, refreshLastSeen any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDeviceStatus", reflect.TypeOf((*MockService)(nil).ReplaceDeviceStatus), ctx, orgId, name, device)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDeviceStatus", reflect.TypeOf((*MockService)(nil).ReplaceDeviceStatus), ctx, orgId, name, device, refreshLastSeen)
 }
 
 // RestartDeviceApplication mocks base method.

--- a/internal/service/device/service.go
+++ b/internal/service/device/service.go
@@ -16,14 +16,14 @@ type Service interface {
 	ListDevicesByServiceCondition(ctx context.Context, orgId uuid.UUID, conditionType string, conditionStatus string, listParams store.ListParams) (*domain.DeviceList, domain.Status)
 	UpdateDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, error)
 	GetDevice(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status)
-	ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, domain.Status)
+	ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status)
 	DeleteDevice(ctx context.Context, orgId uuid.UUID, name string) domain.Status
 	GetDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status)
 	GetDeviceLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*domain.DeviceLastSeen, domain.Status)
-	ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device) (*domain.Device, domain.Status)
+	ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, refreshLastSeen bool) (*domain.Device, domain.Status)
 	PatchDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Device, domain.Status)
 	GetRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, params domain.GetRenderedDeviceParams) (*domain.Device, domain.Status)
-	PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Device, domain.Status)
+	PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status)
 	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status)
 	ResumeDevices(ctx context.Context, orgId uuid.UUID, request domain.DeviceResumeRequest) (domain.DeviceResumeResponse, domain.Status)
 	UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status

--- a/internal/service/device/traced.gen.go
+++ b/internal/service/device/traced.gen.go
@@ -191,10 +191,10 @@ func (_d *TracedDeviceService) OverwriteDeviceRepositoryRefs(ctx context.Context
 	return s1
 }
 
-func (_d *TracedDeviceService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (dp1 *domain.Device, s1 domain.Status) {
+func (_d *TracedDeviceService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "PatchDevice")
 
-	dp1, s1 = _d.inner.PatchDevice(ctx, orgId, name, patch)
+	dp1, s1 = _d.inner.PatchDevice(ctx, orgId, name, patch, enforceOwnership)
 	endSpan(span, s1)
 	return dp1, s1
 }
@@ -207,18 +207,18 @@ func (_d *TracedDeviceService) PatchDeviceStatus(ctx context.Context, orgId uuid
 	return dp1, s1
 }
 
-func (_d *TracedDeviceService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (dp1 *domain.Device, s1 domain.Status) {
+func (_d *TracedDeviceService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceDevice")
 
-	dp1, s1 = _d.inner.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset)
+	dp1, s1 = _d.inner.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
 	endSpan(span, s1)
 	return dp1, s1
 }
 
-func (_d *TracedDeviceService) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device) (dp1 *domain.Device, s1 domain.Status) {
+func (_d *TracedDeviceService) ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, refreshLastSeen bool) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceDeviceStatus")
 
-	dp1, s1 = _d.inner.ReplaceDeviceStatus(ctx, orgId, name, device)
+	dp1, s1 = _d.inner.ReplaceDeviceStatus(ctx, orgId, name, device, refreshLastSeen)
 	endSpan(span, s1)
 	return dp1, s1
 }

--- a/internal/service/enrollmentrequest/handler.go
+++ b/internal/service/enrollmentrequest/handler.go
@@ -67,6 +67,28 @@ func NewServiceHandler(store enrollmentrequeststore.Store, deviceStore devicesto
 
 var _ Service = (*ServiceHandler)(nil)
 
+// SanitizeEnrollmentRequest clears status and managed metadata from an untrusted enrollment
+// request document (HTTP body).
+func SanitizeEnrollmentRequest(er *domain.EnrollmentRequest) {
+	if er == nil {
+		return
+	}
+	er.Status = nil
+	common.NilOutManagedObjectMetaProperties(&er.Metadata)
+}
+
+// CreateEnrollmentRequestFromUntrusted sanitizes an untrusted enrollment request document, then creates it.
+func CreateEnrollmentRequestFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, er domain.EnrollmentRequest) (*domain.EnrollmentRequest, domain.Status) {
+	SanitizeEnrollmentRequest(&er)
+	return svc.CreateEnrollmentRequest(ctx, orgId, er)
+}
+
+// ReplaceEnrollmentRequestFromUntrusted sanitizes an untrusted enrollment request document, then replaces it.
+func ReplaceEnrollmentRequestFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, er domain.EnrollmentRequest) (*domain.EnrollmentRequest, domain.Status) {
+	SanitizeEnrollmentRequest(&er)
+	return svc.ReplaceEnrollmentRequest(ctx, orgId, name, er)
+}
+
 // getTPMCAPool loads the TPM CA certificates from configured paths
 func (h *ServiceHandler) getTPMCAPool() *x509.CertPool {
 	if len(h.tpmCAPaths) == 0 {
@@ -311,13 +333,7 @@ func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, 
 }
 
 func (h *ServiceHandler) CreateEnrollmentRequest(ctx context.Context, orgId uuid.UUID, er domain.EnrollmentRequest) (*domain.EnrollmentRequest, domain.Status) {
-	er.Status = nil
 	addStatusIfNeeded(&er)
-
-	// don't set fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		common.NilOutManagedObjectMetaProperties(&er.Metadata)
-	}
 
 	// Check if knownRenderedVersion is provided and not "0", add awaitingReconnect annotation
 	if er.Spec.KnownRenderedVersion != nil && *er.Spec.KnownRenderedVersion != "" && *er.Spec.KnownRenderedVersion != "0" {
@@ -386,10 +402,7 @@ func (h *ServiceHandler) GetEnrollmentRequest(ctx context.Context, orgId uuid.UU
 }
 
 func (h *ServiceHandler) ReplaceEnrollmentRequest(ctx context.Context, orgId uuid.UUID, name string, er domain.EnrollmentRequest) (*domain.EnrollmentRequest, domain.Status) {
-	// don't set fields that are managed by the service
-	er.Status = nil
 	addStatusIfNeeded(&er)
-	common.NilOutManagedObjectMetaProperties(&er.Metadata)
 
 	if errs := er.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())

--- a/internal/service/enrollmentrequest/handler_test.go
+++ b/internal/service/enrollmentrequest/handler_test.go
@@ -277,6 +277,46 @@ func TestCreateEnrollmentRequest(t *testing.T) {
 		_, status := h.CreateEnrollmentRequest(context.Background(), uuid.New(), er)
 		require.Equal(t, statusBadRequestCode, status.Code)
 	})
+
+	t.Run("When managed metadata fields are set by the caller CreateEnrollmentRequestFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		cn := "untrusted-device"
+		er := domain.EnrollmentRequest{
+			ApiVersion: "v1beta1",
+			Kind:       "EnrollmentRequest",
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.EnrollmentRequestSpec{Csr: csrPEM(t, cn)},
+		}
+
+		_, status := CreateEnrollmentRequestFromUntrusted(context.Background(), h, uuid.New(), er)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.items[cn].Metadata.Owner)
+		require.Nil(t, fakeStore.items[cn].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateEnrollmentRequest (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		cn := "trusted-device"
+		er := domain.EnrollmentRequest{
+			ApiVersion: "v1beta1",
+			Kind:       "EnrollmentRequest",
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.EnrollmentRequestSpec{Csr: csrPEM(t, cn)},
+		}
+
+		_, status := h.CreateEnrollmentRequest(context.Background(), uuid.New(), er)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[cn].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[cn].Metadata.Generation))
+	})
 }
 
 func TestListEnrollmentRequests(t *testing.T) {
@@ -329,6 +369,44 @@ func TestReplaceEnrollmentRequest(t *testing.T) {
 
 		_, status := h.ReplaceEnrollmentRequest(context.Background(), uuid.New(), cn, er)
 		require.Equal(t, statusBadRequestCode, status.Code)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceEnrollmentRequestFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		orgId := uuid.New()
+		cn := "replace-untrusted"
+		er := domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.EnrollmentRequestSpec{Csr: csrPEM(t, cn)},
+		}
+
+		_, status := ReplaceEnrollmentRequestFromUntrusted(context.Background(), h, orgId, cn, er)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.items[cn].Metadata.Owner)
+		require.Nil(t, fakeStore.items[cn].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceEnrollmentRequest (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		orgId := uuid.New()
+		cn := "replace-trusted"
+		er := domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{
+				Name:       lo.ToPtr(cn),
+				Owner:      lo.ToPtr("someone"),
+				Generation: lo.ToPtr(int64(5)),
+			},
+			Spec: domain.EnrollmentRequestSpec{Csr: csrPEM(t, cn)},
+		}
+
+		_, status := h.ReplaceEnrollmentRequest(context.Background(), orgId, cn, er)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[cn].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[cn].Metadata.Generation))
 	})
 }
 

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
@@ -12,6 +13,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -88,6 +90,24 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
+	// External updates of owned fleets cannot change spec or labels (ResourceSync may).
+	// Internal requests skip this check (store fromAPI=false path).
+	if !isInternal {
+		existing, getErr := h.store.Get(ctx, orgId, name)
+		if getErr != nil {
+			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+				return nil, common.StoreErrorToApiStatus(getErr, false, domain.FleetKind, &name)
+			}
+		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 && !common.IsResourceSyncRequest(ctx) {
+			if !domain.FleetSpecsAreEqual(existing.Spec, fleet.Spec) {
+				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
+			}
+			if !reflect.DeepEqual(existing.Metadata.Labels, fleet.Metadata.Labels) {
+				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
+			}
+		}
+	}
+
 	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, !isInternal, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.FleetKind, &name)
 }
@@ -142,6 +162,16 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name s
 
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
+
+	// Owned fleets cannot change spec or labels via patch (ResourceSync may).
+	if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 && !common.IsResourceSyncRequest(ctx) {
+		if !domain.FleetSpecsAreEqual(currentObj.Spec, newObj.Spec) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
+		}
+		if !reflect.DeepEqual(currentObj.Metadata.Labels, newObj.Metadata.Labels) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
+		}
+	}
 
 	result, err := h.store.Update(ctx, orgId, newObj, nil, true, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -30,14 +30,32 @@ func NewServiceHandler(store fleetstore.Store, events events.Service, log logrus
 
 var _ Service = (*ServiceHandler)(nil)
 
-func (h *ServiceHandler) CreateFleet(ctx context.Context, orgId uuid.UUID, fleet domain.Fleet) (*domain.Fleet, domain.Status) {
-	// don't set fields that are managed by the service
+// SanitizeFleet clears status and managed metadata from an untrusted fleet document
+// (HTTP body or ResourceSync YAML). Callers that must set Owner must not use this.
+func SanitizeFleet(fleet *domain.Fleet) {
+	if fleet == nil {
+		return
+	}
 	fleet.Status = nil
 	common.NilOutManagedObjectMetaProperties(&fleet.Metadata)
 	if fleet.Spec.Template.Metadata != nil {
 		common.NilOutManagedObjectMetaProperties(fleet.Spec.Template.Metadata)
 	}
+}
 
+// CreateFleetFromUntrusted sanitizes an untrusted fleet document, then creates it.
+func CreateFleetFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, fleet domain.Fleet) (*domain.Fleet, domain.Status) {
+	SanitizeFleet(&fleet)
+	return svc.CreateFleet(ctx, orgId, fleet)
+}
+
+// ReplaceFleetFromUntrusted sanitizes an untrusted fleet document, then replaces it.
+func ReplaceFleetFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, fleet domain.Fleet, enforceOwnership bool) (*domain.Fleet, domain.Status) {
+	SanitizeFleet(&fleet)
+	return svc.ReplaceFleet(ctx, orgId, name, fleet, enforceOwnership)
+}
+
+func (h *ServiceHandler) CreateFleet(ctx context.Context, orgId uuid.UUID, fleet domain.Fleet) (*domain.Fleet, domain.Status) {
 	if errs := fleet.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -72,17 +90,7 @@ func (h *ServiceHandler) GetFleet(ctx context.Context, orgId uuid.UUID, name str
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 
-func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet) (*domain.Fleet, domain.Status) {
-	// don't overwrite fields that are managed by the service
-	isInternal := common.IsInternalRequest(ctx)
-	if !isInternal {
-		fleet.Status = nil
-		common.NilOutManagedObjectMetaProperties(&fleet.Metadata)
-		if fleet.Spec.Template.Metadata != nil {
-			common.NilOutManagedObjectMetaProperties(fleet.Spec.Template.Metadata)
-		}
-	}
-
+func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet, enforceOwnership bool) (*domain.Fleet, domain.Status) {
 	if errs := fleet.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -90,15 +98,13 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
-	// External updates of owned fleets cannot change spec or labels (ResourceSync may).
-	// Internal requests skip this check (store fromAPI=false path).
-	if !isInternal {
+	if enforceOwnership {
 		existing, getErr := h.store.Get(ctx, orgId, name)
 		if getErr != nil {
 			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
 				return nil, common.StoreErrorToApiStatus(getErr, false, domain.FleetKind, &name)
 			}
-		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 && !common.IsResourceSyncRequest(ctx) {
+		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
 			if !domain.FleetSpecsAreEqual(existing.Spec, fleet.Spec) {
 				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
 			}
@@ -108,11 +114,11 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name
 		}
 	}
 
-	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, !isInternal, h.callbackFleetUpdated)
+	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, false, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.FleetKind, &name)
 }
 
-func (h *ServiceHandler) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
+func (h *ServiceHandler) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status {
 	f, err := h.store.Get(ctx, orgId, name)
 	if err != nil {
 		if errors.Is(err, flterrors.ErrResourceNotFound) {
@@ -121,7 +127,7 @@ func (h *ServiceHandler) DeleteFleet(ctx context.Context, orgId uuid.UUID, name 
 		return common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 	}
 
-	if f.Metadata.Owner != nil && !common.IsResourceSyncRequest(ctx) {
+	if enforceOwnership && len(lo.FromPtr(f.Metadata.Owner)) != 0 {
 		return domain.StatusConflict(flterrors.ErrDeletingResourceWithOwnerNotAllowed.Error())
 	}
 
@@ -140,7 +146,7 @@ func (h *ServiceHandler) ReplaceFleetStatus(ctx context.Context, orgId uuid.UUID
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.
-func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Fleet, domain.Status) {
+func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Fleet, domain.Status) {
 	currentObj, err := h.store.Get(ctx, orgId, name)
 	if err != nil {
 		return nil, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
@@ -163,8 +169,7 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name s
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	// Owned fleets cannot change spec or labels via patch (ResourceSync may).
-	if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 && !common.IsResourceSyncRequest(ctx) {
+	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
 		if !domain.FleetSpecsAreEqual(currentObj.Spec, newObj.Spec) {
 			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
 		}
@@ -173,7 +178,7 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name s
 		}
 	}
 
-	result, err := h.store.Update(ctx, orgId, newObj, nil, true, h.callbackFleetUpdated)
+	result, err := h.store.Update(ctx, orgId, newObj, nil, false, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 

--- a/internal/service/fleet/handler_test.go
+++ b/internal/service/fleet/handler_test.go
@@ -432,6 +432,132 @@ func TestReplaceFleet(t *testing.T) {
 	})
 }
 
+func TestReplaceFleetOwnership(t *testing.T) {
+	owner := "ResourceSync/my-resourcesync"
+
+	t.Run("When replacing an owned fleet with a changed spec it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		updated := createTestFleet("owned-fleet", nil)
+		updated.Spec.Template.Spec.Os.Image = "img-updated"
+
+		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated)
+		require.Equal(t, statusConflictCode, status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+		require.Equal(t, "img", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+
+	t.Run("When replacing an owned fleet with changed labels it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		updated := createTestFleet("owned-fleet", nil)
+		updated.Metadata.Labels = &map[string]string{"labelKey": "changed"}
+
+		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated)
+		require.Equal(t, statusConflictCode, status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+	})
+
+	t.Run("When ResourceSync replaces an owned fleet it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		updated := createTestFleet("owned-fleet", nil)
+		updated.Spec.Template.Spec.Os.Image = "img-updated"
+		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
+
+		result, status := h.ReplaceFleet(ctx, orgId, "owned-fleet", updated)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+
+	t.Run("When an internal request replaces an owned fleet it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		updated := createTestFleet("owned-fleet", nil)
+		updated.Spec.Template.Spec.Os.Image = "img-updated"
+		ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
+
+		result, status := h.ReplaceFleet(ctx, orgId, "owned-fleet", updated)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+
+	t.Run("When replacing an unowned fleet with a changed spec it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		existing := createTestFleet("unowned-fleet", nil)
+		fakeStore.fleets["unowned-fleet"] = &existing
+
+		updated := createTestFleet("unowned-fleet", nil)
+		updated.Spec.Template.Spec.Os.Image = "img-updated"
+
+		result, status := h.ReplaceFleet(context.Background(), orgId, "unowned-fleet", updated)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "img-updated", fakeStore.fleets["unowned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+}
+
+func TestPatchFleetOwnership(t *testing.T) {
+	owner := "ResourceSync/my-resourcesync"
+
+	t.Run("When patching an owned fleet spec it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		var valueIface interface{} = "img-updated"
+		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/template/spec/os/image", Value: &valueIface}}
+
+		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch)
+		require.Equal(t, statusConflictCode, status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+		require.Equal(t, "img", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+
+	t.Run("When patching an owned fleet labels it should return conflict", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		var valueIface interface{} = "changed"
+		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels/labelKey", Value: &valueIface}}
+
+		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch)
+		require.Equal(t, statusConflictCode, status.Code)
+		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
+	})
+
+	t.Run("When ResourceSync patches an owned fleet it should allow the update", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		existing := createTestFleet("owned-fleet", &owner)
+		fakeStore.fleets["owned-fleet"] = &existing
+
+		var valueIface interface{} = "img-updated"
+		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/template/spec/os/image", Value: &valueIface}}
+		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
+
+		result, status := h.PatchFleet(ctx, uuid.New(), "owned-fleet", patch)
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.NotNil(t, result)
+		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
+	})
+}
+
 func TestDeleteFleet(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 

--- a/internal/service/fleet/handler_test.go
+++ b/internal/service/fleet/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/service/events"
@@ -335,16 +334,28 @@ func TestCreateFleet(t *testing.T) {
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
 	})
 
-	t.Run("When managed metadata fields are set by the caller it should clear them before creation", func(t *testing.T) {
+	t.Run("When managed metadata fields are set by the caller CreateFleetFromUntrusted should clear them before creation", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		fleet := createTestFleet("f2", nil)
 		fleet.Metadata.Owner = lo.ToPtr("someone")
 		fleet.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := h.CreateFleet(context.Background(), uuid.New(), fleet)
+		_, status := CreateFleetFromUntrusted(context.Background(), h, uuid.New(), fleet)
 		require.Equal(t, statusCreatedCode, status.Code)
 		require.Nil(t, fakeStore.fleets["f2"].Metadata.Owner)
 		require.Nil(t, fakeStore.fleets["f2"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateFleet (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		fleet := createTestFleet("f2-trusted", nil)
+		fleet.Metadata.Owner = lo.ToPtr("someone")
+		fleet.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateFleet(context.Background(), uuid.New(), fleet)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.fleets["f2-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.fleets["f2-trusted"].Metadata.Generation))
 	})
 
 	t.Run("When the store errors it should return an internal-server-error status", func(t *testing.T) {
@@ -400,7 +411,7 @@ func TestReplaceFleet(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		fleet := createTestFleet("new-fleet", nil)
 
-		result, status := h.ReplaceFleet(context.Background(), uuid.New(), "new-fleet", fleet)
+		result, status := h.ReplaceFleet(context.Background(), uuid.New(), "new-fleet", fleet, true)
 		require.Equal(t, statusCreatedCode, status.Code)
 		require.NotNil(t, result)
 		require.Contains(t, fakeStore.fleets, "new-fleet")
@@ -410,7 +421,7 @@ func TestReplaceFleet(t *testing.T) {
 		h, _, _ := newTestHandler()
 		fleet := createTestFleet("f1", nil)
 
-		_, status := h.ReplaceFleet(context.Background(), uuid.New(), "different-name", fleet)
+		_, status := h.ReplaceFleet(context.Background(), uuid.New(), "different-name", fleet, true)
 		require.Equal(t, statusBadRequestCode, status.Code)
 	})
 
@@ -421,7 +432,7 @@ func TestReplaceFleet(t *testing.T) {
 		_, status := h.CreateFleet(context.Background(), orgId, fleet)
 		require.Equal(t, statusCreatedCode, status.Code)
 
-		result, status := h.ReplaceFleet(context.Background(), orgId, "f1", fleet)
+		result, status := h.ReplaceFleet(context.Background(), orgId, "f1", fleet, true)
 		require.Equal(t, statusSuccessCode, status.Code)
 		require.NotNil(t, result)
 		require.Contains(t, fakeStore.fleets, "f1")
@@ -429,6 +440,32 @@ func TestReplaceFleet(t *testing.T) {
 		// metadata (no generation/labels/owner change) emits nothing further.
 		require.Len(t, fakeEvents.created, 1)
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceFleetFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		fleet := createTestFleet("replace-untrusted", nil)
+		fleet.Metadata.Owner = lo.ToPtr("someone")
+		fleet.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceFleetFromUntrusted(context.Background(), h, orgId, "replace-untrusted", fleet, true)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.fleets["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, fakeStore.fleets["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceFleet (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		fleet := createTestFleet("replace-trusted", nil)
+		fleet.Metadata.Owner = lo.ToPtr("someone")
+		fleet.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceFleet(context.Background(), orgId, "replace-trusted", fleet, true)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.fleets["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.fleets["replace-trusted"].Metadata.Generation))
 	})
 }
 
@@ -444,7 +481,7 @@ func TestReplaceFleetOwnership(t *testing.T) {
 		updated := createTestFleet("owned-fleet", nil)
 		updated.Spec.Template.Spec.Os.Image = "img-updated"
 
-		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated)
+		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated, true)
 		require.Equal(t, statusConflictCode, status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 		require.Equal(t, "img", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
@@ -459,12 +496,12 @@ func TestReplaceFleetOwnership(t *testing.T) {
 		updated := createTestFleet("owned-fleet", nil)
 		updated.Metadata.Labels = &map[string]string{"labelKey": "changed"}
 
-		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated)
+		_, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated, true)
 		require.Equal(t, statusConflictCode, status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 	})
 
-	t.Run("When ResourceSync replaces an owned fleet it should allow the update", func(t *testing.T) {
+	t.Run("When enforceOwnership is false it should allow updating an owned fleet", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		existing := createTestFleet("owned-fleet", &owner)
@@ -472,25 +509,8 @@ func TestReplaceFleetOwnership(t *testing.T) {
 
 		updated := createTestFleet("owned-fleet", nil)
 		updated.Spec.Template.Spec.Os.Image = "img-updated"
-		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
 
-		result, status := h.ReplaceFleet(ctx, orgId, "owned-fleet", updated)
-		require.Equal(t, statusSuccessCode, status.Code)
-		require.NotNil(t, result)
-		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
-	})
-
-	t.Run("When an internal request replaces an owned fleet it should allow the update", func(t *testing.T) {
-		h, fakeStore, _ := newTestHandler()
-		orgId := uuid.New()
-		existing := createTestFleet("owned-fleet", &owner)
-		fakeStore.fleets["owned-fleet"] = &existing
-
-		updated := createTestFleet("owned-fleet", nil)
-		updated.Spec.Template.Spec.Os.Image = "img-updated"
-		ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
-
-		result, status := h.ReplaceFleet(ctx, orgId, "owned-fleet", updated)
+		result, status := h.ReplaceFleet(context.Background(), orgId, "owned-fleet", updated, false)
 		require.Equal(t, statusSuccessCode, status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
@@ -505,7 +525,7 @@ func TestReplaceFleetOwnership(t *testing.T) {
 		updated := createTestFleet("unowned-fleet", nil)
 		updated.Spec.Template.Spec.Os.Image = "img-updated"
 
-		result, status := h.ReplaceFleet(context.Background(), orgId, "unowned-fleet", updated)
+		result, status := h.ReplaceFleet(context.Background(), orgId, "unowned-fleet", updated, true)
 		require.Equal(t, statusSuccessCode, status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", fakeStore.fleets["unowned-fleet"].Spec.Template.Spec.Os.Image)
@@ -523,7 +543,7 @@ func TestPatchFleetOwnership(t *testing.T) {
 		var valueIface interface{} = "img-updated"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/template/spec/os/image", Value: &valueIface}}
 
-		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch)
+		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch, true)
 		require.Equal(t, statusConflictCode, status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 		require.Equal(t, "img", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
@@ -537,21 +557,20 @@ func TestPatchFleetOwnership(t *testing.T) {
 		var valueIface interface{} = "changed"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels/labelKey", Value: &valueIface}}
 
-		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch)
+		_, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch, true)
 		require.Equal(t, statusConflictCode, status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 	})
 
-	t.Run("When ResourceSync patches an owned fleet it should allow the update", func(t *testing.T) {
+	t.Run("When enforceOwnership is false it should allow patching an owned fleet", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		existing := createTestFleet("owned-fleet", &owner)
 		fakeStore.fleets["owned-fleet"] = &existing
 
 		var valueIface interface{} = "img-updated"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/template/spec/os/image", Value: &valueIface}}
-		ctx := context.WithValue(context.Background(), consts.ResourceSyncRequestCtxKey, true)
 
-		result, status := h.PatchFleet(ctx, uuid.New(), "owned-fleet", patch)
+		result, status := h.PatchFleet(context.Background(), uuid.New(), "owned-fleet", patch, false)
 		require.Equal(t, statusSuccessCode, status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", fakeStore.fleets["owned-fleet"].Spec.Template.Spec.Os.Image)
@@ -562,20 +581,21 @@ func TestDeleteFleet(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 
 	tests := []struct {
-		name                  string
-		fleetName             string
-		fleetOwner            *string
-		createFleet           bool
-		isResourceSyncRequest bool
-		expectedStatusCode    int32
-		expectedError         error
-		expectFleetDeleted    bool
+		name               string
+		fleetName          string
+		fleetOwner         *string
+		createFleet        bool
+		enforceOwnership   bool
+		expectedStatusCode int32
+		expectedError      error
+		expectFleetDeleted bool
 	}{
 		{
 			name:               "delete fleet without owner succeeds",
 			fleetName:          "test-fleet",
 			fleetOwner:         nil,
 			createFleet:        true,
+			enforceOwnership:   true,
 			expectedStatusCode: statusSuccessCode,
 			expectFleetDeleted: true,
 		},
@@ -583,6 +603,7 @@ func TestDeleteFleet(t *testing.T) {
 			name:               "delete non-existent fleet returns OK (idempotent)",
 			fleetName:          "nonexistent-fleet",
 			createFleet:        false,
+			enforceOwnership:   true,
 			expectedStatusCode: statusSuccessCode,
 			expectFleetDeleted: true,
 		},
@@ -591,18 +612,19 @@ func TestDeleteFleet(t *testing.T) {
 			fleetName:          "owned-fleet",
 			fleetOwner:         &owner,
 			createFleet:        true,
+			enforceOwnership:   true,
 			expectedStatusCode: statusConflictCode,
 			expectedError:      flterrors.ErrDeletingResourceWithOwnerNotAllowed,
 			expectFleetDeleted: false,
 		},
 		{
-			name:                  "resourceSync can delete fleets it owns",
-			fleetName:             "resourcesync-owned-fleet",
-			fleetOwner:            &owner,
-			createFleet:           true,
-			isResourceSyncRequest: true,
-			expectedStatusCode:    statusSuccessCode,
-			expectFleetDeleted:    true,
+			name:               "delete owned fleet succeeds when enforceOwnership is false",
+			fleetName:          "resourcesync-owned-fleet",
+			fleetOwner:         &owner,
+			createFleet:        true,
+			enforceOwnership:   false,
+			expectedStatusCode: statusSuccessCode,
+			expectFleetDeleted: true,
 		},
 	}
 
@@ -617,12 +639,7 @@ func TestDeleteFleet(t *testing.T) {
 				fakeStore.fleets[tt.fleetName] = &fleet
 			}
 
-			deleteCtx := ctx
-			if tt.isResourceSyncRequest {
-				deleteCtx = context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
-			}
-
-			status := h.DeleteFleet(deleteCtx, testOrgId, tt.fleetName)
+			status := h.DeleteFleet(ctx, testOrgId, tt.fleetName, tt.enforceOwnership)
 			require.Equal(t, tt.expectedStatusCode, status.Code)
 
 			if tt.expectedError != nil {
@@ -689,7 +706,7 @@ func testFleetPatch(t *testing.T, patch domain.PatchRequest) (*domain.Fleet, dom
 	h, fakeStore, _ := newTestHandler()
 	fakeStore.fleets["foo"] = &orig
 
-	resp, status := h.PatchFleet(context.Background(), uuid.New(), "foo", patch)
+	resp, status := h.PatchFleet(context.Background(), uuid.New(), "foo", patch, true)
 	require.NotEqual(int32(0), status.Code)
 	return resp, orig, status
 }
@@ -772,7 +789,7 @@ func TestPatchFleetNonExistingResource(t *testing.T) {
 		{Op: "replace", Path: "/metadata/labels/labelKey", Value: &value},
 	}
 
-	resp, status := h.PatchFleet(context.Background(), uuid.New(), "doesnotexist", pr)
+	resp, status := h.PatchFleet(context.Background(), uuid.New(), "doesnotexist", pr, true)
 	require.Equal(t, statusNotFoundCode, status.Code)
 	require.Nil(t, resp)
 }

--- a/internal/service/fleet/mock.go
+++ b/internal/service/fleet/mock.go
@@ -57,17 +57,17 @@ func (mr *MockServiceMockRecorder) CreateFleet(ctx, orgId, fleet any) *gomock.Ca
 }
 
 // DeleteFleet mocks base method.
-func (m *MockService) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
+func (m *MockService) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFleet", ctx, orgId, name)
+	ret := m.ctrl.Call(m, "DeleteFleet", ctx, orgId, name, enforceOwnership)
 	ret0, _ := ret[0].(domain.Status)
 	return ret0
 }
 
 // DeleteFleet indicates an expected call of DeleteFleet.
-func (mr *MockServiceMockRecorder) DeleteFleet(ctx, orgId, name any) *gomock.Call {
+func (mr *MockServiceMockRecorder) DeleteFleet(ctx, orgId, name, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleet", reflect.TypeOf((*MockService)(nil).DeleteFleet), ctx, orgId, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleet", reflect.TypeOf((*MockService)(nil).DeleteFleet), ctx, orgId, name, enforceOwnership)
 }
 
 // GetFleet mocks base method.
@@ -180,33 +180,33 @@ func (mr *MockServiceMockRecorder) OverwriteFleetRepositoryRefs(ctx, orgId, name
 }
 
 // PatchFleet mocks base method.
-func (m *MockService) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Fleet, domain.Status) {
+func (m *MockService) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Fleet, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchFleet", ctx, orgId, name, patch)
+	ret := m.ctrl.Call(m, "PatchFleet", ctx, orgId, name, patch, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Fleet)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // PatchFleet indicates an expected call of PatchFleet.
-func (mr *MockServiceMockRecorder) PatchFleet(ctx, orgId, name, patch any) *gomock.Call {
+func (mr *MockServiceMockRecorder) PatchFleet(ctx, orgId, name, patch, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchFleet", reflect.TypeOf((*MockService)(nil).PatchFleet), ctx, orgId, name, patch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchFleet", reflect.TypeOf((*MockService)(nil).PatchFleet), ctx, orgId, name, patch, enforceOwnership)
 }
 
 // ReplaceFleet mocks base method.
-func (m *MockService) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet) (*domain.Fleet, domain.Status) {
+func (m *MockService) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet, enforceOwnership bool) (*domain.Fleet, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceFleet", ctx, orgId, name, fleet)
+	ret := m.ctrl.Call(m, "ReplaceFleet", ctx, orgId, name, fleet, enforceOwnership)
 	ret0, _ := ret[0].(*domain.Fleet)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceFleet indicates an expected call of ReplaceFleet.
-func (mr *MockServiceMockRecorder) ReplaceFleet(ctx, orgId, name, fleet any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceFleet(ctx, orgId, name, fleet, enforceOwnership any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceFleet", reflect.TypeOf((*MockService)(nil).ReplaceFleet), ctx, orgId, name, fleet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceFleet", reflect.TypeOf((*MockService)(nil).ReplaceFleet), ctx, orgId, name, fleet, enforceOwnership)
 }
 
 // ReplaceFleetStatus mocks base method.

--- a/internal/service/fleet/service.go
+++ b/internal/service/fleet/service.go
@@ -11,11 +11,11 @@ type Service interface {
 	CreateFleet(ctx context.Context, orgId uuid.UUID, fleet domain.Fleet) (*domain.Fleet, domain.Status)
 	ListFleets(ctx context.Context, orgId uuid.UUID, params domain.ListFleetsParams) (*domain.FleetList, domain.Status)
 	GetFleet(ctx context.Context, orgId uuid.UUID, name string, params domain.GetFleetParams) (*domain.Fleet, domain.Status)
-	ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet) (*domain.Fleet, domain.Status)
-	DeleteFleet(ctx context.Context, orgId uuid.UUID, name string) domain.Status
+	ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet, enforceOwnership bool) (*domain.Fleet, domain.Status)
+	DeleteFleet(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) domain.Status
 	GetFleetStatus(ctx context.Context, orgId uuid.UUID, name string) (*domain.Fleet, domain.Status)
 	ReplaceFleetStatus(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet) (*domain.Fleet, domain.Status)
-	PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Fleet, domain.Status)
+	PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Fleet, domain.Status)
 	ListFleetRolloutDeviceSelection(ctx context.Context, orgId uuid.UUID) (*domain.FleetList, domain.Status)
 	ListDisruptionBudgetFleets(ctx context.Context, orgId uuid.UUID) (*domain.FleetList, domain.Status)
 	UpdateFleetConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status

--- a/internal/service/fleet/traced.gen.go
+++ b/internal/service/fleet/traced.gen.go
@@ -52,10 +52,10 @@ func (_d *TracedService) CreateFleet(ctx context.Context, orgId uuid.UUID, fleet
 	return fp1, s1
 }
 
-func (_d *TracedService) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string) (s1 domain.Status) {
+func (_d *TracedService) DeleteFleet(ctx context.Context, orgId uuid.UUID, name string, enforceOwnership bool) (s1 domain.Status) {
 	ctx, span := startSpan(ctx, "DeleteFleet")
 
-	s1 = _d.inner.DeleteFleet(ctx, orgId, name)
+	s1 = _d.inner.DeleteFleet(ctx, orgId, name, enforceOwnership)
 	endSpan(span, s1)
 	return s1
 }
@@ -116,18 +116,18 @@ func (_d *TracedService) OverwriteFleetRepositoryRefs(ctx context.Context, orgId
 	return s1
 }
 
-func (_d *TracedService) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (fp1 *domain.Fleet, s1 domain.Status) {
+func (_d *TracedService) PatchFleet(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (fp1 *domain.Fleet, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "PatchFleet")
 
-	fp1, s1 = _d.inner.PatchFleet(ctx, orgId, name, patch)
+	fp1, s1 = _d.inner.PatchFleet(ctx, orgId, name, patch, enforceOwnership)
 	endSpan(span, s1)
 	return fp1, s1
 }
 
-func (_d *TracedService) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet) (fp1 *domain.Fleet, s1 domain.Status) {
+func (_d *TracedService) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name string, fleet domain.Fleet, enforceOwnership bool) (fp1 *domain.Fleet, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceFleet")
 
-	fp1, s1 = _d.inner.ReplaceFleet(ctx, orgId, name, fleet)
+	fp1, s1 = _d.inner.ReplaceFleet(ctx, orgId, name, fleet, enforceOwnership)
 	endSpan(span, s1)
 	return fp1, s1
 }

--- a/internal/service/organization/handler.go
+++ b/internal/service/organization/handler.go
@@ -41,43 +41,45 @@ func organizationModelToAPI(org *model.Organization) domain.Organization {
 	}
 }
 
+// ListOrganizations returns the organizations the caller's mapped identity belongs to.
 func (h *ServiceHandler) ListOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
-	var orgs []*model.Organization
-	var err error
+	userOrgs, err := h.listUserOrganizations(ctx)
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.OrganizationKind, nil)
+	}
+
+	if params.FieldSelector == nil || *params.FieldSelector == "" {
+		return buildOrganizationList(userOrgs), domain.StatusOK()
+	}
+
+	allowedIDs := parseFieldSelectorForOrgIDs(*params.FieldSelector)
+	filtered := make([]*model.Organization, 0, len(userOrgs))
+	for _, userOrg := range userOrgs {
+		if _, exists := allowedIDs[userOrg.ID]; exists {
+			filtered = append(filtered, userOrg)
+		}
+	}
+	return buildOrganizationList(filtered), domain.StatusOK()
+}
+
+// ListAllOrganizations returns every organization in the system, bypassing identity-based scoping.
+// It is intended for trusted internal callers (workers, periodic tasks, alert exporter) that need
+// a system-wide view rather than the requesting identity's own organizations.
+func (h *ServiceHandler) ListAllOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
 	listParams, status := common.PrepareListParams(nil, nil, params.FieldSelector, nil)
 	if status.Code != http.StatusOK {
 		return nil, status
 	}
 
-	if !common.IsInternalRequest(ctx) {
-		var listErr error
-		userOrgs, listErr := h.listUserOrganizations(ctx)
-		if listErr != nil {
-			status := common.StoreErrorToApiStatus(listErr, false, domain.OrganizationKind, nil)
-			return nil, status
-		}
-		if params.FieldSelector != nil && *params.FieldSelector != "" {
-			allowedIDs := parseFieldSelectorForOrgIDs(*params.FieldSelector)
-
-			filtered := make([]*model.Organization, 0, len(userOrgs))
-			for _, userOrg := range userOrgs {
-				if _, exists := allowedIDs[userOrg.ID]; exists {
-					filtered = append(filtered, userOrg)
-				}
-			}
-			orgs = filtered
-		} else {
-			orgs = userOrgs
-		}
-
-	} else {
-		orgs, err = h.store.List(ctx, *listParams)
-		if err != nil {
-			status := common.StoreErrorToApiStatus(err, false, domain.OrganizationKind, nil)
-			return nil, status
-		}
+	orgs, err := h.store.List(ctx, *listParams)
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.OrganizationKind, nil)
 	}
 
+	return buildOrganizationList(orgs), domain.StatusOK()
+}
+
+func buildOrganizationList(orgs []*model.Organization) *domain.OrganizationList {
 	apiOrgs := make([]domain.Organization, len(orgs))
 	for i, org := range orgs {
 		apiOrgs[i] = organizationModelToAPI(org)
@@ -88,7 +90,7 @@ func (h *ServiceHandler) ListOrganizations(ctx context.Context, params domain.Li
 		ApiVersion: organizationApiVersion,
 		Kind:       domain.OrganizationListKind,
 		Metadata:   domain.ListMeta{},
-	}, domain.StatusOK()
+	}
 }
 
 func (h *ServiceHandler) listUserOrganizations(ctx context.Context) ([]*model.Organization, error) {

--- a/internal/service/organization/handler_test.go
+++ b/internal/service/organization/handler_test.go
@@ -84,11 +84,10 @@ func createExpectedAPIOrganization(id uuid.UUID, displayName string, externalID 
 	}
 }
 
-func TestListOrganizations_EmptyResult(t *testing.T) {
+func TestListAllOrganizations_EmptyResult(t *testing.T) {
 	handler, _ := newTestHandler([]*model.Organization{})
-	ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
 
-	result, status := handler.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	result, status := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
 
 	require.Equal(t, domain.StatusOK(), status)
 	require.NotNil(t, result)
@@ -98,15 +97,14 @@ func TestListOrganizations_EmptyResult(t *testing.T) {
 	require.Equal(t, domain.ListMeta{}, result.Metadata)
 }
 
-func TestListOrganizations_SingleOrganization(t *testing.T) {
+func TestListAllOrganizations_SingleOrganization(t *testing.T) {
 	orgID := uuid.New()
 	defaultOrg := createTestOrganizationModel(orgID, "default-external-id", "Default")
 	handler, _ := newTestHandler([]*model.Organization{defaultOrg})
-	ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
 
 	expectedOrg := createExpectedAPIOrganization(orgID, "Default", "default-external-id")
 
-	result, status := handler.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	result, status := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
 
 	require.Equal(t, domain.StatusOK(), status)
 	require.NotNil(t, result)
@@ -117,7 +115,7 @@ func TestListOrganizations_SingleOrganization(t *testing.T) {
 	require.Equal(t, domain.ListMeta{}, result.Metadata)
 }
 
-func TestListOrganizations_MultipleOrganizations(t *testing.T) {
+func TestListAllOrganizations_MultipleOrganizations(t *testing.T) {
 	orgID1 := uuid.New()
 	orgID2 := uuid.New()
 
@@ -125,12 +123,11 @@ func TestListOrganizations_MultipleOrganizations(t *testing.T) {
 	org2 := createTestOrganizationModel(orgID2, "external-id-2", "Organization Two")
 
 	handler, _ := newTestHandler([]*model.Organization{org1, org2})
-	ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
 
 	expectedOrg1 := createExpectedAPIOrganization(orgID1, "Organization One", "external-id-1")
 	expectedOrg2 := createExpectedAPIOrganization(orgID2, "Organization Two", "external-id-2")
 
-	result, status := handler.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	result, status := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
 
 	require.Equal(t, domain.StatusOK(), status)
 	require.NotNil(t, result)
@@ -143,24 +140,22 @@ func TestListOrganizations_MultipleOrganizations(t *testing.T) {
 	require.Equal(t, domain.ListMeta{}, result.Metadata)
 }
 
-func TestListOrganizations_StoreError(t *testing.T) {
+func TestListAllOrganizations_StoreError(t *testing.T) {
 	handler, fakeStore := newTestHandler(nil)
 	fakeStore.err = errors.New("database connection failed")
-	ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
 
-	result, status := handler.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	result, status := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
 
 	require.Nil(t, result)
 	require.NotEqual(t, domain.StatusOK(), status)
 	require.Contains(t, status.Message, "database connection failed")
 }
 
-func TestListOrganizations_ResourceNotFoundError(t *testing.T) {
+func TestListAllOrganizations_ResourceNotFoundError(t *testing.T) {
 	handler, fakeStore := newTestHandler(nil)
 	fakeStore.err = flterrors.ErrResourceNotFound
-	ctx := context.WithValue(context.Background(), consts.InternalRequestCtxKey, true)
 
-	result, status := handler.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	result, status := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
 
 	require.Nil(t, result)
 	require.Equal(t, int32(404), status.Code)

--- a/internal/service/organization/mock.go
+++ b/internal/service/organization/mock.go
@@ -40,6 +40,21 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 	return m.recorder
 }
 
+// ListAllOrganizations mocks base method.
+func (m *MockService) ListAllOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllOrganizations", ctx, params)
+	ret0, _ := ret[0].(*domain.OrganizationList)
+	ret1, _ := ret[1].(domain.Status)
+	return ret0, ret1
+}
+
+// ListAllOrganizations indicates an expected call of ListAllOrganizations.
+func (mr *MockServiceMockRecorder) ListAllOrganizations(ctx, params any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllOrganizations", reflect.TypeOf((*MockService)(nil).ListAllOrganizations), ctx, params)
+}
+
 // ListOrganizations mocks base method.
 func (m *MockService) ListOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status) {
 	m.ctrl.T.Helper()

--- a/internal/service/organization/service.go
+++ b/internal/service/organization/service.go
@@ -8,4 +8,5 @@ import (
 
 type Service interface {
 	ListOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status)
+	ListAllOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (*domain.OrganizationList, domain.Status)
 }

--- a/internal/service/organization/traced.gen.go
+++ b/internal/service/organization/traced.gen.go
@@ -43,6 +43,14 @@ func endSpan(span trace.Span, st domain.Status) {
 	span.End()
 }
 
+func (_d *TracedService) ListAllOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (op1 *domain.OrganizationList, s1 domain.Status) {
+	ctx, span := startSpan(ctx, "ListAllOrganizations")
+
+	op1, s1 = _d.inner.ListAllOrganizations(ctx, params)
+	endSpan(span, s1)
+	return op1, s1
+}
+
 func (_d *TracedService) ListOrganizations(ctx context.Context, params domain.ListOrganizationsParams) (op1 *domain.OrganizationList, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ListOrganizations")
 

--- a/internal/service/organization/traced_test.go
+++ b/internal/service/organization/traced_test.go
@@ -23,5 +23,10 @@ func TestWrapWithTracing(t *testing.T) {
 		expected, expectedStatus := handler.ListOrganizations(context.Background(), domain.ListOrganizationsParams{})
 		require.Equal(t, expectedStatus, status)
 		require.Equal(t, expected, result)
+
+		allResult, allStatus := traced.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
+		expectedAll, expectedAllStatus := handler.ListAllOrganizations(context.Background(), domain.ListOrganizationsParams{})
+		require.Equal(t, expectedAllStatus, allStatus)
+		require.Equal(t, expectedAll, allResult)
 	})
 }

--- a/internal/service/repository/handler.go
+++ b/internal/service/repository/handler.go
@@ -37,11 +37,29 @@ func NewServiceHandler(store repositorystore.Store, events events.Service, log l
 
 var _ Service = (*ServiceHandler)(nil)
 
-func (h *ServiceHandler) CreateRepository(ctx context.Context, orgId uuid.UUID, repository domain.Repository) (*domain.Repository, domain.Status) {
-	// don't set fields that are managed by the service
+// SanitizeRepository clears status and managed metadata from an untrusted repository document
+// (HTTP body).
+func SanitizeRepository(repository *domain.Repository) {
+	if repository == nil {
+		return
+	}
 	repository.Status = nil
 	common.NilOutManagedObjectMetaProperties(&repository.Metadata)
+}
 
+// CreateRepositoryFromUntrusted sanitizes an untrusted repository document, then creates it.
+func CreateRepositoryFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, repository domain.Repository) (*domain.Repository, domain.Status) {
+	SanitizeRepository(&repository)
+	return svc.CreateRepository(ctx, orgId, repository)
+}
+
+// ReplaceRepositoryFromUntrusted sanitizes an untrusted repository document, then replaces it.
+func ReplaceRepositoryFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, repository domain.Repository) (*domain.Repository, domain.Status) {
+	SanitizeRepository(&repository)
+	return svc.ReplaceRepository(ctx, orgId, name, repository)
+}
+
+func (h *ServiceHandler) CreateRepository(ctx context.Context, orgId uuid.UUID, repository domain.Repository) (*domain.Repository, domain.Status) {
 	if errs := repository.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -77,12 +95,6 @@ func (h *ServiceHandler) GetRepository(ctx context.Context, orgId uuid.UUID, nam
 }
 
 func (h *ServiceHandler) ReplaceRepository(ctx context.Context, orgId uuid.UUID, name string, repository domain.Repository) (*domain.Repository, domain.Status) {
-	// don't overwrite fields that are managed by the service for external requests
-	if !common.IsInternalRequest(ctx) {
-		repository.Status = nil
-		common.NilOutManagedObjectMetaProperties(&repository.Metadata)
-	}
-
 	if errs := repository.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}

--- a/internal/service/repository/handler_test.go
+++ b/internal/service/repository/handler_test.go
@@ -216,6 +216,30 @@ func TestCreateRepository(t *testing.T) {
 		_, status := h.CreateRepository(context.Background(), uuid.New(), invalid)
 		require.Equal(t, statusBadRequestCode, status.Code)
 	})
+
+	t.Run("When managed metadata fields are set by the caller CreateRepositoryFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, repoStore, _ := newTestHandler()
+		repo := newGitRepository("untrusted-repo", "https://example.com/repo.git")
+		repo.Metadata.Owner = lo.ToPtr("someone")
+		repo.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := CreateRepositoryFromUntrusted(context.Background(), h, uuid.New(), repo)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, repoStore.items["untrusted-repo"].Metadata.Owner)
+		require.Nil(t, repoStore.items["untrusted-repo"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateRepository (trusted) should preserve them", func(t *testing.T) {
+		h, repoStore, _ := newTestHandler()
+		repo := newGitRepository("trusted-repo", "https://example.com/repo.git")
+		repo.Metadata.Owner = lo.ToPtr("someone")
+		repo.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateRepository(context.Background(), uuid.New(), repo)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(repoStore.items["trusted-repo"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(repoStore.items["trusted-repo"].Metadata.Generation))
+	})
 }
 
 // ── ListRepositories / GetRepository ─────────────────────────────────────
@@ -280,6 +304,32 @@ func TestReplaceRepository(t *testing.T) {
 		repo := newGitRepository("repo1", "https://example.com/1.git")
 		_, status := h.ReplaceRepository(context.Background(), uuid.New(), "other-name", repo)
 		require.Equal(t, statusBadRequestCode, status.Code)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceRepositoryFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, repoStore, _ := newTestHandler()
+		orgId := uuid.New()
+		repo := newGitRepository("replace-untrusted", "https://example.com/repo.git")
+		repo.Metadata.Owner = lo.ToPtr("someone")
+		repo.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceRepositoryFromUntrusted(context.Background(), h, orgId, "replace-untrusted", repo)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, repoStore.items["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, repoStore.items["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceRepository (trusted) should preserve them", func(t *testing.T) {
+		h, repoStore, _ := newTestHandler()
+		orgId := uuid.New()
+		repo := newGitRepository("replace-trusted", "https://example.com/repo.git")
+		repo.Metadata.Owner = lo.ToPtr("someone")
+		repo.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceRepository(context.Background(), orgId, "replace-trusted", repo)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(repoStore.items["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(repoStore.items["replace-trusted"].Metadata.Generation))
 	})
 }
 

--- a/internal/service/resourcesync/handler.go
+++ b/internal/service/resourcesync/handler.go
@@ -32,11 +32,29 @@ func NewServiceHandler(store resourcesyncstore.Store, catalogStore catalogstore.
 
 var _ Service = (*ServiceHandler)(nil)
 
-func (h *ServiceHandler) CreateResourceSync(ctx context.Context, orgId uuid.UUID, rs domain.ResourceSync) (*domain.ResourceSync, domain.Status) {
-	// don't set fields that are managed by the service
+// SanitizeResourceSync clears status and managed metadata from an untrusted resourcesync
+// document (HTTP body).
+func SanitizeResourceSync(rs *domain.ResourceSync) {
+	if rs == nil {
+		return
+	}
 	rs.Status = nil
 	common.NilOutManagedObjectMetaProperties(&rs.Metadata)
+}
 
+// CreateResourceSyncFromUntrusted sanitizes an untrusted resourcesync document, then creates it.
+func CreateResourceSyncFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, rs domain.ResourceSync) (*domain.ResourceSync, domain.Status) {
+	SanitizeResourceSync(&rs)
+	return svc.CreateResourceSync(ctx, orgId, rs)
+}
+
+// ReplaceResourceSyncFromUntrusted sanitizes an untrusted resourcesync document, then replaces it.
+func ReplaceResourceSyncFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, rs domain.ResourceSync) (*domain.ResourceSync, domain.Status) {
+	SanitizeResourceSync(&rs)
+	return svc.ReplaceResourceSync(ctx, orgId, name, rs)
+}
+
+func (h *ServiceHandler) CreateResourceSync(ctx context.Context, orgId uuid.UUID, rs domain.ResourceSync) (*domain.ResourceSync, domain.Status) {
 	if errs := rs.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}
@@ -72,11 +90,6 @@ func (h *ServiceHandler) GetResourceSync(ctx context.Context, orgId uuid.UUID, n
 }
 
 func (h *ServiceHandler) ReplaceResourceSync(ctx context.Context, orgId uuid.UUID, name string, rs domain.ResourceSync) (*domain.ResourceSync, domain.Status) {
-	// don't overwrite fields that are managed by the service
-	if !common.IsInternalRequest(ctx) {
-		rs.Status = nil
-		common.NilOutManagedObjectMetaProperties(&rs.Metadata)
-	}
 	if errs := rs.Validate(); len(errs) > 0 {
 		return nil, domain.StatusBadRequest(errors.Join(errs...).Error())
 	}

--- a/internal/service/resourcesync/handler_test.go
+++ b/internal/service/resourcesync/handler_test.go
@@ -232,6 +232,30 @@ func TestCreateResourceSync(t *testing.T) {
 		_, status := h.CreateResourceSync(context.Background(), uuid.New(), rs)
 		require.Equal(t, statusCreatedCode, status.Code)
 	})
+
+	t.Run("When managed metadata fields are set by the caller CreateResourceSyncFromUntrusted should clear them before creation", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler()
+		rs := testResourceSync("untrusted-rs")
+		rs.Metadata.Owner = lo.ToPtr("someone")
+		rs.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := CreateResourceSyncFromUntrusted(context.Background(), h, uuid.New(), rs)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.items["untrusted-rs"].Metadata.Owner)
+		require.Nil(t, fakeStore.items["untrusted-rs"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller CreateResourceSync (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler()
+		rs := testResourceSync("trusted-rs")
+		rs.Metadata.Owner = lo.ToPtr("someone")
+		rs.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.CreateResourceSync(context.Background(), uuid.New(), rs)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items["trusted-rs"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items["trusted-rs"].Metadata.Generation))
+	})
 }
 
 func TestListResourceSyncs(t *testing.T) {
@@ -273,6 +297,32 @@ func TestReplaceResourceSync(t *testing.T) {
 		replaced, status := h.ReplaceResourceSync(ctx, orgId, "catalog-mixed-sync", rs)
 		require.Equal(t, statusSuccessCode, status.Code)
 		require.Equal(t, "updated-repo", replaced.Spec.Repository)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceResourceSyncFromUntrusted should clear them before replacing", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler()
+		orgId := uuid.New()
+		rs := testResourceSync("replace-untrusted")
+		rs.Metadata.Owner = lo.ToPtr("someone")
+		rs.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := ReplaceResourceSyncFromUntrusted(context.Background(), h, orgId, "replace-untrusted", rs)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Nil(t, fakeStore.items["replace-untrusted"].Metadata.Owner)
+		require.Nil(t, fakeStore.items["replace-untrusted"].Metadata.Generation)
+	})
+
+	t.Run("When managed metadata fields are set by the caller ReplaceResourceSync (trusted) should preserve them", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler()
+		orgId := uuid.New()
+		rs := testResourceSync("replace-trusted")
+		rs.Metadata.Owner = lo.ToPtr("someone")
+		rs.Metadata.Generation = lo.ToPtr(int64(5))
+
+		_, status := h.ReplaceResourceSync(context.Background(), orgId, "replace-trusted", rs)
+		require.Equal(t, statusCreatedCode, status.Code)
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items["replace-trusted"].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items["replace-trusted"].Metadata.Generation))
 	})
 }
 

--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -3,10 +3,8 @@ package store
 import (
 	"context"
 	"errors"
-	"reflect"
 	"time"
 
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store/model"
@@ -100,9 +98,6 @@ func (s *GenericStore[P, M, A, AL]) createOrUpdate(ctx context.Context, orgId uu
 		return nil, nil, false, false, err
 	}
 	modelInst.SetOrgID(orgId)
-	if fromAPI {
-		modelInst.SetAnnotations(nil)
-	}
 
 	existing, err := s.getExistingResource(ctx, orgId, modelInst)
 	if err != nil {
@@ -187,34 +182,12 @@ func (s *GenericStore[P, M, A, AL]) createResource(ctx context.Context, resource
 }
 
 func (s *GenericStore[P, M, A, AL]) updateResource(ctx context.Context, fromAPI bool, existing, resource P, fieldsToUnset []string) (bool, error) {
-	hasOwner := len(lo.FromPtr(existing.GetOwner())) != 0
-
-	// TODO: Move ownership validation checks to the service layer. The store layer should
-	// focus on data access, while authorization and business rules belong in the service layer.
-	// This allows resource sync to update resources it owns, but ideally this should be
-	// handled in service.ReplaceFleet() by checking ownership before calling the store.
-	allowResourceSyncUpdate := false
-	if rs, ok := ctx.Value(consts.ResourceSyncRequestCtxKey).(bool); ok && rs {
-		allowResourceSyncUpdate = true
-	}
+	_ = fromAPI
 
 	sameSpec := resource.HasSameSpecAs(existing)
 	if !sameSpec {
-		if fromAPI && hasOwner && !allowResourceSyncUpdate {
-			// Don't let the user update the spec if it has an owner
-			return false, flterrors.ErrUpdatingResourceWithOwnerNotAllowed
-		}
-
 		// Update the generation if the spec was updated
 		resource.SetGeneration(lo.ToPtr(lo.FromPtr(existing.GetGeneration()) + 1))
-	}
-
-	// Don't let the user update a fleet's labels if it has an owner
-	if fromAPI && hasOwner && !allowResourceSyncUpdate && resource.GetKind() == domain.FleetKind {
-		sameLabels := reflect.DeepEqual(existing.GetLabels(), resource.GetLabels())
-		if !sameLabels {
-			return false, flterrors.ErrUpdatingResourceWithOwnerNotAllowed
-		}
 	}
 
 	if resource.GetResourceVersion() != nil &&
@@ -255,8 +228,6 @@ func (s *GenericStore[P, M, A, AL]) updateResource(ctx context.Context, fromAPI 
 		resource.SetOwner(existing.GetOwner())
 	}
 	// Preserve annotations if they were nil (not updated)
-	// When fromAPI=true, annotations are set to nil in createOrUpdate to preserve existing ones
-	// When fromAPI=false, if annotations are nil, they weren't updated, so preserve from existing
 	if resource.GetAnnotations() == nil && !lo.Contains(fieldsToUnset, "annotations") {
 		resource.SetAnnotations(existing.GetAnnotations())
 	}

--- a/internal/store/model/fleet.go
+++ b/internal/store/model/fleet.go
@@ -48,9 +48,12 @@ func NewFleetFromApiResource(resource *domain.Fleet) (*Fleet, error) {
 	}
 	return &Fleet{
 		Resource: Resource{
-			Name:            *resource.Metadata.Name,
-			Labels:          lo.FromPtrOr(resource.Metadata.Labels, make(map[string]string)),
-			Annotations:     lo.FromPtrOr(resource.Metadata.Annotations, make(map[string]string)),
+			Name:   *resource.Metadata.Name,
+			Labels: lo.FromPtrOr(resource.Metadata.Labels, make(map[string]string)),
+			// A nil Annotations pointer (as set by SanitizeFleet for untrusted input) means
+			// "don't touch annotations"; converting it to a nil map (not an empty one) lets the
+			// store's nil-skip merge logic leave existing annotations untouched.
+			Annotations:     lo.FromPtr(resource.Metadata.Annotations),
 			Generation:      resource.Metadata.Generation,
 			Owner:           resource.Metadata.Owner,
 			ResourceVersion: resourceVersion,

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -1072,7 +1072,7 @@ func (f FleetRolloutsLogic) updateDeviceInStore(ctx context.Context, device *dom
 		}
 		device.Spec = newDeviceSpec
 		newCtx := context.WithValue(ctx, consts.DelayDeviceRenderCtxKey, delayDeviceRender)
-		_, status = f.deviceSvc.ReplaceDevice(newCtx, f.orgId, *device.Metadata.Name, *device, nil)
+		_, status = f.deviceSvc.ReplaceDevice(newCtx, f.orgId, *device.Metadata.Name, *device, nil, false)
 		if status.Code != http.StatusOK {
 			if status.Code == http.StatusConflict {
 				device, status = f.deviceSvc.GetDevice(ctx, f.orgId, *device.Metadata.Name)

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -267,8 +267,8 @@ func TestFleetRolloutsLogic_FullDelayDeviceRenderPropagation(t *testing.T) {
 			// Mock ReplaceDevice to capture the delayDeviceRender value from context
 			// This will be called during the device update process, allowing us to verify propagation
 			var capturedDelayDeviceRender bool
-			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, domain.Status) {
+			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
 					// Debug: Print the device owner when ReplaceDevice is called
 					if device.Metadata.Owner != nil {
 						t.Logf("ReplaceDevice called with device owner: %s", *device.Metadata.Owner)
@@ -365,8 +365,8 @@ func TestFleetRolloutsLogic_DelayDeviceRenderPropagationThroughContext(t *testin
 
 			// Mock ReplaceDevice to capture the context value
 			var capturedDelayDeviceRender bool
-			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, domain.Status) {
+			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
 					// Extract the delayDeviceRender value from context
 					if delayValue, ok := ctx.Value(consts.DelayDeviceRenderCtxKey).(bool); ok {
 						capturedDelayDeviceRender = delayValue
@@ -487,7 +487,7 @@ func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_SkipCondition(t *testing
 			tv.Status.Os = &domain.DeviceOsSpec{Image: image}
 
 			if tt.expectReplaceDevice {
-				mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, domain.Status{Code: http.StatusOK})
+				mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, domain.Status{Code: http.StatusOK})
 				mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(domain.Status{Code: http.StatusOK})
 			}
 
@@ -1207,7 +1207,7 @@ func TestRolloutFleetPage_UpsertDeviceRefs(t *testing.T) {
 			},
 		}
 
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, okStatus).AnyTimes()
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, okStatus).AnyTimes()
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any()).Return(okStatus).AnyTimes()
 
 		logic := FleetRolloutsLogic{
@@ -1452,7 +1452,7 @@ func TestDeviceDependencyRefLifecycle(t *testing.T) {
 		fleet := createTestFleetForRollout(fleetName, nil)
 		mockFleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, fleetName, gomock.Any()).Return(fleet, okStatus)
 
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, "device-1", gomock.Any(), gomock.Any()).Return(okStatus)
 
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(
@@ -1763,7 +1763,7 @@ func TestFleetRolloutsLogic_RolloutDevice_ApplicationLifecycleSync(t *testing.T)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName,
 			gomock.Not(gomock.Eq(map[string]string{domain.DeviceAnnotationFleetApplicationLifecycle: `{"app-1":"stopped"}`})), gomock.Any(),
 		).Return(okStatus)
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(gomock.Any(), orgId, deviceName, gomock.Any()).Return(okStatus)
 
 		logic := FleetRolloutsLogic{
@@ -1800,7 +1800,7 @@ func TestFleetRolloutsLogic_RolloutDevice_ApplicationLifecycleSync(t *testing.T)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName,
 			gomock.Not(gomock.Eq(map[string]string{domain.DeviceAnnotationFleetApplicationLifecycle: `{"app-1":"stopped"}`})), gomock.Any(),
 		).Return(okStatus)
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(gomock.Any(), orgId, deviceName, gomock.Any()).Return(okStatus)
 
 		logic := FleetRolloutsLogic{

--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -529,7 +529,7 @@ func (f FleetSelectorMatchingLogic) updateDeviceOwner(ctx context.Context, devic
 
 	f.log.Infof("Updating fleet of device %s from %s to %s", *device.Metadata.Name, util.DefaultIfNil(device.Metadata.Owner, "<none>"), util.DefaultIfNil(newOwnerRef, "<none>"))
 	device.Metadata.Owner = newOwnerRef
-	_, status := f.deviceSvc.ReplaceDevice(ctx, f.orgId, *device.Metadata.Name, lo.FromPtr(device), fieldsToNil)
+	_, status := f.deviceSvc.ReplaceDevice(ctx, f.orgId, *device.Metadata.Name, lo.FromPtr(device), fieldsToNil, false)
 
 	if err := common.ApiStatusToErr(status); err != nil {
 		return err

--- a/internal/tasks/queue_maintenance.go
+++ b/internal/tasks/queue_maintenance.go
@@ -278,7 +278,7 @@ func (t *QueueMaintenanceTask) republishEventsSince(ctx context.Context, since t
 	log.WithField("since", since.Format(time.RFC3339Nano)).Info("Starting event republishing")
 
 	// First, get all organizations
-	orgList, status := t.organizationSvc.ListOrganizations(ctx, domain.ListOrganizationsParams{})
+	orgList, status := t.organizationSvc.ListAllOrganizations(ctx, domain.ListOrganizationsParams{})
 	if status.Code >= 400 {
 		return fmt.Errorf("failed to list organizations: %s", status.Message)
 	}

--- a/internal/tasks/resourcesync.go
+++ b/internal/tasks/resourcesync.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	catalogservice "github.com/flightctl/flightctl/internal/service/catalog"
@@ -312,10 +311,8 @@ func (r *ResourceSync) SyncFleets(ctx context.Context, log logrus.FieldLogger, o
 	}
 	if len(fleetsToRemove) > 0 {
 		log.Infof("Resource %s: found #%d fleets to remove. removing\n", resourceName, len(fleetsToRemove))
-		// Set ResourceSyncRequestCtxKey to allow resource sync to delete resources it owns
-		deleteCtx := context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
 		for _, fleetToRemove := range fleetsToRemove {
-			status := r.fleetSvc.DeleteFleet(deleteCtx, orgId, fleetToRemove)
+			status := r.fleetSvc.DeleteFleet(ctx, orgId, fleetToRemove, false)
 			if status.Code != http.StatusOK {
 				err := fmt.Errorf("resource %s: failed to remove old fleet %s. error: %s", resourceName, fleetToRemove, status.Message)
 				log.Error(err)
@@ -336,15 +333,8 @@ func (r *ResourceSync) SyncFleets(ctx context.Context, log logrus.FieldLogger, o
 func (r *ResourceSync) createOrUpdateMultiple(ctx context.Context, orgId uuid.UUID, owner *string, resources ...*domain.Fleet) error {
 	var errs []error
 	for _, resource := range resources {
-		// Create a context where InternalRequestCtxKey is false so that ReplaceFleet
-		// treats this as an external API request and calls NilOutManagedObjectMetaProperties,
-		// which will nil out annotations. This ensures annotations are not updated by ResourceSync.
-		// Annotations are managed by the service (e.g., fleet-controller/templateVersion)
-		// and should not be overwritten when syncing from YAML.
-		// Set ResourceSyncRequestCtxKey to allow resource sync to update resources it owns.
-		externalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, false)
-		externalCtx = context.WithValue(externalCtx, consts.ResourceSyncRequestCtxKey, true)
-		updatedFleet, status := r.fleetSvc.ReplaceFleet(externalCtx, orgId, *resource.Metadata.Name, *resource)
+		// Untrusted YAML: sanitize managed meta/annotations without enforcing ownership.
+		updatedFleet, status := fleetservice.ReplaceFleetFromUntrusted(ctx, r.fleetSvc, orgId, *resource.Metadata.Name, *resource, false)
 		if status.Code != http.StatusOK && status.Code != http.StatusCreated {
 			if status.Message == flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error() {
 				errs = append(errs, errors.New("one or more fleets are managed by a different resource"))
@@ -353,10 +343,10 @@ func (r *ResourceSync) createOrUpdateMultiple(ctx context.Context, orgId uuid.UU
 			}
 		}
 
-		// Update the owner of the fleet if not already set
+		// Trusted write: set owner without sanitizing (SanitizeFleet clears Owner).
 		if updatedFleet != nil && util.DefaultIfNil(updatedFleet.Metadata.Owner, "") != util.DefaultIfNil(owner, "") {
 			updatedFleet.Metadata.Owner = owner
-			_, status := r.fleetSvc.ReplaceFleet(ctx, orgId, *resource.Metadata.Name, *updatedFleet)
+			_, status := r.fleetSvc.ReplaceFleet(ctx, orgId, *resource.Metadata.Name, *updatedFleet, false)
 			if status.Code != http.StatusOK {
 				errs = append(errs, common.ApiStatusToErr(status))
 			}
@@ -776,9 +766,7 @@ func (r *ResourceSync) SyncCatalogs(ctx context.Context, log logrus.FieldLogger,
 func (r *ResourceSync) createOrUpdateCatalogs(ctx context.Context, orgId uuid.UUID, owner *string, resources ...*domain.Catalog) error {
 	var errs []error
 	for _, resource := range resources {
-		externalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, false)
-		externalCtx = context.WithValue(externalCtx, consts.ResourceSyncRequestCtxKey, true)
-		updatedCatalog, status := r.catalogSvc.ReplaceCatalog(externalCtx, orgId, *resource.Metadata.Name, *resource)
+		updatedCatalog, status := catalogservice.ReplaceCatalogFromUntrusted(ctx, r.catalogSvc, orgId, *resource.Metadata.Name, *resource, false)
 		if status.Code != http.StatusOK && status.Code != http.StatusCreated {
 			if status.Message == flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error() {
 				errs = append(errs, errors.New("one or more catalogs are managed by a different resource"))
@@ -787,10 +775,9 @@ func (r *ResourceSync) createOrUpdateCatalogs(ctx context.Context, orgId uuid.UU
 			}
 		}
 
-		// Set owner if not already set
 		if updatedCatalog != nil && util.DefaultIfNil(updatedCatalog.Metadata.Owner, "") != util.DefaultIfNil(owner, "") {
 			updatedCatalog.Metadata.Owner = owner
-			_, status := r.catalogSvc.ReplaceCatalog(ctx, orgId, *resource.Metadata.Name, *updatedCatalog)
+			_, status := r.catalogSvc.ReplaceCatalog(ctx, orgId, *resource.Metadata.Name, *updatedCatalog, false)
 			if status.Code != http.StatusOK {
 				errs = append(errs, common.ApiStatusToErr(status))
 			}
@@ -903,9 +890,7 @@ func (r *ResourceSync) SyncCatalogItems(ctx context.Context, log logrus.FieldLog
 func (r *ResourceSync) createOrUpdateCatalogItems(ctx context.Context, orgId uuid.UUID, owner *string, items ...*domain.CatalogItem) error {
 	var errs []error
 	for _, item := range items {
-		externalCtx := context.WithValue(ctx, consts.InternalRequestCtxKey, false)
-		externalCtx = context.WithValue(externalCtx, consts.ResourceSyncRequestCtxKey, true)
-		updatedItem, status := r.catalogSvc.ReplaceCatalogItem(externalCtx, orgId, item.Metadata.Catalog, *item.Metadata.Name, *item)
+		updatedItem, status := catalogservice.ReplaceCatalogItemFromUntrusted(ctx, r.catalogSvc, orgId, item.Metadata.Catalog, *item.Metadata.Name, *item, false)
 		if status.Code != http.StatusOK && status.Code != http.StatusCreated {
 			if status.Message == flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error() {
 				errs = append(errs, errors.New("one or more catalog items are managed by a different resource"))
@@ -915,10 +900,9 @@ func (r *ResourceSync) createOrUpdateCatalogItems(ctx context.Context, orgId uui
 			continue
 		}
 
-		// Set owner if not already set
 		if updatedItem != nil && util.DefaultIfNil(updatedItem.Metadata.Owner, "") != util.DefaultIfNil(owner, "") {
 			updatedItem.Metadata.Owner = owner
-			_, status := r.catalogSvc.ReplaceCatalogItem(ctx, orgId, updatedItem.Metadata.Catalog, *updatedItem.Metadata.Name, *updatedItem)
+			_, status := r.catalogSvc.ReplaceCatalogItem(ctx, orgId, updatedItem.Metadata.Catalog, *updatedItem.Metadata.Name, *updatedItem, false)
 			if status.Code != http.StatusOK {
 				errs = append(errs, common.ApiStatusToErr(status))
 			}
@@ -933,9 +917,8 @@ func (r *ResourceSync) deleteStaleCatalogs(ctx context.Context, log logrus.Field
 		return nil
 	}
 	log.Infof("Resource %s: found #%d catalogs to remove. removing", resourceName, len(toRemove))
-	deleteCtx := context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
 	for _, catalogName := range toRemove {
-		status := r.catalogSvc.DeleteCatalog(deleteCtx, orgId, catalogName)
+		status := r.catalogSvc.DeleteCatalog(ctx, orgId, catalogName, false)
 		if status.Code != http.StatusOK {
 			err := fmt.Errorf("resource %s: failed to remove old catalog %s: %s", resourceName, catalogName, status.Message)
 			log.Error(err)
@@ -952,13 +935,12 @@ func (r *ResourceSync) deleteStaleCatalogItems(ctx context.Context, log logrus.F
 		return nil
 	}
 	log.Infof("Resource %s: found #%d catalog items to remove. removing", resourceName, len(toRemove))
-	deleteCtx := context.WithValue(ctx, consts.ResourceSyncRequestCtxKey, true)
 	for _, key := range toRemove {
 		parts := strings.SplitN(key, "/", 2)
 		if len(parts) != 2 {
 			continue
 		}
-		status := r.catalogSvc.DeleteCatalogItem(deleteCtx, orgId, parts[0], parts[1])
+		status := r.catalogSvc.DeleteCatalogItem(ctx, orgId, parts[0], parts[1], false)
 		if status.Code != http.StatusOK {
 			err := fmt.Errorf("resource %s: failed to remove old catalog item %s: %s", resourceName, key, status.Message)
 			log.Error(err)

--- a/internal/tasks/resourcesync_catalog_test.go
+++ b/internal/tasks/resourcesync_catalog_test.go
@@ -143,7 +143,7 @@ func TestSyncCatalogs_InitialCreate(t *testing.T) {
 		Return(&domain.CatalogList{Items: []domain.Catalog{}}, okStatus())
 
 	// ReplaceCatalog for platform-apps (created)
-	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any(), gomock.Any()).
 		Return(&domain.Catalog{
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("platform-apps"), Owner: owner},
 		}, createdStatus())
@@ -169,11 +169,11 @@ func TestSyncCatalogs_InitialCreate(t *testing.T) {
 		Return(&domain.CatalogItemList{Items: []domain.CatalogItem{}}, okStatus())
 
 	// ReplaceCatalogItem for prometheus and nginx
-	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any(), gomock.Any()).
 		Return(&domain.CatalogItem{
 			Metadata: domain.CatalogItemMeta{Name: lo.ToPtr("prometheus"), Catalog: "platform-apps", Owner: owner},
 		}, createdStatus())
-	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx", gomock.Any(), gomock.Any()).
 		Return(&domain.CatalogItem{
 			Metadata: domain.CatalogItemMeta{Name: lo.ToPtr("nginx"), Catalog: "platform-apps", Owner: owner},
 		}, createdStatus())
@@ -226,7 +226,7 @@ func TestSyncCatalogs_UpdateAndRemove(t *testing.T) {
 		}, okStatus())
 
 	// ReplaceCatalog (update)
-	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any(), gomock.Any()).
 		Return(&domain.Catalog{
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("platform-apps"), Owner: owner},
 		}, okStatus())
@@ -260,11 +260,11 @@ func TestSyncCatalogs_UpdateAndRemove(t *testing.T) {
 		}, okStatus())
 
 	// ReplaceCatalogItem for prometheus (update) and redis (create)
-	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any(), gomock.Any()).
 		Return(&domain.CatalogItem{
 			Metadata: domain.CatalogItemMeta{Name: lo.ToPtr("prometheus"), Catalog: "platform-apps", Owner: owner},
 		}, okStatus())
-	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "redis", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "platform-apps", "redis", gomock.Any(), gomock.Any()).
 		Return(&domain.CatalogItem{
 			Metadata: domain.CatalogItemMeta{Name: lo.ToPtr("redis"), Catalog: "platform-apps", Owner: owner},
 		}, createdStatus())
@@ -274,7 +274,7 @@ func TestSyncCatalogs_UpdateAndRemove(t *testing.T) {
 	assert.Equal(t, []string{"platform-apps/nginx"}, itemsToRemove)
 
 	// --- Delete stale items ---
-	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx").
+	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx", gomock.Any()).
 		Return(okStatus())
 
 	err = rs.deleteStaleCatalogItems(context.Background(), log, orgId, rsObj, itemsToRemove, resourceName)
@@ -321,13 +321,13 @@ func TestSyncCatalogs_RemoveAll(t *testing.T) {
 	assert.ElementsMatch(t, []string{"platform-apps/prometheus", "platform-apps/nginx"}, itemsToRemove)
 
 	// Delete items first, then catalogs
-	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus").Return(okStatus())
-	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx").Return(okStatus())
+	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any()).Return(okStatus())
+	mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx", gomock.Any()).Return(okStatus())
 
 	err = rs.deleteStaleCatalogItems(context.Background(), log, orgId, rsObj, itemsToRemove, resourceName)
 	require.NoError(t, err)
 
-	mockCatalogSvc.EXPECT().DeleteCatalog(gomock.Any(), orgId, "platform-apps").Return(okStatus())
+	mockCatalogSvc.EXPECT().DeleteCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any()).Return(okStatus())
 
 	err = rs.deleteStaleCatalogs(context.Background(), log, orgId, rsObj, catalogsToRemove, resourceName)
 	require.NoError(t, err)
@@ -351,9 +351,9 @@ func TestSyncCatalogs_DeleteOrdering(t *testing.T) {
 	catalogsToRemove := []string{"platform-apps"}
 
 	// Enforce ordering: all item deletes happen before catalog deletes.
-	deleteItem1 := mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus").Return(okStatus())
-	deleteItem2 := mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx").Return(okStatus())
-	mockCatalogSvc.EXPECT().DeleteCatalog(gomock.Any(), orgId, "platform-apps").
+	deleteItem1 := mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "prometheus", gomock.Any()).Return(okStatus())
+	deleteItem2 := mockCatalogSvc.EXPECT().DeleteCatalogItem(gomock.Any(), orgId, "platform-apps", "nginx", gomock.Any()).Return(okStatus())
+	mockCatalogSvc.EXPECT().DeleteCatalog(gomock.Any(), orgId, "platform-apps", gomock.Any()).
 		Return(okStatus()).
 		After(deleteItem1).
 		After(deleteItem2)
@@ -471,7 +471,7 @@ func TestSyncCatalogs_MultiversionSync(t *testing.T) {
 		Return(nil, notFoundStatus())
 	mockCatalogSvc.EXPECT().ListCatalogs(gomock.Any(), orgId, gomock.Any()).
 		Return(&domain.CatalogList{Items: []domain.Catalog{}}, okStatus())
-	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "infrastructure", gomock.Any()).
+	mockCatalogSvc.EXPECT().ReplaceCatalog(gomock.Any(), orgId, "infrastructure", gomock.Any(), gomock.Any()).
 		Return(&domain.Catalog{
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("infrastructure"), Owner: owner},
 		}, createdStatus())
@@ -501,8 +501,8 @@ func TestSyncCatalogs_MultiversionSync(t *testing.T) {
 
 	// Capture what gets passed to ReplaceCatalogItem to verify version data round-trips.
 	var capturedItems []domain.CatalogItem
-	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "infrastructure", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ uuid.UUID, catalogName, itemName string, item domain.CatalogItem) (*domain.CatalogItem, domain.Status) {
+	mockCatalogSvc.EXPECT().ReplaceCatalogItem(gomock.Any(), orgId, "infrastructure", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uuid.UUID, catalogName, itemName string, item domain.CatalogItem, _ bool) (*domain.CatalogItem, domain.Status) {
 			capturedItems = append(capturedItems, item)
 			return &domain.CatalogItem{
 				Metadata: domain.CatalogItemMeta{Name: lo.ToPtr(itemName), Catalog: catalogName, Owner: owner},

--- a/internal/transport/agent/v1beta1/handler.go
+++ b/internal/transport/agent/v1beta1/handler.go
@@ -127,7 +127,7 @@ func (s *AgentTransportHandler) ReplaceDeviceStatus(w http.ResponseWriter, r *ht
 	}
 
 	domainDevice := s.converter.Device().ToDomain(device)
-	body, status := s.device.ReplaceDeviceStatus(ctx, transport.OrgIDFromContext(ctx), fingerprint, domainDevice)
+	body, status := s.device.ReplaceDeviceStatus(ctx, transport.OrgIDFromContext(ctx), fingerprint, domainDevice, true)
 	apiResult := s.converter.Device().FromDomain(body)
 	s.SetResponse(w, apiResult, status)
 }
@@ -201,7 +201,7 @@ func (s *AgentTransportHandler) CreateEnrollmentRequest(w http.ResponseWriter, r
 	}
 
 	domainER := s.converter.EnrollmentRequest().ToDomain(er)
-	body, status := s.enrollmentrequest.CreateEnrollmentRequest(ctx, transport.OrgIDFromContext(ctx), domainER)
+	body, status := enrollmentrequest.CreateEnrollmentRequestFromUntrusted(ctx, s.enrollmentrequest, transport.OrgIDFromContext(ctx), domainER)
 	apiResult := s.converter.EnrollmentRequest().FromDomain(body)
 	s.SetResponse(w, apiResult, status)
 }
@@ -279,7 +279,7 @@ func (s *AgentTransportHandler) CreateCertificateSigningRequest(w http.ResponseW
 	service.NilOutManagedObjectMetaProperties(&request.Metadata)
 	request.Metadata.Owner = util.SetResourceOwner(api.DeviceKind, fingerprint)
 	domainCSR := s.converter.CertificateSigningRequest().ToDomain(request)
-	csr, status := s.certificatesigningrequest.CreateCertificateSigningRequest(context.WithValue(ctx, consts.InternalRequestCtxKey, true), transport.OrgIDFromContext(ctx), domainCSR)
+	csr, status := s.certificatesigningrequest.CreateCertificateSigningRequest(ctx, transport.OrgIDFromContext(ctx), domainCSR)
 	if status.Code != http.StatusCreated && status.Code != http.StatusOK {
 		s.SetResponse(w, status, status)
 		return

--- a/internal/transport/v1alpha1/catalog.go
+++ b/internal/transport/v1alpha1/catalog.go
@@ -6,6 +6,7 @@ import (
 
 	apiv1alpha1 "github.com/flightctl/flightctl/api/core/v1alpha1"
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	catalogservice "github.com/flightctl/flightctl/internal/service/catalog"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -18,7 +19,7 @@ func (h *TransportHandler) CreateCatalog(w http.ResponseWriter, r *http.Request)
 	}
 
 	domainCatalog := h.converter.Catalog().ToDomain(catalog)
-	body, status := h.catalog.CreateCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), domainCatalog)
+	body, status := catalogservice.CreateCatalogFromUntrusted(r.Context(), h.catalog, transport.OrgIDFromContext(r.Context()), domainCatalog)
 	apiResult := h.converter.Catalog().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -47,14 +48,14 @@ func (h *TransportHandler) ReplaceCatalog(w http.ResponseWriter, r *http.Request
 	}
 
 	domainCatalog := h.converter.Catalog().ToDomain(catalog)
-	body, status := h.catalog.ReplaceCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainCatalog)
+	body, status := catalogservice.ReplaceCatalogFromUntrusted(r.Context(), h.catalog, transport.OrgIDFromContext(r.Context()), name, domainCatalog, true)
 	apiResult := h.converter.Catalog().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
 
 // (DELETE /api/v1/catalogs/{name})
 func (h *TransportHandler) DeleteCatalog(w http.ResponseWriter, r *http.Request, name string) {
-	status := h.catalog.DeleteCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), name)
+	status := h.catalog.DeleteCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), name, true)
 	h.SetResponse(w, nil, status)
 }
 
@@ -67,7 +68,7 @@ func (h *TransportHandler) PatchCatalog(w http.ResponseWriter, r *http.Request, 
 	}
 
 	domainPatch := h.converter.Common().PatchRequestToDomain(patch)
-	body, status := h.catalog.PatchCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch)
+	body, status := h.catalog.PatchCatalog(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch, true)
 	apiResult := h.converter.Catalog().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -132,7 +133,7 @@ func (h *TransportHandler) CreateCatalogItem(w http.ResponseWriter, r *http.Requ
 	}
 
 	domainItem := h.converter.Catalog().ItemToDomain(item)
-	body, status := h.catalog.CreateCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainItem)
+	body, status := catalogservice.CreateCatalogItemFromUntrusted(r.Context(), h.catalog, transport.OrgIDFromContext(r.Context()), name, domainItem)
 	apiResult := h.converter.Catalog().ItemFromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -153,7 +154,7 @@ func (h *TransportHandler) ReplaceCatalogItem(w http.ResponseWriter, r *http.Req
 	}
 
 	domainItem := h.converter.Catalog().ItemToDomain(item)
-	body, status := h.catalog.ReplaceCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, itemName, domainItem)
+	body, status := catalogservice.ReplaceCatalogItemFromUntrusted(r.Context(), h.catalog, transport.OrgIDFromContext(r.Context()), name, itemName, domainItem, true)
 	apiResult := h.converter.Catalog().ItemFromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -167,13 +168,13 @@ func (h *TransportHandler) PatchCatalogItem(w http.ResponseWriter, r *http.Reque
 	}
 
 	domainPatch := h.converter.Common().PatchRequestToDomain(patch)
-	body, status := h.catalog.PatchCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, itemName, domainPatch)
+	body, status := h.catalog.PatchCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, itemName, domainPatch, true)
 	apiResult := h.converter.Catalog().ItemFromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
 
 // (DELETE /api/v1/catalogs/{name}/items/{item})
 func (h *TransportHandler) DeleteCatalogItem(w http.ResponseWriter, r *http.Request, name string, item string) {
-	status := h.catalog.DeleteCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, item)
+	status := h.catalog.DeleteCatalogItem(r.Context(), transport.OrgIDFromContext(r.Context()), name, item, true)
 	h.SetResponse(w, nil, status)
 }

--- a/internal/transport/v1beta1/authprovider.go
+++ b/internal/transport/v1beta1/authprovider.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	authproviderservice "github.com/flightctl/flightctl/internal/service/authprovider"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateAuthProvider(w http.ResponseWriter, r *http.Req
 	}
 
 	domainAP := h.converter.AuthProvider().ToDomain(authProvider)
-	body, status := h.authprovider.CreateAuthProvider(r.Context(), transport.OrgIDFromContext(r.Context()), domainAP)
+	body, status := authproviderservice.CreateAuthProviderFromUntrusted(r.Context(), h.authprovider, transport.OrgIDFromContext(r.Context()), domainAP)
 	apiResult := h.converter.AuthProvider().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -46,7 +47,7 @@ func (h *TransportHandler) ReplaceAuthProvider(w http.ResponseWriter, r *http.Re
 	}
 
 	domainAP := h.converter.AuthProvider().ToDomain(authProvider)
-	body, status := h.authprovider.ReplaceAuthProvider(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainAP)
+	body, status := authproviderservice.ReplaceAuthProviderFromUntrusted(r.Context(), h.authprovider, transport.OrgIDFromContext(r.Context()), name, domainAP)
 	apiResult := h.converter.AuthProvider().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/certificatesigningrequest.go
+++ b/internal/transport/v1beta1/certificatesigningrequest.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	csrservice "github.com/flightctl/flightctl/internal/service/certificatesigningrequest"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -25,7 +26,7 @@ func (h *TransportHandler) CreateCertificateSigningRequest(w http.ResponseWriter
 	}
 
 	domainCSR := h.converter.CertificateSigningRequest().ToDomain(csr)
-	body, status := h.certificatesigningrequest.CreateCertificateSigningRequest(r.Context(), transport.OrgIDFromContext(r.Context()), domainCSR)
+	body, status := csrservice.CreateCertificateSigningRequestFromUntrusted(r.Context(), h.certificatesigningrequest, transport.OrgIDFromContext(r.Context()), domainCSR)
 	apiResult := h.converter.CertificateSigningRequest().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -66,7 +67,7 @@ func (h *TransportHandler) ReplaceCertificateSigningRequest(w http.ResponseWrite
 	}
 
 	domainCSR := h.converter.CertificateSigningRequest().ToDomain(csr)
-	body, status := h.certificatesigningrequest.ReplaceCertificateSigningRequest(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainCSR)
+	body, status := csrservice.ReplaceCertificateSigningRequestFromUntrusted(r.Context(), h.certificatesigningrequest, transport.OrgIDFromContext(r.Context()), name, domainCSR)
 	apiResult := h.converter.CertificateSigningRequest().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/device.go
+++ b/internal/transport/v1beta1/device.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateDevice(w http.ResponseWriter, r *http.Request) 
 	}
 
 	domainDevice := h.converter.Device().ToDomain(device)
-	body, status := h.device.CreateDevice(r.Context(), transport.OrgIDFromContext(r.Context()), domainDevice)
+	body, status := deviceservice.CreateDeviceFromUntrusted(r.Context(), h.device, transport.OrgIDFromContext(r.Context()), domainDevice)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -46,7 +47,7 @@ func (h *TransportHandler) ReplaceDevice(w http.ResponseWriter, r *http.Request,
 	}
 
 	domainDevice := h.converter.Device().ToDomain(device)
-	body, status := h.device.ReplaceDevice(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainDevice, nil)
+	body, status := deviceservice.ReplaceDeviceFromUntrusted(r.Context(), h.device, transport.OrgIDFromContext(r.Context()), name, domainDevice, nil, true)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -80,7 +81,7 @@ func (h *TransportHandler) ReplaceDeviceStatus(w http.ResponseWriter, r *http.Re
 	}
 
 	domainDevice := h.converter.Device().ToDomain(device)
-	body, status := h.device.ReplaceDeviceStatus(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainDevice)
+	body, status := h.device.ReplaceDeviceStatus(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainDevice, true)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -102,7 +103,7 @@ func (h *TransportHandler) PatchDevice(w http.ResponseWriter, r *http.Request, n
 	}
 
 	domainPatch := h.converter.Common().PatchRequestToDomain(patch)
-	body, status := h.device.PatchDevice(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch)
+	body, status := h.device.PatchDevice(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch, true)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/enrollmentrequest.go
+++ b/internal/transport/v1beta1/enrollmentrequest.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	enrollmentrequestservice "github.com/flightctl/flightctl/internal/service/enrollmentrequest"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateEnrollmentRequest(w http.ResponseWriter, r *htt
 	}
 
 	domainER := h.converter.EnrollmentRequest().ToDomain(er)
-	body, status := h.enrollmentrequest.CreateEnrollmentRequest(r.Context(), transport.OrgIDFromContext(r.Context()), domainER)
+	body, status := enrollmentrequestservice.CreateEnrollmentRequestFromUntrusted(r.Context(), h.enrollmentrequest, transport.OrgIDFromContext(r.Context()), domainER)
 	apiResult := h.converter.EnrollmentRequest().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -46,7 +47,7 @@ func (h *TransportHandler) ReplaceEnrollmentRequest(w http.ResponseWriter, r *ht
 	}
 
 	domainER := h.converter.EnrollmentRequest().ToDomain(er)
-	body, status := h.enrollmentrequest.ReplaceEnrollmentRequest(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainER)
+	body, status := enrollmentrequestservice.ReplaceEnrollmentRequestFromUntrusted(r.Context(), h.enrollmentrequest, transport.OrgIDFromContext(r.Context()), name, domainER)
 	apiResult := h.converter.EnrollmentRequest().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/fleet.go
+++ b/internal/transport/v1beta1/fleet.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateFleet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	domainFleet := h.converter.Fleet().ToDomain(fleet)
-	body, status := h.fleet.CreateFleet(r.Context(), transport.OrgIDFromContext(r.Context()), domainFleet)
+	body, status := fleetservice.CreateFleetFromUntrusted(r.Context(), h.fleet, transport.OrgIDFromContext(r.Context()), domainFleet)
 	apiResult := h.converter.Fleet().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -47,14 +48,14 @@ func (h *TransportHandler) ReplaceFleet(w http.ResponseWriter, r *http.Request, 
 	}
 
 	domainFleet := h.converter.Fleet().ToDomain(fleet)
-	body, status := h.fleet.ReplaceFleet(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainFleet)
+	body, status := fleetservice.ReplaceFleetFromUntrusted(r.Context(), h.fleet, transport.OrgIDFromContext(r.Context()), name, domainFleet, true)
 	apiResult := h.converter.Fleet().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
 
 // (DELETE /api/v1/fleets/{name})
 func (h *TransportHandler) DeleteFleet(w http.ResponseWriter, r *http.Request, name string) {
-	status := h.fleet.DeleteFleet(r.Context(), transport.OrgIDFromContext(r.Context()), name)
+	status := h.fleet.DeleteFleet(r.Context(), transport.OrgIDFromContext(r.Context()), name, true)
 	h.SetResponse(w, nil, status)
 }
 
@@ -88,7 +89,7 @@ func (h *TransportHandler) PatchFleet(w http.ResponseWriter, r *http.Request, na
 	}
 
 	domainPatch := h.converter.Common().PatchRequestToDomain(patch)
-	body, status := h.fleet.PatchFleet(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch)
+	body, status := h.fleet.PatchFleet(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch, true)
 	apiResult := h.converter.Fleet().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/repository.go
+++ b/internal/transport/v1beta1/repository.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateRepository(w http.ResponseWriter, r *http.Reque
 	}
 
 	domainRepo := h.converter.Repository().ToDomain(rs)
-	body, status := h.repository.CreateRepository(r.Context(), transport.OrgIDFromContext(r.Context()), domainRepo)
+	body, status := repositoryservice.CreateRepositoryFromUntrusted(r.Context(), h.repository, transport.OrgIDFromContext(r.Context()), domainRepo)
 	apiResult := h.converter.Repository().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -46,7 +47,7 @@ func (h *TransportHandler) ReplaceRepository(w http.ResponseWriter, r *http.Requ
 	}
 
 	domainRepo := h.converter.Repository().ToDomain(rs)
-	body, status := h.repository.ReplaceRepository(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainRepo)
+	body, status := repositoryservice.ReplaceRepositoryFromUntrusted(r.Context(), h.repository, transport.OrgIDFromContext(r.Context()), name, domainRepo)
 	apiResult := h.converter.Repository().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/internal/transport/v1beta1/resourcesync.go
+++ b/internal/transport/v1beta1/resourcesync.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	resourcesyncservice "github.com/flightctl/flightctl/internal/service/resourcesync"
 	"github.com/flightctl/flightctl/internal/transport"
 )
 
@@ -17,7 +18,7 @@ func (h *TransportHandler) CreateResourceSync(w http.ResponseWriter, r *http.Req
 	}
 
 	domainRS := h.converter.ResourceSync().ToDomain(rs)
-	body, status := h.resourcesync.CreateResourceSync(r.Context(), transport.OrgIDFromContext(r.Context()), domainRS)
+	body, status := resourcesyncservice.CreateResourceSyncFromUntrusted(r.Context(), h.resourcesync, transport.OrgIDFromContext(r.Context()), domainRS)
 	apiResult := h.converter.ResourceSync().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -46,7 +47,7 @@ func (h *TransportHandler) ReplaceResourceSync(w http.ResponseWriter, r *http.Re
 	}
 
 	domainRS := h.converter.ResourceSync().ToDomain(rs)
-	body, status := h.resourcesync.ReplaceResourceSync(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainRS)
+	body, status := resourcesyncservice.ReplaceResourceSyncFromUntrusted(r.Context(), h.resourcesync, transport.OrgIDFromContext(r.Context()), name, domainRS)
 	apiResult := h.converter.ResourceSync().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -304,7 +304,7 @@ func NewTestHarness(ctx context.Context, testDirPath string, goRoutineErrorHandl
 	serversWg.Add(1)
 	go func() {
 		defer serversWg.Done()
-		err := workerServer.Run(context.WithValue(ctx, consts.InternalRequestCtxKey, true))
+		err := workerServer.Run(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			goRoutineErrorHandler(fmt.Errorf("error starting worker server: %w", err))
 			cancel() // cascade failure to other servers

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Device Agent behavior", func() {
 				// Manually overwrite reported status so we can verify the agent pushes and restores the real one.
 				overwrittenDevice := *devBefore
 				overwrittenDevice.Status.Os.Image = "fake-os-overwritten-by-test"
-				_, replaceSt := h.Device.ReplaceDeviceStatus(h.AuthenticatedContext(h.Context), orgID, deviceName, overwrittenDevice)
+				_, replaceSt := h.Device.ReplaceDeviceStatus(h.AuthenticatedContext(h.Context), orgID, deviceName, overwrittenDevice, true)
 				Expect(replaceSt.Code).To(BeEquivalentTo(200))
 				GinkgoWriter.Printf("ConflictPaused test: overwrote device status Os.Image to fake value\n")
 

--- a/test/integration/alerts/exporter_test.go
+++ b/test/integration/alerts/exporter_test.go
@@ -13,7 +13,6 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/alert_exporter"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	checkpointservice "github.com/flightctl/flightctl/internal/service/checkpoint"
@@ -87,7 +86,6 @@ var _ = Describe("Alert Exporter", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		log = flightlog.InitLogs()
 		var err error
 		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)

--- a/test/integration/periodic_checker/periodic_checker_test.go
+++ b/test/integration/periodic_checker/periodic_checker_test.go
@@ -128,7 +128,6 @@ var _ = Describe("Periodic", func() {
 		baseCtx := testutil.StartSpecTracerForGinkgo(suiteCtx)
 		baseCtx = context.WithValue(baseCtx, consts.EventSourceComponentCtxKey, "flightctl-periodic")
 		baseCtx = context.WithValue(baseCtx, consts.EventActorCtxKey, "service:flightctl-periodic")
-		baseCtx = context.WithValue(baseCtx, consts.InternalRequestCtxKey, true)
 		ctx, cancel = context.WithCancel(baseCtx)
 
 		log = flightlog.InitLogs()

--- a/test/integration/restore/enrollmentrequest_test.go
+++ b/test/integration/restore/enrollmentrequest_test.go
@@ -68,8 +68,7 @@ var _ = Describe("EnrollmentRequest restore operations", func() {
 			_, st = s.EnrollmentRequest.CreateEnrollmentRequest(s.Ctx, s.OrgID, toApproveER)
 			Expect(st.Code).To(BeEquivalentTo(201))
 
-			internalCtx := context.WithValue(s.Ctx, consts.InternalRequestCtxKey, true)
-			_, st = s.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, s.OrgID, alreadyAnnotatedER)
+			_, st = s.EnrollmentRequest.CreateEnrollmentRequest(s.Ctx, s.OrgID, alreadyAnnotatedER)
 			Expect(st.Code).To(BeEquivalentTo(201))
 
 			By("Debug: Verifying annotation was preserved")
@@ -205,14 +204,13 @@ var _ = Describe("EnrollmentRequest restore operations", func() {
 			er3Name := lo.FromPtr(er3.Metadata.Name)
 
 			By("creating enrollment requests")
-			internalCtx := context.WithValue(s.Ctx, consts.InternalRequestCtxKey, true)
-			_, status := s.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, s.OrgID, er1)
+			_, status := s.EnrollmentRequest.CreateEnrollmentRequest(s.Ctx, s.OrgID, er1)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 
-			_, status = s.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, s.OrgID, er2)
+			_, status = s.EnrollmentRequest.CreateEnrollmentRequest(s.Ctx, s.OrgID, er2)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 
-			_, status = s.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, s.OrgID, er3)
+			_, status = s.EnrollmentRequest.CreateEnrollmentRequest(s.Ctx, s.OrgID, er3)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 
 			By("approving one enrollment request before restore")

--- a/test/integration/service/catalog_test.go
+++ b/test/integration/service/catalog_test.go
@@ -706,7 +706,7 @@ var _ = Describe("Catalog Integration Tests", func() {
 			_, status = suite.Catalog.CreateCatalogItem(suite.Ctx, suite.OrgID, catalogName, item)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 
-			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName)
+			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName, true)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusConflict))
 		})
 
@@ -723,7 +723,7 @@ var _ = Describe("Catalog Integration Tests", func() {
 			_, status := suite.Catalog.CreateCatalog(suite.Ctx, suite.OrgID, catalog)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 
-			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName)
+			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName, true)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
 		})
 	})

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update device status to reflect the error state
-			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice)
+			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice, true)
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(resultDevice.Status.ApplicationsSummary.Status).To(Equal(api.ApplicationsSummaryStatusError))
 
@@ -258,7 +258,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update device status through the service
-			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice)
+			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice, true)
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(resultDevice).ToNot(BeNil())
 			Expect(resultDevice.Status.ApplicationsSummary.Status).To(Equal(api.ApplicationsSummaryStatusHealthy))
@@ -308,7 +308,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update the device status
-			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithCriticalResources)
+			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithCriticalResources, true)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			// Verify events were generated for CPU and Memory issues but NOT for Disk
@@ -350,7 +350,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update the device
-			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithHealthyResources)
+			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithHealthyResources, true)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			// Verify events were generated for CPU and Memory recovery
@@ -437,7 +437,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update device status through the service
-			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice)
+			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, updatedDevice, true)
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(resultDevice).ToNot(BeNil())
 
@@ -570,7 +570,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update the device status to online
-			resultDevice, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithOnlineStatus)
+			resultDevice, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithOnlineStatus, true)
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(resultDevice).ToNot(BeNil())
 			Expect(resultDevice.Status.Summary.Status).To(Equal(api.DeviceSummaryStatusOnline))
@@ -649,7 +649,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update the device status to online first
-			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithOnlineStatus)
+			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithOnlineStatus, true)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			// Step 3: Set the paused annotation first
@@ -705,7 +705,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 
 			// Update the device status - service should automatically set it to paused
-			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithUpdatedStatus)
+			resultDevice, status := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, deviceWithUpdatedStatus, true)
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(resultDevice).ToNot(BeNil())
 			Expect(resultDevice.Status.Summary.Status).To(Equal(api.DeviceSummaryStatusConflictPaused))
@@ -1101,7 +1101,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				}
 
 				// Save the updated device using ReplaceDeviceStatus for status updates
-				resultDevice, updateStatus := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, d.name, updatedDevice)
+				resultDevice, updateStatus := suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, d.name, updatedDevice, true)
 				Expect(updateStatus.Code).To(Equal(int32(200)))
 				Expect(resultDevice).ToNot(BeNil())
 
@@ -1533,7 +1533,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 
 	Context("Device field selector tests", func() {
 		It("should filter devices by lastSeen field selector", func() {
-			ctx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
+			ctx := suite.Ctx
 			deviceStore := suite.DeviceStore
 			// Create test devices for ListConnectivityChangedDevices: returns devices that need
 			// connection status update (reconnected: lastSeen >= cutoff and status Unknown;

--- a/test/integration/service/enrollmentrequest_awaiting_reconnect_test.go
+++ b/test/integration/service/enrollmentrequest_awaiting_reconnect_test.go
@@ -38,9 +38,7 @@ var _ = Describe("EnrollmentRequest AwaitingReconnect Integration Tests", func()
 			}
 
 			By("creating enrollment request with awaitingReconnect annotation")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 			Expect(created.Metadata.Annotations).ToNot(BeNil())
@@ -80,9 +78,7 @@ var _ = Describe("EnrollmentRequest AwaitingReconnect Integration Tests", func()
 			erName := lo.FromPtr(er.Metadata.Name)
 
 			By("creating enrollment request without awaitingReconnect annotation")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 
@@ -123,9 +119,7 @@ var _ = Describe("EnrollmentRequest AwaitingReconnect Integration Tests", func()
 			}
 
 			By("creating enrollment request with awaitingReconnect annotation set to false")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 
@@ -168,9 +162,7 @@ var _ = Describe("EnrollmentRequest AwaitingReconnect Integration Tests", func()
 			}
 
 			By("creating enrollment request with awaitingReconnect and other annotations")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 

--- a/test/integration/service/enrollmentrequest_device_creation_test.go
+++ b/test/integration/service/enrollmentrequest_device_creation_test.go
@@ -41,9 +41,7 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 				er.Metadata.Annotations = enrollmentRequestAnnotations
 
 				By("creating enrollment request")
-				// Use internal request context to preserve annotations
-				internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-				created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+				created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 				Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 				Expect(created).ToNot(BeNil())
 
@@ -111,9 +109,7 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 			}
 
 			By("creating enrollment request")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 
@@ -158,9 +154,7 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 			er.Status = nil
 
 			By("creating enrollment request with nil status")
-			// Use internal request context to preserve annotations
-			internalCtx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, true)
-			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(internalCtx, suite.OrgID, er)
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
 			Expect(created).ToNot(BeNil())
 

--- a/test/integration/service/enrollmentrequest_test.go
+++ b/test/integration/service/enrollmentrequest_test.go
@@ -256,10 +256,6 @@ var _ = Describe("EnrollmentRequest Integration Tests", func() {
 				// Prepare status update
 				statusUpdate := statusUpdateFunc(*setupResult)
 
-				if !isExternalRequest {
-					ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
-				}
-
 				By("performing status update")
 				updated, st := suite.EnrollmentRequest.ReplaceEnrollmentRequestStatus(ctx, suite.OrgID, erName, statusUpdate)
 

--- a/test/integration/service/fleet_test.go
+++ b/test/integration/service/fleet_test.go
@@ -1,11 +1,10 @@
 package service_test
 
 import (
-	"context"
 	"net/http"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
-	"github.com/flightctl/flightctl/internal/consts"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -24,27 +23,36 @@ var _ = Describe("Fleet create", func() {
 	AfterEach(func() {
 		suite.Teardown()
 	})
-	DescribeTable("ReplaceFleet nilled owner",
-		func(internal bool, expectedOwner string) {
-			ctx := context.WithValue(suite.Ctx, consts.InternalRequestCtxKey, internal)
-			fleet := &api.Fleet{
+	DescribeTable("ReplaceFleet owner handling",
+		func(replace func(fleet api.Fleet) (*api.Fleet, api.Status), expectedOwner string) {
+			fleet := api.Fleet{
 				Metadata: api.ObjectMeta{
 					Name:  lo.ToPtr("test-fleet"),
 					Owner: lo.ToPtr("test-owner"),
 				},
 				Spec: api.FleetSpec{},
 			}
-			createdFleet, status := suite.Fleet.ReplaceFleet(ctx, suite.OrgID, "test-fleet", *fleet)
+			createdFleet, status := replace(fleet)
 			Expect(status.Code).To(Equal(int32(http.StatusCreated)))
 			Expect(lo.FromPtr(createdFleet.Metadata.Name)).To(Equal("test-fleet"))
 			Expect(lo.FromPtr(createdFleet.Metadata.Owner)).To(Equal(expectedOwner))
 
-			retrievedFleet, status := suite.Fleet.GetFleet(ctx, suite.OrgID, "test-fleet", api.GetFleetParams{})
+			retrievedFleet, status := suite.Fleet.GetFleet(suite.Ctx, suite.OrgID, "test-fleet", api.GetFleetParams{})
 			Expect(status.Code).To(Equal(int32(http.StatusOK)))
 			Expect(lo.FromPtr(retrievedFleet.Metadata.Name)).To(Equal("test-fleet"))
 			Expect(lo.FromPtr(retrievedFleet.Metadata.Owner)).To(Equal(expectedOwner))
 		},
-		Entry("Internal request should keep owner", true, "test-owner"),
-		Entry("Non-internal request should nil owner", false, ""),
+		Entry("Trusted caller (ReplaceFleet) should keep owner as given",
+			func(fleet api.Fleet) (*api.Fleet, api.Status) {
+				return suite.Fleet.ReplaceFleet(suite.Ctx, suite.OrgID, "test-fleet", fleet, true)
+			},
+			"test-owner",
+		),
+		Entry("Untrusted caller (ReplaceFleetFromUntrusted) should nil owner",
+			func(fleet api.Fleet) (*api.Fleet, api.Status) {
+				return fleetservice.ReplaceFleetFromUntrusted(suite.Ctx, suite.Fleet, suite.OrgID, "test-fleet", fleet, false)
+			},
+			"",
+		),
 	)
 })

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -152,20 +152,19 @@ var _ = Describe("DeviceStore create", func() {
 		Expect(*dev.Metadata.ResourceVersion).To(Equal("6"))
 	})
 
-	It("CreateOrUpdateDevice update with stale resourceVersion", func() {
+	It("CreateOrUpdateDevice updates owned device (ownership enforced in service)", func() {
 		dev, err := devStore.Get(ctx, orgId, "mydevice-1")
 		Expect(err).ToNot(HaveOccurred())
 		dev.Metadata.Owner = lo.ToPtr("newowner")
 		dev.Spec.Os.Image = "oldos"
-		// Update but don't save the new device, so we still have the old resourceVersion
 		dev, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, false, nil, callback)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(called).To(BeTrue())
 
 		dev.Spec.Os.Image = "newos"
-		_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
+		updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Spec.Os.Image).To(Equal("newos"))
 	})
 
 	Context("Device store", func() {
@@ -556,7 +555,7 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(dev.Spec.Os.Image).To(Equal("newos"))
 		})
 
-		It("CreateOrUpdateDevice update owned from API", func() {
+		It("CreateOrUpdateDevice update owned from API succeeds at store layer", func() {
 			dev, err := devStore.Get(ctx, orgId, "mydevice-1")
 			Expect(err).ToNot(HaveOccurred())
 			dev.Metadata.Owner = lo.ToPtr("newowner")
@@ -566,9 +565,9 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(called).To(BeTrue())
 
 			dev.Spec.Os.Image = "newos"
-			_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
-			Expect(err).To(HaveOccurred())
-			Expect(err).Should(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
+			updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Spec.Os.Image).To(Equal("newos"))
 		})
 
 		It("CreateOrUpdateDevice update labels owned from API", func() {

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -706,8 +706,7 @@ var _ = Describe("FleetStore create", func() {
 			Expect(orgIds).To(HaveKey(otherOrgId.String()))
 		})
 
-		It("Cannot update fleet spec or labels when owned by resourcesync", func() {
-			// Create a resourcesync first
+		It("Store allows updating owned fleet spec and labels (ownership enforced in service)", func() {
 			resourceSync := api.ResourceSync{
 				Metadata: api.ObjectMeta{
 					Name: lo.ToPtr("test-resourcesync"),
@@ -720,7 +719,6 @@ var _ = Describe("FleetStore create", func() {
 			_, err := resourceSyncStore.Create(ctx, orgId, &resourceSync, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Create a fleet owned by the resourcesync
 			owner := util.SetResourceOwner(api.ResourceSyncKind, "test-resourcesync")
 			fleet := api.Fleet{
 				Metadata: api.ObjectMeta{
@@ -737,33 +735,28 @@ var _ = Describe("FleetStore create", func() {
 			_, err = fleetStore.Create(ctx, orgId, &fleet, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify the fleet was created with the owner
 			createdFleet, err := fleetStore.Get(ctx, orgId, "owned-fleet")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdFleet.Metadata.Owner).ToNot(BeNil())
 			Expect(*createdFleet.Metadata.Owner).To(Equal("ResourceSync/test-resourcesync"))
 
-			// Try to update the fleet's spec - should fail
 			updatedFleet := *createdFleet
 			updatedFleet.Spec.Selector = &api.LabelSelector{
 				MatchLabels: &map[string]string{"key": "updated"},
 			}
 			_, err = fleetStore.Update(ctx, orgId, &updatedFleet, nil, true, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
-
-			// Try to update the fleet's labels - should fail
-			updatedFleet = *createdFleet
-			updatedFleet.Metadata.Labels = &map[string]string{"updated": "label"}
-			_, err = fleetStore.Update(ctx, orgId, &updatedFleet, nil, true, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(flterrors.ErrUpdatingResourceWithOwnerNotAllowed))
-
-			// Verify the original fleet is unchanged
-			unchangedFleet, err := fleetStore.Get(ctx, orgId, "owned-fleet")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(unchangedFleet.Spec.Selector.MatchLabels).To(Equal(&map[string]string{"key": "original"}))
-			Expect(unchangedFleet.Metadata.Labels).To(Equal(&map[string]string{"original": "label"}))
+
+			refetched, err := fleetStore.Get(ctx, orgId, "owned-fleet")
+			Expect(err).ToNot(HaveOccurred())
+			refetched.Metadata.Labels = &map[string]string{"updated": "label"}
+			_, err = fleetStore.Update(ctx, orgId, refetched, nil, true, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := fleetStore.Get(ctx, orgId, "owned-fleet")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Spec.Selector.MatchLabels).To(Equal(&map[string]string{"key": "updated"}))
+			Expect(got.Metadata.Labels).To(Equal(&map[string]string{"updated": "label"}))
 		})
 
 		It("MutateAnnotation sets the key from an initial empty value and preserves other annotations", func() {

--- a/test/integration/tasks/device_connection_test.go
+++ b/test/integration/tasks/device_connection_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	"github.com/flightctl/flightctl/internal/service/events"
@@ -46,7 +45,6 @@ var _ = Describe("DeviceConnection", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		var err error

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/rendered"
 	dependencyrefservice "github.com/flightctl/flightctl/internal/service/dependencyref"
@@ -127,7 +126,6 @@ var _ = Describe("DeviceRender", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		fleetName = "myfleet"

--- a/test/integration/tasks/fleet_rollout_lifecycle_test.go
+++ b/test/integration/tasks/fleet_rollout_lifecycle_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/rendered"
 	"github.com/flightctl/flightctl/internal/service/common"
@@ -72,7 +71,6 @@ var _ = Describe("Application lifecycle overlay at render time", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		fleetName = "lifecycle-fleet"

--- a/test/integration/tasks/fleet_rollout_test.go
+++ b/test/integration/tasks/fleet_rollout_test.go
@@ -8,7 +8,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	dependencyrefservice "github.com/flightctl/flightctl/internal/service/dependencyref"
@@ -94,7 +93,6 @@ var _ = Describe("FleetRollout", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		numDevices = 3

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -50,7 +50,6 @@ var _ = Describe("FleetSelector", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		ctx = context.WithValue(ctx, consts.EventSourceComponentCtxKey, "flightctl-worker")
 		ctx = context.WithValue(ctx, consts.EventActorCtxKey, "service:flightctl-worker")
 		orgId = store.NullOrgId

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	"github.com/flightctl/flightctl/internal/service/events"
@@ -63,7 +62,6 @@ var _ = Describe("FleetValidate", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		var err error

--- a/test/integration/tasks/queue_maintenance_test.go
+++ b/test/integration/tasks/queue_maintenance_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 	Describe("Basic Queue Maintenance Operations", func() {
 		It("should execute queue maintenance without errors", func() {
 			// Setup expectations for basic execution - recovery may or may not happen depending on Redis state
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				&api.OrganizationList{Items: []api.Organization{}}, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process
@@ -221,7 +221,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 
 		It("should handle empty system gracefully", func() {
 			// Setup expectations for empty organization list - recovery may or may not happen
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				&api.OrganizationList{Items: []api.Organization{}}, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process
@@ -247,7 +247,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 				orgs := createTestOrganizations([]uuid.UUID{testOrg1ID, testOrg2ID})
 
 				// Setup mock expectations
-				mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200})
+				mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200})
 
 				// Setup database checkpoint to trigger republishing
 				baseTime := time.Now().Add(-1 * time.Hour)
@@ -325,7 +325,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 				emptyOrgID := uuid.New()
 				orgs := createTestOrganizations([]uuid.UUID{emptyOrgID})
 
-				mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200}).AnyTimes()
+				mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200}).AnyTimes()
 
 				// Mock ListEvents for the organization (returns empty list)
 				mockEventSvc.EXPECT().ListEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -352,7 +352,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 		It("should recover when Redis checkpoint is missing but database checkpoint exists", func() {
 			// Setup organizations
 			orgs := createTestOrganizations([]uuid.UUID{testOrg1ID})
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200})
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200})
 
 			// Set only database checkpoint (simulate Redis failure)
 			checkpointTime := time.Now().Add(-30 * time.Minute)
@@ -380,7 +380,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 
 		It("should handle fresh system with no checkpoints", func() {
 			// Setup empty organizations - recovery may or may not happen
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				&api.OrganizationList{Items: []api.Organization{}}, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process
@@ -402,7 +402,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 	Describe("Error Handling", func() {
 		It("should handle service errors gracefully", func() {
 			// Setup service to return an error - may or may not be called depending on Redis state
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				nil, api.Status{Code: 500, Message: "internal server error"}).AnyTimes()
 
 			// Even when ListOrganizations fails, other queue maintenance operations may still run
@@ -433,7 +433,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 			}
 			orgs := &api.OrganizationList{Items: []api.Organization{invalidOrg}}
 
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200}).AnyTimes()
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(orgs, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process
 			mockCheckpointSvc.EXPECT().GetCheckpoint(gomock.Any(), "task_queue", "global_checkpoint").Return(
@@ -454,7 +454,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 	Describe("Timeout and Retry Scenarios", func() {
 		It("should handle message timeouts and retries", func() {
 			// Setup basic organizations for queue operations - recovery may or may not happen
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				&api.OrganizationList{Items: []api.Organization{}}, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process
@@ -478,7 +478,7 @@ var _ = Describe("Queue Maintenance Integration Tests", func() {
 
 		It("should advance checkpoint after processing", func() {
 			// Setup basic organizations - recovery may or may not happen
-			mockOrganizationSvc.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(
+			mockOrganizationSvc.EXPECT().ListAllOrganizations(gomock.Any(), gomock.Any()).Return(
 				&api.OrganizationList{Items: []api.Organization{}}, api.Status{Code: 200}).AnyTimes()
 
 			// The queue maintenance will try to get checkpoint during recovery process

--- a/test/integration/tasks/repo_update_test.go
+++ b/test/integration/tasks/repo_update_test.go
@@ -5,7 +5,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	eventservice "github.com/flightctl/flightctl/internal/service/event"
 	"github.com/flightctl/flightctl/internal/service/events"
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
@@ -46,7 +45,6 @@ var _ = Describe("RepoUpdate", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		var err error

--- a/test/integration/tasks/repotester_conditions_test.go
+++ b/test/integration/tasks/repotester_conditions_test.go
@@ -9,7 +9,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service/events"
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
@@ -115,7 +114,6 @@ var _ = Describe("RepoTester", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		var err error

--- a/test/integration/tasks/resourcesync_test.go
+++ b/test/integration/tasks/resourcesync_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	catalogservice "github.com/flightctl/flightctl/internal/service/catalog"
@@ -40,7 +39,6 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 	var (
 		log               *logrus.Logger
 		ctx               context.Context
-		internalCtx       context.Context
 		orgId             uuid.UUID
 		eventStore        eventstore.Store
 		repositorySvc     repositoryservice.Service
@@ -58,7 +56,6 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		internalCtx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		var err error
@@ -168,7 +165,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			rs := createTestResourceSync(resourceSyncName, "test-repo", "/examples")
 
 			// Test the helper method
-			repo, err := resourceSync.GetRepositoryAndValidateAccess(internalCtx, orgId, rs)
+			repo, err := resourceSync.GetRepositoryAndValidateAccess(ctx, orgId, rs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(repo).ToNot(BeNil())
 
@@ -188,7 +185,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			rs := createTestResourceSync(resourceSyncName, "non-existent-repo", "/examples")
 
 			// Test the helper method
-			repo, err := resourceSync.GetRepositoryAndValidateAccess(internalCtx, orgId, rs)
+			repo, err := resourceSync.GetRepositoryAndValidateAccess(ctx, orgId, rs)
 			Expect(err).To(HaveOccurred())
 			Expect(repo).To(BeNil())
 
@@ -288,7 +285,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			}
 
 			// Test the helper method
-			err := resourceSync.SyncFleets(internalCtx, log, orgId, rs, fleets, "sync-test-resourcesync")
+			err := resourceSync.SyncFleets(ctx, log, orgId, rs, fleets, "sync-test-resourcesync")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify conditions were set
@@ -327,7 +324,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			}
 
 			// Sync fleets
-			err := resourceSync.SyncFleets(internalCtx, log, orgId, rs, fleets, "owner-test-resourcesync")
+			err := resourceSync.SyncFleets(ctx, log, orgId, rs, fleets, "owner-test-resourcesync")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify the fleet was created with the owner set
@@ -339,7 +336,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			// Verify the fleet cannot be edited (spec update should fail)
 			updatedFleet := *createdFleet
 			updatedFleet.Spec.Template.Spec.Os.Image = "quay.io/test/os:updated"
-			_, status = fleetSvc.ReplaceFleet(ctx, orgId, "owned-fleet", updatedFleet)
+			_, status = fleetSvc.ReplaceFleet(ctx, orgId, "owned-fleet", updatedFleet, true)
 			Expect(status.Code).To(Equal(int32(409))) // Conflict
 			Expect(status.Message).To(ContainSubstring("updating the resource is not allowed because it has an owner"))
 		})
@@ -373,8 +370,8 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			_, status := fleetSvc.CreateFleet(ctx, orgId, *conflictingFleet)
 			Expect(status.Code).To(Equal(int32(201)))
 
-			// Update the fleet to set the owner (use internalCtx so owner is preserved)
-			_, status = fleetSvc.ReplaceFleet(internalCtx, orgId, *conflictingFleet.Metadata.Name, *conflictingFleet)
+			// Trusted write: set owner without ownership enforcement
+			_, status = fleetSvc.ReplaceFleet(ctx, orgId, *conflictingFleet.Metadata.Name, *conflictingFleet, false)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			// Verify the fleet was created with the correct owner
@@ -405,7 +402,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			}
 
 			// Test the helper method
-			err := resourceSync.SyncFleets(internalCtx, log, orgId, rs, fleets, "conflict-test-resourcesync")
+			err := resourceSync.SyncFleets(ctx, log, orgId, rs, fleets, "conflict-test-resourcesync")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fleet name(s)"))
 		})
@@ -421,7 +418,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			rs := createTestResourceSync(resourceSyncName, "event-test-repo", "/examples")
 
 			// Call the helper method
-			_, err := resourceSync.GetRepositoryAndValidateAccess(internalCtx, orgId, rs)
+			_, err := resourceSync.GetRepositoryAndValidateAccess(ctx, orgId, rs)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Update the status to trigger event emission
@@ -444,7 +441,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			rs := createTestResourceSync(resourceSyncName, "non-existent-repo", "/examples")
 
 			// Call the helper method
-			_, err := resourceSync.GetRepositoryAndValidateAccess(internalCtx, orgId, rs)
+			_, err := resourceSync.GetRepositoryAndValidateAccess(ctx, orgId, rs)
 			Expect(err).To(HaveOccurred())
 
 			// Update the status to trigger event emission
@@ -469,7 +466,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 
 			// Call the helper method
 			rs, _ := resourcesyncSvc.GetResourceSync(ctx, orgId, resourceSyncName)
-			_, err := resourceSync.GetRepositoryAndValidateAccess(internalCtx, orgId, rs)
+			_, err := resourceSync.GetRepositoryAndValidateAccess(ctx, orgId, rs)
 			Expect(err).ToNot(HaveOccurred())
 
 			events := getEventsForResourceSync(resourceSyncName)
@@ -919,7 +916,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			}
 
 			// Sync the fleet from YAML
-			err := resourceSync.SyncFleets(internalCtx, log, orgId, rs, fleetFromYAML, "annotation-preserve-resourcesync")
+			err := resourceSync.SyncFleets(ctx, log, orgId, rs, fleetFromYAML, "annotation-preserve-resourcesync")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify the annotation is still preserved
@@ -991,7 +988,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 			}
 
 			// Sync the fleet from YAML
-			err := resourceSync.SyncFleets(internalCtx, log, orgId, rs, fleetFromYAML, "annotation-ignore-resourcesync")
+			err := resourceSync.SyncFleets(ctx, log, orgId, rs, fleetFromYAML, "annotation-ignore-resourcesync")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify that user-defined annotations were ignored
@@ -1027,7 +1024,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 				},
 			}
 
-			catalogsToRemove, err := resourceSync.SyncCatalogs(internalCtx, log, orgId, rs, catalogs, "catalog-sync-rs")
+			catalogsToRemove, err := resourceSync.SyncCatalogs(ctx, log, orgId, rs, catalogs, "catalog-sync-rs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(catalogsToRemove).To(BeEmpty())
 
@@ -1070,7 +1067,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 				},
 			}
 
-			itemsToRemove, err := resourceSync.SyncCatalogItems(internalCtx, log, orgId, rs, items, "catalog-sync-rs")
+			itemsToRemove, err := resourceSync.SyncCatalogItems(ctx, log, orgId, rs, items, "catalog-sync-rs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(itemsToRemove).To(BeEmpty())
 
@@ -1102,7 +1099,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 				},
 			}
 
-			_, err := resourceSync.SyncCatalogs(internalCtx, log, orgId, rs, catalogs, "catalog-owner-rs")
+			_, err := resourceSync.SyncCatalogs(ctx, log, orgId, rs, catalogs, "catalog-owner-rs")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify the catalog cannot be edited (spec update should fail due to ownership)
@@ -1111,7 +1108,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 
 			updated := *created
 			updated.Spec.DisplayName = lo.ToPtr("Modified Name")
-			_, status = catalogSvc.ReplaceCatalog(ctx, orgId, "owned-catalog", updated)
+			_, status = catalogSvc.ReplaceCatalog(ctx, orgId, "owned-catalog", updated, true)
 			Expect(status.Code).To(Equal(int32(http.StatusConflict)))
 			Expect(status.Message).To(ContainSubstring("owner"))
 		})
@@ -1130,17 +1127,17 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 				},
 			}
 
-			_, err := resourceSync.SyncCatalogs(internalCtx, log, orgId, rs1, catalogs, "catalog-conflict-rs1")
+			_, err := resourceSync.SyncCatalogs(ctx, log, orgId, rs1, catalogs, "catalog-conflict-rs1")
 			Expect(err).ToNot(HaveOccurred())
 
 			// RS2 tries to claim the same catalog name
 			createTestRepository("catalog-conflict-repo2", "https://github.com/test/repo2")
 			rs2 := createTestResourceSync("catalog-conflict-rs2", "catalog-conflict-repo2", "/catalog")
 
-			err = resourceSync.SyncFleets(internalCtx, log, orgId, rs2, nil, "catalog-conflict-rs2")
+			err = resourceSync.SyncFleets(ctx, log, orgId, rs2, nil, "catalog-conflict-rs2")
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = resourceSync.SyncCatalogs(internalCtx, log, orgId, rs2, catalogs, "catalog-conflict-rs2")
+			_, err = resourceSync.SyncCatalogs(ctx, log, orgId, rs2, catalogs, "catalog-conflict-rs2")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("catalog name(s)"))
 		})
@@ -1158,7 +1155,7 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 					Spec:       domain.CatalogSpec{},
 				},
 			}
-			_, err := resourceSync.SyncCatalogs(internalCtx, log, orgId, rs, catalogs, "catalog-remove-rs")
+			_, err := resourceSync.SyncCatalogs(ctx, log, orgId, rs, catalogs, "catalog-remove-rs")
 			Expect(err).ToNot(HaveOccurred())
 
 			items := []*domain.CatalogItem{
@@ -1183,18 +1180,16 @@ var _ = Describe("ResourceSync Task Integration Tests", func() {
 					},
 				},
 			}
-			_, err = resourceSync.SyncCatalogItems(internalCtx, log, orgId, rs, items, "catalog-remove-rs")
+			_, err = resourceSync.SyncCatalogItems(ctx, log, orgId, rs, items, "catalog-remove-rs")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Second sync with only item-a -- item-b should be stale
-			itemsToRemove, err := resourceSync.SyncCatalogItems(internalCtx, log, orgId, rs, items[:1], "catalog-remove-rs")
+			itemsToRemove, err := resourceSync.SyncCatalogItems(ctx, log, orgId, rs, items[:1], "catalog-remove-rs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(itemsToRemove).To(Equal([]string{"removable-catalog/item-b"}))
 
-			// Delete stale item through service (mirrors what run() does with the toRemove list)
-			// ResourceSync sets ResourceSyncRequestCtxKey when deleting owned items
-			deleteCtx := context.WithValue(internalCtx, consts.ResourceSyncRequestCtxKey, true)
-			status := catalogSvc.DeleteCatalogItem(deleteCtx, orgId, "removable-catalog", "item-b")
+			// Delete stale item through service (mirrors ResourceSync: enforceOwnership=false)
+			status := catalogSvc.DeleteCatalogItem(ctx, orgId, "removable-catalog", "item-b", false)
 			Expect(status.Code).To(Equal(int32(http.StatusOK)))
 
 			// Verify item-b is gone

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -7,7 +7,6 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
-	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/rendered"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
@@ -81,7 +80,6 @@ var _ = Describe("VmApplicationRender", func() {
 
 	BeforeEach(func() {
 		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
-		ctx = context.WithValue(ctx, consts.InternalRequestCtxKey, true)
 		orgId = store.NullOrgId
 		log = flightlog.InitLogs()
 		deviceName = "vm-test-device-" + uuid.New().String()[:8]


### PR DESCRIPTION
Jira: EDM-4826

Enforces fleet and catalog ownership checks in the service layer, extending the sanitize-at-adapter pattern to all mutate services and dropping `IsInternalRequest`.

---
**Stack:** 1/12 in the EDM-4806 (Technical Debt: Store Contains Business Logic) closeout stack.
Base: `main`

Made with [Cursor](https://cursor.com)