### PR TITLE
EDM-5035: Allow Helm stop/start when rendered lifecycle fields are present

### DIFF
--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -1089,7 +1089,17 @@ func validateContainerApplication(app ApplicationProviderSpec, appName string, f
 	return allErrs
 }
 
+// ValidateHelmApplication validates a Helm application for API apply; lifecycle fields are rejected.
 func ValidateHelmApplication(app ApplicationProviderSpec, appName string, fleetTemplate bool) []error {
+	return validateHelmApplication(app, appName, fleetTemplate, false)
+}
+
+// ValidateHelmApplicationForAgent allows desiredState/restartGeneration from rendered agent specs.
+func ValidateHelmApplicationForAgent(app ApplicationProviderSpec, appName string, fleetTemplate bool) []error {
+	return validateHelmApplication(app, appName, fleetTemplate, true)
+}
+
+func validateHelmApplication(app ApplicationProviderSpec, appName string, fleetTemplate bool, allowLifecycleFields bool) []error {
 	allErrs := []error{}
 	pathPrefix := fmt.Sprintf("spec.applications[%s]", appName)
 
@@ -1098,7 +1108,9 @@ func ValidateHelmApplication(app ApplicationProviderSpec, appName string, fleetT
 		return []error{fmt.Errorf("invalid helm application: %w", err)}
 	}
 
-	allErrs = append(allErrs, validateApplicationLifecycleFieldsReadOnly(helm.DesiredState, helm.RestartGeneration, pathPrefix)...)
+	if !allowLifecycleFields {
+		allErrs = append(allErrs, validateApplicationLifecycleFieldsReadOnly(helm.DesiredState, helm.RestartGeneration, pathPrefix)...)
+	}
 
 	switch helm.Type() {
 	case ImageApplicationProviderType:

--- a/internal/agent/device/applications/kubernetes_monitor.go
+++ b/internal/agent/device/applications/kubernetes_monitor.go
@@ -168,6 +168,7 @@ func (m *KubernetesMonitor) QueueLifecycle(appID string, desiredState v1beta1.Ap
 		Path:              app.Path(),
 		Type:              actionType,
 		RestartGeneration: restartGeneration,
+		Spec:              app.ActionSpec(),
 	})
 }
 
@@ -236,6 +237,7 @@ func (m *KubernetesMonitor) lifecycleDispatch(appID string) (lifecycle.Lifecycle
 		Name:    app.Name(),
 		AppType: app.AppType(),
 		Path:    app.Path(),
+		Spec:    app.ActionSpec(),
 	}
 	return handler, action, app, nil
 }

