### PR TITLE
EDM-4838: Final store audit sweep and inventory closeout

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -72,7 +72,7 @@ func (m *MockDevice) Delete(ctx context.Context, orgId uuid.UUID, name string) (
 func (m *MockDevice) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error) {
 	return nil, nil, nil
 }
-func (m *MockDevice) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {
+func (m *MockDevice) GetRendered(ctx context.Context, orgId uuid.UUID, name string, consoleGrpcEndpoint string) (*domain.Device, error) {
 	return nil, nil
 }
 func (m *MockDevice) UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) error {

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -125,8 +125,8 @@ func (m *MockDevice) ApplyAwaitingReconnectOutcome(ctx context.Context, orgId uu
 	return nil
 }
 
-func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error) {
-	return nil, nil, nil
+func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, error) {
+	return nil, nil
 }
 
 func TestDeviceCollectorWithGroupByFleet(t *testing.T) {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -640,35 +640,42 @@ func prepareDeviceForDecommission(existing *domain.Device, decom domain.DeviceDe
 }
 
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
+	existing, err := h.deviceStore.Get(ctx, orgId, name)
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+
+	// Product rule: refuse a second decommission without calling the store (no success event).
+	if existing.Spec != nil && existing.Spec.Decommissioning != nil {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrResourceVersionConflict, false, domain.DeviceKind, &name)
+	}
+
 	// Re-Get + re-prepare on CAS conflicts so concurrent renders/status writes cannot
 	// permanently block decommission with a stale prepared ResourceVersion.
-	const maxAttempts = 10
-	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		existing, err := h.deviceStore.Get(ctx, orgId, name)
-		if err != nil {
-			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	var result, oldDevice *domain.Device
+	err = common.RetryOnNoRowsUpdated(func() error {
+		current, getErr := h.deviceStore.Get(ctx, orgId, name)
+		if getErr != nil {
+			return getErr
 		}
+		// Re-check on every retry: a concurrent decommission may have won the race since
+		// our last read. Unlike the upfront check above, this path has already reached the
+		// store-write step, so a rejection here still emits a callback/event via the return
+		// below (see DecommissionDevice event semantics).
+		if current.Spec != nil && current.Spec.Decommissioning != nil {
+			return flterrors.ErrResourceVersionConflict
+		}
+		oldDevice = current
 
-		// Product rule: refuse a second decommission without calling the store (no success event).
-		if existing.Spec != nil && existing.Spec.Decommissioning != nil {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrResourceVersionConflict, false, domain.DeviceKind, &name)
-		}
+		prepared := prepareDeviceForDecommission(current, decom)
+		common.PinResourceVersionForCAS(current.Metadata.ResourceVersion, &prepared.Metadata)
 
-		prepared := prepareDeviceForDecommission(existing, decom)
-		result, oldDevice, err := h.deviceStore.DecommissionDevice(ctx, orgId, prepared)
-		if err == nil {
-			h.callbackDeviceDecommission(ctx, domain.DeviceKind, orgId, name, oldDevice, result, false, nil)
-			return result, common.StoreErrorToApiStatus(nil, false, domain.DeviceKind, &name)
-		}
-		lastErr = err
-		if !errors.Is(err, flterrors.ErrResourceVersionConflict) && !errors.Is(err, flterrors.ErrNoRowsUpdated) {
-			h.callbackDeviceDecommission(ctx, domain.DeviceKind, orgId, name, oldDevice, result, false, err)
-			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
-		}
-	}
-	h.callbackDeviceDecommission(ctx, domain.DeviceKind, orgId, name, nil, nil, false, lastErr)
-	return nil, common.StoreErrorToApiStatus(lastErr, false, domain.DeviceKind, &name)
+		var writeErr error
+		result, writeErr = h.deviceStore.DecommissionDevice(ctx, orgId, prepared)
+		return writeErr
+	})
+	h.callbackDeviceDecommission(ctx, domain.DeviceKind, orgId, name, oldDevice, result, false, err)
+	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
 func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -494,7 +494,7 @@ func (h *DeviceServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid
 		}
 	}
 
-	result, err := h.deviceStore.GetRendered(ctx, orgId, name, nil, h.agentEndpoint)
+	result, err := h.deviceStore.GetRendered(ctx, orgId, name, h.agentEndpoint)
 	if err != nil {
 		h.log.Errorf("GetRenderedDevice %s/%s: failed to get rendered device: %v", orgId, name, err)
 		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -943,6 +943,28 @@ func TestDecommissionDevice(t *testing.T) {
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 		require.Empty(t, ev.created)
 	})
