### PR TITLE
NO-ISSUE: allow serial and vnc app console sessions to coexist

### DIFF
--- a/api/core/v1beta1/openapi.yaml
+++ b/api/core/v1beta1/openapi.yaml
@@ -2290,7 +2290,7 @@ paths:
         - name: force
           in: query
           required: false
-          description: If true, take over an already-active console session for this application instead of failing with a 409 Conflict. The replaced session is disconnected and told why.
+          description: If true, take over an already-active console session of the same type for this application instead of failing with a 409 Conflict. The replaced session is disconnected and told why.
           schema:
             type: boolean
             default: false

--- a/api/core/v1beta1/spec.gen.go
+++ b/api/core/v1beta1/spec.gen.go
@@ -489,14 +489,14 @@ var swaggerSpec = []string{
 	"s+bD68PLmOX5rG1N8PyBmdordbt8PzCSYCK4Ek7vOPgZPM6BE0r+Ay/PInkFTfwLRIEyBZrFRyN2pFxw",
 	"btkajq3gZLuD3457VIkgeOdrs+GyyOVz0kiCph88UdMr0O4pWOBVn+Z6YDDEHPgN+T5SIBnNvo/sD4pQ",
 	"ouGnJhrkjHGa/ZN8Hy15Unn87d93ZC7FzzXRC84h6+EtmSK/mmoOUW139RhdmeLa2u1mFpuU10sqTQF2",
-	"kt+VRTznb1d++2YBvt0xD2NiK2FjWdpgm3ZmZhJour6miQ0p2uyxYChOxpUGmpoeHlOWmcm8YnpKKPn7",
-	"3/5BcrOb047tqj4tcmSKpEz5uQCppSZpkaVkNe1k0oyF+Yqr3ecDpo4+jGmmoOi2FyEyoDxwevre2YAG",
-	"nKyYTqam/r9LoUUinEKzX28OWR4OMgHxxVd8rRRd2gzC6EC7HrgGyWlGnh3F6ouUQrrUgardUw0ruiZf",
-	"2QzEQtfANy0CEAQi/01sGJkKIuf4WwPeHG5bUf/6U3eB+j7QexBGvy1g/uvM/fOe2tHZXE3gGI5u1ixk",
-	"NvowuqVzdrt8PzLj6SsSmMDSC74bpDYjAFz7D+SmYllrD0Zt41DJSHDyaaGnv0uxZCnIOh25kt/cJ4jm",
-	"dgdSs7EpG57ZxKx9/MgFs07K1MqllsXM6y+n8TVVM/Xj15uD6cA8NLULB93KwP8erckXLkWWzYDrvpZC",
-	"kWpQC53Tiw0KYL5aWJo1czU780O0avXAW9X3XdSdTargY5v4YOgpG49BAg/n7sIibJJ7VS4/mGVNpzzW",
-	"7i7pcZ9XheYfz6mLq1/kVdlqD2hxAsw2OLCd9jkWu5cff/4/AAD//8uRhmLJiAMA",
+	"kt+VRTznb1d++2YBvt0xD2NiK2FjWdpgm3ZmZhJour6miQ0p2uyxPCCIGVXbq8HYnIwrDTQ1qceUZWZ2",
+	"r5ieEkr+/rd/kNwO5zxku8xPiyKYIilTfnJAarlKWmQpWU07qTVjYT7ran/6CKqjD2OaKSj68UWIDCgP",
+	"HKe+d0ahgS8rppOpqf/vUmiRCCfZ7BegQ9aLg2xCfDUWXzxF1zqDQDvQrgeuQXKakWfHufoipZAudaBq",
+	"91TDiq7JVzYDsdA1NE6LiASBUIATG1emAtE5INeQOMffVhjA/tRdKL8POB8E2m8Lqf86c/+8p3Z0NlcT",
+	"OMqjmzULmY0+jG7pnN0u34/MePqKBCaw9ArwBqnNCADX/gO5qZja2oNR21pUMhKcfFro6e9SLFkKss5P",
+	"ruQ39wmiud2B1GxsyoZnNjGLIT9ywayTMrVyqWUx8/rLaXxN1Uz9+PXmYDowj1Xt4kO3MvC/R2vyhUuR",
+	"ZTPguq+lUKQa1ELnBWOjBJivFpZmEV3NzvwQrVo9Elf1fReGZ5Mq+GAnPjp6ysZjkMDDubs4CZvkXtXP",
+	"D2ZZEy6PtbtLi9znVeH9x3PqIu8XeVX23gNanACzDQ7sr32OxXbmx5//DwAA//9s/rRk2ogDAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/core/v1beta1/types.gen.go
+++ b/api/core/v1beta1/types.gen.go
@@ -3503,7 +3503,7 @@ type GetDeviceApplicationConsoleParams struct {
 	// ConsoleType The type of console session to open. "serial" opens a text terminal; "vnc" opens a VNC proxy tunnel.
 	ConsoleType GetDeviceApplicationConsoleParamsConsoleType `form:"consoleType" json:"consoleType"`
 
-	// Force If true, take over an already-active console session for this application instead of failing with a 409 Conflict. The replaced session is disconnected and told why.
+	// Force If true, take over an already-active console session of the same type for this application instead of failing with a 409 Conflict. The replaced session is disconnected and told why.
 	Force *bool `form:"force,omitempty" json:"force,omitempty"`
 }
 

--- a/docs/user/references/cli-commands.md
+++ b/docs/user/references/cli-commands.md
@@ -467,7 +467,7 @@ flightctl app console device/NAME --name APP --type serial|vnc [flags]
 * `--tty` - Allocate a remote pseudo terminal
 * `--notty` - Don't allocate a remote pseudo terminal (mutually exclusive with `--tty`)
 * `--exposed-port <port>` - Local TCP port for the VNC port-forward (`0` = random ephemeral port; only valid with `--type vnc`)
-* `--force` - Take over an already-active console session for the same `--name`, disconnecting it
+* `--force` - Take over an already-active console session of the same `--type` for the same `--name`, disconnecting it
 
 ### Description
 
@@ -477,7 +477,7 @@ A `serial` console bridges stdin/stdout over a WebSocket connection to the devic
 
 A `vnc` console opens a local TCP listener and bridges a single VNC viewer connection through the agent to the application's VNC server. The session ends once that viewer disconnects; run the command again to start a new session.
 
-Only one console session — serial or VNC — is allowed per application at a time. If a console session for the same application is already active, regardless of its type, the command fails with a conflict error unless `--force` is passed, which disconnects the existing session.
+Only one console session of a given type (serial or VNC) is allowed per application at a time; a serial and a VNC session may be open on the same application simultaneously. If a console session of the same type for the same application is already active, the command fails with a conflict error unless `--force` is passed, which disconnects that same-type session.
 
 ### Examples
 

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -967,7 +967,7 @@ A VM application is not otherwise reachable over the network, so a user with the
 
 Use the `flightctl app console` command to open a serial or VNC console to a VM application. See the [`flightctl app console`](../references/cli-commands.md#flightctl-app-console) CLI reference page for command syntax, flags, and examples.
 
-Only one console session — serial or VNC — is allowed per application at a time. If you attempt to connect while another session is already active, the command fails unless you pass `--force`, which takes over the existing session and disconnects it.
+Only one console session of a given type (serial or VNC) is allowed per application at a time; a serial and a VNC session may be open on the same application simultaneously, since they use independent sockets. If you attempt to open a second session of the same type while one is already active, the command fails unless you pass `--force`, which takes over that same-type session and disconnects it.
 
 > [!NOTE]
 > A VNC console session additionally supports only one connected viewer. The command exits once that viewer disconnects; run it again to start a new session.

--- a/internal/cli/app_console.go
+++ b/internal/cli/app_console.go
@@ -149,7 +149,7 @@ func (o *AppConsoleOptions) Bind(fs *pflag.FlagSet) {
 	fs.StringVar(&o.name, "name", o.name, "Application name to open a console for (required)")
 	fs.StringVar(&o.consoleType, "type", o.consoleType, "Console type: serial or vnc (required)")
 	fs.IntVar(&o.exposedPort, "exposed-port", o.exposedPort, "Local TCP port for VNC port-forward (0 = random ephemeral port; only valid with --type vnc)")
-	fs.BoolVar(&o.force, "force", o.force, "Take over an already-active console session for the same --name, disconnecting it")
+	fs.BoolVar(&o.force, "force", o.force, "Take over an already-active console session of the same --type for the same --name, disconnecting it")
 }
 
 func (o *AppConsoleOptions) Complete(cmd *cobra.Command, args []string) error {

--- a/internal/console/app_console.go
+++ b/internal/console/app_console.go
@@ -56,7 +56,9 @@ type ConsoleEventNotifier interface {
 
 // AppConsoleSessionManager manages application console sessions using device annotations.
 // It mirrors ConsoleSessionManager, keyed on DeviceAnnotationRemoteSession with
-// per-appName uniqueness enforcement (stored as a JSON array of DeviceRemoteSession).
+// per-(appName, consoleType) uniqueness enforcement (stored as a JSON array of
+// DeviceRemoteSession). A serial and a vnc session may be active on the same app at once;
+// only two sessions of the same consoleType for the same app conflict.
 type AppConsoleSessionManager struct {
 	svc                 AppConsoleDeviceService
 	log                 logrus.FieldLogger
@@ -137,7 +139,7 @@ func (m *AppConsoleSessionManager) modifyAnnotations(ctx context.Context, orgId 
 }
 
 // addAppSession returns an updater closure that appends a new session entry, returning 409 if
-// an entry for appName already exists.
+// an entry for (appName, consoleType) already exists.
 func addAppSession(sessionID, appName, consoleType string) func(string) (string, error) {
 	return func(existing string) (string, error) {
 		var sessions []domain.DeviceRemoteSession
@@ -147,8 +149,8 @@ func addAppSession(sessionID, appName, consoleType string) func(string) (string,
 			}
 		}
 		for _, s := range sessions {
-			if s.AppName == appName {
-				return "", &duplicateAppSessionError{appName: appName}
+			if s.AppName == appName && s.ConsoleType == consoleType {
+				return "", &duplicateAppSessionError{appName: appName, consoleType: consoleType}
 			}
 		}
 		sessions = append(sessions, domain.DeviceRemoteSession{
@@ -165,10 +167,11 @@ func addAppSession(sessionID, appName, consoleType string) func(string) (string,
 }
 
 // replaceAppSession returns an updater closure that atomically removes any existing session
-// entry for appName and adds a new one in its place, recording the removed entry's SessionID
-// (if any) via ReplacesSessionID. That field is what lets the agent distinguish an explicit
-// takeover from an unrelated close-then-reopen of the same app: it only cancels a running
-// session when a new entry explicitly names it as replaced, never just because it vanished.
+// entry for (appName, consoleType) and adds a new one in its place, recording the removed
+// entry's SessionID (if any) via ReplacesSessionID. That field is what lets the agent
+// distinguish an explicit takeover from an unrelated close-then-reopen of the same app: it
+// only cancels a running session when a new entry explicitly names it as replaced, never just
+// because it vanished. A session for the same app but a different consoleType is left untouched.
 // If no existing entry is found, this behaves exactly like addAppSession.
 //
 // The updater may run more than once (modifyAnnotations retries on conflict), so
@@ -186,7 +189,7 @@ func replaceAppSession(sessionID, appName, consoleType string, replacedSessionID
 		var replacesSessionID string
 		filtered := sessions[:0]
 		for _, s := range sessions {
-			if s.AppName == appName {
+			if s.AppName == appName && s.ConsoleType == consoleType {
 				replacesSessionID = s.SessionID
 				continue
 			}
@@ -242,19 +245,22 @@ func removeAppSession(sessionID string) func(string) (string, error) {
 	}
 }
 
-// duplicateAppSessionError signals a 409 conflict when a session for the same appName already exists.
+// duplicateAppSessionError signals a 409 conflict when a session for the same (appName,
+// consoleType) already exists.
 type duplicateAppSessionError struct {
-	appName string
+	appName     string
+	consoleType string
 }
 
 func (e *duplicateAppSessionError) Error() string {
-	return "console session already active for application " + e.appName
+	return fmt.Sprintf("%s console session already active for application %s", e.consoleType, e.appName)
 }
 
 // StartSession validates inputs, guards against duplicates via annotation, and registers the session.
-// When force is true and a session already exists for appName, that session's annotation entry
-// is atomically replaced (see replaceAppSession) instead of returning a 409 conflict; the agent
-// is responsible for noticing the takeover and tearing down the replaced session itself.
+// When force is true and a session already exists for (appName, consoleType), that session's
+// annotation entry is atomically replaced (see replaceAppSession) instead of returning a 409
+// conflict; the agent is responsible for noticing the takeover and tearing down the replaced
+// session itself. A session of a different consoleType for the same app is unaffected either way.
 func (m *AppConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.UUID, deviceName, appName, consoleType string, force bool) (*AppConsoleSession, domain.Status) {
 	if appName == "" {
 		return nil, domain.StatusBadRequest("appName is required")
@@ -281,15 +287,16 @@ func (m *AppConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.
 		return nil, domain.StatusConflict("Device is paused due to conflicts")
 	}
 
-	// Check for duplicate session for this appName in the current annotation value (fast path).
-	// Skipped when force is set: the atomic updater below replaces any existing entry instead.
+	// Check for duplicate session for this (appName, consoleType) in the current annotation
+	// value (fast path). Skipped when force is set: the atomic updater below replaces any
+	// existing entry instead.
 	if !force {
 		if val, ok := annotations[domain.DeviceAnnotationRemoteSession]; ok && val != "" {
 			var sessions []domain.DeviceRemoteSession
 			if err := json.Unmarshal([]byte(val), &sessions); err == nil {
 				for _, s := range sessions {
-					if s.AppName == appName {
-						return nil, domain.StatusConflict("console session already active for application " + appName)
+					if s.AppName == appName && s.ConsoleType == consoleType {
+						return nil, domain.StatusConflict(fmt.Sprintf("%s console session already active for application %s", consoleType, appName))
 					}
 				}
 			}

--- a/internal/console/app_console_test.go
+++ b/internal/console/app_console_test.go
@@ -147,7 +147,7 @@ func TestAppConsoleSessionManager_StartSession_DecommissionedDevice(t *testing.T
 	reg.AssertNotCalled(t, "StartSession")
 }
 
-func TestAppConsoleSessionManager_StartSession_DuplicateAppName(t *testing.T) {
+func TestAppConsoleSessionManager_StartSession_DuplicateAppNameAndConsoleType(t *testing.T) {
 	svc := &mockAppDeviceService{}
 	reg := &mockAppSessionRegistration{}
 	pub := &mockConsoleEventNotifier{}
@@ -156,8 +156,8 @@ func TestAppConsoleSessionManager_StartSession_DuplicateAppName(t *testing.T) {
 	ctx := context.Background()
 	orgId := uuid.New()
 	device := makeTestDevice("device1")
-	// Pre-populate with an existing session for app1
-	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"existing-id","appName":"app1"}]`
+	// Pre-populate with an existing serial session for app1
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"existing-id","appName":"app1","consoleType":"serial"}]`
 	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
 
 	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "serial", false)
@@ -166,6 +166,31 @@ func TestAppConsoleSessionManager_StartSession_DuplicateAppName(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, int(status.Code))
 	assert.Contains(t, status.Message, "app1")
 	reg.AssertNotCalled(t, "StartSession")
+}
+
+// A serial session and a vnc session on the same app do not contend for the same resource
+// (different sockets: virt-serial0 vs virt-vnc) and must be allowed to coexist.
+func TestAppConsoleSessionManager_StartSession_DifferentConsoleTypeSameApp_Allowed(t *testing.T) {
+	svc := &mockAppDeviceService{}
+	reg := &mockAppSessionRegistration{}
+	pub := &mockConsoleEventNotifier{}
+	mgr := newTestAppManager(svc, reg, pub)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	device := makeTestDevice("device1")
+	// Pre-populate with an existing serial session for app1.
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"existing-id","appName":"app1","consoleType":"serial"}]`
+	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
+	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).Return(device, nil)
+	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(nil)
+	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(nil)
+
+	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "vnc", false)
+
+	assert.Equal(t, http.StatusOK, int(status.Code), "vnc must not conflict with an existing serial session on the same app")
+	require.NotNil(t, session)
+	reg.AssertCalled(t, "StartSession", mock.AnythingOfType("*console.AppConsoleSession"))
 }
 
 func TestAppConsoleSessionManager_CloseSession_RemovesAnnotation(t *testing.T) {
@@ -306,7 +331,7 @@ func TestAddAppSession_DuplicateAppName_ReturnsConflict(t *testing.T) {
 func TestReplaceAppSession_ExistingEntry_SetsReplacesSessionID(t *testing.T) {
 	existing := `[{"sessionID":"old-id","appName":"app1","consoleType":"serial"}]`
 	var replacedSessionID string
-	updater := replaceAppSession("new-id", "app1", "vnc", &replacedSessionID)
+	updater := replaceAppSession("new-id", "app1", "serial", &replacedSessionID)
 
 	result, err := updater(existing)
 
@@ -316,11 +341,34 @@ func TestReplaceAppSession_ExistingEntry_SetsReplacesSessionID(t *testing.T) {
 	require.Len(t, sessions, 1)
 	assert.Equal(t, "new-id", sessions[0].SessionID)
 	assert.Equal(t, "app1", sessions[0].AppName)
-	assert.Equal(t, "vnc", sessions[0].ConsoleType)
+	assert.Equal(t, "serial", sessions[0].ConsoleType)
 	assert.Equal(t, "old-id", sessions[0].ReplacesSessionID,
 		"the new entry must name the session it replaced")
 	assert.Equal(t, "old-id", replacedSessionID,
 		"the out-param must report the evicted session so callers can audit-log it")
+}
+
+// A different consoleType for the same app is not a conflict, so replaceAppSession must add
+// alongside the existing entry rather than evicting it.
+func TestReplaceAppSession_DifferentConsoleType_AddsAlongsideExisting(t *testing.T) {
+	existing := `[{"sessionID":"serial-id","appName":"app1","consoleType":"serial"}]`
+	var replacedSessionID string
+	updater := replaceAppSession("vnc-id", "app1", "vnc", &replacedSessionID)
+
+	result, err := updater(existing)
+
+	assert.NoError(t, err)
+	var sessions []domain.DeviceRemoteSession
+	require.NoError(t, json.Unmarshal([]byte(result), &sessions))
+	require.Len(t, sessions, 2, "the existing serial session must not be evicted by a vnc request")
+	byType := map[string]domain.DeviceRemoteSession{}
+	for _, s := range sessions {
+		byType[s.ConsoleType] = s
+	}
+	assert.Equal(t, "serial-id", byType["serial"].SessionID, "unrelated serial session must be untouched")
+	assert.Equal(t, "vnc-id", byType["vnc"].SessionID)
+	assert.Empty(t, byType["vnc"].ReplacesSessionID, "nothing of the same consoleType existed to replace")
+	assert.Empty(t, replacedSessionID)
 }
 
 func TestReplaceAppSession_NoExistingEntry_BehavesLikeAdd(t *testing.T) {
@@ -404,6 +452,50 @@ func TestAppConsoleSessionManager_StartSession_Force_ReplacesExistingSession(t *
 	require.NotNil(t, auditEntry, "a forced takeover must emit an audit log line naming the evicted session")
 	assert.Contains(t, auditEntry.Message, "existing-id")
 	assert.Contains(t, auditEntry.Message, session.UUID)
+}
+
+// Force takeover of a serial session must not disturb a concurrently active vnc session
+// (or vice versa) for the same app: it should only replace the entry with the same consoleType.
+func TestAppConsoleSessionManager_StartSession_Force_OnlyReplacesSameConsoleType(t *testing.T) {
+	svc := &mockAppDeviceService{}
+	reg := &mockAppSessionRegistration{}
+	pub := &mockConsoleEventNotifier{}
+	mgr := newTestAppManager(svc, reg, pub)
+
+	ctx := context.Background()
+	orgId := uuid.New()
+	device := makeTestDevice("device1")
+	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"serial-id","appName":"app1","consoleType":"serial"},{"sessionID":"vnc-id","appName":"app1","consoleType":"vnc"}]`
+
+	var capturedDevice domain.Device
+	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
+	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			capturedDevice = args.Get(3).(domain.Device)
+		}).
+		Return(device, nil)
+	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(nil)
+	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(nil)
+
+	session, status := mgr.StartSession(ctx, orgId, "device1", "app1", "serial", true)
+
+	assert.Equal(t, http.StatusOK, int(status.Code))
+	require.NotNil(t, session)
+
+	require.NotNil(t, capturedDevice.Metadata.Annotations)
+	val := (*capturedDevice.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession]
+	var sessions []domain.DeviceRemoteSession
+	require.NoError(t, json.Unmarshal([]byte(val), &sessions))
+	require.Len(t, sessions, 2, "the vnc entry must remain alongside the replaced serial entry")
+
+	byType := map[string]domain.DeviceRemoteSession{}
+	for _, s := range sessions {
+		byType[s.ConsoleType] = s
+	}
+	assert.Equal(t, session.UUID, byType["serial"].SessionID)
+	assert.Equal(t, "serial-id", byType["serial"].ReplacesSessionID)
+	assert.Equal(t, "vnc-id", byType["vnc"].SessionID, "the unrelated vnc session must be untouched")
+	assert.Empty(t, byType["vnc"].ReplacesSessionID)
 }
 
 func TestAppConsoleSessionManager_StartSession_Force_NoExistingSession_AddsNormally(t *testing.T) {

--- a/internal/console/app_console_test.go
+++ b/internal/console/app_console_test.go
@@ -181,8 +181,14 @@ func TestAppConsoleSessionManager_StartSession_DifferentConsoleTypeSameApp_Allow
 	device := makeTestDevice("device1")
 	// Pre-populate with an existing serial session for app1.
 	(*device.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession] = `[{"sessionID":"existing-id","appName":"app1","consoleType":"serial"}]`
+
+	var capturedDevice domain.Device
 	svc.On("GetDevice", mock.Anything, orgId, "device1").Return(device, domain.StatusOK())
-	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).Return(device, nil)
+	svc.On("UpdateDevice", mock.Anything, orgId, "device1", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			capturedDevice = args.Get(3).(domain.Device)
+		}).
+		Return(device, nil)
 	pub.On("NotifyConsole", mock.Anything, orgId, "device1").Return(nil)
 	reg.On("StartSession", mock.AnythingOfType("*console.AppConsoleSession")).Return(nil)
 
@@ -191,6 +197,18 @@ func TestAppConsoleSessionManager_StartSession_DifferentConsoleTypeSameApp_Allow
 	assert.Equal(t, http.StatusOK, int(status.Code), "vnc must not conflict with an existing serial session on the same app")
 	require.NotNil(t, session)
 	reg.AssertCalled(t, "StartSession", mock.AnythingOfType("*console.AppConsoleSession"))
+
+	require.NotNil(t, capturedDevice.Metadata.Annotations)
+	val := (*capturedDevice.Metadata.Annotations)[domain.DeviceAnnotationRemoteSession]
+	var sessions []domain.DeviceRemoteSession
+	require.NoError(t, json.Unmarshal([]byte(val), &sessions))
+	require.Len(t, sessions, 2, "the pre-existing serial session must be preserved alongside the new vnc session")
+	byType := map[string]domain.DeviceRemoteSession{}
+	for _, s := range sessions {
+		byType[s.ConsoleType] = s
+	}
+	assert.Equal(t, "existing-id", byType["serial"].SessionID, "unrelated serial session must be untouched")
+	assert.Equal(t, session.UUID, byType["vnc"].SessionID)
 }
 
 func TestAppConsoleSessionManager_CloseSession_RemovesAnnotation(t *testing.T) {
@@ -326,6 +344,26 @@ func TestAddAppSession_DuplicateAppName_ReturnsConflict(t *testing.T) {
 	var dupErr *duplicateAppSessionError
 	assert.ErrorAs(t, err, &dupErr)
 	assert.Contains(t, dupErr.Error(), "app1")
+}
+
+// A different consoleType for the same app is not a conflict, so addAppSession must append
+// alongside the existing entry rather than rejecting it.
+func TestAddAppSession_DifferentConsoleType_AddsAlongsideExisting(t *testing.T) {
+	existing := `[{"sessionID":"serial-id","appName":"app1","consoleType":"serial"}]`
+	updater := addAppSession("vnc-id", "app1", "vnc")
+
+	result, err := updater(existing)
+
+	assert.NoError(t, err)
+	var sessions []domain.DeviceRemoteSession
+	require.NoError(t, json.Unmarshal([]byte(result), &sessions))
+	require.Len(t, sessions, 2, "the existing serial session must not be rejected by a vnc request")
+	byType := map[string]domain.DeviceRemoteSession{}
+	for _, s := range sessions {
+		byType[s.ConsoleType] = s
+	}
+	assert.Equal(t, "serial-id", byType["serial"].SessionID, "unrelated serial session must be untouched")
+	assert.Equal(t, "vnc-id", byType["vnc"].SessionID)
 }
 
 func TestReplaceAppSession_ExistingEntry_SetsReplacesSessionID(t *testing.T) {


### PR DESCRIPTION
## Summary
- `AppConsoleSessionManager` keyed console-session exclusivity on `appName` alone (in `StartSession`'s fast-path check, `addAppSession`, and `replaceAppSession`), so a `serial` and a `vnc` session on the same VM app were mutually exclusive — opening one while the other was active returned 409 unless `--force` was used.
- Serial (`virt-serial0`) and VNC (`virt-vnc`) use different sockets and don't contend for the same resource, so this was unintended: the check predates VNC support (written when only serial existed) and wasn't updated when VNC was added later.
- Exclusivity is now keyed on `(appName, consoleType)`: only two sessions of the *same* console type for the same app conflict. `--force` now only takes over the existing session of the same type, leaving a concurrently active session of the other type untouched.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/console/...` — added:
  - `TestAppConsoleSessionManager_StartSession_DifferentConsoleTypeSameApp_Allowed` — vnc no longer conflicts with an active serial session on the same app
  - `TestAppConsoleSessionManager_StartSession_Force_OnlyReplacesSameConsoleType` — force-takeover of serial leaves a concurrent vnc session on the same app untouched
  - `TestReplaceAppSession_DifferentConsoleType_AddsAlongsideExisting` — lower-level `replaceAppSession` unit test for the same behavior
  - updated `TestAppConsoleSessionManager_StartSession_DuplicateAppNameAndConsoleType` / `TestReplaceAppSession_ExistingEntry_SetsReplacesSessionID` to reflect the new same-type-only semantics
- [x] `gofmt` / `go vet` clean

Made with [Cursor](https://cursor.com)