### PR TITLE
EDM-4066: Add catalog item references e2e tests

### DIFF
--- a/test/e2e/catalog_refs/catalog_refs_suite_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_suite_test.go
@@ -1,0 +1,67 @@
+package catalog_refs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCatalogRefs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Catalog Item References E2E Suite")
+}
+
+var auxSvcs *auxiliary.Services
+
+var _ = BeforeSuite(func() {
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+	e2e.SetupWorkerHarnessOrAbort()
+	auxSvcs = auxFuture.Wait()
+})
+
+var _ = AfterSuite(func() {
+	if auxSvcs != nil {
+		auxSvcs.Cleanup(context.Background())
+	}
+})
+
+var _ = BeforeEach(func() {
+	workerID := GinkgoParallelProcess()
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test with VM from pool\n", workerID)
+
+	ctx := util.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+
+	err := harness.SetupVMFromPoolAndStartAgent(workerID)
+	Expect(err).ToNot(HaveOccurred())
+
+	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
+})
+
+var _ = AfterEach(func() {
+	workerID := GinkgoParallelProcess()
+	GinkgoWriter.Printf("🔄 [AfterEach] Worker %d: Cleaning up test resources\n", workerID)
+
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	harness.PrintAgentLogsIfFailed()
+	harness.CaptureDeploymentLogsIfFailed()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+
+	harness.SetTestContext(suiteCtx)
+
+	GinkgoWriter.Printf("✅ [AfterEach] Worker %d: Test cleanup completed\n", workerID)
+})

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -3,6 +3,7 @@ package catalog_refs_test
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
@@ -14,13 +15,12 @@ import (
 )
 
 const (
-	catalogName = "e2e-catalog-refs"
 	osItemName  = "os-item"
 	appItemName = "app-item"
 
-	osVersion1  = "v1"
-	osVersion2  = "v2"
-	appVersion1 = "v1"
+	osVersion1  = "1.0.0"
+	osVersion2  = "2.0.0"
+	appVersion1 = "1.0.0"
 
 	channel = "stable"
 
@@ -34,17 +34,26 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 	var (
 		harness *e2e.Harness
 
+		catalogName string
 		osImageURI  string
 		appImageURI string
+		osVersions  []e2e.CatalogVersionRef
 	)
 
 	BeforeAll(func() {
 		harness = e2e.GetWorkerHarness()
+		testID := harness.GetTestIDFromContext()
+		catalogName = fmt.Sprintf("e2e-catalog-refs-%s", testID)
 
 		svc := auxiliary.Get(harness.Context)
 		Expect(svc).ToNot(BeNil(), "auxiliary services must be initialized")
 		osImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.DeviceImageRegistryPath)
 		appImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.SleepAppRegistryPath)
+
+		osVersions = []e2e.CatalogVersionRef{
+			{Version: osVersion1, ImageRef: fmt.Sprintf("%s:%s", osImageURI, testutil.DeviceTags.V1)},
+			{Version: osVersion2, ImageRef: fmt.Sprintf("%s:%s", osImageURI, testutil.DeviceTags.V2)},
+		}
 
 		By("Creating test catalog")
 		_, err := harness.CreateCatalog(catalogName, "E2E Test Catalog")
@@ -52,13 +61,14 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		DeferCleanup(func() { _ = harness.DeleteCatalogIgnoreNotFound(catalogName) })
 
 		By("Creating OS catalog item with two versions")
-		osSpec := e2e.NewOSCatalogItemSpecMultiVersion(osImageURI, []string{osVersion1, osVersion2}, channel)
+		osSpec := e2e.NewOSCatalogItemSpecMultiVersion(osImageURI, osVersions, channel)
 		_, err = harness.CreateCatalogItem(catalogName, osItemName, osSpec)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, osItemName) })
 
 		By("Creating application catalog item")
-		appSpec := e2e.NewAppCatalogItemSpec(appImageURI, appVersion1, channel)
+		appVR := e2e.CatalogVersionRef{Version: appVersion1, ImageRef: fmt.Sprintf("%s:%s", appImageURI, testutil.SleepAppTags.V1)}
+		appSpec := e2e.NewAppCatalogItemSpec(appImageURI, appVR, channel)
 		_, err = harness.CreateCatalogItem(catalogName, appItemName, appSpec)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, appItemName) })
