### PR TITLE
NO-ISSUE: Make VM render launcher image and passt workarounds configurable

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -69,6 +69,7 @@ KubeVirt
 Kubernetes
 kustomize
 KVM
+launcherImage
 lifecycle
 lifecycle-bound
 linux
@@ -92,6 +93,8 @@ openssl
 OSes
 ostree
 OTA
+passt
+passtWorkarounds
 pluggable
 Podman
 PostgreSQL
@@ -118,6 +121,9 @@ post-mortem
 150s
 pre-rollback
 red.d
+virt-launcher
+vm-to-quadlet
+vmRender
 rootful
 runtime
 schemas

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -443,7 +443,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | worker.image.tag | string | `""` | Worker image tag |
 | worker.vmRender | object | `{"launcherImage":"quay.io/kubevirt/virt-launcher:v1.8.4","passtWorkarounds":true}` | VM application render options passed to vm-to-quadlet |
 | worker.vmRender.launcherImage | string | `"quay.io/kubevirt/virt-launcher:v1.8.4"` | virt-launcher image used when converting VmApplications to Quadlet units |
-| worker.vmRender.passtWorkarounds | bool | `true` | Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true) |
+| worker.vmRender.passtWorkarounds | bool | `true` | Enable passt networking workarounds for older virt-launcher images (recommended true) |
 
 ## Environment-Specific Values Files
 

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -436,11 +436,14 @@ For more detailed configuration options, see the [Values](#values) section below
 | vulnerabilityReporting.trustify.auth.oidcIssuerUrl | string | `""` | OIDC issuer URL for client-credentials mode. |
 | vulnerabilityReporting.trustify.auth.secretName | string | `""` | Name of the Kubernetes Secret containing 'client_id' and 'client_secret' keys. |
 | vulnerabilityReporting.trustify.endpoint | string | `""` | Trustify API base URL (do not include /api/v1 or /api/v2 paths). |
-| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""}}` | Worker Configuration |
+| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"quay.io/kubevirt/virt-launcher:v1.8.4","passtWorkarounds":true}}` | Worker Configuration |
 | worker.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
 | worker.image.image | string | `"quay.io/flightctl/flightctl-worker-el9"` | Worker container image |
 | worker.image.pullPolicy | string | `""` | Image pull policy for worker container |
 | worker.image.tag | string | `""` | Worker image tag |
+| worker.vmRender | object | `{"launcherImage":"quay.io/kubevirt/virt-launcher:v1.8.4","passtWorkarounds":true}` | VM application render options passed to vm-to-quadlet |
+| worker.vmRender.launcherImage | string | `"quay.io/kubevirt/virt-launcher:v1.8.4"` | virt-launcher image used when converting VmApplications to Quadlet units |
+| worker.vmRender.passtWorkarounds | bool | `true` | Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true) |
 
 ## Environment-Specific Values Files
 

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -436,13 +436,13 @@ For more detailed configuration options, see the [Values](#values) section below
 | vulnerabilityReporting.trustify.auth.oidcIssuerUrl | string | `""` | OIDC issuer URL for client-credentials mode. |
 | vulnerabilityReporting.trustify.auth.secretName | string | `""` | Name of the Kubernetes Secret containing 'client_id' and 'client_secret' keys. |
 | vulnerabilityReporting.trustify.endpoint | string | `""` | Trustify API base URL (do not include /api/v1 or /api/v2 paths). |
-| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"quay.io/kubevirt/virt-launcher:v1.8.4","passtWorkarounds":true}}` | Worker Configuration |
+| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","passtWorkarounds":true}}` | Worker Configuration |
 | worker.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
 | worker.image.image | string | `"quay.io/flightctl/flightctl-worker-el9"` | Worker container image |
 | worker.image.pullPolicy | string | `""` | Image pull policy for worker container |
 | worker.image.tag | string | `""` | Worker image tag |
-| worker.vmRender | object | `{"launcherImage":"quay.io/kubevirt/virt-launcher:v1.8.4","passtWorkarounds":true}` | VM application render options passed to vm-to-quadlet |
-| worker.vmRender.launcherImage | string | `"quay.io/kubevirt/virt-launcher:v1.8.4"` | virt-launcher image used when converting VmApplications to Quadlet units |
+| worker.vmRender | object | `{"launcherImage":"","passtWorkarounds":true}` | VM application render options passed to vm-to-quadlet |
+| worker.vmRender.launcherImage | string | `""` | virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default) |
 | worker.vmRender.passtWorkarounds | bool | `true` | Enable passt networking workarounds for older virt-launcher images (recommended true) |
 
 ## Environment-Specific Values Files

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -26,6 +26,11 @@ data:
         {{- end }}
         {{- end }}
     service: {}
+    worker:
+        vmRender:
+            {{- $vmRender := (.Values.worker).vmRender | default dict }}
+            launcherImage: {{ $vmRender.launcherImage | default "quay.io/kubevirt/virt-launcher:v1.8.4" | quote }}
+            passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}true{{ end }}
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local
         port: 6379

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -29,7 +29,9 @@ data:
     worker:
         vmRender:
             {{- $vmRender := (.Values.worker).vmRender | default dict }}
