### PR TITLE
EDM-4757: Atomic spec rejection on package-mode devices

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -462,6 +462,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		prefetchManager,
 		pullConfigResolver,
 		pruningManager,
+		osMode,
 		backoff,
 		a.log,
 	)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -176,6 +176,20 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 		return
 	}
 
+	if err := a.checkPackageModeSpecCompat(desired); err != nil {
+		a.log.Errorf("Spec rejected for package-mode device: %v", err)
+		if a.specManager.IsUpgrading() {
+			if setErr := a.specManager.SetUpgradeFailed(desired.Version(), desired.SpecHash()); setErr != nil {
+				a.log.Errorf("Failed to set upgrade failed: %v", setErr)
+			}
+			if rbErr := a.rollbackDevice(ctx, current, desired, err, a.sync); rbErr != nil {
+				a.log.Errorf("Rollback did not complete cleanly: %v", rbErr)
+			}
+			a.handleSyncError(ctx, desired, err)
+		}
+		return
+	}
+
 	if syncErr := a.sync(ctx, current, desired); syncErr != nil {
 		// if context is canceled return to exit the sync loop
 		if errors.Is(syncErr, context.Canceled) {
@@ -264,6 +278,19 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 			// Don't return error - pruning failures must not block reconciliation
 		}
 	}
