### PR TITLE
EDM-4768: add package-mode e2e suite

### DIFF
--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -8,9 +8,19 @@ on:
         required: true
         type: string
       os_id:
-        description: "Agent Image OS ID (cs9-bootc / cs10-bootc)"
+        description: "Agent image OS ID (cs9-bootc / cs9-regular / cs10-bootc)"
         required: true
         type: string
+      build_type:
+        description: "Agent image build type (bootc / regular)"
+        required: false
+        type: string
+        default: "bootc"
+      upload_bundle:
+        description: "Whether this flavor should upload an agent image bundle artifact"
+        required: false
+        type: boolean
+        default: true
       tag:
         description: "Image tag"
         required: true
@@ -54,6 +64,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           AGENT_IMAGE_OUTPUT: bundle
           AGENT_OS_ID: ${{ inputs.os_id }}
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           mkdir -p bin/rpm
           # Validate that both agent and selinux RPMs are present from the download step
@@ -87,6 +98,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload agent images bundle (per flavor)
+        if: ${{ inputs.upload_bundle }}
         uses: actions/upload-artifact@v4
         with:
           name: agent-images-bundle-${{ inputs.os_id }}-${{ inputs.tag }}
@@ -105,6 +117,7 @@ jobs:
           retention-days: 1
 
       - name: List bundled agent images
+        if: ${{ inputs.upload_bundle }}
         id: list-agent-images
         env:
           OS_ID: ${{ inputs.os_id }}
@@ -141,6 +154,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           OS_ID: ${{ inputs.os_id }}
           RUN_ID: ${{ github.run_id }}
+          UPLOAD_BUNDLE: ${{ inputs.upload_bundle }}
           IMAGES: ${{ steps.list-agent-images.outputs.images }}
         run: |
           set -euo pipefail
@@ -151,7 +165,7 @@ jobs:
             echo "**Tag:** \`${TAG}\` | [All artifacts](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}#artifacts)"
             echo ""
             
