### PR TITLE
EDM-4832: Condition merge in the service layer

### DIFF
--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -75,9 +75,6 @@ func (m *MockDevice) Delete(ctx context.Context, orgId uuid.UUID, name string, c
 func (m *MockDevice) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {
 	return nil, nil
 }
-func (m *MockDevice) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
-	return nil
-}
 func (m *MockDevice) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {
 	return nil
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -109,9 +109,6 @@ func (f *fakeDeviceStore) ProcessAwaitingReconnectAnnotation(context.Context, uu
 func (f *fakeDeviceStore) GetLastSeen(context.Context, uuid.UUID, string) (*time.Time, error) {
 	panic("not implemented")
 }
-func (f *fakeDeviceStore) SetServiceConditions(context.Context, uuid.UUID, string, []domain.Condition, devicestore.ServiceConditionsCallback) error {
-	panic("not implemented")
-}
 func (f *fakeDeviceStore) OverwriteRepositoryRefs(context.Context, uuid.UUID, string, ...string) error {
 	panic("not implemented")
 }

--- a/internal/service/common/conditions.go
+++ b/internal/service/common/conditions.go
@@ -1,0 +1,16 @@
+package common
+
+import "github.com/flightctl/flightctl/internal/domain"
+
+// MergeStatusConditions copies existing conditions and applies each update via
+// domain.SetStatusCondition, OR-aggregating whether anything changed.
+func MergeStatusConditions(existing []domain.Condition, updates []domain.Condition) (merged []domain.Condition, changed bool) {
+	merged = make([]domain.Condition, len(existing))
+	copy(merged, existing)
+	for _, update := range updates {
+		if domain.SetStatusCondition(&merged, update) {
+			changed = true
+		}
+	}
+	return merged, changed
+}

--- a/internal/service/common/conditions_test.go
+++ b/internal/service/common/conditions_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStatusConditions(t *testing.T) {
+	t.Run("When updates are empty it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, nil)
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+		require.NotSame(t, &existing[0], &merged[0])
+	})
+
+	t.Run("When a new condition type is added it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "r"},
+		})
+		require.True(t, changed)
+		require.Len(t, merged, 2)
+	})
+
+	t.Run("When the same condition is reapplied it should report unchanged", func(t *testing.T) {
+		existing := []domain.Condition{{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"}}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok", Message: "ok"},
+		})
+		require.False(t, changed)
+		require.Equal(t, existing, merged)
+	})
+
+	t.Run("When one of multiple updates changes it should report changed", func(t *testing.T) {
+		existing := []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "old"},
+		}
+		merged, changed := MergeStatusConditions(existing, []domain.Condition{
+			{Type: "A", Status: domain.ConditionStatusTrue, Reason: "ok"},
+			{Type: "B", Status: domain.ConditionStatusFalse, Reason: "new"},
+		})
+		require.True(t, changed)
+		require.Equal(t, "new", domain.FindStatusCondition(merged, "B").Reason)
+	})
+}

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -870,12 +870,61 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 }
 
 func (h *DeviceServiceHandler) SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status {
-	callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
-		h.diffAndEmitConditionEvents(ctx, orgId, device, oldConditions, newConditions)
+	var oldConditions, newConditions []domain.Condition
+	result, _, _, err := h.deviceStore.Mutate(ctx, orgId, name, nil, func(m *devicestore.DeviceMutation) error {
+		if err := m.RequireExisting(); err != nil {
+			return err
+		}
+		existing := serviceConditionsFromDevice(m.Device)
+		merged, changed := common.MergeStatusConditions(existing, conditions)
+		if !changed {
+			return store.ErrMutateSkipWrite
+		}
+		oldConditions = existing
+		newConditions = merged
+		replaceServiceConditionsOnDevice(m.Device, merged)
+		return nil
+	})
+	if err != nil {
+		return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 	}
+	if result != nil {
+		h.diffAndEmitConditionEvents(ctx, orgId, result, oldConditions, newConditions)
+	}
+	return domain.StatusOK()
+}
 
