### PR TITLE
NO-ISSUE: Align authprovider backport with upstream

### DIFF
--- a/test/e2e/authprovider/authprovider_suite_test.go
+++ b/test/e2e/authprovider/authprovider_suite_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
-	"github.com/flightctl/flightctl/test/harness/containers"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
 	"github.com/flightctl/flightctl/test/util"
@@ -23,10 +22,9 @@ import (
 )
 
 const (
-	keycloakAuthProviderName      = "keycloak-e2e"
-	authProviderKeycloakContainer = "e2e-keycloak"
-	authProviderApplyTimeout      = 15 * time.Second
-	loginRateLimitExceeded        = "Login rate limit exceeded"
+	keycloakAuthProviderName = "keycloak-e2e"
+	authProviderApplyTimeout = 15 * time.Second
+	loginRateLimitExceeded   = "Login rate limit exceeded"
 )
 
 func TestAuthprovider(t *testing.T) {
@@ -44,7 +42,6 @@ var _ = BeforeSuite(func() {
 	// Start only Keycloak (not all aux services)
 	ctx := context.Background()
 	var err error
-	removeStaleAuthProviderKeycloak()
 	auxSvcs, err = auxiliary.StartServices(ctx, []auxiliary.Service{auxiliary.ServiceKeycloak})
 	Expect(err).ToNot(HaveOccurred(), "failed to start Keycloak")
 	Expect(auxSvcs.Keycloak.URL).ToNot(BeEmpty())
@@ -143,51 +140,18 @@ var _ = AfterSuite(func() {
 	}
 })
 
-// removeStaleAuthProviderKeycloak removes the suite-owned Keycloak container so each run imports a fresh realm.
-func removeStaleAuthProviderKeycloak() {
-	if !containers.ContainerExistsByName(authProviderKeycloakContainer) {
-		return
-	}
-	logrus.Infof("[authprovider] removing stale %s container before suite setup", authProviderKeycloakContainer)
-	if err := containers.RemoveContainerByName(authProviderKeycloakContainer); err != nil {
-		logrus.Warnf("[authprovider] failed to remove stale %s container: %v", authProviderKeycloakContainer, err)
-	}
-}
-
 // bootstrapLoginWithAuthRateRetry logs in as admin and retries once after resetting the API auth rate limiter.
 func bootstrapLoginWithAuthRateRetry(harness *e2e.Harness) error {
-	if existingErr := verifyExistingAdminClientConfig(harness); existingErr == nil {
-		logrus.Infof("[authprovider] using existing admin client config for suite bootstrap")
-		return nil
-	} else {
-		logrus.Infof("[authprovider] existing admin client config is not usable for suite bootstrap: %v", existingErr)
-	}
-
 	_, err := login.LoginToAPIWithToken(harness)
-	if err == nil {
-		return nil
+	if !isLoginRateLimitError(err) {
+		return err
 	}
-	logrus.Infof("[authprovider] bootstrap login failed; restarting API once before retry: %v", err)
+	logrus.Infof("[authprovider] bootstrap login hit API auth rate limit; restarting API once before retry")
 	if resetErr := restartAPIForAuthRateLimitReset(); resetErr != nil {
-		return fmt.Errorf("reset API after bootstrap login failure: %w; original error: %v", resetErr, err)
+		return fmt.Errorf("reset auth rate limit after bootstrap login failure: %w; original error: %v", resetErr, err)
 	}
 	_, err = login.LoginToAPIWithToken(harness)
 	return err
-}
-
-// verifyExistingAdminClientConfig checks whether the current client config can already perform admin operations.
-func verifyExistingAdminClientConfig(harness *e2e.Harness) error {
-	if harness == nil {
-		return fmt.Errorf("worker harness is required")
-	}
-	if err := harness.RefreshClient(); err != nil {
-		return fmt.Errorf("refresh existing client config: %w", err)
-	}
-	out, err := harness.CLI("get", "authproviders")
-	if err != nil {
-		return fmt.Errorf("get authproviders with existing client config: %w: %s", err, strings.TrimSpace(out))
-	}
-	return nil
 }
 
 // restoreAdminClientConfig restores the suite's saved admin login config and refreshes the harness client.

--- a/test/e2e/authprovider/authprovider_test.go
+++ b/test/e2e/authprovider/authprovider_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -36,34 +35,32 @@ import (
 )
 
 const (
-	keycloakTestUser               = "testuser"
-	keycloakTestPass               = "testpass"
-	keycloakDuplicateName          = "keycloak-e2e-duplicate"
-	keycloakLifecycleName          = "keycloak-e2e-lifecycle"
-	keycloakLifecycleClientID      = "flightctl-client-lifecycle"
-	keycloakOAuth2ProviderName     = "keycloak-oauth2-e2e"
-	keycloakOAuth2ClientID         = "flightctl-oauth2-client"
-	keycloakAccountAudience        = "account"
-	defaultOrganizationName        = "default"
-	defaultAdminRole               = "flightctl-admin"
-	openshiftDefaultUsername       = "kubeadmin"
-	pamDefaultUsername             = "admin"
-	pamDefaultPassword             = "flightctl-e2e"
-	defaultCypressLoginScript      = "cypress/run-provider-login-cypress.sh"
-	providerVisibilityArg          = "--show-providers"
-	loginInsecureTLSArg            = "--insecure-skip-tls-verify"
-	aapConfigSkipMessage           = "AAP quadlet tests require AAP_API_URL and either AAP_CLIENT_ID or AAP_TOKEN"
-	aapCredentialSkipMessage       = "AAP browser login requires AAP_USERNAME and AAP_PASSWORD"
-	openshiftPasswordMessage       = "OPENSHIFT_PASSWORD or KUBEADMIN_PASS must be set for OpenShift browser login"
-	duplicateOIDCErrorSubstring    = "same issuer and clientId already exists"
-	cypressMissingSubstring        = "Cypress is not installed"
-	cypressInstallMissingSubstring = "Cypress install completed, but"
-	npmMissingSubstring            = "npm is not available"
-	npmErrorSubstring              = "npm error"
-	loginFlowTimeout               = 5 * time.Minute
-	loginFormHTTPTimeout           = loginFlowTimeout
-	authProviderLifecycleTimeout   = 30 * time.Second
-	authProviderPollingInterval    = 2 * time.Second
+	keycloakTestUser             = "testuser"
+	keycloakTestPass             = "testpass"
+	keycloakDuplicateName        = "keycloak-e2e-duplicate"
+	keycloakLifecycleName        = "keycloak-e2e-lifecycle"
+	keycloakLifecycleClientID    = "flightctl-client-lifecycle"
+	keycloakOAuth2ProviderName   = "keycloak-oauth2-e2e"
+	keycloakOAuth2ClientID       = "flightctl-oauth2-client"
+	keycloakAccountAudience      = "account"
+	defaultOrganizationName      = "default"
+	defaultAdminRole             = "flightctl-admin"
+	openshiftDefaultUsername     = "kubeadmin"
+	pamDefaultUsername           = "admin"
+	pamDefaultPassword           = "flightctl-e2e"
+	defaultCypressLoginScript    = "cypress/run-provider-login-cypress.sh"
+	providerVisibilityArg        = "--show-providers"
+	loginInsecureTLSArg          = "--insecure-skip-tls-verify"
+	aapConfigSkipMessage         = "AAP quadlet tests require AAP_API_URL and either AAP_CLIENT_ID or AAP_TOKEN"
+	aapCredentialSkipMessage     = "AAP browser login requires AAP_USERNAME and AAP_PASSWORD"
+	openshiftPasswordMessage     = "OPENSHIFT_PASSWORD or KUBEADMIN_PASS must be set for OpenShift browser login"
+	duplicateOIDCErrorSubstring  = "same issuer and clientId already exists"
+	cypressMissingSubstring      = "Cypress is not installed"
+	npmMissingSubstring          = "npm is not available"
+	loginFlowTimeout             = 5 * time.Minute
+	loginFormHTTPTimeout         = loginFlowTimeout
+	authProviderLifecycleTimeout = 30 * time.Second
+	authProviderPollingInterval  = 2 * time.Second
 )
 
 var loginURLRe = regexp.MustCompile(`(?:Opening login URL in default browser|Please open this URL in your browser):\s*(.+)`)
@@ -726,10 +723,7 @@ func isCypressUnavailableError(err error) bool {
 		return false
 	}
 	errText := err.Error()
-	return strings.Contains(errText, cypressMissingSubstring) &&
-		(strings.Contains(errText, npmMissingSubstring) ||
-			strings.Contains(errText, cypressInstallMissingSubstring) ||
-			strings.Contains(errText, npmErrorSubstring))
+	return strings.Contains(errText, cypressMissingSubstring) && strings.Contains(errText, npmMissingSubstring)
 }
 
 // runProviderLoginCLIWithURL starts `flightctl login ... --web --no-browser` for the given provider.
@@ -956,18 +950,16 @@ func submitAuthLoginForm(ctx context.Context, authURL, username, password string
 	if err != nil {
 		return fmt.Errorf("create login form cookie jar: %w", err)
 	}
-	transport := &http.Transport{
-		Proxy: nil,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // E2E follows self-signed local auth endpoints.
-			MinVersion:         tls.VersionTLS12,
-		},
-	}
-	configureLocalBrowserDial(authURL, transport)
 	httpClient := &http.Client{
-		Jar:       jar,
-		Transport: transport,
-		Timeout:   loginFormHTTPTimeout,
+		Jar: jar,
+		Transport: &http.Transport{
+			Proxy: nil,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // E2E follows self-signed local auth endpoints.
+				MinVersion:         tls.VersionTLS12,
+			},
+		},
+		Timeout: loginFormHTTPTimeout,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
@@ -1069,41 +1061,6 @@ func submitAuthLoginForm(ctx context.Context, authURL, username, password string
 		}
 	}
 	return nil
-}
-
-// configureLocalBrowserDial reaches host-mapped Keycloak ports locally without changing the browser URL origin.
-func configureLocalBrowserDial(authURL string, transport *http.Transport) {
-	if transport == nil {
-		return
-	}
-	parsed, err := url.Parse(strings.TrimSpace(authURL))
-	if err != nil {
-		return
-	}
-	if parsed.Port() == "" || isLoopbackHost(parsed.Hostname()) {
-		return
-	}
-	providerHost := parsed.Hostname()
-	providerPort := parsed.Port()
-	dialer := &net.Dialer{}
-	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(address)
-		if err == nil && strings.EqualFold(host, providerHost) && port == providerPort {
-			return dialer.DialContext(ctx, network, net.JoinHostPort("127.0.0.1", port))
-		}
-		return dialer.DialContext(ctx, network, address)
-	}
-	logrus.Infof("[authprovider] dialing provider auth host %s through local mapped port", sanitizedAuthURLForLog(authURL))
-}
-
-// isLoopbackHost reports whether host already points at the local test process.
-func isLoopbackHost(host string) bool {
-	switch strings.ToLower(strings.TrimSpace(host)) {
-	case "", "localhost", "127.0.0.1", "::1":
-		return true
-	default:
-		return false
-	}
 }
 
 // parseLoginForm returns the first form with username and password fields from an HTML document.


### PR DESCRIPTION
## Summary

Follow-up to the release-1.2 authprovider backport. This removes the extra test-environment adaptations that were not part of upstream/main so the backport stays aligned with the upstream authprovider changes.

Changes:
- Remove the Keycloak local-dial workaround that was specific to titan52 host networking.
- Restore Cypress unavailable handling to match upstream/main.
- Remove stale Keycloak container cleanup and existing-client bootstrap shortcuts that were not upstream backport content.

## Release target

release-1.2
