### PR TITLE
EDM-4115: Add fleet VM lifecycle e2e and RBAC coverage for app commands

### DIFF
--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -376,8 +376,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			GinkgoWriter.Printf("Device for lifecycle and console RBAC test: %s\n", deviceName)
 			DeferCleanup(func() {
-				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
-				_ = harness.DeleteDeviceIgnoreNotFound(deviceName)
+				Expect(loginAndSetOrg(harness, users.admin.name, users.admin.password)).To(Succeed())
+				Expect(harness.DeleteDeviceIgnoreNotFound(deviceName)).To(Succeed())
 			})
 
 			appSpec, err := e2e.NewContainerApplicationSpecWithRunAs(
@@ -422,8 +422,8 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(func() {
-				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
-				_ = harness.DeleteFleetIgnoreNotFound(fleetName)
+				Expect(loginAndSetOrg(harness, users.admin.name, users.admin.password)).To(Succeed())
+				Expect(harness.DeleteFleetIgnoreNotFound(fleetName)).To(Succeed())
 			})
 
 			fleetTarget := "fleet/" + fleetName

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -374,6 +375,10 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			deviceName, err := harness.WaitForLabeledSimulatorDevice(testID, 0, deviceEnrollTimeout, deviceEnrollPolling)
 			Expect(err).ToNot(HaveOccurred())
 			GinkgoWriter.Printf("Device for lifecycle and console RBAC test: %s\n", deviceName)
+			DeferCleanup(func() {
+				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				_ = harness.DeleteDeviceIgnoreNotFound(deviceName)
+			})
 
 			appSpec, err := e2e.NewContainerApplicationSpecWithRunAs(
 				rbacAppName,
@@ -416,6 +421,10 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				Applications: &[]v1beta1.ApplicationProviderSpec{appSpec},
 			})
 			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				_ = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+				_ = harness.DeleteFleetIgnoreNotFound(fleetName)
+			})
 
 			fleetTarget := "fleet/" + fleetName
 			By("Rejecting fleet-scoped app restart as admin")
@@ -874,7 +883,11 @@ func assertAppConsoleAccess(harness *e2e.Harness, deviceName, appName string, al
 	if res.err == nil {
 		return
 	}
-	if ctx.Err() != nil {
+	if ctx.Err() != context.Canceled {
+		Fail(fmt.Sprintf("authorized app console failed unexpectedly: %v\n%s", res.err, res.out))
+	}
+	errText := res.err.Error()
+	if strings.Contains(errText, "signal: killed") || strings.Contains(errText, "killed") || strings.Contains(errText, "context canceled") {
 		return
 	}
 	Fail(fmt.Sprintf("authorized app console failed unexpectedly: %v\n%s", res.err, res.out))
@@ -896,6 +909,7 @@ func assertSimulatorConsoleAccess(harness *e2e.Harness, deviceName string, allow
 		ContainSubstring(http403Substring),
 		ContainSubstring(forbiddenSubstring),
 	), "authorized role must not receive 403 for console")
+	Expect(err).To(HaveOccurred(), "authorized simulator console cannot run as flightctl-console")
 	Expect(out).To(ContainSubstring("unknown user flightctl-console"), "authorized console should reach the agent")
 }
 

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -375,10 +375,11 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			GinkgoWriter.Printf("Device for lifecycle and console RBAC test: %s\n", deviceName)
 
