### PR TITLE
EDM 4830 device decommission service

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -115,10 +115,6 @@ func (m *MockDevice) ProcessAwaitingReconnectAnnotation(ctx context.Context, org
 	return false, nil
 }
 
-func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	return nil, nil
-}
-
 func (m *MockDevice) ListDevicesByOsCatalogItemRef(ctx context.Context, orgId uuid.UUID, catalog string, item string, listParams store.ListParams) (*domain.DeviceList, error) {
 	return nil, nil
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -112,9 +112,6 @@ func (f *fakeDeviceStore) GetLastSeen(context.Context, uuid.UUID, string) (*time
 func (f *fakeDeviceStore) SetServiceConditions(context.Context, uuid.UUID, string, []domain.Condition, devicestore.ServiceConditionsCallback) error {
 	panic("not implemented")
 }
-func (f *fakeDeviceStore) DecommissionDevice(context.Context, uuid.UUID, string, domain.DeviceDecommission, store.EventCallback) (*domain.Device, error) {
-	panic("not implemented")
-}
 func (f *fakeDeviceStore) OverwriteRepositoryRefs(context.Context, uuid.UUID, string, ...string) error {
 	panic("not implemented")
 }

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -749,8 +749,42 @@ func snapshotDeviceForStatusUpdate(device *domain.Device) *domain.Device {
 }
 
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
-	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, name, decom, h.callbackDeviceDecommission)
-	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	result, before, _, err := h.deviceStore.Mutate(ctx, orgId, name, nil, func(m *devicestore.DeviceMutation) error {
+		if err := m.RequireExisting(); err != nil {
+			return err
+		}
+		// Product rule: refuse a second decommission without emitting a success event.
+		if m.Device.Spec != nil && m.Device.Spec.Decommissioning != nil {
+			return flterrors.ErrResourceVersionConflict
+		}
+		applyDeviceDecommission(m.Device, decom)
+		return nil
+	})
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+	h.callEventCallback(ctx, h.callbackDeviceDecommission, orgId, name, before, result, false, nil)
+	return result, common.StoreErrorToApiStatus(nil, false, domain.DeviceKind, &name)
+}
+
+// applyDeviceDecommission sets Spec.Decommissioning, Lifecycle Decommissioning, and clears Owner/Labels.
+func applyDeviceDecommission(device *domain.Device, decom domain.DeviceDecommission) {
+	spec := domain.DeviceSpec{}
+	if device.Spec != nil {
+		spec = *device.Spec
+	}
+	spec.Decommissioning = &decom
+	device.Spec = &spec
+
+	status := domain.NewDeviceStatus()
+	if device.Status != nil {
+		status = *device.Status
+	}
+	status.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
+	device.Status = &status
+
+	device.Metadata.Owner = nil
+	device.Metadata.Labels = nil
 }
 
 func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -754,10 +754,13 @@ func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uui
 			return err
 		}
 		// Product rule: refuse a second decommission without emitting a success event.