+
+	t.Run("When a concurrent decommission wins the race between the upfront check and the write it should retry, detect it, and emit a failure event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{},
+			Status:   lo.ToPtr(domain.NewDeviceStatus()),
+		})
+		require.NoError(t, err)
+		// Simulates another request committing a decommission between this call's upfront
+		// check and its store write - the store reports a CAS miss, and the closure's re-Get
+		// on retry must be what catches the now-decommissioning device, not the upfront check.
+		st.device.decommissionRaceOnce = true
+
+		_, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrResourceVersionConflict.Error(), status.Message)
+		require.Len(t, ev.created, 1, "unlike the upfront-rejection case, a race caught on retry has already reached the write step and must emit a failure event")
+		require.Equal(t, domain.EventReasonDeviceDecommissionFailed, ev.created[0].Reason)
+	})
 }
 
 // TestUpdateRenderedDevice covers the "no change in rendered version" path only. The

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -270,7 +270,7 @@ func (s *fakeDeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, n
 	return "", nil
 }
 
-func (s *fakeDeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {
+func (s *fakeDeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name string, consoleGrpcEndpoint string) (*domain.Device, error) {
 	return s.Get(ctx, orgId, name)
 }
 

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -68,6 +68,11 @@ type fakeDeviceStore struct {
 	healthcheckErr            error
 	applyAwaitingOutcomes     []devicestore.AwaitingReconnectOutcome
 	applyAwaitingErrs         []error
+	// decommissionRaceOnce, when true, makes the next DecommissionDevice call simulate a
+	// concurrent winner: it marks the target device as already decommissioning (as if another
+	// request just committed that change) and returns ErrNoRowsUpdated, exercising the
+	// service's re-Get-and-recheck retry path instead of the immediate upfront rejection.
+	decommissionRaceOnce bool
 }
 
 func (s *fakeDeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, error) {
@@ -285,23 +290,31 @@ func (s *fakeDeviceStore) Healthcheck(ctx context.Context, orgId uuid.UUID, name
 	return s.healthcheckErr
 }
 
-func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error) {
-	if device == nil || device.Metadata.Name == nil {
-		return nil, nil, flterrors.ErrResourceIsNil
+// DecommissionDevice mirrors the real store's CAS-only contract: no independent
+// Decommissioning check, just an existence/CAS-style write. decommissionRaceOnce lets tests
+// simulate a concurrent writer winning the race between the caller's last Get and this call.
+func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device) (*domain.Device, error) {
+	if prepared == nil || prepared.Metadata.Name == nil {
+		return nil, flterrors.ErrResourceIsNil
 	}
-	name := *device.Metadata.Name
+	name := *prepared.Metadata.Name
 	d, ok := s.devices[name]
 	if !ok {
-		return nil, nil, flterrors.ErrResourceNotFound
+		return nil, flterrors.ErrNoRowsUpdated
 	}
-	if d.Spec != nil && d.Spec.Decommissioning != nil {
-		return nil, nil, flterrors.ErrResourceVersionConflict
+	if s.decommissionRaceOnce {
+		s.decommissionRaceOnce = false
+		spec := domain.DeviceSpec{}
+		if d.Spec != nil {
+			spec = *d.Spec
+		}
+		spec.Decommissioning = &domain.DeviceDecommission{}
+		d.Spec = &spec
+		return nil, flterrors.ErrNoRowsUpdated
 	}
-	old := deepCopyDevice(d)
-	// Persist the service-prepared device as the source of truth.
-	prepared := deepCopyDevice(device)
-	s.devices[name] = prepared
-	return deepCopyDevice(prepared), old, nil
+	persisted := deepCopyDevice(prepared)
+	s.devices[name] = persisted
+	return deepCopyDevice(persisted), nil
 }
 
 func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) (*domain.Device, []domain.Condition, []domain.Condition, error) {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -72,7 +72,7 @@ type Store interface {
 	Labels(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (domain.LabelList, error)
 	Delete(ctx context.Context, orgId uuid.UUID, name string) (bool, error)
 	UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error)
-	GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error)
+	GetRendered(ctx context.Context, orgId uuid.UUID, name string, consoleGrpcEndpoint string) (*domain.Device, error)
 	Healthcheck(ctx context.Context, orgId uuid.UUID, names []string) error
 	// ApplyAwaitingReconnectOutcome persists a service-prepared awaiting-reconnect
 	// outcome (annotation/status updates). Caller owns version comparison and
@@ -85,10 +85,13 @@ type Store interface {
 	MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error
 	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (string, error)
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) (*domain.Device, []domain.Condition, []domain.Condition, error)
-	// DecommissionDevice persists an already-prepared device under resourceVersion CAS.
-	// Persistence contract: if the stored row already has Spec.Decommissioning set, returns
-	// flterrors.ErrResourceVersionConflict. Caller owns product-rule mutations.
-	DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error)
+	// DecommissionDevice persists an already-prepared device (Spec/Status/Owner/Labels already
+	// decided by the caller) under resourceVersion CAS. The caller must pin
+	// prepared.Metadata.ResourceVersion to the version it last read (e.g. via
+	// common.PinResourceVersionForCAS) before calling. Returns flterrors.ErrNoRowsUpdated when no
+	// row matches that resource_version; the caller owns any re-check/retry, including detecting
+	// a concurrent decommission.
+	DecommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device) (*domain.Device, error)
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -128,7 +131,6 @@ func NewDeviceStore(db *gorm.DB, log logrus.FieldLogger) Store {
 		(*model.Device).ToApiResource,
 		model.DevicesToApiResource,
 	)
-	genericStore.SetPrePersistValidate(decommissionPersistenceGuard)
 	return &DeviceStore{dbHandler: db, log: log, genericStore: genericStore}
 }
 
@@ -386,16 +388,6 @@ func (s *DeviceStore) dropLastSeenColumnIfExists(db *gorm.DB) error {
 
 func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, resource *domain.Device) (*domain.Device, error) {
 	return s.genericStore.Create(ctx, orgId, resource)
-}
-
-// decommissionPersistenceGuard refuses updates when the stored device is already
-// decommissioning. This is a persistence contract of device mutate paths; it runs
-// inside the createOrUpdate retry loop so races are covered.
-func decommissionPersistenceGuard(ctx context.Context, before, after *domain.Device) error {
-	if before != nil && before.Spec != nil && before.Spec.Decommissioning != nil {
-		return flterrors.ErrDecommission
-	}
-	return nil
 }
 
 func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string) (*domain.Device, *domain.Device, error) {
@@ -1125,7 +1117,7 @@ func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name,
 	return rv, err
 }
 
