### PR TITLE
NO-ISSUE: fix flaky management cert rotation integration test

### DIFF
--- a/internal/agent/device/certmanager/manager.go
+++ b/internal/agent/device/certmanager/manager.go
@@ -101,7 +101,7 @@ func NewAgentCertManager(
 	managementBundle, err := pkgcertmanager.NewBundle(
 		managementBundleName,
 		pkgcertmanager.WithConfigProvider(
-			management.NewManagementConfigProvider(renewBeforeExpiryPercentage),
+			management.NewManagementConfigProvider(log, renewBeforeExpiryPercentage),
 		),
 		pkgcertmanager.WithProvisionerFactory(managementProvisionerFactory),
 		pkgcertmanager.WithStorageFactory(managementStorageFactory),
@@ -148,13 +148,12 @@ func (a *AgentCertManager) Sync(ctx context.Context, _ *config.Config) error {
 
 // Run periodically calls Sync until ctx is canceled.
 func (a *AgentCertManager) Run(ctx context.Context) {
-	// First sync immediately.
+	interval := certManagerSyncInterval()
+	a.log.Infof("Certificate manager starting (sync interval=%s)", interval)
+
 	if err := a.cm.Sync(ctx); err != nil {
 		a.log.Errorf("Initial certificate sync failed: %v", err)
 	}
-
-	interval := certManagerSyncInterval()
-	a.log.Debugf("Certificate manager sync interval: %s", interval)
 
 	t := time.NewTicker(interval)
 	defer t.Stop()

--- a/internal/agent/device/certmanager/manager.go
+++ b/internal/agent/device/certmanager/manager.go
@@ -101,7 +101,7 @@ func NewAgentCertManager(
 	managementBundle, err := pkgcertmanager.NewBundle(
 		managementBundleName,
 		pkgcertmanager.WithConfigProvider(
-			management.NewManagementConfigProvider(log, renewBeforeExpiryPercentage),
+			management.NewManagementConfigProvider(renewBeforeExpiryPercentage),
 		),
 		pkgcertmanager.WithProvisionerFactory(managementProvisionerFactory),
 		pkgcertmanager.WithStorageFactory(managementStorageFactory),
@@ -148,12 +148,13 @@ func (a *AgentCertManager) Sync(ctx context.Context, _ *config.Config) error {
 
 // Run periodically calls Sync until ctx is canceled.
 func (a *AgentCertManager) Run(ctx context.Context) {
-	interval := certManagerSyncInterval()
-	a.log.Infof("Certificate manager starting (sync interval=%s)", interval)
-
+	// First sync immediately.
 	if err := a.cm.Sync(ctx); err != nil {
 		a.log.Errorf("Initial certificate sync failed: %v", err)
 	}
+
+	interval := certManagerSyncInterval()
+	a.log.Debugf("Certificate manager sync interval: %s", interval)
 
 	t := time.NewTicker(interval)
 	defer t.Stop()

--- a/internal/agent/device/certmanager/provider/management/management.go
+++ b/internal/agent/device/certmanager/provider/management/management.go
@@ -36,15 +36,11 @@ const (
 // ---- ConfigProvider ----
 
 type managementConfigProvider struct {
-	log                         certmanager.Logger
 	renewBeforeExpiryPercentage int32
 }
 
-func NewManagementConfigProvider(log certmanager.Logger, renewBeforeExpiryPercentage int32) *managementConfigProvider {
-	return &managementConfigProvider{
-		log:                         log,
-		renewBeforeExpiryPercentage: renewBeforeExpiryPercentage,
-	}
+func NewManagementConfigProvider(renewBeforeExpiryPercentage int32) *managementConfigProvider {
+	return &managementConfigProvider{renewBeforeExpiryPercentage: renewBeforeExpiryPercentage}
 }
 
 func (p *managementConfigProvider) Name() string { return configProviderName }
@@ -60,23 +56,14 @@ func (p *managementConfigProvider) GetCertificateConfigs() ([]certmanager.Certif
 		},
 	}
 
+	// Apply env overrides (can set both, precedence handled by certmanager)
 	renewBefore, renewBeforePercent := renewPolicyFromEnv()
 	cfg.RenewBefore = renewBefore
 	cfg.RenewBeforePercentage = renewBeforePercent
 
+	// Fall back to provider default only if neither override is set
 	if cfg.RenewBefore == nil && cfg.RenewBeforePercentage == nil {
 		cfg.RenewBeforePercentage = &p.renewBeforeExpiryPercentage
-	}
-
-	switch {
-	case cfg.RenewBefore != nil:
-		p.log.Infof("Management cert renew policy: renewBefore=%s (from env)", *cfg.RenewBefore)
-	case cfg.RenewBeforePercentage != nil:
-		source := "provider default"
-		if renewBeforePercent != nil {
-			source = "env"
-		}
-		p.log.Infof("Management cert renew policy: renewBeforePercentage=%d (from %s)", *cfg.RenewBeforePercentage, source)
 	}
 
 	return []certmanager.CertificateConfig{cfg}, nil
@@ -170,7 +157,7 @@ func (p *managementProvisioner) Provision(ctx context.Context, req certmanager.P
 		}
 
 		p.csrName = csrName
-		p.log.Infof("Created management certificate CSR %q (signer=%s)", p.csrName, managementSignerName)
+		p.log.Debugf("Created management certificate CSR %q", p.csrName)
 
 		return p.poll(ctx, req)
 	}

--- a/internal/agent/device/certmanager/provider/management/management.go
+++ b/internal/agent/device/certmanager/provider/management/management.go
@@ -36,11 +36,15 @@ const (
 // ---- ConfigProvider ----
 
 type managementConfigProvider struct {
+	log                         certmanager.Logger
 	renewBeforeExpiryPercentage int32
 }
 
-func NewManagementConfigProvider(renewBeforeExpiryPercentage int32) *managementConfigProvider {
-	return &managementConfigProvider{renewBeforeExpiryPercentage: renewBeforeExpiryPercentage}
+func NewManagementConfigProvider(log certmanager.Logger, renewBeforeExpiryPercentage int32) *managementConfigProvider {
+	return &managementConfigProvider{
+		log:                         log,
+		renewBeforeExpiryPercentage: renewBeforeExpiryPercentage,
+	}
 }
 
 func (p *managementConfigProvider) Name() string { return configProviderName }
@@ -56,14 +60,23 @@ func (p *managementConfigProvider) GetCertificateConfigs() ([]certmanager.Certif
 		},
 	}
 
-	// Apply env overrides (can set both, precedence handled by certmanager)
 	renewBefore, renewBeforePercent := renewPolicyFromEnv()
 	cfg.RenewBefore = renewBefore
 	cfg.RenewBeforePercentage = renewBeforePercent
 
-	// Fall back to provider default only if neither override is set
 	if cfg.RenewBefore == nil && cfg.RenewBeforePercentage == nil {
 		cfg.RenewBeforePercentage = &p.renewBeforeExpiryPercentage
+	}
+
+	switch {
+	case cfg.RenewBefore != nil:
+		p.log.Infof("Management cert renew policy: renewBefore=%s (from env)", *cfg.RenewBefore)
+	case cfg.RenewBeforePercentage != nil:
+		source := "provider default"
+		if renewBeforePercent != nil {
+			source = "env"
+		}
+		p.log.Infof("Management cert renew policy: renewBeforePercentage=%d (from %s)", *cfg.RenewBeforePercentage, source)
 	}
 
 	return []certmanager.CertificateConfig{cfg}, nil
@@ -157,7 +170,7 @@ func (p *managementProvisioner) Provision(ctx context.Context, req certmanager.P
 		}
 
 		p.csrName = csrName
-		p.log.Debugf("Created management certificate CSR %q", p.csrName)
+		p.log.Infof("Created management certificate CSR %q (signer=%s)", p.csrName, managementSignerName)
 
 		return p.poll(ctx, req)
 	}

--- a/pkg/certmanager/manager.go
+++ b/pkg/certmanager/manager.go
@@ -338,8 +338,15 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 
 			// We found an existing cert; treat current desired cfg as the baseline for this process.
 			cert.Config = cfg
+			cm.log.Infof(
+				"Loaded existing certificate %q for providerKey %q (notBefore=%s notAfter=%s expiresIn=%s)",
+				certName, pk,
+				parsed.NotBefore.UTC().Format(time.RFC3339),
+				parsed.NotAfter.UTC().Format(time.RFC3339),
+				time.Until(parsed.NotAfter),
+			)
 		} else if loadErr != nil {
-			cm.log.Debugf("no existing cert loaded for %q/%q: %v", pk, certName, loadErr)
+			cm.log.Infof("no existing cert loaded for %q/%q: %v", pk, certName, loadErr)
 		}
 	}
 
@@ -365,7 +372,7 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 		return fmt.Errorf("failed to provision certificate %q from providerKey %q: %w", cert.Name, pk, err)
 	}
 
-	cm.log.Debugf("Provision triggered for certificate %q of providerKey %q", certName, pk)
+	cm.log.Infof("Provision triggered for certificate %q of providerKey %q", certName, pk)
 	return nil
 }
 
@@ -373,7 +380,7 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 func (cm *CertManager) shouldProvisionCertificate(b *bundleRegistry, pk string, cert *certificate, cfg CertificateConfig) bool {
 	// Initial provisioning.
 	if cert.Info.NotAfter == nil || cert.Info.NotBefore == nil {
-		cm.log.Debugf("Certificate %q for providerKey %q: missing NotBefore/NotAfter — provisioning", cert.Name, pk)
+		cm.log.Infof("Certificate %q for providerKey %q: missing NotBefore/NotAfter — provisioning", cert.Name, pk)
 		return true
 	}
 
@@ -401,34 +408,57 @@ func (cm *CertManager) shouldProvisionCertificate(b *bundleRegistry, pk string, 
 	// 1) RenewBefore (if valid) wins.
 	// 2) else RenewBeforePercentage (if valid).
 	// 3) else default to renewing at 2/3 lifetime => renewBefore = lifetime/3.
+	policySource := "default(lifetime/3)"
 	var renewBefore time.Duration
 	switch {
 	case cfg.RenewBefore != nil && *cfg.RenewBefore > 0 && *cfg.RenewBefore < lifetime:
 		renewBefore = *cfg.RenewBefore
+		policySource = "renewBefore"
 	case cfg.RenewBeforePercentage != nil && *cfg.RenewBeforePercentage > 0 && *cfg.RenewBeforePercentage < 100:
-		// Note: percentage-based calculation uses float64 to avoid int64 overflow for long-lived certificates.
+		if cfg.RenewBefore != nil && *cfg.RenewBefore > 0 {
+			cm.log.Infof(
+				"Certificate %q for providerKey %q: ignoring renewBefore=%s (must be >0 and < lifetime=%s); using renewBeforePercentage=%d",
+				cert.Name, pk, *cfg.RenewBefore, lifetime, *cfg.RenewBeforePercentage,
+			)
+		}
 		renewBefore = time.Duration(float64(lifetime) * float64(*cfg.RenewBeforePercentage) / 100.0)
+		policySource = fmt.Sprintf("renewBeforePercentage=%d", *cfg.RenewBeforePercentage)
 	default:
+		if cfg.RenewBefore != nil && *cfg.RenewBefore > 0 {
+			cm.log.Infof(
+				"Certificate %q for providerKey %q: ignoring renewBefore=%s (must be >0 and < lifetime=%s); using default policy",
+				cert.Name, pk, *cfg.RenewBefore, lifetime,
+			)
+		}
 		renewBefore = lifetime / 3
 	}
 
 	renewAt := notAfter.Add(-renewBefore)
+	expiresIn := notAfter.Sub(now)
 	if now.Before(renewAt) {
+		cm.log.Infof(
+			"Certificate %q for providerKey %q: not yet due for renewal (policy=%s renewBefore=%s lifetime=%s notBefore=%s notAfter=%s renewAt=%s expiresIn=%s)",
+			cert.Name, pk, policySource, renewBefore, lifetime,
+			notBefore.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339),
+			renewAt.UTC().Format(time.RFC3339), expiresIn,
+		)
 		return false
 	}
 
 	// Bundle-wide kill switch for time-based renewal.
 	if b != nil && b.disableRenewal {
-		cm.log.Debugf(
-			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (renewBefore=%s, notAfter=%s)",
-			cert.Name, pk, b.name, renewBefore, notAfter.Format(time.RFC3339),
+		cm.log.Infof(
+			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (policy=%s renewBefore=%s notAfter=%s)",
+			cert.Name, pk, b.name, policySource, renewBefore, notAfter.UTC().Format(time.RFC3339),
 		)
 		return false
 	}
 
-	cm.log.Debugf(
-		"Certificate %q for providerKey %q: within renewal window (%s before expiry) — provisioning",
-		cert.Name, pk, renewBefore,
+	cm.log.Infof(
+		"Certificate %q for providerKey %q: within renewal window (policy=%s renewBefore=%s lifetime=%s notBefore=%s notAfter=%s renewAt=%s expiresIn=%s) — provisioning",
+		cert.Name, pk, policySource, renewBefore, lifetime,
+		notBefore.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339),
+		renewAt.UTC().Format(time.RFC3339), expiresIn,
 	)
 	return true
 }

--- a/pkg/certmanager/manager.go
+++ b/pkg/certmanager/manager.go
@@ -448,8 +448,9 @@ func (cm *CertManager) shouldProvisionCertificate(b *bundleRegistry, pk string, 
 	// Bundle-wide kill switch for time-based renewal.
 	if b != nil && b.disableRenewal {
 		cm.log.Infof(
-			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (policy=%s renewBefore=%s notAfter=%s)",
-			cert.Name, pk, b.name, policySource, renewBefore, notAfter.UTC().Format(time.RFC3339),
+			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (policy=%s renewBefore=%s lifetime=%s renewAt=%s notAfter=%s expiresIn=%s)",
+			cert.Name, pk, b.name, policySource, renewBefore, lifetime,
+			renewAt.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339), expiresIn,
 		)
 		return false
 	}

--- a/pkg/certmanager/manager.go
+++ b/pkg/certmanager/manager.go
@@ -338,15 +338,8 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 
 			// We found an existing cert; treat current desired cfg as the baseline for this process.
 			cert.Config = cfg
-			cm.log.Infof(
-				"Loaded existing certificate %q for providerKey %q (notBefore=%s notAfter=%s expiresIn=%s)",
-				certName, pk,
-				parsed.NotBefore.UTC().Format(time.RFC3339),
-				parsed.NotAfter.UTC().Format(time.RFC3339),
-				time.Until(parsed.NotAfter),
-			)
 		} else if loadErr != nil {
-			cm.log.Infof("no existing cert loaded for %q/%q: %v", pk, certName, loadErr)
+			cm.log.Debugf("no existing cert loaded for %q/%q: %v", pk, certName, loadErr)
 		}
 	}
 
@@ -372,7 +365,7 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 		return fmt.Errorf("failed to provision certificate %q from providerKey %q: %w", cert.Name, pk, err)
 	}
 
-	cm.log.Infof("Provision triggered for certificate %q of providerKey %q", certName, pk)
+	cm.log.Debugf("Provision triggered for certificate %q of providerKey %q", certName, pk)
 	return nil
 }
 
@@ -380,7 +373,7 @@ func (cm *CertManager) syncCertificate(ctx context.Context, b *bundleRegistry, p
 func (cm *CertManager) shouldProvisionCertificate(b *bundleRegistry, pk string, cert *certificate, cfg CertificateConfig) bool {
 	// Initial provisioning.
 	if cert.Info.NotAfter == nil || cert.Info.NotBefore == nil {
-		cm.log.Infof("Certificate %q for providerKey %q: missing NotBefore/NotAfter — provisioning", cert.Name, pk)
+		cm.log.Debugf("Certificate %q for providerKey %q: missing NotBefore/NotAfter — provisioning", cert.Name, pk)
 		return true
 	}
 
@@ -408,58 +401,34 @@ func (cm *CertManager) shouldProvisionCertificate(b *bundleRegistry, pk string, 
 	// 1) RenewBefore (if valid) wins.
 	// 2) else RenewBeforePercentage (if valid).
 	// 3) else default to renewing at 2/3 lifetime => renewBefore = lifetime/3.
-	policySource := "default(lifetime/3)"
 	var renewBefore time.Duration
 	switch {
 	case cfg.RenewBefore != nil && *cfg.RenewBefore > 0 && *cfg.RenewBefore < lifetime:
 		renewBefore = *cfg.RenewBefore
-		policySource = "renewBefore"
 	case cfg.RenewBeforePercentage != nil && *cfg.RenewBeforePercentage > 0 && *cfg.RenewBeforePercentage < 100:
-		if cfg.RenewBefore != nil && *cfg.RenewBefore > 0 {
-			cm.log.Infof(
-				"Certificate %q for providerKey %q: ignoring renewBefore=%s (must be >0 and < lifetime=%s); using renewBeforePercentage=%d",
-				cert.Name, pk, *cfg.RenewBefore, lifetime, *cfg.RenewBeforePercentage,
-			)
-		}
+		// Note: percentage-based calculation uses float64 to avoid int64 overflow for long-lived certificates.
 		renewBefore = time.Duration(float64(lifetime) * float64(*cfg.RenewBeforePercentage) / 100.0)
-		policySource = fmt.Sprintf("renewBeforePercentage=%d", *cfg.RenewBeforePercentage)
 	default:
-		if cfg.RenewBefore != nil && *cfg.RenewBefore > 0 {
-			cm.log.Infof(
-				"Certificate %q for providerKey %q: ignoring renewBefore=%s (must be >0 and < lifetime=%s); using default policy",
-				cert.Name, pk, *cfg.RenewBefore, lifetime,
-			)
-		}
 		renewBefore = lifetime / 3
 	}
 
 	renewAt := notAfter.Add(-renewBefore)
-	expiresIn := notAfter.Sub(now)
 	if now.Before(renewAt) {
-		cm.log.Infof(
-			"Certificate %q for providerKey %q: not yet due for renewal (policy=%s renewBefore=%s lifetime=%s notBefore=%s notAfter=%s renewAt=%s expiresIn=%s)",
-			cert.Name, pk, policySource, renewBefore, lifetime,
-			notBefore.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339),
-			renewAt.UTC().Format(time.RFC3339), expiresIn,
-		)
 		return false
 	}
 
 	// Bundle-wide kill switch for time-based renewal.
 	if b != nil && b.disableRenewal {
-		cm.log.Infof(
-			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (policy=%s renewBefore=%s lifetime=%s renewAt=%s notAfter=%s expiresIn=%s)",
-			cert.Name, pk, b.name, policySource, renewBefore, lifetime,
-			renewAt.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339), expiresIn,
+		cm.log.Debugf(
+			"Certificate %q for providerKey %q: renewal window reached but disabled by bundle %q (renewBefore=%s, notAfter=%s)",
+			cert.Name, pk, b.name, renewBefore, notAfter.Format(time.RFC3339),
 		)
 		return false
 	}
 
-	cm.log.Infof(
-		"Certificate %q for providerKey %q: within renewal window (policy=%s renewBefore=%s lifetime=%s notBefore=%s notAfter=%s renewAt=%s expiresIn=%s) — provisioning",
-		cert.Name, pk, policySource, renewBefore, lifetime,
-		notBefore.UTC().Format(time.RFC3339), notAfter.UTC().Format(time.RFC3339),
-		renewAt.UTC().Format(time.RFC3339), expiresIn,
+	cm.log.Debugf(
+		"Certificate %q for providerKey %q: within renewal window (%s before expiry) — provisioning",
+		cert.Name, pk, renewBefore,
 	)
 	return true
 }

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -354,6 +354,10 @@ var _ = Describe("Device Agent behavior", func() {
 					certManagerSyncIntervalEnv, testCertManagerSyncInterval,
 				)()
 
+				// Harness auto-starts the agent in BeforeEach. Restart after TestTempEnv so
+				// cert manager Run() reads FLIGHTCTL_TEST_CERT_MANAGER_SYNC_INTERVAL (once).
+				h.RestartAgent()
+
 				// Enroll device and wait until the agent fetches its initial cert.
 				dev := enrollAndWaitForDevice(h, testutil.TestEnrollmentApproval())
 				deviceName := lo.FromPtr(dev.Metadata.Name)

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -330,13 +330,17 @@ var _ = Describe("Device Agent behavior", func() {
 				const (
 					mgmtCertTTLSecondsEnv         = "FLIGHTCTL_TEST_MGMT_CERT_EXPIRY_SECONDS"
 					mgmtCertRenewBeforeSecondsEnv = "FLIGHTCTL_TEST_MGMT_CERT_RENEW_BEFORE_SECONDS"
+					certManagerSyncIntervalEnv    = "FLIGHTCTL_TEST_CERT_MANAGER_SYNC_INTERVAL"
 					agentCertRelPath              = "var/lib/flightctl/certs/agent.crt"
 
 					// Keep the test fast:
 					// - cert lifetime: 10m
-					// - renewBefore: 10m-1s => renewal condition becomes true almost immediately
-					testCertTTLSeconds     = 10 * 60
-					testRenewBeforeSeconds = testCertTTLSeconds - 1
+					// - renewBefore: 10m-1s => renewAt ≈ issuance+1s (CA NotBefore is now-1s)
+					// - sync every 10s so a first Sync that lands before renewAt still retries
+					//   inside TIMEOUT (default sync is 1h)
+					testCertTTLSeconds          = 10 * 60
+					testRenewBeforeSeconds      = testCertTTLSeconds - 1
+					testCertManagerSyncInterval = "10s"
 
 					expectedRenewalSignerName = "flightctl.io/device-management-renewal"
 
@@ -347,6 +351,7 @@ var _ = Describe("Device Agent behavior", func() {
 				defer testutil.TestTempEnv(
 					mgmtCertTTLSecondsEnv, strconv.Itoa(testCertTTLSeconds),
 					mgmtCertRenewBeforeSecondsEnv, strconv.Itoa(testRenewBeforeSeconds),
+					certManagerSyncIntervalEnv, testCertManagerSyncInterval,
 				)()
 
 				// Enroll device and wait until the agent fetches its initial cert.

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -336,11 +336,11 @@ var _ = Describe("Device Agent behavior", func() {
 					// Keep the test fast:
 					// - cert lifetime: 10m
 					// - renewBefore: 10m-1s => renewAt ≈ issuance+1s (CA NotBefore is now-1s)
-					// - sync every 10s so a first Sync that lands before renewAt still retries
-					//   inside TIMEOUT (default sync is 1h)
+					// - sync every 2s (same as e2e cert rotation) so a first Sync that lands
+					//   before renewAt still retries inside TIMEOUT (default sync is 1h)
 					testCertTTLSeconds          = 10 * 60
 					testRenewBeforeSeconds      = testCertTTLSeconds - 1
-					testCertManagerSyncInterval = "10s"
+					testCertManagerSyncInterval = "2s"
 
 					expectedRenewalSignerName = "flightctl.io/device-management-renewal"
 


### PR DESCRIPTION
## Summary
- Fix the flaky integration spec `renews the cert and switches to the renewal signer` by setting `FLIGHTCTL_TEST_CERT_MANAGER_SYNC_INTERVAL=2s` (same as e2e) via `TestTempEnv`, and restarting the agent so cert manager reads the interval once at `Run()`.
- Raise **agent-side** management cert logs to Info (sync interval, renew policy, CSR create). Leave **`pkg/certmanager` infra at Debug** to avoid log spam.

## Root cause
With `renewBefore=TTL-1` and CA `NotBefore=now-1s`, `renewAt ≈ issuance+1s`. The first Sync can land ~0.6s early. Default sync interval is **1h**, so renewal is not retried inside the 60s Eventually.

Confirmed on [CI run 31688978709](https://github.com/flightctl/flightctl/actions/runs/31688978709).

## Scope
- Test deflake: `test/integration/agent/agent_test.go` only for timing.
- Agent logging only under `internal/agent/device/certmanager/` — no `pkg/certmanager` log-level changes.

## Test plan
- [ ] Focused integration: `renews the cert and switches to the renewal signer`
- [ ] Full `integration-tests` CI on this PR