### PR TITLE
EDM-4827: Device Replace ownership; preserve UpdateDevice quirk

### DIFF
--- a/internal/imagebuilder_api/service/teststore_imagepromotion_test.go
+++ b/internal/imagebuilder_api/service/teststore_imagepromotion_test.go
@@ -229,7 +229,7 @@ func (s *DummyCatalogStore) Create(ctx context.Context, orgId uuid.UUID, catalog
 func (s *DummyCatalogStore) Update(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, callbackEvent flightctlstore.EventCallback) (*coredomain.Catalog, error) {
 	return nil, nil
 }
-func (s *DummyCatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, fromAPI bool, callbackEvent flightctlstore.EventCallback) (*coredomain.Catalog, bool, error) {
+func (s *DummyCatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, callbackEvent flightctlstore.EventCallback) (*coredomain.Catalog, bool, error) {
 	return nil, false, nil
 }
 func (s *DummyCatalogStore) List(ctx context.Context, orgId uuid.UUID, listParams flightctlstore.ListParams) (*coredomain.CatalogList, error) {

--- a/internal/imagebuilder_worker/tasks/imagepromotion_test.go
+++ b/internal/imagebuilder_worker/tasks/imagepromotion_test.go
@@ -296,7 +296,7 @@ func (a *dummyCatalogStoreAdapter) Create(ctx context.Context, orgId uuid.UUID, 
 func (a *dummyCatalogStoreAdapter) Update(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, cb flightctlstore.EventCallback) (*coredomain.Catalog, error) {
 	return nil, nil
 }
-func (a *dummyCatalogStoreAdapter) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, fromAPI bool, cb flightctlstore.EventCallback) (*coredomain.Catalog, bool, error) {
+func (a *dummyCatalogStoreAdapter) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *coredomain.Catalog, cb flightctlstore.EventCallback) (*coredomain.Catalog, bool, error) {
 	return nil, false, nil
 }
 func (a *dummyCatalogStoreAdapter) List(ctx context.Context, orgId uuid.UUID, lp flightctlstore.ListParams) (*coredomain.CatalogList, error) {

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -45,10 +45,10 @@ func (m *MockDevice) InitialMigration(ctx context.Context) error { return nil }
 func (m *MockDevice) Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, callback store.EventCallback) (*domain.Device, error) {
 	return nil, nil
 }
-func (m *MockDevice) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, error) {
+func (m *MockDevice) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, error) {
 	return nil, nil
 }
-func (m *MockDevice) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, bool, error) {
+func (m *MockDevice) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, bool, error) {
 	return nil, false, nil
 }
 func (m *MockDevice) Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error) {

--- a/internal/instrumentation/metrics/domain/fleet_test.go
+++ b/internal/instrumentation/metrics/domain/fleet_test.go
@@ -35,11 +35,11 @@ func (m *MockFleetStore) Create(ctx context.Context, orgId uuid.UUID, fleet *dom
 	return nil, nil
 }
 
-func (m *MockFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, callback store.EventCallback) (*domain.Fleet, error) {
+func (m *MockFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, callback store.EventCallback) (*domain.Fleet, error) {
 	return nil, nil
 }
 
-func (m *MockFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, callback store.EventCallback) (*domain.Fleet, bool, error) {
+func (m *MockFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, callback store.EventCallback) (*domain.Fleet, bool, error) {
 	return nil, false, nil
 }
 

--- a/internal/remote_access_server/server.go
+++ b/internal/remote_access_server/server.go
@@ -63,7 +63,7 @@ func (s *storeAppConsoleService) GetDevice(ctx context.Context, orgId uuid.UUID,
 }
 
 func (s *storeAppConsoleService) UpdateDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, error) {
-	return s.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, false, nil, nil)
+	return s.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, nil, nil)
 }
 
 // New returns a new Server. All initialisation requiring a context (listeners,

--- a/internal/service/authprovider/handler.go
+++ b/internal/service/authprovider/handler.go
@@ -137,18 +137,16 @@ func applyAuthProviderDefaults(spec *domain.AuthProviderSpec) error {
 }
 
 // handleSuperAdminAnnotation checks if the request is from a super admin and sets the annotation if needed.