-func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {
+func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name string, consoleGrpcEndpoint string) (*domain.Device, error) {
 	deviceModel := model.Device{
 		Resource: model.Resource{OrgID: orgId, Name: name},
 	}
@@ -1134,7 +1126,7 @@ func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name str
 		return nil, store.ErrorFromGormError(result.Error)
 	}
 
-	return deviceModel.ToApiResource(model.WithRendered(ctx, knownRenderedVersion))
+	return deviceModel.ToApiResource(model.WithRendered(ctx, nil))
 }
 
 func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {
@@ -1202,79 +1194,51 @@ func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID,
 	return device, oldConditions, newConditions, err
 }
 
-func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device) (retry bool, device *domain.Device, oldDevice *domain.Device, err error) {
+func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device) (retry bool, device *domain.Device, err error) {
 	if prepared == nil || prepared.Metadata.Name == nil {
-		return false, nil, nil, flterrors.ErrResourceIsNil
-	}
-	name := *prepared.Metadata.Name
-
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, nil, nil, store.ErrorFromGormError(result.Error)
+		return false, nil, flterrors.ErrResourceIsNil
 	}
 
-	existingDevice, err := existingRecord.ToApiResource()
+	preparedRecord, err := model.NewDeviceFromApiResource(prepared)
 	if err != nil {
-		return false, nil, nil, err
+		return false, nil, err
 	}
+	preparedRecord.SetOrgID(orgId)
 
