### PR TITLE
NO-ISSUE: Clarify VM app console not-ready errors with a stable error code

### DIFF
--- a/internal/agent/device/applications/console/manager.go
+++ b/internal/agent/device/applications/console/manager.go
@@ -3,6 +3,7 @@ package console
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +16,10 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/grpc/metadata"
 )
+
+// ErrAppNotReady is returned by ResolveConsole when the VM application is tracked
+// but has no active compute workload (e.g. stopped or still starting). Clients may retry.
+var ErrAppNotReady = errors.New("may not be ready yet, please try again later or check the device logs")
 
 // sanitizeGrpcMetadataValue replaces every byte outside the printable ASCII range
 // (0x20-0x7E) with '?'. gRPC-Go rejects outgoing metadata values containing such bytes
@@ -209,6 +214,9 @@ func (m *Manager) Start(ctx context.Context, entry v1beta1.DeviceRemoteSession) 
 	// before the client's connection is upgraded instead of only after.
 	if resolveErr != nil {
 		metadataPairs = append(metadataPairs, consts.GrpcSessionErrorKey, sanitizeGrpcMetadataValue(resolveErr.Error()))
+		if errors.Is(resolveErr, ErrAppNotReady) {
+			metadataPairs = append(metadataPairs, consts.GrpcSessionErrorCodeKey, consts.AppConsoleErrorCodeNotReady)
+		}
 	} else {
 		metadataPairs = append(metadataPairs, consts.GrpcSelectedProtocolKey, entry.ConsoleType)
 	}

--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -287,8 +287,37 @@ func TestAppConsoleManager(t *testing.T) {
 
 		require.Equal("app is not a VM workload", v.sentMetadataValue(consts.GrpcSessionErrorKey),
 			"expected the resolver error to be sent via session-error metadata so the server can fail before protocol selection")
+		require.Empty(v.sentMetadataValue(consts.GrpcSessionErrorCodeKey),
+			"session-error-code must be absent for generic resolver failures")
 		require.Empty(v.sentMetadataValue(consts.GrpcSelectedProtocolKey),
 			"selected-protocol metadata must not be sent when resolution failed")
+	})
+
+	t.Run("When the resolver returns ErrAppNotReady it should include session-error-code metadata", func(t *testing.T) {
+		require := require.New(t)
+
+		resolver := &mockResolver{
+			err: map[string]error{"my-app": fmt.Errorf("app %q %w", "my-app", ErrAppNotReady)},
+		}
+		v := setupTestVars(t, resolver)
+
+		v.mockStream()
+		v.mockCloseSend()
+
+		sessionID := uuid.New().String()
+		device := makeDevice([]v1beta1.DeviceRemoteSession{serialSession(sessionID, "my-app")})
+		v.manager.Sync(v.ctx, device)
+		v.waitSessions(t)
+
+		require.Eventually(func() bool {
+			v.mu.Lock()
+			defer v.mu.Unlock()
+			return v.closeSendCalled
+		}, 2*time.Second, 20*time.Millisecond, "expected CloseSend to be called")
+
+		require.Contains(v.sentMetadataValue(consts.GrpcSessionErrorKey), "may not be ready yet")
+		require.Equal(consts.AppConsoleErrorCodeNotReady, v.sentMetadataValue(consts.GrpcSessionErrorCodeKey))
+		require.Empty(v.sentMetadataValue(consts.GrpcSelectedProtocolKey))
 	})
 
 	t.Run("When the gRPC Stream call fails it should skip the session without panicking", func(t *testing.T) {

--- a/internal/agent/device/applications/podman_monitor.go
+++ b/internal/agent/device/applications/podman_monitor.go
@@ -977,7 +977,7 @@ func (m *PodmanMonitor) resolveConsole(appName, consoleType string) (appconsole.
 		}
 	}
 	if containerName == "" {
-		return nil, fmt.Errorf("app %q: no active compute container found (workload with \"-compute\" suffix required)", appName)
+		return nil, fmt.Errorf("app %q %w", appName, appconsole.ErrAppNotReady)
 	}
 
 	m.log.Infof("console: selected container %q for app %q (type=%s)", containerName, appName, ct)

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -1589,7 +1589,24 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		require.NoError(err)
 		_, err = m.resolveConsole("my-vm", "serial")
 		require.Error(err)
-		require.Contains(err.Error(), "no active compute container found")
+		require.ErrorIs(err, appconsole.ErrAppNotReady)
+		require.Contains(err.Error(), "may not be ready yet")
+	})
+
+	t.Run("When the app is VM serial with only an exited compute workload it should return ErrAppNotReady", func(t *testing.T) {
+		require := require.New(t)
+		m, _, ctrl := newMonitor(t)
+		defer ctrl.Finish()
+		app := createTestVMApplication(require, "my-vm", v1beta1.ApplicationStatusRunning, v1beta1.CurrentProcessUsername)
+		err := m.Ensure(t.Context(), app)
+		require.NoError(err)
+		app.AddWorkload(&Workload{Name: "systemd-my-vm-compute", Status: StatusExited})
+		app.AddWorkload(&Workload{Name: "systemd-my-vm-infra", Status: StatusRunning})
+
+		_, err = m.resolveConsole("my-vm", "serial")
+		require.Error(err)
+		require.ErrorIs(err, appconsole.ErrAppNotReady)
+		require.Contains(err.Error(), `app "my-vm"`)
 	})
 
 	t.Run("When the app is VM vnc with a running workload it should return a session that execs into the VNC socket", func(t *testing.T) {
@@ -1631,7 +1648,8 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		require.NoError(err)
 		_, err = m.resolveConsole("my-vm", "vnc")
 		require.Error(err)
-		require.Contains(err.Error(), "no active compute container found")
+		require.ErrorIs(err, appconsole.ErrAppNotReady)
+		require.Contains(err.Error(), "may not be ready yet")
 	})
 }
 