-// Returns true if the auth provider was created by a super admin, false otherwise.
-func (h *ServiceHandler) handleSuperAdminAnnotation(ctx context.Context, authProvider *domain.AuthProvider) bool {
+func (h *ServiceHandler) handleSuperAdminAnnotation(ctx context.Context, authProvider *domain.AuthProvider) {
 	mappedIdentity, ok := contextutil.GetMappedIdentityFromContext(ctx)
-	createdBySuperAdmin := ok && mappedIdentity.IsSuperAdmin()
-
-	if createdBySuperAdmin {
-		// Clear user-provided annotations and set our annotation
-		authProvider.Metadata.Annotations = lo.ToPtr(map[string]string{
-			domain.AuthProviderAnnotationCreatedBySuperAdmin: "true",
-		})
+	if !ok || !mappedIdentity.IsSuperAdmin() {
+		return
 	}
-	return createdBySuperAdmin
+
+	// Clear user-provided annotations and set our annotation
+	authProvider.Metadata.Annotations = lo.ToPtr(map[string]string{
+		domain.AuthProviderAnnotationCreatedBySuperAdmin: "true",
+	})
 }
 
 func (h *ServiceHandler) CreateAuthProvider(ctx context.Context, orgId uuid.UUID, authProvider domain.AuthProvider) (*domain.AuthProvider, domain.Status) {
@@ -167,16 +165,8 @@ func (h *ServiceHandler) CreateAuthProvider(ctx context.Context, orgId uuid.UUID
 		return nil, domain.StatusBadRequest(sanitizeSchemaError(errors.Join(errs...)))
 	}
 
-	// Check if created by super admin and prepare annotations
-	createdBySuperAdmin := h.handleSuperAdminAnnotation(ctx, &authProvider)
+	h.handleSuperAdminAnnotation(ctx, &authProvider)
 
-	// Use fromAPI=false to preserve annotations when created by super admin
-	if createdBySuperAdmin {
-		result, err := h.store.CreateWithFromAPI(ctx, orgId, &authProvider, false, h.callbackAuthProviderUpdated)
-		return result, common.StoreErrorToApiStatus(err, true, domain.AuthProviderKind, authProvider.Metadata.Name)
-	}
-
-	// For non-super-admin users, use regular Create (fromAPI=true, annotations cleared)
 	result, err := h.store.Create(ctx, orgId, &authProvider, h.callbackAuthProviderUpdated)
 	return result, common.StoreErrorToApiStatus(err, true, domain.AuthProviderKind, authProvider.Metadata.Name)
 }

--- a/internal/service/authprovider/handler_test.go
+++ b/internal/service/authprovider/handler_test.go
@@ -64,10 +64,6 @@ func (f *fakeAuthProviderStore) Create(ctx context.Context, orgId uuid.UUID, aut
 	return authProvider, nil
 }
 
-func (f *fakeAuthProviderStore) CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, fromAPI bool, eventCallback store.EventCallback) (*domain.AuthProvider, error) {
-	return f.Create(ctx, orgId, authProvider, eventCallback)
-}
-
 func (f *fakeAuthProviderStore) Update(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, error) {
 	if f.err != nil {
 		return nil, f.err

--- a/internal/service/catalog/handler.go
+++ b/internal/service/catalog/handler.go
@@ -140,7 +140,7 @@ func (h *ServiceHandler) ReplaceCatalog(ctx context.Context, orgId uuid.UUID, na
 		}
 	}
 
-	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &catalog, false, h.callbackCatalogUpdated)
+	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &catalog, h.callbackCatalogUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.CatalogKind, &name)
 }
 

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -73,7 +73,7 @@ func (f *fakeCatalogStore) Update(ctx context.Context, orgId uuid.UUID, catalog 
 	return catalog, nil
 }
 
-func (f *fakeCatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, fromAPI bool, callbackEvent store.EventCallback) (*domain.Catalog, bool, error) {
+func (f *fakeCatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, bool, error) {
 	name := lo.FromPtr(catalog.Metadata.Name)
 	if _, exists := f.catalogs[name]; exists {
 		result, err := f.Update(ctx, orgId, catalog, callbackEvent)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -250,7 +250,7 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
-	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.DeviceKind, &name)
 }
 
@@ -270,7 +270,7 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
 	// Ownership is never enforced on UpdateDevice (agent/console trusted path).
-	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
 }
 
 func (h *DeviceServiceHandler) DeleteDevice(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
@@ -380,7 +380,7 @@ func (h *DeviceServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
@@ -488,7 +488,7 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, false, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, DeviceVerificationCallback, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -762,6 +762,31 @@ func TestUpdateDevice(t *testing.T) {
 		result, err := svc.UpdateDevice(ctx, orgId, "owned-device", device, nil)
 		require.NoError(t, err)
 		require.Equal(t, "img-updated", result.Spec.Os.Image)
+		require.Equal(t, "Fleet/f1", lo.FromPtr(st.device.devices["owned-device"].Metadata.Owner))
+	})
+
+	t.Run("When fieldsToUnset includes owner it should clear the owner", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["owned-device"] = &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:        lo.ToPtr("owned-device"),
+				Owner:       lo.ToPtr("Fleet/f1"),
+				Annotations: &map[string]string{"k": "v"},
+			},
+			Spec: &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img"}},
+		}
+
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("owned-device")},
+			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
+		}
+		result, err := svc.UpdateDevice(ctx, orgId, "owned-device", device, []string{"owner"})
+		require.NoError(t, err)
+		require.Nil(t, result.Metadata.Owner)
+		require.Nil(t, st.device.devices["owned-device"].Metadata.Owner)
+		require.Equal(t, "v", (*st.device.devices["owned-device"].Metadata.Annotations)["k"])
 	})
 }
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -211,6 +211,9 @@ func TestReplaceDevice(t *testing.T) {
 	})
 }
 
+// TestReplaceDeviceOwnership mirrors fleet.TestReplaceFleetOwnership: an external caller
+// (enforceOwnership=true) must be denied a spec change on an owned device, while an
+// internal/ResourceSync caller (enforceOwnership=false) must still be allowed through.
 func TestReplaceDeviceOwnership(t *testing.T) {
 	owner := "Fleet/f1"
 
@@ -351,6 +354,9 @@ func TestPatchDevice(t *testing.T) {
 	})
 }
 
+// TestPatchDeviceOwnership mirrors fleet.TestPatchFleetOwnership: an external caller
+// (enforceOwnership=true) must be denied a spec-changing patch on an owned device, while an
+// internal/ResourceSync caller (enforceOwnership=false) must still be allowed through.
 func TestPatchDeviceOwnership(t *testing.T) {
 	owner := "Fleet/f1"
 
@@ -738,6 +744,24 @@ func TestUpdateDevice(t *testing.T) {
 		result, err := svc.UpdateDevice(ctx, orgId, "foo", device, nil)
 		require.NoError(t, err)
 		require.Equal(t, "img", result.Spec.Os.Image)
+	})
+
+	t.Run("When updating an owned device it should not deny the change", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["owned-device"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("owned-device"), Owner: lo.ToPtr("Fleet/f1")},
+			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img"}},
+		}
+
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("owned-device")},
+			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
+		}
+		result, err := svc.UpdateDevice(ctx, orgId, "owned-device", device, nil)
+		require.NoError(t, err)
+		require.Equal(t, "img-updated", result.Spec.Os.Image)
 	})
 }
 

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -90,7 +90,7 @@ func (s *fakeDeviceStore) GetWithTimestamp(ctx context.Context, orgId uuid.UUID,
 	return s.Get(ctx, orgId, name)
 }
 
