### PR TITLE
EDM-4758: OS mismatch OutOfDate override for package-mode devices

### DIFF
--- a/internal/service/common/device.go
+++ b/internal/service/common/device.go
@@ -252,9 +252,11 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 	}
 
 	// Override UpToDate if the actual booted OS image doesn't match the desired spec.
+	// Requires capabilities.osMode to be reported; legacy devices without capabilities skip this check.
 	if device.Status.Updated.Status == domain.DeviceUpdatedStatusUpToDate &&
 		device.Spec != nil && device.Spec.Os != nil && device.Spec.Os.Image != "" &&
-		device.Status.Os.Image != "" && device.Status.Os.Image != device.Spec.Os.Image {
+		device.Status.Capabilities != nil && device.Status.Capabilities.OsMode != nil &&
+		device.Status.Os.Image != device.Spec.Os.Image {
 		device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
 		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device OS image mismatch: running %q, expected %q.", device.Status.Os.Image, device.Spec.Os.Image))
 	}

--- a/internal/service/common/device_test.go
+++ b/internal/service/common/device_test.go
@@ -412,32 +412,66 @@ func TestUpdateServerSideDeviceUpdatedStatus_OsImageMismatch(t *testing.T) {
 		name           string
 		specOsImage    string
 		statusOsImage  string
+		capabilities   *domain.DeviceCapabilities
 		expectedStatus domain.DeviceUpdatedStatusType
 		expectMismatch bool
 	}{
 		{
-			name:           "matching OS images remains UpToDate",
+			name:           "When image-mode device has matching OS images it should remain UpToDate",
 			specOsImage:    "quay.io/flightctl/device:v7",
 			statusOsImage:  "quay.io/flightctl/device:v7",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
 			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
 		},
 		{
-			name:           "mismatching OS images overrides to OutOfDate",
+			name:           "When image-mode device has mismatching OS images it should override to OutOfDate",
 			specOsImage:    "quay.io/flightctl/device:v7",
 			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
 			expectedStatus: domain.DeviceUpdatedStatusOutOfDate,
 			expectMismatch: true,
 		},
 		{
-			name:           "no spec OS image remains UpToDate",
+			name:           "When package-mode device has spec OS image it should override to OutOfDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			expectedStatus: domain.DeviceUpdatedStatusOutOfDate,
+			expectMismatch: true,
+		},
+		{
+			name:           "When package-mode device has no spec OS image it should remain UpToDate",
 			specOsImage:    "",
-			statusOsImage:  "quay.io/flightctl/device:base",
+			statusOsImage:  "",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
 		},
 		{
-			name:           "no status OS image remains UpToDate",
+			name:           "When legacy device without capabilities has empty status OS image it should remain UpToDate",
 			specOsImage:    "quay.io/flightctl/device:v7",
 			statusOsImage:  "",
+			capabilities:   nil,
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When legacy device without capabilities has mismatching OS images it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   nil,
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When device has capabilities with nil osMode it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   &domain.DeviceCapabilities{OsMode: nil},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When no spec OS image is set it should remain UpToDate regardless of capabilities",
+			specOsImage:    "",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
 			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
 		},
 	}
@@ -469,6 +503,7 @@ func TestUpdateServerSideDeviceUpdatedStatus_OsImageMismatch(t *testing.T) {
 			if tt.specOsImage != "" {
 				device.Spec.Os = &domain.DeviceOsSpec{Image: tt.specOsImage}
 			}
+			device.Status.Capabilities = tt.capabilities
 
 			updateServerSideDeviceUpdatedStatus(device, ctx, nil, log, orgId)
 


### PR DESCRIPTION
## EDM-4758: OS mismatch OutOfDate override for package-mode devices

**Jira:** https://redhat.atlassian.net/browse/EDM-4758
**Story type:** [DEV]

### Summary
Replace the `status.os.image != ""` guard in the server-side OS mismatch override with a `status.capabilities.osMode` presence check. Package-mode devices permanently report empty `status.os.image`, so the previous guard never fired; with capabilities present they are correctly marked `OutOfDate` when `spec.os.image` is set. Legacy devices without capabilities retain the skip behavior.

### Changes
- **`internal/service/common/device.go`:** Gate the OS mismatch `OutOfDate` override on `Capabilities != nil && OsMode != nil` instead of non-empty `status.os.image`.
- **`internal/service/common/device_test.go`:** Extend `TestUpdateServerSideDeviceUpdatedStatus_OsImageMismatch` with capability-aware table cases (image-mode, package-mode, legacy, nil osMode, no-spec-image).

### Testing
- **Unit tests:** 8 table-driven cases covering AC-1–AC-4
- **Integration tests:** Full suite passed (`make integration-test`)
- **Coverage:** New override paths fully exercised by unit tests

### Acceptance Criteria
- [ ] AC-1: When `status.capabilities.osMode` is present and `status.os.image != spec.os.image`, device marked `OutOfDate` (including package-mode with empty `status.os.image`)
- [ ] AC-2: Legacy devices without capabilities skip the override
- [ ] AC-3: Package-mode device with no `spec.os.image` is not flagged OutOfDate for OS mismatch
- [ ] AC-4: Image-mode OS mismatch continues to work as today

### Note
This branch is stacked on EDM-4759; the PR against `main` also includes those agent commits until EDM-4759 merges.
