### PR TITLE
EDM-4837: Generation wiring for remaining call sites

### DIFF
--- a/internal/imagebuilder_api/service/generation.go
+++ b/internal/imagebuilder_api/service/generation.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
+	"github.com/samber/lo"
+)
+
+// setGenerationOnCreate sets the initial generation for a newly created
+// ImageBuilder API resource. Mirrors internal/service/catalog/generation.go —
+// generation decisions live in the service, not the store.
+func setGenerationOnCreate(meta *domain.ObjectMeta) {
+	meta.Generation = lo.ToPtr(int64(1))
+}
+
+// incrementGenerationOnSpecChange increments generation by 1 when specChanged
+// is true, otherwise carries the existing generation forward unchanged.
+func incrementGenerationOnSpecChange(existingGeneration *int64, specChanged bool) *int64 {
+	next := lo.FromPtr(existingGeneration)
+	if specChanged {
+		next++
+	}
+	return lo.ToPtr(next)
+}

--- a/internal/imagebuilder_api/service/generation.go
+++ b/internal/imagebuilder_api/service/generation.go
@@ -13,9 +13,18 @@ func setGenerationOnCreate(meta *domain.ObjectMeta) {
 }
 
 // incrementGenerationOnSpecChange increments generation by 1 when specChanged
-// is true, otherwise carries the existing generation forward unchanged.
+// is true, otherwise carries the existing generation forward unchanged. A nil
+// existingGeneration stays nil unless specChanged — mirroring the sibling
+// setGenerationOnUpdate convention (e.g. internal/service/catalog/generation.go)
+// — since 0 is never a valid generation value in this system.
 func incrementGenerationOnSpecChange(existingGeneration *int64, specChanged bool) *int64 {
-	next := lo.FromPtr(existingGeneration)
+	if existingGeneration == nil && !specChanged {
+		return nil
+	}
+	if existingGeneration == nil {
+		return lo.ToPtr(int64(1))
+	}
+	next := *existingGeneration
 	if specChanged {
 		next++
 	}

--- a/internal/imagebuilder_api/service/generation_test.go
+++ b/internal/imagebuilder_api/service/generation_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/imagebuilder_api/domain"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGenerationOnCreate(t *testing.T) {
+	t.Run("When called it should set generation to 1", func(t *testing.T) {
+		meta := &domain.ObjectMeta{}
+		setGenerationOnCreate(meta)
+		require.NotNil(t, meta.Generation)
+		require.Equal(t, int64(1), *meta.Generation)
+	})
+
+	t.Run("When a caller-supplied generation is already set it should overwrite it", func(t *testing.T) {
+		meta := &domain.ObjectMeta{Generation: lo.ToPtr(int64(42))}
+		setGenerationOnCreate(meta)
+		require.Equal(t, int64(1), *meta.Generation)
+	})
+}
+
+func TestIncrementGenerationOnSpecChange(t *testing.T) {
+	t.Run("When spec changed it should increment by 1", func(t *testing.T) {
+		result := incrementGenerationOnSpecChange(lo.ToPtr(int64(1)), true)
+		require.Equal(t, int64(2), *result)
+	})
+
+	t.Run("When spec is unchanged it should leave generation as-is", func(t *testing.T) {
+		result := incrementGenerationOnSpecChange(lo.ToPtr(int64(3)), false)
+		require.Equal(t, int64(3), *result)
+	})
+
+	t.Run("When spec changed and existing generation is nil it should treat it as 0 and increment to 1", func(t *testing.T) {
+		result := incrementGenerationOnSpecChange(nil, true)
+		require.Equal(t, int64(1), *result)
+	})
+
+	t.Run("When spec is unchanged and existing generation is nil it should leave it as 0", func(t *testing.T) {
+		result := incrementGenerationOnSpecChange(nil, false)
+		require.Equal(t, int64(0), *result)
+	})
+}

--- a/internal/imagebuilder_api/service/generation_test.go
+++ b/internal/imagebuilder_api/service/generation_test.go
@@ -34,13 +34,14 @@ func TestIncrementGenerationOnSpecChange(t *testing.T) {
 		require.Equal(t, int64(3), *result)
 	})
 