-			appSpec, err := e2e.NewContainerApplicationSpec(
+			appSpec, err := e2e.NewContainerApplicationSpecWithRunAs(
 				rbacAppName,
 				"quay.io/flightctl-tests/nginx:1.28-alpine-slim",
 				nil, nil, nil, nil,
+				"flightctl",
 			)
 			Expect(err).ToNot(HaveOccurred())
 			err = harness.UpdateDeviceWithRetries(deviceName, func(device *v1beta1.Device) {
@@ -416,6 +417,11 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			fleetTarget := "fleet/" + fleetName
+			By("Rejecting fleet-scoped app restart as admin")
+			out, restartErr := harness.CLI("app", "restart", fleetTarget, "--name", rbacAppName, "-y")
+			Expect(restartErr).To(HaveOccurred(), "fleet-scoped restart should be rejected as unsupported")
+			Expect(out).To(ContainSubstring("kind must be Device"))
+
 			for _, tc := range rbacRoleCases(users) {
 				By(fmt.Sprintf("Testing fleet lifecycle as %s", tc.role))
 				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
@@ -858,7 +864,18 @@ func assertAppConsoleAccess(harness *e2e.Harness, deviceName, appName string, al
 		return after != "" && after != before
 	}, 15*time.Second, time.Second).Should(BeTrue(), "authorized role should start an app console session")
 	cancel()
-	<-resultCh
+	res := <-resultCh
+	Expect(string(res.out)).ToNot(Or(
+		ContainSubstring(http403Substring),
+		ContainSubstring(forbiddenSubstring),
+	), "authorized role must not receive 403 for app console")
+	if res.err == nil {
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	Fail(fmt.Sprintf("authorized app console failed unexpectedly: %v\n%s", res.err, res.out))
 }
 
 // assertConsoleAccess verifies devices/console RBAC via flightctl console.

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -389,6 +389,7 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{appSpec}
 			})
 			Expect(err).ToNot(HaveOccurred())
+			waitForAgentReportedApp(harness, deviceName, rbacAppName)
 
 			standaloneTarget := "device/" + deviceName
 			for _, tc := range rbacRoleCases(users) {
@@ -437,9 +438,7 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			harness.WaitForDeviceContents(deviceName, "device owned by fleet", func(device *v1beta1.Device) bool {
 				return device.Metadata.Owner != nil && *device.Metadata.Owner == "Fleet/"+fleetName
 			}, e2e.TIMEOUT)
-			harness.WaitForDeviceContents(deviceName, "fleet application rolled out", func(device *v1beta1.Device) bool {
-				return deviceHasNamedApp(device, rbacAppName)
-			}, e2e.TIMEOUT)
+			waitForAgentReportedApp(harness, deviceName, rbacAppName)
 
 			for _, tc := range rbacRoleCases(users) {
 				By(fmt.Sprintf("Testing fleet-owned device lifecycle as %s", tc.role))
@@ -791,16 +790,19 @@ func rbacRoleCases(users testUserSet) []struct {
 	}
 }
 
-func deviceHasNamedApp(device *v1beta1.Device, appName string) bool {
-	if device == nil || device.Spec == nil || device.Spec.Applications == nil {
+func waitForAgentReportedApp(harness *e2e.Harness, deviceName, appName string) {
+	GinkgoHelper()
+	harness.WaitForDeviceContents(deviceName, "agent reported application "+appName, func(device *v1beta1.Device) bool {
+		return deviceHasNamedAppStatus(device, appName)
+	}, e2e.TIMEOUT)
+}
+
+func deviceHasNamedAppStatus(device *v1beta1.Device, appName string) bool {
+	if device == nil || device.Status == nil {
 		return false
 	}
-	for _, app := range *device.Spec.Applications {
-		name, err := app.GetName()
-		if err != nil || name == nil {
-			continue
-		}
-		if *name == appName {
+	for _, app := range device.Status.Applications {
+		if app.Name == appName && app.Status != "" {
 			return true
 		}
 	}

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -397,17 +397,17 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			waitForAgentReportedApp(harness, deviceName, rbacAppName)
 
 			standaloneTarget := "device/" + deviceName
-			for _, tc := range rbacRoleCases(users) {
+			for _, tc := range rbacAppAccessCases(users) {
 				By(fmt.Sprintf("Testing standalone device lifecycle as %s", tc.role))
 				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
 				Expect(err).ToNot(HaveOccurred())
-				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
+				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.lifecycleAllowed)
 
 				By(fmt.Sprintf("Testing standalone device console as %s", tc.role))
-				assertSimulatorConsoleAccess(harness, deviceName, tc.allowed)
+				assertSimulatorConsoleAccess(harness, deviceName, tc.consoleAllowed)
 
 				By(fmt.Sprintf("Testing standalone application console as %s", tc.role))
-				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
+				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.consoleAllowed)
 			}
 
 			By("Creating a fleet with the same application as admin")
@@ -432,11 +432,11 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(restartErr).To(HaveOccurred(), "fleet-scoped restart should be rejected as unsupported")
 			Expect(out).To(ContainSubstring("kind must be Device"))
 
-			for _, tc := range rbacRoleCases(users) {
+			for _, tc := range rbacAppAccessCases(users) {
 				By(fmt.Sprintf("Testing fleet lifecycle as %s", tc.role))
 				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
 				Expect(err).ToNot(HaveOccurred())
-				assertLifecycleAccess(harness, fleetTarget, rbacAppName, []string{"stop", "start"}, tc.allowed)
+				assertLifecycleAccess(harness, fleetTarget, rbacAppName, []string{"stop", "start"}, tc.lifecycleAllowed)
 			}
 
 			By("Labeling the device into the fleet")
@@ -449,17 +449,17 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			}, e2e.TIMEOUT)
 			waitForAgentReportedApp(harness, deviceName, rbacAppName)
 
-			for _, tc := range rbacRoleCases(users) {
+			for _, tc := range rbacAppAccessCases(users) {
 				By(fmt.Sprintf("Testing fleet-owned device lifecycle as %s", tc.role))
 				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
 				Expect(err).ToNot(HaveOccurred())
-				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
+				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.lifecycleAllowed)
 
 				By(fmt.Sprintf("Testing fleet-owned device console as %s", tc.role))
-				assertSimulatorConsoleAccess(harness, deviceName, tc.allowed)
+				assertSimulatorConsoleAccess(harness, deviceName, tc.consoleAllowed)
 
 				By(fmt.Sprintf("Testing fleet-owned application console as %s", tc.role))
-				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
+				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.consoleAllowed)
 			}
 		})
 
@@ -782,20 +782,19 @@ func loginAndGetOrgID(harness *e2e.Harness, user, password string) (string, erro
 	return orgID, nil
 }
 
-func rbacRoleCases(users testUserSet) []struct {
-	role    string
-	user    userCred
-	allowed bool
-} {
-	return []struct {
-		role    string
-		user    userCred
-		allowed bool
-	}{
-		{"admin", users.admin, true},
-		{"operator", users.operator, true},
-		{"viewer", users.viewer, false},
-		{"installer", users.installer, false},
+type rbacAppAccessCase struct {
+	role             string
+	user             userCred
+	lifecycleAllowed bool
+	consoleAllowed   bool
+}
+
+func rbacAppAccessCases(users testUserSet) []rbacAppAccessCase {
+	return []rbacAppAccessCase{
+		{"admin", users.admin, true, true},
+		{"operator", users.operator, true, true},
+		{"viewer", users.viewer, false, false},
+		{"installer", users.installer, false, false},
 	}
 }
 

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -398,7 +398,7 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
 
 				By(fmt.Sprintf("Testing standalone device console as %s", tc.role))
-				assertConsoleAccess(harness, deviceName, tc.allowed)
+				assertSimulatorConsoleAccess(harness, deviceName, tc.allowed)
 
 				By(fmt.Sprintf("Testing standalone application console as %s", tc.role))
 				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
@@ -448,7 +448,7 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
 
 				By(fmt.Sprintf("Testing fleet-owned device console as %s", tc.role))
-				assertConsoleAccess(harness, deviceName, tc.allowed)
+				assertSimulatorConsoleAccess(harness, deviceName, tc.allowed)
 
 				By(fmt.Sprintf("Testing fleet-owned application console as %s", tc.role))
 				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
@@ -876,6 +876,25 @@ func assertAppConsoleAccess(harness *e2e.Harness, deviceName, appName string, al
 		return
 	}
 	Fail(fmt.Sprintf("authorized app console failed unexpectedly: %v\n%s", res.err, res.out))
+}
+
+// assertSimulatorConsoleAccess verifies devices/console RBAC on a simulator device.
+func assertSimulatorConsoleAccess(harness *e2e.Harness, deviceName string, allowed bool) {
+	GinkgoHelper()
+	out, err := harness.RunConsoleCommand(deviceName, []string{"--notty"}, "true")
+	if !allowed {
+		Expect(err).To(HaveOccurred(), "Console should fail for unauthorized role")
+		Expect(out).To(Or(
+			ContainSubstring(http403Substring),
+			ContainSubstring(forbiddenSubstring),
+		), "Expected 403 Forbidden for console access")
+		return
+	}
+	Expect(out).ToNot(Or(
+		ContainSubstring(http403Substring),
+		ContainSubstring(forbiddenSubstring),
+	), "authorized role must not receive 403 for console")
+	Expect(out).To(ContainSubstring("unknown user flightctl-console"), "authorized console should reach the agent")
 }
 
 // assertConsoleAccess verifies devices/console RBAC via flightctl console.

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(status).To(Equal(http.StatusForbidden), "Expected 403 Forbidden for viewer enrollment approval")
 		})
 
-		It("should enforce application lifecycle and console access by role for standalone and fleet-owned devices", Label("agent"), func() {
+		It("should enforce application lifecycle and console access by role for standalone and fleet-owned devices", Label("90251", "agent"), func() {
 			testID := harness.GetTestIDFromContext()
 			deferOrgSimulatorConfig(harness, users)
 			const rbacAppName = "rbac-app"

--- a/test/e2e/multiorg/multiorg_test.go
+++ b/test/e2e/multiorg/multiorg_test.go
@@ -1,12 +1,14 @@
 package multiorg_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"time"
 
+	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/org"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/harness/e2e"
@@ -355,6 +357,98 @@ var _ = Describe("Multiorg RBAC E2E Tests", Label("multiorg", "e2e"), func() {
 			Expect(status).To(Equal(http.StatusForbidden), "Expected 403 Forbidden for viewer enrollment approval")
 		})
 
+		It("should enforce application lifecycle and console access by role for standalone and fleet-owned devices", Label("agent"), func() {
+			testID := harness.GetTestIDFromContext()
+			deferOrgSimulatorConfig(harness, users)
+			const rbacAppName = "rbac-app"
+
+			By("Creating a device via simulator as admin")
+			err := loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+			setupSharedOrgSimulatorConfig(harness)
+
+			simCmd, simErr := harness.StartLabeledSimulator(harness.Context, testID, "lifecycle-console-rbac", 0, 1)
+			Expect(simErr).ToNot(HaveOccurred())
+			simulatorCmds = append(simulatorCmds, simCmd)
+
+			deviceName, err := harness.WaitForLabeledSimulatorDevice(testID, 0, deviceEnrollTimeout, deviceEnrollPolling)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("Device for lifecycle and console RBAC test: %s\n", deviceName)
+
+			appSpec, err := e2e.NewContainerApplicationSpec(
+				rbacAppName,
+				"quay.io/flightctl-tests/nginx:1.28-alpine-slim",
+				nil, nil, nil, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.UpdateDeviceWithRetries(deviceName, func(device *v1beta1.Device) {
+				if device.Spec == nil {
+					device.Spec = &v1beta1.DeviceSpec{}
+				}
+				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{appSpec}
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			standaloneTarget := "device/" + deviceName
+			for _, tc := range rbacRoleCases(users) {
+				By(fmt.Sprintf("Testing standalone device lifecycle as %s", tc.role))
+				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
+				Expect(err).ToNot(HaveOccurred())
+				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
+
+				By(fmt.Sprintf("Testing standalone device console as %s", tc.role))
+				assertConsoleAccess(harness, deviceName, tc.allowed)
+
+				By(fmt.Sprintf("Testing standalone application console as %s", tc.role))
+				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
+			}
+
+			By("Creating a fleet with the same application as admin")
+			err = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+			fleetName := fmt.Sprintf("lifecycle-rbac-%s", testID)
+			fleetSelector := v1beta1.LabelSelector{
+				MatchLabels: &map[string]string{"fleet": fleetName},
+			}
+			err = harness.CreateOrUpdateTestFleet(fleetName, fleetSelector, v1beta1.DeviceSpec{
+				Applications: &[]v1beta1.ApplicationProviderSpec{appSpec},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			fleetTarget := "fleet/" + fleetName
+			for _, tc := range rbacRoleCases(users) {
+				By(fmt.Sprintf("Testing fleet lifecycle as %s", tc.role))
+				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
+				Expect(err).ToNot(HaveOccurred())
+				assertLifecycleAccess(harness, fleetTarget, rbacAppName, []string{"stop", "start"}, tc.allowed)
+			}
+
+			By("Labeling the device into the fleet")
+			err = loginAndSetOrg(harness, users.admin.name, users.admin.password)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.SetLabelsForDevice(deviceName, map[string]string{"fleet": fleetName})
+			Expect(err).ToNot(HaveOccurred())
+			harness.WaitForDeviceContents(deviceName, "device owned by fleet", func(device *v1beta1.Device) bool {
+				return device.Metadata.Owner != nil && *device.Metadata.Owner == "Fleet/"+fleetName
+			}, e2e.TIMEOUT)
+			harness.WaitForDeviceContents(deviceName, "fleet application rolled out", func(device *v1beta1.Device) bool {
+				return deviceHasNamedApp(device, rbacAppName)
+			}, e2e.TIMEOUT)
+
+			for _, tc := range rbacRoleCases(users) {
+				By(fmt.Sprintf("Testing fleet-owned device lifecycle as %s", tc.role))
+				err = loginAndSetOrg(harness, tc.user.name, tc.user.password)
+				Expect(err).ToNot(HaveOccurred())
+				assertLifecycleAccess(harness, standaloneTarget, rbacAppName, []string{"stop", "start", "restart"}, tc.allowed)
+
+				By(fmt.Sprintf("Testing fleet-owned device console as %s", tc.role))
+				assertConsoleAccess(harness, deviceName, tc.allowed)
+
+				By(fmt.Sprintf("Testing fleet-owned application console as %s", tc.role))
+				assertAppConsoleAccess(harness, deviceName, rbacAppName, tc.allowed)
+			}
+		})
+
 		It("should enforce device console access by role", Label("89607", "agent"), func() {
 			testID := harness.GetTestIDFromContext()
 			deferOrgSimulatorConfig(harness, users)
@@ -672,6 +766,99 @@ func loginAndGetOrgID(harness *e2e.Harness, user, password string) (string, erro
 		return "", fmt.Errorf("getting org for %s: %w", user, err)
 	}
 	return orgID, nil
+}
+
+func rbacRoleCases(users testUserSet) []struct {
+	role    string
+	user    userCred
+	allowed bool
+} {
+	return []struct {
+		role    string
+		user    userCred
+		allowed bool
+	}{
+		{"admin", users.admin, true},
+		{"operator", users.operator, true},
+		{"viewer", users.viewer, false},
+		{"installer", users.installer, false},
+	}
+}
+
+func deviceHasNamedApp(device *v1beta1.Device, appName string) bool {
+	if device == nil || device.Spec == nil || device.Spec.Applications == nil {
+		return false
+	}
+	for _, app := range *device.Spec.Applications {
+		name, err := app.GetName()
+		if err != nil || name == nil {
+			continue
+		}
+		if *name == appName {
+			return true
+		}
+	}
+	return false
+}
+
+func remoteSessionAnnotation(harness *e2e.Harness, deviceName string) string {
+	device, err := harness.GetDevice(deviceName)
+	if err != nil || device.Metadata.Annotations == nil {
+		return ""
+	}
+	return (*device.Metadata.Annotations)[v1beta1.DeviceAnnotationRemoteSession]
+}
+
+func assertLifecycleAccess(harness *e2e.Harness, target, appName string, actions []string, allowed bool) {
+	GinkgoHelper()
+	for _, action := range actions {
+		out, err := harness.CLI("app", action, target, "--name", appName, "-y")
+		if !allowed {
+			Expect(err).To(HaveOccurred(), "%s %s should fail for unauthorized role", action, target)
+			Expect(out).To(Or(
+				ContainSubstring(http403Substring),
+				ContainSubstring(forbiddenSubstring),
+			), "Expected 403 Forbidden for %s %s", action, target)
+			continue
+		}
+		Expect(err).ToNot(HaveOccurred(), "%s %s should succeed for authorized role", action, target)
+	}
+}
+
+func assertAppConsoleAccess(harness *e2e.Harness, deviceName, appName string, allowed bool) {
+	GinkgoHelper()
+	before := remoteSessionAnnotation(harness, deviceName)
+	ctx, cancel := context.WithTimeout(harness.GetTestContext(), 20*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, harness.GetFlightctlPath(), //nolint:gosec // GetFlightctlPath is the in-tree test binary
+		"app", "console", "device/"+deviceName, "--name", appName, "--type", "serial", "--notty", "--force")
+	type consoleResult struct {
+		out []byte
+		err error
+	}
+	resultCh := make(chan consoleResult, 1)
+	go func() {
+		out, err := cmd.CombinedOutput()
+		resultCh <- consoleResult{out, err}
+	}()
+
+	if !allowed {
+		res := <-resultCh
+		Expect(res.err).To(HaveOccurred(), "App console should fail for unauthorized role")
+		Expect(string(res.out)).To(Or(
+			ContainSubstring(http403Substring),
+			ContainSubstring(forbiddenSubstring),
+		), "Expected 403 Forbidden for app console access")
+		return
+	}
+
+	Eventually(func() bool {
+		after := remoteSessionAnnotation(harness, deviceName)
+		return after != "" && after != before
+	}, 15*time.Second, time.Second).Should(BeTrue(), "authorized role should start an app console session")
+	cancel()
+	<-resultCh
 }
 
 // assertConsoleAccess verifies devices/console RBAC via flightctl console.

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -144,7 +144,7 @@ func waitForAppStatus(h *e2e.Harness, deviceID, appName string, status v1beta1.A
 }
 
 func curlNginxHTTPStatus(h *e2e.Harness) (string, error) {
-	out, err := h.VM.RunSSH([]string{"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--connect-timeout", "2", "http://127.0.0.1:" + nginxHostPort + "/"}, nil)
+	out, err := h.VM.RunSSH([]string{"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--connect-timeout", "2", "--max-time", "5", "http://127.0.0.1:" + nginxHostPort + "/"}, nil)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -42,10 +42,12 @@ var _ = Describe("VM Applications on a Fleet", func() {
 		})
 		Expect(harness2.SetupVMFromPoolAndStartAgent(workerID2)).To(Succeed())
 
-		device1ID, _ := harness.EnrollAndWaitForOnlineStatus()
+		device1ID, device1 := harness.EnrollAndWaitForOnlineStatus()
 		Expect(device1ID).NotTo(BeEmpty())
-		device2ID, _ := harness2.EnrollAndWaitForOnlineStatus()
+		Expect(device1).NotTo(BeNil())
+		device2ID, device2 := harness2.EnrollAndWaitForOnlineStatus()
 		Expect(device2ID).NotTo(BeEmpty())
+		Expect(device2).NotTo(BeNil())
 
 		By("Creating a fleet with NGINX and a VM application")
 		nginxSpec, err := e2e.NewContainerApplicationSpecWithRunAs(

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -67,11 +67,11 @@ var _ = Describe("VM Applications on a Fleet", func() {
 		})).To(Succeed())
 
 		By("Labeling device 1 into the fleet")
-		labelDeviceIntoFleet(harness, device1ID, fleetName)
+		harness.LabelDeviceIntoFleet(device1ID, fleetLabelKey, fleetName)
 
 		By("Waiting for both apps to run on device 1")
-		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		Expect(harness.WaitForApplicationStatus(device1ID, nginxAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 		err = harness.WaitForApplicationSummary(device1ID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
 		if err != nil {
 			logVMApplicationUnitStatus(harness, vmAppName)
@@ -83,39 +83,39 @@ var _ = Describe("VM Applications on a Fleet", func() {
 		By("Stopping the VM application on the fleet")
 		_, err = harness.CLI("app", "stop", "fleet/"+fleetName, "--name", vmAppName, "-y")
 		Expect(err).ToNot(HaveOccurred())
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
-		expectSSHInaccessible(harness, vmPublishedSSHPort, vmAppName)
-		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		harness.ExpectSSHUnavailableOnPort(vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+		Expect(harness.WaitForApplicationStatus(device1ID, nginxAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 		expectNginxReachable(harness)
 
 		By("Labeling device 2 into the fleet so it inherits the fleet stop default")
-		labelDeviceIntoFleet(harness, device2ID, fleetName)
-		waitForAppStatus(harness2, device2ID, nginxAppName, v1beta1.ApplicationStatusRunning)
-		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusStopped)
-		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
+		harness.LabelDeviceIntoFleet(device2ID, fleetLabelKey, fleetName)
+		Expect(harness2.WaitForApplicationStatus(device2ID, nginxAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness2.WaitForApplicationStatus(device2ID, vmAppName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness.WaitForApplicationStatus(device1ID, nginxAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 
 		By("Starting the VM application on the fleet")
 		_, err = harness.CLI("app", "start", "fleet/"+fleetName, "--name", vmAppName, "-y")
 		Expect(err).ToNot(HaveOccurred())
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
-		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness2.WaitForApplicationStatus(device2ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
 		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
 
 		By("Stopping the VM application on device 1 only")
 		_, err = harness.CLI("app", "stop", "device/"+device1ID, "--name", vmAppName, "-y")
 		Expect(err).ToNot(HaveOccurred())
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
-		expectSSHInaccessible(harness, vmPublishedSSHPort, vmAppName)
-		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		harness.ExpectSSHUnavailableOnPort(vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+		Expect(harness2.WaitForApplicationStatus(device2ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
 
 		By("Starting the VM application on the fleet again so the newer fleet action wins")
 		_, err = harness.CLI("app", "start", "fleet/"+fleetName, "--name", vmAppName, "-y")
 		Expect(err).ToNot(HaveOccurred())
-		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
-		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		Expect(harness.WaitForApplicationStatus(device1ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
+		Expect(harness2.WaitForApplicationStatus(device2ID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)).To(Succeed())
 		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
 		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
 
@@ -125,23 +125,6 @@ var _ = Describe("VM Applications on a Fleet", func() {
 		Expect(out).To(ContainSubstring("kind must be Device"))
 	})
 })
-
-func labelDeviceIntoFleet(h *e2e.Harness, deviceID, fleetName string) {
-	GinkgoHelper()
-	nextRenderedVersion, err := h.PrepareNextDeviceVersion(deviceID)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(h.SetLabelsForDevice(deviceID, map[string]string{fleetLabelKey: fleetName})).To(Succeed())
-	Expect(h.WaitForDeviceNewRenderedVersion(deviceID, nextRenderedVersion)).To(Succeed())
-}
-
-func waitForAppStatus(h *e2e.Harness, deviceID, appName string, status v1beta1.ApplicationStatusType) {
-	GinkgoHelper()
-	err := h.WaitForApplicationStatus(deviceID, appName, status, testutil.LONG_TIMEOUT, testutil.POLLING)
-	if err != nil && appName == vmAppName {
-		logVMApplicationUnitStatus(h, appName)
-	}
-	Expect(err).ToNot(HaveOccurred())
-}
 
 func curlNginxHTTPStatus(h *e2e.Harness) (string, error) {
 	out, err := h.VM.RunSSH([]string{"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--connect-timeout", "2", "--max-time", "5", "http://127.0.0.1:" + nginxHostPort + "/"}, nil)
@@ -154,12 +137,4 @@ func curlNginxHTTPStatus(h *e2e.Harness) (string, error) {
 func expectNginxReachable(h *e2e.Harness) {
 	GinkgoHelper()
 	Eventually(func() (string, error) { return curlNginxHTTPStatus(h) }, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Equal("200"))
-}
-
-func expectSSHInaccessible(h *e2e.Harness, port int, appName string) {
-	GinkgoHelper()
-	Eventually(func(g Gomega) {
-		_, sshErr := h.RunSSHOnDeviceLocalPort(port, vmGuestUser, vmGuestPassword, "/usr/bin/whoami")
-		g.Expect(sshErr).To(HaveOccurred(), "expected SSH to %s on port %d to fail after stop", appName, port)
-	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 }

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -156,6 +156,8 @@ func expectNginxReachable(h *e2e.Harness) {
 
 func expectSSHInaccessible(h *e2e.Harness, port int, appName string) {
 	GinkgoHelper()
-	_, sshErr := h.RunSSHOnDeviceLocalPort(port, vmGuestUser, vmGuestPassword, "/usr/bin/whoami")
-	Expect(sshErr).To(HaveOccurred(), "expected SSH to %s on port %d to fail after stop", appName, port)
+	Eventually(func(g Gomega) {
+		_, sshErr := h.RunSSHOnDeviceLocalPort(port, vmGuestUser, vmGuestPassword, "/usr/bin/whoami")
+		g.Expect(sshErr).To(HaveOccurred(), "expected SSH to %s on port %d to fail after stop", appName, port)
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 }

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -1,0 +1,161 @@
+package vm_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/test/harness/e2e"
+	testutil "github.com/flightctl/flightctl/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	nginxAppName  = "nginx"
+	nginxImage    = "quay.io/flightctl-tests/nginx:1.28-alpine-slim"
+	nginxHostPort = "8080"
+	flightctlUser = "flightctl"
+	fleetLabelKey = "fleet"
+)
+
+var _ = Describe("VM Applications on a Fleet", func() {
+	It("rolls out VM and container apps and applies fleet vs device lifecycle", Label("vm", "slow"), func() {
+		harness := e2e.GetWorkerHarness()
+		ctx := harness.GetTestContext()
+		testID := harness.GetTestIDFromContext()
+		fleetName := fmt.Sprintf("fleet-with-apps-%s", testID)
+		fleetSelector := v1beta1.LabelSelector{
+			MatchLabels: &map[string]string{fleetLabelKey: fleetName},
+		}
+
+		By("Starting a second agent VM and enrolling both devices unlabeled")
+		workerID2 := GinkgoParallelProcess()*100 + 1
+		harness2, err := e2e.NewTestHarnessWithVMPool(ctx, workerID2)
+		Expect(err).ToNot(HaveOccurred())
+		harness2.SetTestContext(ctx)
+		DeferCleanup(func() {
+			harness2.PrintAgentLogsIfFailed()
+			printVMQuadletDiagnosticsIfFailed(harness2)
+			harness2.CaptureDeploymentLogsIfFailed()
+			Expect(harness2.CleanUpAllTestResources()).To(Succeed(), "harness2 cleanup")
+		})
+		Expect(harness2.SetupVMFromPoolAndStartAgent(workerID2)).To(Succeed())
+
+		device1ID, _ := harness.EnrollAndWaitForOnlineStatus()
+		Expect(device1ID).NotTo(BeEmpty())
+		device2ID, _ := harness2.EnrollAndWaitForOnlineStatus()
+		Expect(device2ID).NotTo(BeEmpty())
+
+		By("Creating a fleet with NGINX and a VM application")
+		nginxSpec, err := e2e.NewContainerApplicationSpecWithRunAs(
+			nginxAppName,
+			nginxImage,
+			[]v1beta1.ApplicationPort{nginxHostPort + ":80"},
+			nil,
+			nil,
+			nil,
+			flightctlUser,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		vmSpec, err := e2e.NewVmApplicationSpec(vmAppName, getVMImage())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(harness.CreateOrUpdateTestFleet(fleetName, fleetSelector, v1beta1.DeviceSpec{
+			Applications: &[]v1beta1.ApplicationProviderSpec{nginxSpec, vmSpec},
+		})).To(Succeed())
+
+		By("Labeling device 1 into the fleet")
+		labelDeviceIntoFleet(harness, device1ID, fleetName)
+
+		By("Waiting for both apps to run on device 1")
+		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		err = harness.WaitForApplicationSummary(device1ID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+		expectNginxReachable(harness)
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		By("Stopping the VM application on the fleet")
+		_, err = harness.CLI("app", "stop", "fleet/"+fleetName, "--name", vmAppName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
+		expectSSHInaccessible(harness, vmPublishedSSHPort, vmAppName)
+		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
+		expectNginxReachable(harness)
+
+		By("Labeling device 2 into the fleet so it inherits the fleet stop default")
+		labelDeviceIntoFleet(harness, device2ID, fleetName)
+		waitForAppStatus(harness2, device2ID, nginxAppName, v1beta1.ApplicationStatusRunning)
+		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusStopped)
+		waitForAppStatus(harness, device1ID, nginxAppName, v1beta1.ApplicationStatusRunning)
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
+
+		By("Starting the VM application on the fleet")
+		_, err = harness.CLI("app", "start", "fleet/"+fleetName, "--name", vmAppName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		By("Stopping the VM application on device 1 only")
+		_, err = harness.CLI("app", "stop", "device/"+device1ID, "--name", vmAppName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusStopped)
+		expectSSHInaccessible(harness, vmPublishedSSHPort, vmAppName)
+		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		By("Starting the VM application on the fleet again so the newer fleet action wins")
+		_, err = harness.CLI("app", "start", "fleet/"+fleetName, "--name", vmAppName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+		waitForAppStatus(harness, device1ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		waitForAppStatus(harness2, device2ID, vmAppName, v1beta1.ApplicationStatusRunning)
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+		expectSSHWhoamiWithPassword(harness2, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		By("Rejecting fleet-scoped app restart")
+		out, err := harness.CLI("app", "restart", "fleet/"+fleetName, "--name", vmAppName, "-y")
+		Expect(err).To(HaveOccurred())
+		Expect(out).To(ContainSubstring("kind must be Device"))
+	})
+})
+
+func labelDeviceIntoFleet(h *e2e.Harness, deviceID, fleetName string) {
+	GinkgoHelper()
+	nextRenderedVersion, err := h.PrepareNextDeviceVersion(deviceID)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(h.SetLabelsForDevice(deviceID, map[string]string{fleetLabelKey: fleetName})).To(Succeed())
+	Expect(h.WaitForDeviceNewRenderedVersion(deviceID, nextRenderedVersion)).To(Succeed())
+}
+
+func waitForAppStatus(h *e2e.Harness, deviceID, appName string, status v1beta1.ApplicationStatusType) {
+	GinkgoHelper()
+	err := h.WaitForApplicationStatus(deviceID, appName, status, testutil.LONG_TIMEOUT, testutil.POLLING)
+	if err != nil && appName == vmAppName {
+		logVMApplicationUnitStatus(h, appName)
+	}
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func expectNginxReachable(h *e2e.Harness) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		ports, portsErr := h.GetContainerPorts()
+		g.Expect(portsErr).NotTo(HaveOccurred())
+		g.Expect(ports).To(ContainSubstring(nginxHostPort), "expected host port %s to be mapped", nginxHostPort)
+
+		out, curlErr := h.VM.RunSSH([]string{"curl", "-sS", "--fail", "--max-time", "5", "http://127.0.0.1:" + nginxHostPort}, nil)
+		g.Expect(curlErr).NotTo(HaveOccurred(), "curl to nginx on port %s failed", nginxHostPort)
+		g.Expect(strings.ToLower(out.String())).To(ContainSubstring("nginx"))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+func expectSSHInaccessible(h *e2e.Harness, port int, appName string) {
+	GinkgoHelper()
+	_, sshErr := h.RunSSHOnDeviceLocalPort(port, vmGuestUser, vmGuestPassword, "/usr/bin/whoami")
+	Expect(sshErr).To(HaveOccurred(), "expected SSH to %s on port %d to fail after stop", appName, port)
+}

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -141,17 +141,17 @@ func waitForAppStatus(h *e2e.Harness, deviceID, appName string, status v1beta1.A
 	Expect(err).ToNot(HaveOccurred())
 }
 
+func curlNginxHTTPStatus(h *e2e.Harness) (string, error) {
+	out, err := h.VM.RunSSH([]string{"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--connect-timeout", "2", "http://127.0.0.1:" + nginxHostPort + "/"}, nil)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
 func expectNginxReachable(h *e2e.Harness) {
 	GinkgoHelper()
-	Eventually(func(g Gomega) {
-		ports, portsErr := h.GetContainerPorts()
-		g.Expect(portsErr).NotTo(HaveOccurred())
-		g.Expect(ports).To(ContainSubstring(nginxHostPort), "expected host port %s to be mapped", nginxHostPort)
-
-		out, curlErr := h.VM.RunSSH([]string{"curl", "-sS", "--fail", "--max-time", "5", "http://127.0.0.1:" + nginxHostPort}, nil)
-		g.Expect(curlErr).NotTo(HaveOccurred(), "curl to nginx on port %s failed", nginxHostPort)
-		g.Expect(strings.ToLower(out.String())).To(ContainSubstring("nginx"))
-	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+	Eventually(func() (string, error) { return curlNginxHTTPStatus(h) }, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Equal("200"))
 }
 
 func expectSSHInaccessible(h *e2e.Harness, port int, appName string) {

--- a/test/e2e/vm/vm_fleet_test.go
+++ b/test/e2e/vm/vm_fleet_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 var _ = Describe("VM Applications on a Fleet", func() {
-	It("rolls out VM and container apps and applies fleet vs device lifecycle", Label("vm", "slow"), func() {
+	It("rolls out VM and container apps and applies fleet vs device lifecycle", Label("vm", "slow", "90242"), func() {
 		harness := e2e.GetWorkerHarness()
 		ctx := harness.GetTestContext()
 		testID := harness.GetTestIDFromContext()

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -1258,7 +1258,7 @@ fi`,
 		quotedPassword,
 		sshCommand,
 	)
-	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", script}, nil)
+	out, err := h.VM.RunSSH([]string{"/bin/sh -c " + shellQuote(script)}, nil)
 	if err != nil {
 		return "", classifyDeviceLocalSSHError(fmt.Errorf(
 			"running /bin/sh -c ssh script on device VM (localhost:%d user=%s remote=%s): %w",
@@ -1358,7 +1358,7 @@ func (h *Harness) RunUDPProbeOnDeviceLocalPort(port int) (string, error) {
 		return "", fmt.Errorf("port must be between 1 and 65535, got %d", port)
 	}
 
-	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", udpProbeDeviceHostScript(port)}, nil)
+	out, err := h.VM.RunSSH([]string{"/bin/sh -c " + shellQuote(udpProbeDeviceHostScript(port))}, nil)
 	if err != nil {
 		return "", fmt.Errorf("running UDP probe on device host localhost:%d: %w", port, err)
 	}

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -1291,6 +1291,25 @@ func classifyDeviceLocalSSHError(err error) error {
 	}
 }
 
+func (h *Harness) ExpectSSHUnavailableOnPort(port int, appName, user, password string) {
+	GinkgoHelper()
+	const remoteCmd = "/usr/bin/whoami"
+	const unavailableWindow = "10s"
+	Eventually(func(g Gomega) {
+		_, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		g.Expect(sshErr).To(HaveOccurred(), "SSH to %s on published port %d should be unavailable", appName, port)
+		g.Expect(errors.Is(sshErr, ErrSSHConnectionRefused) || errors.Is(sshErr, ErrSSHTimeout)).
+			To(BeTrue(), "SSH to %s on port %d failed with %v, want connection refused or timeout", appName, port, sshErr)
+	}, LONGTIMEOUT, POLLING).Should(Succeed())
+
+	Consistently(func(g Gomega) {
+		_, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		g.Expect(sshErr).To(HaveOccurred(), "SSH to %s on published port %d should remain unavailable", appName, port)
+		g.Expect(errors.Is(sshErr, ErrSSHConnectionRefused) || errors.Is(sshErr, ErrSSHTimeout)).
+			To(BeTrue(), "SSH to %s on port %d failed with %v, want connection refused or timeout", appName, port, sshErr)
+	}, unavailableWindow, POLLING).Should(Succeed())
+}
+
 // trimSSHCommandOutput returns the last non-empty line from nested SSH output. Device-side
 // shell profiles can print environment noise before the guest command result on stdout.
 func trimSSHCommandOutput(stdout string) string {

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -923,6 +923,17 @@ func (h *Harness) SetLabelsForDevice(deviceId string, labels map[string]string) 
 	})
 }
 
+func (h *Harness) LabelDeviceIntoFleet(deviceID, labelKey, fleetName string) {
+	GinkgoHelper()
+	if labelKey == "" {
+		Fail("labelKey must be non-empty")
+	}
+	nextRenderedVersion, err := h.PrepareNextDeviceVersion(deviceID)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(h.SetLabelsForDevice(deviceID, map[string]string{labelKey: fleetName})).To(Succeed())
+	Expect(h.WaitForDeviceNewRenderedVersion(deviceID, nextRenderedVersion)).To(Succeed())
+}
+
 func (h *Harness) SetLabelsForDevicesByIndex(deviceIDs []string, labelsList []map[string]string, fleetName string) error {
 	if len(deviceIDs) != len(labelsList) {
 		return fmt.Errorf("mismatched lengths: deviceIDs (%d) and labelsList (%d)", len(deviceIDs), len(labelsList))

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -322,6 +322,9 @@ func (h *Harness) StartLabeledSimulatorWithOptions(ctx context.Context, testID, 
 	if deviceCount <= 0 {
 		return nil, fmt.Errorf("deviceCount must be > 0")
 	}
+	if err := removeSimulatorAgentData(initialIndex, deviceCount); err != nil {
+		return nil, err
+	}
 	args := []string{
 		"--count", fmt.Sprintf("%d", deviceCount),
 		"--initial-device-index", fmt.Sprintf("%d", initialIndex),
@@ -337,6 +340,21 @@ func (h *Harness) StartLabeledSimulatorWithOptions(ctx context.Context, testID, 
 // DeviceSimulatorAgentAlias returns the agent alias label for a simulator device index.
 func DeviceSimulatorAgentAlias(initialDeviceIndex int) string {
 	return fmt.Sprintf("device-%05d", initialDeviceIndex)
+}
+
+func removeSimulatorAgentData(initialIndex, deviceCount int) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting user home: %w", err)
+	}
+	dataDir := filepath.Join(homeDir, ".flightctl", "data")
+	for i := 0; i < deviceCount; i++ {
+		agentDir := filepath.Join(dataDir, DeviceSimulatorAgentAlias(initialIndex+i))
+		if err := os.RemoveAll(agentDir); err != nil {
+			return fmt.Errorf("removing leftover simulator data %s: %w", agentDir, err)
+		}
+	}
+	return nil
 }
 
 // WaitForSimulatorEnrollmentRequest polls until an enrollment request exists whose
@@ -469,25 +487,38 @@ func (h *Harness) CountDevicesByLabel(testID string) int {
 	return len(lines)
 }
 
-// WaitForLabeledSimulatorDevice polls until the simulator device for the given test-id and
-// device index has enrolled and returns its name (the enrollment / device ID).
+// WaitForLabeledSimulatorDevice polls until a device labeled with test-id exists.
 func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceIndex int, timeout, polling time.Duration) (string, error) {
 	alias := DeviceSimulatorAgentAlias(initialDeviceIndex)
 	return pollUntil(timeout.String(), polling.String(),
 		fmt.Sprintf("simulator device with test-id=%s and alias=%s", testID, alias),
 		func() (string, bool, error) {
-			name, found, err := h.findEnrollmentRequestBySpecLabels(testID, alias)
-			if err != nil {
-				return "", false, err
-			}
+			name, found := h.findDeviceNameByTestID(testID)
 			if !found {
-				return "", false, nil
-			}
-			if _, err := h.GetDevice(name); err != nil {
 				return "", false, nil
 			}
 			return name, true, nil
 		})
+}
+
+func (h *Harness) findDeviceNameByTestID(testID string) (string, bool) {
+	if testID == "" {
+		return "", false
+	}
+	out, err := h.CLI("get", "devices", "-l", fmt.Sprintf("test-id=%s", testID), "-o", "name")
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return "", false
+	}
+	first := strings.Split(line, "\n")[0]
+	name := resourceNameFromCLIOutput(strings.TrimSpace(first))
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 // EnrollDeviceForDecommissionTest starts a labeled simulator as the given user, waits for

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -330,6 +330,7 @@ func (h *Harness) StartLabeledSimulatorWithOptions(ctx context.Context, testID, 
 		"--initial-device-index", fmt.Sprintf("%d", initialIndex),
 		"--label", fmt.Sprintf("test-id=%s", testID),
 		"--label", fmt.Sprintf("user=%s", userPrefix),
+		"--label", fmt.Sprintf("alias=%s", DeviceSimulatorAgentAlias(initialIndex)),
 	}
 	if opts.SkipAutoApprove {
 		args = append(args, "--skip-auto-approve")
@@ -487,13 +488,13 @@ func (h *Harness) CountDevicesByLabel(testID string) int {
 	return len(lines)
 }
 
-// WaitForLabeledSimulatorDevice polls until a device labeled with test-id exists.
+// WaitForLabeledSimulatorDevice polls until a device labeled with test-id and alias exists.
 func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceIndex int, timeout, polling time.Duration) (string, error) {
 	alias := DeviceSimulatorAgentAlias(initialDeviceIndex)
 	return pollUntil(timeout.String(), polling.String(),
 		fmt.Sprintf("simulator device with test-id=%s and alias=%s", testID, alias),
 		func() (string, bool, error) {
-			name, found := h.findDeviceNameByTestID(testID)
+			name, found := h.findDeviceNameByTestIDAndAlias(testID, alias)
 			if !found {
 				return "", false, nil
 			}
@@ -501,11 +502,11 @@ func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceInde
 		})
 }
 
-func (h *Harness) findDeviceNameByTestID(testID string) (string, bool) {
-	if testID == "" {
+func (h *Harness) findDeviceNameByTestIDAndAlias(testID, alias string) (string, bool) {
+	if testID == "" || alias == "" {
 		return "", false
 	}
-	out, err := h.CLI("get", "devices", "-l", fmt.Sprintf("test-id=%s", testID), "-o", "name")
+	out, err := h.CLI("get", "devices", "-l", fmt.Sprintf("test-id=%s,alias=%s", testID, alias), "-o", "name")
 	if err != nil {
 		return "", false
 	}

--- a/test/harness/e2e/harness_devicesim.go
+++ b/test/harness/e2e/harness_devicesim.go
@@ -322,12 +322,17 @@ func (h *Harness) StartLabeledSimulatorWithOptions(ctx context.Context, testID, 
 	if deviceCount <= 0 {
 		return nil, fmt.Errorf("deviceCount must be > 0")
 	}
-	if err := removeSimulatorAgentData(initialIndex, deviceCount); err != nil {
+	dataDir, err := simulatorAgentDataDir(testID, initialIndex)
+	if err != nil {
+		return nil, err
+	}
+	if err := removeSimulatorAgentData(dataDir); err != nil {
 		return nil, err
 	}
 	args := []string{
 		"--count", fmt.Sprintf("%d", deviceCount),
 		"--initial-device-index", fmt.Sprintf("%d", initialIndex),
+		"--data-dir", dataDir,
 		"--label", fmt.Sprintf("test-id=%s", testID),
 		"--label", fmt.Sprintf("user=%s", userPrefix),
 		"--label", fmt.Sprintf("alias=%s", DeviceSimulatorAgentAlias(initialIndex)),
@@ -343,17 +348,17 @@ func DeviceSimulatorAgentAlias(initialDeviceIndex int) string {
 	return fmt.Sprintf("device-%05d", initialDeviceIndex)
 }
 
-func removeSimulatorAgentData(initialIndex, deviceCount int) error {
+func simulatorAgentDataDir(testID string, initialIndex int) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("getting user home: %w", err)
+		return "", fmt.Errorf("getting user home: %w", err)
 	}
-	dataDir := filepath.Join(homeDir, ".flightctl", "data")
-	for i := 0; i < deviceCount; i++ {
-		agentDir := filepath.Join(dataDir, DeviceSimulatorAgentAlias(initialIndex+i))
-		if err := os.RemoveAll(agentDir); err != nil {
-			return fmt.Errorf("removing leftover simulator data %s: %w", agentDir, err)
-		}
+	return filepath.Join(homeDir, ".flightctl", "data", fmt.Sprintf("e2e-%s-%d", testID, initialIndex)), nil
+}
+
+func removeSimulatorAgentData(dataDir string) error {
+	if err := os.RemoveAll(dataDir); err != nil {
+		return fmt.Errorf("removing leftover simulator data %s: %w", dataDir, err)
 	}
 	return nil
 }
@@ -494,7 +499,10 @@ func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceInde
 	return pollUntil(timeout.String(), polling.String(),
 		fmt.Sprintf("simulator device with test-id=%s and alias=%s", testID, alias),
 		func() (string, bool, error) {
-			name, found := h.findDeviceNameByTestIDAndAlias(testID, alias)
+			name, found, err := h.findDeviceNameByTestIDAndAlias(testID, alias)
+			if err != nil {
+				return "", false, fmt.Errorf("listing devices with test-id=%s alias=%s: %w", testID, alias, err)
+			}
 			if !found {
 				return "", false, nil
 			}
@@ -502,24 +510,24 @@ func (h *Harness) WaitForLabeledSimulatorDevice(testID string, initialDeviceInde
 		})
 }
 
-func (h *Harness) findDeviceNameByTestIDAndAlias(testID, alias string) (string, bool) {
+func (h *Harness) findDeviceNameByTestIDAndAlias(testID, alias string) (string, bool, error) {
 	if testID == "" || alias == "" {
-		return "", false
+		return "", false, fmt.Errorf("testID and alias must be non-empty")
 	}
 	out, err := h.CLI("get", "devices", "-l", fmt.Sprintf("test-id=%s,alias=%s", testID, alias), "-o", "name")
 	if err != nil {
-		return "", false
+		return "", false, err
 	}
 	line := strings.TrimSpace(out)
 	if line == "" {
-		return "", false
+		return "", false, nil
 	}
 	first := strings.Split(line, "\n")[0]
 	name := resourceNameFromCLIOutput(strings.TrimSpace(first))
 	if name == "" {
-		return "", false
+		return "", false, nil
 	}
-	return name, true
+	return name, true, nil
 }
 
 // EnrollDeviceForDecommissionTest starts a labeled simulator as the given user, waits for

--- a/test/test.mk
+++ b/test/test.mk
@@ -64,8 +64,7 @@ _integration_test: $(REPORTS)
 		$(if $(TEST_DIR),$(TEST_DIR),$(GO_INTEGRATIONTEST_DIRS))
 
 _e2e_test: $(REPORTS)
-	sudo chown $(shell whoami):$(shell whoami) -R bin/output
-	sudo chmod a+x test/scripts/setup_e2e_environment.sh test/scripts/e2e_cleanup.sh test/scripts/e2e_startup.sh
+	chmod a+x test/scripts/setup_e2e_environment.sh test/scripts/e2e_cleanup.sh test/scripts/e2e_startup.sh
 	test/scripts/setup_e2e_environment.sh
 	test/scripts/run_e2e_tests.sh "$(REPORTS)" $(GO_E2E_DIRS)
 


### PR DESCRIPTION
## Summary
- Add a two-device VM e2e that rolls out NGINX + a nested VM on a fleet and exercises fleet vs device start/stop (last write wins), plus rejection of fleet-scoped restart.
- Extend multiorg RBAC to cover application lifecycle (`app stop/start/restart`) and console (`console`, `app console`) for admin/operator vs viewer/installer, on both standalone and fleet-owned devices.
- Stabilize those specs: wipe leftover simulator agent data and wait on the enrolled Device; probe nginx over HTTP; quote SSH remote scripts so probes do not dump the guest shell environment.

## Test plan
- [ ] `GO_E2E_DIRS=test/e2e/vm GINKGO_FOCUS="fleet vs device" make in-cluster-e2e-test`
- [ ] `GO_E2E_DIRS=test/e2e/multiorg GINKGO_FOCUS="application lifecycle and console" make in-cluster-e2e-test`
- [ ] Confirm viewer/installer get 403 on lifecycle and console; admin/operator are allowed
- [ ] Confirm the VM fleet spec covers fleet stop inheritance on a new member and device-level override vs a later fleet start