### PR TITLE
EDM-4780: [QE] E2E tests for encryption-at-rest

### DIFF
--- a/test/e2e/authprovider/authprovider_helpers_test.go
+++ b/test/e2e/authprovider/authprovider_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	internalconfig "github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
@@ -554,6 +555,26 @@ func (f fakeInfraProvider) BuiltinDatabaseWorkloadAvailable() bool {
 // ServiceExists is unused by these tests and satisfies infra.InfraProvider.
 func (f fakeInfraProvider) ServiceExists(context.Context, infra.ServiceName) (bool, error) {
 	return false, nil
+}
+
+// SetEncryptionKey is unused by these tests and satisfies infra.InfraProvider.
+func (f fakeInfraProvider) SetEncryptionKey(infra.ServiceName, string, []byte) error {
+	return errors.New("not implemented")
+}
+
+// ResetEncryptionKeys is unused by these tests and satisfies infra.InfraProvider.
+func (f fakeInfraProvider) ResetEncryptionKeys() error {
+	return errors.New("not implemented")
+}
+
+// GetEncryptionConfig is unused by these tests and satisfies infra.InfraProvider.
+func (f fakeInfraProvider) GetEncryptionConfig(infra.ServiceName) (*internalconfig.EncryptionConfig, error) {
+	return nil, errors.New("not implemented")
+}
+
+// SetEncryptionConfig is unused by these tests and satisfies infra.InfraProvider.
+func (f fakeInfraProvider) SetEncryptionConfig(infra.ServiceName, *internalconfig.EncryptionConfig) error {
+	return errors.New("not implemented")
 }
 
 var _ infra.InfraProvider = fakeInfraProvider{}

--- a/test/e2e/authprovider/authprovider_test.go
+++ b/test/e2e/authprovider/authprovider_test.go
@@ -30,6 +30,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/quadlet/renderer"
+	authproviderhelpers "github.com/flightctl/flightctl/test/e2e/authprovider/helpers"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
 	quadletinfra "github.com/flightctl/flightctl/test/e2e/infra/quadlet"
@@ -602,21 +603,14 @@ func checkAPIEndpointReady(ctx context.Context, apiEndpoint string) error {
 				MinVersion:         tls.VersionTLS12,
 			},
 		},
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
 		Timeout: authConfigHTTPTimeout,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s/readyz: %w", strings.TrimRight(apiEndpoint, "/"), err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logrus.Warnf("[authprovider] failed to close API readiness response body: %v", err)
-		}
-	}()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("GET %s/readyz returned %d", strings.TrimRight(apiEndpoint, "/"), resp.StatusCode)
 	}
 	return nil
@@ -938,6 +932,7 @@ func writeAndApplyAuthProviderManifest(harness *e2e.Harness, providerPath, provi
 }
 
 // deleteAuthProviderByName deletes a dynamic authprovider through the harness resource API.
+// It restores admin login before deletion to handle cases where an OIDC provider is currently active.
 func deleteAuthProviderByName(harness *e2e.Harness, providerName string) (string, error) {
 	if harness == nil {
 		return "", fmt.Errorf("worker harness is required")
@@ -948,7 +943,7 @@ func deleteAuthProviderByName(harness *e2e.Harness, providerName string) (string
 	if err := restoreAdminLoginForResourceManagement(harness); err != nil {
 		return "", err
 	}
-	return harness.ManageResource("delete", "authprovider", providerName)
+	return authproviderhelpers.DeleteAuthProvider(harness, providerName)
 }
 
 // restoreAdminLoginForResourceManagement resets the CLI session to an admin user before authprovider mutations.
@@ -1800,31 +1795,7 @@ func authProviderPackageDir() string {
 
 // buildOIDCAuthProviderYAML renders a dynamic OIDC authprovider manifest for this suite.
 func buildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret string, enabled bool) string {
-	return fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
-kind: AuthProvider
-metadata:
-  name: %s
-spec:
-  providerType: oidc
-  displayName: %s
-  issuer: %s
-  clientId: %s
-  clientSecret: %s
-  enabled: %t
-  scopes:
-    - openid
-    - profile
-    - email
-  usernameClaim:
-    - preferred_username
-  organizationAssignment:
-    type: static
-    organizationName: %s
-  roleAssignment:
-    type: static
-    roles:
-      - %s
-`, name, name, issuerURL, clientID, clientSecret, enabled, defaultOrganizationName, defaultAdminRole)
+	return authproviderhelpers.BuildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret, enabled)
 }
 
 // buildKeycloakOAuth2AuthProviderYAML renders a Keycloak-backed dynamic OAuth2 authprovider manifest for this suite.

--- a/test/e2e/authprovider/helpers/helpers.go
+++ b/test/e2e/authprovider/helpers/helpers.go
@@ -1,0 +1,87 @@
+package authproviderhelpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// BuildOIDCAuthProviderYAML renders a minimal OIDC AuthProvider manifest string.
+// When enabled is false the provider is created in disabled state (safe for e2e tests
+// that only need to exercise encryption or credential storage, not live authentication).
+func BuildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret string, enabled bool) string {
+	return fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
+kind: AuthProvider
+metadata:
+  name: %q
+spec:
+  providerType: oidc
+  displayName: %q
+  issuer: %q
+  clientId: %q
+  clientSecret: %q
+  enabled: %t
+  scopes:
+    - openid
+    - profile
+    - email
+  usernameClaim:
+    - preferred_username
+  organizationAssignment:
+    type: static
+    organizationName: default
+  roleAssignment:
+    type: static
+    roles:
+      - flightctl-admin
+`, name, name, issuerURL, clientID, clientSecret, enabled)
+}
+
+// ApplyManifest writes manifestYAML to a temp file and applies it via the harness CLI.
+// Login must be established by the caller before invoking this function.
+func ApplyManifest(harness *e2e.Harness, manifestYAML string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("ApplyManifest: harness is required")
+	}
+	if manifestYAML == "" {
+		return "", fmt.Errorf("ApplyManifest: manifestYAML is empty")
+	}
+	tmp, err := os.CreateTemp("", "authprovider-manifest-*.yaml")
+	if err != nil {
+		GinkgoWriter.Printf("ApplyManifest: create temp file failed: %v\n", err)
+		return "", fmt.Errorf("create temp manifest file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close() //nolint:errcheck
+	if _, err := tmp.WriteString(manifestYAML); err != nil {
+		GinkgoWriter.Printf("ApplyManifest: write temp file failed: %v\n", err)
+		return "", fmt.Errorf("write manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+	out, err := harness.ApplyResource(tmp.Name())
+	if err != nil {
+		GinkgoWriter.Printf("ApplyManifest: ApplyResource failed: %v\n", err)
+	}
+	return out, err
+}
+
+// DeleteAuthProvider deletes an AuthProvider CR by name via the harness CLI.
+// Login must be established by the caller before invoking this function.
+// Returns the CLI output (e.g. "authprovider/name deleted") so callers can assert on it.
+func DeleteAuthProvider(harness *e2e.Harness, name string) (string, error) {
+	if harness == nil {
+		return "", fmt.Errorf("DeleteAuthProvider: harness is required")
+	}
+	if name == "" {
+		return "", fmt.Errorf("DeleteAuthProvider: name is required")
+	}
+	out, err := harness.ManageResource("delete", "authprovider", name)
+	if err != nil {
+		GinkgoWriter.Printf("DeleteAuthProvider: ManageResource failed for %q: %v\n", name, err)
+	}
+	return out, err
+}

--- a/test/e2e/encryption/backup_restore_test.go
+++ b/test/e2e/encryption/backup_restore_test.go
@@ -1,0 +1,193 @@
+package encryption_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption at rest — Backup", Label("encryption", "backup-restore"), func() {
+	var (
+		harness *e2e.Harness
+		br      *e2e.BackupRestore
+	)
+
+	BeforeEach(func() {
+		if reason := backupRestoreExternalDBSkipReason(); reason != "" {
+			Skip(reason)
+		}
+		harness = e2e.GetWorkerHarness()
+		p := setup.GetDefaultProviders()
+		br = harness.NewBackupRestore(p)
+	})
+
+	Context("When a backup is taken with encryption at rest enabled", func() {
+		It("S3: backup archive should include encryption key material", Label("90094"), func() {
+			By("running flightctl-backup to create an archive")
+			outputDir := GinkgoT().TempDir()
+			archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+			Expect(err).ToNot(HaveOccurred(), "backup must succeed")
+			Expect(archivePath).ToNot(BeEmpty(), "backup must return an archive path")
+			Expect(archivePath).To(BeAnExistingFile(), "backup archive must exist on disk")
+			GinkgoWriter.Printf("Backup archive path: %s\n", archivePath)
+
+			By("listing archive entries")
+			entries, err := listTarGzEntries(archivePath)
+			Expect(err).ToNot(HaveOccurred(), "must be able to read archive entries")
+			Expect(entries).ToNot(BeEmpty(), "archive must have entries")
+
+			By("verifying at least one encryption entry is present in the archive")
+			prefix := encryptionKeyArchiveEntryPrefix()
+			var encryptionEntries []string
+			for _, e := range entries {
+				if strings.HasPrefix(e, prefix) {
+					encryptionEntries = append(encryptionEntries, e)
+				}
+			}
+			Expect(encryptionEntries).ToNot(BeEmpty(),
+				"backup archive must contain encryption key material under %q; entries: %v",
+				prefix, entries)
+
+			By("logging found encryption archive entries")
+			GinkgoWriter.Printf("Encryption entries in backup: %v\n", encryptionEntries)
+		})
+	})
+
+	Context("When restoring from a backup taken before a key rotation", Serial, func() {
+		var (
+			providers   *infra.Providers
+			savedConfig string
+		)
+
+		BeforeEach(func() {
+			providers = setup.GetDefaultProviders()
+			savedConfig = ""
+		})
+
+		// Safety net: if the test mutated the encryption config and did not clean up (e.g. due to
+		// a mid-test failure), restore the original config so subsequent specs can start cleanly.
+		AfterEach(func() {
+			if savedConfig != "" {
+				// Remove stale canary rows before restarting. If S4 failed after rotating the key
+				// (line 123) but before the restore completed, the DB contains a canary for the
+				// rotated key (post-backup-key). Restoring the original config (which only has
+				// "default") without deleting that canary causes ValidateCanaries to crash-loop
+				// on startup (cannot decrypt the rotated-key canary with the restored config).
+				deleteStaleCanaries(defaultKeyID)
+				// Reset migration checkpoints so the restored default config does not inherit a
+				// Complete=true checkpoint from this run's key rotation.
+				resetMigrationCheckpoints()
+				if err := restoreEncryptionConfig(savedConfig); err != nil {
+					GinkgoWriter.Printf("Warning: restore encryption config failed: %v\n", err)
+				}
+				if err := restartServicesAndWait(); err != nil {
+					GinkgoWriter.Printf("Warning: service restart after config restore failed: %v\n", err)
+				}
+				if _, err := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout); err != nil {
+					GinkgoWriter.Printf("Warning: re-login after config restore failed: %v\n", err)
+				}
+			}
+		})
+
+		It("S4: restore should revert DB ciphertexts to the backup-time key and services should decrypt correctly", Label("90151"), func() {
+			const rotatedKeyID = "post-backup-key"
+
+			By("creating a pre-backup AuthProvider with a clientSecret encrypted under the default key")
+			Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+			apName := "enc-restore-ap-" + harness.GetTestIDFromContext()
+			secretBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred(), "generate AuthProvider client secret")
+			clientSecret := fmt.Sprintf("pre-backup-secret-%x", secretBytes[:8])
+			manifest := buildOIDCAuthProviderYAML(apName, auxSvcs.Keycloak.IssuerURL(), "flightctl-client", clientSecret)
+			_, err = applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create pre-backup AuthProvider")
+			DeferCleanup(func() { _ = deleteAuthProvider(harness, apName) })
+
+			By("confirming pre-backup DB ciphertext uses the default key")
+			apCipherBefore, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", apName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(apCipherBefore, defaultKeyID)).To(BeTrue(),
+				"pre-backup AuthProvider ciphertext must use default key; got: %s", apCipherBefore)
+
+			By("running flightctl-backup to capture the pre-rotation state")
+			outputDir := GinkgoT().TempDir()
+			archivePath, _, err := br.RunFlightCtlBackup(outputDir)
+			Expect(err).ToNot(HaveOccurred(), "backup must succeed")
+			Expect(archivePath).ToNot(BeEmpty(), "backup must return an archive path")
+			Expect(archivePath).To(BeAnExistingFile(), "backup archive must exist on disk")
+			GinkgoWriter.Printf("Backup archive: %s\n", archivePath)
+
+			By("rotating the active encryption key to mutate state post-backup")
+			newKeyBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred(), "generate new AES key for post-backup rotation")
+			savedConfig, err = rotateEncryptionKey(rotatedKeyID, newKeyBytes)
+			Expect(err).ToNot(HaveOccurred(), "rotate encryption key post-backup")
+			Expect(restartServicesAndWait()).To(Succeed(), "restart services after key rotation")
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-login after key rotation restart")
+
+			By("triggering re-encryption so the DB ciphertext uses the rotated key")
+			updatedSecret := fmt.Sprintf("post-rotation-secret-%x", newKeyBytes[:8])
+			updatedManifest := buildOIDCAuthProviderYAML(apName, auxSvcs.Keycloak.IssuerURL(), "flightctl-client", updatedSecret)
+			_, err = applyManifest(harness, updatedManifest)
+			Expect(err).ToNot(HaveOccurred(), "update AuthProvider to trigger re-encryption")
+
+			By("confirming DB ciphertext now uses the rotated key")
+			apCipherRotated, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", apName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(apCipherRotated, rotatedKeyID)).To(BeTrue(),
+				"post-rotation AuthProvider ciphertext must use rotated key; got: %s", apCipherRotated)
+			GinkgoWriter.Printf("Post-rotation ciphertext prefix confirmed: %s\n", apCipherRotated[:min(40, len(apCipherRotated))])
+
+			By("running flightctl-restore to revert to the pre-rotation backup")
+			Expect(br.RunFlightCtlRestoreFromArchive(archivePath)).To(Succeed(), "restore from backup must succeed")
+
+			By("waiting for all services to be running after restore")
+			Eventually(br.VerifyAllServicesRunning,
+				testutil.LONG_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(Succeed(), "all services must be running after restore")
+
+			By("waiting for the API to be reachable after restore")
+			Eventually(func() error {
+				_, loginErr := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+				return loginErr
+			}, testutil.LONG_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(Succeed(), "API must be reachable after restore")
+
+			By("verifying DB ciphertext reverted to the backup-time default key")
+			apCipherRestored, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", apName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(apCipherRestored, defaultKeyID)).To(BeTrue(),
+				"restored AuthProvider ciphertext must use default key; got: %s", apCipherRestored)
+			GinkgoWriter.Printf("Restored ciphertext prefix confirmed: %s\n", apCipherRestored[:min(40, len(apCipherRestored))])
+
+			By("verifying the API can read and decrypt the restored AuthProvider")
+			out, err := harness.CLI("get", "authprovider", apName)
+			Expect(err).ToNot(HaveOccurred(), "get AuthProvider after restore must succeed")
+			Expect(out).To(ContainSubstring(apName), "get output must mention the AuthProvider name")
+
+			// Restore succeeded — clear savedConfig so AfterEach does not double-restore.
+			// The restore binary already brought services back up with the backup-time key config.
+			savedConfig = ""
+
+			By("verifying services are ready after restore")
+			for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+				Expect(providers.Lifecycle.WaitForReady(svc, testutil.LONG_TIMEOUT)).To(Succeed(),
+					"service %s must be ready after restore", svc)
+			}
+		})
+	})
+})

