### PR TITLE
NO-ISSUE: Include virt-launcher in flightctl-mirror-images

### DIFF
--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -272,10 +272,10 @@ full workflow.
 ### VM applications
 
 Devices pull the KubeVirt virt-launcher image when they run VM applications. That
-image is **not** included in the default `flightctl-mirror-images` control-plane
-set. Mirror it to a registry devices can reach, set `worker.vmRender.launcherImage`
-to the mirrored reference, and re-render affected devices. Guest OS and other
-workload images still need separate mirroring.
+image is included in the default `flightctl-mirror-images` set. After mirroring,
+set `worker.vmRender.launcherImage` to the destination reference so rendered
+Quadlet units pull from the mirror. Guest OS and other workload images still
+need separate mirroring.
 
 See [VM application rendering in air-gapped environments](configuring-vm-render.md#air-gapped-environments).
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -58,22 +58,22 @@ sudo systemctl restart flightctl-worker.service
 
 ## Air-gapped environments
 
-The default virt-launcher image is pulled by devices when they run VM applications. It is not part of the control-plane image set produced by `flightctl-mirror-images`.
+The virt-launcher image is pulled by devices when they run VM applications. `flightctl-mirror-images` includes it in the default image set:
+
+| Variant | Image |
+| ------- | ----- |
+| Community (`community-el9`, `community-el10`) | `quay.io/kubevirt/virt-launcher:v1.9.0` |
+| Red Hat product (`rhem-el9`, `rhem-el10`) | `registry.redhat.io/container-native-virtualization/virt-launcher:v4.12-1785837377` |
+
+The worker still writes the original image reference into rendered Quadlet units. After mirroring, set `worker.vmRender.launcherImage` to the destination reference so devices pull from the mirror. Guest OS and other workload images still need separate mirroring.
 
 In an air-gapped deployment:
 
-1. Mirror `quay.io/kubevirt/virt-launcher:v1.9.0` (or your chosen virt-launcher image) to a registry that devices can reach.
-2. Set `worker.vmRender.launcherImage` to that mirrored reference so rendered Quadlet units pull from the mirror.
+1. Run `flightctl-mirror-images` for your variant. The tool prints the mirrored virt-launcher reference.
+2. Set `worker.vmRender.launcherImage` to that destination reference.
 3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image reference.
 
-Example (community / upstream registry):
-
-```bash
-INTERNAL=registry.example.com:5000
-skopeo copy --all \
-  docker://quay.io/kubevirt/virt-launcher:v1.9.0 \
-  docker://${INTERNAL}/kubevirt/virt-launcher:v1.9.0
-```
+Example (community):
 
 ```yaml
 worker:
@@ -82,7 +82,19 @@ worker:
     passtWorkarounds: false
 ```
 
-There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` at the mirrored location.
+Example (Red Hat product):
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: "registry.example.com:5000/container-native-virtualization/virt-launcher:v4.12-1785837377"
+    passtWorkarounds: false
+```
+
+If devices already remap the source registry (for example with `registries.conf` or `ImageTagMirrorSet`), you can keep the original source reference instead of the destination path.
+
+> [!IMPORTANT]
+> The Red Hat product image is on `registry.redhat.io`, which requires authentication. Place Red Hat registry credentials in the Podman `auth.json` on each device before the device starts a VM application. For Quadlet units that run as root, the file is `/root/.config/containers/auth.json`. See [Using image pull secrets](../using/managing-devices.md#using-image-pull-secrets). Devices that pull only from an internal mirror need credentials for that registry instead.
 
 ## After changing settings
 
@@ -91,4 +103,5 @@ Conversion results are cached by `vm.yaml` content and these render options. Cha
 ## Related information
 
 - [VM applications](../using/managing-devices.md#vm-applications)
+- [Using image pull secrets](../using/managing-devices.md#using-image-pull-secrets)
 - [Air-gapped installation](air-gapped-installation.md)

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -63,7 +63,7 @@ The virt-launcher image is pulled by devices when they run VM applications. `fli
 | Variant | Image |
 | ------- | ----- |
 | Community (`community-el9`, `community-el10`) | `quay.io/kubevirt/virt-launcher:v1.9.0` |
-| Red Hat product (`rhem-el9`, `rhem-el10`) | `registry.redhat.io/container-native-virtualization/virt-launcher:v4.12-1785837377` |
+| Red Hat product (`rhem-el9`, `rhem-el10`) | `registry.redhat.io/container-native-virtualization/virt-launcher-rhel9:v4.22-1784929080` |
 
 The worker still writes the original image reference into rendered Quadlet units. After mirroring, set `worker.vmRender.launcherImage` to the destination reference so devices pull from the mirror. Guest OS and other workload images still need separate mirroring.
 
@@ -87,7 +87,7 @@ Example (Red Hat product):
 ```yaml
 worker:
   vmRender:
-    launcherImage: "registry.example.com:5000/container-native-virtualization/virt-launcher:v4.12-1785837377"
+    launcherImage: "registry.example.com:5000/container-native-virtualization/virt-launcher-rhel9:v4.22-1784929080"
     passtWorkarounds: false
 ```
 

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -67,3 +67,8 @@ userinfo-proxy:
 remote-access:
   image: quay.io/flightctl/flightctl-remote-access-el10
   tag: latest
+# Device-side VM runtime (not a control-plane service). Mirrored by
+# flightctl-mirror-images. Keep the tag in sync with DefaultVirtLauncherImage.
+virt-launcher:
+  image: quay.io/kubevirt/virt-launcher
+  tag: v1.9.0

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -68,3 +68,8 @@ userinfo-proxy:
 remote-access:
   image: quay.io/flightctl/flightctl-remote-access-el9
   tag: latest
+# Device-side VM runtime (not a control-plane service). Mirrored by
+# flightctl-mirror-images. Keep the tag in sync with DefaultVirtLauncherImage.
+virt-launcher:
+  image: quay.io/kubevirt/virt-launcher
+  tag: v1.9.0

--- a/packaging/images/rhel10/images.yaml
+++ b/packaging/images/rhel10/images.yaml
@@ -15,8 +15,8 @@ userinfo-proxy:
 
 # Device-side VM runtime (not a control-plane service). Mirrored by flightctl-mirror-images.
 virt-launcher:
-  image: registry.redhat.io/container-native-virtualization/virt-launcher
-  tag: v4.12-1785837377
+  image: registry.redhat.io/container-native-virtualization/virt-launcher-rhel9
+  tag: v4.22-1784929080
 
 # grafana and prometheus are intentionally omitted.
 # They belong to the optional flightctl-observability stack and must be mirrored

--- a/packaging/images/rhel10/images.yaml
+++ b/packaging/images/rhel10/images.yaml
@@ -1,8 +1,7 @@
-# RPM-only images for the redhat-el10 (RHEM) variant.
+# RPM-only extras for the redhat-el10 (RHEM) variant.
 #
-# These images are pulled by flightctl RPMs and are NOT listed in
-# deploy/helm/helm-chart-opts.yaml.  They must be mirrored separately
-# for an air-gapped redhat-el10 installation.
+# These images are NOT listed in deploy/helm/helm-chart-opts.yaml. They must be
+# mirrored for an air-gapped redhat-el10 installation.
 #
 # Images that ARE in helm-chart-opts.yaml (api, worker, db, kv, etc.)
 # must NOT be duplicated here — the mirror tool reads both sources and
@@ -13,6 +12,11 @@ pam-issuer:
 
 userinfo-proxy:
   image: registry.redhat.io/rhem/flightctl-userinfo-proxy-rhel10
+
+# Device-side VM runtime (not a control-plane service). Mirrored by flightctl-mirror-images.
+virt-launcher:
+  image: registry.redhat.io/container-native-virtualization/virt-launcher
+  tag: v4.12-1785837377
 
 # grafana and prometheus are intentionally omitted.
 # They belong to the optional flightctl-observability stack and must be mirrored

--- a/packaging/images/rhel9/images.yaml
+++ b/packaging/images/rhel9/images.yaml
@@ -15,8 +15,8 @@ userinfo-proxy:
 
 # Device-side VM runtime (not a control-plane service). Mirrored by flightctl-mirror-images.
 virt-launcher:
-  image: registry.redhat.io/container-native-virtualization/virt-launcher
-  tag: v4.12-1785837377
+  image: registry.redhat.io/container-native-virtualization/virt-launcher-rhel9
+  tag: v4.22-1784929080
 
 # grafana and prometheus are intentionally omitted.
 # They belong to the optional flightctl-observability stack and must be mirrored

--- a/packaging/images/rhel9/images.yaml
+++ b/packaging/images/rhel9/images.yaml
@@ -1,8 +1,7 @@
-# RPM-only images for the redhat-el9 (RHEM) variant.
+# RPM-only extras for the redhat-el9 (RHEM) variant.
 #
-# These images are pulled by flightctl RPMs and are NOT listed in
-# deploy/helm/helm-chart-opts.yaml.  They must be mirrored separately
-# for an air-gapped redhat-el9 installation.
+# These images are NOT listed in deploy/helm/helm-chart-opts.yaml. They must be
+# mirrored for an air-gapped redhat-el9 installation.
 #
 # Images that ARE in helm-chart-opts.yaml (api, worker, db, kv, etc.)
 # must NOT be duplicated here — the mirror tool reads both sources and
@@ -13,6 +12,11 @@ pam-issuer:
 
 userinfo-proxy:
   image: registry.redhat.io/rhem/flightctl-userinfo-proxy-rhel9
+
+# Device-side VM runtime (not a control-plane service). Mirrored by flightctl-mirror-images.
+virt-launcher:
+  image: registry.redhat.io/container-native-virtualization/virt-launcher
+  tag: v4.12-1785837377
 
 # grafana and prometheus are intentionally omitted.
 # They belong to the optional flightctl-observability stack and must be mirrored

--- a/scripts/air-gap/README.md
+++ b/scripts/air-gap/README.md
@@ -135,8 +135,9 @@ The tool reads from two sources and deduplicates:
 
 The `el9`/`el10` files are also consumed by `packaging/rpm/flightctl.spec` to
 drive `flightctl-standalone render quadlets --config`; they must remain
-complete. The `rhel9`/`rhel10` files contain only the downstream
-`registry.redhat.io` equivalents for grafana and prometheus.
+complete. The `rhel9`/`rhel10` files contain RPM-only extras not listed in
+`helm-chart-opts.yaml` (for example PAM issuer, userinfo-proxy, and the
+device-side virt-launcher image).
 
 ---
 

--- a/scripts/air-gap/mirror-images/bundle.go
+++ b/scripts/air-gap/mirror-images/bundle.go
@@ -288,6 +288,8 @@ skopeo copy $DEST_TLS_FLAG "dir:$IMAGES_DIR/%s" "docker://$REGISTRY/%s"
 echo "Import complete: $TOTAL images imported to $REGISTRY"
 `)
 
+	writeVirtLauncherHint(f, pairs)
+
 	if err := os.Chmod(scriptPath, 0o755); err != nil {
 		return fmt.Errorf("chmod import script: %w", err)
 	}

--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -82,6 +82,10 @@ var embeddedBuildManifest = []byte(`
           "tag": ""
         },
         {
+          "ref": "quay.io/kubevirt/virt-launcher",
+          "tag": "v1.9.0"
+        },
+        {
           "ref": "quay.io/openshift/origin-cli",
           "tag": "4.20.0"
         },
@@ -188,6 +192,10 @@ var embeddedBuildManifest = []byte(`
           "tag": ""
         },
         {
+          "ref": "quay.io/kubevirt/virt-launcher",
+          "tag": "v1.9.0"
+        },
+        {
           "ref": "quay.io/openshift/origin-cli",
           "tag": "4.20.0"
         },
@@ -233,6 +241,10 @@ var embeddedBuildManifest = []byte(`
     },
     "rhem-el10": {
       "images": [
+        {
+          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher",
+          "tag": "v4.12-1785837377"
+        },
         {
           "ref": "registry.redhat.io/openshift4/ose-cli-rhel9",
           "tag": "v4.20.0"
@@ -335,6 +347,10 @@ var embeddedBuildManifest = []byte(`
     },
     "rhem-el9": {
       "images": [
+        {
+          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher",
+          "tag": "v4.12-1785837377"
+        },
         {
           "ref": "registry.redhat.io/openshift4/ose-cli-rhel9",
           "tag": "v4.20.0"

--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -242,8 +242,8 @@ var embeddedBuildManifest = []byte(`
     "rhem-el10": {
       "images": [
         {
-          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher",
-          "tag": "v4.12-1785837377"
+          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher-rhel9",
+          "tag": "v4.22-1784929080"
         },
         {
           "ref": "registry.redhat.io/openshift4/ose-cli-rhel9",
@@ -348,8 +348,8 @@ var embeddedBuildManifest = []byte(`
     "rhem-el9": {
       "images": [
         {
-          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher",
-          "tag": "v4.12-1785837377"
+          "ref": "registry.redhat.io/container-native-virtualization/virt-launcher-rhel9",
+          "tag": "v4.22-1784929080"
         },
         {
           "ref": "registry.redhat.io/openshift4/ose-cli-rhel9",

--- a/scripts/air-gap/mirror-images/main.go
+++ b/scripts/air-gap/mirror-images/main.go
@@ -422,6 +422,7 @@ Examples:
 			if err != nil {
 				return err
 			}
+			logVMRuntimeHints(unique)
 
 			ctx := context.Background()
 			exec := executer.NewCommonExecuter()

--- a/scripts/air-gap/mirror-images/mirror.go
+++ b/scripts/air-gap/mirror-images/mirror.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -111,6 +112,45 @@ func GenerateCommands(ctx context.Context, pairs []ImagePair, execute, insecure 
 		return fmt.Errorf("%d image(s) failed to copy: %s", len(failed), strings.Join(failed, ", "))
 	}
 	return nil
+}
+
+func virtLauncherDestPaths(pairs []ImagePair) []string {
+	var dests []string
+	for _, p := range pairs {
+		if !strings.Contains(p.Source, "virt-launcher") {
+			continue
+		}
+		dests = append(dests, p.Dest)
+	}
+	return dests
+}
+
+func logVMRuntimeHints(pairs []ImagePair) {
+	dests := virtLauncherDestPaths(pairs)
+	if len(dests) == 0 {
+		return
+	}
+	logInfo("VM applications: set worker.vmRender.launcherImage to the mirrored virt-launcher image:")
+	for _, dest := range dests {
+		logInfo("  %s", dest)
+	}
+}
+
+func writeVirtLauncherHint(w io.Writer, pairs []ImagePair) {
+	for _, p := range pairs {
+		if !strings.Contains(p.Source, "virt-launcher") {
+			continue
+		}
+		parts := strings.SplitN(p.Source, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		fmt.Fprintf(w, `
+echo ""
+echo "VM applications: set worker.vmRender.launcherImage to:"
+echo "  $REGISTRY/%s"
+`, parts[1])
+	}
 }
 
 // logInfo writes an [INFO] prefixed message to stderr.


### PR DESCRIPTION
## Summary
- Treats virt-launcher as a product runtime for VM applications and includes it in the default `flightctl-mirror-images` set (community: `quay.io/kubevirt/virt-launcher:v1.9.0`; Red Hat product: `registry.redhat.io/container-native-virtualization/virt-launcher:v4.12-1785837377`).
- Prints the mirrored destination reference and documents setting `worker.vmRender.launcherImage` so devices pull from the mirror. Guest OS and other user workload images are still mirrored separately.

## Test plan
- [ ] `make build-mirror-images`
- [ ] `./bin/flightctl-mirror-images --variant community-el9 --dest-registry registry.example.com:5000` includes `quay.io/kubevirt/virt-launcher:v1.9.0` and prints the dest `launcherImage`.
- [ ] `./bin/flightctl-mirror-images --variant rhem-el9 --dest-registry registry.example.com:5000` includes the CNV virt-launcher image.
- [ ] Community variants still have zero `registry.redhat.io` sources.

Note: this overlaps `docs/user/installing/configuring-vm-render.md` with #3416.


Made with [Cursor](https://cursor.com)