@@ -68,8 +78,12 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
+		By("Recording baseline rendered version")
+		baselineVersion, err := harness.PrepareNextDeviceVersion(deviceId)
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Updating device OS spec with catalogItemRef v1")
-		err := harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+		err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Os = &v1beta1.DeviceOsSpec{
 				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
 					Catalog: catalogName,
@@ -80,17 +94,28 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying render succeeds (SpecValid condition is True)")
-		harness.WaitForDeviceContents(deviceId, "SpecValid=True after OS catalog ref v1",
+		By("Verifying render succeeds and rendered version increments for v1")
+		var v1RenderedVersion int
+		harness.WaitForDeviceContents(deviceId, "SpecValid=True and renderedVersion incremented for OS catalog ref v1",
 			func(device *v1beta1.Device) bool {
 				if device.Status == nil {
 					return false
 				}
 				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
-				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+				if cond == nil || cond.Status != v1beta1.ConditionStatusTrue {
+					return false
+				}
+				ver, verErr := e2e.GetRenderedVersion(device)
+				if verErr != nil || ver < baselineVersion {
+					return false
+				}
+				v1RenderedVersion = ver
+				return true
 			}, e2e.TIMEOUT)
+		Expect(v1RenderedVersion).To(BeNumerically(">=", baselineVersion))
 
 		By("Updating catalogItemRef version to v2")
+		expectedV2 := v1RenderedVersion + 1
 		err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Os = &v1beta1.DeviceOsSpec{
 				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
@@ -102,14 +127,21 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying render succeeds for updated version (SpecValid remains True)")
-		harness.WaitForDeviceContents(deviceId, "SpecValid=True after OS catalog ref v2",
+		By("Verifying render succeeds and rendered version increments again for v2")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=True and renderedVersion incremented for OS catalog ref v2",
 			func(device *v1beta1.Device) bool {
 				if device.Status == nil {
 					return false
 				}
 				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
-				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+				if cond == nil || cond.Status != v1beta1.ConditionStatusTrue {
+					return false
+				}
+				ver, verErr := e2e.GetRenderedVersion(device)
+				if verErr != nil {
+					return false
+				}
+				return ver >= expectedV2
 			}, e2e.TIMEOUT)
 	})
 
@@ -247,6 +279,10 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 
 		By("Verifying API rejects deletion (non-200 status)")
 		if resp.StatusCode() == http.StatusOK {
+			// Restore item for subsequent ordered tests before skipping
+			osSpec := e2e.NewOSCatalogItemSpecMultiVersion(osImageURI, osVersions, channel)
+			_, restoreErr := harness.CreateCatalogItem(catalogName, osItemName, osSpec)
+			Expect(restoreErr).ToNot(HaveOccurred())
 			Skip("AC-7: delete protection not yet implemented")
 		}
 		Expect(resp.StatusCode()).To(SatisfyAny(
@@ -276,8 +312,8 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying device reports render error (SpecValid=False)")
-		harness.WaitForDeviceContents(deviceId, "SpecValid=False with type mismatch",
+		By("Verifying device reports render error (SpecValid=False with meaningful message)")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=False with type mismatch error message",
 			func(device *v1beta1.Device) bool {
 				if device.Status == nil {
 					return false
@@ -286,7 +322,11 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 				if cond == nil {
 					return false
 				}
-				return cond.Status == v1beta1.ConditionStatusFalse
+				if cond.Status != v1beta1.ConditionStatusFalse {
+					return false
+				}
+				msg := strings.ToLower(cond.Message)
+				return strings.Contains(msg, "catalog") || strings.Contains(msg, "type") || strings.Contains(msg, "mismatch") || strings.Contains(msg, "not found")
 			}, e2e.TIMEOUT)
 	})
 })

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -66,8 +66,8 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		appImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.SleepAppRegistryPath)
 
 		osVersions = []e2e.CatalogVersionRef{
-			{Version: osVersion1, ImageRef: testutil.DeviceTags.V1},
-			{Version: osVersion2, ImageRef: testutil.DeviceTags.V2},
+			{Version: osVersion1, ImageRef: testutil.DeviceTags.V2},
+			{Version: osVersion2, ImageRef: testutil.DeviceTags.V3},
 		}
 
 		By("Creating test catalog")

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying container application is running on device")
-		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Removing application from device spec")

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -283,8 +283,8 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
-		By("Setting device OS spec to reference app-type catalog item (type mismatch)")
-		err := harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+		By("Attempting to set device OS spec to reference app-type catalog item (type mismatch)")
+		err := harness.UpdateDevice(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Os = &v1beta1.DeviceOsSpec{
 				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
 					Catalog: catalogName,
@@ -293,27 +293,15 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 				},
 			}
 		})