--- a/test/e2e/encryption/encryption_suite_test.go
+++ b/test/e2e/encryption/encryption_suite_test.go
@@ -1,0 +1,130 @@
+package encryption_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// loginRetryTimeout is how long to retry login during recovery restarts.
+	// The API pod may report Ready in K8s before the process accepts TLS connections.
+	loginRetryTimeout = 2 * time.Minute
+	// loginProbeTimeout is how long to retry login at the start of each spec before
+	// triggering recovery. Kept short so a crash-loop is detected quickly without
+	// burning 2 minutes per spec on a broken cluster.
+	loginProbeTimeout = 30 * time.Second
+)
+
+var (
+	auxSvcs *auxiliary.Services
+	// originalServiceConfig is the API service config captured at suite start before
+	// any test mutations. The recovery path uses it to restore services to a known-good
+	// state without synthesizing an encryption block that may reference key files that
+	// don't exist on this deployment.
+	originalServiceConfig string
+)
+
+func TestEncryption(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Encryption at Rest E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+
+	ctx := context.Background()
+
+	// Start all needed auxiliary services:
+	// - Keycloak for OIDC AuthProvider creation (clientSecret encryption tests)
+	// - Git server for SSH Repository credential tests
+	// - Prometheus for metrics validation
+	var err error
+	auxSvcs, err = auxiliary.StartServices(ctx, []auxiliary.Service{
+		auxiliary.ServiceKeycloak,
+		auxiliary.ServiceGitServer,
+		auxiliary.ServicePrometheus,
+	})
+	Expect(err).ToNot(HaveOccurred(), "failed to start auxiliary services")
+	Expect(auxSvcs.Keycloak.URL).ToNot(BeEmpty(), "Keycloak URL must not be empty")
+
+	_, _, err = e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred(), "failed to setup worker harness")
+
+	// Capture the original API config before any test mutations so the recovery path
+	// can restore it exactly — not synthesize an encryption block that may point to
+	// key files that don't exist on this deployment.
+	originalServiceConfig = captureOriginalServiceConfig()
+
+	harness := e2e.GetWorkerHarness()
+	if _, loginErr := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout); loginErr != nil {
+		// The API may be in a crash-loop from a previous test run that left services with a
+		// rotated encryption key config that prevents startup. Restore the original config
+		// (captured above) and restart so the suite can proceed.
+		GinkgoWriter.Printf("BeforeSuite: initial login failed (%v); attempting recovery by restoring original service config\n", loginErr)
+		Expect(recoverServicesToOriginalConfig()).To(Succeed(), "recovery: restore original service config")
+		Expect(restartServicesAndWait()).To(Succeed(), "recovery: restart services after config restore")
+		_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+		Expect(err).ToNot(HaveOccurred(), "bootstrap admin login failed after recovery")
+	}
+	// Best-effort cleanup of stable resources that may have been left by a previous crashed run.
+	// enc-rot-ap-stable uses the same issuer+clientId as other test specs; if it persists from a
+	// prior crash, subsequent tests fail with 409 "issuer and clientId already exists".
+	cleanUpStableEncryptionResources(harness)
+})
+
+var _ = BeforeEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	// Probe with a short timeout first. If the API is down (e.g. a previous test
+	// crashed it with a bad encryption config), trigger the same recovery as
+	// BeforeSuite rather than waiting 2 minutes per spec.
+	if _, loginErr := login.LoginToAPIWithTokenWithRetry(harness, loginProbeTimeout); loginErr != nil {
+		GinkgoWriter.Printf("BeforeEach: login probe failed (%v); attempting recovery by restoring original service config\n", loginErr)
+		Expect(recoverServicesToOriginalConfig()).To(Succeed(), "recovery: restore original service config")
+		Expect(restartServicesAndWait()).To(Succeed(), "recovery: restart services after config restore")
+		_, err := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+		Expect(err).ToNot(HaveOccurred(), "restore admin login before spec (after recovery)")
+	}
+	// Always clean up stable resources that may have been left by a previous crashed spec.
+	// enc-rot-ap-stable uses the same issuer+clientId as S4 and S8; if it persists after a
+	// crash (AfterAll ran with the API down and could not delete it), subsequent specs get
+	// a 409 even when the API is healthy and the recovery branch above is not entered.
+	cleanUpStableEncryptionResources(harness)
+})
+
+var _ = AfterEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	harness.PrintAgentLogsIfFailed()
+	harness.CaptureDeploymentLogsIfFailed()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred(), "cleanup test resources")
+
+	harness.SetTestContext(suiteCtx)
+})
+
+var _ = AfterSuite(func() {
+	if auxSvcs != nil {
+		auxSvcs.Cleanup(context.Background())
+	}
+})
+
+func init() {
+	SetDefaultEventuallyTimeout(testutil.DURATION_TIMEOUT)
+	SetDefaultEventuallyPollingInterval(testutil.EVENTUALLY_POLLING_250)
+}

--- a/test/e2e/encryption/helpers_test.go
+++ b/test/e2e/encryption/helpers_test.go
@@ -1,0 +1,439 @@
+package encryption_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	internalconfig "github.com/flightctl/flightctl/internal/config"
+	authproviderhelpers "github.com/flightctl/flightctl/test/e2e/authprovider/helpers"
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+const (
+	// defaultKeyID is the encryption key ID used at service startup.
+	defaultKeyID = "default"
+)
+
+// ciphertextMatchesKeyID reports whether value begins with the expected ciphertext prefix
+// "enc:v1:<keyID>:" indicating the value was encrypted under keyID.
+func ciphertextMatchesKeyID(value, keyID string) bool {
+	return strings.HasPrefix(value, fmt.Sprintf("enc:v1:%s:", keyID))
+}
+
+// queryDB executes a psql query against the built-in flightctl database and returns
+// the trimmed output. Requires a reachable flightctl-db pod; fails on external-DB deployments.
+func queryDB(p *infra.Providers, sql string) (string, error) {
+	return infra.QueryDB(p, sql)
+}
+
+// buildOIDCAuthProviderYAML renders a minimal OIDC AuthProvider manifest string for encryption tests.
+// All encryption tests create providers with enabled=false since they only exercise credential storage.
+func buildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret string) string {
+	return authproviderhelpers.BuildOIDCAuthProviderYAML(name, issuerURL, clientID, clientSecret, false)
+}
+
+// applyManifest writes manifest YAML to a temp file and applies it via the harness CLI.
+// Login must be established by the caller before invoking this function.
+func applyManifest(harness *e2e.Harness, manifestYAML string) (string, error) {
+	return authproviderhelpers.ApplyManifest(harness, manifestYAML)
+}
+
+// deleteAuthProvider deletes an AuthProvider CR by name via the harness CLI.
+// Login must be established by the caller before invoking this function.
+func deleteAuthProvider(harness *e2e.Harness, name string) error {
+	_, err := authproviderhelpers.DeleteAuthProvider(harness, name)
+	return err
+}
+
+// writeKeyToService makes a named encryption key available to the given service.
+// It delegates to InfraProvider.SetEncryptionKey, which:
+//   - On K8s/OCP: patches the flightctl-encryption-key Secret and triggers a rollout restart
+//     of the service's deployment so pods mount the updated (read-only projected) Secret.
+//   - On Quadlet: writes the key file directly to the host at /etc/flightctl/encryption/<keyFileName>,
+//     which is bind-mounted into the container.
+func writeKeyToService(svc infra.ServiceName, keyFileName string, keyBytes []byte) error {
+	if keyFileName == "" {
+		return fmt.Errorf("writeKeyToService: keyFileName is required")
+	}
+	if len(keyBytes) == 0 {
+		return fmt.Errorf("writeKeyToService: keyBytes is empty")
+	}
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return fmt.Errorf("writeKeyToService: providers not initialized")
+	}
+	if err := p.Infra.SetEncryptionKey(svc, keyFileName, keyBytes); err != nil {
+		GinkgoWriter.Printf("writeKeyToService: failed to set key %s on %s: %v\n", keyFileName, svc, err)
+		return fmt.Errorf("write key file %s on %s: %w", keyFileName, svc, err)
+	}
+	return nil
+}
+
+// setEncryptionConfigOnAllServices writes the given typed encryption config to all three services
+// (API, worker, periodic) using the infra interface.
+func setEncryptionConfigOnAllServices(enc *internalconfig.EncryptionConfig) error {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return fmt.Errorf("setEncryptionConfigOnAllServices: providers not initialized")
+	}
+	for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+		if err := p.Infra.SetEncryptionConfig(svc, enc); err != nil {
+			GinkgoWriter.Printf("setEncryptionConfigOnAllServices: failed to set config on %s: %v\n", svc, err)
+			return fmt.Errorf("set encryption config on %s: %w", svc, err)
+		}
+	}
+	return nil
+}
+
+// setRawConfigOnAllServices writes a raw YAML config string to all three services.
+// Used for restoring a previously saved raw config snapshot.
+func setRawConfigOnAllServices(config string) error {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return fmt.Errorf("setRawConfigOnAllServices: providers not initialized")
+	}
+	for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+		if err := p.Infra.SetServiceConfig(svc, "config.yaml", config); err != nil {
+			GinkgoWriter.Printf("setRawConfigOnAllServices: failed to set config on %s: %v\n", svc, err)
+			return fmt.Errorf("set config on %s: %w", svc, err)
+		}
+	}
+	return nil
+}
+
+// rotateEncryptionKey writes a new key file to the API, worker, and periodic service containers,
+// adds it to the encryption config, and sets it as the active key. Returns the original raw config
+// so the caller can restore it. The caller must restart services after this call.
+func rotateEncryptionKey(newKeyID string, keyBytes []byte) (savedConfig string, err error) {
+	if newKeyID == "" {
+		return "", fmt.Errorf("rotateEncryptionKey: newKeyID is required")
+	}
+	if len(keyBytes) == 0 {
+		return "", fmt.Errorf("rotateEncryptionKey: keyBytes is empty")
+	}
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return "", fmt.Errorf("rotateEncryptionKey: providers not initialized")
+	}
+	savedConfig, err = p.Infra.GetServiceConfig(infra.ServiceAPI)
+	if err != nil {
+		GinkgoWriter.Printf("rotateEncryptionKey: failed to read API service config: %v\n", err)
+		return "", fmt.Errorf("read API service config: %w", err)
+	}
+	keyFileName := "key-" + newKeyID
+	for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+		if err := writeKeyToService(svc, keyFileName, keyBytes); err != nil {
+			return "", fmt.Errorf("write key to %s: %w", svc, err)
+		}
+	}
+
+	// Read the current typed encryption config and add the new key entry.
+	enc, err := p.Infra.GetEncryptionConfig(infra.ServiceAPI)
+	if err != nil {
+		return "", fmt.Errorf("rotateEncryptionKey: read encryption config: %w", err)
+	}
+	// Guard against duplicate key IDs (e.g. on test retry without a successful config restore).
+	for _, k := range enc.Keys {
+		if k.ID == newKeyID {
+			return "", fmt.Errorf("rotateEncryptionKey: key ID %q already present in config — restore original config before adding", newKeyID)
+		}
+	}
+	newKeyPath := filepath.Join(infra.EncryptionKeyDir, keyFileName)
+	enc.ActiveKeyID = newKeyID
+	enc.Keys = append([]internalconfig.EncryptionKeyConfig{{ID: newKeyID, Path: newKeyPath}}, enc.Keys...)
+
+	GinkgoWriter.Printf("rotateEncryptionKey: setting encryption config with activeKeyID=%s, keys=%v\n", enc.ActiveKeyID, enc.Keys)
+	if err := setEncryptionConfigOnAllServices(enc); err != nil {
+		return "", fmt.Errorf("update service configs: %w", err)
+	}
+	// Read back to confirm what was actually stored.
+	if readback, err := p.Infra.GetServiceConfig(infra.ServiceAPI); err == nil {
+		GinkgoWriter.Printf("rotateEncryptionKey: API config readback after set:\n%s\n", readback)
+	}
+	return savedConfig, nil
+}
+
+// removeEncryptionKey removes the entry for keyIDToRemove from all service configs without
+// deleting the key file. Returns the original raw config so the caller can restore it.
+// The caller must restart services after this call.
+func removeEncryptionKey(keyIDToRemove string) (savedConfig string, err error) {
+	if keyIDToRemove == "" {
+		return "", fmt.Errorf("removeEncryptionKey: keyIDToRemove is required")
+	}
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return "", fmt.Errorf("removeEncryptionKey: providers not initialized")
+	}
+	savedConfig, err = p.Infra.GetServiceConfig(infra.ServiceAPI)
+	if err != nil {
+		GinkgoWriter.Printf("removeEncryptionKey: failed to read API service config: %v\n", err)
+		return "", fmt.Errorf("read API service config: %w", err)
+	}
+
+	enc, err := p.Infra.GetEncryptionConfig(infra.ServiceAPI)
+	if err != nil {
+		return "", fmt.Errorf("removeEncryptionKey: read encryption config: %w", err)
+	}
+	if len(enc.Keys) == 0 {
+		return "", fmt.Errorf("removeEncryptionKey: no encryption block in config")
+	}
+
+	filtered := enc.Keys[:0]
+	for _, k := range enc.Keys {
+		if k.ID != keyIDToRemove {
+			filtered = append(filtered, k)
+		}
+	}
+	enc.Keys = filtered
+	// If the removed key was the active key, promote the first remaining key.
+	// Leaving activeKeyID pointing to a key no longer in the ring causes the
+	// service to crash at startup (cannot load the active key).
+	if enc.ActiveKeyID == keyIDToRemove && len(enc.Keys) > 0 {
+		enc.ActiveKeyID = enc.Keys[0].ID
+	}
+
+	if err := setEncryptionConfigOnAllServices(enc); err != nil {
+		return "", fmt.Errorf("update service configs: %w", err)
+	}
+	return savedConfig, nil
+}
+
+// restoreEncryptionConfig restores the original saved raw config to all services.
+// The caller must restart services after this call.
+func restoreEncryptionConfig(savedConfig string) error {
+	if savedConfig == "" {
+		return fmt.Errorf("restoreEncryptionConfig: savedConfig is empty")
+	}
+	return setRawConfigOnAllServices(savedConfig)
+}
+
+// resetEncryptionConfigToDefault rewrites the encryption section on all services to use only the
+// default key (activeKeyID: default, path: EncryptionKeyDir/key). It is used at suite
+// startup to recover from a previous run that left services with a rotated-key config that
+// prevents them from starting (e.g. because the key file or its encoding was incorrect).
+// The caller must restart services after this call.
+func resetEncryptionConfigToDefault() error {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return fmt.Errorf("resetEncryptionConfigToDefault: providers not initialized")
+	}
+	defaultEnc := &internalconfig.EncryptionConfig{
+		ActiveKeyID: defaultKeyID,
+		Keys: []internalconfig.EncryptionKeyConfig{
+			{ID: defaultKeyID, Path: filepath.Join(infra.EncryptionKeyDir, "key")},
+		},
+	}
+	return setEncryptionConfigOnAllServices(defaultEnc)
+}
+
+// captureOriginalServiceConfig reads the current API service config and returns it.
+// Returns empty string on error (non-fatal; recovery falls back to resetEncryptionConfigToDefault).
+func captureOriginalServiceConfig() string {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return ""
+	}
+	cfg, err := p.Infra.GetServiceConfig(infra.ServiceAPI)
+	if err != nil {
+		GinkgoWriter.Printf("captureOriginalServiceConfig: could not read API config: %v\n", err)
+		return ""
+	}
+	return cfg
+}
+
+// resetMigrationCheckpoints deletes all encryption-migration checkpoint rows from the DB.
+// This is called after a key rotation test restores the original config to prevent stale
+// "complete" checkpoints for the rotated key from short-circuiting the migration worker when
+// the same key ID is used again in a subsequent test (e.g. S1 restores → S2 re-rotates to
+// the same "rotated-key" ID; without this reset the worker sees Complete=true and skips).
+// Non-fatal: logs a warning on failure.
+func resetMigrationCheckpoints() {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return
+	}
+	if !p.Infra.BuiltinDatabaseWorkloadAvailable() {
+		return
+	}
+	if _, err := queryDB(p, "DELETE FROM checkpoints WHERE consumer = 'encryption-migration'"); err != nil {
+		GinkgoWriter.Printf("resetMigrationCheckpoints: failed to delete checkpoints (non-fatal): %v\n", err)
+	}
+}
+
+// deleteStaleCanaries removes any canary rows whose key_id does not match keepKeyID.
+// This prevents the service from crash-looping on startup when ValidateCanaries tries to
+// decrypt a canary that was created for a key no longer present in the config.
+// keepKeyID should be the active key ID after config restore (e.g. defaultKeyID).
+// Non-fatal: logs a warning on failure rather than failing the suite.
+func deleteStaleCanaries(keepKeyID string) {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Infra == nil {
+		return
+	}
+	if !p.Infra.BuiltinDatabaseWorkloadAvailable() {
+		return
+	}
+	if _, err := queryDB(p, fmt.Sprintf(
+		"DELETE FROM encryption_canaries WHERE key_id != '%s'", keepKeyID,
+	)); err != nil {
+		GinkgoWriter.Printf("deleteStaleCanaries: failed to delete stale canary rows (non-fatal): %v\n", err)
+	}
+}
+
+// cleanUpStableEncryptionResources deletes resources with stable (non-test-ID) names that may
+// have been left by a previous crashed test run. These resources use a shared issuer+clientId
+// that causes 409 conflicts when subsequent tests try to create their own authproviders.
+// Non-fatal: logs a warning on failure.
+func cleanUpStableEncryptionResources(h *e2e.Harness) {
+	const stableAuthProviderName = "enc-rot-ap-stable"
+	if err := deleteAuthProvider(h, stableAuthProviderName); err != nil {
+		GinkgoWriter.Printf("cleanUpStableEncryptionResources: delete %s (non-fatal): %v\n", stableAuthProviderName, err)
+	}
+}
+
+// recoverServicesToOriginalConfig restores all services to the config captured at suite start
+// and resets the encryption key Secret to only the default "key" entry.
+// Falls back to resetEncryptionConfigToDefault if no original config was saved.
+// The caller must restart services after this call.
+func recoverServicesToOriginalConfig() error {
+	p := setup.GetDefaultProviders()
+	if p != nil && p.Infra != nil {
+		if err := p.Infra.ResetEncryptionKeys(); err != nil {
+			GinkgoWriter.Printf("recoverServicesToOriginalConfig: reset encryption keys failed (non-fatal): %v\n", err)
+		}
+	}
+	// Remove stale canary rows before restarting. If canaries for rotated keys remain in DB,
+	// ValidateCanaries on startup will crash-loop (it cannot decrypt them with the restored config).
+	deleteStaleCanaries(defaultKeyID)
+	if originalServiceConfig != "" {
+		return setRawConfigOnAllServices(originalServiceConfig)
+	}
+	return resetEncryptionConfigToDefault()
+}
+
+// restartServicesAndWait restarts the API, worker, and periodic services and waits for readiness.
+// Uses LONG_TIMEOUT (10m) because OCP pod scheduling and startup can exceed DURATION_TIMEOUT (5m).
+func restartServicesAndWait() error {
+	p := setup.GetDefaultProviders()
+	if p == nil || p.Lifecycle == nil {
+		return fmt.Errorf("restartServicesAndWait: providers not initialized")
+	}
+	for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+		if err := p.Lifecycle.Restart(svc); err != nil {
+			GinkgoWriter.Printf("restartServicesAndWait: failed to restart %s: %v\n", svc, err)
+			return fmt.Errorf("restart %s: %w", svc, err)
+		}
+	}
+	for _, svc := range []infra.ServiceName{infra.ServiceAPI, infra.ServiceWorker, infra.ServicePeriodic} {
+		if err := p.Lifecycle.WaitForReady(svc, testutil.LONG_TIMEOUT); err != nil {
+			GinkgoWriter.Printf("restartServicesAndWait: %s not ready within timeout: %v\n", svc, err)
+			return fmt.Errorf("wait for %s ready: %w", svc, err)
+		}
+	}
+	return nil
+}
+
+// backupRestoreExternalDBSkipReason returns a non-empty skip message when the backup/restore
+// encryption tests cannot run (external DB profile or no built-in DB pod available).
+func backupRestoreExternalDBSkipReason() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("E2E_EXTERNAL_DATABASE"))) {
+	case "1", "true", "yes":
+		return "Encryption backup/restore e2e skipped: E2E_EXTERNAL_DATABASE set (external DB profile). " +
+			"These tests require pg_dump via the built-in flightctl-db pod; external DB coverage tracked under EDM-3213."
+	}
+	p := setup.GetDefaultProviders()
+	if p != nil && p.Infra != nil && !p.Infra.BuiltinDatabaseWorkloadAvailable() {
+		return "Encryption backup/restore e2e skipped: no flightctl-db pod (external PostgreSQL / Helm db.type=external). EDM-3213."
+	}
+	return ""
+}
+
+// skipIfNoBuiltinDB skips the current Ginkgo spec when the built-in PostgreSQL pod is unavailable.
+// Tests that inspect DB ciphertext via queryDB() require psql access through the flightctl-db pod,
+// which is only deployed when db.type=builtin (Helm) or the Quadlet flightctl-db service is active.
+// External PostgreSQL deployments encrypt data the same way but cannot be inspected this way.
+func skipIfNoBuiltinDB() {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("E2E_EXTERNAL_DATABASE"))) {
+	case "1", "true", "yes":
+		Skip("Skipped: E2E_EXTERNAL_DATABASE set — DB ciphertext inspection requires the built-in flightctl-db pod. EDM-3213.")
+	}
+	p := setup.GetDefaultProviders()
+	if p != nil && p.Infra != nil && !p.Infra.BuiltinDatabaseWorkloadAvailable() {
+		Skip("Skipped: no flightctl-db pod (Helm db.type=external) — DB ciphertext inspection not available. EDM-3213.")
+	}
+}
+
+// encryptionKeyArchiveEntryPrefix returns the archive directory prefix for encryption key material.
+// K8s backup writes encryption/flightctl-encryption-key.yaml; Quadlet writes encryption/<keyfiles>.
+func encryptionKeyArchiveEntryPrefix() string {
+	return filepath.Join("encryption") + string(filepath.Separator)
+}
+
+// listTarGzEntries returns the entry names from a .tar.gz archive.
+// Returns an error if the archive cannot be opened or read.
+func listTarGzEntries(archivePath string) ([]string, error) {
+	if archivePath == "" {
+		return nil, fmt.Errorf("listTarGzEntries: archivePath is required")
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		GinkgoWriter.Printf("listTarGzEntries: cannot open archive %q: %v\n", archivePath, err)
+		return nil, fmt.Errorf("open archive: %w", err)
+	}
+	defer file.Close()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		GinkgoWriter.Printf("listTarGzEntries: cannot create gzip reader for %q: %v\n", archivePath, err)
+		return nil, fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	var entries []string
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			GinkgoWriter.Printf("listTarGzEntries: error reading tar entry in %q: %v\n", archivePath, err)
+			return nil, fmt.Errorf("read tar entry: %w", err)
+		}
+		entries = append(entries, hdr.Name)
+	}
+	return entries, nil
+}
+
+// prometheusURL returns the Prometheus base URL for encryption metric assertions.
+// It first tries the infra provider (Quadlet/OCP), then falls back to the auxiliary Prometheus
+// testcontainer started in BeforeSuite (Kind).
+func prometheusURL() (string, func(), error) {
+	noopCleanup := func() {}
+	providers := setup.GetDefaultProviders()
+	if providers == nil || providers.Infra == nil {
+		return "", noopCleanup, fmt.Errorf("prometheusURL: providers not initialized")
+	}
+	url, cleanup, err := providers.Infra.ExposeService(infra.ServicePrometheus, "http")
+	if err == nil && url != "" {
+		if cleanup == nil {
+			cleanup = noopCleanup
+		}
+		GinkgoWriter.Printf("prometheusURL: using infra Prometheus at %s\n", url)
+		return url, cleanup, nil
+	}
+	if auxSvcs == nil || auxSvcs.Prometheus == nil || auxSvcs.Prometheus.URL == "" {
+		return "", noopCleanup, fmt.Errorf("prometheusURL: no Prometheus available (infra: %v; auxiliary not started)", err)
+	}
+	GinkgoWriter.Printf("prometheusURL: using auxiliary Prometheus at %s\n", auxSvcs.Prometheus.URL)
+	return auxSvcs.Prometheus.URL, noopCleanup, nil
+}

