### PR TITLE
EDM-4762: Reject direct spec.os.image on package-mode devices

### DIFF
--- a/internal/flterrors/flterrors.go
+++ b/internal/flterrors/flterrors.go
@@ -26,12 +26,13 @@ var (
 	ErrAnnotationSelectorParseFailed       = errors.New("failed to parse annotation selector")
 
 	// devices
-	ErrTemplateVersionIsNil    = errors.New("spec.templateVersion not set")
-	ErrInvalidTemplateVersion  = errors.New("device's templateVersion is not valid")
-	ErrNoRenderedVersion       = errors.New("no rendered version for device")
-	ErrDecommission            = errors.New("decommissioned device cannot be created or updated")
-	ErrDeviceAwaitingReconnect = errors.New("device is awaiting reconnection after restore")
-	ErrDeviceConflictPaused    = errors.New("device is paused due to conflicts")
+	ErrTemplateVersionIsNil             = errors.New("spec.templateVersion not set")
+	ErrInvalidTemplateVersion           = errors.New("device's templateVersion is not valid")
+	ErrNoRenderedVersion                = errors.New("no rendered version for device")
+	ErrDecommission                     = errors.New("decommissioned device cannot be created or updated")
+	ErrDeviceAwaitingReconnect          = errors.New("device is awaiting reconnection after restore")
+	ErrDeviceConflictPaused             = errors.New("device is paused due to conflicts")
+	ErrOsImageNotSupportedOnPackageMode = errors.New("OS image is not supported on package-mode devices")
 
 	// csr
 	ErrInvalidPEMBlock = errors.New("not a valid PEM block")

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -242,13 +242,17 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
 			}
 		} else {
-			if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
-				if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
-					return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+			if enforceOwnership {
+				if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
+					if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+						return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+					}
 				}
 			}
-			if enforceCapabilities && isPackageModeOsImageConflict(existing, &device) {
-				return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
+			if enforceCapabilities {
+				if isPackageModeOsImageConflict(existing, &device) {
+					return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
+				}
 			}
 		}
 	}
@@ -485,13 +489,17 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
-		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+	if enforceOwnership {
+		if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
+			if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+			}
 		}
 	}
-	if enforceCapabilities && isPackageModeOsImageConflict(currentObj, newObj) {
-		return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
+	if enforceCapabilities {
+		if isPackageModeOsImageConflict(currentObj, newObj) {
+			return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
+		}
 	}
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -237,23 +237,14 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 
 	if enforceOwnership || enforceCapabilities {
 		existing, getErr := h.deviceStore.Get(ctx, orgId, name)
-		if getErr != nil {
-			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
-				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
-			}
-		} else {
-			if enforceOwnership {
-				if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
-					if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
-						return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-					}
-				}
-			}
-			if enforceCapabilities {
-				if isPackageModeOsImageConflict(existing, &device) {
-					return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
-				}
-			}
+		if getErr != nil && !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+			return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
+		}
+		if existing != nil && enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 && !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+		}
+		if existing != nil && enforceCapabilities && isPackageModeOsImageConflict(existing, &device) {
+			return nil, domain.StatusBadRequest(flterrors.ErrOsImageNotSupportedOnPackageMode.Error())
 		}
 	}
 
@@ -489,17 +480,11 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	if enforceOwnership {
-		if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
-			if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
-				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-			}
-		}
+	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 && !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 	}
-	if enforceCapabilities {
-		if isPackageModeOsImageConflict(currentObj, newObj) {
-			return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
-		}
+	if enforceCapabilities && isPackageModeOsImageConflict(currentObj, newObj) {
+		return nil, domain.StatusBadRequest(flterrors.ErrOsImageNotSupportedOnPackageMode.Error())
 	}
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -812,9 +812,9 @@ func (h *DeviceServiceHandler) processAwaitingReconnectIfNeeded(ctx context.Cont
 	return false
 }
 
-// isPackageModeOsImageConflict reports whether the incoming device spec assigns an OS
-// image to a device that is known to be in package mode. Package-mode devices cannot
-// satisfy image-based OS targets, so the caller should reject the request early.
+// isPackageModeOsImageConflict reports whether the incoming device spec newly assigns
+// or changes a non-empty OS image on a package-mode device. Unrelated updates that
+// retain an existing image (e.g. a label PATCH after fleet rollout) are not conflicts.
 func isPackageModeOsImageConflict(existing *domain.Device, incoming *domain.Device) bool {
 	if existing.Status == nil || existing.Status.Capabilities == nil || existing.Status.Capabilities.OsMode == nil {
 		return false
@@ -822,5 +822,16 @@ func isPackageModeOsImageConflict(existing *domain.Device, incoming *domain.Devi
 	if *existing.Status.Capabilities.OsMode != domain.OsModePackage {
 		return false
 	}
-	return incoming.Spec != nil && incoming.Spec.Os != nil && incoming.Spec.Os.Image != ""
+	incomingImage := ""
+	if incoming.Spec != nil && incoming.Spec.Os != nil {
+		incomingImage = incoming.Spec.Os.Image
+	}
+	if incomingImage == "" {
+		return false
+	}
+	existingImage := ""
+	if existing.Spec != nil && existing.Spec.Os != nil {
+		existingImage = existing.Spec.Os.Image
+	}
+	return incomingImage != existingImage
 }

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -78,9 +78,9 @@ func CreateDeviceFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID
 }
 
 // ReplaceDeviceFromUntrusted sanitizes an untrusted device document, then replaces it.
-func ReplaceDeviceFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+func ReplaceDeviceFromUntrusted(ctx context.Context, svc Service, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status) {
 	SanitizeDevice(&device)
-	return svc.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
+	return svc.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership, enforceCapabilities)
 }
 
 func (h *DeviceServiceHandler) CreateDevice(ctx context.Context, orgId uuid.UUID, device domain.Device) (*domain.Device, domain.Status) {
@@ -222,7 +222,7 @@ func DeviceVerificationCallback(ctx context.Context, before, after *domain.Devic
 	return nil
 }
 
-func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status) {
 	if device.Spec != nil && device.Spec.Decommissioning != nil {
 		h.log.WithError(flterrors.ErrDecommission).Error("attempt to set decommissioned status when replacing device, or to replace decommissioned device")
 		return nil, domain.StatusBadRequest(flterrors.ErrDecommission.Error())
@@ -235,19 +235,19 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
-	if enforceOwnership {
+	if enforceOwnership || enforceCapabilities {
 		existing, getErr := h.deviceStore.Get(ctx, orgId, name)
 		if getErr != nil {
 			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
 				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
 			}
 		} else {
-			if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
+			if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
 				if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
 					return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 				}
 			}
-			if isPackageModeOsImageConflict(existing, &device) {
+			if enforceCapabilities && isPackageModeOsImageConflict(existing, &device) {
 				return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
 			}
 		}
@@ -451,7 +451,7 @@ func (h *DeviceServiceHandler) GetRenderedDevice(ctx context.Context, orgId uuid
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.
-func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status) {
+func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status) {
 	currentObj, err := h.deviceStore.Get(ctx, orgId, name)
 	if err != nil {
 		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
@@ -485,15 +485,13 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	if enforceOwnership {
-		if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
-			if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
-				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-			}
+	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
+		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 		}
-		if isPackageModeOsImageConflict(currentObj, newObj) {
-			return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
-		}
+	}
+	if enforceCapabilities && isPackageModeOsImageConflict(currentObj, newObj) {
+		return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
 	}
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -241,9 +241,14 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
 				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
 			}
-		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
-			if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
-				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+		} else {
+			if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
+				if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+					return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+				}
+			}
+			if isPackageModeOsImageConflict(existing, &device) {
+				return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
 			}
 		}
 	}
