### PR TITLE
EDM-4851:  Update imagebuild e2e test to use a registry with basic auth

### DIFF
--- a/test/e2e/imagebuild/imagebuild_advanced_test.go
+++ b/test/e2e/imagebuild/imagebuild_advanced_test.go
@@ -22,9 +22,6 @@ const maxConcurrent = 3
 var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 	Context("ImageBuild parallel builds and exports", func() {
 		It("should run builds and exports in parallel and handle selective cancellation", Label("87341", "imagebuild", "slow"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
 			testID := workerHarness.GetTestIDFromContext()
 			registryAddress := auxSvcs.Registry.Host + ":" + auxSvcs.Registry.Port
 

--- a/test/e2e/imagebuild/imagebuild_invalid_config_test.go
+++ b/test/e2e/imagebuild/imagebuild_invalid_config_test.go
@@ -17,9 +17,6 @@ import (
 var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 	Context("ImageBuild wrong configurations", func() {
 		It("should fail with non-existing repository", Label("87338", "imagebuild"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
 			testID := workerHarness.GetTestIDFromContext()
 
 			By("Step 1: Attempting to create ImageBuild with non-existing source repository")
@@ -54,9 +51,6 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 		})
 
 		It("should fail with wrong image name/tag for source", Label("87706", "imagebuild"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
 			testID := workerHarness.GetTestIDFromContext()
 			registryAddress := auxSvcs.Registry.Host + ":" + auxSvcs.Registry.Port
 
@@ -122,9 +116,6 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 		})
 
 		It("should fail validation with invalid image reference format", Label("87705", "imagebuild"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
 			testID := workerHarness.GetTestIDFromContext()
 			registryAddress := auxSvcs.Registry.Host + ":" + auxSvcs.Registry.Port
 
@@ -191,9 +182,6 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 		})
 
 		It("should fail with empty required fields", Label("87708", "imagebuild"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
 			testID := workerHarness.GetTestIDFromContext()
 
 			emptyFieldCases := []struct {

--- a/test/e2e/imagebuild/imagebuild_negative_api_test.go
+++ b/test/e2e/imagebuild/imagebuild_negative_api_test.go
@@ -46,12 +46,14 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should fail ImageBuild after creation when destination push cannot authenticate", Label("88399", "imagebuild", "slow"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src := createQuaySourceRepository(workerHarness, testID, &negCleanup)
-			dst := createAuthenticatedRegistryDestRepository(workerHarness, testID, &negCleanup, "wrong-password-"+testID)
+			src, err := createUnauthenticatedSourceRepository(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
+			dst, err := createAuthenticatedRegistryDestRepository(workerHarness, testID, &negCleanup, "wrong-password-"+testID)
+			Expect(err).ToNot(HaveOccurred())
 			ib := negImageBuildName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -77,11 +79,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject ImageExport download before export reaches Completed", Label("88401", "imagebuild"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib, ie := negImageBuildName(testID), negImageExportName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -104,11 +107,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject cancel when ImageBuild is Failed", Label("88402", "imagebuild"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib := negImageBuildName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, "this-image-does-not-exist/invalid-image", "nonexistent-tag", dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -122,11 +126,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject cancel when ImageBuild is Canceled", Label("imagebuild"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib := negImageBuildName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -142,11 +147,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject cancel when ImageBuild is Completed", Label("88404", "imagebuild", "slow"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib := negImageBuildName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -165,11 +171,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject second cancel when ImageExport is already Canceled", Label("88403", "imagebuild"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib, ie := negImageBuildName(testID), negImageExportName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -190,11 +197,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 
 		It("should reject cancel when ImageExport is Failed", Label("88405", "imagebuild"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			src, dst := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			src, dst, err := createStandardImageBuildRepositories(workerHarness, testID, &negCleanup)
+			Expect(err).ToNot(HaveOccurred())
 			ib, ie := negImageBuildName(testID), negImageExportName(testID)
 
 			spec := e2e.NewImageBuildSpec(src, sourceImageName, sourceImageTag, dst, destImageName, testID, imagebuilderapi.BindingTypeLate)
-			_, err := workerHarness.CreateImageBuild(ib, spec)
+			_, err = workerHarness.CreateImageBuild(ib, spec)
 			Expect(err).ToNot(HaveOccurred())
 			negCleanup.imageBuild = ib
 
@@ -231,42 +239,70 @@ func negImageExportName(testID string) string {
 	return fmt.Sprintf("ie-%s", testID)
 }
 
-func createStandardImageBuildRepositories(h *e2e.Harness, testID string, c *negAPIResourceCleanup) (sourceRepoName, destRepoName string) {
-	sourceRepoName = createQuaySourceRepository(h, testID, c)
+// createStandardImageBuildRepositories creates an unauthenticated source (quay.io or OCP mirror)
+// and an unauthenticated destination OCI repository, registering both for cleanup.
+// Returns an error if either repository cannot be created.
+func createStandardImageBuildRepositories(h *e2e.Harness, testID string, c *negAPIResourceCleanup) (sourceRepoName, destRepoName string, err error) {
+	sourceRepoName, err = createUnauthenticatedSourceRepository(h, testID, c)
+	if err != nil {
+		return "", "", fmt.Errorf("createStandardImageBuildRepositories: source repo: %w", err)
+	}
 	destRepoName = fmt.Sprintf("repo-dst-%s", testID)
 	registryAddress := auxSvcs.Registry.Host + ":" + auxSvcs.Registry.Port
-	_, err := resources.CreateOCIRepository(h, destRepoName, registryAddress,
+	GinkgoWriter.Printf("createStandardImageBuildRepositories: creating dest repo %q at %s\n", destRepoName, registryAddress)
+	_, err = resources.CreateOCIRepository(h, destRepoName, registryAddress,
 		lo.ToPtr(api.Https), lo.ToPtr(api.ReadWrite), true, nil)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return "", "", fmt.Errorf("createStandardImageBuildRepositories: dest repo: %w", err)
+	}
 	c.destRepo = destRepoName
-	return sourceRepoName, destRepoName
+	return sourceRepoName, destRepoName, nil
 }
 
-func createQuaySourceRepository(h *e2e.Harness, testID string, c *negAPIResourceCleanup) string {
+// createUnauthenticatedSourceRepository creates a read-only OCI repository pointing at quay.io (or the OCP mirror),
+// registering it for cleanup.
+// Returns an error if the repository cannot be created.
+func createUnauthenticatedSourceRepository(h *e2e.Harness, testID string, c *negAPIResourceCleanup) (string, error) {
+	if h == nil {
+		return "", fmt.Errorf("createUnauthenticatedSourceRepository: harness is nil")
+	}
 	resolveSourceRegistry(h)
 	name := fmt.Sprintf("repo-src-%s", testID)
+	GinkgoWriter.Printf("createUnauthenticatedSourceRepository: creating source repo %q at %s\n", name, sourceRegistry)
 	_, err := resources.CreateOCIRepository(h, name, sourceRegistry,
 		lo.ToPtr(api.Https), lo.ToPtr(api.Read), isLocalSourceRegistry(), nil)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return "", fmt.Errorf("createUnauthenticatedSourceRepository %q: %w", name, err)
+	}
 	c.sourceRepo = name
-	return name
+	return name, nil
 }
 
-func createAuthenticatedRegistryDestRepository(h *e2e.Harness, testID string, c *negAPIResourceCleanup, password string) string {
+// createAuthenticatedRegistryDestRepository creates a read-write OCI repository in the basic-auth registry,
+// using the given password (may be wrong, for negative tests). Registers it for cleanup.
+// Returns an error if the repository cannot be created.
+func createAuthenticatedRegistryDestRepository(h *e2e.Harness, testID string, c *negAPIResourceCleanup, password string) (string, error) {
+	if h == nil {
+		return "", fmt.Errorf("createAuthenticatedRegistryDestRepository: harness is nil")
+	}
 	name := fmt.Sprintf("repo-dst-auth-%s", testID)
+	registryAddress := auxSvcs.Registry.Authenticated.HostPort
+	GinkgoWriter.Printf("createAuthenticatedRegistryDestRepository: creating auth dest repo %q at %s\n", name, registryAddress)
 	err := applyOCIRepositoryWithDockerAuth(
 		h,
 		name,
-		auxSvcs.Registry.Authenticated.HostPort,
+		registryAddress,
 		lo.ToPtr(api.Https),
 		lo.ToPtr(api.ReadWrite),
 		true,
 		auxSvcs.Registry.Authenticated.Username,
 		password,
 	)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return "", fmt.Errorf("createAuthenticatedRegistryDestRepository %q: %w", name, err)
+	}
 	c.destRepo = name
-	return name
+	return name, nil
 }
 
 func applyOCIRepositoryWithDockerAuth(
@@ -312,7 +348,7 @@ func applyOCIRepositoryWithDockerAuth(
 	if err != nil {
 		return fmt.Errorf("marshal repository: %w", err)
 	}
-	_, err = h.CLIWithStdin(string(yamlStr), "apply", "-f", "-")
+	_, err = h.CLIWithStdinRedacted(string(yamlStr), "apply", "-f", "-")
 	return err
 }
 

--- a/test/e2e/imagebuild/imagebuild_suite_test.go
+++ b/test/e2e/imagebuild/imagebuild_suite_test.go
@@ -33,15 +33,15 @@ var _ = BeforeEach(func() {
 	workerHarness = e2e.GetWorkerHarness()
 	suiteCtx := e2e.GetWorkerContext()
 
-	GinkgoWriter.Printf("🔄 [BeforeEach] Worker %d: Setting up test\n", workerID)
+	GinkgoWriter.Printf("[BeforeEach] Worker %d: Setting up test\n", workerID)
 
-	// Create test-specific context for proper tracing
+	Expect(workerHarness).ToNot(BeNil(), "worker harness must be initialized")
+	Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
+
 	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
-
-	// Set the test context in the harness
 	workerHarness.SetTestContext(ctx)
 
-	GinkgoWriter.Printf("✅ [BeforeEach] Worker %d: Test setup completed\n", workerID)
+	GinkgoWriter.Printf("[BeforeEach] Worker %d: Test setup completed\n", workerID)
 })
 
 var _ = AfterEach(func() {

--- a/test/e2e/imagebuild/imagebuild_workflow_test.go
+++ b/test/e2e/imagebuild/imagebuild_workflow_test.go
@@ -22,19 +22,25 @@ import (
 
 // Shared constants used across all imagebuild test files
 const (
-	// Test timeouts
-	imageBuildTimeout    = 15 * time.Minute
-	imageExportTimeout   = 15 * time.Minute
-	processingTimeout    = 2 * time.Minute
-	failureTimeout       = 3 * time.Minute
+	// Timeouts
+	imageBuildTimeout   = 15 * time.Minute
+	imageExportTimeout  = 15 * time.Minute
+	processingTimeout   = 2 * time.Minute
+	failureTimeout      = 3 * time.Minute
+	cancelTimeout       = 1 * time.Minute
+	vmBootTimeout       = 2 * time.Minute
+	sbomReferrerTimeout = 30 * time.Second
+
+	// Poll periods
 	processingPollPeriod = 5 * time.Second
-	pollPeriodLong       = 10 * time.Second
-	vmBootTimeout        = 2 * time.Minute
-	cancelTimeout        = 1 * time.Minute
 	vmBootPollPeriod     = 5 * time.Second
-	agentServiceName     = "flightctl-agent"
-	labelEnvironment     = "environment"
-	imageBuildUsername   = "flightctl-ssh-user"
+	pollPeriodLong       = 10 * time.Second
+	sbomPollPeriod       = 2 * time.Second
+
+	// Labels and names
+	labelEnvironment   = "environment"
+	imageBuildUsername = "flightctl-ssh-user"
+	agentServiceName   = "flightctl-agent"
 )
 
 const (
@@ -55,12 +61,11 @@ var sourceRegistryOnce sync.Once
 
 var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 	Context("ImageBuild end-to-end workflow", func() {
-		It("should verify basic image build process - build, export, download, use in an agent", Label("87335", "88406", "imagebuild", "slow"), func() {
-			Expect(workerHarness).ToNot(BeNil())
-			Expect(workerHarness.ImageBuilderClient).ToNot(BeNil(), "ImageBuilderClient must be available")
-
+		It("should verify basic image build process - build, export, download, use in an agent (Basic-auth destination registry)", Label("87335", "88406", "imagebuild", "slow"), func() {
 			testID := workerHarness.GetTestIDFromContext()
-			registryAddress := auxSvcs.Registry.Host + ":" + auxSvcs.Registry.Port
+			registryAddress := auxSvcs.Registry.Authenticated.HostPort
+			authUsername := auxSvcs.Registry.Authenticated.Username
+			authPassword := auxSvcs.Registry.Authenticated.Password
 
 			sshPublicKey, sshPrivateKeyPath, cleanupSSHKeys, keyErr := testutil.GenerateTempSSHKeyPair()
 			Expect(keyErr).ToNot(HaveOccurred(), "Should generate temporary SSH key pair")
@@ -82,8 +87,8 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 				lo.ToPtr(api.Https), lo.ToPtr(api.Read), isLocalSourceRegistry(), nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = resources.CreateOCIRepository(workerHarness, destRepoName, registryAddress,
-				lo.ToPtr(api.Https), lo.ToPtr(api.ReadWrite), true, nil)
+			err = applyOCIRepositoryWithDockerAuth(workerHarness, destRepoName, registryAddress,
+				lo.ToPtr(api.Https), lo.ToPtr(api.ReadWrite), true, authUsername, authPassword)
 			Expect(err).ToNot(HaveOccurred())
 
 			// ============================================================
@@ -129,9 +134,11 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 			GinkgoWriter.Printf("ImageBuild %s status verified\n", imageBuildName)
 
 			// Assert the build completed successfully
-			reason, _ := workerHarness.GetImageBuildConditionReason(imageBuildName)
+			reason, message, err := workerHarness.GetImageBuildConditionReasonAndMessage(imageBuildName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get ImageBuild condition")
+			GinkgoWriter.Printf("ImageBuild %s condition: reason=%s message=%s\n", imageBuildName, reason, message)
 			Expect(reason).To(Equal(string(imagebuilderapi.ImageBuildConditionReasonCompleted)),
-				"Expected ImageBuild to complete successfully")
+				"Expected ImageBuild to complete successfully (message: %s)", message)
 
 			// ============================================================
 			// Step 2b: Verify image upload and SBOM
@@ -146,7 +153,7 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 			GinkgoWriter.Printf("ImageBuild manifest digest from status: %s\n", manifestDigest)
 
 			// Resolve the image in the registry and verify the digest matches
-			resolvedDesc, err := workerHarness.ResolveImage(registryAddress, destImageName, testID)
+			resolvedDesc, err := workerHarness.ResolveImageWithCredentials(registryAddress, destImageName, testID, authUsername, authPassword)
 			Expect(err).ToNot(HaveOccurred(), "Should be able to resolve image in registry")
 			resolvedDigest := resolvedDesc.Digest.String()
 			GinkgoWriter.Printf("Resolved image digest from registry: %s\n", resolvedDigest)
@@ -160,12 +167,12 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 			var sbomResult *e2e.SBOMValidationResult
 			Eventually(func(g Gomega) {
 				var err error
-				sbomResult, err = workerHarness.ValidateImageSBOM(registryAddress, destImageName, manifestDigest)
+				sbomResult, err = workerHarness.ValidateImageSBOMWithCredentials(registryAddress, destImageName, manifestDigest, authUsername, authPassword)
 				g.Expect(err).ToNot(HaveOccurred(), "Should be able to validate SBOM")
 				g.Expect(sbomResult.Found).To(BeTrue(), "SBOM should be found as a referrer")
 				g.Expect(sbomResult.DigestMatches).To(BeTrue(),
 					"SBOM should contain the correct image digest (expected: %s, got: %s)", manifestDigest, sbomResult.ImageDigest)
-			}, "30s", "2s").Should(Succeed(), "SBOM validation should eventually succeed")
+			}, sbomReferrerTimeout, sbomPollPeriod).Should(Succeed(), "SBOM validation should eventually succeed")
 			GinkgoWriter.Printf("SBOM referrer digest: %s\n", sbomResult.ReferrerDigest)
 			GinkgoWriter.Printf("SBOM image PURL: %s\n", sbomResult.ImagePURL)
 			GinkgoWriter.Printf("SBOM image digest: %s\n", sbomResult.ImageDigest)
@@ -197,7 +204,8 @@ var _ = Describe("ImageBuild", Label("imagebuild"), func() {
 			Expect(verifiedExport).ToNot(BeNil())
 			GinkgoWriter.Printf("ImageExport %s status verified\n", imageExportName)
 
-			exportReason, _ := workerHarness.GetImageExportConditionReason(imageExportName)
+			exportReason, err := workerHarness.GetImageExportConditionReason(imageExportName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get ImageExport condition")
 			Expect(exportReason).To(Equal(string(imagebuilderapi.ImageExportConditionReasonCompleted)),
 				"Expected ImageExport to complete successfully")
 
@@ -382,21 +390,26 @@ func isLocalSourceRegistry() bool {
 	return sourceRegistry != defaultSourceRegistry
 }
 
-// getAgentServiceStatus returns the systemctl is-active status of the flightctl-agent service.
+// getAgentServiceStatus returns the systemctl is-active status of the flightctl-agent service on the given VM.
+// Returns an error if the VM is nil or the SSH command fails; callers should wrap this in Eventually.
 func getAgentServiceStatus(libvirtVM vm.TestVMInterface) (string, error) {
 	if libvirtVM == nil {
 		GinkgoWriter.Printf("getAgentServiceStatus: VM is nil\n")
-		return "", nil
+		return "", fmt.Errorf("VM is nil")
 	}
 	stdout, err := libvirtVM.RunSSH([]string{"sudo", "systemctl", "is-active", agentServiceName}, nil)
 	if err != nil {
-		GinkgoWriter.Printf("getAgentServiceStatus: %v\n", err)
-		return "", err
+		GinkgoWriter.Printf("getAgentServiceStatus: SSH error: %v\n", err)
+		return "", fmt.Errorf("get agent service status via SSH: %w", err)
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	status := strings.TrimSpace(stdout.String())
+	GinkgoWriter.Printf("getAgentServiceStatus: %s=%s\n", agentServiceName, status)
+	return status, nil
 }
 
-// getEnrollmentIDFromAgentLogs extracts the enrollment ID from flightctl-agent journal logs.
+// getEnrollmentIDFromAgentLogs extracts the enrollment ID from flightctl-agent journal logs via SSH.
+// Returns an empty string (not an error) when no enrollment ID has appeared yet, so callers can
+// use this inside an Eventually block waiting for the ID to appear.
 func getEnrollmentIDFromAgentLogs(libvirtVM vm.TestVMInterface) string {
 	if libvirtVM == nil {
 		GinkgoWriter.Printf("getEnrollmentIDFromAgentLogs: VM is nil\n")
@@ -404,8 +417,12 @@ func getEnrollmentIDFromAgentLogs(libvirtVM vm.TestVMInterface) string {
 	}
 	stdout, err := libvirtVM.RunSSH([]string{"sudo", "journalctl", "-u", agentServiceName, "--no-pager"}, nil)
 	if err != nil {
-		GinkgoWriter.Printf("getEnrollmentIDFromAgentLogs: %v\n", err)
+		GinkgoWriter.Printf("getEnrollmentIDFromAgentLogs: SSH error: %v\n", err)
 		return ""
 	}
-	return testutil.GetEnrollmentIdFromText(stdout.String())
+	id := testutil.GetEnrollmentIdFromText(stdout.String())
+	if id == "" {
+		GinkgoWriter.Printf("getEnrollmentIDFromAgentLogs: enrollment ID not yet in logs\n")
+	}
+	return id
 }

--- a/test/e2e/infra/auxiliary/registry.go
+++ b/test/e2e/infra/auxiliary/registry.go
@@ -62,6 +62,8 @@ type Registry struct {
 	container testcontainers.Container
 }
 
+// getContainerLogs fetches combined stdout/stderr logs for a container by name,
+// trying podman first and falling back to docker.
 func getContainerLogs(name string) (string, error) {
 	cmd := exec.Command("podman", "logs", name)
 	out, err := cmd.CombinedOutput()
@@ -130,6 +132,8 @@ func (r *Registry) Start(ctx context.Context, network string, reuse bool) error 
 	return nil
 }
 
+// startAuthenticatedEndpoint starts an nginx container that wraps the TLS registry
+// with HTTP Basic Auth on privateRegistryPort, populating r.Authenticated on success.
 func (r *Registry) startAuthenticatedEndpoint(ctx context.Context, certDir, network string, reuse bool) error {
 	logrus.Info("Starting authenticated registry endpoint (nginx + basic auth)")
 	logrus.Infof("Authenticated endpoint upstream: %s:%s (network: %s)", r.Host, r.Port, network)
@@ -190,6 +194,9 @@ func (r *Registry) startAuthenticatedEndpoint(ctx context.Context, certDir, netw
 	return nil
 }
 
+// generateNginxConf returns an nginx configuration that proxies HTTPS requests
+// on port 5002 to the upstream TLS registry at registryHost:registryPort,
+// requiring HTTP Basic Auth via /auth/htpasswd.
 func generateNginxConf(registryHost, registryPort string) string {
 	upstreamAddr := net.JoinHostPort(registryHost, registryPort)
 	return fmt.Sprintf(`error_log /dev/stderr warn;
@@ -217,7 +224,7 @@ http {
       auth_basic_user_file /auth/htpasswd;
       proxy_pass https://registry;
       proxy_ssl_verify off;
-      proxy_set_header Host $host;
+      proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -234,6 +241,8 @@ func generateHtpasswd(username, password string) string {
 	return fmt.Sprintf("%s:{SHA}%s\n", username, encoded)
 }
 
+// ensureRegistryCerts generates a TLS leaf certificate for the registry signed by
+// the e2e CA (created by prepare-e2e-test). Returns the cert directory path.
 func ensureRegistryCerts() (string, error) {
 	projectRoot, err := getProjectRoot()
 	if err != nil {
@@ -318,6 +327,9 @@ func ensureRegistryCerts() (string, error) {
 	return certDir, nil
 }
 
+// configureInsecureRegistry writes a registries.conf.d snippet marking registryURL
+// as insecure so that the local podman/docker daemon can push and pull without TLS
+// verification. It is idempotent: if the file already exists and is non-empty it does nothing.
 func configureInsecureRegistry(registryURL string) error {
 	if existingConfig, err := os.ReadFile(registriesConfPath); err == nil && string(existingConfig) != "" {
 		return nil

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -774,6 +774,12 @@ func (h *Harness) CLIWithStdin(stdin string, args ...string) (string, error) {
 	return h.SHWithStdin(stdin, flightctlPath(), false, args...)
 }
 
+// CLIWithStdinRedacted runs the flightctl CLI with the given stdin, suppressing stdin from logs.
+// Use this when stdin contains credentials or other sensitive data.
+func (h *Harness) CLIWithStdinRedacted(stdin string, args ...string) (string, error) {
+	return h.SHWithStdin(stdin, flightctlPath(), true, args...)
+}
+
 // SHWithStdin runs a command with stdin. Set redactStdin to true to suppress stdin from logs (e.g. secrets).
 func (h *Harness) SHWithStdin(stdin, command string, redactStdin bool, args ...string) (string, error) {
 	stdinLog := stdin

--- a/test/harness/e2e/harness_imagebuild.go
+++ b/test/harness/e2e/harness_imagebuild.go
@@ -621,28 +621,43 @@ func (h *Harness) ImageBuildExists(name string) bool {
 	return err == nil
 }
 
+// newRegistryClient builds an auth.Client for the e2e registry. When username
+// and password are both non-empty, the client sends HTTP Basic credentials for
+// any host (e2e registries use self-signed certs with TLS skip verification).
+func newRegistryClient(username, password string) *auth.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+	}
+	c := &auth.Client{
+		Client: &http.Client{Transport: transport},
+	}
+	if username != "" && password != "" {
+		cred := auth.Credential{Username: username, Password: password}
+		c.Credential = func(_ context.Context, _ string) (auth.Credential, error) {
+			return cred, nil
+		}
+	}
+	return c
+}
+
 // ResolveImage resolves an image reference in an OCI registry and returns its descriptor.
 // registry: the registry host (e.g., "localhost:5000")
 // imageName: the image name (e.g., "myimage" or "namespace/myimage")
 // tag: the image tag (e.g., "latest" or "v1.0")
 func (h *Harness) ResolveImage(registry, imageName, tag string) (ocispec.Descriptor, error) {
+	return h.ResolveImageWithCredentials(registry, imageName, tag, "", "")
+}
+
+// ResolveImageWithCredentials is like ResolveImage but authenticates with the given credentials.
+func (h *Harness) ResolveImageWithCredentials(registry, imageName, tag, username, password string) (ocispec.Descriptor, error) {
 	ref := fmt.Sprintf("%s/%s", registry, imageName)
 
 	repoRef, err := remote.NewRepository(ref)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to create repository reference for %s: %w", ref, err)
 	}
-
-	// Use HTTPS with InsecureSkipVerify for e2e registry (may have cert SAN mismatch)
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec
-	}
-	repoRef.Client = &auth.Client{
-		Client: &http.Client{
-			Transport: transport,
-		},
-	}
+	repoRef.Client = newRegistryClient(username, password)
 
 	ctx, cancel := context.WithTimeout(h.Context, 30*time.Second)
 	defer cancel()
@@ -664,22 +679,18 @@ const cycloneDXMediaType = "application/vnd.cyclonedx+json"
 // digest: the image digest (e.g., "sha256:...")
 // Returns the list of referrer descriptors.
 func (h *Harness) FetchReferrers(registry, imageName, digest string) ([]ocispec.Descriptor, error) {
+	return h.FetchReferrersWithCredentials(registry, imageName, digest, "", "")
+}
+
+// FetchReferrersWithCredentials is like FetchReferrers but authenticates with the given credentials.
+func (h *Harness) FetchReferrersWithCredentials(registry, imageName, digest, username, password string) ([]ocispec.Descriptor, error) {
 	ref := fmt.Sprintf("%s/%s", registry, imageName)
 
 	repoRef, err := remote.NewRepository(ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository reference for %s: %w", ref, err)
 	}
-
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec
-	}
-	repoRef.Client = &auth.Client{
-		Client: &http.Client{
-			Transport: transport,
-		},
-	}
+	repoRef.Client = newRegistryClient(username, password)
 
 	ctx, cancel := context.WithTimeout(h.Context, 30*time.Second)
 	defer cancel()
@@ -702,22 +713,18 @@ func (h *Harness) FetchReferrers(registry, imageName, digest string) ([]ocispec.
 // referrerDesc: the descriptor of the SBOM referrer manifest
 // Returns the raw SBOM JSON content.
 func (h *Harness) FetchSBOMContent(registry, imageName string, referrerDesc ocispec.Descriptor) ([]byte, error) {
+	return h.FetchSBOMContentWithCredentials(registry, imageName, referrerDesc, "", "")
+}
+
+// FetchSBOMContentWithCredentials is like FetchSBOMContent but authenticates with the given credentials.
+func (h *Harness) FetchSBOMContentWithCredentials(registry, imageName string, referrerDesc ocispec.Descriptor, username, password string) ([]byte, error) {
 	ref := fmt.Sprintf("%s/%s", registry, imageName)
 
 	repoRef, err := remote.NewRepository(ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository reference for %s: %w", ref, err)
 	}
-
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec
-	}
-	repoRef.Client = &auth.Client{
-		Client: &http.Client{
-			Transport: transport,
-		},
-	}
+	repoRef.Client = newRegistryClient(username, password)
 
 	ctx, cancel := context.WithTimeout(h.Context, 30*time.Second)
 	defer cancel()
@@ -774,9 +781,14 @@ type SBOMValidationResult struct {
 // imageDigest: the expected image digest (e.g., "sha256:...")
 // Returns the validation result with details about the SBOM.
 func (h *Harness) ValidateImageSBOM(registry, imageName, imageDigest string) (*SBOMValidationResult, error) {
+	return h.ValidateImageSBOMWithCredentials(registry, imageName, imageDigest, "", "")
+}
+
+// ValidateImageSBOMWithCredentials is like ValidateImageSBOM but authenticates with the given credentials.
+func (h *Harness) ValidateImageSBOMWithCredentials(registry, imageName, imageDigest, username, password string) (*SBOMValidationResult, error) {
 	result := &SBOMValidationResult{}
 
-	referrers, err := h.FetchReferrers(registry, imageName, imageDigest)
+	referrers, err := h.FetchReferrersWithCredentials(registry, imageName, imageDigest, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch referrers: %w", err)
 	}
@@ -798,7 +810,7 @@ func (h *Harness) ValidateImageSBOM(registry, imageName, imageDigest string) (*S
 	result.ReferrerDigest = sbomReferrer.Digest.String()
 
 	// Fetch and parse the SBOM content
-	sbomContent, err := h.FetchSBOMContent(registry, imageName, *sbomReferrer)
+	sbomContent, err := h.FetchSBOMContentWithCredentials(registry, imageName, *sbomReferrer, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch SBOM content: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Update the imagebuild e2e workflow test to push the destination OCI image to an authenticated registry (nginx + HTTP Basic Auth at port 5002) instead of the unauthenticated one.
- Extend the imagebuild e2e harness with `*WithCredentials` variants for image resolution, referrer fetching, and SBOM validation; original unauthenticated methods delegate to them with empty credentials (no regressions).
- Propagate registry credentials through the imagebuilder worker's podman build and push flow via a shared auth file (`podman login --authfile`, `REGISTRY_AUTH_FILE` env var).
- Move the worker container auth file from `/build/auth.json` (the podman build context) to `/tmp/auth.json` to keep credentials isolated from the build context.
- Fix nginx `$host` → `$http_host` in the e2e-registry-auth proxy so that OCI blob-upload redirect `Location` URLs include the port, preventing connection refused on port 443.

## Release target

- [x] release-1.3

Target release: release-1.3
