### PR TITLE
EDM-5266: Select virt-launcher image from device OS major

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -31,6 +31,16 @@ runs:
           echo "APT_OPTS=-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20" >> "$GITHUB_ENV"
           mkdir -p "${HOME}/.cache/apt-archives"
 
+      # GitHub-hosted images list azure.archive.ubuntu.com first. When that
+      # host hangs, apt retries it for every index file.
+      - name: Pin Ubuntu apt mirrors
+        if: ${{ inputs.skip_package_install != 'true' }}
+        shell: bash
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            printf 'https://archive.ubuntu.com/ubuntu/\tpriority:1\nhttps://security.ubuntu.com/ubuntu/\tpriority:2\n' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+
       # apt's default archive dir (/var/cache/apt/archives) is root-owned, so
       # actions/cache — which runs as the unprivileged runner user — can't
       # write restored .deb files back into it. Redirecting to a

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -28,6 +28,7 @@ runs:
         shell: bash
         run: |
           echo "APT_CACHE_DIR=${HOME}/.cache/apt-archives" >> "$GITHUB_ENV"
+          echo "APT_OPTS=-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20" >> "$GITHUB_ENV"
           mkdir -p "${HOME}/.cache/apt-archives"
 
       # apt's default archive dir (/var/cache/apt/archives) is root-owned, so
@@ -55,8 +56,8 @@ runs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-          sudo apt update -y 
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
+          sudo apt-get ${APT_OPTS} update -y
+          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
                               virtinst bridge-utils qemu-system-x86 qemu-kvm \
                               swtpm apparmor-utils libguestfs-tools
           sudo usermod -a -G kvm,libvirt,swtpm $USER
@@ -67,8 +68,8 @@ runs:
         shell: bash
         run: |
           echo "::group::Installing general dependencies"
-          sudo apt update -y # fix broken repo cache
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
+          sudo apt-get ${APT_OPTS} update -y
+          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
 
           # Ubuntu noble ships crun 1.14.1 which rejects OCI runtime spec v1.2.1
           # version strings emitted by Podman 4.9+, causing "unknown version specified"
@@ -156,7 +157,7 @@ runs:
         shell: bash
         if: ${{ inputs.unit_tests == 'true' && inputs.skip_package_install != 'true' }}
         run: |
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
+          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/bwrap || true
           sudo apparmor_parser /etc/apparmor.d/bwrap
 

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -56,8 +56,8 @@ runs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-          sudo apt-get ${APT_OPTS} update -y
-          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
+          sudo apt ${APT_OPTS} update -y
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
                               virtinst bridge-utils qemu-system-x86 qemu-kvm \
                               swtpm apparmor-utils libguestfs-tools
           sudo usermod -a -G kvm,libvirt,swtpm $USER
@@ -68,8 +68,8 @@ runs:
         shell: bash
         run: |
           echo "::group::Installing general dependencies"
-          sudo apt-get ${APT_OPTS} update -y
-          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
+          sudo apt ${APT_OPTS} update -y
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
 
           # Ubuntu noble ships crun 1.14.1 which rejects OCI runtime spec v1.2.1
           # version strings emitted by Podman 4.9+, causing "unknown version specified"
@@ -157,7 +157,7 @@ runs:
         shell: bash
         if: ${{ inputs.unit_tests == 'true' && inputs.skip_package_install != 'true' }}
         run: |
-          sudo apt-get ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/bwrap || true
           sudo apparmor_parser /etc/apparmor.d/bwrap
 

--- a/.spelling
+++ b/.spelling
@@ -75,6 +75,9 @@ Kubernetes
 kustomize
 KVM
 launcherImage
+launcherImages
+distroId
+distroVersion
 lifecycle
 lifecycle-bound
 linux

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -446,7 +446,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | worker.image.tag | string | `""` | Worker image tag |
 | worker.vmRender | object | `{"launcherImage":"","launcherImages":{},"passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
 | worker.vmRender.launcherImage | string | `""` | virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default) |
-| worker.vmRender.launcherImages | object | `{}` | virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10") |
+| worker.vmRender.launcherImages | object | `{}` | virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10") |
 | worker.vmRender.passtWorkarounds | bool | `false` | Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images) |
 
 ## Environment-Specific Values Files

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -439,13 +439,14 @@ For more detailed configuration options, see the [Values](#values) section below
 | vulnerabilityReporting.trustify.auth.oidcIssuerUrl | string | `""` | OIDC issuer URL for client-credentials mode. |
 | vulnerabilityReporting.trustify.auth.secretName | string | `""` | Name of the Kubernetes Secret containing 'client_id' and 'client_secret' keys. |
 | vulnerabilityReporting.trustify.endpoint | string | `""` | Trustify API base URL (do not include /api/v1 or /api/v2 paths). |
-| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","passtWorkarounds":false}}` | Worker Configuration |
+| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","launcherImages":{},"passtWorkarounds":false}}` | Worker Configuration |
 | worker.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
 | worker.image.image | string | `"quay.io/flightctl/flightctl-worker-el9"` | Worker container image |
 | worker.image.pullPolicy | string | `""` | Image pull policy for worker container |
 | worker.image.tag | string | `""` | Worker image tag |
-| worker.vmRender | object | `{"launcherImage":"","passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
+| worker.vmRender | object | `{"launcherImage":"","launcherImages":{},"passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
 | worker.vmRender.launcherImage | string | `""` | virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default) |
+| worker.vmRender.launcherImages | object | `{}` | virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10") |
 | worker.vmRender.passtWorkarounds | bool | `false` | Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images) |
 
 ## Environment-Specific Values Files

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -32,6 +32,12 @@ data:
             {{- if $vmRender.launcherImage }}
             launcherImage: {{ $vmRender.launcherImage | quote }}
             {{- end }}
+            {{- if $vmRender.launcherImages }}
+            launcherImages:
+            {{- range $major, $image := $vmRender.launcherImages }}
+              {{ $major | quote }}: {{ $image | quote }}
+            {{- end }}
+            {{- end }}
             passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}false{{ end }}
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -507,7 +507,7 @@
             },
             "launcherImages": {
               "type": "object",
-              "description": "virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. \"9\", \"10\")",
+              "description": "virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. \"rhel-9\", \"rhel-10\")",
               "additionalProperties": { "type": "string" }
             },
             "passtWorkarounds": {

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -505,6 +505,11 @@
               "type": "string",
               "description": "virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)"
             },
+            "launcherImages": {
+              "type": "object",
+              "description": "virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. \"9\", \"10\")",
+              "additionalProperties": { "type": "string" }
+            },
             "passtWorkarounds": {
               "type": "boolean",
               "description": "Enable passt networking workarounds for older virt-launcher images"

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -316,7 +316,7 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
     # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
     launcherImages: {}

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -316,8 +316,10 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
+    # -- virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10")
+    launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false
 

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -318,7 +318,7 @@ worker:
   vmRender:
 	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
-    # -- virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10")
+    # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
     launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -316,7 +316,7 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
     # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
     launcherImages: {}

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -316,8 +316,10 @@ worker:
   clusterLevelSecretAccess: false
   # -- VM application render options passed to vm-to-quadlet
   vmRender:
-    # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
+	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
+    # -- virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10")
+    launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false
 

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -318,7 +318,7 @@ worker:
   vmRender:
 	# -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
-    # -- virt-launcher images keyed by OS major version from status.systemInfo.distroVersion (e.g. "9", "10")
+    # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
     launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -29,6 +29,12 @@ worker:
     {{- if and .worker .worker.vmRender .worker.vmRender.launcherImage }}
     launcherImage: {{.worker.vmRender.launcherImage}}
     {{- end }}
+    {{- if and .worker .worker.vmRender .worker.vmRender.launcherImages }}
+    launcherImages:
+    {{- range $major, $image := .worker.vmRender.launcherImages }}
+      {{ printf "%q" $major }}: {{ $image }}
+    {{- end }}
+    {{- end }}
     passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "true"}}true{{else}}false{{end}}{{else}}false{{end}}
 
 

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -32,7 +32,7 @@ worker:
     {{- if and .worker .worker.vmRender .worker.vmRender.launcherImages }}
     launcherImages:
     {{- range $major, $image := .worker.vmRender.launcherImages }}
-      {{ printf "%q" $major }}: {{ $image }}
+      {{ printf "%q" $major }}: {{ printf "%q" $image }}
     {{- end }}
     {{- end }}
     passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "true"}}true{{else}}false{{end}}{{else}}false{{end}}

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -115,8 +115,9 @@ prometheus:
 
 # Worker VM render options (optional). Uncomment to override defaults.
 # Leave launcherImage unset to use the worker built-in default
-# (quay.io/kubevirt/virt-launcher:v1.9.0). launcherImages selects by OS major
-# from device status.systemInfo.distroVersion (e.g. "9.5 (Plow)" -> "9").
+# (quay.io/kubevirt/virt-launcher:v1.9.0). launcherImages selects by os-release
+# ID and major from status.systemInfo (e.g. rhel + "9.5 (Plow)" -> "rhel-9").
+# Other OS keys (fedora-42, ubuntu-24) are only used if you add them.
 # In air-gapped environments, mirror virt-launcher and set these references
 # to the mirrored location.
 # Enable passtWorkarounds only when using older virt-launcher images that need it.
@@ -124,8 +125,8 @@ prometheus:
 #   vmRender:
 #     launcherImage: ""
 #     launcherImages:
-#       "9": ""
-#       "10": ""
+#       "rhel-9": ""
+#       "rhel-10": ""
 #     passtWorkarounds: false
 
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -115,12 +115,17 @@ prometheus:
 
 # Worker VM render options (optional). Uncomment to override defaults.
 # Leave launcherImage unset to use the worker built-in default
-# (quay.io/kubevirt/virt-launcher:v1.9.0). In air-gapped environments, mirror
-# virt-launcher to a registry devices can pull from and set launcherImage to that reference.
+# (quay.io/kubevirt/virt-launcher:v1.9.0). launcherImages selects by OS major
+# from device status.systemInfo.distroVersion (e.g. "9.5 (Plow)" -> "9").
+# In air-gapped environments, mirror virt-launcher and set these references
+# to the mirrored location.
 # Enable passtWorkarounds only when using older virt-launcher images that need it.
 # worker:
 #   vmRender:
 #     launcherImage: ""
+#     launcherImages:
+#       "9": ""
+#       "10": ""
 #     passtWorkarounds: false
 
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.

--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -273,9 +273,10 @@ full workflow.
 
 Devices pull the KubeVirt virt-launcher image when they run VM applications. That
 image is **not** included in the default `flightctl-mirror-images` control-plane