@@ -480,9 +485,14 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
-	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
-		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+	if enforceOwnership {
+		if len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
+			if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+			}
+		}
+		if isPackageModeOsImageConflict(currentObj, newObj) {
+			return nil, domain.StatusBadRequest("OS image is not supported on package-mode devices")
 		}
 	}
 
@@ -800,4 +810,14 @@ func (h *DeviceServiceHandler) processAwaitingReconnectIfNeeded(ctx context.Cont
 	}
 	h.log.Debugf("Skipping awaiting reconnect annotation processing for device %s - KV value is not 'true' (value: %s)", deviceName, string(kvValue))
 	return false
+}
+
+func isPackageModeOsImageConflict(existing *domain.Device, incoming *domain.Device) bool {
+	if existing.Status == nil || existing.Status.Capabilities == nil || existing.Status.Capabilities.OsMode == nil {
+		return false
+	}
+	if *existing.Status.Capabilities.OsMode != domain.OsModePackage {
+		return false
+	}
+	return incoming.Spec != nil && incoming.Spec.Os != nil && incoming.Spec.Os.Image != ""
 }

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -812,6 +812,9 @@ func (h *DeviceServiceHandler) processAwaitingReconnectIfNeeded(ctx context.Cont
 	return false
 }
 
+// isPackageModeOsImageConflict reports whether the incoming device spec assigns an OS
+// image to a device that is known to be in package mode. Package-mode devices cannot
+// satisfy image-based OS targets, so the caller should reject the request early.
 func isPackageModeOsImageConflict(existing *domain.Device, incoming *domain.Device) bool {
 	if existing.Status == nil || existing.Status.Capabilities == nil || existing.Status.Capabilities.OsMode == nil {
 		return false

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -943,73 +943,73 @@ func TestGetRenderedDevice(t *testing.T) {
 
 func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 	tests := []struct {
-		name             string
-		capabilities     *domain.DeviceCapabilities
-		existingOs       *domain.DeviceOsSpec
-		incomingOs       *domain.DeviceOsSpec
+		name                string
+		capabilities        *domain.DeviceCapabilities
+		existingOs          *domain.DeviceOsSpec
+		incomingOs          *domain.DeviceOsSpec
 		enforceCapabilities bool
-		wantCode         int32
-		wantMessage      string
+		wantCode            int32
+		wantMessage         string
 	}{
 		{
-			name:             "When package-mode device gets os.image with enforceCapabilities it should return 400",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			name:                "When package-mode device gets os.image with enforceCapabilities it should return 400",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusBadRequest,
-			wantMessage:      "OS image is not supported on package-mode devices",
+			wantCode:            http.StatusBadRequest,
+			wantMessage:         "OS image is not supported on package-mode devices",
 		},
 		{
-			name:             "When package-mode device gets os.image with enforceCapabilities=false it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			name:                "When package-mode device gets os.image with enforceCapabilities=false it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
 			enforceCapabilities: false,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When image-mode device gets os.image it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			name:                "When image-mode device gets os.image it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When device has nil capabilities and gets os.image it should allow",
-			capabilities:     nil,
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			name:                "When device has nil capabilities and gets os.image it should allow",
+			capabilities:        nil,
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When package-mode device gets no os spec it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			incomingOs:       nil,
+			name:                "When package-mode device gets no os spec it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:          nil,
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When capabilities has nil osMode and gets os.image it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: nil},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			name:                "When capabilities has nil osMode and gets os.image it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: nil},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When package-mode device retains the same os.image it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			name:                "When package-mode device retains the same os.image it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When package-mode device changes os.image it should return 400",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
-			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
+			name:                "When package-mode device changes os.image it should return 400",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
 			enforceCapabilities: true,
-			wantCode:         http.StatusBadRequest,
-			wantMessage:      "OS image is not supported on package-mode devices",
+			wantCode:            http.StatusBadRequest,
+			wantMessage:         "OS image is not supported on package-mode devices",
 		},
 	}
 
@@ -1042,43 +1042,43 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 
 func TestPatchDevicePackageModeOsReject(t *testing.T) {
 	tests := []struct {
-		name             string
-		capabilities     *domain.DeviceCapabilities
-		existingOs       *domain.DeviceOsSpec
-		patch            domain.PatchRequest
+		name                string
+		capabilities        *domain.DeviceCapabilities
+		existingOs          *domain.DeviceOsSpec
+		patch               domain.PatchRequest
 		enforceCapabilities bool
-		wantCode         int32
-		wantMessage      string
+		wantCode            int32
+		wantMessage         string
 	}{
 		{
-			name:             "When package-mode device gets patch adding os.image with enforceCapabilities it should return 400",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			patch:            patchAddOsImage("quay.io/img:latest"),
+			name:                "When package-mode device gets patch adding os.image with enforceCapabilities it should return 400",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:               patchAddOsImage("quay.io/img:latest"),
 			enforceCapabilities: true,
-			wantCode:         http.StatusBadRequest,
-			wantMessage:      "OS image is not supported on package-mode devices",
+			wantCode:            http.StatusBadRequest,
+			wantMessage:         "OS image is not supported on package-mode devices",
 		},
 		{
-			name:             "When package-mode device gets non-OS patch it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			patch:            patchAddLabel("env", "prod"),
+			name:                "When package-mode device gets non-OS patch it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:               patchAddLabel("env", "prod"),
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When package-mode device already has os.image and gets non-OS patch it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
-			patch:            patchAddLabel("env", "prod"),
+			name:                "When package-mode device already has os.image and gets non-OS patch it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			patch:               patchAddLabel("env", "prod"),
 			enforceCapabilities: true,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 		{
-			name:             "When package-mode device gets patch adding os.image with enforceCapabilities=false it should allow",
-			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
-			patch:            patchAddOsImage("quay.io/img:latest"),
+			name:                "When package-mode device gets patch adding os.image with enforceCapabilities=false it should allow",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:               patchAddOsImage("quay.io/img:latest"),
 			enforceCapabilities: false,
-			wantCode:         http.StatusOK,
+			wantCode:            http.StatusOK,
 		},
 	}
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -945,6 +945,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 	tests := []struct {
 		name             string
 		capabilities     *domain.DeviceCapabilities
+		existingOs       *domain.DeviceOsSpec
 		incomingOs       *domain.DeviceOsSpec
 		enforceOwnership bool
 		wantCode         int32
@@ -993,6 +994,23 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			enforceOwnership: true,
 			wantCode:         http.StatusOK,
 		},
+		{
+			name:             "When package-mode device retains the same os.image it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When package-mode device changes os.image it should return 400",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusBadRequest,
+			wantMessage:      "OS image is not supported on package-mode devices",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1003,7 +1021,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 
 			existing := domain.Device{
 				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
-				Spec:     &domain.DeviceSpec{},
+				Spec:     &domain.DeviceSpec{Os: tt.existingOs},
 				Status:   &domain.DeviceStatus{Capabilities: tt.capabilities},
 			}
 			_, err := st.device.Create(ctx, orgId, &existing, nil)
@@ -1026,6 +1044,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 	tests := []struct {
 		name             string
 		capabilities     *domain.DeviceCapabilities
+		existingOs       *domain.DeviceOsSpec
 		patch            domain.PatchRequest
 		enforceOwnership bool
 		wantCode         int32
@@ -1042,6 +1061,14 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 		{
 			name:             "When package-mode device gets non-OS patch it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:            patchAddLabel("env", "prod"),
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When package-mode device already has os.image and gets non-OS patch it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			patch:            patchAddLabel("env", "prod"),
 			enforceOwnership: true,
 			wantCode:         http.StatusOK,
@@ -1068,7 +1095,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 					Name:   lo.ToPtr("pkg-dev"),
 					Labels: &map[string]string{"env": "staging"},
 				},
-				Spec:   &domain.DeviceSpec{},
+				Spec:   &domain.DeviceSpec{Os: tt.existingOs},
 				Status: &status,
 			}
 			_, err := st.device.Create(ctx, orgId, &existing, nil)

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -123,7 +123,7 @@ func TestReplaceDevice(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Spec:     &domain.DeviceSpec{},
 		}
-		_, status := svc.ReplaceDevice(ctx, orgId, "bar", device, nil, true)
+		_, status := svc.ReplaceDevice(ctx, orgId, "bar", device, nil, true, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -135,7 +135,7 @@ func TestReplaceDevice(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
 			Spec:     &domain.DeviceSpec{},
 		}
-		result, status := svc.ReplaceDevice(ctx, orgId, "foo", device, nil, true)
+		result, status := svc.ReplaceDevice(ctx, orgId, "foo", device, nil, true, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.Equal(t, "foo", lo.FromPtr(result.Metadata.Name))
 	})
@@ -153,7 +153,7 @@ func TestReplaceDevice(t *testing.T) {
 			Spec: &domain.DeviceSpec{},
 		}
 
-		_, status := ReplaceDeviceFromUntrusted(ctx, svc, orgId, "replace-untrusted", device, nil, true)
+		_, status := ReplaceDeviceFromUntrusted(ctx, svc, orgId, "replace-untrusted", device, nil, true, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.Nil(t, st.device.devices["replace-untrusted"].Metadata.Owner)
 		require.Nil(t, st.device.devices["replace-untrusted"].Metadata.Generation)
@@ -184,7 +184,7 @@ func TestReplaceDevice(t *testing.T) {
 			},
 			Spec: &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
 		}
-		result, status := ReplaceDeviceFromUntrusted(ctx, svc, orgId, "rendered-device", updated, nil, true)
+		result, status := ReplaceDeviceFromUntrusted(ctx, svc, orgId, "rendered-device", updated, nil, true, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.Equal(t, "img-updated", result.Spec.Os.Image)
 		require.Equal(t, "1", (*st.device.devices["rendered-device"].Metadata.Annotations)[domain.DeviceAnnotationRenderedVersion])
@@ -204,7 +204,7 @@ func TestReplaceDevice(t *testing.T) {
 			Spec: &domain.DeviceSpec{},
 		}
 
-		_, status := svc.ReplaceDevice(ctx, orgId, "replace-trusted", device, nil, true)
+		_, status := svc.ReplaceDevice(ctx, orgId, "replace-trusted", device, nil, true, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.Equal(t, "Fleet/f1", lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Owner))
 		require.Equal(t, int64(5), lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Generation))
@@ -232,7 +232,7 @@ func TestReplaceDeviceOwnership(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("owned-device")},
 			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
 		}
-		_, status := svc.ReplaceDevice(ctx, orgId, "owned-device", updated, nil, true)
+		_, status := svc.ReplaceDevice(ctx, orgId, "owned-device", updated, nil, true, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 		require.Equal(t, "img", st.device.devices["owned-device"].Spec.Os.Image)
@@ -253,7 +253,7 @@ func TestReplaceDeviceOwnership(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("owned-device")},
 			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
 		}
-		result, status := svc.ReplaceDevice(ctx, orgId, "owned-device", updated, nil, false)
+		result, status := svc.ReplaceDevice(ctx, orgId, "owned-device", updated, nil, false, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", st.device.devices["owned-device"].Spec.Os.Image)
@@ -275,7 +275,7 @@ func TestReplaceDeviceOwnership(t *testing.T) {
 			Metadata: domain.ObjectMeta{Name: lo.ToPtr("unowned-device")},
 			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-updated"}},
 		}
-		result, status := svc.ReplaceDevice(ctx, orgId, "unowned-device", updated, nil, true)
+		result, status := svc.ReplaceDevice(ctx, orgId, "unowned-device", updated, nil, true, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", st.device.devices["unowned-device"].Spec.Os.Image)
@@ -327,7 +327,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/spec/os/image", Value: &value},
 		}
-		result, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true)
+		result, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.Equal(t, "newimg", result.Spec.Os.Image)
 	})
@@ -338,7 +338,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/metadata/name", Value: &value},
 		}
-		_, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true)
+		_, status := svc.PatchDevice(context.Background(), orgId, "foo", patch, true, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -348,7 +348,7 @@ func TestPatchDevice(t *testing.T) {
 		patch := domain.PatchRequest{
 			{Op: "replace", Path: "/metadata/labels/labelKey", Value: &value},
 		}
-		_, status := svc.PatchDevice(context.Background(), orgId, "bar", patch, true)
+		_, status := svc.PatchDevice(context.Background(), orgId, "bar", patch, true, true)
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 		require.Equal(t, domain.StatusResourceNotFound("Device", "bar"), status)
 	})
