### PR TITLE
EDM-4777: Register encryption metrics collector before canary validation

### DIFF
--- a/cmd/flightctl-api/main.go
+++ b/cmd/flightctl-api/main.go
@@ -77,6 +77,15 @@ func main() {
 		log.Fatalf("initializing encryption: %v", err)
 	}
 
+	var encCollector prometheus.Collector
+	if cfg.Metrics != nil && cfg.Metrics.Enabled {
+		if encMgr := encryption.GlobalManager(); encMgr != nil {
+			ec := encmetrics.NewEncryptionCollector(encMgr)
+			encMgr.SetMetricsRecorder(ec)
+			encCollector = ec
+		}
+	}
+
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
@@ -199,9 +208,7 @@ func main() {
 			}
 		}
 
-		if encMgr := encryption.GlobalManager(); encMgr != nil {
-			encCollector := encmetrics.NewEncryptionCollector(encMgr)
-			encMgr.SetMetricsRecorder(encCollector)
+		if encCollector != nil {
 			collectors = append(collectors, encCollector)
 		}
 

--- a/cmd/flightctl-worker/main.go
+++ b/cmd/flightctl-worker/main.go
@@ -56,6 +56,15 @@ func main() {
 		log.Fatalf("initializing encryption: %v", err)
 	}
 
+	var encCollector prometheus.Collector
+	if cfg.Metrics != nil && cfg.Metrics.Enabled {
+		if encMgr := encryption.GlobalManager(); encMgr != nil {
+			ec := encmetrics.NewEncryptionCollector(encMgr)
+			encMgr.SetMetricsRecorder(ec)
+			encCollector = ec
+		}
+	}
+
 	log.Println("Initializing data store")
 	db, err := store.InitDB(cfg, log)
 	if err != nil {
@@ -105,9 +114,7 @@ func main() {
 			}
 		}
 
-		if encMgr := encryption.GlobalManager(); encMgr != nil {
-			encCollector := encmetrics.NewEncryptionCollector(encMgr)
-			encMgr.SetMetricsRecorder(encCollector)
+		if encCollector != nil {
 			collectors = append(collectors, encCollector)
 		}
 


### PR DESCRIPTION
The encryption canary validations metric was never recorded because the metrics collector was created after canary validation already ran during startup. Move collector creation to right after InitGlobalEncryption so the recorder is available when canaryservice.InitEncryption validates.
