### PR TITLE
EDM-5046: use vendor blocklist for greenboot health check disable

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -57,6 +57,7 @@ GCM
 GitLab
 GitOps
 greenboot
+blocklist
 hostname
 hostnames
 HTTPS

--- a/docs/user/installing/configuring-device-greenboot.md
+++ b/docs/user/installing/configuring-device-greenboot.md
@@ -48,10 +48,12 @@ Exiting the health check with a non-zero status declares the boot as failed. The
 
 ### Third-Party Health Check Management
 
-Flight Control is designed to be the sole controller of OS rollback decisions. The `flightctl-configure-greenboot.service` runs before `greenboot-healthcheck.service` on every boot, automatically disabling third-party health checks (e.g., MicroShift) by setting `DISABLED_HEALTHCHECKS` in `/etc/greenboot/greenboot.conf`. Core greenboot scripts and Flight Control's own health checks are preserved.
+Flight Control disables only **known bundled vendor** health checks (for example MicroShift's `40_microshift_running_check.sh`) when they are present under `/usr/lib/greenboot/check/required.d` or `/etc/greenboot/check/required.d`. The `flightctl-configure-greenboot.service` runs before `greenboot-healthcheck.service` on every boot and sets `DISABLED_HEALTHCHECKS` in `/etc/greenboot/greenboot.conf` to that blocklist.
+
+**Customer scripts** in `/etc/greenboot/check/required.d` or image-baked scripts under `/usr/lib/greenboot/check/required.d` are **not** disabled (unless they match the vendor blocklist) and can participate in OS rollback when they fail.
 
 > [!WARNING]
-> Do not manually edit `DISABLED_HEALTHCHECKS` in `/etc/greenboot/greenboot.conf` it is replaced on every boot by `flightctl-configure-greenboot.service`.
+> Do not manually edit `DISABLED_HEALTHCHECKS` in `/etc/greenboot/greenboot.conf` — it is replaced on every boot by `flightctl-configure-greenboot.service`.
 
 ## The `systemd` Journal Service Configuration
 

--- a/packaging/greenboot/flightctl-configure-greenboot.sh
+++ b/packaging/greenboot/flightctl-configure-greenboot.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# Configure greenboot to only allow flightctl health checks to trigger rollback.
+# Disable known bundled vendor greenboot health checks (e.g. MicroShift) so they
+# do not gate OS rollback. Customer scripts in /etc or /usr/lib are preserved.
 # Runs before greenboot-healthcheck.service on every boot.
 #
 # Installed to: /usr/libexec/flightctl/configure-greenboot.sh
@@ -9,13 +10,13 @@ set -x -euo pipefail
 
 source /usr/share/flightctl/functions/greenboot.sh
 
-disabled_scripts=$(find_third_party_scripts)
+disabled_scripts=$(find_blocked_vendor_healthchecks)
 
 if [ -z "$disabled_scripts" ]; then
-    log_info "No third-party greenboot health checks found"
-    exit 0
+    log_info "No bundled vendor greenboot health checks to disable"
+else
+    log_info "Disabling bundled vendor greenboot health checks:$disabled_scripts"
 fi
 
-log_info "Disabling third-party greenboot health checks:$disabled_scripts"
 set_disabled_healthchecks "$disabled_scripts"
 log_info "Updated $GREENBOOT_CONF"

--- a/packaging/greenboot/functions.sh
+++ b/packaging/greenboot/functions.sh
@@ -10,8 +10,8 @@ SCRIPT_NAME=$(basename "$0")
 # Constants
 #
 
-# Greenboot configuration file path
-GREENBOOT_CONF="/etc/greenboot/greenboot.conf"
+# Greenboot configuration file path (override in tests via GREENBOOT_CONF)
+GREENBOOT_CONF="${GREENBOOT_CONF:-/etc/greenboot/greenboot.conf}"
 
 #
 # Logging
@@ -61,27 +61,44 @@ collect_debug_info() {
 # Greenboot configuration (used by flightctl-configure-greenboot.service)
 #
 
-# Find third-party application health check scripts in required.d directories
-# Preserves core greenboot scripts and flightctl scripts
-find_third_party_scripts() {
+# Bundled vendor health checks to disable wherever they appear.
+# MicroShift installs under /etc; some images place checks under /usr/lib.
+# Non-blocklisted customer scripts in either path participate in rollback by default.
+DISABLED_VENDOR_HEALTHCHECKS=(
+    40_microshift_running_check.sh
+)
+
+# Return true if name is already listed in the disabled scripts string.
+_is_already_listed() {
+    local scripts="$1"
+    local name="$2"
+    case " $scripts " in
+        *" \"$name\" "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Find blocklisted vendor health checks in /usr/lib and /etc required.d.
+# Only names in DISABLED_VENDOR_HEALTHCHECKS are returned; customer scripts are left alone.
+find_blocked_vendor_healthchecks() {
+    local usr_lib_dir="${GREENBOOT_USR_LIB_REQUIRED_D:-/usr/lib/greenboot/check/required.d}"
+    local etc_dir="${GREENBOOT_ETC_REQUIRED_D:-/etc/greenboot/check/required.d}"
     local scripts=""
-    for dir in /usr/lib/greenboot/check/required.d /etc/greenboot/check/required.d; do
+    local dir script name blocked
+
+    for dir in "$usr_lib_dir" "$etc_dir"; do
         [ -d "$dir" ] || continue
         for script in "$dir"/*.sh; do
             [ -f "$script" ] || continue
-            local name
             name=$(basename "$script")
-            # Skip flightctl's own health check scripts
-            case "$name" in
-                *flightctl*) continue ;;
-            esac
-            # Skip core greenboot scripts (from greenboot package)
-            case "$name" in
-                00_required_scripts_start.sh) continue ;;
-                01_repository_dns_check.sh) continue ;;
-                02_watchdog.sh) continue ;;
-            esac
-            scripts="$scripts \"$name\""
+            for blocked in "${DISABLED_VENDOR_HEALTHCHECKS[@]}"; do
+                if [ "$name" = "$blocked" ]; then
+                    if ! _is_already_listed "$scripts" "$name"; then
+                        scripts="$scripts \"$name\""
+                    fi
+                    break
+                fi
+            done
         done
     done
     echo "$scripts"

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -549,7 +549,7 @@ chown -R flightctl:flightctl ~flightctl/{.config,.local}
 # See: https://github.com/openshift/microshift/pull/5530
 systemctl enable --quiet greenboot-healthcheck 2>/dev/null || :
 # Enable the greenboot configuration service (runs before greenboot-healthcheck.service)
-# This ensures only flightctl health checks can trigger OS rollback
+# Disables known bundled vendor required.d checks (e.g. MicroShift); customer scripts preserved
 systemctl enable flightctl-configure-greenboot.service >/dev/null 2>&1 || :
 # Mask bootc auto-update timer on first boot (bootc/composefs); the script
 # is also run directly below for immediate effect during RPM install.

--- a/test/e2e/agent/agent_update_test.go
+++ b/test/e2e/agent/agent_update_test.go
@@ -382,9 +382,10 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 
 			By("Updating device to v7 (MicroShift image)")
 			// v7 includes MicroShift which installs 40_microshift_running_check.sh
-			// in /usr/lib/greenboot/check/required.d/. MicroShift will fail its health
-			// check (insufficient VM resources), but flightctl-configure-greenboot.service
-			// should disable it via DISABLED_HEALTHCHECKS before greenboot runs.
+			// under greenboot required.d (/etc and/or /usr/lib). MicroShift will fail
+			// its health check (insufficient VM resources), but
+			// flightctl-configure-greenboot.service should disable it via the vendor
+			// blocklist in DISABLED_HEALTHCHECKS before greenboot runs.
 			_, _, err = harness.WaitForBootstrapAndUpdateToVersion(deviceId, util.DeviceTags.V7)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -408,8 +409,8 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 				"sudo", "journalctl", "-b", "-u", "flightctl-configure-greenboot.service", "--no-pager",
 			}, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(configureOutput.String()).To(ContainSubstring("Disabling third-party greenboot health checks"),
-				"Expected configure-greenboot to disable third-party health checks")
+			Expect(configureOutput.String()).To(ContainSubstring("Disabling bundled vendor greenboot health checks"),
+				"Expected configure-greenboot to disable bundled vendor health checks")
 
 			GinkgoWriter.Println("Confirmed: third-party MicroShift health check did not trigger rollback")
 		})

--- a/test/packaging/greenboot_functions_test.go
+++ b/test/packaging/greenboot_functions_test.go
@@ -1,0 +1,234 @@
+package packaging_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("cannot find repo root: %v", err)
+	}
+	return strings.TrimSpace(string(root))
+}
+
+func runBash(t *testing.T, script string) string {
+	t.Helper()
+	out, err := exec.Command("bash", "-c", script).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("bash failed: %v\nstderr: %s", err, exitErr.Stderr)
+		}
+		t.Fatalf("bash failed: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func runFindBlockedVendorHealthchecks(t *testing.T, usrLibDir, etcDir string) string {
+	t.Helper()
+	root := repoRoot(t)
+	functionsPath := filepath.Join(root, "packaging", "greenboot", "functions.sh")
+
+	return runBash(t,
+		"source '"+functionsPath+"' && "+
+			"GREENBOOT_USR_LIB_REQUIRED_D='"+usrLibDir+"' "+
+			"GREENBOOT_ETC_REQUIRED_D='"+etcDir+"' "+
+			"find_blocked_vendor_healthchecks")
+}
+
+func runSetDisabledHealthchecks(t *testing.T, confPath, disabledScripts string) {
+	t.Helper()
+	root := repoRoot(t)
+	functionsPath := filepath.Join(root, "packaging", "greenboot", "functions.sh")
+
+	runBash(t, "source '"+functionsPath+"' && GREENBOOT_CONF='"+confPath+"' set_disabled_healthchecks '"+disabledScripts+"'")
+}
+
+func writeScript(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindBlockedVendorHealthchecks(t *testing.T) {
+	t.Run("When MicroShift script is in usr lib it should be disabled", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, usrLib, "40_microshift_running_check.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if !strings.Contains(got, "40_microshift_running_check.sh") {
+			t.Fatalf("expected MicroShift script in disabled list, got %q", got)
+		}
+	})
+
+	t.Run("When MicroShift script is in etc it should be disabled", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, etc, "40_microshift_running_check.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if !strings.Contains(got, "40_microshift_running_check.sh") {
+			t.Fatalf("expected MicroShift script in disabled list, got %q", got)
+		}
+	})
+
+	t.Run("When MicroShift is in both paths it should appear once", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, usrLib, "40_microshift_running_check.sh")
+		writeScript(t, etc, "40_microshift_running_check.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if strings.Count(got, "40_microshift_running_check.sh") != 1 {
+			t.Fatalf("expected MicroShift listed once, got %q", got)
+		}
+	})
+
+	t.Run("When customer script is in usr lib it should not be disabled", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, usrLib, "50_customer_selftest.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if got != "" {
+			t.Fatalf("expected no disabled scripts, got %q", got)
+		}
+	})
+
+	t.Run("When customer script is in etc it should not be disabled", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, etc, "50_customer_selftest.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if got != "" {
+			t.Fatalf("expected no disabled scripts, got %q", got)
+		}
+	})
+
+	t.Run("When only flightctl and core scripts are present it should not disable them", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		for _, name := range []string{
+			"20_check_flightctl_agent.sh",
+			"00_required_scripts_start.sh",
+			"01_repository_dns_check.sh",
+			"02_watchdog.sh",
+		} {
+			writeScript(t, usrLib, name)
+		}
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if got != "" {
+			t.Fatalf("expected no disabled scripts, got %q", got)
+		}
+	})
+
+	t.Run("When MicroShift is in etc and customer is in etc it should disable only MicroShift", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, etc, "40_microshift_running_check.sh")
+		writeScript(t, etc, "50_customer_selftest.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if !strings.Contains(got, "40_microshift_running_check.sh") {
+			t.Fatalf("expected MicroShift script in disabled list, got %q", got)
+		}
+		if strings.Contains(got, "50_customer_selftest.sh") {
+			t.Fatalf("customer script must not be disabled, got %q", got)
+		}
+	})
+
+	t.Run("When MicroShift is in usr lib and customer is in etc it should disable only MicroShift", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, usrLib, "40_microshift_running_check.sh")
+		writeScript(t, etc, "50_customer_selftest.sh")
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if !strings.Contains(got, "40_microshift_running_check.sh") {
+			t.Fatalf("expected MicroShift script in disabled list, got %q", got)
+		}
+		if strings.Contains(got, "50_customer_selftest.sh") {
+			t.Fatalf("customer script must not be disabled, got %q", got)
+		}
+	})
+}
+
+func TestSetDisabledHealthchecks(t *testing.T) {
+	t.Run("When stale customer scripts were disabled it should clear them on empty update", func(t *testing.T) {
+		confPath := filepath.Join(t.TempDir(), "greenboot.conf")
+		stale := "DISABLED_HEALTHCHECKS=(\"50_customer_selftest.sh\" \"40_microshift_running_check.sh\")\n"
+		if err := os.WriteFile(confPath, []byte(stale), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		runSetDisabledHealthchecks(t, confPath, "")
+
+		content, err := os.ReadFile(confPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(content)
+		if strings.Contains(got, "50_customer_selftest.sh") {
+			t.Fatalf("stale customer script must be cleared, got %q", got)
+		}
+		if !strings.Contains(got, "DISABLED_HEALTHCHECKS=()") {
+			t.Fatalf("expected empty DISABLED_HEALTHCHECKS, got %q", got)
+		}
+	})
+
+	t.Run("When MicroShift is present it should set only blocklisted scripts", func(t *testing.T) {
+		confPath := filepath.Join(t.TempDir(), "greenboot.conf")
+		if err := os.WriteFile(confPath, []byte("DISABLED_HEALTHCHECKS=(\"50_customer_selftest.sh\")\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		runSetDisabledHealthchecks(t, confPath, " \"40_microshift_running_check.sh\"")
+
+		content, err := os.ReadFile(confPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(content)
+		if strings.Contains(got, "50_customer_selftest.sh") {
+			t.Fatalf("stale customer script must be cleared, got %q", got)
+		}
+		if !strings.Contains(got, "40_microshift_running_check.sh") {
+			t.Fatalf("expected MicroShift in DISABLED_HEALTHCHECKS, got %q", got)
+		}
+	})
+}
+
+func TestFindBlockedVendorHealthchecks_Regression(t *testing.T) {
+	t.Run("When customer script is present blanket old logic would have disabled it", func(t *testing.T) {
+		usrLib := t.TempDir()
+		etc := t.TempDir()
+		writeScript(t, usrLib, "50_customer_selftest.sh")
+
+		got := runFindBlockedVendorHealthchecks(t, usrLib, etc)
+		if got != "" {
+			t.Fatalf("fix must leave customer script enabled (empty disabled list), got %q", got)
+		}
+
+		// Simulate prior blanket disable: any non-allowlisted script was disabled.
+		oldWouldDisable := runBash(t, `
+			dir='`+usrLib+`'
+			scripts=""
+			for script in "$dir"/*.sh; do
+				[ -f "$script" ] || continue
+				name=$(basename "$script")
+				case "$name" in
+					*flightctl*) continue ;;
+					00_required_scripts_start.sh) continue ;;
+					01_repository_dns_check.sh) continue ;;
+					02_watchdog.sh) continue ;;
+				esac
+				scripts="$scripts \"$name\""
+			done
+			echo "$scripts"
+		`)
+		if !strings.Contains(oldWouldDisable, "50_customer_selftest.sh") {
+			t.Fatalf("old logic simulation should have disabled customer script, got %q", oldWouldDisable)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Replace blanket third-party greenboot disable with a vendor blocklist scanned in `/usr/lib` and `/etc` `required.d`
- Preserve customer scripts in both paths for OS rollback participation
- Always rewrite `DISABLED_HEALTHCHECKS` each boot to clear stale blanket-disable entries after upgrade

## Root cause

`flightctl-configure-greenboot.service` called `find_third_party_scripts()` on every boot and disabled every non-flightctl script in `required.d`, overriding customer and image-baked checks without fleet visibility.

## Fix

- `DISABLED_VENDOR_HEALTHCHECKS` with `40_microshift_running_check.sh` (MicroShift)
- `find_blocked_vendor_healthchecks()` scans `/usr/lib` and `/etc` for blocklisted basenames only
- Customer scripts are not added to `DISABLED_HEALTHCHECKS`
- Docs updated to describe vendor vs customer behavior

## Test plan

- [x] `go test ./test/packaging/ -run 'TestFindBlocked|TestSetDisabled'`
- [x] E2E `greenboot-third-party` — MicroShift check disabled, no OS rollback on v7
- [ ] CI agent e2e suite

## Manual verification

On a bootc device with `flightctl-greenboot` installed:

```bash
sudo journalctl -b -u flightctl-configure-greenboot.service --no-pager
grep DISABLED_HEALTHCHECKS /etc/greenboot/greenboot.conf
```

On MicroShift images, expect vendor disable log and `40_microshift_running_check.sh` in `DISABLED_HEALTHCHECKS`. Customer scripts should not appear in that list.

## Related

- Prior blanket-disable behavior: EDM-3260 (`8d5e5b09` — Add systemd service to disable third-party health checks)
