### PR TITLE
NO-ISSUE: Skip redundant FleetRolloutDeviceSelected re-renders

### DIFF
--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -155,6 +155,21 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 			}
 		}
 
+		// FleetRolloutDeviceSelected is re-emitted by the disruption-budget reconciler on every
+		// reconcile tick for any device still mid-rollout, without knowing whether an earlier
+		// event (or an earlier duplicate of itself, still queued behind it) already rendered the
+		// device for the current template version. Skip redundant duplicates here rather than
+		// falling through to bypassHashCheck, which would otherwise force a phantom re-render,
+		// rendered-version bump, and agent update cycle for a device that already caught up.
+		if t.event.Reason == domain.EventReasonFleetRolloutDeviceSelected {
+			templateVersion, hasTemplateVersion := annotations[domain.DeviceAnnotationTemplateVersion]
+			renderedTemplateVersion, hasRenderedTemplateVersion := annotations[domain.DeviceAnnotationRenderedTemplateVersion]
+			if hasTemplateVersion && hasRenderedTemplateVersion && templateVersion == renderedTemplateVersion {
+				t.log.Infof("Device %s already rendered for template version %s, skipping redundant rollout selection event", t.event.InvolvedObject.Name, templateVersion)
+				return nil
+			}
+		}
+
 		// Don't render if the device spec hash hasn't changed since the last render, unless
 		// bypassHashCheck says this event must always produce a fresh render.
 		if !bypassHashCheck {

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -1193,5 +1193,87 @@ var _ = Describe("DeviceRender", func() {
 			Expect(ref.Fingerprint).ToNot(BeNil())
 			Expect(*ref.Fingerprint).To(Equal("42"))
 		})
+
+		// Companion to the re-render case above: after a successful render,
+		// templateVersion == renderedTemplateVersion. A redundant
+		// FleetRolloutDeviceSelected (as the disruption-budget reconciler emits
+		// on every tick for mid-rollout devices) must be a no-op — otherwise
+		// forceUpdate bumps renderedVersion for unchanged content and wakes the
+		// agent into a phantom update cycle.
+		It("When a fleet-owned device receives redundant FleetRolloutDeviceSelected after catching up it should not re-render", func() {
+			k8sConfig := &api.KubernetesSecretProviderSpec{Name: "fleet-secret"}
+			k8sConfig.SecretRef.Name = "my-secret"
+			k8sConfig.SecretRef.Namespace = "default"
+			k8sConfig.SecretRef.MountPath = "/etc/secrets"
+
+			configProvider := api.ConfigProviderSpec{}
+			err := configProvider.FromKubernetesSecretProviderSpec(*k8sConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			fleet := &api.Fleet{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(fleetName)},
+				Spec: api.FleetSpec{
+					Selector: &api.LabelSelector{MatchLabels: &map[string]string{"fleet": fleetName}},
+					Template: struct {
+						Metadata *api.ObjectMeta `json:"metadata,omitempty"`
+						Spec     api.DeviceSpec  `json:"spec"`
+					}{
+						Spec: api.DeviceSpec{Config: &[]api.ConfigProviderSpec{configProvider}},
+					},
+				},
+			}
+			_, err = fleetStore.Create(ctx, orgId, fleet, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			tvStatus := api.TemplateVersionStatus{Config: &[]api.ConfigProviderSpec{configProvider}}
+			err = testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, fleetName, "v1", &tvStatus)
+			Expect(err).ToNot(HaveOccurred())
+
+			testDeviceName := deviceName + "-fleet-rollout-skip-" + uuid.New().String()[:8]
+			device := &api.Device{
+				Metadata: api.ObjectMeta{
+					Name:  lo.ToPtr(testDeviceName),
+					Owner: lo.ToPtr("Fleet/" + fleetName),
+				},
+				Spec: &api.DeviceSpec{Config: &[]api.ConfigProviderSpec{configProvider}},
+			}
+			_, err = deviceStore.Create(ctx, orgId, device, nil)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _, _ = deviceStore.Delete(ctx, orgId, testDeviceName, nil) }()
+
+			annotations := map[string]string{
+				api.DeviceAnnotationTemplateVersion: "v1",
+			}
+			status := deviceSvc.UpdateDeviceAnnotations(ctx, orgId, testDeviceName, annotations, nil)
+			Expect(status.Code).To(Equal(int32(200)))
+
+			firstEvent := api.Event{
+				Reason:         api.EventReasonResourceCreated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
+			}
+			logic := tasks.NewDeviceRenderLogic(log, deviceSvc, repositorySvc, nil, &mockK8sClient{}, kvStoreInst, nil, orgId, firstEvent)
+			err = logic.RenderDevice(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			device, err = deviceStore.Get(ctx, orgId, testDeviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect((*device.Metadata.Annotations)[api.DeviceAnnotationRenderedVersion]).To(Equal("1"))
+			Expect((*device.Metadata.Annotations)[api.DeviceAnnotationRenderedTemplateVersion]).To(Equal("v1"))
+			Expect((*device.Metadata.Annotations)[api.DeviceAnnotationTemplateVersion]).To(Equal("v1"))
+
+			// Redundant selection: templateVersion already equals renderedTemplateVersion.
+			redundantEvent := api.Event{
+				Reason:         api.EventReasonFleetRolloutDeviceSelected,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
+			}
+			logic = tasks.NewDeviceRenderLogic(log, deviceSvc, repositorySvc, nil, &mockK8sClient{}, kvStoreInst, nil, orgId, redundantEvent)
+			err = logic.RenderDevice(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			device, err = deviceStore.Get(ctx, orgId, testDeviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect((*device.Metadata.Annotations)[api.DeviceAnnotationRenderedVersion]).To(Equal("1"),
+				"redundant FleetRolloutDeviceSelected must not bump renderedVersion when already caught up")
+		})
 	})
 })

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -1222,7 +1222,7 @@ var _ = Describe("DeviceRender", func() {
 					},
 				},
 			}
