### PR TITLE
NO-ISSUE: pin crun >= 1.14.3 in CI to fix Smoke container build flake

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -18,6 +18,7 @@ runs:
   using: "composite"
   steps:
       - name: Setup Go
+        if: ${{ inputs.skip_package_install != 'true' }}
         uses: actions/setup-go@v5
         with:
           go-version: '1.25.9'
@@ -76,7 +77,10 @@ runs:
           # its OCI runtime config, so /usr/local/bin alone does not take effect.
           # See: https://github.com/containers/crun/issues/1485
           CRUN_VERSION=1.14.3
+          # sha256 of crun-${CRUN_VERSION}-linux-amd64 from GitHub Releases
+          CRUN_SHA256=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
           curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          echo "${CRUN_SHA256}  /tmp/crun" | sha256sum -c -
           sudo install -m 0755 /tmp/crun /usr/bin/crun
           rm -f /tmp/crun
 
@@ -85,7 +89,7 @@ runs:
           podman info >/dev/null 2>&1 || true
 
           podman --version
-          crun --version
+          /usr/bin/crun --version
 
           curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
           sudo unzip -q -o protoc.zip bin/protoc -d /usr/local
@@ -97,16 +101,29 @@ runs:
           oras version
           echo "::endgroup::"
 
-      # Custom runner image already has apt packages, crun, protoc, oras, and KVM.
-      # Still prime Podman and log versions for diagnostics.
+      # Custom runner image already has apt packages, crun, protoc, oras, Go, and KVM.
+      # Still prime Podman and validate the binary Podman actually invokes.
       - name: Verify preinstalled dependencies
         if: ${{ inputs.skip_package_install == 'true' }}
         shell: bash
         run: |
           echo "::group::Verifying preinstalled dependencies (custom runner image)"
+          set -euo pipefail
+          go version
           podman info >/dev/null 2>&1 || true
           podman --version
-          crun --version
+          # Podman uses /usr/bin/crun by absolute path — check that binary, not PATH.
+          CRUN_MIN=1.14.3
+          /usr/bin/crun --version
+          CRUN_GOT=$(/usr/bin/crun --version | awk '/^crun version /{print $3; exit}')
+          if [[ -z "${CRUN_GOT}" ]]; then
+            echo "ERROR: could not parse /usr/bin/crun version" >&2
+            exit 1
+          fi
+          if [[ "$(printf '%s\n' "${CRUN_MIN}" "${CRUN_GOT}" | sort -V | head -n1)" != "${CRUN_MIN}" ]]; then
+            echo "ERROR: /usr/bin/crun is ${CRUN_GOT}, need >= ${CRUN_MIN}" >&2
+            exit 1
+          fi
           protoc --version
           oras version
           echo "::endgroup::"

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -101,8 +101,9 @@ runs:
           oras version
           echo "::endgroup::"
 
-      # Custom runner image already has apt packages, crun, protoc, oras, Go, and KVM.
-      # Still prime Podman and validate the binary Podman actually invokes.
+      # Custom runner image already has apt packages, protoc, oras, Go, and KVM.
+      # Still prime Podman and ensure /usr/bin/crun is new enough (image rollout of
+      # the crun pin can lag; upgrade in place without apt if needed).
       - name: Verify preinstalled dependencies
         if: ${{ inputs.skip_package_install == 'true' }}
         shell: bash
@@ -112,18 +113,20 @@ runs:
           go version
           podman info >/dev/null 2>&1 || true
           podman --version
