### PR TITLE
EDM-4832: Condition merge in the service layer

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -115,10 +115,6 @@ func (m *MockDevice) ProcessAwaitingReconnectAnnotation(ctx context.Context, org
 	return false, nil
 }
 
-func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	return nil, nil
-}
-
 func (m *MockDevice) ListDevicesByOsCatalogItemRef(ctx context.Context, orgId uuid.UUID, catalog string, item string, listParams store.ListParams) (*domain.DeviceList, error) {
 	return nil, nil
 }

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -75,9 +75,6 @@ func (m *MockDevice) Delete(ctx context.Context, orgId uuid.UUID, name string, c
 func (m *MockDevice) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {
 	return nil, nil
 }
-func (m *MockDevice) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
-	return nil
-}
 func (m *MockDevice) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {
 	return nil
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -112,9 +112,6 @@ func (f *fakeDeviceStore) GetLastSeen(context.Context, uuid.UUID, string) (*time
 func (f *fakeDeviceStore) SetServiceConditions(context.Context, uuid.UUID, string, []domain.Condition, devicestore.ServiceConditionsCallback) error {
 	panic("not implemented")
 }
-func (f *fakeDeviceStore) DecommissionDevice(context.Context, uuid.UUID, string, domain.DeviceDecommission, store.EventCallback) (*domain.Device, error) {
-	panic("not implemented")
-}
 func (f *fakeDeviceStore) OverwriteRepositoryRefs(context.Context, uuid.UUID, string, ...string) error {
 	panic("not implemented")
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -109,9 +109,6 @@ func (f *fakeDeviceStore) ProcessAwaitingReconnectAnnotation(context.Context, uu
 func (f *fakeDeviceStore) GetLastSeen(context.Context, uuid.UUID, string) (*time.Time, error) {
 	panic("not implemented")
 }
-func (f *fakeDeviceStore) SetServiceConditions(context.Context, uuid.UUID, string, []domain.Condition, devicestore.ServiceConditionsCallback) error {
-	panic("not implemented")
-}
 func (f *fakeDeviceStore) OverwriteRepositoryRefs(context.Context, uuid.UUID, string, ...string) error {
 	panic("not implemented")
 }

--- a/internal/service/common/conditions.go
+++ b/internal/service/common/conditions.go
@@ -1,0 +1,16 @@
+package common
+
+import "github.com/flightctl/flightctl/internal/domain"
+
+// MergeStatusConditions copies existing conditions and applies each update via
+// domain.SetStatusCondition, OR-aggregating whether anything changed.
+func MergeStatusConditions(existing []domain.Condition, updates []domain.Condition) (merged []domain.Condition, changed bool) {
+	merged = make([]domain.Condition, len(existing))
+	copy(merged, existing)
+	for _, update := range updates {
+		if domain.SetStatusCondition(&merged, update) {
+			changed = true
+		}
+	}
+	return merged, changed
+}

--- a/internal/service/common/conditions_test.go
+++ b/internal/service/common/conditions_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStatusConditions(t *testing.T) {
+	t.Run("When updates are empty it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, nil)
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+		require.NotSame(t, &existing[0], &merged[0])
+	})
+
+	t.Run("When a new condition type is added it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "r"},
+		})
+		require.True(t, changed)
+		require.Len(t, merged, 2)
+	})
+
+	t.Run("When the same condition is reapplied it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"},
+		})
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+	})
+
+	t.Run("When one of multiple updates changes it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "old"},
+		}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "new"},
+		})
+		require.True(t, changed)
+		require.Equal(t, "new", domain.FindStatusCondition(merged, "B").Reason)
+	})
+}

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -749,8 +749,42 @@ func snapshotDeviceForStatusUpdate(device *domain.Device) *domain.Device {
 }
 
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
-	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, name, decom, h.callbackDeviceDecommission)
-	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	result, before, _, err := h.deviceStore.Mutate(ctx, orgId, name, nil, func(m *devicestore.DeviceMutation) error {
+		if err := m.RequireExisting(); err != nil {
+			return err
+		}
+		// Product rule: refuse a second decommission without emitting a success event.
+		if m.Device.Spec != nil && m.Device.Spec.Decommissioning != nil {
+			return flterrors.ErrResourceVersionConflict
+		}
+		applyDeviceDecommission(m.Device, decom)
+		return nil
+	})
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+	h.callEventCallback(ctx, h.callbackDeviceDecommission, orgId, name, before, result, false, nil)
+	return result, common.StoreErrorToApiStatus(nil, false, domain.DeviceKind, &name)
+}
+
+// applyDeviceDecommission sets Spec.Decommissioning, Lifecycle Decommissioning, and clears Owner/Labels.
+func applyDeviceDecommission(device *domain.Device, decom domain.DeviceDecommission) {
+	spec := domain.DeviceSpec{}
+	if device.Spec != nil {
+		spec = *device.Spec
+	}
+	spec.Decommissioning = &decom
+	device.Spec = &spec
+
+	status := domain.NewDeviceStatus()
+	if device.Status != nil {
+		status = *device.Status
+	}
+	status.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
+	device.Status = &status
+
+	device.Metadata.Owner = nil
+	device.Metadata.Labels = nil
 }
 
 func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -867,12 +867,61 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 }
 
 func (h *DeviceServiceHandler) SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
