### PR TITLE
NO-ISSUE: Stop systemd services and reset failed status after an app …

### DIFF
--- a/internal/agent/device/applications/lifecycle/quadlet.go
+++ b/internal/agent/device/applications/lifecycle/quadlet.go
@@ -146,36 +146,47 @@ func (q *Quadlet) add(ctx context.Context, action Action, systemctl systemd.Mana
 	return nil
 }
 
-func (q *Quadlet) remove(ctx context.Context, action Action, systemctl systemd.Manager) error {
+// stopUnits stops the application target and all loaded dependent services, then
+// clears any failed state left by non-zero exits. That is common when stopping
+// VM/virt-launcher units, which exit non-zero when killed by systemctl stop.
+// It does not remove unit files or Podman resources.
+//
+// An empty dependency list is not treated as target absence: list-dependencies
+// does not include the queried unit and a loaded target can have no transitive
+// deps. The target's load state is checked first; ListDependencies runs only
+// for loaded targets so a missing unit does not fail stop.
+//
+// Returns the dependency list (may be empty) so callers can update exclusions.
+func (q *Quadlet) stopUnits(ctx context.Context, action Action, systemctl systemd.Manager, target string) ([]string, error) {
 	appName := action.Name
 
-	target, err := targetName(action.ID)
+	targetUnits, err := q.loadedUnits(ctx, systemctl, []string{target})
 	if err != nil {
-		return fmt.Errorf("target name: %w", err)
+		return nil, fmt.Errorf("listing loading units: %w", err)
+	}
+	if _, loaded := targetUnits[target]; !loaded {
+		q.log.Debugf("Skipping stop for %s: target %s is not loaded", appName, target)
+		return nil, nil
 	}
 
 	services, err := systemctl.ListDependencies(ctx, target)
 	if err != nil {
-		return fmt.Errorf("listing dependencies: %w", err)
-	}
-
-	// If there are no dependencies, the target was never created or has already
-	// been removed. Skip stopping and proceed directly to resource cleanup for
-	// idempotent removal.
-	if len(services) == 0 {
-		q.log.Debugf("Skipping stop for %s: target has no dependencies", appName)
-		return q.cleanResources(ctx, action)
+		return nil, fmt.Errorf("listing dependencies: %w", err)
 	}
 
 	q.log.Debugf("Stopping quadlet: %s target: %s", appName, target)
-	// stopping the target will begin stopping the individual services, but it is not a synchronous operation.
+	// Stopping the target begins stopping the individual services, but it is not synchronous.
 	if err := systemctl.Stop(ctx, target); err != nil {
-		return fmt.Errorf("stopping target %s: %w", target, err)
+		return nil, fmt.Errorf("stopping target %s: %w", target, err)
+	}
+
+	if len(services) == 0 {
+		return services, nil
 	}
 
 	unitSet, err := q.loadedUnits(ctx, systemctl, services)
 	if err != nil {
-		return fmt.Errorf("listing loading units: %w", err)
+		return nil, fmt.Errorf("listing loading units: %w", err)
 	}
 
 	if len(unitSet) > 0 {
@@ -183,17 +194,32 @@ func (q *Quadlet) remove(ctx context.Context, action Action, systemctl systemd.M
 		for service := range unitSet {
 			servicesToStop = append(servicesToStop, service)
 		}
-		// stop and wait for all services to finish
+		// Stop and wait for all services to finish.
 		q.log.Debugf("Stopping quadlet: %s services: %s", appName, strings.Join(servicesToStop, ", "))
 		if err := systemctl.Stop(ctx, servicesToStop...); err != nil {
-			return fmt.Errorf("stopping services: %w", err)
+			return nil, fmt.Errorf("stopping services: %w", err)
 		}
 		q.log.Debugf("Resetting failed state for services: %q", strings.Join(servicesToStop, ", "))
-		// Reset all services so that properties such as restart counts are reset
+		// Clear failed state (and restart counts) so stopped units do not linger in "Failed Units".
 		if err := systemctl.ResetFailed(ctx, servicesToStop...); err != nil {
-			return fmt.Errorf("resetting failed: %w", err)
+			return nil, fmt.Errorf("resetting failed: %w", err)
 		}
 	}
+
+	return services, nil
+}
+
+func (q *Quadlet) remove(ctx context.Context, action Action, systemctl systemd.Manager) error {
+	target, err := targetName(action.ID)
+	if err != nil {
+		return fmt.Errorf("target name: %w", err)
+	}
+
+	services, err := q.stopUnits(ctx, action, systemctl, target)
+	if err != nil {
+		return err
+	}
+
 	systemctl.RemoveExclusions(append(services, target)...)
 
 	return q.cleanResources(ctx, action)
@@ -284,13 +310,17 @@ func (q *Quadlet) resolveTarget(action Action) (systemd.Manager, string, error) 
 	return systemctl, target, nil
 }
 
-// Stop stops the application's systemd target without removing files or Podman resources.
+// Stop stops the application's systemd target and dependent services without
+// removing files or Podman resources. It also clears failed unit state so that
+// expected non-zero exits (for example virt-launcher killed on stop) do not
+// remain listed as Failed Units.
 func (q *Quadlet) Stop(ctx context.Context, action Action) error {
 	systemctl, target, err := q.resolveTarget(action)
 	if err != nil {
 		return err
 	}
-	return systemctl.Stop(ctx, target)
+	_, err = q.stopUnits(ctx, action, systemctl, target)
+	return err
 }
 
 // Start starts a previously stopped application's systemd target.

--- a/internal/agent/device/applications/lifecycle/quadlet_test.go
+++ b/internal/agent/device/applications/lifecycle/quadlet_test.go
@@ -46,6 +46,15 @@ func newMatcher(expected ...string) gomock.Matcher {
 	return &variadicMatcher{expected: expected}
 }
 
+func expectLoadedTarget(m *systemd.MockManager, target string) *gomock.Call {
+	return m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{target}).Return(
+		[]client.SystemDUnitListEntry{{Unit: target, LoadState: string(api.SystemdLoadStateLoaded)}}, nil)
+}
+
+func expectNotLoadedTarget(m *systemd.MockManager, target string) *gomock.Call {
+	return m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{target}).Return([]client.SystemDUnitListEntry{}, nil)
+}
+
 // unorderedMatcher matches variadic string arguments in any order
 type unorderedMatcher struct {
 	expected []string
@@ -112,6 +121,7 @@ func TestQuadlet_Execute(t *testing.T) {
 				ID:   "test-id",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "test-id-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return([]string{"test-id-app.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-app.service").Return(nil)
@@ -138,6 +148,7 @@ func TestQuadlet_Execute(t *testing.T) {
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
 				// Remove phase
+				expectLoadedTarget(mockSystemdMgr, "test-id-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return([]string{"test-id-app.service"}, nil).Times(2)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-app.service").Return(nil)
@@ -308,6 +319,7 @@ func TestQuadlet_add(t *testing.T) {
 				mockSystemdMgr.EXPECT().Logs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 				// Second call during cleanup (remove is called by defer)
+				expectLoadedTarget(mockSystemdMgr, "test-id-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return([]string{"test-id-app.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-flightctl-quadlet-app.target").Return(nil).AnyTimes()
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "test-id-app.service").Return(nil).AnyTimes()
@@ -416,6 +428,7 @@ func TestQuadlet_add(t *testing.T) {
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "create", "data")).Return("", "Error: creation failed", 1)
 
 				// Second call during cleanup (remove is called by defer)
+				expectLoadedTarget(mockSystemdMgr, "app-vol-fail-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-vol-fail-flightctl-quadlet-app.target").Return([]string{"app-vol-fail-app.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-vol-fail-flightctl-quadlet-app.target").Return(nil).AnyTimes()
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-vol-fail-app.service").Return(nil).AnyTimes()
@@ -484,6 +497,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-123",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-123-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-123-flightctl-quadlet-app.target").Return([]string{"app-123-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-123-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-123-web.service").Return(nil)
@@ -510,6 +524,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-456",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-456-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-456-flightctl-quadlet-app.target").Return(nil, fmt.Errorf("list dependencies failed"))
 			},
 			wantErr: true,
@@ -521,6 +536,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-999",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-999-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-999-flightctl-quadlet-app.target").Return([]string{"app-999-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-999-flightctl-quadlet-app.target").Return(fmt.Errorf("stop failed"))
 			},
@@ -533,6 +549,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-failed-1",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-failed-1-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-failed-1-flightctl-quadlet-app.target").Return([]string{"app-failed-1-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-failed-1-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-failed-1-web.service").Return(nil)
@@ -557,6 +574,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-multi",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-multi-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-multi-flightctl-quadlet-app.target").Return([]string{"app-multi-web.service", "app-multi-db.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-multi-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), newUnorderedMatcher("app-multi-web.service", "app-multi-db.service")).Return(nil)
@@ -582,6 +600,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-reset-fail",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-reset-fail-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-reset-fail-flightctl-quadlet-app.target").Return([]string{"app-reset-fail-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-reset-fail-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-reset-fail-web.service").Return(nil)
@@ -600,6 +619,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-list-fail",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-list-fail-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-list-fail-flightctl-quadlet-app.target").Return([]string{"app-list-fail-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-list-fail-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"app-list-fail-web.service"}).Return(nil, fmt.Errorf("list failed"))
@@ -613,6 +633,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-img-vol",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-img-vol-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-img-vol-flightctl-quadlet-app.target").Return([]string{"app-img-vol-web.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-img-vol-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-img-vol-web.service").Return(nil)
@@ -645,7 +666,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-no-vol",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
-				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-no-vol-flightctl-quadlet-app.target").Return([]string{}, nil)
+				expectNotLoadedTarget(mockSystemdMgr, "app-no-vol-flightctl-quadlet-app.target")
 
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("rm")).Return("", "", 0).AnyTimes()
@@ -664,7 +685,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-local-vol",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
-				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-local-vol-flightctl-quadlet-app.target").Return([]string{}, nil)
+				expectNotLoadedTarget(mockSystemdMgr, "app-local-vol-flightctl-quadlet-app.target")
 
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("rm")).Return("", "", 0).AnyTimes()
@@ -687,7 +708,7 @@ func TestQuadlet_remove(t *testing.T) {
 				ID:   "app-inspect-fail",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
-				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-inspect-fail-flightctl-quadlet-app.target").Return([]string{}, nil)
+				expectNotLoadedTarget(mockSystemdMgr, "app-inspect-fail-flightctl-quadlet-app.target")
 
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("rm")).Return("", "", 0).AnyTimes()
@@ -698,6 +719,44 @@ func TestQuadlet_remove(t *testing.T) {
 					Return(`[{"Name":"app-inspect-fail-gone"}]`, "", 0)
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume", "inspect", "app-inspect-fail-gone", "--format", "{{.Driver}}")).
 					Return("", "Error: no such volume", 1)
+			},
+			wantErr: false,
+		},
+		{
+			name: "When target is not loaded it should still clear the target exclusion",
+			action: Action{
+				Name: "test-app",
+				ID:   "app-excl-unloaded",
+			},
+			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectNotLoadedTarget(mockSystemdMgr, "app-excl-unloaded-flightctl-quadlet-app.target")
+				mockSystemdMgr.EXPECT().RemoveExclusions([]string{"app-excl-unloaded-flightctl-quadlet-app.target"})
+
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume")).Return("[]", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("rm")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("ps")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("network")).Return("", "", 0).AnyTimes()
+			},
+			wantErr: false,
+		},
+		{
+			name: "When target is loaded with no dependencies it should clear the target exclusion",
+			action: Action{
+				Name: "test-app",
+				ID:   "app-excl-empty",
+			},
+			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-excl-empty-flightctl-quadlet-app.target")
+				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-excl-empty-flightctl-quadlet-app.target").Return([]string{}, nil)
+				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-excl-empty-flightctl-quadlet-app.target").Return(nil)
+				mockSystemdMgr.EXPECT().RemoveExclusions([]string{"app-excl-empty-flightctl-quadlet-app.target"})
+
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume")).Return("[]", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("rm")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("ps")).Return("", "", 0).AnyTimes()
+				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("network")).Return("", "", 0).AnyTimes()
 			},
 			wantErr: false,
 		},