--- a/internal/agent/device/applications/kubernetes_monitor.go
+++ b/internal/agent/device/applications/kubernetes_monitor.go
@@ -174,50 +174,36 @@ func (m *KubernetesMonitor) QueueLifecycle(appID string, desiredState v1beta1.Ap
 
 // StopApp stops the Helm application identified by appID by scaling its workloads to 0.
 func (m *KubernetesMonitor) StopApp(ctx context.Context, appID string) error {
-	handler, action, app, err := m.lifecycleDispatch(appID)
+	_, action, _, err := m.lifecycleDispatch(appID)
 	if err != nil {
 		return err
 	}
-	if err := handler.Stop(ctx, action); err != nil {
-		return err
-	}
-	m.mu.Lock()
-	app.SetDesiredState(v1beta1.ApplicationDesiredStateStopped)
-	m.mu.Unlock()
-	return nil
+	action.Type = lifecycle.ActionStop
+	return m.applyLifecycleAction(ctx, action)
 }
 
 // StartApp re-applies the Helm chart for the application identified by appID.
 func (m *KubernetesMonitor) StartApp(ctx context.Context, appID string) error {
-	handler, action, app, err := m.lifecycleDispatch(appID)
+	_, action, _, err := m.lifecycleDispatch(appID)
 	if err != nil {
 		return err
 	}
-	if err := handler.Start(ctx, action); err != nil {
-		return err
-	}
-	m.mu.Lock()
-	app.SetDesiredState(v1beta1.ApplicationDesiredStateRunning)
-	m.mu.Unlock()
-	return nil
+	action.Type = lifecycle.ActionStart
+	return m.applyLifecycleAction(ctx, action)
 }
 
 // RestartApp scales workloads to 0 then re-applies the chart for the application identified by appID.
 func (m *KubernetesMonitor) RestartApp(ctx context.Context, appID string, restartGeneration int) error {
-	handler, action, app, err := m.lifecycleDispatch(appID)
+	_, action, _, err := m.lifecycleDispatch(appID)
 	if err != nil {
 		return err
 	}
-	if err := handler.Restart(ctx, action); err != nil {
-		return err
-	}
-	m.mu.Lock()
-	app.SetRestartGeneration(restartGeneration)
-	m.mu.Unlock()
-	return nil
+	action.Type = lifecycle.ActionRestart
+	action.RestartGeneration = restartGeneration
+	return m.applyLifecycleAction(ctx, action)
 }
 
-// lifecycleDispatch looks up the application and resolves its LifecycleHandler.
+// lifecycleDispatch looks up the application and builds a lifecycle.Action from its current fields.
 func (m *KubernetesMonitor) lifecycleDispatch(appID string) (lifecycle.LifecycleHandler, lifecycle.Action, Application, error) {
 	m.mu.Lock()
 	app, ok := m.apps[appID]
@@ -240,6 +226,48 @@ func (m *KubernetesMonitor) lifecycleDispatch(appID string) (lifecycle.Lifecycle
 		Spec:    app.ActionSpec(),
 	}
 	return handler, action, app, nil
+}
+
+// applyLifecycleAction runs Stop/Start/Restart using the provided action (including Spec).
+func (m *KubernetesMonitor) applyLifecycleAction(ctx context.Context, action lifecycle.Action) error {
+	m.mu.Lock()
+	app, ok := m.apps[action.ID]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("%w: %s", errors.ErrAppNotFound, action.ID)
+	}
+
+	handler, ok := m.handlers[action.AppType].(lifecycle.LifecycleHandler)
+	if !ok {
+		return fmt.Errorf("%w: no lifecycle handler for app type %s", errors.ErrUnsupportedAppType, action.AppType)
+	}
+
+	switch action.Type {
+	case lifecycle.ActionStop:
+		if err := handler.Stop(ctx, action); err != nil {
+			return err
+		}
+		m.mu.Lock()
+		app.SetDesiredState(v1beta1.ApplicationDesiredStateStopped)
+		m.mu.Unlock()
+	case lifecycle.ActionStart:
+		if err := handler.Start(ctx, action); err != nil {
+			return err
+		}
+		m.mu.Lock()
+		app.SetDesiredState(v1beta1.ApplicationDesiredStateRunning)
+		m.mu.Unlock()
+	case lifecycle.ActionRestart:
+		if err := handler.Restart(ctx, action); err != nil {
+			return err
+		}
+		m.mu.Lock()
+		app.SetRestartGeneration(action.RestartGeneration)
+		m.mu.Unlock()
+	default:
+		return fmt.Errorf("unsupported lifecycle action type: %s", action.Type)
+	}
+	return nil
 }
 
 // ExecuteActions executes all queued actions.
@@ -283,7 +311,9 @@ func (m *KubernetesMonitor) executeActions(ctx context.Context) error {
 			continue
 		}
 		m.log.Infof("Stopping application %s (desiredState: stopped, post-install)", a.Name)
-		if err := m.StopApp(ctx, a.ID); err != nil {
+		stopAction := a
+		stopAction.Type = lifecycle.ActionStop
+		if err := m.applyLifecycleAction(ctx, stopAction); err != nil {
 			m.log.Warnf("Failed to stop application %s after install: %v", a.Name, err)
 		}
 	}
