### PR TITLE
EDM-4768: add package-mode e2e suite

### DIFF
--- a/.github/actions/resolve-go-e2e-dirs/action.yaml
+++ b/.github/actions/resolve-go-e2e-dirs/action.yaml
@@ -37,13 +37,34 @@ runs:
 
         excluded_dirs=()
         if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
-          # Tolerate not-yet-present exclude paths so infra PRs can land
-          # before the excluded suite directory exists.
-          mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
-          for dir in "${excluded_dirs_abs[@]}"; do
-            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
-            excluded_dirs+=("./${rel_dir#./}")
-          done
+          # Tolerate only absent exclude paths so infra PRs can land before the
+          # suite directory exists. Propagate other go list failures.
+          exclude_err_file="$(mktemp)"
+          set +e
+          mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>"${exclude_err_file}")
+          exclude_status=$?
+          set -e
+          if [[ "${exclude_status}" -ne 0 ]]; then
+            exclude_err="$(cat "${exclude_err_file}")"
+            rm -f "${exclude_err_file}"
+            if [[ "${exclude_err}" == *"no Go files"* ]] || \
+               [[ "${exclude_err}" == *"matched no packages"* ]] || \
+               [[ "${exclude_err}" == *"cannot find package"* ]] || \
+               [[ "${exclude_err}" == *"directory not found"* ]]; then
+              echo "Exclusion path not present yet; continuing without exclusions"
+              echo "${exclude_err}"
+            else
+              echo "ERROR: failed to resolve excluded_go_e2e_dirs: ${EXCLUDED_GO_E2E_DIRS}" >&2
+              echo "${exclude_err}" >&2
+              exit "${exclude_status}"
+            fi
+          else
+            rm -f "${exclude_err_file}"
+            for dir in "${excluded_dirs_abs[@]}"; do
+              rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+              excluded_dirs+=("./${rel_dir#./}")
+            done
+          fi
         fi
 
         resolved_dirs=()