-set. Mirror it to a registry devices can reach, set `worker.vmRender.launcherImage`
-to the mirrored reference, and re-render affected devices. Guest OS and other
-workload images still need separate mirroring.
+set. Mirror the default image and any per-OS images you pin in
+`worker.vmRender.launcherImages`, set `worker.vmRender.launcherImage` (and the
+map, if used) to the mirrored references, and re-render affected devices. Guest OS
+and other workload images still need separate mirroring.
 
 See [VM application rendering in air-gapped environments](configuring-vm-render.md#air-gapped-environments).
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -10,7 +10,7 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 | `launcherImages` | empty (no per-OS pins) |
 | `passtWorkarounds` | `false` |
 
-`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when you override `launcherImage` to an older image that still requires the workaround.
+`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when the selected `launcherImage` or `launcherImages` entry is an older image that still requires the workaround.
 
 ## How the worker selects an image
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -35,6 +35,8 @@ The worker then chooses an image in this order:
 
 Keys are exact. A Fedora 42 device does not use a `rhel-9` pin. Devices that do not report `distroId` (or whose OS is not in the map) use `launcherImage` or the built-in default.
 
+Selection runs only when the worker renders a device (fleet rollout, spec change, and similar). A status-only `distroId` / `distroVersion` update does not trigger a new render. After an in-place OS major upgrade, trigger a re-render (for example by bumping the fleet template). An agent status PUT is not enough.
+
 ## Prerequisites
 
 - Flight Control deployed with the worker service (`flightctl-worker`)
@@ -148,7 +150,7 @@ There is currently no separate Red Hat product virt-launcher image in the Flight
 
 ## After changing settings
 
-Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage`, `launcherImages`, or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
+Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage`, `launcherImages`, or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings. The same applies after an OS major change: the new `launcherImages` key is used on the next render, not when the agent reports the new `distroId` / `distroVersion`.
 
 ## Related information
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -1,15 +1,39 @@
 # Configuring VM application rendering
 
-The Flight Control worker converts `VmApplication` manifests into Quadlet units with `vm-to-quadlet` before devices receive the rendered application. You can configure the virt-launcher image and passt workarounds used during that conversion.
+The Flight Control worker converts `VmApplication` manifests into Quadlet units with `vm-to-quadlet` before devices receive the rendered application. You can configure the virt-launcher image, optional per-OS images, and passt workarounds used during that conversion.
 
 ## Defaults
 
 | Setting | Default |
 | ------- | ------- |
 | `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.9.0` (built into the worker; leave config unset or empty to use it) |
+| `launcherImages` | empty (no per-OS pins) |
 | `passtWorkarounds` | `false` |
 
 `passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when you override `launcherImage` to an older image that still requires the workaround.
+
+## How the worker selects an image
+
+At render time the worker builds a key from device `status.systemInfo`:
+
+- `distroId` (os-release `ID`, for example `rhel` or `fedora`)
+- The leading major digits of `distroVersion` (os-release `VERSION`, for example `9.5` yields `9`)
+
+The key is `{distroId}-{major}`. Examples:
+
+| Device reports | Key |
+| -------------- | --- |
+| `distroId: rhel`, `distroVersion: 9.5` | `rhel-9` |
+| `distroId: rhel`, `distroVersion: 10.0` | `rhel-10` |
+| `distroId: fedora`, `distroVersion: 42` | `fedora-42` |
+
+The worker then chooses an image in this order:
+
+1. The matching entry in `launcherImages`, if that key is present and non-empty.
+2. `launcherImage`, if set.
+3. The built-in default.
+
+Keys are exact. A Fedora 42 device does not use a `rhel-9` pin. Devices that do not report `distroId` (or whose OS is not in the map) use `launcherImage` or the built-in default.
 
 ## Prerequisites
 
@@ -19,24 +43,43 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. Leave empty to use the worker built-in default. |
+| `worker.vmRender.launcherImage` | string | Default virt-launcher image when `launcherImages` has no match. Leave empty to use the worker built-in default. |
+| `worker.vmRender.launcherImages` | object | Optional map of virt-launcher images keyed by `{distroId}-{major}` from `status.systemInfo` (for example `"rhel-9"`, `"rhel-10"`). |
 | `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt networking workarounds in generated Quadlet units. |
 
 ## Kubernetes (Helm)
 
-Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you need an override:
+Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you need an override. Leave `launcherImages` empty unless you pin images per OS:
 
 ```yaml
 worker:
   vmRender:
     launcherImage: ""
+    launcherImages: {}
     passtWorkarounds: false
 ```
+
+To pin images for mixed OS fleets:
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: ""
+    launcherImages:
+      "rhel-9": "<registry>/virt-launcher-rhel9:<tag>"
+      "rhel-10": "<registry>/virt-launcher-rhel10:<tag>"
+    passtWorkarounds: false
+```
+
+Replace `<registry>` and `<tag>` with the image repository and tag that devices can pull.
 
 Apply the chart upgrade, then restart the worker so it reloads configuration:
 
 ```bash
 helm upgrade flightctl ./deploy/helm/flightctl -n <namespace> -f values.yaml
+```
+
+```bash
 kubectl rollout restart deployment/flightctl-worker -n <namespace>
 ```
 
@@ -47,6 +90,17 @@ Edit `/etc/flightctl/service-config.yaml` only when you need overrides. Omit `la
 ```yaml
 worker:
   vmRender:
+    passtWorkarounds: false
+```
+
+To pin images per OS, add `launcherImages` under the same `vmRender` block:
+
+```yaml
+worker:
+  vmRender:
+    launcherImages:
+      "rhel-9": "<registry>/virt-launcher-rhel9:<tag>"
+      "rhel-10": "<registry>/virt-launcher-rhel10:<tag>"
     passtWorkarounds: false
 ```
 
@@ -62,14 +116,17 @@ The default virt-launcher image is pulled by devices when they run VM applicatio
 
 In an air-gapped deployment:
 
-1. Mirror `quay.io/kubevirt/virt-launcher:v1.9.0` (or your chosen virt-launcher image) to a registry that devices can reach.
-2. Set `worker.vmRender.launcherImage` to that mirrored reference so rendered Quadlet units pull from the mirror.
-3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image reference.
+1. Mirror each virt-launcher image you will use to a registry that devices can reach. Mirror the default image and every image you pin in `launcherImages`.
+2. Set `worker.vmRender.launcherImage` to the mirrored default. Set `worker.vmRender.launcherImages` to the mirrored per-OS references.
+3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image references.
 
 Example (community / upstream registry):
 
 ```bash
 INTERNAL=registry.example.com:5000
+```
+
+```bash
 skopeo copy --all \
   docker://quay.io/kubevirt/virt-launcher:v1.9.0 \
   docker://${INTERNAL}/kubevirt/virt-launcher:v1.9.0
@@ -79,14 +136,19 @@ skopeo copy --all \
 worker:
   vmRender:
     launcherImage: "registry.example.com:5000/kubevirt/virt-launcher:v1.9.0"
+    launcherImages:
+      "rhel-9": "registry.example.com:5000/kubevirt/virt-launcher-rhel9:<tag>"
+      "rhel-10": "registry.example.com:5000/kubevirt/virt-launcher-rhel10:<tag>"
     passtWorkarounds: false
 ```
 
-There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` at the mirrored location.
+Omit `launcherImages` if every device should use the single mirrored `launcherImage`.
+
+There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` and `launcherImages` at the mirrored location.
 
 ## After changing settings
 
-Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage` or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
+Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage`, `launcherImages`, or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
 
 ## Related information
 

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -105,7 +105,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 | `spec-fetch-error-max-delay` | `Duration` | | Maximum delay between `/rendered` retries after repeated failures. Must be greater than or equal to `spec-fetch-error-base-delay`. Default: `5m` |
 | `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. **Important:** Label values must be valid Kubernetes labels (alphanumeric, `-`, `_`, `.`, max 63 chars). Invalid labels are skipped with an error log. Default: `{}` |
 | `label-from-systeminfo`  | `object` (`string`) | | Maps system information fields to device labels at enrollment time. See [Enrollment-time label mapping](#enrollment-time-label-mapping). Default: `{}` |
-| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
+| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "distroId", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
 | `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
 | `system-info-timeout`    | `Duration` | | The timeout for collecting system info. Default: `2m`. Maximum: `2m` |
 | `pull-timeout`           | `Duration` | | The timeout for pulling a single OCI target. Default: `10m` |
@@ -163,6 +163,7 @@ You can specify extra system infos to be included in the device status by listin
 | `kernel`              | The running Linux kernel version                                  |
 | `distroName`          | The name of the operating system distribution.                    |
 | `distroVersion`       | The version of the operating system distribution                  |
+| `distroId`            | The os-release `ID` (for example `rhel` or `fedora`). Used with `distroVersion` to select `launcherImages` keys such as `rhel-9`. See [Configuring VM application rendering](configuring-vm-render.md). |
 | `productName`         | The system’s product or model name (from DMI data)                |
 | `productSerial`       | The hardware serial number (if available)                         |
 | `productUuid`         | The UUID of the system board or chassis                           |
@@ -180,7 +181,7 @@ You can specify extra system infos to be included in the device status by listin
 For example, if you add the following parameter to your agent's `config.yaml`
 
 ```console
-system-info: [hostname, kernel, distroName, distroVersion]
+system-info: [hostname, kernel, distroName, distroVersion, distroId]
 ```
 
 then the reported device status might look like
@@ -197,6 +198,7 @@ status:
     kernel: 5.14.0-503.38.1.el9_5.x86_64
     distroName: Red Hat Enterprise Linux
     distroVersion: 9.5 (Plow)
+    distroId: rhel
 ```
 
 ## Managed system info collectors

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -819,7 +819,7 @@ To deploy a VM application, add an entry to the `applications` section of the de
 | `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
 
 > [!NOTE]
-> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure the virt-launcher image and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
+> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure a default virt-launcher image, optional per-OS images, and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
 
 > [!NOTE]
 > The `spec.running` field in `vm.yaml` is ignored. Use [application lifecycle](#managing-application-lifecycle) commands (`flightctl app start` / `stop` / `restart`) to control whether the VM is running.

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -231,6 +231,7 @@ var DefaultSystemInfo = append([]string{
 	systeminfocommon.KernelKey,
 	systeminfocommon.DistroNameKey,
 	systeminfocommon.DistroVersionKey,
+	systeminfocommon.DistroIdKey,
 	systeminfocommon.ProductNameKey,
 	systeminfocommon.ProductUUIDKey,
 	systeminfocommon.ProductSerialKey,

--- a/internal/agent/device/systeminfo/common/types.go
+++ b/internal/agent/device/systeminfo/common/types.go
@@ -36,6 +36,7 @@ const (
 	// Distribution info keys
 	DistroNameKey    = "distroName"
 	DistroVersionKey = "distroVersion"
+	DistroIdKey      = "distroId"
 
 	// Identity / security (runtime/conditional collectors)
 	ManagementCertNotAfterKey = "managementCertNotAfter"
@@ -110,6 +111,7 @@ var builtInKeys = newKeySet(
 	ProductSerialKey,
 	DistroNameKey,
 	DistroVersionKey,
+	DistroIdKey,
 )
 
 var allKeys = unionKeySets(builtInKeys, runtimeKeys)

--- a/internal/agent/device/systeminfo/system_info.go
+++ b/internal/agent/device/systeminfo/system_info.go
@@ -422,7 +422,7 @@ func collectionOptsFromInfoKeys(infoKeys []string) ([]CollectOpt, error) {
 			opts = append(opts, withCollector(collectorSystem, collectSystemFunc))
 		case common.KernelKey:
 			opts = append(opts, withCollector(collectorKernel, collectKernelFunc))
-		case common.DistroNameKey, common.DistroVersionKey:
+		case common.DistroNameKey, common.DistroVersionKey, common.DistroIdKey:
 			opts = append(opts, withCollector(collectorDistribution, collectDistributionFunc))
 		case common.HostnameKey, common.ArchitectureKey:
 			// No specific collector needed - hostname and architecture are always collected
@@ -542,6 +542,18 @@ var SupportedInfoKeys = map[string]func(info *Info) string{
 			return ""
 		}
 		if val, ok := i.Distribution["version"]; ok {
+			if str, ok := val.(string); ok {
+				return str
+			}
+			return fmt.Sprint(val)
+		}
+		return ""
+	},
+	common.DistroIdKey: func(i *Info) string {
+		if i.Distribution == nil {
+			return ""
+		}
+		if val, ok := i.Distribution["id"]; ok {
 			if str, ok := val.(string); ok {
 				return str
 			}

--- a/internal/agent/device/systeminfo/system_info_test.go
+++ b/internal/agent/device/systeminfo/system_info_test.go
@@ -240,7 +240,7 @@ func TestGetCollectionOptsFromInfoKeys(t *testing.T) {
 		},
 		{
 			name:         "distribution keys",
-			infoKeys:     []string{common.DistroNameKey, common.DistroVersionKey},
+			infoKeys:     []string{common.DistroNameKey, common.DistroVersionKey, common.DistroIdKey},
 			expectDistro: true,
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -432,13 +432,13 @@ func NewDefaultWorkerConfig() *workerConfig {
 }
 
 // EffectiveVmLauncherImage returns the virt-launcher image used for VM render.
-// osMajor is the device OS major version (e.g. "9", "10") from
-// status.systemInfo.distroVersion. An empty osMajor skips per-OS lookup.
-func (c *Config) EffectiveVmLauncherImage(osMajor string) string {
+// osKey is "{os-release ID}-{major}" from status.systemInfo (e.g. "rhel-9").
+// An empty osKey skips per-OS lookup.
+func (c *Config) EffectiveVmLauncherImage(osKey string) string {
 	if c == nil || c.Worker == nil {
 		return DefaultVirtLauncherImage
 	}
-	return c.Worker.EffectiveLauncherImage(osMajor)
+	return c.Worker.EffectiveLauncherImage(osKey)
 }
 
 // EffectiveVmPasstWorkarounds returns whether passt workarounds are enabled for VM render.
@@ -449,13 +449,13 @@ func (c *Config) EffectiveVmPasstWorkarounds() bool {
 	return c.Worker.EffectivePasstWorkarounds()
 }
 
-// EffectiveLauncherImage returns the virt-launcher image for osMajor.
-func (c *workerConfig) EffectiveLauncherImage(osMajor string) string {
+// EffectiveLauncherImage returns the virt-launcher image for osKey.
+func (c *workerConfig) EffectiveLauncherImage(osKey string) string {
 	if c == nil || c.VmRender == nil {
 		return DefaultVirtLauncherImage
 	}
-	if osMajor != "" && c.VmRender.LauncherImages != nil {
-		if img := c.VmRender.LauncherImages[osMajor]; img != "" {
+	if osKey != "" && c.VmRender.LauncherImages != nil {
+		if img := c.VmRender.LauncherImages[osKey]; img != "" {
 			return img
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,8 +415,9 @@ type workerConfig struct {
 // vmRenderConfig holds options for converting VmApplications to Quadlet units
 // via vm-to-quadlet.
 type vmRenderConfig struct {
-	LauncherImage    string `json:"launcherImage,omitempty"`
-	PasstWorkarounds *bool  `json:"passtWorkarounds,omitempty"`
+	LauncherImage    string            `json:"launcherImage,omitempty"`
+	LauncherImages   map[string]string `json:"launcherImages,omitempty"`
+	PasstWorkarounds *bool             `json:"passtWorkarounds,omitempty"`
 }
 
 // NewDefaultWorkerConfig returns the default flightctl-worker configuration.
@@ -431,11 +432,13 @@ func NewDefaultWorkerConfig() *workerConfig {
 }
 
 // EffectiveVmLauncherImage returns the virt-launcher image used for VM render.
-func (c *Config) EffectiveVmLauncherImage() string {
+// osMajor is the device OS major version (e.g. "9", "10") from
+// status.systemInfo.distroVersion. An empty osMajor skips per-OS lookup.
+func (c *Config) EffectiveVmLauncherImage(osMajor string) string {
 	if c == nil || c.Worker == nil {
 		return DefaultVirtLauncherImage
 	}
-	return c.Worker.EffectiveLauncherImage()
+	return c.Worker.EffectiveLauncherImage(osMajor)
 }
 
 // EffectiveVmPasstWorkarounds returns whether passt workarounds are enabled for VM render.
@@ -446,9 +449,17 @@ func (c *Config) EffectiveVmPasstWorkarounds() bool {
 	return c.Worker.EffectivePasstWorkarounds()
 }
 
-// EffectiveLauncherImage returns the virt-launcher image (config override or default).
-func (c *workerConfig) EffectiveLauncherImage() string {
-	if c != nil && c.VmRender != nil && c.VmRender.LauncherImage != "" {
+// EffectiveLauncherImage returns the virt-launcher image for osMajor.
+func (c *workerConfig) EffectiveLauncherImage(osMajor string) string {
+	if c == nil || c.VmRender == nil {
+		return DefaultVirtLauncherImage
+	}
+	if osMajor != "" && c.VmRender.LauncherImages != nil {
+		if img := c.VmRender.LauncherImages[osMajor]; img != "" {
+			return img
+		}
+	}
+	if c.VmRender.LauncherImage != "" {
 		return c.VmRender.LauncherImage
 	}
 	return DefaultVirtLauncherImage

--- a/internal/config/vm_render_test.go
+++ b/internal/config/vm_render_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveVmLauncherImage(t *testing.T) {
+	t.Parallel()
+
+	rhel9 := "registry.example.com/virt-launcher-rhel9:v1"
+	rhel10 := "registry.example.com/virt-launcher-rhel10:v1"
+	pinned := "registry.example.com/virt-launcher:pinned"
+
+	tests := []struct {
+		name    string
+		json    string
+		osMajor string
+		want    string
+	}{
+		{
+			name:    "When config is empty it should use the built-in default",
+			json:    `{}`,
+			osMajor: "9",
+			want:    DefaultVirtLauncherImage,
+		},
+		{
+			name: "When launcherImage is set and no per-OS map it should use launcherImage",
+			json: `{
+				"worker": {"vmRender": {"launcherImage": "` + pinned + `"}}
+			}`,
+			osMajor: "10",
+			want:    pinned,
+		},
+		{
+			name: "When launcherImages has the device major it should use that image",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImages": {"9": "` + rhel9 + `", "10": "` + rhel10 + `"}
+				}}
+			}`,
+			osMajor: "10",
+			want:    rhel10,
+		},
+		{
+			name: "When launcherImages has no entry for the major it should use launcherImage",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImage": "` + pinned + `",
+					"launcherImages": {"9": "` + rhel9 + `"}
+				}}
+			}`,
+			osMajor: "10",
+			want:    pinned,
+		},
+		{
+			name: "When osMajor is empty it should ignore launcherImages",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImage": "` + pinned + `",
+					"launcherImages": {"9": "` + rhel9 + `"}
+				}}
+			}`,
+			osMajor: "",
+			want:    pinned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{}
+			require.NoError(t, json.Unmarshal([]byte(tt.json), cfg))
+			assert.Equal(t, tt.want, cfg.EffectiveVmLauncherImage(tt.osMajor))
+		})
+	}
+}

--- a/internal/config/vm_render_test.go
+++ b/internal/config/vm_render_test.go
@@ -16,56 +16,56 @@ func TestEffectiveVmLauncherImage(t *testing.T) {
 	pinned := "registry.example.com/virt-launcher:pinned"
 
 	tests := []struct {
-		name    string
-		json    string
-		osMajor string
-		want    string
+		name  string
+		json  string
+		osKey string
+		want  string
 	}{
 		{
-			name:    "When config is empty it should use the built-in default",
-			json:    `{}`,
-			osMajor: "9",
-			want:    DefaultVirtLauncherImage,
+			name:  "When config is empty it should use the built-in default",
+			json:  `{}`,
+			osKey: "rhel-9",
+			want:  DefaultVirtLauncherImage,
 		},
 		{
 			name: "When launcherImage is set and no per-OS map it should use launcherImage",
 			json: `{
 				"worker": {"vmRender": {"launcherImage": "` + pinned + `"}}
 			}`,
-			osMajor: "10",
-			want:    pinned,
+			osKey: "rhel-10",
+			want:  pinned,
 		},
 		{
-			name: "When launcherImages has the device major it should use that image",
+			name: "When launcherImages has the device OS key it should use that image",
 			json: `{
 				"worker": {"vmRender": {
-					"launcherImages": {"9": "` + rhel9 + `", "10": "` + rhel10 + `"}
+					"launcherImages": {"rhel-9": "` + rhel9 + `", "rhel-10": "` + rhel10 + `"}
 				}}
 			}`,
-			osMajor: "10",
-			want:    rhel10,
+			osKey: "rhel-10",
+			want:  rhel10,
 		},
 		{
-			name: "When launcherImages has no entry for the major it should use launcherImage",
-			json: `{
-				"worker": {"vmRender": {
-					"launcherImage": "` + pinned + `",
-					"launcherImages": {"9": "` + rhel9 + `"}
-				}}
-			}`,
-			osMajor: "10",
-			want:    pinned,
-		},
-		{
-			name: "When osMajor is empty it should ignore launcherImages",
+			name: "When the OS is not in launcherImages it should use launcherImage",
 			json: `{
 				"worker": {"vmRender": {
 					"launcherImage": "` + pinned + `",
-					"launcherImages": {"9": "` + rhel9 + `"}
+					"launcherImages": {"rhel-9": "` + rhel9 + `"}
 				}}
 			}`,
-			osMajor: "",
-			want:    pinned,
+			osKey: "fedora-42",
+			want:  pinned,
+		},
+		{
+			name: "When osKey is empty it should ignore launcherImages",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImage": "` + pinned + `",
+					"launcherImages": {"rhel-9": "` + rhel9 + `"}
+				}}
+			}`,
+			osKey: "",
+			want:  pinned,
 		},
 	}
 
@@ -74,7 +74,7 @@ func TestEffectiveVmLauncherImage(t *testing.T) {
 			t.Parallel()
 			cfg := &Config{}
 			require.NoError(t, json.Unmarshal([]byte(tt.json), cfg))
-			assert.Equal(t, tt.want, cfg.EffectiveVmLauncherImage(tt.osMajor))
+			assert.Equal(t, tt.want, cfg.EffectiveVmLauncherImage(tt.osKey))
 		})
 	}
 }

--- a/internal/service/enrollmentrequest/handler.go
+++ b/internal/service/enrollmentrequest/handler.go
@@ -190,6 +190,9 @@ func addStatusIfNeeded(enrollmentRequest *domain.EnrollmentRequest) {
 func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, orgId uuid.UUID, enrollmentRequest *domain.EnrollmentRequest) error {
 	deviceStatus := domain.NewDeviceStatus()
 	deviceStatus.Lifecycle = domain.DeviceLifecycleStatus{Status: "Enrolled"}
+	if enrollmentRequest.Spec.DeviceStatus != nil {
+		deviceStatus.SystemInfo = enrollmentRequest.Spec.DeviceStatus.SystemInfo
+	}
 
 	// Check if TPM was verified during enrollment request creation
 	isTPMVerified := false

--- a/internal/service/enrollmentrequest/handler_test.go
+++ b/internal/service/enrollmentrequest/handler_test.go
@@ -582,6 +582,138 @@ func TestCreateDeviceFromEnrollmentRequestOsMode(t *testing.T) {
 	}
 }
 
+func TestCreateDeviceFromEnrollmentRequestSystemInfo(t *testing.T) {
+	t.Run("When DeviceStatus is nil it should create the device with empty systemInfo", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "no-status-device"
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec:     domain.EnrollmentRequestSpec{Csr: "TestCSR"},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.NotNil(t, device.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.False(t, found)
+		require.Empty(t, id)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+
+	t.Run("When systemInfo has distroId it should copy it onto the device", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "rhel9-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.SystemInfo.AgentVersion = "v1.2.3"
+		enrollmentStatus.SystemInfo.OperatingSystem = "linux"
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.NotNil(t, device.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+		version, found := device.Status.SystemInfo.Get("distroVersion")
+		require.True(t, found)
+		require.Equal(t, "9.5 (Plow)", version)
+		require.Equal(t, "v1.2.3", device.Status.SystemInfo.AgentVersion)
+		require.Equal(t, "linux", device.Status.SystemInfo.OperatingSystem)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+
+	t.Run("When enrollment reports integrity verified it should still set integrity from TPM result", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "integrity-overlay-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.Integrity = domain.DeviceIntegrityStatus{
+			Status: domain.DeviceIntegrityStatusVerified,
+		}
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.Equal(t, domain.DeviceIntegrityStatusUnsupported, device.Status.Integrity.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+	})
+
+	t.Run("When awaitingReconnect is set it should keep systemInfo and set awaiting reconnect summary", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "reconnect-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "10.0 (Coughlan)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{
+				Name: lo.ToPtr(deviceName),
+				Annotations: &map[string]string{
+					domain.DeviceAnnotationAwaitingReconnect: "true",
+				},
+			},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.Equal(t, domain.DeviceSummaryStatusAwaitingReconnect, device.Status.Summary.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+		version, found := device.Status.SystemInfo.Get("distroVersion")
+		require.True(t, found)
+		require.Equal(t, "10.0 (Coughlan)", version)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+}
+
 // TestCreateDeviceFromEnrollmentRequestNeverManaged is a regression guard for the deviceOnlyStore
 // adapter's safety invariant: createDeviceFromEnrollmentRequest must never set Metadata.Owner on
 // the device it builds. deviceOnlyStore only overrides Device() on its embedded nil store.Store;

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -65,25 +65,26 @@ func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, devi
 }
 
 type DeviceRenderLogic struct {
-	log             logrus.FieldLogger
-	deviceSvc       deviceservice.Service
-	repositorySvc   repositoryservice.Service
-	catalogSvc      catalogservice.Service
-	k8sClient       k8sclient.K8SClient
-	kvStore         kvstore.KVStore
-	cfg             *config.Config
-	orgId           uuid.UUID
-	event           domain.Event
-	ownerFleet      *string
-	templateVersion *string
-	deviceConfig    *[]domain.ConfigProviderSpec
-	applications    *[]domain.ApplicationProviderSpec
-	vmConverter     VmConverterFn
-	vmRenderOptions VmRenderOptions
+	log               logrus.FieldLogger
+	deviceSvc         deviceservice.Service
+	repositorySvc     repositoryservice.Service
+	catalogSvc        catalogservice.Service
+	k8sClient         k8sclient.K8SClient
+	kvStore           kvstore.KVStore
+	cfg               *config.Config
+	orgId             uuid.UUID
+	event             domain.Event
+	ownerFleet        *string
+	templateVersion   *string
+	deviceConfig      *[]domain.ConfigProviderSpec
+	applications      *[]domain.ApplicationProviderSpec
+	vmConverter       VmConverterFn
+	vmRenderOptions   VmRenderOptions
+	customVmConverter bool
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
-	opts := vmRenderOptionsFromConfig(cfg)
+	opts := vmRenderOptionsFromConfig(cfg, "")
 	return DeviceRenderLogic{
 		log:             log,
 		deviceSvc:       deviceSvc,
@@ -105,7 +106,17 @@ func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Servic
 // NewVmConverter.
 func (t DeviceRenderLogic) WithVmConverter(fn VmConverterFn) DeviceRenderLogic {
 	t.vmConverter = fn
+	t.customVmConverter = true
 	return t
+}
+
+func (t *DeviceRenderLogic) bindVmLauncher(device *domain.Device) {
+	opts := vmRenderOptionsFromConfig(t.cfg, distroMajorFromDevice(device))
+	t.vmRenderOptions = opts
+	if t.customVmConverter {
+		return
+	}
+	t.vmConverter = NewVmConverter(vmToQuadletBinary, opts)
 }
 
 //nolint:gocyclo
@@ -115,8 +126,10 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		return fmt.Errorf("failed getting device %s/%s: %s", t.orgId, t.event.InvolvedObject.Name, status.Message)
 	}
 
-	// Calculate hash including device spec to detect changes
-	specHash := hashRenderedWithSpec(device.Spec)
+	t.bindVmLauncher(device)
+
+	// Calculate hash including device spec and selected virt-launcher image.
+	specHash := hashRenderedWithSpec(device.Spec, t.vmRenderOptions.LauncherImage)
 
 	// bypassHashCheck is true for event reasons that must always produce a fresh render even
 	// though specHash (computed from device.Spec alone) hasn't changed: dependency changes and
@@ -1032,12 +1045,17 @@ func ignitionConfigToRenderedConfig(ignition *config_latest_types.Config) ([]byt
 	return renderedConfig, nil
 }
 
-// hashRenderedWithSpec creates a hash of the device spec to detect changes
-func hashRenderedWithSpec(deviceSpec *domain.DeviceSpec) string {
+// hashRenderedWithSpec creates a hash of the device spec and selected
+// virt-launcher image so an OS-major change re-renders VM applications.
+func hashRenderedWithSpec(deviceSpec *domain.DeviceSpec, launcherImage string) string {
 	if deviceSpec == nil {
 		return ""
 	}
-	specBytes, _ := json.Marshal(deviceSpec)
+	payload := struct {
+		Spec          *domain.DeviceSpec `json:"spec"`
+		LauncherImage string             `json:"launcherImage"`
+	}{deviceSpec, launcherImage}
+	specBytes, _ := json.Marshal(payload)
 	hash := sha256.Sum256(specBytes)
 	return hex.EncodeToString(hash[:])
 }

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -111,7 +111,7 @@ func (t DeviceRenderLogic) WithVmConverter(fn VmConverterFn) DeviceRenderLogic {
 }
 
 func (t *DeviceRenderLogic) bindVmLauncher(device *domain.Device) {
-	opts := vmRenderOptionsFromConfig(t.cfg, distroMajorFromDevice(device))
+	opts := vmRenderOptionsFromConfig(t.cfg, osKeyFromDevice(device))
 	t.vmRenderOptions = opts
 	if t.customVmConverter {
 		return

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -724,7 +724,7 @@ func TestRenderDevice_PermanentError(t *testing.T) {
 
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{
@@ -811,7 +811,7 @@ func TestRenderDevice_PermanentError_StandaloneDevice(t *testing.T) {
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{
@@ -900,7 +900,7 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -44,11 +44,39 @@ func DefaultVmRenderOptions() VmRenderOptions {
 	}
 }
 
-func vmRenderOptionsFromConfig(cfg *config.Config) VmRenderOptions {
+func vmRenderOptionsFromConfig(cfg *config.Config, osMajor string) VmRenderOptions {
 	return VmRenderOptions{
-		LauncherImage:    cfg.EffectiveVmLauncherImage(),
+		LauncherImage:    cfg.EffectiveVmLauncherImage(osMajor),
 		PasstWorkarounds: cfg.EffectiveVmPasstWorkarounds(),
 	}
+}
+
+const deviceDistroVersionKey = "distroVersion"
+
+func distroMajorFromDevice(device *domain.Device) string {
+	if device == nil || device.Status == nil {
+		return ""
+	}
+	version, ok := device.Status.SystemInfo.Get(deviceDistroVersionKey)
+	if !ok {
+		return ""
+	}
+	return parseDistroMajor(version)
+}
+
+func parseDistroMajor(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	end := 0
+	for end < len(version) && version[end] >= '0' && version[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return ""
+	}
+	return version[:end]
 }
 
 // limitedWriter wraps a bytes.Buffer and returns an error once more than limit

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -44,24 +44,33 @@ func DefaultVmRenderOptions() VmRenderOptions {
 	}
 }
 
-func vmRenderOptionsFromConfig(cfg *config.Config, osMajor string) VmRenderOptions {
+func vmRenderOptionsFromConfig(cfg *config.Config, osKey string) VmRenderOptions {
 	return VmRenderOptions{
-		LauncherImage:    cfg.EffectiveVmLauncherImage(osMajor),
+		LauncherImage:    cfg.EffectiveVmLauncherImage(osKey),
 		PasstWorkarounds: cfg.EffectiveVmPasstWorkarounds(),
 	}
 }
 
-const deviceDistroVersionKey = "distroVersion"
+const (
+	deviceDistroVersionKey = "distroVersion"
+	deviceDistroIdKey      = "distroId"
+)
 
-func distroMajorFromDevice(device *domain.Device) string {
+func osKeyFromDevice(device *domain.Device) string {
 	if device == nil || device.Status == nil {
 		return ""
 	}
-	version, ok := device.Status.SystemInfo.Get(deviceDistroVersionKey)
-	if !ok {
+	id, _ := device.Status.SystemInfo.Get(deviceDistroIdKey)
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "" {
 		return ""
 	}
-	return parseDistroMajor(version)
+	version, _ := device.Status.SystemInfo.Get(deviceDistroVersionKey)
+	major := parseDistroMajor(version)
+	if major == "" {
+		return ""
+	}
+	return id + "-" + major
 }
 
 func parseDistroMajor(version string) string {

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -500,19 +500,35 @@ func TestParseDistroMajor(t *testing.T) {
 	}
 }
 
-func TestDistroMajorFromDevice(t *testing.T) {
+func TestOsKeyFromDevice(t *testing.T) {
 	t.Parallel()
 
 	t.Run("When status is missing it should return empty", func(t *testing.T) {
 		t.Parallel()
-		assert.Empty(t, distroMajorFromDevice(&domain.Device{}))
+		assert.Empty(t, osKeyFromDevice(&domain.Device{}))
 	})
 
-	t.Run("When distroVersion is reported it should return the major", func(t *testing.T) {
+	t.Run("When distroId and distroVersion are reported it should return id-major", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroIdKey, "rhel")
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "9.5 (Plow)")
+		assert.Equal(t, "rhel-9", osKeyFromDevice(device))
+	})
+
+	t.Run("When distroId is fedora it should not look like rhel", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroIdKey, "fedora")
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "42 (Adams)")
+		assert.Equal(t, "fedora-42", osKeyFromDevice(device))
+	})
+
+	t.Run("When distroId is missing it should return empty", func(t *testing.T) {
 		t.Parallel()
 		device := &domain.Device{Status: &domain.DeviceStatus{}}
 		device.Status.SystemInfo.Set(deviceDistroVersionKey, "9.5 (Plow)")
-		assert.Equal(t, "9", distroMajorFromDevice(device))
+		assert.Empty(t, osKeyFromDevice(device))
 	})
 }
 
@@ -524,8 +540,8 @@ func TestBindVmLauncher_SelectsPerOSImage(t *testing.T) {
 		"worker": {
 			"vmRender": {
 				"launcherImages": {
-					"9": "registry.example.com/virt-launcher-rhel9:v1",
-					"10": "registry.example.com/virt-launcher-rhel10:v1"
+					"rhel-9": "registry.example.com/virt-launcher-rhel9:v1",
+					"rhel-10": "registry.example.com/virt-launcher-rhel10:v1"
 				}
 			}
 		}
@@ -533,9 +549,32 @@ func TestBindVmLauncher_SelectsPerOSImage(t *testing.T) {
 
 	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
 	device := &domain.Device{Status: &domain.DeviceStatus{}}
+	device.Status.SystemInfo.Set(deviceDistroIdKey, "rhel")
 	device.Status.SystemInfo.Set(deviceDistroVersionKey, "10.0 (Coughlan)")
 	logic.bindVmLauncher(device)
 	assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", logic.vmRenderOptions.LauncherImage)
+}
+
+func TestBindVmLauncher_UnknownOSUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"worker": {
+			"vmRender": {
+				"launcherImages": {
+					"rhel-9": "registry.example.com/virt-launcher-rhel9:v1"
+				}
+			}
+		}
+	}`), cfg))
+
+	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
+	device := &domain.Device{Status: &domain.DeviceStatus{}}
+	device.Status.SystemInfo.Set(deviceDistroIdKey, "fedora")
+	device.Status.SystemInfo.Set(deviceDistroVersionKey, "42 (Adams)")
+	logic.bindVmLauncher(device)
+	assert.Equal(t, config.DefaultVirtLauncherImage, logic.vmRenderOptions.LauncherImage)
 }
 
 func TestHashRenderedWithSpec_IncludesLauncherImage(t *testing.T) {

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -478,6 +478,75 @@ func TestVmRenderOptionsFromConfig(t *testing.T) {
 	assert.False(t, defaults.vmRenderOptions.PasstWorkarounds)
 }
 
+func TestParseDistroMajor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "When VERSION is RHEL 9 pretty string it should return 9", version: "9.5 (Plow)", want: "9"},
+		{name: "When VERSION is RHEL 10 pretty string it should return 10", version: "10.0 (Coughlan)", want: "10"},
+		{name: "When VERSION is a bare major it should return it", version: "9", want: "9"},
+		{name: "When VERSION has leading space it should trim", version: " 10.1", want: "10"},
+		{name: "When VERSION is empty it should return empty", version: "", want: ""},
+		{name: "When VERSION has no leading digits it should return empty", version: "Plow", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseDistroMajor(tt.version))
+		})
+	}
+}
+
+func TestDistroMajorFromDevice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When status is missing it should return empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, distroMajorFromDevice(&domain.Device{}))
+	})
+
+	t.Run("When distroVersion is reported it should return the major", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "9.5 (Plow)")
+		assert.Equal(t, "9", distroMajorFromDevice(device))
+	})
+}
+
+func TestBindVmLauncher_SelectsPerOSImage(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"worker": {
+			"vmRender": {
+				"launcherImages": {
+					"9": "registry.example.com/virt-launcher-rhel9:v1",
+					"10": "registry.example.com/virt-launcher-rhel10:v1"
+				}
+			}
+		}
+	}`), cfg))
+
+	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
+	device := &domain.Device{Status: &domain.DeviceStatus{}}
+	device.Status.SystemInfo.Set(deviceDistroVersionKey, "10.0 (Coughlan)")
+	logic.bindVmLauncher(device)
+	assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", logic.vmRenderOptions.LauncherImage)
+}
+
+func TestHashRenderedWithSpec_IncludesLauncherImage(t *testing.T) {
+	t.Parallel()
+	spec := &domain.DeviceSpec{}
+	hash9 := hashRenderedWithSpec(spec, "image-rhel9")
+	hash10 := hashRenderedWithSpec(spec, "image-rhel10")
+	assert.NotEmpty(t, hash9)
+	assert.NotEqual(t, hash9, hash10)
+}
+
 // TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication
 // using the image: provider returns a clear error.
 func TestRenderVmApplication_ImageProviderUnsupported(t *testing.T) {

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
-	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
@@ -57,16 +56,9 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(enrollmentRequest.Spec.DeviceStatus).ToNot(BeNil())
 			Expect(enrollmentRequest.Spec.DeviceStatus.SystemInfo.IsEmpty()).NotTo(BeTrue())
 
-			// Approve the enrollment and wait for the device details to be populated by the agent
 			harness.ApproveEnrollment(enrollmentID, harness.TestEnrollmentApproval())
-			GinkgoWriter.Printf("Waiting for device %s to report status\n", enrollmentID)
-
-			// wait for the device to pickup enrollment and report measurements on device status
-			Eventually(func() *apiclient.GetDeviceResponse {
-				resp, err := harness.GetDeviceWithStatusSystem(enrollmentID)
-				Expect(err).ToNot(HaveOccurred())
-				return resp
-			}, TIMEOUT, POLLING).ShouldNot(BeNil())
+			GinkgoWriter.Printf("Waiting for device %s to come online\n", enrollmentID)
+			harness.WaitForOnlineStatus(enrollmentID)
 		})
 		It("Should report a message when a device is assigned to multiple fleets", Label("75992", "agent"), func() {
 			// Get harness directly - no shared package-level variable

--- a/test/e2e/backup_restore/backup_restore_test.go
+++ b/test/e2e/backup_restore/backup_restore_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 
 			By("Approving third ER (after backup)")
 			harness3.ApproveEnrollment(er3ID, harness3.TestEnrollmentApproval())
-			Eventually(harness3.GetDeviceWithStatusSummary, testutil.TIMEOUT, testutil.POLLING).WithArguments(er3ID).ShouldNot(BeEmpty())
+			Eventually(harness3.GetDeviceWithStatusSummary, testutil.TIMEOUT, testutil.POLLING).WithArguments(er3ID).Should(Equal(v1beta1.DeviceSummaryStatusOnline))
 
 			// --- Step 4: Wait for device to apply new version; verify new RV > rvAtBackup ---
 			By("Step 4: Waiting for device 1 to apply new version (new RV > previous RV) and be UpToDate")

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -356,23 +356,26 @@ var _ = Describe("cli operation", func() {
 			Expect(out).To(ContainSubstring(deviceName))
 
 			By("Comparing with-slash and no-slash forms for table and JSON output")
-			withSlash, err := harness.CLI("get", "device/"+deviceName)
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s failed", deviceName)
+			// Device status can change between the two GETs (Updated UpToDate vs OutOfDate).
+			Eventually(func(g Gomega) {
+				withSlash, err := harness.CLI("get", "device/"+deviceName)
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s failed", deviceName)
 
-			noSlash, err := harness.CLI("get", "device", deviceName)
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device %s failed", deviceName)
+				noSlash, err := harness.CLI("get", "device", deviceName)
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device %s failed", deviceName)
 
-			Expect(collapse(withSlash)).To(Equal(collapse(noSlash)),
-				"no-slash table output must equal with-slash")
+				g.Expect(collapse(withSlash)).To(Equal(collapse(noSlash)),
+					"no-slash table output must equal with-slash")
 
-			withSlashJSON, err := harness.CLI("get", "device/"+deviceName, "-o", "json")
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s -o json failed", deviceName)
+				withSlashJSON, err := harness.CLI("get", "device/"+deviceName, "-o", "json")
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s -o json failed", deviceName)
 
-			noSlashJSON, err := harness.CLI("get", "device", deviceName, "-o", "json")
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device %s -o json failed", deviceName)
+				noSlashJSON, err := harness.CLI("get", "device", deviceName, "-o", "json")
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device %s -o json failed", deviceName)
 
-			Expect(noSlashJSON).To(MatchJSON(withSlashJSON),
-				"no-slash JSON must deep-equal with-slash")
+				g.Expect(noSlashJSON).To(MatchJSON(withSlashJSON),
+					"no-slash JSON must deep-equal with-slash")
+			}, "10s", "200ms").Should(Succeed())
 		})
 
 		It("Should show last-seen with proper flag", Label("85014", "sanity", "client", e2e.NeedVMLabel), func() {

--- a/test/e2e/decommission/decommission_test.go
+++ b/test/e2e/decommission/decommission_test.go
@@ -79,14 +79,7 @@ var _ = Describe("CLI decommission test", func() {
 			GinkgoWriter.Printf("Approved new enrollment request: %s\n", newEnrollmentId)
 
 			By("Verifying the re-enrolled device comes online with the new ID")
-			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-				newEnrollmentId).ShouldNot(BeNil())
-
-			newDevice, err := harness.GetDevice(newEnrollmentId)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(newDevice).NotTo(BeNil())
-			Expect(newDevice.Status.Summary.Status).To(Equal(v1beta1.DeviceSummaryStatusOnline),
-				"Expected re-enrolled device to be online")
+			harness.WaitForOnlineStatus(newEnrollmentId)
 			GinkgoWriter.Printf("Re-enrolled device %s is now online\n", newEnrollmentId)
 		})
 	})

--- a/test/e2e/fips/fips_test.go
+++ b/test/e2e/fips/fips_test.go
@@ -114,6 +114,6 @@ var _ = Describe("FIPS verification", Label("fips"), func() {
 		Expect(enrollmentID).NotTo(BeEmpty())
 		_ = harness.WaitForEnrollmentRequest(enrollmentID)
 		harness.ApproveEnrollment(enrollmentID, harness.TestEnrollmentApproval())
-		Eventually(harness.GetDeviceWithStatusSystem, fipsTestTimeout, fipsTestPolling).WithArguments(enrollmentID).ShouldNot(BeNil())
+		harness.WaitForOnlineStatus(enrollmentID)
 	})
 })

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -160,6 +160,10 @@ vulnerabilityReporting:
 					require.True(t, ok)
 					assert.Equal(t, "quay.io/kubevirt/virt-launcher:v1.9.0", vmRender["launcherImage"])
 					assert.Equal(t, false, vmRender["passtWorkarounds"])
+					images, ok := vmRender["launcherImages"].(map[string]interface{})
+					require.True(t, ok)
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel9:v1", images["9"])
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", images["10"])
 				}
 			case infra.ServiceImageBuilderWorker:
 				sectionKey = "imageBuilderWorker"
@@ -223,6 +227,10 @@ vulnerabilityReporting:
 				require.True(t, ok)
 				vmRender["launcherImage"] = setValue
 				vmRender["passtWorkarounds"] = false
+				vmRender["launcherImages"] = map[string]interface{}{
+					"9":  "registry.example.com/virt-launcher-rhel9:v1",
+					"10": "registry.example.com/virt-launcher-rhel10:v1",
+				}
 			case infra.ServiceImageBuilderWorker:
 				section["maxConcurrentBuilds"] = setValue
 			case infra.ServiceTelemetryGateway:

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -162,8 +162,8 @@ vulnerabilityReporting:
 					assert.Equal(t, false, vmRender["passtWorkarounds"])
 					images, ok := vmRender["launcherImages"].(map[string]interface{})
 					require.True(t, ok)
-					assert.Equal(t, "registry.example.com/virt-launcher-rhel9:v1", images["9"])
-					assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", images["10"])
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel9:v1", images["rhel-9"])
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", images["rhel-10"])
 				}
 			case infra.ServiceImageBuilderWorker:
 				sectionKey = "imageBuilderWorker"
@@ -228,8 +228,8 @@ vulnerabilityReporting:
 				vmRender["launcherImage"] = setValue
 				vmRender["passtWorkarounds"] = false
 				vmRender["launcherImages"] = map[string]interface{}{
-					"9":  "registry.example.com/virt-launcher-rhel9:v1",
-					"10": "registry.example.com/virt-launcher-rhel10:v1",
+					"rhel-9":  "registry.example.com/virt-launcher-rhel9:v1",
+					"rhel-10": "registry.example.com/virt-launcher-rhel10:v1",
 				}
 			case infra.ServiceImageBuilderWorker:
 				section["maxConcurrentBuilds"] = setValue

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -982,18 +982,25 @@ func waitForResourceContents[T any](id string, description string, fetch func(st
 }
 
 func (h *Harness) WaitForOnlineStatus(deviceId string) *v1beta1.Device {
-	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-		deviceId).Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+	var device *v1beta1.Device
+	Eventually(func() error {
+		response, err := h.GetDeviceWithStatusSystem(deviceId)
+		if err != nil {
+			return err
+		}
+		if response == nil || response.JSON200 == nil || response.JSON200.Status == nil {
+			return fmt.Errorf("device %s status not ready", deviceId)
+		}
+		device = response.JSON200
+		if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
+			return fmt.Errorf("device %s summary status is %s", deviceId, device.Status.Summary.Status)
+		}
+		if device.Status.Summary.Info == nil || *device.Status.Summary.Info != service.DeviceStatusInfoHealthy {
+			return fmt.Errorf("device %s is not healthy", deviceId)
+		}
+		return nil
+	}, TIMEOUT, POLLING).Should(Succeed())
 	logrus.Infof("The device %s is online", deviceId)
-
-	response, err := h.GetDeviceWithStatusSystem(deviceId)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(response).NotTo(BeNil())
-	Expect(response.JSON200).NotTo(BeNil())
-	device := response.JSON200
-	Expect(device.Status).NotTo(BeNil())
-	Expect(device.Status.Summary.Info).NotTo(BeNil())
-	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
 	return device
 }
 

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -698,18 +698,8 @@ func (h *Harness) StartVMAndEnroll() string {
 	err := h.VM.RunAndWaitForSSH()
 	Expect(err).ToNot(HaveOccurred())
 
-	enrollmentID := h.GetEnrollmentIDFromServiceLogs("flightctl-agent")
-	logrus.Infof("Enrollment ID found in flightctl-agent service logs: %s", enrollmentID)
-
-	_ = h.WaitForEnrollmentRequest(enrollmentID)
-	h.ApproveEnrollment(enrollmentID, h.TestEnrollmentApproval())
-	logrus.Infof("Waiting for device %s to report status", enrollmentID)
-
-	// wait for the device to pickup enrollment and report measurements on device status
-	Eventually(h.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-		enrollmentID).ShouldNot(BeNil())
-
-	return enrollmentID
+	deviceId, _ := h.EnrollAndWaitForOnlineStatus()
+	return deviceId
 }
 
 func (h *Harness) ApiEndpoint() string {
@@ -991,32 +981,32 @@ func waitForResourceContents[T any](id string, description string, fetch func(st
 	}, timeout, pollingRate).Should(BeNil())
 }
 
+func (h *Harness) WaitForOnlineStatus(deviceId string) *v1beta1.Device {
+	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
+		deviceId).Should(Equal(v1beta1.DeviceSummaryStatusOnline))
+	logrus.Infof("The device %s is online", deviceId)
+
+	response, err := h.GetDeviceWithStatusSystem(deviceId)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(response).NotTo(BeNil())
+	Expect(response.JSON200).NotTo(BeNil())
+	device := response.JSON200
+	Expect(device.Status).NotTo(BeNil())
+	Expect(device.Status.Summary.Info).NotTo(BeNil())
+	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
+	return device
+}
+
 func (h *Harness) EnrollAndWaitForOnlineStatus(labels ...map[string]string) (string, *v1beta1.Device) {
 	deviceId := h.GetEnrollmentIDFromServiceLogs("flightctl-agent")
 	logrus.Infof("Enrollment ID found in flightctl-agent service logs: %s", deviceId)
 	Expect(deviceId).NotTo(BeNil())
 
-	// Wait for the approve enrollment request response to not be nil
 	h.WaitForEnrollmentRequest(deviceId)
-
-	// Approve the enrollment and wait for the device details to be populated by the agent.
 	h.ApproveEnrollment(deviceId, h.TestEnrollmentApproval(labels...))
-
-	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeEmpty())
 	logrus.Infof("The device %s was approved", deviceId)
 
-	// Wait for the device to pickup enrollment and report measurements on device status.
-	Eventually(h.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeNil())
-	logrus.Infof("The device %s is reporting its status", deviceId)
-
-	// Check the device status.
-	response, err := h.GetDeviceWithStatusSystem(deviceId)
-	Expect(err).NotTo(HaveOccurred())
-	device := response.JSON200
-	Expect(device.Status.Summary.Status).To(Equal(v1beta1.DeviceSummaryStatusOnline))
-	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
+	device := h.WaitForOnlineStatus(deviceId)
 	return deviceId, device
 }
 

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -231,21 +231,28 @@ func (h *Harness) ApproveEnrollmentRequestWithLabels(enrollmentID string, labels
 	return resp.StatusCode(), nil
 }
 
-// WaitForDeviceWithSystemInfo polls until the Device exists and reports populated systemInfo.
+// WaitForDeviceWithSystemInfo polls until the Device is Online with populated systemInfo.
 func (h *Harness) WaitForDeviceWithSystemInfo(deviceID, timeout, polling string) (*v1beta1.Device, error) {
 	if strings.TrimSpace(deviceID) == "" {
 		return nil, fmt.Errorf("device ID is empty")
 	}
 
-	return pollUntil(timeout, polling, fmt.Sprintf("device %s systemInfo", deviceID), func() (*v1beta1.Device, bool, error) {
+	return pollUntil(timeout, polling, fmt.Sprintf("device %s online with systemInfo", deviceID), func() (*v1beta1.Device, bool, error) {
 		resp, err := h.Client.GetDeviceWithResponse(h.Context, deviceID)
 		if err != nil {
 			return nil, false, err
 		}
-		if resp != nil && resp.JSON200 != nil && resp.JSON200.Status != nil && !resp.JSON200.Status.SystemInfo.IsEmpty() {
-			return resp.JSON200, true, nil
+		if resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil {
+			return nil, false, nil
 		}
-		return nil, false, nil
+		device := resp.JSON200
+		if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
+			return nil, false, nil
+		}
+		if device.Status.SystemInfo.IsEmpty() {
+			return nil, false, nil
+		}
+		return device, true, nil
 	})
 }
 

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -386,16 +386,9 @@ func (h *Harness) EnsureDeviceContents(deviceId string, description string, cond
 
 func (h *Harness) WaitForBootstrapAndUpdateToVersion(deviceId string, version string) (*v1beta1.Device, util.ImageReference, error) {
 	var imageReference = util.ImageReference{}
-	// Check the device status right after bootstrap
-	response, err := h.GetDeviceWithStatusSystem(deviceId)
-	if err != nil {
-		return nil, imageReference, err
-	}
-	device := response.JSON200
-	if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
-		return nil, imageReference, fmt.Errorf("device: %q is not online", deviceId)
-	}
+	device := h.WaitForOnlineStatus(deviceId)
 
+	var err error
 	err = h.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
 		currentImage := device.Status.Os.Image
 		logrus.Infof("current image for %s is %s", deviceId, currentImage)

--- a/test/integration/service/enrollmentrequest_device_creation_test.go
+++ b/test/integration/service/enrollmentrequest_device_creation_test.go
@@ -187,6 +187,88 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 		})
 	})
 
+	Context("createDeviceFromEnrollmentRequest with enrollment systemInfo", func() {
+		It("When enrollment systemInfo has distroId it should copy it onto the device after approval", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.OperatingSystem = "linux"
+			enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+			enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+			er.Spec.DeviceStatus = &enrollmentStatus
+
+			By("creating enrollment request with systemInfo")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(suite.Ctx, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			By("verifying device systemInfo")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status).ToNot(BeNil())
+			id, found := device.Status.SystemInfo.Get("distroId")
+			Expect(found).To(BeTrue())
+			Expect(id).To(Equal("rhel"))
+			version, found := device.Status.SystemInfo.Get("distroVersion")
+			Expect(found).To(BeTrue())
+			Expect(version).To(Equal("9.5 (Plow)"))
+			Expect(device.Status.SystemInfo.OperatingSystem).To(Equal("linux"))
+			Expect(device.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusEnrolled))
+		})
+
+		It("When awaitingReconnect is set it should keep systemInfo and set awaiting reconnect summary", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Metadata.Annotations = &map[string]string{
+				api.DeviceAnnotationAwaitingReconnect: "true",
+			}
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+			enrollmentStatus.SystemInfo.Set("distroVersion", "10.0 (Coughlan)")
+			er.Spec.DeviceStatus = &enrollmentStatus
+
+			By("creating enrollment request")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			By("verifying device systemInfo and awaiting reconnect summary")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status.Summary.Status).To(Equal(api.DeviceSummaryStatusAwaitingReconnect))
+			id, found := device.Status.SystemInfo.Get("distroId")
+			Expect(found).To(BeTrue())
+			Expect(id).To(Equal("rhel"))
+			version, found := device.Status.SystemInfo.Get("distroVersion")
+			Expect(found).To(BeTrue())
+			Expect(version).To(Equal("10.0 (Coughlan)"))
+		})
+	})
+
 	Context("createDeviceFromEnrollmentRequest with osMode capabilities", func() {
 		It("When osMode is package it should set device capabilities.osMode to package", func() {
 			er := CreateTestER()

--- a/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
+++ b/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Enrollment VM launcher image selection", func() {
 		repositorySvc      repositoryservice.Service
 		enrollmentSvc      enrollmentrequestservice.Service
 		origPath           string
+		origPathSet        bool
 	)
 
 	BeforeEach(func() {
@@ -159,7 +160,7 @@ var _ = Describe("Enrollment VM launcher image selection", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rendered.Bus.Initialize(ctx, kvStoreInst, queuesProvider, 10*time.Second, log)).To(Succeed())
 
-		origPath = os.Getenv("PATH")
+		origPath, origPathSet = os.LookupEnv("PATH")
 		Expect(os.Setenv("PATH", filepath.Dir(vmBinaryPath)+string(os.PathListSeparator)+origPath)).To(Succeed())
 
 		testutil.CreateTestFleet(ctx, fleetStore, orgId, "vm-launcher-fleet", &map[string]string{testFleetLabelKey: testFleetLabelValue}, nil)
@@ -171,9 +172,7 @@ var _ = Describe("Enrollment VM launcher image selection", func() {
 	})
 
 	AfterEach(func() {
-		if origPath != "" {
-			_ = os.Setenv("PATH", origPath)
-		}
+		restoreOrigPath(origPath, origPathSet)
 		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
 		ctrl.Finish()
 	})
@@ -233,6 +232,15 @@ var _ = Describe("Enrollment VM launcher image selection", func() {
 		Entry("When distro is fedora it should use launcherImage", "fedora", "42 (Adams)", defaultLauncherImage),
 	)
 })
+
+func restoreOrigPath(origPath string, origPathSet bool) {
+	GinkgoHelper()
+	if origPathSet {
+		Expect(os.Setenv("PATH", origPath)).To(Succeed())
+		return
+	}
+	Expect(os.Unsetenv("PATH")).To(Succeed())
+}
 
 func inlineTestVmApp() api.VmApplication {
 	GinkgoHelper()

--- a/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
+++ b/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
@@ -1,0 +1,280 @@
+package vmrender_test
+
+import (
+	"context"
+	"crypto"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	cacfg "github.com/flightctl/flightctl/internal/config/ca"
+	"github.com/flightctl/flightctl/internal/consts"
+	icrypto "github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/identity"
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/rendered"
+	dependencyrefservice "github.com/flightctl/flightctl/internal/service/dependencyref"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	enrollmentrequestservice "github.com/flightctl/flightctl/internal/service/enrollmentrequest"
+	"github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
+	"github.com/flightctl/flightctl/internal/store"
+	certificatesigningrequeststore "github.com/flightctl/flightctl/internal/store/certificatesigningrequest"
+	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
+	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	enrollmentrequeststore "github.com/flightctl/flightctl/internal/store/enrollmentrequest"
+	eventstore "github.com/flightctl/flightctl/internal/store/event"
+	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
+	repositorystore "github.com/flightctl/flightctl/internal/store/repository"
+	templateversionstore "github.com/flightctl/flightctl/internal/store/templateversion"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	fcrypto "github.com/flightctl/flightctl/pkg/crypto"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+const (
+	testFleetLabelKey    = "vm-fleet"
+	testFleetLabelValue  = "true"
+	rhel9LauncherImage   = "registry.example.com/virt-launcher-rhel9:test"
+	rhel10LauncherImage  = "registry.example.com/virt-launcher-rhel10:test"
+	defaultLauncherImage = "registry.example.com/virt-launcher:default"
+)
+
+const testVmYAML = `apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 1
+        memory:
+          guest: 1Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/containerdisks/fedora:40
+`
+
+var _ = Describe("Enrollment VM launcher image selection", func() {
+	var (
+		log                *logrus.Logger
+		ctx                context.Context
+		orgId              uuid.UUID
+		cfg                *config.Config
+		dbName             string
+		db                 *gorm.DB
+		ctrl               *gomock.Controller
+		kvStoreInst        kvstore.KVStore
+		deviceStore        devicestore.Store
+		fleetStore         fleetstore.Store
+		tvStore            templateversionstore.Store
+		deviceSvc          deviceservice.Service
+		fleetSvc           fleetservice.Service
+		templateVersionSvc templateversionservice.Service
+		dependencyrefSvc   dependencyrefservice.Service
+		repositorySvc      repositoryservice.Service
+		enrollmentSvc      enrollmentrequestservice.Service
+		origPath           string
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		orgId = store.NullOrgId
+		log = flightlog.InitLogs()
+
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(json.Unmarshal([]byte(`{
+			"worker": {
+				"vmRender": {
+					"launcherImage": "`+defaultLauncherImage+`",
+					"launcherImages": {
+						"rhel-9": "`+rhel9LauncherImage+`",
+						"rhel-10": "`+rhel10LauncherImage+`"
+					}
+				}
+			}
+		}`), cfg)).To(Succeed())
+
+		deviceStore = devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+		fleetStore = fleetstore.NewFleetStore(db, log.WithField("pkg", "fleet-store"))
+		tvStore = templateversionstore.NewTemplateVersionStore(db, log.WithField("pkg", "templateversion-store"))
+		erStore := enrollmentrequeststore.NewEnrollmentRequestStore(db, log.WithField("pkg", "enrollmentrequest-store"))
+		csrStore := certificatesigningrequeststore.NewCertificateSigningRequestStore(db, log.WithField("pkg", "csr-store"))
+		eventStore := eventstore.NewEventStore(db, log.WithField("pkg", "event-store"))
+		repoStore := repositorystore.NewRepositoryStore(db, log.WithField("pkg", "repository-store"))
+		depStore := dependencyrefstore.NewDependencyRefStore(db, log.WithField("pkg", "dependencyref-store"))
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer := queues.NewMockQueueProducer(ctrl)
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		workerClient := worker_client.NewWorkerClient(mockQueueProducer, log)
+
+		kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+		Expect(err).ToNot(HaveOccurred())
+		eventsSvc := events.NewServiceHandler(eventStore, workerClient, log)
+
+		caClient, _, err := icrypto.EnsureCA(cacfg.NewDefault(GinkgoT().TempDir()))
+		Expect(err).ToNot(HaveOccurred())
+
+		deviceSvc = deviceservice.NewDeviceServiceHandler(deviceStore, nil, fleetStore, eventsSvc, kvStoreInst, "", log)
+		fleetSvc = fleetservice.NewServiceHandler(fleetStore, nil, eventsSvc, log)
+		templateVersionSvc = templateversionservice.NewServiceHandler(tvStore, kvStoreInst, eventsSvc, log)
+		dependencyrefSvc = dependencyrefservice.NewServiceHandler(depStore, log)
+		repositorySvc = repositoryservice.NewServiceHandler(repoStore, eventsSvc, log)
+		enrollmentSvc = enrollmentrequestservice.NewServiceHandler(erStore, deviceStore, csrStore, caClient, kvStoreInst, eventsSvc, log, []string{}, "", "")
+
+		ctx = context.WithValue(ctx, consts.MappedIdentityCtxKey, identity.NewMappedIdentity("admin", "uid-admin", nil, nil, true, nil))
+
+		queuesProvider, err := queues.NewRedisProvider(ctx, log, fmt.Sprintf("vm-enroll-launcher-%s", uuid.New().String()), redisHost, redisPort, redisPassword, queues.DefaultRetryConfig())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rendered.Bus.Initialize(ctx, kvStoreInst, queuesProvider, 10*time.Second, log)).To(Succeed())
+
+		origPath = os.Getenv("PATH")
+		Expect(os.Setenv("PATH", filepath.Dir(vmBinaryPath)+string(os.PathListSeparator)+origPath)).To(Succeed())
+
+		testutil.CreateTestFleet(ctx, fleetStore, orgId, "vm-launcher-fleet", &map[string]string{testFleetLabelKey: testFleetLabelValue}, nil)
+		vmApp := inlineTestVmApp()
+		appSpec := api.ApplicationProviderSpec{}
+		Expect(appSpec.FromVmApplication(vmApp)).To(Succeed())
+		tvStatus := api.TemplateVersionStatus{Applications: &[]api.ApplicationProviderSpec{appSpec}}
+		Expect(testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "vm-launcher-fleet", "1.0.0", &tvStatus)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		if origPath != "" {
+			_ = os.Setenv("PATH", origPath)
+		}
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+		ctrl.Finish()
+	})
+
+	DescribeTable("When a device enrolls into a VM fleet it should render the virt-launcher for its OS",
+		func(distroId, distroVersion, wantImage string) {
+			deviceName, csr := enrollmentNameAndCSR()
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.Set("distroId", distroId)
+			enrollmentStatus.SystemInfo.Set("distroVersion", distroVersion)
+
+			er := api.EnrollmentRequest{
+				ApiVersion: "v1beta1",
+				Kind:       "EnrollmentRequest",
+				Metadata:   api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec: api.EnrollmentRequestSpec{
+					Csr:          csr,
+					DeviceStatus: &enrollmentStatus,
+					Labels:       &map[string]string{testFleetLabelKey: testFleetLabelValue},
+				},
+			}
+			created, status := enrollmentSvc.CreateEnrollmentRequest(ctx, orgId, er)
+			Expect(status.Code).To(BeNumerically("==", 201))
+			Expect(created).ToNot(BeNil())
+
+			_, status = enrollmentSvc.ApproveEnrollmentRequest(ctx, orgId, deviceName, api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{},
+			})
+			Expect(status.Code).To(BeNumerically("==", 200))
+
+			event := api.Event{
+				Reason:         api.EventReasonResourceCreated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: deviceName},
+			}
+			selectorLogic := tasks.NewFleetSelectorMatchingLogic(log, deviceSvc, fleetSvc, orgId, event)
+			Expect(selectorLogic.DeviceLabelsUpdated(ctx)).To(Succeed())
+
+			device, err := deviceStore.Get(ctx, orgId, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lo.FromPtr(device.Metadata.Owner)).To(Equal("Fleet/vm-launcher-fleet"))
+
+			rolloutLogic := tasks.NewFleetRolloutsLogic(log, fleetSvc, templateVersionSvc, deviceSvc, dependencyrefSvc, orgId, event)
+			Expect(rolloutLogic.RolloutDevice(ctx)).To(Succeed())
+
+			renderLogic := tasks.NewDeviceRenderLogic(log, deviceSvc, repositorySvc, nil, &mockK8sClient{}, kvStoreInst, cfg, orgId, event)
+			Expect(renderLogic.RenderDevice(ctx)).To(Succeed())
+
+			renderedDevice, getStatus := deviceSvc.GetRenderedDevice(ctx, orgId, deviceName, api.GetRenderedDeviceParams{})
+			Expect(getStatus.Code).To(BeNumerically("==", 200))
+			Expect(renderedDevice.Spec).ToNot(BeNil())
+			Expect(renderedDevice.Spec.Applications).ToNot(BeNil())
+			Expect(renderedContents(*renderedDevice.Spec.Applications)).To(ContainSubstring("Image=" + wantImage))
+		},
+		Entry("When distro is rhel 9 it should use the rhel-9 launcher", "rhel", "9.5 (Plow)", rhel9LauncherImage),
+		Entry("When distro is rhel 10 it should use the rhel-10 launcher", "rhel", "10.0 (Coughlan)", rhel10LauncherImage),
+		Entry("When distro is fedora it should use launcherImage", "fedora", "42 (Adams)", defaultLauncherImage),
+	)
+})
+
+func inlineTestVmApp() api.VmApplication {
+	GinkgoHelper()
+	inlineSpec := api.InlineApplicationProviderSpec{
+		Inline: []api.ApplicationContent{
+			{Path: "vm.yaml", Content: lo.ToPtr(testVmYAML)},
+		},
+	}
+	vmApp := api.VmApplication{
+		AppType: api.AppTypeVm,
+		Name:    lo.ToPtr("test-vm"),
+	}
+	Expect(vmApp.FromInlineApplicationProviderSpec(inlineSpec)).To(Succeed())
+	return vmApp
+}
+
+func enrollmentNameAndCSR() (string, string) {
+	GinkgoHelper()
+	publicKey, privateKey, err := fcrypto.NewKeyPair()
+	Expect(err).ToNot(HaveOccurred())
+	publicKeyHash, err := fcrypto.HashPublicKey(publicKey)
+	Expect(err).ToNot(HaveOccurred())
+	deviceName := strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(publicKeyHash))
+	csrPEM, err := fcrypto.MakeCSR(privateKey.(crypto.Signer), deviceName)
+	Expect(err).ToNot(HaveOccurred())
+	return deviceName, string(csrPEM)
+}
+
+func renderedContents(apps []api.ApplicationProviderSpec) string {
+	GinkgoHelper()
+	var b strings.Builder
+	for _, app := range apps {
+		quadlet, err := app.AsQuadletApplication()
+		Expect(err).ToNot(HaveOccurred())
+		inline, err := quadlet.AsInlineApplicationProviderSpec()
+		Expect(err).ToNot(HaveOccurred())
+		for _, f := range inline.Inline {
+			if f.Content != nil {
+				b.WriteString(*f.Content)
+				b.WriteByte('\n')
+			}
+		}
+	}
+	return b.String()
+}

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -33,6 +33,7 @@ var (
 	redisCleanup  func()
 
 	vmConverter     tasks.VmConverterFn
+	vmBinaryPath    string
 	vmBinaryCleanup func()
 )
 
@@ -63,7 +64,8 @@ var _ = SynchronizedBeforeSuite(
 			suiteCtx, flightlog.InitLogs())
 		Expect(err).NotTo(HaveOccurred())
 
-		vmConverter = tasks.NewVmConverter(string(binaryPathBytes), tasks.DefaultVmRenderOptions())
+		vmBinaryPath = string(binaryPathBytes)
+		vmConverter = tasks.NewVmConverter(vmBinaryPath, tasks.DefaultVmRenderOptions())
 	},
 )
 

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -10,19 +10,9 @@ bin/output/qcow2/disk.qcow2: $(E2E_AGENT_IMAGES_SENTINEL)
 # Build + bundle artifacts (no push)
 $(E2E_AGENT_IMAGES_SENTINEL): | bin
 	@if [ ! -f "$(AGENT_BUNDLE)" ]; then \
-		# For EL10, use COPR packages instead of local RPMs \
-		case "$(AGENT_OS_ID)" in \
-			cs10*) \
-				echo "Using COPR packages for EL10 build"; \
-				BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
-					FLIGHTCTL_RPM=stable AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
-				;; \
-			*) \
-				$(MAKE) bin/.rpm; \
-				BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
-					AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
-				;; \
-		esac; \
+		$(MAKE) bin/.rpm; \
+		BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
+			AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
 	else \
 		echo "Device bundle already exists at $(AGENT_BUNDLE)"; \
 	fi

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -85,6 +85,7 @@ var DefaultSystemInfo = []string{
 	"kernel",
 	"distroName",
 	"distroVersion",
+	"distroId",
 	"productName",
 	"productUuid",
 	"productSerial",

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -85,7 +85,6 @@ var DefaultSystemInfo = []string{
 	"kernel",
 	"distroName",
 	"distroVersion",
-	"distroId",
 	"productName",
 	"productUuid",
 	"productSerial",


### PR DESCRIPTION
Fixes [EDM-5266](https://issues.redhat.com/browse/EDM-5266): VM apps should be rendered with an OS-compatible virt-launcher image.

## Summary
- Worker VM render still has a single `launcherImage` default. This adds optional `worker.vmRender.launcherImages` keyed by os-release **ID and major** (`rhel-9`, `rhel-10`, `fedora-42`), not a bare numeric major (Fedora 42 must not steal a RHEL image).
- The agent now reports `systemInfo.distroId` (os-release `ID`) in addition to the existing `distroName` / `distroVersion`.
- At per-device render, the worker builds `{distroId}-{major}` from device status and selects the matching map entry.
- Enrollment already sends `spec.deviceStatus` (including `systemInfo`). Approval now copies that `systemInfo` onto the Device so the first fleet/VM render can see `distroId` instead of waiting for a later status PUT (status updates do not re-render).
- Quadlet `service-config.yaml` now ranges `launcherImages` into the worker config (Helm was already wired).
- User docs (`configuring-vm-render.md`, air-gapped, managing devices) describe `launcherImages` and selection order.
- The selected image is included in the render hash so a `rhel-9` → `rhel-10` OS change re-renders VM Quadlets.

`launcherImage` is kept as the unknown-OS default (no `distroId`, OS not in the map, CLI enroll, collect failure). Downstream can set:

```yaml
worker:
  vmRender:
    launcherImages:
      "rhel-9": registry.redhat.io/container-native-virtualization/virt-launcher-rhel9:v4.22-1784929080
      "rhel-10": registry.redhat.io/container-native-virtualization/virt-launcher-4-nv-rhel10:<tag>
```

If the map has no entry, `launcherImage` / the built-in default is used.

**Note:** changing the render hash to include the launcher image will cause a one-time re-render of devices on worker upgrade.

## E2E
Copying `systemInfo` at approval meant e2e helpers that waited for `systemInfo` as a stand-in for “agent has checked in” returned while `summary.status` was still `Unknown`. `EnrollAndWaitForOnlineStatus` and the other post-approval waits now `Eventually` until `Online`.

## Test plan
- [ ] `go test ./internal/config ./internal/tasks ./internal/agent/device/systeminfo ./internal/agent/config ./internal/service/enrollmentrequest ./test/e2e/infra/quadlet`
- [ ] `make integration-test TEST_DIR=./test/integration/service INTEGRATION_GINKGO_FOCUS="enrollment systemInfo"`
- [ ] `make integration-test TEST_DIR=./test/integration/tasks/vmrender INTEGRATION_GINKGO_FOCUS="Enrollment VM launcher"`
- [ ] Confirm a device reporting `distroId: rhel` and `distroVersion: 9.5 (Plow)` gets the `rhel-9` image when the map is set
- [ ] Confirm a device reporting `rhel` / `10.x` gets the `rhel-10` image
- [ ] Confirm `fedora-42` does not match `rhel-9` / `rhel-10` and uses `launcherImage`
- [ ] Confirm enrollment approval copies `systemInfo` so first VM render can select by OS
- [ ] Confirm an OS-major change produces a new rendered version
- [ ] Confirm existing installs with only `launcherImage` behave as before
- [ ] Confirm Quadlet worker config receives `launcherImages`
- [ ] `make lint-docs` and `make spellcheck-docs`
- [ ] Confirm e2e enrollment waits for `summary.status == Online` (not merely populated `systemInfo`)