-	if existingDevice.Spec != nil && existingDevice.Spec.Decommissioning != nil {
-		return false, nil, nil, flterrors.ErrResourceVersionConflict
-	}
-
-	// CAS against the prepared ResourceVersion (service Get), not the freshly loaded one.
-	if prepared.Metadata.ResourceVersion == nil {
-		return false, nil, nil, flterrors.ErrResourceVersionConflict
-	}
-	preparedRV, parseErr := strconv.ParseInt(lo.FromPtr(prepared.Metadata.ResourceVersion), 10, 64)
-	if parseErr != nil || lo.FromPtr(existingRecord.ResourceVersion) != preparedRV {
-		return false, nil, nil, flterrors.ErrResourceVersionConflict
-	}
-
-	oldDevice = existingDevice
-
-	existingRecord.Spec = model.MakeJSONField(lo.FromPtr(prepared.Spec))
-	existingRecord.Status = model.MakeJSONField(lo.FromPtr(prepared.Status))
-	existingRecord.Owner = nil
-	existingRecord.Labels = nil
-
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", preparedRV).Updates(map[string]interface{}{
-		"spec":             existingRecord.Spec,
-		"status":           existingRecord.Status,
+	result := s.getDB(ctx).Model(preparedRecord).Where("resource_version = ?", lo.FromPtr(preparedRecord.ResourceVersion)).Updates(map[string]interface{}{
+		"spec":             preparedRecord.Spec,
+		"status":           preparedRecord.Status,
 		"owner":            nil,
 		"labels":           nil,
 		"resource_version": gorm.Expr("resource_version + 1"),
 	})
 	err = store.ErrorFromGormError(result.Error)
 	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), nil, nil, err
+		return strings.Contains(err.Error(), "deadlock"), nil, err
 	}
 	if result.RowsAffected == 0 {
-		return true, nil, nil, flterrors.ErrNoRowsUpdated
+		// prepared is caller-decided and never refreshed here, so retrying internally would
+		// just resubmit an identical write; the caller owns re-checking and retrying.
+		return false, nil, flterrors.ErrNoRowsUpdated
 	}
-	existingRecord.ResourceVersion = lo.ToPtr(preparedRV + 1)
 
-	updatedDevice, err := existingRecord.ToApiResource()
+	updatedDevice, err := preparedRecord.ToApiResource()
 	if err != nil {
-		return false, nil, nil, err
+		return false, nil, err
 	}
 
-	return false, updatedDevice, oldDevice, nil
+	return false, updatedDevice, nil
 }
 
-func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device) (*domain.Device, *domain.Device, error) {
-	var (
-		result    *domain.Device
-		oldDevice *domain.Device
-	)
+func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device) (*domain.Device, error) {
+	var result *domain.Device
 	err := retryUpdate(func() (bool, error) {
 		var retry bool
 		var err error
-		retry, result, oldDevice, err = s.decommissionDevice(ctx, orgId, device)
+		retry, result, err = s.decommissionDevice(ctx, orgId, prepared)
 		return retry, err
 	})
-	return result, oldDevice, err
+	return result, err
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -3,7 +3,6 @@ package device
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1126,7 +1126,7 @@ func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name str
 		return nil, store.ErrorFromGormError(result.Error)
 	}
 
-	return deviceModel.ToApiResource(model.WithRendered())
+	return deviceModel.ToApiResource(model.WithRendered(ctx))
 }
 
 func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1126,7 +1126,7 @@ func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name str
 		return nil, store.ErrorFromGormError(result.Error)
 	}
 
-	return deviceModel.ToApiResource(model.WithRendered(ctx, nil))
+	return deviceModel.ToApiResource(model.WithRendered())
 }
 
 func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -203,8 +203,7 @@ func (d *Device) ToApiResource(opts ...APIResourceOption) (*domain.Device, error
 		}
 
 		annotations := util.EnsureMap(d.Annotations)
-		renderedVersion, ok := annotations[domain.DeviceAnnotationRenderedVersion]
-		if !ok {
+		if _, ok := annotations[domain.DeviceAnnotationRenderedVersion]; !ok {
 			return nil, flterrors.ErrNoRenderedVersion
 		}
 		consoles := []domain.DeviceConsole{}
@@ -215,25 +214,6 @@ func (d *Device) ToApiResource(opts ...APIResourceOption) (*domain.Device, error
 			}
 		}
 
-		// if we have a console request we ignore the rendered version
-		// TODO: bump the rendered version instead?
-		if len(consoles) == 0 && apiOpts.knownRenderedVersion != nil {
-			// Try numeric comparison first, fall back to lexicographic if parsing fails
-			renderedVersionInt, err1 := strconv.ParseInt(renderedVersion, 10, 64)
-			knownRenderedVersionInt, err2 := strconv.ParseInt(*apiOpts.knownRenderedVersion, 10, 64)
-
-			if err1 == nil && err2 == nil {
-				// Both versions are numeric, use numeric comparison
-				if renderedVersionInt <= knownRenderedVersionInt {
-					return nil, nil
-				}
-			} else {
-				// Fall back to lexicographic comparison for non-numeric versions
-				if renderedVersion <= *apiOpts.knownRenderedVersion {
-					return nil, nil
-				}
-			}
-		}
 		// TODO: handle multiple consoles, for now we just encapsulate our one console in a list
 		spec.Consoles = &consoles
 

