### PR TITLE
EDM-4984: Add openssl as requirement for services

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -27,8 +27,6 @@ BuildRequires:  git
 BuildRequires:  openssl-devel
 BuildRequires:  systemd-rpm-macros
 
-Requires: openssl
-
 %global flightctl_target flightctl.target
 
 
@@ -77,6 +75,7 @@ The flightctl-selinux package provides the SELinux policy modules required by th
 %package services
 Summary: Flight Control services
 Requires: bash
+Requires: openssl
 Requires: podman
 Requires: python3-pyyaml
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
Removes the openssl requirement from the package and instead added it to the services which actually utilizes it. 

This was changed in 1.3 as part of feature work, so there isn't a direct backport PR for this. 