-            if [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
+            if [ "${UPLOAD_BUNDLE}" = "true" ] && [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
               echo "<details>"
               echo "<summary><strong>Container Images in Bundle</strong></summary>"
               echo ""
@@ -167,11 +181,17 @@ jobs:
             echo '```bash'
             echo "# Download artifacts"
             echo "mkdir -p bin/agent-artifacts bin/output/qcow2"
-            echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            fi
             echo "gh run download ${RUN_ID} -n agent-qcow2-image-${OS_ID}-${TAG} -D bin/output/qcow2"
             echo ""
             echo "# Run e2e tests"
-            echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            else
+              echo "# ${OS_ID} is qcow-only in CI; pair this qcow with a bootc agent bundle when running mixed-fleet package-mode tests"
+            fi
             echo '```'
             echo ""
             echo "</details>"

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -144,6 +144,10 @@ jobs:
             go_e2e_dirs: './test/e2e/...'
             excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
+          - label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/package_mode'
+            excluded_go_e2e_dirs: ''
+            ginkgo_total_nodes: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -293,6 +297,16 @@ jobs:
             image_mode_qcow_os_id: ''
             package_mode_qcow_env_var: ''
             image_mode_qcow_env_var: ''
+          - os_id: cs9-bootc
+            backend_type: helm
+            label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/package_mode'
+            excluded_go_e2e_dirs: ''
+            ginkgo_total_nodes: 1
+            package_mode_qcow_os_id: cs9-regular
+            image_mode_qcow_os_id: cs9-bootc
+            package_mode_qcow_env_var: 'E2E_PACKAGE_MODE_QCOW'
+            image_mode_qcow_env_var: 'E2E_IMAGE_MODE_QCOW'
     uses: ./.github/workflows/run-e2e-tests.yaml
     with:
       os_id: ${{ matrix.os_id }}

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -109,12 +109,22 @@ jobs:
         include:
           - os_id: cs9-bootc
             rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: bootc
+            upload_bundle: true
+          - os_id: cs9-regular
+            rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: regular
+            upload_bundle: false
           - os_id: cs10-bootc
             rpm_suffix: epel-10-x86_64
+            build_type: bootc
+            upload_bundle: true
     uses: ./.github/workflows/build-agent-images.yaml
     with:
       rpm_suffix: ${{ matrix.rpm_suffix }}
       os_id: ${{ matrix.os_id }}
+      build_type: ${{ matrix.build_type }}
+      upload_bundle: ${{ matrix.upload_bundle }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   discover-e2e-tests:
@@ -127,8 +137,12 @@ jobs:
       matrix:
         include:
           - label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
           - label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
     steps:
       - name: Checkout
@@ -139,20 +153,63 @@ jobs:
 
       - name: Compute label filter hash
         id: compute-hash
+        env:
+          GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${{ matrix.label_filter }}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "Label filter: ${{ matrix.label_filter }}"
+          echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        env:
+          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t included_dirs < <(go list ${GO_E2E_DIRS})
+          excluded_dirs=()
+          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+            mapfile -t excluded_dirs < <(go list ${EXCLUDED_GO_E2E_DIRS})
+          fi
+
+          resolved_dirs=()
+          for dir in "${included_dirs[@]}"; do
+            skip=false
+            for excluded in "${excluded_dirs[@]}"; do
+              if [[ "${dir}" == "${excluded}" ]]; then
+                skip=true
+                break
+              fi
+            done
+            if [[ "${skip}" != "true" ]]; then
+              resolved_dirs+=("${dir}")
+            fi
+          done
+
+          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+            echo "ERROR: No Go E2E dirs remain after exclusions"
+            exit 1
+          fi
+
+          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
 
       - name: Run test discovery
         env:
           GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           DISCOVERY_ONLY: "true"
           DISCOVERY_PATH: discovery.json
         run: |
           mkdir -p reports
-          test/scripts/run_e2e_tests.sh reports ./test/e2e/...
+          test/scripts/run_e2e_tests.sh reports ${GO_E2E_DIRS}
 
       - name: Validate discovery results
         run: |
@@ -216,20 +273,38 @@ jobs:
           - os_id: cs9-bootc
             backend_type: helm
             label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
           ## CS10: agent tests only; microshift tests are excluded until the cs10-bootc kernel
           ## includes xt_conntrack/xt_comment modules required by kube-proxy. CS9 provides
           ## full microshift coverage via the v12 OKD SCOS variant.
           - os_id: cs10-bootc
             backend_type: helm
             label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
     uses: ./.github/workflows/run-e2e-tests.yaml
     with:
       os_id: ${{ matrix.os_id }}
       backend_type: ${{ matrix.backend_type }}
       ginkgo_total_nodes: ${{ matrix.ginkgo_total_nodes }}
       ginkgo_label_filter: ${{ matrix.label_filter }}
+      go_e2e_dirs: ${{ matrix.go_e2e_dirs }}
+      excluded_go_e2e_dirs: ${{ matrix.excluded_go_e2e_dirs }}
+      package_mode_qcow_os_id: ${{ matrix.package_mode_qcow_os_id }}
+      image_mode_qcow_os_id: ${{ matrix.image_mode_qcow_os_id }}
+      package_mode_qcow_env_var: ${{ matrix.package_mode_qcow_env_var }}
+      image_mode_qcow_env_var: ${{ matrix.image_mode_qcow_env_var }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   api-tests:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -22,6 +22,36 @@ on:
         required: false
         type: string
         default: "sanity"
+      go_e2e_dirs:
+        description: "Space-separated Go e2e package dirs passed to run_e2e_tests.sh"
+        required: false
+        type: string
+        default: "./test/e2e/..."
+      excluded_go_e2e_dirs:
+        description: "Optional Go e2e package dirs to exclude after resolving go_e2e_dirs"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be staged as the primary package-mode qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be injected for mixed-fleet package-mode tests"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_env_var:
+        description: "Optional env var name that should point to the primary staged qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_env_var:
+        description: "Optional env var name that should point to the secondary staged qcow"
+        required: false
+        type: string
+        default: ""
       tag:
         description: "Image tag"
         required: true
@@ -103,9 +133,25 @@ jobs:
           path: test-artifacts
           merge-multiple: true
 
+      - name: Download image-mode qcow artifact
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.image_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-image-mode
+
+      - name: Download package-mode qcow artifact
+        if: ${{ inputs.package_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.package_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-package-mode
+
       - name: Stage test artifacts
         env:
           OS_ID: ${{ inputs.os_id }}
+          PACKAGE_MODE_QCOW_OS_ID: ${{ inputs.package_mode_qcow_os_id }}
+          IMAGE_MODE_QCOW_OS_ID: ${{ inputs.image_mode_qcow_os_id }}
         run: |
           set -euo pipefail
           echo "Downloaded test artifacts:"
@@ -120,17 +166,37 @@ jobs:
           mv "test-artifacts/agent-images-bundle-${OS_ID}.tar" bin/agent-artifacts/
           echo "Agent bundle: bin/agent-artifacts/agent-images-bundle-${OS_ID}.tar"
 
-          # Stage qcow2
+          # Stage the primary qcow2 used by prepare-e2e-qcow-config.
           mkdir -p bin/output/qcow2
-          if [ ! -f "test-artifacts/disk.qcow2" ]; then
-            echo "ERROR: QCOW2 image not found"
-            exit 1
+          if [ -n "${PACKAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-package-mode/disk.qcow2" ]; then
+              echo "ERROR: Package-mode QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts-package-mode/disk.qcow2" bin/output/qcow2/disk.qcow2
+          else
+            if [ ! -f "test-artifacts/disk.qcow2" ]; then
+              echo "ERROR: QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts/disk.qcow2" bin/output/qcow2/disk.qcow2
           fi
-          mv "test-artifacts/disk.qcow2" bin/output/qcow2/
           echo "✓ QCOW2 image: bin/output/qcow2/disk.qcow2"
+
+          if [ -n "${IMAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-image-mode/disk.qcow2" ]; then
+              echo "ERROR: Image-mode QCOW2 image not found"
+              exit 1
+            fi
+            mkdir -p bin/output/qcow2-image-mode
+            mv "test-artifacts-image-mode/disk.qcow2" bin/output/qcow2-image-mode/
+            echo "✓ Image-mode QCOW2 image: bin/output/qcow2-image-mode/disk.qcow2"
+          fi
 
           # Cleanup
           rm -rf test-artifacts
+          rm -rf test-artifacts-package-mode
+          rm -rf test-artifacts-image-mode
 
           echo "Staged artifacts:"
           tree bin
@@ -154,6 +220,21 @@ jobs:
           # All dependencies are resolved automatically by Make
           make prepare-e2e-test
 
+      - name: Inject image-mode qcow for package-mode mixed-fleet tests
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        env:
+          IMAGE_MODE_QCOW: bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+          if [ ! -f "${IMAGE_MODE_QCOW}" ]; then
+            echo "ERROR: Secondary image-mode qcow not staged at ${IMAGE_MODE_QCOW}"
+            exit 1
+          fi
+
+          QCOW="${IMAGE_MODE_QCOW}" \
+          AGENT_DIR=bin/agent/etc/flightctl \
+          test/scripts/inject_agent_files_into_qcow.sh
+
       # ========== RUN E2E TESTS ==========
       - name: Restore Go cache
         uses: actions/cache/restore@v4
@@ -169,11 +250,51 @@ jobs:
         id: compute-hash
         env:
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
+          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${GINKGO_LABEL_FILTER}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
           echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        env:
+          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t included_dirs < <(go list ${GO_E2E_DIRS})
+          excluded_dirs=()
+          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+            mapfile -t excluded_dirs < <(go list ${EXCLUDED_GO_E2E_DIRS})
+          fi
+
+          resolved_dirs=()
+          for dir in "${included_dirs[@]}"; do
+            skip=false
+            for excluded in "${excluded_dirs[@]}"; do
+              if [[ "${dir}" == "${excluded}" ]]; then
+                skip=true
+                break
+              fi
+            done
+            if [[ "${skip}" != "true" ]]; then
+              resolved_dirs+=("${dir}")
+            fi
+          done
+
+          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+            echo "ERROR: No Go E2E dirs remain after exclusions"
+            exit 1
+          fi
+
+          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
 
       - name: Download test discovery
         uses: actions/download-artifact@v4
@@ -184,15 +305,41 @@ jobs:
       - name: Check disk space
         run: df -h
 
+      - name: Validate qcow inputs
+        env:
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" && ! -f "${PACKAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${PACKAGE_MODE_QCOW_ENV_VAR} requires qcow at ${PACKAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" && ! -f "${IMAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${IMAGE_MODE_QCOW_ENV_VAR} requires qcow at ${IMAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
       - name: Run E2E Test Slice
         env:
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
           GINKGO_TOTAL_NODES: ${{ inputs.ginkgo_total_nodes }}
           GINKGO_NODE: ${{ matrix.ginkgo_node }}
           DISCOVERY_PATH: discovery.json
           ASSIGNMENTS_PATH: assignments.json
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
           RUNNER_DEBUG: ${{ runner.debug }}
         run: |
+          set -euo pipefail
+
           if [[ "${RUNNER_DEBUG}" == "1" ]]; then
             echo "Debug mode enabled"
             export DEBUG_VM_CONSOLE=1
@@ -200,6 +347,15 @@ jobs:
           else
             echo "Debug mode disabled"
           fi
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${PACKAGE_MODE_QCOW_ENV_VAR}=${PACKAGE_MODE_QCOW_PATH}"
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${IMAGE_MODE_QCOW_ENV_VAR}=${IMAGE_MODE_QCOW_PATH}"
+          fi
+
           make -e run-e2e-test
 
       - name: Check disk space after E2E tests

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -20,6 +20,7 @@ Defined in **test/test.mk** (included from root Makefile). Coverage reports go t
   - **Full flow (deploy + e2e):** `make e2e-test` – deploys cluster, builds e2e agent images, prepares qcow2, runs e2e.  
   - **Cluster already up:** `make in-cluster-e2e-test` – skips deploy, runs e2e.  
   - **Filter:** `GO_E2E_DIRS=test/e2e/agent`, `GINKGO_FOCUS="description"`, `GINKGO_PROCS=N`.  
+  - **Package-mode CI/local scope:** `GO_E2E_DIRS=./test/e2e/package_mode` runs the dedicated package-mode suite. Mixed-fleet coverage also needs `E2E_PACKAGE_MODE_QCOW` and `E2E_IMAGE_MODE_QCOW` to point at injected package-mode and image-mode qcows.
   - Some e2e suites (e.g. quadlets) need a quadlet-capable VM; see `test/e2e/quadlets/README.md` and `test/e2e/tpm/README.md`. Rollout tests use multiple VMs and have higher RAM requirements; see `test/e2e/rollout/README.md`.
 
 ## E2E layout and harness

--- a/test/e2e/package_mode/package_mode_suite_test.go
+++ b/test/e2e/package_mode/package_mode_suite_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package packagemode_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var packageModeAuxSvcs *auxiliary.Services
+
+func TestPackageMode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Package Mode E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
+	defer func() {
+		packageModeAuxSvcs = auxFuture.Wait()
+	}()
+
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if packageModeAuxSvcs != nil {
+		packageModeAuxSvcs.Cleanup(context.Background())
+	}
+})
+
+var _ = BeforeEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	_, err := login.LoginToAPIWithToken(harness)
+	Expect(err).ToNot(HaveOccurred())
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+})
+
+var _ = AfterEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+	defer harness.SetTestContext(suiteCtx)
+
+	harness.PrintAgentLogsIfFailed()
+	printPackageModeCustomVMLogsIfFailed(harness.GetTestContext())
+	harness.CaptureDeploymentLogsIfFailed()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/e2e/package_mode/package_mode_test.go
+++ b/test/e2e/package_mode/package_mode_test.go
@@ -1,0 +1,712 @@
+//go:build linux
+
+package packagemode_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/harness/e2e/vm"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	packageModeQCOWEnvVar         = "E2E_PACKAGE_MODE_QCOW"
+	imageModeQCOWEnvVar           = "E2E_IMAGE_MODE_QCOW"
+	defaultImageModeQCOWPath      = "bin/output/qcow2/disk.qcow2"
+	packageModeVMUser             = "user"
+	packageModeVMPassword         = "user"
+	packageModeContainerRunAsUser = "flightctl"
+	packageModeDeviceSSHPortBase  = 23100
+	packageModeMixedSSHPortOffset = 50
+	imageModeDeviceSSHPortBase    = 23200
+	packageModeBootTimeout        = 6 * time.Minute
+	packageModeCommandTimeout     = 60 * time.Second
+	packageModeEnrollTimeout      = 5 * time.Minute
+	packageModePollInterval       = 5 * time.Second
+	packageModeConfigPath         = "/etc/flightctl/package-mode-e2e.conf"
+	packageModeConfigContent      = "package-mode-e2e=enabled"
+	packageModeContainerAppName   = "package-mode-sleep"
+	packageModeLogObservationTime = 30 * time.Second
+	packageModeFleetLabelKey      = "package-mode-suite"
+	packageModeNormalFleetPrefix  = "package-mode-normal"
+	packageModeMixedFleetPrefix   = "package-mode-mixed"
+	packageModeVMNamePrefix       = "package-mode"
+	imageModeVMNamePrefix         = "image-mode"
+	packageModeExpectedRejectText = "package-mode device cannot satisfy spec with os.image"
+)
+
+var _ = Describe("Package-mode device scenarios", Ordered, func() {
+	var harness *e2e.Harness
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+	})
+
+	Context("normal package-mode operation", Ordered, func() {
+		var (
+			deviceID      string
+			fleetName     string
+			selector      v1beta1.LabelSelector
+			packageModeVM *vmUnderTest
+		)
+
+		BeforeAll(func() {
+			var err error
+			harness = e2e.GetWorkerHarness()
+			restoreContext := setHarnessSetupContext(harness, packageModeNormalFleetPrefix)
+			defer harness.SetTestContext(restoreContext)
+
+			packageQCOW := requireQCOWPath(packageModeQCOWEnvVar, "")
+			fleetName = uniqueFleetName(packageModeNormalFleetPrefix)
+			selector = v1beta1.LabelSelector{
+				MatchLabels: &map[string]string{
+					packageModeFleetLabelKey: fleetName,
+				},
+			}
+
+			packageModeVM, err = startCustomVMFromQCOW(packageQCOW, packageModeVMNamePrefix, packageModeDeviceSSHPortBase+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			inlineConfig, err := e2e.NewInlineConfigSpec("package-mode-inline", []v1beta1.FileSpec{{
+				Path:    packageModeConfigPath,
+				Content: packageModeConfigContent,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+
+			appImage := harness.GetSleepAppImageRefForFleet(packageModeAuxSvcs.Registry.Host, packageModeAuxSvcs.Registry.Port, testutil.SleepAppTags.V2)
+			containerApp, err := e2e.NewContainerApplicationSpecWithRunAs(
+				packageModeContainerAppName,
+				appImage,
+				nil,
+				nil,
+				nil,
+				nil,
+				packageModeContainerRunAsUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpec := v1beta1.DeviceSpec{
+				Config:       &[]v1beta1.ConfigProviderSpec{inlineConfig},
+				Applications: &[]v1beta1.ApplicationProviderSpec{containerApp},
+			}
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, err = enrollCustomVM(harness, packageModeVM, map[string]string{
+				packageModeFleetLabelKey: fleetName,
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if strings.TrimSpace(deviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(deviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", deviceID, err)
+				}
+			}
+			if strings.TrimSpace(fleetName) != "" {
+				if err := harness.DeleteFleetIgnoreNotFound(fleetName); err != nil {
+					GinkgoWriter.Printf("DeleteFleetIgnoreNotFound(%s): %v\n", fleetName, err)
+				}
+			}
+			cleanupSuiteLibvirtVM(packageModeVM)
+		})
+
+		It("enrolls a package-mode device and reports capabilities.osMode=package", Label("90146", "sanity"), func() {
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+				g.Expect(*device.Status.Capabilities.OsMode).To(Equal(v1beta1.OsModePackage))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+		})
+
+		It("deploys config and a podman application on a package-mode fleet without spec.os.image", Label("90147", "sanity"), func() {
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Spec).ToNot(BeNil())
+				g.Expect(device.Spec.Os).To(BeNil())
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+			Expect(harness.WaitForApplicationStatus(deviceID, packageModeContainerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+			Expect(harness.WaitForApplicationSummary(deviceID, testutil.TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				output, err := runSuiteLibvirtVMCommand(harness.GetTestContext(), packageModeVM.Instance, []string{"cat", packageModeConfigPath})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(output).To(ContainSubstring(packageModeConfigContent))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Applications).ToNot(BeNil())
+				application := findDeviceApplicationStatusByName(device.Status.Applications, packageModeContainerAppName)
+				g.Expect(application).ToNot(BeNil())
+				g.Expect(application.RunAs).To(Equal(v1beta1.Username(packageModeContainerRunAsUser)))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+		})
+
+		It("does not emit the mixed-fleet os.image reject message during normal package-mode operation", Label("90150", "sanity"), func() {
+			observationStart, err := currentSuiteLibvirtVMJournalSince(harness.GetTestContext(), packageModeVM.Instance)
+			Expect(err).ToNot(HaveOccurred())
+
+			Consistently(func(g Gomega) {
+				logs, err := readSuiteLibvirtVMServiceLogsSince(harness.GetTestContext(), packageModeVM.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, observationStart)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(logs).ToNot(ContainSubstring(packageModeExpectedRejectText))
+			}, packageModeLogObservationTime, packageModePollInterval).Should(Succeed())
+		})
+	})
+
+	Context("mixed fleet os image behavior", Ordered, func() {
+		var (
+			packageDeviceID         string
+			imageDeviceID           string
+			fleetName               string
+			selector                v1beta1.LabelSelector
+			packageModeVM           *vmUnderTest
+			imageModeVM             *vmUnderTest
+			packageInitialVersion   int
+			imageExpectedVersion    int
+			requestedImageReference string
+		)
+
+		BeforeAll(func() {
+			var err error
+			harness = e2e.GetWorkerHarness()
+			restoreContext := setHarnessSetupContext(harness, packageModeMixedFleetPrefix)
+			defer harness.SetTestContext(restoreContext)
+
+			packageQCOW := requireQCOWPath(packageModeQCOWEnvVar, "")
+			imageQCOW := requireQCOWPath(imageModeQCOWEnvVar, defaultImageModeQCOWPath)
+			if samePath(packageQCOW, imageQCOW) {
+				failOrSkipForMissingQCOW(fmt.Sprintf("%s must point to an image-mode qcow different from %s", imageModeQCOWEnvVar, packageModeQCOWEnvVar))
+			}
+
+			fleetName = uniqueFleetName(packageModeMixedFleetPrefix)
+			selector = v1beta1.LabelSelector{
+				MatchLabels: &map[string]string{
+					packageModeFleetLabelKey: fleetName,
+				},
+			}
+
+			packageModeVM, err = startCustomVMFromQCOW(packageQCOW, packageModeVMNamePrefix, packageModeDeviceSSHPortBase+packageModeMixedSSHPortOffset+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			imageModeVM, err = startCustomVMFromQCOW(imageQCOW, imageModeVMNamePrefix, imageModeDeviceSSHPortBase+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, v1beta1.DeviceSpec{})
+			Expect(err).ToNot(HaveOccurred())
+
+			labels := map[string]string{packageModeFleetLabelKey: fleetName}
+
+			packageDeviceID, err = enrollCustomVM(harness, packageModeVM, labels)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageDeviceID, err = enrollCustomVM(harness, imageModeVM, labels)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(harness.WaitForDeviceNewRenderedVersion(packageDeviceID, 1)).ToNot(HaveOccurred())
+			Expect(harness.WaitForDeviceNewRenderedVersion(imageDeviceID, 1)).ToNot(HaveOccurred())
+
+			packageInitialVersion, err = harness.GetCurrentDeviceRenderedVersion(packageDeviceID)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageExpectedVersion, err = harness.PrepareNextDeviceVersion(imageDeviceID)
+			Expect(err).ToNot(HaveOccurred())
+
+			registryHost := packageModeAuxSvcs.Registry.Host
+			registryPort := packageModeAuxSvcs.Registry.Port
+			deviceSpec, err := harness.CreateFleetDeviceSpec(registryHost, registryPort, testutil.DeviceTags.V2)
+			Expect(err).ToNot(HaveOccurred())
+			requestedImageReference = harness.GetDeviceImageRefForFleet(registryHost, registryPort, testutil.DeviceTags.V2)
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if strings.TrimSpace(packageDeviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(packageDeviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", packageDeviceID, err)
+				}
+			}
+			if strings.TrimSpace(imageDeviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(imageDeviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", imageDeviceID, err)
+				}
+			}
+			if strings.TrimSpace(fleetName) != "" {
+				if err := harness.DeleteFleetIgnoreNotFound(fleetName); err != nil {
+					GinkgoWriter.Printf("DeleteFleetIgnoreNotFound(%s): %v\n", fleetName, err)
+				}
+			}
+			cleanupSuiteLibvirtVM(packageModeVM)
+			cleanupSuiteLibvirtVM(imageModeVM)
+		})
+
+		It("keeps the package-mode device OutOfDate when the fleet adds spec.os.image", Label("90148", "sanity"), func() {
+			rejectObservationStart, err := currentSuiteLibvirtVMJournalSince(harness.GetTestContext(), packageModeVM.Instance)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(packageDeviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Updated.Status).To(Equal(v1beta1.DeviceUpdatedStatusOutOfDate))
+				g.Expect(device.Status.Config.RenderedVersion).To(Equal(strconv.Itoa(packageInitialVersion)))
+				g.Expect(deviceRejectsMixedFleetUpdate(device, packageModeExpectedRejectText)).To(BeTrue())
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				logs, err := readSuiteLibvirtVMServiceLogsSince(harness.GetTestContext(), packageModeVM.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, rejectObservationStart)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(logs).To(ContainSubstring(packageModeExpectedRejectText))
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+		})
+
+		It("lets the image-mode device converge on the requested os image in the same mixed fleet", Label("90149", "sanity", "slow"), func() {
+			Expect(harness.WaitForDeviceNewRenderedVersion(imageDeviceID, imageExpectedVersion)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(imageDeviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+				g.Expect(*device.Status.Capabilities.OsMode).To(Equal(v1beta1.OsModeImage))
+				g.Expect(device.Status.Updated.Status).To(Equal(v1beta1.DeviceUpdatedStatusUpToDate))
+				g.Expect(device.Status.Os.Image).To(Equal(requestedImageReference))
+				g.Expect(device.Status.Config.RenderedVersion).To(Equal(strconv.Itoa(imageExpectedVersion)))
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+		})
+	})
+})
+
+var (
+	suiteLibvirtVMMu sync.Mutex
+	suiteLibvirtVMs  = map[string]*vmUnderTest{}
+)
+
+// vmUnderTest tracks a libvirt VM instance created for package-mode E2E coverage.
+type vmUnderTest struct {
+	Instance vm.TestVMInterface
+	Name     string
+	SSHPort  int
+	TestDir  string
+}
+
+// requireQCOWPath resolves a qcow input or skips the suite context when the file is unavailable.
+func requireQCOWPath(envVar, defaultRelativePath string) string {
+	candidate := strings.TrimSpace(os.Getenv(envVar))
+	if candidate == "" && defaultRelativePath != "" {
+		candidate = filepath.Join(testutil.GetTopLevelDir(), defaultRelativePath)
+	}
+	if candidate == "" {
+		failOrSkipForMissingQCOW(fmt.Sprintf("set %s to a qcow2 path before running this suite", envVar))
+	}
+
+	absolutePath, err := filepath.Abs(candidate)
+	if err != nil {
+		failOrSkipForMissingQCOW(fmt.Sprintf("resolve %s: %v", envVar, err))
+	}
+	if _, err := os.Stat(absolutePath); err != nil {
+		failOrSkipForMissingQCOW(fmt.Sprintf("%s path %s is not readable: %v", envVar, absolutePath, err))
+	}
+	return absolutePath
+}
+
+// startCustomVMFromQCOW creates and boots a custom libvirt VM from a qcow image.
+func startCustomVMFromQCOW(qcowPath, namePrefix string, sshPort int) (*vmUnderTest, error) {
+	vmName := fmt.Sprintf("%s-%d", namePrefix, time.Now().UnixNano())
+	testDir := GinkgoT().TempDir()
+	vmDiskPath := filepath.Join(testDir, filepath.Base(qcowPath))
+	if err := createQCOWOverlay(qcowPath, vmDiskPath); err != nil {
+		return nil, fmt.Errorf("create qcow overlay for %s: %w", qcowPath, err)
+	}
+	testVM := vm.TestVM{
+		TestDir:        testDir,
+		VMName:         vmName,
+		DiskImagePath:  vmDiskPath,
+		VMUser:         packageModeVMUser,
+		SSHPassword:    packageModeVMPassword,
+		SSHPort:        sshPort,
+		SSHWaitTimeout: packageModeBootTimeout,
+	}
+
+	libvirtVM, err := vm.NewVM(testVM)
+	if err != nil {
+		return nil, fmt.Errorf("create VM %s: %w", vmName, err)
+	}
+	if err := libvirtVM.CreateDomain(); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after CreateDomain failure: %v\n", cleanupErr)
+		}
+		return nil, fmt.Errorf("create domain %s: %w", vmName, err)
+	}
+	if err := libvirtVM.RunAndWaitForSSH(); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after RunAndWaitForSSH failure: %v\n", cleanupErr)
+		}
+		return nil, fmt.Errorf("boot VM %s: %w", vmName, err)
+	}
+
+	candidate := &vmUnderTest{
+		Instance: libvirtVM,
+		Name:     vmName,
+		SSHPort:  sshPort,
+		TestDir:  testDir,
+	}
+	if err := registerSuiteLibvirtVM(candidate); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after registration failure: %v\n", cleanupErr)
+		}
+		return nil, err
+	}
+	return candidate, nil
+}
+
+// enrollCustomVM approves the enrollment request for a custom VM and waits for Online status.
+func enrollCustomVM(harness *e2e.Harness, candidate *vmUnderTest, labels map[string]string) (string, error) {
+	GinkgoHelper()
+
+	if harness == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if candidate == nil || candidate.Instance == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+
+	enrollmentID := waitForSuiteLibvirtVMEnrollmentID(harness.GetTestContext(), candidate.Instance, packageModeEnrollTimeout, packageModePollInterval)
+
+	if _, err := harness.WaitForEnrollmentRequestResource(enrollmentID, testutil.TIMEOUT_5M, testutil.SHORT_POLLING); err != nil {
+		return "", err
+	}
+
+	approvalLabels, err := mergeEnrollmentLabels(harness, labels)
+	if err != nil {
+		return "", err
+	}
+	if _, err := harness.ApproveEnrollmentRequestWithLabels(enrollmentID, approvalLabels); err != nil {
+		return "", err
+	}
+
+	Eventually(func() error {
+		device, err := harness.CheckDeviceStatus(enrollmentID, v1beta1.DeviceSummaryStatusOnline)
+		if err != nil {
+			return err
+		}
+		if device == nil {
+			return fmt.Errorf("device %s is still nil", enrollmentID)
+		}
+		return nil
+	}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+	return enrollmentID, nil
+}
+
+// waitForSuiteLibvirtVMEnrollmentID polls a suite-created libvirt VM's agent logs until an enrollment request ID appears.
+func waitForSuiteLibvirtVMEnrollmentID(ctx context.Context, libvirtVM vm.TestVMInterface, timeout, polling time.Duration) string {
+	GinkgoHelper()
+
+	since, err := currentSuiteLibvirtVMJournalSince(ctx, libvirtVM)
+	Expect(err).ToNot(HaveOccurred())
+
+	var enrollmentID string
+	Eventually(func() string {
+		logs, err := readSuiteLibvirtVMServiceLogsSince(ctx, libvirtVM, testutil.FLIGHTCTL_AGENT_SERVICE, since)
+		if err != nil {
+			GinkgoWriter.Printf("waitForSuiteLibvirtVMEnrollmentID ReadServiceLogsSince: %v\n", err)
+			return ""
+		}
+		enrollmentID = testutil.GetEnrollmentIdFromText(logs)
+		return enrollmentID
+	}, timeout, polling).ShouldNot(BeEmpty())
+
+	return enrollmentID
+}
+
+// mergeEnrollmentLabels adds the harness test-id label to enrollment approval labels.
+func mergeEnrollmentLabels(harness *e2e.Harness, labels map[string]string) (map[string]string, error) {
+	testLabels, err := harness.TestResourceLabels()
+	if err != nil {
+		return nil, err
+	}
+
+	merged := map[string]string{}
+	for key, value := range testLabels {
+		merged[key] = value
+	}
+	for key, value := range labels {
+		merged[key] = value
+	}
+	return merged, nil
+}
+
+// uniqueFleetName returns a predictable, unique fleet name for the current spec run.
+func uniqueFleetName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// setHarnessSetupContext seeds a stable test-id context for Ordered BeforeAll setup work.
+func setHarnessSetupContext(harness *e2e.Harness, prefix string) context.Context {
+	restoreContext := harness.GetTestContext()
+	setupContext := context.WithValue(restoreContext, testutil.TestIDKey, uniqueFleetName(prefix+"-setup"))
+	harness.SetTestContext(setupContext)
+	return restoreContext
+}
+
+// cleanupSuiteLibvirtVM force-deletes a suite-created libvirt VM.
+func cleanupSuiteLibvirtVM(candidate *vmUnderTest) {
+	if candidate == nil {
+		return
+	}
+	defer unregisterSuiteLibvirtVM(candidate)
+	if candidate.Instance != nil {
+		if err := candidate.Instance.ForceDelete(); err != nil {
+			GinkgoWriter.Printf("cleanupSuiteLibvirtVM(%s): %v\n", candidate.Name, err)
+		}
+	}
+}
+
+// runSuiteLibvirtVMCommand executes a command on a suite-created libvirt VM and returns trimmed stdout.
+func runSuiteLibvirtVMCommand(ctx context.Context, libvirtVM vm.TestVMInterface, args []string) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	if len(args) == 0 {
+		return "", fmt.Errorf("command args are empty")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	commandCtx, cancel := context.WithTimeout(ctx, packageModeCommandTimeout)
+	defer cancel()
+
+	stdout, err := libvirtVM.RunSSHContext(commandCtx, args, nil)
+	if err != nil {
+		return "", err
+	}
+	if stdout == nil {
+		return "", fmt.Errorf("command output is nil")
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// registerSuiteLibvirtVM tracks a suite-created libvirt VM for failure log capture.
+func registerSuiteLibvirtVM(candidate *vmUnderTest) error {
+	if candidate == nil || candidate.Instance == nil || strings.TrimSpace(candidate.Name) == "" {
+		return fmt.Errorf("suite libvirt VM is incomplete")
+	}
+
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+	suiteLibvirtVMs[candidate.Name] = candidate
+	return nil
+}
+
+// unregisterSuiteLibvirtVM removes a suite-created libvirt VM from failure log capture tracking.
+func unregisterSuiteLibvirtVM(candidate *vmUnderTest) {
+	if candidate == nil || strings.TrimSpace(candidate.Name) == "" {
+		return
+	}
+
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+	delete(suiteLibvirtVMs, candidate.Name)
+}
+
+// listSuiteLibvirtVMs returns the currently tracked suite-created libvirt VMs.
+func listSuiteLibvirtVMs() []*vmUnderTest {
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+
+	vms := make([]*vmUnderTest, 0, len(suiteLibvirtVMs))
+	for _, candidate := range suiteLibvirtVMs {
+		vms = append(vms, candidate)
+	}
+	return vms
+}
+
+// printPackageModeCustomVMLogsIfFailed prints flightctl-agent logs for suite-created libvirt VMs after a failed spec.
+func printPackageModeCustomVMLogsIfFailed(ctx context.Context) {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	for _, candidate := range listSuiteLibvirtVMs() {
+		if candidate == nil || candidate.Instance == nil {
+			continue
+		}
+
+		running, err := candidate.Instance.IsRunning()
+		if err != nil || !running {
+			continue
+		}
+
+		logs, err := readSuiteLibvirtVMServiceLogsSince(ctx, candidate.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, "")
+		if err != nil {
+			GinkgoWriter.Printf("printPackageModeCustomVMLogsIfFailed(%s): %v\n", candidate.Name, err)
+			continue
+		}
+
+		GinkgoWriter.Printf("flightctl-agent logs for %s:\n%s\n", candidate.Name, logs)
+	}
+}
+
+// deviceRejectsMixedFleetUpdate returns true when package-mode rejection is visible in device status.
+func deviceRejectsMixedFleetUpdate(device *v1beta1.Device, rejectText string) bool {
+	if device == nil || device.Status == nil {
+		return false
+	}
+
+	if e2e.ConditionExists(device, v1beta1.ConditionTypeDeviceUpdating, v1beta1.ConditionStatusFalse, string(v1beta1.UpdateStateError)) {
+		cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
+		if cond != nil && strings.Contains(cond.Message, rejectText) {
+			return true
+		}
+	}
+
+	return device.Status.Updated.Info != nil && strings.Contains(*device.Status.Updated.Info, rejectText)
+}
+
+// samePath compares two paths after cleaning them.
+func samePath(left, right string) bool {
+	if left == "" || right == "" {
+		return false
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+// failOrSkipForMissingQCOW fails in CI and skips in local runs when a required qcow is unavailable.
+func failOrSkipForMissingQCOW(message string) {
+	GinkgoHelper()
+
+	if strings.TrimSpace(os.Getenv("CI")) != "" {
+		Fail(message)
+	}
+	Skip(message)
+}
+
+// createQCOWOverlay creates a qcow2 overlay so each suite VM gets isolated writes without copying the base disk.
+func createQCOWOverlay(baseQCOWPath, overlayQCOWPath string) error {
+	backingFormat, err := detectQCOWFormat(baseQCOWPath)
+	if err != nil {
+		return fmt.Errorf("detect backing qcow format for %s: %w", baseQCOWPath, err)
+	}
+
+	cmd := exec.Command("qemu-img", "create", "-f", "qcow2", "-b", baseQCOWPath, "-F", backingFormat, overlayQCOWPath) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("qemu-img create failed: %w, output: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// currentSuiteLibvirtVMJournalSince returns a guest-aligned RFC3339 timestamp for journalctl --since filtering.
+func currentSuiteLibvirtVMJournalSince(ctx context.Context, libvirtVM vm.TestVMInterface) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	commandCtx, cancel := context.WithTimeout(ctx, packageModeCommandTimeout)
+	defer cancel()
+
+	out, err := libvirtVM.RunSSHContext(commandCtx, []string{"date", "-u", `+%Y-%m-%dT%H:%M:%SZ`}, nil)
+	if err != nil {
+		return "", fmt.Errorf("read VM clock for journal since: %w", err)
+	}
+	timestamp := strings.TrimSpace(out.String())
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return "", fmt.Errorf("parse VM date %q: %w", timestamp, err)
+	}
+	return parsed.Add(-2 * time.Second).UTC().Format(time.RFC3339), nil
+}
+
+// readSuiteLibvirtVMServiceLogsSince returns service journal output produced at or after the provided guest-aligned timestamp.
+func readSuiteLibvirtVMServiceLogsSince(ctx context.Context, libvirtVM vm.TestVMInterface, serviceName, since string) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	return runSuiteLibvirtVMCommand(ctx, libvirtVM, suiteLibvirtVMJournalSinceArgs(serviceName, since, 500))
+}
+
+// detectQCOWFormat returns the qemu-img reported format for the backing image.
+func detectQCOWFormat(qcowPath string) (string, error) {
+	cmd := exec.Command("qemu-img", "info", "--output=json", qcowPath) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("qemu-img info failed: %w, output: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	var metadata struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(output, &metadata); err != nil {
+		return "", fmt.Errorf("parse qemu-img info output: %w", err)
+	}
+	if strings.TrimSpace(metadata.Format) == "" {
+		return "", fmt.Errorf("qemu-img info output missing format")
+	}
+	return metadata.Format, nil
+}
+
+// findDeviceApplicationStatusByName returns the named application status entry or nil when absent.
+func findDeviceApplicationStatusByName(applications []v1beta1.DeviceApplicationStatus, applicationName string) *v1beta1.DeviceApplicationStatus {
+	for i := range applications {
+		if applications[i].Name == applicationName {
+			return &applications[i]
+		}
+	}
+	return nil
+}
+
+// suiteLibvirtVMJournalSinceArgs builds a bounded journalctl command for a specific service and since timestamp.
+func suiteLibvirtVMJournalSinceArgs(serviceName, since string, lines int) []string {
+	args := []string{
+		"sudo",
+		"TZ=UTC",
+		"journalctl",
+		"--no-pager",
+		"--no-hostname",
+		"-u", serviceName,
+		"--boot=all",
+	}
+	if strings.TrimSpace(since) != "" {
+		args = append(args, "--since", since)
+	}
+	if lines > 0 {
+		args = append(args, "-n", strconv.Itoa(lines))
+	}
+	return args
+}

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -153,8 +153,25 @@ func (v *TestVM) sshCommandWithUserContext(ctx context.Context, inputArgs []stri
 		logrus.Infof("Connecting to vm %s. To close connection, use `~.` or `exit`", v.VMName)
 	}
 
-	logrus.Debugf("Running ssh command: %s", cmd.String())
+	logrus.Debugf("Running ssh command: %s", redactSSHCommandArgs(cmd.Args))
 	return cmd
+}
+
+// redactSSHCommandArgs masks the sshpass password argument before logging the SSH command.
+func redactSSHCommandArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	redacted := append([]string(nil), args...)
+	for i := 0; i < len(redacted)-1; i++ {
+		if redacted[i] == "-p" && redacted[0] == "sshpass" {
+			redacted[i+1] = "[REDACTED]"
+			break
+		}
+	}
+
+	return strings.Join(redacted, " ")
 }
 
 // RunSSH runs a command over ssh or starts an interactive ssh connection if no command is provided


### PR DESCRIPTION
**Summary**
Adds a new Linux-only E2E suite for EDM-4768 under test/e2e/package_mode/ to cover package-mode device behavior end to end.
Included coverage:

- package-mode device enrolls and reports status.capabilities.osMode=package
- package-mode fleet without spec.os.image delivers inline config and a podman app successfully
- mixed-fleet behavior where a package-mode device rejects spec.os.image and stays OutOfDate
- mixed-fleet behavior where an image-mode device converges on the requested OS image normally
- negative check that normal package-mode operation does not emit error-level agent logs

**Release target**
 release-1.3
Target release: release-1.3