@@ -764,6 +823,7 @@ func TestQuadlet_update(t *testing.T) {
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("ps")).Return("", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("network")).Return("", "", 0).AnyTimes()
 
+				expectLoadedTarget(mockSystemdMgr, "app-123-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-123-flightctl-quadlet-app.target").Return([]string{"app-123-app.service"}, nil).Times(2)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-123-flightctl-quadlet-app.target").Return(nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-123-app.service").Return(nil)
@@ -785,6 +845,7 @@ func TestQuadlet_update(t *testing.T) {
 				ID:   "app-456",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app-456-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-456-flightctl-quadlet-app.target").Return([]string{"app-456-app.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app-456-flightctl-quadlet-app.target").Return(fmt.Errorf("stop failed"))
 			},
@@ -799,9 +860,9 @@ func TestQuadlet_update(t *testing.T) {
 				ID:   "app-789",
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
-				// When ListDependencies returns empty, we skip Stop and go directly
+				// When the target is not loaded, we skip Stop and go directly
 				// to cleanResources for idempotent removal
-				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app-789-flightctl-quadlet-app.target").Return([]string{}, nil)
+				expectNotLoadedTarget(mockSystemdMgr, "app-789-flightctl-quadlet-app.target")
 
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("volume")).Return("[]", "", 0).AnyTimes()
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", newMatcher("stop")).Return("", "", 0).AnyTimes()
@@ -873,10 +934,12 @@ func TestQuadlet_ExecuteMultipleActions(t *testing.T) {
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", gomock.Any()).Return("[]", "", 0).AnyTimes()
 
 				gomock.InOrder(
+					expectLoadedTarget(mockSystemdMgr, "app2-id-flightctl-quadlet-app.target"),
 					mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app2-id-flightctl-quadlet-app.target").Return([]string{"app2-id-web.service"}, nil),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app2-id-flightctl-quadlet-app.target").Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"app2-id-web.service"}).Return([]client.SystemDUnitListEntry{}, nil),
 