-		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying device reports render error (SpecValid=False with meaningful message)")
-		var lastCondMessage string
-		harness.WaitForDeviceContents(deviceId, "SpecValid=False with type mismatch error message",
-			func(device *v1beta1.Device) bool {
-				if device.Status == nil {
-					return false
-				}
-				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
-				if cond == nil {
-					return false
-				}
-				if cond.Status != v1beta1.ConditionStatusFalse {
-					return false
-				}
-				lastCondMessage = cond.Message
-				msg := strings.ToLower(cond.Message)
-				return strings.Contains(msg, "catalog") &&
-					(strings.Contains(msg, "type") || strings.Contains(msg, "mismatch"))
-			}, e2e.TIMEOUT)
-		GinkgoWriter.Printf("SpecValid condition message: %s\n", lastCondMessage)
+		By("Verifying API rejects the update with a type mismatch error")
+		Expect(err).To(HaveOccurred())
+		errMsg := strings.ToLower(err.Error())
+		GinkgoWriter.Printf("API rejection error: %s\n", err.Error())
+		Expect(errMsg).To(SatisfyAll(
+			ContainSubstring("400"),
+			ContainSubstring("has type"),
+			ContainSubstring("expected"),
+		))
 	})
 })

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -1,0 +1,292 @@
+package catalog_refs_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+const (
+	catalogName = "e2e-catalog-refs"
+	osItemName  = "os-item"
+	appItemName = "app-item"
+
+	osVersion1  = "v1"
+	osVersion2  = "v2"
+	appVersion1 = "v1"
+
+	channel = "stable"
+
+	containerAppName = "catalog-app"
+	containerPort    = "80"
+	hostPort         = "8090"
+	fleetLabelKey    = "fleet"
+)
+
+var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-refs", "sanity"), func() {
+	var (
+		harness *e2e.Harness
+
+		osImageURI  string
+		appImageURI string
+	)
+
+	BeforeAll(func() {
+		harness = e2e.GetWorkerHarness()
+
+		svc := auxiliary.Get(harness.Context)
+		Expect(svc).ToNot(BeNil(), "auxiliary services must be initialized")
+		osImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.DeviceImageRegistryPath)
+		appImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.SleepAppRegistryPath)
+
+		By("Creating test catalog")
+		_, err := harness.CreateCatalog(catalogName, "E2E Test Catalog")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = harness.DeleteCatalogIgnoreNotFound(catalogName) })
+
+		By("Creating OS catalog item with two versions")
+		osSpec := e2e.NewOSCatalogItemSpecMultiVersion(osImageURI, []string{osVersion1, osVersion2}, channel)
+		_, err = harness.CreateCatalogItem(catalogName, osItemName, osSpec)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, osItemName) })
+
+		By("Creating application catalog item")
+		appSpec := e2e.NewAppCatalogItemSpec(appImageURI, appVersion1, channel)
+		_, err = harness.CreateCatalogItem(catalogName, appItemName, appSpec)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, appItemName) })
+	})
+
+	It("resolves OS catalog ref and delivers to agent", func() {
+		harness = e2e.GetWorkerHarness()
+		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+		By("Updating device OS spec with catalogItemRef v1")
+		err := harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Os = &v1beta1.DeviceOsSpec{
+				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
+					Catalog: catalogName,
+					Item:    osItemName,
+					Version: osVersion1,
+				},
+			}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying render succeeds (SpecValid condition is True)")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=True after OS catalog ref v1",
+			func(device *v1beta1.Device) bool {
+				if device.Status == nil {
+					return false
+				}
+				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
+				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+			}, e2e.TIMEOUT)
+
+		By("Updating catalogItemRef version to v2")
+		err = harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Os = &v1beta1.DeviceOsSpec{
+				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
+					Catalog: catalogName,
+					Item:    osItemName,
+					Version: osVersion2,
+				},
+			}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying render succeeds for updated version (SpecValid remains True)")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=True after OS catalog ref v2",
+			func(device *v1beta1.Device) bool {
+				if device.Status == nil {
+					return false
+				}
+				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
+				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+			}, e2e.TIMEOUT)
+	})
+
+	It("deploys and removes application via catalog ref", func() {
+		harness = e2e.GetWorkerHarness()
+		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+		By("Building container application with catalog item ref")
+		containerApp := v1beta1.ContainerApplication{
+			Name:    lo.ToPtr(containerAppName),
+			AppType: v1beta1.AppTypeContainer,
+			Ports:   &[]v1beta1.ApplicationPort{v1beta1.ApplicationPort(hostPort + ":" + containerPort)},
+		}
+		err := containerApp.FromCatalogItemRefApplicationProviderSpec(v1beta1.CatalogItemRefApplicationProviderSpec{
+			CatalogItemRef: v1beta1.CatalogItemRefSpec{
+				Catalog: catalogName,
+				Item:    appItemName,
+				Version: appVersion1,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		var appSpec v1beta1.ApplicationProviderSpec
+		err = appSpec.FromContainerApplication(containerApp)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Updating device spec with the application")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{appSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying container application is running on device")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Removing application from device spec")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying container is stopped")
+		harness.WaitForNoApplications(deviceId)
+	})
+
+	It("propagates fleet catalog refs to enrolled device", func() {
+		harness = e2e.GetWorkerHarness()
+		testID := harness.GetTestIDFromContext()
+		fleetName := fmt.Sprintf("catalog-fleet-%s", testID)
+
+		By("Creating fleet with catalog refs in device template")
+		containerApp := v1beta1.ContainerApplication{
+			Name:    lo.ToPtr(containerAppName),
+			AppType: v1beta1.AppTypeContainer,
+			Ports:   &[]v1beta1.ApplicationPort{v1beta1.ApplicationPort(hostPort + ":" + containerPort)},
+		}
+		err := containerApp.FromCatalogItemRefApplicationProviderSpec(v1beta1.CatalogItemRefApplicationProviderSpec{
+			CatalogItemRef: v1beta1.CatalogItemRefSpec{
+				Catalog: catalogName,
+				Item:    appItemName,
+				Version: appVersion1,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		var appSpec v1beta1.ApplicationProviderSpec
+		err = appSpec.FromContainerApplication(containerApp)
+		Expect(err).ToNot(HaveOccurred())
+
+		deviceSpec := v1beta1.DeviceSpec{
+			Os: &v1beta1.DeviceOsSpec{
+				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
+					Catalog: catalogName,
+					Item:    osItemName,
+					Version: osVersion1,
+				},
+			},
+			Applications: &[]v1beta1.ApplicationProviderSpec{appSpec},
+		}
+		selector := v1beta1.LabelSelector{MatchLabels: &map[string]string{fleetLabelKey: fleetName}}
+		err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = harness.DeleteFleetIgnoreNotFound(fleetName) })
+
+		By("Enrolling device into fleet via label selector")
+		deviceId, _ := harness.EnrollAndWaitForOnlineStatus(map[string]string{fleetLabelKey: fleetName})
+
+		By("Verifying render succeeds via fleet pipeline (SpecValid=True)")
+		harness.WaitForDeviceContents(deviceId, "fleet catalog ref SpecValid=True",
+			func(device *v1beta1.Device) bool {
+				if device.Status == nil {
+					return false
+				}
+				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
+				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+			}, e2e.LONGTIMEOUT)
+
+		By("Verifying application is running via catalog ref")
+		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("rejects deletion of in-use catalog item", func() {
+		harness = e2e.GetWorkerHarness()
+		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+		By("Setting device OS spec with catalog ref")
+		err := harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Os = &v1beta1.DeviceOsSpec{
+				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
+					Catalog: catalogName,
+					Item:    osItemName,
+					Version: osVersion1,
+				},
+			}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for successful render (SpecValid=True)")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=True for delete protection test",
+			func(device *v1beta1.Device) bool {
+				if device.Status == nil {
+					return false
+				}
+				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
+				return cond != nil && cond.Status == v1beta1.ConditionStatusTrue
+			}, e2e.TIMEOUT)
+
+		By("Attempting to delete the referenced OS catalog item")
+		client := harness.GetV1Alpha1Client()
+		Expect(client).ToNot(BeNil())
+		resp, err := client.DeleteCatalogItemWithResponse(harness.Context, catalogName, osItemName)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying API rejects deletion (non-200 status)")
+		if resp.StatusCode() == http.StatusOK {
+			Skip("AC-7: delete protection not yet implemented")
+		}
+		Expect(resp.StatusCode()).To(SatisfyAny(
+			Equal(http.StatusConflict),
+			Equal(http.StatusBadRequest),
+			Equal(http.StatusUnprocessableEntity),
+		))
+
+		By("Verifying catalog item still exists")
+		_, err = harness.GetCatalogItem(catalogName, osItemName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("surfaces render error for type-mismatched ref", func() {
+		harness = e2e.GetWorkerHarness()
+		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
+
+		By("Setting device OS spec to reference app-type catalog item (type mismatch)")
+		err := harness.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
+			device.Spec.Os = &v1beta1.DeviceOsSpec{
+				CatalogItemRef: &v1beta1.CatalogItemRefSpec{
+					Catalog: catalogName,
+					Item:    appItemName,
+					Version: appVersion1,
+				},
+			}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying device reports render error (SpecValid=False)")
+		harness.WaitForDeviceContents(deviceId, "SpecValid=False with type mismatch",
+			func(device *v1beta1.Device) bool {
+				if device.Status == nil {
+					return false
+				}
+				cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceSpecValid)
+				if cond == nil {
+					return false
+				}
+				return cond.Status == v1beta1.ConditionStatusFalse
+			}, e2e.TIMEOUT)
+	})
+})

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -30,6 +30,21 @@ const (
 	fleetLabelKey    = "fleet"
 )
 
+func newCatalogRefAppSpec(catalogName, itemName, version string) v1beta1.ApplicationProviderSpec {
+	containerApp := v1beta1.ContainerApplication{
+		Name:    lo.ToPtr(containerAppName),
+		AppType: v1beta1.AppTypeContainer,
+		Ports:   &[]v1beta1.ApplicationPort{v1beta1.ApplicationPort(hostPort + ":" + containerPort)},
+	}
+	Expect(containerApp.FromCatalogItemRefApplicationProviderSpec(v1beta1.CatalogItemRefApplicationProviderSpec{
+		CatalogItemRef: v1beta1.CatalogItemRefSpec{Catalog: catalogName, Item: itemName, Version: version},
+	})).To(Succeed())
+
+	var appSpec v1beta1.ApplicationProviderSpec
+	Expect(appSpec.FromContainerApplication(containerApp)).To(Succeed())
+	return appSpec
+}
+
 var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-refs", "sanity"), func() {
 	var (
 		harness *e2e.Harness
@@ -51,8 +66,8 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		appImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.SleepAppRegistryPath)
 
 		osVersions = []e2e.CatalogVersionRef{
-			{Version: osVersion1, ImageRef: fmt.Sprintf("%s:%s", osImageURI, testutil.DeviceTags.V1)},
-			{Version: osVersion2, ImageRef: fmt.Sprintf("%s:%s", osImageURI, testutil.DeviceTags.V2)},
+			{Version: osVersion1, ImageRef: testutil.DeviceTags.V1},
+			{Version: osVersion2, ImageRef: testutil.DeviceTags.V2},
 		}
 
 		By("Creating test catalog")
@@ -67,7 +82,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, osItemName) })
 
 		By("Creating application catalog item")