-func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
+func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	old, existed := s.devices[name]
 	if existed && validationCallback != nil {
@@ -115,7 +115,7 @@ func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, d
 	return deepCopyDevice(d), created, nil
 }
 
-func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
+func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	old, ok := s.devices[name]
 	if !ok {

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -90,6 +90,15 @@ func (s *fakeDeviceStore) GetWithTimestamp(ctx context.Context, orgId uuid.UUID,
 	return s.Get(ctx, orgId, name)
 }
 
+func preserveNilMetadata(device, existing *domain.Device, fieldsToUnset []string) {
+	if device.Metadata.Owner == nil && !lo.Contains(fieldsToUnset, "owner") {
+		device.Metadata.Owner = existing.Metadata.Owner
+	}
+	if device.Metadata.Annotations == nil && !lo.Contains(fieldsToUnset, "annotations") {
+		device.Metadata.Annotations = existing.Metadata.Annotations
+	}
+}
+
 func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	old, existed := s.devices[name]
@@ -98,13 +107,8 @@ func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, d
 			return nil, false, err
 		}
 	}
-	// Mirrors the real generic store: fields left nil by the caller are preserved
-	// from the existing resource rather than wiped on update.
-	if existed && device.Metadata.Owner == nil {
-		device.Metadata.Owner = old.Metadata.Owner
-	}
-	if existed && device.Metadata.Annotations == nil {
-		device.Metadata.Annotations = old.Metadata.Annotations
+	if existed {
+		preserveNilMetadata(device, old, fieldsToUnset)
 	}
 	d := deepCopyDevice(device)
 	s.devices[name] = d
@@ -126,14 +130,7 @@ func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *d
 			return nil, err
 		}
 	}
-	// Mirrors the real generic store: fields left nil by the caller are preserved
-	// from the existing resource rather than wiped on update.
-	if device.Metadata.Owner == nil {
-		device.Metadata.Owner = old.Metadata.Owner
-	}
-	if device.Metadata.Annotations == nil {
-		device.Metadata.Annotations = old.Metadata.Annotations
-	}
+	preserveNilMetadata(device, old, fieldsToUnset)
 	d := deepCopyDevice(device)
 	s.devices[name] = d
 	if eventCallback != nil {
@@ -141,7 +138,6 @@ func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *d
 	}
 	return deepCopyDevice(d), nil
 }
