### PR TITLE
EDM-4969: Honor Podman health_status events for application status

### DIFF
--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -88,6 +88,7 @@ type PodmanEvent struct {
 	Status            string            `json:"Status"`
 	Type              string            `json:"Type"`
 	TimeNano          int64             `json:"timeNano"`
+	HealthStatus      string            `json:"health_status,omitempty"`
 	Attributes        map[string]string `json:"Attributes"`
 }
 

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -22,14 +22,15 @@ const (
 type StatusType string
 
 const (
-	StatusCreate  StatusType = "create"
-	StatusInit    StatusType = "init"
-	StatusRunning StatusType = "start"
-	StatusStop    StatusType = "stop"
-	StatusDie     StatusType = "die" // docker only
-	StatusDied    StatusType = "died"
-	StatusRemove  StatusType = "remove"
-	StatusExited  StatusType = "exited"
+	StatusCreate    StatusType = "create"
+	StatusInit      StatusType = "init"
+	StatusRunning   StatusType = "start"
+	StatusStop      StatusType = "stop"
+	StatusDie       StatusType = "die" // docker only
+	StatusDied      StatusType = "died"
+	StatusRemove    StatusType = "remove"
+	StatusExited    StatusType = "exited"
+	StatusUnhealthy StatusType = "unhealthy"
 )
 
 func (c StatusType) String() string {
@@ -302,6 +303,7 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 	restarts := 0
 	exited := 0
 	stopped := 0
+	unhealthy := 0
 	for _, workload := range a.workloads {
 		restarts += workload.Restarts
 		switch workload.Status {
@@ -309,6 +311,8 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 			initializing++
 		case StatusRunning:
 			healthy++
+		case StatusUnhealthy:
+			unhealthy++
 		case StatusExited:
 			exited++
 		}
@@ -350,6 +354,9 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 	case isRunningHealthy(total, healthy, initializing, exited):
 		newStatus = v1beta1.ApplicationStatusRunning
 		summary.Status = v1beta1.ApplicationsSummaryStatusHealthy
+	case isRunningUnhealthy(total, healthy, unhealthy, initializing, stopped):
+		newStatus = v1beta1.ApplicationStatusRunning
+		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
 	case isRunningDegraded(total, healthy, initializing):
 		newStatus = v1beta1.ApplicationStatusRunning
 		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
@@ -410,6 +417,10 @@ func isRunningDegraded(total, healthy, initializing int) bool {
 
 func isRunningHealthy(total, healthy, initializing, exited int) bool {
 	return total > 0 && (healthy == total || healthy+exited == total) && initializing == 0
+}
+
+func isRunningUnhealthy(total, healthy, unhealthy, initializing, terminal int) bool {
+	return total > 0 && unhealthy > 0 && initializing == 0 && healthy+unhealthy+terminal == total
 }
 
 func isErrored(total, healthy, initializing int) bool {

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -303,6 +303,7 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 	restarts := 0
 	exited := 0
 	stopped := 0
+	stopping := 0
 	unhealthy := 0
 	for _, workload := range a.workloads {
 		restarts += workload.Restarts
@@ -315,6 +316,8 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 			unhealthy++
 		case StatusExited:
 			exited++
+		case StatusStop:
+			stopping++
 		}
 		// A workload that has reached a terminal container state counts as stopped
 		// regardless of exit code: when we asked the app to stop, a non-zero exit
@@ -354,7 +357,7 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 	case isRunningHealthy(total, healthy, initializing, exited):
 		newStatus = v1beta1.ApplicationStatusRunning
 		summary.Status = v1beta1.ApplicationsSummaryStatusHealthy
-	case isRunningUnhealthy(total, healthy, unhealthy, initializing, stopped):
+	case isRunningUnhealthy(total, healthy, unhealthy, initializing, stopped+stopping):
 		newStatus = v1beta1.ApplicationStatusRunning
 		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
 	case isRunningDegraded(total, healthy, initializing):

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -224,6 +224,106 @@ func TestApplicationStatus(t *testing.T) {
 			expectedStatus:        v1beta1.ApplicationStatusCompleted,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusHealthy,
 		},
+		{
+			name: "When single workload is unhealthy it should report Running degraded",
+			workloads: []Workload{
+				{
+					Name:   "container1",
+					Status: StatusUnhealthy,
+				},
+			},
+			expectedReady:         "0/1",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When one workload is unhealthy and one is healthy it should report Running degraded",
+			workloads: []Workload{
+				{
+					Name:   "container1",
+					Status: StatusRunning,
+				},
+				{
+					Name:   "container2",
+					Status: StatusUnhealthy,
+				},
+			},
+			expectedReady:         "1/2",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When all workloads are unhealthy it should report Running degraded",
+			workloads: []Workload{
+				{
+					Name:   "container1",
+					Status: StatusUnhealthy,
+				},
+				{
+					Name:   "container2",
+					Status: StatusUnhealthy,
+				},
+			},
+			expectedReady:         "0/2",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When one workload is unhealthy and one is exited it should report Running degraded",
+			workloads: []Workload{
+				{
+					Name:   "container1",
+					Status: StatusUnhealthy,
+				},
+				{
+					Name:   "container2",
+					Status: StatusExited,
+				},
+			},
+			expectedReady:         "0/2",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When one workload is unhealthy and one has died it should report Running degraded",
+			workloads: []Workload{
+				{
+					Name:   "container1",
+					Status: StatusUnhealthy,
+				},
+				{
+					Name:   "container2",
+					Status: StatusDied,
+				},
+			},
+			expectedReady:         "0/2",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When running workloads are healthy and init containers have exited it should report Running healthy",
+			workloads: []Workload{
+				{Name: "compute", Status: StatusRunning},
+				{Name: "virt-launcher", Status: StatusRunning},
+				{Name: "init-volume", Status: StatusExited},
+				{Name: "init-config", Status: StatusExited},
+			},
+			expectedReady:         "2/4",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name: "When a running workload is unhealthy and init containers have exited it should report Running degraded",
+			workloads: []Workload{
+				{Name: "compute", Status: StatusUnhealthy},
+				{Name: "virt-launcher", Status: StatusRunning},
+				{Name: "init-volume", Status: StatusExited},
+				{Name: "init-config", Status: StatusExited},
+			},
+			expectedReady:         "1/4",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,6 +471,28 @@ func TestApplicationStatusWithDesiredStateStopped(t *testing.T) {
 			desiredState:          v1beta1.ApplicationDesiredStateStopped,
 			expectedStatus:        v1beta1.ApplicationStatusStopping,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When desiredState is stopped and a workload is still unhealthy it should report Stopping not Running",
+			workloads: []Workload{
+				{Name: "compute", Status: StatusUnhealthy},
+				{Name: "init-volume", Status: StatusExited},
+			},
+			desiredState:          v1beta1.ApplicationDesiredStateStopped,
+			expectedStatus:        v1beta1.ApplicationStatusStopping,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name: "When desiredState is stopped and all workloads including previously unhealthy are terminal it should report Stopped healthy",
+			workloads: []Workload{
+				{Name: "compute", Status: StatusDied},
+				{Name: "virt-launcher", Status: StatusExited},
+				{Name: "init-volume", Status: StatusExited},
+				{Name: "init-config", Status: StatusExited},
+			},
+			desiredState:          v1beta1.ApplicationDesiredStateStopped,
+			expectedStatus:        v1beta1.ApplicationStatusStopped,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusHealthy,
 		},
 	}
 

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -301,6 +301,16 @@ func TestApplicationStatus(t *testing.T) {
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
+			name: "When one workload is unhealthy and one is stopping it should report Running degraded",
+			workloads: []Workload{
+				{Name: "container1", Status: StatusUnhealthy},
+				{Name: "container2", Status: StatusStop},
+			},
+			expectedReady:         "0/2",
+			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
 			name: "When running workloads are healthy and init containers have exited it should report Running healthy",
 			workloads: []Workload{
 				{Name: "compute", Status: StatusRunning},

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -416,6 +416,7 @@ func mockExecPodmanEvents(mockExec *executer.MockExecuter, sinceTime time.Time) 
 			"--filter", "event=sync",
 			"--filter", "event=remove",
 			"--filter", "event=exited",
+			"--filter", "event=health_status",
 		},
 	).Return(exec.CommandContext(context.Background(), "echo", `{}`))
 }

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -600,6 +600,14 @@ func (m *PodmanMonitor) updateAppStatus(ctx context.Context, app Application, ev
 }
 
 func (m *PodmanMonitor) updateContainerStatus(ctx context.Context, app Application, event *client.PodmanEvent) {
+	if event.Status == podmanHealthStatusEvent {
+		if app.AppType() != v1beta1.AppTypeVm {
+			return
+		}
+		m.updateContainerHealthStatus(app, event)
+		return
+	}
+
 	appType := normalizeActionAppType(app.AppType())
 	switch appType {
 	case v1beta1.AppTypeCompose:
@@ -608,6 +616,37 @@ func (m *PodmanMonitor) updateContainerStatus(ctx context.Context, app Applicati
 		m.updateQuadletContainerStatus(ctx, app, event)
 	default:
 		m.log.Errorf("Cannot update container status for unknown app type: %s", appType)
+	}
+}
+
+func (m *PodmanMonitor) updateContainerHealthStatus(app Application, event *client.PodmanEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	container, exists := app.Workload(event.Name)
+	if !exists {
+		m.log.Debugf("Ignoring health_status for unknown container %s in app %s", event.Name, app.Name())
+		return
+	}
+	if container.ID != "" && event.ID != "" && container.ID != event.ID {
+		m.log.Debugf("Ignoring stale health_status for container %s: event ID %s != tracked ID %s", event.Name, event.ID, container.ID)
+		return
+	}
+
+	switch container.Status {
+	case StatusRunning, StatusUnhealthy:
+	default:
+		m.log.Debugf("Ignoring health_status=%s for container %s in status %s", event.HealthStatus, event.Name, container.Status)
+		return
+	}
+
+	switch event.HealthStatus {
+	case "unhealthy":
+		container.Status = StatusUnhealthy
+	case "healthy":
+		container.Status = StatusRunning
+	default:
+		m.log.Debugf("Ignoring health_status=%s for container %s", event.HealthStatus, event.Name)
 	}
 }
 
@@ -628,9 +667,10 @@ func (m *PodmanMonitor) updateApplicationStatus(app Application, event *client.P
 
 	container, exists := app.Workload(event.Name)
 	if exists {
-		// update existing container
 		container.Status = status
-		// restarts can only increase
+		if event.ID != "" {
+			container.ID = event.ID
+		}
 		if restarts > container.Restarts {
 			container.Restarts = restarts
 		}
@@ -649,10 +689,6 @@ func (m *PodmanMonitor) updateApplicationStatus(app Application, event *client.P
 }
 
 func (m *PodmanMonitor) updateQuadletContainerStatus(ctx context.Context, app Application, event *client.PodmanEvent) {
-	if event.Status == podmanHealthStatusEvent {
-		return
-	}
-
 	systemdUnit, ok := event.Attributes[quadletSystemdLabel]
 	if !ok {
 		m.log.Errorf("Could not find systemd unit label in event %v", event)
@@ -785,7 +821,7 @@ func (e *podmanEventWatcher) Init(log *log.PrefixLogger, username v1beta1.Userna
 
 func (e *podmanEventWatcher) Watch(ctx context.Context, events chan<- client.PodmanEvent) error {
 	// list of podman events to listen for
-	eventsTypes := []string{"create", "init", "start", "stop", "die", "sync", "remove", "exited"}
+	eventsTypes := []string{"create", "init", "start", "stop", "die", "sync", "remove", "exited", "health_status"}
 	e.log.Debugf("Replaying podman events for user %s since: %s", e.username, e.lastEventTime.Load())
 
 	ctx, e.cancel = context.WithCancel(ctx)

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -37,7 +37,7 @@ func streamDataToStdout(t *testing.T, reader io.Reader) *exec.Cmd {
 }
 
 func podmanEventsCommandMock(execMock *executer.MockExecuter) *gomock.Call {
-	return execMock.EXPECT().CommandContext(gomock.Any(), "podman", "events", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	return execMock.EXPECT().CommandContext(gomock.Any(), "podman", "events", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 }
 
 func TestListenForEvents(t *testing.T) {
@@ -467,6 +467,171 @@ func mockPodmanEventSuccess(name string, username v1beta1.Username, service, sta
 
 func mockPodmanEventError(name string, username v1beta1.Username, service, status string, exitCode int) client.PodmanEvent {
 	return createMockPodmanEvent(name, username, service, status, exitCode)
+}
+
+func mockPodmanHealthEvent(name string, username v1beta1.Username, service, health string) client.PodmanEvent {
+	event := createMockPodmanEvent(name, username, service, "health_status", 0)
+	event.HealthStatus = health
+	return event
+}
+
+func TestUpdateContainerHealthStatus(t *testing.T) {
+	const (
+		appName = "app1"
+		service = "app1-service-1"
+	)
+	containerName := fmt.Sprintf("%s-container", service)
+
+	testCases := []struct {
+		name                   string
+		appType                v1beta1.AppType
+		desiredState           v1beta1.ApplicationDesiredState
+		initialWorkloadStatus  StatusType
+		health                 string
+		expectedWorkloadStatus StatusType
+		expectedReady          string
+		expectedAppStatus      v1beta1.ApplicationStatusType
+		expectedSummary        v1beta1.ApplicationsSummaryStatusType
+	}{
+		{
+			name:                   "When running VM workload becomes unhealthy it should report Running degraded",
+			appType:                v1beta1.AppTypeVm,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusUnhealthy,
+			expectedReady:          "0/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name:                   "When unhealthy VM workload becomes healthy it should report Running healthy",
+			appType:                v1beta1.AppTypeVm,
+			initialWorkloadStatus:  StatusUnhealthy,
+			health:                 "healthy",
+			expectedWorkloadStatus: StatusRunning,
+			expectedReady:          "1/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name:                   "When VM health is starting it should leave workload status unchanged",
+			appType:                v1beta1.AppTypeVm,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "starting",
+			expectedWorkloadStatus: StatusRunning,
+			expectedReady:          "1/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name:                   "When VM workload is still initializing it should ignore health_status",
+			appType:                v1beta1.AppTypeVm,
+			initialWorkloadStatus:  StatusInit,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusInit,
+			expectedReady:          "0/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusPreparing,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusUnknown,
+		},
+		{
+			name:                   "When VM desiredState is stopped and workload is still up unhealthy it should report Stopping",
+			appType:                v1beta1.AppTypeVm,
+			desiredState:           v1beta1.ApplicationDesiredStateStopped,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusUnhealthy,
+			expectedReady:          "0/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusStopping,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
+		},
+		{
+			name:                   "When compose app receives health_status it should leave workload unchanged",
+			appType:                v1beta1.AppTypeCompose,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusRunning,
+			expectedReady:          "1/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name:                   "When quadlet app receives health_status it should leave workload unchanged",
+			appType:                v1beta1.AppTypeQuadlet,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusRunning,
+			expectedReady:          "1/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+		{
+			name:                   "When container app receives health_status it should leave workload unchanged",
+			appType:                v1beta1.AppTypeContainer,
+			initialWorkloadStatus:  StatusRunning,
+			health:                 "unhealthy",
+			expectedWorkloadStatus: StatusRunning,
+			expectedReady:          "1/1",
+			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			log := log.NewPrefixLogger("test")
+			monitor := &PodmanMonitor{
+				apps: make(map[string]Application),
+				log:  log,
+			}
+
+			app := createTestApplicationWithType(require, appName, v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, tc.appType)
+			if tc.desiredState != "" {
+				app.SetDesiredState(tc.desiredState)
+			}
+			app.AddWorkload(&Workload{
+				Name:   containerName,
+				Status: tc.initialWorkloadStatus,
+			})
+			monitor.apps[app.ID()] = app
+
+			event := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, tc.health)
+			monitor.handleEvent(t.Context(), event)
+
+			workload, ok := app.Workload(containerName)
+			require.True(ok)
+			require.Equal(tc.expectedWorkloadStatus, workload.Status)
+
+			status, summary, err := app.Status()
+			require.NoError(err)
+			require.Equal(tc.expectedReady, status.Ready)
+			require.Equal(tc.expectedAppStatus, status.Status)
+			require.Equal(tc.expectedSummary, summary.Status)
+		})
+	}
+
+	t.Run("When health_status event ID does not match tracked container it should leave workload unchanged", func(t *testing.T) {
+		require := require.New(t)
+		monitor := &PodmanMonitor{
+			apps: make(map[string]Application),
+			log:  log.NewPrefixLogger("test"),
+		}
+		app := createTestApplicationWithType(require, appName, v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, v1beta1.AppTypeVm)
+		app.AddWorkload(&Workload{
+			ID:     "current-container-id",
+			Name:   containerName,
+			Status: StatusRunning,
+		})
+		monitor.apps[app.ID()] = app
+
+		event := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "unhealthy")
+		event.ID = "stale-container-id"
+		monitor.handleEvent(t.Context(), event)
+
+		workload, ok := app.Workload(containerName)
+		require.True(ok)
+		require.Equal(StatusRunning, workload.Status)
+	})
 }
 
 func createMockPodmanEvent(name string, username v1beta1.Username, service, status string, exitCode int) client.PodmanEvent {


### PR DESCRIPTION
## Summary
- Subscribe to Podman `health_status` events in the agent monitor (previously filtered out and explicitly dropped for Quadlet/VM apps)
- Map `unhealthy` workloads to `StatusUnhealthy` and fold them into application status as **Running + Degraded** (ready count excludes unhealthy); restore **Healthy** when health recovers
- Add unit coverage for status aggregation and health event handling

Fixes follow-up gap from EDM-4095 / #3182 where `vm-to-quadlet` embeds `HealthCmd` but the agent never consumed the resulting events.

Jira: https://issues.redhat.com/browse/EDM-4969

## Test plan
- [x] `go test ./internal/agent/device/applications/ -count=1`
- [ ] Deploy a VM app with failing HealthCmd and confirm device application summary becomes Degraded while status stays Running
- [ ] Confirm recovery to Healthy once the health check passes again


Made with [Cursor](https://cursor.com)