@@ -378,7 +378,7 @@ func TestPatchDeviceOwnership(t *testing.T) {
 		var value interface{} = "img-updated"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/os/image", Value: &value}}
 
-		_, status := svc.PatchDevice(context.Background(), orgId, "owned-device", patch, true)
+		_, status := svc.PatchDevice(context.Background(), orgId, "owned-device", patch, true, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 		require.Equal(t, "img", st.device.devices["owned-device"].Spec.Os.Image)
@@ -389,7 +389,7 @@ func TestPatchDeviceOwnership(t *testing.T) {
 		var value interface{} = "img-updated"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/os/image", Value: &value}}
 
-		result, status := svc.PatchDevice(context.Background(), orgId, "owned-device", patch, false)
+		result, status := svc.PatchDevice(context.Background(), orgId, "owned-device", patch, false, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Equal(t, "img-updated", st.device.devices["owned-device"].Spec.Os.Image)
@@ -947,51 +947,51 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 		capabilities     *domain.DeviceCapabilities
 		existingOs       *domain.DeviceOsSpec
 		incomingOs       *domain.DeviceOsSpec
-		enforceOwnership bool
+		enforceCapabilities bool
 		wantCode         int32
 		wantMessage      string
 	}{
 		{
-			name:             "When package-mode device gets os.image with enforceOwnership it should return 400",
+			name:             "When package-mode device gets os.image with enforceCapabilities it should return 400",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusBadRequest,
 			wantMessage:      "OS image is not supported on package-mode devices",
 		},
 		{
-			name:             "When package-mode device gets os.image with enforceOwnership=false it should allow",
+			name:             "When package-mode device gets os.image with enforceCapabilities=false it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
-			enforceOwnership: false,
+			enforceCapabilities: false,
 			wantCode:         http.StatusOK,
 		},
 		{
 			name:             "When image-mode device gets os.image it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
 			name:             "When device has nil capabilities and gets os.image it should allow",
 			capabilities:     nil,
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
 			name:             "When package-mode device gets no os spec it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:       nil,
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
 			name:             "When capabilities has nil osMode and gets os.image it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: nil},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
@@ -999,7 +999,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
@@ -1007,7 +1007,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusBadRequest,
 			wantMessage:      "OS image is not supported on package-mode devices",
 		},
@@ -1031,7 +1031,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
 				Spec:     &domain.DeviceSpec{Os: tt.incomingOs},
 			}
-			_, status := svc.ReplaceDevice(ctx, orgId, "pkg-dev", incoming, nil, tt.enforceOwnership)
+			_, status := svc.ReplaceDevice(ctx, orgId, "pkg-dev", incoming, nil, true, tt.enforceCapabilities)
 			require.Equal(t, tt.wantCode, status.Code)
 			if tt.wantMessage != "" {
 				require.Contains(t, status.Message, tt.wantMessage)
@@ -1046,15 +1046,15 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 		capabilities     *domain.DeviceCapabilities
 		existingOs       *domain.DeviceOsSpec
 		patch            domain.PatchRequest
-		enforceOwnership bool
+		enforceCapabilities bool
 		wantCode         int32
 		wantMessage      string
 	}{
 		{
-			name:             "When package-mode device gets patch adding os.image with enforceOwnership it should return 400",
+			name:             "When package-mode device gets patch adding os.image with enforceCapabilities it should return 400",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:            patchAddOsImage("quay.io/img:latest"),
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusBadRequest,
 			wantMessage:      "OS image is not supported on package-mode devices",
 		},
@@ -1062,7 +1062,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			name:             "When package-mode device gets non-OS patch it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:            patchAddLabel("env", "prod"),
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
@@ -1070,14 +1070,14 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:       &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			patch:            patchAddLabel("env", "prod"),
-			enforceOwnership: true,
+			enforceCapabilities: true,
 			wantCode:         http.StatusOK,
 		},
 		{
-			name:             "When package-mode device gets patch adding os.image with enforceOwnership=false it should allow",
+			name:             "When package-mode device gets patch adding os.image with enforceCapabilities=false it should allow",
 			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:            patchAddOsImage("quay.io/img:latest"),
-			enforceOwnership: false,
+			enforceCapabilities: false,
 			wantCode:         http.StatusOK,
 		},
 	}
@@ -1101,7 +1101,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			_, err := st.device.Create(ctx, orgId, &existing, nil)
 			require.NoError(t, err)
 
-			_, st2 := svc.PatchDevice(ctx, orgId, "pkg-dev", tt.patch, tt.enforceOwnership)
+			_, st2 := svc.PatchDevice(ctx, orgId, "pkg-dev", tt.patch, true, tt.enforceCapabilities)
 			require.Equal(t, tt.wantCode, st2.Code)
 			if tt.wantMessage != "" {
 				require.Contains(t, st2.Message, tt.wantMessage)

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -940,3 +940,155 @@ func TestGetRenderedDevice(t *testing.T) {
 	require.Equal(t, int32(http.StatusOK), status.Code)
 	require.Equal(t, "foo", lo.FromPtr(result.Metadata.Name))
 }
+
+func TestReplaceDevicePackageModeOsReject(t *testing.T) {
+	tests := []struct {
+		name             string
+		capabilities     *domain.DeviceCapabilities
+		incomingOs       *domain.DeviceOsSpec
+		enforceOwnership bool
+		wantCode         int32
+		wantMessage      string
+	}{
+		{
+			name:             "When package-mode device gets os.image with enforceOwnership it should return 400",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusBadRequest,
+			wantMessage:      "OS image is not supported on package-mode devices",
+		},
+		{
+			name:             "When package-mode device gets os.image with enforceOwnership=false it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership: false,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When image-mode device gets os.image it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When device has nil capabilities and gets os.image it should allow",
+			capabilities:     nil,
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When package-mode device gets no os spec it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:       nil,
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When capabilities has nil osMode and gets os.image it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: nil},
+			incomingOs:       &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, _, svc := newTestHandler()
+			ctx := context.Background()
+			orgId := uuid.New()
+
+			existing := domain.Device{
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
+				Spec:     &domain.DeviceSpec{},
+				Status:   &domain.DeviceStatus{Capabilities: tt.capabilities},
+			}
+			_, err := st.device.Create(ctx, orgId, &existing, nil)
+			require.NoError(t, err)
+
+			incoming := domain.Device{
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
+				Spec:     &domain.DeviceSpec{Os: tt.incomingOs},
+			}
+			_, status := svc.ReplaceDevice(ctx, orgId, "pkg-dev", incoming, nil, tt.enforceOwnership)
+			require.Equal(t, tt.wantCode, status.Code)
+			if tt.wantMessage != "" {
+				require.Contains(t, status.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestPatchDevicePackageModeOsReject(t *testing.T) {
+	tests := []struct {
+		name             string
+		capabilities     *domain.DeviceCapabilities
+		patch            domain.PatchRequest
+		enforceOwnership bool
+		wantCode         int32
+		wantMessage      string
+	}{
+		{
+			name:             "When package-mode device gets patch adding os.image with enforceOwnership it should return 400",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:            patchAddOsImage("quay.io/img:latest"),
+			enforceOwnership: true,
+			wantCode:         http.StatusBadRequest,
+			wantMessage:      "OS image is not supported on package-mode devices",
+		},
+		{
+			name:             "When package-mode device gets non-OS patch it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:            patchAddLabel("env", "prod"),
+			enforceOwnership: true,
+			wantCode:         http.StatusOK,
+		},
+		{
+			name:             "When package-mode device gets patch adding os.image with enforceOwnership=false it should allow",
+			capabilities:     &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:            patchAddOsImage("quay.io/img:latest"),
+			enforceOwnership: false,
+			wantCode:         http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, _, svc := newTestHandler()
+			ctx := context.Background()
+			orgId := uuid.New()
+
+			status := domain.NewDeviceStatus()
+			status.Capabilities = tt.capabilities
+			existing := domain.Device{
+				Metadata: domain.ObjectMeta{
+					Name:   lo.ToPtr("pkg-dev"),
+					Labels: &map[string]string{"env": "staging"},
+				},
+				Spec:   &domain.DeviceSpec{},
+				Status: &status,
+			}
+			_, err := st.device.Create(ctx, orgId, &existing, nil)
+			require.NoError(t, err)
+
+			_, st2 := svc.PatchDevice(ctx, orgId, "pkg-dev", tt.patch, tt.enforceOwnership)
+			require.Equal(t, tt.wantCode, st2.Code)
+			if tt.wantMessage != "" {
+				require.Contains(t, st2.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func patchAddOsImage(image string) domain.PatchRequest {
+	var value interface{} = map[string]interface{}{"image": image}
+	return domain.PatchRequest{{Op: "add", Path: "/spec/os", Value: &value}}
+}
+
+func patchAddLabel(key, value string) domain.PatchRequest {
+	var v interface{} = value
+	return domain.PatchRequest{{Op: "replace", Path: "/metadata/labels/" + key, Value: &v}}
+}

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -947,6 +947,8 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 		capabilities        *domain.DeviceCapabilities
 		existingOs          *domain.DeviceOsSpec
 		incomingOs          *domain.DeviceOsSpec
+		owner               *string
+		enforceOwnership    bool
 		enforceCapabilities bool
 		wantCode            int32
 		wantMessage         string
@@ -955,21 +957,44 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			name:                "When package-mode device gets os.image with enforceCapabilities it should return 400",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusBadRequest,
-			wantMessage:         "OS image is not supported on package-mode devices",
+			wantMessage:         flterrors.ErrOsImageNotSupportedOnPackageMode.Error(),
 		},
 		{
 			name:                "When package-mode device gets os.image with enforceCapabilities=false it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: false,
 			wantCode:            http.StatusOK,
+		},
+		{
+			name:                "When package-mode device gets os.image with enforceOwnership=false and enforceCapabilities=true it should return 400",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    false,
+			enforceCapabilities: true,
+			wantCode:            http.StatusBadRequest,
+			wantMessage:         flterrors.ErrOsImageNotSupportedOnPackageMode.Error(),
+		},
+		{
+			name:                "When owned package-mode device gets os.image with enforceOwnership=true and enforceCapabilities=false it should return ownership conflict",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
+			owner:               lo.ToPtr("Fleet/test"),
+			enforceOwnership:    true,
+			enforceCapabilities: false,
+			wantCode:            http.StatusConflict,
+			wantMessage:         flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(),
 		},
 		{
 			name:                "When image-mode device gets os.image it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -977,6 +1002,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			name:                "When device has nil capabilities and gets os.image it should allow",
 			capabilities:        nil,
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -984,6 +1010,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			name:                "When package-mode device gets no os spec it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			incomingOs:          nil,
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -991,6 +1018,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			name:                "When capabilities has nil osMode and gets os.image it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: nil},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -999,6 +1027,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -1007,9 +1036,10 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			incomingOs:          &domain.DeviceOsSpec{Image: "quay.io/other-img:latest"},
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusBadRequest,
-			wantMessage:         "OS image is not supported on package-mode devices",
+			wantMessage:         flterrors.ErrOsImageNotSupportedOnPackageMode.Error(),
 		},
 	}
 
@@ -1020,7 +1050,7 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 			orgId := uuid.New()
 
 			existing := domain.Device{
-				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
+				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev"), Owner: tt.owner},
 				Spec:     &domain.DeviceSpec{Os: tt.existingOs},
 				Status:   &domain.DeviceStatus{Capabilities: tt.capabilities},
 			}
@@ -1031,10 +1061,10 @@ func TestReplaceDevicePackageModeOsReject(t *testing.T) {
 				Metadata: domain.ObjectMeta{Name: lo.ToPtr("pkg-dev")},
 				Spec:     &domain.DeviceSpec{Os: tt.incomingOs},
 			}
-			_, status := svc.ReplaceDevice(ctx, orgId, "pkg-dev", incoming, nil, true, tt.enforceCapabilities)
+			_, status := svc.ReplaceDevice(ctx, orgId, "pkg-dev", incoming, nil, tt.enforceOwnership, tt.enforceCapabilities)
 			require.Equal(t, tt.wantCode, status.Code)
 			if tt.wantMessage != "" {
-				require.Contains(t, status.Message, tt.wantMessage)
+				require.Equal(t, tt.wantMessage, status.Message)
 			}
 		})
 	}
@@ -1045,7 +1075,9 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 		name                string
 		capabilities        *domain.DeviceCapabilities
 		existingOs          *domain.DeviceOsSpec
+		owner               *string
 		patch               domain.PatchRequest
+		enforceOwnership    bool
 		enforceCapabilities bool
 		wantCode            int32
 		wantMessage         string
@@ -1054,14 +1086,16 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			name:                "When package-mode device gets patch adding os.image with enforceCapabilities it should return 400",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:               patchAddOsImage("quay.io/img:latest"),
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusBadRequest,
-			wantMessage:         "OS image is not supported on package-mode devices",
+			wantMessage:         flterrors.ErrOsImageNotSupportedOnPackageMode.Error(),
 		},
 		{
 			name:                "When package-mode device gets non-OS patch it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:               patchAddLabel("env", "prod"),
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -1070,6 +1104,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			existingOs:          &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
 			patch:               patchAddLabel("env", "prod"),
+			enforceOwnership:    true,
 			enforceCapabilities: true,
 			wantCode:            http.StatusOK,
 		},
@@ -1077,8 +1112,32 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			name:                "When package-mode device gets patch adding os.image with enforceCapabilities=false it should allow",
 			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
 			patch:               patchAddOsImage("quay.io/img:latest"),
+			enforceOwnership:    true,
 			enforceCapabilities: false,
 			wantCode:            http.StatusOK,
+		},
+		{
+			name:                "When package-mode device gets patch adding os.image with enforceOwnership=false and enforceCapabilities=true it should return 400",
+			capabilities:        &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			patch:               patchAddOsImage("quay.io/img:latest"),
+			enforceOwnership:    false,
+			enforceCapabilities: true,
+			wantCode:            http.StatusBadRequest,
+			wantMessage:         flterrors.ErrOsImageNotSupportedOnPackageMode.Error(),
+		},
+		{
+			name:         "When owned package-mode device gets OS patch with enforceOwnership=true and enforceCapabilities=false it should return ownership conflict",
+			capabilities: &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			existingOs:   &domain.DeviceOsSpec{Image: "quay.io/fleet-img:latest"},
+			owner:        lo.ToPtr("Fleet/test"),
+			patch: func() domain.PatchRequest {
+				var value interface{} = "quay.io/other-img:latest"
+				return domain.PatchRequest{{Op: "replace", Path: "/spec/os/image", Value: &value}}
+			}(),
+			enforceOwnership:    true,
+			enforceCapabilities: false,
+			wantCode:            http.StatusConflict,
+			wantMessage:         flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(),
 		},
 	}
 
@@ -1093,6 +1152,7 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			existing := domain.Device{
 				Metadata: domain.ObjectMeta{
 					Name:   lo.ToPtr("pkg-dev"),
+					Owner:  tt.owner,
 					Labels: &map[string]string{"env": "staging"},
 				},
 				Spec:   &domain.DeviceSpec{Os: tt.existingOs},
@@ -1101,10 +1161,10 @@ func TestPatchDevicePackageModeOsReject(t *testing.T) {
 			_, err := st.device.Create(ctx, orgId, &existing, nil)
 			require.NoError(t, err)
 
-			_, st2 := svc.PatchDevice(ctx, orgId, "pkg-dev", tt.patch, true, tt.enforceCapabilities)
+			_, st2 := svc.PatchDevice(ctx, orgId, "pkg-dev", tt.patch, tt.enforceOwnership, tt.enforceCapabilities)
 			require.Equal(t, tt.wantCode, st2.Code)
 			if tt.wantMessage != "" {
-				require.Contains(t, st2.Message, tt.wantMessage)
+				require.Equal(t, tt.wantMessage, st2.Message)
 			}
 		})
 	}

--- a/internal/service/device/mock.go
+++ b/internal/service/device/mock.go
@@ -331,18 +331,18 @@ func (mr *MockServiceMockRecorder) OverwriteDeviceRepositoryRefs(ctx, orgId, nam
 }
 
 // PatchDevice mocks base method.
-func (m *MockService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status) {
+func (m *MockService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership, enforceCapabilities bool) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchDevice", ctx, orgId, name, patch, enforceOwnership)
+	ret := m.ctrl.Call(m, "PatchDevice", ctx, orgId, name, patch, enforceOwnership, enforceCapabilities)
 	ret0, _ := ret[0].(*domain.Device)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // PatchDevice indicates an expected call of PatchDevice.
-func (mr *MockServiceMockRecorder) PatchDevice(ctx, orgId, name, patch, enforceOwnership any) *gomock.Call {
+func (mr *MockServiceMockRecorder) PatchDevice(ctx, orgId, name, patch, enforceOwnership, enforceCapabilities any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDevice", reflect.TypeOf((*MockService)(nil).PatchDevice), ctx, orgId, name, patch, enforceOwnership)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDevice", reflect.TypeOf((*MockService)(nil).PatchDevice), ctx, orgId, name, patch, enforceOwnership, enforceCapabilities)
 }
 
 // PatchDeviceStatus mocks base method.
@@ -361,18 +361,18 @@ func (mr *MockServiceMockRecorder) PatchDeviceStatus(ctx, orgId, name, patch any
 }
 
 // ReplaceDevice mocks base method.
-func (m *MockService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+func (m *MockService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership, enforceCapabilities bool) (*domain.Device, domain.Status) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceDevice", ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
+	ret := m.ctrl.Call(m, "ReplaceDevice", ctx, orgId, name, device, fieldsToUnset, enforceOwnership, enforceCapabilities)
 	ret0, _ := ret[0].(*domain.Device)
 	ret1, _ := ret[1].(domain.Status)
 	return ret0, ret1
 }
 
 // ReplaceDevice indicates an expected call of ReplaceDevice.
-func (mr *MockServiceMockRecorder) ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership, enforceCapabilities any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDevice", reflect.TypeOf((*MockService)(nil).ReplaceDevice), ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceDevice", reflect.TypeOf((*MockService)(nil).ReplaceDevice), ctx, orgId, name, device, fieldsToUnset, enforceOwnership, enforceCapabilities)
 }
 
 // ReplaceDeviceStatus mocks base method.

--- a/internal/service/device/service.go
+++ b/internal/service/device/service.go
@@ -16,14 +16,14 @@ type Service interface {
 	ListDevicesByServiceCondition(ctx context.Context, orgId uuid.UUID, conditionType string, conditionStatus string, listParams store.ListParams) (*domain.DeviceList, domain.Status)
 	UpdateDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, error)
 	GetDevice(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status)
-	ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status)
+	ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status)
 	DeleteDevice(ctx context.Context, orgId uuid.UUID, name string) domain.Status
 	GetDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status)
 	GetDeviceLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*domain.DeviceLastSeen, domain.Status)
 	ReplaceDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, refreshLastSeen bool) (*domain.Device, domain.Status)
 	PatchDeviceStatus(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.Device, domain.Status)
 	GetRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, params domain.GetRenderedDeviceParams) (*domain.Device, domain.Status)