-          # Podman uses /usr/bin/crun by absolute path — check that binary, not PATH.
-          CRUN_MIN=1.14.3
+
+          # Podman uses /usr/bin/crun by absolute path — check/upgrade that binary.
+          CRUN_VERSION=1.14.3
+          CRUN_SHA256=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
+          CRUN_GOT=$(/usr/bin/crun --version 2>/dev/null | awk '/^crun version /{print $3; exit}' || true)
+          if [[ -z "${CRUN_GOT}" || "$(printf '%s\n' "${CRUN_VERSION}" "${CRUN_GOT}" | sort -V | head -n1)" != "${CRUN_VERSION}" ]]; then
+            echo "Upgrading /usr/bin/crun from ${CRUN_GOT:-missing} to ${CRUN_VERSION}"
+            curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+            echo "${CRUN_SHA256}  /tmp/crun" | sha256sum -c -
+            sudo install -m 0755 /tmp/crun /usr/bin/crun
+            rm -f /tmp/crun
+          fi
           /usr/bin/crun --version
-          CRUN_GOT=$(/usr/bin/crun --version | awk '/^crun version /{print $3; exit}')
-          if [[ -z "${CRUN_GOT}" ]]; then
-            echo "ERROR: could not parse /usr/bin/crun version" >&2
-            exit 1
-          fi
-          if [[ "$(printf '%s\n' "${CRUN_MIN}" "${CRUN_GOT}" | sort -V | head -n1)" != "${CRUN_MIN}" ]]; then
-            echo "ERROR: /usr/bin/crun is ${CRUN_GOT}, need >= ${CRUN_MIN}" >&2
-            exit 1
-          fi
+
           protoc --version
           oras version
           echo "::endgroup::"

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -6,6 +6,14 @@ inputs:
     description: 'Setup kvm in the VM'
     required: false
     default: ''
+  skip_package_install:
+    description: >-
+      Skip apt installs and tool downloads already baked into the custom
+      runner image (flightctl-ci-runner). Use on workflows that run on that
+      image so apt does not pull package upgrades every job. Leave false on
+      stock GitHub-hosted runners (e.g. ubuntu-24.04 Smoke).
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -15,6 +23,7 @@ runs:
           go-version: '1.25.9'
 
       - name: Prepare apt cache directory
+        if: ${{ inputs.skip_package_install != 'true' }}
         shell: bash
         run: |
           echo "APT_CACHE_DIR=${HOME}/.cache/apt-archives" >> "$GITHUB_ENV"
@@ -28,6 +37,7 @@ runs:
       # ownership, but actions/cache can too.
       - name: Restore apt cache
         id: restore-apt-cache
+        if: ${{ inputs.skip_package_install != 'true' }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.APT_CACHE_DIR }}
@@ -38,7 +48,7 @@ runs:
 
       - name: Enable KVM group perms
         shell: bash
-        if: inputs.setup_kvm != ''
+        if: ${{ inputs.setup_kvm != '' && inputs.skip_package_install != 'true' }}
         run: |
           echo "::group::Setting up KVM and virtualization tools"
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -52,6 +62,7 @@ runs:
           echo "::endgroup::"
 
       - name: Install dependencies
+        if: ${{ inputs.skip_package_install != 'true' }}
         shell: bash
         run: |
           echo "::group::Installing general dependencies"
@@ -83,10 +94,24 @@ runs:
           go install oras.land/oras/cmd/oras@v1.3.0
           oras version
           echo "::endgroup::"
+
+      # Custom runner image already has apt packages, crun, protoc, oras, and KVM.
+      # Still prime Podman and log versions for diagnostics.
+      - name: Verify preinstalled dependencies
+        if: ${{ inputs.skip_package_install == 'true' }}
+        shell: bash
+        run: |
+          echo "::group::Verifying preinstalled dependencies (custom runner image)"
+          podman info >/dev/null 2>&1 || true
+          podman --version
+          crun --version
+          protoc --version
+          oras version
+          echo "::endgroup::"
       
       - name: Install bubblewrap for unit tests
         shell: bash
-        if: ${{ inputs.unit_tests == 'true' }}
+        if: ${{ inputs.unit_tests == 'true' && inputs.skip_package_install != 'true' }}
         run: |
           sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/bwrap || true
@@ -101,7 +126,7 @@ runs:
           echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
 
       - name: Save apt cache
