### PR TITLE
NO-ISSUE: lower integration CI parallelism to 4 procs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Running integration tests
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
-          make integration-test INTEGRATION_PROCS=8
+          make integration-test INTEGRATION_PROCS=4
         env:
           DISABLE_FIPS: true
 
@@ -144,7 +144,7 @@ jobs:
         # if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         if: false
         run: |
-          make integration-test INTEGRATION_PROCS=8
+          make integration-test INTEGRATION_PROCS=4
         env:
           DISABLE_FIPS: true
 


### PR DESCRIPTION
## Summary
- Drop CI `INTEGRATION_PROCS` from 8 → 4 in `.github/workflows/integration-tests.yaml` (both the live and disabled compatibility jobs).
- Standard `ubuntu-24.04` runners (~7 GB) have been regularly killing parallel agent/harness work with exit **137** / `signal: killed`, which surfaces as Ginkgo “parallel process disappeared” or suite timeouts. 4 matches the makefile default.

## Test plan
- [ ] Confirm integration-tests workflow passes on this PR
- [ ] Spot-check that agent suite no longer loses parallel procs under memory pressure


Made with [Cursor](https://cursor.com)