### PR TITLE
EDM-4889: Add encryption config to Helm values for key rotation support

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -294,6 +294,9 @@ For more detailed configuration options, see the [Values](#values) section below
 | dbSetup.migration.backoffLimit | int | `2147483647` | Number of retries for the migration Job on failure  |
 | dbSetup.wait.sleep | int | `2` | Seconds to sleep between database connection attempts Default sleep interval between connection attempts |
 | dbSetup.wait.timeout | int | `60` | Seconds to wait for database readiness before failing Default timeout for database wait (can be overridden per deployment) |
+| encryption | object | `{"activeKeyID":"default","keys":[{"file":"key","id":"default"}]}` | Encryption-at-rest key configuration. The flightctl-encryption-key Secret is mounted at /root/.flightctl/encryption/ in all services. Each key entry maps a logical key ID to a filename within that Secret. For key rotation: add a new key file to the Secret, add it here, then change activeKeyID. |
+| encryption.activeKeyID | string | `"default"` | Key ID used for new encryptions. Must match one of the IDs in the keys list. |
+| encryption.keys | list | `[{"file":"key","id":"default"}]` | List of available encryption keys. Old keys remain available for decryption during rotation. |
 | global.additionalPVCLabels | string | `nil` | Additional labels for PVCs. |
 | global.additionalRouteLabels | string | `nil` | Additional labels for routes. |
 | global.auth.aap.apiUrl | string | `""` | The URL of the AAP Gateway API endpoint |

--- a/deploy/helm/flightctl/templates/_helpers.tpl
+++ b/deploy/helm/flightctl/templates/_helpers.tpl
@@ -916,3 +916,21 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{- /*
+Render encryption-at-rest config from .Values.encryption.
+Usage: {{ include "flightctl.encryptionConfig" . | nindent 4 }}
+*/}}
+{{- define "flightctl.encryptionConfig" -}}
+{{- $enc := .Values.encryption | default dict -}}
+{{- $keys := $enc.keys | default list -}}
+{{- if or $keys $enc.activeKeyID -}}
+encryption:
+    activeKeyID: {{ $enc.activeKeyID | default "default" | quote }}
+    keys:
+    {{- range $keys }}
+        - id: {{ .id | quote }}
+          path: {{ printf "/root/.flightctl/encryption/%s" .file | quote }}
+    {{- end }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-config.yaml
+++ b/deploy/helm/flightctl/templates/alert-exporter/flightctl-alert-exporter-config.yaml
@@ -43,4 +43,5 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-config.yaml
+++ b/deploy/helm/flightctl/templates/alertmanager/flightctl-alertmanager-proxy-config.yaml
@@ -56,5 +56,6 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
 {{- end }}
 

--- a/deploy/helm/flightctl/templates/api/flightctl-api-config.yaml
+++ b/deploy/helm/flightctl/templates/api/flightctl-api-config.yaml
@@ -101,6 +101,7 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
     {{- if default false (default dict .Values.vulnerabilityReporting).enabled }}
     vulnerabilityReporting:
         enabled: true

--- a/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-config.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-api/flightctl-imagebuilder-api-config.yaml
@@ -55,4 +55,5 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/imagebuilder-worker/flightctl-imagebuilder-worker-config.yaml
@@ -131,4 +131,5 @@ data:
         {{- end }}
     {{- end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/periodic/flightctl-periodic-config.yaml
+++ b/deploy/helm/flightctl/templates/periodic/flightctl-periodic-config.yaml
@@ -63,6 +63,7 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
     {{- $vuln := default dict .Values.vulnerabilityReporting }}
     {{- $trustify := default dict $vuln.trustify }}
     {{- $auth := default dict $trustify.auth }}

--- a/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
+++ b/deploy/helm/flightctl/templates/remote-access/flightctl-remote-access-config.yaml
@@ -43,4 +43,5 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -51,3 +51,4 @@ data:
         insecure: {{ .Values.dev.tracing.insecure }}
     {{ end }}
 {{ include "flightctl.profiling" . | nindent 4 }}
+{{- include "flightctl.encryptionConfig" . | nindent 4 }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -914,6 +914,30 @@
         }
       }
     },
+    "encryption": {
+      "type": "object",
+      "description": "Encryption-at-rest key configuration for key rotation support",
+      "additionalProperties": false,
+      "properties": {
+        "activeKeyID": {
+          "type": "string",
+          "description": "Key ID used for new encryptions. Must match one of the IDs in the keys list."
+        },
+        "keys": {
+          "type": "array",
+          "description": "List of available encryption keys. Old keys remain available for decryption during rotation.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "file"],
+            "properties": {
+              "id": { "type": "string", "description": "Logical key identifier" },
+              "file": { "type": "string", "description": "Filename within the flightctl-encryption-key Secret" }
+            }
+          }
+        }
+      }
+    },
     "upgradeHooks": {
       "type": "object",
       "description": "Upgrade hooks configuration",

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -575,3 +575,15 @@ upgradeHooks:
     timeoutSeconds: 120
   # -- Enable pre-upgrade DB migration dry-run as a hook
   databaseMigrationDryRun: true
+
+# -- Encryption-at-rest key configuration.
+# The flightctl-encryption-key Secret is mounted at /root/.flightctl/encryption/ in all services.
+# Each key entry maps a logical key ID to a filename within that Secret.
+# For key rotation: add a new key file to the Secret, add it here, then change activeKeyID.
+encryption:
+  # -- Key ID used for new encryptions. Must match one of the IDs in the keys list.
+  activeKeyID: "default"
+  # -- List of available encryption keys. Old keys remain available for decryption during rotation.
+  keys:
+    - id: "default"
+      file: "key"

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -575,3 +575,15 @@ upgradeHooks:
     timeoutSeconds: 120
   # -- Enable pre-upgrade DB migration dry-run as a hook
   databaseMigrationDryRun: true
+
+# -- Encryption-at-rest key configuration.
+# The flightctl-encryption-key Secret is mounted at /root/.flightctl/encryption/ in all services.
+# Each key entry maps a logical key ID to a filename within that Secret.
+# For key rotation: add a new key file to the Secret, add it here, then change activeKeyID.
+encryption:
+  # -- Key ID used for new encryptions. Must match one of the IDs in the keys list.
+  activeKeyID: "default"
+  # -- List of available encryption keys. Old keys remain available for decryption during rotation.
+  keys:
+    - id: "default"
+      file: "key"


### PR DESCRIPTION
## Summary

- Add `encryption` section to Helm `values.yaml` so key rotation can be configured through `helm upgrade`
- Add `flightctl.encryptionConfig` helper template in `_helpers.tpl` and include it in all 8 service ConfigMaps
- Add `encryption` schema to `values.schema.json`

Previously, encryption config was only set by Go defaults (single key `"default"` at `/root/.flightctl/encryption/key`). Users who needed to rotate keys had to `kubectl patch` the ConfigMap directly, which gets silently overwritten on the next `helm upgrade`. Now the encryption config flows through Helm values and survives upgrades.

## Key rotation example

1. Generate a new encryption key and add it to the Secret:
```bash
openssl rand 32 > /tmp/key-2
kubectl -n flightctl patch secret flightctl-encryption-key \
  --type merge -p "{\"data\":{\"key-2\":\"$(base64 -w0 /tmp/key-2)\"}}"
rm /tmp/key-2
```

2. Update Helm values to register the new key and make it active:
```bash
encryption:
  activeKeyID: "rotated"
  keys:
    - id: "default"
      file: "key"
    - id: "rotated"
      file: "key-2"
```

3. Apply with helm upgrade:
```bash
helm upgrade flightctl deploy/helm/flightctl -f my-values.yaml
```

All services will restart and begin encrypting new data with the rotated key. The old default key remains available for decrypting existing data.