--- a/internal/store/model/resource.go
+++ b/internal/store/model/resource.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"context"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -53,17 +52,13 @@ func (r *Resource) BeforeCreate(tx *gorm.DB) error {
 type APIResourceOption func(*apiResourceOptions)
 
 type apiResourceOptions struct {
-	devicesSummary       *domain.DevicesSummary // Used by Fleet
-	isRendered           bool                   // Used by Device
-	knownRenderedVersion *string
-	ctx                  context.Context
+	devicesSummary *domain.DevicesSummary // Used by Fleet
+	isRendered     bool                   // Used by Device
 }
 
-func WithRendered(ctx context.Context, knownRenderedVersion *string) APIResourceOption {
+func WithRendered() APIResourceOption {
 	return func(o *apiResourceOptions) {
 		o.isRendered = true
-		o.knownRenderedVersion = knownRenderedVersion
-		o.ctx = ctx
 	}
 }
 

--- a/internal/store/model/resource.go
+++ b/internal/store/model/resource.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -54,11 +55,13 @@ type APIResourceOption func(*apiResourceOptions)
 type apiResourceOptions struct {
 	devicesSummary *domain.DevicesSummary // Used by Fleet
 	isRendered     bool                   // Used by Device
+	ctx            context.Context
 }
 
-func WithRendered() APIResourceOption {
+func WithRendered(ctx context.Context) APIResourceOption {
 	return func(o *apiResourceOptions) {
 		o.isRendered = true
+		o.ctx = ctx
 	}
 }
 

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Device Agent behavior", func() {
 				Expect(err).ToNot(HaveOccurred())
 				st := h.Device.UpdateRenderedDevice(h.Context, orgID, deviceName, cfg, "", "hash1", nil)
 				Expect(st.Code).To(BeEquivalentTo(200))
-				renderedDev, getErr := h.DeviceStore.GetRendered(h.Context, orgID, deviceName, nil, "")
+				renderedDev, getErr := h.DeviceStore.GetRendered(h.Context, orgID, deviceName, "")
 				Expect(getErr).ToNot(HaveOccurred())
 				renderedVersion := renderedDev.Version()
 				Expect(renderedVersion).ToNot(BeEmpty())

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
@@ -847,6 +848,60 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrResourceVersionConflict.Error()))
+		})
+
+		// Regression guard for the removed store-side decommission precondition (formerly
+		// SetPrePersistValidate + an inline check inside DecommissionDevice): concurrent
+		// decommission requests must still converge on exactly one winner, whether the loser
+		// is caught by the upfront check or only on a CAS-miss retry.
+		It("under concurrent decommission requests exactly one succeeds and the rest observe conflict", func() {
+			deviceName := "decom-device-race"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName), Owner: lo.ToPtr("Fleet/f1")},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			const numRacers = 5
+			statuses := make(chan domain.Status, numRacers)
+			var ready, start sync.WaitGroup
+			ready.Add(numRacers)
+			start.Add(1)
+			for i := 0; i < numRacers; i++ {
+				go func() {
+					ready.Done()
+					start.Wait()
+					_, st := suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+						Target: api.DeviceDecommissionTargetTypeUnenroll,
+					})
+					statuses <- st
+				}()
+			}
+			ready.Wait()
+			start.Done()
+
+			var successCount, conflictCount int
+			for i := 0; i < numRacers; i++ {
+				st := <-statuses
+				switch st.Code {
+				case int32(200):
+					successCount++
+				case int32(409):
+					conflictCount++
+					Expect(st.Message).To(Equal(flterrors.ErrResourceVersionConflict.Error()))
+				default:
+					Fail(fmt.Sprintf("unexpected status code %d from concurrent DecommissionDevice", st.Code))
+				}
+			}
+			Expect(successCount).To(Equal(1), "exactly one concurrent decommission should succeed")
+			Expect(conflictCount).To(Equal(numRacers-1), "every other concurrent decommission should observe a conflict")
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Decommissioning).ToNot(BeNil())
+			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(stored.Metadata.Owner).To(BeNil())
 		})
 	})
 

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -714,9 +714,6 @@ var _ = Describe("DeviceStore create", func() {
 					},
 				}
 