--- a/test/e2e/encryption/keyrotation_test.go
+++ b/test/e2e/encryption/keyrotation_test.go
@@ -1,0 +1,544 @@
+package encryption_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption at rest — Key rotation metrics and migration", Label("encryption", "observability"), Serial, func() {
+	var (
+		harness     *e2e.Harness
+		providers   *infra.Providers
+		promURL     string
+		cleanupProm func()
+		savedConfig string
+	)
+
+	BeforeEach(func() {
+		skipIfNoBuiltinDB()
+		harness = e2e.GetWorkerHarness()
+		providers = setup.GetDefaultProviders()
+		infra.SkipIfObservabilityNotConfigured(harness.GetTestContext(), providers)
+
+		Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+
+		var err error
+		promURL, cleanupProm, err = prometheusURL()
+		Expect(err).ToNot(HaveOccurred(), "must be able to reach Prometheus")
+		Expect(promURL).ToNot(BeEmpty(), "Prometheus URL must not be empty")
+		savedConfig = ""
+	})
+
+	AfterEach(func() {
+		if cleanupProm != nil {
+			cleanupProm()
+		}
+		if savedConfig != "" {
+			deleteStaleCanaries(defaultKeyID)
+			// Reset migration checkpoints so the restored default config does not inherit a stale
+			// Complete=true checkpoint for rotated-metrics-key from this run (S8 rotates to that key
+			// and lets the migration worker finish). Without this reset, a subsequent run that
+			// re-uses the same key ID would skip re-encryption and time out.
+			resetMigrationCheckpoints()
+			if err := restoreEncryptionConfig(savedConfig); err != nil {
+				GinkgoWriter.Printf("Warning: restore encryption config failed: %v\n", err)
+			}
+			if err := restartServicesAndWait(); err != nil {
+				GinkgoWriter.Printf("Warning: service restart after config restore failed: %v\n", err)
+			}
+			if _, err := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout); err != nil {
+				GinkgoWriter.Printf("Warning: re-login after config restore failed: %v\n", err)
+			}
+		}
+	})
+
+	Context("When the active encryption key is rotated", func() {
+		It("S8: should update the active-key metric and auto-migrate pre-existing resources", Label("90130"), func() {
+			const rotatedKeyID = "rotated-metrics-key"
+
+			By("creating pre-rotation resources encrypted under the default key")
+			apName := "enc-rot-metrics-ap-" + harness.GetTestIDFromContext()
+			repoName := "enc-rot-metrics-repo-" + harness.GetTestIDFromContext()
+
+			issuerURL := auxSvcs.Keycloak.IssuerURL()
+			secretBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred())
+			preSecret := base64.StdEncoding.EncodeToString(secretBytes)
+			manifest := buildOIDCAuthProviderYAML(apName, issuerURL, "flightctl-client", preSecret)
+			_, err = applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create pre-rotation AuthProvider")
+			DeferCleanup(func() { _ = deleteAuthProvider(harness, apName) })
+
+			keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+			Expect(err).ToNot(HaveOccurred())
+			repoURL := fmt.Sprintf("user@%s:%d:/home/user/repos/rot-metrics.git",
+				auxSvcs.GitServer.Host, auxSvcs.GitServer.Port)
+			Expect(harness.CreateRepositoryWithSSHCredentials(repoName, repoURL, keyContent)).To(Succeed())
+			DeferCleanup(func() {
+				_, _ = harness.ManageResource("delete", "repository", repoName)
+			})
+
+			By("confirming pre-rotation DB ciphertexts use the default key")
+			apCipher, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", apName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(apCipher, defaultKeyID)).To(BeTrue(),
+				"pre-rotation AuthProvider must use default key; got: %s", apCipher)
+
+			By("rotating the active encryption key to " + rotatedKeyID)
+			newKeyBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred())
+			savedConfig, err = rotateEncryptionKey(rotatedKeyID, newKeyBytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("restarting services to pick up the new config and trigger the migration worker")
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-login after restart")
+
+			By("verifying active-key metric reflects the rotated key")
+			activeKeyQuery := `flightctl_encryption_active_key_info{key_id="` + rotatedKeyID + `"}`
+			Eventually(harness.PromQueryResultCount(promURL, activeKeyQuery),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeNumerically(">", 0),
+				"active-key gauge must report rotated-key after rotation and restart")
+
+			By("waiting for the migration worker to re-encrypt the pre-rotation AuthProvider")
+			Eventually(func() bool {
+				cipher, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", apName,
+				))
+				if err != nil {
+					return false
+				}
+				return ciphertextMatchesKeyID(cipher, rotatedKeyID)
+			}, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(),
+				"migration worker must re-encrypt pre-rotation AuthProvider under the rotated key")
+
+			By("waiting for the migration worker to re-encrypt the pre-rotation Repository")
+			Eventually(func() bool {
+				cipher, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				if err != nil {
+					return false
+				}
+				return ciphertextMatchesKeyID(cipher, rotatedKeyID)
+			}, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(),
+				"migration worker must re-encrypt pre-rotation Repository under the rotated key")
+
+			By("cleanup: removing stale canary rows, resetting migration checkpoints, and restoring original config")
+			deleteStaleCanaries(defaultKeyID)
+			// Reset migration checkpoints so a subsequent run (with the same rotated-metrics-key ID)
+			// does not inherit a Complete=true checkpoint from this run's successful migration.
+			resetMigrationCheckpoints()
+			Expect(restoreEncryptionConfig(savedConfig)).To(Succeed())
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			savedConfig = ""
+		})
+	})
+})
+
+var _ = Describe("Encryption at rest — Key rotation", Label("encryption"), Serial, func() {
+	var (
+		harness     *e2e.Harness
+		providers   *infra.Providers
+		savedConfig string
+		// preRotationSecret holds the randomized client secret for pre-rotation resources.
+		// It is set in BeforeAll and shared across S1/S2 within the Ordered context.
+		preRotationSecret string
+	)
+
+	BeforeEach(func() {
+		skipIfNoBuiltinDB()
+		harness = e2e.GetWorkerHarness()
+		providers = setup.GetDefaultProviders()
+		savedConfig = ""
+	})
+
+	AfterEach(func() {
+		// Safety net: restore original config if a test left it mutated.
+		if savedConfig != "" {
+			// Remove stale canary rows before restarting so ValidateCanaries doesn't
+			// crash-loop on a key that no longer exists in the restored config.
+			deleteStaleCanaries(defaultKeyID)
+			// Reset migration checkpoints so subsequent tests don't inherit a stale
+			// Complete=true checkpoint for a key ID that was used in this test.
+			resetMigrationCheckpoints()
+			if err := restoreEncryptionConfig(savedConfig); err != nil {
+				GinkgoWriter.Printf("Warning: restore encryption config failed: %v\n", err)
+			}
+			if err := restartServicesAndWait(); err != nil {
+				GinkgoWriter.Printf("Warning: service restart after config restore failed: %v\n", err)
+			}
+			// Re-authenticate after restart so the suite-level AfterEach (CleanUpAllTestResources)
+			// inherits a valid session rather than failing with a stale token.
+			if _, err := login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout); err != nil {
+				GinkgoWriter.Printf("Warning: re-login after config restore failed: %v\n", err)
+			}
+		}
+	})
+
+	// S1 and S2 share state (S2 needs data encrypted under the old "default" key).
+	// Ordered ensures S1 runs before S2 within the same process.
+	//
+	// Resources use stable constant names so AfterEach/CleanUpAllTestResources (which
+	// matches the per-spec test-ID label) does not delete them between S1 and S2.
+	// AfterAll performs explicit cleanup.
+	Context("When the active encryption key is rotated", Ordered, func() {
+		const (
+			authProviderName = "enc-rot-ap-stable"
+			repoName         = "enc-rot-repo-stable"
+			rotatedKeyID     = "rotated-key"
+		)
+		// gitServerRepoName is the bare git repo name on the aux server.
+		// Set in BeforeAll and used in AfterAll for cleanup.
+		var gitServerRepoName string
+		// sharedRepoURL is the cluster-internal URL for enc-rot-repo-stable.
+		// Set in BeforeAll and used in S1 cleanup to recreate the repo under the default key.
+		var sharedRepoURL string
+
+		BeforeAll(func() {
+			Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+			Expect(auxSvcs.GitServer).ToNot(BeNil(), "git server must be started")
+
+			// Best-effort cleanup of any stale resources and checkpoints from a previous run
+			// that may have crashed before AfterAll / cleanup executed. Ignore errors — resources
+			// may not exist. resetMigrationCheckpoints is critical for S2-standalone runs: if a
+			// prior S1 left a Complete=true checkpoint for rotated-key, S2's migration worker
+			// skips re-encryption and the test times out.
+			_ = deleteAuthProvider(harness, authProviderName)
+			_, _ = harness.ManageResource("delete", "repository", repoName)
+			resetMigrationCheckpoints()
+
+			// Generate a random secret so static analysis does not flag a hardcoded credential literal.
+			secretBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred(), "generate pre-rotation secret")
+			preRotationSecret = base64.StdEncoding.EncodeToString(secretBytes)
+
+			By("creating pre-rotation resources encrypted under the default key")
+			issuerURL := auxSvcs.Keycloak.IssuerURL()
+			manifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, "flightctl-client", preRotationSecret)
+			out, err := applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create pre-rotation AuthProvider")
+			Expect(out).ToNot(BeEmpty(), "apply must produce output")
+
+			keyPath, err := auxSvcs.GetGitSSHPrivateKeyPath()
+			Expect(err).ToNot(HaveOccurred(), "get git SSH key path")
+			keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+			Expect(err).ToNot(HaveOccurred(), "get git SSH key content")
+
+			// Create a bare git repo on the server so repotester (running inside the cluster)
+			// can establish a real SSH connection when the key is valid. Without a real repo
+			// at the URL, WaitForRepositoryAccessible / WaitForRepositoryNotAccessible time out
+			// or produce ambiguous results.
+			gitServerRepoName = "enc-rot-s1s2-stable"
+			gitServerConfig := e2e.GitServerConfig{
+				Host: auxSvcs.GitServer.Host,
+				Port: auxSvcs.GitServer.Port,
+				User: "user",
+			}
+			Expect(harness.CreateGitRepositoryOnServer(gitServerConfig, keyPath, gitServerRepoName)).To(
+				Succeed(), "create bare git repo on aux server for S1/S2")
+
+			// Use InternalHost/InternalPort so repotester (running inside k8s) can reach the
+			// git server via the cluster-reachable address, not the test-runner-only address.
+			repoURL, err := harness.GetInternalGitRepoURL(
+				auxSvcs.GitServer.InternalHost, auxSvcs.GitServer.InternalPort, gitServerRepoName)
+			Expect(err).ToNot(HaveOccurred(), "build internal git repo URL")
+			sharedRepoURL = repoURL
+			// Use CreateSharedRepositoryWithSSHCredentials (no test-id label) so per-test AfterEach
+			// cleanup does not delete this resource after S1. AfterAll handles deletion.
+			Expect(harness.CreateSharedRepositoryWithSSHCredentials(repoName, repoURL, keyContent)).To(
+				Succeed(), "create pre-rotation Repository")
+
+			By("confirming pre-rotation DB ciphertexts use the default key")
+			apCipher, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(apCipher, defaultKeyID)).To(BeTrue(),
+				"pre-rotation AuthProvider ciphertext must use default key, got: %s", apCipher)
+
+			repoCipher, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(repoCipher, defaultKeyID)).To(BeTrue(),
+				"pre-rotation Repository ciphertext must use default key, got: %s", repoCipher)
+		})
+
+		AfterAll(func() {
+			if err := deleteAuthProvider(harness, authProviderName); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete authprovider %s: %v\n", authProviderName, err)
+			}
+			if _, err := harness.ManageResource("delete", "repository", repoName); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete repository %s: %v\n", repoName, err)
+			}
+			if gitServerRepoName != "" && auxSvcs.GitServer != nil {
+				keyPath, err := auxSvcs.GetGitSSHPrivateKeyPath()
+				if err == nil {
+					gitServerConfig := e2e.GitServerConfig{
+						Host: auxSvcs.GitServer.Host,
+						Port: auxSvcs.GitServer.Port,
+						User: "user",
+					}
+					if err := harness.DeleteGitRepositoryOnServer(gitServerConfig, keyPath, gitServerRepoName); err != nil {
+						GinkgoWriter.Printf("Warning: failed to delete git server repo %s: %v\n", gitServerRepoName, err)
+					}
+				}
+			}
+		})
+
+		It("S1: should use the new key ID for new encryptions after rotation", Label("90091"), func() {
+			By("generating a new 256-bit AES encryption key")
+			newKeyBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred(), "generate new AES key")
+
+			By("rotating the active encryption key to " + rotatedKeyID)
+			savedConfig, err = rotateEncryptionKey(rotatedKeyID, newKeyBytes)
+			Expect(err).ToNot(HaveOccurred(), "rotate encryption key")
+
+			By("restarting services to pick up the new config")
+			Expect(restartServicesAndWait()).To(Succeed(), "restart services after key rotation")
+
+			By("restoring admin login after service restart")
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-login after restart")
+
+			By("creating a new Repository with credentials encrypted under the rotated key")
+			newRepoName := "enc-post-rot-" + harness.GetTestIDFromContext()
+			keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+			Expect(err).ToNot(HaveOccurred())
+			repoURL := fmt.Sprintf("user@%s:%d:/home/user/repos/new.git",
+				auxSvcs.GitServer.Host, auxSvcs.GitServer.Port)
+			Expect(harness.CreateRepositoryWithSSHCredentials(newRepoName, repoURL, keyContent)).To(
+				Succeed(), "create post-rotation Repository")
+			DeferCleanup(func() {
+				if _, err := harness.ManageResource("delete", "repository", newRepoName); err != nil {
+					GinkgoWriter.Printf("Warning: failed to delete post-rotation repository %s: %v\n", newRepoName, err)
+				}
+			})
+
+			By("verifying new Repository uses the rotated key in DB")
+			newRepoCipher, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", newRepoName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(newRepoCipher, rotatedKeyID)).To(BeTrue(),
+				"new Repository must use rotated key; got: %s", newRepoCipher)
+
+			By("verifying original Repository (old key) is still readable by the API after rotation")
+			// Getting the repository proves the API can decrypt sshPrivateKey stored under the old
+			// key when both keys are present in the key ring — no SSH connectivity required.
+			out, getErr := harness.CLI("get", "repository", repoName)
+			Expect(getErr).ToNot(HaveOccurred(), "get repository must succeed — API must decrypt old-key data")
+			Expect(out).To(ContainSubstring(repoName), "get output must contain the repository name")
+
+			By("updating the original AuthProvider to trigger re-encryption with rotated key")
+			newSecret := base64.StdEncoding.EncodeToString(newKeyBytes[:12])
+			updatedManifest := buildOIDCAuthProviderYAML(authProviderName, auxSvcs.Keycloak.IssuerURL(),
+				"flightctl-client", newSecret)
+			var applyOut string
+			applyOut, err = applyManifest(harness, updatedManifest)
+			Expect(err).ToNot(HaveOccurred(), "update AuthProvider after rotation")
+			Expect(applyOut).ToNot(BeEmpty(), "update must produce output")
+
+			By("verifying updated AuthProvider uses the rotated key in DB")
+			updatedAPCipher, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(updatedAPCipher, rotatedKeyID)).To(BeTrue(),
+				"updated AuthProvider must use rotated key after update; got: %s", updatedAPCipher)
+
+			By("cleanup: removing stale canary rows and migration checkpoints, then restoring original config")
+			// Delete the canary row created for rotatedKeyID before restarting. If the
+			// rotated-key canary remains in DB, ValidateCanaries on startup will try to
+			// decrypt it with a key not present in the restored config → log.Fatalf → crash-loop.
+			deleteStaleCanaries(defaultKeyID)
+			// Reset migration checkpoints so S2 (which re-uses the same rotated-key ID) sees an
+			// incomplete migration rather than a stale Complete=true checkpoint from S1's run.
+			// Without this reset the worker skips re-encryption in S2 and the test times out.
+			resetMigrationCheckpoints()
+			Expect(restoreEncryptionConfig(savedConfig)).To(Succeed())
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			savedConfig = "" // cleared so AfterEach safety net does not double-restore
+
+			By("resetting shared repo to default-key encryption for S2")
+			// S1's migration re-encrypted enc-rot-repo-stable under rotated-key (S1's key bytes).
+			// S2 rotates to the same key ID with NEW bytes. ProcessEncryption sees
+			// parsed.KeyID == activeKeyID ("rotated-key" == "rotated-key") and returns the row
+			// unchanged — leaving S1's ciphertext in the DB. S2's repotester then decrypts it with
+			// S2's new key bytes → MAC failure. Fix: delete and recreate the repo under the
+			// default key so S2's migration performs a real re-encryption with S2's key bytes.
+			if _, err := harness.ManageResource("delete", "repository", repoName); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete shared repo before S2: %v\n", err)
+			}
+			resetKeyContent, resetErr := auxSvcs.GetGitSSHPrivateKey()
+			Expect(resetErr).ToNot(HaveOccurred(), "get git SSH key for repo reset")
+			Expect(harness.CreateSharedRepositoryWithSSHCredentials(repoName, sharedRepoURL, resetKeyContent)).To(
+				Succeed(), "recreate shared repo under default key for S2")
+		})
+
+		It("S3: should keep services healthy and resources accessible after retiring the previous key post-migration", Label("encryption"), func() {
+			By("rotating to a new key so migration re-encrypts the Repository under rotated-key")
+			newKeyBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred())
+			savedConfig, err = rotateEncryptionKey(rotatedKeyID, newKeyBytes)
+			Expect(err).ToNot(HaveOccurred(), "rotate key for retirement test")
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for migration worker to re-encrypt the Repository under the rotated key")
+			Eventually(func() bool {
+				cipher, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				if err != nil {
+					return false
+				}
+				return ciphertextMatchesKeyID(cipher, rotatedKeyID)
+			}, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(), "migration must re-encrypt Repository under rotated key before retiring default")
+
+			By("confirming Repository is still accessible with both keys in ring")
+			Expect(harness.WaitForRepositoryAccessible(repoName, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+				Succeed(), "Repository must be accessible while both keys are in ring")
+
+			By("retiring the default key — removing it from config (data is already on rotated-key)")
+			// Delete the default-key canary before restarting without it.
+			// ValidateCanaries runs at startup and fatals if it finds a canary for a removed key.
+			deleteStaleCanaries(rotatedKeyID)
+			_, err = removeEncryptionKey(defaultKeyID)
+			Expect(err).ToNot(HaveOccurred(), "remove default key from config (retirement)")
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-login after key retirement restart")
+
+			By("[S3] verifying the Repository remains accessible after default key retirement")
+			Expect(harness.WaitForRepositoryAccessible(repoName, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+				Succeed(), "[S3] Repository must stay accessible: data was migrated to rotated-key before retirement")
+
+			By("[S3] cleanup: remove stale canaries and migration checkpoints, then restore original config")
+			// deleteStaleCanaries(defaultKeyID) removes the rotated-key canary row so ValidateCanaries
+			// does not crash when services restart with the restored default-only config.
+			deleteStaleCanaries(defaultKeyID)
+			resetMigrationCheckpoints()
+			Expect(restoreEncryptionConfig(savedConfig)).To(Succeed())
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			savedConfig = ""
+
+			By("[S3] resetting shared repo to default-key encryption for S2")
+			// S3 retired the default key after migrating enc-rot-repo-stable to rotated-key.
+			// After restoring the default-only config, the migration worker cannot re-encrypt
+			// the rotated-key ciphertext back to default (rotated-key bytes are gone). S2 then
+			// rotates to a new rotated-key with different bytes — MAC failure on the S3-era
+			// ciphertext. Fix: delete and recreate the repo under the default key, exactly like
+			// S1 does, so S2's migration starts from a known default-key ciphertext.
+			if _, err := harness.ManageResource("delete", "repository", repoName); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete shared repo before S2: %v\n", err)
+			}
+			resetKeyContent, resetErr := auxSvcs.GetGitSSHPrivateKey()
+			Expect(resetErr).ToNot(HaveOccurred(), "get git SSH key for repo reset")
+			Expect(harness.CreateSharedRepositoryWithSSHCredentials(repoName, sharedRepoURL, resetKeyContent)).To(
+				Succeed(), "recreate shared repo under default key for S2")
+		})
+
+		It("S2: should report inaccessible condition when active key is removed, and recover when key is restored", Label("90095"), func() {
+			By("rotating to a new key to make rotatedKeyID the active key")
+			newKeyBytes, err := generateAESKey()
+			Expect(err).ToNot(HaveOccurred())
+
+			savedConfig, err = rotateEncryptionKey(rotatedKeyID, newKeyBytes)
+			Expect(err).ToNot(HaveOccurred(), "rotate key to set up old-key scenario")
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for migration to re-encrypt the Repository under the rotated key")
+			// The migration worker automatically re-encrypts all resources under the active key.
+			// We must wait for it to complete before removing rotatedKeyID so the test relies on
+			// a deterministic DB state rather than a race between migration and key removal.
+			Eventually(func() bool {
+				cipher, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				if err != nil {
+					return false
+				}
+				return ciphertextMatchesKeyID(cipher, rotatedKeyID)
+			}, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(), "migration must re-encrypt the Repository under the rotated key before key removal")
+
+			By("confirming Repository is accessible while rotated key is still present")
+			Expect(harness.WaitForRepositoryAccessible(repoName, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+				Succeed(), "pre-removal: Repository must be accessible when active key is present")
+
+			By("removing the rotated key from the config")
+			// Delete the rotated-key canary before restarting with the key removed.
+			// ValidateCanaries runs at startup and fatals if it finds a canary for a key
+			// that is no longer in the key ring — causing a crash-loop. The canary for
+			// rotated-key was created during EnsureActiveCanary on the last restart; deleting
+			// it here lets services start cleanly so repotester can detect inaccessibility.
+			deleteStaleCanaries(defaultKeyID)
+			// The repo is now encrypted under rotatedKeyID. Removing it makes the repo undecryptable.
+			savedConfig2, err := removeEncryptionKey(rotatedKeyID)
+			Expect(err).ToNot(HaveOccurred(), "remove rotated key from config")
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for the background task to detect decryption failure and mark Repository inaccessible")
+			// The background task sets Accessible=False when decryption of sshPrivateKey fails.
+			Expect(harness.WaitForRepositoryNotAccessible(repoName, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+				Succeed(), "Repository must become inaccessible when its active encryption key is removed")
+
+			By("restoring the rotated key to the config")
+			Expect(restoreEncryptionConfig(savedConfig2)).To(Succeed())
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying Repository becomes accessible again after key restore")
+			Expect(harness.WaitForRepositoryAccessible(repoName, testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+				Succeed(), "Repository must be accessible again after encryption key is restored")
+
+			By("final cleanup: remove stale canaries and restore original config")
+			deleteStaleCanaries(defaultKeyID)
+			Expect(restoreEncryptionConfig(savedConfig)).To(Succeed())
+			Expect(restartServicesAndWait()).To(Succeed())
+			_, err = login.LoginToAPIWithTokenWithRetry(harness, loginRetryTimeout)
+			Expect(err).ToNot(HaveOccurred(), "re-login after final config restore")
+			savedConfig = ""
+		})
+	})
+})
+
+// generateAESKey returns 32 random bytes suitable for use as an AES-256 key.
+func generateAESKey() ([]byte, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate AES key: %w", err)
+	}
+	return key, nil
+}