-	callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
-		h.diffAndEmitConditionEvents(ctx, orgId, device, oldConditions, newConditions)
+	var oldConditions, newConditions []domain.Condition
+	result, _, _, err := h.deviceStore.Mutate(ctx, orgId, name, nil, func(m *devicestore.DeviceMutation) error {
+		if err := m.RequireExisting(); err != nil {
+			return err
+		}
+		existing := serviceConditionsFromDevice(m.Device)
+		merged, changed := common.MergeStatusConditions(existing, conditions)
+		if !changed {
+			return store.ErrMutateSkipWrite
+		}
+		oldConditions = existing
+		newConditions = merged
+		replaceServiceConditionsOnDevice(m.Device, merged)
+		return nil
+	})
+	if err != nil {
+		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 	}
+	if result != nil {
+		h.diffAndEmitConditionEvents(ctx, orgId, result, oldConditions, newConditions)
+	}
+	return domain.StatusOK()
+}
 
-	err := h.deviceStore.SetServiceConditions(ctx, orgId, name, conditions, callback)
-	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+// serviceConditionsFromDevice returns SpecValid / MultipleOwners conditions from
+// Status.Conditions (agent and service conditions are stored separately but
+// exposed together by Get).
+func serviceConditionsFromDevice(device *domain.Device) []domain.Condition {
+	if device == nil || device.Status == nil {
+		return nil
+	}
+	var out []domain.Condition
+	for _, c := range device.Status.Conditions {
+		if c.Type.IsServiceConditionType() {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// replaceServiceConditionsOnDevice swaps service-owned conditions on Status while
+// preserving agent conditions. NewDeviceFromApiResource routes service types into
+// the service_conditions column on persist.
+func replaceServiceConditionsOnDevice(device *domain.Device, serviceConds []domain.Condition) {
+	if device.Status == nil {
+		status := domain.NewDeviceStatus()
+		device.Status = &status
+	}
+	var agent []domain.Condition
+	for _, c := range device.Status.Conditions {
+		if !c.Type.IsServiceConditionType() {
+			agent = append(agent, c)
+		}
+	}
+	device.Status.Conditions = append(agent, serviceConds...)
 }
 
 // diffAndEmitConditionEvents compares old and new conditions and emits events for condition changes

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -901,30 +901,80 @@ func TestUpdateRenderedDevice(t *testing.T) {
 	require.Equal(t, int32(http.StatusOK), status.Code)
 }
 
+func TestServiceConditionsFromDevice(t *testing.T) {
+	t.Run("When status is nil it should return nil", func(t *testing.T) {
+		require.Nil(t, serviceConditionsFromDevice(&domain.Device{}))
+	})
+
+	t.Run("When status mixes agent and service conditions it should return only service types", func(t *testing.T) {
+		device := &domain.Device{
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{
+					{Type: domain.ConditionTypeDeviceUpdating, Status: domain.ConditionStatusTrue},
+					{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse},
+					{Type: domain.ConditionTypeDeviceMultipleOwners, Status: domain.ConditionStatusTrue},
+				},
+			},
+		}
+		got := serviceConditionsFromDevice(device)
+		require.Len(t, got, 2)
+		require.Equal(t, domain.ConditionTypeDeviceSpecValid, got[0].Type)
+		require.Equal(t, domain.ConditionTypeDeviceMultipleOwners, got[1].Type)
+	})
+}
+
 func TestSetDeviceServiceConditions(t *testing.T) {
-	st, ev, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{
-		Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
-		Status:   lo.ToPtr(domain.NewDeviceStatus()),
-	}, nil)
-	require.NoError(t, err)
+	t.Run("When a service condition changes it should persist and emit events", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status:   lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
 
-	condition := domain.Condition{
-		Type:    domain.ConditionTypeDeviceSpecValid,
-		Status:  domain.ConditionStatusFalse,
-		Message: "bad spec",
-	}
-	status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	// SpecValid transitioning from absent to invalid emits a DeviceSpecInvalid event.
-	require.Len(t, ev.created, 1)
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
+		})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		stored := st.device.devices["foo"]
+		require.NotNil(t, domain.FindStatusCondition(stored.Status.Conditions, domain.ConditionTypeDeviceSpecValid))
+		require.Len(t, ev.created, 1)
+	})
 