-	err := h.deviceStore.SetServiceConditions(ctx, orgId, name, conditions, callback)
-	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
+// serviceConditionsFromDevice returns SpecValid / MultipleOwners conditions from
+// Status.Conditions (agent and service conditions are stored separately but
+// exposed together by Get).
+func serviceConditionsFromDevice(device *domain.Device) []domain.Condition {
+	if device == nil || device.Status == nil {
+		return nil
+	}
+	var out []domain.Condition
+	for _, c := range device.Status.Conditions {
+		if c.Type.IsServiceConditionType() {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// replaceServiceConditionsOnDevice swaps service-owned conditions on Status while
+// preserving agent conditions. NewDeviceFromApiResource routes service types into
+// the service_conditions column on persist.
+func replaceServiceConditionsOnDevice(device *domain.Device, serviceConds []domain.Condition) {
+	if device.Status == nil {
+		status := domain.NewDeviceStatus()
+		device.Status = &status
+	}
+	var agent []domain.Condition
+	for _, c := range device.Status.Conditions {
+		if !c.Type.IsServiceConditionType() {
+			agent = append(agent, c)
+		}
+	}
+	device.Status.Conditions = append(agent, serviceConds...)
 }
 
 // diffAndEmitConditionEvents compares old and new conditions and emits events for condition changes

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -946,6 +946,44 @@ func TestSetDeviceServiceConditions(t *testing.T) {
 		require.Len(t, ev.created, 1)
 	})
 
+	t.Run("When a service condition is updated it should preserve agent-owned conditions", func(t *testing.T) {
+		st, _, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		agentCond := domain.Condition{
+			Type:    domain.ConditionTypeDeviceUpdating,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "Applying",
+			Message: "applying spec",
+		}
+		serviceCond := domain.Condition{
+			Type:    domain.ConditionTypeDeviceSpecValid,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "ok",
+			Message: "ok",
+		}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{agentCond, serviceCond},
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
+		})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+
+		stored := st.device.devices["foo"]
+		gotAgent := domain.FindStatusCondition(stored.Status.Conditions, domain.ConditionTypeDeviceUpdating)
+		require.Equal(t, &agentCond, gotAgent)
+		gotService := domain.FindStatusCondition(stored.Status.Conditions, domain.ConditionTypeDeviceSpecValid)
+		require.NotNil(t, gotService)
+		require.Equal(t, domain.ConditionStatusFalse, gotService.Status)
+		require.Equal(t, "bad spec", gotService.Message)
+	})
+
 	t.Run("When merge changes nothing it should skip write and not emit events", func(t *testing.T) {
 		st, ev, svc := newTestHandler()
 		ctx := context.Background()

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -904,30 +904,80 @@ func TestUpdateRenderedDevice(t *testing.T) {
 	require.Equal(t, int32(http.StatusOK), status.Code)
 }
 
+func TestServiceConditionsFromDevice(t *testing.T) {
+	t.Run("When status is nil it should return nil", func(t *testing.T) {
+		require.Nil(t, serviceConditionsFromDevice(&domain.Device{}))
+	})
+
+	t.Run("When status mixes agent and service conditions it should return only service types", func(t *testing.T) {
+		device := &domain.Device{
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{
+					{Type: domain.ConditionTypeDeviceUpdating, Status: domain.ConditionStatusTrue},
+					{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse},
+					{Type: domain.ConditionTypeDeviceMultipleOwners, Status: domain.ConditionStatusTrue},
+				},
+			},
+		}
+		got := serviceConditionsFromDevice(device)
+		require.Len(t, got, 2)
+		require.Equal(t, domain.ConditionTypeDeviceSpecValid, got[0].Type)
+		require.Equal(t, domain.ConditionTypeDeviceMultipleOwners, got[1].Type)
+	})
+}
+
 func TestSetDeviceServiceConditions(t *testing.T) {
-	st, ev, svc := newTestHandler()
-	ctx := context.Background()
-	orgId := uuid.New()
-	_, err := st.device.Create(ctx, orgId, &domain.Device{
-		Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
-		Status:   lo.ToPtr(domain.NewDeviceStatus()),
-	}, nil)
-	require.NoError(t, err)
+	t.Run("When a service condition changes it should persist and emit events", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status:   lo.ToPtr(domain.NewDeviceStatus()),
+		}, nil)
+		require.NoError(t, err)
 
-	condition := domain.Condition{
-		Type:    domain.ConditionTypeDeviceSpecValid,
-		Status:  domain.ConditionStatusFalse,
-		Message: "bad spec",
-	}
-	status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	// SpecValid transitioning from absent to invalid emits a DeviceSpecInvalid event.
-	require.Len(t, ev.created, 1)
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusFalse, Message: "bad spec"},
+		})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		stored := st.device.devices["foo"]
+		require.NotNil(t, domain.FindStatusCondition(stored.Status.Conditions, domain.ConditionTypeDeviceSpecValid))
+		require.Len(t, ev.created, 1)
+	})
 