-		if m.Device.Spec != nil && m.Device.Spec.Decommissioning != nil {
+		// Map ErrDecommission → ErrResourceVersionConflict to preserve the historical API.
+		if err := rejectDecommissionedDevice(m.Device); err != nil {
 			return flterrors.ErrResourceVersionConflict
 		}
 		applyDeviceDecommission(m.Device, decom)
+		// Former store DecommissionDevice did not bump generation; keep that contract.
+		m.PreserveGeneration = true
 		return nil
 	})
 	if err != nil {

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -820,14 +820,61 @@ func TestUpdateDevice(t *testing.T) {
 }
 
 func TestDecommissionDevice(t *testing.T) {
-	st, _, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")}}, nil)
-	require.NoError(t, err)
-	result, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	require.NotNil(t, result.Spec.Decommissioning)
+	t.Run("When decommissioning a device it should set decom spec, lifecycle, clear owner and labels, and emit success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		labels := map[string]string{"fleet": "f1"}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("foo"),
+				Owner:  lo.ToPtr("Fleet/f1"),
+				Labels: &labels,
+			},
+			Spec:   &domain.DeviceSpec{},
+			Status: lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
+
+		decom := domain.DeviceDecommission{}
+		result, status := svc.DecommissionDevice(ctx, orgId, "foo", decom)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, result.Status.Lifecycle.Status)
+		require.Nil(t, result.Metadata.Owner)
+		require.Nil(t, result.Metadata.Labels)
+
+		stored := st.device.devices["foo"]
+		require.NotNil(t, stored.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, stored.Status.Lifecycle.Status)
+		require.Nil(t, stored.Metadata.Owner)
+		require.Nil(t, stored.Metadata.Labels)
+
+		require.Len(t, ev.created, 1)
+		require.Equal(t, domain.EventReasonDeviceDecommissioned, ev.created[0].Reason)
+	})
+
+	t.Run("When the device is already decommissioning it should return conflict without success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["foo"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Decommissioning: &domain.DeviceDecommission{}},
+		}
+
+		_, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrResourceVersionConflict.Error(), status.Message)
+		require.Empty(t, ev.created)
+	})
+
+	t.Run("When the device does not exist it should return not found", func(t *testing.T) {
+		_, ev, svc := newTestHandler()
+		_, status := svc.DecommissionDevice(context.Background(), uuid.New(), "missing", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+		require.Empty(t, ev.created)
+	})
 }
 
 // TestUpdateRenderedDevice covers the "no change in rendered version" path only. The

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -827,9 +827,10 @@ func TestDecommissionDevice(t *testing.T) {
 		labels := map[string]string{"fleet": "f1"}
 		_, err := st.device.Create(ctx, orgId, &domain.Device{
 			Metadata: domain.ObjectMeta{
-				Name:   lo.ToPtr("foo"),
-				Owner:  lo.ToPtr("Fleet/f1"),
-				Labels: &labels,
+				Name:       lo.ToPtr("foo"),
+				Owner:      lo.ToPtr("Fleet/f1"),
+				Labels:     &labels,
+				Generation: lo.ToPtr(int64(3)),
 			},
 			Spec:   &domain.DeviceSpec{},
 			Status: lo.ToPtr(domain.NewDeviceStatus()),
@@ -843,12 +844,14 @@ func TestDecommissionDevice(t *testing.T) {
 		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, result.Status.Lifecycle.Status)
 		require.Nil(t, result.Metadata.Owner)
 		require.Nil(t, result.Metadata.Labels)
+		require.Equal(t, int64(3), lo.FromPtr(result.Metadata.Generation))
 
 		stored := st.device.devices["foo"]
 		require.NotNil(t, stored.Spec.Decommissioning)
 		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, stored.Status.Lifecycle.Status)
 		require.Nil(t, stored.Metadata.Owner)
 		require.Nil(t, stored.Metadata.Labels)
+		require.Equal(t, int64(3), lo.FromPtr(stored.Metadata.Generation))
 
 		require.Len(t, ev.created, 1)
 		require.Equal(t, domain.EventReasonDeviceDecommissioned, ev.created[0].Reason)

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -293,22 +293,6 @@ func (s *fakeDeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, own
 	return nil
 }
 
-func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	d, ok := s.devices[name]
-	if !ok {
-		return nil, flterrors.ErrResourceNotFound
-	}
-	old := deepCopyDevice(d)
-	if d.Spec == nil {
-		d.Spec = &domain.DeviceSpec{}
-	}
-	d.Spec.Decommissioning = &decom
-	if eventCallback != nil {
-		eventCallback(ctx, domain.DeviceKind, orgId, name, old, d, false, nil)
-	}
-	return deepCopyDevice(d), nil
-}
-
 func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
 	d, ok := s.devices[name]
 	if !ok {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -84,7 +84,6 @@ type Store interface {
 
 	// Used internally
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
-	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error)
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -1472,84 +1471,6 @@ func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID,
 	return store.RetryUpdate(func() (bool, error) {
 		return s.setServiceConditions(ctx, orgId, name, conditions, callback)
 	})
-}
-
-func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (retry bool, device *domain.Device, err error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, nil, store.ErrorFromGormError(result.Error)
-	}
-
-	// Convert to API resource to check precondition
-	existingDevice, err := existingRecord.ToApiResource()
-	if err != nil {
-		return false, nil, err
-	}
-
-	// Check precondition: device must not already be decommissioning
-	if existingDevice.Spec != nil && existingDevice.Spec.Decommissioning != nil {
-		return false, nil, flterrors.ErrResourceVersionConflict
-	}
-
-	// Capture old device with deep copy for callback
-	var oldDevice domain.Device
-	var devices []domain.Device
-	devices = append(devices, *existingDevice)
-	oldDevice = devices[0]
-
-	// Apply decommissioning changes to the model
-	if existingRecord.Spec == nil {
-		existingRecord.Spec = model.MakeJSONField(domain.DeviceSpec{})
-	}
-	existingRecord.Spec.Data.Decommissioning = &decom
-
-	// Update status
-	if existingRecord.Status == nil {
-		existingRecord.Status = model.MakeJSONField(domain.NewDeviceStatus())
-	}
-	existingRecord.Status.Data.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
-
-	// These fields must be un-set so that device is no longer associated with any fleet
-	existingRecord.Owner = nil
-	existingRecord.Labels = nil
-
-	// Update using optimistic locking
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"spec":             existingRecord.Spec,
-		"status":           existingRecord.Status,
-		"owner":            nil,
-		"labels":           nil,
-		"resource_version": gorm.Expr("resource_version + 1"),
-	})
-	err = store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), nil, err
-	}
-	if result.RowsAffected == 0 {
-		return true, nil, flterrors.ErrNoRowsUpdated
-	}
-
-	// Convert updated record to API resource for return and callback
-	updatedDevice, err := existingRecord.ToApiResource()
-	if err != nil {
-		return false, nil, err
-	}
-
-	// Call event callback
-	s.callEventCallback(ctx, eventCallback, orgId, name, &oldDevice, updatedDevice, false, nil)
-
-	return false, updatedDevice, nil
-}
-
-func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	var device *domain.Device
-	err := store.RetryUpdate(func() (bool, error) {
-		retry, dev, err := s.decommissionDevice(ctx, orgId, name, decom, eventCallback)
-		device = dev
-		return retry, err
-	})
-	return device, err
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -132,6 +132,9 @@ type DeviceRendered struct {
 type DeviceMutation struct {
 	Device   *domain.Device
 	Rendered *DeviceRendered
+	// PreserveGeneration keeps metadata.generation unchanged on PersistUpdate
+	// even when Spec changes (e.g. decommission historically did not bump it).
+	PreserveGeneration bool
 }
 
 func (m *DeviceMutation) Resource() *domain.Device { return m.Device }
@@ -139,7 +142,7 @@ func (m *DeviceMutation) Resource() *domain.Device { return m.Device }
 func (m *DeviceMutation) SetResource(device *domain.Device) { m.Device = device }
 
 func (m *DeviceMutation) Clone() (store.ResourceMutation[domain.Device], error) {
-	out := &DeviceMutation{}
+	out := &DeviceMutation{PreserveGeneration: m.PreserveGeneration}
 	if m.Device != nil {
 		cloned, err := store.CloneJSON(m.Device)
 		if err != nil {
@@ -542,7 +545,7 @@ func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, 
 		},
 		PersistUpdate: func(ctx context.Context, orgId uuid.UUID, _ string, before *domain.Device, m store.ResourceMutation[domain.Device]) (bool, error) {
 			dm := m.(*DeviceMutation)
-			return s.Update(ctx, orgId, before, dm.Device, dm.Rendered)
+			return s.Update(ctx, orgId, before, dm.Device, dm.Rendered, dm.PreserveGeneration)
 		},
 	}
 	if cfg.withTimestamp {
@@ -673,7 +676,7 @@ func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *domai
 
 // Update writes a device update. Returns retry=true on lost optimistic lock / deadlock.
 // rendered is optional; when nil, rendered_* columns are left unchanged.
-func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, before, device *domain.Device, rendered *DeviceRendered) (bool, error) {
+func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, before, device *domain.Device, rendered *DeviceRendered, preserveGeneration bool) (bool, error) {
 	existing, err := model.NewDeviceFromApiResource(before)
 	if err != nil {
 		return false, err
@@ -690,10 +693,12 @@ func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, before, devic
 	// that event emission uses (HasSameSpecAs alone can miss union/ref changes
 	// if model conversion ever loses fields).
 	generation := lo.FromPtr(existing.Generation)
-	apiSpecChanged := before != nil && device != nil &&
-		!domain.DeviceSpecsAreEqual(lo.FromPtr(before.Spec), lo.FromPtr(device.Spec))
-	if apiSpecChanged || !fromAPI.HasSameSpecAs(existing) {
-		generation++
+	if !preserveGeneration {
+		apiSpecChanged := before != nil && device != nil &&
+			!domain.DeviceSpecsAreEqual(lo.FromPtr(before.Spec), lo.FromPtr(device.Spec))
+		if apiSpecChanged || !fromAPI.HasSameSpecAs(existing) {
+			generation++
+		}
 	}
 
 	updates := map[string]interface{}{

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -794,6 +794,64 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("Device decommission", func() {
+		It("decommissions a device and clears owner and labels", func() {
+			deviceName := "decom-device-success"
+			labels := map[string]string{"fleet": "f1"}
+			device := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:   lo.ToPtr(deviceName),
+					Owner:  lo.ToPtr("Fleet/f1"),
+					Labels: &labels,
+				},
+				Spec: &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			result, status := suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result.Spec).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
+			Expect(result.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(result.Metadata.Owner).To(BeNil())
+			Expect(lo.FromPtr(result.Metadata.Labels)).To(BeEmpty())
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Decommissioning).ToNot(BeNil())
+			Expect(stored.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
+			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(stored.Metadata.Owner).To(BeNil())
+			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())
+			Expect(result.Metadata.ResourceVersion).To(Equal(stored.Metadata.ResourceVersion))
+		})
+
+		It("returns conflict when decommissioning an already-decommissioning device", func() {
+			deviceName := "decom-device-conflict"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(409)))
+			Expect(status.Message).To(Equal(flterrors.ErrResourceVersionConflict.Error()))
+		})
+	})
+
 	Context("Package-mode OS image rejection", func() {
 		seedDeviceWithOsMode := func(deviceName string, osMode *api.OsModeType) {
 			GinkgoHelper()

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -809,6 +809,10 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
 			Expect(status.Code).To(Equal(int32(201)))
 
+			before, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			generationBefore := lo.FromPtr(before.Metadata.Generation)
+
 			result, status := suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
 				Target: api.DeviceDecommissionTargetTypeUnenroll,
 			})
@@ -819,6 +823,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			Expect(result.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
 			Expect(result.Metadata.Owner).To(BeNil())
 			Expect(lo.FromPtr(result.Metadata.Labels)).To(BeEmpty())
+			Expect(lo.FromPtr(result.Metadata.Generation)).To(Equal(generationBefore))
 
 			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
 			Expect(err).ToNot(HaveOccurred())
@@ -828,6 +833,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			Expect(stored.Metadata.Owner).To(BeNil())
 			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())
 			Expect(result.Metadata.ResourceVersion).To(Equal(stored.Metadata.ResourceVersion))
+			Expect(lo.FromPtr(stored.Metadata.Generation)).To(Equal(generationBefore))
 		})
 
 		It("returns conflict when decommissioning an already-decommissioning device", func() {


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.