-			_, err = fleetStore.Create(ctx, orgId, fleet, nil)
+			_, err = fleetStore.Create(ctx, orgId, fleet)
 			Expect(err).ToNot(HaveOccurred())
 
 			tvStatus := api.TemplateVersionStatus{Config: &[]api.ConfigProviderSpec{configProvider}}


### PR DESCRIPTION
## Summary

The disruption-budget reconciler (`internal/rollout/disruption_budget/reconciler.go`) re-emits `FleetRolloutDeviceSelected` on every 30s reconcile tick for any device it still sees as mid-rollout, without knowing whether an earlier event (or an earlier duplicate of itself, still queued behind it) already rendered the device for the current template version. Each redundant delivery falls through to the `forceUpdate` bypass in `DeviceStore.updateRendered`, which persists a phantom rendered-version bump even though the rendered output hasn't actually changed. That bump wakes the device's long-poll (`GetRenderedDevice`), triggers a no-op apply on the agent, and cascades into extra `ReplaceDeviceStatus` calls and status-change events on the way back. Under load (many devices, single-threaded worker, queueing delay) this pattern shows up for the large majority of devices in a rollout, roughly doubling render/notify/status traffic for no actual configuration change.

This adds a guard in `DeviceRenderLogic.RenderDevice` that skips the event when the device's own annotations already show it's caught up to the current template version (`DeviceAnnotationTemplateVersion == DeviceAnnotationRenderedTemplateVersion`), before it ever reaches the `forceUpdate` bypass. `DependencyChangeDetected` and `ApplicationLifecycleChanged`, which share the same bypass for reasons unrelated to template version, are unaffected — the guard is scoped specifically to `FleetRolloutDeviceSelected`, and template version doesn't apply to standalone devices at all.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make unit-test` — full suite, 6252 passed / 2 pre-existing skips
- [x] `make integration-test` (`test/integration/tasks`, focused on `DeviceRender|FleetRollout|Application lifecycle overlay`) — 24/24 passed, including the existing `FleetRolloutDeviceSelected after initial render` regression test
- [x] `make integration-test` (`test/integration/rollout/disruption_budget`) — 8/8 passed
- [x] `make integration-test` (`test/integration/rollout/device_selection`) — 23/23 passed

Made with [Cursor](https://cursor.com)