--- a/internal/cli/app_console.go
+++ b/internal/cli/app_console.go
@@ -71,14 +71,36 @@ func deliverVNCData(ctx context.Context, wsRecvCh chan<- []byte, clientAttached 
 }
 
 // ConsoleSessionError indicates the server or agent reported a session-level failure
-// (e.g. the requested application does not exist) over an already-established
-// WebSocket connection, as opposed to a transport/handshake-level error.
+// (e.g. the requested application does not exist, or is not ready yet), as opposed to
+// a transport-level error.
 type ConsoleSessionError struct {
+	// Code is an optional machine-readable code (e.g. consts.AppConsoleErrorCodeNotReady).
+	Code    string
 	Message string
 }
 
 func (e *ConsoleSessionError) Error() string {
 	return e.Message
+}
+
+func consoleSessionErrorFromWSClose(closeErr *websocket.CloseError) *ConsoleSessionError {
+	err := &ConsoleSessionError{Message: closeErr.Text}
+	if closeErr.Code == consts.AppConsoleNotReadyCloseCode {
+		err.Code = consts.AppConsoleErrorCodeNotReady
+	}
+	return err
+}
+
+// consoleErrorFromHandshake maps a failed WebSocket upgrade response to either a
+// typed ConsoleSessionError (when the server supplied a machine-readable code) or a
+// generic UpgradeFailureError.
+func consoleErrorFromHandshake(resp *http.Response, body string) error {
+	if code := resp.Header.Get(consts.AppConsoleErrorCodeHeader); code != "" {
+		return &ConsoleSessionError{Code: code, Message: body}
+	}
+	return &httpstream.UpgradeFailureError{
+		Cause: fmt.Errorf("websocket: bad handshake (%d %s): %s", resp.StatusCode, http.StatusText(resp.StatusCode), body),
+	}
 }
 
 // AppConsoleOptions holds the options for the "app console" command, which connects to the
@@ -307,10 +329,7 @@ func (o *AppConsoleOptions) connectAppViaWS(ctx context.Context, config *client.
 		if resp != nil {
 			defer resp.Body.Close()
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxAppConsoleWSMessageSize))
-			msg := strings.TrimSpace(string(body))
-			return &httpstream.UpgradeFailureError{
-				Cause: fmt.Errorf("websocket: bad handshake (%d %s): %s", resp.StatusCode, http.StatusText(resp.StatusCode), msg),
-			}
+			return consoleErrorFromHandshake(resp, strings.TrimSpace(string(body)))
 		}
 		return err
 	}
