### PR TITLE
EDM-4972: Preserve build environment through sudo in create_agent_images.sh

### DIFF
--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -145,7 +145,7 @@ export OS_ID
 
 build_base() {
     echo "Building base image with PODMAN_BUILD_EXTRA_FLAGS: ${PODMAN_BUILD_EXTRA_FLAGS}"
-    sudo AGENT_OS_ID="${AGENT_OS_ID}" "${SCRIPT_DIR}/scripts/build.sh" --base
+    sudo -E "${SCRIPT_DIR}/scripts/build.sh" --base
 }
 
 build_variants_and_qcow2() {


### PR DESCRIPTION
## Problem

`create_agent_images.sh` invokes `build.sh --base` via `sudo AGENT_OS_ID=... build.sh`, which only forwards `AGENT_OS_ID` through the privilege boundary. Standard `sudo` env scrubbing drops all other caller-provided build controls (`CACHE_MODE`, `EXCLUDE_VARIANTS`, `JOBS`, `PODMAN_BUILD_EXTRA_FLAGS`, etc.), causing `build.sh` to fall back to defaults.

**Observed:** `CACHE_MODE: use` and full variant list, despite caller setting `CACHE_MODE=disable` and `EXCLUDE_VARIANTS="v7 v11 v12"`.

## Root Cause

The `build_base()` function used `sudo AGENT_OS_ID=... build.sh` instead of `sudo -E build.sh`. The sibling script `build_and_qcow2.sh` already uses `sudo -E` for the same `build.sh`, so this was an inconsistency introduced with EDM-2463.

## Fix

Replace `sudo AGENT_OS_ID="${AGENT_OS_ID}" ... build.sh --base` with `sudo -E ... build.sh --base` to preserve the full exported environment. `AGENT_OS_ID` is already exported (line 143), so it's preserved via `-E` along with everything else.

## Testing

- Verified all `sudo build.sh` call sites across the codebase now consistently use `-E`
- Verified other `sudo` calls in the file (`chown`, `qemu-img`) don't need `-E`
- Manual verification: run the ticket's repro command and confirm `build.sh` prints `CACHE_MODE: disable` and filtered variant list

## Risk Assessment

LOW — one-line change in a test/CI build script. Matches existing pattern. No product runtime impact.

Fixes [EDM-4972](https://redhat.atlassian.net/browse/EDM-4972)

Made with [Cursor](https://cursor.com)