### PR TITLE
EDM-5037: Use host networking for ImageExport bootc-image-builder

### DIFF
--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -509,6 +509,7 @@ func (c *Consumer) startBootcImageBuilderContainer(
 		"run", "-d", "--rm",
 		"--name", containerName,
 		"--privileged",
+		"--net=host",
 		"--pull=newer",
 		"--entrypoint", "sleep",
 		"--security-opt", "label=type:unconfined_t",


### PR DESCRIPTION
## Summary
- ImageExport's `startBootcImageBuilderContainer` pulls the source bootc image via nested `podman pull` inside the bootc-image-builder container, but that container used Podman's default bridge network.
- On IPv6-only environments the bridge has no route to non-link-local IPv6 registries, so ImageExport fails with `network is unreachable` even after ImageBuild successfully pushed the same image (ImageBuild already uses `--net=host`).
- Add `--net=host` to match `startPodmanWorker` in ImageBuild so registry login/pull works on IPv6-only labs.

Fixes: https://issues.redhat.com/browse/EDM-5037

## Test plan
- [ ] Unit/package build still compiles for `internal/imagebuilder_worker/tasks`
- [ ] Reproduce on IPv6-only (`IPV6_ONLY=true`): ImageBuild succeeds, then ImageExport pull succeeds against the same registry
- [ ] Smoke ImageExport on IPv4 to confirm no regression
- [ ] Confirm failure still occurs at pull (not conversion) without the flag if validating the RCA


Made with [Cursor](https://cursor.com)