-	status = svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{condition})
-	require.Equal(t, int32(http.StatusOK), status.Code)
-	// Unchanged conditions must not write or emit another event.
-	require.Len(t, ev.created, 1)
+	t.Run("When merge changes nothing it should skip write and not emit events", func(t *testing.T) {
+		st, ev, svc := newTestHandler()
+		ctx := context.Background()
+		orgId := uuid.New()
+		cond := domain.Condition{
+			Type:    domain.ConditionTypeDeviceSpecValid,
+			Status:  domain.ConditionStatusTrue,
+			Reason:  "ok",
+			Message: "ok",
+		}
+		_, err := st.device.Create(ctx, orgId, &domain.Device{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr("foo")},
+			Status: &domain.DeviceStatus{
+				Conditions: []domain.Condition{cond},
+			},
+		}, nil)
+		require.NoError(t, err)
+		beforeRV := lo.FromPtr(st.device.devices["foo"].Metadata.ResourceVersion)
+
+		status := svc.SetDeviceServiceConditions(ctx, orgId, "foo", []domain.Condition{cond})
+		require.Equal(t, int32(http.StatusOK), status.Code)
+		require.Equal(t, beforeRV, lo.FromPtr(st.device.devices["foo"].Metadata.ResourceVersion))
+		require.Empty(t, ev.created)
+	})
+
+	t.Run("When the device does not exist it should return a not-found status", func(t *testing.T) {
+		_, _, svc := newTestHandler()
+		status := svc.SetDeviceServiceConditions(context.Background(), uuid.New(), "missing", []domain.Condition{
+			{Type: domain.ConditionTypeDeviceSpecValid, Status: domain.ConditionStatusTrue},
+		})
+		require.Equal(t, int32(http.StatusNotFound), status.Code)
+	})
 }
 
 func TestUpdateServiceSideDeviceStatus(t *testing.T) {

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -293,35 +293,6 @@ func (s *fakeDeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, own
 	return nil
 }
 
-func (s *fakeDeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback devicestore.ServiceConditionsCallback) error {
-	d, ok := s.devices[name]
-	if !ok {
-		return flterrors.ErrResourceNotFound
-	}
-	var oldConditions []domain.Condition
-	if d.Status != nil {
-		oldConditions = append([]domain.Condition(nil), d.Status.Conditions...)
-	}
-	newConditions := append([]domain.Condition(nil), oldConditions...)
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(&newConditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return nil
-	}
-	if d.Status == nil {
-		d.Status = lo.ToPtr(domain.NewDeviceStatus())
-	}
-	d.Status.Conditions = newConditions
-	if callback != nil {
-		callback(ctx, orgId, d, oldConditions, newConditions)
-	}
-	return nil
-}
-
 func (s *fakeDeviceStore) RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error) {
 	var ids []string
 	for name, d := range s.devices {

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -273,18 +273,15 @@ func (h *ServiceHandler) UpdateFleetConditions(ctx context.Context, orgId uuid.U
 		if current.Status == nil {
 			current.Status = &domain.FleetStatus{}
 		}
-		if current.Status.Conditions == nil {
-			current.Status.Conditions = []domain.Condition{}
+		var existing []domain.Condition
+		if current.Status.Conditions != nil {
+			existing = current.Status.Conditions
 		}
-		changed := false
-		for _, condition := range conditions {
-			if domain.SetStatusCondition(&current.Status.Conditions, condition) {
-				changed = true
-			}
-		}
+		merged, changed := common.MergeStatusConditions(existing, conditions)
 		if !changed {
 			return store.ErrMutateSkipWrite
 		}
+		current.Status.Conditions = merged
 		return nil
 	})
 	h.callEventCallback(ctx, h.callbackFleetUpdated, orgId, name, before, result, false, err)

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -83,7 +83,6 @@ type Store interface {
 	GetLastSeen(ctx context.Context, orgId uuid.UUID, name string) (*time.Time, error)
 
 	// Used internally
-	SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error
 	OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error
 	GetRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, error)
 	RemoveConflictPausedAnnotation(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (int64, []string, error)
@@ -116,8 +115,6 @@ type DeviceStore struct {
 	log          logrus.FieldLogger
 	genericStore *store.GenericStore[*model.Device, model.Device, domain.Device, domain.DeviceList]
 }
-
-type ServiceConditionsCallback func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition)
 
 // DeviceRendered holds rendered_* column values not represented on domain.Device.
 // When set on DeviceMutation, Mutate persists them and bumps render_timestamp.
@@ -1395,87 +1392,6 @@ func (s *DeviceStore) GetLastSeen(ctx context.Context, orgId uuid.UUID, name str
 	}
 
 	return deviceModel.LastSeen, nil
-}
-
-func (s *DeviceStore) setServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) (retry bool, err error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, store.ErrorFromGormError(result.Error)
-	}
-
-	// Capture old conditions with deep copy
-	var oldConditions []domain.Condition
-	if existingRecord.ServiceConditions != nil && existingRecord.ServiceConditions.Data.Conditions != nil {
-		// Deep copy the conditions to avoid shared memory issues
-		oldConditions = append(oldConditions, *existingRecord.ServiceConditions.Data.Conditions...)
-	}
-
-	// Initialize service conditions if needed
-	if existingRecord.ServiceConditions == nil {
-		existingRecord.ServiceConditions = model.MakeJSONField(model.ServiceConditions{})
-	}
-	if existingRecord.ServiceConditions.Data.Conditions == nil {
-		existingRecord.ServiceConditions.Data.Conditions = &[]domain.Condition{}
-	}
-
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(existingRecord.ServiceConditions.Data.Conditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return false, nil
-	}
-
-	// Update using the original pattern with specific field updates and optimistic locking
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"service_conditions": existingRecord.ServiceConditions,
-		"resource_version":   gorm.Expr("resource_version + 1"),
-	})
-	err = store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
-	}
-	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
-	}
-
-	// Call callback if provided (but don't fail the operation if callback fails)
-	if callback != nil {
-		// Convert the updated model to API resource for the callback
-		apiDevice, convertErr := existingRecord.ToApiResource()
-		if convertErr != nil {
-			// Log the error but don't fail the operation
-			s.log.Errorf("Failed to convert device to API resource for callback: %v", convertErr)
-		} else {
-			// Call callback in a defer with error recovery to prevent callback failures from affecting the main operation
-			defer func() {
-				if r := recover(); r != nil {
-					s.log.Errorf("Callback panicked during service conditions update: %v", r)
-				}
-			}()
-
-			// Call the callback - if it fails, log the error but don't propagate it
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						s.log.Errorf("Service conditions callback panicked: %v", r)
-					}
-				}()
-				callback(ctx, orgId, apiDevice, oldConditions, *existingRecord.ServiceConditions.Data.Conditions)
-			}()
-		}
-	}
-
-	return false, nil
-}
-
-func (s *DeviceStore) SetServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, callback ServiceConditionsCallback) error {
-	return store.RetryUpdate(func() (bool, error) {
-		return s.setServiceConditions(ctx, orgId, name, conditions, callback)
-	})
 }
 
 func (s *DeviceStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -858,6 +858,38 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 		})
 	})
 