-        if: ${{ github.ref == 'refs/heads/main' && steps.restore-apt-cache.outputs.cache-hit != 'true' }}
+        if: ${{ inputs.skip_package_install != 'true' && github.ref == 'refs/heads/main' && steps.restore-apt-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ env.APT_CACHE_DIR }}

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -101,8 +101,11 @@ runs:
           oras version
           echo "::endgroup::"
 
-      # Custom runner image already has apt packages, crun, protoc, oras, Go, and KVM.
+      # Custom runner image already has apt packages, crun, protoc, Go, and KVM.
       # Still prime Podman and validate the binary Podman actually invokes.
+      # oras is installed via `go install` into GOPATH/bin at image bake time; setup-go
+      # is skipped here so that dir is often missing from PATH — fix PATH, then install
+      # only if the binary is truly absent (older image snapshots).
       - name: Verify preinstalled dependencies
         if: ${{ inputs.skip_package_install == 'true' }}
         shell: bash
@@ -110,6 +113,8 @@ runs:
           echo "::group::Verifying preinstalled dependencies (custom runner image)"
           set -euo pipefail
           go version
+          # Match non-skip path: go-installed tools live under GOPATH/bin.
+          export PATH="$(go env GOPATH)/bin:${HOME}/go/bin:${PATH}"
           podman info >/dev/null 2>&1 || true
           podman --version
           # Podman uses /usr/bin/crun by absolute path — check that binary, not PATH.
@@ -125,7 +130,13 @@ runs:
             exit 1
           fi
           protoc --version
+          if ! command -v oras >/dev/null 2>&1; then
+            go install oras.land/oras/cmd/oras@v1.3.0
+          fi
           oras version
+          # Persist for later steps in this job (setup-go is skipped in this mode).
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
           echo "::endgroup::"
       
       - name: Install bubblewrap for unit tests

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -101,9 +101,8 @@ runs:
           oras version
           echo "::endgroup::"
 
-      # Custom runner image already has apt packages, protoc, oras, Go, and KVM.
-      # Still prime Podman and ensure /usr/bin/crun is new enough (image rollout of
-      # the crun pin can lag; upgrade in place without apt if needed).
+      # Custom runner image already has apt packages, crun, protoc, oras, Go, and KVM.
+      # Still prime Podman and validate the binary Podman actually invokes.
       - name: Verify preinstalled dependencies
         if: ${{ inputs.skip_package_install == 'true' }}
         shell: bash
@@ -113,20 +112,18 @@ runs:
           go version
           podman info >/dev/null 2>&1 || true
           podman --version
-
-          # Podman uses /usr/bin/crun by absolute path — check/upgrade that binary.
-          CRUN_VERSION=1.14.3
-          CRUN_SHA256=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
-          CRUN_GOT=$(/usr/bin/crun --version 2>/dev/null | awk '/^crun version /{print $3; exit}' || true)
-          if [[ -z "${CRUN_GOT}" || "$(printf '%s\n' "${CRUN_VERSION}" "${CRUN_GOT}" | sort -V | head -n1)" != "${CRUN_VERSION}" ]]; then
-            echo "Upgrading /usr/bin/crun from ${CRUN_GOT:-missing} to ${CRUN_VERSION}"
-            curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
-            echo "${CRUN_SHA256}  /tmp/crun" | sha256sum -c -
-            sudo install -m 0755 /tmp/crun /usr/bin/crun
-            rm -f /tmp/crun
-          fi
+          # Podman uses /usr/bin/crun by absolute path — check that binary, not PATH.
+          CRUN_MIN=1.14.3
           /usr/bin/crun --version
-
+          CRUN_GOT=$(/usr/bin/crun --version | awk '/^crun version /{print $3; exit}')
+          if [[ -z "${CRUN_GOT}" ]]; then
+            echo "ERROR: could not parse /usr/bin/crun version" >&2
+            exit 1
+          fi
+          if [[ "$(printf '%s\n' "${CRUN_MIN}" "${CRUN_GOT}" | sort -V | head -n1)" != "${CRUN_MIN}" ]]; then
+            echo "ERROR: /usr/bin/crun is ${CRUN_GOT}, need >= ${CRUN_MIN}" >&2
+            exit 1
+          fi
           protoc --version
           oras version
           echo "::endgroup::"

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -101,11 +101,10 @@ runs:
           oras version
           echo "::endgroup::"
 