+					expectLoadedTarget(mockSystemdMgr, "app3-id-flightctl-quadlet-app.target"),
 					mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app3-id-flightctl-quadlet-app.target").Return([]string{"app3-id-web.service"}, nil),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app3-id-flightctl-quadlet-app.target").Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"app3-id-web.service"}).Return([]client.SystemDUnitListEntry{}, nil),
@@ -908,10 +971,12 @@ func TestQuadlet_ExecuteMultipleActions(t *testing.T) {
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", gomock.Any()).Return("[]", "", 0).AnyTimes()
 
 				gomock.InOrder(
+					expectLoadedTarget(mockSystemdMgr, "old1-id-flightctl-quadlet-app.target"),
 					mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "old1-id-flightctl-quadlet-app.target").Return([]string{"old1-id-old1.service"}, nil),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), "old1-id-flightctl-quadlet-app.target").Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"old1-id-old1.service"}).Return([]client.SystemDUnitListEntry{}, nil),
 
+					expectLoadedTarget(mockSystemdMgr, "old2-id-flightctl-quadlet-app.target"),
 					mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "old2-id-flightctl-quadlet-app.target").Return([]string{"old2-id-old2.service"}, nil),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), "old2-id-flightctl-quadlet-app.target").Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"old2-id-old2.service"}).Return([]client.SystemDUnitListEntry{}, nil),
