### PR TITLE
EDM-4988: Improve VM application error visibility

### DIFF
--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -72,10 +72,12 @@ func (lw *limitedWriter) Write(p []byte) (int, error) {
 	return lw.buf.Write(p)
 }
 
-// truncateStderr trims and caps subprocess stderr to avoid embedding large or
-// sensitive tool output directly in error messages.
+// truncateStderr trims a redundant leading "Error: " prefix (vm-to-quadlet
+// prints its own error to stderr before exiting) and caps subprocess stderr to
+// avoid embedding large or sensitive tool output directly in error messages.
 func truncateStderr(s string) string {
 	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "Error: ")
 	if len(s) > maxStderrLen {
 		return s[:maxStderrLen] + "... (truncated)"
 	}
@@ -321,7 +323,10 @@ func convertVmYAML(ctx context.Context, vmYAML []byte, converter VmConverterFn, 
 
 	files, stderr, err := converter(ctx, vmYAML)
 	if err != nil {
-		return nil, fmt.Errorf("vm-to-quadlet: %s: %w", truncateStderr(stderr), err)
+		if cleaned := truncateStderr(stderr); cleaned != "" {
+			return nil, fmt.Errorf("vm-to-quadlet: %s", cleaned)
+		}
+		return nil, fmt.Errorf("vm-to-quadlet: %w", err)
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("vm-to-quadlet produced no output files")

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -242,6 +242,24 @@ func TestRenderVmApplication(t *testing.T) {
 			wantErr:   "unsupported vm feature",
 		},
 		{
+			name:      "When converter stderr has a leading Error prefix it should be stripped",
+			vmName:    "my-vm",
+			files:     map[string]string{"vm.yaml": minimalVmYAML("my-vm")},
+			converter: failingConverter("Error: unable to parse quantity's suffix"),
+			kvStore:   newFakeKVStore(),
+			wantErr:   "vm-to-quadlet: unable to parse quantity's suffix",
+		},
+		{
+			name:   "When converter fails with empty stderr it should fall back to the exec error",
+			vmName: "my-vm",
+			files:  map[string]string{"vm.yaml": minimalVmYAML("my-vm")},
+			converter: func(_ context.Context, _ []byte) (map[string]string, string, error) {
+				return nil, "", errors.New("exit status 1")
+			},
+			kvStore: newFakeKVStore(),
+			wantErr: "vm-to-quadlet: exit status 1",
+		},
+		{
 			name:      "When converter returns no files it should return an error",
 			vmName:    "my-vm",
 			files:     map[string]string{"vm.yaml": minimalVmYAML("my-vm")},
@@ -477,6 +495,63 @@ func TestRenderVmApplication_ImageProviderUnsupported(t *testing.T) {
 
 	_, err = renderVmApplication(ctx, vmApp, stubbedConverter(fakeQuadletFiles), DefaultVmRenderOptions(), newFakeKVStore())
 	require.ErrorContains(t, err, "not yet supported")
+}
+
+// ─── truncateStderr ───────────────────────────────────────────────────────────
+
+func TestTruncateStderr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "When stderr has no Error prefix it should be returned unchanged",
+			input: "failed to unmarshal VM: bad quantity",
+			want:  "failed to unmarshal VM: bad quantity",
+		},
+		{
+			name:  "When stderr has a leading Error prefix it should be stripped",
+			input: "Error: failed to unmarshal VM: bad quantity",
+			want:  "failed to unmarshal VM: bad quantity",
+		},
+		{
+			name:  "When stderr exceeds the max length it should be truncated with a marker",
+			input: "Error: " + strings.Repeat("x", maxStderrLen+10),
+			want:  strings.Repeat("x", maxStderrLen) + "... (truncated)",
+		},
+		{
+			name:  "When stderr is empty it should remain empty",
+			input: "  ",
+			want:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, truncateStderr(tc.input))
+		})
+	}
+}
+
+// TestRenderVmApplication_StderrErrorPrefixNotDoubled verifies vm-to-quadlet's
+// own "Error: " stderr prefix is stripped rather than doubled up with the
+// wrapper's own "Error:" text added one level up in renderApplications, and
+// that the redundant exec exit-status text is dropped when stderr already
+// explains the failure.
+func TestRenderVmApplication_StderrErrorPrefixNotDoubled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	appSpec := newTestVmInlineApp(t, "my-vm", map[string]string{"vm.yaml": minimalVmYAML("my-vm")}, nil)
+	vmApp, err := appSpec.AsVmApplication()
+	require.NoError(t, err)
+
+	_, err = renderVmApplication(ctx, vmApp, failingConverter("Error: unable to parse quantity's suffix"), DefaultVmRenderOptions(), newFakeKVStore())
+	require.Error(t, err)
+	assert.Equal(t, `vm-to-quadlet: unable to parse quantity's suffix`, err.Error())
+	assert.NotContains(t, err.Error(), "exit status")
 }
 
 // ─── parseTarFiles ────────────────────────────────────────────────────────────

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as vm-to-quadlet-build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=982eacb71ce62755a9dfd347933f27e0d12cd845
+ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/flightctl/vm-to-quadlet /src && \

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as vm-to-quadlet-build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=982eacb71ce62755a9dfd347933f27e0d12cd845
+ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/flightctl/vm-to-quadlet /src && \

