### PR TITLE
EDM-4760: Populate capabilities.osMode at enrollment approval

### DIFF
--- a/api/core/v1beta1/osmode_test.go
+++ b/api/core/v1beta1/osmode_test.go
@@ -120,19 +120,23 @@ func TestEnrollmentRequestSpecOsModeJSON(t *testing.T) {
 	}
 }
 
-func TestEnrollmentRequestValidateOsMode(t *testing.T) {
-	baseER := func(mode *OsModeType) EnrollmentRequest {
-		return EnrollmentRequest{
-			Metadata: ObjectMeta{Name: lo.ToPtr("test-er")},
-			Spec:     EnrollmentRequestSpec{Csr: "pem-data", OsMode: mode},
-		}
-	}
+type enrollmentRequestValidateOsModeCase struct {
+	name      string
+	osMode    *OsModeType
+	wantError bool
+}
 
-	tests := []struct {
-		name      string
-		osMode    *OsModeType
-		wantError bool
-	}{
+func enrollmentRequestWithOsMode(mode *OsModeType) EnrollmentRequest {
+	return EnrollmentRequest{
+		Metadata: ObjectMeta{Name: lo.ToPtr("test-er")},
+		Spec:     EnrollmentRequestSpec{Csr: "pem-data", OsMode: mode},
+	}
+}
+
+// TestEnrollmentRequestValidateOsMode verifies EnrollmentRequest.Validate accepts
+// nil/image/package osMode and rejects other values with a spec.osMode error.
+func TestEnrollmentRequestValidateOsMode(t *testing.T) {
+	tests := []enrollmentRequestValidateOsModeCase{
 		{
 			name:   "When osMode is absent it should pass validation",
 			osMode: nil,
@@ -154,7 +158,7 @@ func TestEnrollmentRequestValidateOsMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			er := baseER(tt.osMode)
+			er := enrollmentRequestWithOsMode(tt.osMode)
 			errs := er.Validate()
 			if tt.wantError {
 				require.NotEmpty(t, errs)

--- a/api/core/v1beta1/osmode_test.go
+++ b/api/core/v1beta1/osmode_test.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/samber/lo"
@@ -115,6 +116,63 @@ func TestEnrollmentRequestSpecOsModeJSON(t *testing.T) {
 			}
 			require.NotNil(t, spec.OsMode)
 			assert.Equal(t, *tt.wantOsMode, *spec.OsMode)
+		})
+	}
+}
+
+func TestEnrollmentRequestValidateOsMode(t *testing.T) {
+	baseER := func(mode *OsModeType) EnrollmentRequest {
+		return EnrollmentRequest{
+			Metadata: ObjectMeta{Name: lo.ToPtr("test-er")},
+			Spec:     EnrollmentRequestSpec{Csr: "pem-data", OsMode: mode},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		osMode    *OsModeType
+		wantError bool
+	}{
+		{
+			name:   "When osMode is absent it should pass validation",
+			osMode: nil,
+		},
+		{
+			name:   "When osMode is image it should pass validation",
+			osMode: lo.ToPtr(OsModeImage),
+		},
+		{
+			name:   "When osMode is package it should pass validation",
+			osMode: lo.ToPtr(OsModePackage),
+		},
+		{
+			name:      "When osMode is invalid it should return an error",
+			osMode:    lo.ToPtr(OsModeType("foo")),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			er := baseER(tt.osMode)
+			errs := er.Validate()
+			if tt.wantError {
+				require.NotEmpty(t, errs)
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e.Error(), "spec.osMode") {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected an error mentioning spec.osMode, got: %v", errs)
+			} else {
+				for _, e := range errs {
+					if strings.Contains(e.Error(), "spec.osMode") {
+						t.Errorf("unexpected osMode error: %v", e)
+					}
+				}
+			}
 		})
 	}
 }

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -470,6 +470,9 @@ func (r EnrollmentRequest) Validate() []error {
 	allErrs = append(allErrs, validation.ValidateLabels(r.Metadata.Labels)...)
 	allErrs = append(allErrs, validation.ValidateAnnotations(r.Metadata.Annotations)...)
 	allErrs = append(allErrs, validation.ValidateCSRWithTCGSupport([]byte(r.Spec.Csr))...)
+	if r.Spec.OsMode != nil && *r.Spec.OsMode != OsModeImage && *r.Spec.OsMode != OsModePackage {
+		allErrs = append(allErrs, fmt.Errorf("spec.osMode: invalid value %q (must be %q or %q)", *r.Spec.OsMode, OsModeImage, OsModePackage))
+	}
 
 	return allErrs
 }

--- a/internal/service/enrollmentrequest/handler.go
+++ b/internal/service/enrollmentrequest/handler.go
@@ -272,6 +272,12 @@ func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, 
 		}
 	}
 
