### PR TITLE
EDM-4833: Rendered-version / hash decisions in service

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -125,7 +125,7 @@ func (m *MockDevice) ProcessAwaitingReconnectAnnotation(ctx context.Context, org
 	return false, nil
 }
 
-func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
+func (m *MockDevice) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
 	return nil, nil
 }
 

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -82,7 +82,7 @@ func (m *MockDevice) MutateAnnotation(ctx context.Context, orgId uuid.UUID, name
 	_, err := mutate("")
 	return err
 }
-func (m *MockDevice) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (m *MockDevice) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (string, error) {
 	return "", nil
 }
 func (m *MockDevice) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {

--- a/internal/service/catalog/handler.go
+++ b/internal/service/catalog/handler.go
@@ -162,9 +162,10 @@ func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, nam
 		return nil
 	}
 
+	// Product rule: refuse deleting a non-empty catalog. The service chooses store.Delete
+	// (TX primitive that returns ErrResourceNotEmpty when items exist) and maps the error.
 	err = h.store.Delete(ctx, orgId, name, callback, h.callbackCatalogDeleted)
-	status := common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
-	return status
+	return common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.

--- a/internal/service/catalog/handler.go
+++ b/internal/service/catalog/handler.go
@@ -162,10 +162,9 @@ func (h *ServiceHandler) DeleteCatalog(ctx context.Context, orgId uuid.UUID, nam
 		return nil
 	}
 
-	// Product rule: refuse deleting a non-empty catalog. The service chooses store.Delete
-	// (TX primitive that returns ErrResourceNotEmpty when items exist) and maps the error.
 	err = h.store.Delete(ctx, orgId, name, callback, h.callbackCatalogDeleted)
-	return common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
+	status := common.StoreErrorToApiStatus(err, false, domain.CatalogKind, &name)
+	return status
 }
 
 // Only metadata.labels and spec can be patched. If we try to patch other fields, HTTP 400 Bad Request is returned.

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -110,6 +110,11 @@ func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name str
 	if !exists {
 		return flterrors.ErrResourceNotFound
 	}
+	for _, it := range f.items {
+		if it.Metadata.Catalog == name {
+			return flterrors.ErrResourceNotEmpty
+		}
+	}
 	delete(f.catalogs, name)
 	if callback != nil {
 		_ = callback(ctx, nil, orgId, name)

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -638,6 +638,36 @@ func TestDeleteCatalog(t *testing.T) {
 	}
 }
 
+func TestDeleteCatalogNonEmpty(t *testing.T) {
+	t.Run("When deleting a catalog that has items it should return conflict and leave the catalog", func(t *testing.T) {
+		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("catalog-with-items", nil)
+		fakeStore.catalogs["catalog-with-items"] = &catalog
+		item := createTestCatalogItem("catalog-with-items", "app-1", nil)
+		fakeStore.items[itemKey("catalog-with-items", "app-1")] = &item
+
+		status := h.DeleteCatalog(context.Background(), orgId, "catalog-with-items", true)
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrResourceNotEmpty.Error(), status.Message)
+		require.Contains(t, fakeStore.catalogs, "catalog-with-items")
+		require.Empty(t, fakeEvents.deleted)
+	})
+
+	t.Run("When deleting an empty catalog it should succeed and remove it", func(t *testing.T) {
+		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
+		catalog := createTestCatalog("empty-catalog", nil)
+		fakeStore.catalogs["empty-catalog"] = &catalog
+
+		status := h.DeleteCatalog(context.Background(), orgId, "empty-catalog", true)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotContains(t, fakeStore.catalogs, "empty-catalog")
+		require.Len(t, fakeEvents.deleted, 1)
+		require.Equal(t, "empty-catalog", fakeEvents.deleted[0].name)
+	})
+}
+
 func TestPatchCatalog(t *testing.T) {
 	t.Run("When the catalog does not exist it should return a not-found status", func(t *testing.T) {
 		h, _, _ := newTestHandler()

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -23,7 +23,7 @@ import (
 // internal/service/teststore_framework_test.go's DummyCatalog (which cannot be imported
 // directly since it lives in a _test.go file in a different package).
 type fakeCatalogStore struct {
-	catalogs map[string]*domain.Catalog
+	catalogs map[string]*domain.Catalog     // key: catalogKey(orgId, name)
 	items    map[string]*domain.CatalogItem // key: itemKey(orgId, catalogName, itemName)
 	err      error
 }
@@ -39,6 +39,10 @@ func itemKey(orgId uuid.UUID, catalogName, itemName string) string {
 	return orgId.String() + "/" + catalogName + "/" + itemName
 }
 
+func catalogKey(orgId uuid.UUID, name string) string {
+	return orgId.String() + "/" + name
+}
+
 func (f *fakeCatalogStore) InitialMigration(ctx context.Context) error { return f.err }
 
 func (f *fakeCatalogStore) Create(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, error) {
@@ -46,10 +50,11 @@ func (f *fakeCatalogStore) Create(ctx context.Context, orgId uuid.UUID, catalog 
 		return nil, f.err
 	}
 	name := lo.FromPtr(catalog.Metadata.Name)
-	if _, exists := f.catalogs[name]; exists {
+	key := catalogKey(orgId, name)
+	if _, exists := f.catalogs[key]; exists {
 		return nil, flterrors.ErrDuplicateName
 	}
-	f.catalogs[name] = catalog
+	f.catalogs[key] = catalog
 	if callbackEvent != nil {
 		callbackEvent(ctx, domain.CatalogKind, orgId, name, nil, catalog, true, nil)
 	}
@@ -61,7 +66,8 @@ func (f *fakeCatalogStore) Update(ctx context.Context, orgId uuid.UUID, catalog 
 		return nil, f.err
 	}
 	name := lo.FromPtr(catalog.Metadata.Name)
-	old, exists := f.catalogs[name]
+	key := catalogKey(orgId, name)
+	old, exists := f.catalogs[key]
 	if !exists {
 		return nil, flterrors.ErrResourceNotFound
 	}
@@ -70,7 +76,7 @@ func (f *fakeCatalogStore) Update(ctx context.Context, orgId uuid.UUID, catalog 
 	if catalog.Metadata.Owner == nil {
 		catalog.Metadata.Owner = old.Metadata.Owner
 	}
-	f.catalogs[name] = catalog
+	f.catalogs[key] = catalog
 	if callbackEvent != nil {
 		callbackEvent(ctx, domain.CatalogKind, orgId, name, old, catalog, false, nil)
 	}
@@ -79,7 +85,7 @@ func (f *fakeCatalogStore) Update(ctx context.Context, orgId uuid.UUID, catalog 
 
 func (f *fakeCatalogStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, catalog *domain.Catalog, callbackEvent store.EventCallback) (*domain.Catalog, bool, error) {
 	name := lo.FromPtr(catalog.Metadata.Name)
-	if _, exists := f.catalogs[name]; exists {
+	if _, exists := f.catalogs[catalogKey(orgId, name)]; exists {
 		result, err := f.Update(ctx, orgId, catalog, callbackEvent)
 		return result, false, err
 	}
@@ -91,7 +97,7 @@ func (f *fakeCatalogStore) Get(ctx context.Context, orgId uuid.UUID, name string
 	if f.err != nil {
 		return nil, f.err
 	}
-	c, ok := f.catalogs[name]
+	c, ok := f.catalogs[catalogKey(orgId, name)]
 	if !ok {
 		return nil, flterrors.ErrResourceNotFound
 	}
@@ -102,15 +108,19 @@ func (f *fakeCatalogStore) List(ctx context.Context, orgId uuid.UUID, listParams
 	if f.err != nil {
 		return nil, f.err
 	}
+	prefix := orgId.String() + "/"
 	items := make([]domain.Catalog, 0, len(f.catalogs))
-	for _, c := range f.catalogs {
-		items = append(items, *c)
+	for key, c := range f.catalogs {
+		if strings.HasPrefix(key, prefix) {
+			items = append(items, *c)
+		}
 	}
 	return &domain.CatalogList{Items: items}, nil
 }
 
 func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name string, callback store.RemoveOwnerCallback, callbackEvent store.EventCallback) error {
-	old, exists := f.catalogs[name]
+	ckey := catalogKey(orgId, name)
+	old, exists := f.catalogs[ckey]
 	if !exists {
 		return flterrors.ErrResourceNotFound
 	}
@@ -120,7 +130,7 @@ func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name str
 			return flterrors.ErrResourceNotEmpty
 		}
 	}
-	delete(f.catalogs, name)
+	delete(f.catalogs, ckey)
 	if callback != nil {
 		_ = callback(ctx, nil, orgId, name)
 	}
@@ -132,11 +142,12 @@ func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name str
 
 func (f *fakeCatalogStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, resource *domain.Catalog, eventCallback store.EventCallback) (*domain.Catalog, error) {
 	name := lo.FromPtr(resource.Metadata.Name)
-	old, exists := f.catalogs[name]
+	key := catalogKey(orgId, name)
+	old, exists := f.catalogs[key]
 	if !exists {
 		return nil, flterrors.ErrResourceNotFound
 	}
-	f.catalogs[name] = resource
+	f.catalogs[key] = resource
 	if eventCallback != nil {
 		eventCallback(ctx, domain.CatalogKind, orgId, name, old, resource, false, nil)
 	}
@@ -144,7 +155,17 @@ func (f *fakeCatalogStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, re
 }
 
 func (f *fakeCatalogStore) Count(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, error) {
-	return int64(len(f.catalogs)), f.err
+	if f.err != nil {
+		return 0, f.err
+	}
+	prefix := orgId.String() + "/"
+	var n int64
+	for key := range f.catalogs {
+		if strings.HasPrefix(key, prefix) {
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (f *fakeCatalogStore) UnsetOwner(ctx context.Context, tx *gorm.DB, orgId uuid.UUID, owner string) error {
@@ -170,7 +191,7 @@ func (f *fakeCatalogStore) ListAllItems(ctx context.Context, orgId uuid.UUID, li
 }
 
 func (f *fakeCatalogStore) ListItems(ctx context.Context, orgId uuid.UUID, catalogName string, listParams store.ListParams) (*domain.CatalogItemList, error) {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	prefix := orgId.String() + "/" + catalogName + "/"
@@ -184,7 +205,7 @@ func (f *fakeCatalogStore) ListItems(ctx context.Context, orgId uuid.UUID, catal
 }
 
 func (f *fakeCatalogStore) GetItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) (*domain.CatalogItem, error) {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	it, ok := f.items[itemKey(orgId, catalogName, itemName)]
@@ -195,7 +216,7 @@ func (f *fakeCatalogStore) GetItem(ctx context.Context, orgId uuid.UUID, catalog
 }
 
 func (f *fakeCatalogStore) CreateItem(ctx context.Context, orgId uuid.UUID, catalogName string, item *domain.CatalogItem) (*domain.CatalogItem, error) {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	item.Metadata.Catalog = catalogName
@@ -205,7 +226,7 @@ func (f *fakeCatalogStore) CreateItem(ctx context.Context, orgId uuid.UUID, cata
 }
 
 func (f *fakeCatalogStore) UpdateItem(ctx context.Context, orgId uuid.UUID, catalogName string, item *domain.CatalogItem) (*domain.CatalogItem, error) {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	key := itemKey(orgId, catalogName, lo.FromPtr(item.Metadata.Name))
@@ -224,7 +245,7 @@ func (f *fakeCatalogStore) UpdateItem(ctx context.Context, orgId uuid.UUID, cata
 }
 
 func (f *fakeCatalogStore) CreateOrUpdateItem(ctx context.Context, orgId uuid.UUID, catalogName string, item *domain.CatalogItem) (*domain.CatalogItem, bool, error) {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return nil, false, flterrors.ErrParentResourceNotFound
 	}
 	key := itemKey(orgId, catalogName, lo.FromPtr(item.Metadata.Name))
@@ -237,7 +258,7 @@ func (f *fakeCatalogStore) CreateOrUpdateItem(ctx context.Context, orgId uuid.UU
 }
 
 func (f *fakeCatalogStore) DeleteItem(ctx context.Context, orgId uuid.UUID, catalogName string, itemName string) error {
-	if _, ok := f.catalogs[catalogName]; !ok {
+	if _, ok := f.catalogs[catalogKey(orgId, catalogName)]; !ok {
 		return flterrors.ErrParentResourceNotFound
 	}
 	key := itemKey(orgId, catalogName, itemName)
@@ -325,12 +346,13 @@ func createTestCatalogItem(catalogName, itemName string, owner *string) domain.C
 func TestCreateCatalog(t *testing.T) {
 	t.Run("When the catalog is valid it should create it and fire an updated callback", func(t *testing.T) {
 		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 
-		result, status := h.CreateCatalog(context.Background(), uuid.New(), catalog)
+		result, status := h.CreateCatalog(context.Background(), orgId, catalog)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
-		require.Contains(t, fakeStore.catalogs, "c1")
+		require.Contains(t, fakeStore.catalogs, catalogKey(orgId, "c1"))
 		require.Len(t, fakeEvents.created, 1)
 		require.Equal(t, domain.EventReasonResourceCreated, fakeEvents.created[0].Reason)
 	})
@@ -345,36 +367,39 @@ func TestCreateCatalog(t *testing.T) {
 
 	t.Run("When managed metadata fields are set by the caller CreateCatalogFromUntrusted should clear them before creation", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c4", nil)
 		catalog.Metadata.Owner = lo.ToPtr("someone")
 		catalog.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := CreateCatalogFromUntrusted(context.Background(), h, uuid.New(), catalog)
+		_, status := CreateCatalogFromUntrusted(context.Background(), h, orgId, catalog)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Nil(t, fakeStore.catalogs["c4"].Metadata.Owner)
-		require.Nil(t, fakeStore.catalogs["c4"].Metadata.Generation)
+		require.Nil(t, fakeStore.catalogs[catalogKey(orgId, "c4")].Metadata.Owner)
+		require.Nil(t, fakeStore.catalogs[catalogKey(orgId, "c4")].Metadata.Generation)
 	})
 
 	t.Run("When managed metadata fields are set by the caller CreateCatalog (trusted) should preserve them", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c4-trusted", nil)
 		catalog.Metadata.Owner = lo.ToPtr("someone")
 		catalog.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := h.CreateCatalog(context.Background(), uuid.New(), catalog)
+		_, status := h.CreateCatalog(context.Background(), orgId, catalog)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs["c4-trusted"].Metadata.Owner))
-		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs["c4-trusted"].Metadata.Generation))
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "c4-trusted")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "c4-trusted")].Metadata.Generation))
 	})
 }
 
 func TestListCatalogs(t *testing.T) {
 	t.Run("When the store succeeds it should return the list with StatusOK", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		c := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &c
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &c
 
-		result, status := h.ListCatalogs(context.Background(), uuid.New(), domain.ListCatalogsParams{})
+		result, status := h.ListCatalogs(context.Background(), orgId, domain.ListCatalogsParams{})
 		require.Equal(t, domain.StatusOK(), status)
 		require.Len(t, result.Items, 1)
 	})
@@ -391,10 +416,11 @@ func TestListCatalogs(t *testing.T) {
 func TestGetCatalog(t *testing.T) {
 	t.Run("When the catalog exists it should return it with StatusOK", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		c := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &c
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &c
 
-		result, status := h.GetCatalog(context.Background(), uuid.New(), "c1")
+		result, status := h.GetCatalog(context.Background(), orgId, "c1")
 		require.Equal(t, domain.StatusOK(), status)
 		require.Equal(t, "c1", lo.FromPtr(result.Metadata.Name))
 	})
@@ -410,12 +436,13 @@ func TestGetCatalog(t *testing.T) {
 func TestReplaceCatalog(t *testing.T) {
 	t.Run("When the catalog does not exist it should create it", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("new-catalog", nil)
 
-		result, status := h.ReplaceCatalog(context.Background(), uuid.New(), "new-catalog", catalog, true)
+		result, status := h.ReplaceCatalog(context.Background(), orgId, "new-catalog", catalog, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
-		require.Contains(t, fakeStore.catalogs, "new-catalog")
+		require.Contains(t, fakeStore.catalogs, catalogKey(orgId, "new-catalog"))
 	})
 
 	t.Run("When the name in the path does not match metadata.name it should return a bad-request status", func(t *testing.T) {
@@ -436,7 +463,7 @@ func TestReplaceCatalog(t *testing.T) {
 		result, status := h.ReplaceCatalog(context.Background(), orgId, "c1", catalog, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Contains(t, fakeStore.catalogs, "c1")
+		require.Contains(t, fakeStore.catalogs, catalogKey(orgId, "c1"))
 		// Only the create produces a ResourceCreated event; replacing with identical
 		// metadata (no generation/labels/owner change) emits nothing further.
 		require.Len(t, fakeEvents.created, 1)
@@ -452,8 +479,8 @@ func TestReplaceCatalog(t *testing.T) {
 
 		_, status := ReplaceCatalogFromUntrusted(context.Background(), h, orgId, "replace-untrusted", catalog, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Nil(t, fakeStore.catalogs["replace-untrusted"].Metadata.Owner)
-		require.Nil(t, fakeStore.catalogs["replace-untrusted"].Metadata.Generation)
+		require.Nil(t, fakeStore.catalogs[catalogKey(orgId, "replace-untrusted")].Metadata.Owner)
+		require.Nil(t, fakeStore.catalogs[catalogKey(orgId, "replace-untrusted")].Metadata.Generation)
 	})
 
 	t.Run("When managed metadata fields are set by the caller ReplaceCatalog (trusted) should preserve them", func(t *testing.T) {
@@ -465,8 +492,8 @@ func TestReplaceCatalog(t *testing.T) {
 
 		_, status := h.ReplaceCatalog(context.Background(), orgId, "replace-trusted", catalog, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs["replace-trusted"].Metadata.Owner))
-		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs["replace-trusted"].Metadata.Generation))
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "replace-trusted")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "replace-trusted")].Metadata.Generation))
 	})
 }
 
@@ -477,7 +504,7 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "owned-catalog")] = &existing
 
 		updated := createTestCatalog("owned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
@@ -491,7 +518,7 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "owned-catalog")] = &existing
 
 		updated := createTestCatalog("owned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
@@ -499,15 +526,15 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		result, status := h.ReplaceCatalog(context.Background(), orgId, "owned-catalog", updated, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
-		require.Equal(t, owner, lo.FromPtr(fakeStore.catalogs["owned-catalog"].Metadata.Owner))
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "owned-catalog")].Spec.DisplayName))
+		require.Equal(t, owner, lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "owned-catalog")].Metadata.Owner))
 	})
 
 	t.Run("When replacing an unowned catalog with a changed spec it should allow the update", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		existing := createTestCatalog("unowned-catalog", nil)
-		fakeStore.catalogs["unowned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "unowned-catalog")] = &existing
 
 		updated := createTestCatalog("unowned-catalog", nil)
 		updated.Spec.DisplayName = lo.ToPtr("Changed Name")
@@ -515,7 +542,7 @@ func TestReplaceCatalogOwnership(t *testing.T) {
 		result, status := h.ReplaceCatalog(context.Background(), orgId, "unowned-catalog", updated, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["unowned-catalog"].Spec.DisplayName))
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "unowned-catalog")].Spec.DisplayName))
 	})
 }
 