-	t.Run("When spec changed and existing generation is nil it should treat it as 0 and increment to 1", func(t *testing.T) {
+	t.Run("When spec changed and existing generation is nil it should set it to 1", func(t *testing.T) {
 		result := incrementGenerationOnSpecChange(nil, true)
+		require.NotNil(t, result)
 		require.Equal(t, int64(1), *result)
 	})
 
-	t.Run("When spec is unchanged and existing generation is nil it should leave it as 0", func(t *testing.T) {
+	t.Run("When spec is unchanged and existing generation is nil it should leave it nil", func(t *testing.T) {
 		result := incrementGenerationOnSpecChange(nil, false)
-		require.Equal(t, int64(0), *result)
+		require.Nil(t, result)
 	})
 }

--- a/internal/imagebuilder_api/service/imagebuild.go
+++ b/internal/imagebuilder_api/service/imagebuild.go
@@ -98,6 +98,7 @@ func (s *imageBuildService) Create(ctx context.Context, orgId uuid.UUID, imageBu
 	// Don't set fields that are managed by the service
 	imageBuild.Status = nil
 	NilOutManagedObjectMetaProperties(&imageBuild.Metadata)
+	setGenerationOnCreate(&imageBuild.Metadata)
 	if annotations, ok := preservedAnnotations(ctx); ok {
 		imageBuild.Metadata.Annotations = &annotations
 	}

--- a/internal/imagebuilder_api/service/imagebuild_test.go
+++ b/internal/imagebuilder_api/service/imagebuild_test.go
@@ -124,6 +124,8 @@ func TestCreateImageBuild(t *testing.T) {
 	require.Equal(int32(http.StatusCreated), statusCode(status))
 	require.NotNil(result)
 	require.Equal("test-build", lo.FromPtr(result.Metadata.Name))
+	require.NotNil(result.Metadata.Generation)
+	require.Equal(int64(1), lo.FromPtr(result.Metadata.Generation))
 }
 
 func TestCreateImageBuildDuplicate(t *testing.T) {

--- a/internal/imagebuilder_api/service/imageexport.go
+++ b/internal/imagebuilder_api/service/imageexport.go
@@ -114,6 +114,7 @@ func (s *imageExportService) Create(ctx context.Context, orgId uuid.UUID, imageE
 	// Don't set fields that are managed by the service
 	imageExport.Status = nil
 	NilOutManagedObjectMetaProperties(&imageExport.Metadata)
+	setGenerationOnCreate(&imageExport.Metadata)
 
 	// Validate input
 	if errs, internalErr := s.validate(ctx, orgId, &imageExport); internalErr != nil {

--- a/internal/imagebuilder_api/service/imageexport_test.go
+++ b/internal/imagebuilder_api/service/imageexport_test.go
@@ -117,6 +117,8 @@ func TestCreateImageExport(t *testing.T) {
 	require.Equal(int32(http.StatusCreated), statusCode(status))
 	require.NotNil(result)
 	require.Equal("test-export", lo.FromPtr(result.Metadata.Name))
+	require.NotNil(result.Metadata.Generation)
+	require.Equal(int64(1), lo.FromPtr(result.Metadata.Generation))
 }
 
 func TestCreateImageExportDuplicate(t *testing.T) {

--- a/internal/imagebuilder_api/service/imagepromotion.go
+++ b/internal/imagebuilder_api/service/imagepromotion.go
@@ -73,6 +73,7 @@ func NewImagePromotionService(
 func (s *imagePromotionService) Create(ctx context.Context, orgId uuid.UUID, promotion domain.ImagePromotion) (*domain.ImagePromotion, domain.Status) {
 	NilOutManagedObjectMetaProperties(&promotion.Metadata)
 	promotion.Status = nil
+	setGenerationOnCreate(&promotion.Metadata)
 
 	errs, internalErr := s.validateCreate(ctx, orgId, &promotion)
 	if internalErr != nil {
@@ -188,6 +189,10 @@ func (s *imagePromotionService) Replace(ctx context.Context, orgId uuid.UUID, na
 		setPromotionReadyCondition(current, domain.ImagePromotionConditionReasonWaitingForArtifacts,
 			conditionMessageForReason(domain.ImagePromotionConditionReasonWaitingForArtifacts))
 	}
+
+	// Adding an export format is the only spec change Replace allows (labels are not part of
+	// spec); everything else was already locked by validateImmutableSpecFields above.
+	current.Metadata.Generation = incrementGenerationOnSpecChange(current.Metadata.Generation, len(newFormats) > 0)
 
 	updated, err := s.store.Update(ctx, orgId, current)
 	if err != nil {

--- a/internal/imagebuilder_api/service/imagepromotion_test.go
+++ b/internal/imagebuilder_api/service/imagepromotion_test.go
@@ -139,6 +139,8 @@ func TestImagePromotionCreate(t *testing.T) {
 	result, status := svc.Create(ctx, orgId, promotion)
 	require.Equal(int32(http.StatusCreated), status.Code, "expected 201 Created, got: %s", status.Message)
 	require.NotNil(result)
+	require.NotNil(result.Metadata.Generation)
+	require.Equal(int64(1), lo.FromPtr(result.Metadata.Generation))
 
 	// The service must immediately set WaitingForArtifacts; evaluation is deferred to the worker.
 	requirePromotionReason(t, promotionStore, "promo-1", domain.ImagePromotionConditionReasonWaitingForArtifacts)
@@ -279,8 +281,9 @@ func TestImagePromotionReplace_AppendOnlyFormats(t *testing.T) {
 			Target: makeNewCatalogItemTarget("my-catalog", "my-app", "1.0.0"),
 		},
 	}
-	_, status := svc.Create(ctx, orgId, promotion)
+	created, status := svc.Create(ctx, orgId, promotion)
 	require.Equal(int32(http.StatusCreated), status.Code, "create failed: %s", status.Message)
+	require.Equal(int64(1), lo.FromPtr(created.Metadata.Generation))
 
 	// Replace: adding qcow2 format is allowed.
 	updated := domain.ImagePromotion{
@@ -293,8 +296,9 @@ func TestImagePromotionReplace_AppendOnlyFormats(t *testing.T) {
 			Target: makeNewCatalogItemTarget("my-catalog", "my-app", "1.0.0"),
 		},
 	}
-	_, replaceStatus := svc.Replace(ctx, orgId, "promo-replace", updated)
+	replaced, replaceStatus := svc.Replace(ctx, orgId, "promo-replace", updated)
 	require.Equal(int32(http.StatusOK), replaceStatus.Code, "replace with new format should succeed: %s", replaceStatus.Message)
+	require.Equal(int64(2), lo.FromPtr(replaced.Metadata.Generation), "adding an export format is a spec change and should increment generation")
 
 	// Replace: removing an existing format must be rejected.
 	removed := domain.ImagePromotion{
@@ -309,6 +313,51 @@ func TestImagePromotionReplace_AppendOnlyFormats(t *testing.T) {
 	}
 	_, removedStatus := svc.Replace(ctx, orgId, "promo-replace", removed)
 	require.Equal(int32(http.StatusBadRequest), removedStatus.Code, "removing a format should be rejected")
+}
+
+// TestImagePromotionReplace_LabelsOnly_GenerationUnchanged verifies that a Replace which only
+// changes metadata.labels (no export format change) leaves generation untouched.
+func TestImagePromotionReplace_LabelsOnly_GenerationUnchanged(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	orgId := uuid.New()
+
+	imageBuildStore := NewDummyImageBuildStore()
+	promotionStore := NewDummyImagePromotionStore()
+	catalogStore := NewDummyCatalogStore()
+
+	build := newCompletedImageBuild("my-build", "sha256:5678")
+	_, err := imageBuildStore.Create(ctx, orgId, &build)
+	require.NoError(err)
+	catalogStore.AddCatalog("my-catalog")
+
+	svc := newTestImagePromotionService(promotionStore, imageBuildStore, catalogStore)
+
+	promotion := domain.ImagePromotion{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr("promo-labels-only")},
+		Spec: domain.ImagePromotionSpec{
+			Source: domain.ImagePromotionSource{ImageBuildRef: "my-build"},
+			Target: makeNewCatalogItemTarget("my-catalog", "my-app", "1.0.0"),
+		},
+	}
+	created, status := svc.Create(ctx, orgId, promotion)
+	require.Equal(int32(http.StatusCreated), status.Code, "create failed: %s", status.Message)
+	require.Equal(int64(1), lo.FromPtr(created.Metadata.Generation))
+
+	// Replace with the same export formats (none) but new labels — not a spec change.
+	relabeled := domain.ImagePromotion{
+		Metadata: domain.ObjectMeta{
+			Name:   lo.ToPtr("promo-labels-only"),
+			Labels: lo.ToPtr(map[string]string{"env": "prod"}),
+		},
+		Spec: domain.ImagePromotionSpec{
+			Source: domain.ImagePromotionSource{ImageBuildRef: "my-build"},
+			Target: makeNewCatalogItemTarget("my-catalog", "my-app", "1.0.0"),
+		},
+	}
+	replaced, replaceStatus := svc.Replace(ctx, orgId, "promo-labels-only", relabeled)
+	require.Equal(int32(http.StatusOK), replaceStatus.Code, "labels-only replace should succeed: %s", replaceStatus.Message)
+	require.Equal(int64(1), lo.FromPtr(replaced.Metadata.Generation), "labels-only change should not increment generation")
 }
 
 // TestImagePromotionReplace_ImmutableFields verifies that immutable spec fields (imageBuildRef,

--- a/internal/imagebuilder_api/store/imagebuild.go
+++ b/internal/imagebuilder_api/store/imagebuild.go
@@ -87,8 +87,9 @@ func (s *imageBuildStore) Create(ctx context.Context, orgId uuid.UUID, imageBuil
 	}
 	m.OrgID = orgId
 
-	// Set initial Generation and ResourceVersion on create (matching GenericStore pattern)
-	m.Generation = lo.ToPtr(int64(1))
+	// Set initial ResourceVersion on create (matching GenericStore pattern).
+	// Generation is decided by the service, not the store — the model
+	// conversion above already carries it from the domain resource.
 	m.ResourceVersion = lo.ToPtr(int64(1))
 
 	// Set initial status with Ready=False, Reason=Pending if status is nil or empty

--- a/internal/imagebuilder_api/store/imageexport.go
+++ b/internal/imagebuilder_api/store/imageexport.go
@@ -62,8 +62,9 @@ func (s *imageExportStore) Create(ctx context.Context, orgId uuid.UUID, imageExp
 	}
 	m.OrgID = orgId
 
-	// Set initial Generation and ResourceVersion on create (matching GenericStore pattern)
-	m.Generation = lo.ToPtr(int64(1))
+	// Set initial ResourceVersion on create (matching GenericStore pattern).
+	// Generation is decided by the service, not the store — the model
+	// conversion above already carries it from the domain resource.
 	m.ResourceVersion = lo.ToPtr(int64(1))
 
 	// Set initial status with Ready=False, Reason=Pending if status is nil or empty

--- a/internal/imagebuilder_api/store/imagepromotion.go
+++ b/internal/imagebuilder_api/store/imagepromotion.go
@@ -64,7 +64,8 @@ func (s *imagePromotionStore) Create(ctx context.Context, orgId uuid.UUID, pub *
 	}
 	m.OrgID = orgId
 
-	m.Generation = lo.ToPtr(int64(1))
+	// Generation is decided by the service, not the store — the model
+	// conversion above already carries it from the domain resource.
 	m.ResourceVersion = lo.ToPtr(int64(1))
 
 	// Set initial status if not already set
@@ -209,6 +210,7 @@ func (s *imagePromotionStore) Update(ctx context.Context, orgId uuid.UUID, pub *
 	updates := map[string]interface{}{
 		"spec":             m.Spec,
 		"labels":           m.Labels,
+		"generation":       m.Generation,
 		"resource_version": gorm.Expr("resource_version + 1"),
 	}
 	if pub.Status != nil {

--- a/internal/service/events/handler.go
+++ b/internal/service/events/handler.go
@@ -8,6 +8,7 @@ import (
 	eventstore "github.com/flightctl/flightctl/internal/store/event"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,6 +34,10 @@ func (h *ServiceHandler) CreateEvent(ctx context.Context, orgId uuid.UUID, event
 	if event == nil {
 		return
 	}
+
+	// Events are immutable and append-only, so generation is always 1 — no
+	// increment path exists, unlike resources with an update lifecycle.
+	event.Metadata.Generation = lo.ToPtr(int64(1))
 
 	err := h.store.Create(ctx, orgId, event)
 	if err != nil {

--- a/internal/service/events/handler_test.go
+++ b/internal/service/events/handler_test.go
@@ -78,6 +78,16 @@ func TestCreateEvent(t *testing.T) {
 		require.Len(t, fakeWorker.emitted, 1)
 	})
 
+	t.Run("When the event is created it should set generation to 1", func(t *testing.T) {
+		h, fakeStore, _ := newTestHandler()
+		orgId := uuid.New()
+		event := domain.GetBaseEvent(context.Background(), domain.DeviceKind, "dev1", domain.EventReasonResourceCreated, "created", nil)
+		h.CreateEvent(context.Background(), orgId, event)
+		require.Len(t, fakeStore.events, 1)
+		require.NotNil(t, fakeStore.events[0].Metadata.Generation)
+		require.Equal(t, int64(1), *fakeStore.events[0].Metadata.Generation)
+	})
+
 	t.Run("When the store fails it should not notify the worker client", func(t *testing.T) {
 		h, fakeStore, fakeWorker := newTestHandler()
 		fakeStore.createErr = errors.New("db down")

--- a/internal/store/model/event.go
+++ b/internal/store/model/event.go
@@ -38,6 +38,7 @@ func NewEventFromApiResource(resource *domain.Event) (*Event, error) {
 		Resource: Resource{
 			Name:        *resource.Metadata.Name,
 			Annotations: lo.FromPtrOr(resource.Metadata.Annotations, make(map[string]string)),
+			Generation:  resource.Metadata.Generation,
 		},
 		Reason:             string(resource.Reason),
 		SourceComponent:    resource.Source.Component,
@@ -71,6 +72,7 @@ func (e *Event) ToApiResource(opts ...APIResourceOption) (*domain.Event, error) 
 			Name:              lo.ToPtr(e.Name),
 			Annotations:       lo.ToPtr(util.EnsureMap(e.Resource.Annotations)),
 			CreationTimestamp: lo.ToPtr(e.CreatedAt.UTC()),
+			Generation:        e.Generation,
 		},
 		InvolvedObject: domain.ObjectReference{
 			Kind: e.InvolvedObjectKind,

--- a/test/integration/imagebuilder_store/imagebuild_test.go
+++ b/test/integration/imagebuilder_store/imagebuild_test.go
@@ -45,6 +45,9 @@ func newTestImageBuild(name string) *api.ImageBuild {
 		Kind:       string(api.ResourceKindImageBuild),
 		Metadata: v1beta1.ObjectMeta{
 			Name: lo.ToPtr(name),
+			// Generation is service-assigned; these store-level tests call the
+			// store directly, so simulate what the service now sets.
+			Generation: lo.ToPtr(int64(1)),
 		},
 		Spec: api.ImageBuildSpec{
 			Source: api.ImageBuildSource{

--- a/test/integration/imagebuilder_store/imageexport_test.go
+++ b/test/integration/imagebuilder_store/imageexport_test.go
@@ -35,6 +35,9 @@ func newTestImageExport(name string) *api.ImageExport {
 		Kind:       string(api.ResourceKindImageExport),
 		Metadata: v1beta1.ObjectMeta{
 			Name: lo.ToPtr(name),
+			// Generation is service-assigned; these store-level tests call the
+			// store directly, so simulate what the service now sets.
+			Generation: lo.ToPtr(int64(1)),
 		},
 		Spec: api.ImageExportSpec{
 			Source: source,
@@ -55,6 +58,9 @@ func newTestImageExportWithImageBuildRef(name string, imageBuildRef string) *api
 		Kind:       string(api.ResourceKindImageExport),
 		Metadata: v1beta1.ObjectMeta{
 			Name: lo.ToPtr(name),
+			// Generation is service-assigned; these store-level tests call the
+			// store directly, so simulate what the service now sets.
+			Generation: lo.ToPtr(int64(1)),
 		},
 		Spec: api.ImageExportSpec{
 			Source: source,

--- a/test/integration/imagebuilder_store/imagepromotion_test.go
+++ b/test/integration/imagebuilder_store/imagepromotion_test.go
@@ -36,6 +36,9 @@ func newTestImagePromotion(name, imageBuildRef string) *domain.ImagePromotion {
 		Kind:       string(api.ResourceKindImagePromotion),
 		Metadata: v1beta1.ObjectMeta{
 			Name: lo.ToPtr(name),
+			// Generation is service-assigned; these store-level tests call the
+			// store directly, so simulate what the service now sets.
+			Generation: lo.ToPtr(int64(1)),
 		},
 		Spec: api.ImagePromotionSpec{
 			Source: api.ImagePromotionSource{
@@ -281,6 +284,22 @@ var _ = Describe("ImagePromotionStore", func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result.Spec.Source.ImageBuildRef).To(Equal("build-v2"))
 			Expect(*result.Metadata.Labels).To(HaveKeyWithValue("env", "prod"))
+		})
+
+		It("should persist a caller-supplied generation value unchanged", func() {
+			// Update is a pure persistence relay for generation — the service decides
+			// the value (see internal/imagebuilder_api/service/imagepromotion.go), and
+			// the store must not compute or override it.
+			promotion := newTestImagePromotion("generation-update-test", "test-build")
+			created, err := storeInst.ImagePromotion().Create(ctx, orgId, promotion)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*created.Metadata.Generation).To(Equal(int64(1)))
+
+			created.Metadata.Generation = lo.ToPtr(int64(2))
+			result, err := storeInst.ImagePromotion().Update(ctx, orgId, created)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Metadata.Generation).ToNot(BeNil())
+			Expect(*result.Metadata.Generation).To(Equal(int64(2)))
 		})
 
 		It("should increment resource version on update", func() {

--- a/test/integration/store/event_test.go
+++ b/test/integration/store/event_test.go
@@ -172,6 +172,31 @@ var _ = Describe("EventStore Integration Tests", func() {
 			Expect(*(eventList.Items[0].Metadata.Name)).To(Equal("event2"))
 		})
 	})
+
+	Context("Create", func() {
+		It("Persists and round-trips a service-assigned generation", func() {
+			// EventStore.Create does not compute Generation itself — the service
+			// layer assigns it before calling Create. Simulate that here.
+			name := "event-with-generation"
+			ev := &api.Event{
+				Reason:         api.EventReasonResourceCreated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: name},
+				Metadata:       api.ObjectMeta{Name: &name, Generation: lo.ToPtr(int64(1))},
+			}
+			Expect(eventStore.Create(ctx, orgId, ev)).ToNot(HaveOccurred())
+
+			listParams := store.ListParams{
+				Limit: 100,
+				FieldSelector: selector.NewFieldSelectorFromMapOrDie(
+					map[string]string{"involvedObject.name": name}, selector.WithPrivateSelectors()),
+			}
+			eventList, err := eventStore.List(ctx, orgId, listParams)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(eventList.Items).To(HaveLen(1))
+			Expect(eventList.Items[0].Metadata.Generation).ToNot(BeNil())
+			Expect(*eventList.Items[0].Metadata.Generation).To(Equal(int64(1)))
+		})
+	})
 })
 
 func createEvents(ctx context.Context, store eventstore.Store, orgId uuid.UUID) {


### PR DESCRIPTION
Jira: EDM4837-generation-wiring-callsites
Recreated from fork (asafbennatan/flightctl → flightctl/flightctl).

Stack layer head: `asafbennatan:EDM-4837-generation-wiring-callsites`
Base: `EDM-4836-awaitingreconnect-service`

Made with [Cursor](https://cursor.com)