### PR TITLE
EDM-4764: Package-mode upstream documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -142,6 +142,7 @@ SpiceDB
 stream9
 stream10
 subdomains
+subpackage
 substring
 systemd
 targetRevision

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -38,7 +38,7 @@ To generate API code and mocks, use `make generate`  This requires installing mo
 
 For the agent RPM subpackage split (`flightctl-agent` /
 `flightctl-greenboot`) and package-mode e2e (`cs9-regular` OCI image +
-`./test/e2e/package_mode` testcontainer suite), see
+testcontainer suite; suite merge tracked separately), see
 [Package-mode development notes](package-mode.md).
 
 ### Container image building

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -37,8 +37,8 @@ To generate API code and mocks, use `make generate`  This requires installing mo
 ### Package-mode
 
 For the agent RPM subpackage split (`flightctl-agent` /
-`flightctl-greenboot`) and the package-mode e2e image build path
-(`BUILD_TYPE=regular AGENT_OS_ID=cs9-regular`), see
+`flightctl-greenboot`) and package-mode e2e (`cs9-regular` OCI image +
+`./test/e2e/package_mode` testcontainer suite), see
 [Package-mode development notes](package-mode.md).
 
 ### Container image building

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -38,8 +38,8 @@ To generate API code and mocks, use `make generate`  This requires installing mo
 
 For the agent RPM subpackage split (`flightctl-agent` /
 `flightctl-greenboot`) and package-mode e2e (`cs9-regular` OCI image +
-testcontainer suite; suite merge tracked separately), see
-[Package-mode development notes](package-mode.md).
+testcontainer suite; suite in [#3345](https://github.com/flightctl/flightctl/pull/3345)),
+see [Package-mode development notes](package-mode.md).
 
 ### Container image building
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -38,8 +38,8 @@ To generate API code and mocks, use `make generate`  This requires installing mo
 
 For the agent RPM subpackage split (`flightctl-agent` /
 `flightctl-greenboot`) and package-mode e2e (`cs9-regular` OCI image +
-testcontainer suite; suite in [#3345](https://github.com/flightctl/flightctl/pull/3345)),
-see [Package-mode development notes](package-mode.md).
+testcontainer suite), see
+[Package-mode development notes](package-mode.md).
 
 ### Container image building
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -34,6 +34,13 @@ To generate API code and mocks, use `make generate`  This requires installing mo
 
 `go install go.uber.org/mock/mockgen@v0.4.0`
 
+### Package-mode
+
+For the agent RPM subpackage split (`flightctl-agent` /
+`flightctl-greenboot`) and the package-mode e2e image build path
+(`BUILD_TYPE=regular AGENT_OS_ID=cs9-regular`), see
+[Package-mode development notes](package-mode.md).
+
 ### Container image building
 
 Flight Control supports building containers for multiple Enterprise Linux versions using OS-qualified image naming. The build system uses an `OS` variable to specify the target Enterprise Linux version:

--- a/docs/developer/devicesimulator.md
+++ b/docs/developer/devicesimulator.md
@@ -19,7 +19,7 @@ Changes to the configuration of all launched agents can be made in `~/.flightctl
 Some key options available for tuning:
 - `status-update-interval` - How often the agent reports its status to the API. Higher intervals reduce server load.
 
-See [Installing the Agent](../user/installing/installing-agent.md) for all available options.
+See [Installing and configuring the Flight Control Agent](../user/installing/installing-agent.md) for all available options.
 
 ## CLI Reference
 

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -2,7 +2,7 @@
 
 Package-mode devices run the Flight Control agent on hosts that use traditional
 package management (dnf/yum) without `bootc` or `rpm-ostree` image management.
-This page summarizes RPM packaging and e2e image builds for contributors.
+This page summarizes RPM packaging and package-mode e2e for contributors.
 
 For user-facing install and mixed-fleet behavior, see
 [Installing and configuring the Flight Control Agent](../user/installing/installing-agent.md)
@@ -23,24 +23,61 @@ Image-mode installs use the default weak-dependency behavior and pull in
 `--setopt=install_weak_deps=False` so greenboot is not installed. See the
 [user install docs](../user/installing/installing-agent.md#installing-the-agent-rpm).
 
-## Package-mode e2e agent images
+## Package-mode e2e
 
-E2E agent image builds live under `test/scripts/agent-images/`. Package-mode
-coverage uses the `cs9-regular` flavor:
+Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
+Ginkgo suite under [`test/e2e/package_mode`](../../test/e2e/package_mode).
+Tests run the agent in a **testcontainer** (systemd as init, nested Podman for
+apps), not a package-mode QCOW2 VM.
+
+> Until the package-mode e2e suite is merged to `main`, the Package-mode E2E
+> section in [`test/AGENTS.md`](../../test/AGENTS.md) on the suite branch is
+> the authoritative reference for CI and harness details.
+
+### Build the cs9-regular image
 
 ```bash
-BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
+BUILD_TYPE=regular AGENT_OS_ID=cs9-regular SKIP_QCOW_BUILD=true make e2e-agent-images
 ```
 
-That path builds:
+That path builds the package-mode OCI base (and bundle) only. Package-mode
+does not produce a QCOW2 disk image; `*-regular` QCOW builds are unsupported.
 
-* An OCI base image from `containerfiles/cs9-regular/Containerfile`
-* A qcow2 disk image via `scripts/qcow2_regular.sh` (cloud image +
-  `virt-customize`), not `bootc-image-builder`
+CI builds `cs9-regular` with `build_type: regular`, `upload_bundle: true`, and
+`skip_qcow_build: true`, then loads `agent-images-bundle-cs9-regular.tar` into
+local container storage before e2e.
 
-OS-update e2e scenarios that depend on image-based OS switching do not apply
-to package-mode images. Prefer config and application management coverage for
-`cs9-regular`.
+Image reference used by the harness:
 
-For flavors, tagging, variants, and CI wiring details, see
+`quay.io/flightctl/flightctl-device:base-cs9-regular`
+
+For flavors, tagging, and bundling details, see
 [test/scripts/agent-images/README.md](../../test/scripts/agent-images/README.md).
+
+### Run the package-mode suite
+
+```bash
+GO_E2E_DIRS=./test/e2e/package_mode make in-cluster-e2e-test
+```
+
+Prerequisites:
+
+* Agent config under `bin/agent/etc/flightctl` (from a normal deploy / e2e setup)
+* The `cs9-regular` OCI image loaded locally (from the build or CI bundle)
+
+`StartPackageModeAgent()` in
+[`test/harness/e2e/package_mode_agent.go`](../../test/harness/e2e/package_mode_agent.go)
+starts a privileged testcontainer with `/sbin/init`, mounts agent config and
+certs, and waits for `flightctl-agent` to become active.
+
+### What the suite covers
+
+* Enrollment reports `status.capabilities.osMode=package`
+* Config and a Podman application on a fleet **without** `spec.os.image`
+* When the fleet adds `spec.os.image`, the package-mode device stays
+  `OutOfDate` and does not advance the committed config version
+
+Mixed package-mode + image-mode **VM** scenarios remain skipped until
+image-mode VM infrastructure is available for that pairing. See
+[test/AGENTS.md](../../test/AGENTS.md) (Package-mode E2E) for CI wiring and
+harness notes.

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -26,16 +26,9 @@ Image-mode installs use the default weak-dependency behavior and pull in
 ## Package-mode e2e
 
 Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
-Ginkgo suite under `test/e2e/package_mode`. Tests run the agent in a
-**testcontainer** (systemd as init, nested Podman for apps), not a
-package-mode QCOW2 VM.
-
-> The image build path (`BUILD_TYPE=regular`, `SKIP_QCOW_BUILD=true`) is on
-> `main`. The Ginkgo suite and `StartPackageModeAgent` harness land with
-> [EDM-4768 / #3345](https://github.com/flightctl/flightctl/pull/3345). Until
-> that merges, suite paths below may be missing on `main`; use that PR (or
-> its `test/AGENTS.md` Package-mode E2E section) as the source of truth for
-> suite details.
+Ginkgo suite under [`test/e2e/package_mode`](../../test/e2e/package_mode).
+Tests run the agent in a **testcontainer** (systemd as init, nested Podman
+for apps), not a package-mode QCOW2 VM.
 
 ### Build the cs9-regular image
 
@@ -45,8 +38,7 @@ BUILD_TYPE=regular AGENT_OS_ID=cs9-regular SKIP_QCOW_BUILD=true make e2e-agent-i
 
 With `SKIP_QCOW_BUILD=true` (the CI default for package-mode), the path builds
 the package-mode OCI base and bundle only. Do not rely on a package-mode
-QCOW2 disk for e2e; the `qcow2_regular.sh` helper is removed with the
-testcontainer suite.
+QCOW2 disk for e2e.
 
 CI builds `cs9-regular` with `build_type: regular`, `upload_bundle: true`, and
 `skip_qcow_build: true`, then loads `agent-images-bundle-cs9-regular.tar` into
@@ -61,8 +53,6 @@ For OS flavors, tagging, and bundling, see
 
 ### Run the package-mode suite
 
-Once the suite from #3345 is on your tree:
-
 ```bash
 make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/package_mode
 ```
@@ -73,9 +63,9 @@ Prerequisites:
 * The `cs9-regular` OCI image loaded locally (from the build or CI bundle)
 
 The harness helper `StartPackageModeAgent` (in
-`test/harness/e2e/package_mode_agent.go`) starts a privileged testcontainer
-with `/sbin/init`, mounts agent config and certs, and waits for
-`flightctl-agent` to become active.
+[`test/harness/e2e/package_mode_agent.go`](../../test/harness/e2e/package_mode_agent.go))
+starts a privileged testcontainer with `/sbin/init`, mounts agent config and
+certs, and waits for `flightctl-agent` to become active.
 
 ### What the suite covers
 
@@ -86,5 +76,5 @@ with `/sbin/init`, mounts agent config and certs, and waits for
 
 Mixed package-mode + image-mode **VM** scenarios remain skipped until
 image-mode VM infrastructure is available for that pairing. See the
-Package-mode E2E section of `test/AGENTS.md` (after #3345 merges) for CI
+Package-mode E2E section of [`test/AGENTS.md`](../../test/AGENTS.md) for CI
 wiring and harness notes.

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -26,9 +26,9 @@ Image-mode installs use the default weak-dependency behavior and pull in
 ## Package-mode e2e
 
 Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
-Ginkgo suite under [`test/e2e/package_mode`](../../test/e2e/package_mode).
-Tests run the agent in a **testcontainer** (systemd as init, nested Podman
-for apps), not a package-mode QCOW2 VM.
+Ginkgo suite under `test/e2e/package_mode`. Tests run the agent in a
+**testcontainer** (systemd as init, nested Podman for apps), not a
+package-mode QCOW2 VM.
 
 ### Build the cs9-regular image
 
@@ -63,9 +63,9 @@ Prerequisites:
 * The `cs9-regular` OCI image loaded locally (from the build or CI bundle)
 
 The harness helper `StartPackageModeAgent` (in
-[`test/harness/e2e/package_mode_agent.go`](../../test/harness/e2e/package_mode_agent.go))
-starts a privileged testcontainer with `/sbin/init`, mounts agent config and
-certs, and waits for `flightctl-agent` to become active.
+`test/harness/e2e/package_mode_agent.go`) starts a privileged testcontainer
+with `/sbin/init`, mounts agent config and certs, and waits for
+`flightctl-agent` to become active.
 
 ### What the suite covers
 

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -25,14 +25,16 @@ Image-mode installs use the default weak-dependency behavior and pull in
 
 ## Package-mode e2e
 
-Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
-Ginkgo suite under [`test/e2e/package_mode`](../../test/e2e/package_mode).
-Tests run the agent in a **testcontainer** (systemd as init, nested Podman for
-apps), not a package-mode QCOW2 VM.
+> This section describes the package-mode e2e model from the package-mode e2e
+> suite (OCI image + testcontainer). Until that suite is merged to `main`,
+> treat the Package-mode E2E section of `test/AGENTS.md` on the suite branch
+> as authoritative. Suite paths and harness symbols below may not exist on
+> `main` yet.
 
-> Until the package-mode e2e suite is merged to `main`, the Package-mode E2E
-> section in [`test/AGENTS.md`](../../test/AGENTS.md) on the suite branch is
-> the authoritative reference for CI and harness details.
+Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
+Ginkgo suite under `test/e2e/package_mode`. Tests run the agent in a
+**testcontainer** (systemd as init, nested Podman for apps), not a
+package-mode QCOW2 VM.
 
 ### Build the cs9-regular image
 
@@ -40,8 +42,9 @@ apps), not a package-mode QCOW2 VM.
 BUILD_TYPE=regular AGENT_OS_ID=cs9-regular SKIP_QCOW_BUILD=true make e2e-agent-images
 ```
 
-That path builds the package-mode OCI base (and bundle) only. Package-mode
-does not produce a QCOW2 disk image; `*-regular` QCOW builds are unsupported.
+With `SKIP_QCOW_BUILD=true` (the CI default for package-mode), the path builds
+the package-mode OCI base and bundle only. After the suite lands, `*-regular`
+QCOW builds are unsupported; do not rely on a package-mode QCOW2 disk for e2e.
 
 CI builds `cs9-regular` with `build_type: regular`, `upload_bundle: true`, and
 `skip_qcow_build: true`, then loads `agent-images-bundle-cs9-regular.tar` into
@@ -51,13 +54,17 @@ Image reference used by the harness:
 
 `quay.io/flightctl/flightctl-device:base-cs9-regular`
 
-For flavors, tagging, and bundling details, see
+For OS flavors, tagging, and bundling, see
 [test/scripts/agent-images/README.md](../../test/scripts/agent-images/README.md).
+Ignore any package-mode QCOW / `virt-customize` wording there until the suite
+branch documentation is on `main`.
 
 ### Run the package-mode suite
 
+Once the suite is available on your tree:
+
 ```bash
-GO_E2E_DIRS=./test/e2e/package_mode make in-cluster-e2e-test
+make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/package_mode
 ```
 
 Prerequisites:
@@ -65,10 +72,10 @@ Prerequisites:
 * Agent config under `bin/agent/etc/flightctl` (from a normal deploy / e2e setup)
 * The `cs9-regular` OCI image loaded locally (from the build or CI bundle)
 
-`StartPackageModeAgent()` in
-[`test/harness/e2e/package_mode_agent.go`](../../test/harness/e2e/package_mode_agent.go)
-starts a privileged testcontainer with `/sbin/init`, mounts agent config and
-certs, and waits for `flightctl-agent` to become active.
+The harness helper `StartPackageModeAgent` (in
+`test/harness/e2e/package_mode_agent.go` on the suite branch) starts a
+privileged testcontainer with `/sbin/init`, mounts agent config and certs, and
+waits for `flightctl-agent` to become active.
 
 ### What the suite covers
 
@@ -78,6 +85,6 @@ certs, and waits for `flightctl-agent` to become active.
   `OutOfDate` and does not advance the committed config version
 
 Mixed package-mode + image-mode **VM** scenarios remain skipped until
-image-mode VM infrastructure is available for that pairing. See
-[test/AGENTS.md](../../test/AGENTS.md) (Package-mode E2E) for CI wiring and
-harness notes.
+image-mode VM infrastructure is available for that pairing. See the
+Package-mode E2E section of `test/AGENTS.md` on the suite branch for CI
+wiring and harness notes.

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -25,16 +25,17 @@ Image-mode installs use the default weak-dependency behavior and pull in
 
 ## Package-mode e2e
 
-> This section describes the package-mode e2e model from the package-mode e2e
-> suite (OCI image + testcontainer). Until that suite is merged to `main`,
-> treat the Package-mode E2E section of `test/AGENTS.md` on the suite branch
-> as authoritative. Suite paths and harness symbols below may not exist on
-> `main` yet.
-
 Package-mode e2e uses a `cs9-regular` **OCI** agent image and a dedicated
 Ginkgo suite under `test/e2e/package_mode`. Tests run the agent in a
 **testcontainer** (systemd as init, nested Podman for apps), not a
 package-mode QCOW2 VM.
+
+> The image build path (`BUILD_TYPE=regular`, `SKIP_QCOW_BUILD=true`) is on
+> `main`. The Ginkgo suite and `StartPackageModeAgent` harness land with
+> [EDM-4768 / #3345](https://github.com/flightctl/flightctl/pull/3345). Until
+> that merges, suite paths below may be missing on `main`; use that PR (or
+> its `test/AGENTS.md` Package-mode E2E section) as the source of truth for
+> suite details.
 
 ### Build the cs9-regular image
 
@@ -43,8 +44,9 @@ BUILD_TYPE=regular AGENT_OS_ID=cs9-regular SKIP_QCOW_BUILD=true make e2e-agent-i
 ```
 
 With `SKIP_QCOW_BUILD=true` (the CI default for package-mode), the path builds
-the package-mode OCI base and bundle only. After the suite lands, `*-regular`
-QCOW builds are unsupported; do not rely on a package-mode QCOW2 disk for e2e.
+the package-mode OCI base and bundle only. Do not rely on a package-mode
+QCOW2 disk for e2e; the `qcow2_regular.sh` helper is removed with the
+testcontainer suite.
 
 CI builds `cs9-regular` with `build_type: regular`, `upload_bundle: true`, and
 `skip_qcow_build: true`, then loads `agent-images-bundle-cs9-regular.tar` into
@@ -56,12 +58,10 @@ Image reference used by the harness:
 
 For OS flavors, tagging, and bundling, see
 [test/scripts/agent-images/README.md](../../test/scripts/agent-images/README.md).
-Ignore any package-mode QCOW / `virt-customize` wording there until the suite
-branch documentation is on `main`.
 
 ### Run the package-mode suite
 
-Once the suite is available on your tree:
+Once the suite from #3345 is on your tree:
 
 ```bash
 make in-cluster-e2e-test GO_E2E_DIRS=test/e2e/package_mode
@@ -73,9 +73,9 @@ Prerequisites:
 * The `cs9-regular` OCI image loaded locally (from the build or CI bundle)
 
 The harness helper `StartPackageModeAgent` (in
-`test/harness/e2e/package_mode_agent.go` on the suite branch) starts a
-privileged testcontainer with `/sbin/init`, mounts agent config and certs, and
-waits for `flightctl-agent` to become active.
+`test/harness/e2e/package_mode_agent.go`) starts a privileged testcontainer
+with `/sbin/init`, mounts agent config and certs, and waits for
+`flightctl-agent` to become active.
 
 ### What the suite covers
 
@@ -86,5 +86,5 @@ waits for `flightctl-agent` to become active.
 
 Mixed package-mode + image-mode **VM** scenarios remain skipped until
 image-mode VM infrastructure is available for that pairing. See the
-Package-mode E2E section of `test/AGENTS.md` on the suite branch for CI
+Package-mode E2E section of `test/AGENTS.md` (after #3345 merges) for CI
 wiring and harness notes.

--- a/docs/developer/package-mode.md
+++ b/docs/developer/package-mode.md
@@ -1,0 +1,46 @@
+# Package-mode development notes
+
+Package-mode devices run the Flight Control agent on hosts that use traditional
+package management (dnf/yum) without `bootc` or `rpm-ostree` image management.
+This page summarizes RPM packaging and e2e image builds for contributors.
+
+For user-facing install and mixed-fleet behavior, see
+[Installing and configuring the Flight Control Agent](../user/installing/installing-agent.md)
+and
+[Mixed image-mode and package-mode fleets](../user/using/managing-fleets.md#mixed-image-mode-and-package-mode-fleets).
+
+## RPM subpackages
+
+The agent RPM split is defined in [`packaging/rpm/flightctl.spec`](../../packaging/rpm/flightctl.spec):
+
+| Package | Role | Dependencies |
+| ------- | ---- | ------------ |
+| `flightctl-agent` | Agent binary, systemd unit, SELinux requirement, core files | `Recommends: flightctl-greenboot` |
+| `flightctl-greenboot` | Greenboot health checks, bootc timer masking, greenboot configuration | `Requires: greenboot` and matching `flightctl-agent` |
+
+Image-mode installs use the default weak-dependency behavior and pull in
+`flightctl-greenboot`. Package-mode installs use
+`--setopt=install_weak_deps=False` so greenboot is not installed. See the
+[user install docs](../user/installing/installing-agent.md#installing-the-agent-rpm).
+
+## Package-mode e2e agent images
+
+E2E agent image builds live under `test/scripts/agent-images/`. Package-mode
+coverage uses the `cs9-regular` flavor:
+
+```bash
+BUILD_TYPE=regular AGENT_OS_ID=cs9-regular make e2e-agent-images
+```
+
+That path builds:
+
+* An OCI base image from `containerfiles/cs9-regular/Containerfile`
+* A qcow2 disk image via `scripts/qcow2_regular.sh` (cloud image +
+  `virt-customize`), not `bootc-image-builder`
+
+OS-update e2e scenarios that depend on image-based OS switching do not apply
+to package-mode images. Prefer config and application management coverage for
+`cs9-regular`.
+
+For flavors, tagging, variants, and CI wiring details, see
+[test/scripts/agent-images/README.md](../../test/scripts/agent-images/README.md).

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -79,6 +79,7 @@ Welcome to the Flight Control user documentation.
   * [Understanding Fleets](using/managing-fleets.md#understanding-fleets)
   * [Selecting Devices into a Fleet](using/managing-fleets.md#selecting-devices-into-a-fleet)
   * [Defining Device Templates](using/managing-fleets.md#defining-device-templates)
+  * [Mixed image-mode and package-mode fleets](using/managing-fleets.md#mixed-image-mode-and-package-mode-fleets)
   * [Defining Rollout Policies](using/managing-fleets.md#defining-rollout-policies)
 * **[Auto-syncing External Dependencies](using/auto-syncing-dependencies.md)** - How Flight Control automatically detects and applies upstream changes to device configurations.
 * **[Viewing Vulnerabilities](using/viewing-vulnerabilities.md)** - How to view vulnerability data for devices and fleets.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -47,7 +47,10 @@ Welcome to the Flight Control user documentation.
 
 * **[Installing the Flight Control CLI](installing/installing-cli.md)**
 
-* **[Installing the Flight Control Agent](installing/installing-agent.md)**
+* **[Installing and configuring the Flight Control Agent](installing/installing-agent.md)**
+  * [Installing the agent RPM](installing/installing-agent.md#installing-the-agent-rpm)
+  * [Package-mode installation](installing/installing-agent.md#package-mode-installation)
+  * [Image-mode installation](installing/installing-agent.md#image-mode-installation)
   * [Integrating with Greenboot](installing/configuring-device-greenboot.md)
   * [Installing the Flight Control agent offline on RHEL](installing/installing-agent-offline.md)
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -65,6 +65,7 @@ Welcome to the Flight Control user documentation.
 * **[Managing Devices](using/managing-devices.md)** - How to manage individual devices.
   * [Enrolling Devices](using/managing-devices.md#enrolling-devices)
   * [Viewing the Device Inventory and Device Details](using/managing-devices.md#viewing-the-device-inventory-and-device-details)
+  * [OS mode](using/managing-devices.md#os-mode)
   * [Organizing Devices](using/managing-devices.md#organizing-devices)
   * [Updating the OS](using/managing-devices.md#updating-the-os)
   * [Managing OS Configuration](using/managing-devices.md#managing-os-configuration)

--- a/docs/user/building/building-images.md
+++ b/docs/user/building/building-images.md
@@ -47,7 +47,7 @@ When the Flight Control agent starts, it expects to find its configuration in `/
 
 * the Flight Control enrollment service to connect to (enrollment endpoint),
 * the X.509 client certificate and key to connect with (enrollment certificate),
-* optionally, any further agent configuration (see [Installing the Flight Control Agent](../installing/installing-agent.md)).
+* optionally, any further agent configuration (see [Installing and configuring the Flight Control Agent](../installing/installing-agent.md)).
 
 You can provision the enrollment endpoint and certificate to the device in the following ways:
 

--- a/docs/user/installing/configuring-device-attestation.md
+++ b/docs/user/installing/configuring-device-attestation.md
@@ -227,7 +227,7 @@ service:
 
 ## Enabling TPM in Agent Configuration
 
-To enable TPM authentication, configure the `tpm` section in the agent's `/etc/flightctl/config.yaml` file. See [Installing the Flight Control Agent - TPM Configuration](installing-agent.md#tpm-configuration) for detailed configuration parameters and examples.
+To enable TPM authentication, configure the `tpm` section in the agent's `/etc/flightctl/config.yaml` file. See [Installing and configuring the Flight Control Agent - TPM Configuration](installing-agent.md#tpm-configuration) for detailed configuration parameters and examples.
 
 ## Enrollment Process
 
@@ -294,7 +294,7 @@ Upon successful validation and approval:
 
 ## Troubleshooting
 
-For agent-specific TPM troubleshooting and debugging, see [Installing the Flight Control Agent - TPM Troubleshooting](installing-agent.md#tpm-troubleshooting).
+For agent-specific TPM troubleshooting and debugging, see [Installing and configuring the Flight Control Agent - TPM Troubleshooting](installing-agent.md#tpm-troubleshooting).
 
 ## Security Considerations
 

--- a/docs/user/installing/configuring-device-greenboot.md
+++ b/docs/user/installing/configuring-device-greenboot.md
@@ -8,11 +8,20 @@ To mitigate these problems, Flight Control integrates with [greenboot](https://g
 
 This reduces the risk of being locked out of an edge device when upgrades fail.
 
+Greenboot integration ships in the optional `flightctl-greenboot` RPM
+subpackage. Image-mode installs of `flightctl-agent` pull it in through a
+`Recommends` dependency. Package-mode installs that use
+`--setopt=install_weak_deps=False` do not install it; see
+[Installing and configuring the Flight Control Agent](installing-agent.md#package-mode-installation).
+
 ## How It Works
 
 ### Greenboot Configuration
 
-Flight Control includes the `20_check_flightctl_agent.sh` health check script to validate that the agent service is running properly. The script is installed into `/usr/lib/greenboot/check/required.d` and calls `flightctl-agent health` to perform the checks.
+The `flightctl-greenboot` package includes the `20_check_flightctl_agent.sh`
+health check script to validate that the agent service is running properly.
+The script is installed into `/usr/lib/greenboot/check/required.d` and calls
+`flightctl-agent health` to perform the checks.
 
 The `40_flightctl_agent_pre_rollback.sh` pre-rollback script is installed into `/usr/lib/greenboot/red.d`, to be executed right before system rollback. It collects diagnostic information (service status, recent journal entries) for post-mortem analysis.
 
@@ -32,7 +41,10 @@ Exiting the health check with a non-zero status declares the boot as failed. The
 | Wait for service to become active (up to 150s) | Next | exit 1 |
 | Monitor service stability for 60 seconds | Next | exit 1 |
 
-> If the system is not booted using `bootc`, the health check still runs, but no rollback is possible.
+> If the system is not booted using `bootc`, the health check still runs, but
+> no rollback is possible. On package-mode hosts, installing
+> `flightctl-greenboot` is optional; health checks can still run, but there is
+> no image-based OS rollback.
 
 ### Third-Party Health Check Management
 

--- a/docs/user/installing/installing-agent-offline.md
+++ b/docs/user/installing/installing-agent-offline.md
@@ -110,7 +110,7 @@ EOF
 
 Replace `<flightctl_service_host>` with the hostname or IP address of the Flight Control
 service. For full configuration options including TPM, labels, and audit settings, see
-[Configuring the Flight Control Agent](installing-agent.md).
+[Installing and configuring the Flight Control Agent](installing-agent.md).
 
 The CA certificate and enrollment credentials must be distributed to the device through
 your provisioning pipeline before the agent can connect.
@@ -248,7 +248,7 @@ references them), then follow the standard enrollment procedure:
 
 ## Next steps
 
-- [Configuring the Flight Control Agent](installing-agent.md) — full configuration
+- [Installing and configuring the Flight Control Agent](installing-agent.md) — full configuration
   reference for `config.yaml`
 - [Air-gapped fleet operations](air-gapped-operations.md) — managing devices and
   applying OS image updates in an air-gapped environment

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -1,4 +1,84 @@
-# Configuring the Flight Control Agent
+# Installing and configuring the Flight Control Agent
+
+This document describes how to install `flightctl-agent` from the public RPM
+repository on Fedora or CentOS Stream, and how to configure the agent after
+installation.
+
+For air-gapped RHEL installs, see
+[Installing the Flight Control agent offline on RHEL](installing-agent-offline.md).
+
+## Installing the agent RPM
+
+Agent RPM packages are hosted at [rpm.flightctl.io](https://rpm.flightctl.io/).
+Enable the repository, then install the package that matches the device OS mode.
+
+The syntax for adding a repository depends on your `dnf` version (4 or 5).
+
+Get the `dnf` version:
+
+```bash
+dnf --version
+```
+
+### Add the FlightCtl repository
+
+With dnf 4:
+
+```bash
+sudo dnf config-manager --add-repo https://rpm.flightctl.io/flightctl-epel.repo
+```
+
+With dnf 5:
+
+```bash
+sudo dnf config-manager addrepo --from-repofile=https://rpm.flightctl.io/flightctl-epel.repo
+```
+
+### Package-mode installation
+
+On package-mode hosts (traditional package management, without `bootc` or
+`rpm-ostree` image management), install the agent without weak dependencies so
+`flightctl-greenboot` is not pulled in:
+
+```bash
+sudo dnf install -y --setopt=install_weak_deps=False flightctl-agent
+```
+
+This installs the agent binary, systemd unit, and related core files. It does
+not install greenboot health checks or bootc timer masking. See
+[Integrating with Greenboot](configuring-device-greenboot.md) for the optional
+`flightctl-greenboot` subpackage.
+
+### Image-mode installation
+
+On image-mode hosts (`bootc` or `rpm-ostree`), install the agent with the
+default weak-dependency behavior:
+
+```bash
+sudo dnf install -y flightctl-agent
+```
+
+This pulls in `flightctl-greenboot` through a `Recommends` dependency and
+enables greenboot integration for image-based OS updates.
+
+### Start the agent
+
+After installation, enable and start the agent service:
+
+```bash
+sudo systemctl enable --now flightctl-agent
+```
+
+Verify that the service is running:
+
+```bash
+systemctl status flightctl-agent
+```
+
+Configure enrollment and other agent settings before or after starting the
+service. See the configuration sections below.
+
+## Configuring the agent
 
 When the `flightctl-agent` starts, it reads its configuration from `/etc/flightctl/config.yaml` as well as a number of drop-in directories:
 

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -75,8 +75,10 @@ Verify that the service is running:
 systemctl status flightctl-agent
 ```
 
-Configure enrollment and other agent settings before or after starting the
-service. See the configuration sections below.
+Configure enrollment and other agent settings **before** starting the
+service so the agent has a server to connect to. If you start the agent
+first, it keeps retrying until configuration is available. See the
+configuration sections below.
 
 ## Configuring the agent
 

--- a/docs/user/references/certificate-architecture.md
+++ b/docs/user/references/certificate-architecture.md
@@ -158,7 +158,7 @@ For backup and restore procedures, see [Backup and Restore](../installing/backup
 ## See Also
 
 * [Security Guidelines](security-guidelines.md)
-* [Installing the Agent](../installing/installing-agent.md)
+* [Installing and configuring the Flight Control Agent](../installing/installing-agent.md)
 * [Installing on Kubernetes](../installing/installing-service-on-kubernetes.md)
 * [Installing on Linux](../installing/installing-service-on-linux.md)
 * [Deploying the Observability Stack on Linux](../installing/deploying-observability-linux.md)

--- a/docs/user/using/field-selectors.md
+++ b/docs/user/using/field-selectors.md
@@ -25,7 +25,7 @@ The following table lists the fields supported for filtering for each resource k
 | Kind                            | Fields                                              |
 |---------------------------------|-----------------------------------------------------|
 | **Certificate Signing Request** | `status.certificate`                                |
-| **Device**                      | `status.summary.status`<br/>`status.applicationsSummary.status`<br/>`status.updated.status`<br/>`lastSeen`<br/>`status.lifecycle.status` |
+| **Device**                      | `status.summary.status`<br/>`status.applicationsSummary.status`<br/>`status.updated.status`<br/>`status.capabilities.osMode`<br/>`lastSeen`<br/>`status.lifecycle.status` |
 | **Enrollment Request**          | `status.approval.approved`<br/>`status.certificate` |
 | **Fleet**                       | `spec.template.spec.os.image`                       |
 | **Repository**                  | `spec.type`<br/>`spec.url`                          |
@@ -55,7 +55,14 @@ This command retrieves devices owned by `Fleet/pos-fleet`, located in the `us` r
 
 ```bash
 flightctl get devices --field-selector 'metadata.owner=Fleet/pos-fleet, status.updated.status in (Unknown, OutOfDate)' -l 'region=us'
+```
 
+#### Example 4: Filter by OS mode
+
+This command retrieves devices that report package-mode OS management:
+
+```bash
+flightctl get devices --field-selector 'status.capabilities.osMode=package'
 ```
 
 ### Fields Discovery

--- a/docs/user/using/field-selectors.md
+++ b/docs/user/using/field-selectors.md
@@ -74,7 +74,7 @@ For example:
 ```bash
 flightctl get devices --field-selector='text'
 
-Error: listing devices: 400, message: unknown or unsupported selector: unable to resolve selector name "text". Supported selectors are: [metadata.alias metadata.creationTimestamp metadata.name metadata.nameOrAlias metadata.owner status.applicationsSummary.status lastSeen status.summary.status status.updated.status]
+Error: listing devices: 400, message: unknown or unsupported selector: unable to resolve selector name "text". Supported selectors are: [metadata.alias metadata.creationTimestamp metadata.name metadata.nameOrAlias metadata.owner status.applicationsSummary.status lastSeen status.capabilities.osMode status.lifecycle.status status.summary.status status.updated.status]
 ```
 
 In this example, the field `text` is not a valid field for filtering. The error message provides a list of supported fields that can be used with `--field-selector` for the `device` resource.

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -84,9 +84,10 @@ Devices report an OS management mode in `status.capabilities.osMode`:
 | `image` | The device manages the OS with `bootc` or `rpm-ostree` image updates. |
 | `package` | The device has no image-based OS management. The agent manages configuration and applications only. |
 
-Package-mode devices report an empty `status.os.image`. The running distribution
-and version remain available under `status.systemInfo` (for example
-`distroName` and `distroVersion`).
+Package-mode devices report `status.os.image` and `status.os.imageDigest` as
+empty strings (`""`) — there is no image-based OS reference. The running
+distribution and version remain available under `status.systemInfo` (for
+example `distroName` and `distroVersion`).
 
 To list package-mode devices:
 
@@ -307,16 +308,22 @@ hnsu33339f8m5pjqrbh5ak704jjp92r95a83sd5ja8cjnsl7qnrg  <none>   <none>  Online  U
 
 You can update a device's OS by updating the target OS image name or version in the device's specification. The next time the agent checks in, it learns of the requested update and automatically starts downloading and verifying the new OS version in the background. It then schedules the actual system update to be performed according to the update policy. When the time has come to update, it installs the new version in parallel and performs a reboot into the new version.
 
-OS image updates apply to **image-mode** devices (`status.capabilities.osMode`
-is `image`). Package-mode devices cannot apply `spec.os.image`. When a
-package-mode device receives a desired specification that sets `spec.os.image`,
-the agent rejects the entire specification before applying configuration or
-applications. The device stays on its previously committed specification. The
-API also rejects a direct create or update that assigns `spec.os.image` on a
-known package-mode device.
+Package-mode devices cannot apply `spec.os.image`. When a package-mode device
+receives a desired specification that sets `spec.os.image`, the agent rejects
+the entire specification before applying configuration or applications. The
+device stays on its previously committed specification.
 
-OS catalog items cannot be deployed to package-mode devices. For fleets that
-include both modes and set an OS image in the template, see
+For a device that already reports `status.capabilities.osMode=package`, a
+direct replace or patch that newly assigns or changes `spec.os.image` returns
+HTTP 400 (`OS image is not supported on package-mode devices`). Devices that
+have not reported OS mode yet (including create, before enrollment status is
+known) are not rejected by that API check; the agent still rejects
+`spec.os.image` once the device is package-mode.
+
+OS catalog items that set an OS image target are not usable on package-mode
+devices: the device cannot apply the image (same agent reject / `OutOfDate`
+behavior as a fleet or device with `spec.os.image`). For fleets that include
+both modes and set an OS image in the template, see
 [Mixed image-mode and package-mode fleets](managing-fleets.md#mixed-image-mode-and-package-mode-fleets).
 
 Flight Control currently supports the following image types and image references formats:

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -65,15 +65,45 @@ Flight Control automatically gathers system information from each device to help
 
 Here are key considerations when using this feature:
 
-* **What's Collected**: By default, the agent collects basic system information such as hostname, kernel version, OS distribution, product identifiers, and default network interface details. Additional fields such as BIOS data, GPU info, memory, and CPU details can be enabled through configuration. See [Installing the Agent](../installing/installing-agent.md) for a full list of supported fields and how to customize collection.
+* **What's Collected**: By default, the agent collects basic system information such as hostname, kernel version, OS distribution, product identifiers, and default network interface details. Additional fields such as BIOS data, GPU info, memory, and CPU details can be enabled through configuration. See [Installing and configuring the Flight Control Agent](../installing/installing-agent.md) for a full list of supported fields and how to customize collection.
 
-* **Custom Fields**: You can configure the agent to collect additional custom attributes specific to your environment. These are displayed under `systemInfo.customInfo` and can be used for labeling or grouping devices. See [Installing the Agent](../installing/installing-agent.md) for example usage.
+* **Custom Fields**: You can configure the agent to collect additional custom attributes specific to your environment. These are displayed under `systemInfo.customInfo` and can be used for labeling or grouping devices. See [Installing and configuring the Flight Control Agent](../installing/installing-agent.md) for example usage.
 
 * **Collection Timing**: System info is collected during process bootstrap and then cached. It refreshes only if the agent restarts or receives a reload signal (SIGHUP). This avoids unnecessary overhead during regular status updates.
 
 * **Reboot Awareness**: The agent tracks boot time and boot ID, allowing Flight Control to detect whether the device has rebooted. This is useful for update coordination and lifecycle monitoring.
 
 * **Partial Data**: Not all fields may be available on every device or on every process start. Collection is best-effort missing values errors or timeouts will result in empty values.
+
+### OS mode
+
+Devices report an OS management mode in `status.capabilities.osMode`:
+
+| Value | Meaning |
+| ----- | ------- |
+| `image` | The device manages the OS with `bootc` or `rpm-ostree` image updates. |
+| `package` | The device has no image-based OS management. The agent manages configuration and applications only. |
+
+Package-mode devices report an empty `status.os.image`. The running distribution
+and version remain available under `status.systemInfo` (for example
+`distroName` and `distroVersion`).
+
+To list package-mode devices:
+
+```bash
+flightctl get devices --field-selector 'status.capabilities.osMode=package'
+```
+
+To inspect OS mode on a single device, view the device YAML and look for
+`status.capabilities.osMode`:
+
+```bash
+flightctl get device/<device_name> -o yaml
+```
+
+See [Field Selectors](field-selectors.md) for more filter examples. For fleets
+that mix image-mode and package-mode devices, see
+[Mixed image-mode and package-mode fleets](managing-fleets.md#mixed-image-mode-and-package-mode-fleets).
 
 ### Viewing using the Web UI
 
@@ -276,6 +306,18 @@ hnsu33339f8m5pjqrbh5ak704jjp92r95a83sd5ja8cjnsl7qnrg  <none>   <none>  Online  U
 ## Updating the OS
 
 You can update a device's OS by updating the target OS image name or version in the device's specification. The next time the agent checks in, it learns of the requested update and automatically starts downloading and verifying the new OS version in the background. It then schedules the actual system update to be performed according to the update policy. When the time has come to update, it installs the new version in parallel and performs a reboot into the new version.
+
+OS image updates apply to **image-mode** devices (`status.capabilities.osMode`
+is `image`). Package-mode devices cannot apply `spec.os.image`. When a
+package-mode device receives a desired specification that sets `spec.os.image`,
+the agent rejects the entire specification before applying configuration or
+applications. The device stays on its previously committed specification. The
+API also rejects a direct create or update that assigns `spec.os.image` on a
+known package-mode device.
+
+OS catalog items cannot be deployed to package-mode devices. For fleets that
+include both modes and set an OS image in the template, see
+[Mixed image-mode and package-mode fleets](managing-fleets.md#mixed-image-mode-and-package-mode-fleets).
 
 Flight Control currently supports the following image types and image references formats:
 

--- a/docs/user/using/managing-fleets.md
+++ b/docs/user/using/managing-fleets.md
@@ -263,9 +263,12 @@ limits on OS image targets.
 ### Rollout batch behavior with package-mode devices
 
 If package-mode devices are included in a rollout batch for a fleet whose
-template sets `spec.os.image`, the batch can stall until the rollout times
-out. An `OutOfDate` status does not distinguish devices that are still
-rolling out from devices that cannot converge on the OS image target.
+template sets `spec.os.image`, the batch can stall until the batch update
+times out. The default timeout is 24 hours
+(`rolloutPolicy.defaultUpdateTimeout`; see
+[Defining Rollout Policies](#defining-rollout-policies)). An `OutOfDate`
+status does not distinguish devices that are still rolling out from devices
+that cannot converge on the OS image target.
 
 ### Options when a mixed fleet includes an OS image
 

--- a/docs/user/using/managing-fleets.md
+++ b/docs/user/using/managing-fleets.md
@@ -236,6 +236,49 @@ Note: Both the Role/ClusterRole and its corresponding RoleBinding/ClusterRoleBin
 
 Flight Control can automatically detect changes in referenced git repositories, HTTP endpoints, and Kubernetes secrets and create new template versions without manual intervention. For details on configuration, secret labeling, and troubleshooting, see [Auto-syncing External Dependencies](auto-syncing-dependencies.md).
 
+## Mixed image-mode and package-mode fleets
+
+Image-mode and package-mode devices can belong to the same fleet. Fleet
+assignment uses label selectors only; OS mode does not restrict which fleet a
+device can join. See [OS mode](managing-devices.md#os-mode) for how devices
+report `status.capabilities.osMode`.
+
+When a fleet device template does **not** set `spec.os.image`, both modes
+receive the same configuration and application targets. Package-mode and
+image-mode devices converge on those targets the same way.
+
+When a fleet device template **does** set `spec.os.image`, the service renders
+the full template — including the OS image — to every member device:
+
+* Image-mode devices apply the OS image update and converge on the new
+  template version.
+* Package-mode devices reject the entire desired specification before
+  applying configuration or applications. They stay on the previously
+  committed specification and appear `OutOfDate` while the fleet template
+  still includes `spec.os.image`.
+
+See [Updating the OS](managing-devices.md#updating-the-os) for package-mode
+limits on OS image targets.
+
+### Rollout batch behavior with package-mode devices
+
+If package-mode devices are included in a rollout batch for a fleet whose
+template sets `spec.os.image`, the batch can stall until the rollout times
+out. An `OutOfDate` status does not distinguish devices that are still
+rolling out from devices that cannot converge on the OS image target.
+
+### Options when a mixed fleet includes an OS image
+
+Operators can use any of the following actions so package-mode devices can
+advance again:
+
+* Keep OS image rollouts in fleets that contain only image-mode devices, and
+  use a separate fleet without `spec.os.image` for shared configuration and
+  applications across both modes.
+* Remove `spec.os.image` from the fleet device template.
+* Move package-mode devices to a fleet whose template does not set an OS
+  image target.
+
 ## Defining Rollout Policies
 
 You can define policies that govern how a change to a fleet's device template gets rolled out across devices of the fleet. This gives you control over


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [x] **`release-1.3`**

## Summary

Upstream documentation for package-mode: agent RPM install on Fedora/CentOS Stream, OS mode visibility, mixed-fleet Path B behavior (including batch-stall limitation and operator options), and developer notes for the RPM subpackage split plus package-mode e2e.

**Jira:** [EDM-4764](https://redhat.atlassian.net/browse/EDM-4764)

### Changes

- User: package-mode `dnf` install (`install_weak_deps=False`), optional `flightctl-greenboot`, `status.capabilities.osMode`, Path B / batch stall / operator options, field selector
- Developer: `docs/developer/package-mode.md` (RPM table + e2e). E2e section tracks the testcontainer suite from [#3342](https://github.com/flightctl/flightctl/pull/3342) with explicit “until merged” caveats — tighten links after that PR lands

### Testing

- [x] `make lint-docs`
- [x] `make spellcheck-docs`
- Docs-only; no unit/integration code changes

### Acceptance Criteria

- [x] AC-1: User docs cover package-mode agent install on Fedora/CentOS Stream
- [x] AC-2: Developer docs describe RPM subpackage structure and package-mode e2e infra
- [x] AC-3: Docs describe OS mode reporting, Path B mixed fleets, and batch-stall limitation
- [x] AC-4: Docs describe operator options for mixed fleets with OS image targets
- [x] AC-5: `make lint-docs` and `make spellcheck-docs` pass