-		appVR := e2e.CatalogVersionRef{Version: appVersion1, ImageRef: fmt.Sprintf("%s:%s", appImageURI, testutil.SleepAppTags.V1)}
+		appVR := e2e.CatalogVersionRef{Version: appVersion1, ImageRef: testutil.SleepAppTags.V1}
 		appSpec := e2e.NewAppCatalogItemSpec(appImageURI, appVR, channel)
 		_, err = harness.CreateCatalogItem(catalogName, appItemName, appSpec)
 		Expect(err).ToNot(HaveOccurred())
@@ -150,26 +165,10 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
 		By("Building container application with catalog item ref")
-		containerApp := v1beta1.ContainerApplication{
-			Name:    lo.ToPtr(containerAppName),
-			AppType: v1beta1.AppTypeContainer,
-			Ports:   &[]v1beta1.ApplicationPort{v1beta1.ApplicationPort(hostPort + ":" + containerPort)},
-		}
-		err := containerApp.FromCatalogItemRefApplicationProviderSpec(v1beta1.CatalogItemRefApplicationProviderSpec{
-			CatalogItemRef: v1beta1.CatalogItemRefSpec{
-				Catalog: catalogName,
-				Item:    appItemName,
-				Version: appVersion1,
-			},
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		var appSpec v1beta1.ApplicationProviderSpec
-		err = appSpec.FromContainerApplication(containerApp)
-		Expect(err).ToNot(HaveOccurred())
+		appSpec := newCatalogRefAppSpec(catalogName, appItemName, appVersion1)
 
 		By("Updating device spec with the application")
-		err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+		err := harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{appSpec}
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -194,23 +193,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		fleetName := fmt.Sprintf("catalog-fleet-%s", testID)
 
 		By("Creating fleet with catalog refs in device template")
-		containerApp := v1beta1.ContainerApplication{
-			Name:    lo.ToPtr(containerAppName),
-			AppType: v1beta1.AppTypeContainer,
-			Ports:   &[]v1beta1.ApplicationPort{v1beta1.ApplicationPort(hostPort + ":" + containerPort)},
-		}
-		err := containerApp.FromCatalogItemRefApplicationProviderSpec(v1beta1.CatalogItemRefApplicationProviderSpec{
-			CatalogItemRef: v1beta1.CatalogItemRefSpec{
-				Catalog: catalogName,
-				Item:    appItemName,
-				Version: appVersion1,
-			},
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		var appSpec v1beta1.ApplicationProviderSpec
-		err = appSpec.FromContainerApplication(containerApp)
-		Expect(err).ToNot(HaveOccurred())
+		appSpec := newCatalogRefAppSpec(catalogName, appItemName, appVersion1)
 
 		deviceSpec := v1beta1.DeviceSpec{
 			Os: &v1beta1.DeviceOsSpec{
@@ -223,7 +206,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 			Applications: &[]v1beta1.ApplicationProviderSpec{appSpec},
 		}
 		selector := v1beta1.LabelSelector{MatchLabels: &map[string]string{fleetLabelKey: fleetName}}
-		err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+		err := harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() { _ = harness.DeleteFleetIgnoreNotFound(fleetName) })
 
@@ -277,8 +260,8 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		resp, err := client.DeleteCatalogItemWithResponse(harness.Context, catalogName, osItemName)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying API rejects deletion (non-200 status)")
-		if resp.StatusCode() == http.StatusOK {
+		By("Verifying API rejects deletion (non-2xx status)")
+		if resp.StatusCode() >= 200 && resp.StatusCode() < 300 {
 			// Restore item for subsequent ordered tests before skipping
 			osSpec := e2e.NewOSCatalogItemSpecMultiVersion(osImageURI, osVersions, channel)
 			_, restoreErr := harness.CreateCatalogItem(catalogName, osItemName, osSpec)
@@ -313,6 +296,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying device reports render error (SpecValid=False with meaningful message)")
+		var lastCondMessage string
 		harness.WaitForDeviceContents(deviceId, "SpecValid=False with type mismatch error message",
 			func(device *v1beta1.Device) bool {
 				if device.Status == nil {
@@ -325,8 +309,11 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 				if cond.Status != v1beta1.ConditionStatusFalse {
 					return false
 				}
+				lastCondMessage = cond.Message
 				msg := strings.ToLower(cond.Message)
-				return strings.Contains(msg, "catalog") || strings.Contains(msg, "type") || strings.Contains(msg, "mismatch") || strings.Contains(msg, "not found")
+				return strings.Contains(msg, "catalog") &&
+					(strings.Contains(msg, "type") || strings.Contains(msg, "mismatch"))
 			}, e2e.TIMEOUT)
+		GinkgoWriter.Printf("SpecValid condition message: %s\n", lastCondMessage)
 	})
 })

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		svc := auxiliary.Get(harness.Context)
 		Expect(svc).ToNot(BeNil(), "auxiliary services must be initialized")
 		osImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.DeviceImageRegistryPath)
-		appImageURI = fmt.Sprintf("%s:%s/%s", svc.Registry.Host, svc.Registry.Port, testutil.SleepAppRegistryPath)
+		appImageURI = fmt.Sprintf("%s:%s/flightctl-tests/nginx", svc.Registry.Host, svc.Registry.Port)
 
 		osVersions = []e2e.CatalogVersionRef{
 			{Version: osVersion1, ImageRef: testutil.DeviceTags.V2},
@@ -82,7 +82,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, osItemName) })
 
 		By("Creating application catalog item")
