### PR TITLE
EDM-4759: Skip OS update reconciliation paths on package-mode

### DIFF
--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -211,7 +211,7 @@ func (b *Bootstrap) ensureBootstrap(ctx context.Context) error {
 }
 
 func (b *Bootstrap) ensureBootedOS(ctx context.Context) error {
-	if !b.specManager.IsOSUpdate() {
+	if !b.specManager.ShouldApplyOSImageUpdate() {
 		b.log.Info("No OS update in progress")
 		// If not upgrading but rollback.json has a desired version, a rollback
 		// already completed and the agent restarted. Mark the desired version

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -66,7 +66,7 @@ func TestInitialization(t *testing.T) {
 					mockIdentityProvider.EXPECT().CreateManagementClient(gomock.Any(), gomock.Any()).Return(nil, nil),
 					mockStatusManager.EXPECT().SetClient(gomock.Any()),
 					mockSpecManager.EXPECT().SetClient(gomock.Any()),
-					mockSpecManager.EXPECT().IsOSUpdate().Return(false),
+					mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
 					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSystemInfoManager.EXPECT().IsRebooted().Return(false),
@@ -99,7 +99,7 @@ func TestInitialization(t *testing.T) {
 					mockIdentityProvider.EXPECT().CreateManagementClient(gomock.Any(), gomock.Any()).Return(nil, nil),
 					mockStatusManager.EXPECT().SetClient(gomock.Any()),
 					mockSpecManager.EXPECT().SetClient(gomock.Any()),
-					mockSpecManager.EXPECT().IsOSUpdate().Return(true),
+					mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true),
 					mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return(bootedOSVersion, true, nil),
 					mockSystemInfoManager.EXPECT().IsRebooted().Return(false),
 					mockSpecManager.EXPECT().IsUpgrading().Return(true),
@@ -130,7 +130,7 @@ func TestInitialization(t *testing.T) {
 					mockIdentityProvider.EXPECT().CreateManagementClient(gomock.Any(), gomock.Any()).Return(nil, nil),
 					mockStatusManager.EXPECT().SetClient(gomock.Any()),
 					mockSpecManager.EXPECT().SetClient(gomock.Any()),
-					mockSpecManager.EXPECT().IsOSUpdate().Return(false),
+					mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
 					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSystemInfoManager.EXPECT().IsRebooted().Return(false),
@@ -316,7 +316,7 @@ func TestEnsureBootedOS(t *testing.T) {
 		{
 			name: "happy path - no OS update in progress",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
-				mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false)
 				mockSpecManager.EXPECT().IsUpgrading().Return(false)
 				mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil)
 			},
@@ -325,7 +325,7 @@ func TestEnsureBootedOS(t *testing.T) {
 		{
 			name: "no OS update - rollback completed marks version as failed",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
-				mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false)
 				mockSpecManager.EXPECT().IsUpgrading().Return(false)
 				mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{Version: "2", SpecHash: "abc123"}, nil)
 				mockSpecManager.EXPECT().SetUpgradeFailed("2", "abc123").Return(nil)
@@ -335,7 +335,7 @@ func TestEnsureBootedOS(t *testing.T) {
 		{
 			name: "no OS update - still upgrading does not mark as failed",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
-				mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false)
 				mockSpecManager.EXPECT().IsUpgrading().Return(true)
 			},
 			expectedError: nil,
@@ -343,7 +343,7 @@ func TestEnsureBootedOS(t *testing.T) {
 		{
 			name: "OS image reconciliation failure",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("", false, specErr)
 			},
 			expectedError: specErr,
@@ -352,7 +352,7 @@ func TestEnsureBootedOS(t *testing.T) {
 			name: "OS image not reconciled triggers rollback",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
 				mockSpecManager.EXPECT().OSVersion(gomock.Any()).Return("desired-image")
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("unexpected-booted-image", false, nil)
 				mockSpecManager.EXPECT().IsRollingBack(gomock.Any()).Return(true, nil)
 				mockSpecManager.EXPECT().Rollback(gomock.Any(), gomock.Any()).Return(nil)
@@ -365,7 +365,7 @@ func TestEnsureBootedOS(t *testing.T) {
 		{
 			name: "OS image reconciled",
 			setupMocks: func(mockStatusManager *status.MockManager, mockSpecManager *spec.MockManager) {
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("desired-image", true, nil)
 			},
 			expectedError: nil,

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -246,7 +246,7 @@ func (a *Agent) syncDeviceSpec(ctx context.Context) {
 	if a.specManager.IsUpgrading() {
 		// Wait for greenboot to mark the boot as successful before committing the spec.
 		// This only applies to OS updates — greenboot validates the new OS image, not config changes.
-		if a.specManager.IsOSUpdate() && !a.isBootSuccessful(ctx) {
+		if a.specManager.ShouldApplyOSImageUpdate() && !a.isBootSuccessful(ctx) {
 			a.log.Debug("Waiting for greenboot to mark boot as successful before upgrading spec")
 			return
 		}
@@ -327,7 +327,7 @@ func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.De
 	}
 
 	needsOSRollback := false
-	if !errors.IsRetryable(syncErr) && a.specManager.IsOSUpdate() {
+	if !errors.IsRetryable(syncErr) && a.specManager.ShouldApplyOSImageUpdate() {
 		_, isReconciled, err := a.specManager.CheckOsReconciliation(ctx)
 		if err != nil {
 			a.log.Errorf("Failed to check OS reconciliation: %v", err)
@@ -470,7 +470,7 @@ func (a *Agent) beforeUpdate(ctx context.Context, current, desired *v1beta1.Devi
 	a.pullConfigResolver.BeforeUpdate(desired.Spec)
 
 	a.prefetchManager.RegisterOCICollector(a.appManager)
-	if a.specManager.IsOSUpdate() {
+	if a.specManager.ShouldApplyOSImageUpdate() {
 		a.prefetchManager.RegisterOCICollector(a.osManager)
 	}
 
@@ -485,7 +485,7 @@ func (a *Agent) beforeUpdate(ctx context.Context, current, desired *v1beta1.Devi
 	}
 
 	// Compute osUpdatePending once for both prefetch and app managers
-	osUpdatePending, err := a.specManager.IsOSUpdatePending(ctx)
+	osUpdatePending, err := a.specManager.ShouldApplyOSImageUpdatePending(ctx)
 	if err != nil {
 		return fmt.Errorf("checking OS update pending: %w", err)
 	}
@@ -597,7 +597,7 @@ func (a *Agent) afterUpdate(ctx context.Context, current, desired *v1beta1.Devic
 	// execute after update for os first so that the activation of the spec is
 	// after the os is updated.This happens because the os update requires a
 	// reboot so the lower blocks are not executed until after reboot.
-	if !isOSReconciled && a.specManager.IsOSUpdate() {
+	if !isOSReconciled && a.specManager.ShouldApplyOSImageUpdate() {
 		if err = a.afterUpdateOS(ctx, desired); err != nil {
 			a.log.Errorf("Error executing OS: %v", err)
 			return err

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -102,8 +102,8 @@ func TestSync(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
 				mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(false).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
 				mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				// GetDesired, Read, and BeforeUpdate may be called multiple times if syncDeviceSpec is called again
@@ -165,7 +165,7 @@ func TestSync(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
 				mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
 				mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil).AnyTimes()
 				mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil).AnyTimes()
@@ -185,7 +185,7 @@ func TestSync(t *testing.T) {
 				mockPruningManager.EXPECT().PrunePending().Return(false).AnyTimes()
 
 				mockSpecManager.EXPECT().IsUpgrading().Return(true).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true).AnyTimes()
 
 				// greenboot-healthcheck.service is not enabled (exit 1) — greenboot not installed
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("not-found\n", "", 1).AnyTimes()
@@ -224,7 +224,7 @@ func TestSync(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSystemdManager.EXPECT().EnsurePatterns(gomock.Any()).Return(nil).AnyTimes()
 				mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
 				mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().GetDesired(ctx).Return(desired, false, nil).AnyTimes()
 				mockSpecManager.EXPECT().Read(spec.Current).Return(current, nil).AnyTimes()
@@ -242,7 +242,7 @@ func TestSync(t *testing.T) {
 				mockPrefetchManager.EXPECT().Cleanup().AnyTimes()
 
 				mockSpecManager.EXPECT().IsUpgrading().Return(true).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true).AnyTimes()
 
 				// greenboot IS installed and enabled
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "/usr/bin/systemctl", "is-enabled", "greenboot-healthcheck.service").Return("enabled\n", "", 0).AnyTimes()
@@ -633,7 +633,7 @@ func TestOSRollback(t *testing.T) {
 				mockOSManager *os.MockManager,
 			) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
@@ -655,7 +655,7 @@ func TestOSRollback(t *testing.T) {
 				mockOSManager *os.MockManager,
 			) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
@@ -676,7 +676,7 @@ func TestOSRollback(t *testing.T) {
 				mockOSManager *os.MockManager,
 			) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(true)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v1", false, nil)
 				mockSpecManager.EXPECT().Rollback(gomock.Any()).Return(nil)
 			},
@@ -693,7 +693,7 @@ func TestOSRollback(t *testing.T) {
 				mockOSManager *os.MockManager,
 			) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
-				mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false)
 				mockSpecManager.EXPECT().Rollback(gomock.Any()).Return(nil)
 			},
 			wantReboot: false,
@@ -939,7 +939,7 @@ func TestSyncDeviceSpecPackageModeRejection(t *testing.T) {
 				return nil
 			},
 		)
-		mockSpecManager.EXPECT().IsOSUpdate().Return(false)
+		mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false)
 		mockSpecManager.EXPECT().Rollback(ctx).DoAndReturn(
 			func(_ context.Context, _ ...spec.RollbackOption) error {
 				rollbackCalled = true
@@ -955,8 +955,8 @@ func TestSyncDeviceSpecPackageModeRejection(t *testing.T) {
 		mockSpecManager.EXPECT().CheckPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mockPullConfigResolver.EXPECT().BeforeUpdate(gomock.Any()).AnyTimes()
 		mockPrefetchManager.EXPECT().RegisterOCICollector(gomock.Any()).AnyTimes()
-		mockSpecManager.EXPECT().IsOSUpdate().Return(false).AnyTimes()
-		mockSpecManager.EXPECT().IsOSUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
+		mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(false).AnyTimes()
+		mockSpecManager.EXPECT().ShouldApplyOSImageUpdatePending(gomock.Any()).Return(false, nil).AnyTimes()
 		mockPrefetchManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mockAppManager.EXPECT().BeforeUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mockHookManager.EXPECT().OnBeforeUpdating(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/internal/agent/device/os/client.go
+++ b/internal/agent/device/os/client.go
@@ -41,7 +41,7 @@ func NewClient(log *log.PrefixLogger, exec executer.Executer) Client {
 		log.Infof("OS managed by rpm-ostree client")
 		return newRpmOSTreeClient(exec)
 	default:
-		log.Warnf("OS not managed by any supported OS manager. Using dummy client.")
+		log.Infof("package-mode / no image manager; using no-op OS client")
 		return newDummyClient(log)
 	}
 }
@@ -117,7 +117,7 @@ func newDummyClient(log *log.PrefixLogger) *dummy {
 	}
 }
 
-// dummy client for unsupported OS
+// dummy client for package-mode (no image manager)
 type dummy struct {
 	log *log.PrefixLogger
 }
@@ -127,16 +127,16 @@ func (d *dummy) Status(ctx context.Context) (*Status, error) {
 }
 
 func (d *dummy) Switch(ctx context.Context, image string) error {
-	d.log.Debugf("Ignoring switch to image %s from dummy client for unsupported OS", image)
+	d.log.Debugf("Ignoring switch to image %s from dummy client for package-mode", image)
 	return nil
 }
 
 func (d *dummy) Rollback(ctx context.Context) error {
-	d.log.Debugf("Ignoring rollback and reboot from dummy client for unsupported OS")
+	d.log.Debugf("Ignoring rollback and reboot from dummy client for package-mode")
 	return nil
 }
 
 func (d *dummy) Apply(ctx context.Context) error {
-	d.log.Debugf("Ignoring apply from dummy client for unsupported OS")
+	d.log.Debugf("Ignoring apply from dummy client for package-mode")
 	return nil
 }

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -532,15 +532,15 @@ func (s *manager) isNewDesiredVersion(desired *v1beta1.Device) bool {
 	return s.lastConsumedDevice == nil || s.lastConsumedDevice.Version() != desired.Version()
 }
 
-func (s *manager) IsOSUpdate() bool {
+func (s *manager) ShouldApplyOSImageUpdate() bool {
 	if s.osMode == v1beta1.OsModePackage {
 		return false
 	}
 	return s.cache.getOSVersion(Current) != s.cache.getOSVersion(Desired)
 }
 
-func (s *manager) IsOSUpdatePending(ctx context.Context) (bool, error) {
-	if !s.IsOSUpdate() {
+func (s *manager) ShouldApplyOSImageUpdatePending(ctx context.Context) (bool, error) {
+	if !s.ShouldApplyOSImageUpdate() {
 		return false, nil
 	}
 

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -533,6 +533,9 @@ func (s *manager) isNewDesiredVersion(desired *v1beta1.Device) bool {
 }
 
 func (s *manager) IsOSUpdate() bool {
+	if s.osMode == v1beta1.OsModePackage {
+		return false
+	}
 	return s.cache.getOSVersion(Current) != s.cache.getOSVersion(Desired)
 }
 

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -214,35 +214,6 @@ func (mr *MockManagerMockRecorder) Initialize(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockManager)(nil).Initialize), ctx)
 }
 
-// IsOSUpdate mocks base method.
-func (m *MockManager) IsOSUpdate() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsOSUpdate")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsOSUpdate indicates an expected call of IsOSUpdate.
-func (mr *MockManagerMockRecorder) IsOSUpdate() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOSUpdate", reflect.TypeOf((*MockManager)(nil).IsOSUpdate))
-}
-
-// IsOSUpdatePending mocks base method.
-func (m *MockManager) IsOSUpdatePending(ctx context.Context) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsOSUpdatePending", ctx)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsOSUpdatePending indicates an expected call of IsOSUpdatePending.
-func (mr *MockManagerMockRecorder) IsOSUpdatePending(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOSUpdatePending", reflect.TypeOf((*MockManager)(nil).IsOSUpdatePending), ctx)
-}
-
 // IsRollingBack mocks base method.
 func (m *MockManager) IsRollingBack(ctx context.Context) (bool, error) {
 	m.ctrl.T.Helper()
@@ -358,6 +329,35 @@ func (m *MockManager) SetUpgradeFailed(version, specHash string) error {
 func (mr *MockManagerMockRecorder) SetUpgradeFailed(version, specHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeFailed", reflect.TypeOf((*MockManager)(nil).SetUpgradeFailed), version, specHash)
+}
+
+// ShouldApplyOSImageUpdate mocks base method.
+func (m *MockManager) ShouldApplyOSImageUpdate() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldApplyOSImageUpdate")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldApplyOSImageUpdate indicates an expected call of ShouldApplyOSImageUpdate.
+func (mr *MockManagerMockRecorder) ShouldApplyOSImageUpdate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldApplyOSImageUpdate", reflect.TypeOf((*MockManager)(nil).ShouldApplyOSImageUpdate))
+}
+
+// ShouldApplyOSImageUpdatePending mocks base method.
+func (m *MockManager) ShouldApplyOSImageUpdatePending(ctx context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldApplyOSImageUpdatePending", ctx)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldApplyOSImageUpdatePending indicates an expected call of ShouldApplyOSImageUpdatePending.
+func (mr *MockManagerMockRecorder) ShouldApplyOSImageUpdatePending(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldApplyOSImageUpdatePending", reflect.TypeOf((*MockManager)(nil).ShouldApplyOSImageUpdatePending), ctx)
 }
 
 // Status mocks base method.

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -75,11 +75,13 @@ type Manager interface {
 	SetUpgradeFailed(version string, specHash string) error
 	// IsUpdating returns true if the device is in the process of reconciling the desired spec.
 	IsUpgrading() bool
-	// IsOSUpdate returns true if an OS update is in progress by checking the current rendered spec.
-	IsOSUpdate() bool
-	// IsOSUpdatePending returns true if an OS update is specified but the device
-	// has not yet booted into the new image.
-	IsOSUpdatePending(ctx context.Context) (bool, error)
+	// ShouldApplyOSImageUpdate returns true if the agent should run the OS
+	// image update path (desired OS image differs from current). Always false
+	// on package-mode, which has no image manager.
+	ShouldApplyOSImageUpdate() bool
+	// ShouldApplyOSImageUpdatePending returns true if an OS image update is
+	// specified but the device has not yet booted into the new image.
+	ShouldApplyOSImageUpdatePending(ctx context.Context) (bool, error)
 	// CheckOsReconciliation checks if the booted OS image matches the desired OS image.
 	CheckOsReconciliation(ctx context.Context) (string, bool, error)
 	// IsRollingBack returns true if the device is in a rollback state.

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -469,7 +469,7 @@ func TestUpgrade(t *testing.T) {
 	}
 }
 
-func TestIsOSUpdate(t *testing.T) {
+func TestShouldApplyOSImageUpdate(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -491,7 +491,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = ""
 		s.cache.desired.osVersion = ""
 
-		osUpdate := s.IsOSUpdate()
+		osUpdate := s.ShouldApplyOSImageUpdate()
 		require.Equal(false, osUpdate)
 	})
 
@@ -501,7 +501,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = image
 		s.cache.desired.osVersion = image
 
-		osUpdate := s.IsOSUpdate()
+		osUpdate := s.ShouldApplyOSImageUpdate()
 		require.Equal(false, osUpdate)
 	})
 
@@ -511,7 +511,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = currentImage
 		s.cache.desired.osVersion = desiredImage
 
-		osUpdate := s.IsOSUpdate()
+		osUpdate := s.ShouldApplyOSImageUpdate()
 		require.Equal(true, osUpdate)
 	})
 
@@ -520,7 +520,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = "flightctl-device:v2"
 		s.cache.desired.osVersion = "flightctl-device:v3"
 
-		require.False(s.IsOSUpdate())
+		require.False(s.ShouldApplyOSImageUpdate())
 	})
 
 	t.Run("When mode is image it should retain version comparison", func(t *testing.T) {
@@ -528,7 +528,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = "flightctl-device:v2"
 		s.cache.desired.osVersion = "flightctl-device:v3"
 
-		require.True(s.IsOSUpdate())
+		require.True(s.ShouldApplyOSImageUpdate())
 	})
 
 	t.Run("When mode is unset it should retain version comparison", func(t *testing.T) {
@@ -536,7 +536,7 @@ func TestIsOSUpdate(t *testing.T) {
 		s.cache.current.osVersion = "flightctl-device:v2"
 		s.cache.desired.osVersion = "flightctl-device:v3"
 
-		require.True(s.IsOSUpdate())
+		require.True(s.ShouldApplyOSImageUpdate())
 	})
 }
 

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -514,6 +514,30 @@ func TestIsOSUpdate(t *testing.T) {
 		osUpdate := s.IsOSUpdate()
 		require.Equal(true, osUpdate)
 	})
+
+	t.Run("When mode is package it should return false even when versions differ", func(t *testing.T) {
+		s.osMode = v1beta1.OsModePackage
+		s.cache.current.osVersion = "flightctl-device:v2"
+		s.cache.desired.osVersion = "flightctl-device:v3"
+
+		require.False(s.IsOSUpdate())
+	})
+
+	t.Run("When mode is image it should retain version comparison", func(t *testing.T) {
+		s.osMode = v1beta1.OsModeImage
+		s.cache.current.osVersion = "flightctl-device:v2"
+		s.cache.desired.osVersion = "flightctl-device:v3"
+
+		require.True(s.IsOSUpdate())
+	})
+
+	t.Run("When mode is unset it should retain version comparison", func(t *testing.T) {
+		s.osMode = ""
+		s.cache.current.osVersion = "flightctl-device:v2"
+		s.cache.desired.osVersion = "flightctl-device:v3"
+
+		require.True(s.IsOSUpdate())
+	})
 }
 
 func TestCheckOsReconciliation(t *testing.T) {


### PR DESCRIPTION
## EDM-4759: Skip OS update reconciliation paths on package-mode

**Jira:** [EDM-4759](https://redhat.atlassian.net/browse/EDM-4759)
**Epic:** [EDM-4747](https://redhat.atlassian.net/browse/EDM-4747) — Package-Mode Agent Runtime
**Depends on:** EDM-4755 (#3253, merged), EDM-4757 (#3274, merged)

### Summary

Package-mode devices have no image manager, so the OS version cache comparison (`"" != desired-image`) always evaluates to true and would activate the full OS update chain. This PR short-circuits `ShouldApplyOSImageUpdate()` (formerly `IsOSUpdate()`) to return `false` when `osMode` is `package`, and rewords the dummy OS client factory log so package-mode startup is informational rather than a warning.

The rename clarifies that the method gates the OS *image* update path (prefetch/switch/greenboot/rollback), not a mode-agnostic “desired ≠ current” check.

### Changes

- **`internal/agent/device/spec/`**: Renamed `IsOSUpdate` → `ShouldApplyOSImageUpdate` and `IsOSUpdatePending` → `ShouldApplyOSImageUpdatePending` (interface, manager, mocks, callers).
- **`internal/agent/device/spec/manager.go`**: Early return `false` from `ShouldApplyOSImageUpdate()` when `osMode == OsModePackage`. Downstream gates (prefetch, greenboot wait, OS rollback, bootstrap `ensureBootedOS`) skip naturally.
- **`internal/agent/device/spec/spec_test.go`**: Three sub-tests for package-mode, image-mode, and unset `osMode`.
- **`internal/agent/device/os/client.go`**: Factory log `Warnf` → `Infof` with package-mode wording; type comment and dummy method debug messages updated from "unsupported OS" to "package-mode".

### Testing

- **Unit tests:** Extended `TestShouldApplyOSImageUpdate` — package-mode always false even when versions differ; image-mode and unset mode retain version comparison.
- **Integration tests:** N/A — in-memory gate + log wording only.
- **Coverage:** `ShouldApplyOSImageUpdate()` at 100% through public interface.

### Acceptance Criteria

- [x] AC-1: `ShouldApplyOSImageUpdate()` returns `false` when mode is `package`, regardless of spec content
- [x] AC-2: `ensureBootedOS()` / `checkRollback()` skipped on package-mode (transitive via `ShouldApplyOSImageUpdate()`)
- [x] AC-3: Dummy client `Switch` / `Rollback` / `Apply` at Debug — already done in EDM-4755; verified
- [x] AC-4: No error/warn-level OS noise on package-mode with satisfiable spec (factory log downgraded; OS chain gated)

# Release target (required before merge to `main`)

- [x] **`release-1.3`**
