### PR TITLE
NO-ISSUE: overlap e2e kind+Helm with RPM/agent-image build

### DIFF
--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -198,12 +198,16 @@ jobs:
             assignments.json
           retention-days: 1
 
+  # Intentionally does NOT need build-agent-images-unified: kind+Helm only need
+  # backend/CLI/chart, so shard jobs start in parallel with RPM + agent-image build.
+  # Each shard waits for agent-* artifacts after deploy (see run-e2e-tests.yaml).
+  # Per-shard kind cannot move across jobs/runners, so deploy+test stay one job;
+  # the DAG split is what overlaps wall time with make rpm / BIB.
   e2e-tests:
     needs:
       - compute-tag
       - build-images-and-charts
       - build-flightctl-cli
-      - build-agent-images-unified
       - discover-e2e-tests
     if: |
       needs.compute-tag.outputs.any_changed == 'true' &&

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -81,6 +81,8 @@ jobs:
           echo "Computed base domain: ${IP}.nip.io"
 
       # ========== DEPLOY BACKEND WITH HELM ==========
+      # May run while build-rpms / build-agent-images-unified are still in flight
+      # (parent e2e-tests no longer needs those). Agent artifacts gated next.
       - name: Deploy backend with Helm
         uses: ./.github/actions/deploy-backend-with-helm
         with:
@@ -93,6 +95,35 @@ jobs:
           wait: false
 
       # ========== DOWNLOAD E2E TEST ARTIFACTS ==========
+      # Parent starts this job before agent images finish. Wait until both agent
+      # artifacts for this OS/tag are uploaded, then download once.
+      - name: Wait for agent image artifacts
+        env:
+          OS_ID: ${{ inputs.os_id }}
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Waiting for agent-*${OS_ID}-${TAG} artifacts on run ${RUN_ID}..."
+          for attempt in $(seq 1 90); do
+            names=$(gh api --paginate "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+              --jq "[.artifacts[] | select(.name | contains(\"${OS_ID}-${TAG}\")) | .name] | unique | .[]" \
+              || true)
+            count=$(printf '%s\n' "${names}" | sed '/^$/d' | wc -l)
+            # bundle + qcow2 uploads from build-agent-images.yaml
+            if [[ "${count}" -ge 2 ]]; then
+              echo "Agent artifacts ready (attempt ${attempt}):"
+              printf '%s\n' "${names}"
+              exit 0
+            fi
+            echo "not ready yet (attempt ${attempt}/90); sleeping 10s"
+            sleep 10
+          done
+          echo "ERROR: timed out waiting for agent artifacts matching ${OS_ID}-${TAG}"
+          exit 1
+
       - name: Download test artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
# Release target (required before merge to `main`)

- [x] **`release-1.3`**

## Summary

Independent of `#3295` — **Opt A only** (no shard widen, no image bake-ins).

`e2e-tests` no longer `needs: build-agent-images-unified`, so kind+Helm runs in parallel with RPM/agent-image build. After deploy, wait for agent artifacts then a single `download-artifact`.

Expected wall save ~5–6.5m via LPT start offset (same shard counts / same test-slice LPT).

## Test plan

- [ ] `run-e2e` label; full Parallel Build E2E completes
- [ ] Confirm shard jobs start before agent-image jobs finish
- [ ] Record wall + max-shard LPT vs main baseline