@@ -382,13 +401,14 @@ func (o *AppConsoleOptions) connectAppViaWS(ctx context.Context, config *client.
 		for {
 			msgType, msg, err := conn.ReadMessage()
 			if err != nil {
-				// The server closes with consts.AppConsoleErrorCloseCode (instead of a
-				// normal closure) when the session failed server- or agent-side (e.g. the
-				// requested application does not exist) — surface that as a real error
-				// rather than a silent, successful exit.
+				// The server closes with AppConsoleErrorCloseCode / AppConsoleNotReadyCloseCode
+				// (instead of a normal closure) when the session failed server- or agent-side
+				// (e.g. the requested application does not exist, or is not ready yet) —
+				// surface that as a real error rather than a silent, successful exit.
 				var closeErr *websocket.CloseError
-				if errors.As(err, &closeErr) && closeErr.Code == consts.AppConsoleErrorCloseCode {
-					sessionErr.Store(error(&ConsoleSessionError{Message: closeErr.Text}))
+				if errors.As(err, &closeErr) &&
+					(closeErr.Code == consts.AppConsoleErrorCloseCode || closeErr.Code == consts.AppConsoleNotReadyCloseCode) {
+					sessionErr.Store(error(consoleSessionErrorFromWSClose(closeErr)))
 					cancel()
 					return
 				}
@@ -453,10 +473,7 @@ func (o *AppConsoleOptions) connectVNCViaWS(ctx context.Context, config *client.
 		if resp != nil {
 			defer resp.Body.Close()
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxAppConsoleWSMessageSize))
-			msg := strings.TrimSpace(string(body))
-			return &httpstream.UpgradeFailureError{
-				Cause: fmt.Errorf("websocket: bad handshake (%d %s): %s", resp.StatusCode, http.StatusText(resp.StatusCode), msg),
-			}
+			return consoleErrorFromHandshake(resp, strings.TrimSpace(string(body)))
 		}
 		return err
 	}
@@ -496,13 +513,15 @@ func (o *AppConsoleOptions) connectVNCViaWS(ctx context.Context, config *client.
 			_, data, err := wsConn.ReadMessage()
 			if err != nil {
 				if ctx.Err() == nil {
-					// The server closes with consts.AppConsoleErrorCloseCode (instead of a
-					// normal closure) when the session failed server- or agent-side (e.g. the
-					// requested application does not exist) — surface that as a clean,
-					// recognizable error rather than a generic "tunnel connection lost".
+					// The server closes with AppConsoleErrorCloseCode / AppConsoleNotReadyCloseCode
+					// (instead of a normal closure) when the session failed server- or agent-side
+					// (e.g. the requested application does not exist, or is not ready yet) —
+					// surface that as a clean, recognizable error rather than a generic
+					// "tunnel connection lost".
 					var closeErr *websocket.CloseError
-					if errors.As(err, &closeErr) && closeErr.Code == consts.AppConsoleErrorCloseCode {
-						tunnelErr.Store(error(&ConsoleSessionError{Message: closeErr.Text}))
+					if errors.As(err, &closeErr) &&
+						(closeErr.Code == consts.AppConsoleErrorCloseCode || closeErr.Code == consts.AppConsoleNotReadyCloseCode) {
+						tunnelErr.Store(error(consoleSessionErrorFromWSClose(closeErr)))
 					} else {
 						tunnelErr.Store(err)
 					}

--- a/internal/cli/app_console_test.go
+++ b/internal/cli/app_console_test.go
@@ -209,6 +209,12 @@ func TestConnectAppViaWS_HTTPErrors(t *testing.T) {
 			body:        "timed out waiting for agent",
 			errContains: "504",
 		},
+		{
+			name:        "When server returns 503 without error code header it should surface status and message",
+			statusCode:  http.StatusServiceUnavailable,
+			body:        `app "myvm" may not be ready yet, please try again later or check the device logs`,
+			errContains: "503",
+		},
 	}
 
 	for _, tt := range tests {
@@ -235,36 +241,12 @@ func TestConnectAppViaWS_HTTPErrors(t *testing.T) {
 	}
 }
 
-// TestConnectAppViaWS_SessionError_ReturnsConsoleSessionError verifies that when the
-// server closes an already-upgraded WebSocket with consts.AppConsoleErrorCloseCode
-// (signalling a session-level failure reported by the agent, e.g. app not found),
-// connectAppViaWS surfaces it as a *ConsoleSessionError rather than treating the
-// close as a normal, successful end of session.
-func TestConnectAppViaWS_SessionError_ReturnsConsoleSessionError(t *testing.T) {
-	const agentErr = "app is not a VM workload"
+func TestConnectAppViaWS_AppNotReadyHandshake_ReturnsConsoleSessionError(t *testing.T) {
+	const agentErr = `app "myvm" may not be ready yet, please try again later or check the device logs`
 
-	// clientDone is closed once connectAppViaWS returns, so the server handler below can
-	// wait for the client to actually finish processing the close frame instead of relying
-	// on a fixed sleep that would be flaky under load.
-	clientDone := make(chan struct{})
-	upgrader := websocket.Upgrader{}
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		_ = conn.WriteControl(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(consts.AppConsoleErrorCloseCode, agentErr),
-			time.Now().Add(5*time.Second),
-		)
-		// Wait for the client to finish reading the close frame before the handler
-		// returns and the test server tears down the connection.
-		select {
-		case <-clientDone:
-		case <-time.After(5 * time.Second):
-		}
+		w.Header().Set(consts.AppConsoleErrorCodeHeader, consts.AppConsoleErrorCodeNotReady)
+		http.Error(w, agentErr, http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
@@ -275,29 +257,98 @@ func TestConnectAppViaWS_SessionError_ReturnsConsoleSessionError(t *testing.T) {
 		},
 	}
 
-	// connectAppViaWS reads from the real os.Stdin when not attached to a terminal.
-	// Swap in a pipe that blocks until closed, so the stdin-forwarding goroutine
-	// cannot race ahead and return via `done` before the recv goroutine observes
-	// the session error close frame (a real, non-piped stdin may EOF immediately
-	// in CI, which would make that race non-deterministic).
-	stdinR, stdinW, err := os.Pipe()
-	require.NoError(t, err)
-	defer stdinW.Close()
-	defer stdinR.Close()
-	oldStdin := os.Stdin
-	os.Stdin = stdinR
-	defer func() { os.Stdin = oldStdin }()
-
 	o := DefaultAppConsoleOptions()
 	o.consoleType = "serial"
-	o.noTTY = true
 
-	err = o.connectAppViaWS(t.Context(), cfg, "dev1", "myvm", "")
-	close(clientDone)
-
+	err := o.connectAppViaWS(t.Context(), cfg, "dev1", "myvm", "")
 	var sessionErr *ConsoleSessionError
 	require.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, consts.AppConsoleErrorCodeNotReady, sessionErr.Code)
 	assert.Equal(t, agentErr, sessionErr.Message)
+}
+
+// TestConnectAppViaWS_SessionError_ReturnsConsoleSessionError verifies that when the
+// server closes an already-upgraded WebSocket with a session-failure close code
+// (4001 generic or 4002 app-not-ready), connectAppViaWS surfaces it as a
+// *ConsoleSessionError rather than treating the close as a normal, successful end of session.
+func TestConnectAppViaWS_SessionError_ReturnsConsoleSessionError(t *testing.T) {
+	tests := []struct {
+		name      string
+		closeCode int
+		agentErr  string
+		wantCode  string
+	}{
+		{
+			name:      "When close code is AppConsoleErrorCloseCode it should return ConsoleSessionError",
+			closeCode: consts.AppConsoleErrorCloseCode,
+			agentErr:  "app is not a VM workload",
+		},
+		{
+			name:      "When close code is AppConsoleNotReadyCloseCode it should return ConsoleSessionError with app-not-ready code",
+			closeCode: consts.AppConsoleNotReadyCloseCode,
+			agentErr:  `app "myvm" may not be ready yet, please try again later or check the device logs`,
+			wantCode:  consts.AppConsoleErrorCodeNotReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// clientDone is closed once connectAppViaWS returns, so the server handler below can
+			// wait for the client to actually finish processing the close frame instead of relying
+			// on a fixed sleep that would be flaky under load.
+			clientDone := make(chan struct{})
+			upgrader := websocket.Upgrader{}
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				_ = conn.WriteControl(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(tt.closeCode, tt.agentErr),
+					time.Now().Add(5*time.Second),
+				)
+				select {
+				case <-clientDone:
+				case <-time.After(5 * time.Second):
+				}
+			}))
+			defer srv.Close()
+
+			cfg := &client.Config{
+				RemoteAccessService: &client.Service{
+					Server:             srv.URL,
+					InsecureSkipVerify: true,
+				},
+			}
+
+			// connectAppViaWS reads from the real os.Stdin when not attached to a terminal.
+			// Swap in a pipe that blocks until closed, so the stdin-forwarding goroutine
+			// cannot race ahead and return via `done` before the recv goroutine observes
+			// the session error close frame (a real, non-piped stdin may EOF immediately
+			// in CI, which would make that race non-deterministic).
+			stdinR, stdinW, err := os.Pipe()
+			require.NoError(t, err)
+			defer stdinW.Close()
+			defer stdinR.Close()
+			oldStdin := os.Stdin
+			os.Stdin = stdinR
+			defer func() { os.Stdin = oldStdin }()
+
+			o := DefaultAppConsoleOptions()
+			o.consoleType = "serial"
+			o.noTTY = true
+
+			err = o.connectAppViaWS(t.Context(), cfg, "dev1", "myvm", "")
+			close(clientDone)
+
+			var sessionErr *ConsoleSessionError
+			require.ErrorAs(t, err, &sessionErr)
+			assert.Equal(t, tt.agentErr, sessionErr.Message)
+			assert.Equal(t, tt.wantCode, sessionErr.Code)
+		})
+	}
 }
 
 func TestBuildTLSConfigForConsole(t *testing.T) {
@@ -444,51 +495,70 @@ func TestConnectVNCViaWS_HTTPError(t *testing.T) {
 }
 
 // TestConnectVNCViaWS_SessionError_ReturnsConsoleSessionError verifies that connectVNCViaWS
-// mirrors connectAppViaWS's handling of consts.AppConsoleErrorCloseCode: a session-level
-// failure reported by the agent (e.g. app not found) must surface as a *ConsoleSessionError,
-// not a generic "VNC tunnel connection lost" error.
+// mirrors connectAppViaWS's handling of session-failure close codes: a session-level
+// failure reported by the agent must surface as a *ConsoleSessionError, not a generic
+// "VNC tunnel connection lost" error.
 func TestConnectVNCViaWS_SessionError_ReturnsConsoleSessionError(t *testing.T) {
-	const agentErr = "app is not a VM workload"
-
-	// clientDone is closed once connectVNCViaWS returns, so the server handler below can
-	// wait for the client to actually finish processing the close frame instead of relying
-	// on a fixed sleep that would be flaky under load.
-	clientDone := make(chan struct{})
-	upgrader := websocket.Upgrader{}
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		_ = conn.WriteControl(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(consts.AppConsoleErrorCloseCode, agentErr),
-			time.Now().Add(5*time.Second),
-		)
-		select {
-		case <-clientDone:
-		case <-time.After(5 * time.Second):
-		}
-	}))
-	defer srv.Close()
-
-	o := DefaultAppConsoleOptions()
-	o.consoleType = "vnc"
-
-	cfg := &client.Config{
-		RemoteAccessService: &client.Service{
-			Server:             srv.URL,
-			InsecureSkipVerify: true,
+	tests := []struct {
+		name      string
+		closeCode int
+		agentErr  string
+		wantCode  string
+	}{
+		{
+			name:      "When close code is AppConsoleErrorCloseCode it should return ConsoleSessionError",
+			closeCode: consts.AppConsoleErrorCloseCode,
+			agentErr:  "app is not a VM workload",
+		},
+		{
+			name:      "When close code is AppConsoleNotReadyCloseCode it should return ConsoleSessionError with app-not-ready code",
+			closeCode: consts.AppConsoleNotReadyCloseCode,
+			agentErr:  `app "myvm" may not be ready yet, please try again later or check the device logs`,
+			wantCode:  consts.AppConsoleErrorCodeNotReady,
 		},
 	}
 
-	err := o.connectVNCViaWS(t.Context(), cfg, "dev1", "myvm", "")
-	close(clientDone)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientDone := make(chan struct{})
+			upgrader := websocket.Upgrader{}
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				_ = conn.WriteControl(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(tt.closeCode, tt.agentErr),
+					time.Now().Add(5*time.Second),
+				)
+				select {
+				case <-clientDone:
+				case <-time.After(5 * time.Second):
+				}
+			}))
+			defer srv.Close()
 
