### PR TITLE
EDM-4761: add package-mode image build infrastructure

### DIFF
--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -14,6 +14,9 @@ The `AGENT_OS_ID` parameter controls which OS flavor to build:
 # Build for default OS (cs9-bootc)
 make e2e-agent-images
 
+# Build package-mode images
+BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
+
 # Build for specific OS
 AGENT_OS_ID=cs10-bootc make e2e-agent-images
 ```
@@ -22,16 +25,25 @@ AGENT_OS_ID=cs10-bootc make e2e-agent-images
 
 The script is a wrapper that delegates to the modular build system:
 1. **Base image**: Built using `scripts/build.sh --base`
-2. **Variants and qcow2**: Built using `scripts/build_and_qcow2.sh`
+2. **Bootc path**: `scripts/build_and_qcow2.sh` builds variants and a bootc qcow2
+3. **Package-mode path**: `BUILD_TYPE=regular AGENT_OS_ID=cs9-regular` builds the package-mode base image and qcow2 only
 
-The build process automatically handles different OS flavors (cs9-bootc, cs10-bootc)
+The build process automatically handles different OS flavors (cs9-bootc, cs9-regular, cs10-bootc)
 and RPM source detection (local, COPR, or Brew registry).
+
+`BUILD_TYPE=regular` is a package-mode-only path in `create_agent_images.sh`. There,
+omitting `AGENT_OS_ID` defaults it to `cs9-regular`, and any other `AGENT_OS_ID`
+with `BUILD_TYPE=regular` fails fast.
+
+For the `make e2e-agent-images` entrypoint, pass `AGENT_OS_ID=cs9-regular`
+explicitly. Make still defaults `AGENT_OS_ID` to `cs9-bootc`.
 
 ## OS Flavors and Tagging
 
 The build system supports multiple OS flavors with dedicated Containerfiles:
 
 - **cs9-bootc** - Based on CentOS Stream 9 bootc (default)
+- **cs9-regular** - Package-mode base for non-bootc E2E coverage
 - **cs10-bootc** - Based on CentOS Stream 10 bootc
 
 Each flavor has its own explicit Containerfile eliminating conditional logic.
@@ -42,12 +54,17 @@ Each flavor has its own explicit Containerfile eliminating conditional logic.
 # Build cs9-bootc images (default, community)
 ./scripts/build.sh --base
 
+# Build cs9-regular package-mode images
+AGENT_OS_ID=cs9-regular ./scripts/build.sh --base
+
 # Build cs10-bootc images (community)
 AGENT_OS_ID=cs10-bootc ./scripts/build.sh --base
 
 # Build Red Hat variants
 DISTRO=redhat AGENT_OS_ID=cs9-bootc ./scripts/build.sh --base
 DISTRO=redhat AGENT_OS_ID=cs10-bootc ./scripts/build.sh --base
+
+# cs9-regular package-mode does not support DISTRO=redhat/RHEM
 ```
 
 ### Image Tagging
@@ -79,6 +96,8 @@ agent-images/
 ├── containerfiles/        # OS flavor-specific Containerfiles
 │   ├── cs9-bootc/         # CentOS Stream 9 bootc
 │   │   └── Containerfile
+│   ├── cs9-regular/       # Package-mode base image
+│   │   └── Containerfile
 │   ├── cs9-bootc-redhat/  # RHEL 9 bootc
 │   │   └── Containerfile
 │   ├── cs10-bootc/        # CentOS Stream 10 bootc
@@ -105,9 +124,10 @@ The images are built using the `Containerfile` files in the respective directori
 The `scripts/` directory contains modular build automation:
 
 - **`build.sh`** - Main build script with options: `--base`, `--variants`, `--apps`
-- **`build_and_qcow2.sh`** - Orchestrates variants and QCOW2 builds in parallel
+- **`build_and_qcow2.sh`** - Orchestrates variant and QCOW2 builds; for `*-regular` it is QCOW2-only by default unless `SKIP_VARIANTS_BUILD=false` is set explicitly
 - **`bundle.sh`** - Creates tar bundles of built images for distribution
 - **`qcow2.sh`** - Generates bootable QCOW2 disk images using bootc-image-builder
+- **`qcow2_regular.sh`** - Generates package-mode QCOW2 images from the configured cloud image using `virt-customize`
 - **`upload-images.sh`** - Uploads image bundles to container registries
 
 Use `./scripts/build.sh --help` for detailed usage and options.
@@ -135,6 +155,15 @@ Where `<name>` is `base`, `v2`, `v3`, etc.
 
 > **Note:** `qcow2.sh` writes the disk image to `bin/output/agent-qcow2-${OS_ID}/qcow2/disk.qcow2`.
 > When using `create_agent_images.sh`, the image is moved to `bin/output/qcow2/disk.qcow2`.