--- a/.github/actions/resolve-go-e2e-dirs/action.yaml
+++ b/.github/actions/resolve-go-e2e-dirs/action.yaml
@@ -1,0 +1,69 @@
+name: "Resolve Go E2E dirs"
+description: "Expand go_e2e_dirs globs to filesystem paths and subtract excluded dirs"
+
+inputs:
+  go_e2e_dirs:
+    description: "Space-separated Go package patterns (e.g. ./test/e2e/...)"
+    required: true
+  excluded_go_e2e_dirs:
+    description: "Optional space-separated Go package patterns to exclude"
+    required: false
+    default: ""
+
+outputs:
+  resolved_go_e2e_dirs:
+    description: "Space-separated repo-relative filesystem paths for ginkgo"
+    value: ${{ steps.resolve.outputs.resolved_go_e2e_dirs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve dirs
+      id: resolve
+      shell: bash
+      env:
+        GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+        EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
+      run: |
+        set -euo pipefail
+
+        repo_root="$(pwd -P)"
+        mapfile -t included_dirs_abs < <(go list -f '{{.Dir}}' ${GO_E2E_DIRS})
+        included_dirs=()
+        for dir in "${included_dirs_abs[@]}"; do
+          rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+          included_dirs+=("./${rel_dir#./}")
+        done
+
+        excluded_dirs=()
+        if [[ -n "${EXCLUDED_GO_E2E_DIRS}" ]]; then
+          # Tolerate not-yet-present exclude paths so infra PRs can land
+          # before the excluded suite directory exists.
+          mapfile -t excluded_dirs_abs < <(go list -f '{{.Dir}}' ${EXCLUDED_GO_E2E_DIRS} 2>/dev/null || true)
+          for dir in "${excluded_dirs_abs[@]}"; do
+            rel_dir="$(realpath --relative-to="${repo_root}" "${dir}")"
+            excluded_dirs+=("./${rel_dir#./}")
+          done
+        fi
+
+        resolved_dirs=()
+        for dir in "${included_dirs[@]}"; do
+          skip=false
+          for excluded in "${excluded_dirs[@]}"; do
+            if [[ "${dir}" == "${excluded}" ]]; then
+              skip=true
+              break
+            fi
+          done
+          if [[ "${skip}" != "true" ]]; then
+            resolved_dirs+=("${dir}")
+          fi
+        done
+
+        if [[ "${#resolved_dirs[@]}" -eq 0 ]]; then
+          echo "ERROR: No Go E2E dirs remain after exclusions"
+          exit 1
+        fi
+
+        printf 'resolved_go_e2e_dirs=%s\n' "${resolved_dirs[*]}" >> "$GITHUB_OUTPUT"
+        printf 'Resolved dirs: %s\n' "${resolved_dirs[*]}"

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -58,7 +58,7 @@ runs:
           sudo apt update -y 
           sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
                               virtinst bridge-utils qemu-system-x86 qemu-kvm \
-                              swtpm apparmor-utils
+                              swtpm apparmor-utils libguestfs-tools
           sudo usermod -a -G kvm,libvirt,swtpm $USER
           echo "::endgroup::"
 

--- a/.github/workflows/build-agent-images.yaml
+++ b/.github/workflows/build-agent-images.yaml
@@ -8,9 +8,19 @@ on:
         required: true
         type: string
       os_id:
-        description: "Agent Image OS ID (cs9-bootc / cs10-bootc)"
+        description: "Agent image OS ID (cs9-bootc / cs9-regular / cs10-bootc)"
         required: true
         type: string
+      build_type:
+        description: "Agent image build type (bootc / regular)"
+        required: false
+        type: string
+        default: "bootc"
+      upload_bundle:
+        description: "Whether this flavor should upload an agent image bundle artifact"
+        required: false
+        type: boolean
+        default: true
       tag:
         description: "Image tag"
         required: true
@@ -29,6 +39,8 @@ jobs:
       # "unknown version specified" (apt ships crun 1.14.1).
       - name: Setup dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          setup_kvm: yes
 
       - name: Restore bootc-image-builder cache
         id: cache-bootc-restore
@@ -54,6 +66,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           AGENT_IMAGE_OUTPUT: bundle
           AGENT_OS_ID: ${{ inputs.os_id }}
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           mkdir -p bin/rpm
           # Validate that both agent and selinux RPMs are present from the download step
@@ -87,6 +100,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload agent images bundle (per flavor)
+        if: ${{ inputs.upload_bundle }}
         uses: actions/upload-artifact@v4
         with:
           name: agent-images-bundle-${{ inputs.os_id }}-${{ inputs.tag }}
@@ -105,6 +119,7 @@ jobs:
           retention-days: 1
 
       - name: List bundled agent images
+        if: ${{ inputs.upload_bundle }}
         id: list-agent-images
         env:
           OS_ID: ${{ inputs.os_id }}
@@ -141,6 +156,7 @@ jobs:
           TAG: ${{ inputs.tag }}
           OS_ID: ${{ inputs.os_id }}
           RUN_ID: ${{ github.run_id }}
+          UPLOAD_BUNDLE: ${{ inputs.upload_bundle }}
           IMAGES: ${{ steps.list-agent-images.outputs.images }}
         run: |
           set -euo pipefail
@@ -151,7 +167,7 @@ jobs:
             echo "**Tag:** \`${TAG}\` | [All artifacts](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}#artifacts)"
             echo ""
             
-            if [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
+            if [ "${UPLOAD_BUNDLE}" = "true" ] && [ -n "$IMAGES" ] && [ "$IMAGES" != "Bundle inspection failed" ]; then
               echo "<details>"
               echo "<summary><strong>Container Images in Bundle</strong></summary>"
               echo ""
@@ -167,11 +183,17 @@ jobs:
             echo '```bash'
             echo "# Download artifacts"
             echo "mkdir -p bin/agent-artifacts bin/output/qcow2"
-            echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "gh run download ${RUN_ID} -n agent-images-bundle-${OS_ID}-${TAG} -D bin/agent-artifacts"
+            fi
             echo "gh run download ${RUN_ID} -n agent-qcow2-image-${OS_ID}-${TAG} -D bin/output/qcow2"
             echo ""
             echo "# Run e2e tests"
-            echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            if [ "${UPLOAD_BUNDLE}" = "true" ]; then
+              echo "AGENT_OS_ID=${OS_ID} make prepare-e2e-test run-e2e-test"
+            else
+              echo "# ${OS_ID} is qcow-only in CI; pair this qcow with a bootc agent bundle when running mixed-fleet package-mode tests"
+            fi
             echo '```'
             echo ""
             echo "</details>"

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -144,6 +144,10 @@ jobs:
             go_e2e_dirs: './test/e2e/...'
             excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
+          - label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/package_mode'
+            excluded_go_e2e_dirs: ''
+            ginkgo_total_nodes: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -264,6 +268,16 @@ jobs:
             image_mode_qcow_os_id: ''
             package_mode_qcow_env_var: ''
             image_mode_qcow_env_var: ''
+          - os_id: cs9-bootc
+            backend_type: helm
+            label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/package_mode'
+            excluded_go_e2e_dirs: ''
+            ginkgo_total_nodes: 1
+            package_mode_qcow_os_id: cs9-regular
+            image_mode_qcow_os_id: cs9-bootc
+            package_mode_qcow_env_var: 'E2E_PACKAGE_MODE_QCOW'
+            image_mode_qcow_env_var: 'E2E_IMAGE_MODE_QCOW'
     uses: ./.github/workflows/run-e2e-tests.yaml
     with:
       os_id: ${{ matrix.os_id }}

--- a/.github/workflows/pr-e2e-testing.yaml
+++ b/.github/workflows/pr-e2e-testing.yaml
@@ -109,12 +109,22 @@ jobs:
         include:
           - os_id: cs9-bootc
             rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: bootc
+            upload_bundle: true
+          - os_id: cs9-regular
+            rpm_suffix: centos-stream+epel-next-9-x86_64
+            build_type: regular
+            upload_bundle: false
           - os_id: cs10-bootc
             rpm_suffix: epel-10-x86_64
+            build_type: bootc
+            upload_bundle: true
     uses: ./.github/workflows/build-agent-images.yaml
     with:
       rpm_suffix: ${{ matrix.rpm_suffix }}
       os_id: ${{ matrix.os_id }}
+      build_type: ${{ matrix.build_type }}
+      upload_bundle: ${{ matrix.upload_bundle }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   discover-e2e-tests:
@@ -127,8 +137,12 @@ jobs:
       matrix:
         include:
           - label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
           - label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
     steps:
       - name: Checkout
@@ -139,20 +153,34 @@ jobs:
 
       - name: Compute label filter hash
         id: compute-hash
+        env:
+          GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ matrix.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ matrix.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${{ matrix.label_filter }}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "Label filter: ${{ matrix.label_filter }}"
+          echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        uses: ./.github/actions/resolve-go-e2e-dirs
+        with:
+          go_e2e_dirs: ${{ matrix.go_e2e_dirs }}
+          excluded_go_e2e_dirs: ${{ matrix.excluded_go_e2e_dirs }}
 
       - name: Run test discovery
         env:
           GINKGO_LABEL_FILTER: ${{ matrix.label_filter }}
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           DISCOVERY_ONLY: "true"
           DISCOVERY_PATH: discovery.json
         run: |
           mkdir -p reports
-          test/scripts/run_e2e_tests.sh reports ./test/e2e/...
+          test/scripts/run_e2e_tests.sh reports ${GO_E2E_DIRS}
 
       - name: Validate discovery results
         run: |
@@ -216,20 +244,38 @@ jobs:
           - os_id: cs9-bootc
             backend_type: helm
             label_filter: 'sanity'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 10
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
           ## CS10: agent tests only; microshift tests are excluded until the cs10-bootc kernel
           ## includes xt_conntrack/xt_comment modules required by kube-proxy. CS9 provides
           ## full microshift coverage via the v12 OKD SCOS variant.
           - os_id: cs10-bootc
             backend_type: helm
             label_filter: 'sanity && agent && !microshift'
+            go_e2e_dirs: './test/e2e/...'
+            excluded_go_e2e_dirs: './test/e2e/package_mode'
             ginkgo_total_nodes: 5
+            package_mode_qcow_os_id: ''
+            image_mode_qcow_os_id: ''
+            package_mode_qcow_env_var: ''
+            image_mode_qcow_env_var: ''
     uses: ./.github/workflows/run-e2e-tests.yaml
     with:
       os_id: ${{ matrix.os_id }}
       backend_type: ${{ matrix.backend_type }}
       ginkgo_total_nodes: ${{ matrix.ginkgo_total_nodes }}
       ginkgo_label_filter: ${{ matrix.label_filter }}
+      go_e2e_dirs: ${{ matrix.go_e2e_dirs }}
+      excluded_go_e2e_dirs: ${{ matrix.excluded_go_e2e_dirs }}
+      package_mode_qcow_os_id: ${{ matrix.package_mode_qcow_os_id }}
+      image_mode_qcow_os_id: ${{ matrix.image_mode_qcow_os_id }}
+      package_mode_qcow_env_var: ${{ matrix.package_mode_qcow_env_var }}
+      image_mode_qcow_env_var: ${{ matrix.image_mode_qcow_env_var }}
       tag: ${{ needs.compute-tag.outputs.tag }}
 
   api-tests:

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -22,6 +22,36 @@ on:
         required: false
         type: string
         default: "sanity"
+      go_e2e_dirs:
+        description: "Space-separated Go e2e package dirs passed to run_e2e_tests.sh"
+        required: false
+        type: string
+        default: "./test/e2e/..."
+      excluded_go_e2e_dirs:
+        description: "Optional Go e2e package dirs to exclude after resolving go_e2e_dirs"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be staged as the primary package-mode qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_os_id:
+        description: "Optional OS flavor whose qcow should be injected for mixed-fleet package-mode tests"
+        required: false
+        type: string
+        default: ""
+      package_mode_qcow_env_var:
+        description: "Optional env var name that should point to the primary staged qcow"
+        required: false
+        type: string
+        default: ""
+      image_mode_qcow_env_var:
+        description: "Optional env var name that should point to the secondary staged qcow"
+        required: false
+        type: string
+        default: ""
       tag:
         description: "Image tag"
         required: true
@@ -103,9 +133,25 @@ jobs:
           path: test-artifacts
           merge-multiple: true
 
+      - name: Download image-mode qcow artifact
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.image_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-image-mode
+
+      - name: Download package-mode qcow artifact
+        if: ${{ inputs.package_mode_qcow_os_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-qcow2-image-${{ inputs.package_mode_qcow_os_id }}-${{ inputs.tag }}
+          path: test-artifacts-package-mode
+
       - name: Stage test artifacts
         env:
           OS_ID: ${{ inputs.os_id }}
+          PACKAGE_MODE_QCOW_OS_ID: ${{ inputs.package_mode_qcow_os_id }}
+          IMAGE_MODE_QCOW_OS_ID: ${{ inputs.image_mode_qcow_os_id }}
         run: |
           set -euo pipefail
           echo "Downloaded test artifacts:"
@@ -120,17 +166,37 @@ jobs:
           mv "test-artifacts/agent-images-bundle-${OS_ID}.tar" bin/agent-artifacts/
           echo "Agent bundle: bin/agent-artifacts/agent-images-bundle-${OS_ID}.tar"
 
-          # Stage qcow2
+          # Stage the primary qcow2 used by prepare-e2e-qcow-config.
           mkdir -p bin/output/qcow2
-          if [ ! -f "test-artifacts/disk.qcow2" ]; then
-            echo "ERROR: QCOW2 image not found"
-            exit 1
+          if [ -n "${PACKAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-package-mode/disk.qcow2" ]; then
+              echo "ERROR: Package-mode QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts-package-mode/disk.qcow2" bin/output/qcow2/disk.qcow2
+          else
+            if [ ! -f "test-artifacts/disk.qcow2" ]; then
+              echo "ERROR: QCOW2 image not found"
+              exit 1
+            fi
+            mv "test-artifacts/disk.qcow2" bin/output/qcow2/disk.qcow2
           fi
-          mv "test-artifacts/disk.qcow2" bin/output/qcow2/
           echo "✓ QCOW2 image: bin/output/qcow2/disk.qcow2"
+
+          if [ -n "${IMAGE_MODE_QCOW_OS_ID}" ]; then
+            if [ ! -f "test-artifacts-image-mode/disk.qcow2" ]; then
+              echo "ERROR: Image-mode QCOW2 image not found"
+              exit 1
+            fi
+            mkdir -p bin/output/qcow2-image-mode
+            mv "test-artifacts-image-mode/disk.qcow2" bin/output/qcow2-image-mode/
+            echo "✓ Image-mode QCOW2 image: bin/output/qcow2-image-mode/disk.qcow2"
+          fi
 
           # Cleanup
           rm -rf test-artifacts
+          rm -rf test-artifacts-package-mode
+          rm -rf test-artifacts-image-mode
 
           echo "Staged artifacts:"
           tree bin
@@ -154,6 +220,21 @@ jobs:
           # All dependencies are resolved automatically by Make
           make prepare-e2e-test
 
+      - name: Inject image-mode qcow for package-mode mixed-fleet tests
+        if: ${{ inputs.image_mode_qcow_os_id != '' }}
+        env:
+          IMAGE_MODE_QCOW: bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+          if [ ! -f "${IMAGE_MODE_QCOW}" ]; then
+            echo "ERROR: Secondary image-mode qcow not staged at ${IMAGE_MODE_QCOW}"
+            exit 1
+          fi
+
+          QCOW="${IMAGE_MODE_QCOW}" \
+          AGENT_DIR=bin/agent/etc/flightctl \
+          test/scripts/inject_agent_files_into_qcow.sh
+
       # ========== RUN E2E TESTS ==========
       - name: Restore Go cache
         uses: actions/cache/restore@v4
@@ -169,11 +250,22 @@ jobs:
         id: compute-hash
         env:
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
+          GO_E2E_DIRS: ${{ inputs.go_e2e_dirs }}
+          EXCLUDED_GO_E2E_DIRS: ${{ inputs.excluded_go_e2e_dirs }}
         run: |
-          HASH=$(printf '%s' "${GINKGO_LABEL_FILTER}" | sha256sum | cut -c1-8)
+          HASH=$(printf '%s::%s::%s' "${GINKGO_LABEL_FILTER}" "${GO_E2E_DIRS}" "${EXCLUDED_GO_E2E_DIRS}" | sha256sum | cut -c1-8)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
           echo "Label filter: ${GINKGO_LABEL_FILTER}"
+          echo "GO_E2E_DIRS: ${GO_E2E_DIRS}"
+          echo "EXCLUDED_GO_E2E_DIRS: ${EXCLUDED_GO_E2E_DIRS}"
           echo "Hash: ${HASH}"
+
+      - name: Resolve Go E2E dirs
+        id: resolve-go-e2e-dirs
+        uses: ./.github/actions/resolve-go-e2e-dirs
+        with:
+          go_e2e_dirs: ${{ inputs.go_e2e_dirs }}
+          excluded_go_e2e_dirs: ${{ inputs.excluded_go_e2e_dirs }}
 
       - name: Download test discovery
         uses: actions/download-artifact@v4
@@ -184,15 +276,41 @@ jobs:
       - name: Check disk space
         run: df -h
 
+      - name: Validate qcow inputs
+        env:
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" && ! -f "${PACKAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${PACKAGE_MODE_QCOW_ENV_VAR} requires qcow at ${PACKAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" && ! -f "${IMAGE_MODE_QCOW_PATH}" ]]; then
+            echo "ERROR: ${IMAGE_MODE_QCOW_ENV_VAR} requires qcow at ${IMAGE_MODE_QCOW_PATH}"
+            exit 1
+          fi
+
       - name: Run E2E Test Slice
         env:
+          GO_E2E_DIRS: ${{ steps.resolve-go-e2e-dirs.outputs.resolved_go_e2e_dirs }}
           GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_label_filter }}
           GINKGO_TOTAL_NODES: ${{ inputs.ginkgo_total_nodes }}
           GINKGO_NODE: ${{ matrix.ginkgo_node }}
           DISCOVERY_PATH: discovery.json
           ASSIGNMENTS_PATH: assignments.json
+          PACKAGE_MODE_QCOW_ENV_VAR: ${{ inputs.package_mode_qcow_env_var }}
+          IMAGE_MODE_QCOW_ENV_VAR: ${{ inputs.image_mode_qcow_env_var }}
+          PACKAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2/disk.qcow2
+          IMAGE_MODE_QCOW_PATH: ${{ github.workspace }}/bin/output/qcow2-image-mode/disk.qcow2
           RUNNER_DEBUG: ${{ runner.debug }}
         run: |
+          set -euo pipefail
+
           if [[ "${RUNNER_DEBUG}" == "1" ]]; then
             echo "Debug mode enabled"
             export DEBUG_VM_CONSOLE=1
@@ -200,6 +318,15 @@ jobs:
           else
             echo "Debug mode disabled"
           fi
+
+          if [[ -n "${PACKAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${PACKAGE_MODE_QCOW_ENV_VAR}=${PACKAGE_MODE_QCOW_PATH}"
+          fi
+
+          if [[ -n "${IMAGE_MODE_QCOW_ENV_VAR}" ]]; then
+            export "${IMAGE_MODE_QCOW_ENV_VAR}=${IMAGE_MODE_QCOW_PATH}"
+          fi
+
           make -e run-e2e-test
 
       - name: Check disk space after E2E tests

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -45,10 +45,11 @@ BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
 ```
 
 **Disk construction:** Uses a bootable CentOS GenericCloud qcow as the base, then
-installs packages on the host via `guestmount` + `dnf --installroot` (CentOS
-container). Guest `dnf` inside `virt-customize` is avoided — libguestfs guest
-networking is unreliable on GitHub-hosted runners. The OCI container image is not
-exported as the disk (no kernel/bootloader).
+installs packages via `guestmount` + `dnf --installroot` (CentOS container; flightctl
+RPMs with `tsflags=noscripts`). `virt-customize` then loads `flightctl_agent`, configures
+users/linger, and relabels — the build fails if the SELinux module is not loaded. Guest
+`dnf` inside `virt-customize` is avoided. The OCI container image is not exported as the
+disk (no kernel/bootloader).
 
 **E2E suite activation** is deferred to EDM-4768 / PR #3323 (`./test/e2e/package_mode`).
 The current bootc e2e rows exclude `./test/e2e/package_mode` via `excluded_go_e2e_dirs`.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -20,6 +20,7 @@ Defined in **test/test.mk** (included from root Makefile). Coverage reports go t
   - **Full flow (deploy + e2e):** `make e2e-test` – deploys cluster, builds e2e agent images, prepares qcow2, runs e2e.  
   - **Cluster already up:** `make in-cluster-e2e-test` – skips deploy, runs e2e.  
   - **Filter:** `GO_E2E_DIRS=test/e2e/agent`, `GINKGO_FOCUS="description"`, `GINKGO_PROCS=N`.  
+  - **Package-mode CI/local scope:** `GO_E2E_DIRS=./test/e2e/package_mode` runs the dedicated package-mode suite. Mixed-fleet coverage also needs `E2E_PACKAGE_MODE_QCOW` and `E2E_IMAGE_MODE_QCOW` to point at injected package-mode and image-mode qcows.
   - Some e2e suites (e.g. quadlets) need a quadlet-capable VM; see `test/e2e/quadlets/README.md` and `test/e2e/tpm/README.md`. Rollout tests use multiple VMs and have higher RAM requirements; see `test/e2e/rollout/README.md`.
 
 ## E2E layout and harness

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -44,10 +44,11 @@ The CI matrix includes a `cs9-regular` flavor that builds a package-mode QCOW2 i
 BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
 ```
 
-**GHA constraint:** Guest networking inside `virt-customize` is unavailable on
-GitHub-hosted runners (`libguestfs` `passt` requires user-namespace creation).
-`qcow2_regular.sh` downloads RPMs on the host via `sudo podman` and installs them
-offline with `virt-customize --no-network`.
+**Disk construction:** Uses a bootable CentOS GenericCloud qcow as the base, then
+installs packages on the host via `guestmount` + `dnf --installroot` (CentOS
+container). Guest `dnf` inside `virt-customize` is avoided — libguestfs guest
+networking is unreliable on GitHub-hosted runners. The OCI container image is not
+exported as the disk (no kernel/bootloader).
 
 **E2E suite activation** is deferred to EDM-4768 / PR #3323 (`./test/e2e/package_mode`).
 The current bootc e2e rows exclude `./test/e2e/package_mode` via `excluded_go_e2e_dirs`.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -32,6 +32,33 @@ Defined in **test/test.mk** (included from root Makefile). Coverage reports go t
 - **test/scripts/** – Environment setup, kind, certs (`create_e2e_certs.sh`), agent images, git-server, VM creation, redeploy. E2E certs/SSH under `bin/e2e-certs/`, `bin/.ssh/`.
 - **test/integration/** – Integration test packages (store, service, tasks, imagebuilder_worker, etc.); no kind; DB/KV/Alertmanager endpoints are resolved from **`podman port`** when integration containers exist (`test/util/testdb/integration_ports.go`, `test/util/integration_net.go` for Redis helpers).
 
+## Package-mode CI
+
+The CI matrix includes a `cs9-regular` flavor that builds a package-mode QCOW2 image
+(RPM-based, non-bootc). This flavor is built by `build-agent-images-unified` with
+`build_type: regular` and `upload_bundle: false` (QCOW2 only, no OCI bundle).
+
+**Local build:**
+
+```bash
+BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
+```
+
+**GHA constraint:** Guest networking inside `virt-customize` is unavailable on
+GitHub-hosted runners (`libguestfs` `passt` requires user-namespace creation).
+`qcow2_regular.sh` downloads RPMs on the host via `sudo podman` and installs them
+offline with `virt-customize --no-network`.
+
+**E2E suite activation** is deferred to EDM-4768 / PR #3323 (`./test/e2e/package_mode`).
+The current bootc e2e rows exclude `./test/e2e/package_mode` via `excluded_go_e2e_dirs`.
+
+**Reserved env vars for mixed-fleet runs** (staging inputs already in `run-e2e-tests.yaml`):
+
+| Variable | Purpose |
+|----------|---------|
+| `E2E_PACKAGE_MODE_QCOW` | Path to the package-mode QCOW2 disk image |
+| `E2E_IMAGE_MODE_QCOW` | Path to the image-mode (bootc) QCOW2 for mixed-fleet tests |
+
 ## Conventions
 
 - **Unit/integration:** Prefer table-driven tests; use `testify/require`; for agent code use gomock with `defer ctrl.Finish()`. See [internal/agent/AGENTS.md](../internal/agent/AGENTS.md) for agent-specific testing standards.

--- a/test/e2e/package_mode/package_mode_suite_test.go
+++ b/test/e2e/package_mode/package_mode_suite_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package packagemode_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/test/e2e/infra/auxiliary"
+	"github.com/flightctl/flightctl/test/e2e/infra/setup"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/login"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var packageModeAuxSvcs *auxiliary.Services
+
+func TestPackageMode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Package Mode E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	auxFuture := e2e.StartAuxServicesAsync(context.Background())
+	defer func() {
+		packageModeAuxSvcs = auxFuture.Wait()
+	}()
+
+	Expect(setup.EnsureDefaultProviders(nil)).To(Succeed())
+	_, _, err := e2e.SetupWorkerHarnessWithoutVM()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if packageModeAuxSvcs != nil {
+		packageModeAuxSvcs.Cleanup(context.Background())
+	}
+})
+
+var _ = BeforeEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+
+	_, err := login.LoginToAPIWithToken(harness)
+	Expect(err).ToNot(HaveOccurred())
+
+	ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+	harness.SetTestContext(ctx)
+})
+
+var _ = AfterEach(func() {
+	harness := e2e.GetWorkerHarness()
+	suiteCtx := e2e.GetWorkerContext()
+	defer harness.SetTestContext(suiteCtx)
+
+	harness.PrintAgentLogsIfFailed()
+	printPackageModeCustomVMLogsIfFailed(harness.GetTestContext())
+	harness.CaptureDeploymentLogsIfFailed()
+
+	err := harness.CleanUpAllTestResources()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/e2e/package_mode/package_mode_test.go
+++ b/test/e2e/package_mode/package_mode_test.go
@@ -1,0 +1,712 @@
+//go:build linux
+
+package packagemode_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	"github.com/flightctl/flightctl/test/harness/e2e/vm"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	packageModeQCOWEnvVar         = "E2E_PACKAGE_MODE_QCOW"
+	imageModeQCOWEnvVar           = "E2E_IMAGE_MODE_QCOW"
+	defaultImageModeQCOWPath      = "bin/output/qcow2/disk.qcow2"
+	packageModeVMUser             = "user"
+	packageModeVMPassword         = "user"
+	packageModeContainerRunAsUser = "flightctl"
+	packageModeDeviceSSHPortBase  = 23100
+	packageModeMixedSSHPortOffset = 50
+	imageModeDeviceSSHPortBase    = 23200
+	packageModeBootTimeout        = 6 * time.Minute
+	packageModeCommandTimeout     = 60 * time.Second
+	packageModeEnrollTimeout      = 5 * time.Minute
+	packageModePollInterval       = 5 * time.Second
+	packageModeConfigPath         = "/etc/flightctl/package-mode-e2e.conf"
+	packageModeConfigContent      = "package-mode-e2e=enabled"
+	packageModeContainerAppName   = "package-mode-sleep"
+	packageModeLogObservationTime = 30 * time.Second
+	packageModeFleetLabelKey      = "package-mode-suite"
+	packageModeNormalFleetPrefix  = "package-mode-normal"
+	packageModeMixedFleetPrefix   = "package-mode-mixed"
+	packageModeVMNamePrefix       = "package-mode"
+	imageModeVMNamePrefix         = "image-mode"
+	packageModeExpectedRejectText = "package-mode device cannot satisfy spec with os.image"
+)
+
+var _ = Describe("Package-mode device scenarios", Ordered, func() {
+	var harness *e2e.Harness
+
+	BeforeEach(func() {
+		harness = e2e.GetWorkerHarness()
+	})
+
+	Context("normal package-mode operation", Ordered, func() {
+		var (
+			deviceID      string
+			fleetName     string
+			selector      v1beta1.LabelSelector
+			packageModeVM *vmUnderTest
+		)
+
+		BeforeAll(func() {
+			var err error
+			harness = e2e.GetWorkerHarness()
+			restoreContext := setHarnessSetupContext(harness, packageModeNormalFleetPrefix)
+			defer harness.SetTestContext(restoreContext)
+
+			packageQCOW := requireQCOWPath(packageModeQCOWEnvVar, "")
+			fleetName = uniqueFleetName(packageModeNormalFleetPrefix)
+			selector = v1beta1.LabelSelector{
+				MatchLabels: &map[string]string{
+					packageModeFleetLabelKey: fleetName,
+				},
+			}
+
+			packageModeVM, err = startCustomVMFromQCOW(packageQCOW, packageModeVMNamePrefix, packageModeDeviceSSHPortBase+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			inlineConfig, err := e2e.NewInlineConfigSpec("package-mode-inline", []v1beta1.FileSpec{{
+				Path:    packageModeConfigPath,
+				Content: packageModeConfigContent,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+
+			appImage := harness.GetSleepAppImageRefForFleet(packageModeAuxSvcs.Registry.Host, packageModeAuxSvcs.Registry.Port, testutil.SleepAppTags.V2)
+			containerApp, err := e2e.NewContainerApplicationSpecWithRunAs(
+				packageModeContainerAppName,
+				appImage,
+				nil,
+				nil,
+				nil,
+				nil,
+				packageModeContainerRunAsUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceSpec := v1beta1.DeviceSpec{
+				Config:       &[]v1beta1.ConfigProviderSpec{inlineConfig},
+				Applications: &[]v1beta1.ApplicationProviderSpec{containerApp},
+			}
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			deviceID, err = enrollCustomVM(harness, packageModeVM, map[string]string{
+				packageModeFleetLabelKey: fleetName,
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if strings.TrimSpace(deviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(deviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", deviceID, err)
+				}
+			}
+			if strings.TrimSpace(fleetName) != "" {
+				if err := harness.DeleteFleetIgnoreNotFound(fleetName); err != nil {
+					GinkgoWriter.Printf("DeleteFleetIgnoreNotFound(%s): %v\n", fleetName, err)
+				}
+			}
+			cleanupSuiteLibvirtVM(packageModeVM)
+		})
+
+		It("enrolls a package-mode device and reports capabilities.osMode=package", Label("90146", "sanity"), func() {
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+				g.Expect(*device.Status.Capabilities.OsMode).To(Equal(v1beta1.OsModePackage))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+		})
+
+		It("deploys config and a podman application on a package-mode fleet without spec.os.image", Label("90147", "sanity"), func() {
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Spec).ToNot(BeNil())
+				g.Expect(device.Spec.Os).To(BeNil())
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+			Expect(harness.WaitForApplicationStatus(deviceID, packageModeContainerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)).ToNot(HaveOccurred())
+			Expect(harness.WaitForApplicationSummary(deviceID, testutil.TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				output, err := runSuiteLibvirtVMCommand(harness.GetTestContext(), packageModeVM.Instance, []string{"cat", packageModeConfigPath})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(output).To(ContainSubstring(packageModeConfigContent))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(deviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Applications).ToNot(BeNil())
+				application := findDeviceApplicationStatusByName(device.Status.Applications, packageModeContainerAppName)
+				g.Expect(application).ToNot(BeNil())
+				g.Expect(application.RunAs).To(Equal(v1beta1.Username(packageModeContainerRunAsUser)))
+			}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+		})
+
+		It("does not emit the mixed-fleet os.image reject message during normal package-mode operation", Label("90150", "sanity"), func() {
+			observationStart, err := currentSuiteLibvirtVMJournalSince(harness.GetTestContext(), packageModeVM.Instance)
+			Expect(err).ToNot(HaveOccurred())
+
+			Consistently(func(g Gomega) {
+				logs, err := readSuiteLibvirtVMServiceLogsSince(harness.GetTestContext(), packageModeVM.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, observationStart)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(logs).ToNot(ContainSubstring(packageModeExpectedRejectText))
+			}, packageModeLogObservationTime, packageModePollInterval).Should(Succeed())
+		})
+	})
+
+	Context("mixed fleet os image behavior", Ordered, func() {
+		var (
+			packageDeviceID         string
+			imageDeviceID           string
+			fleetName               string
+			selector                v1beta1.LabelSelector
+			packageModeVM           *vmUnderTest
+			imageModeVM             *vmUnderTest
+			packageInitialVersion   int
+			imageExpectedVersion    int
+			requestedImageReference string
+		)
+
+		BeforeAll(func() {
+			var err error
+			harness = e2e.GetWorkerHarness()
+			restoreContext := setHarnessSetupContext(harness, packageModeMixedFleetPrefix)
+			defer harness.SetTestContext(restoreContext)
+
+			packageQCOW := requireQCOWPath(packageModeQCOWEnvVar, "")
+			imageQCOW := requireQCOWPath(imageModeQCOWEnvVar, defaultImageModeQCOWPath)
+			if samePath(packageQCOW, imageQCOW) {
+				failOrSkipForMissingQCOW(fmt.Sprintf("%s must point to an image-mode qcow different from %s", imageModeQCOWEnvVar, packageModeQCOWEnvVar))
+			}
+
+			fleetName = uniqueFleetName(packageModeMixedFleetPrefix)
+			selector = v1beta1.LabelSelector{
+				MatchLabels: &map[string]string{
+					packageModeFleetLabelKey: fleetName,
+				},
+			}
+
+			packageModeVM, err = startCustomVMFromQCOW(packageQCOW, packageModeVMNamePrefix, packageModeDeviceSSHPortBase+packageModeMixedSSHPortOffset+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			imageModeVM, err = startCustomVMFromQCOW(imageQCOW, imageModeVMNamePrefix, imageModeDeviceSSHPortBase+GinkgoParallelProcess())
+			Expect(err).ToNot(HaveOccurred())
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, v1beta1.DeviceSpec{})
+			Expect(err).ToNot(HaveOccurred())
+
+			labels := map[string]string{packageModeFleetLabelKey: fleetName}
+
+			packageDeviceID, err = enrollCustomVM(harness, packageModeVM, labels)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageDeviceID, err = enrollCustomVM(harness, imageModeVM, labels)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(harness.WaitForDeviceNewRenderedVersion(packageDeviceID, 1)).ToNot(HaveOccurred())
+			Expect(harness.WaitForDeviceNewRenderedVersion(imageDeviceID, 1)).ToNot(HaveOccurred())
+
+			packageInitialVersion, err = harness.GetCurrentDeviceRenderedVersion(packageDeviceID)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageExpectedVersion, err = harness.PrepareNextDeviceVersion(imageDeviceID)
+			Expect(err).ToNot(HaveOccurred())
+
+			registryHost := packageModeAuxSvcs.Registry.Host
+			registryPort := packageModeAuxSvcs.Registry.Port
+			deviceSpec, err := harness.CreateFleetDeviceSpec(registryHost, registryPort, testutil.DeviceTags.V2)
+			Expect(err).ToNot(HaveOccurred())
+			requestedImageReference = harness.GetDeviceImageRefForFleet(registryHost, registryPort, testutil.DeviceTags.V2)
+
+			err = harness.CreateOrUpdateTestFleet(fleetName, selector, deviceSpec)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if strings.TrimSpace(packageDeviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(packageDeviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", packageDeviceID, err)
+				}
+			}
+			if strings.TrimSpace(imageDeviceID) != "" {
+				if err := harness.DeleteDeviceIgnoreNotFound(imageDeviceID); err != nil {
+					GinkgoWriter.Printf("DeleteDeviceIgnoreNotFound(%s): %v\n", imageDeviceID, err)
+				}
+			}
+			if strings.TrimSpace(fleetName) != "" {
+				if err := harness.DeleteFleetIgnoreNotFound(fleetName); err != nil {
+					GinkgoWriter.Printf("DeleteFleetIgnoreNotFound(%s): %v\n", fleetName, err)
+				}
+			}
+			cleanupSuiteLibvirtVM(packageModeVM)
+			cleanupSuiteLibvirtVM(imageModeVM)
+		})
+
+		It("keeps the package-mode device OutOfDate when the fleet adds spec.os.image", Label("90148", "sanity"), func() {
+			rejectObservationStart, err := currentSuiteLibvirtVMJournalSince(harness.GetTestContext(), packageModeVM.Instance)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(packageDeviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Updated.Status).To(Equal(v1beta1.DeviceUpdatedStatusOutOfDate))
+				g.Expect(device.Status.Config.RenderedVersion).To(Equal(strconv.Itoa(packageInitialVersion)))
+				g.Expect(deviceRejectsMixedFleetUpdate(device, packageModeExpectedRejectText)).To(BeTrue())
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				logs, err := readSuiteLibvirtVMServiceLogsSince(harness.GetTestContext(), packageModeVM.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, rejectObservationStart)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(logs).To(ContainSubstring(packageModeExpectedRejectText))
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+		})
+
+		It("lets the image-mode device converge on the requested os image in the same mixed fleet", Label("90149", "sanity", "slow"), func() {
+			Expect(harness.WaitForDeviceNewRenderedVersion(imageDeviceID, imageExpectedVersion)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				device, err := harness.GetDevice(imageDeviceID)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(device).ToNot(BeNil())
+				g.Expect(device.Status).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities).ToNot(BeNil())
+				g.Expect(device.Status.Capabilities.OsMode).ToNot(BeNil())
+				g.Expect(*device.Status.Capabilities.OsMode).To(Equal(v1beta1.OsModeImage))
+				g.Expect(device.Status.Updated.Status).To(Equal(v1beta1.DeviceUpdatedStatusUpToDate))
+				g.Expect(device.Status.Os.Image).To(Equal(requestedImageReference))
+				g.Expect(device.Status.Config.RenderedVersion).To(Equal(strconv.Itoa(imageExpectedVersion)))
+			}, testutil.LONG_TIMEOUT, packageModePollInterval).Should(Succeed())
+		})
+	})
+})
+
+var (
+	suiteLibvirtVMMu sync.Mutex
+	suiteLibvirtVMs  = map[string]*vmUnderTest{}
+)
+
+// vmUnderTest tracks a libvirt VM instance created for package-mode E2E coverage.
+type vmUnderTest struct {
+	Instance vm.TestVMInterface
+	Name     string
+	SSHPort  int
+	TestDir  string
+}
+
+// requireQCOWPath resolves a qcow input or skips the suite context when the file is unavailable.
+func requireQCOWPath(envVar, defaultRelativePath string) string {
+	candidate := strings.TrimSpace(os.Getenv(envVar))
+	if candidate == "" && defaultRelativePath != "" {
+		candidate = filepath.Join(testutil.GetTopLevelDir(), defaultRelativePath)
+	}
+	if candidate == "" {
+		failOrSkipForMissingQCOW(fmt.Sprintf("set %s to a qcow2 path before running this suite", envVar))
+	}
+
+	absolutePath, err := filepath.Abs(candidate)
+	if err != nil {
+		failOrSkipForMissingQCOW(fmt.Sprintf("resolve %s: %v", envVar, err))
+	}
+	if _, err := os.Stat(absolutePath); err != nil {
+		failOrSkipForMissingQCOW(fmt.Sprintf("%s path %s is not readable: %v", envVar, absolutePath, err))
+	}
+	return absolutePath
+}
+
+// startCustomVMFromQCOW creates and boots a custom libvirt VM from a qcow image.
+func startCustomVMFromQCOW(qcowPath, namePrefix string, sshPort int) (*vmUnderTest, error) {
+	vmName := fmt.Sprintf("%s-%d", namePrefix, time.Now().UnixNano())
+	testDir := GinkgoT().TempDir()
+	vmDiskPath := filepath.Join(testDir, filepath.Base(qcowPath))
+	if err := createQCOWOverlay(qcowPath, vmDiskPath); err != nil {
+		return nil, fmt.Errorf("create qcow overlay for %s: %w", qcowPath, err)
+	}
+	testVM := vm.TestVM{
+		TestDir:        testDir,
+		VMName:         vmName,
+		DiskImagePath:  vmDiskPath,
+		VMUser:         packageModeVMUser,
+		SSHPassword:    packageModeVMPassword,
+		SSHPort:        sshPort,
+		SSHWaitTimeout: packageModeBootTimeout,
+	}
+
+	libvirtVM, err := vm.NewVM(testVM)
+	if err != nil {
+		return nil, fmt.Errorf("create VM %s: %w", vmName, err)
+	}
+	if err := libvirtVM.CreateDomain(); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after CreateDomain failure: %v\n", cleanupErr)
+		}
+		return nil, fmt.Errorf("create domain %s: %w", vmName, err)
+	}
+	if err := libvirtVM.RunAndWaitForSSH(); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after RunAndWaitForSSH failure: %v\n", cleanupErr)
+		}
+		return nil, fmt.Errorf("boot VM %s: %w", vmName, err)
+	}
+
+	candidate := &vmUnderTest{
+		Instance: libvirtVM,
+		Name:     vmName,
+		SSHPort:  sshPort,
+		TestDir:  testDir,
+	}
+	if err := registerSuiteLibvirtVM(candidate); err != nil {
+		if cleanupErr := libvirtVM.ForceDelete(); cleanupErr != nil {
+			GinkgoWriter.Printf("startCustomVMFromQCOW ForceDelete after registration failure: %v\n", cleanupErr)
+		}
+		return nil, err
+	}
+	return candidate, nil
+}
+
+// enrollCustomVM approves the enrollment request for a custom VM and waits for Online status.
+func enrollCustomVM(harness *e2e.Harness, candidate *vmUnderTest, labels map[string]string) (string, error) {
+	GinkgoHelper()
+
+	if harness == nil {
+		return "", fmt.Errorf("harness is nil")
+	}
+	if candidate == nil || candidate.Instance == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+
+	enrollmentID := waitForSuiteLibvirtVMEnrollmentID(harness.GetTestContext(), candidate.Instance, packageModeEnrollTimeout, packageModePollInterval)
+
+	if _, err := harness.WaitForEnrollmentRequestResource(enrollmentID, testutil.TIMEOUT_5M, testutil.SHORT_POLLING); err != nil {
+		return "", err
+	}
+
+	approvalLabels, err := mergeEnrollmentLabels(harness, labels)
+	if err != nil {
+		return "", err
+	}
+	if _, err := harness.ApproveEnrollmentRequestWithLabels(enrollmentID, approvalLabels); err != nil {
+		return "", err
+	}
+
+	Eventually(func() error {
+		device, err := harness.CheckDeviceStatus(enrollmentID, v1beta1.DeviceSummaryStatusOnline)
+		if err != nil {
+			return err
+		}
+		if device == nil {
+			return fmt.Errorf("device %s is still nil", enrollmentID)
+		}
+		return nil
+	}, packageModeEnrollTimeout, packageModePollInterval).Should(Succeed())
+
+	return enrollmentID, nil
+}
+
+// waitForSuiteLibvirtVMEnrollmentID polls a suite-created libvirt VM's agent logs until an enrollment request ID appears.
+func waitForSuiteLibvirtVMEnrollmentID(ctx context.Context, libvirtVM vm.TestVMInterface, timeout, polling time.Duration) string {
+	GinkgoHelper()
+
+	since, err := currentSuiteLibvirtVMJournalSince(ctx, libvirtVM)
+	Expect(err).ToNot(HaveOccurred())
+
+	var enrollmentID string
+	Eventually(func() string {
+		logs, err := readSuiteLibvirtVMServiceLogsSince(ctx, libvirtVM, testutil.FLIGHTCTL_AGENT_SERVICE, since)
+		if err != nil {
+			GinkgoWriter.Printf("waitForSuiteLibvirtVMEnrollmentID ReadServiceLogsSince: %v\n", err)
+			return ""
+		}
+		enrollmentID = testutil.GetEnrollmentIdFromText(logs)
+		return enrollmentID
+	}, timeout, polling).ShouldNot(BeEmpty())
+
+	return enrollmentID
+}
+
+// mergeEnrollmentLabels adds the harness test-id label to enrollment approval labels.
+func mergeEnrollmentLabels(harness *e2e.Harness, labels map[string]string) (map[string]string, error) {
+	testLabels, err := harness.TestResourceLabels()
+	if err != nil {
+		return nil, err
+	}
+
+	merged := map[string]string{}
+	for key, value := range testLabels {
+		merged[key] = value
+	}
+	for key, value := range labels {
+		merged[key] = value
+	}
+	return merged, nil
+}
+
+// uniqueFleetName returns a predictable, unique fleet name for the current spec run.
+func uniqueFleetName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// setHarnessSetupContext seeds a stable test-id context for Ordered BeforeAll setup work.
+func setHarnessSetupContext(harness *e2e.Harness, prefix string) context.Context {
+	restoreContext := harness.GetTestContext()
+	setupContext := context.WithValue(restoreContext, testutil.TestIDKey, uniqueFleetName(prefix+"-setup"))
+	harness.SetTestContext(setupContext)
+	return restoreContext
+}
+
+// cleanupSuiteLibvirtVM force-deletes a suite-created libvirt VM.
+func cleanupSuiteLibvirtVM(candidate *vmUnderTest) {
+	if candidate == nil {
+		return
+	}
+	defer unregisterSuiteLibvirtVM(candidate)
+	if candidate.Instance != nil {
+		if err := candidate.Instance.ForceDelete(); err != nil {
+			GinkgoWriter.Printf("cleanupSuiteLibvirtVM(%s): %v\n", candidate.Name, err)
+		}
+	}
+}
+
+// runSuiteLibvirtVMCommand executes a command on a suite-created libvirt VM and returns trimmed stdout.
+func runSuiteLibvirtVMCommand(ctx context.Context, libvirtVM vm.TestVMInterface, args []string) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	if len(args) == 0 {
+		return "", fmt.Errorf("command args are empty")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	commandCtx, cancel := context.WithTimeout(ctx, packageModeCommandTimeout)
+	defer cancel()
+
+	stdout, err := libvirtVM.RunSSHContext(commandCtx, args, nil)
+	if err != nil {
+		return "", err
+	}
+	if stdout == nil {
+		return "", fmt.Errorf("command output is nil")
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// registerSuiteLibvirtVM tracks a suite-created libvirt VM for failure log capture.
+func registerSuiteLibvirtVM(candidate *vmUnderTest) error {
+	if candidate == nil || candidate.Instance == nil || strings.TrimSpace(candidate.Name) == "" {
+		return fmt.Errorf("suite libvirt VM is incomplete")
+	}
+
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+	suiteLibvirtVMs[candidate.Name] = candidate
+	return nil
+}
+
+// unregisterSuiteLibvirtVM removes a suite-created libvirt VM from failure log capture tracking.
+func unregisterSuiteLibvirtVM(candidate *vmUnderTest) {
+	if candidate == nil || strings.TrimSpace(candidate.Name) == "" {
+		return
+	}
+
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+	delete(suiteLibvirtVMs, candidate.Name)
+}
+
+// listSuiteLibvirtVMs returns the currently tracked suite-created libvirt VMs.
+func listSuiteLibvirtVMs() []*vmUnderTest {
+	suiteLibvirtVMMu.Lock()
+	defer suiteLibvirtVMMu.Unlock()
+
+	vms := make([]*vmUnderTest, 0, len(suiteLibvirtVMs))
+	for _, candidate := range suiteLibvirtVMs {
+		vms = append(vms, candidate)
+	}
+	return vms
+}
+
+// printPackageModeCustomVMLogsIfFailed prints flightctl-agent logs for suite-created libvirt VMs after a failed spec.
+func printPackageModeCustomVMLogsIfFailed(ctx context.Context) {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	for _, candidate := range listSuiteLibvirtVMs() {
+		if candidate == nil || candidate.Instance == nil {
+			continue
+		}
+
+		running, err := candidate.Instance.IsRunning()
+		if err != nil || !running {
+			continue
+		}
+
+		logs, err := readSuiteLibvirtVMServiceLogsSince(ctx, candidate.Instance, testutil.FLIGHTCTL_AGENT_SERVICE, "")
+		if err != nil {
+			GinkgoWriter.Printf("printPackageModeCustomVMLogsIfFailed(%s): %v\n", candidate.Name, err)
+			continue
+		}
+
+		GinkgoWriter.Printf("flightctl-agent logs for %s:\n%s\n", candidate.Name, logs)
+	}
+}
+
+// deviceRejectsMixedFleetUpdate returns true when package-mode rejection is visible in device status.
+func deviceRejectsMixedFleetUpdate(device *v1beta1.Device, rejectText string) bool {
+	if device == nil || device.Status == nil {
+		return false
+	}
+
+	if e2e.ConditionExists(device, v1beta1.ConditionTypeDeviceUpdating, v1beta1.ConditionStatusFalse, string(v1beta1.UpdateStateError)) {
+		cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
+		if cond != nil && strings.Contains(cond.Message, rejectText) {
+			return true
+		}
+	}
+
+	return device.Status.Updated.Info != nil && strings.Contains(*device.Status.Updated.Info, rejectText)
+}
+
+// samePath compares two paths after cleaning them.
+func samePath(left, right string) bool {
+	if left == "" || right == "" {
+		return false
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+// failOrSkipForMissingQCOW fails in CI and skips in local runs when a required qcow is unavailable.
+func failOrSkipForMissingQCOW(message string) {
+	GinkgoHelper()
+
+	if strings.TrimSpace(os.Getenv("CI")) != "" {
+		Fail(message)
+	}
+	Skip(message)
+}
+
+// createQCOWOverlay creates a qcow2 overlay so each suite VM gets isolated writes without copying the base disk.
+func createQCOWOverlay(baseQCOWPath, overlayQCOWPath string) error {
+	backingFormat, err := detectQCOWFormat(baseQCOWPath)
+	if err != nil {
+		return fmt.Errorf("detect backing qcow format for %s: %w", baseQCOWPath, err)
+	}
+
+	cmd := exec.Command("qemu-img", "create", "-f", "qcow2", "-b", baseQCOWPath, "-F", backingFormat, overlayQCOWPath) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("qemu-img create failed: %w, output: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// currentSuiteLibvirtVMJournalSince returns a guest-aligned RFC3339 timestamp for journalctl --since filtering.
+func currentSuiteLibvirtVMJournalSince(ctx context.Context, libvirtVM vm.TestVMInterface) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	commandCtx, cancel := context.WithTimeout(ctx, packageModeCommandTimeout)
+	defer cancel()
+
+	out, err := libvirtVM.RunSSHContext(commandCtx, []string{"date", "-u", `+%Y-%m-%dT%H:%M:%SZ`}, nil)
+	if err != nil {
+		return "", fmt.Errorf("read VM clock for journal since: %w", err)
+	}
+	timestamp := strings.TrimSpace(out.String())
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return "", fmt.Errorf("parse VM date %q: %w", timestamp, err)
+	}
+	return parsed.Add(-2 * time.Second).UTC().Format(time.RFC3339), nil
+}
+
+// readSuiteLibvirtVMServiceLogsSince returns service journal output produced at or after the provided guest-aligned timestamp.
+func readSuiteLibvirtVMServiceLogsSince(ctx context.Context, libvirtVM vm.TestVMInterface, serviceName, since string) (string, error) {
+	if libvirtVM == nil {
+		return "", fmt.Errorf("VM is nil")
+	}
+	return runSuiteLibvirtVMCommand(ctx, libvirtVM, suiteLibvirtVMJournalSinceArgs(serviceName, since, 500))
+}
+
+// detectQCOWFormat returns the qemu-img reported format for the backing image.
+func detectQCOWFormat(qcowPath string) (string, error) {
+	cmd := exec.Command("qemu-img", "info", "--output=json", qcowPath) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("qemu-img info failed: %w, output: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	var metadata struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(output, &metadata); err != nil {
+		return "", fmt.Errorf("parse qemu-img info output: %w", err)
+	}
+	if strings.TrimSpace(metadata.Format) == "" {
+		return "", fmt.Errorf("qemu-img info output missing format")
+	}
+	return metadata.Format, nil
+}
+
+// findDeviceApplicationStatusByName returns the named application status entry or nil when absent.
+func findDeviceApplicationStatusByName(applications []v1beta1.DeviceApplicationStatus, applicationName string) *v1beta1.DeviceApplicationStatus {
+	for i := range applications {
+		if applications[i].Name == applicationName {
+			return &applications[i]
+		}
+	}
+	return nil
+}
+
+// suiteLibvirtVMJournalSinceArgs builds a bounded journalctl command for a specific service and since timestamp.
+func suiteLibvirtVMJournalSinceArgs(serviceName, since string, lines int) []string {
+	args := []string{
+		"sudo",
+		"TZ=UTC",
+		"journalctl",
+		"--no-pager",
+		"--no-hostname",
+		"-u", serviceName,
+		"--boot=all",
+	}
+	if strings.TrimSpace(since) != "" {
+		args = append(args, "--since", since)
+	}
+	if lines > 0 {
+		args = append(args, "-n", strconv.Itoa(lines))
+	}
+	return args
+}

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -153,8 +153,25 @@ func (v *TestVM) sshCommandWithUserContext(ctx context.Context, inputArgs []stri
 		logrus.Infof("Connecting to vm %s. To close connection, use `~.` or `exit`", v.VMName)
 	}
 
-	logrus.Debugf("Running ssh command: %s", cmd.String())
+	logrus.Debugf("Running ssh command: %s", redactSSHCommandArgs(cmd.Args))
 	return cmd
+}
+
+// redactSSHCommandArgs masks the sshpass password argument before logging the SSH command.
+func redactSSHCommandArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	redacted := append([]string(nil), args...)
+	for i := 0; i < len(redacted)-1; i++ {
+		if redacted[i] == "-p" && redacted[0] == "sshpass" {
+			redacted[i+1] = "[REDACTED]"
+			break
+		}
+	}
+
+	return strings.Join(redacted, " ")
 }
 
 // RunSSH runs a command over ssh or starts an interactive ssh connection if no command is provided

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -127,7 +127,7 @@ The `scripts/` directory contains modular build automation:
 - **`build_and_qcow2.sh`** - Orchestrates variant and QCOW2 builds; for `*-regular` it is QCOW2-only by default unless `SKIP_VARIANTS_BUILD=false` is set explicitly
 - **`bundle.sh`** - Creates tar bundles of built images for distribution
 - **`qcow2.sh`** - Generates bootable QCOW2 disk images using bootc-image-builder
-- **`qcow2_regular.sh`** - Generates package-mode QCOW2 images from a bootable cloud image via host-side `dnf --installroot`
+- **`qcow2_regular.sh`** - Generates package-mode QCOW2 images from a bootable cloud image via host-side `dnf --installroot` plus `virt-customize` post-config
 - **`upload-images.sh`** - Uploads image bundles to container registries
 
 Use `./scripts/build.sh --help` for detailed usage and options.
@@ -166,11 +166,12 @@ They are intentionally parallel because the qcow2 must start from a **bootable**
 GenericCloud image (kernel/bootloader). The OCI image is a container rootfs and is not
 exported as the disk.
 
-`qcow2_regular.sh` mounts that cloud disk on the host (`guestmount`) and installs the same
-package set via `dnf --installroot` inside a CentOS Stream 9 container. The container
-resolves packages over the runner network stack, not through a libguestfs appliance.
-It does **not** run guest `dnf` inside `virt-customize` — libguestfs guest networking is
-unreliable on GitHub-hosted runners.
+`qcow2_regular.sh` mounts that cloud disk on the host (`guestmount`) and installs packages
+via `dnf --installroot` inside a CentOS Stream 9 container (runner network, not libguestfs
+guest networking). Flightctl RPMs use `tsflags=noscripts` — agent/selinux `%post` is
+unreliable under guestmount FUSE. After unmount, `virt-customize` loads the
+`flightctl_agent` SELinux module (build fails if it is missing), finishes user/linger
+setup, and runs `--selinux-relabel`. Guest `dnf` inside `virt-customize` is avoided.
 
 Agent config, certificates, and registry remapping are expected to be injected into the
 qcow2 after build via the existing e2e injection flow.

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -167,9 +167,10 @@ GenericCloud image (kernel/bootloader). The OCI image is a container rootfs and 
 exported as the disk.
 
 `qcow2_regular.sh` mounts that cloud disk on the host (`guestmount`) and installs the same
-package set via `dnf --installroot` inside a CentOS Stream 9 container (host networking).
-It does **not** run guest `dnf` inside a `virt-customize` appliance — libguestfs guest
-networking is unreliable on GitHub-hosted runners.
+package set via `dnf --installroot` inside a CentOS Stream 9 container. The container
+resolves packages over the runner network stack, not through a libguestfs appliance.
+It does **not** run guest `dnf` inside `virt-customize` — libguestfs guest networking is
+unreliable on GitHub-hosted runners.
 
 Agent config, certificates, and registry remapping are expected to be injected into the
 qcow2 after build via the existing e2e injection flow.

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -165,6 +165,11 @@ That means the package-mode OCI base and package-mode qcow2 are parallel build p
 They are intentionally parallel because the qcow2 is built from a cloud image, not converted from the OCI base image.
 Agent config, certificates, and registry remapping are expected to be injected into the qcow2 after build via the existing e2e injection flow.
 
+> **CI constraint:** On GitHub-hosted runners, `libguestfs` guest networking is unavailable
+> (`passt` requires user-namespace creation). `qcow2_regular.sh` works around this by
+> downloading all RPMs on the host via `podman` and installing them offline inside the guest
+> with `virt-customize --no-network`.
+
 ### Local Usage and Registry Remapping
 
 Images are built locally with the default repository prefix `quay.io/flightctl/flightctl-device`

--- a/test/scripts/agent-images/README.md
+++ b/test/scripts/agent-images/README.md
@@ -127,7 +127,7 @@ The `scripts/` directory contains modular build automation:
 - **`build_and_qcow2.sh`** - Orchestrates variant and QCOW2 builds; for `*-regular` it is QCOW2-only by default unless `SKIP_VARIANTS_BUILD=false` is set explicitly
 - **`bundle.sh`** - Creates tar bundles of built images for distribution
 - **`qcow2.sh`** - Generates bootable QCOW2 disk images using bootc-image-builder
-- **`qcow2_regular.sh`** - Generates package-mode QCOW2 images from the configured cloud image using `virt-customize`
+- **`qcow2_regular.sh`** - Generates package-mode QCOW2 images from a bootable cloud image via host-side `dnf --installroot`
 - **`upload-images.sh`** - Uploads image bundles to container registries
 
 Use `./scripts/build.sh --help` for detailed usage and options.
@@ -160,15 +160,19 @@ For `BUILD_TYPE=regular AGENT_OS_ID=cs9-regular`, `create_agent_images.sh` still
 
 That means the package-mode OCI base and package-mode qcow2 are parallel build paths:
 - `containerfiles/cs9-regular/Containerfile` is the source of truth for the OCI base image
-- `scripts/qcow2_regular.sh` is the source of truth for the package-mode qcow2 guest customization
+- `scripts/qcow2_regular.sh` is the source of truth for the package-mode qcow2 disk customization
 
-They are intentionally parallel because the qcow2 is built from a cloud image, not converted from the OCI base image.
-Agent config, certificates, and registry remapping are expected to be injected into the qcow2 after build via the existing e2e injection flow.
+They are intentionally parallel because the qcow2 must start from a **bootable** CentOS
+GenericCloud image (kernel/bootloader). The OCI image is a container rootfs and is not
+exported as the disk.
 
-> **CI constraint:** On GitHub-hosted runners, `libguestfs` guest networking is unavailable
-> (`passt` requires user-namespace creation). `qcow2_regular.sh` works around this by
-> downloading all RPMs on the host via `podman` and installing them offline inside the guest
-> with `virt-customize --no-network`.
+`qcow2_regular.sh` mounts that cloud disk on the host (`guestmount`) and installs the same
+package set via `dnf --installroot` inside a CentOS Stream 9 container (host networking).
+It does **not** run guest `dnf` inside a `virt-customize` appliance — libguestfs guest
+networking is unreliable on GitHub-hosted runners.
+
+Agent config, certificates, and registry remapping are expected to be injected into the
+qcow2 after build via the existing e2e injection flow.
 
 ### Local Usage and Registry Remapping
 

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -16,11 +16,13 @@ RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
 TMP_CLOUD_IMAGE_PATH=""
 RPM_SOURCE_DIR=""
 
-# Remove any partially downloaded cloud image if the script exits before the
-# download is committed into the shared cache path.
-cleanup_temp_cloud_image() {
+PKG_CACHE_DIR=""
+cleanup() {
   if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
     rm -f "${TMP_CLOUD_IMAGE_PATH}"
+  fi
+  if [ -n "${PKG_CACHE_DIR}" ] && [ -d "${PKG_CACHE_DIR}" ]; then
+    rm -rf "${PKG_CACHE_DIR}"
   fi
 }
 
@@ -103,13 +105,14 @@ fi
 require_command curl
 require_command qemu-img
 require_command virt-customize
+require_command podman
 
 resolve_output_dir "${OUTPUT_DIR}"
 OUTPUT_QCOW_DIR="${OUTPUT_DIR}/qcow2"
 OUTPUT_QCOW_PATH="${OUTPUT_QCOW_DIR}/disk.qcow2"
 
 mkdir -p "${CLOUD_IMAGE_CACHE_DIR}" "${OUTPUT_QCOW_DIR}"
-trap cleanup_temp_cloud_image EXIT
+trap cleanup EXIT
 
 if [ ! -f "${BASE_CLOUD_IMAGE_PATH}" ]; then
   echo "Downloading CentOS Stream 9 cloud image from ${BASE_CLOUD_IMAGE_URL}"
@@ -123,10 +126,57 @@ echo "Preparing package-mode qcow2 at ${OUTPUT_QCOW_PATH}"
 qemu-img convert -O qcow2 "${BASE_CLOUD_IMAGE_PATH}" "${OUTPUT_QCOW_PATH}"
 qemu-img resize "${OUTPUT_QCOW_PATH}" +5G
 
+# Guest networking is unavailable on GitHub-hosted runners (libguestfs passt
+# requires user-namespace creation).  Download all required packages on the
+# host via a CentOS 9 container, then install them offline inside the guest.
+echo "Downloading required packages for offline guest installation"
+PKG_CACHE_DIR=$(mktemp -d)
+
+CONTAINER_CMD='
+  set -euo pipefail
+  dnf install -y epel-release epel-next-release dnf-plugins-core
+  dnf download --resolve --destdir=/output \
+    epel-release epel-next-release \
+    cloud-init dnf-plugins-core firewalld openssh-server \
+    podman podman-compose python-dotenv sudo
+'
+
+if [ -n "${RPM_COPR_REPO}" ]; then
+  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
+  validate_copr_repo "${RPM_COPR_REPO}"
+  validate_copr_package "${package_name}"
+  CONTAINER_CMD+="
+    dnf copr -y enable ${RPM_COPR_REPO}
+    dnf download --resolve --destdir=/output ${package_name}
+  "
+else
+  validate_rpm_dir "${RPM_DIR}"
+  resolve_rpm_source_dir "${RPM_DIR}"
+fi
+
+sudo podman run --rm \
+  -v "${PKG_CACHE_DIR}:/output:Z" \
+  quay.io/centos/centos:stream9 \
+  bash -c "${CONTAINER_CMD}"
+sudo chown -R "${USER}:$(id -gn "${USER}")" "${PKG_CACHE_DIR}"
+
+if [ -z "${RPM_COPR_REPO}" ]; then
+  cp "${RPM_SOURCE_DIR}"/flightctl-agent-*.rpm "${RPM_SOURCE_DIR}"/flightctl-selinux-*.rpm \
+    "${PKG_CACHE_DIR}/"
+fi
+
+if ! ls "${PKG_CACHE_DIR}"/*.rpm >/dev/null 2>&1; then
+  echo "No RPMs found in package cache after download" >&2
+  exit 1
+fi
+
 VIRT_CUSTOMIZE_ARGS=(
   -a "${OUTPUT_QCOW_PATH}"
-  --run-command "dnf install -y epel-release epel-next-release"
-  --run-command "dnf install -y cloud-init dnf-plugins-core firewalld openssh-server podman podman-compose python-dotenv sudo"
+  --no-network
+  --mkdir /tmp/pkg-cache
+  --copy-in "${PKG_CACHE_DIR}:/tmp/pkg-cache"
+  --run-command "dnf install -y /tmp/pkg-cache/*.rpm"
+  --run-command "rm -rf /tmp/pkg-cache"
   --run-command "systemctl enable firewalld.service"
   --run-command "systemctl enable podman.service"
   --run-command "systemctl enable sshd.service"
@@ -138,34 +188,13 @@ VIRT_CUSTOMIZE_ARGS=(
   --run-command "printf '#!/bin/bash\necho \"\"\n' > /usr/lib/flightctl/custom-info.d/emptyValue"
   --run-command "printf '#!/bin/bash\necho \"no-show\"\n' > /usr/lib/flightctl/custom-info.d/keyNotShown"
   --run-command "chmod 755 /usr/lib/flightctl/custom-info.d/*"
-)
-
-if [ -n "${RPM_COPR_REPO}" ]; then
-  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
-  validate_copr_repo "${RPM_COPR_REPO}"
-  validate_copr_package "${package_name}"
-  VIRT_CUSTOMIZE_ARGS+=(
-    --run-command "dnf copr -y enable ${RPM_COPR_REPO}"
-    --run-command "dnf install -y ${package_name}"
-  )
-else
-  validate_rpm_dir "${RPM_DIR}"
-  resolve_rpm_source_dir "${RPM_DIR}"
-  VIRT_CUSTOMIZE_ARGS+=(
-    --copy-in "${RPM_SOURCE_DIR}:/tmp"
-    --run-command "dnf install -y /tmp/${RPM_DIR}/flightctl-agent-*.rpm /tmp/${RPM_DIR}/flightctl-selinux-*.rpm"
-    --run-command "rm -rf /tmp/${RPM_DIR}"
-  )
-fi
-
-VIRT_CUSTOMIZE_ARGS+=(
   --run-command "systemctl enable flightctl-agent.service"
   --run-command "dnf clean all"
   --selinux-relabel
 )
 
 echo "Customizing regular package-mode qcow2"
-sudo virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
+sudo env LIBGUESTFS_BACKEND=direct virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
 
 sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"
 

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -101,6 +101,10 @@ resolve_output_dir() {
 # Install packages into a mounted cloud-image root using CentOS Stream 9's dnf
 # (host runners are Ubuntu and have no native dnf). Networking stays on the
 # container/host — never inside a libguestfs appliance.
+#
+# Flightctl RPMs are installed with tsflags=noscripts: agent/selinux %post
+# (semodule, useradd, linger) is unreliable under guestmount FUSE. That work
+# runs later in virt-customize after the disk is unmounted.
 install_into_root() {
   local install_root="$1"
   local container_cmd
@@ -108,22 +112,6 @@ install_into_root() {
   container_cmd=$(cat <<'EOS'
 set -euo pipefail
 root=/installroot
-
-cleanup_mounts() {
-  umount -l "${root}/dev" 2>/dev/null || true
-  umount -l "${root}/sys" 2>/dev/null || true
-  umount -l "${root}/proc" 2>/dev/null || true
-}
-trap cleanup_mounts EXIT
-
-# Minimal stream9 image has no mount/umount; util-linux provides them.
-dnf -y install util-linux
-
-# RPM %post (systemd-tmpfiles, semodule, useradd) needs a live-ish root.
-mkdir -p "${root}/proc" "${root}/sys" "${root}/dev"
-mount -t proc proc "${root}/proc"
-mount -t sysfs sysfs "${root}/sys"
-mount --bind /dev "${root}/dev"
 
 dnf --installroot="${root}" -y install epel-release epel-next-release
 # dnf resolves file:/// GPG key URLs against the running system, not installroot.
@@ -140,12 +128,9 @@ dnf --installroot="${root}" -y install \
   python-dotenv \
   sudo
 
-# Stale semodule sandbox breaks flightctl-selinux %post under installroot.
-rm -rf "${root}/var/lib/selinux/targeted/tmp"
-
 if [ -n "${RPM_COPR_REPO}" ]; then
   dnf --installroot="${root}" copr -y enable "${RPM_COPR_REPO}"
-  dnf --installroot="${root}" -y install "${RPM_COPR_PACKAGE}"
+  dnf --installroot="${root}" --setopt=tsflags=noscripts -y install "${RPM_COPR_PACKAGE}"
 else
   shopt -s nullglob
   rpms=(/rpms/flightctl-agent-*.rpm /rpms/flightctl-selinux-*.rpm)
@@ -154,23 +139,8 @@ else
     echo "No flightctl-agent/flightctl-selinux RPMs found in /rpms" >&2
     exit 1
   fi
-  dnf --installroot="${root}" -y install "${rpms[@]}"
+  dnf --installroot="${root}" --setopt=tsflags=noscripts -y install "${rpms[@]}"
 fi
-
-# Ensure the SELinux module is loaded even if %post hit a transient sandbox error.
-if ! chroot "${root}" semodule -l | grep -q '^flightctl_agent'; then
-  rm -rf "${root}/var/lib/selinux/targeted/tmp"
-  chroot "${root}" semodule -s targeted -i /usr/share/selinux/packages/targeted/flightctl_agent.pp.bz2
-fi
-
-# Finish agent %post work that may have failed without a full systemd environment.
-# User/home/custom-info setup runs later via virt-customize: creating
-# /home/flightctl through the guestmount FUSE bind from the container hits
-# EACCES on GHA even though package installs to the same mount succeed.
-mkdir -p "${root}/var/lib/flightctl"
-chmod 0755 "${root}/var/lib/flightctl"
-mkdir -p "${root}/var/lib/systemd/linger"
-touch "${root}/var/lib/systemd/linger/flightctl"
 
 # centos:stream9 has no systemctl; enable units via the mounted root (has systemd).
 chroot "${root}" systemctl enable firewalld.service
@@ -183,7 +153,7 @@ EOS
 )
 
   local -a podman_args=(
-    run --rm --privileged
+    run --rm
     -e "RPM_COPR_REPO=${RPM_COPR_REPO}"
     -e "RPM_COPR_PACKAGE=${RPM_COPR_PACKAGE:-flightctl-agent}"
     # No :Z — guestmount is FUSE; SELinux relabel of the mount is useless on
@@ -259,19 +229,45 @@ done
 rmdir "${GUEST_MOUNT}" 2>/dev/null || true
 GUEST_MOUNT=""
 
-# Configure users/homedirs and relabel in the libguestfs appliance (not via FUSE).
-echo "Configuring e2e users and SELinux relabel"
+# Finish flightctl %post work and e2e users in the libguestfs appliance (not via FUSE).
+# Load the SELinux module before --selinux-relabel so flightctl_agent_* types exist.
+echo "Configuring SELinux module, e2e users, and SELinux relabel"
 POST_CONFIG_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/cs9-regular-post.XXXXXX.sh")"
 cat >"${POST_CONFIG_SCRIPT}" <<'EOF'
 #!/bin/bash
 set -euo pipefail
+
+flightctl_pp=/usr/share/selinux/packages/targeted/flightctl_agent.pp.bz2
+if [ ! -f "${flightctl_pp}" ]; then
+  echo "Missing flightctl SELinux policy package: ${flightctl_pp}" >&2
+  exit 1
+fi
+if ! semodule -l | grep -q '^flightctl_agent'; then
+  echo "Loading flightctl_agent SELinux module"
+  semodule -s targeted -i "${flightctl_pp}"
+fi
+if ! semodule -l | grep -q '^flightctl_agent'; then
+  echo "flightctl_agent SELinux module is not loaded after semodule -i" >&2
+  exit 1
+fi
+echo "flightctl_agent SELinux module is loaded"
+
+mkdir -p /var/lib/flightctl
+chmod 0755 /var/lib/flightctl
 id -u flightctl >/dev/null 2>&1 || useradd --create-home --user-group flightctl
 flightctl_home="$(getent passwd flightctl | cut -d: -f6)"
+if [ -z "${flightctl_home}" ]; then
+  echo "flightctl user has no home directory in passwd" >&2
+  exit 1
+fi
 mkdir -p \
   "${flightctl_home}/.config/containers/systemd" \
   "${flightctl_home}/.config/systemd/user" \
   "${flightctl_home}/.local"
 chown -R flightctl:flightctl "${flightctl_home}/.config" "${flightctl_home}/.local"
+mkdir -p /var/lib/systemd/linger
+touch /var/lib/systemd/linger/flightctl
+
 id -u user >/dev/null 2>&1 || useradd -ms /bin/bash user
 echo 'user:user' | chpasswd
 if ! grep -q '^user ALL=(ALL) NOPASSWD: ALL' /etc/sudoers; then

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -124,7 +124,14 @@ if [ -n "${RPM_COPR_REPO}" ]; then
   dnf --installroot="${root}" copr -y enable "${RPM_COPR_REPO}"
   dnf --installroot="${root}" -y install "${RPM_COPR_PACKAGE}"
 else
-  dnf --installroot="${root}" -y install /rpms/flightctl-agent-*.rpm /rpms/flightctl-selinux-*.rpm
+  shopt -s nullglob
+  rpms=(/rpms/flightctl-agent-*.rpm /rpms/flightctl-selinux-*.rpm)
+  shopt -u nullglob
+  if [ "${#rpms[@]}" -eq 0 ]; then
+    echo "No flightctl-agent/flightctl-selinux RPMs found in /rpms" >&2
+    exit 1
+  fi
+  dnf --installroot="${root}" -y install "${rpms[@]}"
 fi
 
 systemctl --root="${root}" enable firewalld.service
@@ -162,9 +169,10 @@ EOS
   fi
 
   # Rootful podman matches the BIB path and avoids rootless crun issues on GHA.
-  sudo podman "${podman_args[@]}" \
+  # Feed the script on stdin (static heredoc) rather than bash -c with a variable.
+  printf '%s' "${container_cmd}" | sudo podman "${podman_args[@]}" -i \
     quay.io/centos/centos:stream9 \
-    bash -c "${container_cmd}"
+    bash -s
 }
 
 if [ "${OS_ID}" != "cs9-regular" ]; then
@@ -217,7 +225,10 @@ echo "Installing packages into qcow2 via host-side dnf --installroot"
 install_into_root "${GUEST_MOUNT}"
 
 echo "Unmounting qcow2"
-sudo guestunmount "${GUEST_MOUNT}"
+sudo guestunmount --retry=5 "${GUEST_MOUNT}" || sudo umount -l "${GUEST_MOUNT}"
+while mountpoint -q "${GUEST_MOUNT}" 2>/dev/null; do
+  sleep 1
+done
 rmdir "${GUEST_MOUNT}" 2>/dev/null || true
 GUEST_MOUNT=""
 

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -105,6 +105,19 @@ install_into_root() {
 set -euo pipefail
 root=/installroot
 
+cleanup_mounts() {
+  umount -l "${root}/dev" 2>/dev/null || true
+  umount -l "${root}/sys" 2>/dev/null || true
+  umount -l "${root}/proc" 2>/dev/null || true
+}
+trap cleanup_mounts EXIT
+
+# RPM %post (systemd-tmpfiles, semodule, useradd) needs a live-ish root.
+mkdir -p "${root}/proc" "${root}/sys" "${root}/dev"
+mount -t proc proc "${root}/proc"
+mount -t sysfs sysfs "${root}/sys"
+mount --bind /dev "${root}/dev"
+
 dnf --installroot="${root}" -y install epel-release epel-next-release
 # dnf resolves file:/// GPG key URLs against the running system, not installroot.
 mkdir -p /etc/pki/rpm-gpg
@@ -120,6 +133,9 @@ dnf --installroot="${root}" -y install \
   python-dotenv \
   sudo
 
+# Stale semodule sandbox breaks flightctl-selinux %post under installroot.
+rm -rf "${root}/var/lib/selinux/targeted/tmp"
+
 if [ -n "${RPM_COPR_REPO}" ]; then
   dnf --installroot="${root}" copr -y enable "${RPM_COPR_REPO}"
   dnf --installroot="${root}" -y install "${RPM_COPR_PACKAGE}"
@@ -133,6 +149,26 @@ else
   fi
   dnf --installroot="${root}" -y install "${rpms[@]}"
 fi
+
+# Ensure the SELinux module is loaded even if %post hit a transient sandbox error.
+if ! chroot "${root}" semodule -l | grep -q '^flightctl_agent'; then
+  rm -rf "${root}/var/lib/selinux/targeted/tmp"
+  chroot "${root}" semodule -s targeted -i /usr/share/selinux/packages/targeted/flightctl_agent.pp.bz2
+fi
+
+# Finish agent %post work that may have failed without a full systemd environment.
+mkdir -p "${root}/var/lib/flightctl"
+chmod 0755 "${root}/var/lib/flightctl"
+if ! grep -q '^flightctl:' "${root}/etc/passwd"; then
+  chroot "${root}" useradd --create-home --user-group flightctl
+fi
+mkdir -p "${root}/var/lib/systemd/linger"
+touch "${root}/var/lib/systemd/linger/flightctl"
+flightctl_home="$(chroot "${root}" getent passwd flightctl | cut -d: -f6)"
+mkdir -p "${root}${flightctl_home}/.config/containers/systemd" \
+  "${root}${flightctl_home}/.config/systemd/user" \
+  "${root}${flightctl_home}/.local"
+chroot "${root}" chown -R flightctl:flightctl "${flightctl_home}/.config" "${flightctl_home}/.local"
 
 # centos:stream9 has no systemctl; enable units via the mounted root (has systemd).
 chroot "${root}" systemctl enable firewalld.service
@@ -159,7 +195,7 @@ EOS
 )
 
   local -a podman_args=(
-    run --rm
+    run --rm --privileged
     -e "RPM_COPR_REPO=${RPM_COPR_REPO}"
     -e "RPM_COPR_PACKAGE=${RPM_COPR_PACKAGE:-flightctl-agent}"
     -v "${install_root}:/installroot:Z"

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -134,10 +134,11 @@ else
   dnf --installroot="${root}" -y install "${rpms[@]}"
 fi
 
-systemctl --root="${root}" enable firewalld.service
-systemctl --root="${root}" enable podman.service
-systemctl --root="${root}" enable sshd.service
-systemctl --root="${root}" enable flightctl-agent.service
+# centos:stream9 has no systemctl; enable units via the mounted root (has systemd).
+chroot "${root}" systemctl enable firewalld.service
+chroot "${root}" systemctl enable podman.service
+chroot "${root}" systemctl enable sshd.service
+chroot "${root}" systemctl enable flightctl-agent.service
 
 if ! grep -q '^user:' "${root}/etc/passwd"; then
   chroot "${root}" useradd -ms /bin/bash user

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -112,6 +112,9 @@ cleanup_mounts() {
 }
 trap cleanup_mounts EXIT
 
+# Minimal stream9 image has no mount/umount; util-linux provides them.
+dnf -y install util-linux
+
 # RPM %post (systemd-tmpfiles, semodule, useradd) needs a live-ish root.
 mkdir -p "${root}/proc" "${root}/sys" "${root}/dev"
 mount -t proc proc "${root}/proc"

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -15,18 +15,20 @@ RPM_COPR_REPO="${RPM_COPR_REPO:-}"
 RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
 TMP_CLOUD_IMAGE_PATH=""
 RPM_SOURCE_DIR=""
+GUEST_MOUNT=""
 
-PKG_CACHE_DIR=""
 cleanup() {
+  if [ -n "${GUEST_MOUNT}" ] && mountpoint -q "${GUEST_MOUNT}" 2>/dev/null; then
+    sudo guestunmount "${GUEST_MOUNT}" || sudo umount -l "${GUEST_MOUNT}" || true
+  fi
+  if [ -n "${GUEST_MOUNT}" ] && [ -d "${GUEST_MOUNT}" ]; then
+    rmdir "${GUEST_MOUNT}" 2>/dev/null || true
+  fi
   if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
     rm -f "${TMP_CLOUD_IMAGE_PATH}"
   fi
-  if [ -n "${PKG_CACHE_DIR}" ] && [ -d "${PKG_CACHE_DIR}" ]; then
-    rm -rf "${PKG_CACHE_DIR}"
-  fi
 }
 
-# Fail early with a clear message when a required host-side tool is missing.
 require_command() {
   local command_name="$1"
   if ! command -v "${command_name}" >/dev/null 2>&1; then
@@ -35,7 +37,6 @@ require_command() {
   fi
 }
 
-# Accept only owner/project COPR references before embedding them in guest commands.
 validate_copr_repo() {
   local copr_repo="$1"
   if [[ ! "${copr_repo}" =~ ^@?[A-Za-z0-9._+-]+/[A-Za-z0-9._+-]+$ ]]; then
@@ -44,7 +45,6 @@ validate_copr_repo() {
   fi
 }
 
-# Accept only package-name characters before embedding them in guest commands.
 validate_copr_package() {
   local copr_package="$1"
   if [[ ! "${copr_package}" =~ ^[A-Za-z0-9._:+-]+$ ]]; then
@@ -53,7 +53,6 @@ validate_copr_package() {
   fi
 }
 
-# Keep local RPM lookups confined to a simple directory name beneath bin/.
 validate_rpm_dir() {
   local rpm_dir="$1"
   if [[ ! "${rpm_dir}" =~ ^[A-Za-z0-9._+-]+$ ]] || [[ "${rpm_dir}" == *"/"* ]] || [[ "${rpm_dir}" == *".."* ]]; then
@@ -62,7 +61,6 @@ validate_rpm_dir() {
   fi
 }
 
-# Resolve the caller-provided RPM directory under bin/ and reject path escape.
 resolve_rpm_source_dir() {
   local rpm_dir="$1"
   local bin_root="${ROOT_DIR}/bin"
@@ -82,7 +80,6 @@ resolve_rpm_source_dir() {
   RPM_SOURCE_DIR="${resolved_path}"
 }
 
-# Keep qcow output under bin/output even when callers override OUTPUT_DIR.
 resolve_output_dir() {
   local output_dir="$1"
   local output_root="${ROOT_DIR}/bin/output"
@@ -97,6 +94,75 @@ resolve_output_dir() {
   OUTPUT_DIR="${resolved_path}"
 }
 
+# Install packages into a mounted cloud-image root using CentOS Stream 9's dnf
+# (host runners are Ubuntu and have no native dnf). Networking stays on the
+# container/host — never inside a libguestfs appliance.
+install_into_root() {
+  local install_root="$1"
+  local container_cmd
+
+  container_cmd=$(cat <<'EOS'
+set -euo pipefail
+root=/installroot
+
+dnf --installroot="${root}" -y install epel-release epel-next-release
+dnf --installroot="${root}" -y install \
+  cloud-init \
+  dnf-plugins-core \
+  firewalld \
+  openssh-server \
+  podman \
+  podman-compose \
+  python-dotenv \
+  sudo
+
+if [ -n "${RPM_COPR_REPO}" ]; then
+  dnf --installroot="${root}" copr -y enable "${RPM_COPR_REPO}"
+  dnf --installroot="${root}" -y install "${RPM_COPR_PACKAGE}"
+else
+  dnf --installroot="${root}" -y install /rpms/flightctl-agent-*.rpm /rpms/flightctl-selinux-*.rpm
+fi
+
+systemctl --root="${root}" enable firewalld.service
+systemctl --root="${root}" enable podman.service
+systemctl --root="${root}" enable sshd.service
+systemctl --root="${root}" enable flightctl-agent.service
+
+if ! grep -q '^user:' "${root}/etc/passwd"; then
+  chroot "${root}" useradd -ms /bin/bash user
+fi
+echo 'user:user' | chroot "${root}" chpasswd
+if ! grep -q '^user ALL=(ALL) NOPASSWD: ALL' "${root}/etc/sudoers"; then
+  echo 'user ALL=(ALL) NOPASSWD: ALL' >> "${root}/etc/sudoers"
+fi
+
+mkdir -p "${root}/usr/lib/flightctl/custom-info.d"
+printf '#!/bin/bash\necho "my site"\n' > "${root}/usr/lib/flightctl/custom-info.d/siteName"
+printf '#!/bin/bash\necho ""\n' > "${root}/usr/lib/flightctl/custom-info.d/emptyValue"
+printf '#!/bin/bash\necho "no-show"\n' > "${root}/usr/lib/flightctl/custom-info.d/keyNotShown"
+chmod 755 "${root}/usr/lib/flightctl/custom-info.d" "${root}/usr/lib/flightctl/custom-info.d/"*
+
+dnf --installroot="${root}" clean all
+EOS
+)
+
+  local -a podman_args=(
+    run --rm
+    -e "RPM_COPR_REPO=${RPM_COPR_REPO}"
+    -e "RPM_COPR_PACKAGE=${RPM_COPR_PACKAGE:-flightctl-agent}"
+    -v "${install_root}:/installroot:Z"
+  )
+
+  if [ -z "${RPM_COPR_REPO}" ]; then
+    podman_args+=(-v "${RPM_SOURCE_DIR}:/rpms:ro,Z")
+  fi
+
+  # Rootful podman matches the BIB path and avoids rootless crun issues on GHA.
+  sudo podman "${podman_args[@]}" \
+    quay.io/centos/centos:stream9 \
+    bash -c "${container_cmd}"
+}
+
 if [ "${OS_ID}" != "cs9-regular" ]; then
   echo "qcow2_regular.sh currently supports only cs9-regular, got ${OS_ID}" >&2
   exit 1
@@ -104,8 +170,11 @@ fi
 
 require_command curl
 require_command qemu-img
-require_command virt-customize
+require_command guestmount
+require_command guestunmount
 require_command podman
+require_command virt-customize
+require_command mountpoint
 
 resolve_output_dir "${OUTPUT_DIR}"
 OUTPUT_QCOW_DIR="${OUTPUT_DIR}/qcow2"
@@ -113,6 +182,14 @@ OUTPUT_QCOW_PATH="${OUTPUT_QCOW_DIR}/disk.qcow2"
 
 mkdir -p "${CLOUD_IMAGE_CACHE_DIR}" "${OUTPUT_QCOW_DIR}"
 trap cleanup EXIT
+
+if [ -n "${RPM_COPR_REPO}" ]; then
+  validate_copr_repo "${RPM_COPR_REPO}"
+  validate_copr_package "${RPM_COPR_PACKAGE:-flightctl-agent}"
+else
+  validate_rpm_dir "${RPM_DIR}"
+  resolve_rpm_source_dir "${RPM_DIR}"
+fi
 
 if [ ! -f "${BASE_CLOUD_IMAGE_PATH}" ]; then
   echo "Downloading CentOS Stream 9 cloud image from ${BASE_CLOUD_IMAGE_URL}"
@@ -126,75 +203,23 @@ echo "Preparing package-mode qcow2 at ${OUTPUT_QCOW_PATH}"
 qemu-img convert -O qcow2 "${BASE_CLOUD_IMAGE_PATH}" "${OUTPUT_QCOW_PATH}"
 qemu-img resize "${OUTPUT_QCOW_PATH}" +5G
 
-# Guest networking is unavailable on GitHub-hosted runners (libguestfs passt
-# requires user-namespace creation).  Download all required packages on the
-# host via a CentOS 9 container, then install them offline inside the guest.
-echo "Downloading required packages for offline guest installation"
-PKG_CACHE_DIR=$(mktemp -d)
+# Mount the bootable cloud disk on the host. guestmount uses a libguestfs
+# appliance for filesystem access only (no guest networking / guest dnf).
+GUEST_MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/cs9-regular-guest.XXXXXX")"
+echo "Mounting qcow2 at ${GUEST_MOUNT}"
+sudo env LIBGUESTFS_BACKEND=direct guestmount -a "${OUTPUT_QCOW_PATH}" -i --rw "${GUEST_MOUNT}"
 
-CONTAINER_CMD='
-  set -euo pipefail
-  dnf install -y epel-release epel-next-release dnf-plugins-core
-  dnf download --resolve --destdir=/output \
-    epel-release epel-next-release \
-    cloud-init dnf-plugins-core firewalld openssh-server \
-    podman podman-compose python-dotenv sudo
-'
+echo "Installing packages into qcow2 via host-side dnf --installroot"
+install_into_root "${GUEST_MOUNT}"
 
-if [ -n "${RPM_COPR_REPO}" ]; then
-  package_name="${RPM_COPR_PACKAGE:-flightctl-agent}"
-  validate_copr_repo "${RPM_COPR_REPO}"
-  validate_copr_package "${package_name}"
-  CONTAINER_CMD+="
-    dnf copr -y enable ${RPM_COPR_REPO}
-    dnf download --resolve --destdir=/output ${package_name}
-  "
-else
-  validate_rpm_dir "${RPM_DIR}"
-  resolve_rpm_source_dir "${RPM_DIR}"
-fi
+echo "Unmounting qcow2"
+sudo guestunmount "${GUEST_MOUNT}"
+rmdir "${GUEST_MOUNT}" 2>/dev/null || true
+GUEST_MOUNT=""
 
-sudo podman run --rm \
-  -v "${PKG_CACHE_DIR}:/output:Z" \
-  quay.io/centos/centos:stream9 \
-  bash -c "${CONTAINER_CMD}"
-sudo chown -R "${USER}:$(id -gn "${USER}")" "${PKG_CACHE_DIR}"
-
-if [ -z "${RPM_COPR_REPO}" ]; then
-  cp "${RPM_SOURCE_DIR}"/flightctl-agent-*.rpm "${RPM_SOURCE_DIR}"/flightctl-selinux-*.rpm \
-    "${PKG_CACHE_DIR}/"
-fi
-
-if ! ls "${PKG_CACHE_DIR}"/*.rpm >/dev/null 2>&1; then
-  echo "No RPMs found in package cache after download" >&2
-  exit 1
-fi
-
-VIRT_CUSTOMIZE_ARGS=(
-  -a "${OUTPUT_QCOW_PATH}"
-  --no-network
-  --mkdir /tmp/pkg-cache
-  --copy-in "${PKG_CACHE_DIR}:/tmp/pkg-cache"
-  --run-command "dnf install -y /tmp/pkg-cache/*.rpm"
-  --run-command "rm -rf /tmp/pkg-cache"
-  --run-command "systemctl enable firewalld.service"
-  --run-command "systemctl enable podman.service"
-  --run-command "systemctl enable sshd.service"
-  --run-command "id -u user >/dev/null 2>&1 || useradd -ms /bin/bash user"
-  --run-command "echo 'user:user' | chpasswd"
-  --run-command "echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers"
-  --run-command "mkdir -p /usr/lib/flightctl/custom-info.d"
-  --run-command "printf '#!/bin/bash\necho \"my site\"\n' > /usr/lib/flightctl/custom-info.d/siteName"
-  --run-command "printf '#!/bin/bash\necho \"\"\n' > /usr/lib/flightctl/custom-info.d/emptyValue"
-  --run-command "printf '#!/bin/bash\necho \"no-show\"\n' > /usr/lib/flightctl/custom-info.d/keyNotShown"
-  --run-command "chmod 755 /usr/lib/flightctl/custom-info.d/*"
-  --run-command "systemctl enable flightctl-agent.service"
-  --run-command "dnf clean all"
-  --selinux-relabel
-)
-
-echo "Customizing regular package-mode qcow2"
-sudo env LIBGUESTFS_BACKEND=direct virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
+# Relabel without enabling appliance networking.
+echo "SELinux relabel"
+sudo env LIBGUESTFS_BACKEND=direct virt-customize -a "${OUTPUT_QCOW_PATH}" --no-network --selinux-relabel
 
 sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"
 

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -106,6 +106,10 @@ set -euo pipefail
 root=/installroot
 
 dnf --installroot="${root}" -y install epel-release epel-next-release
+# dnf resolves file:/// GPG key URLs against the running system, not installroot.
+mkdir -p /etc/pki/rpm-gpg
+cp -f "${root}"/etc/pki/rpm-gpg/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
+
 dnf --installroot="${root}" -y install \
   cloud-init \
   dnf-plugins-core \

--- a/test/scripts/agent-images/scripts/qcow2_regular.sh
+++ b/test/scripts/agent-images/scripts/qcow2_regular.sh
@@ -16,6 +16,7 @@ RPM_COPR_PACKAGE="${RPM_COPR_PACKAGE:-}"
 TMP_CLOUD_IMAGE_PATH=""
 RPM_SOURCE_DIR=""
 GUEST_MOUNT=""
+POST_CONFIG_SCRIPT=""
 
 cleanup() {
   if [ -n "${GUEST_MOUNT}" ] && mountpoint -q "${GUEST_MOUNT}" 2>/dev/null; then
@@ -26,6 +27,9 @@ cleanup() {
   fi
   if [ -n "${TMP_CLOUD_IMAGE_PATH}" ] && [ -f "${TMP_CLOUD_IMAGE_PATH}" ]; then
     rm -f "${TMP_CLOUD_IMAGE_PATH}"
+  fi
+  if [ -n "${POST_CONFIG_SCRIPT}" ] && [ -f "${POST_CONFIG_SCRIPT}" ]; then
+    rm -f "${POST_CONFIG_SCRIPT}"
   fi
 }
 
@@ -160,38 +164,19 @@ if ! chroot "${root}" semodule -l | grep -q '^flightctl_agent'; then
 fi
 
 # Finish agent %post work that may have failed without a full systemd environment.
+# User/home/custom-info setup runs later via virt-customize: creating
+# /home/flightctl through the guestmount FUSE bind from the container hits
+# EACCES on GHA even though package installs to the same mount succeed.
 mkdir -p "${root}/var/lib/flightctl"
 chmod 0755 "${root}/var/lib/flightctl"
-if ! grep -q '^flightctl:' "${root}/etc/passwd"; then
-  chroot "${root}" useradd --create-home --user-group flightctl
-fi
 mkdir -p "${root}/var/lib/systemd/linger"
 touch "${root}/var/lib/systemd/linger/flightctl"
-flightctl_home="$(chroot "${root}" getent passwd flightctl | cut -d: -f6)"
-mkdir -p "${root}${flightctl_home}/.config/containers/systemd" \
-  "${root}${flightctl_home}/.config/systemd/user" \
-  "${root}${flightctl_home}/.local"
-chroot "${root}" chown -R flightctl:flightctl "${flightctl_home}/.config" "${flightctl_home}/.local"
 
 # centos:stream9 has no systemctl; enable units via the mounted root (has systemd).
 chroot "${root}" systemctl enable firewalld.service
 chroot "${root}" systemctl enable podman.service
 chroot "${root}" systemctl enable sshd.service
 chroot "${root}" systemctl enable flightctl-agent.service
-
-if ! grep -q '^user:' "${root}/etc/passwd"; then
-  chroot "${root}" useradd -ms /bin/bash user
-fi
-echo 'user:user' | chroot "${root}" chpasswd
-if ! grep -q '^user ALL=(ALL) NOPASSWD: ALL' "${root}/etc/sudoers"; then
-  echo 'user ALL=(ALL) NOPASSWD: ALL' >> "${root}/etc/sudoers"
-fi
-
-mkdir -p "${root}/usr/lib/flightctl/custom-info.d"
-printf '#!/bin/bash\necho "my site"\n' > "${root}/usr/lib/flightctl/custom-info.d/siteName"
-printf '#!/bin/bash\necho ""\n' > "${root}/usr/lib/flightctl/custom-info.d/emptyValue"
-printf '#!/bin/bash\necho "no-show"\n' > "${root}/usr/lib/flightctl/custom-info.d/keyNotShown"
-chmod 755 "${root}/usr/lib/flightctl/custom-info.d" "${root}/usr/lib/flightctl/custom-info.d/"*
 
 dnf --installroot="${root}" clean all
 EOS
@@ -201,7 +186,9 @@ EOS
     run --rm --privileged
     -e "RPM_COPR_REPO=${RPM_COPR_REPO}"
     -e "RPM_COPR_PACKAGE=${RPM_COPR_PACKAGE:-flightctl-agent}"
-    -v "${install_root}:/installroot:Z"
+    # No :Z — guestmount is FUSE; SELinux relabel of the mount is useless on
+    # Ubuntu runners and can interfere with subsequent creates.
+    -v "${install_root}:/installroot:rw"
   )
 
   if [ -z "${RPM_COPR_REPO}" ]; then
@@ -272,9 +259,36 @@ done
 rmdir "${GUEST_MOUNT}" 2>/dev/null || true
 GUEST_MOUNT=""
 
-# Relabel without enabling appliance networking.
-echo "SELinux relabel"
-sudo env LIBGUESTFS_BACKEND=direct virt-customize -a "${OUTPUT_QCOW_PATH}" --no-network --selinux-relabel
+# Configure users/homedirs and relabel in the libguestfs appliance (not via FUSE).
+echo "Configuring e2e users and SELinux relabel"
+POST_CONFIG_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/cs9-regular-post.XXXXXX.sh")"
+cat >"${POST_CONFIG_SCRIPT}" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+id -u flightctl >/dev/null 2>&1 || useradd --create-home --user-group flightctl
+flightctl_home="$(getent passwd flightctl | cut -d: -f6)"
+mkdir -p \
+  "${flightctl_home}/.config/containers/systemd" \
+  "${flightctl_home}/.config/systemd/user" \
+  "${flightctl_home}/.local"
+chown -R flightctl:flightctl "${flightctl_home}/.config" "${flightctl_home}/.local"
+id -u user >/dev/null 2>&1 || useradd -ms /bin/bash user
+echo 'user:user' | chpasswd
+if ! grep -q '^user ALL=(ALL) NOPASSWD: ALL' /etc/sudoers; then
+  echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+fi
+mkdir -p /usr/lib/flightctl/custom-info.d
+printf '#!/bin/bash\necho "my site"\n' > /usr/lib/flightctl/custom-info.d/siteName
+printf '#!/bin/bash\necho ""\n' > /usr/lib/flightctl/custom-info.d/emptyValue
+printf '#!/bin/bash\necho "no-show"\n' > /usr/lib/flightctl/custom-info.d/keyNotShown
+chmod 755 /usr/lib/flightctl/custom-info.d /usr/lib/flightctl/custom-info.d/*
+EOF
+chmod 755 "${POST_CONFIG_SCRIPT}"
+sudo env LIBGUESTFS_BACKEND=direct virt-customize -a "${OUTPUT_QCOW_PATH}" --no-network \
+  --run "${POST_CONFIG_SCRIPT}" \
+  --selinux-relabel
+rm -f "${POST_CONFIG_SCRIPT}"
+POST_CONFIG_SCRIPT=""
 
 sudo chown "${USER}:$(id -gn "${USER}")" "${OUTPUT_QCOW_PATH}"
 


### PR DESCRIPTION
## Summary
- Stacked on [#3336](https://github.com/flightctl/flightctl/pull/3336) (`edm-4765-package-mode-ci`): activates the package-mode e2e suite and adds the Linux-only tests from Eldar’s [#3323](https://github.com/flightctl/flightctl/pull/3323).
- Cherry-picked `EDM-4768: add package-mode e2e suite` onto our CI branch. Eldar’s `EDM-4765: activate package-mode CI leg` was already covered by #3336 (empty cherry-pick after conflict resolution; kept our `resolve-go-e2e-dirs` action).
- Adds `test/e2e/package_mode` coverage (enroll/`osMode=package`, config+podman app, mixed-fleet reject) and a dedicated CI matrix row that pairs `cs9-regular` + `cs9-bootc` qcow artifacts.

## Test plan
- [ ] Wait for #3336 to merge (or run CI on this stack as-is)
- [ ] Confirm `cs9-regular` agent-image build stays green
- [ ] Confirm package-mode e2e discovery + suite row runs
- [ ] Confirm package-mode sanity specs pass


Made with [Cursor](https://cursor.com)