@@ -524,41 +551,44 @@ func TestPatchCatalogOwnership(t *testing.T) {
 
 	t.Run("When patching an owned catalog spec it should return conflict", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "owned-catalog")] = &existing
 
 		var valueIface interface{} = "Changed Name"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
 
-		_, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, true)
+		_, status := h.PatchCatalog(context.Background(), orgId, "owned-catalog", patch, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
 	})
 
 	t.Run("When enforceOwnership is false it should allow patching an owned catalog", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "owned-catalog")] = &existing
 
 		var valueIface interface{} = "Changed Name"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/displayName", Value: &valueIface}}
 
-		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, false)
+		result, status := h.PatchCatalog(context.Background(), orgId, "owned-catalog", patch, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs["owned-catalog"].Spec.DisplayName))
-		require.Equal(t, owner, lo.FromPtr(fakeStore.catalogs["owned-catalog"].Metadata.Owner))
+		require.Equal(t, "Changed Name", lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "owned-catalog")].Spec.DisplayName))
+		require.Equal(t, owner, lo.FromPtr(fakeStore.catalogs[catalogKey(orgId, "owned-catalog")].Metadata.Owner))
 	})
 
 	t.Run("When patching an owned catalog labels it should allow the update", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		existing := createTestCatalog("owned-catalog", &owner)
-		fakeStore.catalogs["owned-catalog"] = &existing
+		fakeStore.catalogs[catalogKey(orgId, "owned-catalog")] = &existing
 
 		var valueIface interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &valueIface}}
 
-		result, status := h.PatchCatalog(context.Background(), uuid.New(), "owned-catalog", patch, true)
+		result, status := h.PatchCatalog(context.Background(), orgId, "owned-catalog", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 	})
@@ -623,7 +653,7 @@ func TestDeleteCatalog(t *testing.T) {
 
 			if tt.createCatalog {
 				catalog := createTestCatalog(tt.catalogName, tt.catalogOwner)
-				fakeStore.catalogs[tt.catalogName] = &catalog
+				fakeStore.catalogs[catalogKey(testOrgId, tt.catalogName)] = &catalog
 			}
 
 			status := h.DeleteCatalog(ctx, testOrgId, tt.catalogName, tt.enforceOwnership)
@@ -633,7 +663,7 @@ func TestDeleteCatalog(t *testing.T) {
 				require.Equal(t, tt.expectedError.Error(), status.Message)
 			}
 
-			_, ok := fakeStore.catalogs[tt.catalogName]
+			_, ok := fakeStore.catalogs[catalogKey(testOrgId, tt.catalogName)]
 			require.Equal(t, !tt.expectCatalogDeleted, ok)
 
 			// Verify the deletion callback wiring survived extraction: a successful delete
@@ -653,14 +683,14 @@ func TestDeleteCatalogNonEmpty(t *testing.T) {
 		h, fakeStore, fakeEvents := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("catalog-with-items", nil)
-		fakeStore.catalogs["catalog-with-items"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "catalog-with-items")] = &catalog
 		item := createTestCatalogItem("catalog-with-items", "app-1", nil)
 		fakeStore.items[itemKey(orgId, "catalog-with-items", "app-1")] = &item
 
 		status := h.DeleteCatalog(context.Background(), orgId, "catalog-with-items", true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrResourceNotEmpty.Error(), status.Message)
-		require.Contains(t, fakeStore.catalogs, "catalog-with-items")
+		require.Contains(t, fakeStore.catalogs, catalogKey(orgId, "catalog-with-items"))
 		require.Empty(t, fakeEvents.deleted)
 	})
 
@@ -669,25 +699,32 @@ func TestDeleteCatalogNonEmpty(t *testing.T) {
 		orgId := uuid.New()
 		otherOrgId := uuid.New()
 		catalog := createTestCatalog("shared-name", nil)
-		fakeStore.catalogs["shared-name"] = &catalog
+		otherCatalog := createTestCatalog("shared-name", nil)
+		fakeStore.catalogs[catalogKey(orgId, "shared-name")] = &catalog
+		fakeStore.catalogs[catalogKey(otherOrgId, "shared-name")] = &otherCatalog
 		item := createTestCatalogItem("shared-name", "app-1", nil)
 		fakeStore.items[itemKey(otherOrgId, "shared-name", "app-1")] = &item
 
 		status := h.DeleteCatalog(context.Background(), orgId, "shared-name", true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
-		require.NotContains(t, fakeStore.catalogs, "shared-name")
+		require.NotContains(t, fakeStore.catalogs, catalogKey(orgId, "shared-name"))
+		require.Contains(t, fakeStore.catalogs, catalogKey(otherOrgId, "shared-name"))
 		require.Len(t, fakeEvents.deleted, 1)
+
+		got, getStatus := h.GetCatalogItem(context.Background(), otherOrgId, "shared-name", "app-1")
+		require.Equal(t, domain.StatusOK(), getStatus)
+		require.Equal(t, "app-1", lo.FromPtr(got.Metadata.Name))
 	})
 
 	t.Run("When deleting an empty catalog it should succeed and remove it", func(t *testing.T) {
 		h, fakeStore, fakeEvents := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("empty-catalog", nil)
-		fakeStore.catalogs["empty-catalog"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "empty-catalog")] = &catalog
 
 		status := h.DeleteCatalog(context.Background(), orgId, "empty-catalog", true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
-		require.NotContains(t, fakeStore.catalogs, "empty-catalog")
+		require.NotContains(t, fakeStore.catalogs, catalogKey(orgId, "empty-catalog"))
 		require.Len(t, fakeEvents.deleted, 1)
 		require.Equal(t, "empty-catalog", fakeEvents.deleted[0].name)
 	})
