### PR TITLE
EDM-5215: CLI shows OS update size, delta eligibility, and fallback

### DIFF
--- a/api/core/v1beta1/delta_fields_test.go
+++ b/api/core/v1beta1/delta_fields_test.go
@@ -198,6 +198,66 @@ func TestDeviceSystemInfoDeltaFieldsJSON(t *testing.T) {
 	}
 }
 
+func TestDevicesSummaryCapabilitiesDeltaEligibleJSON(t *testing.T) {
+	tests := []struct {
+		name            string
+		jsonInput       string
+		wantNil         bool
+		wantCounts      map[string]int64
+		marshalSource   DevicesSummaryCapabilities
+		wantMarshalOmit bool
+	}{
+		{
+			name:      "When deltaEligible is absent it should leave DeltaEligible nil",
+			jsonInput: `{"osMode":{"image":2}}`,
+			wantNil:   true,
+		},
+		{
+			name:       "When deltaEligible is set it should unmarshal true false and unknown counts",
+			jsonInput:  `{"deltaEligible":{"true":1,"false":2,"unknown":3}}`,
+			wantCounts: map[string]int64{"true": 1, "false": 2, "unknown": 3},
+		},
+		{
+			name:            "When DeltaEligible is nil it should omit deltaEligible from JSON",
+			marshalSource:   DevicesSummaryCapabilities{},
+			wantMarshalOmit: true,
+		},
+		{
+			name:          "When DeltaEligible is set it should include the counts in JSON",
+			marshalSource: DevicesSummaryCapabilities{DeltaEligible: &map[string]int64{"true": 4, "false": 1}},
+			wantCounts:    map[string]int64{"true": 4, "false": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.jsonInput != "" {
+				var caps DevicesSummaryCapabilities
+				require.NoError(t, json.Unmarshal([]byte(tt.jsonInput), &caps))
+				if tt.wantNil {
+					assert.Nil(t, caps.DeltaEligible)
+					return
+				}
+				require.NotNil(t, caps.DeltaEligible)
+				assert.Equal(t, tt.wantCounts, *caps.DeltaEligible)
+				return
+			}
+
+			data, err := json.Marshal(tt.marshalSource)
+			require.NoError(t, err)
+			raw := string(data)
+			if tt.wantMarshalOmit {
+				assert.NotContains(t, raw, `"deltaEligible"`)
+				return
+			}
+			var caps DevicesSummaryCapabilities
+			require.NoError(t, json.Unmarshal(data, &caps))
+			require.NotNil(t, caps.DeltaEligible)
+			assert.Equal(t, tt.wantCounts, *caps.DeltaEligible)
+		})
+	}
+}
+
 func TestNewDeviceStatusDoesNotInventDeltaFields(t *testing.T) {
 	status := NewDeviceStatus()
 	assert.Nil(t, status.Capabilities)

--- a/api/core/v1beta1/openapi.yaml
+++ b/api/core/v1beta1/openapi.yaml
@@ -7432,6 +7432,13 @@ components:
             type: integer
             format: int64
           description: Counts by status.capabilities.osMode (e.g. image, package). The key "unknown" counts devices that have not reported the capability.
+        deltaEligible:
+          type: object
+          default: {}
+          additionalProperties:
+            type: integer
+            format: int64
+          description: Counts by status.systemInfo.deltaEligible (true, false). The key "unknown" counts devices that have not reported the field.
       additionalProperties: false
     TemplateVersion:
       type: object

--- a/api/core/v1beta1/types.gen.go
+++ b/api/core/v1beta1/types.gen.go
@@ -1684,6 +1684,9 @@ type DevicesSummary struct {
 
 // DevicesSummaryCapabilities Breakdowns of devices by status.capabilities fields.
 type DevicesSummaryCapabilities struct {
+	// DeltaEligible Counts by status.systemInfo.deltaEligible (true, false). The key "unknown" counts devices that have not reported the field.
+	DeltaEligible *map[string]int64 `json:"deltaEligible,omitempty"`
+
 	// OsMode Counts by status.capabilities.osMode (e.g. image, package). The key "unknown" counts devices that have not reported the capability.
 	OsMode *map[string]int64 `json:"osMode,omitempty"`
 }

--- a/internal/cli/display/table.go
+++ b/internal/cli/display/table.go
@@ -217,18 +217,34 @@ func (f *TableFormatter) printDevicesSummaryTable(w *tabwriter.Writer, summary *
 		f.printTableRowLn(w, "APPLICATIONS", k, fmt.Sprintf("%d", summary.ApplicationStatus[k]))
 	}
 
-	// Print capabilities as a separate section if any are present.
-	if summary.Capabilities != nil && summary.Capabilities.OsMode != nil && len(*summary.Capabilities.OsMode) > 0 {
-		if err := w.Flush(); err != nil {
-			return err
-		}
-		fmt.Fprintln(w)
-		f.printHeaderRowLn(w, "CAPABILITY", "VALUE", "COUNT")
-		for _, k := range slices.Sorted(maps.Keys(*summary.Capabilities.OsMode)) {
-			f.printTableRowLn(w, "OS MODE", k, fmt.Sprintf("%d", (*summary.Capabilities.OsMode)[k]))
-		}
+	if summary.Capabilities == nil {
+		return nil
+	}
+	osMode := summary.Capabilities.OsMode
+	deltaEligible := summary.Capabilities.DeltaEligible
+	hasOsMode := osMode != nil && len(*osMode) > 0
+	hasDeltaEligible := deltaEligible != nil && len(*deltaEligible) > 0
+	if !hasOsMode && !hasDeltaEligible {
+		return nil
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	fmt.Fprintln(w)
+	f.printHeaderRowLn(w, "CAPABILITY", "VALUE", "COUNT")
+	if hasOsMode {
+		f.printCapabilityCountRows(w, "OS MODE", *osMode)
+	}
+	if hasDeltaEligible {
+		f.printCapabilityCountRows(w, "DELTA ELIGIBLE", *deltaEligible)
 	}
 	return nil
+}
+
+func (f *TableFormatter) printCapabilityCountRows(w *tabwriter.Writer, label string, counts map[string]int64) {
+	for _, k := range slices.Sorted(maps.Keys(counts)) {
+		f.printTableRowLn(w, label, k, fmt.Sprintf("%d", counts[k]))
+	}
 }
 
 func (f *TableFormatter) printDevicesLastSeenTable(w *tabwriter.Writer, lastSeen *api.DeviceLastSeen) error {
@@ -239,6 +255,22 @@ func (f *TableFormatter) printDevicesLastSeenTable(w *tabwriter.Writer, lastSeen
 		f.printTableRowLn(w, lastSeen.LastSeen.Format(time.RFC3339), humanize.Time(lastSeen.LastSeen))
 	}
 	return nil
+}
+
+func formatDeviceUpdatedCell(status *api.DeviceStatus) string {
+	if status == nil {
+		return "Unknown"
+	}
+	cell := string(status.Updated.Status)
+	if status.Os.LastDelta != nil {
+		if size := status.Os.LastDelta.Size; size != nil && *size != "" {
+			cell += " " + *size
+		}
+		if reason := status.Os.LastDelta.FallbackReason; reason != nil && *reason != "" {
+			cell += " (fallback)"
+		}
+	}
+	return cell
 }
 
 func (f *TableFormatter) printDevicesTable(w *tabwriter.Writer, wide bool, devices ...api.Device) error {
@@ -259,7 +291,7 @@ func (f *TableFormatter) printDevicesTable(w *tabwriter.Writer, wide bool, devic
 		applicationsStatus := "Unknown"
 		if d.Status != nil {
 			summaryStatus = string(d.Status.Summary.Status)
-			updatedStatus = string(d.Status.Updated.Status)
+			updatedStatus = formatDeviceUpdatedCell(d.Status)
 			applicationsStatus = string(d.Status.ApplicationsSummary.Status)
 		}
 

--- a/internal/cli/display/table_test.go
+++ b/internal/cli/display/table_test.go
@@ -1,0 +1,266 @@
+package display
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	apiclient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+const unsetUpToDateTable = "NAME\tALIAS\tOWNER\tSYSTEM\tUPDATED\t\tAPPLICATIONS\ndev-1\t\t<none>\tUnknown\tUpToDate\tUnknown\n"
+
+const emptyCapabilitiesSummary = "DEVICES\n1\n\nSTATUS TYPE\tSTATUS\t\tCOUNT\nSYSTEM\t\tOnline\t\t1\nUPDATED\t\tUpToDate\t1\nAPPLICATIONS\tHealthy\t\t1\n"
+
+func upToDateDevice(name string) api.Device {
+	status := api.NewDeviceStatus()
+	status.Updated.Status = api.DeviceUpdatedStatusUpToDate
+	return api.Device{
+		Metadata: api.ObjectMeta{Name: lo.ToPtr(name)},
+		Status:   &status,
+	}
+}
+
+func formatDeviceList(t *testing.T, f *TableFormatter, items []api.Device, summary *api.DevicesSummary, opts FormatOptions) string {
+	t.Helper()
+	var buf bytes.Buffer
+	opts.Writer = &buf
+	if opts.Kind == "" {
+		opts.Kind = api.DeviceKind
+	}
+	require.NoError(t, f.Format(&apiclient.ListDevicesResponse{
+		JSON200: &api.DeviceList{Items: items, Summary: summary},
+	}, opts))
+	return buf.String()
+}
+
+func formatDeviceGet(t *testing.T, f *TableFormatter, device api.Device) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(&apiclient.GetDeviceResponse{JSON200: &device}, FormatOptions{
+		Kind:   api.DeviceKind,
+		Name:   *device.Metadata.Name,
+		Writer: &buf,
+	}))
+	return buf.String()
+}
+
+func TestTableFormatter_WhenSizeAndFallbackAreSetItShouldShowThemInUpdatedCell(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		mutate       func(*api.DeviceStatus)
+		wantContains []string
+		wantAbsent   []string
+		wantHeader   []string
+	}{
+		{
+			name: "When size is populated it should include 45 MiB in list and single table",
+			mutate: func(s *api.DeviceStatus) {
+				s.Os.LastDelta = &api.DeviceDeltaApplyStatus{Size: lo.ToPtr("45 MiB")}
+			},
+			wantContains: []string{"45 MiB"},
+			wantHeader:   []string{"NAME", "ALIAS", "OWNER", "SYSTEM", "UPDATED", "APPLICATIONS"},
+		},
+		{
+			name: "When lastDelta.fallbackReason is set it should show (fallback) in list and single table",
+			mutate: func(s *api.DeviceStatus) {
+				s.Os.LastDelta = &api.DeviceDeltaApplyStatus{FallbackReason: lo.ToPtr("delta apply failed: apply error")}
+			},
+			wantContains: []string{"(fallback)"},
+			wantAbsent:   []string{"delta apply failed"},
+			wantHeader:   []string{"NAME", "ALIAS", "OWNER", "SYSTEM", "UPDATED", "APPLICATIONS"},
+		},
+		{
+			name: "When size and fallback are both set it should print status size then (fallback)",
+			mutate: func(s *api.DeviceStatus) {
+				s.Os.LastDelta = &api.DeviceDeltaApplyStatus{
+					Size:           lo.ToPtr("45 MiB"),
+					FallbackReason: lo.ToPtr("delta apply failed: apply error"),
+				}
+			},
+			wantContains: []string{"UpToDate 45 MiB (fallback)"},
+			wantHeader:   []string{"NAME", "ALIAS", "OWNER", "SYSTEM", "UPDATED", "APPLICATIONS"},
+		},
+		{
+			name: "When size is empty string it should treat it as unset",
+			mutate: func(s *api.DeviceStatus) {
+				s.Os.LastDelta = &api.DeviceDeltaApplyStatus{Size: lo.ToPtr("")}
+			},
+			wantAbsent: []string{"(fallback)"},
+		},
+		{
+			name: "When fallback reason is empty string it should treat it as unset",
+			mutate: func(s *api.DeviceStatus) {
+				s.Os.LastDelta = &api.DeviceDeltaApplyStatus{FallbackReason: lo.ToPtr("")}
+			},
+			wantAbsent: []string{"(fallback)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			device := upToDateDevice("dev-1")
+			tt.mutate(device.Status)
+
+			listOut := formatDeviceList(t, &TableFormatter{}, []api.Device{device}, nil, FormatOptions{})
+			singleOut := formatDeviceGet(t, &TableFormatter{}, device)
+
+			for _, out := range []string{listOut, singleOut} {
+				for _, token := range tt.wantContains {
+					require.Contains(t, out, token)
+				}
+				for _, token := range tt.wantAbsent {
+					require.NotContains(t, out, token)
+				}
+				if len(tt.wantContains) == 0 {
+					require.Equal(t, unsetUpToDateTable, out)
+				}
+				if len(tt.wantHeader) > 0 {
+					header := strings.Fields(strings.Split(out, "\n")[0])
+					require.Equal(t, tt.wantHeader, header)
+					require.NotContains(t, header, "SIZE")
+				}
+			}
+		})
+	}
+}
+
+func TestTableFormatter_WhenSizeEligibilityAndFallbackAreUnsetItShouldKeepCurrentLayout(t *testing.T) {
+	t.Parallel()
+
+	device := upToDateDevice("dev-1")
+	device.Status.Capabilities = &api.DeviceCapabilities{}
+
+	listOut := formatDeviceList(t, &TableFormatter{}, []api.Device{device}, nil, FormatOptions{})
+	singleOut := formatDeviceGet(t, &TableFormatter{}, device)
+
+	require.Equal(t, unsetUpToDateTable, listOut)
+	require.Equal(t, unsetUpToDateTable, singleOut)
+}
+
+func TestTableFormatter_WhenDeltaEligibleIsSetItShouldNotPrintItOnDeviceTable(t *testing.T) {
+	t.Parallel()
+
+	device := upToDateDevice("dev-1")
+	device.Status.SystemInfo.DeltaEligible = lo.ToPtr(true)
+
+	out := formatDeviceList(t, &TableFormatter{}, []api.Device{device}, nil, FormatOptions{})
+	require.Equal(t, unsetUpToDateTable, out)
+	require.NotContains(t, out, "DELTA ELIGIBLE")
+}
+
+func TestTableFormatter_WhenStatusIsNilItShouldPrintUnknownWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	device := api.Device{Metadata: api.ObjectMeta{Name: lo.ToPtr("dev-1")}}
+	out := formatDeviceList(t, &TableFormatter{}, []api.Device{device}, nil, FormatOptions{})
+	require.Contains(t, out, "Unknown")
+	require.NotContains(t, out, "(fallback)")
+	require.NotContains(t, out, "45 MiB")
+}
+
+func TestTableFormatter_WhenWideItShouldKeepLabelsLastAndPutSizeFallbackInUpdated(t *testing.T) {
+	t.Parallel()
+
+	device := upToDateDevice("dev-1")
+	device.Status.Os.LastDelta = &api.DeviceDeltaApplyStatus{
+		Size:           lo.ToPtr("45 MiB"),
+		FallbackReason: lo.ToPtr("delta apply failed"),
+	}
+	labels := map[string]string{"alias": "edge-1", "env": "prod"}
+	device.Metadata.Labels = &labels
+	device.Metadata.Owner = lo.ToPtr("Fleet/f1")
+
+	out := formatDeviceList(t, &TableFormatter{wide: true}, []api.Device{device}, nil, FormatOptions{})
+	header := strings.Fields(strings.Split(out, "\n")[0])
+	require.Equal(t, "LABELS", header[len(header)-1])
+	require.Equal(t, []string{"NAME", "ALIAS", "OWNER", "SYSTEM", "UPDATED", "APPLICATIONS", "LABELS"}, header)
+	require.Contains(t, out, "45 MiB")
+	require.Contains(t, out, "(fallback)")
+}
+
+func TestTableFormatter_WhenSummaryHasDeltaEligibleItShouldPrintCapabilityCounts(t *testing.T) {
+	t.Parallel()
+
+	baseSummary := func() *api.DevicesSummary {
+		return &api.DevicesSummary{
+			Total:             2,
+			SummaryStatus:     map[string]int64{"Online": 2},
+			UpdateStatus:      map[string]int64{"UpToDate": 2},
+			ApplicationStatus: map[string]int64{"Healthy": 2},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		caps         *api.DevicesSummaryCapabilities
+		wantContains []string
+		wantAbsent   []string
+		checkOrder   bool
+	}{
+		{
+			name: "When true and false counts are present it should print DELTA ELIGIBLE rows",
+			caps: &api.DevicesSummaryCapabilities{
+				DeltaEligible: &map[string]int64{"true": 1, "false": 1},
+			},
+			wantContains: []string{"CAPABILITY", "DELTA ELIGIBLE", "true", "false"},
+			wantAbsent:   []string{"OS MODE"},
+		},
+		{
+			name: "When only OsMode is present it should print OS MODE and not DELTA ELIGIBLE",
+			caps: &api.DevicesSummaryCapabilities{
+				OsMode: &map[string]int64{"image": 2},
+			},
+			wantContains: []string{"CAPABILITY", "OS MODE", "image"},
+			wantAbsent:   []string{"DELTA ELIGIBLE"},
+		},
+		{
+			name: "When both maps are present it should print OS MODE then DELTA ELIGIBLE",
+			caps: &api.DevicesSummaryCapabilities{
+				OsMode:        &map[string]int64{"image": 1, "package": 1},
+				DeltaEligible: &map[string]int64{"true": 1, "false": 1},
+			},
+			wantContains: []string{"OS MODE", "DELTA ELIGIBLE", "image", "package", "true", "false"},
+			checkOrder:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			summary := baseSummary()
+			summary.Capabilities = tt.caps
+			out := formatDeviceList(t, &TableFormatter{}, nil, summary, FormatOptions{SummaryOnly: true})
+			for _, token := range tt.wantContains {
+				require.Contains(t, out, token)
+			}
+			for _, token := range tt.wantAbsent {
+				require.NotContains(t, out, token)
+			}
+			if tt.checkOrder {
+				require.Greater(t, strings.Index(out, "DELTA ELIGIBLE"), strings.Index(out, "OS MODE"))
+			}
+		})
+	}
+}
+
+func TestTableFormatter_WhenCapabilitiesAreEmptyItShouldOmitCapabilitySection(t *testing.T) {
+	t.Parallel()
+
+	summary := &api.DevicesSummary{
+		Total:             1,
+		SummaryStatus:     map[string]int64{"Online": 1},
+		UpdateStatus:      map[string]int64{"UpToDate": 1},
+		ApplicationStatus: map[string]int64{"Healthy": 1},
+	}
+	out := formatDeviceList(t, &TableFormatter{}, nil, summary, FormatOptions{SummaryOnly: true})
+	require.Equal(t, emptyCapabilitiesSummary, out)
+	require.NotContains(t, out, "CAPABILITY")
+	require.NotContains(t, out, "DELTA ELIGIBLE")
+}

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -1155,7 +1155,8 @@ func (s *DeviceStore) Summary(ctx context.Context, orgId uuid.UUID, listParams s
 		"status.applicationsSummary.status",
 		"status.summary.status",
 		"status.updated.status",
-		"status.capabilities.osMode")
+		"status.capabilities.osMode",
+		"status.systemInfo.deltaEligible")
 	if err != nil {
 		return nil, store.ErrorFromGormError(err)
 	}
