### PR TITLE
EDM-4765: add package-mode E2E CI wiring

### DIFF
--- a/.github/actions/resolve-go-e2e-dirs/action.yaml
+++ b/.github/actions/resolve-go-e2e-dirs/action.yaml
@@ -1,0 +1,69 @@
+name: "Resolve Go E2E dirs"
+description: "Expand go_e2e_dirs globs to filesystem paths and subtract excluded dirs"
+
+inputs:
+  go_e2e_dirs:
+    description: "Space-separated Go package patterns (e.g. ./test/e2e/...)"
+    required: true
+  excluded_go_e2e_dirs:
+    description: "Optional space-separated Go package patterns to exclude"
+    required: false
+    default: ""
+
+outputs:
+  resolved_go_e2e_dirs:
+    description: "Space-separated repo-relative filesystem paths for ginkgo"
+    value: ${{ steps.resolve.outputs.resolved_go_e2e_dirs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve dirs
+      id: resolve
+      shell: bash
+      env:
+        GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+        EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
+      run: |
+        set -euo pipefail
+
+        repo_root="$(pwd -P)"
+        mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
+        included_dirs=()
+        for dir in "${included_dirs_abs[@]}"; do
+          rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+          included_dirs+=("./${rel_dir#./}")
+        done
+
+        excluded_dirs=()
+        if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+          # Tolerate not-yet-present exclude paths so infra PRs can land
+          # before the excluded suite directory exists.
+          mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
+          for dir in "${excluded_dirs_abs[@]}"; do
+            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+            excluded_dirs+=("./${rel_dir#./}")
+          done
+        fi
+
+        resolved_dirs=()
+        for dir in "${included_dirs[@]}"; do
+          skip=false
+          for excluded in "${excluded_dirs[@]}"; do
+            if [[ "${dir}" == "${excluded}" ]]; then
+              skip=true
+              break
+            fi
+          done
+          if [[ "${skip}" != "true" ]]; then
+            resolved_dirs+=("${dir}")
+          fi
+        done
+
+        if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+          echo "ERROR: No Go E2E dirs remain after exclusions"
+          exit 1
+        fi
+
+        printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+        printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -58,7 +58,7 @@ runs:
           sudo apt update -y 
           sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
                               virtinst bridge-utils qemu-system-x86 qemu-kvm \
-                              swtpm apparmor-utils
+                              swtpm apparmor-utils libguestfs-tools
           sudo usermod -a -G kvm,libvirt,swtpm $USER
           echo "::endgroup::"
 

--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -8,9 +8,19 @@ on:
         required: true
         type: string
       os_id:
-        description: "Agent Image OS ID (cs9-bootc / cs10-bootc)"
+        description: "Agent image OS ID (cs9-bootc / cs9-regular / cs10-bootc)"
         required: true
         type: string
+      build_type:
+        description: "Agent image build type (bootc / regular)"
+        required: false
+        type: string
+        default: "bootc"
+      upload_bundle:
+        description: "Whether this flavor should upload an agent image bundle artifact"
+        required: false
+        type: boolean
+        default: true
       tag:
         description: "Image tag"
         required: true
@@ -29,6 +39,8 @@ jobs:
       # "unknown version specified" (apt ships crun 1.14.1).
       - name: Setup dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          setup_kvm: yes
 
       - name: Restore bootc-image-builder cache
         id: cache-bootc-restore
@@ -54,6 +66,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           AGENT_IMAGE_OUTPUT: bundle
           AGENT_OS_ID: ${{ inputs.os_id }}
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           mkdir -p bin/rpm
           # Validate that both agent and selinux RPMs are present from the download step
@@ -87,6 +100,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload agent images bundle (per flavor)
+        if: ${{ inputs.upload_bundle }}
         uses: actions/upload-artifact@v4
         with:
           name: agent-images-bundle-${{ inputs.os_id }}-${{ inputs.tag }}
@@ -105,6 +119,7 @@ jobs:
           retention-days: 1
 
       - name: List bundled agent images
+        if: ${{ inputs.upload_bundle }}
         id: list-agent-images
         env:
           OS_ID: ${{ inputs.os_id }}
@@ -141,6 +156,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           OS_ID: ${{ inputs.os_id }}
           RUN_ID: ${{ github.run_id }}
+          UPLOAD_BUNDLE: ${{ inputs.upload_bundle }}
           IMAGES: ${{ steps.list-agent-images.outputs.images }}
         run: |
           set -euo pipefail
@@ -151,7 +167,7 @@ jobs:
             echo "**Tag:** \`${TAG}\` | [All artifacts](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}#artifacts)"
             echo ""
             
-            if [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
+            if [ "${UPLOAD_BUNDLE}" = "true" ] && [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
               echo "<details>"
               echo "<summary><strong>Container Images in Bundle</strong></summary>"
               echo ""
@@ -167,11 +183,17 @@ jobs:
             echo '```bash'
             echo "# Download artifacts"
             echo "mkdir -p bin/agent-artifacts bin/output/qcow2"
-            echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            fi
             echo "gh run download ${RUN_ID} -n agent-qcow2-image-${OS_ID}-${TAG} -D bin/output/qcow2"
             echo ""
             echo "# Run e2e tests"
-            echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            else
+              echo "# ${OS_ID} is qcow-only in CI; pair this qcow with a bootc agent bundle when running mixed-fleet package-mode tests"
+            fi
             echo '```'
             echo ""
             echo "</details>"

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -167,52 +167,10 @@ jobs:
 
       - name: Resolve Go E2E dirs
         id: resolve-go-e2e-dirs
-        env:
-          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
-          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
-        run: |
-          set -euo pipefail
-
-          repo_root="$(pwd -P)"
-          mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
-          included_dirs=()
-          for dir in "${included_dirs_abs[@]}"; do
-            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
-            included_dirs+=("./${rel_dir#./}")
-          done
-
-          excluded_dirs=()
-          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
-            # EDM-4765 lands before the package-mode suite itself, so tolerate a
-            # not-yet-present exclude path here and keep the bootc discovery legs working.
-            mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
-            for dir in "${excluded_dirs_abs[@]}"; do
-              rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
-              excluded_dirs+=("./${rel_dir#./}")
-            done
-          fi
-
-          resolved_dirs=()
-          for dir in "${included_dirs[@]}"; do
-            skip=false
-            for excluded in "${excluded_dirs[@]}"; do
-              if [[ "${dir}" == "${excluded}" ]]; then
-                skip=true
-                break
-              fi
-            done
-            if [[ "${skip}" != "true" ]]; then
-              resolved_dirs+=("${dir}")
-            fi
-          done
-
-          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
-            echo "ERROR: No Go E2E dirs remain after exclusions"
-            exit 1
-          fi
-
-          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
-          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
+        uses: ./.github/actions/resolve-go-e2e-dirs
+        with:
+          go_e2e_dirs: ${{ matrix.go_e2e_dirs }}
+          excluded_go_e2e_dirs: ${{ matrix.excluded_go_e2e_dirs }}
 
       - name: Run test discovery
         env:

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -109,12 +109,22 @@ jobs:
         include:
           - os_id: cs9-bootc
             rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: bootc
+            upload_bundle: true
+          - os_id: cs9-regular
+            rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: regular
+            upload_bundle: false
           - os_id: cs10-bootc
             rpm_suffix: epel-10-x86_64
+            build_type: bootc
+            upload_bundle: true
     uses: ./.github/workflows/build-agent-images.yaml
     with:
       rpm_suffix: ${{ matrix.rpm_suffix }}
       os_id: ${{ matrix.os_id }}
+      build_type: ${{ matrix.build_type }}
+      upload_bundle: ${{ matrix.upload_bundle }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   discover-e2e-tests:
@@ -127,8 +137,12 @@ jobs:
       matrix:
         include:
           - label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
           - label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
     steps:
       - name: Checkout
@@ -139,20 +153,76 @@ jobs:
 
       - name: Compute label filter hash
         id: compute-hash
+        env:
+          GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${{ matrix.label_filter }}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "Label filter: ${{ matrix.label_filter }}"
+          echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        env:
+          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
+        run: |
+          set -euo pipefail
+
+          repo_root="$(pwd -P)"
+          mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
+          included_dirs=()
+          for dir in "${included_dirs_abs[@]}"; do
+            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+            included_dirs+=("./${rel_dir#./}")
+          done
+
+          excluded_dirs=()
+          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+            # EDM-4765 lands before the package-mode suite itself, so tolerate a
+            # not-yet-present exclude path here and keep the bootc discovery legs working.
+            mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
+            for dir in "${excluded_dirs_abs[@]}"; do
+              rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+              excluded_dirs+=("./${rel_dir#./}")
+            done
+          fi
+
+          resolved_dirs=()
+          for dir in "${included_dirs[@]}"; do
+            skip=false
+            for excluded in "${excluded_dirs[@]}"; do
+              if [[ "${dir}" == "${excluded}" ]]; then
+                skip=true
+                break
+              fi
+            done
+            if [[ "${skip}" != "true" ]]; then
+              resolved_dirs+=("${dir}")
+            fi
+          done
+
+          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+            echo "ERROR: No Go E2E dirs remain after exclusions"
+            exit 1
+          fi
+
+          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
 
       - name: Run test discovery
         env:
           GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           DISCOVERY_ONLY: "true"
           DISCOVERY_PATH: discovery.json
         run: |
           mkdir -p reports
-          test/scripts/run_e2e_tests.sh reports ./test/e2e/...
+          test/scripts/run_e2e_tests.sh reports ${GO_E2E_DIRS}
 
       - name: Validate discovery results
         run: |
@@ -216,20 +286,38 @@ jobs:
           - os_id: cs9-bootc
             backend_type: helm
             label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
           ## CS10: agent tests only; microshift tests are excluded until the cs10-bootc kernel
           ## includes xt_conntrack/xt_comment modules required by kube-proxy. CS9 provides
           ## full microshift coverage via the v12 OKD SCOS variant.
           - os_id: cs10-bootc
             backend_type: helm
             label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
     uses: ./.github/workflows/run-e2e-tests.yaml
     with:
       os_id: ${{ matrix.os_id }}
       backend_type: ${{ matrix.backend_type }}
       ginkgo_total_nodes: ${{ matrix.ginkgo_total_nodes }}
       ginkgo_label_filter: ${{ matrix.label_filter }}
+      go_e2e_dirs: ${{ matrix.go_e2e_dirs }}
+      excluded_go_e2e_dirs: ${{ matrix.excluded_go_e2e_dirs }}
+      package_mode_qcow_os_id: ${{ matrix.package_mode_qcow_os_id }}
+      image_mode_qcow_os_id: ${{ matrix.image_mode_qcow_os_id }}
+      package_mode_qcow_env_var: ${{ matrix.package_mode_qcow_env_var }}
+      image_mode_qcow_env_var: ${{ matrix.image_mode_qcow_env_var }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   api-tests:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -22,6 +22,36 @@ on:
         required: false
         type: string
         default: "sanity"
+      go_e2e_dirs:
+        description: "Space-separated Go e2e package dirs passed to run_e2e_tests.sh"
+        required: false
+        type: string
+        default: "./test/e2e/..."
+      excluded_go_e2e_dirs:
+        description: "Optional Go e2e package dirs to exclude after resolving go_e2e_dirs"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be staged as the primary package-mode qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be injected for mixed-fleet package-mode tests"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_env_var:
+        description: "Optional env var name that should point to the primary staged qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_env_var:
+        description: "Optional env var name that should point to the secondary staged qcow"
+        required: false
+        type: string
+        default: ""
       tag:
         description: "Image tag"
         required: true
@@ -103,9 +133,25 @@ jobs:
           path: test-artifacts
           merge-multiple: true
 
+      - name: Download image-mode qcow artifact
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.image_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-image-mode
+
+      - name: Download package-mode qcow artifact
+        if: ${{ inputs.package_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.package_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-package-mode
+
       - name: Stage test artifacts
         env:
           OS_ID: ${{ inputs.os_id }}
+          PACKAGE_MODE_QCOW_OS_ID: ${{ inputs.package_mode_qcow_os_id }}
+          IMAGE_MODE_QCOW_OS_ID: ${{ inputs.image_mode_qcow_os_id }}
         run: |
           set -euo pipefail
           echo "Downloaded test artifacts:"
@@ -120,17 +166,37 @@ jobs:
           mv "test-artifacts/agent-images-bundle-${OS_ID}.tar" bin/agent-artifacts/
           echo "Agent bundle: bin/agent-artifacts/agent-images-bundle-${OS_ID}.tar"
 
-          # Stage qcow2
+          # Stage the primary qcow2 used by prepare-e2e-qcow-config.
           mkdir -p bin/output/qcow2
-          if [ ! -f "test-artifacts/disk.qcow2" ]; then
-            echo "ERROR: QCOW2 image not found"
-            exit 1
+          if [ -n "${PACKAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-package-mode/disk.qcow2" ]; then
+              echo "ERROR: Package-mode QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts-package-mode/disk.qcow2" bin/output/qcow2/disk.qcow2
+          else
+            if [ ! -f "test-artifacts/disk.qcow2" ]; then
+              echo "ERROR: QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts/disk.qcow2" bin/output/qcow2/disk.qcow2
           fi
-          mv "test-artifacts/disk.qcow2" bin/output/qcow2/
           echo "✓ QCOW2 image: bin/output/qcow2/disk.qcow2"
+
+          if [ -n "${IMAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-image-mode/disk.qcow2" ]; then
+              echo "ERROR: Image-mode QCOW2 image not found"
+              exit 1
+            fi
+            mkdir -p bin/output/qcow2-image-mode
+            mv "test-artifacts-image-mode/disk.qcow2" bin/output/qcow2-image-mode/
+            echo "✓ Image-mode QCOW2 image: bin/output/qcow2-image-mode/disk.qcow2"
+          fi
 
           # Cleanup
           rm -rf test-artifacts
+          rm -rf test-artifacts-package-mode
+          rm -rf test-artifacts-image-mode
 
           echo "Staged artifacts:"
           tree bin
@@ -154,6 +220,21 @@ jobs:
           # All dependencies are resolved automatically by Make
           make prepare-e2e-test
 
+      - name: Inject image-mode qcow for package-mode mixed-fleet tests
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        env:
+          IMAGE_MODE_QCOW: bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+          if [ ! -f "${IMAGE_MODE_QCOW}" ]; then
+            echo "ERROR: Secondary image-mode qcow not staged at ${IMAGE_MODE_QCOW}"
+            exit 1
+          fi
+
+          QCOW="${IMAGE_MODE_QCOW}" \
+          AGENT_DIR=bin/agent/etc/flightctl \
+          test/scripts/inject_agent_files_into_qcow.sh
+
       # ========== RUN E2E TESTS ==========
       - name: Restore Go cache
         uses: actions/cache/restore@v4
@@ -169,11 +250,62 @@ jobs:
         id: compute-hash
         env:
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
+          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${GINKGO_LABEL_FILTER}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
           echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        env:
+          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
+        run: |
+          set -euo pipefail
+
+          repo_root="$(pwd -P)"
+          mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
+          included_dirs=()
+          for dir in "${included_dirs_abs[@]}"; do
+            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+            included_dirs+=("./${rel_dir#./}")
+          done
+
+          excluded_dirs=()
+          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+            mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
+            for dir in "${excluded_dirs_abs[@]}"; do
+              rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+              excluded_dirs+=("./${rel_dir#./}")
+            done
+          fi
+
+          resolved_dirs=()
+          for dir in "${included_dirs[@]}"; do
+            skip=false
+            for excluded in "${excluded_dirs[@]}"; do
+              if [[ "${dir}" == "${excluded}" ]]; then
+                skip=true
+                break
+              fi
+            done
+            if [[ "${skip}" != "true" ]]; then
+              resolved_dirs+=("${dir}")
+            fi
+          done
+
+          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+            echo "ERROR: No Go E2E dirs remain after exclusions"
+            exit 1
+          fi
+
+          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
 
       - name: Download test discovery
         uses: actions/download-artifact@v4
@@ -184,15 +316,41 @@ jobs:
       - name: Check disk space
         run: df -h
 
+      - name: Validate qcow inputs
+        env:
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" && ! -f "${PACKAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${PACKAGE_MODE_QCOW_ENV_VAR} requires qcow at ${PACKAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" && ! -f "${IMAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${IMAGE_MODE_QCOW_ENV_VAR} requires qcow at ${IMAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
       - name: Run E2E Test Slice
         env:
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
           GINKGO_TOTAL_NODES: ${{ inputs.ginkgo_total_nodes }}
           GINKGO_NODE: ${{ matrix.ginkgo_node }}
           DISCOVERY_PATH: discovery.json
           ASSIGNMENTS_PATH: assignments.json
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
           RUNNER_DEBUG: ${{ runner.debug }}
         run: |
+          set -euo pipefail
+
           if [[ "${RUNNER_DEBUG}" == "1" ]]; then
             echo "Debug mode enabled"
             export DEBUG_VM_CONSOLE=1
@@ -200,6 +358,15 @@ jobs:
           else
             echo "Debug mode disabled"
           fi
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${PACKAGE_MODE_QCOW_ENV_VAR}=${PACKAGE_MODE_QCOW_PATH}"
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${IMAGE_MODE_QCOW_ENV_VAR}=${IMAGE_MODE_QCOW_PATH}"
+          fi
+
           make -e run-e2e-test
 
       - name: Check disk space after E2E tests

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -262,50 +262,10 @@ jobs:
 
       - name: Resolve Go E2E dirs
         id: resolve-go-e2e-dirs
-        env:
-          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
-          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
-        run: |
-          set -euo pipefail
-
-          repo_root="$(pwd -P)"
-          mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
-          included_dirs=()
-          for dir in "${included_dirs_abs[@]}"; do
-            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
-            included_dirs+=("./${rel_dir#./}")
-          done
-
-          excluded_dirs=()
-          if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
-            mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
-            for dir in "${excluded_dirs_abs[@]}"; do
-              rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
-              excluded_dirs+=("./${rel_dir#./}")
-            done
-          fi
-
-          resolved_dirs=()
-          for dir in "${included_dirs[@]}"; do
-            skip=false
-            for excluded in "${excluded_dirs[@]}"; do
-              if [[ "${dir}" == "${excluded}" ]]; then
-                skip=true
-                break
-              fi
-            done
-            if [[ "${skip}" != "true" ]]; then
-              resolved_dirs+=("${dir}")
-            fi
-          done
-
-          if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
-            echo "ERROR: No Go E2E dirs remain after exclusions"
-            exit 1
-          fi
-
-          printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
-          printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"
+        uses: ./.github/actions/resolve-go-e2e-dirs
+        with:
+          go_e2e_dirs: ${{ inputs.go_e2e_dirs }}
+          excluded_go_e2e_dirs: ${{ inputs.excluded_go_e2e_dirs }}
 
       - name: Download test discovery
         uses: actions/download-artifact@v4

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -16,13 +16,13 @@ RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
 TMP_CLOUD_IMAGE_PATH=""
 RPM_SOURCE_DIR=""
 
-DISABLED_PASST_BIN=""
+PKG_CACHE_DIR=""
 cleanup() {
   if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
     rm -f "${TMP_CLOUD_IMAGE_PATH}"
   fi
-  if [ -n "${DISABLED_PASST_BIN}" ] && [ -f "${DISABLED_PASST_BIN}" ]; then
-    sudo mv "${DISABLED_PASST_BIN}" "${DISABLED_PASST_BIN%.disabled}" 2>/dev/null || true
+  if [ -n "${PKG_CACHE_DIR}" ] && [ -d "${PKG_CACHE_DIR}" ]; then
+    rm -rf "${PKG_CACHE_DIR}"
   fi
 }
 
@@ -105,6 +105,7 @@ fi
 require_command curl
 require_command qemu-img
 require_command virt-customize
+require_command podman
 
 resolve_output_dir "${OUTPUT_DIR}"
 OUTPUT_QCOW_DIR="${OUTPUT_DIR}/qcow2"
@@ -125,14 +126,50 @@ echo "Preparing package-mode qcow2 at ${OUTPUT_QCOW_PATH}"
 qemu-img convert -O qcow2 "${BASE_CLOUD_IMAGE_PATH}" "${OUTPUT_QCOW_PATH}"
 qemu-img resize "${OUTPUT_QCOW_PATH}" +5G
 
+# Download all required packages on the host using a CentOS 9 container so
+# virt-customize can install them offline (--no-network).  This sidesteps the
+# libguestfs/passt networking issue: on QEMU >= 7.2 libguestfs uses passt for
+# appliance networking, which needs user-namespace creation — denied on
+# GitHub-hosted runners.
+echo "Downloading required packages for offline guest installation"
+PKG_CACHE_DIR=$(mktemp -d)
+
+CONTAINER_CMD='
+  set -euo pipefail
+  dnf install -y epel-release epel-next-release
+  dnf download --resolve --destdir=/output \
+    epel-release epel-next-release \
+    cloud-init dnf-plugins-core firewalld openssh-server \
+    podman podman-compose python-dotenv sudo
+'
+
+if [ -n "${RPM_COPR_REPO}" ]; then
+  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
+  validate_copr_repo "${RPM_COPR_REPO}"
+  validate_copr_package "${package_name}"
+  CONTAINER_CMD+="
+    dnf copr -y enable ${RPM_COPR_REPO}
+    dnf download --resolve --destdir=/output ${package_name}
+  "
+else
+  validate_rpm_dir "${RPM_DIR}"
+  resolve_rpm_source_dir "${RPM_DIR}"
+fi
+
+podman run --rm -v "${PKG_CACHE_DIR}:/output:Z" quay.io/centos/centos:stream9 \
+  bash -c "${CONTAINER_CMD}"
+
+if [ -z "${RPM_COPR_REPO}" ]; then
+  cp "${RPM_SOURCE_DIR}"/flightctl-agent-*.rpm "${RPM_SOURCE_DIR}"/flightctl-selinux-*.rpm \
+    "${PKG_CACHE_DIR}/"
+fi
+
 VIRT_CUSTOMIZE_ARGS=(
   -a "${OUTPUT_QCOW_PATH}"
-  # QEMU SLIRP networking provides a DNS forwarder at 10.0.2.3.  The cloud
-  # image's /etc/resolv.conf may point to an unreachable nameserver, so
-  # inject the SLIRP DNS before any dnf commands.
-  --run-command "echo 'nameserver 10.0.2.3' > /etc/resolv.conf"
-  --run-command "dnf install -y epel-release epel-next-release"
-  --run-command "dnf install -y cloud-init dnf-plugins-core firewalld openssh-server podman podman-compose python-dotenv sudo"
+  --no-network
+  --copy-in "${PKG_CACHE_DIR}:/tmp/pkg-cache"
+  --run-command "dnf install -y /tmp/pkg-cache/*.rpm"
+  --run-command "rm -rf /tmp/pkg-cache"
   --run-command "systemctl enable firewalld.service"
   --run-command "systemctl enable podman.service"
   --run-command "systemctl enable sshd.service"
@@ -144,43 +181,12 @@ VIRT_CUSTOMIZE_ARGS=(
   --run-command "printf '#!/bin/bash\necho \"\"\n' > /usr/lib/flightctl/custom-info.d/emptyValue"
   --run-command "printf '#!/bin/bash\necho \"no-show\"\n' > /usr/lib/flightctl/custom-info.d/keyNotShown"
   --run-command "chmod 755 /usr/lib/flightctl/custom-info.d/*"
-)
-
-if [ -n "${RPM_COPR_REPO}" ]; then
-  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
-  validate_copr_repo "${RPM_COPR_REPO}"
-  validate_copr_package "${package_name}"
-  VIRT_CUSTOMIZE_ARGS+=(
-    --run-command "dnf copr -y enable ${RPM_COPR_REPO}"
-    --run-command "dnf install -y ${package_name}"
-  )
-else
-  validate_rpm_dir "${RPM_DIR}"
-  resolve_rpm_source_dir "${RPM_DIR}"
-  VIRT_CUSTOMIZE_ARGS+=(
-    --copy-in "${RPM_SOURCE_DIR}:/tmp"
-    --run-command "dnf install -y /tmp/${RPM_DIR}/flightctl-agent-*.rpm /tmp/${RPM_DIR}/flightctl-selinux-*.rpm"
-    --run-command "rm -rf /tmp/${RPM_DIR}"
-  )
-fi
-
-VIRT_CUSTOMIZE_ARGS+=(
   --run-command "systemctl enable flightctl-agent.service"
   --run-command "dnf clean all"
   --selinux-relabel
 )
 
 echo "Customizing regular package-mode qcow2"
-# libguestfs on QEMU ≥ 7.2 prefers passt for appliance networking (even with
-# LIBGUESTFS_BACKEND=direct).  passt needs user-namespace creation which is
-# denied on GitHub-hosted runners.  Temporarily hiding the passt binary forces
-# libguestfs to fall back to QEMU's built-in SLIRP networking, which works
-# without extra privileges.  The cleanup trap restores passt on exit.
-PASST_BIN="$(command -v passt 2>/dev/null || true)"
-if [[ -n "${PASST_BIN}" ]]; then
-  sudo mv "${PASST_BIN}" "${PASST_BIN}.disabled"
-  DISABLED_PASST_BIN="${PASST_BIN}.disabled"
-fi
 sudo env LIBGUESTFS_BACKEND=direct virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
 
 sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -136,7 +136,7 @@ PKG_CACHE_DIR=$(mktemp -d)
 
 CONTAINER_CMD='
   set -euo pipefail
-  dnf install -y epel-release epel-next-release
+  dnf install -y epel-release epel-next-release dnf-plugins-core
   dnf download --resolve --destdir=/output \
     epel-release epel-next-release \
     cloud-init dnf-plugins-core firewalld openssh-server \
@@ -156,8 +156,13 @@ else
   resolve_rpm_source_dir "${RPM_DIR}"
 fi
 
-podman run --rm -v "${PKG_CACHE_DIR}:/output:Z" quay.io/centos/centos:stream9 \
+# Use rootful podman (same as qcow2.sh / BIB). Rootless podman hits
+# crun seccomp.bpf linkat Permission denied on GitHub-hosted runners.
+sudo podman run --rm \
+  -v "${PKG_CACHE_DIR}:/output:Z" \
+  quay.io/centos/centos:stream9 \
   bash -c "${CONTAINER_CMD}"
+sudo chown -R "${USER}:$(id -gn "${USER}")" "${PKG_CACHE_DIR}"
 
 if [ -z "${RPM_COPR_REPO}" ]; then
   cp "${RPM_SOURCE_DIR}"/flightctl-agent-*.rpm "${RPM_SOURCE_DIR}"/flightctl-selinux-*.rpm \

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -16,11 +16,13 @@ RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
 TMP_CLOUD_IMAGE_PATH=""
 RPM_SOURCE_DIR=""
 
-# Remove any partially downloaded cloud image if the script exits before the
-# download is committed into the shared cache path.
-cleanup_temp_cloud_image() {
+DISABLED_PASST_BIN=""
+cleanup() {
   if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
     rm -f "${TMP_CLOUD_IMAGE_PATH}"
+  fi
+  if [ -n "${DISABLED_PASST_BIN}" ] && [ -f "${DISABLED_PASST_BIN}" ]; then
+    sudo mv "${DISABLED_PASST_BIN}" "${DISABLED_PASST_BIN%.disabled}" 2>/dev/null || true
   fi
 }
 
@@ -109,7 +111,7 @@ OUTPUT_QCOW_DIR="${OUTPUT_DIR}/qcow2"
 OUTPUT_QCOW_PATH="${OUTPUT_QCOW_DIR}/disk.qcow2"
 
 mkdir -p "${CLOUD_IMAGE_CACHE_DIR}" "${OUTPUT_QCOW_DIR}"
-trap cleanup_temp_cloud_image EXIT
+trap cleanup EXIT
 
 if [ ! -f "${BASE_CLOUD_IMAGE_PATH}" ]; then
   echo "Downloading CentOS Stream 9 cloud image from ${BASE_CLOUD_IMAGE_URL}"
@@ -125,6 +127,10 @@ qemu-img resize "${OUTPUT_QCOW_PATH}" +5G
 
 VIRT_CUSTOMIZE_ARGS=(
   -a "${OUTPUT_QCOW_PATH}"
+  # QEMU SLIRP networking provides a DNS forwarder at 10.0.2.3.  The cloud
+  # image's /etc/resolv.conf may point to an unreachable nameserver, so
+  # inject the SLIRP DNS before any dnf commands.
+  --run-command "echo 'nameserver 10.0.2.3' > /etc/resolv.conf"
   --run-command "dnf install -y epel-release epel-next-release"
   --run-command "dnf install -y cloud-init dnf-plugins-core firewalld openssh-server podman podman-compose python-dotenv sudo"
   --run-command "systemctl enable firewalld.service"
@@ -165,7 +171,17 @@ VIRT_CUSTOMIZE_ARGS+=(
 )
 
 echo "Customizing regular package-mode qcow2"
-sudo virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
+# libguestfs on QEMU ≥ 7.2 prefers passt for appliance networking (even with
+# LIBGUESTFS_BACKEND=direct).  passt needs user-namespace creation which is
+# denied on GitHub-hosted runners.  Temporarily hiding the passt binary forces
+# libguestfs to fall back to QEMU's built-in SLIRP networking, which works
+# without extra privileges.  The cleanup trap restores passt on exit.
+PASST_BIN="$(command -v passt 2>/dev/null || true)"
+if [[ -n "${PASST_BIN}" ]]; then
+  sudo mv "${PASST_BIN}" "${PASST_BIN}.disabled"
+  DISABLED_PASST_BIN="${PASST_BIN}.disabled"
+fi
+sudo env LIBGUESTFS_BACKEND=direct virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
 
 sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"
 


### PR DESCRIPTION
Summary:
add a dedicated package-mode CI entry to the PR E2E matrix
scope package-mode discovery and execution to test/e2e/package_mode
extend the reusable E2E workflow to accept per-job GO_E2E_DIRS
stage both qcows needed by the mixed-fleet package-mode suite
export E2E_PACKAGE_MODE_QCOW and E2E_IMAGE_MODE_QCOW for the package-mode CI run
document the package-mode CI/local run requirements in test/AGENTS.md

Release target
release-1.3
Target release: release-1.3