@@ -938,6 +1003,7 @@ func TestQuadlet_ExecuteMultipleActions(t *testing.T) {
 				{Type: ActionAdd, Name: "app2", ID: "app2-id", Path: "/path/app2"},
 			},
 			setupMocks: func(mockSystemdMgr *systemd.MockManager, mockRW *fileio.MockReadWriter, mockExec *executer.MockExecuter) {
+				expectLoadedTarget(mockSystemdMgr, "app1-id-flightctl-quadlet-app.target")
 				mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app1-id-flightctl-quadlet-app.target").Return([]string{"app1-id-app1.service"}, nil)
 				mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app1-id-flightctl-quadlet-app.target").Return(fmt.Errorf("stop failed"))
 			},
@@ -953,6 +1019,7 @@ func TestQuadlet_ExecuteMultipleActions(t *testing.T) {
 				mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "podman", gomock.Any()).Return("[]", "", 0).AnyTimes()
 
 				gomock.InOrder(
+					expectLoadedTarget(mockSystemdMgr, "app1-id-flightctl-quadlet-app.target"),
 					mockSystemdMgr.EXPECT().ListDependencies(gomock.Any(), "app1-id-flightctl-quadlet-app.target").Return([]string{"app1-id-app1.service"}, nil),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), "app1-id-flightctl-quadlet-app.target").Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"app1-id-app1.service"}).Return([]client.SystemDUnitListEntry{}, nil),
