### PR TITLE
[EDM-4988]: Keep crash-looping VM apps Degraded until healthy

### DIFF
--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -141,6 +141,9 @@ type Workload struct {
 	Name     string
 	Status   StatusType
 	Restarts int
+	// RequiresHealth is set when a VM workload has emitted health_status events.
+	// Gated workloads stay Degraded on start/starting until healthy.
+	RequiresHealth bool
 }
 
 type application struct {

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -641,9 +641,12 @@ func (m *PodmanMonitor) updateContainerHealthStatus(app Application, event *clie
 	}
 
 	switch event.HealthStatus {
-	case "unhealthy":
+	case "starting", "unhealthy":
+		// starting/unhealthy keep the app Degraded; only healthy clears it.
+		container.RequiresHealth = true
 		container.Status = StatusUnhealthy
 	case "healthy":
+		container.RequiresHealth = true
 		container.Status = StatusRunning
 	default:
 		m.log.Debugf("Ignoring health_status=%s for container %s", event.HealthStatus, event.Name)
@@ -667,6 +670,10 @@ func (m *PodmanMonitor) updateApplicationStatus(app Application, event *client.P
 
 	container, exists := app.Workload(event.Name)
 	if exists {
+		// Health-gated workloads stay Degraded on bare start until healthy.
+		if status == StatusRunning && container.RequiresHealth {
+			status = StatusUnhealthy
+		}
 		container.Status = status
 		if event.ID != "" {
 			container.ID = event.ID

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -489,6 +489,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 		initialWorkloadStatus  StatusType
 		health                 string
 		expectedWorkloadStatus StatusType
+		expectedRequiresHealth bool
 		expectedReady          string
 		expectedAppStatus      v1beta1.ApplicationStatusType
 		expectedSummary        v1beta1.ApplicationsSummaryStatusType
@@ -499,6 +500,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusUnhealthy,
+			expectedRequiresHealth: true,
 			expectedReady:          "0/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
@@ -509,19 +511,21 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusUnhealthy,
 			health:                 "healthy",
 			expectedWorkloadStatus: StatusRunning,
+			expectedRequiresHealth: true,
 			expectedReady:          "1/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
 		},
 		{
-			name:                   "When VM health is starting it should leave workload status unchanged",
+			name:                   "When VM health is starting it should report Running degraded",
 			appType:                v1beta1.AppTypeVm,
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "starting",
-			expectedWorkloadStatus: StatusRunning,
-			expectedReady:          "1/1",
+			expectedWorkloadStatus: StatusUnhealthy,
+			expectedRequiresHealth: true,
+			expectedReady:          "0/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
-			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
+			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
 			name:                   "When VM workload is still initializing it should ignore health_status",
@@ -529,6 +533,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusInit,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusInit,
+			expectedRequiresHealth: false,
 			expectedReady:          "0/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusPreparing,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusUnknown,
@@ -540,6 +545,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusUnhealthy,
+			expectedRequiresHealth: true,
 			expectedReady:          "0/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusStopping,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
@@ -550,6 +556,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusRunning,
+			expectedRequiresHealth: false,
 			expectedReady:          "1/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
@@ -560,6 +567,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusRunning,
+			expectedRequiresHealth: false,
 			expectedReady:          "1/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
@@ -570,6 +578,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusRunning,
+			expectedRequiresHealth: false,
 			expectedReady:          "1/1",
 			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
@@ -601,6 +610,7 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			workload, ok := app.Workload(containerName)
 			require.True(ok)
 			require.Equal(tc.expectedWorkloadStatus, workload.Status)
+			require.Equal(tc.expectedRequiresHealth, workload.RequiresHealth)
 
 			status, summary, err := app.Status()
 			require.NoError(err)
@@ -632,6 +642,90 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 		require.True(ok)
 		require.Equal(StatusRunning, workload.Status)
 	})
+}
+
+// TestVMHealthGatedCrashLoopSequence covers: after health_status=starting,
+// subsequent start events must not report Healthy while the VM crash-loops.
+func TestVMHealthGatedCrashLoopSequence(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		appName = "test-vm"
+		service = "virt-launcher-compute"
+	)
+	containerName := fmt.Sprintf("%s-container", service)
+
+	systemdMgr := systemd.NewMockManager(ctrl)
+	// LoadState and NRestarts both use Show. "0" is a valid NRestarts value and
+	// is not SystemdLoadStateNotFound, so both call sites accept it.
+	systemdMgr.EXPECT().Show(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]string{"0"}, nil).AnyTimes()
+
+	tmpDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tmpDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tmpDir)),
+	)
+	testLog := log.NewPrefixLogger("test")
+	podman := client.NewPodman(testLog, executer.NewMockExecuter(ctrl), rw, util.NewPollConfig())
+	var podmanFactory client.PodmanFactory = func(_ v1beta1.Username) (*client.Podman, error) { return podman, nil }
+	var systemdFactory systemd.ManagerFactory = func(_ v1beta1.Username) (systemd.Manager, error) { return systemdMgr, nil }
+	var rwFactory fileio.ReadWriterFactory = func(_ v1beta1.Username) (fileio.ReadWriter, error) { return rw, nil }
+
+	monitor := NewPodmanMonitor(testLog, podmanFactory, systemdFactory, "", rwFactory)
+	app := createTestApplicationWithType(require, appName, v1beta1.ApplicationStatusPreparing, v1beta1.CurrentProcessUsername, v1beta1.AppTypeVm)
+	monitor.apps[app.ID()] = app
+
+	assertSummary := func(ready string, appStatus v1beta1.ApplicationStatusType, summary v1beta1.ApplicationsSummaryStatusType) {
+		t.Helper()
+		status, sum, err := app.Status()
+		require.NoError(err)
+		require.Equal(ready, status.Ready)
+		require.Equal(appStatus, status.Status)
+		require.Equal(summary, sum.Status)
+	}
+
+	start1 := mockPodmanEventSuccess(appName, v1beta1.CurrentProcessUsername, service, "start")
+	start1.ID = "container-id-1"
+	monitor.handleEvent(t.Context(), start1)
+	assertSummary("1/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusHealthy)
+
+	starting := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "starting")
+	starting.ID = "container-id-1"
+	monitor.handleEvent(t.Context(), starting)
+	workload, ok := app.Workload(containerName)
+	require.True(ok)
+	require.True(workload.RequiresHealth)
+	require.Equal(StatusUnhealthy, workload.Status)
+	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+
+	died := mockPodmanEventError(appName, v1beta1.CurrentProcessUsername, service, "died", 2)
+	died.ID = "container-id-1"
+	monitor.handleEvent(t.Context(), died)
+	assertSummary("0/1", v1beta1.ApplicationStatusError, v1beta1.ApplicationsSummaryStatusError)
+
+	// Crash-loop restart: bare start must not restore Healthy.
+	start2 := mockPodmanEventSuccess(appName, v1beta1.CurrentProcessUsername, service, "start")
+	start2.ID = "container-id-2"
+	monitor.handleEvent(t.Context(), start2)
+	workload, ok = app.Workload(containerName)
+	require.True(ok)
+	require.True(workload.RequiresHealth)
+	require.Equal(StatusUnhealthy, workload.Status)
+	require.Equal("container-id-2", workload.ID)
+	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+
+	starting2 := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "starting")
+	starting2.ID = "container-id-2"
+	monitor.handleEvent(t.Context(), starting2)
+	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+
+	healthy := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "healthy")
+	healthy.ID = "container-id-2"
+	monitor.handleEvent(t.Context(), healthy)
+	assertSummary("1/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusHealthy)
 }
 
 func createMockPodmanEvent(name string, username v1beta1.Username, service, status string, exitCode int) client.PodmanEvent {


### PR DESCRIPTION
## Summary
- Keep crash-looping VM apps Degraded until Podman reports `health_status=healthy` (ignore bare `start` / treat `starting` as Degraded).

## Problem
A VirtualMachine app with a bad config (e.g. disk name typo with no matching volume) crash-loops under systemd `Restart=on-failure` and virt-launcher restarts. Application status mostly reported **Healthy**, briefly flipping to Degraded/Error between restarts, so operators had no lasting signal that the VM was not up.

## Root Cause
Podman `start` mapped directly to `StatusRunning` → Healthy. For VMs, `health_status` events were only applied for `healthy`/`unhealthy`; `starting` was ignored. In the failure path the container dies while still `starting` and never reaches `healthy`, so each restart restored Healthy from bare `start`.

## Fix
- Treat VM `health_status=starting` (and `unhealthy`) as Degraded and mark the workload as having seen health status
- For health-gated VM workloads, remap subsequent `start` events to Degraded until `health_status=healthy` (under the monitor mutex)
- Leave sidecars that never emit health events ungated so good VMs still become Healthy

## Testing
- `TestVMHealthGatedCrashLoopSequence`: `start` → `starting` → `died` → `start` stays Degraded; `healthy` restores Healthy
- Updated `TestUpdateContainerHealthStatus` for `starting` → Degraded
- `go test ./internal/agent/device/applications/` pass

## Risk / notes
- Normal VM boot may report Degraded for ~30s until healthcheck passes (accepted)

## Release target
- release-1.3

Fixes EDM-4988

Made with [Cursor](https://cursor.com)