### PR TITLE
EDM-4973: Allow DNF to replace minimal packages in v10 variant build

### DIFF
--- a/test/scripts/agent-images/variants/v10/Containerfile
+++ b/test/scripts/agent-images/variants/v10/Containerfile
@@ -15,7 +15,10 @@ ARG TARGETARCH
 COPY --from=project-root go.mod /tmp/go.mod
 
 # Tools: curl for download, yq (Go), tar/gzip, coreutils, shadow-utils for user/group
-RUN dnf -y install --setopt=install_weak_deps=0 --nodocs \
+# --allowerasing: package-mode bases ship curl-minimal/coreutils-single which
+# conflict with full curl/coreutils; allow DNF to replace them.
+# On bootc bases the full packages are already present so this is a no-op.
+RUN dnf -y install --allowerasing --setopt=install_weak_deps=0 --nodocs \
       curl yq tar gzip coreutils shadow-utils ca-certificates \
   && dnf clean all
 


### PR DESCRIPTION
## Problem

The `v10` e2e agent image variant fails to build when using a package-mode
CentOS Stream 9 base (`cs9-regular`). The base ships `curl-minimal` and
`coreutils-single`, which conflict with the full `curl` and `coreutils`
that the v10 Containerfile installs via `dnf install`.

## Root Cause

The v10 `dnf install` line was written for bootc bases, which already have
full `curl`/`coreutils`. Package-mode bases use minimal alternatives that
DNF treats as conflicting replacements, so the install fails with exit 1.

## Fix

Add `--allowerasing` to the `dnf install` command in
`test/scripts/agent-images/variants/v10/Containerfile`. This lets DNF
replace `curl-minimal`/`coreutils-single` with their full equivalents on
package-mode bases. On bootc bases the full packages are already present,
so the flag is a no-op.

## Testing

- Verified `dnf install --allowerasing` succeeds on `centos:stream9`
  (replaces minimal packages with full)
- Verified same command on `centos-bootc:stream9` is a no-op ("Nothing to do")
- Verified original command without `--allowerasing` fails (confirms bug)
- Full unit test suite: 6053 tests, 0 regressions (2 pre-existing
  inotify failures unrelated to this change)

## Risk Assessment

LOW — single flag addition to one Containerfile; no-op on existing bootc
builds; only affects package-mode builds that don't exist in CI yet.

Fixes [EDM-4973](https://redhat.atlassian.net/browse/EDM-4973)

Made with [Cursor](https://cursor.com)