-
 func (s *fakeDeviceStore) Delete(ctx context.Context, orgId uuid.UUID, name string, eventCallback store.EventCallback) (bool, error) {
 	old, ok := s.devices[name]
 	if !ok {

--- a/internal/service/enrollmentrequest/handler.go
+++ b/internal/service/enrollmentrequest/handler.go
@@ -317,7 +317,7 @@ func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, 
 	// invariant, TestCreateDeviceFromEnrollmentRequestNeverManaged).
 	_ = common.UpdateServiceSideStatus(ctx, orgId, apiResource, nil, h.log)
 
-	_, _, err := h.deviceStore.CreateOrUpdate(ctx, orgId, apiResource, nil, false, func(ctx context.Context, before *domain.Device, after *domain.Device) error {
+	_, _, err := h.deviceStore.CreateOrUpdate(ctx, orgId, apiResource, nil, func(ctx context.Context, before *domain.Device, after *domain.Device) error {
 		// Prevent overwriting existing devices during enrollment request approval
 		if before != nil {
 			return fmt.Errorf("device %s already exists and cannot be overwritten during enrollment request approval", *after.Metadata.Name)
@@ -365,8 +365,7 @@ func (h *ServiceHandler) CreateEnrollmentRequest(ctx context.Context, orgId uuid
 		}
 	}
 
-	// Use fromAPI=false for internal requests to preserve annotations
-	result, err := h.store.CreateWithFromAPI(ctx, orgId, &er, false, h.callbackEnrollmentRequestUpdated)
+	result, err := h.store.Create(ctx, orgId, &er, h.callbackEnrollmentRequestUpdated)
 	return result, common.StoreErrorToApiStatus(err, true, domain.EnrollmentRequestKind, er.Metadata.Name)
 }
 

--- a/internal/service/enrollmentrequest/handler_test.go
+++ b/internal/service/enrollmentrequest/handler_test.go
@@ -47,10 +47,6 @@ func newFakeEnrollmentRequestStore() *fakeEnrollmentRequestStore {
 func (f *fakeEnrollmentRequestStore) InitialMigration(ctx context.Context) error { return nil }
 
 func (f *fakeEnrollmentRequestStore) Create(ctx context.Context, orgId uuid.UUID, req *domain.EnrollmentRequest, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, error) {
-	return f.CreateWithFromAPI(ctx, orgId, req, true, callbackEvent)
-}
-
-func (f *fakeEnrollmentRequestStore) CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, req *domain.EnrollmentRequest, fromAPI bool, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, error) {
 	name := lo.FromPtr(req.Metadata.Name)
 	if _, exists := f.items[name]; exists {
 		return nil, flterrors.ErrDuplicateName
@@ -81,7 +77,7 @@ func (f *fakeEnrollmentRequestStore) CreateOrUpdate(ctx context.Context, orgId u
 		result, err := f.Update(ctx, orgId, req, callbackEvent)
 		return result, false, err
 	}
-	result, err := f.CreateWithFromAPI(ctx, orgId, req, true, callbackEvent)
+	result, err := f.Create(ctx, orgId, req, callbackEvent)
 	return result, true, err
 }
 
@@ -144,7 +140,7 @@ func (f *fakeDeviceStore) Get(ctx context.Context, orgId uuid.UUID, name string)
 	return d, nil
 }
 
-func (f *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
+func (f *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	existing := f.items[name]
 	if validationCallback != nil {

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -109,7 +109,7 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name
 		}
 	}
 
-	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, false, h.callbackFleetUpdated)
+	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.FleetKind, &name)
 }
 
@@ -180,7 +180,7 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name s
 		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
 	}
 
-	result, err := h.store.Update(ctx, orgId, newObj, nil, false, h.callbackFleetUpdated)
+	result, err := h.store.Update(ctx, orgId, newObj, nil, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 

--- a/internal/service/fleet/handler_test.go
+++ b/internal/service/fleet/handler_test.go
@@ -74,7 +74,7 @@ func (f *fakeFleetStore) Create(ctx context.Context, orgId uuid.UUID, fleet *dom
 	return fleet, nil
 }
 
-func (f *fakeFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, error) {
+func (f *fakeFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -95,10 +95,10 @@ func (f *fakeFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *dom
 	return fleet, nil
 }
 
-func (f *fakeFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {
+func (f *fakeFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {
 	name := lo.FromPtr(fleet.Metadata.Name)
 	if _, exists := f.fleets[name]; exists {
-		result, err := f.Update(ctx, orgId, fleet, fieldsToUnset, fromAPI, eventCallback)
+		result, err := f.Update(ctx, orgId, fleet, fieldsToUnset, eventCallback)
 		return result, false, err
 	}
 	result, err := f.Create(ctx, orgId, fleet, eventCallback)

--- a/internal/store/authprovider/store.go
+++ b/internal/store/authprovider/store.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
-	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/store/selector"
@@ -21,7 +20,6 @@ type Store interface {
 	InitialMigration(ctx context.Context) error
 
 	Create(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, error)
-	CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, fromAPI bool, eventCallback store.EventCallback) (*domain.AuthProvider, error)
 	Update(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, error)
 	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, authProvider *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.AuthProvider, error)
@@ -124,26 +122,14 @@ func (s *AuthProviderStore) Create(ctx context.Context, orgId uuid.UUID, resourc
 	return provider, err
 }
 
-func (s *AuthProviderStore) CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, resource *domain.AuthProvider, fromAPI bool, eventCallback store.EventCallback) (*domain.AuthProvider, error) {
-	provider, _, _, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, fromAPI, func(ctx context.Context, before, after *domain.AuthProvider) error {
-		// If there's an existing resource, return an error to enforce create-only behavior
-		if before != nil {
-			return flterrors.ErrDuplicateName
-		}
-		return nil
-	})
-	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), nil, provider, true, err)
-	return provider, err
-}
-
 func (s *AuthProviderStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, error) {
-	newProvider, oldProvider, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newProvider, oldProvider, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldProvider, newProvider, false, err)
 	return newProvider, err
 }
 
 func (s *AuthProviderStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.AuthProvider, eventCallback store.EventCallback) (*domain.AuthProvider, bool, error) {
-	newProvider, oldProvider, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, true, nil)
+	newProvider, oldProvider, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldProvider, newProvider, created, err)
 	return newProvider, created, err
 }

--- a/internal/store/catalog/store.go
+++ b/internal/store/catalog/store.go
@@ -21,7 +21,7 @@ type Store interface {
 
 	Create(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, error)
 	Update(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, error)
-	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, fromAPI bool, callbackEvent store.EventCallback) (*domain.Catalog, bool, error)
+	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.Catalog, error)
 	List(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (*domain.CatalogList, error)
 	Delete(ctx context.Context, orgId uuid.UUID, name string, callback store.RemoveOwnerCallback, callbackEvent store.EventCallback) error
@@ -126,13 +126,13 @@ func (s *CatalogStore) Create(ctx context.Context, orgId uuid.UUID, resource *do
 }
 
 func (s *CatalogStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Catalog, eventCallback store.EventCallback) (*domain.Catalog, error) {
-	newCatalog, oldCatalog, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newCatalog, oldCatalog, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldCatalog, newCatalog, false, err)
 	return newCatalog, err
 }
 
-func (s *CatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Catalog, fromAPI bool, eventCallback store.EventCallback) (*domain.Catalog, bool, error) {
-	newCatalog, oldCatalog, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, fromAPI, nil)
+func (s *CatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Catalog, eventCallback store.EventCallback) (*domain.Catalog, bool, error) {
+	newCatalog, oldCatalog, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldCatalog, newCatalog, created, err)
 	return newCatalog, created, err
 }

--- a/internal/store/certificatesigningrequest/store.go
+++ b/internal/store/certificatesigningrequest/store.go
@@ -98,13 +98,13 @@ func (s *CertificateSigningRequestStore) Create(ctx context.Context, orgId uuid.
 
 // Warning: this is a user-facing function and will set the Status to nil
 func (s *CertificateSigningRequestStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.CertificateSigningRequest, eventCallback store.EventCallback) (*domain.CertificateSigningRequest, error) {
-	newCsr, oldCsr, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newCsr, oldCsr, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldCsr, newCsr, false, err)
 	return newCsr, err
 }
 
 func (s *CertificateSigningRequestStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.CertificateSigningRequest, eventCallback store.EventCallback) (*domain.CertificateSigningRequest, bool, error) {
-	newCsr, oldCsr, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, true, nil)
+	newCsr, oldCsr, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldCsr, newCsr, created, err)
 	return newCsr, created, err
 }

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -55,8 +55,8 @@ type Store interface {
 
 	// Exposed to users
 	Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error)
-	Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error)
-	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error)
+	Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error)
+	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error)
 	List(ctx context.Context, orgId uuid.UUID, listParams DeviceListParams) (*domain.DeviceList, error)
 	Labels(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (domain.LabelList, error)
@@ -387,15 +387,15 @@ func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, resource *dom
 	return device, err
 }
 