-      # Custom runner image already has apt packages, crun, protoc, Go, and KVM.
+      # Custom runner image already has apt packages, crun, protoc, oras, Go, and KVM.
       # Still prime Podman and validate the binary Podman actually invokes.
-      # oras is installed via `go install` into GOPATH/bin at image bake time; setup-go
-      # is skipped here so that dir is often missing from PATH — fix PATH, then install
-      # only if the binary is truly absent (older image snapshots).
+      # oras is baked via `go install` into GOPATH/bin; setup-go is skipped here so that
+      # dir is often missing from PATH — put it on PATH and require the binary (no install).
       - name: Verify preinstalled dependencies
         if: ${{ inputs.skip_package_install == 'true' }}
         shell: bash
@@ -115,6 +114,8 @@ runs:
           go version
           # Match non-skip path: go-installed tools live under GOPATH/bin.
           export PATH="$(go env GOPATH)/bin:${HOME}/go/bin:${PATH}"
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
           podman info >/dev/null 2>&1 || true
           podman --version
           # Podman uses /usr/bin/crun by absolute path — check that binary, not PATH.
@@ -131,12 +132,10 @@ runs:
           fi
           protoc --version
           if ! command -v oras >/dev/null 2>&1; then
-            go install oras.land/oras/cmd/oras@v1.3.0
+            echo "ERROR: oras not found on PATH (expected under GOPATH/bin from the custom image)" >&2
+            exit 1
           fi
           oras version
-          # Persist for later steps in this job (setup-go is skipped in this mode).
-          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
-          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
           echo "::endgroup::"
       
       - name: Install bubblewrap for unit tests

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -58,9 +58,21 @@ runs:
           sudo apt update -y # fix broken repo cache
           sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
 
+          # Ubuntu noble ships crun 1.14.1 which rejects OCI runtime spec v1.2.1
+          # version strings emitted by Podman 4.9+, causing "unknown version specified"
+          # errors on RUN --mount=type=cache steps. Pin to 1.14.3+ (the fix release).
+          # See: https://github.com/containers/crun/issues/1485
+          CRUN_VERSION=1.14.3
+          curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          sudo install -m 0755 /tmp/crun /usr/local/bin/crun
+          rm -f /tmp/crun
+
           # Prime rootless Podman API socket before Go testcontainers init() probes paths (otherwise
           # /var/run/docker.sock can win on runners that ship both Docker and Podman).
           podman info >/dev/null 2>&1 || true
+
+          podman --version
+          crun --version
 
           curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
           sudo unzip -q -o protoc.zip bin/protoc -d /usr/local

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -72,10 +72,12 @@ runs:
           # Ubuntu noble ships crun 1.14.1 which rejects OCI runtime spec v1.2.1
           # version strings emitted by Podman 4.9+, causing "unknown version specified"
           # errors on RUN --mount=type=cache steps. Pin to 1.14.3+ (the fix release).
+          # Overwrite /usr/bin/crun in place — Podman invokes that absolute path from
+          # its OCI runtime config, so /usr/local/bin alone does not take effect.
           # See: https://github.com/containers/crun/issues/1485
           CRUN_VERSION=1.14.3
           curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
-          sudo install -m 0755 /tmp/crun /usr/local/bin/crun
+          sudo install -m 0755 /tmp/crun /usr/bin/crun
           rm -f /tmp/crun
 
           # Prime rootless Podman API socket before Go testcontainers init() probes paths (otherwise

--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -25,6 +25,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # make e2e-agent-images uses podman; pin crun so ubuntu-24.04 doesn't hit
+      # "unknown version specified" (apt ships crun 1.14.1).
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
       - name: Restore bootc-image-builder cache
         id: cache-bootc-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/build-rpms.yaml