--- a/test/e2e/encryption/metrics_test.go
+++ b/test/e2e/encryption/metrics_test.go
@@ -1,0 +1,144 @@
+package encryption_test
+
+import (
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption at rest — Metrics", Label("encryption", "observability"), func() {
+	var (
+		harness *e2e.Harness
+		promURL string
+		cleanup func()
+	)
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+		providers := setup.GetDefaultProviders()
+		infra.SkipIfObservabilityNotConfigured(harness.GetTestContext(), providers)
+
+		var err error
+		promURL, cleanup, err = prometheusURL()
+		Expect(err).ToNot(HaveOccurred(), "must be able to reach Prometheus")
+		Expect(promURL).ToNot(BeEmpty(), "Prometheus URL must not be empty")
+	})
+
+	AfterEach(func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	})
+
+	Context("When the flightctl services run with encryption at rest enabled", func() {
+		It("S4: should expose encryption active-key info metric with expected labels", Label("90096"), func() {
+			By("verifying flightctl_encryption_active_key_info gauge is present")
+			query := `flightctl_encryption_active_key_info`
+			Eventually(harness.PromQueryResultCount(promURL, query),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeNumerically(">", 0),
+				"flightctl_encryption_active_key_info must have at least one sample")
+
+			By("verifying the active-key gauge has the required label dimensions")
+			requiredLabels := []string{"strategy", "key_id", "algorithm"}
+			gaugeQuery := query + `{key_id="` + defaultKeyID + `"}`
+			Eventually(harness.PromQueryHasLabels(promURL, gaugeQuery, nil, requiredLabels),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(),
+				"flightctl_encryption_active_key_info must have strategy, key_id, algorithm labels")
+		})
+
+		It("S5: should expose encryption operation counter metric with expected labels", Label("90098"), func() {
+			By("creating an AuthProvider to trigger an encrypt operation")
+			apName := "enc-metrics-ap-" + harness.GetTestIDFromContext()
+			clientID := "enc-metrics-" + harness.GetTestIDFromContext()
+			manifest := buildOIDCAuthProviderYAML(apName, auxSvcs.Keycloak.IssuerURL(), clientID, "metrics-test-secret")
+			_, err := applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create AuthProvider to trigger encrypt metric")
+			DeferCleanup(func() {
+				if err := deleteAuthProvider(harness, apName); err != nil {
+					GinkgoWriter.Printf("Warning: failed to delete AuthProvider %s: %v\n", apName, err)
+				}
+			})
+
+			By("verifying flightctl_encryption_operations_total counter is present")
+			query := `flightctl_encryption_operations_total`
+			Eventually(harness.PromQueryResultCount(promURL, query),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeNumerically(">", 0),
+				"flightctl_encryption_operations_total must have at least one sample")
+
+			By("verifying the operations counter has the required label dimensions")
+			requiredLabels := []string{"operation", "strategy", "key_id", "status"}
+			Eventually(harness.PromQueryHasLabels(promURL, query, nil, requiredLabels),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(),
+				"flightctl_encryption_operations_total must have operation, strategy, key_id, status labels")
+		})
+
+		It("S6: should report no encryption errors during normal operation", Label("90128"), func() {
+			// Use sum(errors_total) value (not series count) so that a new error that
+			// increments an existing label-set series is detected. PromQueryResultCount
+			// returns the number of matching time series — it stays constant even when
+			// an existing series is incremented, making it unable to detect such errors.
+			errQuery := `sum(flightctl_encryption_errors_total)`
+
+			// Capture the baseline before creating the AuthProvider so any error
+			// produced by the creation itself is counted as a delta, not part of
+			// the baseline. Prometheus counters are process-lifetime values; other
+			// tests (e.g. N2) may have already incremented the counter.
+			baselineErrorValue := harness.PromQueryCountValue(promURL, errQuery)()
+
+			// Capture the baseline operations count before creating the AuthProvider so we can
+			// wait for the S6 operation to be recorded in Prometheus before checking errors.
+			// This prevents a race where the error check runs before the S6 operation reaches Prometheus.
+			opsQuery := `sum(flightctl_encryption_operations_total)`
+			baselineOpsValue := harness.PromQueryCountValue(promURL, opsQuery)()
+
+			By("creating an AuthProvider to produce a successful encrypt operation")
+			apName := "enc-metrics-noerr-ap-" + harness.GetTestIDFromContext()
+			clientID := "enc-metrics-noerr-" + harness.GetTestIDFromContext()
+			manifest := buildOIDCAuthProviderYAML(apName, auxSvcs.Keycloak.IssuerURL(), clientID, "no-error-secret")
+			_, err := applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create AuthProvider to drive a clean encrypt operation")
+			DeferCleanup(func() {
+				if err := deleteAuthProvider(harness, apName); err != nil {
+					GinkgoWriter.Printf("Warning: failed to delete AuthProvider %s: %v\n", apName, err)
+				}
+			})
+
+			By("verifying flightctl_encryption_errors_total did not increase during normal operations")
+			// Wait for the S6 create operation to be recorded (ops counter increased), then confirm
+			// errors didn't grow. Using the counter value (not series count) ensures we detect the
+			// S6 operation itself rather than passing on a pre-existing series from an earlier test.
+			Eventually(harness.PromQueryCountValue(promURL, opsQuery),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeNumerically(">", baselineOpsValue),
+				"must see the S6 encrypt operation recorded before checking error counter")
+
+			Expect(harness.PromQueryCountValue(promURL, errQuery)()).To(Equal(baselineErrorValue),
+				"flightctl_encryption_errors_total must not increase after a successful encrypt operation")
+		})
+
+		It("S7: should record canary validation successes on startup", Label("90129"), func() {
+			By("verifying flightctl_encryption_canary_validations_total{status=success} counter is present")
+			// The canary manager runs at service startup and records a validation for each
+			// configured strategy/key combination. At least one success must be present.
+			query := `flightctl_encryption_canary_validations_total{status="success"}`
+			Eventually(harness.PromQueryResultCount(promURL, query),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeNumerically(">", 0),
+				"flightctl_encryption_canary_validations_total{status=success} must be non-zero after service startup")
+
+			By("verifying the canary counter has the required label dimensions")
+			requiredLabels := []string{"strategy", "key_id", "status"}
+			Eventually(harness.PromQueryHasLabels(promURL, query, nil, requiredLabels),
+				testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250,
+			).Should(BeTrue(),
+				"flightctl_encryption_canary_validations_total must carry strategy, key_id, status labels")
+		})
+	})
+})