-	status = svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	// Unchanged conditions must not write or emit another event.
-	require.Len(t, ev.created, 1)
+	t.Run("When merge changes nothing it should skip write and not emit events", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		cond := domain.Condition{
+			Type:    domain.ConditionTypeDeviceSpecValid,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "ok",
+			Message: "ok",
+		}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{cond},
+			},
+		}, nil)
+		require.NoError(t, err)
+		beforeRV := lo.FromPtr(st.device.devices["foo"].Metadata.ResourceVersion)
+
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{cond})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.Equal(t, beforeRV, lo.FromPtr(st.device.devices["foo"].Metadata.ResourceVersion))
+		require.Empty(t, ev.created)
+	})
+
+	t.Run("When the device does not exist it should return a not-found status", func(t *testing.T) {
+		_, _, svc := newTestHandler()
+		status := svc.SetDeviceServiceConditions(context.Background(), uuid.New(), "missing", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusTrue},
+		})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+	})
 }
 
 func TestUpdateServiceSideDeviceStatus(t *testing.T) {

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -820,14 +820,61 @@ func TestUpdateDevice(t *testing.T) {
 }
 
 func TestDecommissionDevice(t *testing.T) {
-	st, _, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")}}, nil)
-	require.NoError(t, err)
-	result, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	require.NotNil(t, result.Spec.Decommissioning)
+	t.Run("When decommissioning a device it should set decom spec, lifecycle, clear owner and labels, and emit success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		labels := map[string]string{"fleet": "f1"}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("foo"),
+				Owner:  lo.ToPtr("Fleet/f1"),
+				Labels: &labels,
+			},
+			Spec:   &domain.DeviceSpec{},
+			Status: lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
+
+		decom := domain.DeviceDecommission{}
+		result, status := svc.DecommissionDevice(ctx, orgId, "foo", decom)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, result.Status.Lifecycle.Status)
+		require.Nil(t, result.Metadata.Owner)
+		require.Nil(t, result.Metadata.Labels)
+
+		stored := st.device.devices["foo"]
+		require.NotNil(t, stored.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, stored.Status.Lifecycle.Status)
+		require.Nil(t, stored.Metadata.Owner)
+		require.Nil(t, stored.Metadata.Labels)
+
+		require.Len(t, ev.created, 1)
+		require.Equal(t, domain.EventReasonDeviceDecommissioned, ev.created[0].Reason)
+	})
+
+	t.Run("When the device is already decommissioning it should return conflict without success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["foo"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Decommissioning: &domain.DeviceDecommission{}},
+		}
+
+		_, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrResourceVersionConflict.Error(), status.Message)
+		require.Empty(t, ev.created)
+	})
+
+	t.Run("When the device does not exist it should return not found", func(t *testing.T) {
+		_, ev, svc := newTestHandler()
+		_, status := svc.DecommissionDevice(context.Background(), uuid.New(), "missing", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+		require.Empty(t, ev.created)
+	})
 }
 
 // TestUpdateRenderedDevice covers the "no change in rendered version" path only. The

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -293,35 +293,6 @@ func (s *fakeDeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, own
 	return nil
 }
 