@@ -705,13 +742,14 @@ func TestPatchCatalog(t *testing.T) {
 
 	t.Run("When the patch is valid it should apply it and fire an updated callback", func(t *testing.T) {
 		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 
 		var value interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &value}}
 
-		result, status := h.PatchCatalog(context.Background(), uuid.New(), "c1", patch, true)
+		result, status := h.PatchCatalog(context.Background(), orgId, "c1", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		require.Len(t, fakeEvents.created, 1)
@@ -721,10 +759,11 @@ func TestPatchCatalog(t *testing.T) {
 
 func TestGetCatalogStatus(t *testing.T) {
 	h, fakeStore, _ := newTestHandler()
+	orgId := uuid.New()
 	catalog := createTestCatalog("c1", nil)
-	fakeStore.catalogs["c1"] = &catalog
+	fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 
-	result, status := h.GetCatalogStatus(context.Background(), uuid.New(), "c1")
+	result, status := h.GetCatalogStatus(context.Background(), orgId, "c1")
 	require.Equal(t, domain.StatusOK(), status)
 	require.Equal(t, "c1", lo.FromPtr(result.Metadata.Name))
 }
@@ -732,10 +771,11 @@ func TestGetCatalogStatus(t *testing.T) {
 func TestReplaceCatalogStatus(t *testing.T) {
 	t.Run("When the catalog exists it should update its status", func(t *testing.T) {
 		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 
-		result, status := h.ReplaceCatalogStatus(context.Background(), uuid.New(), "c1", catalog)
+		result, status := h.ReplaceCatalogStatus(context.Background(), orgId, "c1", catalog)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 		// Replacing the status with an otherwise-identical catalog doesn't touch
@@ -768,7 +808,7 @@ func TestListAllCatalogItems(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
@@ -791,7 +831,7 @@ func TestListCatalogItems(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
@@ -813,7 +853,7 @@ func TestGetCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
@@ -831,10 +871,11 @@ func TestGetCatalogItem(t *testing.T) {
 
 	t.Run("When the item does not exist it should return a not-found status", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 
-		_, status := h.GetCatalogItem(context.Background(), uuid.New(), "c1", "missing-item")
+		_, status := h.GetCatalogItem(context.Background(), orgId, "c1", "missing-item")
 		require.Equal(t, int32(http.StatusNotFound), status.Code)
 	})
 }
@@ -844,7 +885,7 @@ func TestCreateCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 
 		result, status := h.CreateCatalogItem(context.Background(), orgId, "c1", item)
@@ -865,7 +906,7 @@ func TestCreateCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i2", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
@@ -880,7 +921,7 @@ func TestCreateCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i3", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
@@ -896,25 +937,27 @@ func TestReplaceCatalogItem(t *testing.T) {
 	// Creating a new item via Replace should always succeed (no existing owner to check).
 	t.Run("When the item does not exist it should create it", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalogName := "test-catalog"
 		itemName := "new-item"
 
 		catalog := createTestCatalog(catalogName, nil)
-		fakeStore.catalogs[catalogName] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, catalogName)] = &catalog
 
 		item := createTestCatalogItem(catalogName, itemName, nil)
-		result, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), catalogName, itemName, item, true)
+		result, status := h.ReplaceCatalogItem(context.Background(), orgId, catalogName, itemName, item, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
 	})
 
 	t.Run("When the name in the path does not match metadata.name it should return a bad-request status", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 
-		_, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "different-item", item, true)
+		_, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "different-item", item, true)
 		require.Equal(t, int32(http.StatusBadRequest), status.Code)
 	})
 
@@ -922,7 +965,7 @@ func TestReplaceCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "replace-untrusted", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
@@ -937,7 +980,7 @@ func TestReplaceCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "replace-trusted", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
@@ -956,7 +999,7 @@ func TestReplaceCatalogItemOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		existing := createTestCatalogItem("c1", "owned-item", &owner)
 		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &existing
 
@@ -973,7 +1016,7 @@ func TestReplaceCatalogItemOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		existing := createTestCatalogItem("c1", "owned-item", &owner)
 		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &existing
 
@@ -991,7 +1034,7 @@ func TestReplaceCatalogItemOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		existing := createTestCatalogItem("c1", "unowned-item", nil)
 		fakeStore.items[itemKey(orgId, "c1", "unowned-item")] = &existing
 
@@ -1019,7 +1062,7 @@ func TestPatchCatalogItem(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
@@ -1039,7 +1082,7 @@ func TestPatchCatalogItemOwnership(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
 		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
-		fakeStore.catalogs["c1"] = &catalog
+		fakeStore.catalogs[catalogKey(orgId, "c1")] = &catalog
 		item := createTestCatalogItem("c1", "owned-item", &owner)
 		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &item
 		return h, fakeStore, orgId
@@ -1132,7 +1175,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 			testOrgId := uuid.New()
 
 			catalog := createTestCatalog(tt.catalogName, nil)
-			fakeStore.catalogs[tt.catalogName] = &catalog
+			fakeStore.catalogs[catalogKey(testOrgId, tt.catalogName)] = &catalog
 
 			if tt.createItem {
 				item := createTestCatalogItem(tt.catalogName, tt.itemName, tt.itemOwner)

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -23,8 +24,7 @@ import (
 // directly since it lives in a _test.go file in a different package).
 type fakeCatalogStore struct {
 	catalogs map[string]*domain.Catalog
-	items    map[string]*domain.CatalogItem // key: itemKey(catalogName, itemName)
-	itemOrgs map[string]uuid.UUID           // key: itemKey(catalogName, itemName) -> org that owns the item
+	items    map[string]*domain.CatalogItem // key: itemKey(orgId, catalogName, itemName)
 	err      error
 }
 
@@ -32,12 +32,11 @@ func newFakeCatalogStore() *fakeCatalogStore {
 	return &fakeCatalogStore{
 		catalogs: map[string]*domain.Catalog{},
 		items:    map[string]*domain.CatalogItem{},
-		itemOrgs: map[string]uuid.UUID{},
 	}
 }
 
-func itemKey(catalogName, itemName string) string {
-	return catalogName + "/" + itemName
+func itemKey(orgId uuid.UUID, catalogName, itemName string) string {
+	return orgId.String() + "/" + catalogName + "/" + itemName
 }
 
 func (f *fakeCatalogStore) InitialMigration(ctx context.Context) error { return f.err }
@@ -115,8 +114,9 @@ func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name str
 	if !exists {
 		return flterrors.ErrResourceNotFound
 	}
-	for key, it := range f.items {
-		if it.Metadata.Catalog == name && f.itemOrgs[key] == orgId {
+	prefix := orgId.String() + "/" + name + "/"
+	for key := range f.items {
+		if strings.HasPrefix(key, prefix) {
 			return flterrors.ErrResourceNotEmpty
 		}
 	}
@@ -159,9 +159,12 @@ func (f *fakeCatalogStore) ListAllItems(ctx context.Context, orgId uuid.UUID, li
 	if f.err != nil {
 		return nil, f.err
 	}
+	prefix := orgId.String() + "/"
 	items := make([]domain.CatalogItem, 0, len(f.items))
-	for _, it := range f.items {
-		items = append(items, *it)
+	for key, it := range f.items {
+		if strings.HasPrefix(key, prefix) {
+			items = append(items, *it)
+		}
 	}
 	return &domain.CatalogItemList{Items: items}, nil
 }
@@ -170,9 +173,10 @@ func (f *fakeCatalogStore) ListItems(ctx context.Context, orgId uuid.UUID, catal
 	if _, ok := f.catalogs[catalogName]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
+	prefix := orgId.String() + "/" + catalogName + "/"
 	items := make([]domain.CatalogItem, 0)
-	for _, it := range f.items {
-		if it.Metadata.Catalog == catalogName {
+	for key, it := range f.items {
+		if strings.HasPrefix(key, prefix) {
 			items = append(items, *it)
 		}
 	}
@@ -183,7 +187,7 @@ func (f *fakeCatalogStore) GetItem(ctx context.Context, orgId uuid.UUID, catalog
 	if _, ok := f.catalogs[catalogName]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
-	it, ok := f.items[itemKey(catalogName, itemName)]
+	it, ok := f.items[itemKey(orgId, catalogName, itemName)]
 	if !ok {
 		return nil, flterrors.ErrResourceNotFound
 	}
@@ -195,9 +199,8 @@ func (f *fakeCatalogStore) CreateItem(ctx context.Context, orgId uuid.UUID, cata
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	item.Metadata.Catalog = catalogName
-	key := itemKey(catalogName, lo.FromPtr(item.Metadata.Name))
+	key := itemKey(orgId, catalogName, lo.FromPtr(item.Metadata.Name))
 	f.items[key] = item
-	f.itemOrgs[key] = orgId
 	return item, nil
 }
 
@@ -205,7 +208,7 @@ func (f *fakeCatalogStore) UpdateItem(ctx context.Context, orgId uuid.UUID, cata
 	if _, ok := f.catalogs[catalogName]; !ok {
 		return nil, flterrors.ErrParentResourceNotFound
 	}
-	key := itemKey(catalogName, lo.FromPtr(item.Metadata.Name))
+	key := itemKey(orgId, catalogName, lo.FromPtr(item.Metadata.Name))
 	old, ok := f.items[key]
 	if !ok {
 		return nil, flterrors.ErrResourceNotFound
@@ -224,7 +227,7 @@ func (f *fakeCatalogStore) CreateOrUpdateItem(ctx context.Context, orgId uuid.UU
 	if _, ok := f.catalogs[catalogName]; !ok {
 		return nil, false, flterrors.ErrParentResourceNotFound
 	}
-	key := itemKey(catalogName, lo.FromPtr(item.Metadata.Name))
+	key := itemKey(orgId, catalogName, lo.FromPtr(item.Metadata.Name))
 	if _, ok := f.items[key]; ok {
 		result, err := f.UpdateItem(ctx, orgId, catalogName, item)
 		return result, false, err
@@ -237,12 +240,11 @@ func (f *fakeCatalogStore) DeleteItem(ctx context.Context, orgId uuid.UUID, cata
 	if _, ok := f.catalogs[catalogName]; !ok {
 		return flterrors.ErrParentResourceNotFound
 	}
-	key := itemKey(catalogName, itemName)
+	key := itemKey(orgId, catalogName, itemName)
 	if _, ok := f.items[key]; !ok {
 		return flterrors.ErrResourceNotFound
 	}
 	delete(f.items, key)
-	delete(f.itemOrgs, key)
 	return nil
 }
 
@@ -653,9 +655,7 @@ func TestDeleteCatalogNonEmpty(t *testing.T) {
 		catalog := createTestCatalog("catalog-with-items", nil)
 		fakeStore.catalogs["catalog-with-items"] = &catalog
 		item := createTestCatalogItem("catalog-with-items", "app-1", nil)
-		key := itemKey("catalog-with-items", "app-1")
-		fakeStore.items[key] = &item
-		fakeStore.itemOrgs[key] = orgId
+		fakeStore.items[itemKey(orgId, "catalog-with-items", "app-1")] = &item
 
 		status := h.DeleteCatalog(context.Background(), orgId, "catalog-with-items", true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
@@ -671,9 +671,7 @@ func TestDeleteCatalogNonEmpty(t *testing.T) {
 		catalog := createTestCatalog("shared-name", nil)
 		fakeStore.catalogs["shared-name"] = &catalog
 		item := createTestCatalogItem("shared-name", "app-1", nil)
-		key := itemKey("shared-name", "app-1")
-		fakeStore.items[key] = &item
-		fakeStore.itemOrgs[key] = otherOrgId
+		fakeStore.items[itemKey(otherOrgId, "shared-name", "app-1")] = &item
 
 		status := h.DeleteCatalog(context.Background(), orgId, "shared-name", true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
@@ -768,12 +766,13 @@ func TestPatchCatalogStatus(t *testing.T) {
 func TestListAllCatalogItems(t *testing.T) {
 	t.Run("When the store succeeds it should return the list with StatusOK", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
-		fakeStore.items[itemKey("c1", "i1")] = &item
+		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
-		result, status := h.ListAllCatalogItems(context.Background(), uuid.New(), domain.ListAllCatalogItemsParams{})
+		result, status := h.ListAllCatalogItems(context.Background(), orgId, domain.ListAllCatalogItemsParams{})
 		require.Equal(t, domain.StatusOK(), status)
 		require.Len(t, result.Items, 1)
 	})
@@ -790,12 +789,13 @@ func TestListAllCatalogItems(t *testing.T) {
 func TestListCatalogItems(t *testing.T) {
 	t.Run("When the catalog exists it should return its items with StatusOK", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
-		fakeStore.items[itemKey("c1", "i1")] = &item
+		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
-		result, status := h.ListCatalogItems(context.Background(), uuid.New(), "c1", domain.ListCatalogItemsParams{})
+		result, status := h.ListCatalogItems(context.Background(), orgId, "c1", domain.ListCatalogItemsParams{})
 		require.Equal(t, domain.StatusOK(), status)
 		require.Len(t, result.Items, 1)
 	})
@@ -811,12 +811,13 @@ func TestListCatalogItems(t *testing.T) {
 func TestGetCatalogItem(t *testing.T) {
 	t.Run("When the item exists it should return it with StatusOK", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
-		fakeStore.items[itemKey("c1", "i1")] = &item
+		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
-		result, status := h.GetCatalogItem(context.Background(), uuid.New(), "c1", "i1")
+		result, status := h.GetCatalogItem(context.Background(), orgId, "c1", "i1")
 		require.Equal(t, domain.StatusOK(), status)
 		require.Equal(t, "i1", lo.FromPtr(result.Metadata.Name))
 	})
@@ -841,14 +842,15 @@ func TestGetCatalogItem(t *testing.T) {
 func TestCreateCatalogItem(t *testing.T) {
 	t.Run("When the item is valid it should create it", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
 
-		result, status := h.CreateCatalogItem(context.Background(), uuid.New(), "c1", item)
+		result, status := h.CreateCatalogItem(context.Background(), orgId, "c1", item)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
 		require.NotNil(t, result)
-		require.Contains(t, fakeStore.items, itemKey("c1", "i1"))
+		require.Contains(t, fakeStore.items, itemKey(orgId, "c1", "i1"))
 	})
 
 	t.Run("When the parent catalog does not exist it should return a not-found status", func(t *testing.T) {
@@ -861,30 +863,32 @@ func TestCreateCatalogItem(t *testing.T) {
 
 	t.Run("When managed metadata fields are set by the caller CreateCatalogItemFromUntrusted should clear them before creation", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i2", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := CreateCatalogItemFromUntrusted(context.Background(), h, uuid.New(), "c1", item)
+		_, status := CreateCatalogItemFromUntrusted(context.Background(), h, orgId, "c1", item)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Nil(t, fakeStore.items[itemKey("c1", "i2")].Metadata.Owner)
-		require.Nil(t, fakeStore.items[itemKey("c1", "i2")].Metadata.Generation)
+		require.Nil(t, fakeStore.items[itemKey(orgId, "c1", "i2")].Metadata.Owner)
+		require.Nil(t, fakeStore.items[itemKey(orgId, "c1", "i2")].Metadata.Generation)
 	})
 
 	t.Run("When managed metadata fields are set by the caller CreateCatalogItem (trusted) should preserve them", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i3", nil)
 		item.Metadata.Owner = lo.ToPtr("someone")
 		item.Metadata.Generation = lo.ToPtr(int64(5))
 
-		_, status := h.CreateCatalogItem(context.Background(), uuid.New(), "c1", item)
+		_, status := h.CreateCatalogItem(context.Background(), orgId, "c1", item)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey("c1", "i3")].Metadata.Owner))
-		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey("c1", "i3")].Metadata.Generation))
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "i3")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "i3")].Metadata.Generation))
 	})
 }
 
@@ -925,8 +929,8 @@ func TestReplaceCatalogItem(t *testing.T) {
 
 		_, status := ReplaceCatalogItemFromUntrusted(context.Background(), h, orgId, "c1", "replace-untrusted", item, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Nil(t, fakeStore.items[itemKey("c1", "replace-untrusted")].Metadata.Owner)
-		require.Nil(t, fakeStore.items[itemKey("c1", "replace-untrusted")].Metadata.Generation)
+		require.Nil(t, fakeStore.items[itemKey(orgId, "c1", "replace-untrusted")].Metadata.Owner)
+		require.Nil(t, fakeStore.items[itemKey(orgId, "c1", "replace-untrusted")].Metadata.Generation)
 	})
 
 	t.Run("When managed metadata fields are set by the caller ReplaceCatalogItem (trusted) should preserve them", func(t *testing.T) {
@@ -940,8 +944,8 @@ func TestReplaceCatalogItem(t *testing.T) {
 
 		_, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "replace-trusted", item, true)
 		require.Equal(t, int32(http.StatusCreated), status.Code)
-		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey("c1", "replace-trusted")].Metadata.Owner))
-		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey("c1", "replace-trusted")].Metadata.Generation))
+		require.Equal(t, "someone", lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "replace-trusted")].Metadata.Owner))
+		require.Equal(t, int64(5), lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "replace-trusted")].Metadata.Generation))
 	})
 }
 
@@ -950,51 +954,54 @@ func TestReplaceCatalogItemOwnership(t *testing.T) {
 
 	t.Run("When replacing an owned item with a changed spec it should return conflict", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		existing := createTestCatalogItem("c1", "owned-item", &owner)
-		fakeStore.items[itemKey("c1", "owned-item")] = &existing
+		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &existing
 
 		updated := createTestCatalogItem("c1", "owned-item", nil)
 		updated.Spec.Artifacts[0].Uri = "quay.io/example/changed"
 
-		_, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "owned-item", updated, true)
+		_, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "owned-item", updated, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
-		require.Equal(t, "quay.io/example/app", fakeStore.items[itemKey("c1", "owned-item")].Spec.Artifacts[0].Uri)
+		require.Equal(t, "quay.io/example/app", fakeStore.items[itemKey(orgId, "c1", "owned-item")].Spec.Artifacts[0].Uri)
 	})
 
 	t.Run("When enforceOwnership is false it should allow updating an owned item", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		existing := createTestCatalogItem("c1", "owned-item", &owner)
-		fakeStore.items[itemKey("c1", "owned-item")] = &existing
+		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &existing
 
 		updated := createTestCatalogItem("c1", "owned-item", nil)
 		updated.Spec.Artifacts[0].Uri = "quay.io/example/changed"
 
-		result, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "owned-item", updated, false)
+		result, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "owned-item", updated, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey("c1", "owned-item")].Spec.Artifacts[0].Uri)
-		require.Equal(t, owner, lo.FromPtr(fakeStore.items[itemKey("c1", "owned-item")].Metadata.Owner))
+		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey(orgId, "c1", "owned-item")].Spec.Artifacts[0].Uri)
+		require.Equal(t, owner, lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "owned-item")].Metadata.Owner))
 	})
 
 	t.Run("When replacing an unowned item with a changed spec it should allow the update", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		existing := createTestCatalogItem("c1", "unowned-item", nil)
-		fakeStore.items[itemKey("c1", "unowned-item")] = &existing
+		fakeStore.items[itemKey(orgId, "c1", "unowned-item")] = &existing
 
 		updated := createTestCatalogItem("c1", "unowned-item", nil)
 		updated.Spec.Artifacts[0].Uri = "quay.io/example/changed"
 
-		result, status := h.ReplaceCatalogItem(context.Background(), uuid.New(), "c1", "unowned-item", updated, true)
+		result, status := h.ReplaceCatalogItem(context.Background(), orgId, "c1", "unowned-item", updated, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey("c1", "unowned-item")].Spec.Artifacts[0].Uri)
+		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey(orgId, "c1", "unowned-item")].Spec.Artifacts[0].Uri)
 	})
 }
 
@@ -1010,15 +1017,16 @@ func TestPatchCatalogItem(t *testing.T) {
 
 	t.Run("When the patch is valid it should apply it", func(t *testing.T) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "i1", nil)
-		fakeStore.items[itemKey("c1", "i1")] = &item
+		fakeStore.items[itemKey(orgId, "c1", "i1")] = &item
 
 		var value interface{} = map[string]string{"env": "prod"}
 		patch := domain.PatchRequest{{Op: "replace", Path: "/metadata/labels", Value: &value}}
 
-		result, status := h.PatchCatalogItem(context.Background(), uuid.New(), "c1", "i1", patch, true)
+		result, status := h.PatchCatalogItem(context.Background(), orgId, "c1", "i1", patch, true)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
 	})
@@ -1027,36 +1035,37 @@ func TestPatchCatalogItem(t *testing.T) {
 func TestPatchCatalogItemOwnership(t *testing.T) {
 	owner := "ResourceSync/my-resourcesync"
 
-	setup := func(t *testing.T) (*ServiceHandler, *fakeCatalogStore) {
+	setup := func(t *testing.T) (*ServiceHandler, *fakeCatalogStore, uuid.UUID) {
 		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
 		catalog := createTestCatalog("c1", nil)
 		fakeStore.catalogs["c1"] = &catalog
 		item := createTestCatalogItem("c1", "owned-item", &owner)
-		fakeStore.items[itemKey("c1", "owned-item")] = &item
-		return h, fakeStore
+		fakeStore.items[itemKey(orgId, "c1", "owned-item")] = &item
+		return h, fakeStore, orgId
 	}
 
 	t.Run("When patching an owned item spec it should return conflict", func(t *testing.T) {
-		h, fakeStore := setup(t)
+		h, fakeStore, orgId := setup(t)
 		var value interface{} = "quay.io/example/changed"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/artifacts/0/uri", Value: &value}}
 
-		_, status := h.PatchCatalogItem(context.Background(), uuid.New(), "c1", "owned-item", patch, true)
+		_, status := h.PatchCatalogItem(context.Background(), orgId, "c1", "owned-item", patch, true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error(), status.Message)
-		require.Equal(t, "quay.io/example/app", fakeStore.items[itemKey("c1", "owned-item")].Spec.Artifacts[0].Uri)
+		require.Equal(t, "quay.io/example/app", fakeStore.items[itemKey(orgId, "c1", "owned-item")].Spec.Artifacts[0].Uri)
 	})
 
 	t.Run("When enforceOwnership is false it should allow patching an owned item", func(t *testing.T) {
-		h, fakeStore := setup(t)
+		h, fakeStore, orgId := setup(t)
 		var value interface{} = "quay.io/example/changed"
 		patch := domain.PatchRequest{{Op: "replace", Path: "/spec/artifacts/0/uri", Value: &value}}
 
-		result, status := h.PatchCatalogItem(context.Background(), uuid.New(), "c1", "owned-item", patch, false)
+		result, status := h.PatchCatalogItem(context.Background(), orgId, "c1", "owned-item", patch, false)
 		require.Equal(t, int32(http.StatusOK), status.Code)
 		require.NotNil(t, result)
-		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey("c1", "owned-item")].Spec.Artifacts[0].Uri)
-		require.Equal(t, owner, lo.FromPtr(fakeStore.items[itemKey("c1", "owned-item")].Metadata.Owner))
+		require.Equal(t, "quay.io/example/changed", fakeStore.items[itemKey(orgId, "c1", "owned-item")].Spec.Artifacts[0].Uri)
+		require.Equal(t, owner, lo.FromPtr(fakeStore.items[itemKey(orgId, "c1", "owned-item")].Metadata.Owner))
 	})
 }
 