-		appVR := e2e.CatalogVersionRef{Version: appVersion1, ImageRef: testutil.SleepAppTags.V1}
+		appVR := e2e.CatalogVersionRef{Version: appVersion1, ImageRef: "v1"}
 		appSpec := e2e.NewAppCatalogItemSpec(appImageURI, appVR, channel)
 		_, err = harness.CreateCatalogItem(catalogName, appItemName, appSpec)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/catalog_refs/catalog_refs_test.go
+++ b/test/e2e/catalog_refs/catalog_refs_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		DeferCleanup(func() { _ = harness.DeleteCatalogItemIgnoreNotFound(catalogName, appItemName) })
 	})
 
-	It("resolves OS catalog ref and delivers to agent", func() {
+	It("resolves OS catalog ref and delivers to agent", Label("OCP-90123"), func() {
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
@@ -145,7 +145,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 			}, e2e.TIMEOUT)
 	})
 
-	It("deploys and removes application via catalog ref", func() {
+	It("deploys and removes application via catalog ref", Label("OCP-90124"), func() {
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
@@ -188,7 +188,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		harness.WaitForNoApplications(deviceId)
 	})
 
-	It("propagates fleet catalog refs to enrolled device", func() {
+	It("propagates fleet catalog refs to enrolled device", Label("OCP-90125"), func() {
 		harness = e2e.GetWorkerHarness()
 		testID := harness.GetTestIDFromContext()
 		fleetName := fmt.Sprintf("catalog-fleet-%s", testID)
@@ -245,7 +245,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("rejects deletion of in-use catalog item", func() {
+	It("rejects deletion of in-use catalog item", Label("OCP-90126"), func() {
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 
@@ -296,7 +296,7 @@ var _ = Describe("Catalog item references", Ordered, Label("EDM-4813", "catalog-
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("surfaces render error for type-mismatched ref", func() {
+	It("surfaces render error for type-mismatched ref", Label("OCP-90127"), func() {
 		harness = e2e.GetWorkerHarness()
 		deviceId, _ := harness.EnrollAndWaitForOnlineStatus()
 

--- a/test/harness/e2e/harness_catalog.go
+++ b/test/harness/e2e/harness_catalog.go
@@ -1,0 +1,190 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+
+	v1alpha1 "github.com/flightctl/flightctl/api/core/v1alpha1"
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/samber/lo"
+)
+
+// CreateCatalog creates a new catalog with the given name and display name.
+func (h *Harness) CreateCatalog(name, displayName string) (*v1alpha1.Catalog, error) {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return nil, fmt.Errorf("v1alpha1 client not available")
+	}
+
+	catalog := v1alpha1.Catalog{
+		Metadata: v1beta1.ObjectMeta{
+			Name: lo.ToPtr(name),
+		},
+		Spec: v1alpha1.CatalogSpec{
+			DisplayName: lo.ToPtr(displayName),
+		},
+	}
+
+	resp, err := client.CreateCatalogWithResponse(h.Context, catalog)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog %s: %w", name, err)
+	}
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("failed to create catalog %s: unexpected status %d, body: %s",
+			name, resp.StatusCode(), string(resp.Body))
+	}
+	return resp.JSON201, nil
+}
+
+// CreateCatalogItem creates a new catalog item within the specified catalog.
+func (h *Harness) CreateCatalogItem(catalogName, itemName string, spec v1alpha1.CatalogItemSpec) (*v1alpha1.CatalogItem, error) {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return nil, fmt.Errorf("v1alpha1 client not available")
+	}
+
+	item := v1alpha1.CatalogItem{
+		Metadata: v1alpha1.CatalogItemMeta{
+			Name: lo.ToPtr(itemName),
+		},
+		Spec: spec,
+	}
+
+	resp, err := client.CreateCatalogItemWithResponse(h.Context, catalogName, item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog item %s/%s: %w", catalogName, itemName, err)
+	}
+	if resp.JSON201 == nil {
+		return nil, fmt.Errorf("failed to create catalog item %s/%s: unexpected status %d, body: %s",
+			catalogName, itemName, resp.StatusCode(), string(resp.Body))
+	}
+	return resp.JSON201, nil
+}
+
+// GetCatalogItem retrieves a catalog item by catalog and item name.
+func (h *Harness) GetCatalogItem(catalogName, itemName string) (*v1alpha1.CatalogItem, error) {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return nil, fmt.Errorf("v1alpha1 client not available")
+	}
+
+	resp, err := client.GetCatalogItemWithResponse(h.Context, catalogName, itemName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get catalog item %s/%s: %w", catalogName, itemName, err)
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("failed to get catalog item %s/%s: unexpected status %d, body: %s",
+			catalogName, itemName, resp.StatusCode(), string(resp.Body))
+	}
+	return resp.JSON200, nil
+}
+
+// DeleteCatalog deletes a catalog by name.
+func (h *Harness) DeleteCatalog(name string) error {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return fmt.Errorf("v1alpha1 client not available")
+	}
+
+	resp, err := client.DeleteCatalogWithResponse(h.Context, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete catalog %s: %w", name, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("failed to delete catalog %s: unexpected status %d, body: %s",
+			name, resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}
+
+// DeleteCatalogIgnoreNotFound deletes a catalog, returning nil if not found.
+func (h *Harness) DeleteCatalogIgnoreNotFound(name string) error {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return fmt.Errorf("v1alpha1 client not available")
+	}
+
+	resp, err := client.DeleteCatalogWithResponse(h.Context, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete catalog %s: %w", name, err)
+	}
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNotFound {
+		return fmt.Errorf("failed to delete catalog %s: unexpected status %d, body: %s",
+			name, resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}
+
+// DeleteCatalogItem deletes a catalog item by catalog and item name.
+func (h *Harness) DeleteCatalogItem(catalogName, itemName string) error {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return fmt.Errorf("v1alpha1 client not available")
+	}
+
+	resp, err := client.DeleteCatalogItemWithResponse(h.Context, catalogName, itemName)
+	if err != nil {
+		return fmt.Errorf("failed to delete catalog item %s/%s: %w", catalogName, itemName, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("failed to delete catalog item %s/%s: unexpected status %d, body: %s",
+			catalogName, itemName, resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}
+
+// DeleteCatalogItemIgnoreNotFound deletes a catalog item, returning nil if not found.
+func (h *Harness) DeleteCatalogItemIgnoreNotFound(catalogName, itemName string) error {
+	client := h.GetV1Alpha1Client()
+	if client == nil {
+		return fmt.Errorf("v1alpha1 client not available")
+	}
+
+	resp, err := client.DeleteCatalogItemWithResponse(h.Context, catalogName, itemName)
+	if err != nil {
+		return fmt.Errorf("failed to delete catalog item %s/%s: %w", catalogName, itemName, err)
+	}
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNotFound {
+		return fmt.Errorf("failed to delete catalog item %s/%s: unexpected status %d, body: %s",
+			catalogName, itemName, resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}
+
+// NewOSCatalogItemSpec builds a CatalogItemSpec for an OS-type catalog item with a single version.
+func NewOSCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogItemSpec {
+	return v1alpha1.CatalogItemSpec{
+		DisplayName: lo.ToPtr("Test OS Item"),
+		Category:    lo.ToPtr(v1alpha1.CatalogItemCategorySystem),
+		Type:        v1alpha1.CatalogItemTypeOS,
+		Artifacts: []v1alpha1.CatalogItemArtifact{
+			{Type: v1alpha1.CatalogItemArtifactTypeQcow2DiskContainer, Uri: imageURI},
+		},
+		Versions: []v1alpha1.CatalogItemVersion{
+			{
+				Version:    version,
+				References: map[string]string{"qcow2-disk-container": version},
+				Channels:   []string{channel},
+			},
+		},
+	}
+}
+
+// NewAppCatalogItemSpec builds a CatalogItemSpec for an application-type catalog item with a single version.
+func NewAppCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogItemSpec {
+	return v1alpha1.CatalogItemSpec{
+		DisplayName: lo.ToPtr("Test App Item"),
+		Category:    lo.ToPtr(v1alpha1.CatalogItemCategoryApplication),
+		Type:        v1alpha1.CatalogItemTypeContainer,
+		Artifacts: []v1alpha1.CatalogItemArtifact{
+			{Type: v1alpha1.CatalogItemArtifactTypeContainer, Uri: imageURI},
+		},
+		Versions: []v1alpha1.CatalogItemVersion{
+			{
+				Version:    version,
+				References: map[string]string{"container": version},
+				Channels:   []string{channel},
+			},
+		},
+	}
+}

--- a/test/harness/e2e/harness_catalog.go
+++ b/test/harness/e2e/harness_catalog.go
@@ -151,9 +151,16 @@ func (h *Harness) DeleteCatalogItemIgnoreNotFound(catalogName, itemName string) 
 	return nil
 }
 
+// CatalogVersionRef pairs a semver version identifier with the full image reference
+// that the catalog resolver returns for that version.
+type CatalogVersionRef struct {
+	Version  string // semver version (e.g. "1.0.0")
+	ImageRef string // resolved image reference (e.g. "registry:5000/org/image:v1")
+}
+
 // NewOSCatalogItemSpec builds a CatalogItemSpec for an OS-type catalog item with a single version.
 // The artifact type must be "container" because resolveCatalogItemRef always looks up that type.
-func NewOSCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogItemSpec {
+func NewOSCatalogItemSpec(imageURI string, vr CatalogVersionRef, channel string) v1alpha1.CatalogItemSpec {
 	return v1alpha1.CatalogItemSpec{
 		DisplayName: lo.ToPtr("Test OS Item"),
 		Category:    lo.ToPtr(v1alpha1.CatalogItemCategorySystem),
@@ -163,8 +170,8 @@ func NewOSCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogIte
 		},
 		Versions: []v1alpha1.CatalogItemVersion{
 			{
-				Version:    version,
-				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: version},
+				Version:    vr.Version,
+				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: vr.ImageRef},
 				Channels:   []string{channel},
 			},
 		},
@@ -172,7 +179,7 @@ func NewOSCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogIte
 }
 
 // NewAppCatalogItemSpec builds a CatalogItemSpec for an application-type catalog item with a single version.
-func NewAppCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogItemSpec {
+func NewAppCatalogItemSpec(imageURI string, vr CatalogVersionRef, channel string) v1alpha1.CatalogItemSpec {
 	return v1alpha1.CatalogItemSpec{
 		DisplayName: lo.ToPtr("Test App Item"),
 		Category:    lo.ToPtr(v1alpha1.CatalogItemCategoryApplication),
@@ -182,8 +189,8 @@ func NewAppCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogIt
 		},
 		Versions: []v1alpha1.CatalogItemVersion{
 			{
-				Version:    version,
-				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: version},
+				Version:    vr.Version,
+				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: vr.ImageRef},
 				Channels:   []string{channel},
 			},
 		},
@@ -191,12 +198,12 @@ func NewAppCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogIt
 }
 
 // NewOSCatalogItemSpecMultiVersion builds a CatalogItemSpec for an OS-type item with multiple versions.
-func NewOSCatalogItemSpecMultiVersion(imageURI string, versions []string, channel string) v1alpha1.CatalogItemSpec {
+func NewOSCatalogItemSpecMultiVersion(imageURI string, versions []CatalogVersionRef, channel string) v1alpha1.CatalogItemSpec {
 	catalogVersions := make([]v1alpha1.CatalogItemVersion, 0, len(versions))
-	for _, v := range versions {
+	for _, vr := range versions {
 		catalogVersions = append(catalogVersions, v1alpha1.CatalogItemVersion{
-			Version:    v,
-			References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: v},
+			Version:    vr.Version,
+			References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: vr.ImageRef},
 			Channels:   []string{channel},
 		})
 	}

--- a/test/harness/e2e/harness_catalog.go
+++ b/test/harness/e2e/harness_catalog.go
@@ -152,18 +152,19 @@ func (h *Harness) DeleteCatalogItemIgnoreNotFound(catalogName, itemName string) 
 }
 
 // NewOSCatalogItemSpec builds a CatalogItemSpec for an OS-type catalog item with a single version.
+// The artifact type must be "container" because resolveCatalogItemRef always looks up that type.
 func NewOSCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogItemSpec {
 	return v1alpha1.CatalogItemSpec{
 		DisplayName: lo.ToPtr("Test OS Item"),
 		Category:    lo.ToPtr(v1alpha1.CatalogItemCategorySystem),
 		Type:        v1alpha1.CatalogItemTypeOS,
 		Artifacts: []v1alpha1.CatalogItemArtifact{
-			{Type: v1alpha1.CatalogItemArtifactTypeQcow2DiskContainer, Uri: imageURI},
+			{Type: v1alpha1.CatalogItemArtifactTypeContainer, Uri: imageURI},
 		},
 		Versions: []v1alpha1.CatalogItemVersion{
 			{
 				Version:    version,
-				References: map[string]string{"qcow2-disk-container": version},
+				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: version},
 				Channels:   []string{channel},
 			},
 		},
@@ -182,9 +183,30 @@ func NewAppCatalogItemSpec(imageURI, version, channel string) v1alpha1.CatalogIt
 		Versions: []v1alpha1.CatalogItemVersion{
 			{
 				Version:    version,
-				References: map[string]string{"container": version},
+				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: version},
 				Channels:   []string{channel},
 			},
 		},
+	}
+}
+
+// NewOSCatalogItemSpecMultiVersion builds a CatalogItemSpec for an OS-type item with multiple versions.
+func NewOSCatalogItemSpecMultiVersion(imageURI string, versions []string, channel string) v1alpha1.CatalogItemSpec {
+	catalogVersions := make([]v1alpha1.CatalogItemVersion, 0, len(versions))
+	for _, v := range versions {
+		catalogVersions = append(catalogVersions, v1alpha1.CatalogItemVersion{
+			Version:    v,
+			References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: v},
+			Channels:   []string{channel},
+		})
+	}
+	return v1alpha1.CatalogItemSpec{
+		DisplayName: lo.ToPtr("Test OS Item"),
+		Category:    lo.ToPtr(v1alpha1.CatalogItemCategorySystem),
+		Type:        v1alpha1.CatalogItemTypeOS,
+		Artifacts: []v1alpha1.CatalogItemArtifact{
+			{Type: v1alpha1.CatalogItemArtifactTypeContainer, Uri: imageURI},
+		},
+		Versions: catalogVersions,
 	}
 }

--- a/test/harness/e2e/harness_catalog.go
+++ b/test/harness/e2e/harness_catalog.go
@@ -155,31 +155,17 @@ func (h *Harness) DeleteCatalogItemIgnoreNotFound(catalogName, itemName string) 
 	return nil
 }
 
-// CatalogVersionRef pairs a semver version identifier with the full image reference
-// that the catalog resolver returns for that version.
+// CatalogVersionRef pairs a semver version identifier with the tag or digest
+// that the catalog resolver appends to the artifact URI for that version.
 type CatalogVersionRef struct {
 	Version  string // semver version (e.g. "1.0.0")
-	ImageRef string // resolved image reference (e.g. "registry:5000/org/image:v1")
+	ImageRef string // tag or digest suffix (e.g. "v1", "sha256:abc..."); NOT a full URI
 }
 
 // NewOSCatalogItemSpec builds a CatalogItemSpec for an OS-type catalog item with a single version.
 // The artifact type must be "container" because resolveCatalogItemRef always looks up that type.
 func NewOSCatalogItemSpec(imageURI string, vr CatalogVersionRef, channel string) v1alpha1.CatalogItemSpec {
-	return v1alpha1.CatalogItemSpec{
-		DisplayName: lo.ToPtr("Test OS Item"),
-		Category:    lo.ToPtr(v1alpha1.CatalogItemCategorySystem),
-		Type:        v1alpha1.CatalogItemTypeOS,
-		Artifacts: []v1alpha1.CatalogItemArtifact{
-			{Type: v1alpha1.CatalogItemArtifactTypeContainer, Uri: imageURI},
-		},
-		Versions: []v1alpha1.CatalogItemVersion{
-			{
-				Version:    vr.Version,
-				References: map[v1alpha1.CatalogItemArtifactType]string{v1alpha1.CatalogItemArtifactTypeContainer: vr.ImageRef},
-				Channels:   []string{channel},
-			},
-		},
-	}
+	return NewOSCatalogItemSpecMultiVersion(imageURI, []CatalogVersionRef{vr}, channel)
 }
 
 // NewAppCatalogItemSpec builds a CatalogItemSpec for an application-type catalog item with a single version.

--- a/test/harness/e2e/harness_catalog.go
+++ b/test/harness/e2e/harness_catalog.go
@@ -17,6 +17,8 @@ func (h *Harness) CreateCatalog(name, displayName string) (*v1alpha1.Catalog, er
 	}
 
 	catalog := v1alpha1.Catalog{
+		ApiVersion: v1alpha1.CatalogAPIVersion,
+		Kind:       v1alpha1.CatalogKind,
 		Metadata: v1beta1.ObjectMeta{
 			Name: lo.ToPtr(name),
 		},
@@ -44,6 +46,8 @@ func (h *Harness) CreateCatalogItem(catalogName, itemName string, spec v1alpha1.
 	}
 
 	item := v1alpha1.CatalogItem{
+		ApiVersion: v1alpha1.CatalogAPIVersion,
+		Kind:       v1alpha1.CatalogItemKind,
 		Metadata: v1alpha1.CatalogItemMeta{
 			Name: lo.ToPtr(itemName),
 		},


### PR DESCRIPTION
## EDM-4066: Add catalog item references e2e tests

**Jira:** [EDM-4066](https://issues.redhat.com/browse/EDM-4066) / [EDM-4813](https://issues.redhat.com/browse/EDM-4813)
**Story type:** [QE]

> **Depends on:** #3284 (catalog item references implementation). This PR will not compile until #3284 merges.

### Summary

Adds end-to-end tests for the catalog item references feature. These tests validate the full pipeline: API acceptance → server-side render (catalog ref → resolved image URI) → agent delivery → observable device/application behavior. Integration tests in PR #3284 already verify render logic in isolation; these e2e tests confirm the system works end-to-end with a real agent on a real VM.

### E2E Test Scenarios

- **OS catalog ref resolution** [AC-1, AC-5] — Sets device OS spec with `catalogItemRef`, verifies render succeeds (SpecValid=True), changes version, re-verifies
- **Application deployment via catalog ref** [AC-2, AC-4, AC-6] — Deploys container app using catalog ref, verifies it runs, removes it, verifies it stops
- **Fleet template propagation** [AC-3] — Creates fleet with catalog refs in template, enrolls device, verifies render + app running
- **Delete protection** [AC-7] — Attempts deletion of in-use catalog item, verifies rejection (skips if not yet implemented)
- **Type mismatch error** [AC-8] — References app-type item in OS spec, verifies SpecValid=False condition

### Test Infrastructure

- **Suite location:** `test/e2e/catalog_refs/`
- **Reference suite:** `test/e2e/applications/containers/`
- **Auxiliary services:** OCI registry (for catalog artifact image URIs)
- **New harness helpers:** `CreateCatalog`, `CreateCatalogItem`, `GetCatalogItem`, `DeleteCatalog*`, `NewOSCatalogItemSpec`, `NewAppCatalogItemSpec`, `NewOSCatalogItemSpecMultiVersion` (in `test/harness/e2e/harness_catalog.go`)

### Acceptance Criteria

- [ ] AC-1: Device OS catalog ref resolves via render pipeline
- [ ] AC-2: Device app catalog ref resolves via render pipeline
- [ ] AC-3: Fleet template with catalog refs propagates to enrolled devices
- [ ] AC-4: Applications deployed via catalog ref run on device
- [ ] AC-5: Version update in catalog ref triggers re-render and re-delivery
- [ ] AC-6: Removing catalog ref stops the associated application
- [ ] AC-7: Deletion of in-use catalog item is rejected
- [ ] AC-8: Type-mismatched catalog reference surfaces render error
