### PR TITLE
NO-ISSUE: Default virt-launcher to v1.9.0 and disable passt workarounds

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -436,14 +436,14 @@ For more detailed configuration options, see the [Values](#values) section below
 | vulnerabilityReporting.trustify.auth.oidcIssuerUrl | string | `""` | OIDC issuer URL for client-credentials mode. |
 | vulnerabilityReporting.trustify.auth.secretName | string | `""` | Name of the Kubernetes Secret containing 'client_id' and 'client_secret' keys. |
 | vulnerabilityReporting.trustify.endpoint | string | `""` | Trustify API base URL (do not include /api/v1 or /api/v2 paths). |
-| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","passtWorkarounds":true}}` | Worker Configuration |
+| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","passtWorkarounds":false}}` | Worker Configuration |
 | worker.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
 | worker.image.image | string | `"quay.io/flightctl/flightctl-worker-el9"` | Worker container image |
 | worker.image.pullPolicy | string | `""` | Image pull policy for worker container |
 | worker.image.tag | string | `""` | Worker image tag |
-| worker.vmRender | object | `{"launcherImage":"","passtWorkarounds":true}` | VM application render options passed to vm-to-quadlet |
+| worker.vmRender | object | `{"launcherImage":"","passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
 | worker.vmRender.launcherImage | string | `""` | virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default) |
-| worker.vmRender.passtWorkarounds | bool | `true` | Enable passt networking workarounds for older virt-launcher images (recommended true) |
+| worker.vmRender.passtWorkarounds | bool | `false` | Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images) |
 
 ## Environment-Specific Values Files
 

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -32,7 +32,7 @@ data:
             {{- if $vmRender.launcherImage }}
             launcherImage: {{ $vmRender.launcherImage | quote }}
             {{- end }}
-            passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}true{{ end }}
+            passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}false{{ end }}
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local
         port: 6379

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -318,8 +318,8 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
-    # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
-    passtWorkarounds: true
+    # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
+    passtWorkarounds: false
 
 # -- Periodic Configuration
 periodic:

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -318,8 +318,8 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
-    # -- Enable passt networking workarounds for older virt-launcher images (recommended true)
-    passtWorkarounds: true
+    # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
+    passtWorkarounds: false
 
 # -- Periodic Configuration
 periodic:

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -29,7 +29,7 @@ worker:
     {{- if and .worker .worker.vmRender .worker.vmRender.launcherImage }}
     launcherImage: {{.worker.vmRender.launcherImage}}
     {{- end }}
-    passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "false"}}false{{else}}true{{end}}{{else}}true{{end}}
+    passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "true"}}true{{else}}false{{end}}{{else}}false{{end}}
 
 
 {{- with .profiling }}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -115,12 +115,13 @@ prometheus:
 
 # Worker VM render options (optional). Uncomment to override defaults.
 # Leave launcherImage unset to use the worker built-in default
-# (quay.io/kubevirt/virt-launcher:v1.8.4). In air-gapped environments, mirror
+# (quay.io/kubevirt/virt-launcher:v1.9.0). In air-gapped environments, mirror
 # virt-launcher to a registry devices can pull from and set launcherImage to that reference.
+# Enable passtWorkarounds only when using older virt-launcher images that need it.
 # worker:
 #   vmRender:
 #     launcherImage: ""
-#     passtWorkarounds: true
+#     passtWorkarounds: false
 
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.
 # imagebuilderWorker:

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -6,10 +6,10 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 
 | Setting | Default |
 | ------- | ------- |
-| `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.8.4` (built into the worker; leave config unset or empty to use it) |
-| `passtWorkarounds` | `true` |
+| `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.9.0` (built into the worker; leave config unset or empty to use it) |
+| `passtWorkarounds` | `false` |
 
-`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). Keep this enabled unless your virt-launcher image already includes a fixed passt build.
+`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when you override `launcherImage` to an older image that still requires the workaround.
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you n
 worker:
   vmRender:
     launcherImage: ""
-    passtWorkarounds: true
+    passtWorkarounds: false
 ```
 
 Apply the chart upgrade, then restart the worker so it reloads configuration:
@@ -47,7 +47,7 @@ Edit `/etc/flightctl/service-config.yaml` only when you need overrides. Omit `la
 ```yaml
 worker:
   vmRender:
-    passtWorkarounds: true
+    passtWorkarounds: false
 ```
 
 Restart the worker so the config template is re-rendered and the service reloads:
@@ -62,7 +62,7 @@ The default virt-launcher image is pulled by devices when they run VM applicatio
 
 In an air-gapped deployment:
 
-1. Mirror `quay.io/kubevirt/virt-launcher:v1.8.4` (or your chosen virt-launcher image) to a registry that devices can reach.
+1. Mirror `quay.io/kubevirt/virt-launcher:v1.9.0` (or your chosen virt-launcher image) to a registry that devices can reach.
 2. Set `worker.vmRender.launcherImage` to that mirrored reference so rendered Quadlet units pull from the mirror.
 3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image reference.
 
@@ -71,15 +71,15 @@ Example (community / upstream registry):
 ```bash
 INTERNAL=registry.example.com:5000
 skopeo copy --all \
-  docker://quay.io/kubevirt/virt-launcher:v1.8.4 \
-  docker://${INTERNAL}/kubevirt/virt-launcher:v1.8.4
+  docker://quay.io/kubevirt/virt-launcher:v1.9.0 \
+  docker://${INTERNAL}/kubevirt/virt-launcher:v1.9.0
 ```
 
 ```yaml
 worker:
   vmRender:
-    launcherImage: "registry.example.com:5000/kubevirt/virt-launcher:v1.8.4"
-    passtWorkarounds: true
+    launcherImage: "registry.example.com:5000/kubevirt/virt-launcher:v1.9.0"
+    passtWorkarounds: false
 ```
 
 There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` at the mirrored location.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,7 +405,7 @@ func (c *imageBuilderWorkerConfig) EffectiveSyftSkipTLSVerify() bool {
 	return c != nil && c.ServiceImages != nil && c.ServiceImages.Syft != nil && c.ServiceImages.Syft.SkipTLSVerify
 }
 
-const DefaultVirtLauncherImage = "quay.io/kubevirt/virt-launcher:v1.8.4"
+const DefaultVirtLauncherImage = "quay.io/kubevirt/virt-launcher:v1.9.0"
 
 // workerConfig holds configuration for the flightctl-worker service.
 type workerConfig struct {
@@ -421,7 +421,7 @@ type vmRenderConfig struct {
 
 // NewDefaultWorkerConfig returns the default flightctl-worker configuration.
 func NewDefaultWorkerConfig() *workerConfig {
-	passt := true
+	passt := false
 	return &workerConfig{
 		VmRender: &vmRenderConfig{
 			LauncherImage:    DefaultVirtLauncherImage,
@@ -441,7 +441,7 @@ func (c *Config) EffectiveVmLauncherImage() string {
 // EffectiveVmPasstWorkarounds returns whether passt workarounds are enabled for VM render.
 func (c *Config) EffectiveVmPasstWorkarounds() bool {
 	if c == nil || c.Worker == nil {
-		return true
+		return false
 	}
 	return c.Worker.EffectivePasstWorkarounds()
 }
@@ -454,12 +454,12 @@ func (c *workerConfig) EffectiveLauncherImage() string {
 	return DefaultVirtLauncherImage
 }
 
-// EffectivePasstWorkarounds returns whether passt workarounds are enabled (default true).
+// EffectivePasstWorkarounds returns whether passt workarounds are enabled (default false).
 func (c *workerConfig) EffectivePasstWorkarounds() bool {
 	if c != nil && c.VmRender != nil && c.VmRender.PasstWorkarounds != nil {
 		return *c.VmRender.PasstWorkarounds
 	}
-	return true
+	return false
 }
 
 // IsSBOMEnabled returns whether SBOM generation is enabled.

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -40,7 +40,7 @@ type VmRenderOptions struct {
 func DefaultVmRenderOptions() VmRenderOptions {
 	return VmRenderOptions{
 		LauncherImage:    config.DefaultVirtLauncherImage,
-		PasstWorkarounds: true,
+		PasstWorkarounds: false,
 	}
 }
 

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -175,7 +175,7 @@ const fakePodUnit = "[Pod]\nNetwork=podman\n\n[Install]\nWantedBy=default.target
 // pod convention (not the raw VM name) to mirror real vm-to-quadlet output.
 var fakeQuadletFiles = map[string]string{
 	"virt-launcher-my-vm.pod":               fakePodUnit,
-	"virt-launcher-my-vm-compute.container": "[Container]\nImage=quay.io/kubevirt/virt-launcher:v1.8.4\n",
+	"virt-launcher-my-vm-compute.container": "[Container]\nImage=quay.io/kubevirt/virt-launcher:v1.9.0\n",
 }
 
 func TestRenderVmApplication(t *testing.T) {

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -369,7 +369,7 @@ func TestRenderVmApplication_CachePopulatedOnMiss(t *testing.T) {
 	assert.Equal(t, 1, callCount, "converter must not be called again on the second (cache hit) call")
 
 	opts := DefaultVmRenderOptions()
-	opts.PasstWorkarounds = false
+	opts.PasstWorkarounds = true
 	_, err = renderVmApplication(ctx, vmApp, converter, opts, kv)
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "converter should run again when passtWorkarounds changes")
@@ -457,7 +457,7 @@ func TestVmRenderOptionsFromConfig(t *testing.T) {
 
 	defaults := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, &config.Config{}, [16]byte{}, domain.Event{})
 	assert.Equal(t, config.DefaultVirtLauncherImage, defaults.vmRenderOptions.LauncherImage)
-	assert.True(t, defaults.vmRenderOptions.PasstWorkarounds)
+	assert.False(t, defaults.vmRenderOptions.PasstWorkarounds)
 }
 
 // TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication


### PR DESCRIPTION
## Summary
- Bump the built-in default virt-launcher image from `quay.io/kubevirt/virt-launcher:v1.8.4` to `v1.9.0`
- Default `passtWorkarounds` to `false` across worker config, Helm, and Podman quadlets (v1.9.0 does not need the workaround)
- Update docs and unit tests to match the new defaults

## Test plan
- [x] `go test ./internal/tasks/ -run 'TestVmRenderOptionsFromConfig|TestNewVmConverter|TestRenderVmApplication_CachePopulatedOnMiss'`
- [ ] Confirm a fresh deploy renders VM apps with virt-launcher `v1.9.0` and `--passt-workarounds=false`
- [ ] Confirm explicitly setting `passtWorkarounds: true` still enables the flag for older launcher images


Made with [Cursor](https://cursor.com)