@@ -1127,7 +1136,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 
 			if tt.createItem {
 				item := createTestCatalogItem(tt.catalogName, tt.itemName, tt.itemOwner)
-				fakeStore.items[itemKey(tt.catalogName, tt.itemName)] = &item
+				fakeStore.items[itemKey(testOrgId, tt.catalogName, tt.itemName)] = &item
 			}
 
 			status := h.DeleteCatalogItem(ctx, testOrgId, tt.catalogName, tt.itemName, tt.enforceOwnership)
@@ -1137,7 +1146,7 @@ func TestDeleteCatalogItem(t *testing.T) {
 				require.Equal(t, tt.expectedError.Error(), status.Message)
 			}
 
-			_, ok := fakeStore.items[itemKey(tt.catalogName, tt.itemName)]
+			_, ok := fakeStore.items[itemKey(testOrgId, tt.catalogName, tt.itemName)]
 			require.Equal(t, !tt.expectItemDeleted, ok)
 		})
 	}

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -24,11 +24,16 @@ import (
 type fakeCatalogStore struct {
 	catalogs map[string]*domain.Catalog
 	items    map[string]*domain.CatalogItem // key: itemKey(catalogName, itemName)
+	itemOrgs map[string]uuid.UUID           // key: itemKey(catalogName, itemName) -> org that owns the item
 	err      error
 }
 
 func newFakeCatalogStore() *fakeCatalogStore {
-	return &fakeCatalogStore{catalogs: map[string]*domain.Catalog{}, items: map[string]*domain.CatalogItem{}}
+	return &fakeCatalogStore{
+		catalogs: map[string]*domain.Catalog{},
+		items:    map[string]*domain.CatalogItem{},
+		itemOrgs: map[string]uuid.UUID{},
+	}
 }
 
 func itemKey(catalogName, itemName string) string {
@@ -110,8 +115,8 @@ func (f *fakeCatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name str
 	if !exists {
 		return flterrors.ErrResourceNotFound
 	}
-	for _, it := range f.items {
-		if it.Metadata.Catalog == name {
+	for key, it := range f.items {
+		if it.Metadata.Catalog == name && f.itemOrgs[key] == orgId {
 			return flterrors.ErrResourceNotEmpty
 		}
 	}
@@ -190,7 +195,9 @@ func (f *fakeCatalogStore) CreateItem(ctx context.Context, orgId uuid.UUID, cata
 		return nil, flterrors.ErrParentResourceNotFound
 	}
 	item.Metadata.Catalog = catalogName
-	f.items[itemKey(catalogName, lo.FromPtr(item.Metadata.Name))] = item
+	key := itemKey(catalogName, lo.FromPtr(item.Metadata.Name))
+	f.items[key] = item
+	f.itemOrgs[key] = orgId
 	return item, nil
 }
 
@@ -235,6 +242,7 @@ func (f *fakeCatalogStore) DeleteItem(ctx context.Context, orgId uuid.UUID, cata
 		return flterrors.ErrResourceNotFound
 	}
 	delete(f.items, key)
+	delete(f.itemOrgs, key)
 	return nil
 }
 
@@ -645,13 +653,32 @@ func TestDeleteCatalogNonEmpty(t *testing.T) {
 		catalog := createTestCatalog("catalog-with-items", nil)
 		fakeStore.catalogs["catalog-with-items"] = &catalog
 		item := createTestCatalogItem("catalog-with-items", "app-1", nil)
-		fakeStore.items[itemKey("catalog-with-items", "app-1")] = &item
+		key := itemKey("catalog-with-items", "app-1")
+		fakeStore.items[key] = &item
+		fakeStore.itemOrgs[key] = orgId
 
 		status := h.DeleteCatalog(context.Background(), orgId, "catalog-with-items", true)
 		require.Equal(t, int32(http.StatusConflict), status.Code)
 		require.Equal(t, flterrors.ErrResourceNotEmpty.Error(), status.Message)
 		require.Contains(t, fakeStore.catalogs, "catalog-with-items")
 		require.Empty(t, fakeEvents.deleted)
+	})
+
+	t.Run("When items exist only under another org it should delete the catalog", func(t *testing.T) {
+		h, fakeStore, fakeEvents := newTestHandler()
+		orgId := uuid.New()
+		otherOrgId := uuid.New()
+		catalog := createTestCatalog("shared-name", nil)
+		fakeStore.catalogs["shared-name"] = &catalog
+		item := createTestCatalogItem("shared-name", "app-1", nil)
+		key := itemKey("shared-name", "app-1")
+		fakeStore.items[key] = &item
+		fakeStore.itemOrgs[key] = otherOrgId
+
+		status := h.DeleteCatalog(context.Background(), orgId, "shared-name", true)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotContains(t, fakeStore.catalogs, "shared-name")
+		require.Len(t, fakeEvents.deleted, 1)
 	})
 
 	t.Run("When deleting an empty catalog it should succeed and remove it", func(t *testing.T) {

--- a/internal/service/certificatesigningrequest/handler.go
+++ b/internal/service/certificatesigningrequest/handler.go
@@ -257,6 +257,27 @@ func (h *ServiceHandler) GetCertificateSigningRequest(ctx context.Context, orgId
 	return result, common.StoreErrorToApiStatus(err, false, domain.CertificateSigningRequestKind, &name)
 }
 
+// UpdateCertificateSigningRequestConditions merges condition updates into the
+// CSR status. When nothing changes, the update is skipped.
+func (h *ServiceHandler) UpdateCertificateSigningRequestConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
+	err := common.RetryOnNoRowsUpdated(func() error {
+		csr, getErr := h.store.Get(ctx, orgId, name)
+		if getErr != nil {
+			return getErr
+		}
+		var existing []domain.Condition
+		if csr.Status != nil {
+			existing = csr.Status.Conditions
+		}
+		merged, changed := common.MergeStatusConditions(existing, conditions)
+		if !changed {
+			return nil
+		}
+		return h.store.UpdateConditions(ctx, orgId, name, merged)
+	})
+	return common.StoreErrorToApiStatus(err, false, domain.CertificateSigningRequestKind, &name)
+}
+
 func (h *ServiceHandler) PatchCertificateSigningRequest(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.CertificateSigningRequest, domain.Status) {
 	currentObj, err := h.store.Get(ctx, orgId, name)
 	if err != nil {

--- a/internal/service/certificatesigningrequest/handler_test.go
+++ b/internal/service/certificatesigningrequest/handler_test.go
@@ -36,7 +36,8 @@ const (
 // fakeCertificateSigningRequestStore is a small in-memory implementation of
 // internal/store/certificatesigningrequest.Store.
 type fakeCertificateSigningRequestStore struct {
-	items map[string]*domain.CertificateSigningRequest
+	items                 map[string]*domain.CertificateSigningRequest
+	updateConditionsCalls int
 }
 
 func newFakeCertificateSigningRequestStore() *fakeCertificateSigningRequestStore {
@@ -127,11 +128,15 @@ func (f *fakeCertificateSigningRequestStore) UpdateStatus(ctx context.Context, o
 }
 
 func (f *fakeCertificateSigningRequestStore) UpdateConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) error {
+	f.updateConditionsCalls++
 	csr, exists := f.items[name]
 	if !exists {
 		return flterrors.ErrResourceNotFound
 	}
-	csr.Status.Conditions = conditions
+	if csr.Status == nil {
+		csr.Status = &domain.CertificateSigningRequestStatus{}
+	}
+	csr.Status.Conditions = append([]domain.Condition(nil), conditions...)
 	return nil
 }
 
@@ -696,5 +701,48 @@ func TestVerifyTPMCSRRequest(t *testing.T) {
 		cond := domain.FindStatusCondition(csr.Status.Conditions, domain.ConditionTypeCertificateSigningRequestTPMVerified)
 		require.NotNil(t, cond)
 		require.Equal(t, domain.ConditionStatusFalse, cond.Status)
+	})
+}
+
+func TestUpdateCertificateSigningRequestConditions(t *testing.T) {
+	t.Run("When merge changes conditions it should persist the merged slice", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		fakeStore.items["csr1"] = &domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("csr1")},
+			Status:   &domain.CertificateSigningRequestStatus{Conditions: []domain.Condition{}},
+		}
+
+		status := h.UpdateCertificateSigningRequestConditions(context.Background(), uuid.New(), "csr1", []domain.Condition{
+			{Type: domain.ConditionTypeCertificateSigningRequestApproved, Status: domain.ConditionStatusTrue, Reason: "Approved", Message: "ok"},
+		})
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.Equal(t, 1, fakeStore.updateConditionsCalls)
+		require.Equal(t, domain.ConditionStatusTrue, fakeStore.items["csr1"].Status.Conditions[0].Status)
+	})
+
+	t.Run("When merge changes nothing it should return OK without persisting", func(t *testing.T) {
+		h, fakeStore, _, _, _ := newTestHandler(t)
+		cond := domain.Condition{
+			Type:    domain.ConditionTypeCertificateSigningRequestApproved,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "Approved",
+			Message: "ok",
+		}
+		fakeStore.items["csr1"] = &domain.CertificateSigningRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("csr1")},
+			Status:   &domain.CertificateSigningRequestStatus{Conditions: []domain.Condition{cond}},
+		}
+
+		status := h.UpdateCertificateSigningRequestConditions(context.Background(), uuid.New(), "csr1", []domain.Condition{cond})
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.Equal(t, 0, fakeStore.updateConditionsCalls)
+	})
+
+	t.Run("When the CSR does not exist it should return a not-found status", func(t *testing.T) {
+		h, _, _, _, _ := newTestHandler(t)
+		status := h.UpdateCertificateSigningRequestConditions(context.Background(), uuid.New(), "missing", []domain.Condition{
+			{Type: domain.ConditionTypeCertificateSigningRequestApproved, Status: domain.ConditionStatusTrue},
+		})
+		require.Equal(t, statusNotFoundCode, status.Code)
 	})
 }

--- a/internal/service/certificatesigningrequest/mock.go
+++ b/internal/service/certificatesigningrequest/mock.go
@@ -144,3 +144,17 @@ func (mr *MockServiceMockRecorder) UpdateCertificateSigningRequestApproval(ctx, 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCertificateSigningRequestApproval", reflect.TypeOf((*MockService)(nil).UpdateCertificateSigningRequestApproval), ctx, orgId, name, csr)
 }
+
+// UpdateCertificateSigningRequestConditions mocks base method.
+func (m *MockService) UpdateCertificateSigningRequestConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCertificateSigningRequestConditions", ctx, orgId, name, conditions)
+	ret0, _ := ret[0].(domain.Status)
+	return ret0
+}
+
+// UpdateCertificateSigningRequestConditions indicates an expected call of UpdateCertificateSigningRequestConditions.
+func (mr *MockServiceMockRecorder) UpdateCertificateSigningRequestConditions(ctx, orgId, name, conditions any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCertificateSigningRequestConditions", reflect.TypeOf((*MockService)(nil).UpdateCertificateSigningRequestConditions), ctx, orgId, name, conditions)
+}

--- a/internal/service/certificatesigningrequest/service.go
+++ b/internal/service/certificatesigningrequest/service.go
@@ -15,4 +15,5 @@ type Service interface {
 	PatchCertificateSigningRequest(ctx context.Context, orgId uuid.UUID, name string, patch domain.PatchRequest) (*domain.CertificateSigningRequest, domain.Status)
 	ReplaceCertificateSigningRequest(ctx context.Context, orgId uuid.UUID, name string, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status)
 	UpdateCertificateSigningRequestApproval(ctx context.Context, orgId uuid.UUID, name string, csr domain.CertificateSigningRequest) (*domain.CertificateSigningRequest, domain.Status)
+	UpdateCertificateSigningRequestConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status
 }

--- a/internal/service/certificatesigningrequest/traced.gen.go
+++ b/internal/service/certificatesigningrequest/traced.gen.go
@@ -99,3 +99,11 @@ func (_d *TracedService) UpdateCertificateSigningRequestApproval(ctx context.Con
 	endSpan(span, s1)
 	return cp1, s1
 }
+
+func (_d *TracedService) UpdateCertificateSigningRequestConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) (s1 domain.Status) {
+	ctx, span := startSpan(ctx, "UpdateCertificateSigningRequestConditions")
+
+	s1 = _d.inner.UpdateCertificateSigningRequestConditions(ctx, orgId, name, conditions)
+	endSpan(span, s1)
+	return s1
+}

--- a/internal/service/common/conditions.go
+++ b/internal/service/common/conditions.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"errors"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+)
+
+const ConditionUpdateRetryIterations = 10
+
+// MergeStatusConditions copies existing conditions and applies each update via
+// domain.SetStatusCondition, OR-aggregating whether anything changed.
+func MergeStatusConditions(existing []domain.Condition, updates []domain.Condition) (merged []domain.Condition, changed bool) {
+	merged = make([]domain.Condition, len(existing))
+	copy(merged, existing)
+	for _, update := range updates {
+		if domain.SetStatusCondition(&merged, update) {
+			changed = true
+		}
+	}
+	return merged, changed
+}
+
+// RetryOnNoRowsUpdated runs fn until it succeeds or returns a non-CAS error.
+func RetryOnNoRowsUpdated(fn func() error) error {
+	var err error
+	for i := 0; i < ConditionUpdateRetryIterations; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			return err
+		}
+	}
+	return err
+}

--- a/internal/service/common/conditions.go
+++ b/internal/service/common/conditions.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
@@ -22,7 +23,14 @@ func MergeStatusConditions(existing []domain.Condition, updates []domain.Conditi
 	return merged, changed
 }
 