@@ -1164,12 +1165,13 @@ func (s *DeviceStore) Summary(ctx context.Context, orgId uuid.UUID, listParams s
 	summaryStatus := statusCount.List("status.summary.status")
 	updateStatus := statusCount.List("status.updated.status")
 	osModeStatus := statusCount.List("status.capabilities.osMode")
+	deltaEligibleStatus := statusCount.List("status.systemInfo.deltaEligible")
 	return &domain.DevicesSummary{
 		Total:             devicesCount,
 		ApplicationStatus: applicationStatus,
 		SummaryStatus:     summaryStatus,
 		UpdateStatus:      updateStatus,
-		Capabilities:      model.NewDevicesSummaryCapabilities(osModeStatus),
+		Capabilities:      model.NewDevicesSummaryCapabilities(osModeStatus, deltaEligibleStatus),
 	}, nil
 }
 

--- a/internal/store/fleet/store.go
+++ b/internal/store/fleet/store.go
@@ -382,7 +382,8 @@ func (s *FleetStore) addStatusSummary(ctx context.Context, orgId uuid.UUID, flee
 		"status.applicationsSummary.status",
 		"status.summary.status",
 		"status.updated.status",
-		"status.capabilities.osMode")
+		"status.capabilities.osMode",
+		"status.systemInfo.deltaEligible")
 	if err != nil {
 		return store.ErrorFromGormError(err)
 	}
