### PR TITLE
NO-ISSUE: remove tmpfs-backed local volumes on Quadlet/Compose app removal

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -724,6 +724,12 @@ func (p *Podman) InspectVolumeDriver(ctx context.Context, name string) (string, 
 	return p.inspectVolumeProperty(ctx, name, "{{.Driver}}")
 }
 
+// InspectVolumeOptionType returns the volume's "type" mount option (e.g. "tmpfs"
+// for a tmpfs-backed local volume), or an empty string if not set.
+func (p *Podman) InspectVolumeOptionType(ctx context.Context, name string) (string, error) {
+	return p.inspectVolumeProperty(ctx, name, "{{.Options.type}}")
+}
+
 func (p *Podman) InspectVolumeMount(ctx context.Context, name string) (string, error) {
 	return p.inspectVolumeProperty(ctx, name, "{{.Mountpoint}}")
 }

--- a/internal/agent/device/applications/lifecycle/compose.go
+++ b/internal/agent/device/applications/lifecycle/compose.go
@@ -112,7 +112,7 @@ func (c *Compose) update(ctx context.Context, action *Action) error {
 }
 
 // stopAndRemoveContainers stops and removes all containers, pods, networks,
-// and image-backed volumes created by the compose application.
+// and ephemeral (image-backed or tmpfs-backed) volumes created by the compose application.
 func (c *Compose) stopAndRemoveContainers(ctx context.Context, action *Action, podman *client.Podman) error {
 	return cleanPodmanResources(
 		ctx,
@@ -149,7 +149,7 @@ func cleanPodmanResources(ctx context.Context, log *log.PrefixLogger, podman *cl
 	if err := podman.RemoveNetworks(ctx, networks...); err != nil {
 		errs = append(errs, err)
 	}
-	if err := removeImageBackedVolumes(ctx, log, podman, labels, filters); err != nil {
+	if err := removeEphemeralVolumes(ctx, log, podman, labels, filters); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/agent/device/applications/lifecycle/compose_test.go
+++ b/internal/agent/device/applications/lifecycle/compose_test.go
@@ -80,6 +80,8 @@ func TestComposeRemoveImageBackedVolumes(t *testing.T) {
 					Return("image", "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-img-vol-data", "--format", "{{.Driver}}")).
 					Return("local", "", 0)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-img-vol-data", "--format", "{{.Options.type}}")).
+					Return("", "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "rm", "app-img-vol-html")).
 					Return("", "", 0)
 			},
@@ -118,6 +120,8 @@ func TestComposeRemoveImageBackedVolumes(t *testing.T) {
 					Return(`[{"Name":"app-local-vol-data"}]`, "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-local-vol-data", "--format", "{{.Driver}}")).
 					Return("local", "", 0)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-local-vol-data", "--format", "{{.Options.type}}")).
+					Return("", "", 0)
 			},
 		},
 		{

--- a/internal/agent/device/applications/lifecycle/quadlet.go
+++ b/internal/agent/device/applications/lifecycle/quadlet.go
@@ -24,6 +24,8 @@ const (
 	QuadletTargetName        = "flightctl-quadlet-app.target"
 
 	podmanImageVolumeDriver = "image"
+	podmanLocalVolumeDriver = "local"
+	podmanTmpfsVolumeType   = "tmpfs"
 )
 
 var _ ActionHandler = (*Quadlet)(nil)
@@ -222,16 +224,20 @@ func (q *Quadlet) cleanResources(ctx context.Context, action Action) error {
 	return nil
 }
 
-// removeImageBackedVolumes removes volumes that use Podman's native image driver.
-// Image-driver volumes are read-only overlays fully derived from their
-// source image — they contain no user data and Podman recreates them automatically on next container start.
-func removeImageBackedVolumes(ctx context.Context, log *log.PrefixLogger, podman *client.Podman, labels, filters []string) error {
+// removeEphemeralVolumes removes volumes that require no explicit cleanup:
+//   - image-driver volumes: read-only overlays fully derived from their source
+//     image, containing no user data. Podman recreates them automatically on
+//     next container start.
+//   - tmpfs-backed local volumes: Podman's stand-in for a Kubernetes emptyDir.
+//     Like emptyDir, their content must not survive pod deletion/recreation;
+//     Podman recreates them empty on next container start.
+func removeEphemeralVolumes(ctx context.Context, log *log.PrefixLogger, podman *client.Podman, labels, filters []string) error {
 	volumes, err := podman.ListVolumes(ctx, labels, filters)
 	if err != nil {
 		return fmt.Errorf("listing volumes: %w", err)
 	}
 
-	var imageVolumes []string
+	var ephemeralVolumes []string
 	for _, volume := range volumes {
 		driver, err := podman.InspectVolumeDriver(ctx, volume)
 		if err != nil {
@@ -239,13 +245,26 @@ func removeImageBackedVolumes(ctx context.Context, log *log.PrefixLogger, podman
 			continue
 		}
 		if driver == podmanImageVolumeDriver {
-			imageVolumes = append(imageVolumes, volume)
+			ephemeralVolumes = append(ephemeralVolumes, volume)
+			continue
+		}
+		if driver != podmanLocalVolumeDriver {
+			continue
+		}
+
+		optionType, err := podman.InspectVolumeOptionType(ctx, volume)
+		if err != nil {
+			log.Warnf("Failed to inspect volume %q options, skipping: %v", volume, err)
+			continue
+		}
+		if optionType == podmanTmpfsVolumeType {
+			ephemeralVolumes = append(ephemeralVolumes, volume)
 		}
 	}
 
-	if len(imageVolumes) > 0 {
-		log.Debugf("Removing %d image-backed volume(s)", len(imageVolumes))
-		if err := podman.RemoveVolumes(ctx, imageVolumes...); err != nil {
+	if len(ephemeralVolumes) > 0 {
+		log.Debugf("Removing %d ephemeral volume(s)", len(ephemeralVolumes))
+		if err := podman.RemoveVolumes(ctx, ephemeralVolumes...); err != nil {
 			return fmt.Errorf("removing volumes: %w", err)
 		}
 	}

--- a/internal/agent/device/applications/lifecycle/quadlet_test.go
+++ b/internal/agent/device/applications/lifecycle/quadlet_test.go
@@ -631,6 +631,8 @@ func TestQuadlet_remove(t *testing.T) {
 					Return("image", "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-img-vol-data", "--format", "{{.Driver}}")).
 					Return("local", "", 0)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-img-vol-data", "--format", "{{.Options.type}}")).
+					Return("", "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "rm", "app-img-vol-html")).
 					Return("", "", 0)
 			},
@@ -673,6 +675,8 @@ func TestQuadlet_remove(t *testing.T) {
 					Return(`[{"Name":"app-local-vol-data"}]`, "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-local-vol-data", "--format", "{{.Driver}}")).
 					Return("local", "", 0)
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-local-vol-data", "--format", "{{.Options.type}}")).
+					Return("", "", 0)
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Problem

VM apps (and any Quadlet/Compose app) that use tmpfs-backed `local`-driver volumes to emulate Kubernetes `emptyDir` (e.g. `vm-to-quadlet`'s per-pod `private-libvirt-qemu-empty`, `ephemeral-disks-empty`, etc.) can end up with stale content surviving across a pod recreation.

Podman named volumes are not pod-scoped: recreating a Quadlet app's pod (which always happens via a full Remove+Install on any content update — see `manager.Update()`) does not implicitly destroy and recreate the volumes it mounts. Nothing in the agent removed these volumes, so a brand-new pod could still mount a volume containing state from a previous pod incarnation.

Concretely, this was observed with a KubeVirt-backed VM app: `virt-launcher`'s libvirt domain XML persisted inside a tmpfs-backed `.volume` across a genuine pod recreation (confirmed via unchanged `podman volume inspect --format '{{.CreatedAt}}'` timestamps before/after), causing disk configuration changes (e.g. adding/removing a `dataVolume`) not to take effect even after the pod was fully recreated.

## Fix

Extend the existing image-backed volume cleanup (`removeImageBackedVolumes`, now `removeEphemeralVolumes`) to also remove `local`-driver volumes whose `Options.type` is `tmpfs`. Podman recreates them empty on the next container start, matching Kubernetes `emptyDir` semantics.

This is scoped precisely to match k8s emptyDir lifecycle: it only runs from `cleanResources()`, reached only via `remove()`, which `Execute()` only invokes for `Removes`/`Updates` — the only two actions that actually call `podman.RemovePods(...)` (i.e. genuine pod deletion/replacement). `Stop()`/`Start()`/`Restart()` never go through this path, so a container crash-restart, device reboot, or bare restart-generation bump does not wipe this state — exactly mirroring emptyDir surviving container restarts but not pod deletion.

## Changes

- `internal/agent/client/podman.go`: add `InspectVolumeOptionType()` (`podman volume inspect --format '{{.Options.type}}'`).
- `internal/agent/device/applications/lifecycle/quadlet.go`: rename `removeImageBackedVolumes` → `removeEphemeralVolumes`; also match `Driver == local && Options.type == tmpfs`.
- `internal/agent/device/applications/lifecycle/compose.go`: update call site (shared by Compose and Quadlet apps).
- Updated existing `quadlet_test.go`/`compose_test.go` mocks for the new inspection call.

## Behavior change / compatibility note

This affects **any** Compose or Quadlet app (not just VM apps): any `local`-driver volume with `Options.type == tmpfs` is now removed whenever that app is Removed or Updated, then recreated empty on next start. This mirrors the pre-existing behavior for `image`-driver volumes (already unconditionally removed on every Remove/Update, regardless of app type), just extended to a second class of inherently-ephemeral volume.

No first-party example/sample app in this repo currently uses a tmpfs-typed volume — `vm-to-quadlet`'s emptyDir emulation is the only known consumer of this pattern today. A hand-written app that explicitly creates a *named* `Driver=local, Type=tmpfs` volume and relies on its content surviving a content-triggered app update (as opposed to just a container restart) would see a behavior change here. This is considered acceptable: choosing tmpfs backing for a volume already signals non-persistent, in-memory storage (it never survives a host reboot either), so relying on it surviving an app redeploy specifically would be an unusual and fragile design choice.

## Testing

- `go build ./...`
- `go vet` on touched packages
- `internal/agent/device/applications/...` and `internal/agent/client/...` unit test suites pass

Made with [Cursor](https://cursor.com)
