### PR TITLE
EDM-4115: Extend VM e2e Basic test

### DIFF
--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -284,11 +284,8 @@ var _ = Describe("CLI - device console", Label(e2e.NeedVMLabel), func() {
 
 		By("verifying that the ~. sequence exits the shell")
 		cs := harness.NewConsoleSession(deviceID)
-		cs.SkipGracefulExitOnClose()
 		DeferCleanup(cs.Close)
-
-		Expect(cs.Stdin.Write([]byte("\n~.\n"))).To(BeNumerically(">", 0))
-		Eventually(cs.Stdout.Closed).Should(BeTrue())
+		cs.Disconnect()
 
 		By("running a command without opening a shell")
 		out, err = harness.RunConsoleCommand(deviceID, nil, "flightctl-agent", "system-info")

--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -17,6 +17,9 @@ import (
 const (
 	vmAppName                    = "test-vm"
 	defaultVMImage               = "quay.io/containerdisks/fedora:40"
+	vmGuestUser                  = "fedora"
+	vmGuestPassword              = "fedora"
+	vmPublishedSSHPort           = 2222
 	systemdSubStateActive        = "active"
 	systemdSubStateRunning       = "running"
 	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
@@ -51,7 +54,7 @@ var _ = Describe("VM Applications", Ordered, func() {
 		deviceID, _ = harness.EnrollAndWaitForOnlineStatus()
 	})
 
-	It("deploys a VM application and reports Running status", Label("vm"), func() {
+	It("deploys a VM application and reports Running status", Label("vm", "90228"), func() {
 		By("Adding the VM application to the device")
 		err := harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppSpec}
@@ -71,6 +74,26 @@ var _ = Describe("VM Applications", Ordered, func() {
 			logVMApplicationUnitStatus(harness, vmAppName)
 		}
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for the VM serial console login prompt")
+		cs := harness.NewAppConsoleSessionWaitingForLogin(deviceID, vmAppName, testutil.LONG_TIMEOUT, testutil.POLLING)
+		DeferCleanup(cs.Close)
+		cs.MustSend(vmGuestUser)
+		cs.MustExpectWithin(`(?i)password:`, testutil.DURATION_TIMEOUT, testutil.POLLING)
+		cs.MustSend(vmGuestPassword)
+		cs.MustExpectWithin(fmt.Sprintf(`.*%s@.*\$`, vmGuestUser), testutil.DURATION_TIMEOUT, testutil.POLLING)
+		cs.MustSend(fmt.Sprintf("printf '<<whoami>>%%s<<whoami>>\\n' \"$(whoami)\""))
+		cs.MustExpectWithin(fmt.Sprintf("<<whoami>>%s<<whoami>>", vmGuestUser), testutil.DURATION_TIMEOUT, testutil.POLLING)
+
+		By("Disconnecting the serial console with ~.")
+		cs.Disconnect()
+
+		By("Verifying SSH via the published host port works")
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmPublishedSSHPort, vmGuestUser, vmGuestPassword, "hostname")
+			g.Expect(sshErr).NotTo(HaveOccurred(), "SSH to published port %d failed", vmPublishedSSHPort)
+			g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty())
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 	})
 })
 

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -42,8 +42,6 @@ spec:
           interfaces:
           - masquerade: {}
             name: default
-            ports:
-            - port: 2222
           rng: {}
         memory:
           guest: 1024M
@@ -271,7 +269,7 @@ func NewMountVolume(name, mountPath string) (v1beta1.ApplicationVolume, error) {
 // generated .pod unit.
 func NewVmApplicationSpec(name, image string) (v1beta1.ApplicationProviderSpec, error) {
 	vmYAML := fmt.Sprintf(vmYAMLTemplate, name, image)
-	publishPorts := []string{"2222:2222"}
+	publishPorts := []string{"2222:22"}
 
 	vmApp := v1beta1.VmApplication{
 		AppType:      v1beta1.AppTypeVm,
@@ -1153,6 +1151,63 @@ func (h *Harness) GetContainerPorts() (string, error) {
 // =============================================================================
 // VM operations
 // =============================================================================
+
+// RunSSHOnDeviceLocalPort runs ssh on the device host to localhost:port using password auth.
+// This exercises VM publishPorts mappings (e.g. host 2222 to guest 22).
+func (h *Harness) RunSSHOnDeviceLocalPort(port int, user, password string, remoteArgs ...string) (string, error) {
+	if h.VM == nil {
+		return "", fmt.Errorf("device VM is not configured")
+	}
+	if port <= 0 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+	if user == "" {
+		return "", fmt.Errorf("ssh user is required")
+	}
+	if password == "" {
+		return "", fmt.Errorf("ssh password is required")
+	}
+	if len(remoteArgs) == 0 {
+		return "", fmt.Errorf("remote command is required")
+	}
+
+	quotedRemoteArgs := make([]string, len(remoteArgs))
+	for i, arg := range remoteArgs {
+		quotedRemoteArgs[i] = shellQuote(arg)
+	}
+	quotedPassword := shellQuote(password)
+	script := fmt.Sprintf(`set -euo pipefail
+ssh_common=(ssh -p %d \
+  -o ConnectTimeout=10 \
+  -o PubkeyAuthentication=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=no \
+  -o LogLevel=ERROR \
+  %s %s)
+if command -v sshpass >/dev/null 2>&1; then
+  sshpass -p %s "${ssh_common[@]}"
+else
+  askpass=$(mktemp)
+  trap 'rm -f "$askpass"' EXIT
+  printf '#!/bin/sh\necho %%s\n' %s >"$askpass"
+  chmod 700 "$askpass"
+  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid "${ssh_common[@]}"
+fi`,
+		port,
+		shellQuote(user+"@127.0.0.1"),
+		strings.Join(quotedRemoteArgs, " "),
+		quotedPassword,
+		quotedPassword,
+	)
+	out, err := h.VM.RunSSH([]string{"bash", "-lc", script}, nil)
+	if err != nil {
+		return "", fmt.Errorf(
+			"running bash -lc ssh script on device VM (localhost:%d user=%s remote=%s): %w",
+			port, user, strings.Join(remoteArgs, " "), err,
+		)
+	}
+	return out.String(), nil
+}
 
 // RebootVMAndWaitForSSH triggers a reboot on the VM and waits for SSH to become ready again.
 func (h *Harness) RebootVMAndWaitForSSH(waitInterval time.Duration, maxAttempts int) error {

--- a/test/harness/e2e/harness_console.go
+++ b/test/harness/e2e/harness_console.go
@@ -3,7 +3,9 @@ package e2e
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,10 +14,70 @@ import (
 
 // ConsoleSession represents a PTY console session to a device
 type ConsoleSession struct {
-	Stdin            io.WriteCloser
-	Stdout           *Buffer
-	closeOnce        sync.Once
-	skipGracefulExit bool // when true, Close only releases fds (e.g. after flightctl "~." disconnect)
+	Stdin     io.WriteCloser
+	Stdout    *Buffer
+	closeOnce sync.Once
+}
+
+// NewAppConsoleSession starts a PTY console session to a VM application's serial or VNC console.
+func (h *Harness) NewAppConsoleSession(deviceID, appName, consoleType string) *ConsoleSession {
+	in, out, err := h.RunInteractiveCLI(
+		"app", "console", fmt.Sprintf("device/%s", deviceID),
+		"--name", appName,
+		"--type", consoleType,
+		"--tty",
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &ConsoleSession{Stdin: in, Stdout: BufferReader(out)}
+}
+
+// NewAppConsoleSessionWaitingForLogin opens a serial console and retries until the guest
+// login prompt appears. The VM app may report Running before getty is ready; connecting
+// too early can drop the session before boot completes.
+func (h *Harness) NewAppConsoleSessionWaitingForLogin(deviceID, appName string, timeout, polling time.Duration) *ConsoleSession {
+	if polling <= 0 {
+		polling = time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+	loginRE := regexp.MustCompile(`(?i)login:`)
+	var cs *ConsoleSession
+
+	for time.Now().Before(deadline) {
+		if cs == nil || cs.Stdout.Closed() {
+			if cs != nil {
+				cs.Close()
+				cs = nil
+			}
+			in, out, err := h.RunInteractiveCLI(
+				"app", "console", fmt.Sprintf("device/%s", deviceID),
+				"--name", appName,
+				"--type", "serial",
+				"--tty",
+			)
+			if err != nil {
+				GinkgoWriter.Printf("app serial console start failed: %v\n", err)
+				time.Sleep(polling)
+				continue
+			}
+			cs = &ConsoleSession{Stdin: in, Stdout: BufferReader(out)}
+		}
+
+		contents := cs.Stdout.Contents()
+		if loginRE.Match(contents) {
+			Expect(cs.Stdout.Clear()).To(Succeed())
+			return cs
+		}
+
+		time.Sleep(polling)
+	}
+
+	if cs != nil {
+		cs.Close()
+	}
+	Expect(fmt.Errorf("serial console login prompt not seen within %s", timeout)).NotTo(HaveOccurred())
+	return nil
 }
 
 // NewConsoleSession starts a PTY console session to the specified device.
@@ -40,24 +102,39 @@ func (cs *ConsoleSession) MustSend(cmd string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-// MustExpect waits for a pattern to appear in the console output
+// MustExpect waits for a pattern to appear in the console output.
+// Uses the suite's default Eventually timeout (e.g. cli_suite_test sets 1m/1s).
 func (cs *ConsoleSession) MustExpect(pattern string) {
 	GinkgoWriter.Printf("console EXPECT %q\n", pattern)
 	Eventually(cs.Stdout).Should(Say(pattern))
 	Expect(cs.Stdout.Clear()).To(Succeed())
 }
 
-// When called set Close function not to send the "exit" command before disconnecting the client
-// (e.g. flightctl "~." escape) and only release local PTY fds.
-func (cs *ConsoleSession) SkipGracefulExitOnClose() {
-	cs.skipGracefulExit = true
+// MustExpectWithin waits up to timeout for a pattern to appear in the console output.
+// Use a long timeout when the remote end may still be booting (e.g. VM serial console).
+func (cs *ConsoleSession) MustExpectWithin(pattern string, timeout, polling time.Duration) {
+	GinkgoWriter.Printf("console EXPECT %q (timeout %s)\n", pattern, timeout)
+	Eventually(cs.Stdout).WithTimeout(timeout).WithPolling(polling).Should(Say(pattern))
+	Expect(cs.Stdout.Clear()).To(Succeed())
 }
 
-// Close terminates the console session. When SkipGracefulExitOnClose was set (e.g. after "~."),
-// it only closes stdin/stdout without sending "exit".
+func mustParseDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	Expect(err).NotTo(HaveOccurred(), "parsing duration %q", s)
+	return d
+}
+
+// Disconnect sends the flightctl ~. escape sequence and waits for the CLI to exit.
+func (cs *ConsoleSession) Disconnect() {
+	Expect(cs.Stdin.Write([]byte("\n~.\n"))).To(BeNumerically(">", 0))
+	Eventually(cs.Stdout.Closed).WithTimeout(mustParseDuration(TIMEOUT)).WithPolling(mustParseDuration(POLLING)).Should(BeTrue())
+}
+
+// Close releases the console session. Sends exit when the session is still open;
+// after Disconnect() the buffer is already closed so only local fds are released.
 func (cs *ConsoleSession) Close() {
 	cs.closeOnce.Do(func() {
-		if !cs.skipGracefulExit {
+		if cs.Stdout != nil && !cs.Stdout.Closed() {
 			cs.sendExit()
 		}
 
@@ -72,6 +149,24 @@ func (cs *ConsoleSession) Close() {
 			}
 		}
 	})
+}
+
+// sendExit attempts to gracefully close the remote console without failing cleanup.
+func (cs *ConsoleSession) sendExit() {
+	if cs.Stdout == nil {
+		GinkgoWriter.Printf("console stdout is nil; sending graceful exit without clearing stdout\n")
+	} else if err := cs.Stdout.Clear(); err != nil {
+		GinkgoWriter.Printf("failed to clear console stdout before graceful exit: %v\n", err)
+	}
+	if cs.Stdin == nil {
+		GinkgoWriter.Printf("console stdin is nil; skipping graceful exit\n")
+		return
+	}
+
+	GinkgoWriter.Printf("console> exit\n")
+	if _, err := io.WriteString(cs.Stdin, "exit\n"); err != nil {
+		GinkgoWriter.Printf("failed to send graceful console exit: %v\n", err)
+	}
 }
 
 // RunConsoleCommand executes the flightctl console command for the given
@@ -93,24 +188,4 @@ func (h *Harness) RunConsoleCommand(deviceID string, flags []string, cmd ...stri
 	}
 
 	return h.CLI(args...)
-}
-
-// sendExit attempts to gracefully close the remote console without failing cleanup.
-func (cs *ConsoleSession) sendExit() {
-	if cs.Stdout == nil {
-		GinkgoWriter.Printf("console stdout is nil; sending graceful exit without clearing stdout\n")
-	} else if cs.Stdout.Closed() {
-		GinkgoWriter.Printf("console stdout is already closed; sending graceful exit without clearing stdout\n")
-	} else if err := cs.Stdout.Clear(); err != nil {
-		GinkgoWriter.Printf("failed to clear console stdout before graceful exit: %v\n", err)
-	}
-	if cs.Stdin == nil {
-		GinkgoWriter.Printf("console stdin is nil; skipping graceful exit\n")
-		return
-	}
-
-	GinkgoWriter.Printf("console> exit\n")
-	if _, err := io.WriteString(cs.Stdin, "exit\n"); err != nil {
-		GinkgoWriter.Printf("failed to send graceful console exit: %v\n", err)
-	}
 }


### PR DESCRIPTION
Extend the VM basic e2e test to log in over the serial console, disconnect with the flightctl ~. escape, and confirm SSH works on the published host port. Fix VM publishPorts mapping to 2222:22 (guest SSH)

Add add harness helpers for console sessions and password-based SSH on the device host.

Update the CLI console e2e test to use Disconnect() after removing SkipGracefulExitOnClose.

Assisted-by: Cursor