+++ b/.github/workflows/build-rpms.yaml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # make rpm uses podman; pin crun so ubuntu-24.04 doesn't hit
+      # "unknown version specified" (apt ships crun 1.14.1).
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
       - name: Restore Go modules cache
         id: cache-go-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -122,6 +122,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # buildah needs pinned crun on ubuntu-24.04 (apt ships 1.14.1).
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
       - name: Prepare version variables
         id: version-vars
         run: |

--- a/.github/workflows/publish-e2e-containers.yaml
+++ b/.github/workflows/publish-e2e-containers.yaml
@@ -128,6 +128,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # buildah/podman need pinned crun on ubuntu-24.04 (apt ships 1.14.1).
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/publish-e2e-containers.yaml
+++ b/.github/workflows/publish-e2e-containers.yaml
@@ -59,6 +59,11 @@ jobs:
         run: |
           test/scripts/create_e2e_certs.sh
 
+      # make rpm / buildah use podman; pin crun so ubuntu-24.04 doesn't hit
+      # "unknown version specified" (apt ships crun 1.14.1).
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
+
       - name: Build RPMs
         run: |
           make rpm

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -71,6 +71,9 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           setup_kvm: yes
+          # Custom image (flightctl-ci-ubuntu-24) already has apt packages, KVM,
+          # crun, protoc, and oras. Skipping avoids apt upgrades every job.
+          skip_package_install: 'true'
 
       - name: Compute base domain
         id: base-domain


### PR DESCRIPTION
## Summary

Smoke / API CI on GitHub-hosted `ubuntu-24.04` intermittently fails during `podman build` with:

```
error running container: from /usr/bin/crun creating container for [...]: unknown version specified
```

**Root cause:** Ubuntu noble ships crun **1.14.1**, which rejects OCI Runtime Spec v1.2.1 version strings from Podman 4.9+. Fixed in crun **1.14.3** ([containers/crun#1485](https://github.com/containers/crun/issues/1485)).

**Important detail:** Podman invokes `/usr/bin/crun` by absolute path, so installing into `/usr/local/bin` does nothing. We overwrite `/usr/bin/crun` in place.

## Changes

### `.github/actions/setup-dependencies/action.yaml`
- Download + install crun **1.14.3** over `/usr/bin/crun` (stock runners)
- SHA-256 verify the download before `sudo install`
- Add `skip_package_install` input for custom runner image jobs:
  - skips apt, KVM package setup, crun/protoc/oras downloads, and `setup-go`
  - verifies preinstalled tools instead, including `/usr/bin/crun >= 1.14.3` and `go version`

### `.github/workflows/run-e2e-tests.yaml`
- Set `skip_package_install: true` on `flightctl-ci-runner` so e2e does not apt-upgrade packages every job

## Companion PRs (custom image)

- [flightctl-ci-images#1](https://github.com/flightctl/flightctl-ci-images/pull/1) — initial bake (merged; used `/usr/local/bin`, insufficient)
- [flightctl-ci-images#2](https://github.com/flightctl/flightctl-ci-images/pull/2) — overwrite `/usr/bin/crun` + SHA-256 check

Once all workflows that use `setup-dependencies` run on the custom image, the crun download in this action can be removed.

## Testing

- [ ] Smoke on this PR (stock `ubuntu-24.04`) — installs + pins crun
- [ ] API tests / merge queue — `make test-api` schemathesis `podman build` should not hit `unknown version specified`
- [ ] e2e on custom image — skip path verifies `/usr/bin/crun >= 1.14.3` without apt/tool downloads

### Example failing runs (before fix)

| Run | Context | Error |
|-----|---------|-------|
| [30526915912](https://github.com/flightctl/flightctl/actions/runs/30526915912) | Smoke / EDM-4778 | crun at `go mod download` |
| Merge queue API tests | `make test-api` / schemathesis | crun at `apk add` RUN step |