@@ -1234,12 +1301,20 @@ func TestQuadlet_LifecycleHandler(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name: "When Stop is called it should stop the target unit without daemon reload or resource cleanup",
+			name: "When Stop is called it should stop the target and reset failed dependent services",
 			operation: func(q *Quadlet, action Action) error {
 				return q.Stop(context.Background(), action)
 			},
 			setupMocks: func(m *systemd.MockManager) {
+				expectLoadedTarget(m, testTarget)
+				m.EXPECT().ListDependencies(gomock.Any(), testTarget).Return([]string{"test-id-app.service"}, nil)
 				m.EXPECT().Stop(gomock.Any(), testTarget).Return(nil)
+				units := []client.SystemDUnitListEntry{
+					{Unit: "test-id-app.service", LoadState: "loaded", ActiveState: string(api.SystemdActiveStateInactive), SubState: "dead", Description: "Test service"},
+				}
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"test-id-app.service"}).Return(units, nil)
+				m.EXPECT().Stop(gomock.Any(), "test-id-app.service").Return(nil)
+				m.EXPECT().ResetFailed(gomock.Any(), "test-id-app.service").Return(nil)
 			},
 		},
 		{
@@ -1248,7 +1323,47 @@ func TestQuadlet_LifecycleHandler(t *testing.T) {
 				return q.Stop(context.Background(), action)
 			},
 			setupMocks: func(m *systemd.MockManager) {
+				expectLoadedTarget(m, testTarget)
+				m.EXPECT().ListDependencies(gomock.Any(), testTarget).Return([]string{"test-id-app.service"}, nil)
 				m.EXPECT().Stop(gomock.Any(), testTarget).Return(fmt.Errorf("unit not found"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "When Stop finds the target not loaded it should succeed without stopping",
+			operation: func(q *Quadlet, action Action) error {
+				return q.Stop(context.Background(), action)
+			},
+			setupMocks: func(m *systemd.MockManager) {
+				expectNotLoadedTarget(m, testTarget)
+			},
+		},
+		{
+			name: "When Stop finds a loaded target with no dependencies it should stop only the target",
+			operation: func(q *Quadlet, action Action) error {
+				return q.Stop(context.Background(), action)
+			},
+			setupMocks: func(m *systemd.MockManager) {
+				expectLoadedTarget(m, testTarget)
+				m.EXPECT().ListDependencies(gomock.Any(), testTarget).Return(nil, nil)
+				m.EXPECT().Stop(gomock.Any(), testTarget).Return(nil)
+			},
+		},
+		{
+			name: "When Stop reset-failed fails it should propagate the error",
+			operation: func(q *Quadlet, action Action) error {
+				return q.Stop(context.Background(), action)
+			},
+			setupMocks: func(m *systemd.MockManager) {
+				expectLoadedTarget(m, testTarget)
+				m.EXPECT().ListDependencies(gomock.Any(), testTarget).Return([]string{"test-id-app.service"}, nil)
+				m.EXPECT().Stop(gomock.Any(), testTarget).Return(nil)
+				units := []client.SystemDUnitListEntry{
+					{Unit: "test-id-app.service", LoadState: "loaded", ActiveState: string(api.SystemdActiveStateFailed), SubState: "failed", Description: "Test service"},
+				}
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{"test-id-app.service"}).Return(units, nil)
+				m.EXPECT().Stop(gomock.Any(), "test-id-app.service").Return(nil)
+				m.EXPECT().ResetFailed(gomock.Any(), "test-id-app.service").Return(fmt.Errorf("reset failed"))
 			},
 			wantErr: true,
 		},

--- a/internal/agent/device/applications/manager_test.go
+++ b/internal/agent/device/applications/manager_test.go
@@ -162,6 +162,8 @@ func TestManager(t *testing.T) {
 					mockExecPodmanEvents(mockExec, bootTime),
 
 					// remove quadlet app (second AfterUpdate after syncProviders)
+					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{target}).Return(
+						[]client.SystemDUnitListEntry{{Unit: target, LoadState: "loaded"}}, nil),
 					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), target).Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return([]client.SystemDUnitListEntry{{Unit: services[0], LoadState: "loaded"}}, nil),
