### PR TITLE
NO-ISSUE: align package image preload with testcontainers runtime

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -108,6 +108,10 @@ jobs:
           OS_ID: ${{ inputs.os_id }}
         run: |
           set -euo pipefail
+          # Keep runtime detection aligned with test/harness/containers/docker_host.go.
+          . ./test/scripts/detect_container_runtime.sh
+          configure_testcontainers_docker_host
+
           echo "Downloaded test artifacts:"
           tree test-artifacts
 
@@ -131,11 +135,15 @@ jobs:
           echo "✓ QCOW2 image: bin/output/qcow2/disk.qcow2"
 
           PACKAGE_REF="quay.io/flightctl/flightctl-device:package"
-          if [[ "${DOCKER_HOST:-}" == *podman* ]]; then
-            echo "Loading package-mode image into Podman containers-storage (DOCKER_HOST=${DOCKER_HOST})"
-            skopeo copy "docker-archive:${BUNDLE}:${PACKAGE_REF}" "containers-storage:${PACKAGE_REF}"
+          CONTAINER_RUNTIME="$(detect_testcontainers_runtime)"
+          echo "Detected testcontainers runtime: ${CONTAINER_RUNTIME} (DOCKER_HOST=${DOCKER_HOST:-unset})"
+          if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+            echo "Loading package-mode image into Podman image storage"
+            export CONTAINER_HOST="${DOCKER_HOST}"
+            podman load -i "${BUNDLE}"
+            podman image exists "${PACKAGE_REF}"
           else
-            echo "Loading package-mode image into Docker daemon (DOCKER_HOST=${DOCKER_HOST:-unset})"
+            echo "Loading package-mode image into Docker daemon"
             skopeo copy "docker-archive:${BUNDLE}:${PACKAGE_REF}" "docker-daemon:${PACKAGE_REF}"
           fi
 

--- a/test/scripts/detect_container_runtime.sh
+++ b/test/scripts/detect_container_runtime.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the socket precedence here aligned with
+# test/harness/containers/docker_host.go (detectContainerSocket,
+# ConfigureDockerHost, RuntimeCLIName).
+
+detect_container_socket() {
+  local uid home_dir
+
+  uid="$(id -u)"
+  home_dir=""
+
+  if command -v getent >/dev/null 2>&1; then
+    home_dir="$(getent passwd "${uid}" | cut -d: -f6 2>/dev/null || true)"
+  fi
+  if [[ -z "${home_dir}" ]]; then
+    home_dir="${HOME:-}"
+  fi
+
+  if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    if [[ -S "${XDG_RUNTIME_DIR}/podman/podman.sock" ]]; then
+      printf '%s\n' "${XDG_RUNTIME_DIR}/podman/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ "${uid}" != "0" ]]; then
+    if [[ -S "/run/user/${uid}/podman/podman.sock" ]]; then
+      printf '%s\n' "/run/user/${uid}/podman/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ -n "${home_dir}" ]]; then
+    if [[ -S "${home_dir}/.local/share/containers/podman/machine/podman.sock" ]]; then
+      printf '%s\n' "${home_dir}/.local/share/containers/podman/machine/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ -S /var/run/docker.sock ]]; then
+    printf '%s\n' /var/run/docker.sock
+    return 0
+  fi
+
+  if [[ -S /run/podman/podman.sock ]]; then
+    printf '%s\n' /run/podman/podman.sock
+    return 0
+  fi
+
+  return 1
+}
+
+configure_testcontainers_docker_host() {
+  local socket_path
+
+  if [[ -n "${DOCKER_HOST:-}" ]]; then
+    return 0
+  fi
+
+  if socket_path="$(detect_container_socket)"; then
+    export DOCKER_HOST="unix://${socket_path}"
+  fi
+}
+
+detect_testcontainers_runtime() {
+  if [[ "${DOCKER_HOST:-}" == *podman* ]]; then
+    printf '%s\n' podman
+    return 0
+  fi
+
+  if [[ -n "${DOCKER_HOST:-}" ]]; then
+    printf '%s\n' docker
+    return 0
+  fi
+
+  printf '%s\n' docker
+}


### PR DESCRIPTION
## Summary
- detect the container runtime for the package helper image preload using the same socket precedence as the Go test harness
- load `quay.io/flightctl/flightctl-device:package` into Podman containers-storage when testcontainers will run on Podman
- keep Docker-based jobs loading the image into the Docker daemon as before

## Why
The package-mode suite starts the helper container from the local `:package` image. In some CI profiles the preload step defaulted to Docker while the Go harness later selected Podman, so testcontainers could not find the local image and tried to pull from Quay instead, failing with `unauthorized` before 90146 even started.

## Testing
- inspected the merged `upstream/main` workflow and harness runtime-selection paths
- kept the change scoped to `.github/workflows/run-e2e-tests.yaml`
- no local end-to-end run here; this needs CI to validate the runtime/image preload path

# Release target
release-1.3
Target release: release-1.3