-func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
-	d, ok := s.devices[name]
-	if !ok {
-		return flterrors.ErrResourceNotFound
-	}
-	var oldConditions []domain.Condition
-	if d.Status != nil {
-		oldConditions = append([]domain.Condition(nil), d.Status.Conditions...)
-	}
-	newConditions := append([]domain.Condition(nil), oldConditions...)
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(&newConditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return nil
-	}
-	if d.Status == nil {
-		d.Status = lo.ToPtr(domain.NewDeviceStatus())
-	}
-	d.Status.Conditions = newConditions
-	if callback != nil {
-		callback(ctx, orgId, d, oldConditions, newConditions)
-	}
-	return nil
-}
-
 func (s *fakeDeviceStore) RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error) {
 	var ids []string
 	for name, d := range s.devices {

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -293,22 +293,6 @@ func (s *fakeDeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, own
 	return nil
 }
 
-func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	d, ok := s.devices[name]
-	if !ok {
-		return nil, flterrors.ErrResourceNotFound
-	}
-	old := deepCopyDevice(d)
-	if d.Spec == nil {
-		d.Spec = &domain.DeviceSpec{}
-	}
-	d.Spec.Decommissioning = &decom
-	if eventCallback != nil {
-		eventCallback(ctx, domain.DeviceKind, orgId, name, old, d, false, nil)
-	}
-	return deepCopyDevice(d), nil
-}
-
 func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
 	d, ok := s.devices[name]
 	if !ok {

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -273,18 +273,15 @@ func (h *ServiceHandler) UpdateFleetConditions(ctx context.Context, orgId uuid.U
 		if current.Status == nil {
 			current.Status = &domain.FleetStatus{}
 		}
-		if current.Status.Conditions == nil {
-			current.Status.Conditions = []domain.Condition{}
+		var existing []domain.Condition
+		if current.Status.Conditions != nil {
+			existing = current.Status.Conditions
 		}
-		changed := false
-		for _, condition := range conditions {
-			if domain.SetStatusCondition(&current.Status.Conditions, condition) {
-				changed = true
-			}
-		}
+		merged, changed := common.MergeStatusConditions(existing, conditions)
 		if !changed {
 			return store.ErrMutateSkipWrite
 		}
+		current.Status.Conditions = merged
 		return nil
 	})
 	h.callEventCallback(ctx, h.callbackFleetUpdated, orgId, name, before, result, false, err)

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -84,7 +84,6 @@ type Store interface {
 
 	// Used internally
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
-	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error)
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -1472,84 +1471,6 @@ func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID,
 	return store.RetryUpdate(func() (bool, error) {
 		return s.setServiceConditions(ctx, orgId, name, conditions, callback)
 	})
-}
-
-func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (retry bool, device *domain.Device, err error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, nil, store.ErrorFromGormError(result.Error)
-	}
-
-	// Convert to API resource to check precondition
-	existingDevice, err := existingRecord.ToApiResource()
-	if err != nil {
-		return false, nil, err
-	}
-
-	// Check precondition: device must not already be decommissioning
-	if existingDevice.Spec != nil && existingDevice.Spec.Decommissioning != nil {
-		return false, nil, flterrors.ErrResourceVersionConflict
-	}
-
-	// Capture old device with deep copy for callback
-	var oldDevice domain.Device
-	var devices []domain.Device
-	devices = append(devices, *existingDevice)
-	oldDevice = devices[0]
-
-	// Apply decommissioning changes to the model
-	if existingRecord.Spec == nil {
-		existingRecord.Spec = model.MakeJSONField(domain.DeviceSpec{})
-	}
-	existingRecord.Spec.Data.Decommissioning = &decom
-
-	// Update status
-	if existingRecord.Status == nil {
-		existingRecord.Status = model.MakeJSONField(domain.NewDeviceStatus())
-	}
-	existingRecord.Status.Data.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
-
-	// These fields must be un-set so that device is no longer associated with any fleet
-	existingRecord.Owner = nil
-	existingRecord.Labels = nil
-
-	// Update using optimistic locking
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"spec":             existingRecord.Spec,
-		"status":           existingRecord.Status,
-		"owner":            nil,
-		"labels":           nil,
-		"resource_version": gorm.Expr("resource_version + 1"),
-	})
-	err = store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), nil, err
-	}
-	if result.RowsAffected == 0 {
-		return true, nil, flterrors.ErrNoRowsUpdated
-	}
-
-	// Convert updated record to API resource for return and callback
-	updatedDevice, err := existingRecord.ToApiResource()
-	if err != nil {
-		return false, nil, err
-	}
-
-	// Call event callback
-	s.callEventCallback(ctx, eventCallback, orgId, name, &oldDevice, updatedDevice, false, nil)
-
-	return false, updatedDevice, nil
-}
-
-func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	var device *domain.Device
-	err := store.RetryUpdate(func() (bool, error) {
-		retry, dev, err := s.decommissionDevice(ctx, orgId, name, decom, eventCallback)
-		device = dev
-		return retry, err
-	})
-	return device, err
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -83,7 +83,6 @@ type Store interface {
 	GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error)
 
 	// Used internally
