### PR TITLE
EDM-4833: Rendered-version / hash decisions in service

### DIFF
--- a/internal/service/device/rendered.go
+++ b/internal/service/device/rendered.go
@@ -28,9 +28,7 @@ func applyRenderedUpdate(
 	if err != nil {
 		return "", err
 	}
-	specUnchanged := lo.HasKey(ann, domain.DeviceAnnotationRenderedSpecHash) &&
-		ann[domain.DeviceAnnotationRenderedSpecHash] == specHash
-	if specUnchanged && len(configFingerprints) == 0 && !forceUpdate {
+	if !shouldPersistRenderedUpdate(ann, specHash, configFingerprints, forceUpdate) {
 		return "", store.ErrMutateSkipWrite
 	}
 	ann[domain.DeviceAnnotationRenderedVersion] = next
@@ -57,6 +55,15 @@ func applyRenderedUpdate(
 		OsImage:      osImage,
 	}
 	return next, nil
+}
+
+func shouldPersistRenderedUpdate(ann map[string]string, specHash string, fingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) bool {
+	specUnchanged := lo.HasKey(ann, domain.DeviceAnnotationRenderedSpecHash) &&
+		ann[domain.DeviceAnnotationRenderedSpecHash] == specHash
+	if specUnchanged && len(fingerprints) == 0 && !forceUpdate {
+		return false
+	}
+	return true
 }
 
 func applyDependencySyncFingerprints(device *domain.Device, fingerprints []domain.DependencySyncConfigRefStatus) {

--- a/internal/service/device/rendered_test.go
+++ b/internal/service/device/rendered_test.go
@@ -1,0 +1,66 @@
+package device
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldPersistRenderedUpdate(t *testing.T) {
+	const hash = "abc123"
+	fingerprint := []domain.DependencySyncConfigRefStatus{{
+		ConfigProviderName: "cfg",
+		Fingerprint:        lo.ToPtr("fp1"),
+	}}
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		specHash     string
+		fingerprints []domain.DependencySyncConfigRefStatus
+		forceUpdate  bool
+		want         bool
+	}{
+		{
+			name:        "When hash matches with no fingerprints and forceUpdate false it should skip",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			want:        false,
+		},
+		{
+			name:        "When hash mismatches it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: "old"},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:        "When rendered spec hash annotation is missing it should write",
+			annotations: map[string]string{},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:         "When hash matches with non-empty fingerprints it should write",
+			annotations:  map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:     hash,
+			fingerprints: fingerprint,
+			want:         true,
+		},
+		{
+			name:        "When hash matches and forceUpdate is true it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			forceUpdate: true,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPersistRenderedUpdate(tt.annotations, tt.specHash, tt.fingerprints, tt.forceUpdate)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -918,6 +918,61 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	err := logic.RenderDevice(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnknownApplicationType)
+func TestShouldPersistRenderedUpdate(t *testing.T) {
+	const hash = "abc123"
+	fingerprint := []domain.DependencySyncConfigRefStatus{{
+		ConfigProviderName: "cfg",
+		Fingerprint:        lo.ToPtr("fp1"),
+	}}
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		specHash     string
+		fingerprints []domain.DependencySyncConfigRefStatus
+		forceUpdate  bool
+		want         bool
+	}{
+		{
+			name:        "When hash matches with no fingerprints and forceUpdate false it should skip",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			want:        false,
+		},
+		{
+			name:        "When hash mismatches it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: "old"},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:        "When rendered spec hash annotation is missing it should write",
+			annotations: map[string]string{},
+			specHash:    hash,
+			want:        true,
+		},
+		{
+			name:         "When hash matches with non-empty fingerprints it should write",
+			annotations:  map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:     hash,
+			fingerprints: fingerprint,
+			want:         true,
+		},
+		{
+			name:        "When hash matches and forceUpdate is true it should write",
+			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
+			specHash:    hash,
+			forceUpdate: true,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPersistRenderedUpdate(tt.annotations, tt.specHash, tt.fingerprints, tt.forceUpdate)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func makeK8sSecretConfigItem(configName, namespace, name, mountPath string) domain.ConfigProviderSpec {

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -920,63 +920,6 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnknownApplicationType)
 }
 
-func TestShouldPersistRenderedUpdate(t *testing.T) {
-	const hash = "abc123"
-	fingerprint := []domain.DependencySyncConfigRefStatus{{
-		ConfigProviderName: "cfg",
-		Fingerprint:        lo.ToPtr("fp1"),
-	}}
-
-	tests := []struct {
-		name         string
-		annotations  map[string]string
-		specHash     string
-		fingerprints []domain.DependencySyncConfigRefStatus
-		forceUpdate  bool
-		want         bool
-	}{
-		{
-			name:        "When hash matches with no fingerprints and forceUpdate false it should skip",
-			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
-			specHash:    hash,
-			want:        false,
-		},
-		{
-			name:        "When hash mismatches it should write",
-			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: "old"},
-			specHash:    hash,
-			want:        true,
-		},
-		{
-			name:        "When rendered spec hash annotation is missing it should write",
-			annotations: map[string]string{},
-			specHash:    hash,
-			want:        true,
-		},
-		{
-			name:         "When hash matches with non-empty fingerprints it should write",
-			annotations:  map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
-			specHash:     hash,
-			fingerprints: fingerprint,
-			want:         true,
-		},
-		{
-			name:        "When hash matches and forceUpdate is true it should write",
-			annotations: map[string]string{domain.DeviceAnnotationRenderedSpecHash: hash},
-			specHash:    hash,
-			forceUpdate: true,
-			want:        true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shouldPersistRenderedUpdate(tt.annotations, tt.specHash, tt.fingerprints, tt.forceUpdate)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func makeK8sSecretConfigItem(configName, namespace, name, mountPath string) domain.ConfigProviderSpec {
 	item := domain.ConfigProviderSpec{}
 	_ = item.FromKubernetesSecretProviderSpec(api.KubernetesSecretProviderSpec{

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -918,6 +918,8 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	err := logic.RenderDevice(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnknownApplicationType)
+}
+
 func TestShouldPersistRenderedUpdate(t *testing.T) {
 	const hash = "abc123"
 	fingerprint := []domain.DependencySyncConfigRefStatus{{


### PR DESCRIPTION
Jira: EDM-4833

Moves the rendered skip-vs-write decision into `device_render` and removes the rendered-hash short-circuit from `DeviceStore`.

## Release target (required before merge to `main`)

- [x] **`release-1.3`**

---
**Stack:** 6/12 in the EDM-4806 closeout stack (based on `main`; depends on and should merge after #3403 — EDM-4832).