+}
+
+// checkPackageModeSpecCompat validates that a package-mode device can satisfy
+// the desired spec. Returns a non-retryable error if the spec contains
+// spec.os.image, which package-mode devices cannot fulfill.
+func (a *Agent) checkPackageModeSpecCompat(desired *v1beta1.Device) error {
+	if a.osMode != v1beta1.OsModePackage {
+		return nil
+	}
+	if desired.Spec != nil && desired.Spec.Os != nil && desired.Spec.Os.Image != "" {
+		return fmt.Errorf("package-mode device cannot satisfy spec with os.image %q: %w", desired.Spec.Os.Image, errors.ErrNoRetry)
+	}
+	return nil
 }
 
 // handleMissingSpec checks if the error is due to a missing spec file. If so,

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -51,6 +51,7 @@ type Agent struct {
 	prefetchManager        dependency.PrefetchManager
 	pullConfigResolver     dependency.PullConfigResolver
 	pruningManager         imagepruning.Manager
+	osMode                 v1beta1.OsModeType
 
 	statusUpdateInterval util.Duration
 
@@ -81,6 +82,7 @@ func NewAgent(
 	prefetchManager dependency.PrefetchManager,
 	pullConfigResolver dependency.PullConfigResolver,
 	pruningManager imagepruning.Manager,
+	osMode v1beta1.OsModeType,
 	backoff wait.Backoff,
 	log *log.PrefixLogger,
 ) *Agent {
@@ -106,6 +108,7 @@ func NewAgent(
 		prefetchManager:        prefetchManager,
 		pullConfigResolver:     pullConfigResolver,
 		pruningManager:         pruningManager,
+		osMode:                 osMode,
 		backoff:                backoff,
 		log:                    log,
 	}

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -820,6 +820,210 @@ func TestSyncHandleMissingSpec(t *testing.T) {
 	}
 }
 
+func TestCheckPackageModeSpecCompat(t *testing.T) {
+	testCases := []struct {
+		name      string
+		osMode    v1beta1.OsModeType
+		desired   *v1beta1.Device
+		expectErr bool
+	}{
+		{
+			name:      "When package-mode and spec has os.image it should return error",
+			osMode:    v1beta1.OsModePackage,
+			desired:   newVersionedDeviceWithOS("2", "quay.io/org/os:v1"),
+			expectErr: true,
+		},
+		{
+			name:      "When package-mode and spec has no os it should return nil",
+			osMode:    v1beta1.OsModePackage,
+			desired:   newVersionedDevice("2"),
+			expectErr: false,
+		},
+		{
+			name:      "When package-mode and spec has os with empty image it should return nil",
+			osMode:    v1beta1.OsModePackage,
+			desired:   newVersionedDeviceWithOS("2", ""),
+			expectErr: false,
+		},
+		{
+			name:      "When image-mode and spec has os.image it should return nil",
+			osMode:    v1beta1.OsModeImage,
+			desired:   newVersionedDeviceWithOS("2", "quay.io/org/os:v1"),
+			expectErr: false,
+		},
+		{
+			name:   "When package-mode and spec.os is nil it should return nil",
+			osMode: v1beta1.OsModePackage,
+			desired: func() *v1beta1.Device {
+				d := newVersionedDevice("2")
+				d.Spec.Os = nil
+				return d
+			}(),
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := Agent{osMode: tc.osMode}
+			err := agent.checkPackageModeSpecCompat(tc.desired)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, errors.ErrNoRetry), "error should wrap ErrNoRetry")
+				require.False(t, errors.IsRetryable(err), "error should not be retryable")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSyncDeviceSpecPackageModeRejection(t *testing.T) {
+	deviceName := "test-device"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("When package-mode and upgrading with os.image it should mark failed and rollback", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		desired := newVersionedDeviceWithOS("2", "quay.io/org/os:v1")
+		current := newVersionedDevice("1")
+
+		mockSpecManager := spec.NewMockManager(ctrl)
+		mockManagementClient := client.NewMockManagement(ctrl)
+		mockResourceManager := resource.NewMockManager(ctrl)
+		mockHookManager := hook.NewMockManager(ctrl)
+		mockAppManager := applications.NewMockManager(ctrl)
+		mockLifecycleManager := lifecycle.NewMockManager(ctrl)
+		mockSystemdManager := systemd.NewMockManager(ctrl)
+		mockPrefetchManager := dependency.NewMockPrefetchManager(ctrl)
+		mockOSManager := os.NewMockManager(ctrl)
+		mockPruningManager := imagepruning.NewMockManager(ctrl)
+		mockPullConfigResolver := dependency.NewMockPullConfigResolver(ctrl)
+		mockExec := executer.NewMockExecuter(ctrl)
+
+		logger := log.NewPrefixLogger("test")
+		logger.SetLevel(logrus.DebugLevel)
+
+		statusMgr := status.NewManager(deviceName, logger)
+		statusMgr.SetClient(mockManagementClient)
+
+		tempDir := t.TempDir()
+		readWriter := fileio.NewReadWriter(
+			fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+			fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+		)
+		systemdClient := client.NewSystemd(mockExec, v1beta1.RootUsername)
+		podmanClient := client.NewPodman(logger, mockExec, readWriter, testutil.NewPollConfig())
+		mockWatcher := spec.NewMockWatcher(ctrl)
+		var podmanFactory client.PodmanFactory = func(user v1beta1.Username) (*client.Podman, error) {
+			return podmanClient, nil
+		}
+		var rwFactory fileio.ReadWriterFactory = func(username v1beta1.Username) (fileio.ReadWriter, error) {
+			return readWriter, nil
+		}
+		consoleManager := console.NewManager(nil, deviceName, "root", mockExec, mockWatcher, logger)
+		appController := applications.NewController(podmanFactory, nil, mockAppManager, rwFactory, logger, "2025-01-01T00:00:00Z")
+		configController := config.NewController(readWriter, logger)
+
+		upgradeFailed := false
+		rollbackCalled := false
+
+		mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil)
+		mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil)
+		mockSpecManager.EXPECT().IsUpgrading().Return(true)
+		mockSpecManager.EXPECT().SetUpgradeFailed(desired.Version(), desired.SpecHash()).DoAndReturn(
+			func(version, hash string) error {
+				upgradeFailed = true
+				return nil
+			},
+		)
+		mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+		mockSpecManager.EXPECT().Rollback(ctx).DoAndReturn(
+			func(_ context.Context, _ ...spec.RollbackOption) error {
+				rollbackCalled = true
+				return nil
+			},
+		)
+		mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
+
+		// rollback calls a.sync(ctx, desired, current) which goes through beforeUpdate → syncDevice → afterUpdate
+		mockSpecManager.EXPECT().IsUpgrading().Return(false).AnyTimes()
+		mockResourceManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockResourceManager.EXPECT().IsCriticalAlert(gomock.Any()).Return(false).AnyTimes()
+		mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockPullConfigResolver.EXPECT().BeforeUpdate(gomock.Any()).AnyTimes()
+		mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
+		mockSpecManager.EXPECT().IsOSUpdate().Return(false).AnyTimes()
+		mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+		mockPrefetchManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockAppManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockHookManager.EXPECT().OnBeforeUpdating(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockPruningManager.EXPECT().RecordReferences(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockHookManager.EXPECT().Sync(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
+		mockLifecycleManager.EXPECT().Sync(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockLifecycleManager.EXPECT().AfterUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("", true, nil).AnyTimes()
+		mockHookManager.EXPECT().OnAfterUpdating(gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).AnyTimes()
+		mockAppManager.EXPECT().AfterUpdate(gomock.Any()).Return(nil).AnyTimes()
+		mockPullConfigResolver.EXPECT().Cleanup().AnyTimes()
+		mockPrefetchManager.EXPECT().Cleanup().AnyTimes()
+
+		agent := Agent{
+			log:                    logger,
+			systemdClient:          systemdClient,
+			deviceWriter:           readWriter,
+			specManager:            mockSpecManager,
+			statusManager:          statusMgr,
+			appManager:             mockAppManager,
+			applicationsController: appController,
+			hookManager:            mockHookManager,
+			consoleManager:         consoleManager,
+			configController:       configController,
+			resourceManager:        mockResourceManager,
+			systemdManager:         mockSystemdManager,
+			lifecycleManager:       mockLifecycleManager,
+			prefetchManager:        mockPrefetchManager,
+			osManager:              mockOSManager,
+			pruningManager:         mockPruningManager,
+			pullConfigResolver:     mockPullConfigResolver,
+			osMode:                 v1beta1.OsModePackage,
+		}
+
+		agent.syncDeviceSpec(ctx)
+
+		require.True(t, upgradeFailed, "SetUpgradeFailed should have been called")
+		require.True(t, rollbackCalled, "Rollback should have been called")
+	})
+
+	t.Run("When package-mode and not upgrading with os.image it should reject without rollback", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		desired := newVersionedDeviceWithOS("1", "quay.io/org/os:v1")
+		current := newVersionedDevice("1")
+
+		mockSpecManager := spec.NewMockManager(ctrl)
+
+		logger := log.NewPrefixLogger("test")
+		logger.SetLevel(logrus.DebugLevel)
+
+		mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil)
+		mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil)
+		mockSpecManager.EXPECT().IsUpgrading().Return(false)
+
+		agent := Agent{
+			log:         logger,
+			specManager: mockSpecManager,
+			osMode:      v1beta1.OsModePackage,
+		}
+
+		agent.syncDeviceSpec(ctx)
+	})
+}
+
 func newVersionedDevice(version string) *v1beta1.Device {
 	device := &v1beta1.Device{
 		Metadata: v1beta1.ObjectMeta{


### PR DESCRIPTION
## EDM-4757: Atomic spec rejection on package-mode devices

**Jira:** [EDM-4757](https://redhat.atlassian.net/browse/EDM-4757)
**Epic:** EDM-4747 — Package-Mode Agent Runtime

### Summary

Package-mode devices now reject the entire desired spec atomically when it
contains a non-empty `spec.os.image`, preventing partial application of
config/apps while the OS image target cannot be satisfied. The rejection
fires before any reconcilers run (no prefetch, no `beforeUpdate`, no
`syncDevice`), marks the version as failed, rolls back to the previously
committed spec, and reports an upgrade failure.

### Changes

- **`internal/agent/device/device.go`**
  - Added `osMode` field to `Agent` struct and `NewAgent` constructor
  - Added `checkPackageModeSpecCompat()` — returns non-retryable error when
    `osMode == package` and `spec.os.image` is set
  - Added early gate in `syncDeviceSpec()` before `sync()` that calls the
    check and routes through the existing failure path (`SetUpgradeFailed` →
    `rollbackDevice` → `handleSyncError`)

- **`internal/agent/agent.go`**
  - Pass `osMode` to `device.NewAgent()` call site

### Testing

- **Unit tests:** 7 new tests across 2 test functions
  - `TestCheckPackageModeSpecCompat` (5 cases): package+image→error, package+no-os→nil, package+empty-image→nil, image+image→nil, package+nil-os→nil
  - `TestSyncDeviceSpecPackageModeRejection` (2 cases): upgrading→SetUpgradeFailed+rollback; not-upgrading→reject-only
- **Integration tests:** N/A — gate is fully testable via unit tests
- **Coverage:** `checkPackageModeSpecCompat` at 100%

### Acceptance Criteria

- [x] AC-1: When mode is `package` and desired spec has non-empty `spec.os.image`, agent rejects entire spec before config/app/OS reconcilers run
- [x] AC-2: Device stays on previously committed spec and reports upgrade failure
- [x] AC-3: When spec has no `spec.os.image`, package-mode device reconciles config and apps normally
- [x] AC-4: Recovery: device advances when next satisfiable spec (no OS image) is delivered