-// RetryOnNoRowsUpdated runs fn until it succeeds or returns a non-CAS error.
+func shouldRetryConditionUpdate(err error) bool {
+	if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+		return true
+	}
+	return err != nil && strings.Contains(err.Error(), "deadlock")
+}
+
+// RetryOnNoRowsUpdated runs fn until it succeeds or returns a non-retryable error.
 func RetryOnNoRowsUpdated(fn func() error) error {
 	var err error
 	for i := 0; i < ConditionUpdateRetryIterations; i++ {
@@ -30,7 +38,7 @@ func RetryOnNoRowsUpdated(fn func() error) error {
 		if err == nil {
 			return nil
 		}
-		if !errors.Is(err, flterrors.ErrNoRowsUpdated) {
+		if !shouldRetryConditionUpdate(err) {
 			return err
 		}
 	}

--- a/internal/service/common/conditions_test.go
+++ b/internal/service/common/conditions_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/flightctl/flightctl/internal/domain"
@@ -71,5 +72,18 @@ func TestRetryOnNoRowsUpdated(t *testing.T) {
 		})
 		require.ErrorIs(t, err, flterrors.ErrResourceNotFound)
 		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("When fn returns a deadlock error it should retry", func(t *testing.T) {
+		attempts := 0
+		err := RetryOnNoRowsUpdated(func() error {
+			attempts++
+			if attempts < 2 {
+				return errors.New("ERROR: deadlock detected")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
 	})
 }

--- a/internal/service/common/conditions_test.go
+++ b/internal/service/common/conditions_test.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStatusConditions(t *testing.T) {
+	t.Run("When updates are empty it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, nil)
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+		require.NotSame(t, &existing[0], &merged[0])
+	})
+
+	t.Run("When a new condition type is added it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "r"},
+		})
+		require.True(t, changed)
+		require.Len(t, merged, 2)
+	})
+
+	t.Run("When the same condition is reapplied it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"},
+		})
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+	})
+
+	t.Run("When one of multiple updates changes it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "old"},
+		}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "new"},
+		})
+		require.True(t, changed)
+		require.Equal(t, "new", domain.FindStatusCondition(merged, "B").Reason)
+	})
+}
+
+func TestRetryOnNoRowsUpdated(t *testing.T) {
+	t.Run("When fn succeeds on a later attempt it should return nil", func(t *testing.T) {
+		attempts := 0
+		err := RetryOnNoRowsUpdated(func() error {
+			attempts++
+			if attempts < 3 {
+				return flterrors.ErrNoRowsUpdated
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("When fn returns a non-CAS error it should stop immediately", func(t *testing.T) {
+		attempts := 0
+		err := RetryOnNoRowsUpdated(func() error {
+			attempts++
+			return flterrors.ErrResourceNotFound
+		})
+		require.ErrorIs(t, err, flterrors.ErrResourceNotFound)
+		require.Equal(t, 1, attempts)
+	})
+}

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -215,9 +215,10 @@ func (h *DeviceServiceHandler) GetDevice(ctx context.Context, orgId uuid.UUID, n
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
-// DeviceVerificationCallback ensures the device wasn't decommissioned before an update proceeds.
-func DeviceVerificationCallback(ctx context.Context, before, after *domain.Device) error {
-	if before != nil && before.Spec != nil && before.Spec.Decommissioning != nil {
+// rejectIfAlreadyDecommissioning returns flterrors.ErrDecommission when the existing
+// device already has Spec.Decommissioning set.
+func rejectIfAlreadyDecommissioning(existing *domain.Device) error {
+	if existing != nil && existing.Spec != nil && existing.Spec.Decommissioning != nil {
 		return flterrors.ErrDecommission
 	}
 	return nil
@@ -236,13 +237,16 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusBadRequest("resource name specified in metadata does not match name in path")
 	}
 
-	if enforceOwnership {
-		existing, getErr := h.deviceStore.Get(ctx, orgId, name)
-		if getErr != nil {
-			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
-				return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
-			}
-		} else if len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
+	existing, getErr := h.deviceStore.Get(ctx, orgId, name)
+	if getErr != nil {
+		if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+			return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
+		}
+	} else {
+		if err := rejectIfAlreadyDecommissioning(existing); err != nil {
+			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+		}
+		if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
 			if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
 				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 			}
@@ -251,7 +255,7 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
-	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, nil, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, created, domain.DeviceKind, &name)
 }
 
@@ -268,10 +272,18 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 		return nil, fmt.Errorf("resource name specified in metadata does not match name in path")
 	}
 
+	existing, err := h.deviceStore.Get(ctx, orgId, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectIfAlreadyDecommissioning(existing); err != nil {
+		return nil, err
+	}
+
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
 	// Ownership is never enforced on UpdateDevice (agent/console trusted path).
-	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, nil, h.callbackDeviceUpdated)
 }
 
 func (h *DeviceServiceHandler) DeleteDevice(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
@@ -376,12 +388,16 @@ func (h *DeviceServiceHandler) PatchDeviceStatus(ctx context.Context, orgId uuid
 		return nil, domain.StatusBadRequest("spec is immutable")
 	}
 
+	if err := rejectIfAlreadyDecommissioning(currentObj); err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, nil, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
@@ -481,6 +497,10 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 	common.NilOutManagedObjectMetaProperties(&newObj.Metadata)
 	newObj.Metadata.ResourceVersion = nil
 
+	if err := rejectIfAlreadyDecommissioning(currentObj); err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+
 	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
 		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
 			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
@@ -489,7 +509,7 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, nil, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -625,12 +625,38 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
+// serviceConditionsFromDevice returns SpecValid / MultipleOwners conditions from
+// Status.Conditions (agent and service conditions are stored separately but
+// exposed together by Get).
+func serviceConditionsFromDevice(device *domain.Device) []domain.Condition {
+	if device == nil || device.Status == nil {
+		return nil
+	}
+	var out []domain.Condition
+	for _, c := range device.Status.Conditions {
+		if c.Type.IsServiceConditionType() {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// SetDeviceServiceConditions merges condition updates into the device's service
+// conditions and persists the result (including when the merge is a no-op).
 func (h *DeviceServiceHandler) SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
 	callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
 		h.diffAndEmitConditionEvents(ctx, orgId, device, oldConditions, newConditions)
 	}
 
-	err := h.deviceStore.SetServiceConditions(ctx, orgId, name, conditions, callback)
+	err := common.RetryOnNoRowsUpdated(func() error {
+		device, getErr := h.deviceStore.Get(ctx, orgId, name)
+		if getErr != nil {
+			return getErr
+		}
+		existing := serviceConditionsFromDevice(device)
+		merged, _ := common.MergeStatusConditions(existing, conditions)
+		return h.deviceStore.SetServiceConditions(ctx, orgId, name, merged, callback)
+	})
 	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -603,8 +603,7 @@ func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgI
 }
 
 func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) domain.Status {
-	// Caller owns skip-vs-write; forceUpdate=true ensures the store always persists.
-	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, true)
+	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints)
 	if err != nil {
 		h.log.Errorf("Failed to update rendered device %s/%s: %v", orgId, name, err)
 		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -550,15 +550,15 @@ func prepareDeviceForDecommission(existing *domain.Device, decom domain.DeviceDe
 	prepared := util.Clone(existing)
 
 	spec := domain.DeviceSpec{}
-	if existing.Spec != nil {
-		spec = *existing.Spec
+	if prepared.Spec != nil {
+		spec = *prepared.Spec
 	}
 	spec.Decommissioning = &decom
 	prepared.Spec = &spec
 
 	status := domain.NewDeviceStatus()
-	if existing.Status != nil {
-		status = *existing.Status
+	if prepared.Status != nil {
+		status = *prepared.Status
 	}
 	status.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
 	prepared.Status = &status
@@ -567,20 +567,34 @@ func prepareDeviceForDecommission(existing *domain.Device, decom domain.DeviceDe
 	prepared.Metadata.Labels = nil
 	return prepared
 }
+
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
-	existing, err := h.deviceStore.Get(ctx, orgId, name)
-	if err != nil {
-		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
-	}
+	// Re-Get + re-prepare on CAS conflicts so concurrent renders/status writes cannot
+	// permanently block decommission with a stale prepared ResourceVersion.
+	const maxAttempts = 10
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		existing, err := h.deviceStore.Get(ctx, orgId, name)
+		if err != nil {
+			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+		}
 
-	// Product rule: refuse a second decommission without calling the store (no success event).
-	if existing.Spec != nil && existing.Spec.Decommissioning != nil {
-		return nil, common.StoreErrorToApiStatus(flterrors.ErrResourceVersionConflict, false, domain.DeviceKind, &name)
-	}
+		// Product rule: refuse a second decommission without calling the store (no success event).
+		if existing.Spec != nil && existing.Spec.Decommissioning != nil {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrResourceVersionConflict, false, domain.DeviceKind, &name)
+		}
 
-	prepared := prepareDeviceForDecommission(existing, decom)
-	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, prepared, h.callbackDeviceDecommission)
-	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+		prepared := prepareDeviceForDecommission(existing, decom)
+		result, err := h.deviceStore.DecommissionDevice(ctx, orgId, prepared, h.callbackDeviceDecommission)
+		if err == nil {
+			return result, common.StoreErrorToApiStatus(nil, false, domain.DeviceKind, &name)
+		}
+		lastErr = err
+		if !errors.Is(err, flterrors.ErrResourceVersionConflict) && !errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+		}
+	}
+	return nil, common.StoreErrorToApiStatus(lastErr, false, domain.DeviceKind, &name)
 }
 
 func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) domain.Status {

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -215,13 +215,14 @@ func (h *DeviceServiceHandler) GetDevice(ctx context.Context, orgId uuid.UUID, n
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
-// rejectIfAlreadyDecommissioning returns flterrors.ErrDecommission when the existing
-// device already has Spec.Decommissioning set.
 func rejectIfAlreadyDecommissioning(existing *domain.Device) error {
-	if existing != nil && existing.Spec != nil && existing.Spec.Decommissioning != nil {
-		return flterrors.ErrDecommission
+	if existing == nil || existing.Spec == nil {
+		return nil
 	}
-	return nil
+	if existing.Spec.Decommissioning == nil {
+		return nil
+	}
+	return flterrors.ErrDecommission
 }
 
 func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string, enforceOwnership bool) (*domain.Device, domain.Status) {
@@ -238,18 +239,16 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 	}
 
 	existing, getErr := h.deviceStore.Get(ctx, orgId, name)
-	if getErr != nil {
-		if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
-			return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
-		}
-	} else {
+	if getErr != nil && !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+		return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
+	}
+	if getErr == nil {
 		if err := rejectIfAlreadyDecommissioning(existing); err != nil {
 			return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 		}
-		if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 {
-			if !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
-				return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-			}
+		if enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 &&
+			!domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 		}
 	}
 
@@ -501,10 +500,9 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 	}
 
-	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 {
-		if !domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-		}
+	if enforceOwnership && len(lo.FromPtr(currentObj.Metadata.Owner)) != 0 &&
+		!domain.DeviceSpecsAreEqual(lo.FromPtr(currentObj.Spec), lo.FromPtr(newObj.Spec)) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
 	}
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -602,8 +602,9 @@ func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgI
 	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
-func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status {
-	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) domain.Status {
+	// Caller owns skip-vs-write; forceUpdate=true ensures the store always persists.
+	renderedVersion, err := h.deviceStore.UpdateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, true)
 	if err != nil {
 		h.log.Errorf("Failed to update rendered device %s/%s: %v", orgId, name, err)
 		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -21,6 +21,7 @@ import (
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/util/validation"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -525,8 +526,42 @@ func (h *DeviceServiceHandler) ForceUpdateServerSideDeviceStatus(ctx context.Con
 	return nil
 }
 
+// prepareDeviceForDecommission applies decommission mutations: set Spec.Decommissioning,
+// Lifecycle status Decommissioning, and clear Owner and Labels.
+func prepareDeviceForDecommission(existing *domain.Device, decom domain.DeviceDecommission) *domain.Device {
+	prepared := util.Clone(existing)
+
+	spec := domain.DeviceSpec{}
+	if existing.Spec != nil {
+		spec = *existing.Spec
+	}
+	spec.Decommissioning = &decom
+	prepared.Spec = &spec
+
+	status := domain.NewDeviceStatus()
+	if existing.Status != nil {
+		status = *existing.Status
+	}
+	status.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
+	prepared.Status = &status
+
+	prepared.Metadata.Owner = nil
+	prepared.Metadata.Labels = nil
+	return prepared
+}
 func (h *DeviceServiceHandler) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission) (*domain.Device, domain.Status) {
-	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, name, decom, h.callbackDeviceDecommission)
+	existing, err := h.deviceStore.Get(ctx, orgId, name)
+	if err != nil {
+		return nil, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+	}
+
+	// Product rule: refuse a second decommission without calling the store (no success event).
+	if existing.Spec != nil && existing.Spec.Decommissioning != nil {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrResourceVersionConflict, false, domain.DeviceKind, &name)
+	}
+
+	prepared := prepareDeviceForDecommission(existing, decom)
+	result, err := h.deviceStore.DecommissionDevice(ctx, orgId, prepared, h.callbackDeviceDecommission)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -895,7 +895,7 @@ func TestUpdateRenderedDevice(t *testing.T) {
 		Status:   lo.ToPtr(domain.NewDeviceStatus()),
 	}, nil)
 	require.NoError(t, err)
-	status := svc.UpdateRenderedDevice(ctx, orgId, "foo", "config", "apps", "hash", nil, false)
+	status := svc.UpdateRenderedDevice(ctx, orgId, "foo", "config", "apps", "hash", nil)
 	require.Equal(t, int32(http.StatusOK), status.Code)
 }
 

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -209,6 +209,23 @@ func TestReplaceDevice(t *testing.T) {
 		require.Equal(t, "Fleet/f1", lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Owner))
 		require.Equal(t, int64(5), lo.FromPtr(st.device.devices["replace-trusted"].Metadata.Generation))
 	})
+
+	t.Run("When replacing an already-decommissioning device it should return conflict", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["foo"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Decommissioning: &domain.DeviceDecommission{}},
+		}
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img"}},
+		}
+		_, status := svc.ReplaceDevice(ctx, orgId, "foo", device, nil, true)
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrDecommission.Error(), status.Message)
+	})
 }
 
 // TestReplaceDeviceOwnership mirrors fleet.TestReplaceFleetOwnership: an external caller
@@ -788,17 +805,80 @@ func TestUpdateDevice(t *testing.T) {
 		require.Nil(t, st.device.devices["owned-device"].Metadata.Owner)
 		require.Equal(t, "v", (*st.device.devices["owned-device"].Metadata.Annotations)["k"])
 	})
+
+	t.Run("When updating an already-decommissioning device it should return ErrDecommission", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["foo"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Decommissioning: &domain.DeviceDecommission{}},
+		}
+		device := domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img"}},
+		}
+		_, err := svc.UpdateDevice(ctx, orgId, "foo", device, nil)
+		require.ErrorIs(t, err, flterrors.ErrDecommission)
+	})
 }
 
 func TestDecommissionDevice(t *testing.T) {
-	st, _, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")}}, nil)
-	require.NoError(t, err)
-	result, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	require.NotNil(t, result.Spec.Decommissioning)
+	t.Run("When decommissioning a device it should set decom spec, lifecycle, clear owner and labels, and emit success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		labels := map[string]string{"fleet": "f1"}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{
+				Name:   lo.ToPtr("foo"),
+				Owner:  lo.ToPtr("Fleet/f1"),
+				Labels: &labels,
+			},
+			Spec:   &domain.DeviceSpec{},
+			Status: lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
+
+		decom := domain.DeviceDecommission{}
+		result, status := svc.DecommissionDevice(ctx, orgId, "foo", decom)
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.NotNil(t, result.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, result.Status.Lifecycle.Status)
+		require.Nil(t, result.Metadata.Owner)
+		require.Nil(t, result.Metadata.Labels)
+
+		stored := st.device.devices["foo"]
+		require.NotNil(t, stored.Spec.Decommissioning)
+		require.Equal(t, domain.DeviceLifecycleStatusDecommissioning, stored.Status.Lifecycle.Status)
+		require.Nil(t, stored.Metadata.Owner)
+		require.Nil(t, stored.Metadata.Labels)
+
+		require.Len(t, ev.created, 1)
+		require.Equal(t, domain.EventReasonDeviceDecommissioned, ev.created[0].Reason)
+	})
+
+	t.Run("When the device is already decommissioning it should return conflict without success event", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		st.device.devices["foo"] = &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Spec:     &domain.DeviceSpec{Decommissioning: &domain.DeviceDecommission{}},
+		}
+
+		_, status := svc.DecommissionDevice(ctx, orgId, "foo", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusConflict), status.Code)
+		require.Equal(t, flterrors.ErrResourceVersionConflict.Error(), status.Message)
+		require.Empty(t, ev.created)
+	})
+
+	t.Run("When the device does not exist it should return not found", func(t *testing.T) {
+		_, ev, svc := newTestHandler()
+		_, status := svc.DecommissionDevice(context.Background(), uuid.New(), "missing", domain.DeviceDecommission{})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+		require.Empty(t, ev.created)
+	})
 }
 
 // TestUpdateRenderedDevice covers the "no change in rendered version" path only. The

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -899,22 +899,74 @@ func TestUpdateRenderedDevice(t *testing.T) {
 	require.Equal(t, int32(http.StatusOK), status.Code)
 }
 
