### PR TITLE
EDM-4885: reap leftover nc before VM console dial

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -509,6 +509,17 @@ func (c *pipeConn) Close() error {
 	return c.closeErr
 }
 
+// Exec runs a short-lived `podman exec <containerName> <cmd...>` and returns an
+// error when the command exits non-zero. Used by console sessions to reap leftover
+// in-container clients that survive host-side podman exec teardown.
+func (p *Podman) Exec(ctx context.Context, containerName string, cmd ...string) error {
+	_, stderr, exitCode := p.ExecInContainer(ctx, containerName, cmd...)
+	if exitCode != 0 {
+		return fmt.Errorf("podman exec %s: %w", containerName, deviceerrors.FromStderr(stderr, exitCode))
+	}
+	return nil
+}
+
 // ExecStream starts `podman exec -i <containerName> <cmd...>` and returns the
 // process's stdin/stdout as an io.ReadWriteCloser. Caller must Close() to release resources.
 func (p *Podman) ExecStream(ctx context.Context, containerName string, cmd ...string) (io.ReadWriteCloser, error) {

--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -24,12 +24,22 @@ import (
 
 // mockExecStreamer is a minimal ExecStreamer for tests.
 type mockExecStreamer struct {
-	conn io.ReadWriteCloser
-	err  error
+	conn      io.ReadWriteCloser
+	err       error
+	execCalls [][]string
+	mu        sync.Mutex
 }
 
 func (m *mockExecStreamer) ExecStream(_ context.Context, _ string, _ ...string) (io.ReadWriteCloser, error) {
 	return m.conn, m.err
+}
+
+func (m *mockExecStreamer) Exec(_ context.Context, _ string, cmd ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := append([]string(nil), cmd...)
+	m.execCalls = append(m.execCalls, cp)
+	return nil
 }
 
 // mockResolver is a minimal AppConsoleResolver for tests. When seq[appName] is non-empty,

--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -24,13 +24,26 @@ import (
 
 // mockExecStreamer is a minimal ExecStreamer for tests.
 type mockExecStreamer struct {
-	conn      io.ReadWriteCloser
-	err       error
-	execCalls [][]string
-	mu        sync.Mutex
+	conn       io.ReadWriteCloser
+	err        error
+	streamErrs []error // if non-empty, each ExecStream pops the next error (nil means success with conn)
+	execCalls  [][]string
+	streamN    int
+	mu         sync.Mutex
 }
 
 func (m *mockExecStreamer) ExecStream(_ context.Context, _ string, _ ...string) (io.ReadWriteCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.streamN++
+	if len(m.streamErrs) > 0 {
+		err := m.streamErrs[0]
+		m.streamErrs = m.streamErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+		return m.conn, nil
+	}
 	return m.conn, m.err
 }
 

--- a/internal/agent/device/applications/console/session.go
+++ b/internal/agent/device/applications/console/session.go
@@ -15,6 +15,8 @@ import (
 // *client.Podman satisfies this interface in production; tests may inject a fake.
 type ExecStreamer interface {
 	ExecStream(ctx context.Context, containerName string, cmd ...string) (io.ReadWriteCloser, error)
+	// Exec runs a short-lived command inside the container (used to reap leftover console clients).
+	Exec(ctx context.Context, containerName string, cmd ...string) error
 }
 
 // evictionReasonKey is the context key under which Start stashes a flag that bridgeConn

--- a/internal/agent/device/applications/console/unix_socket.go
+++ b/internal/agent/device/applications/console/unix_socket.go
@@ -1,0 +1,49 @@
+package console
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+
+	"github.com/flightctl/flightctl/pkg/log"
+)
+
+// killNCSocketHoldersTimeout bounds best-effort cleanup of leftover `nc -U` processes
+// left behind when the host-side `podman exec` is killed (Podman does not reliably
+// signal the in-container process).
+const killNCSocketHoldersTimeout = 5 * time.Second
+
+// dialVMUnixSocket connects to a Unix socket inside the container via `nc -U`.
+// It reaps any leftover `nc` clients for that socket before dialing so a previous
+// crashed or cancelled session cannot permanently occupy QEMU's single-client
+// serial/VNC chardev. Cleanup runs only before dial (not on Close) so a --force
+// takeover cannot kill the successor session's newly started nc.
+func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) (io.ReadWriteCloser, error) {
+	if exec == nil {
+		return nil, fmt.Errorf("dial VM Unix socket %q: no exec streamer", socketPath)
+	}
+	killNCSocketHolders(ctx, exec, containerName, socketPath, logger)
+
+	conn, err := exec.ExecStream(ctx, containerName, "nc", "-U", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("dial VM Unix socket %q in container %q: %w", socketPath, containerName, err)
+	}
+	return conn, nil
+}
+
+func killNCSocketHolders(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) {
+	if exec == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, killNCSocketHoldersTimeout)
+	defer cancel()
+
+	// Anchor the pattern so virt-serial0 does not match virt-serial0-log.
+	pattern := "^nc -U " + regexp.QuoteMeta(socketPath) + "$"
+	script := fmt.Sprintf("pkill -f %q || true", pattern)
+	if err := exec.Exec(ctx, containerName, "sh", "-c", script); err != nil {
+		logger.Debugf("failed to kill leftover nc for %s in %s: %v", socketPath, containerName, err)
+	}
+}

--- a/internal/agent/device/applications/console/unix_socket.go
+++ b/internal/agent/device/applications/console/unix_socket.go
@@ -10,27 +10,64 @@ import (
 	"github.com/flightctl/flightctl/pkg/log"
 )
 
-// killNCSocketHoldersTimeout bounds best-effort cleanup of leftover `nc -U` processes
-// left behind when the host-side `podman exec` is killed (Podman does not reliably
-// signal the in-container process).
-const killNCSocketHoldersTimeout = 5 * time.Second
+const (
+	// killNCSocketHoldersTimeout bounds best-effort cleanup of leftover `nc -U` processes
+	// left behind when the host-side `podman exec` is killed (Podman does not reliably
+	// signal the in-container process).
+	killNCSocketHoldersTimeout = 5 * time.Second
+
+	// maxDialAttempts covers the race where pkill has sent SIGTERM but the old nc has
+	// not yet released QEMU's single-client socket when the first dial runs.
+	maxDialAttempts = 3
+)
+
+// dialRetryDelay is the pause between failed dial attempts. Mutable for tests.
+var dialRetryDelay = 200 * time.Millisecond
 
 // dialVMUnixSocket connects to a Unix socket inside the container via `nc -U`.
-// It reaps any leftover `nc` clients for that socket before dialing so a previous
-// crashed or cancelled session cannot permanently occupy QEMU's single-client
+// It reaps any leftover `nc` clients for that socket before each dial attempt so a
+// previous crashed or cancelled session cannot permanently occupy QEMU's single-client
 // serial/VNC chardev. Cleanup runs only before dial (not on Close) so a --force
-// takeover cannot kill the successor session's newly started nc.
+// takeover cannot kill the successor session's newly started nc. Dial is retried a
+// limited number of times if ExecStream fails while the chardev is still freeing.
 func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) (io.ReadWriteCloser, error) {
 	if exec == nil {
 		return nil, fmt.Errorf("dial VM Unix socket %q: no exec streamer", socketPath)
 	}
-	killNCSocketHolders(ctx, exec, containerName, socketPath, logger)
 
-	conn, err := exec.ExecStream(ctx, containerName, "nc", "-U", socketPath)
-	if err != nil {
-		return nil, fmt.Errorf("dial VM Unix socket %q in container %q: %w", socketPath, containerName, err)
+	var lastErr error
+	for attempt := 1; attempt <= maxDialAttempts; attempt++ {
+		killNCSocketHolders(ctx, exec, containerName, socketPath, logger)
+
+		conn, err := exec.ExecStream(ctx, containerName, "nc", "-U", socketPath)
+		if err == nil {
+			if attempt > 1 {
+				logger.Debugf("dialed %s in %s on attempt %d/%d", socketPath, containerName, attempt, maxDialAttempts)
+			}
+			return conn, nil
+		}
+		lastErr = err
+		logger.Debugf("dial attempt %d/%d failed for %s in %s: %v", attempt, maxDialAttempts, socketPath, containerName, err)
+
+		if attempt == maxDialAttempts {
+			break
+		}
+		if err := sleepWithContext(ctx, dialRetryDelay); err != nil {
+			return nil, fmt.Errorf("dial VM Unix socket %q in container %q: %w", socketPath, containerName, err)
+		}
 	}
-	return conn, nil
+	return nil, fmt.Errorf("dial VM Unix socket %q in container %q after %d attempts: %w", socketPath, containerName, maxDialAttempts, lastErr)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func killNCSocketHolders(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) {

--- a/internal/agent/device/applications/console/unix_socket_test.go
+++ b/internal/agent/device/applications/console/unix_socket_test.go
@@ -2,9 +2,11 @@ package console
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/stretchr/testify/require"
@@ -45,10 +47,53 @@ func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverNCBeforeDial(t *testing
 	require.Len(exec.execCalls, 1, "expected a pre-dial cleanup Exec call")
 	require.Contains(strings.Join(exec.execCalls[0], " "), socketPath)
 	require.Contains(strings.Join(exec.execCalls[0], " "), "pkill")
+	require.Equal(1, exec.streamN)
 
 	require.NoError(conn.Close())
 	require.True(closer.closed)
 	require.Len(exec.execCalls, 1, "Close must not pkill (avoids killing a --force successor's nc)")
+}
+
+func TestDialVMUnixSocket_WhenDialFailsItShouldRetryUpToThreeTimes(t *testing.T) {
+	require := require.New(t)
+	closer := &recordingCloser{}
+	exec := &mockExecStreamer{
+		conn: closer,
+		streamErrs: []error{
+			fmt.Errorf("busy"),
+			fmt.Errorf("busy"),
+			nil,
+		},
+	}
+	logger := log.NewPrefixLogger("test")
+
+	start := time.Now()
+	conn, err := dialWithRetryDelay(t, context.Background(), exec, "compute", vmSerialSocketPath, logger, time.Millisecond)
+	require.NoError(err)
+	require.NotNil(conn)
+	require.Equal(3, exec.streamN)
+	require.Len(exec.execCalls, 3, "each attempt reaps before dial")
+	require.Less(time.Since(start), time.Second)
+	require.NoError(conn.Close())
+}
+
+func TestDialVMUnixSocket_WhenAllDialAttemptsFailItShouldReturnError(t *testing.T) {
+	require := require.New(t)
+	exec := &mockExecStreamer{
+		streamErrs: []error{
+			fmt.Errorf("busy"),
+			fmt.Errorf("busy"),
+			fmt.Errorf("still busy"),
+		},
+	}
+	logger := log.NewPrefixLogger("test")
+
+	conn, err := dialWithRetryDelay(t, context.Background(), exec, "compute", vmSerialSocketPath, logger, time.Millisecond)
+	require.Error(err)
+	require.Nil(conn)
+	require.Contains(err.Error(), "after 3 attempts")
+	require.Equal(3, exec.streamN)
+	require.Len(exec.execCalls, 3)
 }
 
 func TestDialVMUnixSocket_WhenOldSessionClosesAfterNewDialItShouldNotReap(t *testing.T) {
@@ -83,4 +128,13 @@ func TestKillNCSocketHolders_WhenPatternBuiltItShouldNotMatchLogSuffix(t *testin
 	script := strings.Join(exec.execCalls[0], " ")
 	require.Contains(script, "^nc -U "+vmSerialSocketPath+"$")
 	require.NotContains(script, "virt-serial0-log")
+}
+
+// dialWithRetryDelay runs dialVMUnixSocket with a shortened retry delay for tests.
+func dialWithRetryDelay(t *testing.T, ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger, delay time.Duration) (io.ReadWriteCloser, error) {
+	t.Helper()
+	prev := dialRetryDelay
+	dialRetryDelay = delay
+	t.Cleanup(func() { dialRetryDelay = prev })
+	return dialVMUnixSocket(ctx, exec, containerName, socketPath, logger)
 }

--- a/internal/agent/device/applications/console/unix_socket_test.go
+++ b/internal/agent/device/applications/console/unix_socket_test.go
@@ -1,0 +1,86 @@
+package console
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingCloser struct {
+	closed bool
+}
+
+func (c *recordingCloser) Read([]byte) (int, error)    { return 0, io.EOF }
+func (c *recordingCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (c *recordingCloser) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestDialVMUnixSocket_WhenExecIsNilItShouldReturnError(t *testing.T) {
+	require := require.New(t)
+	logger := log.NewPrefixLogger("test")
+
+	conn, err := dialVMUnixSocket(context.Background(), nil, "compute", vmSerialSocketPath, logger)
+	require.Error(err)
+	require.Nil(conn)
+	require.Contains(err.Error(), "no exec streamer")
+}
+
+func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverNCBeforeDial(t *testing.T) {
+	require := require.New(t)
+	closer := &recordingCloser{}
+	exec := &mockExecStreamer{conn: closer}
+	logger := log.NewPrefixLogger("test")
+	socketPath := "/var/run/kubevirt-private/default/virt-serial0"
+
+	conn, err := dialVMUnixSocket(context.Background(), exec, "compute", socketPath, logger)
+	require.NoError(err)
+	require.NotNil(conn)
+
+	require.Len(exec.execCalls, 1, "expected a pre-dial cleanup Exec call")
+	require.Contains(strings.Join(exec.execCalls[0], " "), socketPath)
+	require.Contains(strings.Join(exec.execCalls[0], " "), "pkill")
+
+	require.NoError(conn.Close())
+	require.True(closer.closed)
+	require.Len(exec.execCalls, 1, "Close must not pkill (avoids killing a --force successor's nc)")
+}
+
+func TestDialVMUnixSocket_WhenOldSessionClosesAfterNewDialItShouldNotReap(t *testing.T) {
+	require := require.New(t)
+	logger := log.NewPrefixLogger("test")
+	socketPath := vmSerialSocketPath
+	shared := &mockExecStreamer{conn: &recordingCloser{}}
+
+	oldConn, err := dialVMUnixSocket(context.Background(), shared, "compute", socketPath, logger)
+	require.NoError(err)
+	require.Len(shared.execCalls, 1)
+
+	// Simulate --force: new dial starts while old session still open.
+	shared.conn = &recordingCloser{}
+	newConn, err := dialVMUnixSocket(context.Background(), shared, "compute", socketPath, logger)
+	require.NoError(err)
+	require.Len(shared.execCalls, 2, "new dial issues its own pre-dial pkill")
+
+	require.NoError(oldConn.Close())
+	require.Len(shared.execCalls, 2, "old Close must not issue another pkill")
+	require.NoError(newConn.Close())
+	require.Len(shared.execCalls, 2)
+}
+
+func TestKillNCSocketHolders_WhenPatternBuiltItShouldNotMatchLogSuffix(t *testing.T) {
+	require := require.New(t)
+	exec := &mockExecStreamer{}
+	logger := log.NewPrefixLogger("test")
+
+	killNCSocketHolders(context.Background(), exec, "compute", vmSerialSocketPath, logger)
+	require.Len(exec.execCalls, 1)
+	script := strings.Join(exec.execCalls[0], " ")
+	require.Contains(script, "^nc -U "+vmSerialSocketPath+"$")
+	require.NotContains(script, "virt-serial0-log")
+}

--- a/internal/agent/device/applications/console/vm_serial_session.go
+++ b/internal/agent/device/applications/console/vm_serial_session.go
@@ -34,7 +34,7 @@ func (s *vmSerialSession) Run(ctx context.Context, streamClient grpc_v1.RouterSe
 	s.log.Debugf("vm serial console session started for container %s", s.containerName)
 	defer s.log.Debugf("vm serial console session finished for container %s", s.containerName)
 
-	conn, err := s.exec.ExecStream(ctx, s.containerName, "nc", "-U", vmSerialSocketPath)
+	conn, err := dialVMUnixSocket(ctx, s.exec, s.containerName, vmSerialSocketPath, s.log)
 	if err != nil {
 		sendErrorOverStream(streamClient, fmt.Sprintf("failed to connect to serial console for %s: %v", s.containerName, err))
 		return

--- a/internal/agent/device/applications/console/vm_vnc_session.go
+++ b/internal/agent/device/applications/console/vm_vnc_session.go
@@ -40,7 +40,7 @@ func (s *vmVNCSession) Run(ctx context.Context, streamClient grpc_v1.RouterServi
 		return
 	}
 
-	conn, err := s.exec.ExecStream(ctx, s.containerName, "nc", "-U", vmVNCSocketPath)
+	conn, err := dialVMUnixSocket(ctx, s.exec, s.containerName, vmVNCSocketPath, s.log)
 	if err != nil {
 		sendErrorOverStream(streamClient, fmt.Sprintf("failed to connect to VNC console for %s: %v", s.containerName, err))
 		return

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -1397,6 +1397,8 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		// Asserting only NotNil would still pass if console-type routing regressed to
 		// always return the same session type. Assert the VNC-specific observable
 		// behavior instead: the underlying exec targets the serial socket, not the VNC one.
+		execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "exec", "systemd-my-vm-compute", "sh", "-c", gomock.Any()).
+			Return("", "", 0).Times(1)
 		execMock.EXPECT().CommandContext(gomock.Any(), "podman", "exec", "-i", "systemd-my-vm-compute", "nc", "-U", "/var/run/kubevirt-private/default/virt-serial0").
 			DoAndReturn(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 				return exec.CommandContext(ctx, "cat")
@@ -1437,6 +1439,8 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		// Asserting only NotNil would still pass if console-type routing regressed to
 		// always return the serial session. Assert the VNC-specific observable behavior
 		// instead: the underlying exec targets the VNC socket, not the serial one.
+		execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "exec", "systemd-my-vm-compute", "sh", "-c", gomock.Any()).
+			Return("", "", 0).Times(1)
 		execMock.EXPECT().CommandContext(gomock.Any(), "podman", "exec", "-i", "systemd-my-vm-compute", "nc", "-U", "/var/run/kubevirt-private/default/virt-vnc").
 			DoAndReturn(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 				return exec.CommandContext(ctx, "cat")


### PR DESCRIPTION
## Summary
- Fixes [EDM-4885](https://issues.redhat.com/browse/EDM-4885): leftover in-container `nc -U` processes after VM console sessions close uncleanly.
- Killing host-side `podman exec` does not terminate those processes, so they keep occupying QEMU's single-client serial/VNC sockets and later `flightctl app console` attaches fail silently.
- Before dialing, reap matching `nc` clients for the target socket (serial and VNC). Cleanup is **pre-dial only** so a `--force` takeover cannot kill the successor session's newly started `nc`.
- Dial is retried up to 3 times (with re-reap and a short delay) if `ExecStream` fails while the chardev is still freeing after SIGTERM.

## Test plan
- [x] `go test ./internal/agent/device/applications/console/ ./internal/agent/device/applications/ -run 'TestDialVMUnixSocket|TestKillNCSocketHolders|TestPodmanMonitorResolveConsole'`
- [ ] On a device with a wedged serial console (`ps` shows leftover `nc -U …/virt-serial0`), open a new serial console session and confirm leftovers are cleared and the login prompt appears
- [ ] Disconnect (including abrupt CLI/`podman exec` kill scenarios) and confirm no leftover `nc` remains in the compute container after a later successful reconnect
- [ ] Repeat for `--type vnc`
- [ ] `--force` takeover while a session is active still gets a working console