### PR TITLE
4.2 multiple vms

### DIFF
--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -1,6 +1,7 @@
 package vm_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -16,10 +17,18 @@ import (
 
 const (
 	vmAppName                    = "test-vm"
+	vmAppAName                   = "test-vm-a"
+	vmAppBName                   = "test-vm-b"
 	defaultVMImage               = "quay.io/containerdisks/fedora:40"
 	vmGuestUser                  = "fedora"
 	vmGuestPassword              = "fedora"
+	vmCloudUser                  = "cloud-user"
+	vmCloudUserPassword          = "cloud-user-pass"
 	vmPublishedSSHPort           = 2222
+	vmBPublishedSSHPort          = 2223
+	vmBPublishedUDPPort          = 9090
+	vmGuestMemory                = "1024M"
+	configDriveIndexHTMLContent  = "Hello from ConfigDrive"
 	systemdSubStateActive        = "active"
 	systemdSubStateRunning       = "running"
 	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
@@ -95,7 +104,210 @@ var _ = Describe("VM Applications", Ordered, func() {
 			g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty())
 		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 	})
+
+	// Two VM apps on one device without conflict. Both use KubeVirt ConfigDrive
+	// (userDataBase64). test-vm-a maps 2222:22; test-vm-b maps 2223:22/tcp and
+	// 9090:9090/udp. Verifies concurrent Running/Healthy state, cloud-user login
+	// via password, ssh_authorized_keys in ConfigDrive userdata, write_files/runcmd
+	// on test-vm-b (python3 http.server, index.html), TCP/UDP publishPorts, and that
+	// stopping one VM leaves the other reachable.
+	It("runs two VM applications concurrently with TCP and UDP publishPorts", Label("vm", "90230", "90235"), func() {
+		sshPublicKey, _, sshKeyCleanup, err := testutil.GenerateTempSSHKeyPair()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(sshKeyCleanup)
+
+		image := getVMImage()
+		vmAppASpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppAName,
+			[]string{fmt.Sprintf("%d:22", vmPublishedSSHPort)},
+			e2e.VMYAMLWithConfigDrive(vmAppAName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserData(sshPublicKey, vmCloudUserPassword))),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		vmAppBSpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppBName,
+			[]string{
+				fmt.Sprintf("%d:22/tcp", vmBPublishedSSHPort),
+				fmt.Sprintf("%d:%d/udp", vmBPublishedUDPPort, vmBPublishedUDPPort),
+			},
+			e2e.VMYAMLWithConfigDrive(vmAppBName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserDataWithServices(sshPublicKey, vmCloudUserPassword))),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Adding both VM applications to the device")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppASpec, vmAppBSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, appName := range []string{vmAppAName, vmAppBName} {
+			By(fmt.Sprintf("Waiting for VM application %s to reach Running", appName))
+			err = harness.WaitForApplicationStatus(deviceID, appName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+			if err != nil {
+				logVMApplicationUnitStatus(harness, appName)
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Verifying the applications summary is Healthy")
+		err = harness.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppAName)
+			logVMApplicationUnitStatus(harness, vmAppBName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying SSH via published host ports for both VMs")
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppAName, vmCloudUser, vmCloudUserPassword)
+		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppBName, vmCloudUser, vmCloudUserPassword)
+
+		expectAuthorizedKeyPresent := func(port int, appName string) {
+			Eventually(func(g Gomega) {
+				out, sshErr := harness.RunSSHOnDeviceLocalPort(
+					port,
+					vmCloudUser,
+					vmCloudUserPassword,
+					fmt.Sprintf(`bash -lc 'grep -F %q ~/.ssh/authorized_keys'`, sshPublicKey),
+				)
+				g.Expect(sshErr).NotTo(HaveOccurred(), "checking authorized_keys on %s failed", appName)
+				g.Expect(strings.TrimSpace(out)).To(Equal(sshPublicKey))
+			}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+		}
+
+		By("Verifying ssh_authorized_keys from ConfigDrive are present on both VMs")
+		expectAuthorizedKeyPresent(vmPublishedSSHPort, vmAppAName)
+		expectAuthorizedKeyPresent(vmBPublishedSSHPort, vmAppBName)
+
+		By("Verifying ConfigDrive write_files and runcmd on test-vm-b")
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmBPublishedSSHPort, vmCloudUser, vmCloudUserPassword, `bash -lc 'systemctl is-active hello-http.service'`)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("active"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'command -v python3'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(ContainSubstring("python3"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'cat /var/www/html/index.html'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal(configDriveIndexHTMLContent))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'curl -sS http://127.0.0.1/'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal(configDriveIndexHTMLContent))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmBPublishedSSHPort, vmCloudUser, vmCloudUserPassword, `bash -lc 'systemctl is-active hello-udp.service'`)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("active"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		By("Verifying UDP hello service inside test-vm-b")
+		expectGuestUDPHello(harness, vmBPublishedSSHPort, vmBPublishedUDPPort, vmAppBName)
+
+		By("Verifying published UDP port on the device host")
+		expectPublishedUDPHello(harness, vmBPublishedUDPPort, vmAppBName, "hello")
+
+		By(fmt.Sprintf("Stopping %s and verifying %s remains reachable", vmAppAName, vmAppBName))
+		_, err = harness.CLI("app", "stop", fmt.Sprintf("device/%s", deviceID), "--name", vmAppAName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = harness.WaitForApplicationStatus(deviceID, vmAppAName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppAName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		err = harness.WaitForApplicationStatus(deviceID, vmAppBName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppBName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppBName, vmCloudUser, vmCloudUserPassword)
+	})
 })
