### PR TITLE
EDM-5037: drop IPv4 default route on IPV6_ONLY agent qcow

### DIFF
--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -399,12 +399,65 @@ EOF
   log "Hosts entry added successfully"
 }
 
+# IPV6_ONLY: never install an IPv4 default route. Lab DNS often returns
+# unreachable A records for *.apps; an IPv4 default (e.g. libvirt NAT
+# 10.0.2.2) blackholes those dials until systemd TimeoutStartSec. With no
+# IPv4 default, A lookups fail fast (ENETUNREACH) and the agent uses AAAA.
+inject_ipv4_never_default() {
+  local base="$1"
+
+  if [[ "${IPV6_ONLY:-false}" != "true" ]]; then
+    return
+  fi
+
+  local nm_dir="$base/NetworkManager/conf.d"
+  local nm_conf="$nm_dir/99-flightctl-e2e-ipv6-only.conf"
+  local unit_dir="$base/systemd/system"
+  local unit="$unit_dir/flightctl-e2e-no-ipv4-default.service"
+  local wants_dir="$base/systemd/system/multi-user.target.wants"
+
+  log "IPv6 mode: Configuring ipv4.never-default + oneshot to drop IPv4 default route"
+
+  sudo mkdir -p "$nm_dir" "$unit_dir" "$wants_dir"
+
+  sudo tee "$nm_conf" >/dev/null <<'EOF'
+# flightctl e2e IPV6_ONLY: do not install an IPv4 default route on any connection.
+[connection]
+ipv4.never-default=true
+EOF
+  sudo chown root:root "$nm_conf"
+  sudo chmod 0644 "$nm_conf"
+
+  sudo tee "$unit" >/dev/null <<'EOF'
+[Unit]
+Description=FlightCtl e2e IPV6_ONLY: remove IPv4 default route
+Documentation=https://github.com/flightctl/flightctl
+After=NetworkManager.service network-online.target
+Before=flightctl-agent.service
+DefaultDependencies=yes
+
+[Service]
+Type=oneshot
+# DHCP/NM may install more than one; delete until gone.
+ExecStart=/usr/bin/bash -c 'while ip -4 route show default 2>/dev/null | grep -q .; do ip -4 route del default || exit 0; done'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  sudo chown root:root "$unit"
+  sudo chmod 0644 "$unit"
+
+  sudo ln -sfn ../flightctl-e2e-no-ipv4-default.service "$wants_dir/flightctl-e2e-no-ipv4-default.service"
+}
+
 # Write to deployment etc so it appears at guest /etc
 copy_into "$DEPLOY_ETC"
 inject_registry_ca "$DEPLOY_ETC"
 write_registry_remap "$DEPLOY_ETC"
 write_mirror_registry "$DEPLOY_ETC"
 inject_hosts_entry "$DEPLOY_ETC"
+inject_ipv4_never_default "$DEPLOY_ETC"
 
 # Also mirror to on-disk etc so it shows under guest /sysroot/etc
 if [[ "$SYSROOT_ETC" != "$DEPLOY_ETC" ]]; then
@@ -413,6 +466,7 @@ if [[ "$SYSROOT_ETC" != "$DEPLOY_ETC" ]]; then
   write_registry_remap "$SYSROOT_ETC"
   write_mirror_registry "$SYSROOT_ETC"
   inject_hosts_entry "$SYSROOT_ETC"
+  inject_ipv4_never_default "$SYSROOT_ETC"
 fi
 
 sync

--- a/test/scripts/inject_agent_files_into_qcow.sh
+++ b/test/scripts/inject_agent_files_into_qcow.sh
@@ -393,62 +393,21 @@ EOF
     else
       log "IPv6 mode: Registry hostname entry already exists"
     fi
