### PR TITLE
NO-ISSUE: include remote-access in flightctl.target

### DIFF
--- a/deploy/podman/flightctl.target
+++ b/deploy/podman/flightctl.target
@@ -25,6 +25,7 @@ Wants=flightctl-certs-init.service
 Wants=flightctl-telemetry-gateway.service
 Wants=flightctl-imagebuilder-api.service
 Wants=flightctl-imagebuilder-worker.service
+Wants=flightctl-remote-access.service
 Wants=flightctl-gateway.service
 
 After=network.target
@@ -47,6 +48,7 @@ After=flightctl-certs-init.service
 After=flightctl-telemetry-gateway.service
 After=flightctl-imagebuilder-api.service
 After=flightctl-imagebuilder-worker.service
+After=flightctl-remote-access.service
 After=flightctl-gateway.service
 
 [Install]


### PR DESCRIPTION
## Summary
- Add `Wants=` / `After=` for `flightctl-remote-access.service` on `flightctl.target` so the target explicitly starts remote-access with the rest of the stack.
- The unit already has `PartOf=` / `WantedBy=flightctl.target` (stop/restart still worked); without target `Wants=`, start depended on gateway's soft `Wants=` or enable-time `.wants/` symlinks.

## Test plan
- [ ] Confirm `flightctl.target` lists remote-access before gateway in both `Wants=` and `After=`
- [ ] On a quadlet deploy: `systemctl start flightctl.target` starts `flightctl-remote-access.service`
- [ ] `systemctl stop flightctl.target` still stops remote-access (`PartOf=`)


Made with [Cursor](https://cursor.com)