@@ -397,7 +398,8 @@ func (s *FleetStore) addStatusSummary(ctx context.Context, orgId uuid.UUID, flee
 	summary.UpdateStatus = updateStatus
 
 	osModeStatus := statusCount.List("status.capabilities.osMode")
-	summary.Capabilities = model.NewDevicesSummaryCapabilities(osModeStatus)
+	deltaEligibleStatus := statusCount.List("status.systemInfo.deltaEligible")
+	summary.Capabilities = model.NewDevicesSummaryCapabilities(osModeStatus, deltaEligibleStatus)
 
 	return nil
 }

--- a/internal/store/model/device.go
+++ b/internal/store/model/device.go
@@ -308,6 +308,7 @@ func DevicesToApiResource[D DeviceType](devices []D, cont *string, numRemaining 
 	summaryStatuses := make(map[string]int64)
 	updateStatuses := make(map[string]int64)
 	osModeStatuses := make(map[string]int64)
+	deltaEligibleStatuses := make(map[string]int64)
 	for i, device := range devices {
 		dptr, ok := any(&device).(DeviceTypePtr)
 		if !ok {
@@ -322,6 +323,7 @@ func DevicesToApiResource[D DeviceType](devices []D, cont *string, numRemaining 
 		updateStatus := string(deviceList[i].Status.Updated.Status)
 		updateStatuses[updateStatus] = updateStatuses[updateStatus] + 1
 		osModeStatuses[deviceOsModeCountKey(deviceList[i].Status)]++
+		deltaEligibleStatuses[deviceDeltaEligibleCountKey(deviceList[i].Status)]++
 	}
 	ret := domain.DeviceList{
 		ApiVersion: DeviceAPIVersion(),
@@ -332,7 +334,7 @@ func DevicesToApiResource[D DeviceType](devices []D, cont *string, numRemaining 
 			ApplicationStatus: applicationStatuses,
 			SummaryStatus:     summaryStatuses,
 			UpdateStatus:      updateStatuses,
-			Capabilities:      NewDevicesSummaryCapabilities(osModeStatuses),
+			Capabilities:      NewDevicesSummaryCapabilities(osModeStatuses, deltaEligibleStatuses),
 			Total:             int64(len(devices)),
 		},
 	}

--- a/internal/store/model/devices_summary.go
+++ b/internal/store/model/devices_summary.go
@@ -1,6 +1,10 @@
 package model
 
-import "github.com/flightctl/flightctl/internal/domain"
+import (
+	"strconv"
+
+	"github.com/flightctl/flightctl/internal/domain"
+)
 
 // CapabilityCountUnknown is the DevicesSummary capabilities map key for devices
 // that have not reported a given capability (missing status.capabilities field).
@@ -34,11 +38,20 @@ func deviceOsModeCountKey(status *domain.DeviceStatus) string {
 	return string(*status.Capabilities.OsMode)
 }
 
+func deviceDeltaEligibleCountKey(status *domain.DeviceStatus) string {
+	if status == nil || status.SystemInfo.DeltaEligible == nil {
+		return CapabilityCountUnknown
+	}
+	return strconv.FormatBool(*status.SystemInfo.DeltaEligible)
+}
+
 // NewDevicesSummaryCapabilities builds the capabilities breakdown for a DevicesSummary,
-// normalizing missing osMode values to CapabilityCountUnknown.
-func NewDevicesSummaryCapabilities(osMode map[string]int64) *domain.DevicesSummaryCapabilities {
-	normalizedCounts := NormalizeCapabilityCounts(osMode)
+// normalizing missing osMode and deltaEligible values to CapabilityCountUnknown.
+func NewDevicesSummaryCapabilities(osMode, deltaEligible map[string]int64) *domain.DevicesSummaryCapabilities {
+	normalizedOsMode := NormalizeCapabilityCounts(osMode)
+	normalizedDeltaEligible := NormalizeCapabilityCounts(deltaEligible)
 	return &domain.DevicesSummaryCapabilities{
-		OsMode: &normalizedCounts,
+		OsMode:        &normalizedOsMode,
+		DeltaEligible: &normalizedDeltaEligible,
 	}
 }

--- a/internal/store/model/devices_summary_test.go
+++ b/internal/store/model/devices_summary_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,4 +98,69 @@ func TestDeviceOsModeCountKey(t *testing.T) {
 			require.Equal(t, tt.want, deviceOsModeCountKey(tt.status))
 		})
 	}
+}
+
+func TestDeviceDeltaEligibleCountKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status *domain.DeviceStatus
+		want   string
+	}{
+		{
+			name:   "When status is nil it should return unknown",
+			status: nil,
+			want:   CapabilityCountUnknown,
+		},
+		{
+			name:   "When capabilities is nil it should return unknown",
+			status: &domain.DeviceStatus{},
+			want:   CapabilityCountUnknown,
+		},
+		{
+			name:   "When DeltaEligible is nil it should return unknown",
+			status: &domain.DeviceStatus{},
+			want:   CapabilityCountUnknown,
+		},
+		{
+			name: "When DeltaEligible is true it should return true",
+			status: func() *domain.DeviceStatus {
+				s := &domain.DeviceStatus{}
+				s.SystemInfo.DeltaEligible = lo.ToPtr(true)
+				return s
+			}(),
+			want: "true",
+		},
+		{
+			name: "When DeltaEligible is false it should return false",
+			status: func() *domain.DeviceStatus {
+				s := &domain.DeviceStatus{}
+				s.SystemInfo.DeltaEligible = lo.ToPtr(false)
+				return s
+			}(),
+			want: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, deviceDeltaEligibleCountKey(tt.status))
+		})
+	}
+}
+
+func TestNewDevicesSummaryCapabilities(t *testing.T) {
+	t.Parallel()
+
+	got := NewDevicesSummaryCapabilities(
+		map[string]int64{"": 2, "image": 1},
+		map[string]int64{"": 1, "true": 3},
+	)
+	require.NotNil(t, got)
+	require.NotNil(t, got.OsMode)
+	require.Equal(t, map[string]int64{CapabilityCountUnknown: 2, "image": 1}, *got.OsMode)
+	require.NotNil(t, got.DeltaEligible)
+	require.Equal(t, map[string]int64{CapabilityCountUnknown: 1, "true": 3}, *got.DeltaEligible)
 }

