### PR TITLE
NO-ISSUE: Add risk label justification to CodeRabbit PR summary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,7 +23,11 @@ reviews:
     change affects the API surface (OpenAPI, types, gRPC), the device agent,
     the server-side control plane (store, service, worker, periodic), deployment
     (Helm, quadlets, RPM), or test infrastructure, and flag any backward-
-    compatibility implications.
+    compatibility implications. End the summary with a "Risk classification"
+    section that states which risk label (risk:ship, risk:show, or risk:ask)
+    was applied and the specific criteria from the labeling instructions that
+    determined the classification. If the PR was close to a different
+    classification, note which one and why it did not qualify.
   collapse_walkthrough: false
   sequence_diagrams: true
 


### PR DESCRIPTION
## Summary

- Extends `high_level_summary_instructions` to include a "Risk classification" section in CodeRabbit's PR summary
- States which risk label was applied and the specific criteria that determined the classification
- Notes when a PR was close to a different classification and why it did not qualify

## Context

Follow-up to the Ship/Show/Ask labeling PR (merged in #3415). During the data-collection phase, the team needs to evaluate not just whether labels feel right, but whether the reasoning holds up. This adds that reasoning to the existing review summary — no new tooling needed.

## Test plan

- [ ] Observe CodeRabbit summaries on new PRs include a "Risk classification" section
- [ ] Verify the justification references specific criteria from the labeling instructions

Assisted-by: Claude Opus 4.6 (1M) <noreply@anthropic.com>