### PR TITLE
EDM-5028: fix Mutate status poisoning without LastSeen; trim UpdateStatus clones

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -45,7 +45,7 @@ func (m *MockDevice) InitialMigration(ctx context.Context) error { return nil }
 func (m *MockDevice) Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, rendered *devicestore.DeviceRendered) (*domain.Device, error) {
 	return nil, nil
 }
-func (m *MockDevice) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc) (*domain.Device, *domain.Device, bool, error) {
+func (m *MockDevice) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, _ ...devicestore.MutateOption) (*domain.Device, *domain.Device, bool, error) {
 	return nil, nil, false, nil
 }
 func (m *MockDevice) UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, previous *domain.Device) (*domain.Device, *domain.Device, error) {

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -76,7 +76,7 @@ func (f *fakeDeviceStore) InitialMigration(context.Context) error { panic("not i
 func (f *fakeDeviceStore) Create(context.Context, uuid.UUID, *domain.Device, *devicestore.DeviceRendered) (*domain.Device, error) {
 	panic("not implemented")
 }
-func (f *fakeDeviceStore) Mutate(context.Context, uuid.UUID, string, *domain.Device, devicestore.DeviceApplyFunc) (*domain.Device, *domain.Device, bool, error) {
+func (f *fakeDeviceStore) Mutate(context.Context, uuid.UUID, string, *domain.Device, devicestore.DeviceApplyFunc, ...devicestore.MutateOption) (*domain.Device, *domain.Device, bool, error) {
 	panic("not implemented")
 }
 func (f *fakeDeviceStore) UpdateStatus(context.Context, uuid.UUID, *domain.Device, *domain.Device) (*domain.Device, *domain.Device, error) {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -288,7 +288,7 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 		}
 		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
 		return pruneLifecycleOnCurrent(h.log, current)
-	})
+	}, devicestore.WithTimestamp())
 	h.callEventCallback(ctx, h.callbackDeviceUpdated, orgId, name, before, result, created, err)
 	return result, common.StoreErrorToApiStatus(err, created, domain.DeviceKind, &name)
 }
@@ -321,7 +321,7 @@ func (h *DeviceServiceHandler) ReplaceDeviceSpec(ctx context.Context, orgId uuid
 		current.Metadata.Annotations = &ann
 		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
 		return pruneLifecycleOnCurrent(h.log, current)
-	})
+	}, devicestore.WithTimestamp())
 	h.callEventCallback(ctx, h.callbackDeviceUpdated, orgId, name, before, result, false, err)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
@@ -385,7 +385,7 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 		}
 		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
 		return pruneLifecycleOnCurrent(h.log, current)
-	})
+	}, devicestore.WithTimestamp())
 	h.callEventCallback(ctx, h.callbackDeviceUpdated, orgId, name, before, result, false, err)
 	return result, err
 }
@@ -489,7 +489,7 @@ func (h *DeviceServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid
 		m.Device.Status = patched.Status
 		_ = common.UpdateServiceSideStatus(ctx, orgId, m.Device, h.fleetStore, h.log)
 		return nil
-	})
+	}, devicestore.WithTimestamp())
 	h.callEventCallback(ctx, h.callbackDeviceUpdated, orgId, name, before, result, false, err)
 	if err != nil && callbackStatus.Code != 0 {
 		return result, callbackStatus
@@ -639,7 +639,7 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 		}
 		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
 		return pruneLifecycleOnCurrent(h.log, current)
-	})
+	}, devicestore.WithTimestamp())
 	h.callEventCallback(ctx, h.callbackDeviceUpdated, orgId, name, before, result, false, err)
 	if err != nil && callbackStatus.Code != 0 {
 		return result, callbackStatus
@@ -789,7 +789,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 		// Always emit the update when renderedVersion advanced, even if USSS made no status change.
 		updated = m.Device
 		return nil
-	})
+	}, devicestore.WithTimestamp())
 	if err != nil {
 		h.log.Errorf("Failed to update rendered device %s/%s: %v", orgId, name, err)
 		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -258,6 +258,8 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 				Status:     &status,
 			}
 			m.Device.Metadata.Name = lo.ToPtr(name)
