### PR TITLE
EDM-4971: Support linked git worktrees in RPM build

### DIFF
--- a/hack/build_rpms.sh
+++ b/hack/build_rpms.sh
@@ -53,7 +53,82 @@ PACKIT_BUILDER_IMAGE="${PACKIT_BUILDER_IMAGE:-quay.io/flightctl-tests/packit-bui
 ##############################################################################
 
 current_tree_state() {
-  (cd "${REPO_ROOT}" && ( ( [ ! -d ".git" ] || git diff --quiet ) && echo "clean" ) || echo "dirty")
+  # Use git status --porcelain to detect all dirty states: unstaged changes,
+  # staged changes, and untracked files. Linked worktrees use a .git *file*,
+  # so the old `[ ! -d .git ]` probe would always report "clean".
+  (cd "${REPO_ROOT}" && {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "clean"
+    elif [ -z "$(git status --porcelain)" ]; then
+      echo "clean"
+    else
+      echo "dirty"
+    fi
+  })
+}
+
+# Absolute path to the shared git object store for repo_root.
+# Falls back when --path-format=absolute is unavailable (git < 2.31).
+absolute_git_common_dir() {
+  local repo_root="$1"
+  local common
+  if common="$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+    printf '%s\n' "${common}"
+    return 0
+  fi
+  common="$(git -C "${repo_root}" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  if [[ "${common}" != /* ]]; then
+    common="$(cd "${repo_root}" && cd "${common}" && pwd)"
+  fi
+  printf '%s\n' "${common}"
+}
+
+# Extra podman -v args so Packit can resolve git metadata from a linked worktree.
+# Normal clones need nothing: .git lives under the /work mount. Linked worktrees
+# store objects under the main repo's .git, referenced via absolute paths in the
+# worktree's .git file — mount that common dir at the same host path.
+collect_git_worktree_mounts() {
+  local repo_root="$1"
+  local -n _mounts="$2"
+  local git_common_dir
+
+  if [[ ! -f "${repo_root}/.git" ]]; then
+    return 0
+  fi
+
+  if ! git_common_dir="$(absolute_git_common_dir "${repo_root}")" || [[ ! -d "${git_common_dir}" ]]; then
+    echo "ERROR: Linked git worktree detected at ${repo_root}, but the git common directory could not be resolved." >&2
+    echo "Packit requires git metadata for 'git archive'. Use a full clone, or ensure the main repository .git is readable." >&2
+    return 1
+  fi
+
+  repo_root="$(cd "${repo_root}" && pwd)"
+  git_common_dir="$(cd "${git_common_dir}" && pwd)"
+
+  case "${git_common_dir}/" in
+    "${repo_root}/"*)
+      return 0
+      ;;
+  esac
+
+  # Validate the resolved path is a legitimate git directory to prevent
+  # mounting arbitrary host paths via a crafted .git file.
+  if [[ ! -f "${git_common_dir}/HEAD" ]] || [[ ! -d "${git_common_dir}/objects" ]]; then
+    echo "ERROR: Resolved git common directory ${git_common_dir} does not look like a valid git directory." >&2
+    return 1
+  fi
+
+  # Verify bidirectional worktree relationship: the common dir must have a
+  # worktrees/ entry whose gitdir points back to our repo.
+  local worktree_name
+  worktree_name="$(basename "$(git -C "${repo_root}" rev-parse --absolute-git-dir 2>/dev/null || git -C "${repo_root}" rev-parse --git-dir)")"
+  if [[ ! -d "${git_common_dir}/worktrees/${worktree_name}" ]]; then
+    echo "ERROR: ${git_common_dir} does not contain a worktree entry for this repository." >&2
+    return 1
+  fi
+
+  echo "Linked git worktree detected; mounting git common dir read-only at ${git_common_dir}"
+  _mounts+=(-v "${git_common_dir}:${git_common_dir}:ro,z")
 }
 
 current_commit() {
@@ -373,10 +448,14 @@ run_build_in_container() {
   local repo_root="${REPO_ROOT}"
   cd "${repo_root}"
 
+  local -a git_mount_args=()
+  collect_git_worktree_mounts "${repo_root}" git_mount_args
+
   podman run --rm \
     --privileged \
     --network=host \
     -v "${repo_root}:/work:z" \
+    ${git_mount_args[@]+"${git_mount_args[@]}"} \
     -v "${host_gomodcache}:${container_gomodcache}" \
     -v "${host_gocache}:${container_gocache}" \
     -e GOPATH="${container_gopath}" \

--- a/test/scripts/agent-images/scripts/build.sh
+++ b/test/scripts/agent-images/scripts/build.sh
@@ -11,9 +11,21 @@ APP_REPO="${APP_REPO:-quay.io/flightctl}"
 AGENT_OS_ID="${AGENT_OS_ID:-cs9-bootc}"
 VARIANTS="${VARIANTS:-v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12}"
 
+current_tree_state() {
+  (cd "${ROOT_DIR}" && {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "clean"
+    elif [ -z "$(git status --porcelain)" ]; then
+      echo "clean"
+    else
+      echo "dirty"
+    fi
+  })
+}
+
 SOURCE_GIT_TAG="${SOURCE_GIT_TAG:-$(${ROOT_DIR}/hack/current-version)}"
-SOURCE_GIT_TREE_STATE="${SOURCE_GIT_TREE_STATE:-$(cd "${ROOT_DIR}" && ( ( [ ! -d ".git" ] || git diff --quiet ) && echo "clean" ) || echo "dirty")}"
-SOURCE_GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(cd "${ROOT_DIR}" && git rev-parse --short "HEAD^{commit}" 2>/dev/null) || echo "unknown"}"
+SOURCE_GIT_TREE_STATE="${SOURCE_GIT_TREE_STATE:-$(current_tree_state)}"
+SOURCE_GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(cd "${ROOT_DIR}" && git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")}"
 TAG="${TAG:-$SOURCE_GIT_TAG}"
 
 PODMAN_LOG_LEVEL="${PODMAN_LOG_LEVEL:-info}"


### PR DESCRIPTION
## Problem

`make e2e-agent-images` fails when run from a linked git worktree. Packit's `git archive` inside the build container cannot resolve git metadata because the worktree's `.git` file points to a host path not mounted in the container.

```
fatal: not a git repository: (null)
packit.exceptions.PackitSRPMException
Command 'git archive --output packaging/rpm/flightctl-.tar.gz --prefix flightctl-/ HEAD' failed
```

## Root Cause

`hack/build_rpms.sh` mounts only the checkout directory (`-v $repo_root:/work`). Linked worktrees store git objects under the main repo's `.git/` (referenced via an absolute path in the worktree's `.git` file), which is outside the mounted tree.

A secondary issue: `current_tree_state` used `[ ! -d .git ]` which always evaluates true for worktrees (`.git` is a file), falsely reporting "clean".

## Fix

1. Detect linked worktrees and bind-mount the git common directory at the same host-absolute path so Packit can resolve git metadata. The resolved path is validated as a legitimate git directory before mounting.
2. Replace the `[ -d .git ]` / `git diff --quiet` probes with `git status --porcelain` which correctly detects staged changes, untracked files, and works regardless of `.git`'s shape.
3. Apply the same tree-state fix to `test/scripts/agent-images/scripts/build.sh`.

## Testing

- Full `sudo ./hack/build_rpms.sh` from a linked worktree: all 6 RPMs built successfully with correct version strings.
- Verified `git archive` fails without the mount and succeeds with it in an isolated container.
- Normal clone path unchanged (no extra mounts produced).

## Risk Assessment

Low — no-op for normal clones; only activates for linked worktrees. Same trust boundary as the existing repo mount.

## Release Target

release-1.3

Fixes https://redhat.atlassian.net/browse/EDM-4971

Made with [Cursor](https://cursor.com)