### PR TITLE
EDM-4894: Render encryption config in Quadlet service templates

### DIFF
--- a/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter-config/config.yaml.template
+++ b/deploy/podman/flightctl-alert-exporter/flightctl-alert-exporter-config/config.yaml.template
@@ -65,3 +65,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-config/config.yaml.template
+++ b/deploy/podman/flightctl-alertmanager-proxy/flightctl-alertmanager-proxy-config/config.yaml.template
@@ -130,3 +130,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-api/flightctl-api-config/config.yaml.template
@@ -159,3 +159,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api-config/config.yaml.template
+++ b/deploy/podman/flightctl-imagebuilder-api/flightctl-imagebuilder-api-config/config.yaml.template
@@ -143,3 +143,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker-config/config.yaml.template
@@ -154,3 +154,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-periodic/flightctl-periodic-config/config.yaml.template
+++ b/deploy/podman/flightctl-periodic/flightctl-periodic-config/config.yaml.template
@@ -80,3 +80,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
+++ b/deploy/podman/flightctl-remote-access/flightctl-remote-access-config/config.yaml.template
@@ -148,3 +148,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -67,3 +67,12 @@ profiling:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with .encryption }}
+encryption:
+  activeKeyID: {{ .activeKeyID }}
+  keys:
+  {{- range .keys }}
+    - id: {{ .id }}
+      path: {{ .path }}
+  {{- end }}
+{{- end }}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -203,7 +203,9 @@ gateway:
 # Encryption-at-rest key configuration.
 # The encryption key files live in /etc/flightctl/encryption/ and are mounted
 # at /root/.flightctl/encryption/ inside each service container.
-# For key rotation: add a new key file, add it here, then change activeKeyID.
+# For key rotation: write the new key under /etc/flightctl/encryption/ on the host,
+# then list it here with path: /root/.flightctl/encryption/<filename> (container
+# mount path, not host path), and change activeKeyID.
 encryption:
   activeKeyID: default
   keys:

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -199,3 +199,13 @@ userinfoProxy:
 
 gateway:
   suppressOldPorts: false
+
+# Encryption-at-rest key configuration.
+# The encryption key files live in /etc/flightctl/encryption/ and are mounted
+# at /root/.flightctl/encryption/ inside each service container.
+# For key rotation: add a new key file, add it here, then change activeKeyID.
+encryption:
+  activeKeyID: default
+  keys:
+    - id: default
+      path: /root/.flightctl/encryption/key

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -3,8 +3,10 @@ package quadlet
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	v1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/pkg/template"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/stretchr/testify/assert"
@@ -509,4 +511,73 @@ func TestDeepCopyMap(t *testing.T) {
 	inner := copied["b"].(map[string]interface{})
 	inner["c"] = 100
 	assert.Equal(t, 2, orig["b"].(map[string]interface{})["c"], "nested map should be copied")
+}
+
+func TestEncryptionConfigSurvivesRender(t *testing.T) {
+	serviceConfig := map[string]interface{}{
+		"global": map[string]interface{}{
+			"baseDomain":           "test.example.com",
+			"generateCertificates": "builtin",
+			"auth": map[string]interface{}{
+				"type":                  "none",
+				"insecureSkipTlsVerify": true,
+			},
+		},
+		"db": map[string]interface{}{
+			"name": "flightctl",
+			"type": "builtin",
+		},
+		"service": map[string]interface{}{
+			"rateLimit": map[string]interface{}{
+				"enabled": false,
+			},
+		},
+		"encryption": map[string]interface{}{
+			"activeKeyID": "key-2026-07",
+			"keys": []interface{}{
+				map[string]interface{}{"id": "default", "path": "/root/.flightctl/encryption/key"},
+				map[string]interface{}{"id": "key-2026-07", "path": "/root/.flightctl/encryption/key-2026-07"},
+			},
+		},
+	}
+
+	encryptionServices := []string{
+		"flightctl-api",
+		"flightctl-worker",
+		"flightctl-periodic",
+		"flightctl-alert-exporter",
+		"flightctl-alertmanager-proxy",
+		"flightctl-remote-access",
+		"flightctl-imagebuilder-api",
+		"flightctl-imagebuilder-worker",
+	}
+
+	repoRoot := findRepoRoot(t)
+	for _, svc := range encryptionServices {
+		t.Run(svc, func(t *testing.T) {
+			tplPath := filepath.Join(repoRoot, "deploy", "podman", svc, svc+"-config", "config.yaml.template")
+			if _, err := os.Stat(tplPath); err != nil {
+				t.Fatalf("template not found (run from repo root): %s", tplPath)
+			}
+
+			outDir := t.TempDir()
+			outPath := filepath.Join(outDir, "config.yaml")
+			err := template.RenderWithData(serviceConfig, tplPath, outPath,
+				template.WithFuncMap(v1beta1.GetGoTemplateFuncMap()))
+			require.NoError(t, err)
+
+			rendered, err := os.ReadFile(outPath)
+			require.NoError(t, err)
+			content := string(rendered)
+
+			assert.True(t, strings.Contains(content, "activeKeyID: key-2026-07"),
+				"%s: rendered config should contain activeKeyID: key-2026-07", svc)
+			assert.True(t, strings.Contains(content, "id: default"),
+				"%s: rendered config should contain the default key entry", svc)
+			assert.True(t, strings.Contains(content, "id: key-2026-07"),
+				"%s: rendered config should contain the rotated key entry", svc)
+			assert.True(t, strings.Contains(content, "path: /root/.flightctl/encryption/key-2026-07"),
+				"%s: rendered config should contain the rotated key path", svc)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add encryption config block to all 8 Quadlet service `config.yaml.template` files
- Add default encryption config to `service-config.yaml`

On Quadlet deployments, `ExecStartPre` runs `flightctl-standalone render template` which overwrites each service's `config.yaml` from its template on every restart. None of the templates rendered an `encryption:` block, so any encryption config added to `service-config.yaml` was silently dropped. Services fell back to Go defaults (`activeKeyID: "default"`, single key), making key rotation impossible.

The fix uses `{{- with .encryption }}` so the block only renders when encryption config is present in `service-config.yaml`. The default config matches what Go already hardcodes, so existing deployments are unaffected.

## Key rotation on Quadlets

1. Add a new key file:
```bash
openssl rand 32 > /etc/flightctl/encryption/key-rotated
```

2. Update /etc/flightctl/service-config.yaml:
```bash
encryption:
  activeKeyID: rotated
  keys:
    - id: default
      path: /root/.flightctl/encryption/key
    - id: rotated
      path: /root/.flightctl/encryption/key-rotated
```

3. Restart services:
```bash
systemctl restart flightctl-api flightctl-worker flightctl-periodic \
  flightctl-alert-exporter flightctl-alertmanager-proxy flightctl-remote-access \
  flightctl-imagebuilder-api flightctl-imagebuilder-worker
```