-func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
-	device, oldDevice, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, fromAPI, validationCallback)
+func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
+	device, oldDevice, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, validationCallback)
 	name := lo.FromPtr(resource.Metadata.Name)
 	s.callEventCallback(ctx, eventCallback, orgId, name, oldDevice, device, false, err)
 	return device, err
 }
 
-func (s *DeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, fromAPI bool, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
-	device, oldDevice, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, fromAPI, validationCallback)
+func (s *DeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
+	device, oldDevice, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, validationCallback)
 	name := lo.FromPtr(resource.Metadata.Name)
 	s.callEventCallback(ctx, eventCallback, orgId, name, oldDevice, device, created, err)
 	return device, created, err

--- a/internal/store/enrollmentrequest/store.go
+++ b/internal/store/enrollmentrequest/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/flightctl/flightctl/internal/domain"
-	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/google/uuid"
@@ -17,7 +16,6 @@ type Store interface {
 	InitialMigration(ctx context.Context) error
 
 	Create(ctx context.Context, orgId uuid.UUID, req *domain.EnrollmentRequest, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, error)
-	CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, req *domain.EnrollmentRequest, fromAPI bool, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, error)
 	Update(ctx context.Context, orgId uuid.UUID, req *domain.EnrollmentRequest, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, error)
 	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, enrollmentrequest *domain.EnrollmentRequest, callbackEvent store.EventCallback) (*domain.EnrollmentRequest, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.EnrollmentRequest, error)
@@ -93,27 +91,14 @@ func (s *EnrollmentRequestStore) Create(ctx context.Context, orgId uuid.UUID, re
 	return er, err
 }
 
-func (s *EnrollmentRequestStore) CreateWithFromAPI(ctx context.Context, orgId uuid.UUID, resource *domain.EnrollmentRequest, fromAPI bool, eventCallback store.EventCallback) (*domain.EnrollmentRequest, error) {
-	// Use CreateOrUpdate with a custom validation callback that ensures create-only behavior
-	er, _, _, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, fromAPI, func(ctx context.Context, before, after *domain.EnrollmentRequest) error {
-		// If there's an existing resource, return an error to enforce create-only behavior
-		if before != nil {
-			return flterrors.ErrDuplicateName
-		}
-		return nil
-	})
-	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), nil, er, true, err)
-	return er, err
-}
-
 func (s *EnrollmentRequestStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.EnrollmentRequest, eventCallback store.EventCallback) (*domain.EnrollmentRequest, error) {
-	newEr, oldEr, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newEr, oldEr, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldEr, newEr, false, err)
 	return newEr, err
 }
 
 func (s *EnrollmentRequestStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.EnrollmentRequest, eventCallback store.EventCallback) (*domain.EnrollmentRequest, bool, error) {
-	newEr, oldEr, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, true, nil)
+	newEr, oldEr, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldEr, newEr, created, err)
 	return newEr, created, err
 }

--- a/internal/store/fleet/store.go
+++ b/internal/store/fleet/store.go
@@ -23,8 +23,8 @@ type Store interface {
 	InitialMigration(ctx context.Context) error
 
 	Create(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, eventCallback store.EventCallback) (*domain.Fleet, error)
-	Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, error)
-	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, bool, error)
+	Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, error)
+	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string, opts ...GetOption) (*domain.Fleet, error)
 	List(ctx context.Context, orgId uuid.UUID, listParams store.ListParams, opts ...ListOption) (*domain.FleetList, error)
 	Delete(ctx context.Context, orgId uuid.UUID, name string, eventCallback store.EventCallback) error
@@ -120,14 +120,14 @@ func (s *FleetStore) Create(ctx context.Context, orgId uuid.UUID, resource *doma
 	return fleet, err
 }
 
-func (s *FleetStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, error) {
-	newFleet, oldFleet, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, fromAPI, nil)
+func (s *FleetStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, error) {
+	newFleet, oldFleet, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, nil)
 	s.callEventCallback(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldFleet, newFleet, false, err)
 	return newFleet, err
 }
 
-func (s *FleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, fromAPI bool, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {
-	newFleet, oldFleet, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, fromAPI, nil)
+func (s *FleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {
+	newFleet, oldFleet, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, nil)
 	s.callEventCallback(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldFleet, newFleet, created, err)
 	return newFleet, created, err
 }

--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -75,20 +75,14 @@ func (s *GenericStore[P, M, A, AL]) Create(ctx context.Context, orgId uuid.UUID,
 	return updated, err
 }
 
-// fromAPI is accepted for interface compatibility with callers across all domain stores
-// but is no longer used internally; ownership/ACL enforcement for this resource has moved
-// to the service layer. Other domain stores still thread fromAPI through until their own
-// service-layer migration lands.
-func (s *GenericStore[P, M, A, AL]) Update(ctx context.Context, orgId uuid.UUID, resource *A, fieldsToUnset []string, fromAPI bool, validationCallback func(ctx context.Context, before, after *A) error) (*A, *A, error) {
-	_ = fromAPI
+func (s *GenericStore[P, M, A, AL]) Update(ctx context.Context, orgId uuid.UUID, resource *A, fieldsToUnset []string, validationCallback func(ctx context.Context, before, after *A) error) (*A, *A, error) {
 	updated, before, _, err := retryCreateOrUpdate(func() (*A, *A, bool, bool, error) {
 		return s.createOrUpdate(ctx, orgId, resource, fieldsToUnset, ModeUpdateOnly, validationCallback)
 	})
 	return updated, before, err
 }
 
-func (s *GenericStore[P, M, A, AL]) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *A, fieldsToUnset []string, fromAPI bool, validationCallback func(ctx context.Context, before, after *A) error) (*A, *A, bool, error) {
-	_ = fromAPI
+func (s *GenericStore[P, M, A, AL]) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *A, fieldsToUnset []string, validationCallback func(ctx context.Context, before, after *A) error) (*A, *A, bool, error) {
 	return retryCreateOrUpdate(func() (*A, *A, bool, bool, error) {
 		return s.createOrUpdate(ctx, orgId, resource, fieldsToUnset, ModeCreateOrUpdate, validationCallback)
 	})

--- a/internal/store/repository/store.go
+++ b/internal/store/repository/store.go
@@ -99,13 +99,13 @@ func (s *RepositoryStore) Create(ctx context.Context, orgId uuid.UUID, resource 
 }
 
 func (s *RepositoryStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Repository, eventCallback store.EventCallback) (*domain.Repository, error) {
-	newRepo, oldRepo, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newRepo, oldRepo, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldRepo, newRepo, false, err)
 	return newRepo, err
 }
 
 func (s *RepositoryStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Repository, eventCallback store.EventCallback) (*domain.Repository, bool, error) {
-	newRepo, oldRepo, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, true, nil)
+	newRepo, oldRepo, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldRepo, newRepo, created, err)
 
 	return newRepo, created, err