--- a/test/e2e/encryption/negative_test.go
+++ b/test/e2e/encryption/negative_test.go
@@ -1,0 +1,323 @@
+package encryption_test
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption at rest — Negative", Label("encryption", "negative"), func() {
+	var (
+		harness   *e2e.Harness
+		providers *infra.Providers
+	)
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+		providers = setup.GetDefaultProviders()
+		Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+	})
+
+	// N3: Sensitive fields are redacted in LIST responses, not just GET-by-name.
+	// HideSensitiveData() runs for every response via WriteJSONResponse — this
+	// test confirms LIST does not regress to exposing plaintext credentials.
+	Context("When sensitive resources are listed via the API", func() {
+		It("N3: should redact sensitive fields in LIST responses, not only in GET-by-name",
+			Label("90111", "sanity"), func() {
+
+				ctx := harness.GetTestContext()
+				testID := harness.GetTestIDFromContext()
+
+				issuerURL := auxSvcs.Keycloak.IssuerURL()
+				apName1 := "enc-neg-ap1-" + testID
+				apName2 := "enc-neg-ap2-" + testID
+				secret1 := "neg-secret-one-" + testID
+				secret2 := "neg-secret-two-" + testID
+				clientID1 := "enc-neg-c1-" + testID
+				clientID2 := "enc-neg-c2-" + testID
+
+				By("creating two AuthProviders with distinct clientSecrets")
+				manifest1 := buildOIDCAuthProviderYAML(apName1, issuerURL, clientID1, secret1)
+				_, err := applyManifest(harness, manifest1)
+				Expect(err).ToNot(HaveOccurred(), "create first AuthProvider")
+
+				manifest2 := buildOIDCAuthProviderYAML(apName2, issuerURL, clientID2, secret2)
+				_, err = applyManifest(harness, manifest2)
+				Expect(err).ToNot(HaveOccurred(), "create second AuthProvider")
+
+				DeferCleanup(func() {
+					_ = deleteAuthProvider(harness, apName1)
+					_ = deleteAuthProvider(harness, apName2)
+				})
+
+				By("creating an SSH Repository with a known private key")
+				Expect(auxSvcs.GitServer).ToNot(BeNil(), "git server must be started")
+				repoName := "enc-neg-repo-" + testID
+				keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+				Expect(err).ToNot(HaveOccurred(), "get git SSH key")
+				repoURL := fmt.Sprintf("user@%s:%d:/home/user/repos/test.git",
+					auxSvcs.GitServer.Host, auxSvcs.GitServer.Port)
+				Expect(harness.CreateRepositoryWithSSHCredentials(repoName, repoURL, keyContent)).To(
+					Succeed(), "create SSH Repository")
+
+				DeferCleanup(func() {
+					_, _ = harness.ManageResource("delete", "repository", repoName)
+				})
+
+				By("[N3] listing AuthProviders and verifying clientSecret is redacted")
+				apListResp, err := harness.Client.ListAuthProvidersWithResponse(ctx, nil)
+				Expect(err).ToNot(HaveOccurred(), "LIST AuthProviders")
+				Expect(apListResp.StatusCode()).To(Equal(200), "LIST AuthProviders must return 200")
+				apListBody := string(apListResp.Body)
+				Expect(apListBody).ToNot(ContainSubstring(secret1),
+					"LIST AuthProviders must not expose first plaintext clientSecret")
+				Expect(apListBody).ToNot(ContainSubstring(secret2),
+					"LIST AuthProviders must not expose second plaintext clientSecret")
+				Expect(apListBody).To(ContainSubstring("*****"),
+					"LIST AuthProviders must show redacted placeholder")
+
+				By("[N3] listing Repositories and verifying sshPrivateKey is redacted")
+				repoListResp, err := harness.Client.ListRepositoriesWithResponse(ctx, nil)
+				Expect(err).ToNot(HaveOccurred(), "LIST Repositories")
+				Expect(repoListResp.StatusCode()).To(Equal(200), "LIST Repositories must return 200")
+				repoListBody := string(repoListResp.Body)
+				Expect(repoListBody).ToNot(ContainSubstring("BEGIN"),
+					"LIST Repositories must not contain PEM headers")
+				Expect(repoListBody).To(ContainSubstring("*****"),
+					"LIST Repositories must show redacted placeholder")
+			})
+	})
+
+	// N1: A plaintext value stored directly in DB (e.g. pre-migration data) is
+	// re-encrypted on the next API write. The plaintext-passthrough path in
+	// Manager.Decrypt is backward-compatible; ProcessEncryption re-encrypts on save.
+	Context("When a sensitive field stored as plaintext in the DB is updated via the API", func() {
+		It("N1: should store the field encrypted after the update", Label("90113"), func() {
+			skipIfNoBuiltinDB()
+			ctx := harness.GetTestContext()
+			testID := harness.GetTestIDFromContext()
+			Expect(auxSvcs.Keycloak).ToNot(BeNil(), "Keycloak must be started")
+
+			authProviderName := "enc-neg-n1-" + testID
+			clientID := "enc-neg-n1-c-" + testID
+			issuerURL := auxSvcs.Keycloak.IssuerURL()
+			initialSecret := "initial-secret-" + testID
+
+			By("creating an AuthProvider via the API (gets a valid ciphertext in DB)")
+			manifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, clientID, initialSecret)
+			_, err := applyManifest(harness, manifest)
+			Expect(err).ToNot(HaveOccurred(), "create AuthProvider")
+
+			DeferCleanup(func() {
+				_ = deleteAuthProvider(harness, authProviderName)
+			})
+
+			By("verifying initial DB value is encrypted")
+			dbVal, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(dbVal, defaultKeyID)).To(BeTrue(),
+				"initial DB value must be encrypted, got: %s", dbVal)
+
+			By("overwriting the DB column with a plaintext value directly")
+			plaintextValue := "plaintext-injected-" + testID
+			_, err = queryDB(providers, fmt.Sprintf(
+				`UPDATE auth_providers SET spec = jsonb_set(spec, '{clientSecret}', '"%s"') WHERE name = '%s'`,
+				plaintextValue, authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred(), "inject plaintext into DB")
+
+			By("confirming the DB now contains plaintext (no enc: prefix)")
+			rawVal, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rawVal).To(Equal(plaintextValue), "DB should contain injected plaintext")
+
+			By("confirming GET still returns redacted value (not the plaintext)")
+			getResp, err := harness.Client.GetAuthProviderWithResponse(ctx, authProviderName)
+			Expect(err).ToNot(HaveOccurred(), "GET AuthProvider")
+			Expect(getResp.StatusCode()).To(Equal(200))
+			Expect(string(getResp.Body)).ToNot(ContainSubstring(plaintextValue),
+				"GET must not expose the injected plaintext value")
+			Expect(string(getResp.Body)).To(ContainSubstring("*****"),
+				"GET must show redacted placeholder")
+
+			By("[N1] updating the AuthProvider via the API to trigger a write")
+			newSecret := "re-encrypted-secret-" + testID
+			updatedManifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, clientID, newSecret)
+			_, err = applyManifest(harness, updatedManifest)
+			Expect(err).ToNot(HaveOccurred(), "update AuthProvider to trigger re-encryption")
+
+			By("[N1] verifying the DB value is now encrypted under the active key")
+			dbValAfter, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ciphertextMatchesKeyID(dbValAfter, defaultKeyID)).To(BeTrue(),
+				"[N1] DB value must be encrypted after write; got: %s", dbValAfter)
+			Expect(dbValAfter).ToNot(ContainSubstring(newSecret),
+				"[N1] DB must not store the new secret in plaintext")
+		})
+	})
+
+	// N4: A client submitting a pre-formed enc:v1: prefixed string as a credential
+	// value must not succeed. The GORM plugin tries to decrypt it (ProcessEncryption
+	// treats the enc: prefix as an encrypted value), fails GCM authentication, and
+	// aborts the DB write. The resource must not be created.
+	Context("When a client submits a pre-formed enc:v1: value as a credential", func() {
+		It("N4: should reject the request — not store the fake ciphertext", Label("90110"), func() {
+			skipIfNoBuiltinDB()
+			testID := harness.GetTestIDFromContext()
+			Expect(auxSvcs.Keycloak).ToNot(BeNil(), "Keycloak must be started")
+
+			authProviderName := "enc-neg-n4-" + testID
+			clientID := "enc-neg-n4-c-" + testID
+			issuerURL := auxSvcs.Keycloak.IssuerURL()
+
+			// Syntactically valid enc:v1: prefix with base64-decodable payload that
+			// is long enough to contain a nonce (≥28 bytes decoded) but whose GCM
+			// authentication tag will not verify against the server's real AES key.
+			fakeSecret := "enc:v1:default:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+
+			DeferCleanup(func() {
+				// Best-effort: resource should not exist, but clean up in case of partial success.
+				_ = deleteAuthProvider(harness, authProviderName)
+			})
+
+			By("[N4] attempting to create an AuthProvider with a fake enc:v1: clientSecret")
+			manifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, clientID, fakeSecret)
+			_, err := applyManifest(harness, manifest)
+			Expect(err).To(HaveOccurred(),
+				"[N4] apply with fake enc:v1: secret must return an error")
+
+			By("[N4] verifying no AuthProvider was persisted in the DB")
+			dbVal, err := queryDB(providers, fmt.Sprintf(
+				"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+			))
+			Expect(err).ToNot(HaveOccurred(), "DB query must not error (resource absence is not a query error)")
+			Expect(dbVal).To(BeEmpty(),
+				"[N4] no AuthProvider must exist in DB after rejected write; got: %s", dbVal)
+		})
+	})
+
+	// N2: A Repository whose encrypted credential is corrupted directly in the DB
+	// transitions to Accessible=False when the background task attempts decryption.
+	// Restoring the original ciphertext causes recovery to Accessible=True.
+	// The service must not crash — API must remain reachable throughout.
+	Context("When a Repository's encrypted credential is corrupted in the DB", func() {
+		It("N2: should mark the Repository Accessible=False and recover when the value is restored",
+			Label("90112"), func() {
+				skipIfNoBuiltinDB()
+				testID := harness.GetTestIDFromContext()
+				Expect(auxSvcs.GitServer).ToNot(BeNil(), "git server must be started")
+
+				// Use a unique repo name derived from the test ID so concurrent test runs don't collide.
+				gitRepoName := "n2-" + testID
+				repoName := "enc-neg-n2-" + testID
+
+				keyPath, err := auxSvcs.GetGitSSHPrivateKeyPath()
+				Expect(err).ToNot(HaveOccurred(), "get git SSH key path")
+				keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+				Expect(err).ToNot(HaveOccurred(), "get git SSH key content")
+
+				gitServerConfig := e2e.GitServerConfig{
+					Host: auxSvcs.GitServer.Host,
+					Port: auxSvcs.GitServer.Port,
+					User: "user",
+				}
+
+				By("creating a bare git repo on the server so the repository can become Accessible=True")
+				Expect(harness.CreateGitRepositoryOnServer(gitServerConfig, keyPath, gitRepoName)).To(
+					Succeed(), "create bare git repo on server")
+				// Register git-server cleanup immediately so leaks are prevented even if subsequent
+				// steps (CreateRepositoryWithSSHCredentials) fail before the shared DeferCleanup below.
+				DeferCleanup(func() {
+					if err := harness.DeleteGitRepositoryOnServer(gitServerConfig, keyPath, gitRepoName); err != nil {
+						GinkgoWriter.Printf("Warning: failed to delete git server repo %s: %v\n", gitRepoName, err)
+					}
+				})
+
+				// Use InternalHost/InternalPort for the Repository URL so that repotester
+				// (running inside the cluster) can reach the git server via the correct
+				// network path. On OCP, E2E_AUX_HOST must be set to a cluster-reachable
+				// address for the git server to be accessible.
+				repoURL, err := harness.GetInternalGitRepoURL(
+					auxSvcs.GitServer.InternalHost, auxSvcs.GitServer.InternalPort, gitRepoName)
+				Expect(err).ToNot(HaveOccurred(), "build internal git repo URL")
+
+				// savedCipherN2 captures the original DB ciphertext so DeferCleanup can
+				// restore it before deletion (avoids broken-decrypt errors in the cleanup path).
+				var savedCipherN2 string
+
+				By("creating an SSH Repository resource pointing to the bare git repo")
+				Expect(harness.CreateRepositoryWithSSHCredentials(repoName, repoURL, keyContent)).To(
+					Succeed(), "create SSH Repository")
+
+				DeferCleanup(func() {
+					// Restore the valid ciphertext before deleting so the delete does not fail
+					// due to a broken decrypt during any cleanup read path.
+					if savedCipherN2 != "" {
+						_, _ = queryDB(providers, fmt.Sprintf(
+							`UPDATE repositories SET spec = jsonb_set(spec, '{sshConfig,sshPrivateKey}', '"%s"') WHERE name = '%s'`,
+							savedCipherN2, repoName,
+						))
+					}
+					_, _ = harness.ManageResource("delete", "repository", repoName)
+				})
+
+				By("waiting for the Repository to become Accessible=True initially")
+				Expect(harness.WaitForRepositoryAccessible(repoName,
+					testutil.DURATION_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+					Succeed(), "Repository must be accessible before corruption")
+
+				By("saving the valid ciphertext from DB before corruption")
+				savedCipherN2, err = queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(savedCipherN2).To(HavePrefix("enc:v1:"), "saved value must be an encrypted ciphertext")
+
+				// Structurally valid enc:v1: prefix; base64 payload decodes to >32 bytes
+				// (satisfies nonce length check) but the GCM authentication tag will not
+				// verify, causing DecryptParsed to return ErrDecryptionFailed.
+				brokenCipher := "enc:v1:default:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+
+				By("corrupting the DB ciphertext directly")
+				_, err = queryDB(providers, fmt.Sprintf(
+					`UPDATE repositories SET spec = jsonb_set(spec, '{sshConfig,sshPrivateKey}', '"%s"') WHERE name = '%s'`,
+					brokenCipher, repoName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "corrupt ciphertext in DB")
+
+				By("[N2] waiting for the background task to detect decryption failure → Accessible=False")
+				Expect(harness.WaitForRepositoryNotAccessible(repoName,
+					testutil.LONG_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+					Succeed(), "[N2] Repository must become Accessible=False after ciphertext corruption")
+
+				By("[N2] verifying the API is still reachable (service did not crash)")
+				ctx := harness.GetTestContext()
+				resp, err := harness.Client.GetRepositoryWithResponse(ctx, repoName)
+				Expect(err).ToNot(HaveOccurred(), "[N2] GET Repository must succeed after corruption")
+				Expect(resp.StatusCode()).To(Equal(200), "[N2] API must return 200 — service must not crash")
+
+				By("[N2] restoring the original valid ciphertext in DB")
+				_, err = queryDB(providers, fmt.Sprintf(
+					`UPDATE repositories SET spec = jsonb_set(spec, '{sshConfig,sshPrivateKey}', '"%s"') WHERE name = '%s'`,
+					savedCipherN2, repoName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "restore valid ciphertext")
+
+				By("[N2] verifying the Repository recovers to Accessible=True")
+				Expect(harness.WaitForRepositoryAccessible(repoName,
+					testutil.LONG_TIMEOUT, testutil.EVENTUALLY_POLLING_250)).To(
+					Succeed(), "[N2] Repository must return to Accessible=True after ciphertext restore")
+			})
+	})
+})

--- a/test/e2e/encryption/sensitive_fields_test.go
+++ b/test/e2e/encryption/sensitive_fields_test.go
@@ -1,0 +1,247 @@
+package encryption_test
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/flightctl/flightctl/test/e2e/infra"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption at rest — AuthProvider", Label("encryption"), func() {
+	var (
+		harness      *e2e.Harness
+		providers    *infra.Providers
+		clientSecret string
+	)
+
+	BeforeEach(func() {
+		skipIfNoBuiltinDB()
+		harness = e2e.GetWorkerHarness()
+		providers = setup.GetDefaultProviders()
+		clientSecret = "e2e-secret-" + harness.GetTestIDFromContext()
+		Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+		Expect(auxSvcs.Keycloak).ToNot(BeNil(), "Keycloak must be started")
+	})
+
+	Context("When an OIDC AuthProvider with a clientSecret is created", func() {
+		It("should redact clientSecret in GET response and store it encrypted in the database",
+			Label("sanity", "90089"), func() {
+
+				ctx := harness.GetTestContext()
+				testID := harness.GetTestIDFromContext()
+				authProviderName := "enc-ap-" + testID
+				clientID := "enc-ap-client-" + testID
+
+				By("creating an OIDC AuthProvider with a known clientSecret")
+				issuerURL := auxSvcs.Keycloak.IssuerURL()
+				manifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, clientID, clientSecret)
+				out, err := applyManifest(harness, manifest)
+				Expect(err).ToNot(HaveOccurred(), "apply AuthProvider manifest")
+				Expect(out).ToNot(BeEmpty(), "apply must produce output")
+
+				DeferCleanup(func() {
+					if deleteErr := deleteAuthProvider(harness, authProviderName); deleteErr != nil {
+						GinkgoWriter.Printf("Warning: failed to delete authprovider %s: %v\n", authProviderName, deleteErr)
+					}
+				})
+
+				By("fetching the AuthProvider via the API")
+				resp, err := harness.Client.GetAuthProviderWithResponse(ctx, authProviderName)
+				Expect(err).ToNot(HaveOccurred(), "GET AuthProvider")
+				Expect(resp.StatusCode()).To(Equal(200), "GET AuthProvider must return 200")
+				Expect(resp.JSON200).ToNot(BeNil(), "GET response body must parse")
+
+				By("verifying clientSecret is redacted in the API response")
+				rawBody := string(resp.Body)
+				Expect(rawBody).ToNot(ContainSubstring(clientSecret),
+					"API response body must not contain the plaintext clientSecret")
+				Expect(rawBody).To(ContainSubstring("*****"),
+					"API response body must show redacted placeholder")
+
+				By("querying the database and verifying the ciphertext format")
+				dbVal, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "psql query for clientSecret")
+				Expect(dbVal).ToNot(BeEmpty(), "DB value must not be empty")
+				Expect(dbVal).ToNot(ContainSubstring(clientSecret),
+					"DB must not store the plaintext clientSecret")
+				Expect(ciphertextMatchesKeyID(dbVal, defaultKeyID)).To(BeTrue(),
+					"DB value must start with enc:v1:%s: but got: %s", defaultKeyID, dbVal)
+
+				firstCiphertext := dbVal
+
+				By("updating the AuthProvider with a new clientSecret")
+				newSecret := "e2e-newsecret-" + harness.GetTestIDFromContext()
+				updatedManifest := buildOIDCAuthProviderYAML(authProviderName, issuerURL, clientID, newSecret)
+				out, err = applyManifest(harness, updatedManifest)
+				Expect(err).ToNot(HaveOccurred(), "update AuthProvider with new clientSecret")
+				Expect(out).ToNot(BeEmpty(), "update must produce output")
+
+				By("verifying the updated API response still redacts the secret")
+				resp2, err := harness.Client.GetAuthProviderWithResponse(ctx, authProviderName)
+				Expect(err).ToNot(HaveOccurred(), "GET updated AuthProvider")
+				Expect(resp2.StatusCode()).To(Equal(200), "GET updated AuthProvider must return 200")
+				Expect(string(resp2.Body)).ToNot(ContainSubstring(newSecret),
+					"updated API response must not expose the new plaintext secret")
+
+				By("verifying the DB value changed and is still encrypted")
+				dbVal2, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->>'clientSecret' FROM auth_providers WHERE name = '%s'", authProviderName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "psql query after update")
+				Expect(dbVal2).ToNot(BeEmpty(), "updated DB value must not be empty")
+				Expect(ciphertextMatchesKeyID(dbVal2, defaultKeyID)).To(BeTrue(),
+					"updated DB value must start with enc:v1:%s: but got: %s", defaultKeyID, dbVal2)
+				Expect(dbVal2).ToNot(Equal(firstCiphertext),
+					"ciphertext must change after credential update (re-encrypted on save)")
+				Expect(dbVal2).ToNot(ContainSubstring(newSecret),
+					"DB must not store the new plaintext secret")
+			})
+	})
+})
+
+var _ = Describe("Encryption at rest — Repository", Label("encryption"), func() {
+	var (
+		harness   *e2e.Harness
+		providers *infra.Providers
+	)
+
+	BeforeEach(func() {
+		skipIfNoBuiltinDB()
+		harness = e2e.GetWorkerHarness()
+		providers = setup.GetDefaultProviders()
+
+		Expect(auxSvcs).ToNot(BeNil(), "auxiliary services must be initialized")
+		Expect(auxSvcs.GitServer).ToNot(BeNil(), "git server must be started")
+	})
+
+	Context("When a Repository with SSH credentials is created", func() {
+		It("should redact sshPrivateKey in GET response and store it encrypted in the database",
+			Label("sanity", "90088"), func() {
+
+				repoName := "enc-repo-ssh-" + harness.GetTestIDFromContext()
+				repoURL := fmt.Sprintf("user@%s:%d:/home/user/repos/test.git",
+					auxSvcs.GitServer.Host, auxSvcs.GitServer.Port)
+
+				By("creating an SSH-auth Repository")
+				keyContent, err := auxSvcs.GetGitSSHPrivateKey()
+				Expect(err).ToNot(HaveOccurred(), "get git server SSH key")
+				err = harness.CreateRepositoryWithSSHCredentials(repoName, repoURL, keyContent)
+				Expect(err).ToNot(HaveOccurred(), "create SSH Repository")
+				DeferCleanup(func() {
+					if _, err := harness.ManageResource("delete", "repository", repoName); err != nil {
+						GinkgoWriter.Printf("Warning: failed to delete repository %s: %v\n", repoName, err)
+					}
+				})
+
+				By("fetching the Repository via the API")
+				ctx := harness.GetTestContext()
+				resp, err := harness.Client.GetRepositoryWithResponse(ctx, repoName)
+				Expect(err).ToNot(HaveOccurred(), "GET Repository")
+				Expect(resp.StatusCode()).To(Equal(200), "GET Repository must return 200")
+				Expect(resp.JSON200).ToNot(BeNil(), "GET response body must parse")
+
+				By("verifying sshPrivateKey is redacted in API response")
+				rawBody := string(resp.Body)
+				Expect(rawBody).ToNot(ContainSubstring("BEGIN"),
+					"API response body must not contain PEM key material")
+				Expect(rawBody).To(ContainSubstring("*****"),
+					"API response body must show redacted placeholder")
+				rawKeyB64 := base64.StdEncoding.EncodeToString([]byte(keyContent))
+				Expect(rawBody).ToNot(ContainSubstring(rawKeyB64),
+					"API response body must not contain base64-encoded key material")
+
+				By("querying the database and verifying ciphertext format")
+				dbVal, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "psql query for sshPrivateKey")
+				Expect(dbVal).ToNot(BeEmpty(), "DB value must not be empty")
+				Expect(dbVal).ToNot(ContainSubstring("BEGIN"),
+					"DB must not contain PEM headers")
+				Expect(ciphertextMatchesKeyID(dbVal, defaultKeyID)).To(BeTrue(),
+					"DB value must start with enc:v1:%s: but got: %s", defaultKeyID, dbVal)
+
+				firstCiphertext := dbVal
+
+				By("updating the Repository with a new credential to verify re-encryption")
+				// AES-GCM uses a random nonce per encryption, so ciphertext differs even for same plaintext.
+				updatedManifest := fmt.Sprintf(`apiVersion: flightctl.io/v1beta1
+kind: Repository
+metadata:
+  name: %s
+spec:
+  type: git
+  url: %s
+  sshConfig:
+    sshPrivateKey: %s
+    skipServerVerification: true
+`, repoName, repoURL, base64.StdEncoding.EncodeToString([]byte(keyContent)))
+				out, err := applyManifest(harness, updatedManifest)
+				Expect(err).ToNot(HaveOccurred(), "update Repository via apply")
+				Expect(out).ToNot(BeEmpty(), "update must produce output")
+
+				By("verifying the re-encrypted DB value is still in ciphertext format")
+				dbVal2, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'sshConfig'->>'sshPrivateKey' FROM repositories WHERE name = '%s'", repoName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "psql query after SSH key update")
+				Expect(dbVal2).ToNot(BeEmpty(), "updated DB value must not be empty")
+				Expect(ciphertextMatchesKeyID(dbVal2, defaultKeyID)).To(BeTrue(),
+					"updated DB value must start with enc:v1:%s: but got: %s", defaultKeyID, dbVal2)
+				Expect(dbVal2).ToNot(Equal(firstCiphertext),
+					"ciphertext must differ after update (new random nonce per encryption)")
+			})
+	})
+
+	Context("When a Repository with HTTP credentials is created", func() {
+		It("should redact password in GET response and store it encrypted in the database",
+			Label("sanity", "90087"), func() {
+
+				repoName := "enc-repo-http-" + harness.GetTestIDFromContext()
+				repoURL := fmt.Sprintf("http://%s:%d/test.git",
+					auxSvcs.GitServer.Host, auxSvcs.GitServer.Port)
+
+				username := "testuser"
+				password := "e2e-http-pass-" + harness.GetTestIDFromContext()
+
+				By("creating an HTTP-auth Repository")
+				_, err := harness.CreateHTTPRepository(repoName, repoURL, &username, &password)
+				Expect(err).ToNot(HaveOccurred(), "create HTTP Repository")
+				DeferCleanup(func() {
+					if _, err := harness.ManageResource("delete", "repository", repoName); err != nil {
+						GinkgoWriter.Printf("Warning: failed to delete repository %s: %v\n", repoName, err)
+					}
+				})
+
+				By("fetching the Repository via the API")
+				ctx := harness.GetTestContext()
+				resp, err := harness.Client.GetRepositoryWithResponse(ctx, repoName)
+				Expect(err).ToNot(HaveOccurred(), "GET Repository")
+				Expect(resp.StatusCode()).To(Equal(200), "GET Repository must return 200")
+
+				By("verifying password is redacted in API response")
+				rawBody := string(resp.Body)
+				Expect(rawBody).ToNot(ContainSubstring(password),
+					"API response body must not contain the plaintext HTTP password")
+				Expect(rawBody).To(ContainSubstring("*****"),
+					"API response body must show redacted placeholder")
+
+				By("querying the database and verifying ciphertext format")
+				dbVal, err := queryDB(providers, fmt.Sprintf(
+					"SELECT spec->'httpConfig'->>'password' FROM repositories WHERE name = '%s'", repoName,
+				))
+				Expect(err).ToNot(HaveOccurred(), "psql query for HTTP password")
+				Expect(dbVal).ToNot(BeEmpty(), "DB value must not be empty")
+				Expect(dbVal).ToNot(ContainSubstring(password),
+					"DB must not store the plaintext HTTP password")
+				Expect(ciphertextMatchesKeyID(dbVal, defaultKeyID)).To(BeTrue(),
+					"DB value must start with enc:v1:%s: but got: %s", defaultKeyID, dbVal)
+			})
+	})
+})