-func TestSetDeviceServiceConditions(t *testing.T) {
-	st, ev, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{
-		Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
-		Status:   lo.ToPtr(domain.NewDeviceStatus()),
-	}, nil)
-	require.NoError(t, err)
-
-	status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
-		{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
+func TestServiceConditionsFromDevice(t *testing.T) {
+	t.Run("When status mixes agent and service conditions it should return only service types", func(t *testing.T) {
+		device := &domain.Device{
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{
+					{Type: domain.ConditionTypeDeviceUpdating, Status: domain.ConditionStatusTrue},
+					{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse},
+					{Type: domain.ConditionTypeDeviceMultipleOwners, Status: domain.ConditionStatusTrue},
+				},
+			},
+		}
+		got := serviceConditionsFromDevice(device)
+		require.Len(t, got, 2)
+		require.Equal(t, domain.ConditionTypeDeviceSpecValid, got[0].Type)
+		require.Equal(t, domain.ConditionTypeDeviceMultipleOwners, got[1].Type)
 	})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	// SpecValid transitioning from absent to invalid emits a DeviceSpecInvalid event.
-	require.Len(t, ev.created, 1)
+}
+
+func TestSetDeviceServiceConditions(t *testing.T) {
+	t.Run("When a service condition changes it should persist and emit events", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status:   lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
+
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
+		})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.Equal(t, 1, st.device.setServiceConditionsCalls)
+		// SpecValid transitioning from absent to invalid emits a DeviceSpecInvalid event.
+		require.Len(t, ev.created, 1)
+	})
+
+	t.Run("When merge changes nothing it should still persist", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		cond := domain.Condition{
+			Type:    domain.ConditionTypeDeviceSpecValid,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "ok",
+			Message: "ok",
+		}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{cond},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{cond})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.Equal(t, 1, st.device.setServiceConditionsCalls)
+	})
+
+	t.Run("When the device does not exist it should return a not-found status", func(t *testing.T) {
+		_, _, svc := newTestHandler()
+		status := svc.SetDeviceServiceConditions(context.Background(), uuid.New(), "missing", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusTrue},
+		})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+	})
 }
 
 func TestUpdateServiceSideDeviceStatus(t *testing.T) {

--- a/internal/service/device/mock.go
+++ b/internal/service/device/mock.go
@@ -522,17 +522,17 @@ func (mr *MockServiceMockRecorder) UpdateDeviceAnnotations(ctx, orgId, name, ann
 }
 
 // UpdateRenderedDevice mocks base method.
-func (m *MockService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status {
+func (m *MockService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) domain.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRenderedDevice", ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+	ret := m.ctrl.Call(m, "UpdateRenderedDevice", ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints)
 	ret0, _ := ret[0].(domain.Status)
 	return ret0
 }
 
 // UpdateRenderedDevice indicates an expected call of UpdateRenderedDevice.
-func (mr *MockServiceMockRecorder) UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate any) *gomock.Call {
+func (mr *MockServiceMockRecorder) UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRenderedDevice", reflect.TypeOf((*MockService)(nil).UpdateRenderedDevice), ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRenderedDevice", reflect.TypeOf((*MockService)(nil).UpdateRenderedDevice), ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints)
 }
 
 // UpdateServerSideDeviceStatus mocks base method.

--- a/internal/service/device/service.go
+++ b/internal/service/device/service.go
@@ -30,7 +30,7 @@ type Service interface {
 	StopDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
 	StartDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
 	RestartDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
-	UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status
+	UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) domain.Status
 	SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status
 	OverwriteDeviceRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) domain.Status
 	GetDeviceRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, domain.Status)

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -274,7 +274,7 @@ func (s *fakeDeviceStore) MutateAnnotation(ctx context.Context, orgId uuid.UUID,
 	return nil
 }
 
-func (s *fakeDeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (s *fakeDeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (string, error) {
 	if _, ok := s.devices[name]; !ok {
 		return "", flterrors.ErrResourceNotFound
 	}

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -102,9 +102,14 @@ func preserveNilMetadata(device, existing *domain.Device, fieldsToUnset []string
 func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	old, existed := s.devices[name]
-	if existed && validationCallback != nil {
-		if err := validationCallback(ctx, old, device); err != nil {
-			return nil, false, err
+	if existed {
+		if old.Spec != nil && old.Spec.Decommissioning != nil {
+			return nil, false, flterrors.ErrDecommission
+		}
+		if validationCallback != nil {
+			if err := validationCallback(ctx, old, device); err != nil {
+				return nil, false, err
+			}
 		}
 	}
 	if existed {
@@ -124,6 +129,9 @@ func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *d
 	old, ok := s.devices[name]
 	if !ok {
 		return nil, flterrors.ErrResourceNotFound
+	}
+	if old.Spec != nil && old.Spec.Decommissioning != nil {
+		return nil, flterrors.ErrDecommission
 	}
 	if validationCallback != nil {
 		if err := validationCallback(ctx, old, device); err != nil {

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -61,8 +61,9 @@ func newFakeStore() *fakeStore {
 // methods this package's handler_test.go exercises.
 type fakeDeviceStore struct {
 	devicestore.Store
-	devices  map[string]*domain.Device
-	repoRefs map[string][]string
+	devices                   map[string]*domain.Device
+	repoRefs                  map[string][]string
+	setServiceConditionsCalls int
 }
 
 func (s *fakeDeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
@@ -322,6 +323,7 @@ func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUI
 }
 
 func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
+	s.setServiceConditionsCalls++
 	d, ok := s.devices[name]
 	if !ok {
 		return flterrors.ErrResourceNotFound
@@ -329,10 +331,19 @@ func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.U
 	if d.Status == nil {
 		d.Status = lo.ToPtr(domain.NewDeviceStatus())
 	}
-	oldConditions := d.Status.Conditions
-	d.Status.Conditions = conditions
+	var oldServiceConditions []domain.Condition
+	var kept []domain.Condition
+	for _, c := range d.Status.Conditions {
+		if c.Type.IsServiceConditionType() {
+			oldServiceConditions = append(oldServiceConditions, c)
+			continue
+		}
+		kept = append(kept, c)
+	}
+	prepared := append([]domain.Condition(nil), conditions...)
+	d.Status.Conditions = append(kept, prepared...)
 	if callback != nil {
-		callback(ctx, orgId, d, oldConditions, conditions)
+		callback(ctx, orgId, d, oldServiceConditions, prepared)
 	}
 	return nil
 }

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -291,20 +291,26 @@ func (s *fakeDeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, own
 	return nil
 }
 
-func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
+func (s *fakeDeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
+	if device == nil || device.Metadata.Name == nil {
+		return nil, flterrors.ErrResourceIsNil
+	}
+	name := *device.Metadata.Name
 	d, ok := s.devices[name]
 	if !ok {
 		return nil, flterrors.ErrResourceNotFound
 	}
+	if d.Spec != nil && d.Spec.Decommissioning != nil {
+		return nil, flterrors.ErrResourceVersionConflict
+	}
 	old := deepCopyDevice(d)
-	if d.Spec == nil {
-		d.Spec = &domain.DeviceSpec{}
-	}
-	d.Spec.Decommissioning = &decom
+	// Persist the service-prepared device as the source of truth.
+	prepared := deepCopyDevice(device)
+	s.devices[name] = prepared
 	if eventCallback != nil {
-		eventCallback(ctx, domain.DeviceKind, orgId, name, old, d, false, nil)
+		eventCallback(ctx, domain.DeviceKind, orgId, name, old, prepared, false, nil)
 	}
-	return deepCopyDevice(d), nil
+	return deepCopyDevice(prepared), nil
 }
 
 func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {

--- a/internal/service/device/traced.gen.go
+++ b/internal/service/device/traced.gen.go
@@ -315,10 +315,10 @@ func (_d *TracedDeviceService) UpdateDeviceAnnotations(ctx context.Context, orgI
 	return s1
 }
 
-func (_d *TracedDeviceService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, renderedConfig string, renderedApplications string, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (s1 domain.Status) {
+func (_d *TracedDeviceService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, renderedConfig string, renderedApplications string, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (s1 domain.Status) {
 	ctx, span := startSpan(ctx, "UpdateRenderedDevice")
 
-	s1 = _d.inner.UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+	s1 = _d.inner.UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints)
 	endSpan(span, s1)
 	return s1
 }

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -194,8 +194,24 @@ func (h *ServiceHandler) ListDisruptionBudgetFleets(ctx context.Context, orgId u
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, nil)
 }
 
+// UpdateFleetConditions merges condition updates into the fleet status. When
+// nothing changes, the update is skipped.
 func (h *ServiceHandler) UpdateFleetConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
-	err := h.store.UpdateConditions(ctx, orgId, name, conditions, h.callbackFleetUpdated)
+	err := common.RetryOnNoRowsUpdated(func() error {
+		fleet, getErr := h.store.Get(ctx, orgId, name)
+		if getErr != nil {
+			return getErr
+		}
+		var existing []domain.Condition
+		if fleet.Status != nil {
+			existing = fleet.Status.Conditions
+		}
+		merged, changed := common.MergeStatusConditions(existing, conditions)
+		if !changed {
+			return nil
+		}
+		return h.store.UpdateConditions(ctx, orgId, name, merged, h.callbackFleetUpdated)
+	})
 	return common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 

--- a/internal/service/fleet/handler_test.go
+++ b/internal/service/fleet/handler_test.go
@@ -48,6 +48,8 @@ type fakeFleetStore struct {
 	getRepositoryRefsErr       error
 	overwriteRepositoryRefsErr error
 	lastOverwrittenRepoNames   []string
+
+	updateConditionsCalls int
 }
 
 func newFakeFleetStore() *fakeFleetStore {
@@ -180,6 +182,7 @@ func (f *fakeFleetStore) UnsetOwnerByKind(ctx context.Context, tx *gorm.DB, orgI
 }
 
 func (f *fakeFleetStore) UpdateConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, eventCallback store.EventCallback) error {
+	f.updateConditionsCalls++
 	fleet, ok := f.fleets[name]
 	if !ok {
 		return flterrors.ErrResourceNotFound
@@ -188,9 +191,7 @@ func (f *fakeFleetStore) UpdateConditions(ctx context.Context, orgId uuid.UUID, 
 		fleet.Status = &domain.FleetStatus{}
 	}
 	old := *fleet
-	for _, c := range conditions {
-		domain.SetStatusCondition(&fleet.Status.Conditions, c)
-	}
+	fleet.Status.Conditions = append([]domain.Condition(nil), conditions...)
 	if eventCallback != nil {
 		eventCallback(ctx, domain.FleetKind, orgId, name, &old, fleet, false, nil)
 	}
@@ -851,15 +852,37 @@ func TestUpdateFleetConditions(t *testing.T) {
 			{Type: "Approved", Status: "True"},
 		})
 		require.Equal(t, statusSuccessCode, status.Code)
+		require.Equal(t, 1, fakeStore.updateConditionsCalls)
+		require.Equal(t, domain.ConditionStatusTrue, fakeStore.fleets["f1"].Status.Conditions[0].Status)
 		// A non-FleetValid condition change doesn't touch ObjectMeta and isn't the
 		// FleetValid condition emitFleetValidEvents watches, so no event is emitted.
+		require.Empty(t, fakeEvents.created)
+	})
+
+	t.Run("When merge changes nothing it should return OK without persisting", func(t *testing.T) {
+		h, fakeStore, fakeEvents := newTestHandler()
+		fl := createTestFleet("f1", nil)
+		fl.Status = &domain.FleetStatus{
+			Conditions: []domain.Condition{
+				{Type: "Approved", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"},
+			},
+		}
+		fakeStore.fleets["f1"] = &fl
+
+		status := h.UpdateFleetConditions(context.Background(), uuid.New(), "f1", []domain.Condition{
+			{Type: "Approved", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"},
+		})
+		require.Equal(t, statusSuccessCode, status.Code)
+		require.Equal(t, 0, fakeStore.updateConditionsCalls)
 		require.Empty(t, fakeEvents.created)
 	})
 
 	t.Run("When the fleet does not exist it should return a not-found status", func(t *testing.T) {
 		h, _, _ := newTestHandler()
 
-		status := h.UpdateFleetConditions(context.Background(), uuid.New(), "missing", []domain.Condition{})
+		status := h.UpdateFleetConditions(context.Background(), uuid.New(), "missing", []domain.Condition{
+			{Type: "Approved", Status: domain.ConditionStatusTrue},
+		})
 		require.Equal(t, statusNotFoundCode, status.Code)
 	})
 }

--- a/internal/store/catalog/store.go
+++ b/internal/store/catalog/store.go
@@ -153,7 +153,8 @@ func (s *CatalogStore) Delete(ctx context.Context, orgId uuid.UUID, name string,
 			return store.ErrorFromGormError(result.Error)
 		}
 
-		// Check if catalog has any items - cannot delete non-empty catalogs
+		// Persistence contract of this delete path: count+delete in one TX.
+		// Returns ErrResourceNotEmpty when items still exist (not a separate policy API).
 		var itemCount int64
 		if err := innerTx.Model(&model.CatalogItem{}).Where("org_id = ? AND catalog_name = ?", orgId, name).Count(&itemCount).Error; err != nil {
 			return store.ErrorFromGormError(err)

--- a/internal/store/certificatesigningrequest/store.go
+++ b/internal/store/certificatesigningrequest/store.go
@@ -139,16 +139,8 @@ func (s *CertificateSigningRequestStore) updateConditions(ctx context.Context, o
 	if existingRecord.Status == nil {
 		existingRecord.Status = model.MakeJSONField(domain.CertificateSigningRequestStatus{})
 	}
-	if existingRecord.Status.Data.Conditions == nil {
-		existingRecord.Status.Data.Conditions = []domain.Condition{}
-	}
-	changed := false
-	for _, condition := range conditions {
-		changed = domain.SetStatusCondition(&existingRecord.Status.Data.Conditions, condition)
-	}
-	if !changed {
-		return false, nil
-	}
+
+	existingRecord.Status.Data.Conditions = conditions
 
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
 		"status":           existingRecord.Status,
@@ -159,7 +151,7 @@ func (s *CertificateSigningRequestStore) updateConditions(ctx context.Context, o
 		return strings.Contains(err.Error(), "deadlock"), err
 	}
 	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
+		return false, flterrors.ErrNoRowsUpdated
 	}
 	return false, nil
 }

--- a/internal/store/certificatesigningrequest/store.go
+++ b/internal/store/certificatesigningrequest/store.go
@@ -2,7 +2,6 @@ package certificatesigningrequest
 
 import (
 	"context"
-	"strings"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
@@ -148,7 +147,7 @@ func (s *CertificateSigningRequestStore) updateConditions(ctx context.Context, o
 	})
 	err := store.ErrorFromGormError(result.Error)
 	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
+		return false, err
 	}
 	if result.RowsAffected == 0 {
 		return false, flterrors.ErrNoRowsUpdated

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -390,15 +390,31 @@ func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, resource *dom
 	return device, err
 }
 
+// withDecommissionPersistenceGuard refuses updates when the stored device is already
+// decommissioning. This is a persistence contract of device mutate paths (not a pluggable
+// product-policy callback); it runs inside the createOrUpdate retry loop so races are
+// no weaker than when the service previously supplied that check as validationCallback.
+func withDecommissionPersistenceGuard(userCallback DeviceStoreValidationCallback) DeviceStoreValidationCallback {
+	return func(ctx context.Context, before, after *domain.Device) error {
+		if before != nil && before.Spec != nil && before.Spec.Decommissioning != nil {
+			return flterrors.ErrDecommission
+		}
+		if userCallback != nil {
+			return userCallback(ctx, before, after)
+		}
+		return nil
+	}
+}
+
 func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
-	device, oldDevice, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, validationCallback)
+	device, oldDevice, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, withDecommissionPersistenceGuard(validationCallback))
 	name := lo.FromPtr(resource.Metadata.Name)
 	s.callEventCallback(ctx, eventCallback, orgId, name, oldDevice, device, false, err)
 	return device, err
 }
 
 func (s *DeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
-	device, oldDevice, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, validationCallback)
+	device, oldDevice, created, err := s.genericStore.CreateOrUpdate(ctx, orgId, resource, fieldsToUnset, withDecommissionPersistenceGuard(validationCallback))
 	name := lo.FromPtr(resource.Metadata.Name)
 	s.callEventCallback(ctx, eventCallback, orgId, name, oldDevice, device, created, err)
 	return device, created, err

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -72,7 +72,10 @@ type Store interface {
 	MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error
 	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error)
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
-	DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error)
+	// DecommissionDevice persists an already-prepared device under resourceVersion CAS.
+	// Persistence contract: if the stored row already has Spec.Decommissioning set, returns
+	// flterrors.ErrResourceVersionConflict. Caller owns product-rule mutations.
+	DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error)
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -1349,47 +1352,39 @@ func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID,
 	})
 }
 
-func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (retry bool, device *domain.Device, err error) {
+func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, prepared *domain.Device, eventCallback store.EventCallback) (retry bool, device *domain.Device, err error) {
+	if prepared == nil || prepared.Metadata.Name == nil {
+		return false, nil, flterrors.ErrResourceIsNil
+	}
+	name := *prepared.Metadata.Name
+
 	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
 	result := s.getDB(ctx).Take(&existingRecord)
 	if result.Error != nil {
 		return false, nil, store.ErrorFromGormError(result.Error)
 	}
 
-	// Convert to API resource to check precondition
 	existingDevice, err := existingRecord.ToApiResource()
 	if err != nil {
 		return false, nil, err
 	}
 
-	// Check precondition: device must not already be decommissioning
+	// Persistence contract of this write path: refuse when already decommissioning.
 	if existingDevice.Spec != nil && existingDevice.Spec.Decommissioning != nil {
 		return false, nil, flterrors.ErrResourceVersionConflict
 	}
 
-	// Capture old device with deep copy for callback
 	var oldDevice domain.Device
 	var devices []domain.Device
 	devices = append(devices, *existingDevice)
 	oldDevice = devices[0]
 
-	// Apply decommissioning changes to the model
-	if existingRecord.Spec == nil {
-		existingRecord.Spec = model.MakeJSONField(domain.DeviceSpec{})
-	}
-	existingRecord.Spec.Data.Decommissioning = &decom
-
-	// Update status
-	if existingRecord.Status == nil {
-		existingRecord.Status = model.MakeJSONField(domain.NewDeviceStatus())
-	}
-	existingRecord.Status.Data.Lifecycle.Status = domain.DeviceLifecycleStatusDecommissioning
-
-	// These fields must be un-set so that device is no longer associated with any fleet
+	// Persist the service-prepared state (spec/status/cleared owner+labels).
+	existingRecord.Spec = model.MakeJSONField(lo.FromPtr(prepared.Spec))
+	existingRecord.Status = model.MakeJSONField(lo.FromPtr(prepared.Status))
 	existingRecord.Owner = nil
 	existingRecord.Labels = nil
 
-	// Update using optimistic locking
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
 		"spec":             existingRecord.Spec,
 		"status":           existingRecord.Status,
@@ -1405,26 +1400,24 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, n
 		return true, nil, flterrors.ErrNoRowsUpdated
 	}
 
-	// Convert updated record to API resource for return and callback
 	updatedDevice, err := existingRecord.ToApiResource()
 	if err != nil {
 		return false, nil, err
 	}
 
-	// Call event callback
 	s.callEventCallback(ctx, eventCallback, orgId, name, &oldDevice, updatedDevice, false, nil)
 
 	return false, updatedDevice, nil
 }
 
-func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, name string, decom domain.DeviceDecommission, eventCallback store.EventCallback) (*domain.Device, error) {
-	var device *domain.Device
+func (s *DeviceStore) DecommissionDevice(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error) {
+	var result *domain.Device
 	err := retryUpdate(func() (bool, error) {
-		retry, dev, err := s.decommissionDevice(ctx, orgId, name, decom, eventCallback)
-		device = dev
+		retry, dev, err := s.decommissionDevice(ctx, orgId, device, eventCallback)
+		result = dev
 		return retry, err
 	})
-	return device, err
+	return result, err
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1308,10 +1308,7 @@ func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID,
 	if existingRecord.ServiceConditions == nil {
 		existingRecord.ServiceConditions = model.MakeJSONField(model.ServiceConditions{})
 	}
-	prepared := conditions
-	if prepared == nil {
-		prepared = []domain.Condition{}
-	}
+	prepared := append([]domain.Condition(nil), conditions...)
 	existingRecord.ServiceConditions.Data.Conditions = &prepared
 
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
@@ -1320,7 +1317,7 @@ func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID,
 	})
 	err = store.ErrorFromGormError(result.Error)
 	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
+		return false, err
 	}
 	if result.RowsAffected == 0 {
 		return false, flterrors.ErrNoRowsUpdated

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1302,24 +1302,18 @@ func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID,
 	// Capture old conditions with deep copy
 	var oldConditions []domain.Condition
 	if existingRecord.ServiceConditions != nil && existingRecord.ServiceConditions.Data.Conditions != nil {
-		// Deep copy the conditions to avoid shared memory issues
 		oldConditions = append(oldConditions, *existingRecord.ServiceConditions.Data.Conditions...)
 	}
 
-	// Initialize service conditions if needed
 	if existingRecord.ServiceConditions == nil {
 		existingRecord.ServiceConditions = model.MakeJSONField(model.ServiceConditions{})
 	}
-	if existingRecord.ServiceConditions.Data.Conditions == nil {
-		existingRecord.ServiceConditions.Data.Conditions = &[]domain.Condition{}
+	prepared := conditions
+	if prepared == nil {
+		prepared = []domain.Condition{}
 	}
+	existingRecord.ServiceConditions.Data.Conditions = &prepared
 
-	// Set new conditions
-	for _, condition := range conditions {
-		domain.SetStatusCondition(existingRecord.ServiceConditions.Data.Conditions, condition)
-	}
-
-	// Update using the original pattern with specific field updates and optimistic locking
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
 		"service_conditions": existingRecord.ServiceConditions,
 		"resource_version":   gorm.Expr("resource_version + 1"),
@@ -1329,7 +1323,7 @@ func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID,
 		return strings.Contains(err.Error(), "deadlock"), err
 	}
 	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
+		return false, flterrors.ErrNoRowsUpdated
 	}
 
 	// Call callback if provided (but don't fail the operation if callback fails)

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1399,10 +1399,7 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, p
 		return false, nil, flterrors.ErrResourceVersionConflict
 	}
 
