### PR TITLE
EDM-4970: Harden authprovider API readiness probe

### DIFF
--- a/test/e2e/authprovider/authprovider_test.go
+++ b/test/e2e/authprovider/authprovider_test.go
@@ -602,14 +602,21 @@ func checkAPIEndpointReady(ctx context.Context, apiEndpoint string) error {
 				MinVersion:         tls.VersionTLS12,
 			},
 		},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 		Timeout: authConfigHTTPTimeout,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s/readyz: %w", strings.TrimRight(apiEndpoint, "/"), err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= http.StatusBadRequest {
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logrus.Warnf("[authprovider] failed to close API readiness response body: %v", err)
+		}
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("GET %s/readyz returned %d", strings.TrimRight(apiEndpoint, "/"), resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
Hardened the authprovider API readiness check used during browser-login setup.
The test now stops on redirects, only treats real 2xx responses as ready, and logs response body close errors instead of silently ignoring them. This makes failures clearer and avoids treating an unexpected redirect/error response as a healthy API.


Release target
release-1.3
Target release: release-1.3