-	PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (*domain.Device, domain.Status)
+	PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status)
 	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status)
 	ResumeDevices(ctx context.Context, orgId uuid.UUID, request domain.DeviceResumeRequest) (domain.DeviceResumeResponse, domain.Status)
 	UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status

--- a/internal/service/device/traced.gen.go
+++ b/internal/service/device/traced.gen.go
@@ -203,10 +203,10 @@ func (_d *TracedDeviceService) OverwriteDeviceRepositoryRefs(ctx context.Context
 	return s1
 }
 
-func (_d *TracedDeviceService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool) (dp1 *domain.Device, s1 domain.Status) {
+func (_d *TracedDeviceService) PatchDevice(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest, enforceOwnership bool, enforceCapabilities bool) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "PatchDevice")
 
-	dp1, s1 = _d.inner.PatchDevice(ctx, orgId, name, patch, enforceOwnership)
+	dp1, s1 = _d.inner.PatchDevice(ctx, orgId, name, patch, enforceOwnership, enforceCapabilities)
 	endSpan(span, s1)
 	return dp1, s1
 }
@@ -219,10 +219,10 @@ func (_d *TracedDeviceService) PatchDeviceStatus(ctx context.Context, orgId uuid
 	return dp1, s1
 }
 
-func (_d *TracedDeviceService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (dp1 *domain.Device, s1 domain.Status) {
+func (_d *TracedDeviceService) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (dp1 *domain.Device, s1 domain.Status) {
 	ctx, span := startSpan(ctx, "ReplaceDevice")
 
-	dp1, s1 = _d.inner.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership)
+	dp1, s1 = _d.inner.ReplaceDevice(ctx, orgId, name, device, fieldsToUnset, enforceOwnership, enforceCapabilities)
 	endSpan(span, s1)
 	return dp1, s1
 }

--- a/internal/tasks/fleet_rollout.go
+++ b/internal/tasks/fleet_rollout.go
@@ -1075,7 +1075,7 @@ func (f FleetRolloutsLogic) updateDeviceInStore(ctx context.Context, device *dom
 		}
 		device.Spec = newDeviceSpec
 		newCtx := context.WithValue(ctx, consts.DelayDeviceRenderCtxKey, delayDeviceRender)
-		_, status = f.deviceSvc.ReplaceDevice(newCtx, f.orgId, *device.Metadata.Name, *device, nil, false)
+		_, status = f.deviceSvc.ReplaceDevice(newCtx, f.orgId, *device.Metadata.Name, *device, nil, false, false)
 		if status.Code != http.StatusOK {
 			if status.Code == http.StatusConflict {
 				device, status = f.deviceSvc.GetDevice(ctx, f.orgId, *device.Metadata.Name)

--- a/internal/tasks/fleet_rollout_test.go
+++ b/internal/tasks/fleet_rollout_test.go
@@ -267,8 +267,8 @@ func TestFleetRolloutsLogic_FullDelayDeviceRenderPropagation(t *testing.T) {
 			// Mock ReplaceDevice to capture the delayDeviceRender value from context
 			// This will be called during the device update process, allowing us to verify propagation
 			var capturedDelayDeviceRender bool
-			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status) {
 					// Debug: Print the device owner when ReplaceDevice is called
 					if device.Metadata.Owner != nil {
 						t.Logf("ReplaceDevice called with device owner: %s", *device.Metadata.Owner)
@@ -365,8 +365,8 @@ func TestFleetRolloutsLogic_DelayDeviceRenderPropagationThroughContext(t *testin
 
 			// Mock ReplaceDevice to capture the context value
 			var capturedDelayDeviceRender bool
-			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
+			mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), gomock.Any(), "test-device", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool, enforceCapabilities bool) (*domain.Device, domain.Status) {
 					// Extract the delayDeviceRender value from context
 					if delayValue, ok := ctx.Value(consts.DelayDeviceRenderCtxKey).(bool); ok {
 						capturedDelayDeviceRender = delayValue
@@ -536,7 +536,7 @@ func TestFleetRolloutsLogic_updateDeviceToFleetTemplate_SkipCondition(t *testing
 			tv.Status.Os = &domain.DeviceOsSpec{Image: image}
 
 			if tt.expectReplaceDevice {
-				mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, domain.Status{Code: http.StatusOK})
+				mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, domain.Status{Code: http.StatusOK})
 				mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any()).Return(domain.Status{Code: http.StatusOK})
 			}
 
@@ -1256,7 +1256,7 @@ func TestRolloutFleetPage_UpsertDeviceRefs(t *testing.T) {
 			},
 		}
 
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, okStatus).AnyTimes()
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, okStatus).AnyTimes()
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any()).Return(okStatus).AnyTimes()
 
 		logic := FleetRolloutsLogic{
@@ -1501,7 +1501,7 @@ func TestDeviceDependencyRefLifecycle(t *testing.T) {
 		fleet := createTestFleetForRollout(fleetName, nil)
 		mockFleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, fleetName, gomock.Any()).Return(fleet, okStatus)
 
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, "device-1", gomock.Any(), gomock.Any()).Return(okStatus)
 
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(
@@ -1812,7 +1812,7 @@ func TestFleetRolloutsLogic_RolloutDevice_ApplicationLifecycleSync(t *testing.T)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName,
 			gomock.Not(gomock.Eq(map[string]string{domain.DeviceAnnotationFleetApplicationLifecycle: `{"app-1":"stopped"}`})), gomock.Any(),
 		).Return(okStatus)
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(gomock.Any(), orgId, deviceName, gomock.Any()).Return(okStatus)
 
 		logic := FleetRolloutsLogic{
@@ -1849,7 +1849,7 @@ func TestFleetRolloutsLogic_RolloutDevice_ApplicationLifecycleSync(t *testing.T)
 		mockDeviceSvc.EXPECT().UpdateDeviceAnnotations(gomock.Any(), orgId, deviceName,
 			gomock.Not(gomock.Eq(map[string]string{domain.DeviceAnnotationFleetApplicationLifecycle: `{"app-1":"stopped"}`})), gomock.Any(),
 		).Return(okStatus)
-		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
+		mockDeviceSvc.EXPECT().ReplaceDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(device, okStatus)
 		mockDependencyRefSvc.EXPECT().ReplaceFleetScopedDeviceDependencyRefs(gomock.Any(), orgId, deviceName, gomock.Any()).Return(okStatus)
 
 		logic := FleetRolloutsLogic{

--- a/internal/tasks/fleet_selector.go
+++ b/internal/tasks/fleet_selector.go
@@ -529,7 +529,7 @@ func (f FleetSelectorMatchingLogic) updateDeviceOwner(ctx context.Context, devic
 
 	f.log.Infof("Updating fleet of device %s from %s to %s", *device.Metadata.Name, util.DefaultIfNil(device.Metadata.Owner, "<none>"), util.DefaultIfNil(newOwnerRef, "<none>"))
 	device.Metadata.Owner = newOwnerRef
-	_, status := f.deviceSvc.ReplaceDevice(ctx, f.orgId, *device.Metadata.Name, lo.FromPtr(device), fieldsToNil, false)
+	_, status := f.deviceSvc.ReplaceDevice(ctx, f.orgId, *device.Metadata.Name, lo.FromPtr(device), fieldsToNil, false, false)
 
 	if err := common.ApiStatusToErr(status); err != nil {
 		return err

--- a/internal/transport/v1beta1/device.go
+++ b/internal/transport/v1beta1/device.go
@@ -47,7 +47,7 @@ func (h *TransportHandler) ReplaceDevice(w http.ResponseWriter, r *http.Request,
 	}
 
 	domainDevice := h.converter.Device().ToDomain(device)
-	body, status := deviceservice.ReplaceDeviceFromUntrusted(r.Context(), h.device, transport.OrgIDFromContext(r.Context()), name, domainDevice, nil, true)
+	body, status := deviceservice.ReplaceDeviceFromUntrusted(r.Context(), h.device, transport.OrgIDFromContext(r.Context()), name, domainDevice, nil, true, true)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }
@@ -103,7 +103,7 @@ func (h *TransportHandler) PatchDevice(w http.ResponseWriter, r *http.Request, n
 	}
 
 	domainPatch := h.converter.Common().PatchRequestToDomain(patch)
-	body, status := h.device.PatchDevice(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch, true)
+	body, status := h.device.PatchDevice(r.Context(), transport.OrgIDFromContext(r.Context()), name, domainPatch, true, true)
 	apiResult := h.converter.Device().FromDomain(body)
 	h.SetResponse(w, apiResult, status)
 }

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -751,7 +751,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
 
@@ -766,7 +766,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 			var value interface{} = "img-updated"
 			patch := api.PatchRequest{{Op: "replace", Path: "/spec/os/image", Value: &value}}
-			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true)
+			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true, true)
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
 
