### PR TITLE
EDM-4335: status update path optimizations

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -69,7 +69,7 @@ func (m *MockDevice) Labels(ctx context.Context, orgId uuid.UUID, listParams sto
 func (m *MockDevice) Delete(ctx context.Context, orgId uuid.UUID, name string, callback store.EventCallback) (bool, error) {
 	return true, nil
 }
-func (m *MockDevice) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, callbackEvent store.EventCallback) (*domain.Device, error) {
+func (m *MockDevice) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, callbackEvent store.EventCallback, previous *domain.Device) (*domain.Device, error) {
 	return nil, nil
 }
 func (m *MockDevice) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -82,7 +82,7 @@ func (m *MockDevice) MutateAnnotation(ctx context.Context, orgId uuid.UUID, name
 	_, err := mutate("")
 	return err
 }
-func (m *MockDevice) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (m *MockDevice) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus devicestore.RenderedStatusMutator) (string, error) {
 	return "", nil
 }
 func (m *MockDevice) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -562,10 +562,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 		h.log.Debugf("Rendered device %s/%s: no change in rendered version", orgId, name)
 		return domain.StatusOK()
 	}
-	err = h.UpdateServerSideDeviceStatus(ctx, orgId, name)
-	if err != nil {
-		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
-	}
+	// Status refresh is owned by device-render setStatus (avoids a duplicate write).
 
 	err = rendered.Bus.Instance().StoreAndNotify(ctx, orgId, name, renderedVersion)
 	if err != nil {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -567,13 +567,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 			updated = nil
 			if device.Status != nil {
 				oldConditions = append([]domain.Condition(nil), device.Status.Conditions...)
-			}
-			// device.Status.Conditions still holds the pre-render SpecValid at this point
-			// (oldConditions above is the diff baseline for event emission). Apply the
-			// SpecValid=Valid that this render is about to commit before computing derived
-			// status, so e.g. Status.Updated (via IsUpdatedToDeviceSpec) isn't computed
-			// against a stale Invalid condition from before this render.
-			if device.Status != nil {
+				// Apply the SpecValid this render is about to commit before computing derived status.
 				domain.SetStatusCondition(&device.Status.Conditions, specValid)
 			}
 			if !common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log) {
@@ -588,8 +582,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 	}
 	if renderedVersion == "" {
 		h.log.Debugf("Rendered device %s/%s: no change in rendered version", orgId, name)
-		// No rendered write; still ensure SpecValid=Valid (e.g. recovered from Invalid), and
-		// refresh derived status since it may have been computed against the stale condition.
+		// No rendered write; still ensure SpecValid=Valid and refresh derived status.
 		status := h.SetDeviceServiceConditions(ctx, orgId, name, []domain.Condition{specValid})
 		if status.Code != http.StatusOK {
 			return status
@@ -612,10 +605,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 		h.diffAndEmitConditionEvents(ctx, orgId, deviceForEvents, oldConditions, newConditions)
 	}
 
-	// StoreAndNotify only wakes up agents already long-polling for a new version; it is not
-	// the source of truth (the render above already persisted successfully). Treat failure
-	// here as best-effort: agents still pick up the new rendered version on their next poll.
-	// Do not fail the call or touch SpecValid over a notify-only failure.
+	// Best-effort: StoreAndNotify only wakes up already-polling agents, it's not the source of truth.
 	if err := rendered.Bus.Instance().StoreAndNotify(ctx, orgId, name, renderedVersion); err != nil {
 		h.log.Errorf("Failed to publish rendered device %s/%s: %v", orgId, name, err)
 	}

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -553,16 +553,48 @@ func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgI
 }
 
 func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status {
-	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+	specValid := domain.Condition{
+		Type:   domain.ConditionTypeDeviceSpecValid,
+		Status: domain.ConditionStatusTrue,
+		Reason: "Valid",
+	}
+	var previous, updated *domain.Device
+	var oldConditions []domain.Condition
+	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate,
+		func(device *domain.Device) bool {
+			previous = snapshotDeviceForStatusUpdate(device)
+			oldConditions = nil
+			updated = nil
+			if device.Status != nil {
+				oldConditions = append([]domain.Condition(nil), device.Status.Conditions...)
+			}
+			if !common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log) {
+				return false
+			}
+			updated = device
+			return true
+		})
 	if err != nil {
 		h.log.Errorf("Failed to update rendered device %s/%s: %v", orgId, name, err)
 		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 	}
 	if renderedVersion == "" {
 		h.log.Debugf("Rendered device %s/%s: no change in rendered version", orgId, name)
-		return domain.StatusOK()
+		// No rendered write; still ensure SpecValid=Valid (e.g. recovered from Invalid).
+		return h.SetDeviceServiceConditions(ctx, orgId, name, []domain.Condition{specValid})
 	}