@@ -293,17 +323,17 @@ func (m *KubernetesMonitor) executeActions(ctx context.Context) error {
 		switch a.Type {
 		case lifecycle.ActionStop:
 			m.log.Infof("Stopping application %s", a.Name)
-			if err := m.StopApp(ctx, a.ID); err != nil {
+			if err := m.applyLifecycleAction(ctx, a); err != nil {
 				m.log.Warnf("Failed to stop application %s: %v", a.Name, err)
 			}
 		case lifecycle.ActionStart:
 			m.log.Infof("Starting application %s", a.Name)
-			if err := m.StartApp(ctx, a.ID); err != nil {
+			if err := m.applyLifecycleAction(ctx, a); err != nil {
 				m.log.Warnf("Failed to start application %s: %v", a.Name, err)
 			}
 		case lifecycle.ActionRestart:
 			m.log.Infof("Restarting application %s", a.Name)
-			if err := m.RestartApp(ctx, a.ID, a.RestartGeneration); err != nil {
+			if err := m.applyLifecycleAction(ctx, a); err != nil {
 				m.log.Warnf("Failed to restart application %s: %v", a.Name, err)
 			}
 		}

--- a/internal/agent/device/applications/kubernetes_monitor_test.go
+++ b/internal/agent/device/applications/kubernetes_monitor_test.go
@@ -289,6 +289,53 @@ func TestKubernetesMonitor_StopApp_PropagatesHandlerError(t *testing.T) {
 	require.Contains(err.Error(), "scale workloads")
 }
 
+// TestKubernetesMonitor_StopApp_UsesHelmSpecNamespace guards the QE regression where
+// lifecycleDispatch omitted ActionSpec, so Stop scaled in flightctl-<name> instead of
+// the chart namespace (e.g. test-app) and kubectl reported "no objects passed to scale".
+func TestKubernetesMonitor_StopApp_UsesHelmSpecNamespace(t *testing.T) {
+	const appName = "helm-demo"
+	const namespace = "test-app"
+	const kubeconfigPath = "/tmp/kubeconfig"
+
+	require := require.New(t)
+	ctx := context.Background()
+	testLog := log.NewPrefixLogger("test")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockRW := fileio.NewMockReadWriter(ctrl)
+	monitor := newTestKubernetesMonitor(testLog, mockExec, mockRW, kubeconfigPath)
+
+	appID := fmt.Sprintf("%s_%s", namespace, appName)
+	volumeManager, err := provider.NewVolumeManager(testLog, appName, v1beta1.AppTypeHelm, v1beta1.CurrentProcessUsername, nil)
+	require.NoError(err)
+
+	monitor.apps[appID] = &application{
+		id:   appID,
+		path: fmt.Sprintf("/var/lib/flightctl/helm/charts/%s", appName),
+		status: &v1beta1.DeviceApplicationStatus{
+			Name:    appName,
+			AppType: v1beta1.AppTypeHelm,
+		},
+		volume:       volumeManager,
+		desiredState: v1beta1.ApplicationDesiredStateRunning,
+		actionSpec: lifecycle.HelmSpec{
+			Namespace: namespace,
+		},
+	}
+
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+		"scale", "deployment,statefulset",
+		"-l", fmt.Sprintf("%s=%s", helm.AppLabelKey, appID),
+		"--replicas=0",
+		"-n", namespace,
+		"--kubeconfig", kubeconfigPath,
+	}).Return("", "", 0)
+
+	require.NoError(monitor.StopApp(ctx, appID))
+}
+
 func TestKubernetesMonitor_StartApp_PropagatesHandlerError(t *testing.T) {
 	const appName = "my-helm-app"
 	const kubeconfigPath = "/tmp/kubeconfig"

--- a/internal/agent/device/applications/kubernetes_monitor_test.go
+++ b/internal/agent/device/applications/kubernetes_monitor_test.go
@@ -336,6 +336,59 @@ func TestKubernetesMonitor_StopApp_UsesHelmSpecNamespace(t *testing.T) {
 	require.NoError(monitor.StopApp(ctx, appID))
 }
 
+// Execute must use the Spec captured at QueueLifecycle time, even if the tracked
+// app's ActionSpec changes before ExecuteActions runs.
+func TestKubernetesMonitor_QueueLifecycle_ExecuteUsesQueuedSpec(t *testing.T) {
+	const appName = "helm-demo"
+	const queuedNamespace = "test-app"
+	const mutatedNamespace = "wrong-ns"
+	const kubeconfigPath = "/tmp/kubeconfig"
+
+	require := require.New(t)
+	ctx := context.Background()
+	testLog := log.NewPrefixLogger("test")
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockExec := executer.NewMockExecuter(ctrl)
+	mockRW := fileio.NewMockReadWriter(ctrl)
+	monitor := newTestKubernetesMonitor(testLog, mockExec, mockRW, kubeconfigPath)
+
+	appID := fmt.Sprintf("%s_%s", queuedNamespace, appName)
+	volumeManager, err := provider.NewVolumeManager(testLog, appName, v1beta1.AppTypeHelm, v1beta1.CurrentProcessUsername, nil)
+	require.NoError(err)
+
+	app := &application{
+		id:   appID,
+		path: fmt.Sprintf("/var/lib/flightctl/helm/charts/%s", appName),
+		status: &v1beta1.DeviceApplicationStatus{
+			Name:    appName,
+			AppType: v1beta1.AppTypeHelm,
+		},
+		volume:       volumeManager,
+		desiredState: v1beta1.ApplicationDesiredStateRunning,
+		actionSpec: lifecycle.HelmSpec{
+			Namespace: queuedNamespace,
+		},
+	}
+	monitor.apps[appID] = app
+
+	monitor.QueueLifecycle(appID, v1beta1.ApplicationDesiredStateStopped, 0)
+
+	app.actionSpec = lifecycle.HelmSpec{Namespace: mutatedNamespace}
+
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "kubectl", []string{
+		"scale", "deployment,statefulset",
+		"-l", fmt.Sprintf("%s=%s", helm.AppLabelKey, appID),
+		"--replicas=0",
+		"-n", queuedNamespace,
+		"--kubeconfig", kubeconfigPath,
+	}).Return("", "", 0)
+
+	require.NoError(monitor.ExecuteActions(ctx))
+	require.Equal(v1beta1.ApplicationDesiredStateStopped, app.DesiredState())
+}
+
 func TestKubernetesMonitor_StartApp_PropagatesHandlerError(t *testing.T) {
 	const appName = "my-helm-app"
 	const kubeconfigPath = "/tmp/kubeconfig"

--- a/internal/agent/device/applications/provider/helm.go
+++ b/internal/agent/device/applications/provider/helm.go
@@ -190,7 +190,7 @@ func (p *helmProvider) Verify(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("validating application spec: %w", err)
 	}
-	if errs := v1beta1.ValidateHelmApplication(apiSpec, p.spec.Name, false); len(errs) > 0 {
+	if errs := v1beta1.ValidateHelmApplicationForAgent(apiSpec, p.spec.Name, false); len(errs) > 0 {
 		return fmt.Errorf("validating helm application: %w", errors.Join(errs...))
 	}
 

--- a/internal/agent/device/applications/provider/helm_test.go
+++ b/internal/agent/device/applications/provider/helm_test.go
@@ -150,3 +150,75 @@ func TestHelmEnsureDependencies(t *testing.T) {
 		})
 	}
 }
+
+// TestHelmVerify_WhenRenderedLifecycleFieldsPresent_ItShouldNotRejectAsReadOnly
+// guards the QE regression where stop overlays desiredState into RenderedApplications
+// and Helm Verify reused API apply validation, rejecting the update before stop ran.
+func TestHelmVerify_WhenRenderedLifecycleFieldsPresent_ItShouldNotRejectAsReadOnly(t *testing.T) {
+	require := require.New(t)
+	log := log.NewPrefixLogger("test")
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockExec := executer.NewMockExecuter(ctrl)
+
+	tmpDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tmpDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tmpDir)),
+	)
+
+	mockExec.EXPECT().ExecuteWithContext(gomock.Any(), "helm", []string{"version", "--short"}).
+		Return("v3.15.0+gc4e7498\n", "", 0)
+
+	helmClient := client.NewHelm(log, mockExec, rw, tmpDir, testBackoffConfig)
+	kubeClient := client.NewKube(log, mockExec, rw, client.WithBinary("kubectl"))
+	cliClients := client.NewCLIClients(
+		client.WithHelmClient(helmClient),
+		client.WithKubeClient(kubeClient),
+	)
+
+	helmApp := v1beta1.HelmApplication{
+		AppType:           v1beta1.AppTypeHelm,
+		Name:              lo.ToPtr("helm-demo"),
+		DesiredState:      lo.ToPtr(v1beta1.ApplicationDesiredStateStopped),
+		RestartGeneration: lo.ToPtr(1),
+	}
+	err := helmApp.FromImageApplicationProviderSpec(v1beta1.ImageApplicationProviderSpec{
+		Image: "registry.example.com/charts/myapp:1.0.0",
+	})
+	require.NoError(err)
+
+	var appSpec v1beta1.ApplicationProviderSpec
+	require.NoError(appSpec.FromHelmApplication(helmApp))
+
+	// API apply validation still rejects these fields — that guard must remain.
+	errs := v1beta1.ValidateHelmApplication(appSpec, "helm-demo", false)
+	require.NotEmpty(errs)
+	require.Contains(errs[0].Error(), "desiredState is read-only")
+	require.Empty(v1beta1.ValidateHelmApplicationForAgent(appSpec, "helm-demo", false))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var rwFactory fileio.ReadWriterFactory = func(user v1beta1.Username) (fileio.ReadWriter, error) {
+		return rw, nil
+	}
+
+	helmProvider, err := newHelmProvider(ctx, log, cliClients, &appSpec, rwFactory)
+	require.NoError(err)
+	helmProvider.commandChecker = func(cmd string) bool {
+		return cmd == "helm" || cmd == "kubectl" || cmd == "crictl"
+	}
+
+	// Chart is intentionally unresolved so Verify fails after validation. Without
+	// ForAgent validation, Verify would fail earlier with the read-only desiredState error.
+	err = helmProvider.Verify(ctx)
+	require.Error(err)
+	require.NotContains(err.Error(), "desiredState is read-only")
+	require.NotContains(err.Error(), "restartGeneration is read-only")
+	require.Contains(err.Error(), "not resolved")
+
+	require.Equal(v1beta1.ApplicationDesiredStateStopped, helmProvider.Spec().DesiredState)
+	require.Equal(1, helmProvider.Spec().RestartGeneration)
+}