--- a/internal/store/resourcesync/store.go
+++ b/internal/store/resourcesync/store.go
@@ -104,13 +104,13 @@ func (s *ResourceSyncStore) Create(ctx context.Context, orgId uuid.UUID, resourc
 }
 
 func (s *ResourceSyncStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.ResourceSync, eventCallback store.EventCallback) (*domain.ResourceSync, error) {
-	newRs, oldRs, err := s.genericStore.Update(ctx, orgId, resource, nil, true, nil)
+	newRs, oldRs, err := s.genericStore.Update(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldRs, newRs, false, err)
 	return newRs, err
 }
 
 func (s *ResourceSyncStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.ResourceSync, eventCallback store.EventCallback) (*domain.ResourceSync, bool, error) {
-	newRs, oldRs, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, true, nil)
+	newRs, oldRs, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, nil, nil)
 	s.eventCallbackCaller(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldRs, newRs, created, err)
 	return newRs, created, err
 }

--- a/test/integration/restore/device_test.go
+++ b/test/integration/restore/device_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Device restore operations", func() {
 				},
 			}
 
-			createdDevice, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, testDevice, nil, false, nil, callback)
+			createdDevice, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, testDevice, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(createdDevice).ToNot(BeNil())
 			Expect(created).To(BeTrue())
@@ -118,7 +118,7 @@ var _ = Describe("Device restore operations", func() {
 				Status: nil,
 			}
 
-			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, &device, nil, true, nil, callback)
+			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, &device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 
@@ -214,17 +214,17 @@ var _ = Describe("Device restore operations", func() {
 				},
 			}
 
-			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, &decommissioningDevice, nil, false, nil, callback)
+			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, &decommissioningDevice, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 			s.SetDeviceLastSeen(decommissioningDeviceName, *decommissioningDevice.Status.LastSeen)
 
-			_, created, err = devStore.CreateOrUpdate(s.Ctx, s.OrgID, &decommissionedDevice, nil, false, nil, callback)
+			_, created, err = devStore.CreateOrUpdate(s.Ctx, s.OrgID, &decommissionedDevice, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 			s.SetDeviceLastSeen(decommissionedDeviceName, *decommissionedDevice.Status.LastSeen)
 
-			_, created, err = devStore.CreateOrUpdate(s.Ctx, s.OrgID, &normalDevice, nil, false, nil, callback)
+			_, created, err = devStore.CreateOrUpdate(s.Ctx, s.OrgID, &normalDevice, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 			s.SetDeviceLastSeen(normalDeviceName, *normalDevice.Status.LastSeen)
@@ -283,7 +283,7 @@ var _ = Describe("Device restore operations", func() {
 				},
 			}
 
-			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, device, nil, false, nil, callback)
+			_, created, err := devStore.CreateOrUpdate(s.Ctx, s.OrgID, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 

--- a/test/integration/rollout/device_selection/device_selection_test.go
+++ b/test/integration/rollout/device_selection/device_selection_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 	}
 	updateDeviceLabels := func(device *api.Device, labels map[string]string) {
 		device.Metadata.Labels = &labels
-		_, err := deviceStore.Update(ctx, store.NullOrgId, device, nil, false, nil, nil)
+		_, err := deviceStore.Update(ctx, store.NullOrgId, device, nil, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 	}
 	setRolledOut := func(deviceName string) {
@@ -724,7 +724,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 					fleet.Spec.RolloutPolicy = &api.RolloutPolicy{}
 				}
 				fleet.Spec.RolloutPolicy.DeviceSelection = definition
-				_, err = fleetStore.Update(ctx, store.NullOrgId, fleet, nil, false, nil)
+				_, err = fleetStore.Update(ctx, store.NullOrgId, fleet, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 			}
 			fromBatchSequence := func(b api.BatchSequence) *api.RolloutDeviceSelection {

--- a/test/integration/rollout/disruption_budget/disruptions_budget_test.go
+++ b/test/integration/rollout/disruption_budget/disruptions_budget_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 	)
 	updateDeviceLabels := func(device *api.Device, labels map[string]string) {
 		device.Metadata.Labels = &labels
-		_, err := deviceStore.Update(ctx, store.NullOrgId, device, nil, false, nil, nil)
+		_, err := deviceStore.Update(ctx, store.NullOrgId, device, nil, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/healthchecker"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/rendered"
@@ -725,6 +726,55 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 	})
 
 	// PrepareDevicesAfterRestore tests have been moved to test/integration/restore/device_test.go
+
+	Context("Device ownership enforcement", func() {
+		seedOwnedDevice := func(deviceName string) {
+			device := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:  lo.ToPtr(deviceName),
+					Owner: lo.ToPtr("Fleet/f1"),
+				},
+				Spec: &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			// Trusted caller (CreateDevice) preserves Owner as given, unlike
+			// CreateDeviceFromUntrusted, which would sanitize it away.
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+		}
+
+		It("denies a spec change on an owned device when enforceOwnership is true", func() {
+			deviceName := "owned-device-deny"
+			seedOwnedDevice(deviceName)
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			Expect(status.Code).To(Equal(int32(409)))
+			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Os.Image).To(Equal("img"))
+		})
+
+		It("allows a spec change on an owned device when enforceOwnership is false", func() {
+			deviceName := "owned-device-allow"
+			seedOwnedDevice(deviceName)
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, false)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Os.Image).To(Equal("img-updated"))
+		})
+	})
 
 	Context("GetRenderedDevice when AwaitingReconnect moves to ConflictPaused", func() {
 		var (

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -729,6 +729,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 	Context("Device ownership enforcement", func() {
 		seedOwnedDevice := func(deviceName string) {
+			GinkgoHelper()
 			device := api.Device{
 				Metadata: api.ObjectMeta{
 					Name:  lo.ToPtr(deviceName),
@@ -751,6 +752,21 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
 			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			Expect(status.Code).To(Equal(int32(409)))
+			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Os.Image).To(Equal("img"))
+		})
+
+		It("denies a spec patch on an owned device when enforceOwnership is true", func() {
+			deviceName := "owned-device-patch-deny"
+			seedOwnedDevice(deviceName)
+
+			var value interface{} = "img-updated"
+			patch := api.PatchRequest{{Op: "replace", Path: "/spec/os/image", Value: &value}}
+			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true)
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
 

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -109,7 +109,7 @@ var _ = Describe("DeviceStore create", func() {
 		}
 		devStore.SetIntegrationTestCreateOrUpdateCallback(race)
 
-		_, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, true, nil, callback)
+		_, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(created).To(BeFalse())
 	})
@@ -143,7 +143,7 @@ var _ = Describe("DeviceStore create", func() {
 		}
 		devStore.SetIntegrationTestCreateOrUpdateCallback(race)
 
-		dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, true, nil, callback)
+		dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(created).To(Equal(false))
 		Expect(dev.ApiVersion).To(Equal(model.DeviceAPIVersion()))
@@ -158,12 +158,12 @@ var _ = Describe("DeviceStore create", func() {
 		Expect(err).ToNot(HaveOccurred())
 		dev.Metadata.Owner = lo.ToPtr("newowner")
 		dev.Spec.Os.Image = "oldos"
-		dev, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, false, nil, callback)
+		dev, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, nil, callback)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(called).To(BeTrue())
 
 		dev.Spec.Os.Image = "newos"
-		updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
+		updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, nil, callback)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updated.Spec.Os.Image).To(Equal("newos"))
 	})