+	if enrollmentRequest.Spec.OsMode != nil {
+		deviceStatus.Capabilities = &domain.DeviceCapabilities{
+			OsMode: enrollmentRequest.Spec.OsMode,
+		}
+	}
+
 	name := lo.FromPtr(enrollmentRequest.Metadata.Name)
 	apiResource := &domain.Device{
 		Metadata: domain.ObjectMeta{

--- a/internal/service/enrollmentrequest/handler_test.go
+++ b/internal/service/enrollmentrequest/handler_test.go
@@ -533,6 +533,62 @@ func TestReplaceEnrollmentRequestStatus(t *testing.T) {
 	require.Equal(t, statusNotFoundCode, status.Code)
 }
 
+func TestCreateDeviceFromEnrollmentRequestOsMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		osMode     *domain.OsModeType
+		wantCaps   bool
+		wantOsMode *domain.OsModeType
+	}{
+		{
+			name:       "When osMode is package it should set capabilities.osMode to package",
+			osMode:     lo.ToPtr(domain.OsModePackage),
+			wantCaps:   true,
+			wantOsMode: lo.ToPtr(domain.OsModePackage),
+		},
+		{
+			name:       "When osMode is image it should set capabilities.osMode to image",
+			osMode:     lo.ToPtr(domain.OsModeImage),
+			wantCaps:   true,
+			wantOsMode: lo.ToPtr(domain.OsModeImage),
+		},
+		{
+			name:     "When osMode is absent it should leave capabilities nil",
+			osMode:   nil,
+			wantCaps: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _, fakeDevices, _, _ := newTestHandler(t)
+			ctx := context.Background()
+			orgId := uuid.New()
+			deviceName := "osmode-test-device"
+
+			er := &domain.EnrollmentRequest{
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     domain.EnrollmentRequestSpec{Csr: "TestCSR", OsMode: tt.osMode, DeviceStatus: lo.ToPtr(domain.NewDeviceStatus())},
+			}
+
+			err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+			require.NoError(t, err)
+
+			device, err := fakeDevices.Get(ctx, orgId, deviceName)
+			require.NoError(t, err)
+			require.NotNil(t, device.Status)
+
+			if !tt.wantCaps {
+				require.Nil(t, device.Status.Capabilities, "expected nil Capabilities for absent osMode")
+			} else {
+				require.NotNil(t, device.Status.Capabilities, "expected non-nil Capabilities")
+				require.NotNil(t, device.Status.Capabilities.OsMode, "expected non-nil OsMode in Capabilities")
+				require.Equal(t, *tt.wantOsMode, *device.Status.Capabilities.OsMode)
+			}
+		})
+	}
+}
+
 // TestCreateDeviceFromEnrollmentRequestNeverManaged is a regression guard for the deviceOnlyStore
 // adapter's safety invariant: createDeviceFromEnrollmentRequest must never set Metadata.Owner on
 // the device it builds. deviceOnlyStore only overrides Device() on its embedded nil store.Store;

--- a/test/integration/service/enrollmentrequest_device_creation_test.go
+++ b/test/integration/service/enrollmentrequest_device_creation_test.go
@@ -187,6 +187,86 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 		})
 	})
 