-	var sessionErr *ConsoleSessionError
-	require.ErrorAs(t, err, &sessionErr)
-	assert.Equal(t, agentErr, sessionErr.Message)
+			o := DefaultAppConsoleOptions()
+			o.consoleType = "vnc"
+
+			cfg := &client.Config{
+				RemoteAccessService: &client.Service{
+					Server:             srv.URL,
+					InsecureSkipVerify: true,
+				},
+			}
+
+			err := o.connectVNCViaWS(t.Context(), cfg, "dev1", "myvm", "")
+			close(clientDone)
+
+			var sessionErr *ConsoleSessionError
+			require.ErrorAs(t, err, &sessionErr)
+			assert.Equal(t, tt.agentErr, sessionErr.Message)
+			assert.Equal(t, tt.wantCode, sessionErr.Code)
+		})
+	}
 }
 
 func TestBridgeVNCClient_ClientDisconnectDoesNotCloseWebSocket(t *testing.T) {

--- a/internal/console/app_console.go
+++ b/internal/console/app_console.go
@@ -17,6 +17,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SessionFailure is a session-level failure reported by the agent.
+type SessionFailure struct {
+	// Code is an optional machine-readable code (e.g. consts.AppConsoleErrorCodeNotReady).
+	// Empty for generic failures.
+	Code string
+	// Message is the human-readable failure detail.
+	Message string
+}
+
 // AppConsoleSession is the server-side session object bridging the WebSocket handler
 // and the gRPC stream from the agent.
 type AppConsoleSession struct {
@@ -31,7 +40,7 @@ type AppConsoleSession struct {
 	// application does not exist). The WebSocket handler must close the client
 	// connection with a distinguishable close code/reason instead of relaying this as
 	// console payload data.
-	ErrCh chan string
+	ErrCh chan SessionFailure
 }
 
 // AppConsoleDeviceService is the narrow interface AppConsoleSessionManager needs,
@@ -311,7 +320,7 @@ func (m *AppConsoleSessionManager) StartSession(ctx context.Context, orgId uuid.
 		SendCh:     make(chan []byte, ChannelSize),
 		RecvCh:     make(chan []byte, ChannelSize),
 		ProtocolCh: make(chan string, 1),
-		ErrCh:      make(chan string, 1),
+		ErrCh:      make(chan SessionFailure, 1),
 	}
 
 	var replacedSessionID string

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -51,6 +51,16 @@ const (
 	// of (never alongside) GrpcSelectedProtocolKey so the server can fail the session before
 	// upgrading the client's connection, rather than reporting the error only after upgrade.
 	GrpcSessionErrorKey = "session-error"
+	// GrpcSessionErrorCodeKey carries an optional machine-readable code for the failure in
+	// GrpcSessionErrorKey (e.g. AppConsoleErrorCodeNotReady). Absent for generic failures.
+	GrpcSessionErrorCodeKey = "session-error-code"
+
+	// AppConsoleErrorCodeNotReady is the machine-readable code for a console request made
+	// while the VM application has no active compute workload (e.g. stopped or still starting).
+	AppConsoleErrorCodeNotReady = "app-not-ready"
+	// AppConsoleErrorCodeHeader is set on the HTTP response when a console session fails
+	// before WebSocket upgrade with a known machine-readable code.
+	AppConsoleErrorCodeHeader = "X-Flightctl-App-Console-Error"
 
 	// AppConsoleErrorCloseCode is the WebSocket close status code the flightctl-remote-access
 	// service uses to signal an application console session-level failure (e.g. the requested
@@ -58,6 +68,9 @@ const (
 	// 4000-4999 range reserved by RFC 6455 for private use. Shared between
 	// internal/remote_access_server (sender) and internal/cli (receiver).
 	AppConsoleErrorCloseCode = 4001
+	// AppConsoleNotReadyCloseCode signals that the application console is temporarily
+	// unavailable (AppConsoleErrorCodeNotReady). Clients may retry.
+	AppConsoleNotReadyCloseCode = 4002
 
 	// Tasks
 	TaskQueue           = "task-queue"

--- a/internal/remote_access_server/grpc.go
+++ b/internal/remote_access_server/grpc.go
@@ -61,8 +61,12 @@ func (s *Server) Stream(stream pb.RouterService_StreamServer) error {
 		if agentErrs := md.Get(consts.GrpcSessionErrorKey); len(agentErrs) == 1 && agentErrs[0] != "" {
 			s.log.Infof("agent reported session-level failure before protocol selection for session %s device %s app %s",
 				sessionID, session.DeviceName, session.AppName)
+			failure := console.SessionFailure{Message: agentErrs[0]}
+			if errCodes := md.Get(consts.GrpcSessionErrorCodeKey); len(errCodes) == 1 {
+				failure.Code = errCodes[0]
+			}
 			select {
-			case session.ErrCh <- agentErrs[0]:
+			case session.ErrCh <- failure:
 			default:
 			}
 			return status.Error(codes.FailedPrecondition, agentErrs[0])
@@ -96,7 +100,7 @@ func (s *Server) forwardChannels(ctx context.Context, stream pb.RouterService_St
 // race and observe the close before (or instead of) the error, silently losing it. Since
 // the consumer is expected to stop reading from ch as soon as it observes errCh, leaving
 // ch open here is harmless — it is simply never read from again.
-func (s *Server) pipeStreamToChannel(ctx context.Context, stream pb.RouterService_StreamServer, ch chan []byte, errCh chan string) {
+func (s *Server) pipeStreamToChannel(ctx context.Context, stream pb.RouterService_StreamServer, ch chan []byte, errCh chan console.SessionFailure) {
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
@@ -111,7 +115,7 @@ func (s *Server) pipeStreamToChannel(ctx context.Context, stream pb.RouterServic
 		if agentErr := msg.GetError(); agentErr != "" {
 			s.log.Debugf("app console stream reported session error: %s", agentErr)
 			select {
-			case errCh <- agentErr:
+			case errCh <- console.SessionFailure{Message: agentErr}:
 			case <-ctx.Done():
 			}
 			return

--- a/internal/remote_access_server/server_test.go
+++ b/internal/remote_access_server/server_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	pb "github.com/flightctl/flightctl/api/grpc/v1"
+	"github.com/flightctl/flightctl/internal/console"
+	"github.com/flightctl/flightctl/internal/consts"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +113,73 @@ func TestServerStream_MissingSessionID(t *testing.T) {
 	}
 }
 
+func TestServerStream_SessionErrorMetadata_RoutesToErrCh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		errorCode    string
+		wantFailure  console.SessionFailure
+		wantGRPCCode codes.Code
+	}{
+		{
+			name:      "When session-error has no code it should forward message only",
+			errorCode: "",
+			wantFailure: console.SessionFailure{
+				Message: "app is not a VM workload",
+			},
+			wantGRPCCode: codes.FailedPrecondition,
+		},
+		{
+			name:      "When session-error-code is app-not-ready it should forward code and message",
+			errorCode: consts.AppConsoleErrorCodeNotReady,
+			wantFailure: console.SessionFailure{
+				Code:    consts.AppConsoleErrorCodeNotReady,
+				Message: `app "my-vm" may not be ready yet, please try again later or check the device logs`,
+			},
+			wantGRPCCode: codes.FailedPrecondition,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := &console.AppConsoleSession{
+				UUID:       "session-1",
+				DeviceName: "device-1",
+				AppName:    "my-vm",
+				ProtocolCh: make(chan string, 1),
+				ErrCh:      make(chan console.SessionFailure, 1),
+			}
+			srv := &Server{
+				log:            logrus.New(),
+				pendingStreams: &sync.Map{},
+			}
+			require.NoError(t, srv.StartSession(session))
+
+			md := metadata.Pairs(
+				consts.GrpcSessionIDKey, session.UUID,
+				consts.GrpcSessionErrorKey, tt.wantFailure.Message,
+			)
+			if tt.errorCode != "" {
+				md.Append(consts.GrpcSessionErrorCodeKey, tt.errorCode)
+			}
+			ctx := metadata.NewIncomingContext(context.Background(), md)
+			err := srv.Stream(&stubStreamServer{ctx: ctx})
+			require.Error(t, err)
+			require.Equal(t, tt.wantGRPCCode, status.Code(err))
+
+			select {
+			case got := <-session.ErrCh:
+				assert.Equal(t, tt.wantFailure, got)
+			case <-time.After(time.Second):
+				t.Fatal("expected session failure on ErrCh")
+			}
+		})
+	}
+}
+
 // scriptedStreamServer is a stubStreamServer whose Recv() replays a fixed
 // sequence of StreamRequest messages, then blocks until the test's context
 // is cancelled (mimicking a live gRPC stream that has nothing left to say).
@@ -150,7 +219,7 @@ func TestPipeStreamToChannel_AgentError_RoutesToErrChNotPayloadCh(t *testing.T) 
 
 	srv := &Server{log: logrus.New()}
 	ch := make(chan []byte, 4)
-	errCh := make(chan string, 1)
+	errCh := make(chan console.SessionFailure, 1)
 
 	done := make(chan struct{})
 	go func() {
@@ -168,7 +237,7 @@ func TestPipeStreamToChannel_AgentError_RoutesToErrChNotPayloadCh(t *testing.T) 
 
 	select {
 	case agentErr := <-errCh:
-		assert.Equal(t, "app is not a VM workload", agentErr)
+		assert.Equal(t, console.SessionFailure{Message: "app is not a VM workload"}, agentErr)
 	case <-time.After(time.Second):
 		t.Fatal("expected the agent error to be forwarded on errCh")
 	}

--- a/internal/remote_access_server/ws_handler.go
+++ b/internal/remote_access_server/ws_handler.go
@@ -31,6 +31,27 @@ func truncateWSCloseReason(msg string) string {
 	return strings.ToValidUTF8(msg[:maxWSCloseReasonBytes], "")
 }
 
+func httpStatusForSessionFailure(f console.SessionFailure) int {
+	if f.Code == consts.AppConsoleErrorCodeNotReady {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusNotFound
+}
+
+func wsCloseCodeForSessionFailure(f console.SessionFailure) int {
+	if f.Code == consts.AppConsoleErrorCodeNotReady {
+		return consts.AppConsoleNotReadyCloseCode
+	}
+	return consts.AppConsoleErrorCloseCode
+}
+
+func writeSessionFailure(w http.ResponseWriter, f console.SessionFailure) {
+	if f.Code != "" {
+		w.Header().Set(consts.AppConsoleErrorCodeHeader, f.Code)
+	}
+	http.Error(w, truncateWSCloseReason(f.Message), httpStatusForSessionFailure(f))
+}
+
 // AppConsoleHandler handles WebSocket connections for application-level console sessions.
 type AppConsoleHandler struct {
 	log                      logrus.FieldLogger
@@ -122,8 +143,8 @@ func (h *AppConsoleHandler) HandleApplicationConsole(w http.ResponseWriter, r *h
 		// client never sees a false "connected" state for a session that never started.
 		close(session.SendCh)
 		h.log.Infof("app console session for device %s app %s failed before protocol selection with an agent-reported error", deviceName, appName)
-		h.log.Debugf("app console session %s failure detail: %s", session.UUID, agentErr)
-		http.Error(w, truncateWSCloseReason(agentErr), http.StatusNotFound)
+		h.log.Debugf("app console session %s failure detail: code=%q msg=%s", session.UUID, agentErr.Code, agentErr.Message)
+		writeSessionFailure(w, agentErr)
 		return
 	case <-timer.C:
 		close(session.SendCh)
@@ -214,9 +235,9 @@ func (h *AppConsoleHandler) HandleApplicationConsole(w http.ResponseWriter, r *h
 				// agentErr is agent/session-supplied and not sanitized; keep it (and the
 				// session ID) out of the info-level log and only surface it at debug level.
 				h.log.Infof("app console session for device %s app %s failed with an agent-reported error", deviceName, appName)
-				h.log.Debugf("app console session %s failure detail: %s", session.UUID, agentErr)
-				closeCode = consts.AppConsoleErrorCloseCode
-				closeReason = truncateWSCloseReason(agentErr)
+				h.log.Debugf("app console session %s failure detail: code=%q msg=%s", session.UUID, agentErr.Code, agentErr.Message)
+				closeCode = wsCloseCodeForSessionFailure(agentErr)
+				closeReason = truncateWSCloseReason(agentErr.Message)
 				return
 			case message, ok := <-session.RecvCh:
 				if !ok {

--- a/internal/remote_access_server/ws_handler_test.go
+++ b/internal/remote_access_server/ws_handler_test.go
@@ -246,7 +246,7 @@ func TestHandleApplicationConsole_AgentError_ClosesWithCustomCode(t *testing.T) 
 	// Simulate the agent reporting a session-level failure (e.g. app not found).
 	const agentErr = "app is not a VM workload"
 	select {
-	case session.ErrCh <- agentErr:
+	case session.ErrCh <- console.SessionFailure{Message: agentErr}:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out sending agent error")
 	}
@@ -258,6 +258,78 @@ func TestHandleApplicationConsole_AgentError_ClosesWithCustomCode(t *testing.T) 
 	closeErr, ok := err.(*websocket.CloseError)
 	require.True(t, ok, "expected a *websocket.CloseError, got %T: %v", err, err)
 	require.Equal(t, consts.AppConsoleErrorCloseCode, closeErr.Code)
+	require.Equal(t, agentErr, closeErr.Text)
+}
+
+// TestHandleApplicationConsole_AgentNotReady_AfterUpgrade_ClosesWithNotReadyCode verifies
+// that a post-upgrade app-not-ready failure uses close code 4002 rather than the generic 4001.
+func TestHandleApplicationConsole_AgentNotReady_AfterUpgrade_ClosesWithNotReadyCode(t *testing.T) {
+	t.Parallel()
+
+	startedCh := make(chan *console.AppConsoleSession, 1)
+	mgr := console.NewAppConsoleSessionManager(
+		&fakeAppDeviceService{},
+		logrus.NewEntry(logrus.New()),
+		&fakeAppSessionRegistration{startedCh: startedCh},
+		&fakeConsoleEventNotifier{},
+	)
+	handler := NewAppConsoleHandler(logrus.New(), mgr)
+
+	router := chi.NewRouter()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws/v1/devices/device1/applications/app1/console?consoleType=serial"
+
+	type dialResult struct {
+		conn *websocket.Conn
+		err  error
+	}
+	dialDone := make(chan dialResult, 1)
+	dialer := websocket.Dialer{Subprotocols: []string{"serial"}}
+	go func() {
+		conn, _, err := dialer.Dial(wsURL, nil)
+		dialDone <- dialResult{conn: conn, err: err}
+	}()
+
+	var session *console.AppConsoleSession
+	select {
+	case session = <-startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartSession to be called")
+	}
+
+	select {
+	case session.ProtocolCh <- "serial":
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out sending selected protocol")
+	}
+
+	var res dialResult
+	select {
+	case res = <-dialDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket handshake")
+	}
+	require.NoError(t, res.err)
+	conn := res.conn
+	defer conn.Close()
+
+	const agentErr = `app "app1" may not be ready yet, please try again later or check the device logs`
+	select {
+	case session.ErrCh <- console.SessionFailure{Code: consts.AppConsoleErrorCodeNotReady, Message: agentErr}:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out sending agent error")
+	}
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err, "expected the connection to be closed by the server")
+
+	closeErr, ok := err.(*websocket.CloseError)
+	require.True(t, ok, "expected a *websocket.CloseError, got %T: %v", err, err)
+	require.Equal(t, consts.AppConsoleNotReadyCloseCode, closeErr.Code)
 	require.Equal(t, agentErr, closeErr.Text)
 }
 
@@ -307,7 +379,7 @@ func TestHandleApplicationConsole_AgentError_BeforeProtocolSelection_ReturnsNotF
 	// requested app does not exist.
 	const agentErr = "app is not a VM workload"
 	select {
-	case session.ErrCh <- agentErr:
+	case session.ErrCh <- console.SessionFailure{Message: agentErr}:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out sending agent error")
 	}
@@ -322,6 +394,72 @@ func TestHandleApplicationConsole_AgentError_BeforeProtocolSelection_ReturnsNotF
 	require.Nil(t, res.conn)
 	require.NotNil(t, res.resp)
 	require.Equal(t, http.StatusNotFound, res.resp.StatusCode)
+	require.Empty(t, res.resp.Header.Get(consts.AppConsoleErrorCodeHeader))
+
+	body, readErr := io.ReadAll(res.resp.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, agentErr+"\n", string(body))
+}
+
+// TestHandleApplicationConsole_AgentNotReady_BeforeProtocolSelection_ReturnsServiceUnavailable
+// covers the app-not-ready resolve failure: HTTP 503 with a machine-readable error header
+// so UI clients can distinguish "retry later" from "app not found" without parsing the body.
+func TestHandleApplicationConsole_AgentNotReady_BeforeProtocolSelection_ReturnsServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	startedCh := make(chan *console.AppConsoleSession, 1)
+	mgr := console.NewAppConsoleSessionManager(
+		&fakeAppDeviceService{},
+		logrus.NewEntry(logrus.New()),
+		&fakeAppSessionRegistration{startedCh: startedCh},
+		&fakeConsoleEventNotifier{},
+	)
+	handler := NewAppConsoleHandler(logrus.New(), mgr)
+
+	router := chi.NewRouter()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws/v1/devices/device1/applications/app1/console?consoleType=serial"
+
+	type dialResult struct {
+		conn *websocket.Conn
+		resp *http.Response
+		err  error
+	}
+	dialDone := make(chan dialResult, 1)
+	dialer := websocket.Dialer{Subprotocols: []string{"serial"}}
+	go func() {
+		conn, resp, err := dialer.Dial(wsURL, nil)
+		dialDone <- dialResult{conn: conn, resp: resp, err: err}
+	}()
+
+	var session *console.AppConsoleSession
+	select {
+	case session = <-startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected StartSession to be called")
+	}
+
+	const agentErr = `app "app1" may not be ready yet, please try again later or check the device logs`
+	select {
+	case session.ErrCh <- console.SessionFailure{Code: consts.AppConsoleErrorCodeNotReady, Message: agentErr}:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out sending agent error")
+	}
+
+	var res dialResult
+	select {
+	case res = <-dialDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the dial to fail")
+	}
+	require.Error(t, res.err, "expected the WebSocket handshake to fail rather than upgrade")
+	require.Nil(t, res.conn)
+	require.NotNil(t, res.resp)
+	require.Equal(t, http.StatusServiceUnavailable, res.resp.StatusCode)
+	require.Equal(t, consts.AppConsoleErrorCodeNotReady, res.resp.Header.Get(consts.AppConsoleErrorCodeHeader))
 
 	body, readErr := io.ReadAll(res.resp.Body)
 	require.NoError(t, readErr)


### PR DESCRIPTION
## Summary
- Replace the internal "no active compute container / -compute suffix" console error with a clear user-facing message when a VM app is stopped or not ready yet.
- Add a machine-readable `app-not-ready` signal (`session-error-code` gRPC metadata → HTTP `503` + `X-Flightctl-App-Console-Error` before upgrade, WebSocket close code `4002` after upgrade) so UI/CLI can detect the case without parsing error text.
- Teach the CLI to map that signal to `ConsoleSessionError.Code = app-not-ready` on both handshake and post-upgrade close paths.

## Test plan
- [x] Unit: agent resolve returns `ErrAppNotReady` for missing/exited compute workloads
- [x] Unit: agent sends `session-error-code=app-not-ready` metadata
- [x] Unit: remote-access Stream() forwards code on `ErrCh`; WS returns `503`+header / close `4002`
- [x] Unit: CLI identifies `app-not-ready` from header and close code `4002` (serial + VNC)
- [ ] Manual: stop a running VM app, immediately run `flightctl app console device/$dev --name <app> --type serial` and confirm the clearer message (and UI can key off `503` / header / `4002`)


Made with [Cursor](https://cursor.com)