-            launcherImage: {{ $vmRender.launcherImage | default "quay.io/kubevirt/virt-launcher:v1.8.4" | quote }}
+            {{- if $vmRender.launcherImage }}
+            launcherImage: {{ $vmRender.launcherImage | quote }}
+            {{- end }}
             passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}true{{ end }}
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -507,7 +507,7 @@
             },
             "passtWorkarounds": {
               "type": "boolean",
-              "description": "Enable passt mrg_rxbuf workarounds for older virt-launcher images"
+              "description": "Enable passt networking workarounds for older virt-launcher images"
             }
           }
         }

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -503,7 +503,7 @@
           "properties": {
             "launcherImage": {
               "type": "string",
-              "description": "virt-launcher image used when converting VmApplications to Quadlet units"
+              "description": "virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)"
             },
             "passtWorkarounds": {
               "type": "boolean",

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -495,6 +495,21 @@
         "clusterLevelSecretAccess": {
           "type": "boolean",
           "description": "Allow worker to access cluster-level secrets for embedding in device configs"
+        },
+        "vmRender": {
+          "type": "object",
+          "description": "VM application render options passed to vm-to-quadlet",
+          "additionalProperties": false,
+          "properties": {
+            "launcherImage": {
+              "type": "string",
+              "description": "virt-launcher image used when converting VmApplications to Quadlet units"
+            },
+            "passtWorkarounds": {
+              "type": "boolean",
+              "description": "Enable passt mrg_rxbuf workarounds for older virt-launcher images"
+            }
+          }
         }
       }
     },

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -314,6 +314,12 @@ worker:
     pullPolicy: ""
   # -- Allow flightctl-worker to access secrets at the cluster level for embedding in device configs
   clusterLevelSecretAccess: false
+  # -- VM application render options passed to vm-to-quadlet
+  vmRender:
+    # -- virt-launcher image used when converting VmApplications to Quadlet units
+    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    # -- Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true)
+    passtWorkarounds: true
 
 # -- Periodic Configuration
 periodic:

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -316,8 +316,8 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-    # -- virt-launcher image used when converting VmApplications to Quadlet units
-    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+    launcherImage: ""
     # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
     passtWorkarounds: true
 

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -318,7 +318,7 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units
     launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
-    # -- Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true)
+    # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
     passtWorkarounds: true
 
 # -- Periodic Configuration

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -314,6 +314,12 @@ worker:
     pullPolicy: ""
   # -- Allow flightctl-worker to access secrets at the cluster level for embedding in device configs
   clusterLevelSecretAccess: false
+  # -- VM application render options passed to vm-to-quadlet
+  vmRender:
+    # -- virt-launcher image used when converting VmApplications to Quadlet units
+    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    # -- Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true)
+    passtWorkarounds: true
 
 # -- Periodic Configuration
 periodic:

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -316,8 +316,8 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-    # -- virt-launcher image used when converting VmApplications to Quadlet units
-    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+    launcherImage: ""
     # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
     passtWorkarounds: true
 

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -318,7 +318,7 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units
     launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
-    # -- Enable passt mrg_rxbuf workarounds for older virt-launcher images (recommended true)
+    # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
     passtWorkarounds: true
 
 # -- Periodic Configuration

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -26,7 +26,9 @@ kv:
 service: {}
 worker:
   vmRender:
-    launcherImage: {{if and .worker .worker.vmRender .worker.vmRender.launcherImage}}{{.worker.vmRender.launcherImage}}{{else}}quay.io/kubevirt/virt-launcher:v1.8.4{{end}}
+    {{- if and .worker .worker.vmRender .worker.vmRender.launcherImage }}
+    launcherImage: {{.worker.vmRender.launcherImage}}
+    {{- end }}
     passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "false"}}false{{else}}true{{end}}{{else}}true{{end}}
 
 

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -24,6 +24,10 @@ kv:
   hostname: flightctl-kv
   port: 6379
 service: {}
+worker:
+  vmRender:
+    launcherImage: {{if and .worker .worker.vmRender .worker.vmRender.launcherImage}}{{.worker.vmRender.launcherImage}}{{else}}quay.io/kubevirt/virt-launcher:v1.8.4{{end}}
+    passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "false"}}false{{else}}true{{end}}{{else}}true{{end}}
 
 
 {{- with .profiling }}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -113,10 +113,13 @@ grafana:
 
 prometheus:
 
-# Worker VM render options (optional). Uncomment to override virt-launcher image or passt workarounds.
+# Worker VM render options (optional). Uncomment to override defaults.
+# Leave launcherImage unset to use the worker built-in default
+# (quay.io/kubevirt/virt-launcher:v1.8.4). In air-gapped environments, mirror
+# virt-launcher to a registry devices can pull from and set launcherImage to that reference.
 # worker:
 #   vmRender:
-#     launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+#     launcherImage: ""
 #     passtWorkarounds: true
 
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -113,6 +113,12 @@ grafana:
 
 prometheus:
 
+# Worker VM render options (optional). Uncomment to override virt-launcher image or passt workarounds.
+# worker:
+#   vmRender:
+#     launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+#     passtWorkarounds: true
+
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.
 # imagebuilderWorker:
 #   logLevel: info

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -23,6 +23,7 @@ Welcome to the Flight Control user documentation.
     * [Configuring Authentication and Authorization](installing/configuring-auth/overview.md)
     * [Configuring an External PostgreSQL Database](installing/configuring-external-database.md)
     * [Configuring the ImageBuilder Worker](installing/configuring-imagebuilder.md)
+    * [Configuring VM application rendering](installing/configuring-vm-render.md)
     * [Configuring Device Attestation](installing/configuring-device-attestation.md)
     * [Configuring Rate Limits on API Requests](installing/configuring-rate-limiting.md)
     * [Configuring Vulnerability Integration](installing/configuring-vulnerability-integration.md)