+	Context("createDeviceFromEnrollmentRequest with osMode capabilities", func() {
+		approveER := func(suite *ServiceTestSuite, erName string) {
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+		}
+
+		It("When osMode is package it should set device capabilities.osMode to package", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.OsMode = lo.ToPtr(api.OsModePackage)
+
+			By("creating enrollment request with osMode=package")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			approveER(suite, erName)
+
+			By("verifying device capabilities")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status.Capabilities).ToNot(BeNil())
+			Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+			Expect(*device.Status.Capabilities.OsMode).To(Equal(api.OsModePackage))
+		})
+
+		It("When osMode is image it should set device capabilities.osMode to image", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Spec.OsMode = lo.ToPtr(api.OsModeImage)
+
+			By("creating enrollment request with osMode=image")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			approveER(suite, erName)
+
+			By("verifying device capabilities")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status.Capabilities).ToNot(BeNil())
+			Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+			Expect(*device.Status.Capabilities.OsMode).To(Equal(api.OsModeImage))
+		})
+
+		It("When osMode is absent it should leave device capabilities nil", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+
+			By("creating enrollment request without osMode")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			approveER(suite, erName)
+
+			By("verifying device capabilities are nil")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status.Capabilities).To(BeNil())
+		})
+	})
+
 	Context("createDeviceFromEnrollmentRequest with replaceLabels", func() {
 		DescribeTable("should handle replaceLabels correctly",
 			func(

--- a/test/integration/service/enrollmentrequest_device_creation_test.go
+++ b/test/integration/service/enrollmentrequest_device_creation_test.go
@@ -188,24 +188,6 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 	})
 
 	Context("createDeviceFromEnrollmentRequest with osMode capabilities", func() {
-		approveER := func(suite *ServiceTestSuite, erName string) {
-			defaultOrg := &model.Organization{
-				ID:          org.DefaultID,
-				ExternalID:  org.DefaultID.String(),
-				DisplayName: org.DefaultID.String(),
-			}
-			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
-			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
-
-			approval := api.EnrollmentRequestApproval{
-				Approved: true,
-				Labels:   &map[string]string{"approved": "true"},
-			}
-
-			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
-			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
-		}
-
 		It("When osMode is package it should set device capabilities.osMode to package", func() {
 			er := CreateTestER()
 			erName := lo.FromPtr(er.Metadata.Name)
@@ -217,7 +199,12 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 			Expect(created).ToNot(BeNil())
 
 			By("approving the enrollment request")
-			approveER(suite, erName)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(suite.Ctx, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
 
 			By("verifying device capabilities")
 			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
@@ -238,7 +225,12 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 			Expect(created).ToNot(BeNil())
 
 			By("approving the enrollment request")
-			approveER(suite, erName)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(suite.Ctx, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
 
 			By("verifying device capabilities")
 			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
@@ -258,7 +250,12 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 			Expect(created).ToNot(BeNil())
 
 			By("approving the enrollment request")
-			approveER(suite, erName)
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(suite.Ctx, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
 
 			By("verifying device capabilities are nil")
 			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)


### PR DESCRIPTION
### Summary

On enrollment approval, copy `EnrollmentRequest.spec.osMode` onto the new device's `status.capabilities.osMode`. Omit capabilities when the ER has no `osMode`. Add explicit enum validation for `spec.osMode` in `EnrollmentRequest.Validate()`.

Agent status updates already replace full status (including capabilities), so later reports continue to refresh `osMode` as before — no change required on that path.

### Changes

- **API validation** (`api/core/v1beta1/validation.go`): Reject `spec.osMode` values other than `image` / `package` when present
- **Enrollment approval** (`internal/service/enrollmentrequest/handler.go`): Populate `device.status.capabilities.osMode` from the ER on device creation
- **Tests:** Unit coverage for Validate and device creation; integration coverage for approve → get-device with package/image/absent osMode

### Why this change

After enrollment is approved, the server creates a Device and can immediately assign a fleet (or evaluate fleet templates against the new device). OS mode used to appear only later, on the agent's first status report — so for a window after approval the server treated the device as “unknown mode.”

That gap matters for package-mode (and mixed fleets):

**race condition** — A package-mode device can be approved and matched to a fleet whose rendered spec includes `spec.os.image`. Without `status.capabilities.osMode` yet, the server cannot treat the device as package-mode during that window (early validation, OutOfDate / OS-mismatch awareness from EDM-4758, and downstream stories that gate on mode).


### Testing

- **Unit tests:** `TestEnrollmentRequestValidateOsMode` (nil/image/package/invalid); `TestCreateDeviceFromEnrollmentRequestOsMode` (package/image/absent)
- **Integration tests:** EnrollmentRequest device creation suite — osMode capabilities context (3 cases)
- **Coverage:** New behavioral paths exercised; AC-3 status refresh verified via existing `ReplaceDeviceStatus` full status replace

### Acceptance Criteria

- [ ] AC-1: `ApproveEnrollmentRequest()` reads `EnrollmentRequest.spec.osMode` and sets `status.capabilities.osMode` on the created device
- [ ] AC-2: Missing `spec.osMode` (legacy agent) leaves capabilities empty
- [ ] AC-3: Subsequent agent status reports refresh `capabilities.osMode` (full status replace)
- [ ] AC-4: `EnrollmentRequest.Validate()` rejects invalid `osMode` enum values when present