--- a/test/e2e/infra/db.go
+++ b/test/e2e/infra/db.go
@@ -1,0 +1,26 @@
+package infra
+
+import (
+	"fmt"
+	"strings"
+)
+
+// QueryDB executes a psql query against the built-in flightctl PostgreSQL database
+// and returns the trimmed output.
+//
+// This requires a reachable flightctl-db pod/container (the built-in deployment).
+// It will fail on external-database deployments where no such pod exists.
+// Callers that run in mixed environments should guard with
+// Providers.Infra.BuiltinDatabaseWorkloadAvailable() before calling.
+func QueryDB(p *Providers, sql string) (string, error) {
+	if p == nil || p.Infra == nil {
+		return "", fmt.Errorf("QueryDB: providers not initialized")
+	}
+	output, err := p.Infra.ExecInService(ServiceDB, []string{
+		"psql", "-d", "flightctl", "-t", "-A", "-c", sql,
+	})
+	if err != nil {
+		return "", fmt.Errorf("psql query failed: %w; output: %s", err, strings.TrimSpace(output))
+	}
+	return strings.TrimSpace(output), nil
+}

--- a/test/e2e/infra/encryption_config.go
+++ b/test/e2e/infra/encryption_config.go
@@ -1,0 +1,74 @@
+package infra
+
+import (
+	"fmt"
+	"path/filepath"
+
+	internalconfig "github.com/flightctl/flightctl/internal/config"
+	"sigs.k8s.io/yaml"
+)
+
+// EncryptionKeyDir is the in-container directory where encryption key files are mounted.
+// Both K8s (via Secret volume) and Quadlet (via bind mount at /etc/flightctl/encryption)
+// present keys at this path inside the container.
+const EncryptionKeyDir = "/root/.flightctl/encryption"
+
+// ParseEncryptionConfig extracts the encryption block from a service config YAML string
+// and returns a typed EncryptionConfig. If no encryption block is present (e.g. Quadlet
+// with defaults baked in), it synthesizes the default — activeKeyID=default,
+// path=EncryptionKeyDir/key.
+func ParseEncryptionConfig(configYAML string) (*internalconfig.EncryptionConfig, error) {
+	var root map[string]interface{}
+	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
+		return nil, fmt.Errorf("ParseEncryptionConfig: parse config: %w", err)
+	}
+
+	if raw, ok := root["encryption"]; ok && raw != nil {
+		sub, err := yaml.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("ParseEncryptionConfig: re-marshal encryption block: %w", err)
+		}
+		var enc internalconfig.EncryptionConfig
+		if err := yaml.Unmarshal(sub, &enc); err != nil {
+			return nil, fmt.Errorf("ParseEncryptionConfig: parse encryption block: %w", err)
+		}
+		return &enc, nil
+	}
+
+	// No encryption block — synthesize the implicit default.
+	return &internalconfig.EncryptionConfig{
+		ActiveKeyID: "default",
+		Keys: []internalconfig.EncryptionKeyConfig{
+			{ID: "default", Path: filepath.Join(EncryptionKeyDir, "key")},
+		},
+	}, nil
+}
+
+// MarshalEncryptionConfigIntoYAML merges the given EncryptionConfig into the provided
+// service config YAML string, replacing the existing encryption block (if any).
+// Unrelated top-level keys are preserved.
+func MarshalEncryptionConfigIntoYAML(configYAML string, enc *internalconfig.EncryptionConfig) (string, error) {
+	var root map[string]interface{}
+	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
+		return "", fmt.Errorf("MarshalEncryptionConfigIntoYAML: parse config: %w", err)
+	}
+	if root == nil {
+		root = make(map[string]interface{})
+	}
+
+	encBytes, err := yaml.Marshal(enc)
+	if err != nil {
+		return "", fmt.Errorf("MarshalEncryptionConfigIntoYAML: marshal encryption config: %w", err)
+	}
+	var encMap interface{}
+	if err := yaml.Unmarshal(encBytes, &encMap); err != nil {
+		return "", fmt.Errorf("MarshalEncryptionConfigIntoYAML: re-parse encryption config: %w", err)
+	}
+	root["encryption"] = encMap
+
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("MarshalEncryptionConfigIntoYAML: marshal config: %w", err)
+	}
+	return string(out), nil
+}