@@ -783,7 +783,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, false)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, false, false)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
@@ -822,7 +822,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(400)))
 			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
 		})
@@ -833,7 +833,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 			var value interface{} = map[string]interface{}{"image": "quay.io/img:latest"}
 			patch := api.PatchRequest{{Op: "add", Path: "/spec/os", Value: &value}}
-			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true)
+			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true, true)
 			Expect(status.Code).To(Equal(int32(400)))
 			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
 		})
@@ -846,7 +846,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(200)))
 		})
 
@@ -858,7 +858,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(200)))
 		})
 	})

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -792,6 +792,77 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("Package-mode OS image rejection", func() {
+		seedDeviceWithOsMode := func(deviceName string, osMode *api.OsModeType) {
+			GinkgoHelper()
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			deviceStatus := api.NewDeviceStatus()
+			if osMode != nil {
+				deviceStatus.Capabilities = &api.DeviceCapabilities{OsMode: osMode}
+			}
+			statusDevice := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Status:   &deviceStatus,
+			}
+			_, status = suite.Device.ReplaceDeviceStatus(suite.Ctx, suite.OrgID, deviceName, statusDevice, false)
+			Expect(status.Code).To(Equal(int32(200)))
+		}
+
+		It("denies PUT with spec.os.image on a package-mode device", func() {
+			deviceName := "pkg-mode-put-deny"
+			seedDeviceWithOsMode(deviceName, lo.ToPtr(api.OsModePackage))
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			Expect(status.Code).To(Equal(int32(400)))
+			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
+		})
+
+		It("denies PATCH adding spec.os.image on a package-mode device", func() {
+			deviceName := "pkg-mode-patch-deny"
+			seedDeviceWithOsMode(deviceName, lo.ToPtr(api.OsModePackage))
+
+			var value interface{} = map[string]interface{}{"image": "quay.io/img:latest"}
+			patch := api.PatchRequest{{Op: "add", Path: "/spec/os", Value: &value}}
+			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true)
+			Expect(status.Code).To(Equal(int32(400)))
+			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
+		})
+
+		It("allows PUT with spec.os.image on an image-mode device", func() {
+			deviceName := "img-mode-put-allow"
+			seedDeviceWithOsMode(deviceName, lo.ToPtr(api.OsModeImage))
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			Expect(status.Code).To(Equal(int32(200)))
+		})
+
+		It("allows PUT with spec.os.image on a device with no capabilities", func() {
+			deviceName := "no-caps-put-allow"
+			seedDeviceWithOsMode(deviceName, nil)
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/img:latest"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			Expect(status.Code).To(Equal(int32(200)))
+		})
+	})
+
 	Context("GetRenderedDevice when AwaitingReconnect moves to ConflictPaused", func() {
 		var (
 			suite           *ServiceTestSuite

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -824,7 +824,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(400)))
-			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
+			Expect(status.Message).To(Equal(flterrors.ErrOsImageNotSupportedOnPackageMode.Error()))
 		})
 
 		It("denies PATCH adding spec.os.image on a package-mode device", func() {
@@ -835,7 +835,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			patch := api.PatchRequest{{Op: "add", Path: "/spec/os", Value: &value}}
 			_, status := suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true, true)
 			Expect(status.Code).To(Equal(int32(400)))
-			Expect(status.Message).To(ContainSubstring("OS image is not supported on package-mode devices"))
+			Expect(status.Message).To(Equal(flterrors.ErrOsImageNotSupportedOnPackageMode.Error()))
 		})
 
 		It("allows PUT with spec.os.image on an image-mode device", func() {
@@ -860,6 +860,32 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			}
 			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true, true)
 			Expect(status.Code).To(Equal(int32(200)))