@@ -197,6 +199,8 @@ func TestManager(t *testing.T) {
 					mockExecPodmanEvents(mockExec, bootTime),
 
 					// update: stop current quadlet app (remove phase)
+					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{target}).Return(
+						[]client.SystemDUnitListEntry{{Unit: target, LoadState: "loaded"}}, nil),
 					mockExecSystemdListDependencies(mockSystemdMgr, appID, services),
 					mockSystemdMgr.EXPECT().Stop(gomock.Any(), target).Return(nil),
 					mockSystemdMgr.EXPECT().ListUnitsByMatchPattern(gomock.Any(), services).Return([]client.SystemDUnitListEntry{{Unit: services[0], LoadState: "loaded"}}, nil),

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -1649,23 +1649,43 @@ func TestPodmanMonitorLifecycleDispatch(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "When StopApp is called for a quadlet app it should stop the target",
+			name:    "When StopApp is called for a quadlet app it should stop the target and reset failed services",
 			appType: v1beta1.AppTypeQuadlet,
 			operation: func(m *PodmanMonitor, appID string) error {
 				return m.StopApp(context.Background(), appID)
 			},
 			setupMocks: func(m *systemd.MockManager) {
+				svc := appID + "-app.service"
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{targetName}).Return(
+					[]client.SystemDUnitListEntry{{Unit: targetName, LoadState: "loaded"}}, nil)
+				m.EXPECT().ListDependencies(gomock.Any(), targetName).Return([]string{svc}, nil)
 				m.EXPECT().Stop(gomock.Any(), targetName).Return(nil)
+				units := []client.SystemDUnitListEntry{
+					{Unit: svc, LoadState: "loaded", ActiveState: string(v1beta1.SystemdActiveStateInactive), SubState: "dead"},
+				}
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{svc}).Return(units, nil)
+				m.EXPECT().Stop(gomock.Any(), svc).Return(nil)
+				m.EXPECT().ResetFailed(gomock.Any(), svc).Return(nil)
 			},
 		},
 		{
-			name:    "When StopApp is called for a container app it should stop the target via quadlet handler",
+			name:    "When StopApp is called for a container app it should stop via quadlet handler and reset failed services",
 			appType: v1beta1.AppTypeContainer,
 			operation: func(m *PodmanMonitor, appID string) error {
 				return m.StopApp(context.Background(), appID)
 			},
 			setupMocks: func(m *systemd.MockManager) {
+				svc := appID + "-app.service"
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{targetName}).Return(
+					[]client.SystemDUnitListEntry{{Unit: targetName, LoadState: "loaded"}}, nil)
+				m.EXPECT().ListDependencies(gomock.Any(), targetName).Return([]string{svc}, nil)
 				m.EXPECT().Stop(gomock.Any(), targetName).Return(nil)
+				units := []client.SystemDUnitListEntry{
+					{Unit: svc, LoadState: "loaded", ActiveState: string(v1beta1.SystemdActiveStateInactive), SubState: "dead"},
+				}
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{svc}).Return(units, nil)
+				m.EXPECT().Stop(gomock.Any(), svc).Return(nil)
+				m.EXPECT().ResetFailed(gomock.Any(), svc).Return(nil)
 			},
 		},
 		{
@@ -1689,13 +1709,23 @@ func TestPodmanMonitorLifecycleDispatch(t *testing.T) {
 			},
 		},
 		{
-			name:    "When StopApp is called for a VM app it should stop the target via quadlet handler",
+			name:    "When StopApp is called for a VM app it should stop via quadlet handler and reset failed services",
 			appType: v1beta1.AppTypeVm,
 			operation: func(m *PodmanMonitor, appID string) error {
 				return m.StopApp(context.Background(), appID)
 			},
 			setupMocks: func(m *systemd.MockManager) {
+				svc := appID + "-virt-launcher-compute.service"
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{targetName}).Return(
+					[]client.SystemDUnitListEntry{{Unit: targetName, LoadState: "loaded"}}, nil)
+				m.EXPECT().ListDependencies(gomock.Any(), targetName).Return([]string{svc}, nil)
 				m.EXPECT().Stop(gomock.Any(), targetName).Return(nil)
+				units := []client.SystemDUnitListEntry{
+					{Unit: svc, LoadState: "loaded", ActiveState: string(v1beta1.SystemdActiveStateFailed), SubState: "failed"},
+				}
+				m.EXPECT().ListUnitsByMatchPattern(gomock.Any(), []string{svc}).Return(units, nil)
+				m.EXPECT().Stop(gomock.Any(), svc).Return(nil)
+				m.EXPECT().ResetFailed(gomock.Any(), svc).Return(nil)
 			},
 		},
 	}


### PR DESCRIPTION
Stop systemd services and reset failed status after an app stop

Lifecycle Stop previously only stopped the Quadlet app target. Dependent units (for example VM virt-launcher compute services) were left to stop asynchronously and often exited non-zero when killed by systemd, so they remained listed under Failed Units even though the app was intentionally stopped.
Reuse the same stop path already used on remove: stop the target, stop loaded dependent services, then reset-failed. Unit files and Podman resources are still kept so start/restart can bring the app back without redeploying.