-				// Omit Spec.Decommissioning: DeviceStore.CreateOrUpdate refuses updates when
-				// the stored device is already decommissioning (persistence contract).
-
 				// Create systemd spec
 				systemd := &struct {
 					MatchPatterns *[]string `json:"matchPatterns,omitempty"`
@@ -771,33 +768,6 @@ var _ = Describe("DeviceStore create", func() {
 			_, _, _, err = devStore.CreateOrUpdate(ctx, orgId, &newDev, nil)
 
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("CreateOrUpdateDevice refuses update when device is already decommissioning", func() {
-			name := "decom-guard-device"
-			device := api.Device{
-				Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
-				Spec: &api.DeviceSpec{
-					Os:              &api.DeviceOsSpec{Image: "img"},
-					Decommissioning: &api.DeviceDecommission{Target: api.DeviceDecommissionTargetTypeUnenroll},
-				},
-			}
-			_, _, _, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			stored, err := devStore.Get(ctx, orgId, name)
-			Expect(err).ToNot(HaveOccurred())
-
-			updated := api.Device{
-				Metadata: api.ObjectMeta{
-					Name:            lo.ToPtr(name),
-					ResourceVersion: stored.Metadata.ResourceVersion,
-					Labels:          &map[string]string{"k": "v"},
-				},
-				Spec: stored.Spec,
-			}
-			_, _, _, err = devStore.CreateOrUpdate(ctx, orgId, &updated, nil)
-			Expect(err).To(MatchError(flterrors.ErrDecommission))
 		})
 
 		It("UpdateDeviceStatus", func() {

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -1134,7 +1134,7 @@ var _ = Describe("DeviceStore create", func() {
 			testutil.CreateTestDevice(ctx, devStore, orgId, "dev", nil, nil, nil)
 
 			// No rendered version
-			_, err := devStore.GetRendered(ctx, orgId, "dev", nil, "")
+			_, err := devStore.GetRendered(ctx, orgId, "dev", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err).Should(MatchError(flterrors.ErrNoRenderedVersion))
 
@@ -1161,7 +1161,7 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(string(plaintext)).To(ContainSubstring("this is the first config"))
 
 			// Getting first rendered config (decrypts transparently)
-			renderedDevice, err := devStore.GetRendered(ctx, orgId, "dev", nil, "")
+			renderedDevice, err := devStore.GetRendered(ctx, orgId, "dev", "")
 			Expect(err).ToNot(HaveOccurred())
 			renderedConfig := *renderedDevice.Spec.Config
 			Expect(len(renderedConfig)).To(BeNumerically(">", 0))
@@ -1172,19 +1172,14 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(renderedDevice.Spec.Os.Image).To(Equal("os"))
 			Expect(renderedDevice.Version()).To(Equal("1"))
 
-			// Passing correct renderedVersion
-			renderedDevice, err = devStore.GetRendered(ctx, orgId, "dev", lo.ToPtr("1"), "")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(renderedDevice).To(BeNil())
-
 			// Set second rendered config
 			secondConfig, err := createTestConfigProvider("this is the second config")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = devStore.UpdateRendered(ctx, orgId, "dev", secondConfig, "", "hash2", nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Passing previous renderedVersion
-			renderedDevice, err = devStore.GetRendered(ctx, orgId, "dev", lo.ToPtr("1"), "")
+			// Getting second rendered config
+			renderedDevice, err = devStore.GetRendered(ctx, orgId, "dev", "")
 			Expect(err).ToNot(HaveOccurred())
 			renderedConfig = *renderedDevice.Spec.Config
 			Expect(len(renderedConfig)).To(BeNumerically(">", 0))

--- a/test/integration/tasks/vmrender/device_render_vm_test.go
+++ b/test/integration/tasks/vmrender/device_render_vm_test.go
@@ -145,7 +145,7 @@ var _ = Describe("VmApplicationRender", func() {
 			WithVmConverter(vmConverter)
 		Expect(logic.RenderDevice(ctx)).To(Succeed())
 
-		rendered, err := deviceStore.GetRendered(ctx, orgId, deviceName, nil, "")
+		rendered, err := deviceStore.GetRendered(ctx, orgId, deviceName, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rendered.Spec).ToNot(BeNil())
 		Expect(rendered.Spec.Applications).ToNot(BeNil())


### PR DESCRIPTION
Jira: EDM-4838 (folds in EDM-4823's exhaustive store business-logic audit)

Removes the duplicate decommission precondition from the device store (now a CAS-gated update, with retry/recheck moved to the service layer) and removes the dead rendered-version comparison from the device store read path.

## Release target (required before merge to `main`)

- [x] **`release-1.3`**

---
**Stack:** 12/12 (top) in the EDM-4806 closeout stack (based on `main`; depends on and should merge after #3268 — EDM-4837).
