### PR TITLE
EDM-4756: Declare osMode during enrollment

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -331,6 +331,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		csr,
 		a.config.DefaultLabels,
 		a.config.LabelFromSystemInfo,
+		osMode,
 		statusManager,
 		rootSystemdClient,
 		identityProvider,

--- a/internal/agent/device/lifecycle/manager.go
+++ b/internal/agent/device/lifecycle/manager.go
@@ -50,6 +50,7 @@ type LifecycleManager struct {
 	enrollmentClient    client.Enrollment
 	defaultLabels       map[string]string
 	labelFromSystemInfo map[string]string
+	osMode              v1beta1.OsModeType
 	enrollmentCSR       []byte
 	statusManager       status.Manager
 	systemdClient       *client.Systemd
@@ -71,6 +72,7 @@ func NewManager(
 	enrollmentCSR []byte,
 	defaultLabels map[string]string,
 	labelFromSystemInfo map[string]string,
+	osMode v1beta1.OsModeType,
 	statusManager status.Manager,
 	systemdClient *client.Systemd,
 	identityProvider identity.Provider,
@@ -89,6 +91,7 @@ func NewManager(
 		enrollmentCSR:        enrollmentCSR,
 		defaultLabels:        defaultLabels,
 		labelFromSystemInfo:  labelFromSystemInfo,
+		osMode:               osMode,
 		backoff:              backoff,
 		statusManager:        statusManager,
 		systemdClient:        systemdClient,
@@ -440,6 +443,7 @@ func (m *LifecycleManager) enrollmentRequest(ctx context.Context, deviceStatus *
 			DeviceStatus:         deviceStatus,
 			Labels:               &enrollmentLabels,
 			KnownRenderedVersion: knownRenderedVersion,
+			OsMode:               &m.osMode,
 		},
 	}
 

--- a/internal/agent/device/lifecycle/manager_test.go
+++ b/internal/agent/device/lifecycle/manager_test.go
@@ -296,6 +296,64 @@ func TestLifecycleManager_Initialize_NoBannerOnEnrollmentFailure(t *testing.T) {
 	}
 }
 
+func TestLifecycleManager_enrollmentRequest_osMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		osMode         v1beta1.OsModeType
+		expectedOsMode *v1beta1.OsModeType
+	}{
+		{
+			name:           "When osMode is image it should include osMode in enrollment request",
+			osMode:         v1beta1.OsModeImage,
+			expectedOsMode: ptr(v1beta1.OsModeImage),
+		},
+		{
+			name:           "When osMode is package it should include osMode in enrollment request",
+			osMode:         v1beta1.OsModePackage,
+			expectedOsMode: ptr(v1beta1.OsModePackage),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEnrollment := client.NewMockEnrollment(ctrl)
+			mockReadWriter := fileio.NewMockReadWriter(ctrl)
+
+			manager := &LifecycleManager{
+				deviceName:       "test-device",
+				enrollmentCSR:    []byte("test-csr"),
+				enrollmentClient: mockEnrollment,
+				deviceReadWriter: mockReadWriter,
+				osMode:           tt.osMode,
+				backoff: wait.Backoff{
+					Steps:    1,
+					Duration: time.Millisecond,
+				},
+				log: log.NewPrefixLogger("test"),
+			}
+
+			mockReadWriter.EXPECT().ReadFile(gomock.Any()).Return(nil, errors.New("not found")).AnyTimes()
+
+			var capturedReq v1beta1.EnrollmentRequest
+			mockEnrollment.EXPECT().CreateEnrollmentRequest(gomock.Any(), gomock.Any()).
+				Do(func(_ context.Context, req v1beta1.EnrollmentRequest, _ ...any) {
+					capturedReq = req
+				}).Return(nil, nil)
+
+			ctx := context.Background()
+			err := manager.enrollmentRequest(ctx, &v1beta1.DeviceStatus{})
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedOsMode, capturedReq.Spec.OsMode)
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
 func TestLifecycleManager_buildEnrollmentLabels(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
## EDM-4756: Declare osMode during enrollment

**Jira:** [EDM-4756](https://redhat.atlassian.net/browse/EDM-4756)
**Epic:** [EDM-4747](https://redhat.atlassian.net/browse/EDM-4747) — Package-Mode Agent Runtime
**Depends on:** EDM-4755 (#3253, merged)

### Summary

Sets `EnrollmentRequest.spec.osMode` during agent enrollment based on the `DetectMode()` result from EDM-4755. This gives the server OS mode signal at enrollment time, before the first status report.

### Changes

- **`internal/agent/device/lifecycle/manager.go`**: Added `osMode` field to `LifecycleManager`, accepted via `NewManager`, and set `Spec.OsMode: &m.osMode` in the enrollment request payload.
- **`internal/agent/agent.go`**: Passes `osMode` to `lifecycle.NewManager(...)`.
- **`internal/agent/device/lifecycle/manager_test.go`**: Added `TestLifecycleManager_enrollmentRequest_osMode` with table-driven tests for image and package modes, verifying the ER payload via `gomock` capture.

### Testing

- **Unit tests:** 2 test cases verifying enrollment request payload contains correct `osMode` for both `OsModeImage` and `OsModePackage`.
- **Integration tests:** N/A — agent-side payload construction only; server-side handling is EDM-4760.
- **Coverage:** All new behavioral paths covered through public interface.

### Acceptance Criteria

- [x] AC-1: Agent sets `EnrollmentRequest.spec.osMode` during enrollment based on `DetectMode()` result
- [x] AC-2: Legacy agents omitting `spec.osMode` continue to enroll (backward compatible — field is `*OsModeType` with `omitempty`)
- [x] AC-3: Enrollment request payload validates `osMode` enum when present (OpenAPI middleware from EDM-4751; server-side `Validate()` hardening tracked on EDM-4760)

# Release target (required before merge to `main`)

- [x] **`release-1.3`**
