### PR TITLE
NO-ISSUE: overwrite protoc on custom runner images

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -63,7 +63,7 @@ runs:
           podman info >/dev/null 2>&1 || true
 
           curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
-          sudo unzip -q protoc.zip bin/protoc -d /usr/local
+          sudo unzip -q -o protoc.zip bin/protoc -d /usr/local
           sudo chmod a+x /usr/local/bin/protoc
           protoc --version
           rm -rf protoc.zip


### PR DESCRIPTION
## Summary
- Custom GitHub runner images pre-install `/usr/local/bin/protoc`, so `setup-dependencies` fails when `unzip` prompts to replace the existing binary and gets EOF under non-interactive CI.
- Pass `-o` to `unzip` so protoc is overwritten unconditionally and the step remains idempotent on both stock and custom images.

## Test plan
- [ ] Re-run a workflow that uses `setup-dependencies` on the custom runner image and confirm the Install dependencies step no longer fails on the protoc unzip prompt
- [ ] Confirm `protoc --version` still prints successfully after the step


Made with [Cursor](https://cursor.com)