+	Context("SetDeviceServiceConditions", func() {
+		It("persists a changed service condition and skips write when unchanged", func() {
+			deviceName := "svc-conditions-device"
+			_, status := suite.Device.CreateDevice(suite.Ctx, suite.OrgID, api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec:     &api.DeviceSpec{Os: &api.DeviceOsSpec{Image: "img"}},
+			})
+			Expect(status.Code).To(Equal(int32(201)))
+
+			cond := api.Condition{
+				Type:    api.ConditionTypeDeviceSpecValid,
+				Status:  api.ConditionStatusTrue,
+				Reason:  "ok",
+				Message: "ok",
+			}
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterWrite, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(api.IsStatusConditionTrue(afterWrite.Status.Conditions, api.ConditionTypeDeviceSpecValid)).To(BeTrue())
+			rvAfterWrite := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
+
+			status = suite.Device.SetDeviceServiceConditions(suite.Ctx, suite.OrgID, deviceName, []api.Condition{cond})
+			Expect(status.Code).To(Equal(int32(200)))
+
+			afterNoop, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, deviceName)
+			Expect(status.Code).To(Equal(int32(200)))
+			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(rvAfterWrite))
+		})
+	})
+
 	Context("Package-mode OS image rejection", func() {
 		seedDeviceWithOsMode := func(deviceName string, osMode *api.OsModeType) {
 			GinkgoHelper()

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -1653,37 +1653,6 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(renderedDevice.Spec.Os.Image).To(Equal("os"))
 		})
 
-		It("SetServiceConditions skips write and callback when conditions are unchanged", func() {
-			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-svc-conditions-noop", nil, nil, nil)
-
-			condition := domain.Condition{
-				Type:    domain.ConditionTypeDeviceSpecValid,
-				Status:  domain.ConditionStatusTrue,
-				Reason:  "Valid",
-				Message: "Valid",
-			}
-			callbackCalls := 0
-			callback := func(ctx context.Context, orgId uuid.UUID, device *domain.Device, oldConditions, newConditions []domain.Condition) {
-				callbackCalls++
-			}
-
-			err := devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(callbackCalls).To(Equal(1))
-
-			afterWrite, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
-			Expect(err).ToNot(HaveOccurred())
-			resourceVersion := lo.FromPtr(afterWrite.Metadata.ResourceVersion)
-
-			err = devStore.SetServiceConditions(ctx, orgId, "dev-svc-conditions-noop", []domain.Condition{condition}, callback)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(callbackCalls).To(Equal(1))
-
-			afterNoop, err := devStore.Get(ctx, orgId, "dev-svc-conditions-noop")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lo.FromPtr(afterNoop.Metadata.ResourceVersion)).To(Equal(resourceVersion))
-		})
-
 		It("UpdateRendered persists status in the same resource_version bump", func() {
 			testutil.CreateTestDevice(ctx, devStore, orgId, "dev-render-status", nil, nil, nil)
 

--- a/test/integration/tasks/fleet_selector_test.go
+++ b/test/integration/tasks/fleet_selector_test.go
@@ -352,7 +352,17 @@ var _ = Describe("FleetSelector", func() {
 			Expect(len(devices.Items)).To(Equal(7))
 			for _, device := range devices.Items {
 				condition := api.Condition{Type: api.ConditionTypeDeviceMultipleOwners, Status: api.ConditionStatusTrue, Message: "fleet2,fleet3"}
-				err = deviceStore.SetServiceConditions(ctx, orgId, *device.Metadata.Name, []api.Condition{condition}, nil)
+				_, _, _, err = deviceStore.Mutate(ctx, orgId, *device.Metadata.Name, nil, func(m *devicestore.DeviceMutation) error {
+					if err := m.RequireExisting(); err != nil {
+						return err
+					}
+					if m.Device.Status == nil {
+						st := api.NewDeviceStatus()
+						m.Device.Status = &st
+					}
+					api.SetStatusCondition(&m.Device.Status.Conditions, condition)
+					return nil
+				})
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -431,7 +441,17 @@ var _ = Describe("FleetSelector", func() {
 			noLabelsNoOwnerDevice := "nolabels-noowner"
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, noLabelsNoOwnerDevice, nil, nil, &map[string]string{})
 			condition := api.Condition{Type: api.ConditionTypeDeviceMultipleOwners, Status: api.ConditionStatusTrue, Message: "fleet1,fleet2"}
-			err := deviceStore.SetServiceConditions(ctx, orgId, noLabelsNoOwnerDevice, []api.Condition{condition}, nil)
+			_, _, _, err := deviceStore.Mutate(ctx, orgId, noLabelsNoOwnerDevice, nil, func(m *devicestore.DeviceMutation) error {
+				if err := m.RequireExisting(); err != nil {
+					return err
+				}
+				if m.Device.Status == nil {
+					st := api.NewDeviceStatus()
+					m.Device.Status = &st
+				}
+				api.SetStatusCondition(&m.Device.Status.Conditions, condition)
+				return nil
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			listParams := devicestore.DeviceListParams{ListParams: store.ListParams{Limit: 0}}


### PR DESCRIPTION
Jira: EDM-4832

Moves device service-condition merge and no-op decisions into the service layer using store-native `Mutate` CAS (EDM-5028).

## Summary

- `SetDeviceServiceConditions` merges via `common.MergeStatusConditions` inside a `Mutate` apply callback
- Unchanged merges return `ErrMutateSkipWrite` (no RV bump, no events) — same pattern as fleet on `main`
- Removes store `SetServiceConditions` (merge + callback lived there)
- Fleet `UpdateFleetConditions` shares `MergeStatusConditions` (already Mutate-based on `main`)
- Unit + service integration coverage for change / no-op / not-found

**Note:** CSR `UpdateConditions` remains an unused store API with in-store merge; leave for a later cleanup (no production callers).

## Release target (required before merge to `main`)

- [x] **`release-1.3`**

---
**Stack:** depends on #3402 (EDM-4830 Mutate-based decommission).

Made with [Cursor](https://cursor.com)