### PR TITLE
EDM-4775: Encrypt device rendered config and applications at rest

### DIFF
--- a/internal/instrumentation/encryption/gorm_plugin.go
+++ b/internal/instrumentation/encryption/gorm_plugin.go
@@ -80,7 +80,7 @@ func (p *Plugin) beforeSave(tx *gorm.DB) {
 	val := reflect.ValueOf(dest)
 
 	// Dereference pointer if needed (GORM passes *[]T for batch creates).
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -98,12 +98,6 @@ func (p *Plugin) beforeSave(tx *gorm.DB) {
 				return
 			}
 		}
-		return
-	}
-
-	// Partial updates (map[string]interface{}, etc.) don't carry the full model.
-	// Only encrypt pointer-to-struct, the normal single-model create/update path.
-	if val.Kind() != reflect.Struct {
 		return
 	}
 

--- a/internal/instrumentation/encryption/gorm_plugin_test.go
+++ b/internal/instrumentation/encryption/gorm_plugin_test.go
@@ -37,7 +37,7 @@ func TestPlugin_Name(t *testing.T) {
 func TestPlugin_Initialize_Success(t *testing.T) {
 	mgr := createTestManager(t)
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			return nil
 		},
 	}
@@ -53,7 +53,7 @@ func TestPlugin_Initialize_Success(t *testing.T) {
 
 func TestPlugin_Initialize_NilManager(t *testing.T) {
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			return nil
 		},
 	}