--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -335,6 +335,7 @@ minor version.
 
 - [Installing Flight Control in a Disconnected OpenShift Cluster](installing-service-on-openshift-disconnected.md)
 - [Image Builder configuration for air-gapped environments](configuring-imagebuilder.md#end-to-end-disconnected-image-build-walkthrough)
+- [VM application rendering in air-gapped environments](configuring-vm-render.md#air-gapped-environments)
 
 ### Day-2 operations
 

--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -269,6 +269,16 @@ image in the local registry and update the fleet's `os.image` reference. See
 [Air-gapped fleet operations and OS image updates](air-gapped-operations.md) for the
 full workflow.
 
+### VM applications
+
+Devices pull the KubeVirt virt-launcher image when they run VM applications. That
+image is **not** included in the default `flightctl-mirror-images` control-plane
+set. Mirror it to a registry devices can reach, set `worker.vmRender.launcherImage`
+to the mirrored reference, and re-render affected devices. Guest OS and other
+workload images still need separate mirroring.
+
+See [VM application rendering in air-gapped environments](configuring-vm-render.md#air-gapped-environments).
+
 ---
 
 ## Troubleshooting

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -1,0 +1,66 @@
+# Configuring VM application rendering
+
+The Flight Control worker converts `VmApplication` manifests into Quadlet units with `vm-to-quadlet` before devices receive the rendered application. You can configure the virt-launcher image and passt workarounds used during that conversion.
+
+## Defaults
+
+| Setting | Default |
+| ------- | ------- |
+| `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.8.4` |
+| `passtWorkarounds` | `true` |
+
+`passtWorkarounds` enables a startup patch for older virt-launcher images that can crash with two or more vCPUs (passt `mrg_rxbuf` issue). Keep this enabled unless your virt-launcher image already includes a fixed passt build.
+
+## Prerequisites
+
+- Flight Control deployed with the worker service (`flightctl-worker`)
+
+## Configuration reference
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. |
+| `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt workarounds in generated Quadlet units. |
+
+## Kubernetes (Helm)
+
+Set the values under `worker.vmRender`:
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    passtWorkarounds: true
+```
+
+Apply the chart upgrade, then restart the worker so it reloads configuration:
+
+```bash
+helm upgrade flightctl ./deploy/helm/flightctl -n <namespace> -f values.yaml
+kubectl rollout restart deployment/flightctl-worker -n <namespace>
+```
+
+## Podman Quadlet
+
+Edit `/etc/flightctl/service-config.yaml`:
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    passtWorkarounds: true
+```
+
+Restart the worker so the config template is re-rendered and the service reloads:
+
+```bash
+sudo systemctl restart flightctl-worker.service
+```
+
+## After changing settings
+
+Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage` or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
+
+## Related information
+
+- [VM applications](../using/managing-devices.md#vm-applications)

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -9,7 +9,7 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 | `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.8.4` |
 | `passtWorkarounds` | `true` |
 
-`passtWorkarounds` enables a startup patch for older virt-launcher images that can crash with two or more vCPUs (passt `mrg_rxbuf` issue). Keep this enabled unless your virt-launcher image already includes a fixed passt build.
+`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). Keep this enabled unless your virt-launcher image already includes a fixed passt build.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. |
-| `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt workarounds in generated Quadlet units. |
+| `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt networking workarounds in generated Quadlet units. |
 
 ## Kubernetes (Helm)
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -6,7 +6,7 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 
 | Setting | Default |
 | ------- | ------- |
-| `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.8.4` |
+| `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.8.4` (built into the worker; leave config unset or empty to use it) |
 | `passtWorkarounds` | `true` |
 
 `passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). Keep this enabled unless your virt-launcher image already includes a fixed passt build.
@@ -19,17 +19,17 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. |
+| `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. Leave empty to use the worker built-in default. |
 | `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt networking workarounds in generated Quadlet units. |
 
 ## Kubernetes (Helm)
 
-Set the values under `worker.vmRender`:
+Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you need an override:
 
 ```yaml
 worker:
   vmRender:
-    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    launcherImage: ""
     passtWorkarounds: true
 ```
 
@@ -42,12 +42,11 @@ kubectl rollout restart deployment/flightctl-worker -n <namespace>
 
 ## Podman Quadlet
 
-Edit `/etc/flightctl/service-config.yaml`:
+Edit `/etc/flightctl/service-config.yaml` only when you need overrides. Omit `launcherImage` to keep the worker default:
 
 ```yaml
 worker:
   vmRender:
-    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
     passtWorkarounds: true
 ```
 
@@ -57,6 +56,34 @@ Restart the worker so the config template is re-rendered and the service reloads
 sudo systemctl restart flightctl-worker.service
 ```
 
+## Air-gapped environments
+
+The default virt-launcher image is pulled by devices when they run VM applications. It is not part of the control-plane image set produced by `flightctl-mirror-images`.
+
+In an air-gapped deployment:
+
+1. Mirror `quay.io/kubevirt/virt-launcher:v1.8.4` (or your chosen virt-launcher image) to a registry that devices can reach.
+2. Set `worker.vmRender.launcherImage` to that mirrored reference so rendered Quadlet units pull from the mirror.
+3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image reference.
+
+Example (community / upstream registry):
+
+```bash
+INTERNAL=registry.example.com:5000
+skopeo copy --all \
+  docker://quay.io/kubevirt/virt-launcher:v1.8.4 \
+  docker://${INTERNAL}/kubevirt/virt-launcher:v1.8.4
+```
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: "registry.example.com:5000/kubevirt/virt-launcher:v1.8.4"
+    passtWorkarounds: true
+```
+
+There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` at the mirrored location.
+
 ## After changing settings
 
 Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage` or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
@@ -64,3 +91,4 @@ Conversion results are cached by `vm.yaml` content and these render options. Cha
 ## Related information
 
 - [VM applications](../using/managing-devices.md#vm-applications)
+- [Air-gapped installation](air-gapped-installation.md)

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -768,7 +768,7 @@ To deploy a VM application, add an entry to the `applications` section of the de
 | `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
 
 > [!NOTE]
-> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly.
+> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure the virt-launcher image and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
 
 > [!NOTE]
 > The `spec.running` field in `vm.yaml` is ignored. Use [application lifecycle](#managing-application-lifecycle) commands (`flightctl app start` / `stop` / `restart`) to control whether the VM is running.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	RemoteAccessService    *RemoteAccessServiceConfig `json:"remoteAccessService,omitempty"`
 	ImageBuilderService    *ImageBuilderServiceConfig `json:"imageBuilderService,omitempty"`
 	ImageBuilderWorker     *imageBuilderWorkerConfig  `json:"imageBuilderWorker,omitempty"`
+	Worker                 *workerConfig              `json:"worker,omitempty"`
 	KV                     *kvConfig                  `json:"kv,omitempty"`
 	Alertmanager           *alertmanagerConfig        `json:"alertmanager,omitempty"`
 	Auth                   *authConfig                `json:"auth,omitempty"`
@@ -402,6 +403,63 @@ func (c *imageBuilderWorkerConfig) EffectiveSyftImage() string {
 // EffectiveSyftSkipTLSVerify returns whether to skip TLS verification when pulling the Syft image.
 func (c *imageBuilderWorkerConfig) EffectiveSyftSkipTLSVerify() bool {
 	return c != nil && c.ServiceImages != nil && c.ServiceImages.Syft != nil && c.ServiceImages.Syft.SkipTLSVerify
+}
+
+const DefaultVirtLauncherImage = "quay.io/kubevirt/virt-launcher:v1.8.4"
+
+// workerConfig holds configuration for the flightctl-worker service.
+type workerConfig struct {
+	VmRender *vmRenderConfig `json:"vmRender,omitempty"`
+}
+
+// vmRenderConfig holds options for converting VmApplications to Quadlet units
+// via vm-to-quadlet.
+type vmRenderConfig struct {
+	LauncherImage    string `json:"launcherImage,omitempty"`
+	PasstWorkarounds *bool  `json:"passtWorkarounds,omitempty"`
+}
+
+// NewDefaultWorkerConfig returns the default flightctl-worker configuration.
+func NewDefaultWorkerConfig() *workerConfig {
+	passt := true
+	return &workerConfig{
+		VmRender: &vmRenderConfig{
+			LauncherImage:    DefaultVirtLauncherImage,
+			PasstWorkarounds: &passt,
+		},
+	}
+}
+
+// EffectiveVmLauncherImage returns the virt-launcher image used for VM render.
+func (c *Config) EffectiveVmLauncherImage() string {
+	if c == nil || c.Worker == nil {
+		return DefaultVirtLauncherImage
+	}
+	return c.Worker.EffectiveLauncherImage()
+}
+
+// EffectiveVmPasstWorkarounds returns whether passt workarounds are enabled for VM render.
+func (c *Config) EffectiveVmPasstWorkarounds() bool {
+	if c == nil || c.Worker == nil {
+		return true
+	}
+	return c.Worker.EffectivePasstWorkarounds()
+}
+
+// EffectiveLauncherImage returns the virt-launcher image (config override or default).
+func (c *workerConfig) EffectiveLauncherImage() string {
+	if c != nil && c.VmRender != nil && c.VmRender.LauncherImage != "" {
+		return c.VmRender.LauncherImage
+	}
+	return DefaultVirtLauncherImage
+}
+
+// EffectivePasstWorkarounds returns whether passt workarounds are enabled (default true).
+func (c *workerConfig) EffectivePasstWorkarounds() bool {
+	if c != nil && c.VmRender != nil && c.VmRender.PasstWorkarounds != nil {
+		return *c.VmRender.PasstWorkarounds
+	}
+	return true
 }
 
 // IsSBOMEnabled returns whether SBOM generation is enabled.
@@ -940,6 +998,7 @@ func NewDefault(opts ...ConfigOption) *Config {
 		RemoteAccessService: NewDefaultRemoteAccessServiceConfig(),
 		ImageBuilderService: NewDefaultImageBuilderServiceConfig(),
 		ImageBuilderWorker:  NewDefaultImageBuilderWorkerConfig(),
+		Worker:              NewDefaultWorkerConfig(),
 		KV: &kvConfig{
 			Hostname: "localhost",
 			Port:     6379,

--- a/internal/kvstore/keys.go
+++ b/internal/kvstore/keys.go
@@ -114,11 +114,20 @@ func (a *AwaitingReconnectionKey) ComposeKey() string {
 // VmQuadletFilesKey is a content-addressed KV key for caching the Quadlet unit
 // files produced by vm-to-quadlet. The key is global (not scoped to
 // org/fleet/templateVersion) because the conversion is deterministic: the same
-// vm.yaml input always produces the same Quadlet files. The cached value is a
-// JSON-encoded map[string]string (filename → content).
+// vm.yaml input and render options always produce the same Quadlet files. The
+// cached value is a JSON-encoded map[string]string (filename → content).
 type VmQuadletFilesKey struct{}
 
-func (k *VmQuadletFilesKey) ComposeKey(vmYAML []byte) string {
-	sum := sha256.Sum256(vmYAML)
-	return fmt.Sprintf("v1/vm-quadlet-files/%x", sum)
+func (k *VmQuadletFilesKey) ComposeKey(vmYAML []byte, launcherImage string, passtWorkarounds bool) string {
+	h := sha256.New()
+	_, _ = h.Write(vmYAML)
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(launcherImage))
+	_, _ = h.Write([]byte{0})
+	if passtWorkarounds {
+		_, _ = h.Write([]byte("passt=1"))
+	} else {
+		_, _ = h.Write([]byte("passt=0"))
+	}
+	return fmt.Sprintf("v1/vm-quadlet-files/%x", h.Sum(nil))
 }

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -76,19 +76,22 @@ type DeviceRenderLogic struct {
 	deviceConfig    *[]domain.ConfigProviderSpec
 	applications    *[]domain.ApplicationProviderSpec
 	vmConverter     VmConverterFn
+	vmRenderOptions VmRenderOptions
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
+	opts := vmRenderOptionsFromConfig(cfg)
 	return DeviceRenderLogic{
-		log:           log,
-		deviceSvc:     deviceSvc,
-		repositorySvc: repositorySvc,
-		k8sClient:     k8sClient,
-		kvStore:       kvStore,
-		cfg:           cfg,
-		orgId:         orgId,
-		event:         event,
-		vmConverter:   defaultVmConverter,
+		log:             log,
+		deviceSvc:       deviceSvc,
+		repositorySvc:   repositorySvc,
+		k8sClient:       k8sClient,
+		kvStore:         kvStore,
+		cfg:             cfg,
+		orgId:           orgId,
+		event:           event,
+		vmConverter:     NewVmConverter(vmToQuadletBinary, opts),
+		vmRenderOptions: opts,
 	}
 }
 
@@ -284,7 +287,7 @@ func (t *DeviceRenderLogic) renderApplications(ctx context.Context) ([]byte, err
 
 	for i := range *t.applications {
 		application := (*t.applications)[i]
-		name, renderedApplication, renderErr := renderApplication(ctx, &application, t.vmConverter, t.kvStore)
+		name, renderedApplication, renderErr := renderApplication(ctx, &application, t.vmConverter, t.vmRenderOptions, t.kvStore)
 		applicationName := util.DefaultIfNil(name, "<unknown>")
 
 		// Append invalid configs only if there's an error
@@ -404,7 +407,7 @@ func (t *DeviceRenderLogic) renderConfigItem(ctx context.Context, configItem *do
 	}
 }
 
-func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec, vmConverter VmConverterFn, kvStore kvstore.KVStore) (*string, *domain.ApplicationProviderSpec, error) {
+func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec, vmConverter VmConverterFn, vmOpts VmRenderOptions, kvStore kvstore.KVStore) (*string, *domain.ApplicationProviderSpec, error) {
 	appType, err := (*app).GetAppType()
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: failed to get app type: %w", ErrUnknownApplicationType, err)
@@ -425,7 +428,7 @@ func renderApplication(ctx context.Context, app *domain.ApplicationProviderSpec,
 			return nil, nil, fmt.Errorf("%w: failed to parse application spec for type %s: %w", ErrUnknownApplicationType, appType, parseErr)
 		}
 		appName := vmApp.Name
-		converted, renderErr := renderVmApplication(ctx, vmApp, vmConverter, kvStore)
+		converted, renderErr := renderVmApplication(ctx, vmApp, vmConverter, vmOpts, kvStore)
 		if renderErr != nil {
 			return appName, nil, renderErr
 		}

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -682,7 +682,7 @@ func TestRenderApplication_PreservesLifecycleFields(t *testing.T) {
 	t.Run("When rendering a container application it should preserve lifecycle fields", func(t *testing.T) {
 		app := makeContainerApp(t, "my-app", lo.ToPtr(domain.ApplicationDesiredStateStopped), lo.ToPtr(2))
 
-		name, rendered, err := renderApplication(context.Background(), &app, nil, nil)
+		name, rendered, err := renderApplication(context.Background(), &app, nil, DefaultVmRenderOptions(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, name)
 		assert.Equal(t, "my-app", *name)

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -10,8 +10,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/quadlet"
@@ -27,6 +29,27 @@ const (
 	maxStderrBytes                      = 64 * 1024        // 64 KiB
 	maxTarEntryBytes              int64 = 1 * 1024 * 1024  // 1 MiB per TAR entry
 )
+
+// VmRenderOptions controls vm-to-quadlet conversion for VmApplications.
+type VmRenderOptions struct {
+	LauncherImage    string
+	PasstWorkarounds bool
+}
+
+// DefaultVmRenderOptions returns the default conversion options.
+func DefaultVmRenderOptions() VmRenderOptions {
+	return VmRenderOptions{
+		LauncherImage:    config.DefaultVirtLauncherImage,
+		PasstWorkarounds: true,
+	}
+}
+
+func vmRenderOptionsFromConfig(cfg *config.Config) VmRenderOptions {
+	return VmRenderOptions{
+		LauncherImage:    cfg.EffectiveVmLauncherImage(),
+		PasstWorkarounds: cfg.EffectiveVmPasstWorkarounds(),
+	}
+}
 
 // limitedWriter wraps a bytes.Buffer and returns an error once more than limit
 // bytes have been written. This causes cmd.Run() to fail fast rather than
@@ -66,13 +89,21 @@ func truncateStderr(s string) string {
 type VmConverterFn func(ctx context.Context, vmYAML []byte) (files map[string]string, stderr string, err error)
 
 // NewVmConverter returns a VmConverterFn that invokes the vm-to-quadlet binary
-// at binaryPath. The binary reads VM YAML from stdin and writes a TAR archive
-// of Quadlet unit files to stdout. binaryPath may be an absolute path or a
-// bare binary name resolved via PATH. Exported so integration tests can point
-// the converter at a binary extracted to a temporary directory.
-func NewVmConverter(binaryPath string) VmConverterFn {
+// at binaryPath with the given render options. The binary reads VM YAML from
+// stdin and writes a TAR archive of Quadlet unit files to stdout. binaryPath
+// may be an absolute path or a bare binary name resolved via PATH. Exported so
+// integration tests can point the converter at a binary extracted to a
+// temporary directory.
+func NewVmConverter(binaryPath string, opts VmRenderOptions) VmConverterFn {
+	if opts.LauncherImage == "" {
+		opts.LauncherImage = config.DefaultVirtLauncherImage
+	}
+	args := []string{
+		"--launcher-image=" + opts.LauncherImage,
+		"--passt-workarounds=" + strconv.FormatBool(opts.PasstWorkarounds),
+	}
 	return func(ctx context.Context, vmYAML []byte) (map[string]string, string, error) {
-		cmd := exec.CommandContext(ctx, binaryPath)
+		cmd := exec.CommandContext(ctx, binaryPath, args...)
 		cmd.Stdin = bytes.NewReader(vmYAML)
 
 		stdoutBuf := &limitedWriter{limit: maxStdoutBytes}
@@ -128,15 +159,11 @@ func parseTarFiles(data []byte) (map[string]string, error) {
 	return files, nil
 }
 
-// defaultVmConverter is the production converter backed by the vm-to-quadlet
-// binary that must be present in PATH at runtime.
-var defaultVmConverter = NewVmConverter(vmToQuadletBinary)
-
 // renderVmApplication converts a VmApplication (inline: provider) into a
 // QuadletApplication by:
 //  1. Extracting vm.yaml from the VmApplication inline set.
-//  2. Checking the KV-store cache (SHA-256 of vm.yaml content); returning
-//     the cached Quadlet files directly on a hit.
+//  2. Checking the KV-store cache (SHA-256 of vm.yaml + render options);
+//     returning the cached Quadlet files directly on a hit.
 //  3. On a cache miss: invoking the vm-to-quadlet subprocess via the
 //     provided converter, then storing the result in the cache.
 //  4. Injecting PublishPort= directives from VmApplication.publishPorts into
@@ -144,7 +171,7 @@ var defaultVmConverter = NewVmConverter(vmToQuadletBinary)
 //  5. Emitting a QuadletApplication with the flightctl.io/workload-type: vm
 //     annotation so the agent can identify the workload without inspecting
 //     image names.
-func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, converter VmConverterFn, kvStore kvstore.KVStore) (*domain.ApplicationProviderSpec, error) {
+func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, converter VmConverterFn, opts VmRenderOptions, kvStore kvstore.KVStore) (*domain.ApplicationProviderSpec, error) {
 	providerType, err := vmApp.Type()
 	if err != nil {
 		return nil, fmt.Errorf("invalid vm application provider type: %w", err)
@@ -174,7 +201,7 @@ func renderVmApplication(ctx context.Context, vmApp domain.VmApplication, conver
 		return nil, fmt.Errorf("vm.yaml content is empty in VmApplication inline set")
 	}
 
-	quadletFiles, err := convertVmYAML(ctx, []byte(*vmYAMLContent), converter, kvStore)
+	quadletFiles, err := convertVmYAML(ctx, []byte(*vmYAMLContent), converter, opts, kvStore)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +301,8 @@ func findPodFile(files map[string]string) (string, error) {
 // convertVmYAML converts vm.yaml to a set of Quadlet unit files using the KV
 // cache and the converter subprocess. On a cache hit the subprocess is skipped
 // entirely. The cached value is a JSON-encoded map[string]string.
-func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, kvStore kvstore.KVStore) (map[string]string, error) {
-	cacheKey := (&kvstore.VmQuadletFilesKey{}).ComposeKey(vmYAML)
+func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, opts VmRenderOptions, kvStore kvstore.KVStore) (map[string]string, error) {
+	cacheKey := (&kvstore.VmQuadletFilesKey{}).ComposeKey(vmYAML, opts.LauncherImage, opts.PasstWorkarounds)
 
 	if kvStore != nil {
 		cached, err := kvStore.Get(ctx, cacheKey)

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -381,18 +381,27 @@ func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
 	assert.Equal(t, 3, callCount, "converter should run again when launcherImage changes")
 }
 
+// fakeVmToQuadletBinary writes a shell script that records argv and emits a
+// minimal Quadlet TAR on stdout. Returns the script path and the args file path.
+func fakeVmToQuadletBinary(t *testing.T) (scriptPath, argsPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath = filepath.Join(dir, "args")
+	tarPath := filepath.Join(dir, "out.tar")
+	require.NoError(t, os.WriteFile(tarPath, makeTar(t, map[string]string{"my-vm.pod": "[Pod]\n"}), 0o600))
+
+	scriptPath = filepath.Join(dir, "vm-to-quadlet")
+	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\n", argsPath, tarPath)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(scriptBody), 0o600))
+	require.NoError(t, os.Chmod(scriptPath, 0o700))
+	return scriptPath, argsPath
+}
+
 // TestNewVmConverter_PassesRenderFlags verifies the converter invokes the binary
 // with --launcher-image and --passt-workarounds from VmRenderOptions.
 func TestNewVmConverter_PassesRenderFlags(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	argsPath := filepath.Join(dir, "args")
-	tarPath := filepath.Join(dir, "out.tar")
-	require.NoError(t, os.WriteFile(tarPath, makeTar(t, map[string]string{"my-vm.pod": "[Pod]\n"}), 0o600))
-
-	script := filepath.Join(dir, "vm-to-quadlet")
-	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\n", argsPath, tarPath)
-	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+	script, argsPath := fakeVmToQuadletBinary(t)
 
 	opts := VmRenderOptions{
 		LauncherImage:    "registry.example.com/kubevirt/virt-launcher:custom",
@@ -414,14 +423,7 @@ func TestNewVmConverter_PassesRenderFlags(t *testing.T) {
 // image falls back to the built-in default before argv is built.
 func TestNewVmConverter_EmptyLauncherImageUsesDefault(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	argsPath := filepath.Join(dir, "args")
-	tarPath := filepath.Join(dir, "out.tar")
-	require.NoError(t, os.WriteFile(tarPath, makeTar(t, map[string]string{"my-vm.pod": "[Pod]\n"}), 0o600))
-
-	script := filepath.Join(dir, "vm-to-quadlet")
-	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\n", argsPath, tarPath)
-	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+	script, argsPath := fakeVmToQuadletBinary(t)
 
 	_, _, err := NewVmConverter(script, VmRenderOptions{PasstWorkarounds: true})(context.Background(), []byte("apiVersion: v1\n"))
 	require.NoError(t, err)

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -362,6 +362,12 @@ func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
 	_, err = renderVmApplication(ctx, vmApp, converter, DefaultVmRenderOptions(), kv)
 	require.NoError(t, err)
 	assert.Equal(t, 1, callCount, "converter must not be called again on the second (cache hit) call")
+
+	opts := DefaultVmRenderOptions()
+	opts.PasstWorkarounds = false
+	_, err = renderVmApplication(ctx, vmApp, converter, opts, kv)
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "converter should run again when passtWorkarounds changes")
 }
 
 // TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -220,7 +220,8 @@ func TestRenderVmApplication(t *testing.T) {
 			},
 			kvStore: func() kvstore.KVStore {
 				kv := newFakeKVStore()
-				key := (&kvstore.VmQuadletFilesKey{}).ComposeKey([]byte(minimalVmYAML("my-vm")))
+				opts := DefaultVmRenderOptions()
+				key := (&kvstore.VmQuadletFilesKey{}).ComposeKey([]byte(minimalVmYAML("my-vm")), opts.LauncherImage, opts.PasstWorkarounds)
 				encoded, _ := json.Marshal(fakeQuadletFiles)
 				kv.data[key] = encoded
 				return kv
@@ -260,7 +261,7 @@ func TestRenderVmApplication(t *testing.T) {
 			vmApp, err := appSpec.AsVmApplication()
 			require.NoError(t, err)
 
-			result, err := renderVmApplication(ctx, vmApp, tc.converter, tc.kvStore)
+			result, err := renderVmApplication(ctx, vmApp, tc.converter, DefaultVmRenderOptions(), tc.kvStore)
 
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
@@ -320,7 +321,7 @@ func TestRenderVmApplication_PreservesLifecycleFields(t *testing.T) {
 	vmApp.DesiredState = lo.ToPtr(domain.ApplicationDesiredStateStopped)
 	vmApp.RestartGeneration = lo.ToPtr(3)
 
-	result, err := renderVmApplication(ctx, vmApp, stubbedConverter(fakeQuadletFiles), newFakeKVStore())
+	result, err := renderVmApplication(ctx, vmApp, stubbedConverter(fakeQuadletFiles), DefaultVmRenderOptions(), newFakeKVStore())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -354,11 +355,11 @@ func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
 	vmApp, err := appSpec.AsVmApplication()
 	require.NoError(t, err)
 
-	_, err = renderVmApplication(ctx, vmApp, converter, kv)
+	_, err = renderVmApplication(ctx, vmApp, converter, DefaultVmRenderOptions(), kv)
 	require.NoError(t, err)
 	assert.Equal(t, 1, callCount, "converter should be called on the first (cache miss) call")
 
-	_, err = renderVmApplication(ctx, vmApp, converter, kv)
+	_, err = renderVmApplication(ctx, vmApp, converter, DefaultVmRenderOptions(), kv)
 	require.NoError(t, err)
 	assert.Equal(t, 1, callCount, "converter must not be called again on the second (cache hit) call")
 }
@@ -378,7 +379,7 @@ func TestRenderVmApplication_ImageProviderUnsupported(t *testing.T) {
 	vmApp, err := appSpec.AsVmApplication()
 	require.NoError(t, err)
 
-	_, err = renderVmApplication(ctx, vmApp, stubbedConverter(fakeQuadletFiles), newFakeKVStore())
+	_, err = renderVmApplication(ctx, vmApp, stubbedConverter(fakeQuadletFiles), DefaultVmRenderOptions(), newFakeKVStore())
 	require.ErrorContains(t, err, "not yet supported")
 }
 

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -7,12 +7,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -368,6 +373,89 @@ func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
 	_, err = renderVmApplication(ctx, vmApp, converter, opts, kv)
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "converter should run again when passtWorkarounds changes")
+
+	opts = DefaultVmRenderOptions()
+	opts.LauncherImage = "registry.example.com/kubevirt/virt-launcher:custom"
+	_, err = renderVmApplication(ctx, vmApp, converter, opts, kv)
+	require.NoError(t, err)
+	assert.Equal(t, 3, callCount, "converter should run again when launcherImage changes")
+}
+
+// TestNewVmConverter_PassesRenderFlags verifies the converter invokes the binary
+// with --launcher-image and --passt-workarounds from VmRenderOptions.
+func TestNewVmConverter_PassesRenderFlags(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	tarPath := filepath.Join(dir, "out.tar")
+	require.NoError(t, os.WriteFile(tarPath, makeTar(t, map[string]string{"my-vm.pod": "[Pod]\n"}), 0o600))
+
+	script := filepath.Join(dir, "vm-to-quadlet")
+	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\n", argsPath, tarPath)
+	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+
+	opts := VmRenderOptions{
+		LauncherImage:    "registry.example.com/kubevirt/virt-launcher:custom",
+		PasstWorkarounds: false,
+	}
+	files, _, err := NewVmConverter(script, opts)(context.Background(), []byte("apiVersion: v1\n"))
+	require.NoError(t, err)
+	assert.Contains(t, files, "my-vm.pod")
+
+	argsBytes, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--launcher-image=registry.example.com/kubevirt/virt-launcher:custom",
+		"--passt-workarounds=false",
+	}, strings.Split(strings.TrimSpace(string(argsBytes)), "\n"))
+}
+
+// TestNewVmConverter_EmptyLauncherImageUsesDefault verifies an empty launcher
+// image falls back to the built-in default before argv is built.
+func TestNewVmConverter_EmptyLauncherImageUsesDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	tarPath := filepath.Join(dir, "out.tar")
+	require.NoError(t, os.WriteFile(tarPath, makeTar(t, map[string]string{"my-vm.pod": "[Pod]\n"}), 0o600))
+
+	script := filepath.Join(dir, "vm-to-quadlet")
+	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\ncat %q\n", argsPath, tarPath)
+	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+
+	_, _, err := NewVmConverter(script, VmRenderOptions{PasstWorkarounds: true})(context.Background(), []byte("apiVersion: v1\n"))
+	require.NoError(t, err)
+
+	argsBytes, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--launcher-image=" + config.DefaultVirtLauncherImage,
+		"--passt-workarounds=true",
+	}, strings.Split(strings.TrimSpace(string(argsBytes)), "\n"))
+}
+
+// TestVmRenderOptionsFromConfig verifies NewDeviceRenderLogic wires Worker.VmRender
+// into the options used for conversion.
+func TestVmRenderOptionsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"worker": {
+			"vmRender": {
+				"launcherImage": "registry.example.com/kubevirt/virt-launcher:custom",
+				"passtWorkarounds": false
+			}
+		}
+	}`), cfg))
+
+	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
+	assert.Equal(t, "registry.example.com/kubevirt/virt-launcher:custom", logic.vmRenderOptions.LauncherImage)
+	assert.False(t, logic.vmRenderOptions.PasstWorkarounds)
+
+	defaults := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, &config.Config{}, [16]byte{}, domain.Event{})
+	assert.Equal(t, config.DefaultVirtLauncherImage, defaults.vmRenderOptions.LauncherImage)
+	assert.True(t, defaults.vmRenderOptions.PasstWorkarounds)
 }
 
 // TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication

--- a/test/e2e/infra/quadlet/service_config_mapping.go
+++ b/test/e2e/infra/quadlet/service_config_mapping.go
@@ -31,6 +31,13 @@ type SectionMapping struct {
 // here will have SetServiceConfig write to service-config.yaml; others write
 // to the per-service config file.
 var serviceConfigSectionMappings = map[infra.ServiceName][]SectionMapping{
+	infra.ServiceWorker: {
+		{
+			RenderedKey:      "worker",
+			ServiceConfigKey: "worker",
+			Transform:        nil,
+		},
+	},
 	infra.ServiceImageBuilderWorker: {
 		{
 			RenderedKey:      "imageBuilderWorker",

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -158,6 +158,7 @@ vulnerabilityReporting:
 					vmRender, ok := s["vmRender"].(map[string]interface{})
 					require.True(t, ok)
 					assert.Equal(t, "quay.io/kubevirt/virt-launcher:v1.9.0", vmRender["launcherImage"])
+					assert.Equal(t, false, vmRender["passtWorkarounds"])
 				}
 			case infra.ServiceImageBuilderWorker:
 				sectionKey = "imageBuilderWorker"
@@ -220,6 +221,7 @@ vulnerabilityReporting:
 				vmRender, ok := section["vmRender"].(map[string]interface{})
 				require.True(t, ok)
 				vmRender["launcherImage"] = setValue
+				vmRender["passtWorkarounds"] = false
 			case infra.ServiceImageBuilderWorker:
 				section["maxConcurrentBuilds"] = setValue
 			case infra.ServiceTelemetryGateway:

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -110,6 +110,10 @@ db:
 service:
   rateLimit:
     enabled: false
+worker:
+  vmRender:
+    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
+    passtWorkarounds: true
 imagebuilderWorker:
   logLevel: info
   maxConcurrentBuilds: 2
@@ -144,6 +148,17 @@ vulnerabilityReporting:
 			var assertValue func(t *testing.T, section interface{})
 
 			switch service {
+			case infra.ServiceWorker:
+				sectionKey = "worker"
+				setValue = "quay.io/kubevirt/virt-launcher:v1.9.0"
+				getSection = func(m map[string]interface{}) interface{} { return m["worker"] }
+				assertValue = func(t *testing.T, section interface{}) {
+					s, ok := section.(map[string]interface{})
+					require.True(t, ok)
+					vmRender, ok := s["vmRender"].(map[string]interface{})
+					require.True(t, ok)
+					assert.Equal(t, "quay.io/kubevirt/virt-launcher:v1.9.0", vmRender["launcherImage"])
+				}
 			case infra.ServiceImageBuilderWorker:
 				sectionKey = "imageBuilderWorker"
 				setValue = float64(6)
@@ -201,6 +216,10 @@ vulnerabilityReporting:
 			require.NotNil(t, section, "section %q not found in config", sectionKey)
 			// Set the field we care about based on service type
 			switch service {
+			case infra.ServiceWorker:
+				vmRender, ok := section["vmRender"].(map[string]interface{})
+				require.True(t, ok)
+				vmRender["launcherImage"] = setValue
 			case infra.ServiceImageBuilderWorker:
 				section["maxConcurrentBuilds"] = setValue
 			case infra.ServiceTelemetryGateway:
@@ -272,8 +291,8 @@ imagebuilderWorker:
 }
 
 func TestApplyServiceConfigMappings_NoMappingReturnsNil(t *testing.T) {
-	// Use a service without mappings (ServiceWorker has none)
-	updates, err := applyServiceConfigMappings(infra.ServiceWorker, exampleImageBuilderWorkerPerServiceYAML)
+	// Use a service without mappings (ServiceUI has none)
+	updates, err := applyServiceConfigMappings(infra.ServiceUI, exampleImageBuilderWorkerPerServiceYAML)
 	require.NoError(t, err)
 	assert.Nil(t, updates)
 }

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -112,7 +112,6 @@ service:
     enabled: false
 worker:
   vmRender:
-    launcherImage: "quay.io/kubevirt/virt-launcher:v1.8.4"
     passtWorkarounds: true
 imagebuilderWorker:
   logLevel: info

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -63,7 +63,7 @@ var _ = SynchronizedBeforeSuite(
 			suiteCtx, flightlog.InitLogs())
 		Expect(err).NotTo(HaveOccurred())
 
-		vmConverter = tasks.NewVmConverter(string(binaryPathBytes))
+		vmConverter = tasks.NewVmConverter(string(binaryPathBytes), tasks.DefaultVmRenderOptions())
 	},
 )
 


### PR DESCRIPTION
## Summary
- Enable `worker.vmRender.launcherImage` and `worker.vmRender.passtWorkarounds` in Flight Control config (defaults: `quay.io/kubevirt/virt-launcher:v1.8.4`, `passtWorkarounds: true`)
- Wire both options into `vm-to-quadlet` during VM application rendering, and include them in the Quadlet cache key
- Expose the settings in Helm values and Podman `service-config.yaml`, with user docs

## Test plan
- [x] `go test ./internal/tasks/ ./test/e2e/infra/quadlet/`
- [x] `helm lint` / template render of worker config with defaults and overrides
- [x] Podman worker config template render with defaults and overrides
- [ ] CI unit/integration checks on PR


Made with [Cursor](https://cursor.com)