### PR TITLE
NO-ISSUE: point qcow2 bootc caches at bin/ for Actions hits

### DIFF
--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -32,8 +32,6 @@ jobs:
           path: |
             bin/dnf-cache
             bin/osbuild-cache
-            dnf-cache
-            osbuild-cache
           key: ${{ runner.os }}-bootc-cache-e2e-unified-${{ hashFiles('test/scripts/agent-images/containerfiles/*/Containerfile') }}
           restore-keys: |
             ${{ runner.os }}-bootc-cache-e2e-

--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -175,7 +175,15 @@ jobs:
         # saving even if a later step fails. main-only + cache-hit skip: see the "Save Go
         # modules cache" step in pr-smoke-testing.yaml for why (restrict writes to main,
         # avoid re-archiving on a hit).
-        if: always() && github.ref == 'refs/heads/main' && steps.cache-bootc-restore.outputs.cache-hit != 'true'
+        # TEMP (testing only): also save on e2e-fix-qcow-cache (push ref or PR head_ref)
+        # so we can verify bin/ path alignment produces a real Actions cache entry.
+        # Revert to main-only after; drop the matching push branch in pr-e2e-testing.yaml.
+        if: >-
+          always()
+          && (github.ref == 'refs/heads/main'
+              || github.ref == 'refs/heads/e2e-fix-qcow-cache'
+              || github.head_ref == 'e2e-fix-qcow-cache')
+          && steps.cache-bootc-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
       - 'release-*'
+      # TEMP (testing only): allow e2e-fix-qcow-cache to populate bootc Actions cache.
+      # Pair with Save caches gate in build-agent-images.yaml; remove both after.
+      - e2e-fix-qcow-cache
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   merge_group:

--- a/test/scripts/agent-images/scripts/qcow2.sh
+++ b/test/scripts/agent-images/scripts/qcow2.sh
@@ -11,7 +11,8 @@ IMAGE_REPO="${IMAGE_REPO:-quay.io/flightctl/flightctl-device}"
 BASE_IMAGE="${IMAGE_REPO}:base-${OS_ID}-${TAG}"
 
 mkdir -p "${OUTPUT_DIR}"
-# Align with CI cache + agent-images.mk: bin/{dnf,osbuild}-cache
+# BIB volumes are /rpmmd (dnf) and /store (osbuild), not /var/cache/*.
+# Host paths match CI Actions cache + agent-images.mk: bin/{dnf,osbuild}-cache.
 mkdir -p "${ROOT_DIR}/bin/dnf-cache" "${ROOT_DIR}/bin/osbuild-cache"
 
 echo -e "\033[32mProducing qcow2 image for ${BASE_IMAGE}, writing to ${OUTPUT_DIR}\033[m"
@@ -22,15 +23,18 @@ sudo podman run --rm \
                 --pull=newer \
                 --security-opt label=type:unconfined_t \
                 -v "${OUTPUT_DIR}":/output \
-                -v "${ROOT_DIR}"/bin/dnf-cache:/var/cache/dnf:Z \
-                -v "${ROOT_DIR}"/bin/osbuild-cache:/var/cache/osbuild:Z \
+                -v "${ROOT_DIR}"/bin/dnf-cache:/rpmmd:Z \
+                -v "${ROOT_DIR}"/bin/osbuild-cache:/store:Z \
                 -v /var/lib/containers/storage:/var/lib/containers/storage \
                 quay.io/centos-bootc/bootc-image-builder:latest \
                 build \
                 --type qcow2 \
                 "${BASE_IMAGE}"
 
-sudo chown -R "${USER}:$(id -gn ${USER})" "${OUTPUT_DIR}"
+sudo chown -R "${USER}:$(id -gn ${USER})" \
+  "${OUTPUT_DIR}" \
+  "${ROOT_DIR}/bin/dnf-cache" \
+  "${ROOT_DIR}/bin/osbuild-cache"
 
 echo -e "\033[32mqcow2 image created at ${OUTPUT_DIR}/qcow2/disk.qcow2\033[m"
 

--- a/test/scripts/agent-images/scripts/qcow2.sh
+++ b/test/scripts/agent-images/scripts/qcow2.sh
@@ -11,7 +11,8 @@ IMAGE_REPO="${IMAGE_REPO:-quay.io/flightctl/flightctl-device}"
 BASE_IMAGE="${IMAGE_REPO}:base-${OS_ID}-${TAG}"
 
 mkdir -p "${OUTPUT_DIR}"
-mkdir -p "${ROOT_DIR}/dnf-cache" "${ROOT_DIR}/osbuild-cache"
+# Align with CI cache + agent-images.mk: bin/{dnf,osbuild}-cache
+mkdir -p "${ROOT_DIR}/bin/dnf-cache" "${ROOT_DIR}/bin/osbuild-cache"
 
 echo -e "\033[32mProducing qcow2 image for ${BASE_IMAGE}, writing to ${OUTPUT_DIR}\033[m"
 
@@ -21,8 +22,8 @@ sudo podman run --rm \
                 --pull=newer \
                 --security-opt label=type:unconfined_t \
                 -v "${OUTPUT_DIR}":/output \
-                -v "${ROOT_DIR}"/dnf-cache:/var/cache/dnf:Z \
-                -v "${ROOT_DIR}"/osbuild-cache:/var/cache/osbuild:Z \
+                -v "${ROOT_DIR}"/bin/dnf-cache:/var/cache/dnf:Z \
+                -v "${ROOT_DIR}"/bin/osbuild-cache:/var/cache/osbuild:Z \
                 -v /var/lib/containers/storage:/var/lib/containers/storage \
                 quay.io/centos-bootc/bootc-image-builder:latest \
                 build \


### PR DESCRIPTION
## Summary
- Align `qcow2.sh` dnf/osbuild cache mounts with `bin/{dnf,osbuild}-cache` (what CI already saves/restores)
- Drop unused root-level `dnf-cache` / `osbuild-cache` restore paths from `build-agent-images.yaml`

Stacked on `#3295` (`e2e-under-30m`). Fixes a cache path mismatch that prevented bootc-image-builder cache hits on the agent-image critical path.

## Test plan
- [ ] Confirm `build-agent-images` restores `bin/dnf-cache` / `bin/osbuild-cache` after a main-populated cache
- [ ] Compare agent-image step duration vs pre-fix ~8m on cold vs warm cache
- [ ] Smoke: `make e2e-agent-images` still writes qcow under `bin/output`


Made with [Cursor](https://cursor.com)