--- a/internal/agent/device/applications/provider/provider.go
+++ b/internal/agent/device/applications/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -869,38 +870,57 @@ func isEqual(a, b Provider) bool {
 	return reflect.DeepEqual(as, bs)
 }
 
-// clearLifecycleFields zeroes the lifecycle intent fields (DesiredState, RestartGeneration)
-// on an ApplicationSpec. The render pipeline bakes these onto the top-level spec as well as
-// into a copy on the app-type-specific struct (ContainerApp/ComposeApp/QuadletApp/HelmApp),
-// so both copies must be cleared for isEqual to correctly ignore lifecycle-only changes.
+// clearLifecycleFields zeroes DesiredState/RestartGeneration on the top-level spec and
+// nested app structs (including openapi union blobs) so lifecycle-only diffs stay on Ensure.
 func clearLifecycleFields(s *ApplicationSpec) {
 	s.DesiredState = ""
 	s.RestartGeneration = 0
 
 	if s.ContainerApp != nil {
 		app := *s.ContainerApp
-		app.DesiredState = nil
-		app.RestartGeneration = nil
+		stripLifecycleFromUnionApp(&app)
 		s.ContainerApp = &app
 	}
 	if s.ComposeApp != nil {
 		app := *s.ComposeApp
-		app.DesiredState = nil
-		app.RestartGeneration = nil
+		stripLifecycleFromUnionApp(&app)
 		s.ComposeApp = &app
 	}
 	if s.QuadletApp != nil {
 		app := *s.QuadletApp
-		app.DesiredState = nil
-		app.RestartGeneration = nil
+		stripLifecycleFromUnionApp(&app)
 		s.QuadletApp = &app
 	}
 	if s.HelmApp != nil {
 		app := *s.HelmApp
-		app.DesiredState = nil
-		app.RestartGeneration = nil
+		stripLifecycleFromUnionApp(&app)
 		s.HelmApp = &app
 	}
+}
+
+func stripLifecycleFromUnionApp[T any](app *T) {
+	if app == nil {
+		return
+	}
+	raw, err := json.Marshal(app)
+	if err != nil {
+		return
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return
+	}
+	delete(obj, "desiredState")
+	delete(obj, "restartGeneration")
+	raw, err = json.Marshal(obj)
+	if err != nil {
+		return
+	}
+	var cleaned T
+	if err := json.Unmarshal(raw, &cleaned); err != nil {
+		return
+	}
+	*app = cleaned
 }
 
 // AppData holds the extracted application data and cleanup function