--- a/test/e2e/infra/infra_provider.go
+++ b/test/e2e/infra/infra_provider.go
@@ -11,6 +11,8 @@ package infra
 import (
 	"context"
 	"io"
+
+	internalconfig "github.com/flightctl/flightctl/internal/config"
 )
 
 // ServiceName is a type-safe identifier for flightctl services.
@@ -111,6 +113,32 @@ type InfraProvider interface {
 	// ServiceExists reports whether the deployment-specific resource for a logical service is present.
 	// For K8s: checks the Service object exists. For Quadlet: checks the systemd unit is active.
 	ServiceExists(ctx context.Context, service ServiceName) (bool, error)
+
+	// SetEncryptionKey writes a named encryption key so it is available to the given service.
+	// For K8s: patches the flightctl-encryption-key Secret to add/update the key entry, then
+	// triggers a rollout restart of the service's deployment so the new Secret is mounted.
+	// For Quadlet: writes the key file directly to the host filesystem at the encryption key directory.
+	// keyFileName is the base name of the key file (e.g. "key-rotated-key").
+	// keyBytes is the raw key material to store.
+	SetEncryptionKey(service ServiceName, keyFileName string, keyBytes []byte) error
+
+	// ResetEncryptionKeys removes all non-default encryption key files, leaving only the
+	// original "key" file (the deployment default). Used by test recovery to undo key rotation.
+	// For K8s: replaces the flightctl-encryption-key Secret's data with only the "key" entry.
+	// For Quadlet: removes all key-* files from the encryption key directory.
+	ResetEncryptionKeys() error
+
+	// GetEncryptionConfig reads the current encryption block from the service's config.
+	// Returns the parsed EncryptionConfig. If the service config has no encryption block
+	// (e.g. Quadlet with defaults baked in), returns a synthesized default config with
+	// activeKeyID=default and path=EncryptionKeyDir/key.
+	// For K8s: reads ConfigMap config.yaml. For Quadlet: reads the service config file.
+	GetEncryptionConfig(service ServiceName) (*internalconfig.EncryptionConfig, error)
+
+	// SetEncryptionConfig writes the given encryption block into the service's config,
+	// merging it with any existing top-level keys so unrelated settings are preserved.
+	// For K8s: updates ConfigMap data["config.yaml"]. For Quadlet: writes per-service config.
+	SetEncryptionConfig(service ServiceName, enc *internalconfig.EncryptionConfig) error
 }
 
 // DeploymentServiceNames maps deployment/service names (same in K8s and Quadlet) to ServiceName.

--- a/test/e2e/infra/k8s/infra.go
+++ b/test/e2e/infra/k8s/infra.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	internalconfig "github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -486,6 +487,114 @@ func (p *InfraProvider) GetAPILoginToken() (string, error) {
 	}
 }
 
+// encryptionKeySecretName is the K8s Secret that holds the encryption key files.
+const encryptionKeySecretName = "flightctl-encryption-key"
+
+// SetEncryptionKey patches the flightctl-encryption-key Secret to add/update a key entry,
+// then triggers a rollout restart of the service's deployment so pods mount the updated Secret.
+func (p *InfraProvider) SetEncryptionKey(service infra.ServiceName, keyFileName string, keyBytes []byte) error {
+	if keyFileName == "" {
+		return fmt.Errorf("SetEncryptionKey: keyFileName is required")
+	}
+	if strings.ContainsAny(keyFileName, "/\\.") {
+		return fmt.Errorf("SetEncryptionKey: keyFileName must be a plain basename, got %q", keyFileName)
+	}
+	if len(keyBytes) == 0 {
+		return fmt.Errorf("SetEncryptionKey: keyBytes is empty")
+	}
+
+	_, ns, err := p.getServiceInfo(service)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionKey: resolve service %s: %w", service, err)
+	}
+
+	// Patch the Secret via stringData so the mounted file contains the base64-encoded key string,
+	// matching the format produced by generate-encryption-key.sh (openssl rand -base64 32).
+	// DecodeAES256Key expects a base64-encoded string; if we patched via data with raw bytes,
+	// K8s would decode them on mount and the file would contain raw binary that DecodeAES256Key
+	// cannot parse.
+	encodedKey := base64.StdEncoding.EncodeToString(keyBytes)
+	patch := map[string]interface{}{
+		"stringData": map[string]string{keyFileName: encodedKey},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionKey: marshal patch: %w", err)
+	}
+	tmp, err := os.CreateTemp("", "infra-secret-patch-*.json")
+	if err != nil {
+		return fmt.Errorf("SetEncryptionKey: create temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close() //nolint:errcheck
+	if _, err := tmp.Write(patchBytes); err != nil {
+		return fmt.Errorf("SetEncryptionKey: write patch: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("SetEncryptionKey: close temp file: %w", err)
+	}
+	args := p.kubectlArgs("patch", "secret", encryptionKeySecretName, "-n", ns, "--patch-file", tmp.Name(), "--type", "merge")
+	cmd := exec.Command("kubectl", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("SetEncryptionKey: patch secret %s/%s: %w: %s", ns, encryptionKeySecretName, err, strings.TrimSpace(string(output)))
+	}
+	logrus.Infof("K8s: patched secret %s/%s with key %q", ns, encryptionKeySecretName, keyFileName)
+	// The caller (rotateEncryptionKey) restarts services via restartServicesAndWait after all
+	// key files and config are updated. No rollout restart here to avoid racing with that restart.
+	return nil
+}
+
+// ResetEncryptionKeys replaces the flightctl-encryption-key Secret with only the original
+// "key" entry, removing any additional keys added during tests (e.g. after key rotation).
+// After calling this, restart services so pods mount the updated Secret.
+func (p *InfraProvider) ResetEncryptionKeys() error {
+	_, ns, err := p.getServiceInfo(infra.ServiceAPI)
+	if err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: resolve namespace: %w", err)
+	}
+
+	// Read the current Secret to get the original "key" value.
+	args := p.kubectlArgs("get", "secret", encryptionKeySecretName, "-n", ns, "-o", "jsonpath={.data.key}")
+	cmd := exec.Command("kubectl", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: read secret %s/%s: %w: %s", ns, encryptionKeySecretName, err, strings.TrimSpace(string(output)))
+	}
+	originalKeyData := strings.TrimSpace(string(output))
+	if originalKeyData == "" {
+		logrus.Warnf("ResetEncryptionKeys: 'key' entry not found in %s/%s — Secret may not have been set up yet; skipping reset", ns, encryptionKeySecretName)
+		return nil
+	}
+
+	// Use kubectl replace with a minimal Secret manifest so K8s removes all extra data keys.
+	// Strategic merge patch cannot remove keys (null values are ignored), so replace is required.
+	secretYAML := fmt.Sprintf("apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\ndata:\n  key: %s\n",
+		encryptionKeySecretName, ns, originalKeyData)
+
+	tmpYAML, err := os.CreateTemp("", "infra-secret-reset-*.yaml")
+	if err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: create yaml temp file: %w", err)
+	}
+	defer os.Remove(tmpYAML.Name())
+	defer tmpYAML.Close() //nolint:errcheck
+	if _, err := tmpYAML.WriteString(secretYAML); err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: write yaml: %w", err)
+	}
+	if err := tmpYAML.Close(); err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: close yaml: %w", err)
+	}
+
+	replaceArgs := p.kubectlArgs("replace", "-f", tmpYAML.Name())
+	replaceCmd := exec.Command("kubectl", replaceArgs...)
+	replaceOut, err := replaceCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: replace secret: %w: %s", err, strings.TrimSpace(string(replaceOut)))
+	}
+	logrus.Infof("K8s: reset secret %s/%s to only the default 'key' entry", ns, encryptionKeySecretName)
+	return nil
+}
+
 // SetServiceConfig updates a service's ConfigMap data key with the given content.
 func (p *InfraProvider) SetServiceConfig(service infra.ServiceName, configKey, content string) error {
 	info, ns, err := p.getServiceInfo(service)
@@ -649,4 +758,29 @@ func (p *InfraProvider) detectInternalNamespace() (string, error) {
 		return "", fmt.Errorf("no pod with label flightctl.service=flightctl-worker found (set %s to override)", envInternalNS)
 	}
 	return list.Items[0].Namespace, nil
+}
+
+// GetEncryptionConfig reads the current encryption block from the service's ConfigMap config.yaml
+// and returns a typed EncryptionConfig. If no encryption block is present, a synthesized default
+// is returned (activeKeyID=default, path=EncryptionKeyDir/key).
+func (p *InfraProvider) GetEncryptionConfig(service infra.ServiceName) (*internalconfig.EncryptionConfig, error) {
+	raw, err := p.GetServiceConfig(service)
+	if err != nil {
+		return nil, fmt.Errorf("GetEncryptionConfig: read service config for %s: %w", service, err)
+	}
+	return infra.ParseEncryptionConfig(raw)
+}
+
+// SetEncryptionConfig writes the given encryption block into the service's ConfigMap config.yaml,
+// preserving all other top-level keys.
+func (p *InfraProvider) SetEncryptionConfig(service infra.ServiceName, enc *internalconfig.EncryptionConfig) error {
+	raw, err := p.GetServiceConfig(service)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionConfig: read service config for %s: %w", service, err)
+	}
+	updated, err := infra.MarshalEncryptionConfigIntoYAML(raw, enc)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionConfig: merge encryption config for %s: %w", service, err)
+	}
+	return p.SetServiceConfig(service, "config.yaml", updated)
 }