+		})
+
+		It("allows an unrelated PATCH when a package-mode device already has os.image", func() {
+			deviceName := "pkg-mode-retain-image-patch"
+			seedDeviceWithOsMode(deviceName, lo.ToPtr(api.OsModePackage))
+
+			fleetApplied := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:   lo.ToPtr(deviceName),
+					Labels: &map[string]string{"env": "staging"},
+				},
+				Spec: &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "quay.io/fleet-img:latest"}},
+			}
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, fleetApplied, nil, false, false)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			var value interface{} = "prod"
+			patch := api.PatchRequest{{Op: "replace", Path: "/metadata/labels/env", Value: &value}}
+			_, status = suite.Device.PatchDevice(suite.Ctx, suite.OrgID, deviceName, patch, true, true)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Os).ToNot(BeNil())
+			Expect(stored.Spec.Os.Image).To(Equal("quay.io/fleet-img:latest"))
+			Expect(lo.FromPtr(stored.Metadata.Labels)["env"]).To(Equal("prod"))
 		})
 	})
 


### PR DESCRIPTION
## EDM-4762: Reject direct spec.os.image on package-mode devices

**Jira:** https://redhat.atlassian.net/browse/EDM-4762
**Story type:** [DEV]

### Summary

Adds a server-side guard in `ReplaceDevice` and `PatchDevice` that returns `400 Bad Request` when a direct device edit newly assigns or changes `spec.os.image` on a device whose `status.capabilities.osMode` is `package`. The check is gated on a dedicated `enforceCapabilities` flag (separate from `enforceOwnership`) so API callers enforce it while fleet rollout can still write the full fleet spec to every device; package-mode agents reject an incompatible `os.image` locally and report OutOfDate.