-	var oldDevice domain.Device
-	var devices []domain.Device
-	devices = append(devices, *existingDevice)
-	oldDevice = devices[0]
+	oldDevice := *existingDevice
 
 	// Persist the service-prepared state (spec/status/cleared owner+labels).
 	existingRecord.Spec = model.MakeJSONField(lo.FromPtr(prepared.Spec))

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -70,7 +70,7 @@ type Store interface {
 	// Used internally
 	UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) error
 	MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error
-	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error)
+	UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (string, error)
 	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
 	// DecommissionDevice persists an already-prepared device under resourceVersion CAS.
 	// Persistence contract: if the stored row already has Spec.Decommissioning set, returns
@@ -1138,7 +1138,7 @@ func (s *DeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, owner s
 	})
 }
 
-func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (retry bool, renderedVersion string, err error) {
+func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (retry bool, renderedVersion string, err error) {
 	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
 	result := s.getDB(ctx).Take(&existingRecord)
 	if result.Error != nil {
@@ -1156,31 +1156,15 @@ func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name,
 		return false, "", err
 	}
 
-	hash := specHash
-
 	existingAnnotations[domain.DeviceAnnotationRenderedVersion] = nextRenderedVersion
 	if lo.HasKey(existingAnnotations, domain.DeviceAnnotationTemplateVersion) {
 		existingAnnotations[domain.DeviceAnnotationRenderedTemplateVersion] = existingAnnotations[domain.DeviceAnnotationTemplateVersion]
 	}
 
-	specUnchanged := false
-	if lo.HasKey(existingAnnotations, domain.DeviceAnnotationRenderedSpecHash) {
-		if existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] == hash {
-			specUnchanged = true
-		}
-	}
-
 	// Build dependency sync status from fingerprints, preserving lastUpdatedAt for unchanged entries
 	updatedServiceConditions := buildDependencySyncStatus(existingRecord.ServiceConditions, configFingerprints)
 
-	// forceUpdate bypasses the specUnchanged short-circuit for callers that already determined
-	// (using fresher or additional context than specHash alone, e.g. a device-level application
-	// lifecycle annotation change) that this render must be persisted regardless of hash equality.
-	if specUnchanged && len(configFingerprints) == 0 && !forceUpdate {
-		return false, "", nil
-	}
-
-	existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] = hash
+	existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] = specHash
 
 	renderedApplicationsJSON := renderedApplications
 	if strings.TrimSpace(renderedApplications) == "" {
@@ -1254,13 +1238,13 @@ func buildDependencySyncStatus(existing *model.JSONField[model.ServiceConditions
 	return model.MakeJSONField(sc)
 }
 
-func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (string, error) {
+func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash string, configFingerprints []domain.DependencySyncConfigRefStatus) (string, error) {
 	var rv string
 
 	wrapper := func() (bool, error) {
 		var retry bool
 		var err error
-		retry, rv, err = s.updateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints, forceUpdate)
+		retry, rv, err = s.updateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, configFingerprints)
 		return retry, err
 	}
 

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1390,6 +1390,15 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, p
 		return false, nil, flterrors.ErrResourceVersionConflict
 	}
 
+	// CAS against the prepared ResourceVersion (service Get), not the freshly loaded one.
+	if prepared.Metadata.ResourceVersion == nil {
+		return false, nil, flterrors.ErrResourceVersionConflict
+	}
+	preparedRV, parseErr := strconv.ParseInt(lo.FromPtr(prepared.Metadata.ResourceVersion), 10, 64)
+	if parseErr != nil || lo.FromPtr(existingRecord.ResourceVersion) != preparedRV {
+		return false, nil, flterrors.ErrResourceVersionConflict
+	}
+
 	var oldDevice domain.Device
 	var devices []domain.Device
 	devices = append(devices, *existingDevice)
@@ -1401,7 +1410,7 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, p
 	existingRecord.Owner = nil
 	existingRecord.Labels = nil
 
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
+	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", preparedRV).Updates(map[string]interface{}{
 		"spec":             existingRecord.Spec,
 		"status":           existingRecord.Status,
 		"owner":            nil,
@@ -1415,7 +1424,7 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, p
 	if result.RowsAffected == 0 {
 		return true, nil, flterrors.ErrNoRowsUpdated
 	}
-	existingRecord.ResourceVersion = lo.ToPtr(lo.FromPtr(existingRecord.ResourceVersion) + 1)
+	existingRecord.ResourceVersion = lo.ToPtr(preparedRV + 1)
 
 	updatedDevice, err := existingRecord.ToApiResource()
 	if err != nil {

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1415,6 +1415,7 @@ func (s *DeviceStore) decommissionDevice(ctx context.Context, orgId uuid.UUID, p
 	if result.RowsAffected == 0 {
 		return true, nil, flterrors.ErrNoRowsUpdated
 	}
+	existingRecord.ResourceVersion = lo.ToPtr(lo.FromPtr(existingRecord.ResourceVersion) + 1)
 
 	updatedDevice, err := existingRecord.ToApiResource()
 	if err != nil {

--- a/internal/store/fleet/store.go
+++ b/internal/store/fleet/store.go
@@ -432,7 +432,7 @@ func (s *FleetStore) updateConditions(ctx context.Context, orgId uuid.UUID, name
 	})
 	err := store.ErrorFromGormError(result.Error)
 	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
+		return false, err
 	}
 	if result.RowsAffected == 0 {
 		return false, flterrors.ErrNoRowsUpdated

--- a/internal/store/fleet/store.go
+++ b/internal/store/fleet/store.go
@@ -420,23 +420,11 @@ func (s *FleetStore) updateConditions(ctx context.Context, orgId uuid.UUID, name
 	if existingRecord.Status == nil {
 		existingRecord.Status = model.MakeJSONField(domain.FleetStatus{})
 	}
-	if existingRecord.Status.Data.Conditions == nil {
-		existingRecord.Status.Data.Conditions = []domain.Condition{}
-	}
 
-	// Make a full copy of the existing conditions
 	existingConditions := make([]domain.Condition, len(existingRecord.Status.Data.Conditions))
 	copy(existingConditions, existingRecord.Status.Data.Conditions)
 
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(&existingRecord.Status.Data.Conditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return false, nil
-	}
+	existingRecord.Status.Data.Conditions = conditions
 
 	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
 		"status":           existingRecord.Status,
@@ -447,7 +435,7 @@ func (s *FleetStore) updateConditions(ctx context.Context, orgId uuid.UUID, name
 		return strings.Contains(err.Error(), "deadlock"), err
 	}
 	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
+		return false, flterrors.ErrNoRowsUpdated
 	}
 
 	oldFleet, _ := existingRecord.ToApiResource()

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -34,8 +34,8 @@ import (
 // by the edge device, and stores the rendered output.
 //
 // To ensure idempotency:
-// - If the device spec hasn't changed (as determined by UpdateRenderedDevice), the rendered
-//   version is not bumped.
+// - If the device spec hasn't changed (as determined by shouldPersistRenderedUpdate), the
+//   rendered version is not bumped and UpdateRenderedDevice is not called.
 // - The rendering process is deterministic, based on the device spec, configuration sources,
 //   and application specs.
 // - External inputs (e.g., Git repositories, HTTP endpoints, Kubernetes secrets) are frozen per
@@ -151,14 +151,11 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		}
 
 		// Don't render if the device spec hash hasn't changed since the last render, unless
-		// bypassHashCheck says this event must always produce a fresh render.
-		if !bypassHashCheck {
-			if val, ok := annotations[domain.DeviceAnnotationRenderedSpecHash]; ok {
-				if val == specHash {
-					t.log.Infof("Device %s spec hash hasn't changed since the last render", t.event.InvolvedObject.Name)
-					return nil
-				}
-			}
+		// bypassHashCheck / fingerprints would force a persist (fingerprints are unknown
+		// until after render, so the early gate uses an empty fingerprint list).
+		if !shouldPersistRenderedUpdate(annotations, specHash, nil, bypassHashCheck) {
+			t.log.Infof("Device %s spec hash hasn't changed since the last render", t.event.InvolvedObject.Name)
+			return nil
 		}
 	}
 
@@ -235,9 +232,13 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		syncRefs = append(syncRefs, ref)
 	}
 
-	// forceUpdate tells the store layer to persist this render and bump the rendered version
-	// even though specHash is unchanged (see bypassHashCheck above).
-	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(renderedConfig), string(renderedApplications), specHash, syncRefs, bypassHashCheck)
+	annotations = lo.FromPtr(device.Metadata.Annotations)
+	if !shouldPersistRenderedUpdate(annotations, specHash, syncRefs, bypassHashCheck) {
+		t.log.Infof("Device %s rendered output unchanged; skipping persist", t.event.InvolvedObject.Name)
+		return t.setStatus(ctx, nil)
+	}
+
+	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(renderedConfig), string(renderedApplications), specHash, syncRefs)
 	return t.setStatus(ctx, common.ApiStatusToErr(status))
 }
 
@@ -255,6 +256,16 @@ func (t *DeviceRenderLogic) markPermanentRenderFailure(ctx context.Context, spec
 	}
 }
 