--- a/test/e2e/infra/quadlet/infra.go
+++ b/test/e2e/infra/quadlet/infra.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	internalconfig "github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
@@ -689,6 +690,53 @@ func quadletServiceConfigDBType(serviceConfigYAML []byte) string {
 	return strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", tRaw)))
 }
 
+// quadletEncryptionKeyDir is the host-side directory where Quadlet mounts encryption key files.
+// This matches the Volume source in the .container files: /etc/flightctl/encryption:/root/.flightctl/encryption:ro,z
+const quadletEncryptionKeyDir = "/etc/flightctl/encryption"
+
+// SetEncryptionKey writes a named encryption key file to the host filesystem at
+// /etc/flightctl/encryption/<keyFileName> so it becomes available to the service container.
+// For Quadlet the volume is bind-mounted from the host, so a host-side write is sufficient;
+// there is no need to restart the container for the file to appear inside it.
+func (p *InfraProvider) SetEncryptionKey(_ infra.ServiceName, keyFileName string, keyBytes []byte) error {
+	if keyFileName == "" {
+		return fmt.Errorf("SetEncryptionKey: keyFileName is required")
+	}
+	if strings.ContainsAny(keyFileName, "/\\.") {
+		return fmt.Errorf("SetEncryptionKey: keyFileName must be a plain basename, got %q", keyFileName)
+	}
+	if len(keyBytes) == 0 {
+		return fmt.Errorf("SetEncryptionKey: keyBytes is empty")
+	}
+	// Write the base64-encoded key so the file format matches generate-encryption-key.sh output
+	// (openssl rand -base64 32). DecodeAES256Key expects a base64-encoded string on disk.
+	hostPath := filepath.Join(quadletEncryptionKeyDir, keyFileName)
+	encoded := []byte(base64.StdEncoding.EncodeToString(keyBytes))
+	if err := p.writeHostFile(hostPath, encoded); err != nil {
+		return fmt.Errorf("SetEncryptionKey: write %s: %w", hostPath, err)
+	}
+	return nil
+}
+
+// ResetEncryptionKeys removes all key-* files from the Quadlet encryption key directory,
+// leaving only the original "key" file. Used by test recovery to undo key rotation.
+func (p *InfraProvider) ResetEncryptionKeys() error {
+	out, err := p.runCommand("ls", quadletEncryptionKeyDir)
+	if err != nil {
+		return fmt.Errorf("ResetEncryptionKeys: list %s: %w", quadletEncryptionKeyDir, err)
+	}
+	for _, name := range strings.Fields(out) {
+		if name != "key" && strings.HasPrefix(name, "key-") {
+			hostPath := filepath.Join(quadletEncryptionKeyDir, name)
+			if err := p.RemoveHostFile(hostPath); err != nil {
+				return fmt.Errorf("ResetEncryptionKeys: remove %s: %w", hostPath, err)
+			}
+			logrus.Infof("Quadlet: removed extra encryption key file %s", hostPath)
+		}
+	}
+	return nil
+}
+
 // SetServiceConfig writes the config content to the service's config file on the host.
 // Quadlet has a single config file per service; configKey is ignored (callers may pass
 // "" or "config.yaml" for API compatibility). For services with a section mapping
@@ -916,4 +964,30 @@ func isLoopbackPublishedHost(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// GetEncryptionConfig reads the current encryption block from the service's config file
+// and returns a typed EncryptionConfig. If no encryption block is present (e.g. Quadlet
+// with defaults baked in), a synthesized default is returned (activeKeyID=default,
+// path=EncryptionKeyDir/key).
+func (p *InfraProvider) GetEncryptionConfig(service infra.ServiceName) (*internalconfig.EncryptionConfig, error) {
+	raw, err := p.GetServiceConfig(service)
+	if err != nil {
+		return nil, fmt.Errorf("GetEncryptionConfig: read service config for %s: %w", service, err)
+	}
+	return infra.ParseEncryptionConfig(raw)
+}
+
+// SetEncryptionConfig writes the given encryption block into the service's config file,
+// preserving all other top-level keys.
+func (p *InfraProvider) SetEncryptionConfig(service infra.ServiceName, enc *internalconfig.EncryptionConfig) error {
+	raw, err := p.GetServiceConfig(service)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionConfig: read service config for %s: %w", service, err)
+	}
+	updated, err := infra.MarshalEncryptionConfigIntoYAML(raw, enc)
+	if err != nil {
+		return fmt.Errorf("SetEncryptionConfig: merge encryption config for %s: %w", service, err)
+	}
+	return p.SetServiceConfig(service, "config.yaml", updated)
 }

--- a/test/e2e/infra/quadlet/service_config_mapping.go
+++ b/test/e2e/infra/quadlet/service_config_mapping.go
@@ -17,13 +17,17 @@ import (
 // is copied as-is (use when structure is 1:1, with key normalization).
 //
 // Key behavior:
-//   - Key missing from config: left unchanged in service-config.yaml
+//   - Key missing from config: left unchanged in service-config.yaml (or deleted if DeleteOnAbsent=true)
 //   - Key present with value: merged into service-config.yaml
 //   - Key present with null: deleted from service-config.yaml
 type SectionMapping struct {
 	RenderedKey      string
 	ServiceConfigKey string
 	Transform        func(renderedSubtree interface{}) (interface{}, error)
+	// DeleteOnAbsent, when true, deletes ServiceConfigKey from service-config.yaml when
+	// RenderedKey is absent from the per-service config. Use for keys that must be fully
+	// removed when the caller restores a config that never had the key (e.g. encryption).
+	DeleteOnAbsent bool
 }
 
 // serviceConfigSectionMappings defines, per service, how to map rendered
@@ -36,6 +40,12 @@ var serviceConfigSectionMappings = map[infra.ServiceName][]SectionMapping{
 			RenderedKey:      "worker",
 			ServiceConfigKey: "worker",
 			Transform:        nil,
+		},
+		{
+			RenderedKey:      "encryption",
+			ServiceConfigKey: "encryption",
+			Transform:        nil,
+			DeleteOnAbsent:   true,
 		},
 	},
 	infra.ServiceImageBuilderWorker: {
@@ -64,6 +74,12 @@ var serviceConfigSectionMappings = map[infra.ServiceName][]SectionMapping{
 			ServiceConfigKey: "vulnerabilityReporting",
 			Transform:        nil,
 		},
+		{
+			RenderedKey:      "encryption",
+			ServiceConfigKey: "encryption",
+			Transform:        nil,
+			DeleteOnAbsent:   true,
+		},
 	},
 	infra.ServicePeriodic: {
 		{
@@ -75,6 +91,12 @@ var serviceConfigSectionMappings = map[infra.ServiceName][]SectionMapping{
 			RenderedKey:      "dependenciesSync",
 			ServiceConfigKey: "dependenciesSync",
 			Transform:        nil,
+		},
+		{
+			RenderedKey:      "encryption",
+			ServiceConfigKey: "encryption",
+			Transform:        nil,
+			DeleteOnAbsent:   true,
 		},
 	},
 }
@@ -112,7 +134,11 @@ func applyServiceConfigMappings(service infra.ServiceName, perServiceContent str
 	for _, m := range mappings {
 		subtree, found := getSubtreeWithKeyNormalization(perService, m.RenderedKey)
 		if !found {
-			// Key not present in config - leave existing value unchanged
+			if m.DeleteOnAbsent {
+				// Key absent and DeleteOnAbsent set: remove it from service-config.yaml.
+				updates[m.ServiceConfigKey] = nil
+			}
+			// else: key not present - leave existing value unchanged
 			continue
 		}
 		if subtree == nil {

--- a/test/harness/e2e/harness_repository.go
+++ b/test/harness/e2e/harness_repository.go
@@ -45,6 +45,17 @@ func (h *Harness) GetInternalGitRepoURL(internalHost string, internalPort int, r
 // CreateRepositoryWithSSHCredentials creates a Repository resource with SSH credentials.
 // keyContent must be the raw SSH private key (e.g. from auxiliary.Get(ctx).GetGitSSHPrivateKey()).
 func (h *Harness) CreateRepositoryWithSSHCredentials(repoName, repoURL string, keyContent util.SSHPrivateKeyContent) error {
+	return h.createRepositoryWithSSHCredentials(repoName, repoURL, keyContent, true)
+}
+
+// CreateSharedRepositoryWithSSHCredentials creates a Repository resource with SSH credentials
+// without adding a per-test test-id label. Use this for resources shared across multiple It blocks
+// (e.g. created in BeforeAll) where per-test AfterEach cleanup must not delete the resource.
+func (h *Harness) CreateSharedRepositoryWithSSHCredentials(repoName, repoURL string, keyContent util.SSHPrivateKeyContent) error {
+	return h.createRepositoryWithSSHCredentials(repoName, repoURL, keyContent, false)
+}
+
+func (h *Harness) createRepositoryWithSSHCredentials(repoName, repoURL string, keyContent util.SSHPrivateKeyContent, addTestLabel bool) error {
 	sshPrivateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(keyContent))
 
 	repoSpec := v1beta1.RepositorySpec{}
@@ -69,7 +80,9 @@ func (h *Harness) CreateRepositoryWithSSHCredentials(repoName, repoURL string, k
 		Spec: repoSpec,
 	}
 
-	h.addTestLabelToRepositoryMetadata(&repository.Metadata)
+	if addTestLabel {
+		h.addTestLabelToRepositoryMetadata(&repository.Metadata)
+	}
 
 	resp, err := h.Client.CreateRepositoryWithResponse(h.Context, repository)
 	if err != nil {

--- a/test/login/login.go
+++ b/test/login/login.go
@@ -3,8 +3,11 @@ package login
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/flightctl/flightctl/internal/client"
 	"github.com/flightctl/flightctl/test/e2e/infra"
@@ -213,7 +216,7 @@ func LoginToFlightctl(harness *e2e.Harness, token string) error {
 	loginArgs := append(baseLoginArgs(), "--token", token)
 	out, err := harness.CLI(loginArgs...)
 	if err != nil {
-		return fmt.Errorf("flightctl login: %w", err)
+		return fmt.Errorf("flightctl login: %w; output: %s", err, out)
 	}
 	if !isLoginSuccessful(out) {
 		return fmt.Errorf("flightctl login did not succeed: %s", out)
@@ -235,6 +238,58 @@ func LoginToAPIWithToken(harness *e2e.Harness) (AuthMethod, error) {
 		return 0, fmt.Errorf("login to flightctl: %w", err)
 	}
 	return method, nil
+}
+
+// isTransientLoginError returns true for network errors that indicate the API is
+// mid-restart and not yet accepting connections (EOF, connection refused, reset).
+func isTransientLoginError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset")
+}
+
+// LoginToAPIWithTokenWithRetry retries LoginToAPIWithToken on transient network errors
+// (EOF, connection refused) for up to the given timeout with exponential backoff.
+// Use this after a service restart where the pod may be "Ready" in K8s before the
+// API process is actually accepting TLS connections.
+func LoginToAPIWithTokenWithRetry(harness *e2e.Harness, timeout time.Duration) (AuthMethod, error) {
+	deadline := time.Now().Add(timeout)
+	backoff := 2 * time.Second
+	const maxBackoff = 15 * time.Second
+	// Always attempt at least once, even if timeout is zero or already elapsed,
+	// so lastErr is always set and the error message is never "<nil>".
+	var lastErr error
+	for {
+		method, err := LoginToAPIWithToken(harness)
+		if err == nil {
+			return method, nil
+		}
+		if !isTransientLoginError(err) {
+			return 0, err
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			break
+		}
+		logrus.Infof("LoginToAPIWithTokenWithRetry: transient error (%v), retrying in %s", err, backoff)
+		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+	return 0, fmt.Errorf("login did not succeed within %s: %w", timeout, lastErr)
 }
 
 // Login logs in to the cluster and flightctl API as the given user.


### PR DESCRIPTION
## EDM-4780: [QE] E2E tests for encryption-at-rest 

**Jira:** https://redhat.atlassian.net/browse/EDM-4780
**Story type:** [QE]

### Summary

Adds a dedicated `test/e2e/encryption/` suite that validates the encryption-at-rest Phase 1 feature end-to-end. Tests verify that sensitive credential fields (OIDC `clientSecret`, SSH private keys, HTTP passwords) are encrypted in the database using the `enc:v1:<key-id>:...` ciphertext format, that API GET responses always redact these fields as `*****`, and that encryption-specific behaviors (key rotation, backup key material, Prometheus metrics) work correctly across deployment environments.



### Test Infrastructure

- **Suite location:** `test/e2e/encryption/`
- **Reference suite:** `test/e2e/authprovider/` (primary — API-only, Keycloak, no VM); `test/e2e/backup_restore/` (secondary — backup helper and archive inspection patterns)
- **Auxiliary services:** Keycloak (AuthProvider OIDC tests), Git server (SSH/HTTP Repository tests), Prometheus (metrics tests)
- **Test infrastructure used:** `e2e.SetupWorkerHarnessWithoutVM`, `harness.CreateRepositoryWithSSHCredentials`, `harness.CreateHTTPRepository`, `harness.WaitForRepositoryAccessible`, `harness.WaitForRepositoryNotAccessible`, `harness.NewBackupRestore`, `p.Infra.ExecInService` (psql queries), `p.Infra.GetServiceConfig`/`SetServiceConfig` (key rotation), `p.Lifecycle.Restart`/`WaitForReady`, `p.Infra.ExposeService` (Prometheus), `harness.PromQueryResultCount`, `harness.PromQueryHasLabels`