### Changes

- `internal/service/device/{service,handler}.go` — `enforceCapabilities` on Replace/Patch; `isPackageModeOsImageConflict` helper (compares existing vs incoming image)
- `internal/transport/v1beta1/device.go` — API path passes `true, true`
- `internal/tasks/fleet_{rollout,selector}.go` — fleet path passes `false, false`
- Unit + integration tests for reject/allow paths, including retained-image PATCH and `enforceCapabilities=false`

### Testing

- **Unit tests:** `TestReplaceDevicePackageModeOsReject`, `TestPatchDevicePackageModeOsReject`
- **Integration tests:** "Package-mode OS image rejection" Context
- **Coverage:** `make lint`, focused unit/integration tests pass

### Acceptance Criteria

- [ ] AC-1: `ReplaceDevice` / `PatchDevice` (`enforceCapabilities=true`) return 400 when incoming `spec.os.image` is newly set/changed and existing device has `status.capabilities.osMode = package`
- [ ] AC-2: Validation applies to direct edits only — fleet rollout (`enforceCapabilities=false`) is not rejected
- [ ] AC-3: Devices with unknown/missing osMode are not rejected
- [ ] AC-4: Error message: `OS image is not supported on package-mode devices`
- [ ] AC-5: Retaining an existing `os.image` on an unrelated PATCH is not rejected

### Out of scope

`spec.os.catalogItemRef` package-mode guards → [EDM-4968](https://redhat.atlassian.net/browse/EDM-4968) (blocked on Catalog API #3284).

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`