### PR TITLE
EDM-4858: Add version mismatch diagnostics

### DIFF
--- a/test/e2e/authprovider/authprovider_helpers_test.go
+++ b/test/e2e/authprovider/authprovider_helpers_test.go
@@ -503,6 +503,11 @@ func (f fakeInfraProvider) GetServiceEndpoint(infra.ServiceName) (string, int, e
 	return "", 0, errors.New("not implemented")
 }
 
+// GetServiceImage is unused by these tests and satisfies infra.InfraProvider.
+func (f fakeInfraProvider) GetServiceImage(infra.ServiceName) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 // ExposeService is unused by these tests and satisfies infra.InfraProvider.
 func (f fakeInfraProvider) ExposeService(infra.ServiceName, string) (string, func(), error) {
 	return "", func() {}, errors.New("not implemented")

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
 	"github.com/flightctl/flightctl/test/harness/e2e"
 	"github.com/flightctl/flightctl/test/login"
 	"github.com/flightctl/flightctl/test/util"
@@ -27,7 +29,21 @@ var (
 	invalidResource      = "invalid resource kind"
 	strictfipsruntimeTag = "X:strictfipsruntime"
 	applyOperation       = "apply"
+	unsetDiagnosticValue = "<unset>"
 )
+
+var versionDiagnosticEnvVars = []string{
+	"BREW_BUILD_URL",
+	"FLIGHTCTL_RPM",
+	"RPM_COPR",
+	"SOURCE_GIT_TAG",
+	"SOURCE_GIT_COMMIT",
+	"FLIGHTCTL_NS",
+	"FLIGHTCTL_INTERNAL_NS",
+	"FLIGHTCTL_EXTERNAL_NS",
+	"E2E_ENVIRONMENT",
+	"API_ENDPOINT",
+}
 
 type fleetTestManager struct {
 	harness          *e2e.Harness
@@ -514,7 +530,7 @@ var _ = Describe("cli operation", func() {
 	})
 
 	Context("Flightctl Version Checks", func() {
-		It("should show matching client and server versions", Label("79621", "sanity", "rpm-sanity", "client"), func() {
+		It("should show matching agent and server versions", Label("79621", "sanity", "rpm-sanity", "client"), func() {
 			// Get harness directly - no shared package-level variable
 			harness := e2e.GetWorkerHarness()
 
@@ -530,7 +546,9 @@ var _ = Describe("cli operation", func() {
 			GinkgoWriter.Printf("Agent version: %s\n", agentVersion)
 
 			By("Comparing versions")
-			// Expect(clientVersion).To(Equal(serverVersion), "client and server versions should match")
+			if agentVersion != serverVersion {
+				logVersionMismatchDiagnostics(harness, clientVersion, serverVersion, agentVersion)
+			}
 			Expect(agentVersion).To(Equal(serverVersion), "agent and server versions should match")
 		})
 
@@ -1502,6 +1520,48 @@ func ExpectCompletion(h CLIRunner, args []string, expected string) {
 	Expect(strings.Join(lines, "\n")).To(ContainSubstring(expected),
 		"expected completion %q for args: flightctl %s\nFull output:\n%s",
 		expected, strings.Join(args, " "), out)
+}
+
+func logVersionMismatchDiagnostics(harness *e2e.Harness, clientVersion, serverVersion, agentVersion string) {
+	GinkgoWriter.Printf("Version mismatch diagnostics:\n")
+	GinkgoWriter.Printf("  Client version: %s\n", clientVersion)
+	GinkgoWriter.Printf("  Server version: %s\n", serverVersion)
+	GinkgoWriter.Printf("  Agent version: %s\n", agentVersion)
+
+	agentVersionInfo, err := harness.GetAgentVersionInfo()
+	if err != nil {
+		GinkgoWriter.Printf("  Agent version details error: %v\n", err)
+	} else {
+		GinkgoWriter.Printf("  Agent Git commit: %s\n", valueOrUnset(agentVersionInfo.GitCommit))
+		GinkgoWriter.Printf("  Raw agent version output:\n%s\n", agentVersionInfo.RawOutput)
+	}
+
+	providers := setup.GetDefaultProviders()
+	if providers == nil || providers.Infra == nil {
+		GinkgoWriter.Printf("  Infra provider: <unset>\n")
+	} else {
+		GinkgoWriter.Printf("  Environment type: %s\n", valueOrUnset(providers.Infra.GetEnvironmentType()))
+		GinkgoWriter.Printf("  Internal namespace: %s\n", valueOrUnset(providers.Infra.GetInternalNamespace()))
+		GinkgoWriter.Printf("  External namespace: %s\n", valueOrUnset(providers.Infra.GetExternalNamespace()))
+
+		apiImage, err := providers.Infra.GetServiceImage(infra.ServiceAPI)
+		if err != nil {
+			GinkgoWriter.Printf("  flightctl-api image error: %v\n", err)
+		} else {
+			GinkgoWriter.Printf("  flightctl-api image: %s\n", apiImage)
+		}
+	}
+
+	for _, envVar := range versionDiagnosticEnvVars {
+		GinkgoWriter.Printf("  %s: %s\n", envVar, valueOrUnset(os.Getenv(envVar)))
+	}
+}
+
+func valueOrUnset(value string) string {
+	if value == "" {
+		return unsetDiagnosticValue
+	}
+	return value
 }
 
 // completeFleetYaml defines a YAML template for creating a Fleet resource with specified metadata and spec configuration.

--- a/test/e2e/infra/infra_provider.go
+++ b/test/e2e/infra/infra_provider.go
@@ -57,6 +57,10 @@ type InfraProvider interface {
 	// For Quadlet: returns the configured host with the service's port
 	GetServiceEndpoint(service ServiceName) (host string, port int, err error)
 
+	// GetServiceImage returns the deployed container image reference for a named service.
+	// For K8s: reads the service deployment pod template. For Quadlet: inspects the running container.
+	GetServiceImage(service ServiceName) (string, error)
+
 	// ExposeService makes an internal service accessible from the test host.
 	// Use this for services not normally exposed externally (e.g., metrics endpoints).
 	// For K8s: starts port-forwarding and returns localhost URL + cleanup function

--- a/test/e2e/infra/k8s/infra.go
+++ b/test/e2e/infra/k8s/infra.go
@@ -218,6 +218,30 @@ func (p *InfraProvider) GetServiceNamespaceAndMetadata(service infra.ServiceName
 	return info.ServiceName, info.Label, ns, nil
 }
 
+// GetServiceImage returns the image references from a service deployment.
+func (p *InfraProvider) GetServiceImage(service infra.ServiceName) (string, error) {
+	info, ns, err := p.getServiceInfo(service)
+	if err != nil {
+		return "", err
+	}
+
+	deployment, err := p.client.AppsV1().Deployments(ns).Get(context.Background(), info.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get deployment %s/%s: %w", ns, info.ServiceName, err)
+	}
+
+	containers := deployment.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return "", fmt.Errorf("deployment %s/%s has no containers", ns, info.ServiceName)
+	}
+
+	images := make([]string, 0, len(containers))
+	for _, container := range containers {
+		images = append(images, fmt.Sprintf("%s=%s", container.Name, container.Image))
+	}
+	return strings.Join(images, ", "), nil
+}
+
 // resolveNamespace returns the actual namespace based on type (internal or external only).
 func (p *InfraProvider) resolveNamespace(nsType namespaceType) (string, error) {
 	switch nsType {

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -370,6 +370,25 @@ func (p *InfraProvider) GetServiceEndpoint(service infra.ServiceName) (string, i
 	return p.host, info.Port, nil
 }
 
+// GetServiceImage returns the image reference used by a Quadlet service container.
+func (p *InfraProvider) GetServiceImage(service infra.ServiceName) (string, error) {
+	info := GetServiceInfo(service)
+	if info.ContainerName == "" {
+		return "", fmt.Errorf("service %s has no container name", service)
+	}
+
+	output, err := p.runCommand("podman", "inspect", "--format", "{{if .ImageName}}{{.ImageName}}{{else}}{{.Config.Image}}{{end}}", info.ContainerName)
+	if err != nil {
+		return "", fmt.Errorf("inspect container %s: %w", info.ContainerName, err)
+	}
+
+	image := strings.TrimSpace(output)
+	if image == "" {
+		return "", fmt.Errorf("container %s image is empty", info.ContainerName)
+	}
+	return image, nil
+}
+
 // ExposeService makes an internal service accessible from the test host.
 // If the container already publishes the port (e.g. flightctl-api), returns that URL and a no-op cleanup.
 // Otherwise (e.g. Redis) starts a TCP forwarder from a local port to the container, using SSH for remote Quadlet hosts.

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -96,6 +96,8 @@ const (
 	cliRateLimitServerReturned      = "server returned 429"
 	cliRateLimitExceeded            = "rate limit exceeded"
 	cliLoginRateLimitExceededOutput = "Login rate limit exceeded, please try again later"
+	agentVersionPrefix              = "Agent Version:"
+	agentGitCommitPrefix            = "Git Commit:"
 )
 
 const (
@@ -2425,31 +2427,51 @@ func (h *Harness) GetVersionsFromCLI() (clientVersion, serverVersion, agentVersi
 	return clientVersion, serverVersion, agentVersion, nil
 }
 
-// GetAgentVersion returns the agent version from the flightctl-agent version command
-func (h *Harness) GetAgentVersion() (string, error) {
+// AgentVersionInfo contains parsed and raw flightctl-agent version output.
+type AgentVersionInfo struct {
+	Version   string
+	GitCommit string
+	RawOutput string
+}
+
+// GetAgentVersionInfo returns the agent version details from the flightctl-agent version command.
+func (h *Harness) GetAgentVersionInfo() (AgentVersionInfo, error) {
 	if h.VM == nil {
-		return "", fmt.Errorf("VM is not initialized")
+		return AgentVersionInfo{}, fmt.Errorf("VM is not initialized")
 	}
 
 	// Run flightctl-agent version command on the VM
 	stdout, err := h.VM.RunSSH([]string{"flightctl-agent", "version"}, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to run flightctl-agent version: %w", err)
+		return AgentVersionInfo{}, fmt.Errorf("failed to run flightctl-agent version: %w", err)
 	}
 
 	output := stdout.String()
-	versionPrefix := "Agent Version:"
-	if !strings.Contains(output, versionPrefix) {
-		return "", fmt.Errorf("agent version not found in output: %s", output)
+	if !strings.Contains(output, agentVersionPrefix) {
+		return AgentVersionInfo{}, fmt.Errorf("agent version not found in output: %s", output)
 	}
 
 	// Extract version using the existing helper function
-	agentVersion := h.getVersionByPrefix(output, versionPrefix)
+	agentVersion := h.getVersionByPrefix(output, agentVersionPrefix)
 	if agentVersion == "" {
-		return "", fmt.Errorf("failed to parse agent version from output")
+		return AgentVersionInfo{}, fmt.Errorf("failed to parse agent version from output")
 	}
 
-	return agentVersion, nil
+	return AgentVersionInfo{
+		Version:   agentVersion,
+		GitCommit: h.getVersionByPrefix(output, agentGitCommitPrefix),
+		RawOutput: strings.TrimSpace(output),
+	}, nil
+}
+
+// GetAgentVersion returns the agent version from the flightctl-agent version command
+func (h *Harness) GetAgentVersion() (string, error) {
+	versionInfo, err := h.GetAgentVersionInfo()
+	if err != nil {
+		return "", err
+	}
+
+	return versionInfo.Version, nil
 }
 
 // GetAgentVersionFromLogs returns the agent version from the flightctl-agent service logs


### PR DESCRIPTION
## Summary

Add failure-time diagnostics to the rpm-sanity version check for label `79621`.

The test still validates that the enrolled agent version matches the deployed server version. When that comparison fails, it now logs the agent version details, deployed `flightctl-api` image, relevant env inputs, namespaces, and runtime environment so we can tell whether the mismatch came from the agent RPM, server deployment image, or build metadata.

## Release target

- [x] release-1.3

Target release: release-1.3