+			// Intentional: brand-new devices have no LastSeen yet, so USSS leaves
+			// summary/applications as Unknown until the agent first reports in.
 			_ = common.UpdateServiceSideStatus(ctx, orgId, m.Device, h.fleetStore, h.log)
 			return pruneLifecycleOnCurrent(h.log, m.Device)
 		}
@@ -734,6 +736,12 @@ func snapshotDeviceForStatusUpdate(device *domain.Device) *domain.Device {
 		status := *device.Status
 		if device.Status.Conditions != nil {
 			status.Conditions = append([]domain.Condition(nil), device.Status.Conditions...)
+		}
+		// LastSeen is a pointer; copy the value so later writes to Status.LastSeen
+		// on the live device do not mutate the event baseline snapshot.
+		if device.Status.LastSeen != nil {
+			ls := *device.Status.LastSeen
+			status.LastSeen = &ls
 		}
 		previous.Status = &status
 	}

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -282,6 +282,35 @@ func TestReplaceDeviceOwnership(t *testing.T) {
 	})
 }
 
+func TestReplaceDeviceSpec_PreservesOnlineWhenRecentlySeen(t *testing.T) {
+	st, _, svc := newTestHandler()
+	ctx := context.Background()
+	orgId := uuid.New()
+	lastSeen := time.Now().UTC().Add(-time.Minute)
+	status := domain.NewDeviceStatus()
+	status.Summary.Status = domain.DeviceSummaryStatusOnline
+	status.Summary.Info = lo.ToPtr("Device's system resources are healthy.")
+	status.ApplicationsSummary.Status = domain.ApplicationsSummaryStatusHealthy
+	status.Applications = []domain.DeviceApplicationStatus{{
+		Name:   "app1",
+		Status: domain.ApplicationStatusRunning,
+	}}
+	status.LastSeen = lo.ToPtr(lastSeen)
+	_, err := st.device.Create(ctx, orgId, &domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr("live")},
+		Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "old"}},
+		Status:   &status,
+	}, nil)
+	require.NoError(t, err)
+
+	result, apiStatus := svc.ReplaceDeviceSpec(ctx, orgId, "live", nil, domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "new"}}, nil, nil)
+	require.Equal(t, int32(http.StatusOK), apiStatus.Code)
+	require.Equal(t, domain.DeviceSummaryStatusOnline, result.Status.Summary.Status)
+	require.Equal(t, domain.ApplicationsSummaryStatusHealthy, result.Status.ApplicationsSummary.Status)
+	require.NotNil(t, result.Status.LastSeen)
+	require.Equal(t, "new", result.Spec.Os.Image)
+}
+
 func TestDeleteDevice(t *testing.T) {
 	t.Run("When the device does not exist it should return not found", func(t *testing.T) {
 		_, _, svc := newTestHandler()

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -55,7 +55,12 @@ type fakeStore struct {
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		device:  &fakeDeviceStore{devices: map[string]*domain.Device{}, rendered: map[string]*devicestore.DeviceRendered{}, repoRefs: map[string][]string{}},
+		device: &fakeDeviceStore{
+			devices:  map[string]*domain.Device{},
+			rendered: map[string]*devicestore.DeviceRendered{},
+			repoRefs: map[string][]string{},
+			lastSeen: map[string]*time.Time{},
+		},
 		catalog: &fakeCatalogStore{items: map[string]*domain.CatalogItem{}},
 		fleet:   &fakeFleetStore{fleets: map[string]*domain.Fleet{}},
 	}
@@ -68,6 +73,27 @@ type fakeDeviceStore struct {
 	devices  map[string]*domain.Device
 	rendered map[string]*devicestore.DeviceRendered
 	repoRefs map[string][]string
+	lastSeen map[string]*time.Time
+}
+
+func (s *fakeDeviceStore) rememberLastSeen(name string, device *domain.Device) {
+	if s.lastSeen == nil {
+		s.lastSeen = map[string]*time.Time{}
+	}
+	if device != nil && device.Status != nil && device.Status.LastSeen != nil {
+		ls := *device.Status.LastSeen
+		s.lastSeen[name] = &ls
+	}
+}
+
+func (s *fakeDeviceStore) attachLastSeen(name string, device *domain.Device) {
+	if device == nil || device.Status == nil {
+		return
+	}
+	if ls, ok := s.lastSeen[name]; ok && ls != nil {
+		cp := *ls
+		device.Status.LastSeen = &cp
+	}
 }
 
 func (s *fakeDeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, rendered *devicestore.DeviceRendered) (*domain.Device, error) {
@@ -77,6 +103,7 @@ func (s *fakeDeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *d
 	}
 	d := deepCopyDevice(device)
 	s.devices[name] = d
+	s.rememberLastSeen(name, d)
 	if rendered != nil {
 		if s.rendered == nil {
 			s.rendered = map[string]*devicestore.DeviceRendered{}
@@ -96,10 +123,15 @@ func (s *fakeDeviceStore) Get(ctx context.Context, orgId uuid.UUID, name string)
 }
 
 func (s *fakeDeviceStore) GetWithTimestamp(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error) {
-	return s.Get(ctx, orgId, name)
+	d, err := s.Get(ctx, orgId, name)
+	if err != nil {
+		return nil, err
+	}
+	s.attachLastSeen(name, d)
+	return d, nil
 }
 
-func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, _ ...devicestore.MutateOption) (*domain.Device, *domain.Device, bool, error) {
+func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, opts ...devicestore.MutateOption) (*domain.Device, *domain.Device, bool, error) {
 	old, ok := s.devices[name]
 	creating := !ok
 	var before *domain.Device
@@ -107,6 +139,10 @@ func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name stri
 	if !creating {
 		before = deepCopyDevice(old)
 		current = deepCopyDevice(old)
+		if devicestore.HasWithTimestamp(opts...) {
+			s.attachLastSeen(name, before)
+			s.attachLastSeen(name, current)
+		}
 	}
 	mutation := &devicestore.DeviceMutation{Device: current}
 	if apply != nil {
@@ -125,6 +161,7 @@ func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name stri
 	}
 	d := deepCopyDevice(mutation.Device)
 	s.devices[name] = d
+	s.rememberLastSeen(name, d)
 	if mutation.Rendered != nil {
 		if s.rendered == nil {
 			s.rendered = map[string]*devicestore.DeviceRendered{}
@@ -144,6 +181,9 @@ func (s *fakeDeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, dev
 		m.Device.Status = device.Status
 		return nil
 	})
+	if err == nil {
+		s.rememberLastSeen(name, device)
+	}
 	return updated, before, err
 }
 
@@ -241,6 +281,10 @@ func (s *fakeDeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name
 func (s *fakeDeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error) {
 	if _, ok := s.devices[name]; !ok {
 		return nil, flterrors.ErrResourceNotFound
+	}
+	if ls, ok := s.lastSeen[name]; ok && ls != nil {
+		cp := *ls
+		return &cp, nil
 	}
 	return nil, nil
 }

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -99,7 +99,7 @@ func (s *fakeDeviceStore) GetWithTimestamp(ctx context.Context, orgId uuid.UUID,
 	return s.Get(ctx, orgId, name)
 }
 
-func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc) (*domain.Device, *domain.Device, bool, error) {
+func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, _ ...devicestore.MutateOption) (*domain.Device, *domain.Device, bool, error) {
 	old, ok := s.devices[name]
 	creating := !ok
 	var before *domain.Device

--- a/internal/store/common.go
+++ b/internal/store/common.go
@@ -70,6 +70,9 @@ type MutateHooks[A any] struct {
 	// Wrap turns a loaded API object into the typed mutation. Wrap(nil) is the create path.
 	// Required.
 	Wrap func(*A) ResourceMutation[A]
+	// Load fetches the current resource when previous is unset / on retry.
+	// Return (nil, nil) when not found (create path). When nil, GenericStore uses loadByName.
+	Load func(ctx context.Context, orgId uuid.UUID, name string) (*A, error)
 	// PersistCreate inserts after apply on the create path.
 	// Defaults to GenericStore.Create on m.Resource().
 	PersistCreate func(ctx context.Context, orgId uuid.UUID, m ResourceMutation[A]) (*A, error)

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -3,6 +3,7 @@ package device
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -65,7 +66,8 @@ type Store interface {
 	// the caller can fire its own event callback; Mutate itself never calls one.
 	// Create-only API callers should use Create instead. Update-only callers should call
 	// m.RequireExisting() in apply.
-	Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc) (updated *domain.Device, before *domain.Device, created bool, err error)
+	// Pass WithTimestamp() when apply will run UpdateServiceSideStatus (needs LastSeen).
+	Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc, opts ...MutateOption) (updated *domain.Device, before *domain.Device, created bool, err error)
 	// UpdateStatus writes status + resource_version only (service_conditions unchanged).
 	// previous is optional (first attempt only). No events; caller uses before/updated.
 	UpdateStatus(ctx context.Context, orgId uuid.UUID, device *domain.Device, previous *domain.Device) (updated *domain.Device, before *domain.Device, err error)
@@ -168,6 +170,21 @@ func (m *DeviceMutation) RequireExisting() error {
 
 // DeviceApplyFunc mutates m in place on every Mutate attempt.
 type DeviceApplyFunc func(m *DeviceMutation) error
+
+type mutateConfig struct {
+	withTimestamp bool
+}
+
+// MutateOption configures DeviceStore.Mutate.
+type MutateOption func(*mutateConfig)
+
+// WithTimestamp loads the device via GetWithTimestamp (devices ⨝ device_timestamps) so
+// Status.LastSeen is populated. Use when apply will call UpdateServiceSideStatus.
+func WithTimestamp() MutateOption {
+	return func(c *mutateConfig) {
+		c.withTimestamp = true
+	}
+}
 
 var _ store.ResourceMutation[domain.Device] = (*DeviceMutation)(nil)
 
@@ -491,11 +508,23 @@ func (s *DeviceStore) dropLastSeenColumnIfExists(db *gorm.DB) error {
 // Missing devices are created (apply must set Device); existing ones are updated.
 // The caller is responsible for firing any event callback using the returned
 // before/updated/created values.
-func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc) (*domain.Device, *domain.Device, bool, error) {
+// WithTimestamp() makes loads use a single devices⨝device_timestamps query so
+// Status.LastSeen is set (required before UpdateServiceSideStatus).
+func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc, opts ...MutateOption) (*domain.Device, *domain.Device, bool, error) {
+	cfg := &mutateConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	if previous != nil && lo.FromPtr(previous.Metadata.Name) != name {
 		previous = nil
 	}
-	return s.genericStore.Mutate(ctx, orgId, name, previous, store.MutateHooks[domain.Device]{
+	// previous without LastSeen would defeat WithTimestamp on attempt 0; force a joined load.
+	if cfg.withTimestamp && previous != nil && (previous.Status == nil || previous.Status.LastSeen == nil) {
+		previous = nil
+	}
+
+	hooks := store.MutateHooks[domain.Device]{
 		Wrap: func(device *domain.Device) store.ResourceMutation[domain.Device] {
 			return &DeviceMutation{Device: device}
 		},
@@ -507,7 +536,18 @@ func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, 
 			dm := m.(*DeviceMutation)
 			return s.Update(ctx, orgId, before, dm.Device, dm.Rendered)
 		},
-	}, func(m store.ResourceMutation[domain.Device]) error {
+	}
+	if cfg.withTimestamp {
+		hooks.Load = func(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error) {
+			device, err := s.getWithTimestamp(ctx, orgId, name)
+			if errors.Is(err, flterrors.ErrResourceNotFound) {
+				return nil, nil
+			}
+			return device, err
+		}
+	}
+
+	return s.genericStore.Mutate(ctx, orgId, name, previous, hooks, func(m store.ResourceMutation[domain.Device]) error {
 		return apply(m.(*DeviceMutation))
 	})
 }
@@ -519,9 +559,15 @@ func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device 
 		return nil, nil, flterrors.ErrResourceIsNil
 	}
 	name := lo.FromPtr(device.Metadata.Name)
+	// device doesn't change across retries, so convert it once instead of on every attempt.
+	fromAPI, err := model.NewDeviceFromApiResource(device)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var before, updated *domain.Device
 	attempt := 0
-	err := store.RetryUpdate(func() (bool, error) {
+	err = store.RetryUpdate(func() (bool, error) {
 		var current *domain.Device
 		if attempt == 0 && previous != nil && lo.FromPtr(previous.Metadata.Name) == name {
 			current = previous
@@ -533,24 +579,20 @@ func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device 
 			current = loaded
 		}
 		attempt++
-		beforeSnapshot, snapErr := store.CloneJSON(current)
-		if snapErr != nil {
-			return false, snapErr
-		}
-		before = beforeSnapshot
+		// current is only read below, never mutated, so it's safe to return directly as
+		// "before" instead of paying for a full JSON round-trip clone (which would also
+		// silently drop Status.LastSeen, since it's tagged json:"-").
+		before = current
 
-		existing, err := model.NewDeviceFromApiResource(current)
-		if err != nil {
-			return false, err
+		rv, rvErr := strconv.ParseInt(lo.FromPtr(current.Metadata.ResourceVersion), 10, 64)
+		if rvErr != nil {
+			return false, flterrors.ErrIllegalResourceVersionFormat
 		}
-		existing.OrgID = orgId
+		// Only OrgID/Name are needed for GORM to target the row by primary key; no need to
+		// convert the rest of current (spec, labels, annotations, ...).
+		existing := &model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
 
-		fromAPI, err := model.NewDeviceFromApiResource(device)
-		if err != nil {
-			return false, err
-		}
-
-		result := s.getDB(ctx).Model(existing).Where("resource_version = ?", lo.FromPtr(existing.ResourceVersion)).Updates(map[string]interface{}{
+		result := s.getDB(ctx).Model(existing).Where("resource_version = ?", rv).Updates(map[string]interface{}{
 			"status":           fromAPI.Status,
 			"resource_version": gorm.Expr("resource_version + 1"),
 		})
@@ -561,13 +603,13 @@ func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device 
 		if result.RowsAffected == 0 {
 			return true, flterrors.ErrNoRowsUpdated
 		}
-		next, cloneErr := store.CloneJSON(current)
-		if cloneErr != nil {
-			return false, cloneErr
-		}
+		// Shallow copy: Metadata is a value type, so reassigning next.Metadata.ResourceVersion
+		// below doesn't touch before.Metadata.ResourceVersion; Status is fully replaced, not
+		// mutated in place.
+		next := *current
 		next.Status = device.Status
-		next.Metadata.ResourceVersion = lo.ToPtr(strconv.FormatInt(lo.FromPtr(existing.ResourceVersion)+1, 10))
-		updated = next
+		next.Metadata.ResourceVersion = lo.ToPtr(strconv.FormatInt(rv+1, 10))
+		updated = &next
 		return false, nil
 	})
 	return updated, before, err

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -178,12 +178,21 @@ type mutateConfig struct {
 // MutateOption configures DeviceStore.Mutate.
 type MutateOption func(*mutateConfig)
 
-// WithTimestamp loads the device via GetWithTimestamp (devices ⨝ device_timestamps) so
+// WithTimestamp loads the device via GetWithTimestamp (devices ⟕ device_timestamps) so
 // Status.LastSeen is populated. Use when apply will call UpdateServiceSideStatus.
 func WithTimestamp() MutateOption {
 	return func(c *mutateConfig) {
 		c.withTimestamp = true
 	}
+}
+
+// HasWithTimestamp reports whether opts include WithTimestamp (for tests/fakes).
+func HasWithTimestamp(opts ...MutateOption) bool {
+	cfg := &mutateConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg.withTimestamp
 }
 
 var _ store.ResourceMutation[domain.Device] = (*DeviceMutation)(nil)
@@ -508,7 +517,7 @@ func (s *DeviceStore) dropLastSeenColumnIfExists(db *gorm.DB) error {
 // Missing devices are created (apply must set Device); existing ones are updated.
 // The caller is responsible for firing any event callback using the returned
 // before/updated/created values.
-// WithTimestamp() makes loads use a single devices⨝device_timestamps query so
+// WithTimestamp() makes loads use a single devices⟕device_timestamps query so
 // Status.LastSeen is set (required before UpdateServiceSideStatus).
 func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc, opts ...MutateOption) (*domain.Device, *domain.Device, bool, error) {
 	cfg := &mutateConfig{}
@@ -572,7 +581,7 @@ func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, device 
 		if attempt == 0 && previous != nil && lo.FromPtr(previous.Metadata.Name) == name {
 			current = previous
 		} else {
-			loaded, getErr := s.Get(ctx, orgId, name)
+			loaded, getErr := s.getWithTimestamp(ctx, orgId, name)
 			if getErr != nil {
 				return false, getErr
 			}
@@ -731,10 +740,12 @@ func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, before, devic
 
 func (s *DeviceStore) getWithTimestamp(ctx context.Context, orgId uuid.UUID, name string, opts ...model.APIResourceOption) (*domain.Device, error) {
 	var deviceModel model.DeviceWithTimestamp
+	// LEFT JOIN so a devices row without a device_timestamps row still loads
+	// (LastSeen nil → disconnected), instead of masquerading as not-found/create.
 	device := s.getDB(ctx).Raw(`SELECT d.*, dt.last_seen
-          FROM devices d, device_timestamps dt
-          WHERE d.org_id = ? AND d.name = ? AND d.deleted_at is NULL AND
-          d.org_id = dt.org_id AND d.name = dt.name`, orgId, name).Scan(&deviceModel)
+          FROM devices d
+          LEFT JOIN device_timestamps dt ON d.org_id = dt.org_id AND d.name = dt.name
+          WHERE d.org_id = ? AND d.name = ? AND d.deleted_at is NULL`, orgId, name).Scan(&deviceModel)
 	if device.Error != nil {
 		return nil, store.ErrorFromGormError(device.Error)
 	}

--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -143,13 +143,14 @@ func (s *GenericStore[P, M, A, AL]) Mutate(
 			return false, fmt.Errorf("mutate Wrap returned nil")
 		}
 		if !creating {
-			// Snapshot before independently of the working copy so PersistUpdate /
-			// event callbacks never observe a shared pointer with the mutation.
-			beforeSnapshot, snapErr := CloneJSON(current)
+			// Snapshot before via typed Clone so fields tagged json:"-" (e.g. Device
+			// Status.LastSeen) survive; CloneJSON alone would drop them and event
+			// callbacks would see a poisoned pre-mutation snapshot.
+			beforeMutation, snapErr := mutation.Clone()
 			if snapErr != nil {
 				return false, snapErr
 			}
-			before = beforeSnapshot
+			before = beforeMutation.Resource()
 
 			cloned, cloneErr := mutation.Clone()
 			if cloneErr != nil {

--- a/internal/store/generic.go
+++ b/internal/store/generic.go
@@ -108,6 +108,18 @@ func (s *GenericStore[P, M, A, AL]) Mutate(
 		creating := false
 		if usePrevious {
 			current = previous
+		} else if hooks.Load != nil {
+			apiResource, loadErr := hooks.Load(ctx, orgId, name)
+			if loadErr != nil {
+				return false, loadErr
+			}
+			if apiResource == nil {
+				creating = true
+				before = nil
+				current = nil
+			} else {
+				current = apiResource
+			}
 		} else {
 			existing, getErr := s.loadByName(ctx, orgId, name)
 			if getErr != nil {

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
+	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/store"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
@@ -2843,3 +2844,87 @@ func setLastSeen(db *gorm.DB, orgId uuid.UUID, name string, lastSeen time.Time) 
 	Expect(db.Model(&model.DeviceTimestamp{}).Where("org_id = ? AND name = ?", orgId, name).
 		Update("last_seen", lastSeen).Error).ToNot(HaveOccurred())
 }
+
+var _ = Describe("DeviceStore Mutate WithTimestamp status integrity", func() {
+	var (
+		log      *logrus.Logger
+		ctx      context.Context
+		orgId    uuid.UUID
+		devStore devicestore.Store
+		cfg      *config.Config
+		db       *gorm.DB
+		dbName   string
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		log = flightlog.InitLogs()
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		devStore = devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+		organizationStore := organizationstore.NewOrganizationStore(db)
+		orgId = uuid.New()
+		Expect(testutil.CreateTestOrganization(ctx, organizationStore, orgId)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+	})
+
+	It("When Mutate WithTimestamp runs UpdateServiceSideStatus it should keep Online summaries for a recently-seen device", func() {
+		name := "live-device"
+		status := api.NewDeviceStatus()
+		status.Summary.Status = api.DeviceSummaryStatusOnline
+		status.Summary.Info = lo.ToPtr("Device's system resources are healthy.")
+		status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusHealthy
+		status.ApplicationsSummary.Info = lo.ToPtr("All application workloads are healthy.")
+		status.Applications = []api.DeviceApplicationStatus{{
+			Name:   "app1",
+			Status: api.ApplicationStatusRunning,
+		}}
+		device := &api.Device{
+			Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
+			Spec:     &api.DeviceSpec{},
+			Status:   &status,
+		}
+		_, err := devStore.Create(ctx, orgId, device, nil)
+		Expect(err).ToNot(HaveOccurred())
+		setLastSeen(db, orgId, name, time.Now().UTC().Add(-time.Minute))
+
+		_, _, _, err = devStore.Mutate(ctx, orgId, name, nil, func(m *devicestore.DeviceMutation) error {
+			Expect(m.RequireExisting()).To(Succeed())
+			Expect(m.Device.Status).ToNot(BeNil())
+			Expect(m.Device.Status.LastSeen).ToNot(BeNil())
+			m.Device.Spec = &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "new-image"}}
+			_ = common.UpdateServiceSideStatus(ctx, orgId, m.Device, nil, log)
+			return nil
+		}, devicestore.WithTimestamp())
+		Expect(err).ToNot(HaveOccurred())
+
+		got, err := devStore.GetWithTimestamp(ctx, orgId, name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got.Status.Summary.Status).To(Equal(api.DeviceSummaryStatusOnline))
+		Expect(got.Status.ApplicationsSummary.Status).To(Equal(api.ApplicationsSummaryStatusHealthy))
+		Expect(got.Status.LastSeen).ToNot(BeNil())
+	})
+
+	It("When device_timestamps row is missing GetWithTimestamp should still return the device", func() {
+		name := "orphan-ts-device"
+		device := &api.Device{
+			Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
+			Spec:     &api.DeviceSpec{},
+			Status:   lo.ToPtr(api.NewDeviceStatus()),
+		}
+		_, err := devStore.Create(ctx, orgId, device, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(db.Where("org_id = ? AND name = ?", orgId, name).Delete(&model.DeviceTimestamp{}).Error).ToNot(HaveOccurred())
+
+		got, err := devStore.GetWithTimestamp(ctx, orgId, name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).ToNot(BeNil())
+		Expect(lo.FromPtr(got.Metadata.Name)).To(Equal(name))
+		Expect(got.Status.LastSeen).To(BeNil())
+	})
+})
+

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -2927,4 +2927,3 @@ var _ = Describe("DeviceStore Mutate WithTimestamp status integrity", func() {
 		Expect(got.Status.LastSeen).To(BeNil())
 	})
 })
-


### PR DESCRIPTION
## Summary
- **Fix QE regression:** `Mutate`-based writes (`ReplaceDevice` / `ReplaceDeviceSpec` / render / patch) were recomputing service-side status without `Status.LastSeen` (loaded from `device_timestamps`). `IsDisconnected()` treated nil `LastSeen` as disconnected, and CAS `Update` persisted `applicationsSummary`/`summary` as `Unknown` even for live devices.
- **API:** optional `devicestore.WithTimestamp()` on `Mutate` uses the existing single `devices ⨝ device_timestamps` query (same as `GetWithTimestamp`). Call sites that run `UpdateServiceSideStatus` opt in; owner/lifecycle/annotation-only Mutates do not.
- **Perf cleanup:** `UpdateStatus` no longer pays for two full `CloneJSON` round-trips (and no longer drops `LastSeen` via `json:"-"`) on the agent status hot path.

## Test plan
- [x] `make lint`
- [x] `make unit-test RACE=0 COVERAGE=0`
- [x] `make integration-test TEST_DIR=./test/integration/store`
- [x] `make integration-test TEST_DIR=./test/integration/service`
- [x] Focused tasks: `FleetRollout|DeviceRender|FleetSelector`
- [ ] QE: confirm device with running apps stays `Online`/`Healthy` after fleet membership / rollout / console activity (not stuck `Applications: Unknown`)


Made with [Cursor](https://cursor.com)