--- a/test/integration/store/device_test.go
+++ b/test/integration/store/device_test.go
@@ -332,6 +332,7 @@ var _ = Describe("DeviceStore create", func() {
 			expectedSummaryMap := make(map[string]int64)
 			expectedUpdatedMap := make(map[string]int64)
 			expectedOsModeMap := make(map[string]int64)
+			expectedDeltaEligibleMap := make(map[string]int64)
 			for i := range allDevices.Items {
 				d := &allDevices.Items[i]
 				applicationStatus := fmt.Sprintf("application-%d", i)
@@ -346,13 +347,18 @@ var _ = Describe("DeviceStore create", func() {
 				switch i {
 				case 0:
 					d.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModeImage)}
+					d.Status.SystemInfo.DeltaEligible = lo.ToPtr(true)
 					expectedOsModeMap[string(api.OsModeImage)]++
+					expectedDeltaEligibleMap["true"]++
 				case 1:
 					d.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModePackage)}
+					d.Status.SystemInfo.DeltaEligible = lo.ToPtr(false)
 					expectedOsModeMap[string(api.OsModePackage)]++
+					expectedDeltaEligibleMap["false"]++
 				default:
 					d.Status.Capabilities = nil
 					expectedOsModeMap[model.CapabilityCountUnknown]++
+					expectedDeltaEligibleMap[model.CapabilityCountUnknown]++
 				}
 				_, _, err = devStore.UpdateStatus(ctx, orgId, d, nil)
 				Expect(err).ToNot(HaveOccurred())
@@ -366,6 +372,8 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(allDevices.Summary.Capabilities).ToNot(BeNil())
 			Expect(allDevices.Summary.Capabilities.OsMode).ToNot(BeNil())
 			Expect(*allDevices.Summary.Capabilities.OsMode).To(Equal(expectedOsModeMap))
+			Expect(allDevices.Summary.Capabilities.DeltaEligible).ToNot(BeNil())
+			Expect(*allDevices.Summary.Capabilities.DeltaEligible).To(Equal(expectedDeltaEligibleMap))
 			Expect(allDevices.Summary.Total).To(Equal(int64(3)))
 
 			allDevicesSummary, err := devStore.Summary(ctx, orgId, store.ListParams{})
@@ -376,6 +384,8 @@ var _ = Describe("DeviceStore create", func() {
 			Expect(allDevicesSummary.Capabilities).ToNot(BeNil())
 			Expect(allDevicesSummary.Capabilities.OsMode).ToNot(BeNil())
 			Expect(*allDevicesSummary.Capabilities.OsMode).To(Equal(expectedOsModeMap))
+			Expect(allDevicesSummary.Capabilities.DeltaEligible).ToNot(BeNil())
+			Expect(*allDevicesSummary.Capabilities.DeltaEligible).To(Equal(expectedDeltaEligibleMap))
 			Expect(allDevicesSummary.Total).To(Equal(int64(3)))
 		})
 

--- a/test/integration/store/fleet_test.go
+++ b/test/integration/store/fleet_test.go
@@ -114,6 +114,7 @@ var _ = Describe("FleetStore create", func() {
 						Status: api.DeviceUpdatedStatusUpToDate,
 					},
 					Capabilities: &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModeImage)},