-	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -116,8 +115,6 @@ type DeviceStore struct {
 	log          logrus.FieldLogger
 	genericStore *store.GenericStore[*model.Device, model.Device, domain.Device, domain.DeviceList]
 }
-
-type ServiceConditionsCallback func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition)
 
 // DeviceRendered holds rendered_* column values not represented on domain.Device.
 // When set on DeviceMutation, Mutate persists them and bumps render_timestamp.
@@ -1390,87 +1387,6 @@ func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name str
 	}
 
 	return deviceModel.LastSeen, nil
-}
-
-func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) (retry bool, err error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, store.ErrorFromGormError(result.Error)
-	}
-
-	// Capture old conditions with deep copy
-	var oldConditions []domain.Condition
-	if existingRecord.ServiceConditions != nil && existingRecord.ServiceConditions.Data.Conditions != nil {
-		// Deep copy the conditions to avoid shared memory issues
-		oldConditions = append(oldConditions, *existingRecord.ServiceConditions.Data.Conditions...)
-	}
-
-	// Initialize service conditions if needed
-	if existingRecord.ServiceConditions == nil {
-		existingRecord.ServiceConditions = model.MakeJSONField(model.ServiceConditions{})
-	}
-	if existingRecord.ServiceConditions.Data.Conditions == nil {
-		existingRecord.ServiceConditions.Data.Conditions = &[]domain.Condition{}
-	}
-
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(existingRecord.ServiceConditions.Data.Conditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return false, nil
-	}
-
-	// Update using the original pattern with specific field updates and optimistic locking
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"service_conditions": existingRecord.ServiceConditions,
-		"resource_version":   gorm.Expr("resource_version + 1"),
-	})
-	err = store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
-	}
-	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
-	}
-
-	// Call callback if provided (but don't fail the operation if callback fails)
-	if callback != nil {
-		// Convert the updated model to API resource for the callback
-		apiDevice, convertErr := existingRecord.ToApiResource()
-		if convertErr != nil {
-			// Log the error but don't fail the operation
-			s.log.Errorf("Failed to convert device to API resource for callback: %v", convertErr)
-		} else {
-			// Call callback in a defer with error recovery to prevent callback failures from affecting the main operation
-			defer func() {
-				if r := recover(); r != nil {
-					s.log.Errorf("Callback panicked during service conditions update: %v", r)
-				}
-			}()
-
-			// Call the callback - if it fails, log the error but don't propagate it
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						s.log.Errorf("Service conditions callback panicked: %v", r)
-					}
-				}()
-				callback(ctx, orgId, apiDevice, oldConditions, *existingRecord.ServiceConditions.Data.Conditions)
-			}()
-		}
-	}
-
-	return false, nil
-}
-
-func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error {
-	return store.RetryUpdate(func() (bool, error) {
-		return s.setServiceConditions(ctx, orgId, name, conditions, callback)
-	})
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -794,6 +794,64 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("Device decommission", func() {
+		It("decommissions a device and clears owner and labels", func() {
+			deviceName := "decom-device-success"
+			labels := map[string]string{"fleet": "f1"}
+			device := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:   lo.ToPtr(deviceName),
+					Owner:  lo.ToPtr("Fleet/f1"),
+					Labels: &labels,
+				},
+				Spec: &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			result, status := suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result.Spec).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
+			Expect(result.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(result.Metadata.Owner).To(BeNil())
+			Expect(lo.FromPtr(result.Metadata.Labels)).To(BeEmpty())
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Decommissioning).ToNot(BeNil())
+			Expect(stored.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
+			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(stored.Metadata.Owner).To(BeNil())
+			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())
+			Expect(result.Metadata.ResourceVersion).To(Equal(stored.Metadata.ResourceVersion))
+		})
+
+		It("returns conflict when decommissioning an already-decommissioning device", func() {
+			deviceName := "decom-device-conflict"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(409)))
+			Expect(status.Message).To(Equal(flterrors.ErrResourceVersionConflict.Error()))
+		})
+	})
+
 	Context("Package-mode OS image rejection", func() {
 		seedDeviceWithOsMode := func(deviceName string, osMode *api.OsModeType) {
 			GinkgoHelper()

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -852,6 +852,38 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("SetDeviceServiceConditions", func() {
+		It("persists a changed service condition and skips write when unchanged", func() {
+			deviceName := "svc-conditions-device"
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			cond := api.Condition{
+				Type:    api.ConditionTypeDeviceSpecValid,
+				Status:  api.ConditionStatusTrue,
+				Reason:  "ok",
+				Message: "ok",
+			}
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterWrite, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(api.IsStatusConditionTrue(afterWrite.Status.Conditions, api.ConditionTypeDeviceSpecValid)).To(BeTrue())
+			rvAfterWrite := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
+
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterNoop, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(rvAfterWrite))
+		})
+	})
+
 	Context("Package-mode OS image rejection", func() {
 		seedDeviceWithOsMode := func(deviceName string, osMode *api.OsModeType) {
 			GinkgoHelper()

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -1569,37 +1569,6 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(renderedDevice.Spec.Os.Image).To(Equal("os"))
 		})
 
-		It("SetServiceConditions skips write and callback when conditions are unchanged", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-svc-conditions-noop", nil, nil, nil)
-
-			condition := domain.Condition{
-				Type:    domain.ConditionTypeDeviceSpecValid,
-				Status:  domain.ConditionStatusTrue,
-				Reason:  "Valid",
-				Message: "Valid",
-			}
-			callbackCalls := 0
-			callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
-				callbackCalls++
-			}
-
-			err := devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(callbackCalls).To(Equal(1))
-
-			afterWrite, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
-			Expect(err).ToNot(HaveOccurred())
-			resourceVersion := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
-
-			err = devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(callbackCalls).To(Equal(1))
-
-			afterNoop, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(resourceVersion))
-		})
-
 		It("UpdateRendered persists status in the same resource_version bump", func() {
 			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-render-status", nil, nil, nil)
 

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -352,7 +352,17 @@ var _ = Describe("FleetSelector", func() {
 			Expect(len(devices.Items)).To(Equal(7))
 			for _, device := range devices.Items {
 				condition := api.Condition{Type: api.ConditionTypeDeviceMultipleOwners, Status: api.ConditionStatusTrue, Message: "fleet2,fleet3"}
-				err = deviceStore.SetServiceConditions(ctx, orgId, *device.Metadata.Name, []api.Condition{condition}, nil)
+				_, _, _, err = deviceStore.Mutate(ctx, orgId, *device.Metadata.Name, nil, func(m *devicestore.DeviceMutation) error {
+					if err := m.RequireExisting(); err != nil {
+						return err
+					}
+					if m.Device.Status == nil {
+						st := api.NewDeviceStatus()
+						m.Device.Status = &st
+					}
+					api.SetStatusCondition(&m.Device.Status.Conditions, condition)
+					return nil
+				})
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -431,7 +441,17 @@ var _ = Describe("FleetSelector", func() {
 			noLabelsNoOwnerDevice := "nolabels-noowner"
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, noLabelsNoOwnerDevice, nil, nil, &map[string]string{})
 			condition := api.Condition{Type: api.ConditionTypeDeviceMultipleOwners, Status: api.ConditionStatusTrue, Message: "fleet1,fleet2"}
-			err := deviceStore.SetServiceConditions(ctx, orgId, noLabelsNoOwnerDevice, []api.Condition{condition}, nil)
+			_, _, _, err := deviceStore.Mutate(ctx, orgId, noLabelsNoOwnerDevice, nil, func(m *devicestore.DeviceMutation) error {
+				if err := m.RequireExisting(); err != nil {
+					return err
+				}
+				if m.Device.Status == nil {
+					st := api.NewDeviceStatus()
+					m.Device.Status = &st
+				}
+				api.SetStatusCondition(&m.Device.Status.Conditions, condition)
+				return nil
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			listParams := devicestore.DeviceListParams{ListParams: store.ListParams{Limit: 0}}


### PR DESCRIPTION
Jira: EDM4832-condition-merge-service
Recreated from fork (asafbennatan/flightctl → flightctl/flightctl).

Stack layer head: `asafbennatan:EDM-4832-condition-merge-service`
Base: `EDM-4830-device-decommission-service`

Made with [Cursor](https://cursor.com)