### PR TITLE
NO-ISSUE: devicesimulator scale tooling (clean, fleets, rollout)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ help:
 	@echo "    clean-quadlets:  clean up all systemd services and quadlet files"
 	@echo "    rpm/deb:         generate rpm or debian packages"
 	@echo "    verify-rpm-install: verify package-mode and image-mode RPM install paths (requires podman, bin/rpm)"
+	@echo "    simulate-devices: build and run devicesimulator (pass flags via ARGS=...)"
 	@echo ""
 	@echo "CI/CD Targets:"
 	@echo "    login:           login to container registry (requires REGISTRY_USER env var)"
@@ -205,6 +206,10 @@ build-remote-access: bin
 
 build-devicesimulator: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/devicesimulator
+
+.PHONY: simulate-devices
+simulate-devices: build-devicesimulator
+	bin/devicesimulator $(ARGS)
 
 build-standalone: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-standalone

--- a/cmd/devicesimulator/clean.go
+++ b/cmd/devicesimulator/clean.go
@@ -25,17 +25,27 @@ type cleanupProgress struct {
 	log       *logrus.Logger
 	kind      string
 	deleted   int
+	processed int
 	remaining *int64
 	lastLog   time.Time
 }
 
 func (p *cleanupProgress) maybeLog() {
-	if p.deleted%cleanupProgressEveryN != 0 && time.Since(p.lastLog) < cleanupProgressInterval {
+	count := p.processed
+	if count == 0 {
+		count = p.deleted
+	}
+	if count%cleanupProgressEveryN != 0 && time.Since(p.lastLog) < cleanupProgressInterval {
 		return
 	}
-	if p.remaining != nil {
+	switch {
+	case p.remaining != nil && p.processed > 0:
+		p.log.Infof("deleted %d %s so far (%d processed, %d remaining)", p.deleted, p.kind, p.processed, *p.remaining)
+	case p.remaining != nil:
 		p.log.Infof("deleted %d %s so far (%d remaining)", p.deleted, p.kind, *p.remaining)
-	} else {
+	case p.processed > 0:
+		p.log.Infof("deleted %d %s so far (%d processed)", p.deleted, p.kind, p.processed)
+	default:
 		p.log.Infof("deleted %d %s so far", p.deleted, p.kind)
 	}
 	p.lastLog = time.Now()
@@ -140,22 +150,31 @@ func deleteLabeledDevices(ctx context.Context, log *logrus.Logger, serviceClient
 }
 
 func deleteEnrollmentRequestsByName(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, names []string) (int, error) {
-	progress := &cleanupProgress{log: log, kind: "matched enrollment requests", lastLog: time.Now()}
+	if len(names) == 0 {
+		return 0, nil
+	}
+	log.Infof("deleting enrollment requests for %d devices", len(names))
+	total := int64(len(names))
+	remaining := total
+	progress := &cleanupProgress{log: log, kind: "matched enrollment requests", remaining: &remaining, lastLog: time.Now()}
 	for _, name := range names {
 		delResp, err := serviceClient.DeleteEnrollmentRequestWithResponse(ctx, name)
+		progress.processed++
+		remaining = total - int64(progress.processed)
 		if err != nil {
 			log.Warnf("delete enrollment request %s: %v", name, err)
+			progress.maybeLog()
 			continue
 		}
 		code := delResp.StatusCode()
-		if code == http.StatusNotFound {
-			continue
-		}
-		if code != http.StatusOK && code != http.StatusNoContent {
+		if code != http.StatusNotFound && code != http.StatusOK && code != http.StatusNoContent {
 			log.Warnf("delete enrollment request %s: status %d", name, code)
+			progress.maybeLog()
 			continue
 		}
-		progress.deleted++
+		if code != http.StatusNotFound {
+			progress.deleted++
+		}
 		progress.maybeLog()
 	}
 	return progress.deleted, nil
@@ -165,6 +184,7 @@ func deletePendingSimulatorEnrollmentRequests(ctx context.Context, log *logrus.L
 	fieldSelector := "status.approval.approved!=true"
 	limit := cleanupListLimit
 	var continueToken *string
+	log.Infoln("deleting pending simulator enrollment requests")
 	progress := &cleanupProgress{log: log, kind: "pending simulator enrollment requests", lastLog: time.Now()}
 
 	for {
@@ -182,10 +202,9 @@ func deletePendingSimulatorEnrollmentRequests(ctx context.Context, log *logrus.L
 
 		progress.remaining = resp.JSON200.Metadata.RemainingItemCount
 		for _, er := range resp.JSON200.Items {
-			if er.Metadata.Name == nil || er.Spec.Labels == nil {
-				continue
-			}
-			if (*er.Spec.Labels)["created_by"] != simulatorCreatedByValue {
+			progress.processed++
+			if er.Metadata.Name == nil || er.Spec.Labels == nil || (*er.Spec.Labels)["created_by"] != simulatorCreatedByValue {
+				progress.maybeLog()
 				continue
 			}
 			name := *er.Metadata.Name
@@ -195,6 +214,7 @@ func deletePendingSimulatorEnrollmentRequests(ctx context.Context, log *logrus.L
 			}
 			code := delResp.StatusCode()
 			if code == http.StatusNotFound {
+				progress.maybeLog()
 				continue
 			}
 			if code != http.StatusOK && code != http.StatusNoContent {

--- a/cmd/devicesimulator/clean.go
+++ b/cmd/devicesimulator/clean.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	simulatorCreatedByLabel = "created_by=device-simulator"
+	simulatorCreatedByValue = "device-simulator"
+	cleanupProgressEveryN   = 500
+	cleanupProgressInterval = 5 * time.Second
+	cleanupListLimit        = int32(500)
+)
+
+type cleanupProgress struct {
+	log       *logrus.Logger
+	kind      string
+	deleted   int
+	remaining *int64
+	lastLog   time.Time
+}
+
+func (p *cleanupProgress) maybeLog() {
+	if p.deleted%cleanupProgressEveryN != 0 && time.Since(p.lastLog) < cleanupProgressInterval {
+		return
+	}
+	if p.remaining != nil {
+		p.log.Infof("deleted %d %s so far (%d remaining)", p.deleted, p.kind, *p.remaining)
+	} else {
+		p.log.Infof("deleted %d %s so far", p.deleted, p.kind)
+	}
+	p.lastLog = time.Now()
+}
+
+func cleanSimulatorState(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, dataDir string) error {
+	start := time.Now()
+	log.Infoln("cleaning simulator-created resources")
+
+	localRemoved, err := wipeLocalAgentDirs(log, dataDir)
+	if err != nil {
+		return fmt.Errorf("wiping local agent dirs: %w", err)
+	}
+
+	deviceNames, devicesDeleted, err := deleteLabeledDevices(ctx, log, serviceClient)
+	if err != nil {
+		return fmt.Errorf("deleting simulator devices: %w", err)
+	}
+
+	matchedERs, err := deleteEnrollmentRequestsByName(ctx, log, serviceClient, deviceNames)
+	if err != nil {
+		return fmt.Errorf("deleting enrollment requests by device name: %w", err)
+	}
+
+	pendingERs, err := deletePendingSimulatorEnrollmentRequests(ctx, log, serviceClient)
+	if err != nil {
+		return fmt.Errorf("deleting pending simulator enrollment requests: %w", err)
+	}
+
+	log.Infof("cleanup complete in %s: removed %d local dirs, deleted %d devices, %d matched ERs, %d pending simulator ERs",
+		time.Since(start).Round(time.Millisecond), localRemoved, devicesDeleted, matchedERs, pendingERs)
+	return nil
+}
+
+func wipeLocalAgentDirs(log *logrus.Logger, dataDir string) (int, error) {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	removed := 0
+	for _, entry := range entries {
+		path := filepath.Join(dataDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return removed, fmt.Errorf("removing %s: %w", path, err)
+		}
+		removed++
+	}
+	log.Infof("removed %d local entries under %s", removed, dataDir)
+	return removed, nil
+}
+
+func deleteLabeledDevices(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses) ([]string, int, error) {
+	selector := simulatorCreatedByLabel
+	limit := cleanupListLimit
+	var continueToken *string
+	names := make([]string, 0)
+	progress := &cleanupProgress{log: log, kind: "devices", lastLog: time.Now()}
+
+	for {
+		resp, err := serviceClient.ListDevicesWithResponse(ctx, &v1beta1.ListDevicesParams{
+			LabelSelector: &selector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return nil, progress.deleted, err
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return nil, progress.deleted, fmt.Errorf("list devices: status %d", resp.StatusCode())
+		}
+
+		progress.remaining = resp.JSON200.Metadata.RemainingItemCount
+		for _, device := range resp.JSON200.Items {
+			if device.Metadata.Name == nil {
+				continue
+			}
+			name := *device.Metadata.Name
+			delResp, err := serviceClient.DeleteDeviceWithResponse(ctx, name)
+			if err != nil {
+				return names, progress.deleted, fmt.Errorf("delete device %s: %w", name, err)
+			}
+			code := delResp.StatusCode()
+			if code != http.StatusOK && code != http.StatusNoContent && code != http.StatusNotFound {
+				return names, progress.deleted, fmt.Errorf("delete device %s: status %d", name, code)
+			}
+			if code != http.StatusNotFound {
+				names = append(names, name)
+				progress.deleted++
+				progress.maybeLog()
+			}
+		}
+
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return names, progress.deleted, nil
+}
+
+func deleteEnrollmentRequestsByName(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, names []string) (int, error) {
+	progress := &cleanupProgress{log: log, kind: "matched enrollment requests", lastLog: time.Now()}
+	for _, name := range names {
+		delResp, err := serviceClient.DeleteEnrollmentRequestWithResponse(ctx, name)
+		if err != nil {
+			log.Warnf("delete enrollment request %s: %v", name, err)
+			continue
+		}
+		code := delResp.StatusCode()
+		if code == http.StatusNotFound {
+			continue
+		}
+		if code != http.StatusOK && code != http.StatusNoContent {
+			log.Warnf("delete enrollment request %s: status %d", name, code)
+			continue
+		}
+		progress.deleted++
+		progress.maybeLog()
+	}
+	return progress.deleted, nil
+}
+
+func deletePendingSimulatorEnrollmentRequests(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses) (int, error) {
+	fieldSelector := "status.approval.approved!=true"
+	limit := cleanupListLimit
+	var continueToken *string
+	progress := &cleanupProgress{log: log, kind: "pending simulator enrollment requests", lastLog: time.Now()}
+
+	for {
+		resp, err := serviceClient.ListEnrollmentRequestsWithResponse(ctx, &v1beta1.ListEnrollmentRequestsParams{
+			FieldSelector: &fieldSelector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return progress.deleted, err
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return progress.deleted, fmt.Errorf("list enrollment requests: status %d", resp.StatusCode())
+		}
+
+		progress.remaining = resp.JSON200.Metadata.RemainingItemCount
+		for _, er := range resp.JSON200.Items {
+			if er.Metadata.Name == nil || er.Spec.Labels == nil {
+				continue
+			}
+			if (*er.Spec.Labels)["created_by"] != simulatorCreatedByValue {
+				continue
+			}
+			name := *er.Metadata.Name
+			delResp, err := serviceClient.DeleteEnrollmentRequestWithResponse(ctx, name)
+			if err != nil {
+				return progress.deleted, fmt.Errorf("delete enrollment request %s: %w", name, err)
+			}
+			code := delResp.StatusCode()
+			if code == http.StatusNotFound {
+				continue
+			}
+			if code != http.StatusOK && code != http.StatusNoContent {
+				return progress.deleted, fmt.Errorf("delete enrollment request %s: status %d", name, code)
+			}
+			progress.deleted++
+			progress.maybeLog()
+		}
+
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return progress.deleted, nil
+}

--- a/cmd/devicesimulator/fleets.go
+++ b/cmd/devicesimulator/fleets.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
@@ -23,10 +25,10 @@ func scaleFleetNames(prefix string, count int) []string {
 func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, prefix string, count int) ([]string, error) {
 	names := scaleFleetNames(prefix, count)
 	for _, name := range names {
+		exists := false
 		response, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
 		if err == nil && response.HTTPResponse != nil && response.HTTPResponse.StatusCode == http.StatusOK {
-			log.Infof("Fleet %s already exists, skipping creation", name)
-			continue
+			exists = true
 		}
 
 		fleet, err := newScaleFleet(name)
@@ -37,6 +39,8 @@ func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *a
 		if err != nil {
 			return nil, fmt.Errorf("marshaling fleet %s: %w", name, err)
 		}
+		// Always replace so scale fleets pick up the current process uid/gid and a non-empty template
+		// (skipping left stale empty fleets from older host scripts).
 		createResponse, err := serviceClient.ReplaceFleetWithBodyWithResponse(ctx, name, "application/json", bytes.NewReader(fleetJSON))
 		if err != nil {
 			return nil, fmt.Errorf("creating fleet %s: %w", name, err)
@@ -44,13 +48,20 @@ func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *a
 		if createResponse.StatusCode() < http.StatusOK || createResponse.StatusCode() >= http.StatusMultipleChoices {
 			return nil, fmt.Errorf("creating fleet %s: status %d, body: %s", name, createResponse.StatusCode(), string(createResponse.Body))
 		}
-		log.Infof("Successfully created fleet: %s", name)
+		if exists {
+			log.Infof("Updated scale fleet template: %s", name)
+		} else {
+			log.Infof("Successfully created fleet: %s", name)
+		}
 	}
 	return names, nil
 }
 
 func newScaleFleet(name string) (*v1beta1.Fleet, error) {
 	mode := 0644
+	// FileSpec defaults omit user/group to root; non-root simulator agents cannot chown to 0.
+	uid := v1beta1.Username(strconv.Itoa(os.Getuid()))
+	gid := strconv.Itoa(os.Getgid())
 	content := fmt.Sprintf("This system is managed by flightctl (fleet %s).", name)
 	var configItem v1beta1.ConfigProviderSpec
 	if err := configItem.FromInlineConfigProviderSpec(v1beta1.InlineConfigProviderSpec{
@@ -60,6 +71,8 @@ func newScaleFleet(name string) (*v1beta1.Fleet, error) {
 				Path:    "/etc/motd",
 				Content: content,
 				Mode:    &mode,
+				User:    uid,
+				Group:   gid,
 			},
 		},
 	}); err != nil {

--- a/cmd/devicesimulator/fleets.go
+++ b/cmd/devicesimulator/fleets.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+)
+
+func scaleFleetNames(prefix string, count int) []string {
+	names := make([]string, count)
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("%s-%02d", prefix, i)
+	}
+	return names
+}
+
+func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, prefix string, count int) ([]string, error) {
+	names := scaleFleetNames(prefix, count)
+	for _, name := range names {
+		response, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
+		if err == nil && response.HTTPResponse != nil && response.HTTPResponse.StatusCode == http.StatusOK {
+			log.Infof("Fleet %s already exists, skipping creation", name)
+			continue
+		}
+
+		fleet, err := newScaleFleet(name)
+		if err != nil {
+			return nil, fmt.Errorf("building fleet %s: %w", name, err)
+		}
+		fleetJSON, err := json.Marshal(fleet)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling fleet %s: %w", name, err)
+		}
+		createResponse, err := serviceClient.ReplaceFleetWithBodyWithResponse(ctx, name, "application/json", bytes.NewReader(fleetJSON))
+		if err != nil {
+			return nil, fmt.Errorf("creating fleet %s: %w", name, err)
+		}
+		if createResponse.StatusCode() < http.StatusOK || createResponse.StatusCode() >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("creating fleet %s: status %d, body: %s", name, createResponse.StatusCode(), string(createResponse.Body))
+		}
+		log.Infof("Successfully created fleet: %s", name)
+	}
+	return names, nil
+}
+
+func newScaleFleet(name string) (*v1beta1.Fleet, error) {
+	mode := 0644
+	content := fmt.Sprintf("This system is managed by flightctl (fleet %s).", name)
+	var configItem v1beta1.ConfigProviderSpec
+	if err := configItem.FromInlineConfigProviderSpec(v1beta1.InlineConfigProviderSpec{
+		Name: "motd-update",
+		Inline: []v1beta1.FileSpec{
+			{
+				Path:    "/etc/motd",
+				Content: content,
+				Mode:    &mode,
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	matchLabels := map[string]string{"fleet": name}
+	templateLabels := map[string]string{"fleet": name}
+	return &v1beta1.Fleet{
+		ApiVersion: v1beta1.ApiVersion("flightctl.io/v1beta1"),
+		Kind:       v1beta1.FleetKind,
+		Metadata: v1beta1.ObjectMeta{
+			Name: &name,
+		},
+		Spec: v1beta1.FleetSpec{
+			Selector: &v1beta1.LabelSelector{
+				MatchLabels: &matchLabels,
+			},
+			Template: struct {
+				Metadata *v1beta1.ObjectMeta `json:"metadata,omitempty"`
+				Spec     v1beta1.DeviceSpec  `json:"spec"`
+			}{
+				Metadata: &v1beta1.ObjectMeta{
+					Labels: &templateLabels,
+				},
+				Spec: v1beta1.DeviceSpec{
+					Config: &[]v1beta1.ConfigProviderSpec{configItem},
+				},
+			},
+		},
+	}, nil
+}

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -91,7 +91,8 @@ func main() {
 	rolloutTemplate := pflag.String("rollout-template", "", "path to a Fleet YAML whose .spec.template is applied during --rollout")
 	rolloutTimeout := pflag.Duration("rollout-timeout", 15*time.Minute, "how long --rollout waits for devices to become UpToDate")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
-	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
+	logLevel := pflag.StringP("log-level", "v", "error", "log level for simulated device agents only (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
+	orchestratorLogLevel := pflag.String("orchestrator-log-level", "info", "log level for devicesimulator orchestration (cleanup, fleets, enrollment progress)")
 
 	pflag.Usage = printUsage
 
@@ -118,12 +119,18 @@ func main() {
 		}
 	}
 
-	log := flightlog.InitLogs(*logLevel)
-	if log == nil {
-		fmt.Fprintf(os.Stderr, "Invalid log level: %s\n\n", *logLevel)
+	if _, err := logrus.ParseLevel(*logLevel); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid device log level: %s\n\n", *logLevel)
 		printUsage()
 		os.Exit(1)
 	}
+	if _, err := logrus.ParseLevel(*orchestratorLogLevel); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid orchestrator log level: %s\n\n", *orchestratorLogLevel)
+		printUsage()
+		os.Exit(1)
+	}
+
+	log := flightlog.InitLogs(*orchestratorLogLevel)
 
 	if *setupSourceIPsFlag && *teardownSourceIPsFlag {
 		log.Fatalf("--setup-source-ips and --teardown-source-ips are mutually exclusive")

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -73,7 +73,13 @@ func main() {
 	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))")
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
-	sourceIPs := pflag.StringSlice("source-ips", []string{}, "comma-separated list of source IP addresses for device management HTTP connections")
+	sourceIPs := pflag.StringSlice("source-ips", []string{}, "comma-separated list of existing source IP addresses for device management HTTP connections (non-root)")
+	setupSourceIPsFlag := pflag.Bool("setup-source-ips", false, "standalone root-capable mode: create source IP aliases on an interface, then exit")
+	teardownSourceIPsFlag := pflag.Bool("teardown-source-ips", false, "standalone root-capable mode: remove source IP aliases created for scale tests, then exit")
+	sourceIPIface := pflag.String("source-ip-iface", "", "interface for --setup-source-ips/--teardown-source-ips (e.g. eno1)")
+	sourceIPBase := pflag.String("source-ip-base", "", "first IPv4 address for --setup-source-ips/--teardown-source-ips (e.g. 192.168.223.60)")
+	sourceIPCount := pflag.Int("source-ip-count", 0, "number of consecutive IPv4 aliases for --setup-source-ips/--teardown-source-ips")
+	sourceIPPrefix := pflag.Int("source-ip-prefix", 24, "prefix length for --setup-source-ips/--teardown-source-ips")
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
@@ -119,6 +125,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *setupSourceIPsFlag && *teardownSourceIPsFlag {
+		log.Fatalf("--setup-source-ips and --teardown-source-ips are mutually exclusive")
+	}
+	if (*setupSourceIPsFlag || *teardownSourceIPsFlag) && len(*sourceIPs) > 0 {
+		log.Fatalf("--source-ips is mutually exclusive with --setup-source-ips/--teardown-source-ips")
+	}
+	if (*setupSourceIPsFlag || *teardownSourceIPsFlag) && (*clean || *cleanOnly || *rollout) {
+		log.Fatalf("--setup-source-ips/--teardown-source-ips are mutually exclusive with --clean/--clean-only/--rollout")
+	}
+	autoSourceIPFlags := *sourceIPIface != "" || *sourceIPBase != "" || *sourceIPCount > 0
+	if autoSourceIPFlags && !*setupSourceIPsFlag && !*teardownSourceIPsFlag {
+		log.Fatalf("--source-ip-iface/--source-ip-base/--source-ip-count require --setup-source-ips or --teardown-source-ips")
+	}
 	if *rollout && (*clean || *cleanOnly) {
 		log.Fatalf("--rollout is mutually exclusive with --clean/--clean-only")
 	}
@@ -129,26 +148,39 @@ func main() {
 		log.Fatalf("--rollout requires --fleet-count > 0")
 	}
 
+	log.Infoln("command line flags:")
+	pflag.CommandLine.VisitAll(func(flg *pflag.Flag) {
+		log.Infof("  %s=%s", flg.Name, flg.Value)
+	})
+
+	if *setupSourceIPsFlag {
+		ips, err := setupSourceIPs(log, *sourceIPIface, *sourceIPBase, *sourceIPCount, *sourceIPPrefix)
+		if err != nil {
+			log.Fatalf("source IP setup failed: %v", err)
+		}
+		flagValue := sourceIPsFlagValue(ips)
+		log.Infof("source IPs ready; run the simulator as a non-root user with --source-ips=%s", flagValue)
+		fmt.Printf("--source-ips=%s\n", flagValue)
+		return
+	}
+	if *teardownSourceIPsFlag {
+		if err := teardownSourceIPs(log, *sourceIPIface, *sourceIPBase, *sourceIPCount, *sourceIPPrefix); err != nil {
+			log.Fatalf("source IP teardown failed: %v", err)
+		}
+		log.Infoln("source IP teardown complete")
+		return
+	}
+
 	// Disable console banner for all simulated agents
 	if err := os.Setenv("FLIGHTCTL_DISABLE_CONSOLE_BANNER", "true"); err != nil {
 		log.Fatalf("Error setting banner disable environment variable: %v", err)
 	}
 
-	// Parse and validate source IPs
-	var parsedSourceIPs []net.IP
-	for _, ipStr := range *sourceIPs {
-		if ip := net.ParseIP(ipStr); ip != nil {
-			parsedSourceIPs = append(parsedSourceIPs, ip)
-			log.Infof("Using source IP: %s", ip.String())
-		} else {
-			log.Fatalf("Invalid source IP address: %s", ipStr)
-		}
+	// Explicit --source-ips only binds to existing addresses; no privileges required.
+	parsedSourceIPs, err := parseExplicitSourceIPs(log, *sourceIPs)
+	if err != nil {
+		log.Fatalf("%v", err)
 	}
-
-	log.Infoln("command line flags:")
-	pflag.CommandLine.VisitAll(func(flg *pflag.Flag) {
-		log.Infof("  %s=%s", flg.Name, flg.Value)
-	})
 
 	log.Infoln("starting device simulator")
 	defer log.Infoln("device simulator stopped")

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -539,6 +539,8 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 		ClientKey:         filepath.Join(cfg.ConfigDir, agent_config.EnrollmentKeyFile),
 	}
 	cfg.SpecFetchInterval = agentCfg.agentConfigTemplate.SpecFetchInterval
+	cfg.SpecFetchErrorBaseDelay = agentCfg.agentConfigTemplate.SpecFetchErrorBaseDelay
+	cfg.SpecFetchErrorMaxDelay = agentCfg.agentConfigTemplate.SpecFetchErrorMaxDelay
 	cfg.StatusUpdateInterval = agentCfg.agentConfigTemplate.StatusUpdateInterval
 	cfg.TPM = agentCfg.agentConfigTemplate.TPM
 	cfg.LogPrefix = agentName

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -73,12 +73,12 @@ func main() {
 	initialDeviceIndex := pflag.Int("initial-device-index", 0, "starting index for device name suffix, (e.g., device-0000 for 0, device-0200 for 200))")
 	metricsAddr := pflag.String("metrics", "localhost:9093", "address for the metrics endpoint")
 	stopAfter := pflag.Duration("stop-after", 0, "stop the simulator after the specified duration")
-	sourceIPs := pflag.StringSlice("source-ips", []string{}, "comma-separated list of existing source IP addresses for device management HTTP connections (non-root)")
+	sourceIPs := pflag.StringSlice("source-ips", []string{}, "comma-separated list of existing source IP addresses for device management HTTP connections (mutually exclusive with --source-ip-base/--source-ip-count)")
 	setupSourceIPsFlag := pflag.Bool("setup-source-ips", false, "standalone root-capable mode: create source IP aliases on an interface, then exit")
 	teardownSourceIPsFlag := pflag.Bool("teardown-source-ips", false, "standalone root-capable mode: remove source IP aliases created for scale tests, then exit")
-	sourceIPIface := pflag.String("source-ip-iface", "", "interface for --setup-source-ips/--teardown-source-ips (e.g. eno1)")
-	sourceIPBase := pflag.String("source-ip-base", "", "first IPv4 address for --setup-source-ips/--teardown-source-ips (e.g. 192.168.223.60)")
-	sourceIPCount := pflag.Int("source-ip-count", 0, "number of consecutive IPv4 aliases for --setup-source-ips/--teardown-source-ips")
+	sourceIPIface := pflag.String("source-ip-iface", "", "interface for --setup-source-ips/--teardown-source-ips (optional on normal runs)")
+	sourceIPBase := pflag.String("source-ip-base", "", "first IPv4 in a consecutive source-IP range (used by setup/teardown and non-root runs)")
+	sourceIPCount := pflag.Int("source-ip-count", 0, "number of consecutive IPv4 addresses in the source-IP range")
 	sourceIPPrefix := pflag.Int("source-ip-prefix", 24, "prefix length for --setup-source-ips/--teardown-source-ips")
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
@@ -134,10 +134,6 @@ func main() {
 	if (*setupSourceIPsFlag || *teardownSourceIPsFlag) && (*clean || *cleanOnly || *rollout) {
 		log.Fatalf("--setup-source-ips/--teardown-source-ips are mutually exclusive with --clean/--clean-only/--rollout")
 	}
-	autoSourceIPFlags := *sourceIPIface != "" || *sourceIPBase != "" || *sourceIPCount > 0
-	if autoSourceIPFlags && !*setupSourceIPsFlag && !*teardownSourceIPsFlag {
-		log.Fatalf("--source-ip-iface/--source-ip-base/--source-ip-count require --setup-source-ips or --teardown-source-ips")
-	}
 	if *rollout && (*clean || *cleanOnly) {
 		log.Fatalf("--rollout is mutually exclusive with --clean/--clean-only")
 	}
@@ -158,9 +154,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("source IP setup failed: %v", err)
 		}
-		flagValue := sourceIPsFlagValue(ips)
-		log.Infof("source IPs ready; run the simulator as a non-root user with --source-ips=%s", flagValue)
-		fmt.Printf("--source-ips=%s\n", flagValue)
+		log.Infof("source IPs ready; run the simulator as a non-root user with the same --source-ip-base/--source-ip-count (or --source-ips=%s)", sourceIPsFlagValue(ips))
 		return
 	}
 	if *teardownSourceIPsFlag {
@@ -176,8 +170,8 @@ func main() {
 		log.Fatalf("Error setting banner disable environment variable: %v", err)
 	}
 
-	// Explicit --source-ips only binds to existing addresses; no privileges required.
-	parsedSourceIPs, err := parseExplicitSourceIPs(log, *sourceIPs)
+	// Bind to existing addresses only; no privileges required. Missing IPs fail at dial/bind time.
+	parsedSourceIPs, err := resolveRuntimeSourceIPs(log, *sourceIPs, *sourceIPIface, *sourceIPBase, *sourceIPCount, *sourceIPPrefix)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"math/rand/v2"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -20,7 +19,6 @@ import (
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent"
 	agent_config "github.com/flightctl/flightctl/internal/agent/config"
-	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	baseclient "github.com/flightctl/flightctl/internal/client"
@@ -248,23 +246,15 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
-		bannerFileData, err := readBannerFile(agentDir)
-		if err != nil {
-			return false, nil
+	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Errorf("Error waiting for enrollment request: %v", err)
 		}
-		enrollmentID := testutil.GetEnrollmentIdFromText(bannerFileData)
-		if enrollmentID == "" {
-			log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-			return false, nil
-		}
-		log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error waiting for enrollment request: %v", err)
+		return
 	}
+	log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
 }
 
 func reportVersion(versionFormat *string) error {
@@ -471,80 +461,27 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			enrollmentTransport,
 		)
 
-		if err := cfg.Complete(); err != nil {
+		cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
+		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName)
+		if err != nil {
 			logger.Fatalf("agent config %d: %v", i, err)
 		}
-		if err := cfg.Validate(); err != nil {
-			logger.Fatalf("agent config %d: %v", i, err)
-		}
-
-		logWithPrefix := flightlog.NewPrefixLogger(agentName)
-		logWithPrefix.Level(agentCfg.agentConfigTemplate.LogLevel)
-		agents[i] = agent.New(logWithPrefix, cfg, "")
+		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
 	return agents, agentsFolders
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
-	enrollmentId := ""
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
-		if enrollmentId == "" {
-			bannerFileData, err := readBannerFile(agentDir)
-			if err != nil {
-				log.Warnf("Error reading banner file: %v", err)
-				return false, nil
-			}
-			enrollmentId = testutil.GetEnrollmentIdFromText(bannerFileData)
-			if enrollmentId == "" {
-				log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-				return false, nil
-			}
-		}
-		// timeout after 30s and retry
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
-			ctx,
-			enrollmentId,
-			v1beta1.EnrollmentRequestApproval{
-				Approved: true,
-				Labels:   labels,
-			})
-		if err != nil {
-			log.Errorf("Error approving device %s enrollment: %v", enrollmentId, err)
-			return false, nil
-		}
-		responseCode := resp.StatusCode()
-		if responseCode == http.StatusNotFound {
-			// no error, but don't log this. There could be a race condition in posting vs approving and is not exceptional
-			return false, nil
-		}
-		if responseCode < http.StatusOK || responseCode >= http.StatusMultipleChoices {
-			log.Warnf("Failed approving device %s enrollment: %d", enrollmentId, responseCode)
-			return false, nil
-		}
-		log.Infof("Approved device enrollment %s", enrollmentId)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error approving device enrollment: %v", err)
-	}
-}
-
-func readBannerFile(agentDir string) (string, error) {
-	var data []byte
-	var err error
-	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
-	if _, err = os.Stat(bannerFile); err != nil {
-		return "", err
-	}
-	data, err = os.ReadFile(bannerFile)
+	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
 	if err != nil {
-		return "", err
+		if ctx.Err() == nil {
+			log.Errorf("Error approving device enrollment: %v", err)
+		}
+		return
 	}
-	return string(data), nil
+	log.Infof("Approved device enrollment %s", enrollmentID)
 }
 
 func copyFile(from, to string) error {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -76,6 +76,8 @@ func main() {
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
+	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
+	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -162,12 +164,23 @@ func main() {
 		log.Fatalf("Error creating service client: %v", err)
 	}
 
-	log.Infoln("creating agents")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	serviceClient.Start(ctx)
 	defer serviceClient.Stop()
+
+	if *clean || *cleanOnly {
+		if err := cleanSimulatorState(ctx, log, serviceClient.ClientWithResponses, *dataDir); err != nil {
+			log.Fatalf("cleanup failed: %v", err)
+		}
+		if *cleanOnly {
+			log.Infoln("clean-only complete, exiting")
+			return
+		}
+	}
+
+	log.Infoln("creating agents")
 
 	// Create simulator fleet configuration
 	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
@@ -521,7 +534,7 @@ func formatLabels(lableArgs *[]string) *map[string]string {
 		formattedLabels = util.LabelArrayToMap(*lableArgs)
 	}
 
-	formattedLabels["created_by"] = "device-simulator"
+	formattedLabels["created_by"] = simulatorCreatedByValue
 	return &formattedLabels
 }
 

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -557,6 +557,7 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 	cfg.SpecFetchErrorBaseDelay = agentCfg.agentConfigTemplate.SpecFetchErrorBaseDelay
 	cfg.SpecFetchErrorMaxDelay = agentCfg.agentConfigTemplate.SpecFetchErrorMaxDelay
 	cfg.StatusUpdateInterval = agentCfg.agentConfigTemplate.StatusUpdateInterval
+	cfg.StatusUpdateJitter = agentCfg.agentConfigTemplate.StatusUpdateJitter
 	cfg.TPM = agentCfg.agentConfigTemplate.TPM
 	cfg.LogPrefix = agentName
 

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -150,6 +150,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not parse config file: %v", err)
 	}
+	if cfg.Organization != "" {
+		log.Infof("using organization %s from client config", cfg.Organization)
+	} else {
+		log.Infoln("no organization set in client config")
+	}
 	// allow many idle conns to prevent tearing down connections we may need again
 	cfg.AddHTTPOptions(client.WithMaxIdleConnsPerHost(*maxConcurrency))
 	serviceClient, err := client.NewFromConfig(cfg, baseDir)
@@ -248,6 +253,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
 	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error waiting for enrollment request: %v", err)
@@ -477,6 +483,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
 	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error approving device enrollment: %v", err)

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -383,22 +383,24 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		agentName := fmt.Sprintf("device-%05d", agentCfg.initialDeviceIndex+i)
 		certDir := filepath.Join(agentCfg.agentConfigTemplate.ConfigDir, "certs")
 		agentDir := filepath.Join(agentCfg.agentConfigTemplate.DataDir, agentName)
-		// Cleanup if exists and initialize the agent's expected
-		os.RemoveAll(agentDir)
-		if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
-			logger.Fatalf("Error creating directory: %v", err)
+
+		_, err := os.Stat(agentDir)
+		resuming := err == nil
+		if resuming {
+			logger.Infof("resuming existing state for agent %s", agentName)
+		} else {
+			if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
+				logger.Fatalf("Error creating directory: %v", err)
+			}
+			if ex.IsEnabled() {
+				setupTPMLinks(agentDir, logger)
+			}
+			copyAgentFiles(logger, certDir, agentDir)
 		}
 
-		if ex.IsEnabled() {
-			setupTPMLinks(agentDir, logger)
-		}
-
-		err := os.Setenv(client.TestRootDirEnvKey, agentDir)
-		if err != nil {
+		if err := os.Setenv(client.TestRootDirEnvKey, agentDir); err != nil {
 			logger.Fatalf("Error setting environment variable: %v", err)
 		}
-
-		copyAgentFiles(logger, certDir, agentDir)
 
 		cfg := agent_config.NewDefault()
 		if agentCfg.simulatorLabels != nil {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -553,7 +553,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string, []*map
 		)
 
 		cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
-		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName)
+		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
 		if err != nil {
 			logger.Fatalf("agent config %d: %v", i, err)
 		}

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/flightctl/flightctl/internal/util"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/pkg/version"
-	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/simagent"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/semaphore"
@@ -358,7 +358,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
 	log.Debugf("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
-	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, enrollmentPollInterval, enrollmentTimeout)
+	enrollmentID, err := simagent.WaitForEnrollmentID(ctx, agentDir, enrollmentPollInterval, enrollmentTimeout)
 	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
@@ -586,7 +586,7 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 	)
 
 	cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
-	agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
+	agentInstance, err := simagent.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
 	if err != nil {
 		return nil, "", nil, false, fmt.Errorf("agent config %d: %w", i, err)
 	}
@@ -595,7 +595,7 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
 	log.Debugf("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
-	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, enrollmentPollInterval, enrollmentTimeout)
+	enrollmentID, err := simagent.ApproveEnrollment(ctx, serviceClient, agentDir, labels, enrollmentPollInterval, enrollmentTimeout)
 	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -14,6 +14,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -42,6 +44,9 @@ const (
 	jsonFormat      = "json"
 	yamlFormat      = "yaml"
 	cliVersionTitle = "flightctl simulator version"
+
+	enrollmentPollInterval = 500 * time.Millisecond
+	enrollmentTimeout      = 5 * time.Minute
 )
 
 var (
@@ -80,8 +85,8 @@ func main() {
 	sourceIPBase := pflag.String("source-ip-base", "", "first IPv4 in a consecutive source-IP range (used by setup/teardown and non-root runs)")
 	sourceIPCount := pflag.Int("source-ip-count", 0, "number of consecutive IPv4 addresses in the source-IP range")
 	sourceIPPrefix := pflag.Int("source-ip-prefix", 24, "prefix length for --setup-source-ips/--teardown-source-ips")
-	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
-	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
+	maxConcurrency := pflag.Int("max-concurrency", 200, "maximum number of concurrent agent create/enroll operations")
+	agentStartupJitter := pflag.Duration("agent-startup-jitter", 0, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
 	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
@@ -238,8 +243,6 @@ func main() {
 	formattedLables := formatLabels(labels)
 	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile, *logLevel)
 
-	log.Infoln("creating agents")
-
 	var fleetNames []string
 	if *fleetCount > 0 {
 		log.Infof("skipping default simulator-disk-monitoring fleet because --fleet-count=%d", *fleetCount)
@@ -252,17 +255,6 @@ func main() {
 		log.Warnf("Failed to create simulator fleet: %v", err)
 	}
 
-	agents, agentsFolders, perAgentLabels := createAgents(createAgentsConfig{
-		log:                 log,
-		numDevices:          *numDevices,
-		initialDeviceIndex:  *initialDeviceIndex,
-		agentConfigTemplate: agentConfigTemplate,
-		parsedSourceIPs:     parsedSourceIPs,
-		maxConcurrency:      *maxConcurrency,
-		simulatorLabels:     formattedLables,
-		fleetNames:          fleetNames,
-	})
-
 	sigShutdown := make(chan os.Signal, 1)
 	signal.Notify(sigShutdown, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -272,25 +264,40 @@ func main() {
 		cancel()
 	}()
 
-	log.Infoln("running agents")
-	// limit the maximum number of devices that are being approved.
+	log.Infof("starting %d agents (concurrency=%d, jitter=%s)", *numDevices, *maxConcurrency, agentStartupJitter.String())
 	sem := semaphore.NewWeighted(int64(*maxConcurrency))
 
-	// default to using the agent configuration's StatusUpdateInterval
 	jitterDuration := *agentStartupJitter
 	if *agentStartupJitter < 0 {
 		jitterDuration = time.Duration(agentConfigTemplate.StatusUpdateInterval)
 	}
 
+	createCfg := createAgentsConfig{
+		log:                 log,
+		numDevices:          *numDevices,
+		initialDeviceIndex:  *initialDeviceIndex,
+		agentConfigTemplate: agentConfigTemplate,
+		parsedSourceIPs:     parsedSourceIPs,
+		maxConcurrency:      *maxConcurrency,
+		simulatorLabels:     formattedLables,
+		fleetNames:          fleetNames,
+		enrollmentTransport: client.WithCachedTransport(),
+	}
+	var createMu sync.Mutex
+	var enrolled atomic.Int64
+	started := time.Now()
+
 	launchParams := agentLaunchParams{
-		agents:          agents,
-		agentFolders:    agentsFolders,
+		createCfg:       createCfg,
+		createMu:        &createMu,
 		log:             log,
 		serviceClient:   serviceClient.ClientWithResponses,
-		perAgentLabels:  perAgentLabels,
 		sem:             sem,
 		jitterDuration:  jitterDuration,
 		skipAutoApprove: *skipAutoApprove,
+		enrolled:        &enrolled,
+		total:           *numDevices,
+		started:         started,
 	}
 	for i := range *numDevices {
 		if err := sem.Acquire(ctx, 1); err != nil {
@@ -301,6 +308,7 @@ func main() {
 	// block until we can acquire all entries. This is an indication that all devices have been
 	// enrolled, and it's safe to start the "stopAfter" function.
 	_ = sem.Acquire(ctx, int64(*maxConcurrency))
+	log.Infof("all %d agents enrolled in %s (%.1f devices/s)", *numDevices, time.Since(started).Round(time.Second), float64(*numDevices)/time.Since(started).Seconds())
 	if stopAfter != nil && *stopAfter > 0 {
 		time.AfterFunc(*stopAfter, func() {
 			log.Infoln("stopping simulator after duration")
@@ -314,24 +322,38 @@ func main() {
 
 func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 	defer params.sem.Release(1)
-	select {
-	case <-ctx.Done():
+	if params.jitterDuration > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(rand.Float64() * float64(params.jitterDuration))): //nolint:gosec
+		}
+	}
+	agentInstance, agentDir, labels, err := createOneAgent(params.createCfg, params.createMu, i)
+	if err != nil {
+		params.log.Errorf("creating agent %d: %v", i, err)
+		recordEnrollmentOutcome(ctx, err)
 		return
-	case <-time.After(time.Duration(rand.Float64() * float64(params.jitterDuration))): //nolint:gosec
 	}
 	// leave the agent process running in the background
 	// when the agent is approved, we return and release the semaphore to allow other agents to onboard
-	go startAgent(ctx, params.agents[i], params.log, i)
+	go startAgent(ctx, agentInstance, params.log, i)
 	if params.skipAutoApprove {
-		waitForEnrollmentRequest(ctx, params.log, params.agentFolders[i])
-		return
+		waitForEnrollmentRequest(ctx, params.log, agentDir)
+	} else {
+		approveAgent(ctx, params.log, params.serviceClient, agentDir, labels)
 	}
-	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.perAgentLabels[i])
+	done := params.enrolled.Add(1)
+	if done%100 == 0 || done == int64(params.total) {
+		elapsed := time.Since(params.started).Seconds()
+		rate := float64(done) / elapsed
+		params.log.Infof("enrollment progress: %d/%d (%.1f devices/s)", done, params.total, rate)
+	}
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
-	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
-	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	log.Debugf("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, enrollmentPollInterval, enrollmentTimeout)
 	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
@@ -339,7 +361,7 @@ func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir 
 		}
 		return
 	}
-	log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
+	log.Debugf("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
 }
 
 func reportVersion(versionFormat *string) error {
@@ -423,12 +445,13 @@ func createAgentConfigTemplate(dataDir string, configFile string, logLevelOverri
 	return agentConfigTemplate
 }
 
-func copyAgentFiles(log *logrus.Logger, certDir, agentDir string) {
+func copyAgentFiles(certDir, agentDir string) error {
 	for _, filename := range []string{"ca.crt", "client-enrollment.crt", "client-enrollment.key"} {
 		if err := copyFile(filepath.Join(certDir, filename), filepath.Join(agentDir, agent_config.DefaultConfigDir, filename)); err != nil {
-			log.Fatalf("copying %s: %v", filename, err)
+			return fmt.Errorf("copying %s: %w", filename, err)
 		}
 	}
+	return nil
 }
 
 type createAgentsConfig struct {
@@ -440,139 +463,121 @@ type createAgentsConfig struct {
 	maxConcurrency      int
 	simulatorLabels     *map[string]string
 	fleetNames          []string
+	enrollmentTransport baseclient.HTTPClientOption
 }
 
 type agentLaunchParams struct {
-	agents          []*agent.Agent
-	agentFolders    []string
+	createCfg       createAgentsConfig
+	createMu        *sync.Mutex
 	log             *logrus.Logger
 	serviceClient   *apiClient.ClientWithResponses
-	perAgentLabels  []*map[string]string
 	sem             *semaphore.Weighted
 	jitterDuration  time.Duration
 	skipAutoApprove bool
+	enrolled        *atomic.Int64
+	total           int
+	started         time.Time
 }
 
-func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string, []*map[string]string) {
+func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*agent.Agent, string, *map[string]string, error) {
 	logger := agentCfg.log
-	logger.Infoln("creating agents")
-	agents := make([]*agent.Agent, agentCfg.numDevices)
-	agentsFolders := make([]string, agentCfg.numDevices)
-	perAgentLabels := make([]*map[string]string, agentCfg.numDevices)
-	ex := experimental.NewFeatures()
-	if ex.IsEnabled() && agentCfg.numDevices > 1 {
-		logger.Warnf("Using experimental features with more than one device could cause unexpected issues.")
+	agentName := fmt.Sprintf("device-%05d", agentCfg.initialDeviceIndex+i)
+	certDir := filepath.Join(agentCfg.agentConfigTemplate.ConfigDir, "certs")
+	agentDir := filepath.Join(agentCfg.agentConfigTemplate.DataDir, agentName)
+
+	_, err := os.Stat(agentDir)
+	resuming := err == nil
+	if resuming {
+		logger.Debugf("resuming existing state for agent %s", agentName)
+	} else {
+		if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
+			return nil, "", nil, fmt.Errorf("creating directory: %w", err)
+		}
+		if experimental.NewFeatures().IsEnabled() {
+			setupTPMLinks(agentDir, logger)
+		}
+		if err := copyAgentFiles(certDir, agentDir); err != nil {
+			return nil, "", nil, err
+		}
 	}
 
-	enrollmentTransport := client.WithCachedTransport()
-
-	for i := 0; i < agentCfg.numDevices; i++ {
-		agentName := fmt.Sprintf("device-%05d", agentCfg.initialDeviceIndex+i)
-		certDir := filepath.Join(agentCfg.agentConfigTemplate.ConfigDir, "certs")
-		agentDir := filepath.Join(agentCfg.agentConfigTemplate.DataDir, agentName)
-
-		_, err := os.Stat(agentDir)
-		resuming := err == nil
-		if resuming {
-			logger.Infof("resuming existing state for agent %s", agentName)
-		} else {
-			if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
-				logger.Fatalf("Error creating directory: %v", err)
-			}
-			if ex.IsEnabled() {
-				setupTPMLinks(agentDir, logger)
-			}
-			copyAgentFiles(logger, certDir, agentDir)
+	labels := map[string]string{}
+	if agentCfg.simulatorLabels != nil {
+		for k, v := range *agentCfg.simulatorLabels {
+			labels[k] = v
 		}
-
-		if err := os.Setenv(client.TestRootDirEnvKey, agentDir); err != nil {
-			logger.Fatalf("Error setting environment variable: %v", err)
-		}
-
-		labels := map[string]string{}
-		if agentCfg.simulatorLabels != nil {
-			for k, v := range *agentCfg.simulatorLabels {
-				labels[k] = v
-			}
-		}
-		if len(agentCfg.fleetNames) > 0 {
-			labels["fleet"] = agentCfg.fleetNames[i%len(agentCfg.fleetNames)]
-		}
-		perAgentLabels[i] = &labels
-
-		cfg := agent_config.NewDefault()
-		for k, v := range labels {
-			cfg.DefaultLabels[k] = v
-		}
-		cfg.DefaultLabels["alias"] = agentName
-		cfg.ConfigDir = agent_config.DefaultConfigDir
-		cfg.DataDir = agent_config.DefaultConfigDir
-		cfg.EnrollmentService = config.EnrollmentService{}
-		cfg.EnrollmentService.Config = *client.NewDefault()
-		cfg.EnrollmentService.Config.Service = client.Service{
-			Server:               agentCfg.agentConfigTemplate.EnrollmentService.Config.Service.Server,
-			CertificateAuthority: filepath.Join(cfg.ConfigDir, agent_config.CacertFile),
-		}
-		cfg.EnrollmentService.Config.AuthInfo = client.AuthInfo{
-			ClientCertificate: filepath.Join(cfg.ConfigDir, agent_config.EnrollmentCertFile),
-			ClientKey:         filepath.Join(cfg.ConfigDir, agent_config.EnrollmentKeyFile),
-		}
-		cfg.SpecFetchInterval = agentCfg.agentConfigTemplate.SpecFetchInterval
-		cfg.StatusUpdateInterval = agentCfg.agentConfigTemplate.StatusUpdateInterval
-		cfg.TPM = agentCfg.agentConfigTemplate.TPM
-		cfg.LogPrefix = agentName
-
-		// create managementService config
-		cfg.ManagementService = config.ManagementService{}
-		cfg.ManagementService.Config = *client.NewDefault()
-		cfg.ManagementService.Service = client.Service{
-			Server:               agentCfg.agentConfigTemplate.ManagementService.Config.Service.Server,
-			CertificateAuthority: filepath.Join(cfg.ConfigDir, agent_config.CacertFile),
-		}
-		cfg.SystemInfo = []string{}
-
-		cfg.SetEnrollmentMetricsCallback(rpcMetricsCallback)
-
-		// Device management currently requires setting up individual mTLS connections. This makes HTTP connection reuse
-		// effectively impossible across agents. When a device is onboarded, a new http connection must be generated.
-		// To avoid ephemeral port exhaustion, we allow the management client to bind to specific IPs.
-		if len(agentCfg.parsedSourceIPs) > 0 {
-			// Assign source IP if provided (round-robin distribution)
-			sourceIP := agentCfg.parsedSourceIPs[i%len(agentCfg.parsedSourceIPs)]
-			// Create dialer with source IP, using same defaults as the default http dialer (30s timeout/keepalive)
-			cfg.ManagementService.Config.AddHTTPOptions(baseclient.WithDialer(&net.Dialer{
-				LocalAddr: &net.TCPAddr{IP: sourceIP},
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}))
-			logger.Infof("Agent %s assigned source IP: %s", agentName, sourceIP.String())
-		}
-		// The enrollment client configuration is the same for all agents and thus no need to create a new connection for
-		// each agent. By using the CachedTransport option, we let the agents setup their enrollment clients (and
-		// individual transports), and then swap out the transport such that all HTTP clients are using the same transport.
-		// This allows for connection reuse across all agents during the enrollment phase.
-		// Additionally, the number of connections required is limited to the concurrency level defined.
-		// As the expected concurrency level is relatively low (compared to the total number of running agents), we're
-		// not as concerned with ephemeral port exhaustion and can just use the default option of letting the OS choose.
-		cfg.EnrollmentService.Config.AddHTTPOptions(
-			baseclient.WithMaxIdleConnsPerHost(agentCfg.maxConcurrency),
-			enrollmentTransport,
-		)
-
-		cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
-		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
-		if err != nil {
-			logger.Fatalf("agent config %d: %v", i, err)
-		}
-		agents[i] = agentInstance
-		agentsFolders[i] = agentDir
 	}
-	return agents, agentsFolders, perAgentLabels
+	if len(agentCfg.fleetNames) > 0 {
+		labels["fleet"] = agentCfg.fleetNames[i%len(agentCfg.fleetNames)]
+	}
+
+	// FLIGHTCTL_TEST_ROOT_DIR is process-global; only Setenv + NewDefault must be serialized.
+	createMu.Lock()
+	if err := os.Setenv(client.TestRootDirEnvKey, agentDir); err != nil {
+		createMu.Unlock()
+		return nil, "", nil, fmt.Errorf("setting %s: %w", client.TestRootDirEnvKey, err)
+	}
+	cfg := agent_config.NewDefault()
+	enrollmentCfg := client.NewDefault()
+	managementCfg := client.NewDefault()
+	createMu.Unlock()
+
+	for k, v := range labels {
+		cfg.DefaultLabels[k] = v
+	}
+	cfg.DefaultLabels["alias"] = agentName
+	cfg.ConfigDir = agent_config.DefaultConfigDir
+	cfg.DataDir = agent_config.DefaultConfigDir
+	cfg.EnrollmentService = config.EnrollmentService{}
+	cfg.EnrollmentService.Config = *enrollmentCfg
+	cfg.EnrollmentService.Config.Service = client.Service{
+		Server:               agentCfg.agentConfigTemplate.EnrollmentService.Config.Service.Server,
+		CertificateAuthority: filepath.Join(cfg.ConfigDir, agent_config.CacertFile),
+	}
+	cfg.EnrollmentService.Config.AuthInfo = client.AuthInfo{
+		ClientCertificate: filepath.Join(cfg.ConfigDir, agent_config.EnrollmentCertFile),
+		ClientKey:         filepath.Join(cfg.ConfigDir, agent_config.EnrollmentKeyFile),
+	}
+	cfg.SpecFetchInterval = agentCfg.agentConfigTemplate.SpecFetchInterval
+	cfg.StatusUpdateInterval = agentCfg.agentConfigTemplate.StatusUpdateInterval
+	cfg.TPM = agentCfg.agentConfigTemplate.TPM
+	cfg.LogPrefix = agentName
+
+	cfg.ManagementService = config.ManagementService{}
+	cfg.ManagementService.Config = *managementCfg
+	cfg.ManagementService.Service = client.Service{
+		Server:               agentCfg.agentConfigTemplate.ManagementService.Config.Service.Server,
+		CertificateAuthority: filepath.Join(cfg.ConfigDir, agent_config.CacertFile),
+	}
+	cfg.SystemInfo = []string{}
+
+	cfg.SetEnrollmentMetricsCallback(rpcMetricsCallback)
+
+	if len(agentCfg.parsedSourceIPs) > 0 {
+		sourceIP := agentCfg.parsedSourceIPs[i%len(agentCfg.parsedSourceIPs)]
+		cfg.ManagementService.Config.AddHTTPOptions(baseclient.WithDialer(&net.Dialer{
+			LocalAddr: &net.TCPAddr{IP: sourceIP},
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}))
+		logger.Debugf("Agent %s assigned source IP: %s", agentName, sourceIP.String())
+	}
+	cfg.EnrollmentService.Config.AddHTTPOptions(
+		baseclient.WithMaxIdleConnsPerHost(agentCfg.maxConcurrency),
+		agentCfg.enrollmentTransport,
+	)
+
+	cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
+	agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("agent config %d: %w", i, err)
+	}
+	return agentInstance, agentDir, &labels, nil
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
-	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
-	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
+	log.Debugf("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, enrollmentPollInterval, enrollmentTimeout)
 	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
@@ -580,7 +585,7 @@ func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiCli
 		}
 		return
 	}
-	log.Infof("Approved device enrollment %s", enrollmentID)
+	log.Debugf("Approved device enrollment %s", enrollmentID)
 }
 
 func copyFile(from, to string) error {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -329,7 +329,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 		case <-time.After(time.Duration(rand.Float64() * float64(params.jitterDuration))): //nolint:gosec
 		}
 	}
-	agentInstance, agentDir, labels, err := createOneAgent(params.createCfg, params.createMu, i)
+	agentInstance, agentDir, labels, alreadyEnrolled, err := createOneAgent(params.createCfg, params.createMu, i)
 	if err != nil {
 		params.log.Errorf("creating agent %d: %v", i, err)
 		recordEnrollmentOutcome(ctx, err)
@@ -338,9 +338,14 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 	// leave the agent process running in the background
 	// when the agent is approved, we return and release the semaphore to allow other agents to onboard
 	go startAgent(ctx, agentInstance, params.log, i)
-	if params.skipAutoApprove {
+	switch {
+	case params.skipAutoApprove:
 		waitForEnrollmentRequest(ctx, params.log, agentDir)
-	} else {
+	case alreadyEnrolled:
+		// Resume path: management cert exists; approve would 404-poll for up to enrollmentTimeout.
+		params.log.Debugf("agent %s already enrolled, skipping approve", filepath.Base(agentDir))
+		recordEnrollmentOutcome(ctx, nil)
+	default:
 		approveAgent(ctx, params.log, params.serviceClient, agentDir, labels)
 	}
 	done := params.enrolled.Add(1)
@@ -479,7 +484,11 @@ type agentLaunchParams struct {
 	started         time.Time
 }
 
-func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*agent.Agent, string, *map[string]string, error) {
+func managementCertPath(agentDir string) string {
+	return filepath.Join(agentDir, agent_config.DefaultConfigDir, agent_config.DefaultCertsDirName, agent_config.GeneratedCertFile)
+}
+
+func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*agent.Agent, string, *map[string]string, bool, error) {
 	logger := agentCfg.log
 	agentName := fmt.Sprintf("device-%05d", agentCfg.initialDeviceIndex+i)
 	certDir := filepath.Join(agentCfg.agentConfigTemplate.ConfigDir, "certs")
@@ -491,13 +500,19 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 		logger.Debugf("resuming existing state for agent %s", agentName)
 	} else {
 		if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
-			return nil, "", nil, fmt.Errorf("creating directory: %w", err)
+			return nil, "", nil, false, fmt.Errorf("creating directory: %w", err)
 		}
 		if experimental.NewFeatures().IsEnabled() {
 			setupTPMLinks(agentDir, logger)
 		}
 		if err := copyAgentFiles(certDir, agentDir); err != nil {
-			return nil, "", nil, err
+			return nil, "", nil, false, err
+		}
+	}
+	alreadyEnrolled := false
+	if resuming {
+		if _, err := os.Stat(managementCertPath(agentDir)); err == nil {
+			alreadyEnrolled = true
 		}
 	}
 
@@ -515,7 +530,7 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 	createMu.Lock()
 	if err := os.Setenv(client.TestRootDirEnvKey, agentDir); err != nil {
 		createMu.Unlock()
-		return nil, "", nil, fmt.Errorf("setting %s: %w", client.TestRootDirEnvKey, err)
+		return nil, "", nil, false, fmt.Errorf("setting %s: %w", client.TestRootDirEnvKey, err)
 	}
 	cfg := agent_config.NewDefault()
 	enrollmentCfg := client.NewDefault()
@@ -572,9 +587,9 @@ func createOneAgent(agentCfg createAgentsConfig, createMu *sync.Mutex, i int) (*
 	cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
 	agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName, agent.WithExecuter(newSimulatorExecuter()))
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("agent config %d: %w", i, err)
+		return nil, "", nil, false, fmt.Errorf("agent config %d: %w", i, err)
 	}
-	return agentInstance, agentDir, &labels, nil
+	return agentInstance, agentDir, &labels, alreadyEnrolled, nil
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -80,6 +80,9 @@ func main() {
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
 	fleetCount := pflag.Int("fleet-count", 0, "number of scale fleets to create and distribute devices across (0 disables)")
 	fleetPrefix := pflag.String("fleet-prefix", "scale-fleet", "prefix for scale fleet names (<prefix>-NN)")
+	rollout := pflag.Bool("rollout", false, "standalone mode: update fleet templates and measure rollout convergence, then exit")
+	rolloutTemplate := pflag.String("rollout-template", "", "path to a Fleet YAML whose .spec.template is applied during --rollout")
+	rolloutTimeout := pflag.Duration("rollout-timeout", 15*time.Minute, "how long --rollout waits for devices to become UpToDate")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -115,6 +118,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *rollout && (*clean || *cleanOnly) {
+		log.Fatalf("--rollout is mutually exclusive with --clean/--clean-only")
+	}
+	if *rollout && *rolloutTemplate == "" {
+		log.Fatalf("--rollout requires --rollout-template")
+	}
+	if *rollout && *fleetCount <= 0 {
+		log.Fatalf("--rollout requires --fleet-count > 0")
+	}
+
 	// Disable console banner for all simulated agents
 	if err := os.Setenv("FLIGHTCTL_DISABLE_CONSOLE_BANNER", "true"); err != nil {
 		log.Fatalf("Error setting banner disable environment variable: %v", err)
@@ -135,10 +148,6 @@ func main() {
 	pflag.CommandLine.VisitAll(func(flg *pflag.Flag) {
 		log.Infof("  %s=%s", flg.Name, flg.Value)
 	})
-
-	formattedLables := formatLabels(labels)
-
-	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile, *logLevel)
 
 	log.Infoln("starting device simulator")
 	defer log.Infoln("device simulator stopped")
@@ -181,6 +190,16 @@ func main() {
 			return
 		}
 	}
+
+	if *rollout {
+		if err := runRollout(ctx, log, serviceClient.ClientWithResponses, *fleetPrefix, *fleetCount, *rolloutTemplate, *rolloutTimeout); err != nil {
+			log.Fatalf("rollout failed: %v", err)
+		}
+		return
+	}
+
+	formattedLables := formatLabels(labels)
+	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile, *logLevel)
 
 	log.Infoln("creating agents")
 

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -161,7 +162,10 @@ func main() {
 	}
 	cfg, err := client.ParseConfigFile(baseDir)
 	if err != nil {
-		log.Fatalf("could not parse config file: %v", err)
+		if errors.Is(err, os.ErrNotExist) {
+			log.Fatalf("no client config found at %s — run 'flightctl login' first", baseDir)
+		}
+		log.Fatalf("could not parse config file %s: %v", baseDir, err)
 	}
 	if cfg.Organization != "" {
 		log.Infof("using organization %s from client config", cfg.Organization)

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -78,6 +78,8 @@ func main() {
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
 	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
+	fleetCount := pflag.Int("fleet-count", 0, "number of scale fleets to create and distribute devices across (0 disables)")
+	fleetPrefix := pflag.String("fleet-prefix", "scale-fleet", "prefix for scale fleet names (<prefix>-NN)")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -182,12 +184,19 @@ func main() {
 
 	log.Infoln("creating agents")
 
-	// Create simulator fleet configuration
-	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
+	var fleetNames []string
+	if *fleetCount > 0 {
+		log.Infof("skipping default simulator-disk-monitoring fleet because --fleet-count=%d", *fleetCount)
+		var err error
+		fleetNames, err = createScaleFleets(ctx, log, serviceClient.ClientWithResponses, *fleetPrefix, *fleetCount)
+		if err != nil {
+			log.Fatalf("Failed to create scale fleets: %v", err)
+		}
+	} else if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
 		log.Warnf("Failed to create simulator fleet: %v", err)
 	}
 
-	agents, agentsFolders := createAgents(createAgentsConfig{
+	agents, agentsFolders, perAgentLabels := createAgents(createAgentsConfig{
 		log:                 log,
 		numDevices:          *numDevices,
 		initialDeviceIndex:  *initialDeviceIndex,
@@ -195,6 +204,7 @@ func main() {
 		parsedSourceIPs:     parsedSourceIPs,
 		maxConcurrency:      *maxConcurrency,
 		simulatorLabels:     formattedLables,
+		fleetNames:          fleetNames,
 	})
 
 	sigShutdown := make(chan os.Signal, 1)
@@ -221,7 +231,7 @@ func main() {
 		agentFolders:    agentsFolders,
 		log:             log,
 		serviceClient:   serviceClient.ClientWithResponses,
-		formattedLabels: formattedLables,
+		perAgentLabels:  perAgentLabels,
 		sem:             sem,
 		jitterDuration:  jitterDuration,
 		skipAutoApprove: *skipAutoApprove,
@@ -260,7 +270,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 		waitForEnrollmentRequest(ctx, params.log, params.agentFolders[i])
 		return
 	}
-	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.perAgentLabels[i])
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
@@ -373,6 +383,7 @@ type createAgentsConfig struct {
 	parsedSourceIPs     []net.IP
 	maxConcurrency      int
 	simulatorLabels     *map[string]string
+	fleetNames          []string
 }
 
 type agentLaunchParams struct {
@@ -380,17 +391,18 @@ type agentLaunchParams struct {
 	agentFolders    []string
 	log             *logrus.Logger
 	serviceClient   *apiClient.ClientWithResponses
-	formattedLabels *map[string]string
+	perAgentLabels  []*map[string]string
 	sem             *semaphore.Weighted
 	jitterDuration  time.Duration
 	skipAutoApprove bool
 }
 
-func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
+func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string, []*map[string]string) {
 	logger := agentCfg.log
 	logger.Infoln("creating agents")
 	agents := make([]*agent.Agent, agentCfg.numDevices)
 	agentsFolders := make([]string, agentCfg.numDevices)
+	perAgentLabels := make([]*map[string]string, agentCfg.numDevices)
 	ex := experimental.NewFeatures()
 	if ex.IsEnabled() && agentCfg.numDevices > 1 {
 		logger.Warnf("Using experimental features with more than one device could cause unexpected issues.")
@@ -421,11 +433,20 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			logger.Fatalf("Error setting environment variable: %v", err)
 		}
 
-		cfg := agent_config.NewDefault()
+		labels := map[string]string{}
 		if agentCfg.simulatorLabels != nil {
 			for k, v := range *agentCfg.simulatorLabels {
-				cfg.DefaultLabels[k] = v
+				labels[k] = v
 			}
+		}
+		if len(agentCfg.fleetNames) > 0 {
+			labels["fleet"] = agentCfg.fleetNames[i%len(agentCfg.fleetNames)]
+		}
+		perAgentLabels[i] = &labels
+
+		cfg := agent_config.NewDefault()
+		for k, v := range labels {
+			cfg.DefaultLabels[k] = v
 		}
 		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent_config.DefaultConfigDir
@@ -490,7 +511,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
-	return agents, agentsFolders
+	return agents, agentsFolders, perAgentLabels
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {

--- a/cmd/devicesimulator/prometheus.go
+++ b/cmd/devicesimulator/prometheus.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -51,6 +56,15 @@ var (
 		},
 		[]string{"operation", "result"},
 	)
+	enrollmentOutcomes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "enrollment_outcomes_total",
+			Help:      "Total enrollment wait/approve outcomes, partitioned by result",
+		},
+		[]string{"result"},
+	)
 )
 
 func setupMetricsEndpoint(metricsAddress string) {
@@ -66,6 +80,7 @@ func setupMetricsEndpoint(metricsAddress string) {
 	prometheus.MustRegister(apiRequests)
 	prometheus.MustRegister(apiErrors)
 	prometheus.MustRegister(apiRequestDurations)
+	prometheus.MustRegister(enrollmentOutcomes)
 }
 
 func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
@@ -80,6 +95,48 @@ func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
 }
 
 func reasonFromAPIError(err error) string {
-	errorType := "unknown"
-	return errorType
+	if err == nil {
+		return "unknown"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		msg := opErr.Error()
+		if strings.Contains(msg, "cannot assign requested address") {
+			return "bind"
+		}
+		if opErr.Op == "dial" {
+			return "dial"
+		}
+		return "connection"
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "cannot assign requested address") {
+		return "bind"
+	}
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "connection reset") {
+		return "connection"
+	}
+	if strings.Contains(msg, "dial ") {
+		return "dial"
+	}
+	return "unknown"
+}
+
+func recordEnrollmentOutcome(ctx context.Context, err error) {
+	switch {
+	case err == nil:
+		enrollmentOutcomes.WithLabelValues("approved").Inc()
+	case ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled):
+		enrollmentOutcomes.WithLabelValues("cancelled").Inc()
+	case wait.Interrupted(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+		enrollmentOutcomes.WithLabelValues("timeout").Inc()
+	default:
+		enrollmentOutcomes.WithLabelValues("error").Inc()
+	}
 }

--- a/cmd/devicesimulator/prometheus.go
+++ b/cmd/devicesimulator/prometheus.go
@@ -65,6 +65,15 @@ var (
 		},
 		[]string{"result"},
 	)
+	rolloutDevicesByStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "rollout_devices_by_status",
+			Help:      "Current device counts during rollout, partitioned by fleet and updated status",
+		},
+		[]string{"fleet", "status"},
+	)
 )
 
 func setupMetricsEndpoint(metricsAddress string) {
@@ -81,6 +90,7 @@ func setupMetricsEndpoint(metricsAddress string) {
 	prometheus.MustRegister(apiErrors)
 	prometheus.MustRegister(apiRequestDurations)
 	prometheus.MustRegister(enrollmentOutcomes)
+	prometheus.MustRegister(rolloutDevicesByStatus)
 }
 
 func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {

--- a/cmd/devicesimulator/rollout.go
+++ b/cmd/devicesimulator/rollout.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+// fleetTemplate aliases the anonymous Template struct on FleetSpec.
+type fleetTemplate = struct {
+	Metadata *v1beta1.ObjectMeta `json:"metadata,omitempty"`
+	Spec     v1beta1.DeviceSpec  `json:"spec"`
+}
+
+func runRollout(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, fleetPrefix string, fleetCount int, templatePath string, timeout time.Duration) error {
+	if fleetCount <= 0 {
+		return fmt.Errorf("--rollout requires --fleet-count > 0")
+	}
+	if templatePath == "" {
+		return fmt.Errorf("--rollout requires --rollout-template")
+	}
+
+	template, err := loadFleetTemplate(templatePath)
+	if err != nil {
+		return err
+	}
+
+	fleetNames := scaleFleetNames(fleetPrefix, fleetCount)
+	for _, name := range fleetNames {
+		if err := applyFleetTemplate(ctx, log, serviceClient, name, template); err != nil {
+			return err
+		}
+	}
+
+	log.Infof("waiting up to %s for rollout convergence across %d fleets", timeout, len(fleetNames))
+	log.Infoln("note: devices stuck at OutOfDate may reproduce the known non-atomic fleet rollout render race")
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(cleanupProgressInterval)
+	defer ticker.Stop()
+
+	for {
+		allUpToDate, summaries, err := pollRolloutStatus(ctx, serviceClient, fleetNames)
+		if err != nil {
+			return err
+		}
+		for _, summary := range summaries {
+			log.Infof("fleet %s: upToDate=%d updating=%d outOfDate=%d unknown=%d total=%d",
+				summary.name, summary.upToDate, summary.updating, summary.outOfDate, summary.unknown, summary.total)
+		}
+		if allUpToDate {
+			log.Infoln("rollout complete: all devices report UpToDate")
+			return nil
+		}
+		if time.Now().After(deadline) {
+			log.Warnln("rollout timed out before full convergence")
+			for _, summary := range summaries {
+				log.Warnf("final fleet %s: upToDate=%d updating=%d outOfDate=%d unknown=%d total=%d",
+					summary.name, summary.upToDate, summary.updating, summary.outOfDate, summary.unknown, summary.total)
+			}
+			return fmt.Errorf("rollout timed out after %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func loadFleetTemplate(path string) (fleetTemplate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fleetTemplate{}, fmt.Errorf("reading rollout template %s: %w", path, err)
+	}
+	var fleet v1beta1.Fleet
+	if err := yaml.Unmarshal(data, &fleet); err != nil {
+		return fleetTemplate{}, fmt.Errorf("unmarshaling rollout template: %w", err)
+	}
+	return fleet.Spec.Template, nil
+}
+
+func applyFleetTemplate(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, name string, template fleetTemplate) error {
+	getResp, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
+	if err != nil {
+		return fmt.Errorf("get fleet %s: %w", name, err)
+	}
+	if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+		return fmt.Errorf("get fleet %s: status %d", name, getResp.StatusCode())
+	}
+	fleet := *getResp.JSON200
+	fleet.Spec.Template = template
+	replaceResp, err := serviceClient.ReplaceFleetWithResponse(ctx, name, fleet)
+	if err != nil {
+		return fmt.Errorf("replace fleet %s: %w", name, err)
+	}
+	if replaceResp.StatusCode() < http.StatusOK || replaceResp.StatusCode() >= http.StatusMultipleChoices {
+		return fmt.Errorf("replace fleet %s: status %d, body: %s", name, replaceResp.StatusCode(), string(replaceResp.Body))
+	}
+	log.Infof("updated fleet template for %s", name)
+	return nil
+}
+
+type fleetRolloutSummary struct {
+	name      string
+	upToDate  int
+	updating  int
+	outOfDate int
+	unknown   int
+	total     int
+}
+
+func pollRolloutStatus(ctx context.Context, serviceClient *apiClient.ClientWithResponses, fleetNames []string) (bool, []fleetRolloutSummary, error) {
+	summaries := make([]fleetRolloutSummary, 0, len(fleetNames))
+	allUpToDate := true
+	for _, name := range fleetNames {
+		summary, err := tallyFleetDevices(ctx, serviceClient, name)
+		if err != nil {
+			return false, nil, err
+		}
+		summaries = append(summaries, summary)
+		updateRolloutMetrics(summary)
+		if summary.total == 0 || summary.upToDate != summary.total {
+			allUpToDate = false
+		}
+	}
+	return allUpToDate, summaries, nil
+}
+
+func tallyFleetDevices(ctx context.Context, serviceClient *apiClient.ClientWithResponses, fleetName string) (fleetRolloutSummary, error) {
+	summary := fleetRolloutSummary{name: fleetName}
+	selector := fmt.Sprintf("fleet=%s", fleetName)
+	limit := cleanupListLimit
+	var continueToken *string
+
+	for {
+		resp, err := serviceClient.ListDevicesWithResponse(ctx, &v1beta1.ListDevicesParams{
+			LabelSelector: &selector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return summary, fmt.Errorf("list devices for fleet %s: %w", fleetName, err)
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return summary, fmt.Errorf("list devices for fleet %s: status %d", fleetName, resp.StatusCode())
+		}
+		for _, device := range resp.JSON200.Items {
+			summary.total++
+			if device.Status == nil {
+				summary.unknown++
+				continue
+			}
+			switch device.Status.Updated.Status {
+			case v1beta1.DeviceUpdatedStatusUpToDate:
+				summary.upToDate++
+			case v1beta1.DeviceUpdatedStatusUpdating:
+				summary.updating++
+			case v1beta1.DeviceUpdatedStatusOutOfDate:
+				summary.outOfDate++
+			default:
+				summary.unknown++
+			}
+		}
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return summary, nil
+}
+
+func updateRolloutMetrics(summary fleetRolloutSummary) {
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUpToDate)).Set(float64(summary.upToDate))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUpdating)).Set(float64(summary.updating))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusOutOfDate)).Set(float64(summary.outOfDate))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUnknown)).Set(float64(summary.unknown))
+}

--- a/cmd/devicesimulator/sim_executer.go
+++ b/cmd/devicesimulator/sim_executer.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/flightctl/flightctl/pkg/executer"
+)
+
+// simulatorExecuter stubs host tooling that simulated agents must not invoke for real
+// (notably podman), while delegating everything else to the normal executer.
+type simulatorExecuter struct {
+	wrapped executer.Executer
+}
+
+func newSimulatorExecuter() *simulatorExecuter {
+	return &simulatorExecuter{wrapped: executer.NewCommonExecuter()}
+}
+
+func isPodmanCommand(command string) bool {
+	return command == "podman" || strings.HasSuffix(command, "/podman")
+}
+
+func stubPodman(args []string) (stdout string, stderr string, exitCode int) {
+	if len(args) > 0 && args[0] == "--version" {
+		return "podman version 4.9.0\n", "", 0
+	}
+	return "", "", 0
+}
+
+func (s *simulatorExecuter) CommandContext(ctx context.Context, command string, args ...string) *exec.Cmd {
+	if isPodmanCommand(command) {
+		if len(args) > 0 && args[0] == "--version" {
+			return exec.CommandContext(ctx, "echo", "podman version 4.9.0")
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+	return s.wrapped.CommandContext(ctx, command, args...)
+}
+
+func (s *simulatorExecuter) Execute(command string, args ...string) (stdout string, stderr string, exitCode int) {
+	if isPodmanCommand(command) {
+		return stubPodman(args)
+	}
+	return s.wrapped.Execute(command, args...)
+}
+
+func (s *simulatorExecuter) ExecuteWithContext(ctx context.Context, command string, args ...string) (stdout string, stderr string, exitCode int) {
+	if isPodmanCommand(command) {
+		return stubPodman(args)
+	}
+	return s.wrapped.ExecuteWithContext(ctx, command, args...)
+}
+
+func (s *simulatorExecuter) ExecuteWithContextFromDir(ctx context.Context, workingDir string, command string, args []string, env ...string) (stdout string, stderr string, exitCode int) {
+	if isPodmanCommand(command) {
+		return stubPodman(args)
+	}
+	return s.wrapped.ExecuteWithContextFromDir(ctx, workingDir, command, args, env...)
+}

--- a/cmd/devicesimulator/sourceips.go
+++ b/cmd/devicesimulator/sourceips.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func parseExplicitSourceIPs(log *logrus.Logger, explicit []string) ([]net.IP, error) {
+	ips := make([]net.IP, 0, len(explicit))
+	for _, ipStr := range explicit {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid source IP address: %s", ipStr)
+		}
+		ips = append(ips, ip)
+		log.Infof("Using source IP: %s", ip.String())
+	}
+	return ips, nil
+}
+
+func setupSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen int) ([]net.IP, error) {
+	ips, err := expandSourceIPRange(iface, base, count, prefixLen)
+	if err != nil {
+		return nil, err
+	}
+	for _, ip := range ips {
+		cidr := fmt.Sprintf("%s/%d", ip.String(), prefixLen)
+		added, err := ensureAddrOnIface(iface, cidr)
+		if err != nil {
+			return nil, fmt.Errorf("adding %s on %s: %w (run this setup step as root)", cidr, iface, err)
+		}
+		if added {
+			log.Infof("added source IP %s on %s", cidr, iface)
+		} else {
+			log.Infof("source IP %s already present on %s", cidr, iface)
+		}
+	}
+	return ips, nil
+}
+
+func teardownSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen int) error {
+	ips, err := expandSourceIPRange(iface, base, count, prefixLen)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, ip := range ips {
+		cidr := fmt.Sprintf("%s/%d", ip.String(), prefixLen)
+		cmd := exec.Command("ip", "addr", "del", cidr, "dev", iface)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			msg := string(out)
+			if strings.Contains(msg, "Cannot find address") || strings.Contains(msg, "Address not found") {
+				log.Infof("source IP %s already absent from %s", cidr, iface)
+				continue
+			}
+			log.Warnf("removing source IP %s from %s: %v (%s)", cidr, iface, err, strings.TrimSpace(msg))
+			if firstErr == nil {
+				firstErr = fmt.Errorf("removing %s from %s: %w (run this teardown step as root)", cidr, iface, err)
+			}
+			continue
+		}
+		log.Infof("removed source IP %s from %s", cidr, iface)
+	}
+	return firstErr
+}
+
+func expandSourceIPRange(iface, base string, count, prefixLen int) ([]net.IP, error) {
+	if iface == "" || base == "" || count <= 0 {
+		return nil, fmt.Errorf("--source-ip-iface, --source-ip-base, and --source-ip-count (>0) are all required")
+	}
+	if prefixLen < 1 || prefixLen > 32 {
+		return nil, fmt.Errorf("--source-ip-prefix must be between 1 and 32")
+	}
+	baseIP := net.ParseIP(base)
+	if baseIP == nil || baseIP.To4() == nil {
+		return nil, fmt.Errorf("--source-ip-base must be a valid IPv4 address: %s", base)
+	}
+	ips := make([]net.IP, 0, count)
+	for i := 0; i < count; i++ {
+		ips = append(ips, nextIPv4(baseIP.To4(), i))
+	}
+	return ips, nil
+}
+
+func sourceIPsFlagValue(ips []net.IP) string {
+	parts := make([]string, len(ips))
+	for i, ip := range ips {
+		parts[i] = ip.String()
+	}
+	return strings.Join(parts, ",")
+}
+
+func ensureAddrOnIface(iface, cidr string) (added bool, err error) {
+	cmd := exec.Command("ip", "addr", "add", cidr, "dev", iface)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	msg := string(out)
+	if strings.Contains(msg, "File exists") || strings.Contains(msg, "already assigned") {
+		return false, nil
+	}
+	return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(msg))
+}
+
+func nextIPv4(ip net.IP, n int) net.IP {
+	v := binary.BigEndian.Uint32(ip.To4())
+	v += uint32(n)
+	out := make(net.IP, 4)
+	binary.BigEndian.PutUint32(out, v)
+	return out
+}

--- a/cmd/devicesimulator/sourceips.go
+++ b/cmd/devicesimulator/sourceips.go
@@ -10,6 +10,33 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func resolveRuntimeSourceIPs(log *logrus.Logger, explicit []string, iface, base string, count, prefixLen int) ([]net.IP, error) {
+	explicitSet := len(explicit) > 0
+	rangeSet := iface != "" || base != "" || count > 0
+	if explicitSet && rangeSet {
+		return nil, fmt.Errorf("--source-ips is mutually exclusive with --source-ip-iface/--source-ip-base/--source-ip-count")
+	}
+	if explicitSet {
+		return parseExplicitSourceIPs(log, explicit)
+	}
+	if !rangeSet {
+		return nil, nil
+	}
+	// Non-root path: expand the same range flags used by setup; do not create addresses.
+	_ = prefixLen
+	ips, err := expandSourceIPRange(base, count)
+	if err != nil {
+		return nil, err
+	}
+	for _, ip := range ips {
+		log.Infof("Using source IP: %s", ip.String())
+	}
+	if iface != "" {
+		log.Infof("source IP range expanded for interface %s (addresses must already exist)", iface)
+	}
+	return ips, nil
+}
+
 func parseExplicitSourceIPs(log *logrus.Logger, explicit []string) ([]net.IP, error) {
 	ips := make([]net.IP, 0, len(explicit))
 	for _, ipStr := range explicit {
@@ -24,7 +51,10 @@ func parseExplicitSourceIPs(log *logrus.Logger, explicit []string) ([]net.IP, er
 }
 
 func setupSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen int) ([]net.IP, error) {
-	ips, err := expandSourceIPRange(iface, base, count, prefixLen)
+	if err := validateSourceIPSetupArgs(iface, base, count, prefixLen); err != nil {
+		return nil, err
+	}
+	ips, err := expandSourceIPRange(base, count)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +74,10 @@ func setupSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen int
 }
 
 func teardownSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen int) error {
-	ips, err := expandSourceIPRange(iface, base, count, prefixLen)
+	if err := validateSourceIPSetupArgs(iface, base, count, prefixLen); err != nil {
+		return err
+	}
+	ips, err := expandSourceIPRange(base, count)
 	if err != nil {
 		return err
 	}
@@ -70,12 +103,20 @@ func teardownSourceIPs(log *logrus.Logger, iface, base string, count, prefixLen 
 	return firstErr
 }
 
-func expandSourceIPRange(iface, base string, count, prefixLen int) ([]net.IP, error) {
-	if iface == "" || base == "" || count <= 0 {
-		return nil, fmt.Errorf("--source-ip-iface, --source-ip-base, and --source-ip-count (>0) are all required")
+func validateSourceIPSetupArgs(iface, base string, count, prefixLen int) error {
+	if iface == "" {
+		return fmt.Errorf("--source-ip-iface is required")
 	}
 	if prefixLen < 1 || prefixLen > 32 {
-		return nil, fmt.Errorf("--source-ip-prefix must be between 1 and 32")
+		return fmt.Errorf("--source-ip-prefix must be between 1 and 32")
+	}
+	_, err := expandSourceIPRange(base, count)
+	return err
+}
+
+func expandSourceIPRange(base string, count int) ([]net.IP, error) {
+	if base == "" || count <= 0 {
+		return nil, fmt.Errorf("--source-ip-base and --source-ip-count (>0) are required")
 	}
 	baseIP := net.ParseIP(base)
 	if baseIP == nil || baseIP.To4() == nil {

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -175,11 +175,13 @@ make agent-container
 make clean-agent-container
 ```
 
-Use the **[devicesimulator](devicesimulator.md)** to simulate load from devices
+Use the **[devicesimulator](devicesimulator.md)** to simulate load from devices. Preferred entrypoint:
 
 ```
-bin/devicesimulator --count=100
+make simulate-devices ARGS='--count=100 --log-level=error'
 ```
+
+For large-scale runs (source IP setup/teardown, fleets, clean, rollout), see [Scale testing with make simulate-devices](devicesimulator.md#scale-testing-with-make-simulate-devices).
 
 ## Backup and restore
 

--- a/docs/developer/devicesimulator.md
+++ b/docs/developer/devicesimulator.md
@@ -15,11 +15,116 @@ Copy the necessary setup files to run a `devicesimulator`.
     cp bin/agent/etc/flightctl/certs/* ~/.flightctl/certs/
     cp bin/agent/etc/flightctl/config.yaml ~/.flightctl/agent.yaml
 
-Changes to the configuration of all launched agents can be made in `~/.flightctl/agent.yaml`
+Changes to the configuration of all launched agents can be made in `~/.flightctl/agent.yaml`.
 Some key options available for tuning:
-- `status-update-interval` - How often the agent reports its status to the API. Higher intervals reduce server load.
+
+- `status-update-interval` — how often the agent reports status to the API (higher reduces server load)
+- `status-update-jitter` — random delay before the first status push (spreads mass-start herds)
+- `spec-fetch-error-base-delay` / `spec-fetch-error-max-delay` — exponential backoff on `/rendered` **errors** only
 
 See [Installing and configuring the Flight Control Agent](../user/installing/installing-agent.md) for all available options.
+
+Log in with the CLI first so the simulator can use your client config (including organization):
+
+```bash
+bin/flightctl login <server> --web --certificate-authority ~/.flightctl/certs/ca.crt
+# or: bin/flightctl login <server> -k -u <user> -p <password>
+```
+
+## Scale testing with `make simulate-devices`
+
+Preferred entrypoint: build and run via Make, passing flags through `ARGS`.
+
+```bash
+make simulate-devices ARGS='--count=100 --log-level=error --orchestrator-log-level=info'
+```
+
+Equivalent binary: `bin/devicesimulator` (same flags). Raise the process file-descriptor limit for large runs (`ulimit -n`).
+
+### Source IP setup and teardown (large scale)
+
+Above roughly tens of thousands of agents, a single client IP can exhaust ephemeral ports. Use multiple source IPs.
+
+**1. As root — create aliases** (standalone mode; exits after setup):
+
+```bash
+sudo make simulate-devices ARGS='--setup-source-ips \
+  --source-ip-iface=br-sim \
+  --source-ip-base=10.100.0.100 \
+  --source-ip-count=4 \
+  --source-ip-prefix=24'
+```
+
+If the interface does not exist yet, create a host-only bridge first (optional isolation):
+
+```bash
+sudo ip link add name br-sim type bridge
+sudo ip link set br-sim up
+```
+
+**2. As a normal user — run the simulator** with the same range (addresses must already exist; setup does not run as non-root):
+
+```bash
+make simulate-devices ARGS='--count=100000 \
+  --max-concurrency=200 \
+  --fleet-count=10 \
+  --fleet-prefix=scale-fleet \
+  --source-ip-base=10.100.0.100 \
+  --source-ip-count=4 \
+  --log-level=error \
+  --orchestrator-log-level=info'
+```
+
+You can pass an explicit list instead of a range: `--source-ips=10.100.0.100,10.100.0.101,...` (mutually exclusive with `--source-ip-base` / `--source-ip-count`).
+
+**3. As root — remove aliases** when finished:
+
+```bash
+sudo make simulate-devices ARGS='--teardown-source-ips \
+  --source-ip-iface=br-sim \
+  --source-ip-base=10.100.0.100 \
+  --source-ip-count=4 \
+  --source-ip-prefix=24'
+```
+
+Optional: remove the bridge entirely with `sudo ip link delete br-sim`.
+
+`--setup-source-ips` / `--teardown-source-ips` are mutually exclusive with each other and with a normal simulator run (including `--clean` / `--rollout`).
+
+### Fleets, clean, resume, rollout
+
+| Flag | Purpose |
+|------|---------|
+| `--fleet-count=N` | Create/replace `scale-fleet-00`…`NN-1` (prefix via `--fleet-prefix`) and round-robin label devices. Skips the default `simulator-disk-monitoring` fleet when `N > 0`. Inline `/etc/motd` sets `user`/`group` to the simulator process uid/gid (FileSpec omit defaults to root, which non-root agents cannot `chown`). |
+| `--clean` | Wipe local `data-dir` simulator state and delete simulator-created devices / related enrollment requests, then start |
+| `--clean-only` | Same wipe, then exit |
+| Resume (default) | Restarts agents from local state; skips re-approve when `agent.crt` already exists |
+| `--rollout` | Standalone: apply `--rollout-template` to all scale fleets, poll until UpToDate or `--rollout-timeout` |
+| `--skip-auto-approve` | Do not approve enrollment requests (agents wait for manual approval) |
+
+Clean enroll example:
+
+```bash
+make simulate-devices ARGS='--clean --count=100000 --fleet-count=10 \
+  --source-ip-base=10.100.0.100 --source-ip-count=4 \
+  --log-level=error --orchestrator-log-level=info'
+```
+
+Rollout example (agents must already be running in another process; use a different `--metrics` port if needed):
+
+```bash
+make simulate-devices ARGS='--rollout --fleet-count=10 \
+  --rollout-template=/path/to/fleet-template.yaml \
+  --rollout-timeout=6h \
+  --metrics=localhost:9094 \
+  --orchestrator-log-level=info'
+```
+
+The rollout template only needs a Fleet YAML whose `.spec.template` is copied onto every scale fleet. Avoid hard-coding a single `fleet:` label in `template.metadata.labels` if that would reassign all fleets. For inline files under a non-root simulator, set `user`/`group` to the simulator uid/gid (not omitted — omit means root per the API).
+
+### Metrics
+
+Default Prometheus scrape endpoint: `http://localhost:9093/metrics`. Override with `--metrics` when a second simulator process is already bound to that port.
 
 ## CLI Reference
 
@@ -29,16 +134,28 @@ The device simulator supports various command-line options organized into logica
 - `--count` (default: 1): Number of devices to simulate
 - `--initial-device-index` (default: 0): Starting index for device name suffix (e.g., device-00000 for 0, device-00200 for 200)
 - `--label`: Label applied to simulated devices in the format key=value (can be specified multiple times)
+- `--fleet-count` (default: 0): Number of scale fleets to create and distribute devices across (`0` disables)
+- `--fleet-prefix` (default: `scale-fleet`): Prefix for scale fleet names (`<prefix>-NN`)
 
 ### Concurrency Configuration
-- `--max-concurrency` (default: 100): Maximum number of agents that can be creating simultaneously
-- `--agent-startup-jitter` (default: -1s): Maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)
+- `--max-concurrency` (default: 200): Maximum number of concurrent agent create/enroll operations
+- `--agent-startup-jitter` (default: 0): Maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)
 
 ### Runtime Configuration
 - `--stop-after`: Stop the simulator after the specified duration (format: 1h30m, 5m, etc.)
-- `--log-level, -v` (default: debug): Logger verbosity level (fatal, error, warn, warning, info, debug)
+- `--log-level, -v` (default: error): Log level for simulated device agents
+- `--orchestrator-log-level` (default: info): Log level for cleanup, fleets, and enrollment progress
 - `--metrics` (default: localhost:9093): Address for the metrics endpoint
-- `--source-ips`: Comma-separated list of source IP addresses for device management HTTP connections
+- `--skip-auto-approve`: Do not auto-approve enrollment requests
+- `--clean` / `--clean-only`: Wipe local state and simulator-created API resources
+- `--rollout` / `--rollout-template` / `--rollout-timeout`: Standalone fleet template rollout mode
+
+### Source IP Configuration
+- `--source-ips`: Comma-separated list of existing source IPs (mutually exclusive with range flags)
+- `--setup-source-ips`: Root-capable standalone mode: add IP aliases on an interface, then exit
+- `--teardown-source-ips`: Root-capable standalone mode: remove those aliases, then exit
+- `--source-ip-iface`: Interface for setup/teardown
+- `--source-ip-base` / `--source-ip-count` / `--source-ip-prefix`: Consecutive IPv4 range (setup, teardown, or non-root run)
 
 ### File and Directory Configuration
 - `--config` (default: ~/.flightctl/agent.yaml): Path of the agent configuration template
@@ -121,16 +238,11 @@ Devices are named using the format `device-XXXXX` where XXXXX is a zero-padded 5
 
 The simulator uses configurable random jitter when starting agents to prevent thundering herd effects. The jitter behavior is controlled by the `--agent-startup-jitter` flag:
 
-- **Negative values (default: -1s)**: Use the agent's `status-update-interval` setting as the maximum jitter duration. This provides backward-compatible behavior with random delays between 0 and the status update interval (typically 60 seconds).
-- **Zero (0)**: No jitter - agents start immediately without any random delay. Useful for testing scenarios requiring precise timing.
-- **Positive values**: Use the specified duration as the maximum jitter. For example, `--agent-startup-jitter=30s` creates random delays between 0 and 30 seconds.
+- **Zero (default: 0)**: No startup jitter — agents start without an extra random delay (status-path herd spreading uses `status-update-jitter` in the agent template instead).
+- **Negative values**: Use the agent's `status-update-interval` as the maximum startup jitter.
+- **Positive values**: Use the specified duration as the maximum jitter (for example `--agent-startup-jitter=30s`).
 
-**Common Usage Patterns:**
-- **Default behavior**: Omit the flag or use `--agent-startup-jitter=-1s` for production-like load distribution
-- **Immediate startup**: Use `--agent-startup-jitter=0` for testing scenarios requiring synchronized agent launches
-- **Custom timing**: Use `--agent-startup-jitter=30s` or similar for specific load distribution needs
-
-For testing scenarios where you need precise timing or want to minimize startup delays, setting jitter to 0 or a small positive value can be beneficial. For production-like load testing, the default behavior usually provides good load distribution.
+For production-like load testing, prefer raising `status-update-interval` / `status-update-jitter` in `~/.flightctl/agent.yaml` and use `--agent-startup-jitter` only when you need extra desync at process start.
 
 Today the agent assumes a bootc host so the default disk alerts are based on /sysroot path.
 To avoid many errors in the logs as a result of being unable to read from `/sysroot` consider either:
@@ -172,55 +284,7 @@ It is possible to run 10k devices on a single instance running the flightctl ser
    bin/devicesimulator --max-concurrency=100
    ```
 
-6. **Source IP Distribution**: For very large-scale simulations (>30,000 devices), use multiple source IPs to overcome ephemeral port limitations:
-   ```bash
-   # Setup network aliases first (requires root)
-   sudo ip addr add 192.168.1.100/24 dev eth0
-   sudo ip addr add 192.168.1.101/24 dev eth0
-   sudo ip addr add 192.168.1.102/24 dev eth0
-   
-   # Run simulator with source IP distribution
-   bin/devicesimulator --count=50000 --source-ips=192.168.1.100,192.168.1.101,192.168.1.102 --max-concurrency=100
-   ```
-
-   **Note:** This method adds IP aliases to a physical interface, making them visible and accessible to other hosts on the same network. You must ensure the chosen IPs do not conflict with other devices on your LAN.
-
-   **Advanced: Using a Network Bridge for IP Isolation**
-
-   For a cleaner and more isolated setup, especially when adding a large number of IPs, you can create a virtual bridge interface. This avoids cluttering your main network interface and uses a dedicated, non-existent network range, preventing any potential IP conflicts on your LAN.
-
-   **Note:** This creates a *host-only* bridge. It is isolated within the host machine and is not connected to any physical network. This is the desired setup for the simulator as it prevents network conflicts and is simple to manage.
-
-   1.  **Create and activate a bridge:**
-       ```bash
-       # Create a new bridge named br-sim
-       sudo ip link add name br-sim type bridge
-
-       # Bring the bridge interface up
-       sudo ip link set br-sim up
-       ```
-
-   2.  **Assign a block of IP addresses to the bridge:**
-       This example assigns IPs in the `10.100.0.0/24` range. The host's kernel will handle routing traffic from this bridge to the flightctl service.
-       ```bash
-       # Assign multiple IPs to the bridge for the simulator to use
-       for i in {100..103}; do sudo ip addr add 10.100.0.$i/24 dev br-sim; done
-       ```
-
-   3.  **Run the simulator with the new IPs:**
-       ```bash
-       bin/devicesimulator \
-         --count=10000 \
-         --source-ips=10.100.0.100,10.100.0.101,10.100.0.102,10.100.0.103 \
-         --max-concurrency=100
-       ```
-
-   4.  **Cleanup (when finished):**
-       When you are done with the simulation, you can remove the bridge and all its associated IPs with a single command:
-       ```bash
-       sudo ip link delete br-sim
-       ```
-
+6. **Source IP Distribution**: For very large-scale simulations (typically >30,000 devices), use multiple source IPs to overcome ephemeral port limitations. Prefer the built-in setup/teardown flags documented in [Scale testing with `make simulate-devices`](#scale-testing-with-make-simulate-devices) (`--setup-source-ips` / `--teardown-source-ips` with `--source-ip-base` / `--source-ip-count`). Manual `ip addr add` on a physical NIC or a host-only bridge (`br-sim`) still works; avoid LAN conflicts if you alias a shared interface.
 ### System-level Connection Limits
 
 When simulating a large number of devices, each running agent establishes multiple HTTP connections to the flightctl server. This can exhaust system resources related to network connections. Understanding these limits is crucial for large-scale simulations.
@@ -246,22 +310,22 @@ When running the device simulator, you may need to tune these system parameters 
 
 #### Automatic Fleet Creation
 
-The device simulator automatically creates a fleet configuration named `simulator-disk-monitoring` if it doesn't already exist. This fleet:
+By default (when `--fleet-count=0`), the device simulator creates a fleet named `simulator-disk-monitoring` if it does not already exist. That fleet:
 - Eliminates disk usage errors that would occur with default monitoring configurations
-- Uses the selector `created_by: device-simulator` to automatically match all devices created by the simulator
+- Uses the selector `created_by: device-simulator` to match simulator devices
 - Loads configuration from `examples/fleet-disk-simulator.yaml`
-- Provides appropriate disk monitoring settings for simulated devices
 
-All devices created by the simulator are automatically labeled with `created_by: device-simulator`, ensuring they are matched by this fleet without manual intervention.
+With `--fleet-count > 0`, the simulator creates scale fleets instead and **skips** creating `simulator-disk-monitoring`. Devices still get `created_by=device-simulator` plus a round-robin `fleet=<prefix>-NN` label.
 
 #### Device Enrollment Process
 
 The simulator handles the complete device lifecycle:
 1. Creates agent instances with unique device names (format: device-XXXXX)
 2. Starts agent processes that initiate enrollment requests
-3. Automatically approves enrollment requests when they appear
-4. Applies configured labels to enrolled devices
-5. Manages concurrent device creation with configurable limits
+3. Automatically approves enrollment requests when they appear (unless `--skip-auto-approve`)
+4. On resume, skips approve when the agent certificate already exists
+5. Applies configured labels to enrolled devices
+6. Manages concurrent device creation with configurable limits
 
 ## Monitoring
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -179,8 +179,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	osMode := os.DetectMode(stdexec.LookPath)
 	a.log.Infof("OS mode detected: %s", osMode)
 
-	// create podman client
-	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory)
+	// create podman client (honors Agent.WithExecuter for the current-process user)
+	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory, exec)
 	rootPodmanClient, err := podmanClientFactory("")
 	if err != nil {
 		return err
@@ -457,6 +457,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		applicationsManager,
 		rootSystemdManager,
 		a.config.StatusUpdateInterval,
+		a.config.StatusUpdateJitter,
 		hookManager,
 		osManager,
 		policyManager,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -179,8 +179,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	osMode := os.DetectMode(stdexec.LookPath)
 	a.log.Infof("OS mode detected: %s", osMode)
 
-	// create podman client
-	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory)
+	// create podman client (honors Agent.WithExecuter for the current-process user)
+	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory, exec)
 	rootPodmanClient, err := podmanClientFactory("")
 	if err != nil {
 		return err

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -166,6 +166,13 @@ func (a *Agent) Run(ctx context.Context) error {
 		JitterFactor: 0.1,
 	}
 
+	specFetchErrorBackoff := poll.Config{
+		BaseDelay:    time.Duration(a.config.SpecFetchErrorBaseDelay),
+		MaxDelay:     time.Duration(a.config.SpecFetchErrorMaxDelay),
+		Factor:       2.0,
+		JitterFactor: 0.2,
+	}
+
 	// create os client
 	osClient := os.NewClient(a.log, exec)
 
@@ -261,6 +268,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		osClient,
 		osMode,
 		pollBackoff,
+		specFetchErrorBackoff,
 		deviceNotFoundHandler,
 		auditLogger,
 		a.log,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -179,8 +179,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	osMode := os.DetectMode(stdexec.LookPath)
 	a.log.Infof("OS mode detected: %s", osMode)
 
-	// create podman client (honors Agent.WithExecuter for the current-process user)
-	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory, exec)
+	// create podman client
+	podmanClientFactory := client.NewPodmanFactory(a.log, pollBackoff, rwFactory)
 	rootPodmanClient, err := podmanClientFactory("")
 	if err != nil {
 		return err

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -457,7 +457,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		applicationsManager,
 		rootSystemdManager,
 		a.config.StatusUpdateInterval,
-		a.config.StatusUpdateJitter,
+		*a.config.StatusUpdateJitter,
 		hookManager,
 		osManager,
 		policyManager,

--- a/internal/agent/client/podman.go
+++ b/internal/agent/client/podman.go
@@ -104,16 +104,19 @@ type Podman struct {
 // PodmanFactory creates a podman client. A blank username means to use the process user.
 type PodmanFactory func(user v1beta1.Username) (*Podman, error)
 
-func NewPodmanFactory(log *log.PrefixLogger, backoff poll.Config, rwFactory fileio.ReadWriterFactory) PodmanFactory {
+func NewPodmanFactory(log *log.PrefixLogger, backoff poll.Config, rwFactory fileio.ReadWriterFactory, baseExec executer.Executer) PodmanFactory {
 	return func(username v1beta1.Username) (*Podman, error) {
 		readWriter, err := rwFactory(username)
 		if err != nil {
 			return nil, err
 		}
 
-		exec, err := ExecuterForUser(username)
-		if err != nil {
-			return nil, err
+		exec := baseExec
+		if !username.IsCurrentProcessUser() {
+			exec, err = ExecuterForUser(username)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		log.Debugf("Creating podman client for user %s", username)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -34,8 +34,6 @@ const (
 	DefaultSpecFetchInterval = util.Duration(60 * time.Second)
 	// DefaultStatusUpdateInterval is the default interval between two status updates
 	DefaultStatusUpdateInterval = util.Duration(60 * time.Second)
-	// DefaultStatusUpdateJitter is the default max random delay before the first status push
-	DefaultStatusUpdateJitter = DefaultStatusUpdateInterval
 	// DefaultSpecFetchErrorBaseDelay is the initial backoff after a failed /rendered poll
 	DefaultSpecFetchErrorBaseDelay = util.Duration(5 * time.Second)
 	// DefaultSpecFetchErrorMaxDelay caps exponential backoff after failed /rendered polls
@@ -124,8 +122,9 @@ type Config struct {
 	StatusUpdateInterval util.Duration `json:"status-update-interval,omitempty"`
 	// StatusUpdateJitter is the maximum random delay before the first status push after
 	// agent start. The delay is chosen uniformly in [0, StatusUpdateJitter). Zero disables
-	// jitter (immediate first push). Defaults to StatusUpdateInterval.
-	StatusUpdateJitter util.Duration `json:"status-update-jitter,omitempty"`
+	// jitter (immediate first push). Nil means omitted; Complete() sets it from
+	// StatusUpdateInterval. A pointer preserves explicit zero through drop-in merges.
+	StatusUpdateJitter *util.Duration `json:"status-update-jitter,omitempty"`
 	// EnrollmentVerifyInterval is the initial interval between checks for enrollment
 	// approval. Retries back off from this value (see agent.go's enrollment backoff).
 	EnrollmentVerifyInterval util.Duration `json:"enrollment-verify-interval,omitempty"`
@@ -245,7 +244,6 @@ func NewDefault() *Config {
 		ConfigDir:                DefaultConfigDir,
 		DataDir:                  DefaultDataDir,
 		StatusUpdateInterval:     DefaultStatusUpdateInterval,
-		StatusUpdateJitter:       DefaultStatusUpdateJitter,
 		SpecFetchInterval:        DefaultSpecFetchInterval,
 		SpecFetchErrorBaseDelay:  DefaultSpecFetchErrorBaseDelay,
 		SpecFetchErrorMaxDelay:   DefaultSpecFetchErrorMaxDelay,
@@ -363,6 +361,10 @@ func (cfg *Config) Complete() error {
 		cfg.RemoteAccessService.Config = *cfg.EnrollmentService.Config.DeepCopy()
 		cfg.RemoteAccessService.Config.AuthInfo = baseclient.AuthInfo{}
 		cfg.RemoteAccessService.Config.Service.Server = remoteAccessServer
+	}
+	if cfg.StatusUpdateJitter == nil {
+		jitter := cfg.StatusUpdateInterval
+		cfg.StatusUpdateJitter = &jitter
 	}
 	return nil
 }
@@ -516,8 +518,8 @@ func (cfg *Config) validateSyncIntervals() error {
 	if cfg.StatusUpdateInterval < MinSyncInterval {
 		return fmt.Errorf("minimum status update interval is %s have %s", MinSyncInterval, cfg.StatusUpdateInterval)
 	}
-	if cfg.StatusUpdateJitter < 0 {
-		return fmt.Errorf("status update jitter must be >= 0 have %s", cfg.StatusUpdateJitter)
+	if cfg.StatusUpdateJitter != nil && *cfg.StatusUpdateJitter < 0 {
+		return fmt.Errorf("status update jitter must be >= 0 have %s", *cfg.StatusUpdateJitter)
 	}
 	if cfg.SpecFetchErrorBaseDelay < MinSyncInterval {
 		return fmt.Errorf("minimum spec fetch error base delay is %s have %s", MinSyncInterval, cfg.SpecFetchErrorBaseDelay)
@@ -597,7 +599,9 @@ func mergeConfigs(base, override *Config) {
 
 	overrideIfNotEmpty(&base.SpecFetchErrorBaseDelay, override.SpecFetchErrorBaseDelay)
 	overrideIfNotEmpty(&base.SpecFetchErrorMaxDelay, override.SpecFetchErrorMaxDelay)
-	overrideIfNotEmpty(&base.StatusUpdateJitter, override.StatusUpdateJitter)
+	if override.StatusUpdateJitter != nil {
+		base.StatusUpdateJitter = override.StatusUpdateJitter
+	}
 
 	// system info
 	overrideSliceIfNotNil(&base.SystemInfo, override.SystemInfo)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -33,6 +33,10 @@ const (
 	DefaultSpecFetchInterval = util.Duration(60 * time.Second)
 	// DefaultStatusUpdateInterval is the default interval between two status updates
 	DefaultStatusUpdateInterval = util.Duration(60 * time.Second)
+	// DefaultSpecFetchErrorBaseDelay is the initial backoff after a failed /rendered poll
+	DefaultSpecFetchErrorBaseDelay = util.Duration(5 * time.Second)
+	// DefaultSpecFetchErrorMaxDelay caps exponential backoff after failed /rendered polls
+	DefaultSpecFetchErrorMaxDelay = util.Duration(5 * time.Minute)
 	// DefaultEnrollmentVerifyInterval is the default initial interval between checks for
 	// enrollment approval while the agent waits to be enrolled.
 	DefaultEnrollmentVerifyInterval = util.Duration(10 * time.Second)
@@ -106,6 +110,11 @@ type Config struct {
 	// This field is deprecated and will be removed in a future release. The functionality
 	// is controlled by the server rendered wait timeout.
 	SpecFetchInterval util.Duration `json:"spec-fetch-interval,omitempty"`
+	// SpecFetchErrorBaseDelay is the initial delay after a failed /rendered poll before retrying.
+	// Subsequent failures double this delay up to SpecFetchErrorMaxDelay.
+	SpecFetchErrorBaseDelay util.Duration `json:"spec-fetch-error-base-delay,omitempty"`
+	// SpecFetchErrorMaxDelay is the maximum delay between /rendered retries after repeated failures.
+	SpecFetchErrorMaxDelay util.Duration `json:"spec-fetch-error-max-delay,omitempty"`
 	// StatusUpdateInterval is the interval between two status updates
 	StatusUpdateInterval util.Duration `json:"status-update-interval,omitempty"`
 	// EnrollmentVerifyInterval is the initial interval between checks for enrollment
@@ -228,6 +237,8 @@ func NewDefault() *Config {
 		DataDir:                  DefaultDataDir,
 		StatusUpdateInterval:     DefaultStatusUpdateInterval,
 		SpecFetchInterval:        DefaultSpecFetchInterval,
+		SpecFetchErrorBaseDelay:  DefaultSpecFetchErrorBaseDelay,
+		SpecFetchErrorMaxDelay:   DefaultSpecFetchErrorMaxDelay,
 		EnrollmentVerifyInterval: DefaultEnrollmentVerifyInterval,
 		EnrollmentVerifyCap:      DefaultEnrollmentVerifyCap,
 		EnrollmentVerifySteps:    DefaultEnrollmentVerifySteps,
@@ -493,6 +504,12 @@ func (cfg *Config) validateSyncIntervals() error {
 	if cfg.StatusUpdateInterval < MinSyncInterval {
 		return fmt.Errorf("minimum status update interval is %s have %s", MinSyncInterval, cfg.StatusUpdateInterval)
 	}
+	if cfg.SpecFetchErrorBaseDelay < MinSyncInterval {
+		return fmt.Errorf("minimum spec fetch error base delay is %s have %s", MinSyncInterval, cfg.SpecFetchErrorBaseDelay)
+	}
+	if cfg.SpecFetchErrorMaxDelay < cfg.SpecFetchErrorBaseDelay {
+		return fmt.Errorf("spec fetch error max delay %s must be >= base delay %s", cfg.SpecFetchErrorMaxDelay, cfg.SpecFetchErrorBaseDelay)
+	}
 	if cfg.EnrollmentVerifyInterval < MinSyncInterval {
 		return fmt.Errorf("minimum enrollment verify interval is %s have %s", MinSyncInterval, cfg.EnrollmentVerifyInterval)
 	}
@@ -562,6 +579,9 @@ func mergeConfigs(base, override *Config) {
 	// log
 	overrideIfNotEmpty(&base.LogLevel, override.LogLevel)
 	overrideIfNotEmpty(&base.LogPrefix, override.LogPrefix)
+
+	overrideIfNotEmpty(&base.SpecFetchErrorBaseDelay, override.SpecFetchErrorBaseDelay)
+	overrideIfNotEmpty(&base.SpecFetchErrorMaxDelay, override.SpecFetchErrorMaxDelay)
 
 	// system info
 	overrideSliceIfNotNil(&base.SystemInfo, override.SystemInfo)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/agent/client"
@@ -33,6 +34,8 @@ const (
 	DefaultSpecFetchInterval = util.Duration(60 * time.Second)
 	// DefaultStatusUpdateInterval is the default interval between two status updates
 	DefaultStatusUpdateInterval = util.Duration(60 * time.Second)
+	// DefaultStatusUpdateJitter is the default max random delay before the first status push
+	DefaultStatusUpdateJitter = DefaultStatusUpdateInterval
 	// DefaultSpecFetchErrorBaseDelay is the initial backoff after a failed /rendered poll
 	DefaultSpecFetchErrorBaseDelay = util.Duration(5 * time.Second)
 	// DefaultSpecFetchErrorMaxDelay caps exponential backoff after failed /rendered polls
@@ -98,6 +101,8 @@ const (
 	DefaultProfilingEnabled = false
 )
 
+var testRootDirWarningOnce sync.Once
+
 type Config struct {
 	config.ServiceConfig
 
@@ -117,6 +122,10 @@ type Config struct {
 	SpecFetchErrorMaxDelay util.Duration `json:"spec-fetch-error-max-delay,omitempty"`
 	// StatusUpdateInterval is the interval between two status updates
 	StatusUpdateInterval util.Duration `json:"status-update-interval,omitempty"`
+	// StatusUpdateJitter is the maximum random delay before the first status push after
+	// agent start. The delay is chosen uniformly in [0, StatusUpdateJitter). Zero disables
+	// jitter (immediate first push). Defaults to StatusUpdateInterval.
+	StatusUpdateJitter util.Duration `json:"status-update-jitter,omitempty"`
 	// EnrollmentVerifyInterval is the initial interval between checks for enrollment
 	// approval. Retries back off from this value (see agent.go's enrollment backoff).
 	EnrollmentVerifyInterval util.Duration `json:"enrollment-verify-interval,omitempty"`
@@ -236,6 +245,7 @@ func NewDefault() *Config {
 		ConfigDir:                DefaultConfigDir,
 		DataDir:                  DefaultDataDir,
 		StatusUpdateInterval:     DefaultStatusUpdateInterval,
+		StatusUpdateJitter:       DefaultStatusUpdateJitter,
 		SpecFetchInterval:        DefaultSpecFetchInterval,
 		SpecFetchErrorBaseDelay:  DefaultSpecFetchErrorBaseDelay,
 		SpecFetchErrorMaxDelay:   DefaultSpecFetchErrorMaxDelay,
@@ -266,7 +276,9 @@ func NewDefault() *Config {
 	}
 
 	if value := os.Getenv(TestRootDirEnvKey); value != "" {
-		fmt.Fprintf(os.Stderr, "WARNING: Setting testRootDir is intended for testing only. Do not use in production.\n")
+		testRootDirWarningOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "WARNING: Setting testRootDir is intended for testing only. Do not use in production.\n")
+		})
 		c.testRootDir = filepath.Clean(value)
 	}
 
@@ -504,6 +516,9 @@ func (cfg *Config) validateSyncIntervals() error {
 	if cfg.StatusUpdateInterval < MinSyncInterval {
 		return fmt.Errorf("minimum status update interval is %s have %s", MinSyncInterval, cfg.StatusUpdateInterval)
 	}
+	if cfg.StatusUpdateJitter < 0 {
+		return fmt.Errorf("status update jitter must be >= 0 have %s", cfg.StatusUpdateJitter)
+	}
 	if cfg.SpecFetchErrorBaseDelay < MinSyncInterval {
 		return fmt.Errorf("minimum spec fetch error base delay is %s have %s", MinSyncInterval, cfg.SpecFetchErrorBaseDelay)
 	}
@@ -582,6 +597,7 @@ func mergeConfigs(base, override *Config) {
 
 	overrideIfNotEmpty(&base.SpecFetchErrorBaseDelay, override.SpecFetchErrorBaseDelay)
 	overrideIfNotEmpty(&base.SpecFetchErrorMaxDelay, override.SpecFetchErrorMaxDelay)
+	overrideIfNotEmpty(&base.StatusUpdateJitter, override.StatusUpdateJitter)
 
 	// system info
 	overrideSliceIfNotNil(&base.SystemInfo, override.SystemInfo)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -54,6 +54,7 @@ type Agent struct {
 	osMode                 v1beta1.OsModeType
 
 	statusUpdateInterval util.Duration
+	statusUpdateJitter   util.Duration
 
 	backoff wait.Backoff
 	log     *log.PrefixLogger
@@ -69,6 +70,7 @@ func NewAgent(
 	appManager applications.Manager,
 	systemdManager systemd.Manager,
 	statusUpdateInterval util.Duration,
+	statusUpdateJitter util.Duration,
 	hookManager hook.Manager,
 	osManager os.Manager,
 	policyManager policy.Manager,
@@ -99,6 +101,7 @@ func NewAgent(
 		appManager:             appManager,
 		systemdManager:         systemdManager,
 		statusUpdateInterval:   statusUpdateInterval,
+		statusUpdateJitter:     statusUpdateJitter,
 		applicationsController: applicationsController,
 		configController:       configController,
 		resourceManager:        resourceManager,
@@ -121,6 +124,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		a.syncDeviceSpec,
 		a.statusUpdateInterval,
 		a.statusUpdate,
+		time.Duration(a.statusUpdateJitter),
 	)
 
 	return engine.Run(ctx)

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -539,6 +539,7 @@ func TestRollbackDevice(t *testing.T) {
 				mockOSClient,
 				v1beta1.OsModeImage,
 				poll.NewConfig(time.Second, 1.5),
+				poll.Config{BaseDelay: 5 * time.Second, Factor: 2, MaxDelay: 5 * time.Minute, JitterFactor: 0.2},
 				func() error { return nil },
 				mockAuditLogger,
 				log,

--- a/internal/agent/device/engine.go
+++ b/internal/agent/device/engine.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"math/rand/v2"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/util"
@@ -17,6 +18,11 @@ type Engine struct {
 	pushStatusInterval util.Duration
 	pushStatusFn       func(context.Context)
 
+	// statusStartupDelay waits this long after Run starts before the first
+	// status push (and before the status ticker). NewEngine picks a random
+	// value in [0, pushStatusInterval) to desynchronize fleets after restart.
+	statusStartupDelay time.Duration
+
 	clock Clock
 	// startedCh is used to signal when the ticker has started used for testing
 	startedCh chan struct{}
@@ -28,10 +34,16 @@ func NewEngine(
 	pushStatusInterval util.Duration,
 	pushStatusFn func(context.Context),
 ) *Engine {
+	interval := time.Duration(pushStatusInterval)
+	var startupDelay time.Duration
+	if interval > 0 {
+		startupDelay = time.Duration(rand.Int64N(int64(interval)))
+	}
 	return &Engine{
 		syncSpecFn:         syncSpecFn,
 		pushStatusInterval: pushStatusInterval,
 		pushStatusFn:       pushStatusFn,
+		statusStartupDelay: startupDelay,
 		clock:              &realClock{},
 		startedCh:          make(chan struct{}),
 	}
@@ -41,12 +53,27 @@ func (e *Engine) Run(ctx context.Context) error {
 	specTicker := e.clock.NewTicker(specSyncInterval)
 	defer specTicker.Stop()
 
-	statusTicker := e.clock.NewTicker(time.Duration(e.pushStatusInterval))
-	defer statusTicker.Stop()
+	statusInterval := time.Duration(e.pushStatusInterval)
+	var statusTicker Ticker
+	defer func() {
+		if statusTicker != nil {
+			statusTicker.Stop()
+		}
+	}()
 
-	// sync immediately on startup
+	// Spec sync immediately; status is delayed by statusStartupDelay so mass
+	// agent restarts do not align every status push on the same second.
 	e.syncSpecFn(ctx)
-	e.pushStatusFn(ctx)
+
+	var statusCh <-chan time.Time
+	var firstStatusCh <-chan time.Time
+	if e.statusStartupDelay <= 0 {
+		e.pushStatusFn(ctx)
+		statusTicker = e.clock.NewTicker(statusInterval)
+		statusCh = statusTicker.C()
+	} else {
+		firstStatusCh = e.clock.After(e.statusStartupDelay)
+	}
 
 	close(e.startedCh)
 	for {
@@ -58,7 +85,12 @@ func (e *Engine) Run(ctx context.Context) error {
 				return nil
 			}
 			e.syncSpecFn(ctx)
-		case t := <-statusTicker.C():
+		case <-firstStatusCh:
+			firstStatusCh = nil
+			e.pushStatusFn(ctx)
+			statusTicker = e.clock.NewTicker(statusInterval)
+			statusCh = statusTicker.C()
+		case t := <-statusCh:
 			if t.IsZero() {
 				return nil
 			}
@@ -71,6 +103,7 @@ func (e *Engine) Run(ctx context.Context) error {
 type Clock interface {
 	Now() time.Time
 	NewTicker(d time.Duration) Ticker
+	After(d time.Duration) <-chan time.Time
 }
 
 // Tick is an interface that resembles time.Ticker.
@@ -88,6 +121,10 @@ func (r *realClock) Now() time.Time {
 
 func (r *realClock) NewTicker(d time.Duration) Ticker {
 	return &realTicker{time.NewTicker(d)}
+}
+
+func (r *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
 }
 
 type realTicker struct {

--- a/internal/agent/device/engine.go
+++ b/internal/agent/device/engine.go
@@ -39,7 +39,7 @@ func NewEngine(
 ) *Engine {
 	var startupDelay time.Duration
 	if statusJitterMax > 0 {
-		startupDelay = time.Duration(rand.Int64N(int64(statusJitterMax)))
+		startupDelay = time.Duration(rand.Int64N(int64(statusJitterMax))) //nolint:gosec // G404: status-push jitter
 	}
 	return &Engine{
 		syncSpecFn:         syncSpecFn,

--- a/internal/agent/device/engine.go
+++ b/internal/agent/device/engine.go
@@ -29,15 +29,17 @@ type Engine struct {
 }
 
 // NewEngine creates a new device engine.
+// statusJitterMax is the maximum random delay before the first status push
+// (uniform in [0, statusJitterMax)). Zero disables jitter.
 func NewEngine(
 	syncSpecFn func(context.Context),
 	pushStatusInterval util.Duration,
 	pushStatusFn func(context.Context),
+	statusJitterMax time.Duration,
 ) *Engine {
-	interval := time.Duration(pushStatusInterval)
 	var startupDelay time.Duration
-	if interval > 0 {
-		startupDelay = time.Duration(rand.Int64N(int64(interval)))
+	if statusJitterMax > 0 {
+		startupDelay = time.Duration(rand.Int64N(int64(statusJitterMax)))
 	}
 	return &Engine{
 		syncSpecFn:         syncSpecFn,

--- a/internal/agent/device/engine_test.go
+++ b/internal/agent/device/engine_test.go
@@ -131,6 +131,7 @@ func TestEngineStatusStartupJitter(t *testing.T) {
 }
 
 type mockClock struct {
+	mu     sync.Mutex
 	now    time.Time
 	ticks  map[time.Duration]*mockTicker
 	afters []mockAfter
@@ -148,6 +149,11 @@ type mockTicker struct {
 	clock      *mockClock
 }
 
+type mockFire struct {
+	ch chan time.Time
+	t  time.Time
+}
+
 func newMockClock(start time.Time) *mockClock {
 	return &mockClock{
 		now:   start,
@@ -156,11 +162,15 @@ func newMockClock(start time.Time) *mockClock {
 }
 
 func (m *mockClock) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.now
 }
 
 // NewTicker creates a a mock ticker, storing its nextTickAt as now + duration.
 func (m *mockClock) NewTicker(d time.Duration) Ticker {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	t := &mockTicker{
 		c:          make(chan time.Time, 1),
 		d:          d,
@@ -172,6 +182,8 @@ func (m *mockClock) NewTicker(d time.Duration) Ticker {
 }
 
 func (m *mockClock) After(d time.Duration) <-chan time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	ch := make(chan time.Time, 1)
 	at := m.now.Add(d)
 	if !at.After(m.now) {
@@ -191,24 +203,26 @@ func (m *mockTicker) Stop() {
 }
 
 func (m *mockClock) Advance(d time.Duration) {
+	m.mu.Lock()
 	m.now = m.now.Add(d)
+	var fires []mockFire
 	remaining := m.afters[:0]
 	for _, a := range m.afters {
 		if !a.at.After(m.now) {
-			a.ch <- a.at
+			fires = append(fires, mockFire{ch: a.ch, t: a.at})
 			continue
 		}
 		remaining = append(remaining, a)
 	}
 	m.afters = remaining
-	// check how many intervals (dur) we crossed,
-	// send ticks for each crossing.
 	for dur, t := range m.ticks {
 		for !t.nextTickAt.After(m.now) {
-			// send a tick
-			t.c <- t.nextTickAt
-			// move forward by its interval.
+			fires = append(fires, mockFire{ch: t.c, t: t.nextTickAt})
 			t.nextTickAt = t.nextTickAt.Add(dur)
 		}
+	}
+	m.mu.Unlock()
+	for _, f := range fires {
+		f.ch <- f.t
 	}
 }

--- a/internal/agent/device/engine_test.go
+++ b/internal/agent/device/engine_test.go
@@ -82,9 +82,63 @@ func TestEngineRun(t *testing.T) {
 	cancel()
 }
 
+func TestEngineStatusStartupJitter(t *testing.T) {
+	require := require.New(t)
+
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mockClock := newMockClock(startTime)
+
+	var (
+		mu          sync.Mutex
+		statusCount int
+	)
+	engine := Engine{
+		syncSpecFn:         func(context.Context) {},
+		pushStatusInterval: util.Duration(60 * time.Second),
+		pushStatusFn: func(context.Context) {
+			mu.Lock()
+			defer mu.Unlock()
+			statusCount++
+		},
+		statusStartupDelay: 30 * time.Second,
+		clock:              mockClock,
+		startedCh:          make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		require.NoError(engine.Run(ctx))
+	}()
+	<-engine.startedCh
+
+	time.Sleep(10 * time.Millisecond)
+	mu.Lock()
+	require.Equal(0, statusCount, "status should wait for startup jitter")
+	mu.Unlock()
+
+	mockClock.Advance(30 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	require.Equal(1, statusCount, "status should push after jitter")
+	mu.Unlock()
+
+	mockClock.Advance(60 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	require.Equal(2, statusCount, "status ticker should start after first push")
+	mu.Unlock()
+}
+
 type mockClock struct {
-	now   time.Time
-	ticks map[time.Duration]*mockTicker
+	now    time.Time
+	ticks  map[time.Duration]*mockTicker
+	afters []mockAfter
+}
+
+type mockAfter struct {
+	at time.Time
+	ch chan time.Time
 }
 
 type mockTicker struct {
@@ -117,6 +171,17 @@ func (m *mockClock) NewTicker(d time.Duration) Ticker {
 	return t
 }
 
+func (m *mockClock) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	at := m.now.Add(d)
+	if !at.After(m.now) {
+		ch <- m.now
+		return ch
+	}
+	m.afters = append(m.afters, mockAfter{at: at, ch: ch})
+	return ch
+}
+
 func (m *mockTicker) C() <-chan time.Time {
 	return m.c
 }
@@ -127,6 +192,15 @@ func (m *mockTicker) Stop() {
 
 func (m *mockClock) Advance(d time.Duration) {
 	m.now = m.now.Add(d)
+	remaining := m.afters[:0]
+	for _, a := range m.afters {
+		if !a.at.After(m.now) {
+			a.ch <- a.at
+			continue
+		}
+		remaining = append(remaining, a)
+	}
+	m.afters = remaining
 	// check how many intervals (dur) we crossed,
 	// send ticks for each crossing.
 	for dur, t := range m.ticks {

--- a/internal/agent/device/engine_test.go
+++ b/internal/agent/device/engine_test.go
@@ -88,17 +88,12 @@ func TestEngineStatusStartupJitter(t *testing.T) {
 	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	mockClock := newMockClock(startTime)
 
-	var (
-		mu          sync.Mutex
-		statusCount int
-	)
+	pushed := make(chan struct{}, 8)
 	engine := Engine{
 		syncSpecFn:         func(context.Context) {},
 		pushStatusInterval: util.Duration(60 * time.Second),
 		pushStatusFn: func(context.Context) {
-			mu.Lock()
-			defer mu.Unlock()
-			statusCount++
+			pushed <- struct{}{}
 		},
 		statusStartupDelay: 30 * time.Second,
 		clock:              mockClock,
@@ -112,22 +107,25 @@ func TestEngineStatusStartupJitter(t *testing.T) {
 	}()
 	<-engine.startedCh
 
-	time.Sleep(10 * time.Millisecond)
-	mu.Lock()
-	require.Equal(0, statusCount, "status should wait for startup jitter")
-	mu.Unlock()
+	select {
+	case <-pushed:
+		t.Fatal("status should wait for startup jitter")
+	case <-time.After(20 * time.Millisecond):
+	}
 
 	mockClock.Advance(30 * time.Second)
-	time.Sleep(20 * time.Millisecond)
-	mu.Lock()
-	require.Equal(1, statusCount, "status should push after jitter")
-	mu.Unlock()
+	select {
+	case <-pushed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for status push after jitter")
+	}
 
 	mockClock.Advance(60 * time.Second)
-	time.Sleep(20 * time.Millisecond)
-	mu.Lock()
-	require.Equal(2, statusCount, "status ticker should start after first push")
-	mu.Unlock()
+	select {
+	case <-pushed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for status ticker push")
+	}
 }
 
 type mockClock struct {
@@ -199,7 +197,11 @@ func (m *mockTicker) C() <-chan time.Time {
 }
 
 func (m *mockTicker) Stop() {
-	close(m.c)
+	m.clock.mu.Lock()
+	defer m.clock.mu.Unlock()
+	if m.clock.ticks[m.d] == m {
+		delete(m.clock.ticks, m.d)
+	}
 }
 
 func (m *mockClock) Advance(d time.Duration) {

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -64,6 +64,7 @@ func NewManager(
 	osClient os.Client,
 	osMode v1beta1.OsModeType,
 	pollConfig poll.Config,
+	errorBackoff poll.Config,
 	deviceNotFoundHandler func() error,
 	auditLogger audit.Logger,
 	log *log.PrefixLogger,
@@ -98,7 +99,7 @@ func NewManager(
 		lastKnownVersion = desired.Version()
 	}
 
-	pub := newPublisher(deviceName, pollConfig, lastKnownVersion, deviceNotFoundHandler, log)
+	pub := newPublisher(deviceName, pollConfig, errorBackoff, lastKnownVersion, deviceNotFoundHandler, log)
 	m.publisher = pub
 	m.watcher = pub.Watch()
 

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	longPollTimeout = 4 * time.Minute
-	// defaultMinPollDelay is used when errorBackoff.BaseDelay is unset (tests).
+	// defaultMinPollDelay paces successful / no-content polls so a fast response
+	// does not immediately hammer /rendered. Error backoff uses a separate config.
 	defaultMinPollDelay       = 5 * time.Second
 	defaultErrorBackoffFactor = 2.0
 	defaultMaxErrorPollDelay  = 5 * time.Minute
@@ -252,7 +253,6 @@ func (n *publisher) Run(ctx context.Context) {
 	defer n.stop()
 	n.log.Debug("Starting publisher with continuous long-polling")
 
-	minDelay := n.errorBackoff.BaseDelay
 	errorTries := 0
 	backoffCfg := n.errorBackoff
 
@@ -273,8 +273,8 @@ func (n *publisher) Run(ctx context.Context) {
 			n.log.Debugf("Poll failed, backing off %v before next poll (attempt %d)", delay, errorTries)
 		} else {
 			errorTries = 0
-			if elapsed < minDelay {
-				delay = minDelay - elapsed
+			if elapsed < defaultMinPollDelay {
+				delay = defaultMinPollDelay - elapsed
 				n.log.Debugf("Poll completed quickly, waiting %v before next poll", delay)
 			}
 		}

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -19,11 +19,11 @@ import (
 
 const (
 	longPollTimeout = 4 * time.Minute
-	// minPollDelay is the minimum delay between polls to prevent hot-looping
-	minPollDelay = 5 * time.Second
-	// maxErrorPollDelay caps exponential backoff after /rendered failures
-	maxErrorPollDelay = 5 * time.Minute
-	errorBackoffFactor = 2.0
+	// defaultMinPollDelay is used when errorBackoff.BaseDelay is unset (tests).
+	defaultMinPollDelay = 5 * time.Second
+	defaultErrorBackoffFactor = 2.0
+	defaultMaxErrorPollDelay  = 5 * time.Minute
+	defaultErrorJitterFactor  = 0.2
 )
 
 // watcher wraps a ring buffer to implement the Watcher interface
@@ -67,20 +67,31 @@ type publisher struct {
 	stopped                     atomic.Bool
 	log                         *log.PrefixLogger
 	pollConfig                  poll.Config
+	errorBackoff                poll.Config
 	deviceNotFoundHandler       func() error
 	onConflictPausedInvalidator LastStatusInvalidator
-	minDelay                    time.Duration
 	mu                          sync.Mutex
+}
+
+func defaultErrorBackoff() poll.Config {
+	return poll.Config{
+		BaseDelay:    defaultMinPollDelay,
+		Factor:       defaultErrorBackoffFactor,
+		MaxDelay:     defaultMaxErrorPollDelay,
+		JitterFactor: defaultErrorJitterFactor,
+	}
 }
 
 func newPublisher(deviceName string,
 	pollConfig poll.Config,
+	errorBackoff poll.Config,
 	lastKnownVersion string,
 	deviceNotFoundHandler func() error,
 	log *log.PrefixLogger) Publisher {
 	return &publisher{
 		deviceName:            deviceName,
 		pollConfig:            pollConfig,
+		errorBackoff:          errorBackoff,
 		lastKnownVersion:      lastKnownVersion,
 		deviceNotFoundHandler: deviceNotFoundHandler,
 		log:                   log,
@@ -237,29 +248,13 @@ func (n *publisher) pollAndPublish(ctx context.Context) error {
 	return nil
 }
 
-func (n *publisher) errorBackoffConfig() poll.Config {
-	base := n.minDelay
-	if base == 0 {
-		base = minPollDelay
-	}
-	return poll.Config{
-		BaseDelay:    base,
-		Factor:       errorBackoffFactor,
-		MaxDelay:     maxErrorPollDelay,
-		JitterFactor: 0.2,
-	}
-}
-
 func (n *publisher) Run(ctx context.Context) {
 	defer n.stop()
 	n.log.Debug("Starting publisher with continuous long-polling")
 
-	minDelay := n.minDelay
-	if minDelay == 0 {
-		minDelay = minPollDelay
-	}
+	minDelay := n.errorBackoff.BaseDelay
 	errorTries := 0
-	backoffCfg := n.errorBackoffConfig()
+	backoffCfg := n.errorBackoff
 
 	for {
 		if ctx.Err() != nil {

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -21,6 +21,9 @@ const (
 	longPollTimeout = 4 * time.Minute
 	// minPollDelay is the minimum delay between polls to prevent hot-looping
 	minPollDelay = 5 * time.Second
+	// maxErrorPollDelay caps exponential backoff after /rendered failures
+	maxErrorPollDelay = 5 * time.Minute
+	errorBackoffFactor = 2.0
 )
 
 // watcher wraps a ring buffer to implement the Watcher interface
@@ -146,10 +149,13 @@ func (n *publisher) SetOnConflictPausedInvalidator(invalidator LastStatusInvalid
 	n.onConflictPausedInvalidator = invalidator
 }
 
-func (n *publisher) pollAndPublish(ctx context.Context) {
+// pollAndPublish fetches the rendered spec once. Returns a non-nil error for
+// failures that should trigger exponential backoff before the next poll.
+// 204/timeout and successful 200 return nil (normal pacing).
+func (n *publisher) pollAndPublish(ctx context.Context) error {
 	if n.stopped.Load() {
 		n.log.Debug("Publisher is stopped, skipping poll")
-		return
+		return nil
 	}
 
 	n.log.Debugf("Polling management service for new rendered device spec: last known version: %s", n.lastKnownVersion)
@@ -164,31 +170,30 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 		return n.getRenderedFromManagementAPIWithRetry(ctx, n.lastKnownVersion, newDesired)
 	})
 
-	// log slow calls
 	duration := time.Since(startTime)
 	if duration >= longPollTimeout {
 		n.log.Debugf("Dialing management API took: %v", duration)
 	}
 	if err != nil {
-		// Check for device not found error - handle certificate wiping and restart
 		if errors.Is(err, client.ErrDeviceNotFound) {
 			n.log.Warn("Device not found on management server")
-			if n.deviceNotFoundHandler != nil {
-				if handlerErr := n.deviceNotFoundHandler(); handlerErr != nil {
-					n.log.Warnf("Failed to handle device not found: %v", handlerErr)
-					return
-				}
-				n.log.Info("Successfully handled device not found - certificate wiped and agent restarted")
+			if n.deviceNotFoundHandler == nil {
+				return err
 			}
-			return
+			if handlerErr := n.deviceNotFoundHandler(); handlerErr != nil {
+				n.log.Warnf("Failed to handle device not found: %v", handlerErr)
+				return handlerErr
+			}
+			n.log.Info("Successfully handled device not found - certificate wiped and agent restarted")
+			return err
 		}
 
 		if errors.Is(err, errors.ErrNoContent) || errors.IsTimeoutError(err) {
 			n.log.Debug("No new template version from management service")
-			return
+			return nil
 		}
 		n.log.Errorf("Received non-retryable error from management service: %v", err)
-		return
+		return err
 	}
 
 	n.mu.Lock()
@@ -203,7 +208,6 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 	newVersion := newDesired.Version()
 	n.log.Debugf("Received rendered device with version: '%s'", newVersion)
 
-	// Parse versions with defaults
 	newVersionInt := int64(0)
 	if newVersion != "" {
 		if parsed, err := strconv.ParseInt(newVersion, 10, 64); err == nil {
@@ -218,7 +222,6 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 		}
 	}
 
-	// Update if new version is greater, or if either version is empty/invalid
 	if newVersionInt > lastVersionInt {
 		n.log.Infof("New spec version received: %s -> %s", n.lastKnownVersion, newVersion)
 		n.lastKnownVersion = newVersion
@@ -226,11 +229,24 @@ func (n *publisher) pollAndPublish(ctx context.Context) {
 		n.log.Debugf("Received rendered device with unchanged version %s (last known: %s)", newVersion, n.lastKnownVersion)
 	}
 
-	// notify all watchers of the new device spec
 	for _, w := range n.watchers {
 		if err := w.buffer.Push(newDesired); err != nil {
 			n.log.Errorf("Failed to notify watcher: %v", err)
 		}
+	}
+	return nil
+}
+
+func (n *publisher) errorBackoffConfig() poll.Config {
+	base := n.minDelay
+	if base == 0 {
+		base = minPollDelay
+	}
+	return poll.Config{
+		BaseDelay:    base,
+		Factor:       errorBackoffFactor,
+		MaxDelay:     maxErrorPollDelay,
+		JitterFactor: 0.2,
 	}
 }
 
@@ -242,6 +258,8 @@ func (n *publisher) Run(ctx context.Context) {
 	if minDelay == 0 {
 		minDelay = minPollDelay
 	}
+	errorTries := 0
+	backoffCfg := n.errorBackoffConfig()
 
 	for {
 		if ctx.Err() != nil {
@@ -250,18 +268,30 @@ func (n *publisher) Run(ctx context.Context) {
 		}
 
 		startTime := time.Now()
-		n.pollAndPublish(ctx)
-
+		err := n.pollAndPublish(ctx)
 		elapsed := time.Since(startTime)
-		if elapsed < minDelay {
-			delay := minDelay - elapsed
-			n.log.Debugf("Poll completed quickly, waiting %v before next poll", delay)
-			select {
-			case <-ctx.Done():
-				n.log.Debug("Publisher context done during delay")
-				return
-			case <-time.After(delay):
+
+		var delay time.Duration
+		if err != nil {
+			errorTries++
+			delay = poll.CalculateBackoffDelay(&backoffCfg, errorTries)
+			n.log.Debugf("Poll failed, backing off %v before next poll (attempt %d)", delay, errorTries)
+		} else {
+			errorTries = 0
+			if elapsed < minDelay {
+				delay = minDelay - elapsed
+				n.log.Debugf("Poll completed quickly, waiting %v before next poll", delay)
 			}
+		}
+		if delay <= 0 {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			n.log.Debug("Publisher context done during delay")
+			return
+		case <-time.After(delay):
 		}
 	}
 }

--- a/internal/agent/device/spec/publisher.go
+++ b/internal/agent/device/spec/publisher.go
@@ -20,7 +20,7 @@ import (
 const (
 	longPollTimeout = 4 * time.Minute
 	// defaultMinPollDelay is used when errorBackoff.BaseDelay is unset (tests).
-	defaultMinPollDelay = 5 * time.Second
+	defaultMinPollDelay       = 5 * time.Second
 	defaultErrorBackoffFactor = 2.0
 	defaultMaxErrorPollDelay  = 5 * time.Minute
 	defaultErrorJitterFactor  = 0.2

--- a/internal/agent/device/spec/publisher_test.go
+++ b/internal/agent/device/spec/publisher_test.go
@@ -157,7 +157,7 @@ func TestDevicePublisher_pollAndNotify(t *testing.T) {
 		v := setup(tt)
 		defer v.finish()
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, http.StatusServiceUnavailable, specErr)
-		v.notifier.pollAndPublish(v.ctx)
+		_ = v.notifier.pollAndPublish(v.ctx)
 		_, popped, err := v.watcher.TryPop()
 		require.NoError(t, err)
 		require.False(t, popped)
@@ -166,7 +166,7 @@ func TestDevicePublisher_pollAndNotify(t *testing.T) {
 		v := setup(tt)
 		defer v.finish()
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, http.StatusNoContent, nil)
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(tt, v.notifier.pollAndPublish(v.ctx))
 		_, popped, err := v.watcher.TryPop()
 		require.NoError(t, err)
 		require.False(t, popped)
@@ -176,7 +176,7 @@ func TestDevicePublisher_pollAndNotify(t *testing.T) {
 		defer v.finish()
 		renderedDesiredSpec := createTestRenderedDevice("flightctl-device:v2")
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(renderedDesiredSpec, 200, nil)
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(tt, v.notifier.pollAndPublish(v.ctx))
 		result, popped, err := v.watcher.TryPop()
 		require.NoError(t, err)
 		require.True(t, popped)
@@ -305,7 +305,7 @@ func TestDevicePublisher_DeviceNotFoundHandling(t *testing.T) {
 			v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), v.deviceName, gomock.Any()).Return(nil, http.StatusNotFound, tt.mockReturnError)
 
 			// Call pollAndPublish
-			publisher.pollAndPublish(v.ctx)
+			_ = publisher.pollAndPublish(v.ctx)
 
 			// Verify the handler behavior
 			v.assertions.Equal(tt.expectedHandlerCalled, handlerCalled, tt.description)
@@ -339,7 +339,7 @@ func TestDevicePublisher_ConflictPausedCallback(t *testing.T) {
 
 		invalidator := &fakeLastStatusInvalidator{}
 		v.notifier.SetOnConflictPausedInvalidator(invalidator)
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(tt, v.notifier.pollAndPublish(v.ctx))
 
 		v.assertions.True(invalidator.invalidated, "InvalidateLastStatus should be called when device has ConflictPaused annotation")
 	})
@@ -353,7 +353,7 @@ func TestDevicePublisher_ConflictPausedCallback(t *testing.T) {
 
 		invalidator := &fakeLastStatusInvalidator{}
 		v.notifier.SetOnConflictPausedInvalidator(invalidator)
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(tt, v.notifier.pollAndPublish(v.ctx))
 
 		v.assertions.False(invalidator.invalidated, "InvalidateLastStatus should not be called when device has no ConflictPaused annotation")
 	})
@@ -473,7 +473,7 @@ func TestVersionComparison(t *testing.T) {
 			initialVersion := v.notifier.lastKnownVersion
 
 			// Call pollAndPublish
-			v.notifier.pollAndPublish(v.ctx)
+			require.NoError(t, v.notifier.pollAndPublish(v.ctx))
 
 			// Check if the version was updated
 			if tt.expectedUpdate {
@@ -501,7 +501,7 @@ func TestVersionComparisonWithRealAPI(t *testing.T) {
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), v.deviceName, gomock.Any()).Return(newDevice, http.StatusOK, nil)
 
 		// Call pollAndPublish
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(t, v.notifier.pollAndPublish(v.ctx))
 
 		// Verify version was updated
 		v.assertions.Equal("7", v.notifier.lastKnownVersion)
@@ -522,7 +522,7 @@ func TestVersionComparisonWithRealAPI(t *testing.T) {
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), v.deviceName, gomock.Any()).Return(newDevice, http.StatusOK, nil)
 
 		// Call pollAndPublish
-		v.notifier.pollAndPublish(v.ctx)
+		require.NoError(t, v.notifier.pollAndPublish(v.ctx))
 
 		// Verify version was NOT updated
 		v.assertions.Equal("10", v.notifier.lastKnownVersion)

--- a/internal/agent/device/spec/publisher_test.go
+++ b/internal/agent/device/spec/publisher_test.go
@@ -157,7 +157,7 @@ func TestDevicePublisher_pollAndNotify(t *testing.T) {
 		v := setup(tt)
 		defer v.finish()
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, http.StatusServiceUnavailable, specErr)
-		_ = v.notifier.pollAndPublish(v.ctx)
+		require.ErrorIs(tt, v.notifier.pollAndPublish(v.ctx), errors.ErrGettingDeviceSpec)
 		_, popped, err := v.watcher.TryPop()
 		require.NoError(t, err)
 		require.False(t, popped)

--- a/internal/agent/device/spec/publisher_test.go
+++ b/internal/agent/device/spec/publisher_test.go
@@ -52,6 +52,7 @@ func setupWithInitialVersion(t *testing.T, initialVersion string) *vars {
 		log:                         log.NewPrefixLogger(""),
 		lastKnownVersion:            initialVersion,
 		pollConfig:                  poll.NewConfig(time.Second, 1.5),
+		errorBackoff:                defaultErrorBackoff(),
 		deviceNotFoundHandler:       deviceNotFoundHandler,
 		onConflictPausedInvalidator: nil,
 	}
@@ -188,8 +189,9 @@ func TestDevicePublisher_Run(t *testing.T) {
 		v := setup(tt)
 		defer v.ctrl.Finish()
 
-		// short minDelay for testing
-		v.notifier.minDelay = 10 * time.Millisecond
+		// short base delay for testing
+		v.notifier.errorBackoff.BaseDelay = 10 * time.Millisecond
+		v.notifier.errorBackoff.MaxDelay = 50 * time.Millisecond
 
 		v.mockClient.EXPECT().GetRenderedDevice(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil, http.StatusNoContent, nil).AnyTimes()
@@ -538,7 +540,7 @@ func TestNewWithInitialVersion(t *testing.T) {
 
 	t.Run("creates publisher with initial version", func(t *testing.T) {
 		initialVersion := "42"
-		p := newPublisher("test-device", pollCfg, initialVersion, nil, log.NewPrefixLogger(""))
+		p := newPublisher("test-device", pollCfg, defaultErrorBackoff(), initialVersion, nil, log.NewPrefixLogger(""))
 
 		publisher, ok := p.(*publisher)
 		require.True(t, ok)
@@ -547,7 +549,7 @@ func TestNewWithInitialVersion(t *testing.T) {
 
 	t.Run("creates publisher with empty initial version", func(t *testing.T) {
 		initialVersion := ""
-		p := newPublisher("test-device", pollCfg, initialVersion, nil, log.NewPrefixLogger(""))
+		p := newPublisher("test-device", pollCfg, defaultErrorBackoff(), initialVersion, nil, log.NewPrefixLogger(""))
 
 		publisher, ok := p.(*publisher)
 		require.True(t, ok)

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -233,7 +233,7 @@ func TestEnsure(t *testing.T) {
 			deviceReadWriter: mockReadWriter,
 			queue:            mockPriorityQueue,
 			cache:            newCache(log),
-			publisher:        newPublisher("test", poll.NewConfig(time.Second, 1.5), "1", nil, log),
+			publisher:        newPublisher("test", poll.NewConfig(time.Second, 1.5), defaultErrorBackoff(), "1", nil, log),
 		}
 
 		// single loop: current exists, desired exists, rollback missing (allMissing=false, anyMissing=true)
@@ -852,7 +852,7 @@ func TestRollback(t *testing.T) {
 			)
 			log := log.NewPrefixLogger("test")
 			mockPolicyManager := policy.NewMockManager(ctrl)
-			pub := newPublisher("testDevice", poll.NewConfig(10*time.Millisecond, 1.5), "0", nil, log)
+			pub := newPublisher("testDevice", poll.NewConfig(10*time.Millisecond, 1.5), defaultErrorBackoff(), "0", nil, log)
 			cache := newCache(log)
 			queue := newQueueManager(
 				defaultSpecQueueMaxSize,

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -347,6 +347,9 @@ func NewTestHarness(ctx context.Context, testDirPath string, goRoutineErrorHandl
 	}
 	cfg.SpecFetchInterval = fetchSpecInterval
 	cfg.StatusUpdateInterval = statusUpdateInterval
+	// Disable startup status jitter so integration tests that wait on first status
+	// are not delayed by up to StatusUpdateInterval.
+	cfg.StatusUpdateJitter = 0
 	if err := cfg.Complete(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("NewTestHarness: %w", err)

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -456,11 +456,13 @@ func (h *TestHarness) StopAgent() {
 }
 
 func (h *TestHarness) StartAgent() {
-	agentLog := log.NewPrefixLogger("")
-
 	// Use SafeExecuter in tests to prevent dangerous commands like systemctl reboot
 	safeExec := testutil.NewDefaultSafeExecuter()
-	agentInstance := agent.New(agentLog, h.agentConfig, "", agent.WithExecuter(safeExec))
+	agentInstance, err := testutil.NewSimulatedAgent(h.agentConfig, "", agent.WithExecuter(safeExec))
+	if err != nil {
+		h.goRoutineErrorHandler(fmt.Errorf("error constructing agent: %w", err))
+		return
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h.agentFinished = make(chan struct{})

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -349,7 +349,8 @@ func NewTestHarness(ctx context.Context, testDirPath string, goRoutineErrorHandl
 	cfg.StatusUpdateInterval = statusUpdateInterval
 	// Disable startup status jitter so integration tests that wait on first status
 	// are not delayed by up to StatusUpdateInterval.
-	cfg.StatusUpdateJitter = 0
+	zeroJitter := util.Duration(0)
+	cfg.StatusUpdateJitter = &zeroJitter
 	if err := cfg.Complete(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("NewTestHarness: %w", err)

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -44,6 +44,7 @@ import (
 	"github.com/flightctl/flightctl/pkg/log"
 	"github.com/flightctl/flightctl/test/integration/integrationstack"
 	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/simagent"
 	"github.com/flightctl/flightctl/test/util/testdb"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -458,7 +459,7 @@ func (h *TestHarness) StopAgent() {
 func (h *TestHarness) StartAgent() {
 	// Use SafeExecuter in tests to prevent dangerous commands like systemctl reboot
 	safeExec := testutil.NewDefaultSafeExecuter()
-	agentInstance, err := testutil.NewSimulatedAgent(h.agentConfig, "", agent.WithExecuter(safeExec))
+	agentInstance, err := simagent.NewSimulatedAgent(h.agentConfig, "", agent.WithExecuter(safeExec))
 	if err != nil {
 		h.goRoutineErrorHandler(fmt.Errorf("error constructing agent: %w", err))
 		return

--- a/test/util/simagent.go
+++ b/test/util/simagent.go
@@ -52,7 +52,7 @@ func ReadBannerFile(agentDir string) (string, error) {
 // the poll error, if any.
 func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, timeout time.Duration) (string, error) {
 	enrollmentID := ""
-	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		bannerFileData, err := ReadBannerFile(agentDir)
 		if err != nil {
 			return false, nil
@@ -68,7 +68,7 @@ func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, tim
 // Returns the discovered enrollment ID (empty if never found) and a terminal error (nil on success).
 func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string, pollInterval, timeout time.Duration) (string, error) {
 	enrollmentID := ""
-	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		if enrollmentID == "" {
 			bannerFileData, err := ReadBannerFile(agentDir)
 			if err != nil {

--- a/test/util/simagent.go
+++ b/test/util/simagent.go
@@ -1,0 +1,105 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// NewSimulatedAgent finalizes cfg (Complete + Validate) and constructs the corresponding agent.Agent
+// with a prefixed logger. This consolidates the setup sequence previously duplicated between
+// devicesimulator and integration test harnesses.
+func NewSimulatedAgent(cfg *agent_config.Config, name string, opts ...agent.AgentOption) (*agent.Agent, error) {
+	if err := cfg.Complete(); err != nil {
+		return nil, fmt.Errorf("completing agent config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating agent config: %w", err)
+	}
+	logWithPrefix := flightlog.NewPrefixLogger(name)
+	if cfg.LogLevel != "" {
+		logWithPrefix.Level(cfg.LogLevel)
+	}
+	return agent.New(logWithPrefix, cfg, "", opts...), nil
+}
+
+// ReadBannerFile reads the enrollment banner file written by the agent's lifecycle manager under agentDir.
+func ReadBannerFile(agentDir string) (string, error) {
+	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
+	if _, err := os.Stat(bannerFile); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(bannerFile)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WaitForEnrollmentID polls agentDir's banner file until an enrollment ID appears, the context is
+// cancelled, or timeout elapses. Returns the discovered enrollment ID (empty if never found) and
+// the poll error, if any.
+func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		bannerFileData, err := ReadBannerFile(agentDir)
+		if err != nil {
+			return false, nil
+		}
+		enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+		return enrollmentID != "", nil
+	})
+	return enrollmentID, err
+}
+
+// ApproveEnrollment polls agentDir's banner file for the enrollment ID and repeatedly attempts to
+// approve it via serviceClient until it succeeds, the context is cancelled, or timeout elapses.
+// Returns the discovered enrollment ID (empty if never found) and a terminal error (nil on success).
+func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		if enrollmentID == "" {
+			bannerFileData, err := ReadBannerFile(agentDir)
+			if err != nil {
+				return false, nil
+			}
+			enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+			if enrollmentID == "" {
+				return false, nil
+			}
+		}
+		approveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
+			approveCtx,
+			enrollmentID,
+			v1beta1.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   labels,
+			})
+		if err != nil {
+			return false, nil
+		}
+		code := resp.StatusCode()
+		if code == http.StatusNotFound {
+			// no error, but don't treat as exceptional: there can be a race between posting and approving
+			return false, nil
+		}
+		if code < http.StatusOK || code >= http.StatusMultipleChoices {
+			return false, nil
+		}
+		return true, nil
+	})
+	return enrollmentID, err
+}

--- a/test/util/simagent/simagent.go
+++ b/test/util/simagent/simagent.go
@@ -1,4 +1,4 @@
-package util
+package simagent
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/test/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -57,7 +58,7 @@ func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, tim
 		if err != nil {
 			return false, nil
 		}
-		enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+		enrollmentID = util.GetEnrollmentIdFromText(bannerFileData)
 		return enrollmentID != "", nil
 	})
 	return enrollmentID, err
@@ -74,7 +75,7 @@ func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithR
 			if err != nil {
 				return false, nil
 			}
-			enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+			enrollmentID = util.GetEnrollmentIdFromText(bannerFileData)
 			if enrollmentID == "" {
 				return false, nil
 			}
@@ -93,7 +94,6 @@ func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithR
 		}
 		code := resp.StatusCode()
 		if code == http.StatusNotFound {
-			// no error, but don't treat as exceptional: there can be a race between posting and approving
 			return false, nil
 		}
 		if code < http.StatusOK || code >= http.StatusMultipleChoices {


### PR DESCRIPTION
## Summary
- Extract shared simulated-agent helpers into `test/util` and resume device identity across reruns
- Add enrollment outcome metrics, RPC error classification, and org logging
- Add `--clean`/`--clean-only`, `--fleet-count` distribution, standalone `--rollout`, and `make simulate-devices`

Branch is based on `EDM-4335-status-update-optimizations` (#3288). Prefer merging #3288 first (or together) so this lands cleanly on `main`.

## Test plan
- [ ] `go build ./cmd/devicesimulator/... ./test/util/... ./test/harness/...`
- [ ] `make simulate-devices ARGS='--count=1 --log-level=info'`
- [ ] `make simulate-devices ARGS='--clean-only'`
- [ ] `make simulate-devices ARGS='--count=10 --fleet-count=2'`
- [ ] Rollout: `make simulate-devices ARGS='--rollout --fleet-count=2 --rollout-template=<fleet.yaml>'`


Made with [Cursor](https://cursor.com)