+
+    # Avoid IPv4 default (e.g. libvirt NAT) blackholing unreachable *.apps A records.
+    local nm_dir="$base/NetworkManager/conf.d"
+    sudo mkdir -p "$nm_dir"
+    log "IPv6 mode: Setting ipv4.never-default in NetworkManager"
+    printf '%s\n' \
+      '# flightctl e2e IPV6_ONLY: do not install an IPv4 default route' \
+      '[connection]' \
+      'ipv4.never-default=true' |
+      sudo tee "$nm_dir/99-flightctl-e2e-ipv6-only.conf" >/dev/null
+    sudo chown root:root "$nm_dir/99-flightctl-e2e-ipv6-only.conf"
   fi
 
   sudo chown root:root "$hosts_file"
   log "Hosts entry added successfully"
-}
-
-# IPV6_ONLY: never install an IPv4 default route. Lab DNS often returns
-# unreachable A records for *.apps; an IPv4 default (e.g. libvirt NAT
-# 10.0.2.2) blackholes those dials until systemd TimeoutStartSec. With no
-# IPv4 default, A lookups fail fast (ENETUNREACH) and the agent uses AAAA.
-inject_ipv4_never_default() {
-  local base="$1"
-
-  if [[ "${IPV6_ONLY:-false}" != "true" ]]; then
-    return
-  fi
-
-  local nm_dir="$base/NetworkManager/conf.d"
-  local nm_conf="$nm_dir/99-flightctl-e2e-ipv6-only.conf"
-  local unit_dir="$base/systemd/system"
-  local unit="$unit_dir/flightctl-e2e-no-ipv4-default.service"
-  local wants_dir="$base/systemd/system/multi-user.target.wants"
-
-  log "IPv6 mode: Configuring ipv4.never-default + oneshot to drop IPv4 default route"
-
-  sudo mkdir -p "$nm_dir" "$unit_dir" "$wants_dir"
-
-  sudo tee "$nm_conf" >/dev/null <<'EOF'
-# flightctl e2e IPV6_ONLY: do not install an IPv4 default route on any connection.
-[connection]
-ipv4.never-default=true
-EOF
-  sudo chown root:root "$nm_conf"
-  sudo chmod 0644 "$nm_conf"
-
-  sudo tee "$unit" >/dev/null <<'EOF'
-[Unit]
-Description=FlightCtl e2e IPV6_ONLY: remove IPv4 default route
-Documentation=https://github.com/flightctl/flightctl
-After=NetworkManager.service network-online.target
-Before=flightctl-agent.service
-DefaultDependencies=yes
-
-[Service]
-Type=oneshot
-# DHCP/NM may install more than one; delete until gone.
-ExecStart=/usr/bin/bash -c 'while ip -4 route show default 2>/dev/null | grep -q .; do ip -4 route del default || exit 0; done'
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-EOF
-  sudo chown root:root "$unit"
-  sudo chmod 0644 "$unit"
-
-  sudo ln -sfn ../flightctl-e2e-no-ipv4-default.service "$wants_dir/flightctl-e2e-no-ipv4-default.service"
 }
 
 # Write to deployment etc so it appears at guest /etc
@@ -457,7 +416,6 @@ inject_registry_ca "$DEPLOY_ETC"
 write_registry_remap "$DEPLOY_ETC"
 write_mirror_registry "$DEPLOY_ETC"
 inject_hosts_entry "$DEPLOY_ETC"
-inject_ipv4_never_default "$DEPLOY_ETC"
 
 # Also mirror to on-disk etc so it shows under guest /sysroot/etc
 if [[ "$SYSROOT_ETC" != "$DEPLOY_ETC" ]]; then
@@ -466,7 +424,6 @@ if [[ "$SYSROOT_ETC" != "$DEPLOY_ETC" ]]; then
   write_registry_remap "$SYSROOT_ETC"
   write_mirror_registry "$SYSROOT_ETC"
   inject_hosts_entry "$SYSROOT_ETC"
-  inject_ipv4_never_default "$SYSROOT_ETC"
 fi
 
 sync


### PR DESCRIPTION
Lab dual-stack DNS for *.apps often has an unreachable A record. Agent VMs with a libvirt NAT IPv4 default blackhole that dial until systemd TimeoutStartSec. When IPV6_ONLY=true, inject NM ipv4.never-default and a oneshot so enrollment uses AAAA immediately.

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