-	// Status refresh is owned by device-render setStatus (avoids a duplicate write).
+	if updated != nil {
+		h.callbackDeviceUpdated(ctx, domain.DeviceKind, orgId, name, previous, updated, false, nil)
+	}
+	deviceForEvents := updated
+	if deviceForEvents == nil {
+		deviceForEvents = previous
+	}
+	if deviceForEvents != nil {
+		newConditions := append([]domain.Condition(nil), oldConditions...)
+		domain.SetStatusCondition(&newConditions, specValid)
+		h.diffAndEmitConditionEvents(ctx, orgId, deviceForEvents, oldConditions, newConditions)
+	}
 
 	err = rendered.Bus.Instance().StoreAndNotify(ctx, orgId, name, renderedVersion)
 	if err != nil {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -339,7 +339,7 @@ func (h *DeviceServiceHandler) ReplaceDeviceStatus(ctx context.Context, orgId uu
 	deviceToStore.Status = incomingDevice.Status
 	_ = common.UpdateServiceSideStatus(ctx, orgId, deviceToStore, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.UpdateStatus(ctx, orgId, deviceToStore, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.UpdateStatus(ctx, orgId, deviceToStore, h.callbackDeviceUpdated, originalDevice)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
@@ -502,8 +502,9 @@ func (h *DeviceServiceHandler) UpdateServerSideDeviceStatus(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	previous := snapshotDeviceForStatusUpdate(device)
 	if changed := common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log); changed {
-		_, err = h.deviceStore.UpdateStatus(ctx, orgId, device, h.callbackDeviceUpdated)
+		_, err = h.deviceStore.UpdateStatus(ctx, orgId, device, h.callbackDeviceUpdated, previous)
 		if err != nil {
 			h.log.WithError(err).Errorf("failed to update status for device %s/%s", orgId, name)
 			return err
@@ -517,13 +518,28 @@ func (h *DeviceServiceHandler) ForceUpdateServerSideDeviceStatus(ctx context.Con
 	if err != nil {
 		return err
 	}
+	previous := snapshotDeviceForStatusUpdate(device)
 	common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log)
-	_, err = h.deviceStore.UpdateStatus(ctx, orgId, device, h.callbackDeviceUpdated)
+	_, err = h.deviceStore.UpdateStatus(ctx, orgId, device, h.callbackDeviceUpdated, previous)
 	if err != nil {
 		h.log.WithError(err).Errorf("failed to update status for device %s/%s", orgId, name)
 		return err
 	}
 	return nil
+}
+
+// snapshotDeviceForStatusUpdate copies the device enough that in-place status mutations
+// in UpdateServiceSideStatus do not alter the pre-update snapshot used for events.
+func snapshotDeviceForStatusUpdate(device *domain.Device) *domain.Device {
+	if device == nil {
+		return nil
+	}
+	previous := *device
+	if device.Status != nil {
+		status := *device.Status
+		previous.Status = &status
+	}
+	return &previous
 }
 
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -568,6 +568,14 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 			if device.Status != nil {
 				oldConditions = append([]domain.Condition(nil), device.Status.Conditions...)
 			}
+			// device.Status.Conditions still holds the pre-render SpecValid at this point
+			// (oldConditions above is the diff baseline for event emission). Apply the
+			// SpecValid=Valid that this render is about to commit before computing derived
+			// status, so e.g. Status.Updated (via IsUpdatedToDeviceSpec) isn't computed
+			// against a stale Invalid condition from before this render.
+			if device.Status != nil {
+				domain.SetStatusCondition(&device.Status.Conditions, specValid)
+			}
 			if !common.UpdateServiceSideStatus(ctx, orgId, device, h.fleetStore, h.log) {
 				return false
 			}
@@ -580,8 +588,16 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 	}
 	if renderedVersion == "" {
 		h.log.Debugf("Rendered device %s/%s: no change in rendered version", orgId, name)
-		// No rendered write; still ensure SpecValid=Valid (e.g. recovered from Invalid).
-		return h.SetDeviceServiceConditions(ctx, orgId, name, []domain.Condition{specValid})
+		// No rendered write; still ensure SpecValid=Valid (e.g. recovered from Invalid), and
+		// refresh derived status since it may have been computed against the stale condition.
+		status := h.SetDeviceServiceConditions(ctx, orgId, name, []domain.Condition{specValid})
+		if status.Code != http.StatusOK {
+			return status
+		}
+		if err := h.UpdateServerSideDeviceStatus(ctx, orgId, name); err != nil {
+			h.log.Errorf("Failed updating device status for device %s/%s: %v", orgId, name, err)
+		}
+		return status
 	}
 	if updated != nil {
 		h.callbackDeviceUpdated(ctx, domain.DeviceKind, orgId, name, previous, updated, false, nil)
@@ -596,12 +612,14 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 		h.diffAndEmitConditionEvents(ctx, orgId, deviceForEvents, oldConditions, newConditions)
 	}
 
-	err = rendered.Bus.Instance().StoreAndNotify(ctx, orgId, name, renderedVersion)
-	if err != nil {
+	// StoreAndNotify only wakes up agents already long-polling for a new version; it is not
+	// the source of truth (the render above already persisted successfully). Treat failure
+	// here as best-effort: agents still pick up the new rendered version on their next poll.
+	// Do not fail the call or touch SpecValid over a notify-only failure.
+	if err := rendered.Bus.Instance().StoreAndNotify(ctx, orgId, name, renderedVersion); err != nil {
 		h.log.Errorf("Failed to publish rendered device %s/%s: %v", orgId, name, err)
-		return domain.StatusInternalServerError(fmt.Sprintf("failed to publish rendered device: %v", err))
 	}
-	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	return domain.StatusOK()
 }
 
 func (h *DeviceServiceHandler) SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -829,11 +829,19 @@ func TestSetDeviceServiceConditions(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
-		{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
-	})
+	condition := domain.Condition{
+		Type:    domain.ConditionTypeDeviceSpecValid,
+		Status:  domain.ConditionStatusFalse,
+		Message: "bad spec",
+	}
+	status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
 	require.Equal(t, int32(http.StatusOK), status.Code)
 	// SpecValid transitioning from absent to invalid emits a DeviceSpecInvalid event.
+	require.Len(t, ev.created, 1)
+
+	status = svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
+	require.Equal(t, int32(http.StatusOK), status.Code)
+	// Unchanged conditions must not write or emit another event.
 	require.Len(t, ev.created, 1)
 }
 

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -318,10 +318,20 @@ func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.U
 	if d.Status == nil {
 		d.Status = lo.ToPtr(domain.NewDeviceStatus())
 	}
-	oldConditions := d.Status.Conditions
-	d.Status.Conditions = conditions
+	oldConditions := append([]domain.Condition(nil), d.Status.Conditions...)
+	newConditions := append([]domain.Condition(nil), d.Status.Conditions...)
+	changed := false
+	for _, condition := range conditions {
+		if domain.SetStatusCondition(&newConditions, condition) {
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	d.Status.Conditions = newConditions
 	if callback != nil {
-		callback(ctx, orgId, d, oldConditions, conditions)
+		callback(ctx, orgId, d, oldConditions, newConditions)
 	}
 	return nil
 }

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -315,11 +315,11 @@ func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.U
 	if !ok {
 		return flterrors.ErrResourceNotFound
 	}
-	if d.Status == nil {
-		d.Status = lo.ToPtr(domain.NewDeviceStatus())
+	var oldConditions []domain.Condition
+	if d.Status != nil {
+		oldConditions = append([]domain.Condition(nil), d.Status.Conditions...)
 	}
-	oldConditions := append([]domain.Condition(nil), d.Status.Conditions...)
-	newConditions := append([]domain.Condition(nil), d.Status.Conditions...)
+	newConditions := append([]domain.Condition(nil), oldConditions...)
 	changed := false
 	for _, condition := range conditions {
 		if domain.SetStatusCondition(&newConditions, condition) {
@@ -328,6 +328,9 @@ func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.U
 	}
 	if !changed {
 		return nil
+	}
+	if d.Status == nil {
+		d.Status = lo.ToPtr(domain.NewDeviceStatus())
 	}
 	d.Status.Conditions = newConditions
 	if callback != nil {

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -268,7 +268,7 @@ func (s *fakeDeviceStore) MutateAnnotation(ctx context.Context, orgId uuid.UUID,
 	return nil
 }
 
-func (s *fakeDeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (s *fakeDeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus devicestore.RenderedStatusMutator) (string, error) {
 	if _, ok := s.devices[name]; !ok {
 		return "", flterrors.ErrResourceNotFound
 	}

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -150,9 +150,12 @@ func (s *fakeDeviceStore) Delete(ctx context.Context, orgId uuid.UUID, name stri
 	return true, nil
 }
 
-func (s *fakeDeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
+func (s *fakeDeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback, previous *domain.Device) (*domain.Device, error) {
 	name := lo.FromPtr(device.Metadata.Name)
-	old := s.devices[name]
+	old := previous
+	if old == nil {
+		old = s.devices[name]
+	}
 	d := deepCopyDevice(device)
 	s.devices[name] = d
 	if eventCallback != nil {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -61,7 +61,9 @@ type Store interface {
 	List(ctx context.Context, orgId uuid.UUID, listParams DeviceListParams) (*domain.DeviceList, error)
 	Labels(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (domain.LabelList, error)
 	Delete(ctx context.Context, orgId uuid.UUID, name string, eventCallback store.EventCallback) (bool, error)
-	UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error)
+	// UpdateStatus persists device status. When previous is non-nil it is used as the
+	// pre-update snapshot for event callbacks and the store does not re-fetch the device.
+	UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback, previous *domain.Device) (*domain.Device, error)
 	GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error)
 	Healthcheck(ctx context.Context, orgId uuid.UUID, names []string) error
 	ProcessAwaitingReconnectAnnotation(ctx context.Context, orgId uuid.UUID, deviceName string, deviceReportedVersion *string) (bool, error)
@@ -830,20 +832,21 @@ func (s *DeviceStore) Summary(ctx context.Context, orgId uuid.UUID, listParams s
 	}, nil
 }
 
-func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, resource *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
+func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, resource *domain.Device, eventCallback store.EventCallback, previous *domain.Device) (*domain.Device, error) {
 	var oldDevice domain.Device
 	name := lo.FromPtr(resource.Metadata.Name)
-	device, err := s.Get(ctx, orgId, name)
-	if err != nil {
-		s.log.Errorf("error fetching device %s/%s for update status event processing", orgId, name)
-	} else if device != nil {
-		// Capture old device with deep copy
-		var devices []domain.Device
-		devices = append(devices, *device)
-		oldDevice = devices[0]
+	if previous != nil {
+		oldDevice = *previous
+	} else {
+		device, err := s.Get(ctx, orgId, name)
+		if err != nil {
+			s.log.Errorf("error fetching device %s/%s for update status event processing", orgId, name)
+		} else if device != nil {
+			oldDevice = *device
+		}
 	}
 
-	device, err = s.genericStore.UpdateStatus(ctx, orgId, resource)
+	device, err := s.genericStore.UpdateStatus(ctx, orgId, resource)
 	s.callEventCallback(ctx, eventCallback, orgId, name, &oldDevice, device, false, err)
 	return device, err
 }

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1298,9 +1298,14 @@ func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID,
 		existingRecord.ServiceConditions.Data.Conditions = &[]domain.Condition{}
 	}
 
-	// Set new conditions
+	changed := false
 	for _, condition := range conditions {
-		domain.SetStatusCondition(existingRecord.ServiceConditions.Data.Conditions, condition)
+		if domain.SetStatusCondition(existingRecord.ServiceConditions.Data.Conditions, condition) {
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
 	}
 
 	// Update using the original pattern with specific field updates and optimistic locking

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -72,7 +72,7 @@ type Store interface {
 	// Used internally
 	UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) error
 	MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error
-	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error)
+	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus RenderedStatusMutator) (string, error)
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
 	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error)
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
@@ -105,6 +105,11 @@ type DeviceStore struct {
 
 type DeviceStoreValidationCallback func(ctx context.Context, before *domain.Device, after *domain.Device) error
 type ServiceConditionsCallback func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition)
+
+// RenderedStatusMutator recomputes server-side status on a device that already has the
+// next rendered-version annotations applied. It returns true when status should be
+// persisted in the same CAS UPDATE as the rendered fields. Invoked on every retry.
+type RenderedStatusMutator func(device *domain.Device) bool
 
 // Make sure we conform to the Store interface
 var _ Store = (*DeviceStore)(nil)
@@ -1122,7 +1127,7 @@ func (s *DeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, owner s
 	})
 }
 
-func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (retry bool, renderedVersion string, err error) {
+func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus RenderedStatusMutator) (retry bool, renderedVersion string, err error) {
 	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
 	result := s.getDB(ctx).Take(&existingRecord)
 	if result.Error != nil {
@@ -1178,9 +1183,28 @@ func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name,
 		"resource_version":      gorm.Expr("resource_version + 1"),
 		"render_timestamp":      time.Now(),
 	}
-	if updatedServiceConditions != nil {
-		updates["service_conditions"] = updatedServiceConditions
+
+	if mutateStatus != nil {
+		existingRecord.Annotations = model.MakeJSONMap(existingAnnotations)
+		apiDevice, convertErr := existingRecord.ToApiResource()
+		if convertErr != nil {
+			return false, "", convertErr
+		}
+		if mutateStatus(apiDevice) && apiDevice.Status != nil {
+			// apiDevice.Status.Conditions/DependencySync were merged in by ToApiResource above
+			// for the mutator's benefit (e.g. diffing SpecValid). Round-trip back through
+			// NewDeviceFromApiResource to split them back out into service_conditions before
+			// writing the status column, the same way every other device write does.
+			deviceOnlyRecord, convertErr := model.NewDeviceFromApiResource(apiDevice)
+			if convertErr != nil {
+				return false, "", convertErr
+			}
+			updates["status"] = deviceOnlyRecord.Status
+		}
 	}
+
+	// SpecValid=Valid is part of a successful render write (same CAS UPDATE).
+	updates["service_conditions"] = withSpecValidCondition(updatedServiceConditions, existingRecord.ServiceConditions)
 
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(updates)
 
@@ -1192,6 +1216,30 @@ func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name,
 		return true, "", flterrors.ErrNoRowsUpdated
 	}
 	return false, nextRenderedVersion, nil
+}
+
+// withSpecValidCondition returns service conditions for a successful render write,
+// starting from fingerprint updates when present, otherwise the existing row, and
+// setting SpecValid=Valid in the same payload.
+func withSpecValidCondition(fromFingerprints, existing *model.JSONField[model.ServiceConditions]) *model.JSONField[model.ServiceConditions] {
+	var sc model.ServiceConditions
+	switch {
+	case fromFingerprints != nil:
+		sc = fromFingerprints.Data
+	case existing != nil:
+		sc = existing.Data
+	}
+	var conditions []domain.Condition
+	if sc.Conditions != nil {
+		conditions = append(conditions, *sc.Conditions...)
+	}
+	domain.SetStatusCondition(&conditions, domain.Condition{
+		Type:   domain.ConditionTypeDeviceSpecValid,
+		Status: domain.ConditionStatusTrue,
+		Reason: "Valid",
+	})
+	sc.Conditions = &conditions
+	return model.MakeJSONField(sc)
 }
 
 // buildDependencySyncStatus merges new fingerprints with existing service conditions,
@@ -1238,13 +1286,13 @@ func buildDependencySyncStatus(existing *model.JSONField[model.ServiceConditions
 	return model.MakeJSONField(sc)
 }
 
-func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus RenderedStatusMutator) (string, error) {
 	var rv string
 
 	wrapper := func() (bool, error) {
 		var retry bool
 		var err error
-		retry, rv, err = s.updateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+		retry, rv, err = s.updateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate, mutateStatus)
 		return retry, err
 	}
 

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -207,7 +207,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	if device.Metadata.Owner == nil || *device.Metadata.Owner == "" {
 		status = t.deviceSvc.OverwriteDeviceRepositoryRefs(ctx, t.orgId, *device.Metadata.Name, referencedRepos...)
 		if status.Code != http.StatusOK {
-			return t.setStatus(ctx, fmt.Errorf("setting repository references: %s", status.Message))
+			return t.setErrorStatus(ctx, fmt.Errorf("setting repository references: %s", status.Message))
 		}
 	}
 
@@ -215,7 +215,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		if isPermanentRenderError(renderErr) {
 			t.markPermanentRenderFailure(ctx, specHash)
 		}
-		return t.setStatus(ctx, renderErr)
+		return t.setErrorStatus(ctx, renderErr)
 	}
 
 	renderedApplications, err := t.renderApplications(ctx)
@@ -223,7 +223,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		if isPermanentRenderError(err) {
 			t.markPermanentRenderFailure(ctx, specHash)
 		}
-		return t.setStatus(ctx, err)
+		return t.setErrorStatus(ctx, err)
 	}
 
 	var syncRefs []domain.DependencySyncConfigRefStatus
@@ -237,8 +237,13 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 
 	// forceUpdate tells the store layer to persist this render and bump the rendered version
 	// even though specHash is unchanged (see bypassHashCheck above).
+	// On success, UpdateRenderedDevice persists SpecValid=Valid (and derived status when the
+	// rendered version advances). setErrorStatus is only needed for failure paths.
 	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(renderedConfig), string(renderedApplications), specHash, syncRefs, bypassHashCheck)
-	return t.setStatus(ctx, common.ApiStatusToErr(status))
+	if err := common.ApiStatusToErr(status); err != nil {
+		return t.setErrorStatus(ctx, err)
+	}
+	return nil
 }
 
 func (t *DeviceRenderLogic) markPermanentRenderFailure(ctx context.Context, specHash string) {
@@ -255,16 +260,14 @@ func (t *DeviceRenderLogic) markPermanentRenderFailure(ctx context.Context, spec
 	}
 }
 
-func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {
-	condition := domain.Condition{Type: domain.ConditionTypeDeviceSpecValid}
-
-	if renderErr == nil {
-		condition.Status = domain.ConditionStatusTrue
-		condition.Reason = "Valid"
-	} else {
-		condition.Status = domain.ConditionStatusFalse
-		condition.Reason = "Invalid"
-		condition.Message = renderErr.Error()
+// setErrorStatus records a render failure as SpecValid=False. All call sites already gate
+// on a non-nil error, so renderErr is always expected to be set.
+func (t *DeviceRenderLogic) setErrorStatus(ctx context.Context, renderErr error) error {
+	condition := domain.Condition{
+		Type:    domain.ConditionTypeDeviceSpecValid,
+		Status:  domain.ConditionStatusFalse,
+		Reason:  "Invalid",
+		Message: renderErr.Error(),
 	}
 
 	status := t.deviceSvc.SetDeviceServiceConditions(ctx, t.orgId, t.event.InvolvedObject.Name, []domain.Condition{condition})

--- a/test/integration/rollout/device_selection/device_selection_test.go
+++ b/test/integration/rollout/device_selection/device_selection_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 			condition = &device.Status.Conditions[len(device.Status.Conditions)-1]
 		}
 		condition.Reason = "Error"
-		_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, device, nil)
+		_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, device, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
@@ -405,7 +405,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 				for i := range devices.Items {
 					device := &devices.Items[i]
 					device.Status.Summary.Status = "Online"
-					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, device, nil)
+					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, device, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}
@@ -616,7 +616,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 				for i := range devices.Items {
 					d := devices.Items[i]
 					d.Status.Summary.Status = "Online"
-					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil)
+					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}
@@ -643,7 +643,7 @@ var _ = Describe("Rollout batch sequence test", func() {
 				}
 				Expect(deviceStore.UpdateAnnotations(ctx, store.NullOrgId, lo.FromPtr(d.Metadata.Name), annotations, nil)).ToNot(HaveOccurred())
 				d.Status.Config.RenderedVersion = renderedVersion
-				_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil)
+				_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		}