+
+// expectSSHWhoamiWithPassword polls password SSH to a published host port until whoami returns the guest user.
+func expectSSHWhoamiWithPassword(h *e2e.Harness, port int, appName, user, password string) {
+	GinkgoHelper()
+	const remoteCmd = "/usr/bin/whoami"
+	Eventually(func(g Gomega) {
+		GinkgoWriter.Printf(
+			"Password SSH probe on device host to %s@127.0.0.1:%d running %s (app=%s)\n",
+			user, port, remoteCmd, appName,
+		)
+		out, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		if sshErr != nil {
+			GinkgoWriter.Printf("SSH failed for %s on port %d: %v\n", appName, port, sshErr)
+		} else {
+			GinkgoWriter.Printf("SSH output for %s on port %d: %q\n", appName, port, strings.TrimSpace(out))
+		}
+		g.Expect(sshErr).NotTo(HaveOccurred(), "password SSH to %s on published port %d failed", appName, port)
+		g.Expect(strings.TrimSpace(out)).To(Equal(user))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+// expectGuestUDPHello polls a UDP probe inside the guest via SSH to a published TCP port.
+func expectGuestUDPHello(h *e2e.Harness, sshPort, udpPort int, appName string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		probeCmd := e2e.UDPProbePythonCommand(udpPort)
+		GinkgoWriter.Printf(
+			"Guest UDP probe via SSH on %s@127.0.0.1:%d running %q (app=%s)\n",
+			vmCloudUser, sshPort, probeCmd, appName,
+		)
+		out, sshErr := h.RunSSHOnDeviceLocalPort(sshPort, vmCloudUser, vmCloudUserPassword, probeCmd)
+		if sshErr != nil {
+			GinkgoWriter.Printf("Guest UDP probe failed for %s on guest port %d: %v\n", appName, udpPort, sshErr)
+		} else {
+			GinkgoWriter.Printf("Guest UDP probe output for %s on guest port %d: %q\n", appName, udpPort, strings.TrimSpace(out))
+		}
+		g.Expect(sshErr).NotTo(HaveOccurred(), "guest UDP probe for %s on port %d failed", appName, udpPort)
+		g.Expect(strings.TrimSpace(out)).To(Equal("hello"))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+// expectPublishedUDPHello polls a UDP probe on the device host published port until the expected reply is received.
+func expectPublishedUDPHello(h *e2e.Harness, port int, appName, expectedReply string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		GinkgoWriter.Printf(
+			"UDP probe: socat/python3 send b\"ping\" recv UDP4:127.0.0.1:%d (app=%s)\n",
+			port, appName,
+		)
+		out, udpErr := h.RunUDPProbeOnDeviceLocalPort(port)
+		if udpErr != nil {
+			GinkgoWriter.Printf("UDP probe failed for %s on port %d: %v\n", appName, port, udpErr)
+		} else {
+			GinkgoWriter.Printf("UDP probe output for %s on port %d: %q\n", appName, port, out)
+		}
+		g.Expect(udpErr).NotTo(HaveOccurred(), "UDP probe to %s on published port %d failed", appName, port)
+		g.Expect(out).To(Equal(expectedReply))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
 
 // logVMApplicationUnitStatus logs generated systemd unit state when product-level VM app status checks fail.
 func logVMApplicationUnitStatus(h *e2e.Harness, appName string) {
@@ -197,4 +409,92 @@ func vmApplicationComputeServiceName(appName string) string {
 // vmApplicationID returns the production app ID used to namespace generated VM units.
 func vmApplicationID(appName string) string {
 	return lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername)
+}
+
+func encodeConfigDriveUserData(cloudConfig string) string {
+	return base64.StdEncoding.EncodeToString([]byte(cloudConfig))
+}
+
+func configDriveCloudUserIdentityYAML(sshPublicKey, password string) string {
+	return fmt.Sprintf(`ssh_pwauth: true
+users:
+  - name: %s
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: false
+    ssh_authorized_keys:
+      - %s
+chpasswd:
+  expire: false
+  users:
+    - name: %s
+      password: %s
+      type: text`, vmCloudUser, sshPublicKey, vmCloudUser, password)
+}
+
+func configDriveCloudUserData(sshPublicKey, password string) string {
+	return "#cloud-config\n" + configDriveCloudUserIdentityYAML(sshPublicKey, password) + "\n"
+}
+
+func configDriveCloudUserDataWithServices(sshPublicKey, password string) string {
+	return fmt.Sprintf(`#cloud-config
+%s
+write_files:
+  - path: /var/www/html/index.html
+    content: %q
+    owner: root:root
+    permissions: '0644'
+  - path: /usr/local/bin/hello-udp-listener.py
+    owner: root:root
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env python3
+      import socket
+
+      PORT = %d
+
+      sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+      sock.bind(("0.0.0.0", PORT))
+      while True:
+          _data, addr = sock.recvfrom(1024)
+          sock.sendto(b"hello\n", addr)
+  - path: /etc/systemd/system/hello-http.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Hello HTTP service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      WorkingDirectory=/var/www/html
+      ExecStart=/usr/bin/python3 -m http.server 80
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/hello-udp.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Hello UDP reply service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/python3 /usr/local/bin/hello-udp-listener.py
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable --now hello-http.service
+  - systemctl enable --now hello-udp.service
+`, configDriveCloudUserIdentityYAML(sshPublicKey, password), configDriveIndexHTMLContent, vmBPublishedUDPPort)
 }

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -20,9 +20,19 @@ const (
 	// QuadletUnitPath is the quadlet unit path on device (rootful)
 	QuadletUnitPath = "/etc/containers/systemd"
 
-	// vmYAMLTemplate is a KubeVirt VirtualMachine manifest template for e2e VM tests.
-	// Placeholders: 1=name, 2=containerdisk image.
-	vmYAMLTemplate = `apiVersion: kubevirt.io/v1
+	// VMGuestMemoryDefault is the guest RAM for e2e KubeVirt VM manifests.
+	VMGuestMemoryDefault = "1024M"
+)
+
+const vmFedoraNoCloudUserData = `#cloud-config
+ssh_pwauth: true
+password: fedora
+chpasswd: { expire: False }`
+
+// VMYAML builds a KubeVirt VirtualMachine manifest for e2e tests. cloudInitVolumeYAML
+// is the cloudinitdisk volume entry (including list-item indentation under volumes)
+func VMYAML(name, guestMemory, image, cloudInitVolumeYAML string) string {
+	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: %s
@@ -44,7 +54,7 @@ spec:
             name: default
           rng: {}
         memory:
-          guest: 1024M
+          guest: %s
         resources: {}
       networks:
       - name: default
@@ -53,15 +63,36 @@ spec:
       - containerdisk:
           image: %s
         name: containerdisk
-      - cloudInitNoCloud:
+%s`, name, guestMemory, image, cloudInitVolumeYAML)
+}
+
+// VMYAMLWithConfigDrive builds a VM manifest using cloudInitConfigDrive userDataBase64.
+func VMYAMLWithConfigDrive(name, guestMemory, image, userDataBase64 string) string {
+	return VMYAML(name, guestMemory, image, vmCloudInitConfigDriveVolume(userDataBase64))
+}
+
+// VMCloudInitNoCloudVolume returns the cloudinitdisk volume using cloudInitNoCloud.
+func VMCloudInitNoCloudVolume(userData string) string {
+	return fmt.Sprintf(`      - cloudInitNoCloud:
           userData: |-
-            #cloud-config
-            ssh_pwauth: true
-            password: fedora
-            chpasswd: { expire: False }
-        name: cloudinitdisk
-`
-)
+%s
+        name: cloudinitdisk`, vmIndentCloudInitUserData(userData, 12))
+}
+
+func vmCloudInitConfigDriveVolume(userDataBase64 string) string {
+	return fmt.Sprintf(`      - cloudInitConfigDrive:
+          userDataBase64: %s
+        name: cloudinitdisk`, userDataBase64)
+}
+
+func vmIndentCloudInitUserData(userData string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimSuffix(userData, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
 
 // QuadletPathForUser returns the quadlet systemd path for the given user.
 // Empty or "root" returns the root path; any other user returns the user's config path.
@@ -268,9 +299,13 @@ func NewMountVolume(name, mountPath string) (v1beta1.ApplicationVolume, error) {
 // publishPorts so that the server-side renderer can inject it into the
 // generated .pod unit.
 func NewVmApplicationSpec(name, image string) (v1beta1.ApplicationProviderSpec, error) {
-	vmYAML := fmt.Sprintf(vmYAMLTemplate, name, image)
-	publishPorts := []string{"2222:22"}
+	vmYAML := VMYAML(name, VMGuestMemoryDefault, image, VMCloudInitNoCloudVolume(vmFedoraNoCloudUserData))
+	return NewVmApplicationSpecFromYAML(name, []string{"2222:22"}, vmYAML)
+}
 
+// NewVmApplicationSpecFromYAML creates an inline VmApplication spec from a pre-built
+// KubeVirt VirtualMachine manifest and publishPorts list.
+func NewVmApplicationSpecFromYAML(name string, publishPorts []string, vmYAML string) (v1beta1.ApplicationProviderSpec, error) {
 	vmApp := v1beta1.VmApplication{
 		AppType:      v1beta1.AppTypeVm,
 		Name:         lo.ToPtr(name),
@@ -1176,37 +1211,123 @@ func (h *Harness) RunSSHOnDeviceLocalPort(port int, user, password string, remot
 		quotedRemoteArgs[i] = shellQuote(arg)
 	}
 	quotedPassword := shellQuote(password)
-	script := fmt.Sprintf(`set -euo pipefail
-ssh_common=(ssh -p %d \
-  -o ConnectTimeout=10 \
-  -o PubkeyAuthentication=no \
-  -o UserKnownHostsFile=/dev/null \
-  -o StrictHostKeyChecking=no \
-  -o LogLevel=ERROR \
-  %s %s)
-if command -v sshpass >/dev/null 2>&1; then
-  sshpass -p %s "${ssh_common[@]}"
-else
-  askpass=$(mktemp)
-  trap 'rm -f "$askpass"' EXIT
-  printf '#!/bin/sh\necho %%s\n' %s >"$askpass"
-  chmod 700 "$askpass"
-  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid "${ssh_common[@]}"
-fi`,
+	remoteCommand := strings.Join(quotedRemoteArgs, " ")
+	sshCommand := fmt.Sprintf(
+		`ssh -T -p %d -o ConnectTimeout=10 -o RequestTTY=no -o PubkeyAuthentication=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR %s %s`,
 		port,
 		shellQuote(user+"@127.0.0.1"),
-		strings.Join(quotedRemoteArgs, " "),
-		quotedPassword,
-		quotedPassword,
+		remoteCommand,
 	)
-	out, err := h.VM.RunSSH([]string{"bash", "-lc", script}, nil)
+	// Run via /bin/sh on the device. Inline the ssh command (not a shell function) because
+	// sshpass/setsid execute a binary and cannot invoke shell functions.
+	script := fmt.Sprintf(`set -eu
+ssh_home=$(mktemp -d)
+trap 'rm -rf "$ssh_home"' EXIT
+export HOME="$ssh_home"
+export PATH=/usr/local/bin:/usr/bin:/bin
+if command -v sshpass >/dev/null 2>&1; then
+  sshpass -p %s %s
+else
+  askpass="$ssh_home/askpass"
+  {
+    printf '%%s\n' '#!/bin/sh'
+    printf '%%s\n' "printf '%%s\n' %s"
+  } >"$askpass"
+  chmod 700 "$askpass"
+  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid %s
+fi`,
+		quotedPassword,
+		sshCommand,
+		quotedPassword,
+		sshCommand,
+	)
+	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", script}, nil)
 	if err != nil {
 		return "", fmt.Errorf(
-			"running bash -lc ssh script on device VM (localhost:%d user=%s remote=%s): %w",
+			"running /bin/sh -c ssh script on device VM (localhost:%d user=%s remote=%s): %w",
 			port, user, strings.Join(remoteArgs, " "), err,
 		)
 	}
-	return out.String(), nil
+	return trimSSHCommandOutput(out.String()), nil
+}
+
+// trimSSHCommandOutput returns the last non-empty line from nested SSH output. Device-side
+// shell profiles can print environment noise before the guest command result on stdout.
+func trimSSHCommandOutput(stdout string) string {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// UDPProbePythonCommand returns a remote shell command that sends a UDP datagram with
+// payload "ping" to 127.0.0.1:port and prints the trimmed reply. Intended for nested
+// SSH (device host -> guest published TCP port); uses a single-quoted python -c string.
+func UDPProbePythonCommand(port int) string {
+	return fmt.Sprintf(
+		`python3 -c 'import socket; port=%d; s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b"ping", ("127.0.0.1", port)); print(s.recv(1024).decode().strip())'`,
+		port,
+	)
+}
+
+// udpProbeDeviceHostScript returns a shell script that probes localhost:port over UDP
+// using socat when available, otherwise python3 via a heredoc (avoids fragile -c quoting).
+func udpProbeDeviceHostScript(port int) string {
+	return fmt.Sprintf(`set -eu
+export PATH=/usr/local/bin:/usr/bin:/bin
+port=%d
+if command -v socat >/dev/null 2>&1; then
+  printf 'ping\n' | socat -t2 - UDP4:127.0.0.1:${port}
+elif command -v python3 >/dev/null 2>&1; then
+  python3 - "$port" <<'PY'
+import socket
+import sys
+port = int(sys.argv[1])
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.settimeout(2)
+s.sendto(b"ping", ("127.0.0.1", port))
+print(s.recv(1024).decode().strip())
+PY
+else
+  echo "UDP probe requires socat or python3" >&2
+  exit 127
+fi`, port)
+}
+
+// lastNonEmptyLine returns the last non-empty line from command output.
+func lastNonEmptyLine(stdout string) string {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// RunUDPProbeOnDeviceLocalPort sends a UDP "ping" datagram to localhost:port on the device host
+// and returns the response. This exercises VM publishPorts UDP mappings.
+func (h *Harness) RunUDPProbeOnDeviceLocalPort(port int) (string, error) {
+	if h.VM == nil {
+		return "", fmt.Errorf("device VM is not configured")
+	}
+	if port <= 0 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+
+	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", udpProbeDeviceHostScript(port)}, nil)
+	if err != nil {
+		return "", fmt.Errorf("running UDP probe on device host localhost:%d: %w", port, err)
+	}
+	raw := out.String()
+	reply := lastNonEmptyLine(raw)
+	if reply == "" {
+		return "", fmt.Errorf("UDP probe on localhost:%d returned empty output (raw stdout=%q)", port, raw)
+	}
+	return reply, nil
 }
 
 // RebootVMAndWaitForSSH triggers a reboot on the VM and waits for SSH to become ready again.

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -137,6 +137,10 @@ func (v *TestVM) sshCommandWithUserContext(ctx context.Context, inputArgs []stri
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "LogLevel=ERROR",
 		"-o", "SetEnv=LC_ALL="}
+	if len(inputArgs) > 0 {
+		// Non-interactive remote commands: no TTY so motd/profile noise stays off stdout.
+		sshArgs = append(sshArgs, "-T")
+	}
 
 	var cmd *exec.Cmd
 	if v.SSHPrivateKeyPath != "" {


### PR DESCRIPTION
Add an e2e test that runs test-vm-a and test-vm-b on one device using KubeVirt ConfigDrive (userDataBase64).
Covering:
 - TCP/UDP publishPorts
 - password SSH
 - ConfigDrive userdata (authorized keys, packages, write_files, runcmd)
 - Isolation when one VM is stopped. Extend the harness with NewVmApplicationSpecFromYAML and RunUDPProbeOnDeviceLocalPort for custom VM manifests and UDP checks.

Assisted-by: Cursor
