### PR TITLE
NO-ISSUE: Add Fedora 44 build targets to packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,6 +22,7 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-43-x86_64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-10-aarch64
     module_hotfixes: true
@@ -36,6 +37,8 @@ jobs:
       - fedora-42-x86_64
       - fedora-43-aarch64
       - fedora-43-x86_64
+      - fedora-44-aarch64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-9-x86_64
       - epel-10-aarch64
@@ -51,6 +54,8 @@ jobs:
       - fedora-42-x86_64
       - fedora-43-aarch64
       - fedora-43-x86_64
+      - fedora-44-aarch64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-9-x86_64
       - epel-10-aarch64


### PR DESCRIPTION
## Summary
- Adds `fedora-44-x86_64` to the PR build targets
- Adds `fedora-44-aarch64` and `fedora-44-x86_64` to the commit and release build targets
- COPR project already has Fedora 44 enabled but packit was not submitting builds for it

## Test plan
- [ ] Verify packit triggers Fedora 44 COPR builds on the next PR/commit

Assisted-by: Claude <noreply@anthropic.com>