+func shouldPersistRenderedUpdate(annotations map[string]string, specHash string, fingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) bool {
+	if forceUpdate || len(fingerprints) > 0 {
+		return true
+	}
+	existing, ok := annotations[domain.DeviceAnnotationRenderedSpecHash]
+	if !ok {
+		return true
+	}
+	return existing != specHash
+}
 func (t *DeviceRenderLogic) setStatus(ctx context.Context, renderErr error) error {
 	condition := domain.Condition{Type: domain.ConditionTypeDeviceSpecValid}
 

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -916,6 +916,61 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	err := logic.RenderDevice(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnknownApplicationType)
+func TestShouldPersistRenderedUpdate(t *testing.T) {
+	const hash = "abc123"
+	fingerprint := []domain.DependencySyncConfigRefStatus{{
+		ConfigProviderName: "cfg",
+		Fingerprint:        lo.ToPtr("fp1"),
+	}}
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		specHash     string
+		fingerprints []domain.DependencySyncConfigRefStatus
+		forceUpdate  bool
+		want         bool
+	}{
+		{
+			name:        "When hash matches with no fingerprints and forceUpdate false it should skip",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			want:        false,
+		},
+		{
+			name:        "When hash mismatches it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: "old"},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:        "When rendered spec hash annotation is missing it should write",
+			annotations: map[string]string{},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:         "When hash matches with non-empty fingerprints it should write",
+			annotations:  map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:     hash,
+			fingerprints: fingerprint,
+			want:         true,
+		},
+		{
+			name:        "When hash matches and forceUpdate is true it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			forceUpdate: true,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPersistRenderedUpdate(tt.annotations, tt.specHash, tt.fingerprints, tt.forceUpdate)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func makeK8sSecretConfigItem(configName, namespace, name, mountPath string) domain.ConfigProviderSpec {

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Device Agent behavior", func() {
 				// Update rendered once via the service so the rendered bus is notified (agent will see new version).
 				cfg, err := createMinimalRenderedConfig("config-v1")
 				Expect(err).ToNot(HaveOccurred())
-				st := h.Device.UpdateRenderedDevice(h.Context, orgID, deviceName, cfg, "", "hash1", nil, false)
+				st := h.Device.UpdateRenderedDevice(h.Context, orgID, deviceName, cfg, "", "hash1", nil)
 				Expect(st.Code).To(BeEquivalentTo(200))
 				renderedDev, getErr := h.DeviceStore.GetRendered(h.Context, orgID, deviceName, nil, "")
 				Expect(getErr).ToNot(HaveOccurred())

--- a/test/integration/service/catalog_test.go
+++ b/test/integration/service/catalog_test.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/flightctl/flightctl/api/core/v1alpha1"
 	apiv1beta1 "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/flterrors"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -708,6 +709,7 @@ var _ = Describe("Catalog Integration Tests", func() {
 
 			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName, true)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusConflict))
+			Expect(status.Message).To(Equal(flterrors.ErrResourceNotEmpty.Error()))
 		})
 
 		It("should allow deletion of empty catalog", func() {

--- a/test/integration/service/catalog_test.go
+++ b/test/integration/service/catalog_test.go
@@ -710,6 +710,11 @@ var _ = Describe("Catalog Integration Tests", func() {
 			status = suite.Catalog.DeleteCatalog(suite.Ctx, suite.OrgID, catalogName, true)
 			Expect(status.Code).To(BeEquivalentTo(http.StatusConflict))
 			Expect(status.Message).To(Equal(flterrors.ErrResourceNotEmpty.Error()))
+
+			stored, getStatus := suite.Catalog.GetCatalog(suite.Ctx, suite.OrgID, catalogName)
+			Expect(getStatus.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(stored).ToNot(BeNil())
+			Expect(lo.FromPtr(stored.Metadata.Name)).To(Equal(catalogName))
 		})
 
 		It("should allow deletion of empty catalog", func() {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -824,6 +824,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
 			Expect(stored.Metadata.Owner).To(BeNil())
 			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())
+			Expect(result.Metadata.ResourceVersion).To(Equal(stored.Metadata.ResourceVersion))
 		})
 
 		It("returns conflict when decommissioning an already-decommissioning device", func() {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -851,6 +851,38 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("SetDeviceServiceConditions", func() {
+		It("always writes even when the merged conditions are unchanged", func() {
+			deviceName := "svc-conditions-device"
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			cond := api.Condition{
+				Type:    api.ConditionTypeDeviceSpecValid,
+				Status:  api.ConditionStatusTrue,
+				Reason:  "ok",
+				Message: "ok",
+			}
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterWrite, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(api.IsStatusConditionTrue(afterWrite.Status.Conditions, api.ConditionTypeDeviceSpecValid)).To(BeTrue())
+			rvAfterWrite := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
+
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterRewrite, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(lo.FromPtr(afterRewrite.Metadata.ResourceVersion)).NotTo(Equal(rvAfterWrite))
+		})
+	})
+
 	Context("GetRenderedDevice when AwaitingReconnect moves to ConflictPaused", func() {
 		var (
 			suite           *ServiceTestSuite

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -751,7 +751,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil)
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
 
@@ -783,7 +783,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, false)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
@@ -945,7 +945,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			// Give device rendered content (version 1)
 			renderedConfig, err := createMinimalRenderedConfig("test-config")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", nil, false)
+			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set device annotations: AwaitingReconnect and service version 1 (device 5 > service 1 -> ConflictPaused)
@@ -996,7 +996,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 
 			renderedConfig, err := createMinimalRenderedConfig("test-config-2")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash2", nil, false)
+			_, err = suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash2", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = suite.DeviceStore.UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{
@@ -1894,7 +1894,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash1", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash1", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Prime the KV rendered-version to match what the agent reports.
@@ -1926,7 +1926,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash2", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash2", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			renderedKey := fmt.Sprintf("v1/%s/device/%s/rendered", suite.OrgID, deviceName)
@@ -1966,7 +1966,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash3", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash3", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Pin the DeviceAnnotationRenderedVersion annotation to a known value.
@@ -2010,7 +2010,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash4", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash4", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set console annotation to simulate an open console session.
@@ -2041,7 +2041,7 @@ var _ = Describe("Device LastSeen Integration Tests", func() {
 			})
 			Expect(status.Code).To(Equal(int32(201)))
 
-			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash5", nil, false)
+			_, err := suite.DeviceStore.UpdateRendered(suite.Ctx, suite.OrgID, deviceName, buildRenderedConfig("cfg"), "", "hash5", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = suite.DeviceStore.UpdateAnnotations(suite.Ctx, suite.OrgID, deviceName, map[string]string{

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -751,7 +751,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, true)
 			Expect(status.Code).To(Equal(int32(409)))
 			Expect(status.Message).To(Equal(flterrors.ErrUpdatingResourceWithOwnerNotAllowed.Error()))
 
@@ -783,7 +783,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
 				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img-updated"}},
 			}
-			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil)
+			_, status := suite.Device.ReplaceDevice(suite.Ctx, suite.OrgID, deviceName, updated, nil, false)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -813,6 +813,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			Expect(status.Code).To(Equal(int32(200)))
 			Expect(result.Spec).ToNot(BeNil())
 			Expect(result.Spec.Decommissioning).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
 			Expect(result.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
 			Expect(result.Metadata.Owner).To(BeNil())
 			// ToApiResource always materializes labels via EnsureMap; cleared labels surface as empty.
@@ -821,6 +822,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stored.Spec.Decommissioning).ToNot(BeNil())
+			Expect(stored.Spec.Decommissioning.Target).To(Equal(api.DeviceDecommissionTargetTypeUnenroll))
 			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
 			Expect(stored.Metadata.Owner).To(BeNil())
 			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -792,6 +792,62 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("Device decommission", func() {
+		It("decommissions a device and clears owner and labels", func() {
+			deviceName := "decom-device-success"
+			labels := map[string]string{"fleet": "f1"}
+			device := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:   lo.ToPtr(deviceName),
+					Owner:  lo.ToPtr("Fleet/f1"),
+					Labels: &labels,
+				},
+				Spec: &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			result, status := suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(result.Spec).ToNot(BeNil())
+			Expect(result.Spec.Decommissioning).ToNot(BeNil())
+			Expect(result.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(result.Metadata.Owner).To(BeNil())
+			// ToApiResource always materializes labels via EnsureMap; cleared labels surface as empty.
+			Expect(lo.FromPtr(result.Metadata.Labels)).To(BeEmpty())
+
+			stored, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Spec.Decommissioning).ToNot(BeNil())
+			Expect(stored.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusDecommissioning))
+			Expect(stored.Metadata.Owner).To(BeNil())
+			Expect(lo.FromPtr(stored.Metadata.Labels)).To(BeEmpty())
+		})
+
+		It("returns conflict when decommissioning an already-decommissioning device", func() {
+			deviceName := "decom-device-conflict"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			}
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, device)
+			Expect(status.Code).To(Equal(int32(201)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			_, status = suite.Device.DecommissionDevice(suite.Ctx, suite.OrgID, deviceName, api.DeviceDecommission{
+				Target: api.DeviceDecommissionTargetTypeUnenroll,
+			})
+			Expect(status.Code).To(Equal(int32(409)))
+			Expect(status.Message).To(Equal(flterrors.ErrResourceVersionConflict.Error()))
+		})
+	})
+
 	Context("GetRenderedDevice when AwaitingReconnect moves to ConflictPaused", func() {
 		var (
 			suite           *ServiceTestSuite

--- a/test/integration/service/fleet_test.go
+++ b/test/integration/service/fleet_test.go
@@ -56,3 +56,46 @@ var _ = Describe("Fleet create", func() {
 		),
 	)
 })
+
+var _ = Describe("Fleet condition updates", func() {
+	var suite *ServiceTestSuite
+
+	BeforeEach(func() {
+		suite = NewServiceTestSuite()
+		suite.Setup()
+	})
+
+	AfterEach(func() {
+		suite.Teardown()
+	})
+
+	It("merges a new condition and skips persist when reapplied unchanged", func() {
+		fleet := api.Fleet{
+			Metadata: api.ObjectMeta{Name: lo.ToPtr("cond-fleet")},
+			Spec:     api.FleetSpec{},
+		}
+		_, status := suite.Fleet.ReplaceFleet(suite.Ctx, suite.OrgID, "cond-fleet", fleet, true)
+		Expect(status.Code).To(Equal(int32(http.StatusCreated)))
+
+		cond := api.Condition{
+			Type:    api.ConditionTypeFleetValid,
+			Status:  api.ConditionStatusTrue,
+			Reason:  "ok",
+			Message: "ok",
+		}
+		status = suite.Fleet.UpdateFleetConditions(suite.Ctx, suite.OrgID, "cond-fleet", []api.Condition{cond})
+		Expect(status.Code).To(Equal(int32(http.StatusOK)))
+
+		afterWrite, status := suite.Fleet.GetFleet(suite.Ctx, suite.OrgID, "cond-fleet", api.GetFleetParams{})
+		Expect(status.Code).To(Equal(int32(http.StatusOK)))
+		Expect(api.IsStatusConditionTrue(afterWrite.Status.Conditions, api.ConditionTypeFleetValid)).To(BeTrue())
+		rvAfterWrite := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
+
+		status = suite.Fleet.UpdateFleetConditions(suite.Ctx, suite.OrgID, "cond-fleet", []api.Condition{cond})
+		Expect(status.Code).To(Equal(int32(http.StatusOK)))
+
+		afterNoop, status := suite.Fleet.GetFleet(suite.Ctx, suite.OrgID, "cond-fleet", api.GetFleetParams{})
+		Expect(status.Code).To(Equal(int32(http.StatusOK)))
+		Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(rvAfterWrite))
+	})
+})

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -791,6 +791,33 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(called).To(BeTrue())
 		})
 
+		It("CreateOrUpdateDevice refuses update when device is already decommissioning", func() {
+			name := "decom-guard-device"
+			device := api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
+				Spec: &api.DeviceSpec{
+					Os:              &api.DeviceOsSpec{Image: "img"},
+					Decommissioning: &api.DeviceDecommission{Target: api.DeviceDecommissionTargetTypeUnenroll},
+				},
+			}
+			_, _, err := devStore.CreateOrUpdate(ctx, orgId, &device, nil, nil, callback)
+			Expect(err).ToNot(HaveOccurred())
+
+			stored, err := devStore.Get(ctx, orgId, name)
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := api.Device{
+				Metadata: api.ObjectMeta{
+					Name:            lo.ToPtr(name),
+					ResourceVersion: stored.Metadata.ResourceVersion,
+					Labels:          &map[string]string{"k": "v"},
+				},
+				Spec: stored.Spec,
+			}
+			_, _, err = devStore.CreateOrUpdate(ctx, orgId, &updated, nil, nil, callback)
+			Expect(err).To(MatchError(flterrors.ErrDecommission))
+		})
+
 		It("UpdateDeviceStatus", func() {
 			// Random Condition to make sure Conditions do get stored
 			status := api.NewDeviceStatus()

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -731,10 +731,8 @@ var _ = Describe("DeviceStore create", func() {
 					},
 				}
 
-				// Create decommissioning spec
-				decommissioning := &api.DeviceDecommission{
-					Target: api.DeviceDecommissionTargetTypeUnenroll,
-				}
+				// Omit Spec.Decommissioning: DeviceStore.CreateOrUpdate refuses updates when
+				// the stored device is already decommissioning (persistence contract).
 
 				// Create systemd spec
 				systemd := &struct {
@@ -762,14 +760,13 @@ var _ = Describe("DeviceStore create", func() {
 						Owner:  owner,
 					},
 					Spec: &api.DeviceSpec{
-						Os:              osSpec,
-						Config:          &[]api.ConfigProviderSpec{gitItem, inlineItem, httpItem},
-						Applications:    &[]api.ApplicationProviderSpec{imageAppItem, inlineAppItem},
-						Resources:       &[]api.ResourceMonitor{cpuMonitor, memoryMonitor, diskMonitor},
-						Consoles:        &consoles,
-						Decommissioning: decommissioning,
-						Systemd:         systemd,
-						UpdatePolicy:    updatePolicy,
+						Os:           osSpec,
+						Config:       &[]api.ConfigProviderSpec{gitItem, inlineItem, httpItem},
+						Applications: &[]api.ApplicationProviderSpec{imageAppItem, inlineAppItem},
+						Resources:    &[]api.ResourceMonitor{cpuMonitor, memoryMonitor, diskMonitor},
+						Consoles:     &consoles,
+						Systemd:      systemd,
+						UpdatePolicy: updatePolicy,
 					},
 				}
 			}

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -79,7 +79,7 @@ var _ = Describe("DeviceStore create", func() {
 		err = testutil.CreateTestOrganization(ctx, organizationStore, orgId)
 		Expect(err).ToNot(HaveOccurred())
 
-		testutil.CreateTestDevices(ctx, 3, devStore, orgId, nil)
+		testutil.CreateTestDevices(ctx, 3, devStore, orgId, nil, false)
 	})
 
 	AfterEach(func() {

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -79,7 +79,7 @@ var _ = Describe("DeviceStore create", func() {
 		err = testutil.CreateTestOrganization(ctx, organizationStore, orgId)
 		Expect(err).ToNot(HaveOccurred())
 
-		testutil.CreateTestDevices(ctx, 3, devStore, orgId, nil, false)
+		testutil.CreateTestDevices(ctx, 3, devStore, orgId, nil)
 	})
 
 	AfterEach(func() {
@@ -1194,7 +1194,7 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Set first rendered config
-			_, err = devStore.UpdateRendered(ctx, orgId, "dev", firstConfig, "", "hash1", nil, false)
+			_, err = devStore.UpdateRendered(ctx, orgId, "dev", firstConfig, "", "hash1", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify rendered config is encrypted at rest
@@ -1232,7 +1232,7 @@ var _ = Describe("DeviceStore create", func() {
 			// Set second rendered config
 			secondConfig, err := createTestConfigProvider("this is the second config")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = devStore.UpdateRendered(ctx, orgId, "dev", secondConfig, "", "hash2", nil, false)
+			_, err = devStore.UpdateRendered(ctx, orgId, "dev", secondConfig, "", "hash2", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Passing previous renderedVersion
@@ -1248,29 +1248,21 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(renderedDevice.Version()).To(Equal("2"))
 		})
 
-		It("UpdateRendered forceUpdate bypasses the specUnchanged short-circuit", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-force-update", nil, nil, nil)
+		It("UpdateRendered always persists when called", func() {
+			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-always-write", nil, nil, nil)
 
 			config, err := createTestConfigProvider("initial config")
 			Expect(err).ToNot(HaveOccurred())
 
-			// Establish an initial rendered version for a given specHash.
-			firstVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false)
+			firstVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-always-write", config, "", "samehash", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(firstVersion).ToNot(BeEmpty())
 
-			// Same specHash, no config fingerprints, forceUpdate=false: short-circuits as a no-op.
-			noopVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, false)
+			// Skip-vs-write is owned by the caller; the store persists even when specHash is unchanged.
+			secondVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-always-write", config, "", "samehash", nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(noopVersion).To(BeEmpty())
-
-			// Same specHash, no config fingerprints, forceUpdate=true: must still persist and
-			// advance the rendered version, e.g. to reflect a device-level application lifecycle
-			// annotation change that isn't captured by specHash at all.
-			forcedVersion, err := devStore.UpdateRendered(ctx, orgId, "dev-force-update", config, "", "samehash", nil, true)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(forcedVersion).ToNot(BeEmpty())
-			Expect(forcedVersion).ToNot(Equal(firstVersion))
+			Expect(secondVersion).ToNot(BeEmpty())
+			Expect(secondVersion).ToNot(Equal(firstVersion))
 		})
 
 		It("OverwriteRepositoryRefs", func() {

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -537,7 +537,7 @@ var _ = Describe("FleetStore create", func() {
 			Expect(len(fleets.Items)).To(BeZero())
 		})
 
-		It("UpdateConditions", func() {
+		It("UpdateConditions persists a prepared conditions slice", func() {
 			conditions := []api.Condition{
 				{
 					Type:    api.ConditionTypeEnrollmentRequestApproved,


### PR DESCRIPTION
Jira: EDM4833-rendered-version-service
Recreated from fork (asafbennatan/flightctl → flightctl/flightctl).

Stack layer head: `asafbennatan:EDM-4833-rendered-version-service`
Base: `EDM-4832-condition-merge-service`

Made with [Cursor](https://cursor.com)