### PR TITLE
EDM-5037: increase greenboot timeout to 5m for disconnected environments

### DIFF
--- a/test/harness/e2e/vm_pool.go
+++ b/test/harness/e2e/vm_pool.go
@@ -13,9 +13,19 @@ import (
 )
 
 const (
-	greenbootTimeout      = 2 * time.Minute
-	greenbootPollInterval = 1 * time.Second
+	greenbootTimeoutDefault      = 2 * time.Minute
+	greenbootTimeoutDisconnected = 5 * time.Minute
+	greenbootPollInterval        = 1 * time.Second
 )
+
+func getGreenbootTimeout() time.Duration {
+	if os.Getenv("E2E_DISCONNECTED") == "true" {
+		fmt.Printf("📡 [VMPool] E2E_DISCONNECTED=true → greenboot timeout %s\n", greenbootTimeoutDisconnected)
+		return greenbootTimeoutDisconnected
+	}
+	fmt.Printf("📡 [VMPool] greenboot timeout %s (default)\n", greenbootTimeoutDefault)
+	return greenbootTimeoutDefault
+}
 
 // VMPool manages VMs across all test suites
 type VMPool struct {
@@ -269,7 +279,8 @@ func (p *VMPool) createVMForWorker(workerID int) (vm.TestVMInterface, error) {
 // successfully or is not installed, and an error if the service failed,
 // timed out, or could not be queried.
 func waitForGreenbootHealthcheck(testVM vm.TestVMInterface) error {
-	deadline := time.Now().Add(greenbootTimeout)
+	timeout := getGreenbootTimeout()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		stdout, err := testVM.RunSSH([]string{"systemctl", "show", "-p", "ActiveState", "--value", "greenboot-healthcheck.service"}, nil)
 		if err != nil {
@@ -296,7 +307,7 @@ func waitForGreenbootHealthcheck(testVM vm.TestVMInterface) error {
 
 		return fmt.Errorf("greenboot-healthcheck completed with state=%q result=%q", state, result)
 	}
-	return fmt.Errorf("timed out after %s waiting for greenboot-healthcheck", greenbootTimeout)
+	return fmt.Errorf("timed out after %s waiting for greenboot-healthcheck", timeout)
 }
 
 // createFreshVMBase creates a fresh VM with an overlay disk, starts it, waits for SSH,


### PR DESCRIPTION
## Summary
- Disconnected labs often take ~3.5m for `greenboot-healthcheck` to complete (activating subscriptions, pulling metadata over slower mirrors), exceeding the hard-coded 2m limit and failing VM pool setup during rollouts
- Replace the hardcoded `greenbootTimeout` constant with a `getGreenbootTimeout()` function that reads the `E2E_DISCONNECTED` env var: when `true` → 5m, otherwise 2m (default unchanged)
- Logs which timeout value is active so CI output is self-documenting

## Context
Companion CI change in ocp-edge-ci sets `disconnected: true` on all disconnected profiles, which exports `E2E_DISCONNECTED=true` into the test harness.

Part of [EDM-5037](https://issues.redhat.com/browse/EDM-5037).

## Test plan
- [ ] `E2E_DISCONNECTED=true`: rollout fresh-VM (e.g. OCP-79648) passes; log shows `5m` greenboot budget
- [ ] Flag unset: greenboot timeout remains `2m`
- [ ] IPv4 connected: unchanged behavior

Made with [Cursor](https://cursor.com)