+					SystemInfo:   api.DeviceSystemInfo{DeltaEligible: lo.ToPtr(true)},
 				},
 			}
 			_, _, err := deviceStore.UpdateStatus(ctx, orgId, &device, nil)
@@ -122,6 +123,7 @@ var _ = Describe("FleetStore create", func() {
 			device.Status.ApplicationsSummary.Status = api.ApplicationsSummaryStatusDegraded
 			device.Status.Summary.Status = api.DeviceSummaryStatusDegraded
 			device.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModePackage)}
+			device.Status.SystemInfo.DeltaEligible = lo.ToPtr(false)
 			_, _, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-3")
@@ -129,6 +131,7 @@ var _ = Describe("FleetStore create", func() {
 			device.Status.Summary.Status = api.DeviceSummaryStatusOnline
 			device.Status.Updated.Status = api.DeviceUpdatedStatusUpdating
 			device.Status.Capabilities = &api.DeviceCapabilities{OsMode: lo.ToPtr(api.OsModeImage)}
+			device.Status.SystemInfo.DeltaEligible = lo.ToPtr(true)
 			_, _, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-4")
@@ -136,6 +139,7 @@ var _ = Describe("FleetStore create", func() {
 			device.Status.Summary.Status = api.DeviceSummaryStatusRebooting
 			device.Status.Updated.Status = api.DeviceUpdatedStatusUpdating
 			device.Status.Capabilities = nil
+			device.Status.SystemInfo.DeltaEligible = nil
 			_, _, err = deviceStore.UpdateStatus(ctx, orgId, &device, nil)
 			Expect(err).ToNot(HaveOccurred())
 			device.Metadata.Name = lo.ToPtr("mydevice-5")
@@ -153,12 +157,12 @@ var _ = Describe("FleetStore create", func() {
 			// A device in another org that shouldn't be included
 			testutil.CreateTestDevice(ctx, deviceStore, otherOrgId, "other-org-dev", util.SetResourceOwner(api.FleetKind, "myfleet-1"), nil, nil)
 
-			//				App:        Device:     updated:   osMode:
-			// mydevice-1 | Healthy   | Online    | UpToDate | image
-			// mydevice-2 | Degraded  | Degraded  | UpToDate | package
-			// mydevice-3 | Healthy   | Online    | Updating | image
-			// mydevice-4 | Healthy   | Rebooting | Updating | unknown
-			// mydevice-5 | Error     | Error     | Unknown  | package
+			//				App:        Device:     updated:   osMode:  deltaEligible:
+			// mydevice-1 | Healthy   | Online    | UpToDate | image    | true
+			// mydevice-2 | Degraded  | Degraded  | UpToDate | package  | false
+			// mydevice-3 | Healthy   | Online    | Updating | image    | true
+			// mydevice-4 | Healthy   | Rebooting | Updating | unknown  | unknown
+			// mydevice-5 | Error     | Error     | Unknown  | package  | unknown
 			fleet, err := fleetStore.Get(ctx, orgId, "myfleet-1", fleetstore.GetWithDeviceSummary(true))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fleet.Status.DevicesSummary).ToNot(BeNil())
@@ -185,6 +189,11 @@ var _ = Describe("FleetStore create", func() {
 			Expect(osModeStatus[string(api.OsModeImage)]).To(Equal(int64(2)))
 			Expect(osModeStatus[string(api.OsModePackage)]).To(Equal(int64(2)))
 			Expect(osModeStatus[model.CapabilityCountUnknown]).To(Equal(int64(1)))
+			Expect(fleet.Status.DevicesSummary.Capabilities.DeltaEligible).ToNot(BeNil())
+			deltaEligibleStatus := *fleet.Status.DevicesSummary.Capabilities.DeltaEligible
+			Expect(deltaEligibleStatus["true"]).To(Equal(int64(2)))
+			Expect(deltaEligibleStatus["false"]).To(Equal(int64(1)))
+			Expect(deltaEligibleStatus[model.CapabilityCountUnknown]).To(Equal(int64(2)))
 		})
 
 		It("Delete fleet success", func() {


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [x] **`release-1.4`**

## EDM-5215: CLI shows OS update size, delta eligibility, and fallback

**Jira:** https://issues.redhat.com/browse/EDM-5215
**Story type:** [DEV]
**Stack:** on [EDM-5214](https://github.com/flightctl/flightctl/pull/3424) (top of EDM-5213 → EDM-5214 → EDM-5215)

### Summary

`flightctl get devices` and `flightctl get device <name> -o table` show OS update size and a `(fallback)` indicator in the existing UPDATED cell (no new columns). Device list summary prints `DELTA ELIGIBLE` counts in the same CAPABILITY / VALUE / COUNT pattern as `OS MODE`. Layout is unchanged when size, eligibility, and fallback are all unset.

### Changes

- Additive `DevicesSummaryCapabilities.deltaEligible` map on the list/fleet summary API (summary counts, not `DeviceCapabilities`)
- Store aggregation of `status.systemInfo.deltaEligible` next to `osMode` (List, `Summary()`, fleet device summary)
- CLI UPDATED cell: `UpToDate`, `UpToDate 45 MiB`, `UpToDate (fallback)`, or `UpToDate 45 MiB (fallback)` from `status.os.lastDelta`
- Summary table prints `DELTA ELIGIBLE` when that map is present, including when `OsMode` is empty

### Testing

- **Unit tests:** summary JSON omit/round-trip; count-key `true` / `false` / `unknown`; `TableFormatter.Format` for list, single-device table, wide, and `--summary-only`
- **Integration tests:** store List / `Summary()` and fleet device summary counts

### Acceptance Criteria

- [ ] AC-1: List and `-o table` show lastDelta size when populated
- [ ] AC-2: Those views show a fallback indicator when `status.os.lastDelta.fallbackReason` is set
- [ ] AC-3: Device list summary counts `systemInfo.deltaEligible` like `osMode`
- [ ] AC-4: Table layout unchanged when size, eligibility, and fallback are unset