@@ -545,7 +545,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 				Status: nil,
 			}
-			dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, true, nil, callback)
+			dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(Equal(true))
 			Expect(dev.ApiVersion).To(Equal(model.DeviceAPIVersion()))
@@ -566,7 +566,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 				Status: &status,
 			}
-			dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, true, nil, callback)
+			dev, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(Equal(false))
 			Expect(dev.ApiVersion).To(Equal(model.DeviceAPIVersion()))
@@ -579,12 +579,12 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			dev.Metadata.Owner = lo.ToPtr("newowner")
 			dev.Spec.Os.Image = "oldos"
-			dev, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, false, nil, callback)
+			dev, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 
 			dev.Spec.Os.Image = "newos"
-			updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, true, nil, callback)
+			updated, _, err := devStore.CreateOrUpdate(ctx, orgId, dev, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Spec.Os.Image).To(Equal("newos"))
 		})
@@ -776,7 +776,7 @@ var _ = Describe("DeviceStore create", func() {
 
 			// Create the first device with comprehensive spec
 			device1 := createComprehensiveTestDevice(orgId, "owned-device", lo.ToPtr("ownerfleet"), nil)
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, &device1, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, &device1, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get the device from the store
@@ -788,7 +788,7 @@ var _ = Describe("DeviceStore create", func() {
 			newDev.Metadata.ResourceVersion = dev.Metadata.ResourceVersion
 
 			// This should succeed because only labels (metadata) are different, not the spec
-			_, _, err = devStore.CreateOrUpdate(ctx, orgId, &newDev, nil, true, nil, callback)
+			_, _, err = devStore.CreateOrUpdate(ctx, orgId, &newDev, nil, nil, callback)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
@@ -830,7 +830,7 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			dev.Metadata.Owner = lo.ToPtr("newowner")
-			_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, false, nil, callback)
+			_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 
@@ -841,7 +841,7 @@ var _ = Describe("DeviceStore create", func() {
 
 			called = false
 			dev.Metadata.Owner = nil
-			_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, []string{"owner"}, false, nil, callback)
+			_, _, err = devStore.CreateOrUpdate(ctx, orgId, dev, []string{"owner"}, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(called).To(BeTrue())
 
@@ -981,7 +981,7 @@ var _ = Describe("DeviceStore create", func() {
 							},
 						}
 
-						_, _, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, false, nil, callback)
+						_, _, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 						Expect(err).ToNot(HaveOccurred())
 
 						if d.hasConflict {
@@ -1373,7 +1373,7 @@ var _ = Describe("DeviceStore create", func() {
 			}
 
 			// Store the device in database
-			_, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, true, nil, callback)
+			_, created, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 
@@ -1659,7 +1659,7 @@ var _ = Describe("DeviceStore create", func() {
 
 			// Create the devices
 			for _, device := range devices {
-				_, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+				_, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 				setLastSeen(db, orgId, *device.Metadata.Name, *device.Status.LastSeen)
@@ -1723,7 +1723,7 @@ var _ = Describe("DeviceStore create", func() {
 			}
 
 			// Create the device
-			createdDevice, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			createdDevice, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 
@@ -1768,7 +1768,7 @@ var _ = Describe("DeviceStore create", func() {
 			}
 
 			// Create the device
-			_, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, created, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeTrue())
 			initialLastSeen := time.Now().Add(-1 * time.Hour)
@@ -1803,7 +1803,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation - should return false
@@ -1833,7 +1833,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation - should return false
@@ -1869,7 +1869,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation with device version <= service version
@@ -1925,7 +1925,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation with device version > service version
@@ -1983,7 +1983,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation with nil device reported version
@@ -2029,7 +2029,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation with empty device reported version
@@ -2076,7 +2076,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation with invalid device reported version
@@ -2123,7 +2123,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation
@@ -2173,7 +2173,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation
@@ -2234,7 +2234,7 @@ var _ = Describe("DeviceStore create", func() {
 				},
 			}
 
-			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Process awaiting reconnect annotation

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -382,7 +382,7 @@ var _ = Describe("FleetStore create", func() {
 				},
 				Status: nil,
 			}
-			_, created, err := fleetStore.CreateOrUpdate(ctx, orgId, &fleet, nil, true, callback)
+			_, created, err := fleetStore.CreateOrUpdate(ctx, orgId, &fleet, nil, callback)
 			Expect(called).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(Equal(true))
@@ -421,7 +421,7 @@ var _ = Describe("FleetStore create", func() {
 			updatedFleet.Metadata.Labels = nil
 			updatedFleet.Metadata.Annotations = nil
 
-			returnedFleet, created, err := fleetStore.CreateOrUpdate(ctx, orgId, updatedFleet, nil, true, callback)
+			returnedFleet, created, err := fleetStore.CreateOrUpdate(ctx, orgId, updatedFleet, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeFalse())
 			Expect(called).To(BeTrue())
@@ -444,7 +444,7 @@ var _ = Describe("FleetStore create", func() {
 			fleet.Spec.Template.Spec.Os = &api.DeviceOsSpec{Image: "my new OS"}
 			fleet.Status = nil
 
-			_, created, err := fleetStore.CreateOrUpdate(ctx, orgId, fleet, nil, true, callback)
+			_, created, err := fleetStore.CreateOrUpdate(ctx, orgId, fleet, nil, callback)
 			Expect(called).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(created).To(BeFalse())
@@ -755,13 +755,13 @@ var _ = Describe("FleetStore create", func() {
 			updatedFleet.Spec.Selector = &api.LabelSelector{
 				MatchLabels: &map[string]string{"key": "updated"},
 			}
-			_, err = fleetStore.Update(ctx, orgId, &updatedFleet, nil, true, nil)
+			_, err = fleetStore.Update(ctx, orgId, &updatedFleet, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			refetched, err := fleetStore.Get(ctx, orgId, "owned-fleet")
 			Expect(err).ToNot(HaveOccurred())
 			refetched.Metadata.Labels = &map[string]string{"updated": "label"}
-			_, err = fleetStore.Update(ctx, orgId, refetched, nil, true, nil)
+			_, err = fleetStore.Update(ctx, orgId, refetched, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			got, err := fleetStore.Get(ctx, orgId, "owned-fleet")

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -439,7 +439,7 @@ var _ = Describe("DeviceRender", func() {
 				"device": "camera",
 				"size":   "big",
 			}
-			_, err = deviceStore.Update(ctx, orgId, device, nil, false, nil, nil)
+			_, err = deviceStore.Update(ctx, orgId, device, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Trigger fleet rollout again to update device spec

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -496,14 +496,14 @@ var _ = Describe("FleetSelector", func() {
 			Expect(err).ToNot(HaveOccurred())
 			device.Spec.Decommissioning = &api.DeviceDecommission{}
 			callback := store.EventCallback(func(context.Context, api.ResourceKind, uuid.UUID, string, interface{}, interface{}, bool, error) {})
-			_, _, err = deviceStore.CreateOrUpdate(ctx, orgId, device, nil, false, nil, callback)
+			_, _, err = deviceStore.CreateOrUpdate(ctx, orgId, device, nil, nil, callback)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Change fleet selector so device no longer matches
 			fleet, err := fleetStore.Get(ctx, orgId, "fleet")
 			Expect(err).ToNot(HaveOccurred())
 			fleet.Spec.Selector.MatchLabels = &map[string]string{"different": "value"}
-			_, _, err = fleetStore.CreateOrUpdate(ctx, orgId, fleet, nil, false, nil)
+			_, _, err = fleetStore.CreateOrUpdate(ctx, orgId, fleet, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = logic.FleetSelectorUpdated(ctx)


### PR DESCRIPTION
Jira: EDM-4827

Completes Device ownership coverage and finishes removing the dead store-layer `fromAPI` plumbing left after #3258.

## Summary

- Adds unit and integration tests that lock in Device ownership behavior:
  - `ReplaceDevice` / `PatchDevice` with `enforceOwnership=true` reject spec changes on owned devices (`OwnerNotAllowed`)
  - `UpdateDevice` remains the trusted agent/console path and never enforces ownership
- Removes the unused `fromAPI` parameter from `GenericStore.Update` / `CreateOrUpdate` and all domain store call sites
- Deletes redundant `CreateWithFromAPI` helpers from the AuthProvider and EnrollmentRequest stores (create-only behavior stays on `Create`)

Ownership enforcement for Device Replace/Patch itself landed with #3258; this PR is the test closeout plus the store-signature cleanup that #3258 deferred.

## API backward compatibility note

Removing `fromAPI` / `CreateWithFromAPI` changes Go symbols under `internal/store/**` only. Those packages are not part of the public REST API or any published SDK, and the Go toolchain already prevents import from outside this module. No external consumer can observe this change.

## Release target (required before merge to `main`)

- [x] **`release-1.3`**

---
**Stack:** 2/12 in the EDM-4806 (Technical Debt: Store Contains Business Logic) closeout stack.
Base: `main` (after #3258)

Made with [Cursor](https://cursor.com)