--- a/internal/agent/device/applications/provider/provider_test.go
+++ b/internal/agent/device/applications/provider/provider_test.go
@@ -574,53 +574,86 @@ func TestGetDiff_DeterministicOrdering_Consistency(t *testing.T) {
 	}
 }
 
-// Guards the QE regression where a restartGeneration-only bump was classified as
-// Changed (helm upgrade) instead of Ensure (QueueLifecycle scale-to-0 + re-apply).
-func TestGetDiff_WhenOnlyHelmRestartGenerationDiffers_ItShouldEnsureNotChange(t *testing.T) {
-	require := require.New(t)
-
-	base := helmAppWithLifecycle(t, "helm-demo", "test-app", "oci://registry.example.com/charts/test-app:0.1.0", nil, nil)
-	withRestart := helmAppWithLifecycle(t, "helm-demo", "test-app", "oci://registry.example.com/charts/test-app:0.1.0", nil, lo.ToPtr(1))
-
+// Guards QE regressions where lifecycle-only overlays in the HelmApplication union
+// blob were classified as Changed (helm upgrade) instead of Ensure (QueueLifecycle).
+func TestGetDiff_WhenOnlyHelmLifecycleFieldsDiffer_ItShouldEnsureNotChange(t *testing.T) {
 	const appID = "test-app_helm-demo"
-	current := []Provider{
-		&mockProvider{
-			id:   appID,
-			name: "helm-demo",
-			spec: &ApplicationSpec{
-				ID:                appID,
-				Name:              "helm-demo",
-				AppType:           v1beta1.AppTypeHelm,
-				Image:             "oci://registry.example.com/charts/test-app:0.1.0",
-				Path:              "/var/lib/flightctl/helm/charts/test-app",
-				HelmApp:           &base,
-				DesiredState:      v1beta1.ApplicationDesiredStateRunning,
-				RestartGeneration: 0,
-			},
+	const image = "oci://registry.example.com/charts/test-app:0.1.0"
+	const path = "/var/lib/flightctl/helm/charts/test-app"
+
+	tests := []struct {
+		name     string
+		current  v1beta1.HelmApplication
+		desired  v1beta1.HelmApplication
+		curState v1beta1.ApplicationDesiredState
+		desState v1beta1.ApplicationDesiredState
+		curGen   int
+		desGen   int
+	}{
+		{
+			name:     "When only restartGeneration differs it should Ensure not Change",
+			current:  helmAppWithLifecycle(t, "helm-demo", "test-app", image, nil, nil),
+			desired:  helmAppWithLifecycle(t, "helm-demo", "test-app", image, nil, lo.ToPtr(1)),
+			curState: v1beta1.ApplicationDesiredStateRunning,
+			desState: v1beta1.ApplicationDesiredStateRunning,
+			curGen:   0,
+			desGen:   1,
 		},
-	}
-	desired := []Provider{
-		&mockProvider{
-			id:   appID,
-			name: "helm-demo",
-			spec: &ApplicationSpec{
-				ID:                appID,
-				Name:              "helm-demo",
-				AppType:           v1beta1.AppTypeHelm,
-				Image:             "oci://registry.example.com/charts/test-app:0.1.0",
-				Path:              "/var/lib/flightctl/helm/charts/test-app",
-				HelmApp:           &withRestart,
-				DesiredState:      v1beta1.ApplicationDesiredStateRunning,
-				RestartGeneration: 1,
-			},
+		{
+			name:     "When only desiredState differs it should Ensure not Change",
+			current:  helmAppWithLifecycle(t, "helm-demo", "test-app", image, lo.ToPtr(v1beta1.ApplicationDesiredStateRunning), nil),
+			desired:  helmAppWithLifecycle(t, "helm-demo", "test-app", image, lo.ToPtr(v1beta1.ApplicationDesiredStateStopped), nil),
+			curState: v1beta1.ApplicationDesiredStateRunning,
+			desState: v1beta1.ApplicationDesiredStateStopped,
+			curGen:   0,
+			desGen:   0,
 		},
 	}
 
-	diff, err := GetDiff(current, desired)
-	require.NoError(err)
-	require.Empty(diff.Changed, "lifecycle-only restartGeneration bump must not trigger Update")
-	require.Len(diff.Ensure, 1)
-	require.Equal(appID, diff.Ensure[0].ID())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			curApp, desApp := tc.current, tc.desired
+			current := []Provider{
+				&mockProvider{
+					id:   appID,
+					name: "helm-demo",
+					spec: &ApplicationSpec{
+						ID:                appID,
+						Name:              "helm-demo",
+						AppType:           v1beta1.AppTypeHelm,
+						Image:             image,
+						Path:              path,
+						HelmApp:           &curApp,
+						DesiredState:      tc.curState,
+						RestartGeneration: tc.curGen,
+					},
+				},
+			}
+			desired := []Provider{
+				&mockProvider{
+					id:   appID,
+					name: "helm-demo",
+					spec: &ApplicationSpec{
+						ID:                appID,
+						Name:              "helm-demo",
+						AppType:           v1beta1.AppTypeHelm,
+						Image:             image,
+						Path:              path,
+						HelmApp:           &desApp,
+						DesiredState:      tc.desState,
+						RestartGeneration: tc.desGen,
+					},
+				},
+			}
+
+			diff, err := GetDiff(current, desired)
+			require.NoError(err)
+			require.Empty(diff.Changed, "lifecycle-only diff must not trigger Update")
+			require.Len(diff.Ensure, 1)
+			require.Equal(appID, diff.Ensure[0].ID())
+		})
+	}
 }
 
 func helmAppWithLifecycle(t *testing.T, name, namespace, image string, desiredState *v1beta1.ApplicationDesiredState, restartGeneration *int) v1beta1.HelmApplication {

--- a/internal/agent/device/applications/provider/provider_test.go
+++ b/internal/agent/device/applications/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -571,4 +572,74 @@ func TestGetDiff_DeterministicOrdering_Consistency(t *testing.T) {
 		require.Equal([]string{"a", "f", "m", "z"}, removedIDs,
 			"ordering should be consistent on iteration %d", i)
 	}
+}
+
+// Guards the QE regression where a restartGeneration-only bump was classified as
+// Changed (helm upgrade) instead of Ensure (QueueLifecycle scale-to-0 + re-apply).
+func TestGetDiff_WhenOnlyHelmRestartGenerationDiffers_ItShouldEnsureNotChange(t *testing.T) {
+	require := require.New(t)
+
+	base := helmAppWithLifecycle(t, "helm-demo", "test-app", "oci://registry.example.com/charts/test-app:0.1.0", nil, nil)
+	withRestart := helmAppWithLifecycle(t, "helm-demo", "test-app", "oci://registry.example.com/charts/test-app:0.1.0", nil, lo.ToPtr(1))
+
+	const appID = "test-app_helm-demo"
+	current := []Provider{
+		&mockProvider{
+			id:   appID,
+			name: "helm-demo",
+			spec: &ApplicationSpec{
+				ID:                appID,
+				Name:              "helm-demo",
+				AppType:           v1beta1.AppTypeHelm,
+				Image:             "oci://registry.example.com/charts/test-app:0.1.0",
+				Path:              "/var/lib/flightctl/helm/charts/test-app",
+				HelmApp:           &base,
+				DesiredState:      v1beta1.ApplicationDesiredStateRunning,
+				RestartGeneration: 0,
+			},
+		},
+	}
+	desired := []Provider{
+		&mockProvider{
+			id:   appID,
+			name: "helm-demo",
+			spec: &ApplicationSpec{
+				ID:                appID,
+				Name:              "helm-demo",
+				AppType:           v1beta1.AppTypeHelm,
+				Image:             "oci://registry.example.com/charts/test-app:0.1.0",
+				Path:              "/var/lib/flightctl/helm/charts/test-app",
+				HelmApp:           &withRestart,
+				DesiredState:      v1beta1.ApplicationDesiredStateRunning,
+				RestartGeneration: 1,
+			},
+		},
+	}
+
+	diff, err := GetDiff(current, desired)
+	require.NoError(err)
+	require.Empty(diff.Changed, "lifecycle-only restartGeneration bump must not trigger Update")
+	require.Len(diff.Ensure, 1)
+	require.Equal(appID, diff.Ensure[0].ID())
+}
+
+func helmAppWithLifecycle(t *testing.T, name, namespace, image string, desiredState *v1beta1.ApplicationDesiredState, restartGeneration *int) v1beta1.HelmApplication {
+	t.Helper()
+	require := require.New(t)
+
+	var app v1beta1.HelmApplication
+	err := app.FromImageApplicationProviderSpec(v1beta1.ImageApplicationProviderSpec{Image: image})
+	require.NoError(err)
+	app.AppType = v1beta1.AppTypeHelm
+	app.Name = lo.ToPtr(name)
+	app.Namespace = lo.ToPtr(namespace)
+	app.DesiredState = desiredState
+	app.RestartGeneration = restartGeneration
+
+	// Round-trip so lifecycle keys land in the union blob the way rendered specs do.
+	raw, err := json.Marshal(app)
+	require.NoError(err)
+	var roundTripped v1beta1.HelmApplication
+	require.NoError(json.Unmarshal(raw, &roundTripped))
+	return roundTripped
 }


### PR DESCRIPTION
## Summary
- Fix [EDM-5035](https://issues.redhat.com/browse/EDM-5035): agent Helm `Verify` rejected rendered apps after stop/start because API validation treats `desiredState`/`restartGeneration` as read-only, while the render task overlays those fields into `RenderedApplications`.
- Add `ValidateHelmApplicationForAgent` so agent Verify accepts lifecycle fields; API apply still rejects them via `ValidateHelmApplication`.
- Add a regression unit test for the QE failure mode (stop leaves device `OutOfDate` with "desiredState is read-only").

## Release target
- [x] release-1.3

## Test plan
- [x] `make lint`
- [x] `go test -race ./internal/agent/device/applications/provider/ ./internal/agent/device/applications/`
- [x] Lifecycle-focused integration (`ApplicationLifecycle` / DeviceRender) — passed
- [ ] QE: stop a running Helm app on MicroShift; device should leave `OutOfDate` and app should reach `Stopped` (scale-to-0)
- [ ] QE: start the same Helm app again; should return to `Running`