### PR TITLE
EDM-4842: Fix console rendered version e2e assertion

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -92,9 +92,11 @@ var _ = Describe("CLI - device console", Label(e2e.NeedVMLabel), func() {
 		harness := e2e.GetWorkerHarness()
 
 		const sessionsToOpen = 4
-		const expectedRenderedVersion = 2 + sessionsToOpen*2
 
-		// kick off an update
+		initialRenderedVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("initiating a device update")
 		device, _, err := harness.WaitForBootstrapAndUpdateToVersion(deviceID, util.DeviceTags.V4)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(resources.GetJSONByName[*v1beta1.Device]).
@@ -126,7 +128,7 @@ var _ = Describe("CLI - device console", Label(e2e.NeedVMLabel), func() {
 
 		currentRenderedVersion, err := harness.GetCurrentDeviceRenderedVersion(deviceID)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(currentRenderedVersion).To(Equal(expectedRenderedVersion))
+		Expect(currentRenderedVersion).To(BeNumerically(">", initialRenderedVersion))
 
 		By("returns a helpful error when the device is not found")
 		out, err := harness.CLI("console", "device/nonexistent")


### PR DESCRIPTION
## What changed

Updated the `81786` console e2e test to compare the final renderedVersion against the device's initial renderedVersion instead of expecting a fixed value of `10`.

## Why

Console open/close operations no longer intentionally bump `device-controller/renderedVersion`; console wakeups now use the console notification path. The old assertion assumed **4** sessions would add **8** renderedVersion increments, so the test failed after the product behavior changed even though the device update completed successfully.

## Release
release-1.3
Target release: release-1.3