--- a/test/integration/rollout/disruption_budget/disruptions_budget_test.go
+++ b/test/integration/rollout/disruption_budget/disruptions_budget_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 				for i := range devices.Items {
 					d := devices.Items[i]
 					d.Status.Summary.Status = "Online"
-					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil)
+					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 					annotations := make(map[string]string)
 					if annotateTv {
@@ -275,7 +275,7 @@ var _ = Describe("Rollout disruption budget test", func() {
 					annotations[api.DeviceAnnotationRenderedVersion] = "5"
 					Expect(deviceStore.UpdateAnnotations(ctx, store.NullOrgId, lo.FromPtr(d.Metadata.Name), annotations, nil)).ToNot(HaveOccurred())
 					d.Status.Config.RenderedVersion = "5"
-					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil)
+					_, err = deviceStore.UpdateStatus(ctx, store.NullOrgId, &d, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -1722,7 +1722,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			dev1, err := deviceStore.Get(ctx, suite.OrgID, device1Name)
 			Expect(err).ToNot(HaveOccurred())
 			dev1.Status.Summary.Status = api.DeviceSummaryStatusUnknown
-			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev1, nil)
+			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev1, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Device 2: Before cutoff, Unknown → should not be returned
@@ -1738,7 +1738,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			dev2, err := deviceStore.Get(ctx, suite.OrgID, device2Name)
 			Expect(err).ToNot(HaveOccurred())
 			dev2.Status.Summary.Status = api.DeviceSummaryStatusUnknown
-			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev2, nil)
+			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev2, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Device 3: After cutoff, Online → should not be returned
@@ -1756,7 +1756,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			dev3.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			dev3.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 			dev3.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev3, nil)
+			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev3, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Device 4: Before cutoff, Online → should be returned (disconnected)
@@ -1774,7 +1774,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			dev4.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			dev4.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 			dev4.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev4, nil)
+			_, err = deviceStore.UpdateStatus(ctx, suite.OrgID, dev4, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			params := api.ListDevicesParams{

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -951,7 +951,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			// Give device rendered content (version 1)
 			renderedConfig, err := createMinimalRenderedConfig("test-config")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", nil, false)
+			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set device annotations: AwaitingReconnect and service version 1 (device 5 > service 1 -> ConflictPaused)
@@ -1002,7 +1002,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 			renderedConfig, err := createMinimalRenderedConfig("test-config-2")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash2", nil, false)
+			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash2", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = suite.DeviceStore.UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
@@ -1579,6 +1579,64 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		)
 
 	})