+
+For `BUILD_TYPE=regular AGENT_OS_ID=cs9-regular`, `create_agent_images.sh` still writes the final QCOW2 to the same `bin/output/qcow2/disk.qcow2` path, but it is produced by `scripts/qcow2_regular.sh` from the configured cloud image instead of `bootc-image-builder`.
+
+That means the package-mode OCI base and package-mode qcow2 are parallel build paths:
+- `containerfiles/cs9-regular/Containerfile` is the source of truth for the OCI base image
+- `scripts/qcow2_regular.sh` is the source of truth for the package-mode qcow2 guest customization
+
+They are intentionally parallel because the qcow2 is built from a cloud image, not converted from the OCI base image.
+Agent config, certificates, and registry remapping are expected to be injected into the qcow2 after build via the existing e2e injection flow.
 
 ### Local Usage and Registry Remapping
 

--- a/test/scripts/agent-images/containerfiles/cs9-regular/Containerfile
+++ b/test/scripts/agent-images/containerfiles/cs9-regular/Containerfile
@@ -1,0 +1,111 @@
+# syntax=docker/dockerfile:1.6
+#
+# Multi-stage base image build for flightctl package-mode device images - CentOS Stream 9
+# Targets:
+#   - prebase: package-mode base with repos, tooling, users, services (no flightctl RPMs)
+#   - base:    final base image starting from prebase and layering flightctl RPMs
+#
+
+# ---------- Stage: prebase ----------
+FROM quay.io/centos/centos:stream9 AS prebase
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y epel-release epel-next-release
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y python-dotenv
+
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    dnf install -y \
+      cloud-init \
+      dnf-plugins-core \
+      firewalld \
+      openssh-server \
+      podman \
+      podman-compose \
+      sudo && \
+    systemctl enable firewalld.service && \
+    systemctl enable podman.service && \
+    systemctl enable sshd.service
+
+RUN useradd -ms /bin/bash user && \
+    echo "user:user" | chpasswd && \
+    echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN mkdir -p /usr/lib/flightctl/custom-info.d && \
+    chmod 755 /usr/lib/flightctl/custom-info.d
+
+RUN echo -e '#!/bin/bash\necho "my site"' > /usr/lib/flightctl/custom-info.d/siteName && \
+    echo -e '#!/bin/bash\necho ""' > /usr/lib/flightctl/custom-info.d/emptyValue && \
+    echo -e '#!/bin/bash\necho "no-show"' > /usr/lib/flightctl/custom-info.d/keyNotShown && \
+    chmod 755 /usr/lib/flightctl/custom-info.d/*
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_COMMIT
+LABEL org.opencontainers.image.source="https://github.com/flightctl/flightctl"
+LABEL org.opencontainers.image.version="${SOURCE_GIT_TAG}"
+LABEL org.opencontainers.image.revision="${SOURCE_GIT_COMMIT}"
+
+# ---------- Stage: base ----------
+FROM prebase AS base
+
+ARG SOURCE_GIT_TAG
+ARG SOURCE_GIT_COMMIT
+
+ARG RPM_DIR=rpm
+ARG RPM_COPR_REPO=
+ARG RPM_COPR_PACKAGE=flightctl-agent
+
+ARG TRUST_CA_FROM=
+ARG AGENT_CONFIG_FROM=
+ARG AGENT_CERTS_FROM=
+
+COPY --from=variant-context flightctl-e2e.tmpfiles.conf /usr/lib/tmpfiles.d/flightctl-e2e.tmpfiles.conf
+
+RUN --mount=type=bind,from=project-bin,source=.,target=/build-context \
+    sh -exc '\
+      if [ -n "${TRUST_CA_FROM}" ]; then \
+        echo "Installing custom CA certificate from ${TRUST_CA_FROM}"; \
+        cp "/build-context/${TRUST_CA_FROM}" /etc/pki/ca-trust/source/anchors/; \
+        update-ca-trust; \
+      fi; \
+      if [ -n "${AGENT_CONFIG_FROM}" ]; then \
+        echo "Installing agent config from ${AGENT_CONFIG_FROM}"; \
+        mkdir -p /etc/flightctl; \
+        cp "/build-context/${AGENT_CONFIG_FROM}" /etc/flightctl/config.yaml; \
+      fi; \
+      if [ -n "${AGENT_CERTS_FROM}" ]; then \
+        echo "Installing agent certificates from ${AGENT_CERTS_FROM}"; \
+        mkdir -p /etc/flightctl/certs; \
+        if ls "/build-context/${AGENT_CERTS_FROM}"/* >/dev/null 2>&1; then \
+          cp "/build-context/${AGENT_CERTS_FROM}"/* /etc/flightctl/certs/; \
+        else \
+          echo "No certificate files found in ${AGENT_CERTS_FROM}, skipping copy"; \
+        fi; \
+      fi'
+
+RUN --mount=type=bind,from=project-bin,source=.,target=/build-context \
+    --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
+    sh -exc '\
+      mkdir -p /tmp/rpms; \
+      if [ -n "${RPM_COPR_REPO}" ]; then \
+        echo "Installing from COPR: ${RPM_COPR_REPO}, package: ${RPM_COPR_PACKAGE}"; \
+        dnf copr -y enable ${RPM_COPR_REPO}; \
+        dnf install -y ${RPM_COPR_PACKAGE}; \
+      else \
+        echo "Installing local RPMs from ${RPM_DIR}"; \
+        cp /build-context/${RPM_DIR}/flightctl-agent-*.rpm \
+           /build-context/${RPM_DIR}/flightctl-selinux-*.rpm /tmp/rpms/; \
+        ls -l /tmp/rpms; \
+        dnf install -y /tmp/rpms/*.rpm; \
+        rm -rf /tmp/rpms; \
+      fi; \
+      systemctl enable flightctl-agent.service'
+
+LABEL org.opencontainers.image.source="https://github.com/flightctl/flightctl"
+LABEL org.opencontainers.image.version="${SOURCE_GIT_TAG}"
+LABEL org.opencontainers.image.revision="${SOURCE_GIT_COMMIT}"

--- a/test/scripts/agent-images/create_agent_images.sh
+++ b/test/scripts/agent-images/create_agent_images.sh
@@ -31,12 +31,25 @@ fi
 
 export JOBS="${PARALLEL_JOBS}"
 
+if [ "${BUILD_TYPE}" = "regular" ]; then
+    if [ -z "${AGENT_OS_ID:-}" ]; then
+        AGENT_OS_ID="cs9-regular"
+        echo "BUILD_TYPE=regular defaults AGENT_OS_ID to cs9-regular"
+    elif [ "${AGENT_OS_ID}" != "cs9-regular" ]; then
+        echo "BUILD_TYPE=regular supports only AGENT_OS_ID=cs9-regular, got ${AGENT_OS_ID}" >&2
+        exit 1
+    fi
+fi
+
 # Handle v7 variant based on OS and RHOCP access
 # Only auto-detect if user hasn't explicitly set EXCLUDE_VARIANTS
 if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
     if [ "${AGENT_OS_ID:-cs9-bootc}" = "cs10-bootc" ]; then
         export EXCLUDE_VARIANTS="v7"
         echo "cs10: v7 excluded (no RHOCP MicroShift for cs10)"
+    elif [ "${AGENT_OS_ID:-cs9-bootc}" = "cs9-regular" ]; then
+        export EXCLUDE_VARIANTS="v7 v11 v12"
+        echo "cs9-regular: v7, v11, v12 excluded (bootc-specific variants)"
     elif has_rhocp_access; then
         export EXCLUDE_VARIANTS=""
         echo "RHOCP access available, enabling v7"
@@ -46,7 +59,7 @@ if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
     fi
 fi
 
-# Determine OS suffix based on flavor
+# Determine the RPM suffix used when the selected COPR package name is versioned.
 get_os_suffix() {
     local flavor="${1:-cs9-bootc}"
     case "${flavor}" in
@@ -56,12 +69,17 @@ get_os_suffix() {
     esac
 }
 
+# Treat the shared qcow output as current only when it matches the requested
+# flavor and is newer than the last relevant build input we can observe here.
 qcow_is_up_to_date() {
     local os_id="$1"
     local qcow_path="${ROOT_DIR}/bin/output/qcow2/disk.qcow2"
+    local qcow_os_id_path="${ROOT_DIR}/bin/output/qcow2/disk.qcow2.os-id"
     local touch_file="${ROOT_DIR}/bin/.e2e-agent-images-${os_id}"
 
     [[ -f "${qcow_path}" ]] || return 1
+    [[ -f "${qcow_os_id_path}" ]] || return 1
+    [[ "$(cat "${qcow_os_id_path}")" = "${os_id}" ]] || return 1
 
     if [[ -f "${touch_file}" && "${qcow_path}" -nt "${touch_file}" ]]; then
         return 0
@@ -87,16 +105,75 @@ qcow_is_up_to_date() {
     return 1
 }
 
-# Build extra flags for RPM source
+# Record which OS flavor produced the shared qcow path so later runs do not
+# mistake a bootc artifact for a regular one, or vice versa.
+write_qcow_os_id_sidecar() {
+    local os_id="$1"
+    local qcow_dir="${ROOT_DIR}/bin/output/qcow2"
+
+    mkdir -p "${qcow_dir}"
+    printf '%s\n' "${os_id}" > "${qcow_dir}/disk.qcow2.os-id"
+}
+
+# Build extra flags for RPM source.
+# Keep these source selectors initialized here so the OCI build path and the
+# regular qcow path consume the same RPM-source inputs when this wrapper is used.
 BUILD_ARGS=""
+RPM_DIR="${RPM_DIR:-rpm}"
+RPM_COPR_REPO="${RPM_COPR_REPO:-}"
+RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
+
+# Log only the brew host so build logs stay useful without echoing caller-supplied
+# URLs verbatim. Some URLs may carry embedded credentials or tokens.
+safe_brew_build_url() {
+    local brew_url="$1"
+    local host
+
+    host="$(printf '%s\n' "${brew_url}" | sed -E 's#^[A-Za-z]+://([^/@]+@)?([^/:?#]+).*#\2#')"
+    if [ -z "${host}" ] || [ "${host}" = "${brew_url}" ]; then
+        echo "<redacted>"
+        return
+    fi
+
+    echo "${host}"
+}
+
+# Accept only owner/project COPR references before forwarding them into build args.
+validate_copr_repo() {
+    local copr_repo="$1"
+    if [[ ! "${copr_repo}" =~ ^@?[A-Za-z0-9._+-]+/[A-Za-z0-9._+-]+$ ]]; then
+        echo "Invalid RPM_COPR_REPO: ${copr_repo}" >&2
+        exit 1
+    fi
+}
+
+# Accept only package-name characters before forwarding the package into build args.
+validate_copr_package() {
+    local copr_package="$1"
+    if [[ ! "${copr_package}" =~ ^[A-Za-z0-9._:+-]+$ ]]; then
+        echo "Invalid RPM_COPR_PACKAGE: ${copr_package}" >&2
+        exit 1
+    fi
+}
+
+# Keep local RPM lookups confined to a simple directory name beneath bin/.
+validate_rpm_dir() {
+    local rpm_dir="$1"
+    if [[ ! "${rpm_dir}" =~ ^[A-Za-z0-9._+-]+$ ]] || [[ "${rpm_dir}" == *"/"* ]] || [[ "${rpm_dir}" == *".."* ]]; then
+        echo "Invalid RPM_DIR: ${rpm_dir}" >&2
+        exit 1
+    fi
+}
 
 if [ -n "${BREW_BUILD_URL:-}" ]; then
-    echo "Using BREW_BUILD_URL=${BREW_BUILD_URL} for brew registry RPMs"
+    echo "Using brew registry RPMs from host: $(safe_brew_build_url "${BREW_BUILD_URL}")"
 
     if ! download_brew_rpms "${ROOT_DIR}/bin/brew-rpm" "${BREW_BUILD_URL}" "flightctl-agent-*" "flightctl-selinux*"; then
         exit 1
     fi
 
+    RPM_DIR="brew-rpm"
+    validate_rpm_dir "${RPM_DIR}"
     BUILD_ARGS="--build-arg RPM_DIR=brew-rpm"
 
 elif [ -n "${FLIGHTCTL_RPM:-}" ]; then
@@ -111,11 +188,15 @@ elif [ -n "${FLIGHTCTL_RPM:-}" ]; then
         RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE}${OS_SUFFIX}"
     fi
 
+    validate_copr_repo "${RPM_COPR_REPO}"
+    validate_copr_package "${RPM_COPR_PACKAGE}"
+
     BUILD_ARGS="--build-arg RPM_COPR_REPO=${RPM_COPR_REPO}"
     BUILD_ARGS="${BUILD_ARGS} --build-arg RPM_COPR_PACKAGE=${RPM_COPR_PACKAGE}"
 
 else
     echo "No BREW_BUILD_URL or FLIGHTCTL_RPM provided, using local RPMs only"
+    validate_rpm_dir "${RPM_DIR}"
 fi
 
 # Merge with any existing PODMAN_BUILD_EXTRA_FLAGS
@@ -128,13 +209,17 @@ fi
 export PODMAN_BUILD_EXTRA_FLAGS
 export IMAGE_REPO
 export TAG
+export RPM_DIR
+export RPM_COPR_REPO
+export RPM_COPR_PACKAGE
 # Calculate registry endpoint for pushing (if not already set)
 export REGISTRY_ENDPOINT
 
 # Determine OS_ID strictly from AGENT_OS_ID (single source of truth)
 AGENT_OS_ID="${AGENT_OS_ID:-cs9-bootc}"
 case "${AGENT_OS_ID}" in
-    cs9*)  OS_ID="cs9-bootc" ;;
+    cs9-bootc)   OS_ID="cs9-bootc" ;;
+    cs9-regular) OS_ID="cs9-regular" ;;
     cs10*) OS_ID="cs10-bootc" ;;
     *)     OS_ID="${AGENT_OS_ID}" ;;
 esac
@@ -144,7 +229,11 @@ export AGENT_OS_ID
 export OS_ID
 
 build_base() {
-    echo "Building base image with PODMAN_BUILD_EXTRA_FLAGS: ${PODMAN_BUILD_EXTRA_FLAGS}"
+    if [ -n "${PODMAN_BUILD_EXTRA_FLAGS}" ]; then
+        echo "Building base image with caller-provided podman build extra flags"
+    else
+        echo "Building base image"
+    fi
     sudo -E "${SCRIPT_DIR}/scripts/build.sh" --base
 }
 
@@ -176,6 +265,7 @@ build_variants_and_qcow2() {
     if [ -f "${QCOW_SRC}" ]; then
         mkdir -p "${ROOT_DIR}/bin/output/qcow2"
         mv "${QCOW_SRC}" "${QCOW_DST}"
+        write_qcow_os_id_sidecar "${OS_ID}"
         echo "Moved qcow2 to ${QCOW_DST}"
 
         # Resize disk if v7 is enabled (for MicroShift)
@@ -189,9 +279,30 @@ build_variants_and_qcow2() {
     fi
 }
 
+# Build the package-mode path: regular base image plus qcow2 only, then move the
+# resulting qcow into the shared output location and record its OS flavor.
+build_regular_qcow2() {
+    echo "Building package-mode base and qcow2 for OS_ID=${OS_ID}"
+    SKIP_VARIANTS_BUILD=true SKIP_QCOW_BUILD=false "${SCRIPT_DIR}/scripts/build_and_qcow2.sh" --os-id "${OS_ID}"
+
+    sudo chown -R "${USER}:$(id -gn "${USER}")" "${ROOT_DIR}/artifacts" || true
+
+    OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/bin/output/agent-qcow2-${OS_ID}}"
+    QCOW_SRC="${ROOT_DIR}/bin/output/agent-qcow2-${OS_ID}/qcow2/disk.qcow2"
+    QCOW_DST="${ROOT_DIR}/bin/output/qcow2/disk.qcow2"
+    if [ -f "${QCOW_SRC}" ]; then
+        mkdir -p "${ROOT_DIR}/bin/output/qcow2"
+        mv "${QCOW_SRC}" "${QCOW_DST}"
+        write_qcow_os_id_sidecar "${OS_ID}"
+        echo "Moved qcow2 to ${QCOW_DST}"
+        sudo chown -R "${USER}:$(id -gn "${USER}")" "${ROOT_DIR}/bin/output" || true
+    fi
+}
+
 case "$BUILD_TYPE" in
     regular)
         build_base
+        build_regular_qcow2
         ;;
     bootc)
         build_base

--- a/test/scripts/agent-images/scripts/build.sh
+++ b/test/scripts/agent-images/scripts/build.sh
@@ -120,10 +120,19 @@ if [ "${DISTRO:-}" = "redhat" ] || [ -n "${RHEM:-}" ]; then
   DISTRO_SUFFIX="-redhat"
 fi
 
+if [ "${AGENT_OS_ID}" = "cs9-regular" ] && [ -n "${DISTRO_SUFFIX}" ]; then
+  echo "[ERROR] AGENT_OS_ID=cs9-regular does not support DISTRO=redhat/RHEM package-mode builds" >&2
+  exit 1
+fi
+
 case "${AGENT_OS_ID}" in
   cs9-bootc)
     CONTAINERFILE_DIR="${BASE_DIR}/containerfiles/cs9-bootc${DISTRO_SUFFIX}"
     OS_ID="cs9-bootc"
+    ;;
+  cs9-regular)
+    CONTAINERFILE_DIR="${BASE_DIR}/containerfiles/cs9-regular${DISTRO_SUFFIX}"
+    OS_ID="cs9-regular"
     ;;
   cs10-bootc)
     CONTAINERFILE_DIR="${BASE_DIR}/containerfiles/cs10-bootc${DISTRO_SUFFIX}"
@@ -131,7 +140,7 @@ case "${AGENT_OS_ID}" in
     ;;
   *)
     echo "[ERROR] Unsupported AGENT_OS_ID: ${AGENT_OS_ID}" >&2
-    echo "Supported values: cs9-bootc, cs10-bootc" >&2
+    echo "Supported values: cs9-bootc, cs9-regular, cs10-bootc" >&2
     exit 1
     ;;
 esac

--- a/test/scripts/agent-images/scripts/build_and_qcow2.sh
+++ b/test/scripts/agent-images/scripts/build_and_qcow2.sh
@@ -54,11 +54,20 @@ fi
 export OS_ID="${OS_ID_ENV}"
 export AGENT_OS_ID="${OS_ID}"
 
+if [[ "${OS_ID}" == *-regular ]]; then
+  SKIP_VARIANTS_BUILD="${SKIP_VARIANTS_BUILD:-true}"
+else
+  SKIP_VARIANTS_BUILD="${SKIP_VARIANTS_BUILD:-false}"
+fi
+
 # Handle v7/v12 variant exclusion for CS10 (no MicroShift support)
 if [ -z "${EXCLUDE_VARIANTS+x}" ]; then
     if [ "${AGENT_OS_ID}" = "cs10-bootc" ]; then
-        export EXCLUDE_VARIANTS="v7,v12"
+        export EXCLUDE_VARIANTS="v7 v12"
         echo "cs10: v7,v12 excluded (no MicroShift for cs10)"
+    elif [ "${AGENT_OS_ID}" = "cs9-regular" ]; then
+        export EXCLUDE_VARIANTS="v7 v11 v12"
+        echo "cs9-regular: v7, v11, v12 excluded (bootc-specific variants)"
     fi
 fi
 
@@ -70,44 +79,55 @@ mkdir -p "${LOG_DIR}"
 variants_log="${LOG_DIR}/variants.log"
 qcow2_log="${LOG_DIR}/qcow2.log"
 
-echo "Building variants and creating bundle for ${OS_ID}"
+# Keep the top-level banner generic because *-regular defaults to a qcow-only
+# flow here, while bootc flavors still build variants, a bundle, and qcow2.
+echo "Building artifacts for ${OS_ID}"
 echo "Variants log: ${variants_log}"
 echo "QCOW2 log: ${qcow2_log}"
 
 sudo rm -f "${variants_log}" "${qcow2_log}"
 
-(
-  set -euo pipefail
-  echo "Building variants and creating bundle for ${OS_ID}"
-  sudo -E "${SCRIPT_DIR}/build.sh" --variants 2>&1 | tee "${variants_log}"
+VARIANTS_PID=""
+if [ "${SKIP_VARIANTS_BUILD}" != "true" ]; then
+  (
+    set -euo pipefail
+    echo "Building variants and creating bundle for ${OS_ID}"
+    sudo -E "${SCRIPT_DIR}/build.sh" --variants 2>&1 | tee "${variants_log}"
 
-  printf '%s\n' "----------" "Bundle variants" "----------"
+    printf '%s\n' "----------" "Bundle variants" "----------"
 
-  sudo -E "${SCRIPT_DIR}/bundle.sh" \
-    --filter "label=io.flightctl.e2e.component" \
-    --filter "reference=${IMAGE_REPO}:*-${OS_ID}-*" \
-    --output-path "${ARTIFACTS_OUTPUT_DIR}/agent-images-bundle-${OS_ID}.tar" 2>&1 | tee -a "${variants_log}"
-  sudo chown -R "$(id -un)":"$(id -gn)" "${ARTIFACTS_OUTPUT_DIR}" || true
+    sudo -E "${SCRIPT_DIR}/bundle.sh" \
+      --filter "label=io.flightctl.e2e.component" \
+      --filter "reference=${IMAGE_REPO}:*-${OS_ID}-*" \
+      --output-path "${ARTIFACTS_OUTPUT_DIR}/agent-images-bundle-${OS_ID}.tar" 2>&1 | tee -a "${variants_log}"
+    sudo chown -R "$(id -un)":"$(id -gn)" "${ARTIFACTS_OUTPUT_DIR}" || true
 
-  # Push images if requested
-  if [ "${DO_PUSH}" = "true" ]; then
-    BUNDLE_TAR="${ARTIFACTS_OUTPUT_DIR}/agent-images-bundle-${OS_ID}.tar"
-    if [ -f "${BUNDLE_TAR}" ]; then
-      echo "Pushing images from bundle..."
-      "${SCRIPT_DIR}/upload-images.sh" "${BUNDLE_TAR}" 2>&1 | tee -a "${variants_log}"
-    else
-      echo "Warning: Bundle not found at ${BUNDLE_TAR}, skipping push"
+    # Push images if requested
+    if [ "${DO_PUSH}" = "true" ]; then
+      BUNDLE_TAR="${ARTIFACTS_OUTPUT_DIR}/agent-images-bundle-${OS_ID}.tar"
+      if [ -f "${BUNDLE_TAR}" ]; then
+        echo "Pushing images from bundle..."
+        "${SCRIPT_DIR}/upload-images.sh" "${BUNDLE_TAR}" 2>&1 | tee -a "${variants_log}"
+      else
+        echo "Warning: Bundle not found at ${BUNDLE_TAR}, skipping push"
+      fi
     fi
-  fi
-) &
-VARIANTS_PID=$!
+  ) &
+  VARIANTS_PID=$!
+else
+  echo "Skipping variants and bundle for ${OS_ID}"
+fi
 
 QCOW2_PID=""
 if [ "${SKIP_QCOW_BUILD}" != "true" ]; then
   (
     set -euo pipefail
     echo "Building qcow2 for ${OS_ID}"
-    OUTPUT_DIR="${QCOW2_OUTPUT_DIR}" "${SCRIPT_DIR}/qcow2.sh" 2>&1 | tee "${qcow2_log}"
+    if [[ "${OS_ID}" == *-regular ]]; then
+      OUTPUT_DIR="${QCOW2_OUTPUT_DIR}" "${SCRIPT_DIR}/qcow2_regular.sh" 2>&1 | tee "${qcow2_log}"
+    else
+      OUTPUT_DIR="${QCOW2_OUTPUT_DIR}" "${SCRIPT_DIR}/qcow2.sh" 2>&1 | tee "${qcow2_log}"
+    fi
     sudo chown -R "$(id -un)":"$(id -gn)" "${QCOW2_OUTPUT_DIR}" || true
     echo "endgroup"
   ) &
@@ -118,7 +138,9 @@ fi
 
 variants_exit=0
 qcow2_exit=0
-wait "${VARIANTS_PID}" || variants_exit=$?
+if [ -n "${VARIANTS_PID}" ]; then
+  wait "${VARIANTS_PID}" || variants_exit=$?
+fi
 if [ -n "${QCOW2_PID}" ]; then
   wait "${QCOW2_PID}" || qcow2_exit=$?
 fi

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+OS_ID="${OS_ID:?OS_ID is required}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/bin/output/agent-qcow2-${OS_ID}}"
+
+BASE_CLOUD_IMAGE_URL="${BASE_CLOUD_IMAGE_URL:-https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2}"
+CLOUD_IMAGE_CACHE_DIR="${CLOUD_IMAGE_CACHE_DIR:-${ROOT_DIR}/bin/cloud-images}"
+BASE_CLOUD_IMAGE_PATH="${CLOUD_IMAGE_CACHE_DIR}/$(basename "${BASE_CLOUD_IMAGE_URL}")"
+
+RPM_DIR="${RPM_DIR:-rpm}"
+RPM_COPR_REPO="${RPM_COPR_REPO:-}"
+RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
+TMP_CLOUD_IMAGE_PATH=""
+RPM_SOURCE_DIR=""
+
+# Remove any partially downloaded cloud image if the script exits before the
+# download is committed into the shared cache path.
+cleanup_temp_cloud_image() {
+  if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
+    rm -f "${TMP_CLOUD_IMAGE_PATH}"
+  fi
+}
+
+# Fail early with a clear message when a required host-side tool is missing.
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Missing required command: ${command_name}" >&2
+    exit 1
+  fi
+}
+
+# Accept only owner/project COPR references before embedding them in guest commands.
+validate_copr_repo() {
+  local copr_repo="$1"
+  if [[ ! "${copr_repo}" =~ ^@?[A-Za-z0-9._+-]+/[A-Za-z0-9._+-]+$ ]]; then
+    echo "Invalid RPM_COPR_REPO: ${copr_repo}" >&2
+    exit 1
+  fi
+}
+
+# Accept only package-name characters before embedding them in guest commands.
+validate_copr_package() {
+  local copr_package="$1"
+  if [[ ! "${copr_package}" =~ ^[A-Za-z0-9._:+-]+$ ]]; then
+    echo "Invalid RPM_COPR_PACKAGE: ${copr_package}" >&2
+    exit 1
+  fi
+}
+
+# Keep local RPM lookups confined to a simple directory name beneath bin/.
+validate_rpm_dir() {
+  local rpm_dir="$1"
+  if [[ ! "${rpm_dir}" =~ ^[A-Za-z0-9._+-]+$ ]] || [[ "${rpm_dir}" == *"/"* ]] || [[ "${rpm_dir}" == *".."* ]]; then
+    echo "Invalid RPM_DIR: ${rpm_dir}" >&2
+    exit 1
+  fi
+}
+
+# Resolve the caller-provided RPM directory under bin/ and reject path escape.
+resolve_rpm_source_dir() {
+  local rpm_dir="$1"
+  local bin_root="${ROOT_DIR}/bin"
+  local resolved_path
+
+  resolved_path="$(realpath -m "${bin_root}/${rpm_dir}")"
+  if [[ "${resolved_path}" != "${bin_root}"/* ]]; then
+    echo "RPM_DIR resolves outside ${bin_root}: ${rpm_dir}" >&2
+    exit 1
+  fi
+
+  if [ ! -d "${resolved_path}" ]; then
+    echo "Local RPM directory not found: ${resolved_path}" >&2
+    exit 1
+  fi
+
+  RPM_SOURCE_DIR="${resolved_path}"
+}
+
+# Keep qcow output under bin/output even when callers override OUTPUT_DIR.
+resolve_output_dir() {
+  local output_dir="$1"
+  local output_root="${ROOT_DIR}/bin/output"
+  local resolved_path
+
+  resolved_path="$(realpath -m "${output_dir}")"
+  if [[ "${resolved_path}" != "${output_root}"/* ]]; then
+    echo "OUTPUT_DIR must resolve beneath ${output_root}: ${output_dir}" >&2
+    exit 1
+  fi
+
+  OUTPUT_DIR="${resolved_path}"
+}
+
+if [ "${OS_ID}" != "cs9-regular" ]; then
+  echo "qcow2_regular.sh currently supports only cs9-regular, got ${OS_ID}" >&2
+  exit 1
+fi
+
+require_command curl
+require_command qemu-img
+require_command virt-customize
+
+resolve_output_dir "${OUTPUT_DIR}"
+OUTPUT_QCOW_DIR="${OUTPUT_DIR}/qcow2"
+OUTPUT_QCOW_PATH="${OUTPUT_QCOW_DIR}/disk.qcow2"
+
+mkdir -p "${CLOUD_IMAGE_CACHE_DIR}" "${OUTPUT_QCOW_DIR}"
+trap cleanup_temp_cloud_image EXIT
+
+if [ ! -f "${BASE_CLOUD_IMAGE_PATH}" ]; then
+  echo "Downloading CentOS Stream 9 cloud image from ${BASE_CLOUD_IMAGE_URL}"
+  TMP_CLOUD_IMAGE_PATH="$(mktemp "${CLOUD_IMAGE_CACHE_DIR}/$(basename "${BASE_CLOUD_IMAGE_PATH}").tmp.XXXXXX")"
+  curl --fail --location --retry 3 --output "${TMP_CLOUD_IMAGE_PATH}" "${BASE_CLOUD_IMAGE_URL}"
+  mv "${TMP_CLOUD_IMAGE_PATH}" "${BASE_CLOUD_IMAGE_PATH}"
+  TMP_CLOUD_IMAGE_PATH=""
+fi
+
+echo "Preparing package-mode qcow2 at ${OUTPUT_QCOW_PATH}"
+qemu-img convert -O qcow2 "${BASE_CLOUD_IMAGE_PATH}" "${OUTPUT_QCOW_PATH}"
+qemu-img resize "${OUTPUT_QCOW_PATH}" +5G
+
+VIRT_CUSTOMIZE_ARGS=(
+  -a "${OUTPUT_QCOW_PATH}"
+  --run-command "dnf install -y epel-release epel-next-release"
+  --run-command "dnf install -y cloud-init dnf-plugins-core firewalld openssh-server podman podman-compose python-dotenv sudo"
+  --run-command "systemctl enable firewalld.service"
+  --run-command "systemctl enable podman.service"
+  --run-command "systemctl enable sshd.service"
+  --run-command "id -u user >/dev/null 2>&1 || useradd -ms /bin/bash user"
+  --run-command "echo 'user:user' | chpasswd"
+  --run-command "echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers"
+  --run-command "mkdir -p /usr/lib/flightctl/custom-info.d"
+  --run-command "printf '#!/bin/bash\necho \"my site\"\n' > /usr/lib/flightctl/custom-info.d/siteName"
+  --run-command "printf '#!/bin/bash\necho \"\"\n' > /usr/lib/flightctl/custom-info.d/emptyValue"
+  --run-command "printf '#!/bin/bash\necho \"no-show\"\n' > /usr/lib/flightctl/custom-info.d/keyNotShown"
+  --run-command "chmod 755 /usr/lib/flightctl/custom-info.d/*"
+)
+
+if [ -n "${RPM_COPR_REPO}" ]; then
+  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
+  validate_copr_repo "${RPM_COPR_REPO}"
+  validate_copr_package "${package_name}"
+  VIRT_CUSTOMIZE_ARGS+=(
+    --run-command "dnf copr -y enable ${RPM_COPR_REPO}"
+    --run-command "dnf install -y ${package_name}"
+  )
+else
+  validate_rpm_dir "${RPM_DIR}"
+  resolve_rpm_source_dir "${RPM_DIR}"
+  VIRT_CUSTOMIZE_ARGS+=(
+    --copy-in "${RPM_SOURCE_DIR}:/tmp"
+    --run-command "dnf install -y /tmp/${RPM_DIR}/flightctl-agent-*.rpm /tmp/${RPM_DIR}/flightctl-selinux-*.rpm"
+    --run-command "rm -rf /tmp/${RPM_DIR}"
+  )
+fi
+
+VIRT_CUSTOMIZE_ARGS+=(
+  --run-command "systemctl enable flightctl-agent.service"
+  --run-command "dnf clean all"
+  --selinux-relabel
+)
+
+echo "Customizing regular package-mode qcow2"
+sudo virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
+
+sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"
+
+echo "qcow2 image created at ${OUTPUT_QCOW_PATH}"
+ls -lh "${OUTPUT_QCOW_DIR}"


### PR DESCRIPTION
Summary:
add a new CentOS Stream 9 package-mode base Containerfile at test/scripts/agent-images/containerfiles/cs9-regular/Containerfile
extend the agent image build scripts to recognize AGENT_OS_ID=cs9-regular
wire BUILD_TYPE=regular through create_agent_images.sh so it builds the base image, variants bundle, and qcow artifact for the package-mode flavor
add scripts/qcow2_regular.sh to produce a libvirt-ready package-mode qcow from the CentOS Stream 9 cloud image using virt-customize
keep package-mode qcow generation separate from the existing bootc bootc-image-builder flow
document the new cs9-regular flavor and package-mode qcow path in test/scripts/agent-images/README.md
Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.

Release target
release-1.3
Target release: release-1.3