@@ -74,7 +74,7 @@ func TestPlugin_HandlerCalled_OnCreate(t *testing.T) {
 
 	handlerCalled := false
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			handlerCalled = true
 			user := v.(*TestUser)
 			if user.Password != "" {
@@ -108,7 +108,7 @@ func TestPlugin_HandlerCalled_OnUpdate(t *testing.T) {
 
 	callCount := 0
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			callCount++
 			user := v.(*TestUser)
 			if user.Password != "" {
@@ -168,7 +168,7 @@ func TestPlugin_HandlerError_PropagatesError(t *testing.T) {
 	mgr := createTestManager(t)
 
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			return assert.AnError // Simulate handler error
 		},
 	}
@@ -193,11 +193,11 @@ func TestPlugin_MultipleModels_CorrectHandler(t *testing.T) {
 	repoHandlerCalled := false
 
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			userHandlerCalled = true
 			return nil
 		},
-		"TestRepository": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestRepository": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			repoHandlerCalled = true
 			return nil
 		},
@@ -229,7 +229,7 @@ func TestPlugin_UsesProcessEncryption(t *testing.T) {
 	var encryptFuncReceived EncryptFunc
 
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			encryptFuncReceived = encrypt
 			return nil
 		},
@@ -259,7 +259,7 @@ func TestPlugin_BatchCreate_HandlerCalledForSlice(t *testing.T) {
 	var callCount int
 
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			user, ok := v.(*TestUser)
 			if !ok {
 				return fmt.Errorf("expected *TestUser, got %T", v)
@@ -299,7 +299,7 @@ func TestPlugin_NilContext_UsesBackground(t *testing.T) {
 	var ctxReceived context.Context
 
 	handlers := map[string]ModelEncryptHandler{
-		"TestUser": func(ctx context.Context, v interface{}, encrypt EncryptFunc) error {
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
 			ctxReceived = ctx
 			return nil
 		},
@@ -312,6 +312,41 @@ func TestPlugin_NilContext_UsesBackground(t *testing.T) {
 	db.Create(&user)
 
 	assert.NotNil(t, ctxReceived, "Handler should receive a context even if Statement.Context is nil")
+}
+
+func TestPlugin_MapUpdate_HandlerCalled(t *testing.T) {
+	mgr := createTestManager(t)
+
+	handlerCalled := false
+	handlers := map[string]ModelEncryptHandler{
+		"TestUser": func(ctx context.Context, v any, encrypt EncryptFunc) error {
+			m, ok := v.(map[string]any)
+			if !ok {
+				return nil
+			}
+			handlerCalled = true
+			if pw, ok := m["password"].(string); ok && pw != "" {
+				encrypted, err := encrypt(ctx, []byte(pw))
+				if err != nil {
+					return err
+				}
+				m["password"] = string(encrypted)
+			}
+			return nil
+		},
+	}
+
+	db := setupTestDB(t, mgr, handlers)
+
+	user := TestUser{Name: "Eve", Password: "original", Email: "eve@example.com"}
+	db.Create(&user)
+	handlerCalled = false
+
+	result := db.Model(&user).Updates(map[string]any{
+		"password": "newpass",
+	})
+	require.NoError(t, result.Error)
+	assert.True(t, handlerCalled, "Handler should be called for map-based Updates")
 }
 
 // Helper functions

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1255,7 +1255,7 @@ func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name str
 		return nil, store.ErrorFromGormError(result.Error)
 	}
 
-	return deviceModel.ToApiResource(model.WithRendered(knownRenderedVersion))
+	return deviceModel.ToApiResource(model.WithRendered(ctx, knownRenderedVersion))
 }
 
 func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -28,14 +31,15 @@ type Device struct {
 	// Conditions set by the service, as opposed to the agent.
 	ServiceConditions *JSONField[ServiceConditions] `gorm:"type:jsonb"`
 
-	// The rendered device config
-	RenderedConfig *JSONField[*[]domain.ConfigProviderSpec] `gorm:"type:jsonb"`
+	// Encrypted at rest as a whole blob. The existing DB column is jsonb;
+	// keeping the tag prevents GORM from attempting a column type migration.
+	RenderedConfig *JSONField[json.RawMessage] `gorm:"type:jsonb"`
 
 	// Timestamp when the device was rendered
 	RenderTimestamp time.Time
 
-	// The rendered application provided by the service.
-	RenderedApplications *JSONField[*[]domain.ApplicationProviderSpec] `gorm:"type:jsonb"`
+	// Encrypted at rest as a whole blob (see RenderedConfig).
+	RenderedApplications *JSONField[json.RawMessage] `gorm:"type:jsonb"`
 
 	// Join table with the relationship of devices to repositories (only maintained for standalone devices)
 	Repositories []Repository `gorm:"many2many:device_repos;constraint:OnDelete:CASCADE;"`
@@ -155,6 +159,28 @@ func DeviceAPIVersion() string {
 	return fmt.Sprintf("%s/%s", domain.APIGroup, domain.DeviceAPIVersion)
 }
 
+// decryptRenderedField decrypts a rendered config or applications field stored
+// as jsonb. The RawMessage holds the raw JSON token: a quoted string for
+// encrypted data ("enc:v1:default:...") or a bare array for legacy plaintext.
+func decryptRenderedField(ctx context.Context, field *JSONField[json.RawMessage]) ([]byte, error) {
+	if field == nil || len(field.Data) == 0 {
+		return nil, nil
+	}
+	raw := []byte(field.Data)
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	// Encrypted: RawMessage is a JSON string "enc:v1:default:...".
+	// Unmarshal extracts the inner string for decryption.
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		decrypted, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(str))
+		return decrypted, err
+	}
+	// BC: unencrypted legacy data is a bare JSON array, e.g. [{...}]
+	return raw, nil
+}
+
 func (d *Device) ToApiResource(opts ...APIResourceOption) (*domain.Device, error) {
 	if d == nil {
 		return &domain.Device{}, nil
@@ -171,6 +197,11 @@ func (d *Device) ToApiResource(opts ...APIResourceOption) (*domain.Device, error
 	}
 
 	if apiOpts.isRendered {
+		ctx := apiOpts.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
 		annotations := util.EnsureMap(d.Annotations)
 		renderedVersion, ok := annotations[domain.DeviceAnnotationRenderedVersion]
 		if !ok {
@@ -204,9 +235,26 @@ func (d *Device) ToApiResource(opts ...APIResourceOption) (*domain.Device, error
 			}
 		}
 		// TODO: handle multiple consoles, for now we just encapsulate our one console in a list
-		spec.Config = d.RenderedConfig.Data
-		spec.Applications = d.RenderedApplications.Data
 		spec.Consoles = &consoles
+
+		if data, err := decryptRenderedField(ctx, d.RenderedConfig); err != nil {
+			return nil, fmt.Errorf("decrypt rendered config: %w", err)
+		} else if data != nil {
+			var config []domain.ConfigProviderSpec
+			if err := json.Unmarshal(data, &config); err != nil {
+				return nil, fmt.Errorf("unmarshal rendered config: %w", err)
+			}
+			spec.Config = &config
+		}
+		if data, err := decryptRenderedField(ctx, d.RenderedApplications); err != nil {
+			return nil, fmt.Errorf("decrypt rendered applications: %w", err)
+		} else if data != nil {
+			var apps []domain.ApplicationProviderSpec
+			if err := json.Unmarshal(data, &apps); err != nil {
+				return nil, fmt.Errorf("unmarshal rendered applications: %w", err)
+			}
+			spec.Applications = &apps
+		}
 	}
 
 	status := domain.NewDeviceStatus()

--- a/internal/store/model/encryption.go
+++ b/internal/store/model/encryption.go
@@ -127,20 +127,8 @@ func genericEncryptHandler(kind string) encryption.ModelEncryptHandler {
 			return nil
 		}
 
-		modifiedBytes, err := json.Marshal(data)
-		if err != nil {
-			return fmt.Errorf("marshal encrypted %s: %w", kind, err)
-		}
-
-		// json.Unmarshal reuses existing slice backing arrays (e.g. json.RawMessage).
-		// The model shares slices with the API resource, so reuse would corrupt it.
-		// Zeroing forces fresh allocations.
-		if err := zeroModel(model); err != nil {
-			return fmt.Errorf("zero %s before unmarshal: %w", kind, err)
-		}
-
-		if err := json.Unmarshal(modifiedBytes, model); err != nil {
-			return fmt.Errorf("unmarshal encrypted %s back to struct: %w", kind, err)
+		if err := replaceModelFromJSON(model, data, kind); err != nil {
+			return err
 		}
 
 		return nil
@@ -226,15 +214,8 @@ func encryptMap(ctx context.Context, m map[string]any, paths [][]string, encrypt
 			if !modified {
 				continue
 			}
-			modifiedBytes, err := json.Marshal(nested)
-			if err != nil {
-				return fmt.Errorf("marshal encrypted nested %q: %w", columnKey, err)
-			}
-			if err := zeroModel(v); err != nil {
-				return fmt.Errorf("zero nested %q before unmarshal: %w", columnKey, err)
-			}
-			if err := v.UnmarshalJSON(modifiedBytes); err != nil {
-				return fmt.Errorf("unmarshal encrypted nested %q back: %w", columnKey, err)
+			if err := replaceModelFromJSON(v, nested, columnKey); err != nil {
+				return err
 			}
 
 		default:
@@ -307,12 +288,18 @@ func encryptJSONPath(ctx context.Context, data map[string]any, path []string, en
 	return true, nil
 }
 
-// zeroModel sets all fields of the struct behind the pointer to their zero values.
-// This breaks shared slice backing arrays (e.g. json.RawMessage) so that a
-// subsequent json.Unmarshal allocates fresh memory instead of overwriting shared data.
-func zeroModel(model any) error {
+// replaceModelFromJSON marshals data to JSON, then unmarshals into a fresh instance
+// of the same type as model, swapping the result in only on success.
+// This avoids shared-slice corruption: json.Unmarshal reuses existing backing arrays
+// (e.g. json.RawMessage), and the model may share slices with the API resource.
+func replaceModelFromJSON(model any, data any, kind string) error {
+	modifiedBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal encrypted %s: %w", kind, err)
+	}
+
 	v := reflect.ValueOf(model)
-	if !v.IsValid() || v.Kind() != reflect.Ptr || v.IsNil() {
+	if !v.IsValid() || v.Kind() != reflect.Pointer || v.IsNil() {
 		return fmt.Errorf("model must be a non-nil pointer")
 	}
 
@@ -321,6 +308,11 @@ func zeroModel(model any) error {
 		return fmt.Errorf("model value cannot be set")
 	}
 
-	elem.Set(reflect.Zero(elem.Type()))
+	tmp := reflect.New(elem.Type())
+	if err := json.Unmarshal(modifiedBytes, tmp.Interface()); err != nil {
+		return fmt.Errorf("unmarshal encrypted %s back to struct: %w", kind, err)
+	}
+
+	elem.Set(tmp.Elem())
 	return nil
 }

--- a/internal/store/model/encryption.go
+++ b/internal/store/model/encryption.go
@@ -1,172 +1,326 @@
 package model
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/stoewer/go-strcase"
 )
 
-// EncryptionHandlers maps model type name to its encryption handler.
-// This registry is used by the GORM encryption plugin to know how to encrypt each model.
+var ErrUnsupportedEncryptionType = errors.New("unsupported encryption map value type")
+
+// EncryptedField defines a single sensitive field that must be encrypted at rest.
+// Path segments use JSON key names from the struct root (e.g., {"Spec", "httpConfig", "password"}).
+type EncryptedField struct {
+	Kind string
+	Path []string
+}
+
+// encryptionRegistry is the canonical list of all encrypted fields across all model types.
+// The migration process can hash this list to detect when new fields are added between versions.
+var encryptionRegistry = []EncryptedField{
+	{domain.RepositoryKind, []string{"Spec", "httpConfig", "password"}},
+	{domain.RepositoryKind, []string{"Spec", "httpConfig", "token"}},
+	{domain.RepositoryKind, []string{"Spec", "httpConfig", "tls.key"}},
+	{domain.RepositoryKind, []string{"Spec", "httpConfig", "tls.crt"}},
+	{domain.RepositoryKind, []string{"Spec", "sshConfig", "sshPrivateKey"}},
+	{domain.RepositoryKind, []string{"Spec", "sshConfig", "privateKeyPassphrase"}},
+	{domain.RepositoryKind, []string{"Spec", "ociAuth", "password"}},
+	{domain.AuthProviderKind, []string{"Spec", "clientSecret"}},
+	{domain.DeviceKind, []string{"RenderedConfig"}},
+	{domain.DeviceKind, []string{"RenderedApplications"}},
+}
+
+// encryptionPathsByKind is built from encryptionRegistry on init for O(1) lookup.
+var encryptionPathsByKind map[string][][]string
+
+func init() {
+	encryptionPathsByKind = make(map[string][][]string)
+	for _, ef := range encryptionRegistry {
+		encryptionPathsByKind[ef.Kind] = append(encryptionPathsByKind[ef.Kind], ef.Path)
+	}
+}
+
+// PathsForKind returns the encryption paths for a given model kind.
+func PathsForKind(kind string) [][]string {
+	return encryptionPathsByKind[kind]
+}
+
+// RegistryHash returns a SHA-256 hash of the encryptionRegistry.
+// The migration process compares this hash across versions to detect when
+// encrypted fields are added or removed, triggering a re-encryption migration.
+func RegistryHash() string {
+	return hashFields(encryptionRegistry)
+}
+
+func hashFields(fields []EncryptedField) string {
+	entries := make([]string, len(fields))
+	for i, ef := range fields {
+		entries[i] = fmt.Sprintf("%s:%s", ef.Kind, strings.Join(ef.Path, "/"))
+	}
+	sort.Strings(entries)
+	h := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintln(h, e)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// EncryptionHandlers returns encryption handlers for all model types.
 func EncryptionHandlers() map[string]encryption.ModelEncryptHandler {
 	return map[string]encryption.ModelEncryptHandler{
-		domain.RepositoryKind:   encryptRepository,
-		domain.AuthProviderKind: encryptAuthProvider,
+		domain.RepositoryKind:   genericEncryptHandler(domain.RepositoryKind),
+		domain.AuthProviderKind: genericEncryptHandler(domain.AuthProviderKind),
+		domain.DeviceKind:       genericEncryptHandler(domain.DeviceKind),
 	}
 }
 
-// repositoryEncryptPaths lists the sensitive fields in the Repository Spec JSONB
-// that must be encrypted at rest.
-// Each entry is a slice of JSON key segments (e.g. {"httpConfig", "tls.key"}).
-var repositoryEncryptPaths = [][]string{
-	{"httpConfig", "password"},
-	{"httpConfig", "token"},
-	{"httpConfig", "tls.key"},
-	{"httpConfig", "tls.crt"},
-	{"sshConfig", "sshPrivateKey"},
-	{"sshConfig", "privateKeyPassphrase"},
-	{"ociAuth", "password"},
-}
+// genericEncryptHandler returns an encryption handler that works for any model type.
+// For structs: marshal to nested map, encrypt at registered paths, unmarshal back.
+// For maps (GORM partial updates): convert path segments from PascalCase to snake_case
+// and encrypt *string values in-place.
+func genericEncryptHandler(kind string) encryption.ModelEncryptHandler {
+	paths := encryptionPathsByKind[kind]
 
-// authProviderEncryptPaths lists the sensitive fields in the AuthProvider Spec JSONB.
-// clientSecret appears at the top level of all provider type variants (OIDC, OAuth2,
-// OpenShift, AAP).
-var authProviderEncryptPaths = [][]string{
-	{"clientSecret"},
-}
-
-func encryptRepository(ctx context.Context, v interface{}, encrypt encryption.EncryptFunc) error {
-	repo, ok := v.(*Repository)
-	if !ok {
-		return fmt.Errorf("expected *Repository, got %T", v)
-	}
-
-	if repo.Spec == nil {
-		return nil
-	}
-
-	updated, err := encryptJSONField(ctx, repo.Spec.Data, repositoryEncryptPaths, encrypt)
-	if err != nil {
-		return err
-	}
-	// Unmarshal into a new object — Spec.Data shares a pointer with the API
-	// resource, and mutating in-place corrupts its json.RawMessage on retry.
-	if updated != nil {
-		var newSpec domain.RepositorySpec
-		if err := json.Unmarshal(updated, &newSpec); err != nil {
-			return fmt.Errorf("unmarshal encrypted repo spec: %w", err)
+	return func(ctx context.Context, model any, encrypt encryption.EncryptFunc) error {
+		if len(paths) == 0 {
+			return nil
 		}
-		repo.Spec.Data = newSpec
-	}
-	return nil
-}
 
-func encryptAuthProvider(ctx context.Context, v interface{}, encrypt encryption.EncryptFunc) error {
-	ap, ok := v.(*AuthProvider)
-	if !ok {
-		return fmt.Errorf("expected *AuthProvider, got %T", v)
-	}
-
-	if ap.Spec == nil {
-		return nil
-	}
-
-	updated, err := encryptJSONField(ctx, ap.Spec.Data, authProviderEncryptPaths, encrypt)
-	if err != nil {
-		return err
-	}
-	// See comment in encryptRepository for why we unmarshal into a new object.
-	if updated != nil {
-		var newSpec domain.AuthProviderSpec
-		if err := json.Unmarshal(updated, &newSpec); err != nil {
-			return fmt.Errorf("unmarshal encrypted auth provider spec: %w", err)
+		if m, ok := model.(map[string]any); ok {
+			return encryptMap(ctx, m, paths, encrypt)
 		}
-		ap.Spec.Data = newSpec
-	}
-	return nil
-}
 
-// encryptJSONField encrypts string values at the given paths within a JSONB field.
-// It marshals the data to a generic map, encrypts matching paths, and returns the
-// updated JSON bytes. Returns nil if no fields were modified. The caller is
-// responsible for unmarshaling into a new object to avoid corrupting shared pointers.
-func encryptJSONField(ctx context.Context, data any, paths [][]string, encrypt encryption.EncryptFunc) ([]byte, error) {
-	jsonBytes, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("marshal spec: %w", err)
-	}
-
-	var jsonData map[string]any
-	if err := json.Unmarshal(jsonBytes, &jsonData); err != nil {
-		return nil, fmt.Errorf("unmarshal spec to map: %w", err)
-	}
-
-	modified := false
-	for _, path := range paths {
-		encrypted, err := encryptJSONPath(ctx, jsonData, path, encrypt)
+		jsonBytes, err := json.Marshal(model)
 		if err != nil {
-			return nil, fmt.Errorf("encrypt field %v: %w", path, err)
+			return fmt.Errorf("marshal %s: %w", kind, err)
 		}
-		if encrypted {
-			modified = true
+
+		var data map[string]any
+		dec := json.NewDecoder(bytes.NewReader(jsonBytes))
+		dec.UseNumber()
+		if err := dec.Decode(&data); err != nil {
+			return fmt.Errorf("unmarshal %s to map: %w", kind, err)
 		}
-	}
 
-	if !modified {
-		return nil, nil
-	}
+		modified := false
+		for _, path := range paths {
+			encrypted, err := encryptJSONPath(ctx, data, path, encrypt)
+			if err != nil {
+				return fmt.Errorf("encrypt field %v: %w", path, err)
+			}
+			if encrypted {
+				modified = true
+			}
+		}
 
-	updatedJSON, err := json.Marshal(jsonData)
-	if err != nil {
-		return nil, fmt.Errorf("marshal updated spec: %w", err)
-	}
+		if !modified {
+			return nil
+		}
 
-	return updatedJSON, nil
+		modifiedBytes, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("marshal encrypted %s: %w", kind, err)
+		}
+
+		// json.Unmarshal reuses existing slice backing arrays (e.g. json.RawMessage).
+		// The model shares slices with the API resource, so reuse would corrupt it.
+		// Zeroing forces fresh allocations.
+		if err := zeroModel(model); err != nil {
+			return fmt.Errorf("zero %s before unmarshal: %w", kind, err)
+		}
+
+		if err := json.Unmarshal(modifiedBytes, model); err != nil {
+			return fmt.Errorf("unmarshal encrypted %s back to struct: %w", kind, err)
+		}
+
+		return nil
+	}
 }
 
-// encryptJSONPath encrypts a string value at the given path segments in a JSON map.
-// Returns true if encryption was performed, false if the path doesn't exist or the
-// value was already encrypted with the current key.
+// encryptMap handles GORM partial updates where model is a map[string]interface{}.
+// Map keys use snake_case DB column names, so the first path segment is converted
+// from PascalCase. Paths sharing the same top-level key are grouped so nested
+// values (json.Unmarshaler) get a single marshal/unmarshal cycle per key.
+func encryptMap(ctx context.Context, m map[string]any, paths [][]string, encrypt encryption.EncryptFunc) error {
+	// Group paths by column key so nested values are marshaled once per key.
+	grouped := make(map[string][][]string)
+	var order []string
+	for _, path := range paths {
+		key := pascalToSnake(path[0])
+		if _, seen := grouped[key]; !seen {
+			order = append(order, key)
+		}
+		grouped[key] = append(grouped[key], path)
+	}
+
+	for _, columnKey := range order {
+		val, ok := m[columnKey]
+		if !ok || val == nil {
+			continue
+		}
+
+		switch v := val.(type) {
+		case *string:
+			if v == nil || *v == "" {
+				continue
+			}
+			for _, path := range grouped[columnKey] {
+				if len(path) > 1 {
+					return fmt.Errorf("encrypt map key %q: nested path %v requires a structured value, got *string", columnKey, path)
+				}
+			}
+			// The value may be JSON-quoted from a prior encrypt pass
+			// (e.g. "enc:v1:default:..."). Unwrap so ProcessEncryption
+			// sees the raw enc: prefix and returns it as-is.
+			plain := *v
+			var unquoted string
+			if json.Unmarshal([]byte(plain), &unquoted) == nil {
+				plain = unquoted
+			}
+			encrypted, err := encrypt(ctx, []byte(plain))
+			if err != nil {
+				return fmt.Errorf("encrypt map key %q: %w", columnKey, err)
+			}
+			encStr := string(encrypted)
+			if encStr == plain {
+				continue
+			}
+			jsonStr, err := json.Marshal(encStr)
+			if err != nil {
+				return fmt.Errorf("marshal encrypted value for %q: %w", columnKey, err)
+			}
+			*v = string(jsonStr)
+
+		case json.Unmarshaler:
+			jsonBytes, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf("marshal map key %q for nested encrypt: %w", columnKey, err)
+			}
+			var nested map[string]any
+			if err := json.Unmarshal(jsonBytes, &nested); err != nil {
+				return fmt.Errorf("unmarshal map key %q to nested map: %w", columnKey, err)
+			}
+			modified := false
+			for _, path := range grouped[columnKey] {
+				if len(path) < 2 {
+					return fmt.Errorf("encrypt map key %q: root-level path requires a string value, got %T", columnKey, val)
+				}
+				encrypted, err := encryptJSONPath(ctx, nested, path[1:], encrypt)
+				if err != nil {
+					return fmt.Errorf("encrypt nested field %v: %w", path, err)
+				}
+				if encrypted {
+					modified = true
+				}
+			}
+			if !modified {
+				continue
+			}
+			modifiedBytes, err := json.Marshal(nested)
+			if err != nil {
+				return fmt.Errorf("marshal encrypted nested %q: %w", columnKey, err)
+			}
+			if err := zeroModel(v); err != nil {
+				return fmt.Errorf("zero nested %q before unmarshal: %w", columnKey, err)
+			}
+			if err := v.UnmarshalJSON(modifiedBytes); err != nil {
+				return fmt.Errorf("unmarshal encrypted nested %q back: %w", columnKey, err)
+			}
+
+		default:
+			return fmt.Errorf("encrypt map key %q: %w: %T", columnKey, ErrUnsupportedEncryptionType, val)
+		}
+	}
+	return nil
+}
+
+// pascalToSnake converts a PascalCase string to snake_case.
+// e.g. "RenderedConfig" → "rendered_config", "Spec" → "spec"
+func pascalToSnake(s string) string {
+	return strcase.SnakeCase(s)
+}
+
+// encryptJSONPath encrypts the value at the given path in a JSON map.
+// If the leaf is a string, it encrypts the string directly.
+// If the leaf is anything else (map, array, etc.), it marshals the value to JSON bytes,
+// encrypts the blob, and stores the encrypted string back.
 func encryptJSONPath(ctx context.Context, data map[string]any, path []string, encrypt encryption.EncryptFunc) (bool, error) {
+	if len(path) == 0 {
+		return false, fmt.Errorf("empty encryption path")
+	}
 	current := data
 	for i := 0; i < len(path)-1; i++ {
 		val, exists := current[path[i]]
-		if !exists {
+		if !exists || val == nil {
 			return false, nil
 		}
-
 		nestedMap, ok := val.(map[string]any)
 		if !ok {
-			return false, nil
+			return false, fmt.Errorf("path %v: segment %q is %T, expected object", path, path[i], val)
 		}
-
 		current = nestedMap
 	}
 
-	lastPart := path[len(path)-1]
-	val, exists := current[lastPart]
-	if !exists {
+	lastKey := path[len(path)-1]
+	val, exists := current[lastKey]
+	if !exists || val == nil {
 		return false, nil
 	}
 
-	strVal, ok := val.(string)
-	if !ok || strVal == "" {
-		return false, nil
+	var plaintext []byte
+
+	switch v := val.(type) {
+	case string:
+		if v == "" {
+			return false, nil
+		}
+		plaintext = []byte(v)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return false, fmt.Errorf("marshal blob at %v: %w", path, err)
+		}
+		plaintext = b
 	}
 
-	encrypted, err := encrypt(ctx, []byte(strVal))
+	encrypted, err := encrypt(ctx, plaintext)
 	if err != nil {
-		return false, fmt.Errorf("encrypt path %s: %w", path, err)
+		return false, fmt.Errorf("encrypt path %v: %w", path, err)
 	}
 
 	newValue := string(encrypted)
-	if newValue == strVal {
+	if newValue == string(plaintext) {
 		return false, nil
 	}
 
-	current[lastPart] = newValue
+	current[lastKey] = newValue
 	return true, nil
+}
+
+// zeroModel sets all fields of the struct behind the pointer to their zero values.
+// This breaks shared slice backing arrays (e.g. json.RawMessage) so that a
+// subsequent json.Unmarshal allocates fresh memory instead of overwriting shared data.
+func zeroModel(model any) error {
+	v := reflect.ValueOf(model)
+	if !v.IsValid() || v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("model must be a non-nil pointer")
+	}
+
+	elem := v.Elem()
+	if !elem.CanSet() {
+		return fmt.Errorf("model value cannot be set")
+	}
+
+	elem.Set(reflect.Zero(elem.Type()))
+	return nil
 }

--- a/internal/store/model/encryption_test.go
+++ b/internal/store/model/encryption_test.go
@@ -646,6 +646,9 @@ func TestEncryptHandler_RepositoryFailClosed(t *testing.T) {
 	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
 	require.NoError(t, err)
 
+	before, err := json.Marshal(modelRepo)
+	require.NoError(t, err)
+
 	errEncrypt := fmt.Errorf("KMS unavailable")
 	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
 		return nil, errEncrypt
@@ -654,6 +657,10 @@ func TestEncryptHandler_RepositoryFailClosed(t *testing.T) {
 	handler := EncryptionHandlers()[domain.RepositoryKind]
 	err = handler(context.Background(), modelRepo, failingEncrypt)
 	require.ErrorIs(t, err, errEncrypt)
+
+	after, err := json.Marshal(modelRepo)
+	require.NoError(t, err)
+	require.JSONEq(t, string(before), string(after), "model should be unmodified on encrypt failure")
 }
 
 // ---------------------------------------------------------------------------
@@ -925,6 +932,9 @@ func TestEncryptHandler_AuthProviderFailClosed(t *testing.T) {
 	modelAP, err := NewAuthProviderFromApiResource(apiProv)
 	require.NoError(t, err)
 
+	before, err := json.Marshal(modelAP)
+	require.NoError(t, err)
+
 	errEncrypt := fmt.Errorf("KMS unavailable")
 	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
 		return nil, errEncrypt
@@ -933,6 +943,10 @@ func TestEncryptHandler_AuthProviderFailClosed(t *testing.T) {
 	handler := EncryptionHandlers()[domain.AuthProviderKind]
 	err = handler(context.Background(), modelAP, failingEncrypt)
 	require.ErrorIs(t, err, errEncrypt)
+
+	after, err := json.Marshal(modelAP)
+	require.NoError(t, err)
+	require.JSONEq(t, string(before), string(after), "model should be unmodified on encrypt failure")
 }
 
 // ---------------------------------------------------------------------------
@@ -1265,14 +1279,21 @@ func TestEncryptHandler_DeviceStructFailClosed(t *testing.T) {
 		RenderedConfig: MakeJSONField(json.RawMessage(`[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`)),
 	}
 
+	before, err := json.Marshal(device)
+	require.NoError(t, err)
+
 	errEncrypt := fmt.Errorf("KMS unavailable")
 	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
 		return nil, errEncrypt
 	}
 
 	handler := EncryptionHandlers()[domain.DeviceKind]
-	err := handler(context.Background(), device, failingEncrypt)
+	err = handler(context.Background(), device, failingEncrypt)
 	require.ErrorIs(t, err, errEncrypt)
+
+	after, err := json.Marshal(device)
+	require.NoError(t, err)
+	require.JSONEq(t, string(before), string(after), "model should be unmodified on encrypt failure")
 }
 
 func TestEncryptHandler_DeviceOnlyConfig(t *testing.T) {
@@ -1451,6 +1472,7 @@ func TestEncryptHandler_DeviceMapFailClosed(t *testing.T) {
 	_ = setupEncryption(t)
 
 	configVal := `[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`
+	configBefore := configVal
 	m := map[string]any{
 		"rendered_config": &configVal,
 	}
@@ -1463,6 +1485,7 @@ func TestEncryptHandler_DeviceMapFailClosed(t *testing.T) {
 	handler := EncryptionHandlers()[domain.DeviceKind]
 	err := handler(context.Background(), m, failingEncrypt)
 	require.ErrorIs(t, err, errEncrypt)
+	require.Equal(t, configBefore, configVal, "map value should be unmodified on encrypt failure")
 }
 
 func TestEncryptHandler_DeviceMapUnsupportedTypeFailsClosed(t *testing.T) {
@@ -1512,7 +1535,7 @@ func TestEncryptHandler_DeviceMapRoundTrip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared-slice corruption — zeroModel prevents backing array reuse
+// Shared-slice corruption — fresh-instance unmarshal prevents backing array reuse
 // ---------------------------------------------------------------------------
 
 func TestNoSharedSliceCorruption_AuthProvider(t *testing.T) {

--- a/internal/store/model/encryption_test.go
+++ b/internal/store/model/encryption_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/flightctl/flightctl/internal/config"
@@ -16,15 +18,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTestEncryption(t *testing.T) *encryption.Manager {
-	t.Helper()
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
-	dir := t.TempDir()
+func setupEncryption(tb testing.TB) *encryption.Manager {
+	tb.Helper()
+
+	dir := tb.TempDir()
 	keyPath := filepath.Join(dir, "key")
 
 	key, err := crypto.GenerateAES256Key()
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(keyPath, []byte(key), 0600))
+	require.NoError(tb, err)
+	require.NoError(tb, os.WriteFile(keyPath, []byte(key), 0600))
 
 	cfg := config.NewDefault()
 	cfg.Encryption = &config.EncryptionConfig{
@@ -35,46 +41,90 @@ func setupTestEncryption(t *testing.T) *encryption.Manager {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)
 
-	err = encryption.InitGlobalEncryption(logger, cfg)
-	require.NoError(t, err)
+	require.NoError(tb, encryption.InitGlobalEncryption(logger, cfg))
 
 	mgr := encryption.GlobalManager()
-	require.NotNil(t, mgr)
+	require.NotNil(tb, mgr)
 	return mgr
 }
 
-func TestEncryptionHandlersRegistry(t *testing.T) {
-	mgr := setupTestEncryption(t)
+func strPtr(s string) *string {
+	return &s
+}
 
-	mockEncryptFunc := func(ctx context.Context, data []byte) ([]byte, error) {
-		return data, nil
+// sameLenEncrypt returns ciphertext of identical length so the result could fit
+// in the input's backing array, exposing accidental aliasing.
+func sameLenEncrypt(_ context.Context, data []byte) ([]byte, error) {
+	out := make([]byte, len(data))
+	for i, b := range data {
+		out[i] = b ^ 0x42
 	}
-	_ = mgr
+	return out, nil
+}
 
-	for modelName, handler := range EncryptionHandlers() {
-		t.Run(modelName, func(t *testing.T) {
-			require.NotNil(t, handler, "Encryption handler for %s is nil", modelName)
+func staticOrgAssignment() domain.AuthOrganizationAssignment {
+	var oa domain.AuthOrganizationAssignment
+	_ = oa.FromAuthStaticOrganizationAssignment(domain.AuthStaticOrganizationAssignment{
+		Type: domain.AuthStaticOrganizationAssignmentTypeStatic,
+	})
+	return oa
+}
 
-			var model any
-			switch modelName {
-			case "Repository":
-				model = &Repository{}
-			case "AuthProvider":
-				model = &AuthProvider{}
-			default:
-				t.Fatalf("Unknown model type in registry: %s - add a case for it in this test", modelName)
+func extractClientSecret(t *testing.T, specMap map[string]any) string {
+	t.Helper()
+	val, ok := specMap["clientSecret"]
+	if ok {
+		s, ok := val.(string)
+		require.True(t, ok, "clientSecret should be a string")
+		return s
+	}
+	t.Fatal("clientSecret not found in spec map")
+	return ""
+}
+
+func extractPlaintextFields(m map[string]any) map[string]string {
+	result := make(map[string]string)
+	collectStrings(m, "", result, false)
+	return result
+}
+
+func extractEncryptedFields(m map[string]any) map[string]string {
+	result := make(map[string]string)
+	collectStrings(m, "", result, true)
+	return result
+}
+
+func collectStrings(m map[string]any, prefix string, result map[string]string, wantEncrypted bool) {
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch val := v.(type) {
+		case string:
+			isEnc := encryption.IsEncrypted([]byte(val))
+			if wantEncrypted == isEnc {
+				result[key] = val
 			}
-
-			err := handler(context.Background(), model, mockEncryptFunc)
-			if err != nil {
-				t.Logf("Handler %s returned error (expected for empty model): %v", modelName, err)
+		case map[string]any:
+			collectStrings(val, key, result, wantEncrypted)
+		case []any:
+			for i, elem := range val {
+				elemKey := fmt.Sprintf("%s[%d]", key, i)
+				if nested, ok := elem.(map[string]any); ok {
+					collectStrings(nested, elemKey, result, wantEncrypted)
+				}
 			}
-		})
+		}
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Encryption format stability
+// ---------------------------------------------------------------------------
+
 func TestEncryptionFormatStability(t *testing.T) {
-	mgr := setupTestEncryption(t)
+	mgr := setupEncryption(t)
 
 	plaintext := []byte("test-secret")
 	encrypted, err := mgr.Encrypt(context.Background(), plaintext)
@@ -90,16 +140,152 @@ func TestEncryptionFormatStability(t *testing.T) {
 	require.Equal(t, plaintext, decrypted, "Decrypted value should match plaintext")
 }
 
-func TestRepositoryEncryptionEndToEnd(t *testing.T) {
-	mgr := setupTestEncryption(t)
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+func TestEncryptionHandlers_Registry(t *testing.T) {
+	_ = setupEncryption(t)
+
+	handlers := EncryptionHandlers()
+	require.Len(t, handlers, 3, "Should have 3 handlers registered")
+
+	require.Contains(t, handlers, domain.RepositoryKind)
+	require.Contains(t, handlers, domain.AuthProviderKind)
+	require.Contains(t, handlers, domain.DeviceKind)
+
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+
+	for modelName, handler := range handlers {
+		t.Run(modelName, func(t *testing.T) {
+			require.NotNil(t, handler)
+
+			var model any
+			switch modelName {
+			case domain.RepositoryKind:
+				model = &Repository{}
+			case domain.AuthProviderKind:
+				model = &AuthProvider{}
+			case domain.DeviceKind:
+				model = &Device{}
+			default:
+				t.Fatalf("Unknown model type: %s", modelName)
+			}
+
+			err := handler(context.Background(), model, noopEncrypt)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registry helpers
+// ---------------------------------------------------------------------------
+
+func TestRegistryHash_Deterministic(t *testing.T) {
+	hash1 := RegistryHash()
+	require.NotEmpty(t, hash1)
+
+	hash2 := RegistryHash()
+	require.Equal(t, hash1, hash2, "Hash should be deterministic across calls")
+
+	require.Len(t, hash1, 64, "SHA-256 hex digest should be 64 chars")
+}
+
+func TestRegistryHash_ChangesWhenFieldAdded(t *testing.T) {
+	originalHash := RegistryHash()
+
+	extended := make([]EncryptedField, len(encryptionRegistry), len(encryptionRegistry)+1)
+	copy(extended, encryptionRegistry)
+	extended = append(extended, EncryptedField{
+		Kind: domain.RepositoryKind,
+		Path: []string{"Spec", "httpConfig", "newSecret"},
+	})
+
+	newHash := hashFields(extended)
+	require.NotEqual(t, originalHash, newHash,
+		"Hash should change when a new encrypted field is added")
+}
+
+func TestPathsForKind_AllKinds(t *testing.T) {
+	repoPaths := PathsForKind(domain.RepositoryKind)
+	require.Len(t, repoPaths, 7, "Repository should have 7 encrypted paths")
+
+	for _, p := range repoPaths {
+		require.True(t, len(p) >= 2, "Each path should have at least 2 segments (field + key)")
+		require.Equal(t, "Spec", p[0], "First segment should be 'Spec'")
+	}
+
+	apPaths := PathsForKind(domain.AuthProviderKind)
+	require.Len(t, apPaths, 1, "AuthProvider should have 1 encrypted path")
+	require.Equal(t, []string{"Spec", "clientSecret"}, apPaths[0])
+
+	devicePaths := PathsForKind(domain.DeviceKind)
+	require.Len(t, devicePaths, 2, "Device should have 2 encrypted paths")
+	require.Equal(t, []string{"RenderedConfig"}, devicePaths[0])
+	require.Equal(t, []string{"RenderedApplications"}, devicePaths[1])
+
+	unknownPaths := PathsForKind("UnknownKind")
+	require.Nil(t, unknownPaths, "Unknown kind should return nil")
+}
+
+func TestEncryptionRegistry_Completeness(t *testing.T) {
+	for _, ef := range encryptionRegistry {
+		paths := PathsForKind(ef.Kind)
+		require.NotNil(t, paths, "Kind %q should be resolvable via PathsForKind", ef.Kind)
+		found := false
+		for _, p := range paths {
+			if reflect.DeepEqual(p, ef.Path) {
+				found = true
+				break
+			}
+		}
+		require.True(t, found,
+			"Registry entry %v for kind %q should be returned by PathsForKind", ef.Path, ef.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pascalToSnake helper
+// ---------------------------------------------------------------------------
+
+func TestPascalToSnake(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"RenderedConfig", "rendered_config"},
+		{"RenderedApplications", "rendered_applications"},
+		{"Spec", "spec"},
+		{"ID", "id"},
+		{"ResourceVersion", "resource_version"},
+		{"", ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, pascalToSnake(tc.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repository — encrypt end-to-end
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryGitHTTP(t *testing.T) {
+	mgr := setupEncryption(t)
 
 	testCases := []struct {
-		name        string
-		apiRepo     *domain.Repository
-		checkValues []string
+		name           string
+		apiRepo        *domain.Repository
+		encryptedKeys  []string
+		plaintextVals  []string
+		encryptedCount int
 	}{
 		{
-			name: "When encrypting GitRepoSpec with httpConfig it should encrypt password and token",
+			name: "When encrypting GitRepoSpec with httpConfig it should encrypt password and token but not username",
 			apiRepo: &domain.Repository{
 				Metadata: domain.ObjectMeta{Name: strPtr("test-http")},
 				Spec: func() domain.RepositorySpec {
@@ -114,10 +300,12 @@ func TestRepositoryEncryptionEndToEnd(t *testing.T) {
 					return spec
 				}(),
 			},
-			checkValues: []string{"testpass", "testtoken"},
+			encryptedKeys:  []string{"testpass", "testtoken"},
+			plaintextVals:  []string{"testuser"},
+			encryptedCount: 2,
 		},
 		{
-			name: "When encrypting GitRepoSpec with httpConfig it should encrypt TLS key and cert",
+			name: "When encrypting GitRepoSpec with TLS it should encrypt key and cert",
 			apiRepo: &domain.Repository{
 				Metadata: domain.ObjectMeta{Name: strPtr("test-tls")},
 				Spec: func() domain.RepositorySpec {
@@ -131,61 +319,30 @@ func TestRepositoryEncryptionEndToEnd(t *testing.T) {
 					return spec
 				}(),
 			},
-			checkValues: []string{"base64-encoded-private-key", "base64-encoded-certificate"},
+			encryptedKeys:  []string{"base64-encoded-private-key", "base64-encoded-certificate"},
+			encryptedCount: 2,
 		},
 		{
-			name: "When encrypting GitRepoSpec with sshConfig it should encrypt private key and passphrase",
+			name: "When encrypting GitRepoSpec with all httpConfig fields it should encrypt all sensitive ones",
 			apiRepo: &domain.Repository{
-				Metadata: domain.ObjectMeta{Name: strPtr("test-ssh")},
+				Metadata: domain.ObjectMeta{Name: strPtr("test-all-http")},
 				Spec: func() domain.RepositorySpec {
 					var spec domain.RepositorySpec
 					_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
-						SshConfig: &domain.SshConfig{
-							SshPrivateKey:        strPtr("ssh-key-content"),
-							PrivateKeyPassphrase: strPtr("ssh-passphrase"),
-						},
-					})
-					return spec
-				}(),
-			},
-			checkValues: []string{"ssh-key-content", "ssh-passphrase"},
-		},
-		{
-			name: "When encrypting OciRepoSpec with ociAuth it should encrypt password",
-			apiRepo: &domain.Repository{
-				Metadata: domain.ObjectMeta{Name: strPtr("test-oci")},
-				Spec: func() domain.RepositorySpec {
-					var ociAuth domain.OciAuth
-					_ = ociAuth.FromDockerAuth(domain.DockerAuth{
-						AuthType: domain.OciAuthTypeDocker,
-						Username: "ociuser",
-						Password: "ocipass",
-					})
-					var spec domain.RepositorySpec
-					_ = spec.FromOciRepoSpec(domain.OciRepoSpec{
-						OciAuth: &ociAuth,
-					})
-					return spec
-				}(),
-			},
-			checkValues: []string{"ocipass"},
-		},
-		{
-			name: "When encrypting HttpRepoSpec with httpConfig it should encrypt password and token",
-			apiRepo: &domain.Repository{
-				Metadata: domain.ObjectMeta{Name: strPtr("test-http-repo")},
-				Spec: func() domain.RepositorySpec {
-					var spec domain.RepositorySpec
-					_ = spec.FromHttpRepoSpec(domain.HttpRepoSpec{
 						HttpConfig: &domain.HttpConfig{
-							Password: strPtr("http-repo-pass"),
-							Token:    strPtr("http-repo-token"),
+							Username: strPtr("myuser"),
+							Password: strPtr("mypass"),
+							Token:    strPtr("mytoken"),
+							TlsKey:   strPtr("my-tls-key"),
+							TlsCrt:   strPtr("my-tls-crt"),
 						},
 					})
 					return spec
 				}(),
 			},
-			checkValues: []string{"http-repo-pass", "http-repo-token"},
+			encryptedKeys:  []string{"mypass", "mytoken", "my-tls-key", "my-tls-crt"},
+			plaintextVals:  []string{"myuser"},
+			encryptedCount: 4,
 		},
 	}
 
@@ -194,7 +351,7 @@ func TestRepositoryEncryptionEndToEnd(t *testing.T) {
 			modelRepo, err := NewRepositoryFromApiResource(tc.apiRepo)
 			require.NoError(t, err)
 
-			handler := EncryptionHandlers()["Repository"]
+			handler := EncryptionHandlers()[domain.RepositoryKind]
 			err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
 			require.NoError(t, err)
 
@@ -202,28 +359,35 @@ func TestRepositoryEncryptionEndToEnd(t *testing.T) {
 			require.NoError(t, err)
 			specStr := string(specJSON)
 
-			for _, plaintext := range tc.checkValues {
-				require.NotContains(t, specStr, plaintext,
-					"Plaintext '%s' found in spec after encryption", plaintext)
+			for _, val := range tc.encryptedKeys {
+				require.NotContains(t, specStr, val,
+					"Plaintext '%s' found in spec after encryption", val)
+			}
+			for _, val := range tc.plaintextVals {
+				require.Contains(t, specStr, val,
+					"Non-sensitive '%s' should remain in plaintext", val)
 			}
 
-			require.Contains(t, specStr, "enc:v1:default:",
-				"Spec should contain encrypted values with proper format")
+			var specMap map[string]any
+			require.NoError(t, json.Unmarshal(specJSON, &specMap))
+			encrypted := extractEncryptedFields(specMap)
+			require.Len(t, encrypted, tc.encryptedCount,
+				"Should have exactly %d encrypted fields", tc.encryptedCount)
 		})
 	}
 }
 
-func TestRepositoryEncryption_UsernameNotEncrypted(t *testing.T) {
-	mgr := setupTestEncryption(t)
+func TestEncryptHandler_RepositoryGitSSH(t *testing.T) {
+	mgr := setupEncryption(t)
 
 	apiRepo := &domain.Repository{
-		Metadata: domain.ObjectMeta{Name: strPtr("test-username")},
+		Metadata: domain.ObjectMeta{Name: strPtr("test-ssh")},
 		Spec: func() domain.RepositorySpec {
 			var spec domain.RepositorySpec
 			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
-				HttpConfig: &domain.HttpConfig{
-					Username: strPtr("testuser"),
-					Password: strPtr("testpass"),
+				SshConfig: &domain.SshConfig{
+					SshPrivateKey:        strPtr("ssh-key-content"),
+					PrivateKeyPassphrase: strPtr("ssh-passphrase"),
 				},
 			})
 			return spec
@@ -233,7 +397,7 @@ func TestRepositoryEncryption_UsernameNotEncrypted(t *testing.T) {
 	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
 	require.NoError(t, err)
 
-	handler := EncryptionHandlers()["Repository"]
+	handler := EncryptionHandlers()[domain.RepositoryKind]
 	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
 	require.NoError(t, err)
 
@@ -241,22 +405,280 @@ func TestRepositoryEncryption_UsernameNotEncrypted(t *testing.T) {
 	require.NoError(t, err)
 	specStr := string(specJSON)
 
-	require.Contains(t, specStr, "testuser",
-		"Username should NOT be encrypted - it is not a sensitive field")
-	require.NotContains(t, specStr, "testpass",
-		"Password should be encrypted")
+	require.NotContains(t, specStr, "ssh-key-content")
+	require.NotContains(t, specStr, "ssh-passphrase")
+	require.Contains(t, specStr, "enc:v1:default:")
 }
 
-func staticOrgAssignment() domain.AuthOrganizationAssignment {
-	var oa domain.AuthOrganizationAssignment
-	_ = oa.FromAuthStaticOrganizationAssignment(domain.AuthStaticOrganizationAssignment{
-		Type: domain.AuthStaticOrganizationAssignmentTypeStatic,
-	})
-	return oa
+func TestEncryptHandler_RepositoryOCI(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-oci")},
+		Spec: func() domain.RepositorySpec {
+			var ociAuth domain.OciAuth
+			_ = ociAuth.FromDockerAuth(domain.DockerAuth{
+				AuthType: domain.OciAuthTypeDocker,
+				Username: "ociuser",
+				Password: "ocipass",
+			})
+			var spec domain.RepositorySpec
+			_ = spec.FromOciRepoSpec(domain.OciRepoSpec{
+				OciAuth: &ociAuth,
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.NotContains(t, specStr, "ocipass")
+	require.Contains(t, specStr, "ociuser", "Username should remain in plaintext")
+	require.Contains(t, specStr, "enc:v1:default:")
 }
 
-func TestAuthProviderEncryptionEndToEnd(t *testing.T) {
-	mgr := setupTestEncryption(t)
+func TestEncryptHandler_RepositoryHTTPRepo(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-http-repo")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromHttpRepoSpec(domain.HttpRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Password: strPtr("http-repo-pass"),
+					Token:    strPtr("http-repo-token"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.NotContains(t, specStr, "http-repo-pass")
+	require.NotContains(t, specStr, "http-repo-token")
+	require.Contains(t, specStr, "enc:v1:default:")
+}
+
+// ---------------------------------------------------------------------------
+// Repository — decrypt round-trip
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryDecryptRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-roundtrip")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Username: strPtr("testuser"),
+					Password: strPtr("testpass"),
+					Token:    strPtr("testtoken"),
+				},
+				SshConfig: &domain.SshConfig{
+					SshPrivateKey:        strPtr("ssh-key"),
+					PrivateKeyPassphrase: strPtr("ssh-passphrase"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	originalSpecJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(ctx, modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	encryptedSpecJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	var encryptedMap map[string]any
+	require.NoError(t, json.Unmarshal(encryptedSpecJSON, &encryptedMap))
+	encFields := extractEncryptedFields(encryptedMap)
+
+	var originalMap map[string]any
+	require.NoError(t, json.Unmarshal(originalSpecJSON, &originalMap))
+	originalAll := map[string]string{}
+	collectStrings(originalMap, "", originalAll, false)
+
+	for key, encValue := range encFields {
+		decrypted, err := mgr.Decrypt(ctx, []byte(encValue))
+		require.NoError(t, err, "Failed to decrypt field %s", key)
+		require.Equal(t, originalAll[key], string(decrypted),
+			"Field %s should decrypt back to its original plaintext", key)
+	}
+
+	originalPlaintext := extractPlaintextFields(originalMap)
+	encryptedPlaintext := extractPlaintextFields(encryptedMap)
+
+	for key, val := range originalPlaintext {
+		if _, wasEncrypted := encFields[key]; wasEncrypted {
+			continue
+		}
+		require.Equal(t, val, encryptedPlaintext[key],
+			"Non-sensitive field %s should be preserved", key)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repository — idempotency
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryIdempotent(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-idempotent")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Password: strPtr("secret-password"),
+					Token:    strPtr("secret-token"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterFirst, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterSecond, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(afterFirst), string(afterSecond),
+		"Encrypting an already-encrypted spec should be idempotent")
+}
+
+// ---------------------------------------------------------------------------
+// Repository — no sensitive fields present
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryNoSensitiveFields(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-no-sensitive")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Username: strPtr("justuser"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	originalJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), modelRepo, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	afterJSON, err := json.Marshal(modelRepo.Spec.Data)
+	require.NoError(t, err)
+	require.JSONEq(t, string(originalJSON), string(afterJSON),
+		"Spec with no sensitive fields should remain unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// Repository — fail closed
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryFailClosed(t *testing.T) {
+	_ = setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-fail")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Password: strPtr("secret-password"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	errEncrypt := fmt.Errorf("KMS unavailable")
+	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errEncrypt
+	}
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), modelRepo, failingEncrypt)
+	require.ErrorIs(t, err, errEncrypt)
+}
+
+// ---------------------------------------------------------------------------
+// Repository — nil spec
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryNilSpec(t *testing.T) {
+	_ = setupEncryption(t)
+
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+
+	repo := &Repository{}
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err := handler(context.Background(), repo, noopEncrypt)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// AuthProvider — all provider types
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderAllTypes(t *testing.T) {
+	mgr := setupEncryption(t)
 
 	testCases := []struct {
 		name    string
@@ -343,7 +765,7 @@ func TestAuthProviderEncryptionEndToEnd(t *testing.T) {
 			modelAP, err := NewAuthProviderFromApiResource(tc.apiProv)
 			require.NoError(t, err)
 
-			handler := EncryptionHandlers()["AuthProvider"]
+			handler := EncryptionHandlers()[domain.AuthProviderKind]
 			err = handler(context.Background(), modelAP, mgr.ProcessEncryption)
 			require.NoError(t, err)
 
@@ -355,85 +777,145 @@ func TestAuthProviderEncryptionEndToEnd(t *testing.T) {
 				"Plaintext clientSecret '%s' found in spec after encryption", tc.secret)
 			require.Contains(t, specStr, "enc:v1:default:",
 				"Spec should contain encrypted clientSecret with proper format")
+		})
+	}
+}
 
-			// Verify decrypt round-trip: extract the encrypted clientSecret from
-			// the spec JSON and decrypt it back to the original value.
+// ---------------------------------------------------------------------------
+// AuthProvider — decrypt round-trip
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderDecryptRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	testCases := []struct {
+		name    string
+		apiProv *domain.AuthProvider
+		secret  string
+	}{
+		{
+			name: "When decrypting OIDC provider it should recover original clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-oidc-rt")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+						ClientId:               "my-client",
+						ClientSecret:           "oidc-roundtrip-secret",
+						Issuer:                 "https://issuer.example.com",
+						ProviderType:           domain.Oidc,
+						OrganizationAssignment: staticOrgAssignment(),
+					})
+					return spec
+				}(),
+			},
+			secret: "oidc-roundtrip-secret",
+		},
+		{
+			name: "When decrypting AAP provider it should recover original clientSecret",
+			apiProv: &domain.AuthProvider{
+				Metadata: domain.ObjectMeta{Name: strPtr("test-aap-rt")},
+				Spec: func() domain.AuthProviderSpec {
+					var spec domain.AuthProviderSpec
+					_ = spec.FromAapProviderSpec(domain.AapProviderSpec{
+						ClientId:         "aap-client",
+						ClientSecret:     "aap-roundtrip-secret",
+						ApiUrl:           "https://aap.example.com/api",
+						AuthorizationUrl: "https://aap.example.com/authorize",
+						TokenUrl:         "https://aap.example.com/token",
+						ProviderType:     domain.Aap,
+					})
+					return spec
+				}(),
+			},
+			secret: "aap-roundtrip-secret",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modelAP, err := NewAuthProviderFromApiResource(tc.apiProv)
+			require.NoError(t, err)
+
+			handler := EncryptionHandlers()[domain.AuthProviderKind]
+			err = handler(ctx, modelAP, mgr.ProcessEncryption)
+			require.NoError(t, err)
+
+			specJSON, err := json.Marshal(modelAP.Spec.Data)
+			require.NoError(t, err)
+
 			var specMap map[string]any
 			require.NoError(t, json.Unmarshal(specJSON, &specMap))
 
 			encryptedSecret := extractClientSecret(t, specMap)
 			require.True(t, encryption.IsEncrypted([]byte(encryptedSecret)),
-				"clientSecret should be encrypted in spec")
+				"clientSecret should be encrypted")
 
-			decrypted, err := mgr.Decrypt(context.Background(), []byte(encryptedSecret))
+			decrypted, err := mgr.Decrypt(ctx, []byte(encryptedSecret))
 			require.NoError(t, err)
 			require.Equal(t, tc.secret, string(decrypted),
-				"Decrypted clientSecret should match original plaintext")
+				"Decrypted clientSecret should match original")
 		})
 	}
 }
 
-func extractClientSecret(t *testing.T, specMap map[string]any) string {
-	t.Helper()
-	val, ok := specMap["clientSecret"]
-	if ok {
-		s, ok := val.(string)
-		require.True(t, ok, "clientSecret should be a string")
-		return s
-	}
-	t.Fatal("clientSecret not found in spec map")
-	return ""
-}
+// ---------------------------------------------------------------------------
+// AuthProvider — idempotency
+// ---------------------------------------------------------------------------
 
-func TestRepositoryEncryption_FailClosed(t *testing.T) {
-	_ = setupTestEncryption(t)
+func TestEncryptHandler_AuthProviderIdempotent(t *testing.T) {
+	mgr := setupEncryption(t)
 
-	apiRepo := &domain.Repository{
-		Metadata: domain.ObjectMeta{Name: strPtr("test-fail-closed")},
-		Spec: func() domain.RepositorySpec {
-			var spec domain.RepositorySpec
-			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
-				HttpConfig: &domain.HttpConfig{
-					Password: strPtr("secret-password"),
-					Token:    strPtr("secret-token"),
-				},
+	apiProv := &domain.AuthProvider{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-idempotent")},
+		Spec: func() domain.AuthProviderSpec {
+			var spec domain.AuthProviderSpec
+			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				ClientId:               "my-client",
+				ClientSecret:           "idempotent-secret",
+				Issuer:                 "https://issuer.example.com",
+				ProviderType:           domain.Oidc,
+				OrganizationAssignment: staticOrgAssignment(),
 			})
 			return spec
 		}(),
 	}
 
-	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	modelAP, err := NewAuthProviderFromApiResource(apiProv)
 	require.NoError(t, err)
 
-	originalSpec, err := json.Marshal(modelRepo.Spec.Data)
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+
+	err = handler(context.Background(), modelAP, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterFirst, err := json.Marshal(modelAP.Spec.Data)
 	require.NoError(t, err)
 
-	errEncrypt := fmt.Errorf("KMS unavailable")
-	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
-		return nil, errEncrypt
-	}
-
-	handler := EncryptionHandlers()["Repository"]
-	err = handler(context.Background(), modelRepo, failingEncrypt)
-	require.ErrorIs(t, err, errEncrypt)
-
-	afterSpec, err := json.Marshal(modelRepo.Spec.Data)
+	err = handler(context.Background(), modelAP, mgr.ProcessEncryption)
 	require.NoError(t, err)
-	require.JSONEq(t, string(originalSpec), string(afterSpec),
-		"spec must remain unmodified after encryption failure")
+	afterSecond, err := json.Marshal(modelAP.Spec.Data)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(afterFirst), string(afterSecond),
+		"Encrypting an already-encrypted spec should be idempotent")
 }
 
-func TestAuthProviderEncryption_FailClosed(t *testing.T) {
-	_ = setupTestEncryption(t)
+// ---------------------------------------------------------------------------
+// AuthProvider — fail closed
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderFailClosed(t *testing.T) {
+	_ = setupEncryption(t)
 
 	apiProv := &domain.AuthProvider{
-		Metadata: domain.ObjectMeta{Name: strPtr("test-fail-closed")},
+		Metadata: domain.ObjectMeta{Name: strPtr("test-fail")},
 		Spec: func() domain.AuthProviderSpec {
 			var spec domain.AuthProviderSpec
 			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
-				Issuer:       "https://issuer.example.com",
-				ClientId:     "client-id",
+				ClientId:     "client",
 				ClientSecret: "top-secret",
+				Issuer:       "https://issuer.example.com",
 				ProviderType: domain.Oidc,
 			})
 			return spec
@@ -443,24 +925,852 @@ func TestAuthProviderEncryption_FailClosed(t *testing.T) {
 	modelAP, err := NewAuthProviderFromApiResource(apiProv)
 	require.NoError(t, err)
 
-	originalSpec, err := json.Marshal(modelAP.Spec.Data)
+	errEncrypt := fmt.Errorf("KMS unavailable")
+	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errEncrypt
+	}
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err = handler(context.Background(), modelAP, failingEncrypt)
+	require.ErrorIs(t, err, errEncrypt)
+}
+
+// ---------------------------------------------------------------------------
+// AuthProvider — nil spec
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderNilSpec(t *testing.T) {
+	_ = setupEncryption(t)
+
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+
+	ap := &AuthProvider{}
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err := handler(context.Background(), ap, noopEncrypt)
 	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// AuthProvider — non-secret fields preserved
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderNonSecretPreserved(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	apiProv := &domain.AuthProvider{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-preserve")},
+		Spec: func() domain.AuthProviderSpec {
+			var spec domain.AuthProviderSpec
+			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				ClientId:               "my-preserved-client",
+				ClientSecret:           "my-secret",
+				Issuer:                 "https://issuer.example.com",
+				ProviderType:           domain.Oidc,
+				OrganizationAssignment: staticOrgAssignment(),
+			})
+			return spec
+		}(),
+	}
+
+	modelAP, err := NewAuthProviderFromApiResource(apiProv)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err = handler(context.Background(), modelAP, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(modelAP.Spec.Data)
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.Contains(t, specStr, "my-preserved-client",
+		"clientId should remain in plaintext")
+	require.Contains(t, specStr, "https://issuer.example.com",
+		"issuer URL should remain in plaintext")
+	require.NotContains(t, specStr, "my-secret",
+		"clientSecret should be encrypted")
+}
+
+// ---------------------------------------------------------------------------
+// AuthProvider — map encrypt (GORM partial updates)
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_AuthProviderMapEncryptsClientSecret(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	var spec domain.AuthProviderSpec
+	require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		ClientId:     "my-client",
+		ClientSecret: "super-secret-value",
+		Issuer:       "https://issuer.example.com",
+		ProviderType: domain.Oidc,
+	}))
+
+	m := map[string]any{
+		"spec": MakeJSONField(spec),
+	}
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err := handler(ctx, m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(m["spec"])
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.NotContains(t, specStr, "super-secret-value",
+		"clientSecret should be encrypted in map update")
+	require.Contains(t, specStr, "enc:v1:default:",
+		"clientSecret should contain encryption prefix")
+	require.Contains(t, specStr, "my-client",
+		"clientId should remain in plaintext")
+	require.Contains(t, specStr, "https://issuer.example.com",
+		"issuer should remain in plaintext")
+}
+
+func TestEncryptHandler_AuthProviderMapDecryptRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	var spec domain.AuthProviderSpec
+	require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		ClientId:     "roundtrip-client",
+		ClientSecret: "roundtrip-secret",
+		Issuer:       "https://issuer.example.com",
+		ProviderType: domain.Oidc,
+	}))
+
+	m := map[string]any{
+		"spec": MakeJSONField(spec),
+	}
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err := handler(ctx, m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(m["spec"])
+	require.NoError(t, err)
+
+	var decryptedSpec map[string]any
+	require.NoError(t, json.Unmarshal(specJSON, &decryptedSpec))
+
+	encSecret := decryptedSpec["clientSecret"].(string)
+	require.Contains(t, encSecret, "enc:v1:default:")
+
+	decrypted, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(encSecret))
+	require.NoError(t, err)
+	require.Equal(t, "roundtrip-secret", string(decrypted))
+}
+
+func TestEncryptHandler_AuthProviderMapNoSecret(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	var spec domain.AuthProviderSpec
+	require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		ClientId:     "no-secret-client",
+		Issuer:       "https://issuer.example.com",
+		ProviderType: domain.Oidc,
+	}))
+
+	m := map[string]any{
+		"spec": MakeJSONField(spec),
+	}
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err := handler(context.Background(), m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(m["spec"])
+	require.NoError(t, err)
+	specStr := string(specJSON)
+	require.Contains(t, specStr, "no-secret-client",
+		"clientId should remain in plaintext")
+	require.NotContains(t, specStr, "enc:v1:",
+		"No fields should be encrypted when no secret is present")
+}
+
+// ---------------------------------------------------------------------------
+// Repository — map encrypt (GORM partial updates)
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_RepositoryMapEncryptsPassword(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	repoSpec := domain.RepositorySpec{}
+	require.NoError(t, repoSpec.FromHttpRepoSpec(domain.HttpRepoSpec{
+		Url:  "https://repo.example.com",
+		Type: "http",
+		HttpConfig: &domain.HttpConfig{
+			Password: strPtr("my-http-password"),
+			Token:    strPtr("my-http-token"),
+		},
+	}))
+
+	m := map[string]any{
+		"spec": MakeJSONField(repoSpec),
+	}
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err := handler(ctx, m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(m["spec"])
+	require.NoError(t, err)
+	specStr := string(specJSON)
+
+	require.NotContains(t, specStr, "my-http-password",
+		"password should be encrypted")
+	require.NotContains(t, specStr, "my-http-token",
+		"token should be encrypted")
+	require.Contains(t, specStr, "https://repo.example.com",
+		"url should remain in plaintext")
+}
+
+func TestEncryptHandler_RepositoryMapDecryptRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	repoSpec := domain.RepositorySpec{}
+	require.NoError(t, repoSpec.FromHttpRepoSpec(domain.HttpRepoSpec{
+		Url:  "https://repo.example.com",
+		Type: "http",
+		HttpConfig: &domain.HttpConfig{
+			Password: strPtr("decrypt-me-password"),
+			Token:    strPtr("decrypt-me-token"),
+		},
+	}))
+
+	m := map[string]any{
+		"spec": MakeJSONField(repoSpec),
+	}
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err := handler(ctx, m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	specJSON, err := json.Marshal(m["spec"])
+	require.NoError(t, err)
+
+	var specMap map[string]any
+	require.NoError(t, json.Unmarshal(specJSON, &specMap))
+
+	httpConfig := specMap["httpConfig"].(map[string]any)
+
+	encPass := httpConfig["password"].(string)
+	require.Contains(t, encPass, "enc:v1:default:")
+	decryptedPass, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(encPass))
+	require.NoError(t, err)
+	require.Equal(t, "decrypt-me-password", string(decryptedPass))
+
+	encToken := httpConfig["token"].(string)
+	require.Contains(t, encToken, "enc:v1:default:")
+	decryptedToken, _, err := encryption.Decrypt(ctx, encryption.Ciphertext(encToken))
+	require.NoError(t, err)
+	require.Equal(t, "decrypt-me-token", string(decryptedToken))
+}
+
+// ---------------------------------------------------------------------------
+// Device — struct encrypt
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_DeviceStructRenderedFields(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	configInput := `[{"inline":[{"path":"/etc/file","content":"secret-content","mode":420}],"name":""}]`
+	appsInput := `[{"appType":"container","name":"app","image":"img:v1","envVars":{"SECRET":"value123"}}]`
+
+	device := &Device{
+		RenderedConfig:       MakeJSONField(json.RawMessage(configInput)),
+		RenderedApplications: MakeJSONField(json.RawMessage(appsInput)),
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(device.RenderedConfig.Data), "secret-content")
+	require.Contains(t, string(device.RenderedConfig.Data), "enc:v1:default:")
+
+	require.NotContains(t, string(device.RenderedApplications.Data), "value123")
+	require.Contains(t, string(device.RenderedApplications.Data), "enc:v1:default:")
+}
+
+func TestEncryptHandler_DeviceStructNilFields(t *testing.T) {
+	_ = setupEncryption(t)
+
+	device := &Device{}
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+	err := handler(context.Background(), device, noopEncrypt)
+	require.NoError(t, err)
+}
+
+func TestEncryptHandler_DeviceStructDecryptRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	configInput := `[{"inline":[{"path":"/etc/file","content":"my-secret","mode":420}],"name":""}]`
+	appsInput := `[{"appType":"container","name":"app","image":"img:v1","envVars":{"KEY":"app-secret"}}]`
+
+	device := &Device{
+		RenderedConfig:       MakeJSONField(json.RawMessage(configInput)),
+		RenderedApplications: MakeJSONField(json.RawMessage(appsInput)),
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(ctx, device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	configResult, err := decryptRenderedField(ctx, device.RenderedConfig)
+	require.NoError(t, err)
+	require.JSONEq(t, configInput, string(configResult))
+
+	appsResult, err := decryptRenderedField(ctx, device.RenderedApplications)
+	require.NoError(t, err)
+	require.JSONEq(t, appsInput, string(appsResult))
+}
+
+func TestEncryptHandler_DeviceStructIdempotent(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	configInput := `[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`
+	device := &Device{
+		RenderedConfig: MakeJSONField(json.RawMessage(configInput)),
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+
+	err := handler(context.Background(), device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterFirst := string(device.RenderedConfig.Data)
+
+	err = handler(context.Background(), device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterSecond := string(device.RenderedConfig.Data)
+
+	require.Equal(t, afterFirst, afterSecond,
+		"Encrypting already-encrypted device should be idempotent")
+}
+
+func TestEncryptHandler_DeviceStructFailClosed(t *testing.T) {
+	_ = setupEncryption(t)
+
+	device := &Device{
+		RenderedConfig: MakeJSONField(json.RawMessage(`[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`)),
+	}
 
 	errEncrypt := fmt.Errorf("KMS unavailable")
 	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
 		return nil, errEncrypt
 	}
 
-	handler := EncryptionHandlers()["AuthProvider"]
-	err = handler(context.Background(), modelAP, failingEncrypt)
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), device, failingEncrypt)
 	require.ErrorIs(t, err, errEncrypt)
-
-	afterSpec, err := json.Marshal(modelAP.Spec.Data)
-	require.NoError(t, err)
-	require.JSONEq(t, string(originalSpec), string(afterSpec),
-		"spec must remain unmodified after encryption failure")
 }
 
-func strPtr(s string) *string {
-	return &s
+func TestEncryptHandler_DeviceOnlyConfig(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	device := &Device{
+		RenderedConfig: MakeJSONField(json.RawMessage(`[{"inline":[{"path":"/etc/secret.conf","content":"password=hunter2","mode":420}],"name":""}]`)),
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(device.RenderedConfig.Data), "password=hunter2")
+	require.Contains(t, string(device.RenderedConfig.Data), "enc:v1:default:")
+	require.Nil(t, device.RenderedApplications)
+}
+
+func TestEncryptHandler_DeviceOnlyApps(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	device := &Device{
+		RenderedApplications: MakeJSONField(json.RawMessage(`[{"appType":"container","name":"myapp","image":"img:v1","envVars":{"DB_PASSWORD":"secret123"}}]`)),
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), device, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(device.RenderedApplications.Data), "secret123")
+	require.Contains(t, string(device.RenderedApplications.Data), "enc:v1:default:")
+	require.Nil(t, device.RenderedConfig)
+}
+
+// ---------------------------------------------------------------------------
+// Device — legacy unencrypted data
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_DeviceLegacyUnencryptedData(t *testing.T) {
+	setupEncryption(t)
+	ctx := context.Background()
+
+	configInput := `[{"inline":[{"path":"/etc/file","content":"plaintext-value","mode":420}],"name":""}]`
+
+	result, err := decryptRenderedField(ctx, MakeJSONField(json.RawMessage(configInput)))
+	require.NoError(t, err)
+	require.JSONEq(t, configInput, string(result))
+
+	result, err = decryptRenderedField(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	result, err = decryptRenderedField(ctx, MakeJSONField(json.RawMessage{}))
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+// ---------------------------------------------------------------------------
+// Device — map encrypt (GORM partial updates)
+// ---------------------------------------------------------------------------
+
+func TestEncryptHandler_DeviceMapRenderedFields(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	configVal := `[{"inline":[{"path":"/etc/file","content":"secret-content","mode":420}],"name":""}]`
+	appsVal := `[{"appType":"container","name":"app","image":"img:v1","envVars":{"SECRET":"value123"}}]`
+
+	m := map[string]any{
+		"rendered_config":       &configVal,
+		"rendered_applications": &appsVal,
+		"resource_version":      42,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, configVal, "secret-content",
+		"Config plaintext should be encrypted")
+	require.NotContains(t, appsVal, "value123",
+		"Apps plaintext should be encrypted")
+
+	require.Equal(t, 42, m["resource_version"],
+		"resource_version should not be changed")
+}
+
+func TestEncryptHandler_DeviceMapIdempotent(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	configVal := `[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`
+
+	m := map[string]any{
+		"rendered_config": &configVal,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+
+	err := handler(context.Background(), m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterFirst := configVal
+
+	err = handler(context.Background(), m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+	afterSecond := configVal
+
+	require.Equal(t, afterFirst, afterSecond,
+		"Encrypting already-encrypted map value should be idempotent")
+}
+
+func TestEncryptHandler_DeviceMapOnlyConfig(t *testing.T) {
+	mgr := setupEncryption(t)
+
+	configVal := `[{"inline":[{"path":"/etc/secret.conf","content":"password=hunter2","mode":420}],"name":""}]`
+
+	m := map[string]any{
+		"rendered_config":  &configVal,
+		"resource_version": 1,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, configVal, "password=hunter2")
+}
+
+func TestEncryptHandler_DeviceMapMissingKeys(t *testing.T) {
+	_ = setupEncryption(t)
+
+	m := map[string]any{
+		"annotations":      "some-value",
+		"resource_version": 1,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+	err := handler(context.Background(), m, noopEncrypt)
+	require.NoError(t, err)
+}
+
+func TestEncryptHandler_DeviceMapNilValue(t *testing.T) {
+	_ = setupEncryption(t)
+
+	m := map[string]any{
+		"rendered_config": nil,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+	err := handler(context.Background(), m, noopEncrypt)
+	require.NoError(t, err)
+}
+
+func TestEncryptHandler_DeviceMapEmptyString(t *testing.T) {
+	_ = setupEncryption(t)
+
+	emptyVal := ""
+	m := map[string]any{
+		"rendered_config": &emptyVal,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+	err := handler(context.Background(), m, noopEncrypt)
+	require.NoError(t, err)
+	require.Equal(t, "", emptyVal, "Empty string should remain empty")
+}
+
+func TestEncryptHandler_DeviceMapFailClosed(t *testing.T) {
+	_ = setupEncryption(t)
+
+	configVal := `[{"inline":[{"path":"/etc/file","content":"secret","mode":420}],"name":""}]`
+	m := map[string]any{
+		"rendered_config": &configVal,
+	}
+
+	errEncrypt := fmt.Errorf("KMS unavailable")
+	failingEncrypt := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errEncrypt
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), m, failingEncrypt)
+	require.ErrorIs(t, err, errEncrypt)
+}
+
+func TestEncryptHandler_DeviceMapUnsupportedTypeFailsClosed(t *testing.T) {
+	_ = setupEncryption(t)
+
+	m := map[string]any{
+		"rendered_config": "not-a-pointer",
+	}
+
+	noopEncrypt := func(_ context.Context, data []byte) ([]byte, error) {
+		return data, nil
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(context.Background(), m, noopEncrypt)
+	require.ErrorIs(t, err, ErrUnsupportedEncryptionType)
+}
+
+func TestEncryptHandler_DeviceMapRoundTrip(t *testing.T) {
+	mgr := setupEncryption(t)
+	ctx := context.Background()
+
+	configInput := `[{"inline":[{"path":"/etc/file","content":"secret-data","mode":420}],"name":""}]`
+	appsInput := `[{"appType":"container","name":"app","image":"img:v1","envVars":{"KEY":"secret-val"}}]`
+
+	configStr := configInput
+	appsStr := appsInput
+	m := map[string]any{
+		"rendered_config":       &configStr,
+		"rendered_applications": &appsStr,
+	}
+
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	err := handler(ctx, m, mgr.ProcessEncryption)
+	require.NoError(t, err)
+
+	require.NotContains(t, configStr, "secret-data")
+	require.NotContains(t, appsStr, "secret-val")
+
+	configResult, err := decryptRenderedField(ctx, MakeJSONField(json.RawMessage(configStr)))
+	require.NoError(t, err)
+	require.JSONEq(t, configInput, string(configResult))
+
+	appsResult, err := decryptRenderedField(ctx, MakeJSONField(json.RawMessage(appsStr)))
+	require.NoError(t, err)
+	require.JSONEq(t, appsInput, string(appsResult))
+}
+
+// ---------------------------------------------------------------------------
+// Shared-slice corruption — zeroModel prevents backing array reuse
+// ---------------------------------------------------------------------------
+
+func TestNoSharedSliceCorruption_AuthProvider(t *testing.T) {
+	_ = setupEncryption(t)
+
+	apiProv := &domain.AuthProvider{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-corruption")},
+		Spec: func() domain.AuthProviderSpec {
+			var spec domain.AuthProviderSpec
+			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				ClientId:               "my-client",
+				ClientSecret:           "original-secret",
+				Issuer:                 "https://issuer.example.com",
+				ProviderType:           domain.Oidc,
+				OrganizationAssignment: staticOrgAssignment(),
+			})
+			return spec
+		}(),
+	}
+
+	specBefore, err := apiProv.Spec.MarshalJSON()
+	require.NoError(t, err)
+
+	modelAP, err := NewAuthProviderFromApiResource(apiProv)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err = handler(context.Background(), modelAP, sameLenEncrypt)
+	require.NoError(t, err)
+
+	specAfter, err := apiProv.Spec.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(specBefore), string(specAfter),
+		"API resource spec must not be corrupted by encrypting the model")
+	require.Contains(t, string(specAfter), "original-secret",
+		"API resource should still have plaintext clientSecret")
+}
+
+func TestNoSharedSliceCorruption_Repository(t *testing.T) {
+	_ = setupEncryption(t)
+
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("test-corruption")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Password: strPtr("original-password"),
+					Token:    strPtr("original-token"),
+				},
+			})
+			return spec
+		}(),
+	}
+
+	specBefore, err := apiRepo.Spec.MarshalJSON()
+	require.NoError(t, err)
+
+	modelRepo, err := NewRepositoryFromApiResource(apiRepo)
+	require.NoError(t, err)
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), modelRepo, sameLenEncrypt)
+	require.NoError(t, err)
+
+	specAfter, err := apiRepo.Spec.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(specBefore), string(specAfter),
+		"API resource spec must not be corrupted by encrypting the model")
+	require.Contains(t, string(specAfter), "original-password",
+		"API resource should still have plaintext password")
+}
+
+func TestNoSharedSliceCorruption_AuthProviderMap(t *testing.T) {
+	_ = setupEncryption(t)
+
+	var spec domain.AuthProviderSpec
+	require.NoError(t, spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+		ClientId:     "my-client",
+		ClientSecret: "map-secret",
+		Issuer:       "https://issuer.example.com",
+		ProviderType: domain.Oidc,
+	}))
+
+	specBefore, err := spec.MarshalJSON()
+	require.NoError(t, err)
+
+	m := map[string]any{
+		"spec": MakeJSONField(spec),
+	}
+
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	err = handler(context.Background(), m, sameLenEncrypt)
+	require.NoError(t, err)
+
+	specAfter, err := spec.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(specBefore), string(specAfter),
+		"Original spec must not be corrupted by encrypting the map")
+	require.Contains(t, string(specAfter), "map-secret",
+		"Original spec should still have plaintext clientSecret")
+}
+
+func TestNoSharedSliceCorruption_RepositoryMap(t *testing.T) {
+	_ = setupEncryption(t)
+
+	var spec domain.RepositorySpec
+	require.NoError(t, spec.FromGitRepoSpec(domain.GitRepoSpec{
+		HttpConfig: &domain.HttpConfig{
+			Password: strPtr("map-password"),
+			Token:    strPtr("map-token"),
+		},
+	}))
+
+	specBefore, err := spec.MarshalJSON()
+	require.NoError(t, err)
+
+	m := map[string]any{
+		"spec": MakeJSONField(spec),
+	}
+
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	err = handler(context.Background(), m, sameLenEncrypt)
+	require.NoError(t, err)
+
+	specAfter, err := spec.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(specBefore), string(specAfter),
+		"Original spec must not be corrupted by encrypting the map")
+	require.Contains(t, string(specAfter), "map-password",
+		"Original spec should still have plaintext password")
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func makeRepoModel(b *testing.B, secretSize int) *Repository {
+	b.Helper()
+	secret := strings.Repeat("s", secretSize)
+	apiRepo := &domain.Repository{
+		Metadata: domain.ObjectMeta{Name: strPtr("bench-repo")},
+		Spec: func() domain.RepositorySpec {
+			var spec domain.RepositorySpec
+			_ = spec.FromGitRepoSpec(domain.GitRepoSpec{
+				HttpConfig: &domain.HttpConfig{
+					Username: strPtr("user"),
+					Password: strPtr(secret),
+					Token:    strPtr(secret),
+					TlsKey:   strPtr(secret),
+					TlsCrt:   strPtr(secret),
+				},
+				SshConfig: &domain.SshConfig{
+					SshPrivateKey:        strPtr(secret),
+					PrivateKeyPassphrase: strPtr(secret),
+				},
+			})
+			return spec
+		}(),
+	}
+	model, err := NewRepositoryFromApiResource(apiRepo)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return model
+}
+
+func makeAuthProviderModel(b *testing.B, secretSize int) *AuthProvider {
+	b.Helper()
+	secret := strings.Repeat("s", secretSize)
+	apiProv := &domain.AuthProvider{
+		Metadata: domain.ObjectMeta{Name: strPtr("bench-ap")},
+		Spec: func() domain.AuthProviderSpec {
+			var spec domain.AuthProviderSpec
+			_ = spec.FromOIDCProviderSpec(domain.OIDCProviderSpec{
+				ClientId:               "bench-client",
+				ClientSecret:           secret,
+				Issuer:                 "https://issuer.example.com",
+				ProviderType:           domain.Oidc,
+				OrganizationAssignment: staticOrgAssignment(),
+			})
+			return spec
+		}(),
+	}
+	model, err := NewAuthProviderFromApiResource(apiProv)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return model
+}
+
+func makeDeviceModel(b *testing.B, configSize int) *Device {
+	b.Helper()
+	content := strings.Repeat("x", configSize)
+	configJSON := fmt.Sprintf(`[{"inline":[{"path":"/etc/secret","content":"%s","mode":420}],"name":""}]`, content)
+	appsJSON := fmt.Sprintf(`[{"appType":"container","name":"app","image":"img:v1","envVars":{"SECRET":"%s"}}]`, content)
+	return &Device{
+		RenderedConfig:       MakeJSONField(json.RawMessage(configJSON)),
+		RenderedApplications: MakeJSONField(json.RawMessage(appsJSON)),
+	}
+}
+
+func BenchmarkEncryptHandler_Repository(b *testing.B) {
+	mgr := setupEncryption(b)
+	handler := EncryptionHandlers()[domain.RepositoryKind]
+	ctx := context.Background()
+
+	for _, size := range []int{32, 256, 1024, 4096} {
+		b.Run(fmt.Sprintf("secret_%dB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				model := makeRepoModel(b, size)
+				b.StartTimer()
+				if err := handler(ctx, model, mgr.ProcessEncryption); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEncryptHandler_AuthProvider(b *testing.B) {
+	mgr := setupEncryption(b)
+	handler := EncryptionHandlers()[domain.AuthProviderKind]
+	ctx := context.Background()
+
+	for _, size := range []int{32, 256, 1024, 4096} {
+		b.Run(fmt.Sprintf("secret_%dB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				model := makeAuthProviderModel(b, size)
+				b.StartTimer()
+				if err := handler(ctx, model, mgr.ProcessEncryption); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEncryptHandler_Device(b *testing.B) {
+	mgr := setupEncryption(b)
+	handler := EncryptionHandlers()[domain.DeviceKind]
+	ctx := context.Background()
+
+	for _, size := range []int{256, 1024, 4096, 16384, 65536} {
+		b.Run(fmt.Sprintf("payload_%dB", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				model := makeDeviceModel(b, size)
+				b.StartTimer()
+				if err := handler(ctx, model, mgr.ProcessEncryption); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/internal/store/model/resource.go
+++ b/internal/store/model/resource.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -55,12 +56,14 @@ type apiResourceOptions struct {
 	devicesSummary       *domain.DevicesSummary // Used by Fleet
 	isRendered           bool                   // Used by Device
 	knownRenderedVersion *string
+	ctx                  context.Context
 }
 
-func WithRendered(knownRenderedVersion *string) APIResourceOption {
+func WithRendered(ctx context.Context, knownRenderedVersion *string) APIResourceOption {
 	return func(o *apiResourceOptions) {
 		o.isRendered = true
 		o.knownRenderedVersion = knownRenderedVersion
+		o.ctx = ctx
 	}
 }
 

--- a/test/integration/store/authprovider_test.go
+++ b/test/integration/store/authprovider_test.go
@@ -7,6 +7,7 @@ import (
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/store"
 	authproviderstore "github.com/flightctl/flightctl/internal/store/authprovider"
 	organizationstore "github.com/flightctl/flightctl/internal/store/organization"
@@ -132,6 +133,24 @@ var _ = Describe("AuthProviderStore", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 			Expect(*result.Metadata.Name).To(Equal("get-test-provider"))
+		})
+
+		It("should store clientSecret encrypted at rest", func() {
+			provider := createTestAuthProvider("encrypted-provider")
+			_, err := authStore.Create(ctx, orgId, &provider, callback)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := authStore.Get(ctx, orgId, "encrypted-provider")
+			Expect(err).ToNot(HaveOccurred())
+
+			oidcSpec, err := result.Spec.AsOIDCProviderSpec()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(oidcSpec.ClientSecret).ToNot(Equal("test-client-secret"),
+				"clientSecret should not be stored as plaintext")
+			plaintext, wasEncrypted, err := encryption.Decrypt(ctx, encryption.Ciphertext(oidcSpec.ClientSecret))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(wasEncrypted).To(BeTrue(), "clientSecret should be encrypted")
+			Expect(string(plaintext)).To(Equal("test-client-secret"))
 		})
 
 		It("GetAuthProvider - not found error", func() {

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/store"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
@@ -1155,7 +1156,22 @@ var _ = Describe("DeviceStore create", func() {
 			_, err = devStore.UpdateRendered(ctx, orgId, "dev", firstConfig, "", "hash1", nil, false)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Getting first rendered config
+			// Verify rendered config is encrypted at rest
+			var rawDevice model.Device
+			Expect(db.WithContext(ctx).Where("org_id = ? AND name = ?", orgId, "dev").First(&rawDevice).Error).To(Succeed())
+			Expect(rawDevice.RenderedConfig).ToNot(BeNil())
+			Expect(string(rawDevice.RenderedConfig.Data)).ToNot(ContainSubstring("this is the first config"),
+				"rendered config should be encrypted at rest")
+			// RawMessage holds the JSON string token: "enc:v1:default:..."
+			// Unmarshal extracts the inner string for decryption.
+			var encStr string
+			Expect(json.Unmarshal(rawDevice.RenderedConfig.Data, &encStr)).To(Succeed())
+			plaintext, wasEncrypted, err := encryption.Decrypt(ctx, encryption.Ciphertext(encStr))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(wasEncrypted).To(BeTrue(), "rendered config should be encrypted")
+			Expect(string(plaintext)).To(ContainSubstring("this is the first config"))
+
+			// Getting first rendered config (decrypts transparently)
 			renderedDevice, err := devStore.GetRendered(ctx, orgId, "dev", nil, "")
 			Expect(err).ToNot(HaveOccurred())
 			renderedConfig := *renderedDevice.Spec.Config


### PR DESCRIPTION
Encrypt rendered_config and rendered_applications as whole blobs to protect sensitive data from secret-backed config providers. Consolidate all encryption into a generic handler with a unified registry, replacing per-type handlers. Backward-compatible with unencrypted legacy data.
