### PR TITLE
EDM-4845: Stabilize vulnerability lifecycle fleet check

### DIFF
--- a/test/e2e/vulnerability/vulnerability_test.go
+++ b/test/e2e/vulnerability/vulnerability_test.go
@@ -62,9 +62,19 @@ var _ = Describe("Vulnerability API", Label("vulnerability"), func() {
 			Expect(len(deviceVulns.Items)).To(BeNumerically(">=", DigestACVECount))
 
 			By("Verifying fleet-level vulnerabilities show all CVEs")
-			fleetVulns, err := harness.GetFleetVulnerabilities(v1alpha1Client, fleetName, nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(fleetVulns.Items)).To(BeNumerically(">=", DigestACVECount))
+			Eventually(func() error {
+				harness.DumpVulnerabilityState(v1alpha1Client, fleetName, deviceName1)
+
+				fleetVulns, err := harness.GetFleetVulnerabilities(v1alpha1Client, fleetName, nil)
+				if err != nil {
+					return fmt.Errorf("fleet %q vulnerabilities for device %q: %w", fleetName, deviceName1, err)
+				}
+				if len(fleetVulns.Items) < DigestACVECount {
+					return fmt.Errorf("fleet %q vulnerabilities for device %q: got %d CVEs, expected at least %d",
+						fleetName, deviceName1, len(fleetVulns.Items), DigestACVECount)
+				}
+				return nil
+			}, syncWaitTimeoutExtended, syncInterval).Should(Succeed())
 
 			By("Verifying Critical CVE generates DeviceVulnerabilityCVECritical event")
 			events, err := harness.GetDeviceEvents(deviceName1, nil)


### PR DESCRIPTION
## Summary

- Wait for fleet-level vulnerability aggregation in the lifecycle E2E test before asserting the CVE count.
- Reuse the existing vulnerability state dump while polling so flakes include useful diagnostics.

## Release target

- [x] release-1.3

Target release: release-1.3