--- a/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
+++ b/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
@@ -1,7 +1,7 @@
 # Build stage: compile vm-to-quadlet at a pinned commit.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 AS build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=982eacb71ce62755a9dfd347933f27e0d12cd845
+ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN git clone https://github.com/flightctl/vm-to-quadlet /src && \
     cd /src && git checkout ${VM_TO_QUADLET_COMMIT} && \
     CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -trimpath -ldflags="-s -w" -o /out/vm-to-quadlet ./cmd/vm-to-quadlet

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	vmToQuadletImage = "quay.io/flightctl/vm-to-quadlet:8ebab33"
+	vmToQuadletImage = "quay.io/flightctl/vm-to-quadlet:1acc159"
 )
 
 var (


### PR DESCRIPTION
## Summary

Users deploying VM applications get little to no signal when something is wrong:

- A disk name that doesn't match a volume (typo) currently passes silently through rendering; the only symptom is the VM's restart count climbing forever with no error/event.
- A malformed value (e.g. an invalid memory quantity like `2Giiiii`) surfaces as a raw, double-`"Error:"`-prefixed chain crowded out by `vm-to-quadlet`'s own CLI usage/flags dump, truncated at 512 bytes.

This is the flightctl-side half of the fix (paired with [flightctl/vm-to-quadlet#1](https://github.com/flightctl/vm-to-quadlet/pull/1), now merged, which fixes the root causes: no CLI usage dump on error, sentinel-error-based hints for bad quantity/uint32 values, disk/volume cross-validation, and non-positive CPU/memory resource validation).

- `internal/tasks/device_render_vm.go`: strip a redundant leading `"Error: "` from captured `vm-to-quadlet` stderr, and only fall back to the raw `exec` error (`exit status 1`) when stderr is empty, so the `Device specification is invalid` event shows the real failure instead of a doubled/noisy chain.
- `packaging/images/el9/Containerfile.worker`, `packaging/images/el10/Containerfile.worker`, `test/integration/tasks/vmrender/Containerfile.vm-to-quadlet`: bump the pinned `VM_TO_QUADLET_COMMIT` to vm-to-quadlet's master HEAD (`1acc159843578adad2a27c55f6887c879f68d0c5`, the vm-to-quadlet#1 merge commit) so built `flightctl-worker` images actually pick up the fix.
- `test/integration/tasks/vmrender/suite_test.go`: bump `vmToQuadletImage` to a freshly built+pushed `quay.io/flightctl/vm-to-quadlet:1acc159` (built from the same vm-to-quadlet#1 merge commit) so the integration suite actually exercises the disk/volume and quantity validation instead of a stale pre-fix image.

A generic restart-streak/crash-loop classifier for the agent's application monitor was explored but dropped: as implemented it didn't self-heal (a workload that crossed the restart threshold once stayed classified as `Error` forever, even after running healthy indefinitely), and the specific disk-typo case it was meant to backstop is already root-caused by the fail-fast validation in vm-to-quadlet#1. Keeping this PR scoped to the error-message cleanup and the pin bumps.

## Test plan

- [x] `go test ./internal/tasks/...` (new + existing tests pass)
- [x] `go test ./test/integration/tasks/vmrender/...` — passes against the newly pushed `vm-to-quadlet:1acc159` image
- [x] `make unit-test RACE=0` — full suite passes (one pre-existing, unrelated failure in `internal/backup` due to a local `/etc/flightctl/service-config.yaml` file on this dev machine)
- [x] `make lint` — 0 issues