+
+	Context("UpdateRenderedDevice", func() {
+		var (
+			testKvStore    kvstore.KVStore
+			queuesProvider queues.Provider
+		)
+
+		BeforeEach(func() {
+			var err error
+			if testKvStore == nil {
+				testKvStore, err = kvstore.NewKVStore(suite.Ctx, suite.Log, redisHost, redisPort, redisPassword)
+				Expect(err).ToNot(HaveOccurred())
+				processID := fmt.Sprintf("update-rendered-device-test-%s", uuid.New().String())
+				queuesProvider, err = queues.NewRedisProvider(suite.Ctx, suite.Log, processID, redisHost, redisPort, redisPassword, queues.DefaultRetryConfig())
+				Expect(err).ToNot(HaveOccurred())
+				err = rendered.Bus.Initialize(suite.Ctx, testKvStore, queuesProvider, 10*time.Second, suite.Log)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		buildRenderedConfig := func(contents string) (string, error) {
+			provider := api.ConfigProviderSpec{}
+			if err := provider.FromInlineConfigProviderSpec(api.InlineConfigProviderSpec{Inline: []api.FileSpec{{Content: contents}}}); err != nil {
+				return "", err
+			}
+			b, err := json.Marshal(&[]api.ConfigProviderSpec{provider})
+			return string(b), err
+		}
+
+		It("persists a new rendered version, updates derived status/SpecValid, and emits events", func() {
+			deviceName := "update-rendered-device-success"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fedora/fedora-coreos:stable"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			renderedConfig, err := buildRenderedConfig("update-rendered-device-config")
+			Expect(err).ToNot(HaveOccurred())
+
+			status = suite.Device.UpdateRenderedDevice(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", nil, false)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			updated, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Version()).To(Equal("1"))
+			specValid := domain.FindStatusCondition(updated.Status.Conditions, domain.ConditionTypeDeviceSpecValid)
+			Expect(specValid).ToNot(BeNil())
+			Expect(specValid.Status).To(Equal(domain.ConditionStatusTrue))
+
+			// First render of a fresh device: SpecValid goes from absent to True, which
+			// EmitSpecValidEvents reports as a DeviceSpecValidEvent.
+			events := getEventsForDevice(deviceName)
+			specValidEvent := findEventByReason(events, api.EventReasonDeviceSpecValid)
+			Expect(specValidEvent).ToNot(BeNil())
+		})
+	})
 })
 
 var _ = Describe("Device LastSeen Integration Tests", func() {
@@ -1900,7 +1958,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash1", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash1", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Prime the KV rendered-version to match what the agent reports.
@@ -1932,7 +1990,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash2", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash2", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			renderedKey := fmt.Sprintf("v1/%s/device/%s/rendered", suite.OrgID, deviceName)
@@ -1972,7 +2030,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash3", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash3", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Pin the DeviceAnnotationRenderedVersion annotation to a known value.
@@ -2016,7 +2074,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash4", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash4", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set console annotation to simulate an open console session.
@@ -2047,7 +2105,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash5", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash5", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = suite.DeviceStore.UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -1249,6 +1249,37 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(forcedVersion).ToNot(Equal(firstVersion))
 		})
 
+		It("SetServiceConditions skips write and callback when conditions are unchanged", func() {
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-svc-conditions-noop", nil, nil, nil)
+
+			condition := domain.Condition{
+				Type:    domain.ConditionTypeDeviceSpecValid,
+				Status:  domain.ConditionStatusTrue,
+				Reason:  "Valid",
+				Message: "Valid",
+			}
+			callbackCalls := 0
+			callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
+				callbackCalls++
+			}
+
+			err := devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(callbackCalls).To(Equal(1))
+
+			afterWrite, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
+			Expect(err).ToNot(HaveOccurred())
+			resourceVersion := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
+
+			err = devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(callbackCalls).To(Equal(1))
+
+			afterNoop, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(resourceVersion))
+		})
+
 		It("OverwriteRepositoryRefs", func() {
 			repositoryStore := repositorystore.NewRepositoryStore(db, log.WithField("pkg", "repository-store"))
 			err := testutil.CreateRepositories(ctx, 2, repositoryStore, orgId)

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -232,7 +232,7 @@ var _ = Describe("DeviceStore create", func() {
 					d.Status.Capabilities = nil
 					expectedOsModeMap[model.CapabilityCountUnknown]++
 				}
-				_, err = devStore.UpdateStatus(ctx, orgId, d, nil)
+				_, err = devStore.UpdateStatus(ctx, orgId, d, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 			}
 			allDevices, err = devStore.List(ctx, orgId, devicestore.DeviceListParams{})
@@ -325,9 +325,9 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("List with status.capabilities.osMode field filter", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-package", nil, nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-image", nil, nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-absent", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-package", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-image", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-absent", nil, nil)
 
 			setOsMode := func(name string, mode *api.OsModeType) {
 				status := api.NewDeviceStatus()
@@ -338,7 +338,7 @@ var _ = Describe("DeviceStore create", func() {
 					Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
 					Status:   &status,
 				}
-				_, err := devStore.UpdateStatus(ctx, orgId, &device, nil)
+				_, err := devStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -413,9 +413,9 @@ var _ = Describe("DeviceStore create", func() {
 			findingStore := vulnerabilityfindingstore.NewVulnerabilityFindingStore(db, log.WithField("pkg", "vulnerabilityfinding-store"))
 
 			// Create devices with OS image digests
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-with-cve", nil, nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-without-cve", nil, nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-no-digest", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-with-cve", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-without-cve", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-no-digest", nil, nil)
 
 			// Set OS digests for two devices
 			digest1 := "sha256:aaaa1111"
@@ -490,8 +490,8 @@ var _ = Describe("DeviceStore create", func() {
 			findingStore := vulnerabilityfindingstore.NewVulnerabilityFindingStore(db, log.WithField("pkg", "vulnerabilityfinding-store"))
 			digest := "sha256:cve-fs-digest"
 
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-enrolled", nil, nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-not-enrolled", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-enrolled", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-not-enrolled", nil, nil)
 
 			setDeviceOsDigest(ctx, devStore, orgId, "device-cve-fs-enrolled", digest)
 			setDeviceOsDigest(ctx, devStore, orgId, "device-cve-fs-not-enrolled", digest)
@@ -499,7 +499,7 @@ var _ = Describe("DeviceStore create", func() {
 			enrolled, err := devStore.Get(ctx, orgId, "device-cve-fs-enrolled")
 			Expect(err).ToNot(HaveOccurred())
 			enrolled.Status.Lifecycle.Status = api.DeviceLifecycleStatusEnrolled
-			_, err = devStore.UpdateStatus(ctx, orgId, enrolled, nil)
+			_, err = devStore.UpdateStatus(ctx, orgId, enrolled, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			notEnrolledDev, err := devStore.Get(ctx, orgId, "device-cve-fs-not-enrolled")
@@ -814,7 +814,7 @@ var _ = Describe("DeviceStore create", func() {
 				Status: &status,
 			}
 			api.SetStatusCondition(&device.Status.Conditions, condition)
-			_, err := devStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err := devStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			dev, err := devStore.Get(ctx, orgId, "mydevice-1")
 			Expect(err).ToNot(HaveOccurred())
@@ -1159,7 +1159,7 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("GetRendered", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev", nil, nil)
 
 			// No rendered version
 			_, err := devStore.GetRendered(ctx, orgId, "dev", nil, "")
@@ -1225,7 +1225,7 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("UpdateRendered forceUpdate bypasses the specUnchanged short-circuit", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-force-update", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-force-update", nil, nil)
 
 			config, err := createTestConfigProvider("initial config")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -325,9 +325,9 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("List with status.capabilities.osMode field filter", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-package", nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-image", nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-absent", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-package", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-image", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "osmode-absent", nil, nil, nil)
 
 			setOsMode := func(name string, mode *api.OsModeType) {
 				status := api.NewDeviceStatus()
@@ -413,9 +413,9 @@ var _ = Describe("DeviceStore create", func() {
 			findingStore := vulnerabilityfindingstore.NewVulnerabilityFindingStore(db, log.WithField("pkg", "vulnerabilityfinding-store"))
 
 			// Create devices with OS image digests
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-with-cve", nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-without-cve", nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-no-digest", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-with-cve", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-without-cve", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-no-digest", nil, nil, nil)
 
 			// Set OS digests for two devices
 			digest1 := "sha256:aaaa1111"
@@ -490,8 +490,8 @@ var _ = Describe("DeviceStore create", func() {
 			findingStore := vulnerabilityfindingstore.NewVulnerabilityFindingStore(db, log.WithField("pkg", "vulnerabilityfinding-store"))
 			digest := "sha256:cve-fs-digest"
 
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-enrolled", nil, nil)
-			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-not-enrolled", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-enrolled", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "device-cve-fs-not-enrolled", nil, nil, nil)
 
 			setDeviceOsDigest(ctx, devStore, orgId, "device-cve-fs-enrolled", digest)
 			setDeviceOsDigest(ctx, devStore, orgId, "device-cve-fs-not-enrolled", digest)
@@ -1159,7 +1159,7 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("GetRendered", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev", nil, nil, nil)
 
 			// No rendered version
 			_, err := devStore.GetRendered(ctx, orgId, "dev", nil, "")
@@ -1225,7 +1225,7 @@ var _ = Describe("DeviceStore create", func() {
 		})
 
 		It("UpdateRendered forceUpdate bypasses the specUnchanged short-circuit", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-force-update", nil, nil)
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-force-update", nil, nil, nil)
 
 			config, err := createTestConfigProvider("initial config")
 			Expect(err).ToNot(HaveOccurred())

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -1170,7 +1170,7 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set first rendered config
-			_, err = devStore.UpdateRendered(ctx, orgId, "dev", firstConfig, "", "hash1", nil, false)
+			_, err = devStore.UpdateRendered(ctx, orgId, "dev", firstConfig, "", "hash1", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify rendered config is encrypted at rest
@@ -1208,7 +1208,7 @@ var _ = Describe("DeviceStore create", func() {
 			// Set second rendered config
 			secondConfig, err := createTestConfigProvider("this is the second config")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = devStore.UpdateRendered(ctx, orgId, "dev", secondConfig, "", "hash2", nil, false)
+			_, err = devStore.UpdateRendered(ctx, orgId, "dev", secondConfig, "", "hash2", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Passing previous renderedVersion
@@ -1231,19 +1231,19 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Establish an initial rendered version for a given specHash.
-			firstVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false)
+			firstVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(firstVersion).ToNot(BeEmpty())
 
 			// Same specHash, no config fingerprints, forceUpdate=false: short-circuits as a no-op.
-			noopVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false)
+			noopVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(noopVersion).To(BeEmpty())
 
 			// Same specHash, no config fingerprints, forceUpdate=true: must still persist and
 			// advance the rendered version, e.g. to reflect a device-level application lifecycle
 			// annotation change that isn't captured by specHash at all.
-			forcedVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, true)
+			forcedVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, true, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(forcedVersion).ToNot(BeEmpty())
 			Expect(forcedVersion).ToNot(Equal(firstVersion))
@@ -1278,6 +1278,67 @@ var _ = Describe("DeviceStore create", func() {
 			afterNoop, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(resourceVersion))
+		})
+
+		It("UpdateRendered persists status in the same resource_version bump", func() {
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-render-status", nil, nil, nil)
+
+			before, err := devStore.Get(ctx, orgId, "dev-render-status")
+			Expect(err).ToNot(HaveOccurred())
+			beforeRV := lo.FromPtr(before.Metadata.ResourceVersion)
+			beforeConditionCount := len(before.Status.Conditions)
+
+			config, err := createTestConfigProvider("rendered with status")
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatorCalls := 0
+			version, err := devStore.UpdateRendered(ctx, orgId, "dev-render-status", config, "", "hash-status", nil, false,
+				func(device *domain.Device) bool {
+					mutatorCalls++
+					Expect(device.Version()).ToNot(BeEmpty())
+					if device.Status == nil {
+						device.Status = lo.ToPtr(domain.NewDeviceStatus())
+					}
+					device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
+					device.Status.Updated.Info = lo.ToPtr("rendered ahead of agent")
+					return true
+				})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).ToNot(BeEmpty())
+			Expect(mutatorCalls).To(Equal(1))
+
+			after, err := devStore.Get(ctx, orgId, "dev-render-status")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lo.FromPtr(after.Metadata.ResourceVersion)).ToNot(Equal(beforeRV))
+			Expect(after.Status.Updated.Status).To(Equal(domain.DeviceUpdatedStatusOutOfDate))
+			Expect(lo.FromPtr(after.Status.Updated.Info)).To(Equal("rendered ahead of agent"))
+			specValid := domain.FindStatusCondition(after.Status.Conditions, domain.ConditionTypeDeviceSpecValid)
+			Expect(specValid).ToNot(BeNil())
+			Expect(specValid.Status).To(Equal(domain.ConditionStatusTrue))
+			Expect(specValid.Reason).To(Equal("Valid"))
+			// SpecValid is newly added on top of whatever device-owned conditions already
+			// existed; it must not also duplicate itself (or any other service-managed
+			// condition) into the status column alongside service_conditions.
+			Expect(after.Status.Conditions).To(HaveLen(beforeConditionCount+1),
+				"the service-managed SpecValid condition must live only in service_conditions, not duplicated into status")
+
+			// A second render that also mutates status must not duplicate service-managed
+			// conditions (or DependencySync) into the status column on top of the first render.
+			config2, err := createTestConfigProvider("rendered with status, second render")
+			Expect(err).ToNot(HaveOccurred())
+			version2, err := devStore.UpdateRendered(ctx, orgId, "dev-render-status", config2, "", "hash-status-2", nil, false,
+				func(device *domain.Device) bool {
+					device.Status.Updated.Status = domain.DeviceUpdatedStatusUpdating
+					return true
+				})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version2).ToNot(BeEmpty())
+
+			afterSecond, err := devStore.Get(ctx, orgId, "dev-render-status")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(afterSecond.Status.Conditions).To(HaveLen(beforeConditionCount+1),
+				"repeated renders must not accumulate duplicate service-managed conditions in status")
+			Expect(afterSecond.Status.DependencySync).To(BeNil())
 		})
 
 		It("OverwriteRepositoryRefs", func() {

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -115,34 +115,34 @@ var _ = Describe("FleetStore create", func() {
 					Capabilities: &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModeImage)},
 				},
 			}
-			_, err := deviceStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err := deviceStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-2")
 			device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusDegraded
 			device.Status.Summary.Status = api.DeviceSummaryStatusDegraded
 			device.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModePackage)}
-			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-3")
 			device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
 			device.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			device.Status.Updated.Status = api.DeviceUpdatedStatusUpdating
 			device.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModeImage)}
-			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-4")
 			device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
 			device.Status.Summary.Status = api.DeviceSummaryStatusRebooting
 			device.Status.Updated.Status = api.DeviceUpdatedStatusUpdating
 			device.Status.Capabilities = nil
-			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-5")
 			device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusError
 			device.Status.Summary.Status = api.DeviceSummaryStatusError
 			device.Status.Updated.Status = api.DeviceUpdatedStatusUnknown
 			device.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModePackage)}
-			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			otherOrgId := uuid.New()

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -88,18 +88,18 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest2 := "sha256:bbbb2222"
 
 			// Create a device and set its OS status to include digest1.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-1", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-1", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-1", digest1)
 
 			// Create a second device in the same org with digest2.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-2", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-2", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-2", digest2)
 
 			// Create a third device in a different org with digest1 (duplicate, should collapse).
 			orgId2 := uuid.New()
 			err := testutil.CreateTestOrganization(ctx, organizationStore, orgId2)
 			Expect(err).ToNot(HaveOccurred())
-			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId2, "device-3", digest1)
 
 			digests, err := findingStore.ListDeployedImageDigests(ctx)
@@ -253,7 +253,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a new Critical CVE affects a device it should return a new action", func() {
 			digest := "sha256:newcve"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-new", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-new", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-new", digest)
 
 			// Insert the finding first
@@ -277,7 +277,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a CVE changes to not_affected it should return a resolved action", func() {
 			digest := "sha256:resolvedcve"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-resolved", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-resolved", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-resolved", digest)
 
 			// Insert a Critical finding first
@@ -309,7 +309,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a CVE severity upgrades from High to Critical it should return a supersede action", func() {
 			digest := "sha256:supersede"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-supersede", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-supersede", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-supersede", digest)
 
 			// Insert the finding
@@ -342,11 +342,11 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When multiple devices share the same digest it should return actions for all affected devices", func() {
 			digest := "sha256:multidevice"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-1", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-1", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-1", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-2", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-2", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-2", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-3", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-3", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-3", digest)
 
 			// Insert the finding
@@ -376,7 +376,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			newDigest := "sha256:newimage"
 
 			// Create device on NEW digest (simulating it already changed)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-image-change", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-image-change", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-image-change", newDigest)
 
 			// Insert findings for both digests
@@ -429,7 +429,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When CVE severity downgrades from Critical to Medium it should resolve the event", func() {
 			digest := "sha256:downgrade"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-downgrade", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-downgrade", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-downgrade", digest)
 
 			// Insert the finding with Medium severity
@@ -531,7 +531,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			published := time.Date(2024, 3, 10, 0, 0, 0, 0, time.UTC)
 
 			// Seed a device with the OS image digest.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-1", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-1", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-1", digest)
 
 			// Start a mock Trustify HTTP server.
@@ -572,7 +572,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest := "sha256:ddeeff445566"
 			published := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-2", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-2", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-2", digest)
 
 			// First sync: severity = "medium", score = 5.0.
@@ -614,9 +614,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			purlStr := "pkg:oci/test-image@" + digest
 
 			// Two devices, same digest.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3a", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3a", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-3a", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3b", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3b", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-3b", digest)
 
 			var purlListCallCount int32
@@ -695,7 +695,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("when a finding with Critical severity exists ListCriticalCVEEventCandidates returns the device", func() {
 			digest := "sha256:cve_list_sql_1"
 			score := 9.0
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-list-a", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-list-a", nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-cve-list-a", digest, "registry.example/os:v1")
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -731,9 +731,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			})
 			Expect(upsertErr).ToNot(HaveOccurred())
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-a", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-a", nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-shared-a", digest, "img:a")
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-b", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-b", nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-shared-b", digest, "img:b")
 
 			deviceCrit, err := findingStore.ListCriticalCVEEventCandidates(ctx)
@@ -746,7 +746,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("When a Critical severity finding exists it should create Device DeviceVulnerabilityCVECritical events", func() {
 			digest := "sha256:cve_lifecycle_evt_1"
 			score := 9.0
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-lifecycle", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-lifecycle", nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-cve-lifecycle", digest, "quay.io/example/os:9.4")
 
 			findings := []model.VulnerabilityFinding{
@@ -969,7 +969,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "ob-dev1", ownerB, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "ob-dev1", d2)
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "standalone-org", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "standalone-org", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "standalone-org", d2)
 
 			digests, err := findingStore.ListOrgDeviceImageDigests(ctx, orgId)
@@ -986,12 +986,12 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When devices belong to another org they should not be included", func() {
 			d := "sha256:org-scope-digest"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mine", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mine", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "mine", d)
 
 			org2 := uuid.New()
 			Expect(testutil.CreateTestOrganization(ctx, organizationStore, org2)).To(Succeed())
-			testutil.CreateTestDevice(ctx, deviceStore, org2, "theirs", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, org2, "theirs", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, org2, "theirs", d)
 
 			digests, err := findingStore.ListOrgDeviceImageDigests(ctx, orgId)
@@ -1010,12 +1010,12 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			advB := "RHSA-2024:TENANT-B"
 			desc := "tenant isolation scope"
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "tenant-a-dev", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "tenant-a-dev", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "tenant-a-dev", digestA)
 
 			orgB := uuid.New()
 			Expect(testutil.CreateTestOrganization(ctx, organizationStore, orgB)).To(Succeed())
-			testutil.CreateTestDevice(ctx, deviceStore, orgB, "tenant-b-dev", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgB, "tenant-b-dev", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgB, "tenant-b-dev", digestB)
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -1316,9 +1316,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			score := 8.0
 
 			// Create devices so the org has deployed digests
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev1", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev1", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev1", digest1)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev2", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev2", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev2", digest2)
 
 			// CVE-2024-SAME appears as High in digest1 and Critical in digest2
@@ -1348,7 +1348,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest := "sha256:org-sum-notaffected"
 			score := 5.0
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev-na", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev-na", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev-na", digest)
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -1411,7 +1411,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			setDeviceOsDigest(ctx, deviceStore, orgId, "impact-dev-3", digest2)
 
 			// Create a fleetless device with digest1
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "impact-dev-fleetless", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "impact-dev-fleetless", nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "impact-dev-fleetless", digest1)
 
 			// Upsert CVE findings for both digests
@@ -1549,7 +1549,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "detail-dev-3", digest1, "quay.io/os:v1-alt")
 
 			// Create a fleetless device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "detail-dev-fleetless", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "detail-dev-fleetless", nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "detail-dev-fleetless", digest1, "quay.io/os:v1")
 
 			// Upsert CVE findings
@@ -1776,6 +1776,6 @@ func setDeviceOsDigestWithImage(ctx context.Context, devStore devicestore.Store,
 	}
 	dev.Status = &status
 
-	_, err = devStore.UpdateStatus(ctx, orgId, dev, nil)
+	_, err = devStore.UpdateStatus(ctx, orgId, dev, nil, nil)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -88,18 +88,18 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest2 := "sha256:bbbb2222"
 
 			// Create a device and set its OS status to include digest1.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-1", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-1", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-1", digest1)
 
 			// Create a second device in the same org with digest2.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-2", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-2", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-2", digest2)
 
 			// Create a third device in a different org with digest1 (duplicate, should collapse).
 			orgId2 := uuid.New()
 			err := testutil.CreateTestOrganization(ctx, organizationStore, orgId2)
 			Expect(err).ToNot(HaveOccurred())
-			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId2, "device-3", digest1)
 
 			digests, err := findingStore.ListDeployedImageDigests(ctx)
@@ -253,7 +253,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a new Critical CVE affects a device it should return a new action", func() {
 			digest := "sha256:newcve"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-new", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-new", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-new", digest)
 
 			// Insert the finding first
@@ -277,7 +277,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a CVE changes to not_affected it should return a resolved action", func() {
 			digest := "sha256:resolvedcve"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-resolved", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-resolved", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-resolved", digest)
 
 			// Insert a Critical finding first
@@ -309,7 +309,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When a CVE severity upgrades from High to Critical it should return a supersede action", func() {
 			digest := "sha256:supersede"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-supersede", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-supersede", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-supersede", digest)
 
 			// Insert the finding
@@ -342,11 +342,11 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When multiple devices share the same digest it should return actions for all affected devices", func() {
 			digest := "sha256:multidevice"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-1", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-1", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-1", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-2", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-2", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-2", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-3", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-multi-3", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-multi-3", digest)
 
 			// Insert the finding
@@ -376,7 +376,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			newDigest := "sha256:newimage"
 
 			// Create device on NEW digest (simulating it already changed)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-image-change", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-image-change", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-image-change", newDigest)
 
 			// Insert findings for both digests
@@ -429,7 +429,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When CVE severity downgrades from Critical to Medium it should resolve the event", func() {
 			digest := "sha256:downgrade"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-downgrade", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-cve-downgrade", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-cve-downgrade", digest)
 
 			// Insert the finding with Medium severity
@@ -531,7 +531,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			published := time.Date(2024, 3, 10, 0, 0, 0, 0, time.UTC)
 
 			// Seed a device with the OS image digest.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-1", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-1", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-1", digest)
 
 			// Start a mock Trustify HTTP server.
@@ -572,7 +572,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest := "sha256:ddeeff445566"
 			published := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-2", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-2", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-2", digest)
 
 			// First sync: severity = "medium", score = 5.0.
@@ -614,9 +614,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			purlStr := "pkg:oci/test-image@" + digest
 
 			// Two devices, same digest.
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3a", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3a", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-3a", digest)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3b", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-e2e-3b", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "device-e2e-3b", digest)
 
 			var purlListCallCount int32
@@ -695,7 +695,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("when a finding with Critical severity exists ListCriticalCVEEventCandidates returns the device", func() {
 			digest := "sha256:cve_list_sql_1"
 			score := 9.0
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-list-a", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-list-a", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-cve-list-a", digest, "registry.example/os:v1")
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -731,9 +731,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			})
 			Expect(upsertErr).ToNot(HaveOccurred())
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-a", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-a", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-shared-a", digest, "img:a")
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-b", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-shared-b", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-shared-b", digest, "img:b")
 
 			deviceCrit, err := findingStore.ListCriticalCVEEventCandidates(ctx)
@@ -746,7 +746,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("When a Critical severity finding exists it should create Device DeviceVulnerabilityCVECritical events", func() {
 			digest := "sha256:cve_lifecycle_evt_1"
 			score := 9.0
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-lifecycle", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "dev-cve-lifecycle", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "dev-cve-lifecycle", digest, "quay.io/example/os:9.4")
 
 			findings := []model.VulnerabilityFinding{
@@ -969,7 +969,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "ob-dev1", ownerB, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "ob-dev1", d2)
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "standalone-org", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "standalone-org", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "standalone-org", d2)
 
 			digests, err := findingStore.ListOrgDeviceImageDigests(ctx, orgId)
@@ -986,12 +986,12 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 		It("When devices belong to another org they should not be included", func() {
 			d := "sha256:org-scope-digest"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mine", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mine", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "mine", d)
 
 			org2 := uuid.New()
 			Expect(testutil.CreateTestOrganization(ctx, organizationStore, org2)).To(Succeed())
-			testutil.CreateTestDevice(ctx, deviceStore, org2, "theirs", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, org2, "theirs", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, org2, "theirs", d)
 
 			digests, err := findingStore.ListOrgDeviceImageDigests(ctx, orgId)
@@ -1010,12 +1010,12 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			advB := "RHSA-2024:TENANT-B"
 			desc := "tenant isolation scope"
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "tenant-a-dev", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "tenant-a-dev", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "tenant-a-dev", digestA)
 
 			orgB := uuid.New()
 			Expect(testutil.CreateTestOrganization(ctx, organizationStore, orgB)).To(Succeed())
-			testutil.CreateTestDevice(ctx, deviceStore, orgB, "tenant-b-dev", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgB, "tenant-b-dev", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgB, "tenant-b-dev", digestB)
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -1316,9 +1316,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			score := 8.0
 
 			// Create devices so the org has deployed digests
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev1", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev1", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev1", digest1)
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev2", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev2", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev2", digest2)
 
 			// CVE-2024-SAME appears as High in digest1 and Critical in digest2
@@ -1348,7 +1348,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			digest := "sha256:org-sum-notaffected"
 			score := 5.0
 
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev-na", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "org-sum-dev-na", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "org-sum-dev-na", digest)
 
 			_, upsertErr := findingStore.UpsertFindings(ctx, []model.VulnerabilityFinding{
@@ -1411,7 +1411,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			setDeviceOsDigest(ctx, deviceStore, orgId, "impact-dev-3", digest2)
 
 			// Create a fleetless device with digest1
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "impact-dev-fleetless", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "impact-dev-fleetless", nil, nil, nil)
 			setDeviceOsDigest(ctx, deviceStore, orgId, "impact-dev-fleetless", digest1)
 
 			// Upsert CVE findings for both digests
@@ -1549,7 +1549,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "detail-dev-3", digest1, "quay.io/os:v1-alt")
 
 			// Create a fleetless device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "detail-dev-fleetless", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "detail-dev-fleetless", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "detail-dev-fleetless", digest1, "quay.io/os:v1")
 
 			// Upsert CVE findings

--- a/test/integration/tasks/device_connection_test.go
+++ b/test/integration/tasks/device_connection_test.go
@@ -91,7 +91,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create devices that have checked in recently
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("connected-device-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -127,7 +127,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create devices that haven't checked in for a while
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("disconnected-device-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -169,7 +169,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create connected devices
 			for i := 1; i <= 2; i++ {
 				deviceName := fmt.Sprintf("connected-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -190,7 +190,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create disconnected devices
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("disconnected-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -238,7 +238,7 @@ var _ = Describe("DeviceConnection", func() {
 		BeforeEach(func() {
 			// Create a device that's right at the disconnection threshold
 			deviceName := "threshold-device"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
 
 			// Get the device and update its status
 			device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -270,7 +270,7 @@ var _ = Describe("DeviceConnection", func() {
 		BeforeEach(func() {
 			// Create a mix of devices with different last seen times
 			// Recent device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "recent-device", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "recent-device", nil, nil, nil)
 			recentDevice, err := deviceStore.Get(ctx, orgId, "recent-device")
 			Expect(err).ToNot(HaveOccurred())
 			recentDevice.Status.Summary.Status = api.DeviceSummaryStatusOnline
@@ -285,7 +285,7 @@ var _ = Describe("DeviceConnection", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Old device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "old-device", nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "old-device", nil, nil, nil)
 			oldDevice, err := deviceStore.Get(ctx, orgId, "old-device")
 			Expect(err).ToNot(HaveOccurred())
 			oldDevice.Status.Summary.Status = api.DeviceSummaryStatusOnline

--- a/test/integration/tasks/device_connection_test.go
+++ b/test/integration/tasks/device_connection_test.go
@@ -91,7 +91,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create devices that have checked in recently
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("connected-device-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -99,7 +99,7 @@ var _ = Describe("DeviceConnection", func() {
 
 				// Set device status to online
 				device.Status.Summary.Status = api.DeviceSummaryStatusOnline
-				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil)
+				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Set a recent last seen time directly in the database
@@ -127,7 +127,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create devices that haven't checked in for a while
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("disconnected-device-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -137,7 +137,7 @@ var _ = Describe("DeviceConnection", func() {
 				device.Status.Summary.Status = api.DeviceSummaryStatusOnline
 				device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 				device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil)
+				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Set an old last seen time directly in the database (more than DeviceDisconnectedTimeout ago)
@@ -169,7 +169,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create connected devices
 			for i := 1; i <= 2; i++ {
 				deviceName := fmt.Sprintf("connected-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -178,7 +178,7 @@ var _ = Describe("DeviceConnection", func() {
 				device.Status.Summary.Status = api.DeviceSummaryStatusOnline
 				device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 				device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil)
+				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Set a recent last seen time directly in the database
@@ -190,7 +190,7 @@ var _ = Describe("DeviceConnection", func() {
 			// Create disconnected devices
 			for i := 1; i <= 3; i++ {
 				deviceName := fmt.Sprintf("disconnected-%d", i)
-				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
+				testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
 
 				// Get the device and update its status
 				device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -199,7 +199,7 @@ var _ = Describe("DeviceConnection", func() {
 				device.Status.Summary.Status = api.DeviceSummaryStatusOnline
 				device.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 				device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil)
+				_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Set an old last seen time directly in the database
@@ -238,7 +238,7 @@ var _ = Describe("DeviceConnection", func() {
 		BeforeEach(func() {
 			// Create a device that's right at the disconnection threshold
 			deviceName := "threshold-device"
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, nil, nil)
 
 			// Get the device and update its status
 			device, err := deviceStore.Get(ctx, orgId, deviceName)
@@ -246,7 +246,7 @@ var _ = Describe("DeviceConnection", func() {
 
 			// Set device status to online
 			device.Status.Summary.Status = api.DeviceSummaryStatusOnline
-			_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, device, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set last seen to exactly the disconnection timeout directly in the database
@@ -270,13 +270,13 @@ var _ = Describe("DeviceConnection", func() {
 		BeforeEach(func() {
 			// Create a mix of devices with different last seen times
 			// Recent device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "recent-device", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "recent-device", nil, nil)
 			recentDevice, err := deviceStore.Get(ctx, orgId, "recent-device")
 			Expect(err).ToNot(HaveOccurred())
 			recentDevice.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			recentDevice.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 			recentDevice.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-			_, err = deviceStore.UpdateStatus(ctx, orgId, recentDevice, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, recentDevice, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set a recent last seen time directly in the database
@@ -285,13 +285,13 @@ var _ = Describe("DeviceConnection", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Old device
-			testutil.CreateTestDevice(ctx, deviceStore, orgId, "old-device", nil, nil, nil)
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "old-device", nil, nil)
 			oldDevice, err := deviceStore.Get(ctx, orgId, "old-device")
 			Expect(err).ToNot(HaveOccurred())
 			oldDevice.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			oldDevice.Status.Updated.Status = api.DeviceUpdatedStatusUpToDate
 			oldDevice.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
-			_, err = deviceStore.UpdateStatus(ctx, orgId, oldDevice, nil)
+			_, err = deviceStore.UpdateStatus(ctx, orgId, oldDevice, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set an old last seen time directly in the database


### PR DESCRIPTION
## Summary
- Avoid re-fetching the device in `UpdateStatus` when callers already have a pre-update snapshot (`ReplaceDeviceStatus`, server-side status updates).
- Persist rendered config and derived status atomically via an `UpdateRendered` status mutator: apply `SpecValid=Valid`, compute server-side status against that committed condition set, and write both in the same CAS update.
- Skip no-op `SetServiceConditions` DB writes and callbacks when conditions are unchanged (common on worker render when SpecValid is already Valid).
- Treat `StoreAndNotify` as best-effort after a successful persist so a notify failure cannot flip freshly committed `SpecValid=Valid` back to False via `setErrorStatus`.
- Keep `setErrorStatus` for actual render/validation failures only (renamed from the old catch-all `setStatus` path).

## Release target
- release-1.3

## Test plan
- [x] `go test ./internal/store/device/ ./internal/service/device/ ./internal/tasks/ -count=1`
- [x] Compile `./test/integration/store/` and `./test/integration/tasks/`
- [x] Store integration: no-op `SetServiceConditions` leaves `resourceVersion`/callback unchanged
- [x] Integration coverage for `UpdateRenderedDevice` success path (rendered version, events, notify)
- [ ] Broader e2e as needed for status update and device-render paths

## Measured improvement
vs `v1.3.0-main-335-g94098fd2`:

| | Before | After |
|---|---|---|
| Duration | 22m (1370s) | 9m (587s) |
| Rollout rate | 7.3 devices/s | 17.04 devices/s |