### PR TITLE
EDM-5204: do not fail RPM %pre when no dry-run temp script is created

### DIFF
--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -730,11 +730,11 @@ if [ "$1" -eq 2 ]; then
         DB_SETUP_IMAGE="%{db_setup_image}" \
         CONFIG_PATH="%{_sysconfdir}/flightctl/flightctl-api/config.yaml" \
         bash "$SCRIPT" "$IMAGE_TAG" "%{_sysconfdir}/flightctl/flightctl-api/config.yaml" || {
-            [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
+            [ -z "${TMPSCRIPT:-}" ] || rm -f "$TMPSCRIPT"
             echo "flightctl: dry-run failed; aborting upgrade." >&2
             exit 1
         }
-        [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
+        [ -z "${TMPSCRIPT:-}" ] || rm -f "$TMPSCRIPT"
     else
         echo "flightctl: pre-upgrade-dry-run.sh not found at %{_libexecdir}/flightctl; skipping."
     fi


### PR DESCRIPTION
## Summary
- `%pre services` cleanup used `[ -n "${TMPSCRIPT:-}" ] && rm`, so when the EDM-3833 image patch is skipped (already-fixed 1.2.0 dry-run script) the last command exits 1 and RPM aborts the upgrade.
- Invert the test to `[ -z "${TMPSCRIPT:-}" ] || rm` so an unset `TMPSCRIPT` is a successful no-op, while a temp copy is still removed.
- Fixes `1.2.0 → 1.3.0` `%prein(flightctl-services) scriptlet failed, exit status 1`. `%pre` comes from the new RPM, so this build unblocks that upgrade path.

## Test plan
- [ ] RPM upgrade `flightctl-services` 1.2.0 → this build (no hardcoded db-setup image; TMPSCRIPT unset) succeeds
- [ ] RPM upgrade from a pre-EDM-3833 version (hardcoded `quay.io/flightctl/flightctl-db-setup:`) still patches the on-disk script and proceeds
- [ ] Failed dry-run still aborts the upgrade and removes the temp script when one was created


Made with [Cursor](https://cursor.com)