### PR TITLE
[Backport to 1.3] Mass backport from PR 3370 to 3429

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -28,7 +28,18 @@ runs:
         shell: bash
         run: |
           echo "APT_CACHE_DIR=${HOME}/.cache/apt-archives" >> "$GITHUB_ENV"
+          echo "APT_OPTS=-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20" >> "$GITHUB_ENV"
           mkdir -p "${HOME}/.cache/apt-archives"
+
+      # GitHub-hosted images list azure.archive.ubuntu.com first. When that
+      # host hangs, apt retries it for every index file.
+      - name: Pin Ubuntu apt mirrors
+        if: ${{ inputs.skip_package_install != 'true' }}
+        shell: bash
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            printf 'https://archive.ubuntu.com/ubuntu/\tpriority:1\nhttps://security.ubuntu.com/ubuntu/\tpriority:2\n' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
 
       # apt's default archive dir (/var/cache/apt/archives) is root-owned, so
       # actions/cache — which runs as the unprivileged runner user — can't
@@ -55,8 +66,8 @@ runs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-          sudo apt update -y 
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
+          sudo apt ${APT_OPTS} update -y
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y libvirt-clients libvirt-daemon-system libvirt-daemon \
                               virtinst bridge-utils qemu-system-x86 qemu-kvm \
                               swtpm apparmor-utils libguestfs-tools
           sudo usermod -a -G kvm,libvirt,swtpm $USER
@@ -67,8 +78,8 @@ runs:
         shell: bash
         run: |
           echo "::group::Installing general dependencies"
-          sudo apt update -y # fix broken repo cache
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
+          sudo apt ${APT_OPTS} update -y
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y make python3-pip podman podman-compose libvirt-dev libpam0g-dev
 
           # Ubuntu noble ships crun 1.14.1 which rejects OCI runtime spec v1.2.1
           # version strings emitted by Podman 4.9+, causing "unknown version specified"
@@ -156,7 +167,7 @@ runs:
         shell: bash
         if: ${{ inputs.unit_tests == 'true' && inputs.skip_package_install != 'true' }}
         run: |
-          sudo apt -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
+          sudo apt ${APT_OPTS} -o Dir::Cache::Archives="${APT_CACHE_DIR}" install -y bubblewrap apparmor-profiles
           sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/bwrap || true
           sudo apparmor_parser /etc/apparmor.d/bwrap
 

--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -42,10 +42,10 @@ runs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.APT_CACHE_DIR }}
-          key: ${{ runner.os }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-${{ hashFiles('.github/actions/setup-dependencies/action.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-${{ hashFiles('.github/actions/setup-dependencies/action.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-
-            ${{ runner.os }}-apt-
+            ${{ runner.os }}-${{ runner.arch }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-
+            ${{ runner.os }}-${{ runner.arch }}-apt-
 
       - name: Enable KVM group perms
         shell: bash
@@ -77,9 +77,18 @@ runs:
           # its OCI runtime config, so /usr/local/bin alone does not take effect.
           # See: https://github.com/containers/crun/issues/1485
           CRUN_VERSION=1.14.3
-          # sha256 of crun-${CRUN_VERSION}-linux-amd64 from GitHub Releases
-          CRUN_SHA256=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
-          curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          ARCH=$(uname -m)
+          if [ "${ARCH}" = "x86_64" ]; then
+            CRUN_ARCH=amd64
+            CRUN_SHA256=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
+          elif [ "${ARCH}" = "aarch64" ]; then
+            CRUN_ARCH=arm64
+            CRUN_SHA256=0486629e1599c3bccded279f6555ff22691958cde56203ceca099af6f2407263
+          else
+            echo "Unsupported architecture: ${ARCH}" >&2
+            exit 1
+          fi
+          curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${CRUN_ARCH}"
           echo "${CRUN_SHA256}  /tmp/crun" | sha256sum -c -
           sudo install -m 0755 /tmp/crun /usr/bin/crun
           rm -f /tmp/crun
@@ -91,7 +100,12 @@ runs:
           podman --version
           /usr/bin/crun --version
 
-          curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip"
+          if [ "$(uname -m)" = "x86_64" ]; then
+            PROTOC_ARCH=x86_64
+          else
+            PROTOC_ARCH=aarch_64
+          fi
+          curl -Lo protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-${PROTOC_ARCH}.zip"
           sudo unzip -q -o protoc.zip bin/protoc -d /usr/local
           sudo chmod a+x /usr/local/bin/protoc
           protoc --version
@@ -150,7 +164,7 @@ runs:
         shell: bash
         run: |
           # Fix storage driver so it can be used with BIB (see https://github.com/osbuild/bootc-image-builder/issues/446)
-          sudo rm -rf /var/lib/containers/storage
+          sudo rm -rf /var/lib/containers/storage || true
           sudo mkdir -p /etc/containers
           echo -e "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"" | sudo tee /etc/containers/storage.conf
 
@@ -159,4 +173,4 @@ runs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.APT_CACHE_DIR }}
-          key: ${{ runner.os }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-${{ hashFiles('.github/actions/setup-dependencies/action.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-apt-${{ inputs.setup_kvm != '' && 'kvm' || 'base' }}-${{ hashFiles('.github/actions/setup-dependencies/action.yaml') }}

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -15,6 +15,9 @@ env:
   # Enable BuildKit for cache mounts
   DOCKER_BUILDKIT: 1
   BUILDKIT_PROGRESS: plain
+  SUPPORTED_OS: "el9 el10"
+  SUPPORTED_IMAGES: "api pam-issuer periodic worker cli-artifacts alert-exporter alertmanager-proxy userinfo-proxy db-setup telemetry-gateway imagebuilder-api imagebuilder-worker remote-access"
+  SUPPORTED_ARCHES: "amd64 arm64"
 
 jobs:
   generate-tags:
@@ -23,6 +26,8 @@ jobs:
       image_tags: ${{ steps.get-tags.outputs.image_tags }}
       helm_tag: ${{ steps.get-tags.outputs.helm_tag }}
       helm_ui_image_tag: ${{ steps.get-tags.outputs.helm_ui_image_tag }}
+      os_matrix: ${{ steps.build-matrix.outputs.os }}
+      image_matrix: ${{ steps.build-matrix.outputs.images }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,11 +38,16 @@ jobs:
         id: get-tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          if [[ ! "${REF_NAME}" =~ ^[a-zA-Z0-9_][a-zA-Z0-9._~-]*$ ]]; then
+            echo "ERROR: ref name '${REF_NAME}' contains invalid characters" >&2
+            exit 1
+          fi
           if ${{ github.ref_type == 'tag' }}; then
             # The images tags will match the Release tag
-            image_tags=( ${{ github.ref_name }} )
+            image_tags=( "${REF_NAME}" )
             # image tags should not have the leading v, and we tag rcs with ~rc1..rcX for rpm version ordering
             image_tags=$(echo "${image_tags#v}" | sed 's/~/-/g')
 
@@ -54,7 +64,7 @@ jobs:
             if ${{ github.ref_name == 'main' }}; then
               latest_tag="latest"
             else
-              latest_tag="${{ github.ref_name }}"
+              latest_tag="${REF_NAME}"
             fi
 
             # The images tags are taken from git
@@ -76,9 +86,17 @@ jobs:
             echo "helm_ui_image_tag=${helm_ui_image_tag}"
           fi
 
+      - name: Build matrix arrays
+        id: build-matrix
+        run: |
+          os_json=$(echo "${SUPPORTED_OS}" | jq -R -c 'split(" ")')
+          images_json=$(echo "${SUPPORTED_IMAGES}" | jq -R -c 'split(" ")')
+          echo "os=${os_json}" >> "$GITHUB_OUTPUT"
+          echo "images=${images_json}" >> "$GITHUB_OUTPUT"
+
   publish-helm-charts-containers:
     runs-on: "ubuntu-24.04"
-    needs: [publish-flightctl-containers, generate-tags]
+    needs: [create-manifest-lists, generate-tags]
     steps:
       - uses: actions/checkout@v4
 
@@ -86,17 +104,20 @@ jobs:
         uses: ./.github/actions/setup-dependencies
 
       - name: Build helm charts
+        env:
+          HELM_TAG: ${{ needs.generate-tags.outputs.helm_tag }}
+          HELM_UI_IMAGE_TAG: ${{ needs.generate-tags.outputs.helm_ui_image_tag }}
         run: |
-          echo packaging "${{ needs.generate-tags.outputs.helm_tag }}"
+          echo packaging "${HELM_TAG}"
 
-          if [ -n "${{ needs.generate-tags.outputs.helm_ui_image_tag }}" ]; then
-            echo "Updating ui.image.tag to ${{ needs.generate-tags.outputs.helm_ui_image_tag }}"
-            yq -i '.ui.image.tag = "${{ needs.generate-tags.outputs.helm_ui_image_tag }}"' deploy/helm/flightctl/values.yaml
+          if [ -n "${HELM_UI_IMAGE_TAG}" ]; then
+            echo "Updating ui.image.tag to ${HELM_UI_IMAGE_TAG}"
+            yq -i ".ui.image.tag = \"${HELM_UI_IMAGE_TAG}\"" deploy/helm/flightctl/values.yaml
           fi
 
           helm package ./deploy/helm/flightctl \
-              --version "${{ needs.generate-tags.outputs.helm_tag }}" \
-              --app-version "${{ needs.generate-tags.outputs.helm_tag }}"
+              --version "${HELM_TAG}" \
+              --app-version "${HELM_TAG}"
 
       - name: Login helm
         env:
@@ -106,16 +127,24 @@ jobs:
           helm registry login quay.io -u ${USER} -p ${PASSWORD}
 
       - name: Push helm charts
+        env:
+          HELM_TAG: ${{ needs.generate-tags.outputs.helm_tag }}
         run: |
-          helm push "flightctl-${{ needs.generate-tags.outputs.helm_tag }}.tgz" oci://${{ env.QUAY_CHARTS }}/
+          helm push "flightctl-${HELM_TAG}.tgz" oci://${QUAY_CHARTS}/
 
   publish-flightctl-containers:
     strategy:
       matrix:
-        os: ['el9', 'el10']
-        image: ['api', 'pam-issuer', 'periodic', 'worker', 'cli-artifacts', 'alert-exporter', 'alertmanager-proxy', 'userinfo-proxy', 'db-setup', 'telemetry-gateway', 'imagebuilder-api', 'imagebuilder-worker', 'remote-access']
+        os: ${{ fromJson(needs.generate-tags.outputs.os_matrix) }}
+        image: ${{ fromJson(needs.generate-tags.outputs.image_matrix) }}
+        arch: ['amd64', 'arm64']
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     needs: [generate-tags]
-    runs-on: "ubuntu-24.04"
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -163,9 +192,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-${{ matrix.arch }}-go-
 
       - name: Cache DNF packages
         uses: actions/cache@v4
@@ -173,17 +202,17 @@ jobs:
           path: |
             /var/cache/dnf
             /var/lib/dnf
-          key: ${{ runner.os }}-dnf-${{ matrix.os }}-${{ matrix.image }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-dnf-${{ matrix.os }}-${{ matrix.image }}
           restore-keys: |
-            ${{ runner.os }}-dnf-${{ matrix.os }}-
-            ${{ runner.os }}-dnf-
+            ${{ runner.os }}-${{ matrix.arch }}-dnf-${{ matrix.os }}-
+            ${{ runner.os }}-${{ matrix.arch }}-dnf-
 
       - name: Build
         id: build
         uses: redhat-actions/buildah-build@v2
         with:
           image: flightctl-${{ matrix.image }}-${{ matrix.os }}
-          tags: ${{ needs.generate-tags.outputs.image_tags }}
+          tags: _build
           labels: |
             io.flightctl.flightctl-${{ matrix.image }}-${{ matrix.os }}.github.repository=${{ github.repository }}
             io.flightctl.flightctl-${{ matrix.image }}-${{ matrix.os }}.github.actor=${{ github.actor }}
@@ -201,17 +230,67 @@ jobs:
 
       - name: Validate FIPS
         id: fips
+        env:
+          BUILD_IMAGE: ${{ steps.build.outputs.image }}
         run: |
           go install github.com/flightctl/fips-validator@latest
-          TAGS=(${{ steps.build.outputs.tags }})
-          podman unshare -- $HOME/go/bin/fips-validator image ${{ steps.build.outputs.image }}:${TAGS[0]}
+          podman unshare -- $HOME/go/bin/fips-validator image "${BUILD_IMAGE}:_build"
 
-      - name: Push to Quay.io
-        id: push
-        uses: redhat-actions/push-to-registry@v2.7
+      - name: Save image as OCI archive
+        env:
+          BUILD_IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          mkdir -p /tmp/image-archives
+          buildah push "${BUILD_IMAGE}:_build" \
+            "oci-archive:/tmp/image-archives/${{ matrix.os }}-${{ matrix.image }}-${{ matrix.arch }}.tar"
+
+      - name: Upload image archive
+        uses: actions/upload-artifact@v4
         with:
-          image: ${{ steps.build.outputs.image }}
-          tags: ${{ steps.build.outputs.tags }}
-          registry: ${{ env.QUAY_ORG }}
-          username: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }}
-          password: ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }}
+          name: image-${{ matrix.os }}-${{ matrix.image }}-${{ matrix.arch }}
+          path: /tmp/image-archives/${{ matrix.os }}-${{ matrix.image }}-${{ matrix.arch }}.tar
+          retention-days: 1
+          compression-level: 0
+
+  create-manifest-lists:
+    needs: [publish-flightctl-containers, generate-tags]
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: Download all image archives
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/image-archives
+          pattern: image-*
+          merge-multiple: true
+
+      - name: Login to Quay.io
+        run: |
+          buildah login -u ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_USERNAME }} \
+            -p ${{ secrets.QUAY_FLIGHTCTL_INFRA_ROBOT_PASSWORD }} quay.io
+
+      - name: Load images and create manifest lists
+        env:
+          IMAGE_TAGS: ${{ needs.generate-tags.outputs.image_tags }}
+        run: |
+          for os in ${SUPPORTED_OS}; do
+            for image in ${SUPPORTED_IMAGES}; do
+              FULL_IMAGE="${QUAY_ORG}/flightctl-${image}-${os}"
+
+              for arch in ${SUPPORTED_ARCHES}; do
+                echo "Loading ${os}-${image}-${arch}"
+                buildah pull "oci-archive:/tmp/image-archives/${os}-${image}-${arch}.tar"
+              done
+
+              for tag in ${IMAGE_TAGS}; do
+                echo "Creating manifest list for ${FULL_IMAGE}:${tag}"
+                buildah manifest create "${FULL_IMAGE}:${tag}"
+                for arch in ${SUPPORTED_ARCHES}; do
+                  buildah manifest add "${FULL_IMAGE}:${tag}" \
+                    "oci-archive:/tmp/image-archives/${os}-${image}-${arch}.tar"
+                done
+                buildah manifest push --all "${FULL_IMAGE}:${tag}" "docker://${FULL_IMAGE}:${tag}"
+                buildah manifest rm "${FULL_IMAGE}:${tag}"
+              done
+            done
+          done
+

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -108,6 +108,10 @@ jobs:
           OS_ID: ${{ inputs.os_id }}
         run: |
           set -euo pipefail
+          # Keep runtime detection aligned with test/harness/containers/docker_host.go.
+          . ./test/scripts/detect_container_runtime.sh
+          configure_testcontainers_docker_host
+
           echo "Downloaded test artifacts:"
           tree test-artifacts
 
@@ -131,11 +135,15 @@ jobs:
           echo "✓ QCOW2 image: bin/output/qcow2/disk.qcow2"
 
           PACKAGE_REF="quay.io/flightctl/flightctl-device:package"
-          if [[ "${DOCKER_HOST:-}" == *podman* ]]; then
-            echo "Loading package-mode image into Podman containers-storage (DOCKER_HOST=${DOCKER_HOST})"
-            skopeo copy "docker-archive:${BUNDLE}:${PACKAGE_REF}" "containers-storage:${PACKAGE_REF}"
+          CONTAINER_RUNTIME="$(detect_testcontainers_runtime)"
+          echo "Detected testcontainers runtime: ${CONTAINER_RUNTIME} (DOCKER_HOST=${DOCKER_HOST:-unset})"
+          if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
+            echo "Loading package-mode image into Podman image storage"
+            export CONTAINER_HOST="${DOCKER_HOST}"
+            podman load -i "${BUNDLE}"
+            podman image exists "${PACKAGE_REF}"
           else
-            echo "Loading package-mode image into Docker daemon (DOCKER_HOST=${DOCKER_HOST:-unset})"
+            echo "Loading package-mode image into Docker daemon"
             skopeo copy "docker-archive:${BUNDLE}:${PACKAGE_REF}" "docker-daemon:${PACKAGE_REF}"
           fi
 

--- a/.spelling
+++ b/.spelling
@@ -74,6 +74,9 @@ Kubernetes
 kustomize
 KVM
 launcherImage
+launcherImages
+distroId
+distroVersion
 lifecycle
 lifecycle-bound
 linux

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -383,15 +383,15 @@ For more detailed configuration options, see the [Values](#values) section below
 | imageBuilderWorker.serviceImages.syft.image | string | `""` | Syft image for SBOM generation. If empty, defaults to `docker.io/anchore/syft:v1.44.0`. |
 | imageBuilderWorker.serviceImages.syft.skipTlsVerify | bool | `false` | Set to true to skip TLS verification when pulling the Syft image. |
 | imageBuilderWorker.yumReposSecretName | string | `""` | Secret name containing yum repository configuration files, mounted at /etc/yum.repos.d |
-| kv | object | `{"fsGroup":"","image":{"image":"quay.io/sclorg/redis-7-c9s","pullPolicy":"","tag":"20250108"},"loglevel":"warning","maxmemory":"1gb","maxmemoryPolicy":"allkeys-lru","passwordSecretName":""}` | Key-Value Store Configuration |
-| kv.fsGroup | string | `""` | File system group ID for Redis pod security context |
-| kv.image.image | string | `"quay.io/sclorg/redis-7-c9s"` | Redis container image |
-| kv.image.pullPolicy | string | `""` | Image pull policy for Redis container |
-| kv.image.tag | string | `"20250108"` | Redis image tag |
-| kv.loglevel | string | `"warning"` | Redis log level (debug, verbose, notice, warning) |
-| kv.maxmemory | string | `"1gb"` | Maximum memory usage for Redis |
-| kv.maxmemoryPolicy | string | `"allkeys-lru"` | Redis memory eviction policy |
-| kv.passwordSecretName | string | `""` | Secret containing password for Redis password (leave empty for auto-generation) |
+| kv | object | `{"fsGroup":"","image":{"image":"quay.io/sclorg/valkey-8-c10s","pullPolicy":"","tag":"20260121"},"loglevel":"warning","maxmemory":"1gb","maxmemoryPolicy":"allkeys-lru","passwordSecretName":""}` | Key-Value Store Configuration |
+| kv.fsGroup | string | `""` | File system group ID for Valkey pod security context |
+| kv.image.image | string | `"quay.io/sclorg/valkey-8-c10s"` | Valkey container image |
+| kv.image.pullPolicy | string | `""` | Image pull policy for Valkey container |
+| kv.image.tag | string | `"20260121"` | Valkey image tag |
+| kv.loglevel | string | `"warning"` | Valkey log level (debug, verbose, notice, warning) |
+| kv.maxmemory | string | `"1gb"` | Maximum memory usage for Valkey |
+| kv.maxmemoryPolicy | string | `"allkeys-lru"` | Valkey memory eviction policy |
+| kv.passwordSecretName | string | `""` | Secret containing password for Valkey (leave empty for auto-generation) |
 | periodic | object | `{"clusterLevelSecretAccess":false,"consumers":5,"image":{"image":"quay.io/flightctl/flightctl-periodic-el9","pullPolicy":"","tag":""},"metrics":{"address":":15690","enabled":true}}` | Periodic Configuration |
 | periodic.clusterLevelSecretAccess | bool | `false` | Allow flightctl-periodic to list/watch secrets at the cluster level for change detection |
 | periodic.consumers | int | `5` | Number of periodic consumers |

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -439,13 +439,14 @@ For more detailed configuration options, see the [Values](#values) section below
 | vulnerabilityReporting.trustify.auth.oidcIssuerUrl | string | `""` | OIDC issuer URL for client-credentials mode. |
 | vulnerabilityReporting.trustify.auth.secretName | string | `""` | Name of the Kubernetes Secret containing 'client_id' and 'client_secret' keys. |
 | vulnerabilityReporting.trustify.endpoint | string | `""` | Trustify API base URL (do not include /api/v1 or /api/v2 paths). |
-| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","passtWorkarounds":false}}` | Worker Configuration |
+| worker | object | `{"clusterLevelSecretAccess":false,"image":{"image":"quay.io/flightctl/flightctl-worker-el9","pullPolicy":"","tag":""},"vmRender":{"launcherImage":"","launcherImages":{},"passtWorkarounds":false}}` | Worker Configuration |
 | worker.clusterLevelSecretAccess | bool | `false` | Allow flightctl-worker to access secrets at the cluster level for embedding in device configs |
 | worker.image.image | string | `"quay.io/flightctl/flightctl-worker-el9"` | Worker container image |
 | worker.image.pullPolicy | string | `""` | Image pull policy for worker container |
 | worker.image.tag | string | `""` | Worker image tag |
-| worker.vmRender | object | `{"launcherImage":"","passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
+| worker.vmRender | object | `{"launcherImage":"","launcherImages":{},"passtWorkarounds":false}` | VM application render options passed to vm-to-quadlet |
 | worker.vmRender.launcherImage | string | `""` | virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default) |
+| worker.vmRender.launcherImages | object | `{}` | virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10") |
 | worker.vmRender.passtWorkarounds | bool | `false` | Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images) |
 
 ## Environment-Specific Values Files

--- a/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
+++ b/deploy/helm/flightctl/templates/worker/flightctl-worker-config.yaml
@@ -32,6 +32,12 @@ data:
             {{- if $vmRender.launcherImage }}
             launcherImage: {{ $vmRender.launcherImage | quote }}
             {{- end }}
+            {{- if $vmRender.launcherImages }}
+            launcherImages:
+            {{- range $major, $image := $vmRender.launcherImages }}
+              {{ $major | quote }}: {{ $image | quote }}
+            {{- end }}
+            {{- end }}
             passtWorkarounds: {{ if kindIs "bool" $vmRender.passtWorkarounds }}{{ $vmRender.passtWorkarounds }}{{ else }}false{{ end }}
     kv:
         hostname: flightctl-kv.{{ default .Release.Namespace .Values.global.internalNamespace }}.svc.cluster.local

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -505,6 +505,11 @@
               "type": "string",
               "description": "virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)"
             },
+            "launcherImages": {
+              "type": "object",
+              "description": "virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. \"rhel-9\", \"rhel-10\")",
+              "additionalProperties": { "type": "string" }
+            },
             "passtWorkarounds": {
               "type": "boolean",
               "description": "Enable passt networking workarounds for older virt-launcher images"

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -318,6 +318,8 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
+    # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
+    launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false
 

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -214,22 +214,22 @@ db:
 # -- Key-Value Store Configuration
 kv:
   image:
-    # -- Redis container image
-    image: quay.io/sclorg/redis-7-c9s
-    # -- Redis image tag
-    tag: "20250108"
-    # -- Image pull policy for Redis container
+    # -- Valkey container image
+    image: quay.io/sclorg/valkey-8-c10s
+    # -- Valkey image tag
+    tag: "20260121"
+    # -- Image pull policy for Valkey container
     pullPolicy: ""
-  # -- Secret containing password for Redis password (leave empty for auto-generation)
+  # -- Secret containing password for Valkey (leave empty for auto-generation)
   passwordSecretName: ""
-  # -- Redis log level (debug, verbose, notice, warning)
+  # -- Valkey log level (debug, verbose, notice, warning)
   loglevel: warning
-  # -- File system group ID for Redis pod security context
+  # -- File system group ID for Valkey pod security context
   fsGroup: ""
-  # Memory management for in-memory Redis
-  # -- Maximum memory usage for Redis
+  # Memory management for in-memory Valkey
+  # -- Maximum memory usage for Valkey
   maxmemory: "1gb"
-  # -- Redis memory eviction policy
+  # -- Valkey memory eviction policy
   maxmemoryPolicy: "allkeys-lru"
 
 # -- Alertmanager Configuration

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -214,22 +214,22 @@ db:
 # -- Key-Value Store Configuration
 kv:
   image:
-    # -- Redis container image
+    # -- Valkey container image
     image: {{ .Images.kv.Image }}
-    # -- Redis image tag
+    # -- Valkey image tag
     tag: "{{ .Images.kv.Tag}}"
-    # -- Image pull policy for Redis container
+    # -- Image pull policy for Valkey container
     pullPolicy: ""
-  # -- Secret containing password for Redis password (leave empty for auto-generation)
+  # -- Secret containing password for Valkey (leave empty for auto-generation)
   passwordSecretName: ""
-  # -- Redis log level (debug, verbose, notice, warning)
+  # -- Valkey log level (debug, verbose, notice, warning)
   loglevel: warning
-  # -- File system group ID for Redis pod security context
+  # -- File system group ID for Valkey pod security context
   fsGroup: ""
-  # Memory management for in-memory Redis
-  # -- Maximum memory usage for Redis
+  # Memory management for in-memory Valkey
+  # -- Maximum memory usage for Valkey
   maxmemory: "1gb"
-  # -- Redis memory eviction policy
+  # -- Valkey memory eviction policy
   maxmemoryPolicy: "allkeys-lru"
 
 # -- Alertmanager Configuration

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -318,6 +318,8 @@ worker:
   vmRender:
     # -- virt-launcher image used when converting VmApplications to Quadlet units (leave empty to use the worker default)
     launcherImage: ""
+    # -- virt-launcher images keyed by os-release ID and major from status.systemInfo (e.g. "rhel-9", "rhel-10")
+    launcherImages: {}
     # -- Enable passt networking workarounds for older virt-launcher images (default false; enable only for older images)
     passtWorkarounds: false
 

--- a/deploy/helm/helm-chart-opts.yaml
+++ b/deploy/helm/helm-chart-opts.yaml
@@ -12,8 +12,8 @@ community-el9:
       image: quay.io/sclorg/postgresql-16-c9s
       tag: "20250214"
     kv:
-      image: quay.io/sclorg/redis-7-c9s
-      tag: "20250108"
+      image: quay.io/sclorg/valkey-8-c10s
+      tag: "20260121"
     alertmanager:
       image: quay.io/prometheus/alertmanager
       tag: "v0.28.1"
@@ -114,7 +114,7 @@ community-el10:
     supportURL: https://github.com/flightctl/flightctl
   images:
     db:
-      image: quay.io/sclorg/postgresql-16-c10s
+      image: quay.io/sclorg/postgresql-16-c9s
       tag: "20250214"
     kv:
       image: quay.io/sclorg/valkey-8-c10s

--- a/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
+++ b/deploy/podman/flightctl-worker/flightctl-worker-config/config.yaml.template
@@ -29,6 +29,12 @@ worker:
     {{- if and .worker .worker.vmRender .worker.vmRender.launcherImage }}
     launcherImage: {{.worker.vmRender.launcherImage}}
     {{- end }}
+    {{- if and .worker .worker.vmRender .worker.vmRender.launcherImages }}
+    launcherImages:
+    {{- range $major, $image := .worker.vmRender.launcherImages }}
+      {{ printf "%q" $major }}: {{ printf "%q" $image }}
+    {{- end }}
+    {{- end }}
     passtWorkarounds: {{if and .worker .worker.vmRender}}{{if eq (printf "%v" .worker.vmRender.passtWorkarounds) "true"}}true{{else}}false{{end}}{{else}}false{{end}}
 
 

--- a/deploy/podman/flightctl.target
+++ b/deploy/podman/flightctl.target
@@ -25,6 +25,7 @@ Wants=flightctl-certs-init.service
 Wants=flightctl-telemetry-gateway.service
 Wants=flightctl-imagebuilder-api.service
 Wants=flightctl-imagebuilder-worker.service
+Wants=flightctl-remote-access.service
 Wants=flightctl-gateway.service
 
 After=network.target
@@ -47,6 +48,7 @@ After=flightctl-certs-init.service
 After=flightctl-telemetry-gateway.service
 After=flightctl-imagebuilder-api.service
 After=flightctl-imagebuilder-worker.service
+After=flightctl-remote-access.service
 After=flightctl-gateway.service
 
 [Install]

--- a/deploy/podman/service-config.yaml
+++ b/deploy/podman/service-config.yaml
@@ -115,12 +115,18 @@ prometheus:
 
 # Worker VM render options (optional). Uncomment to override defaults.
 # Leave launcherImage unset to use the worker built-in default
-# (quay.io/kubevirt/virt-launcher:v1.9.0). In air-gapped environments, mirror
-# virt-launcher to a registry devices can pull from and set launcherImage to that reference.
+# (quay.io/kubevirt/virt-launcher:v1.9.0). launcherImages selects by os-release
+# ID and major from status.systemInfo (e.g. rhel + "9.5 (Plow)" -> "rhel-9").
+# Other OS keys (fedora-42, ubuntu-24) are only used if you add them.
+# In air-gapped environments, mirror virt-launcher and set these references
+# to the mirrored location.
 # Enable passtWorkarounds only when using older virt-launcher images that need it.
 # worker:
 #   vmRender:
 #     launcherImage: ""
+#     launcherImages:
+#       "rhel-9": ""
+#       "rhel-10": ""
 #     passtWorkarounds: false
 
 # ImageBuilder Worker (optional). Uncomment and set when using custom builder images, SBOM, or skip-TLS.

--- a/docs/user/installing/air-gapped-installation.md
+++ b/docs/user/installing/air-gapped-installation.md
@@ -273,9 +273,10 @@ full workflow.
 
 Devices pull the KubeVirt virt-launcher image when they run VM applications. That
 image is **not** included in the default `flightctl-mirror-images` control-plane
-set. Mirror it to a registry devices can reach, set `worker.vmRender.launcherImage`
-to the mirrored reference, and re-render affected devices. Guest OS and other
-workload images still need separate mirroring.
+set. Mirror the default image and any per-OS images you pin in
+`worker.vmRender.launcherImages`, set `worker.vmRender.launcherImage` (and the
+map, if used) to the mirrored references, and re-render affected devices. Guest OS
+and other workload images still need separate mirroring.
 
 See [VM application rendering in air-gapped environments](configuring-vm-render.md#air-gapped-environments).
 

--- a/docs/user/installing/configuring-vm-render.md
+++ b/docs/user/installing/configuring-vm-render.md
@@ -1,15 +1,41 @@
 # Configuring VM application rendering
 
-The Flight Control worker converts `VmApplication` manifests into Quadlet units with `vm-to-quadlet` before devices receive the rendered application. You can configure the virt-launcher image and passt workarounds used during that conversion.
+The Flight Control worker converts `VmApplication` manifests into Quadlet units with `vm-to-quadlet` before devices receive the rendered application. You can configure the virt-launcher image, optional per-OS images, and passt workarounds used during that conversion.
 
 ## Defaults
 
 | Setting | Default |
 | ------- | ------- |
 | `launcherImage` | `quay.io/kubevirt/virt-launcher:v1.9.0` (built into the worker; leave config unset or empty to use it) |
+| `launcherImages` | empty (no per-OS pins) |
 | `passtWorkarounds` | `false` |
 
-`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when you override `launcherImage` to an older image that still requires the workaround.
+`passtWorkarounds` enables startup patches for known networking issues in older virt-launcher passt builds (for example guest network instability and related passt failures). The default virt-launcher image does not need this. Enable it only when the selected `launcherImage` or `launcherImages` entry is an older image that still requires the workaround.
+
+## How the worker selects an image
+
+At render time the worker builds a key from device `status.systemInfo`:
+
+- `distroId` (os-release `ID`, for example `rhel` or `fedora`)
+- The leading major digits of `distroVersion` (os-release `VERSION`, for example `9.5` yields `9`)
+
+The key is `{distroId}-{major}`. Examples:
+
+| Device reports | Key |
+| -------------- | --- |
+| `distroId: rhel`, `distroVersion: 9.5` | `rhel-9` |
+| `distroId: rhel`, `distroVersion: 10.0` | `rhel-10` |
+| `distroId: fedora`, `distroVersion: 42` | `fedora-42` |
+
+The worker then chooses an image in this order:
+
+1. The matching entry in `launcherImages`, if that key is present and non-empty.
+2. `launcherImage`, if set.
+3. The built-in default.
+
+Keys are exact. A Fedora 42 device does not use a `rhel-9` pin. Devices that do not report `distroId` (or whose OS is not in the map) use `launcherImage` or the built-in default.
+
+Selection runs only when the worker renders a device (fleet rollout, spec change, and similar). A status-only `distroId` / `distroVersion` update does not trigger a new render. After an in-place OS major upgrade, trigger a re-render (for example by bumping the fleet template). An agent status PUT is not enough.
 
 ## Prerequisites
 
@@ -19,24 +45,43 @@ The Flight Control worker converts `VmApplication` manifests into Quadlet units 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `worker.vmRender.launcherImage` | string | Container image reference for the KubeVirt virt-launcher compute container. Leave empty to use the worker built-in default. |
+| `worker.vmRender.launcherImage` | string | Default virt-launcher image when `launcherImages` has no match. Leave empty to use the worker built-in default. |
+| `worker.vmRender.launcherImages` | object | Optional map of virt-launcher images keyed by `{distroId}-{major}` from `status.systemInfo` (for example `"rhel-9"`, `"rhel-10"`). |
 | `worker.vmRender.passtWorkarounds` | boolean | When `true`, enable passt networking workarounds in generated Quadlet units. |
 
 ## Kubernetes (Helm)
 
-Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you need an override:
+Set the values under `worker.vmRender`. Leave `launcherImage` empty unless you need an override. Leave `launcherImages` empty unless you pin images per OS:
 
 ```yaml
 worker:
   vmRender:
     launcherImage: ""
+    launcherImages: {}
     passtWorkarounds: false
 ```
+
+To pin images for mixed OS fleets:
+
+```yaml
+worker:
+  vmRender:
+    launcherImage: ""
+    launcherImages:
+      "rhel-9": "<registry>/virt-launcher-rhel9:<tag>"
+      "rhel-10": "<registry>/virt-launcher-rhel10:<tag>"
+    passtWorkarounds: false
+```
+
+Replace `<registry>` and `<tag>` with the image repository and tag that devices can pull.
 
 Apply the chart upgrade, then restart the worker so it reloads configuration:
 
 ```bash
 helm upgrade flightctl ./deploy/helm/flightctl -n <namespace> -f values.yaml
+```
+
+```bash
 kubectl rollout restart deployment/flightctl-worker -n <namespace>
 ```
 
@@ -47,6 +92,17 @@ Edit `/etc/flightctl/service-config.yaml` only when you need overrides. Omit `la
 ```yaml
 worker:
   vmRender:
+    passtWorkarounds: false
+```
+
+To pin images per OS, add `launcherImages` under the same `vmRender` block:
+
+```yaml
+worker:
+  vmRender:
+    launcherImages:
+      "rhel-9": "<registry>/virt-launcher-rhel9:<tag>"
+      "rhel-10": "<registry>/virt-launcher-rhel10:<tag>"
     passtWorkarounds: false
 ```
 
@@ -62,14 +118,17 @@ The default virt-launcher image is pulled by devices when they run VM applicatio
 
 In an air-gapped deployment:
 
-1. Mirror `quay.io/kubevirt/virt-launcher:v1.9.0` (or your chosen virt-launcher image) to a registry that devices can reach.
-2. Set `worker.vmRender.launcherImage` to that mirrored reference so rendered Quadlet units pull from the mirror.
-3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image reference.
+1. Mirror each virt-launcher image you will use to a registry that devices can reach. Mirror the default image and every image you pin in `launcherImages`.
+2. Set `worker.vmRender.launcherImage` to the mirrored default. Set `worker.vmRender.launcherImages` to the mirrored per-OS references.
+3. Restart the worker, then re-render devices that already have VM applications so they pick up the new image references.
 
 Example (community / upstream registry):
 
 ```bash
 INTERNAL=registry.example.com:5000
+```
+
+```bash
 skopeo copy --all \
   docker://quay.io/kubevirt/virt-launcher:v1.9.0 \
   docker://${INTERNAL}/kubevirt/virt-launcher:v1.9.0
@@ -79,14 +138,19 @@ skopeo copy --all \
 worker:
   vmRender:
     launcherImage: "registry.example.com:5000/kubevirt/virt-launcher:v1.9.0"
+    launcherImages:
+      "rhel-9": "registry.example.com:5000/kubevirt/virt-launcher-rhel9:<tag>"
+      "rhel-10": "registry.example.com:5000/kubevirt/virt-launcher-rhel10:<tag>"
     passtWorkarounds: false
 ```
 
-There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` at the mirrored location.
+Omit `launcherImages` if every device should use the single mirrored `launcherImage`.
+
+There is currently no separate Red Hat product virt-launcher image in the Flight Control packaging set. Use the upstream `quay.io/kubevirt/virt-launcher` reference, or another virt-launcher image you supply, and point `launcherImage` and `launcherImages` at the mirrored location.
 
 ## After changing settings
 
-Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage` or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings.
+Conversion results are cached by `vm.yaml` content and these render options. Changing `launcherImage`, `launcherImages`, or `passtWorkarounds` affects newly rendered devices. Re-render existing devices (for example by updating the device or fleet) if they must pick up the new settings. The same applies after an OS major change: the new `launcherImages` key is used on the next render, not when the agent reports the new `distroId` / `distroVersion`.
 
 ## Related information
 

--- a/docs/user/installing/installing-agent.md
+++ b/docs/user/installing/installing-agent.md
@@ -102,7 +102,7 @@ The agent's configuration file `/etc/flightctl/config.yaml` takes the following 
 | `status-update-interval` | `Duration` | | Interval in which the agent reports its device status under normal conditions. The agent immediately sends status reports on major events related to the health of the system and application workloads as well as on the progress during a system update. Default: `60s` |
 | `default-labels`         | `object` (`string`) | | Labels (`key: value`-pairs) that the agent requests for the device during enrollment. **Important:** Label values must be valid Kubernetes labels (alphanumeric, `-`, `_`, `.`, max 63 chars). Invalid labels are skipped with an error log. Default: `{}` |
 | `label-from-systeminfo`  | `object` (`string`) | | Maps system information fields to device labels at enrollment time. See [Enrollment-time label mapping](#enrollment-time-label-mapping). Default: `{}` |
-| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
+| `system-info`            | `array` (`string`) | | System info that the agent shall include in status updates from built-in collectors. See [Built-in system info collectors](#built-in-system-info-collectors) and [Managed system-info collectors](#managed-system-info-collectors). Default: `["hostname", "kernel", "distroName", "distroVersion", "distroId", "productName", "productUuid", "productSerial", "netInterfaceDefault", "netIpDefault", "netMacDefault", "managementCertNotAfter", "managementCertSerial", "tpmVendorInfo"]` |
 | `system-info-custom`     | `array` (`string`) | | System info that the agent shall include in status updates from user-defined collectors. See [Custom system info collectors](#custom-system-info-collectors). Default: `[]` |
 | `system-info-timeout`    | `Duration` | | The timeout for collecting system info. Default: `2m`. Maximum: `2m` |
 | `pull-timeout`           | `Duration` | | The timeout for pulling a single OCI target. Default: `10m` |
@@ -160,6 +160,7 @@ You can specify extra system infos to be included in the device status by listin
 | `kernel`              | The running Linux kernel version                                  |
 | `distroName`          | The name of the operating system distribution.                    |
 | `distroVersion`       | The version of the operating system distribution                  |
+| `distroId`            | The os-release `ID` (for example `rhel` or `fedora`). Used with `distroVersion` to select `launcherImages` keys such as `rhel-9`. See [Configuring VM application rendering](configuring-vm-render.md). |
 | `productName`         | The system’s product or model name (from DMI data)                |
 | `productSerial`       | The hardware serial number (if available)                         |
 | `productUuid`         | The UUID of the system board or chassis                           |
@@ -177,7 +178,7 @@ You can specify extra system infos to be included in the device status by listin
 For example, if you add the following parameter to your agent's `config.yaml`
 
 ```console
-system-info: [hostname, kernel, distroName, distroVersion]
+system-info: [hostname, kernel, distroName, distroVersion, distroId]
 ```
 
 then the reported device status might look like
@@ -194,6 +195,7 @@ status:
     kernel: 5.14.0-503.38.1.el9_5.x86_64
     distroName: Red Hat Enterprise Linux
     distroVersion: 9.5 (Plow)
+    distroId: rhel
 ```
 
 ## Managed system info collectors

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -819,7 +819,7 @@ To deploy a VM application, add an entry to the `applications` section of the de
 | `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
 
 > [!NOTE]
-> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure the virt-launcher image and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
+> The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure a default virt-launcher image, optional per-OS images, and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
 
 > [!NOTE]
 > The `spec.running` field in `vm.yaml` is ignored. Use [application lifecycle](#managing-application-lifecycle) commands (`flightctl app start` / `stop` / `restart`) to control whether the VM is running.

--- a/hack/build_flightctl-base.sh
+++ b/hack/build_flightctl-base.sh
@@ -2,25 +2,42 @@
 set -euo pipefail
 
 IMAGE_REPO=${IMAGE_REPO:-quay.io/flightctl/flightctl-base}
-IMAGE_TAG=9.7-1762965531
+read -r -a image_tags <<< "${IMAGE_TAGS:-"9.7-1762965531 10.1-1769518576"}"
+read -r -a arches <<< "${ARCHES:-"amd64 arm64"}"
 
-arch=$(uname -m)
-case $arch in
-    x86_64) arch=amd64;;
-    aarch64) arch=arm64;;
-esac
+CONTAINERS_TO_CLEAN=()
+cleanup() {
+    for c in "${CONTAINERS_TO_CLEAN[@]}"; do
+        buildah umount "$c" 2>/dev/null || true
+        buildah rm "$c" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
 
-container=$(buildah from registry.redhat.io/ubi9-micro:$IMAGE_TAG)
+for IMAGE_TAG in "${image_tags[@]}"; do
+    UBI_MAJOR=${IMAGE_TAG%%.*}
+    UBI_BASE=registry.redhat.io/ubi${UBI_MAJOR}-micro:${IMAGE_TAG}
 
-mountdir=$(buildah mount $container)
-dnf install \
-    --installroot $mountdir \
-    --releasever 9 \
-    --setopt install_weak_deps=false \
-    --nodocs -y \
-    openssl-libs tzdata
-dnf clean all \
-    --installroot $mountdir
-buildah umount $container
+    for arch in "${arches[@]}"; do
+        forcearch=$(case "$arch" in amd64) echo x86_64;; arm64) echo aarch64;; *) echo "$arch";; esac)
+        container=$(buildah from --arch "$arch" "$UBI_BASE")
+        CONTAINERS_TO_CLEAN+=("$container")
+        mountdir=$(buildah mount "$container")
+        dnf install --installroot "$mountdir" --releasever "$UBI_MAJOR" \
+            --setopt install_weak_deps=false --forcearch "$forcearch" --nodocs -y \
+            openssl-libs tzdata
+        dnf clean all --installroot "$mountdir"
+        buildah umount "$container"
+        buildah commit "$container" "$IMAGE_REPO:${arch}-${IMAGE_TAG}"
+        buildah rm "$container"
+        unset 'CONTAINERS_TO_CLEAN[-1]'
+    done
 
-buildah commit $container $IMAGE_REPO:$arch-$IMAGE_TAG
+    buildah manifest rm "$IMAGE_REPO:${IMAGE_TAG}" 2>/dev/null || true
+    buildah rmi "$IMAGE_REPO:${IMAGE_TAG}" 2>/dev/null || true
+    buildah manifest create "$IMAGE_REPO:${IMAGE_TAG}"
+    for arch in "${arches[@]}"; do
+        buildah manifest add "$IMAGE_REPO:${IMAGE_TAG}" "$IMAGE_REPO:${arch}-${IMAGE_TAG}"
+    done
+    buildah manifest push --all "$IMAGE_REPO:${IMAGE_TAG}" "docker://$IMAGE_REPO:${IMAGE_TAG}"
+done

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -214,6 +214,7 @@ var DefaultSystemInfo = append([]string{
 	systeminfocommon.KernelKey,
 	systeminfocommon.DistroNameKey,
 	systeminfocommon.DistroVersionKey,
+	systeminfocommon.DistroIdKey,
 	systeminfocommon.ProductNameKey,
 	systeminfocommon.ProductUUIDKey,
 	systeminfocommon.ProductSerialKey,

--- a/internal/agent/device/systeminfo/common/types.go
+++ b/internal/agent/device/systeminfo/common/types.go
@@ -36,6 +36,7 @@ const (
 	// Distribution info keys
 	DistroNameKey    = "distroName"
 	DistroVersionKey = "distroVersion"
+	DistroIdKey      = "distroId"
 
 	// Identity / security (runtime/conditional collectors)
 	ManagementCertNotAfterKey = "managementCertNotAfter"
@@ -110,6 +111,7 @@ var builtInKeys = newKeySet(
 	ProductSerialKey,
 	DistroNameKey,
 	DistroVersionKey,
+	DistroIdKey,
 )
 
 var allKeys = unionKeySets(builtInKeys, runtimeKeys)

--- a/internal/agent/device/systeminfo/system_info.go
+++ b/internal/agent/device/systeminfo/system_info.go
@@ -422,7 +422,7 @@ func collectionOptsFromInfoKeys(infoKeys []string) ([]CollectOpt, error) {
 			opts = append(opts, withCollector(collectorSystem, collectSystemFunc))
 		case common.KernelKey:
 			opts = append(opts, withCollector(collectorKernel, collectKernelFunc))
-		case common.DistroNameKey, common.DistroVersionKey:
+		case common.DistroNameKey, common.DistroVersionKey, common.DistroIdKey:
 			opts = append(opts, withCollector(collectorDistribution, collectDistributionFunc))
 		case common.HostnameKey, common.ArchitectureKey:
 			// No specific collector needed - hostname and architecture are always collected
@@ -542,6 +542,18 @@ var SupportedInfoKeys = map[string]func(info *Info) string{
 			return ""
 		}
 		if val, ok := i.Distribution["version"]; ok {
+			if str, ok := val.(string); ok {
+				return str
+			}
+			return fmt.Sprint(val)
+		}
+		return ""
+	},
+	common.DistroIdKey: func(i *Info) string {
+		if i.Distribution == nil {
+			return ""
+		}
+		if val, ok := i.Distribution["id"]; ok {
 			if str, ok := val.(string); ok {
 				return str
 			}

--- a/internal/agent/device/systeminfo/system_info_test.go
+++ b/internal/agent/device/systeminfo/system_info_test.go
@@ -240,7 +240,7 @@ func TestGetCollectionOptsFromInfoKeys(t *testing.T) {
 		},
 		{
 			name:         "distribution keys",
-			infoKeys:     []string{common.DistroNameKey, common.DistroVersionKey},
+			infoKeys:     []string{common.DistroNameKey, common.DistroVersionKey, common.DistroIdKey},
 			expectDistro: true,
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,8 +415,9 @@ type workerConfig struct {
 // vmRenderConfig holds options for converting VmApplications to Quadlet units
 // via vm-to-quadlet.
 type vmRenderConfig struct {
-	LauncherImage    string `json:"launcherImage,omitempty"`
-	PasstWorkarounds *bool  `json:"passtWorkarounds,omitempty"`
+	LauncherImage    string            `json:"launcherImage,omitempty"`
+	LauncherImages   map[string]string `json:"launcherImages,omitempty"`
+	PasstWorkarounds *bool             `json:"passtWorkarounds,omitempty"`
 }
 
 // NewDefaultWorkerConfig returns the default flightctl-worker configuration.
@@ -431,11 +432,13 @@ func NewDefaultWorkerConfig() *workerConfig {
 }
 
 // EffectiveVmLauncherImage returns the virt-launcher image used for VM render.
-func (c *Config) EffectiveVmLauncherImage() string {
+// osKey is "{os-release ID}-{major}" from status.systemInfo (e.g. "rhel-9").
+// An empty osKey skips per-OS lookup.
+func (c *Config) EffectiveVmLauncherImage(osKey string) string {
 	if c == nil || c.Worker == nil {
 		return DefaultVirtLauncherImage
 	}
-	return c.Worker.EffectiveLauncherImage()
+	return c.Worker.EffectiveLauncherImage(osKey)
 }
 
 // EffectiveVmPasstWorkarounds returns whether passt workarounds are enabled for VM render.
@@ -446,9 +449,17 @@ func (c *Config) EffectiveVmPasstWorkarounds() bool {
 	return c.Worker.EffectivePasstWorkarounds()
 }
 
-// EffectiveLauncherImage returns the virt-launcher image (config override or default).
-func (c *workerConfig) EffectiveLauncherImage() string {
-	if c != nil && c.VmRender != nil && c.VmRender.LauncherImage != "" {
+// EffectiveLauncherImage returns the virt-launcher image for osKey.
+func (c *workerConfig) EffectiveLauncherImage(osKey string) string {
+	if c == nil || c.VmRender == nil {
+		return DefaultVirtLauncherImage
+	}
+	if osKey != "" && c.VmRender.LauncherImages != nil {
+		if img := c.VmRender.LauncherImages[osKey]; img != "" {
+			return img
+		}
+	}
+	if c.VmRender.LauncherImage != "" {
 		return c.VmRender.LauncherImage
 	}
 	return DefaultVirtLauncherImage

--- a/internal/config/vm_render_test.go
+++ b/internal/config/vm_render_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveVmLauncherImage(t *testing.T) {
+	t.Parallel()
+
+	rhel9 := "registry.example.com/virt-launcher-rhel9:v1"
+	rhel10 := "registry.example.com/virt-launcher-rhel10:v1"
+	pinned := "registry.example.com/virt-launcher:pinned"
+
+	tests := []struct {
+		name  string
+		json  string
+		osKey string
+		want  string
+	}{
+		{
+			name:  "When config is empty it should use the built-in default",
+			json:  `{}`,
+			osKey: "rhel-9",
+			want:  DefaultVirtLauncherImage,
+		},
+		{
+			name: "When launcherImage is set and no per-OS map it should use launcherImage",
+			json: `{
+				"worker": {"vmRender": {"launcherImage": "` + pinned + `"}}
+			}`,
+			osKey: "rhel-10",
+			want:  pinned,
+		},
+		{
+			name: "When launcherImages has the device OS key it should use that image",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImages": {"rhel-9": "` + rhel9 + `", "rhel-10": "` + rhel10 + `"}
+				}}
+			}`,
+			osKey: "rhel-10",
+			want:  rhel10,
+		},
+		{
+			name: "When the OS is not in launcherImages it should use launcherImage",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImage": "` + pinned + `",
+					"launcherImages": {"rhel-9": "` + rhel9 + `"}
+				}}
+			}`,
+			osKey: "fedora-42",
+			want:  pinned,
+		},
+		{
+			name: "When osKey is empty it should ignore launcherImages",
+			json: `{
+				"worker": {"vmRender": {
+					"launcherImage": "` + pinned + `",
+					"launcherImages": {"rhel-9": "` + rhel9 + `"}
+				}}
+			}`,
+			osKey: "",
+			want:  pinned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{}
+			require.NoError(t, json.Unmarshal([]byte(tt.json), cfg))
+			assert.Equal(t, tt.want, cfg.EffectiveVmLauncherImage(tt.osKey))
+		})
+	}
+}

--- a/internal/imagebuilder_worker/tasks/imageexport.go
+++ b/internal/imagebuilder_worker/tasks/imageexport.go
@@ -509,6 +509,7 @@ func (c *Consumer) startBootcImageBuilderContainer(
 		"run", "-d", "--rm",
 		"--name", containerName,
 		"--privileged",
+		"--net=host",
 		"--pull=newer",
 		"--entrypoint", "sleep",
 		"--security-opt", "label=type:unconfined_t",

--- a/internal/service/enrollmentrequest/handler.go
+++ b/internal/service/enrollmentrequest/handler.go
@@ -190,6 +190,9 @@ func addStatusIfNeeded(enrollmentRequest *domain.EnrollmentRequest) {
 func (h *ServiceHandler) createDeviceFromEnrollmentRequest(ctx context.Context, orgId uuid.UUID, enrollmentRequest *domain.EnrollmentRequest) error {
 	deviceStatus := domain.NewDeviceStatus()
 	deviceStatus.Lifecycle = domain.DeviceLifecycleStatus{Status: "Enrolled"}
+	if enrollmentRequest.Spec.DeviceStatus != nil {
+		deviceStatus.SystemInfo = enrollmentRequest.Spec.DeviceStatus.SystemInfo
+	}
 
 	// Check if TPM was verified during enrollment request creation
 	isTPMVerified := false

--- a/internal/service/enrollmentrequest/handler_test.go
+++ b/internal/service/enrollmentrequest/handler_test.go
@@ -582,6 +582,138 @@ func TestCreateDeviceFromEnrollmentRequestOsMode(t *testing.T) {
 	}
 }
 
+func TestCreateDeviceFromEnrollmentRequestSystemInfo(t *testing.T) {
+	t.Run("When DeviceStatus is nil it should create the device with empty systemInfo", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "no-status-device"
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec:     domain.EnrollmentRequestSpec{Csr: "TestCSR"},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.NotNil(t, device.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.False(t, found)
+		require.Empty(t, id)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+
+	t.Run("When systemInfo has distroId it should copy it onto the device", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "rhel9-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.SystemInfo.AgentVersion = "v1.2.3"
+		enrollmentStatus.SystemInfo.OperatingSystem = "linux"
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.NotNil(t, device.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+		version, found := device.Status.SystemInfo.Get("distroVersion")
+		require.True(t, found)
+		require.Equal(t, "9.5 (Plow)", version)
+		require.Equal(t, "v1.2.3", device.Status.SystemInfo.AgentVersion)
+		require.Equal(t, "linux", device.Status.SystemInfo.OperatingSystem)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+
+	t.Run("When enrollment reports integrity verified it should still set integrity from TPM result", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "integrity-overlay-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.Integrity = domain.DeviceIntegrityStatus{
+			Status: domain.DeviceIntegrityStatusVerified,
+		}
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.Equal(t, domain.DeviceIntegrityStatusUnsupported, device.Status.Integrity.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+	})
+
+	t.Run("When awaitingReconnect is set it should keep systemInfo and set awaiting reconnect summary", func(t *testing.T) {
+		h, _, fakeDevices, _, _ := newTestHandler(t)
+		ctx := context.Background()
+		orgId := uuid.New()
+		deviceName := "reconnect-device"
+
+		enrollmentStatus := domain.NewDeviceStatus()
+		enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+		enrollmentStatus.SystemInfo.Set("distroVersion", "10.0 (Coughlan)")
+
+		er := &domain.EnrollmentRequest{
+			Metadata: domain.ObjectMeta{
+				Name: lo.ToPtr(deviceName),
+				Annotations: &map[string]string{
+					domain.DeviceAnnotationAwaitingReconnect: "true",
+				},
+			},
+			Spec: domain.EnrollmentRequestSpec{
+				Csr:          "TestCSR",
+				DeviceStatus: &enrollmentStatus,
+			},
+		}
+
+		err := h.createDeviceFromEnrollmentRequest(ctx, orgId, er)
+		require.NoError(t, err)
+
+		device, err := fakeDevices.Get(ctx, orgId, deviceName)
+		require.NoError(t, err)
+		require.Equal(t, domain.DeviceSummaryStatusAwaitingReconnect, device.Status.Summary.Status)
+		id, found := device.Status.SystemInfo.Get("distroId")
+		require.True(t, found)
+		require.Equal(t, "rhel", id)
+		version, found := device.Status.SystemInfo.Get("distroVersion")
+		require.True(t, found)
+		require.Equal(t, "10.0 (Coughlan)", version)
+		require.Equal(t, domain.DeviceLifecycleStatusEnrolled, device.Status.Lifecycle.Status)
+	})
+}
+
 // TestCreateDeviceFromEnrollmentRequestNeverManaged is a regression guard for the deviceOnlyStore
 // adapter's safety invariant: createDeviceFromEnrollmentRequest must never set Metadata.Owner on
 // the device it builds. deviceOnlyStore only overrides Device() on its embedded nil store.Store;

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -65,25 +65,26 @@ func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, devi
 }
 
 type DeviceRenderLogic struct {
-	log             logrus.FieldLogger
-	deviceSvc       deviceservice.Service
-	repositorySvc   repositoryservice.Service
-	catalogSvc      catalogservice.Service
-	k8sClient       k8sclient.K8SClient
-	kvStore         kvstore.KVStore
-	cfg             *config.Config
-	orgId           uuid.UUID
-	event           domain.Event
-	ownerFleet      *string
-	templateVersion *string
-	deviceConfig    *[]domain.ConfigProviderSpec
-	applications    *[]domain.ApplicationProviderSpec
-	vmConverter     VmConverterFn
-	vmRenderOptions VmRenderOptions
+	log               logrus.FieldLogger
+	deviceSvc         deviceservice.Service
+	repositorySvc     repositoryservice.Service
+	catalogSvc        catalogservice.Service
+	k8sClient         k8sclient.K8SClient
+	kvStore           kvstore.KVStore
+	cfg               *config.Config
+	orgId             uuid.UUID
+	event             domain.Event
+	ownerFleet        *string
+	templateVersion   *string
+	deviceConfig      *[]domain.ConfigProviderSpec
+	applications      *[]domain.ApplicationProviderSpec
+	vmConverter       VmConverterFn
+	vmRenderOptions   VmRenderOptions
+	customVmConverter bool
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
-	opts := vmRenderOptionsFromConfig(cfg)
+	opts := vmRenderOptionsFromConfig(cfg, "")
 	return DeviceRenderLogic{
 		log:             log,
 		deviceSvc:       deviceSvc,
@@ -105,7 +106,17 @@ func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Servic
 // NewVmConverter.
 func (t DeviceRenderLogic) WithVmConverter(fn VmConverterFn) DeviceRenderLogic {
 	t.vmConverter = fn
+	t.customVmConverter = true
 	return t
+}
+
+func (t *DeviceRenderLogic) bindVmLauncher(device *domain.Device) {
+	opts := vmRenderOptionsFromConfig(t.cfg, osKeyFromDevice(device))
+	t.vmRenderOptions = opts
+	if t.customVmConverter {
+		return
+	}
+	t.vmConverter = NewVmConverter(vmToQuadletBinary, opts)
 }
 
 //nolint:gocyclo
@@ -115,8 +126,10 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		return fmt.Errorf("failed getting device %s/%s: %s", t.orgId, t.event.InvolvedObject.Name, status.Message)
 	}
 
-	// Calculate hash including device spec to detect changes
-	specHash := hashRenderedWithSpec(device.Spec)
+	t.bindVmLauncher(device)
+
+	// Calculate hash including device spec and selected virt-launcher image.
+	specHash := hashRenderedWithSpec(device.Spec, t.vmRenderOptions.LauncherImage)
 
 	// bypassHashCheck is true for event reasons that must always produce a fresh render even
 	// though specHash (computed from device.Spec alone) hasn't changed: dependency changes and
@@ -1032,12 +1045,17 @@ func ignitionConfigToRenderedConfig(ignition *config_latest_types.Config) ([]byt
 	return renderedConfig, nil
 }
 
-// hashRenderedWithSpec creates a hash of the device spec to detect changes
-func hashRenderedWithSpec(deviceSpec *domain.DeviceSpec) string {
+// hashRenderedWithSpec creates a hash of the device spec and selected
+// virt-launcher image so an OS-major change re-renders VM applications.
+func hashRenderedWithSpec(deviceSpec *domain.DeviceSpec, launcherImage string) string {
 	if deviceSpec == nil {
 		return ""
 	}
-	specBytes, _ := json.Marshal(deviceSpec)
+	payload := struct {
+		Spec          *domain.DeviceSpec `json:"spec"`
+		LauncherImage string             `json:"launcherImage"`
+	}{deviceSpec, launcherImage}
+	specBytes, _ := json.Marshal(payload)
 	hash := sha256.Sum256(specBytes)
 	return hex.EncodeToString(hash[:])
 }

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -724,7 +724,7 @@ func TestRenderDevice_PermanentError(t *testing.T) {
 
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{
@@ -811,7 +811,7 @@ func TestRenderDevice_PermanentError_StandaloneDevice(t *testing.T) {
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{
@@ -900,7 +900,7 @@ func TestRenderDevice_PermanentAppError(t *testing.T) {
 	mockSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 
-	specHash := hashRenderedWithSpec(device.Spec)
+	specHash := hashRenderedWithSpec(device.Spec, config.DefaultVirtLauncherImage)
 	mockSvc.EXPECT().UpdateDeviceAnnotations(
 		gomock.Any(), orgId, deviceName,
 		map[string]string{

--- a/internal/tasks/device_render_vm.go
+++ b/internal/tasks/device_render_vm.go
@@ -44,11 +44,48 @@ func DefaultVmRenderOptions() VmRenderOptions {
 	}
 }
 
-func vmRenderOptionsFromConfig(cfg *config.Config) VmRenderOptions {
+func vmRenderOptionsFromConfig(cfg *config.Config, osKey string) VmRenderOptions {
 	return VmRenderOptions{
-		LauncherImage:    cfg.EffectiveVmLauncherImage(),
+		LauncherImage:    cfg.EffectiveVmLauncherImage(osKey),
 		PasstWorkarounds: cfg.EffectiveVmPasstWorkarounds(),
 	}
+}
+
+const (
+	deviceDistroVersionKey = "distroVersion"
+	deviceDistroIdKey      = "distroId"
+)
+
+func osKeyFromDevice(device *domain.Device) string {
+	if device == nil || device.Status == nil {
+		return ""
+	}
+	id, _ := device.Status.SystemInfo.Get(deviceDistroIdKey)
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "" {
+		return ""
+	}
+	version, _ := device.Status.SystemInfo.Get(deviceDistroVersionKey)
+	major := parseDistroMajor(version)
+	if major == "" {
+		return ""
+	}
+	return id + "-" + major
+}
+
+func parseDistroMajor(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	end := 0
+	for end < len(version) && version[end] >= '0' && version[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return ""
+	}
+	return version[:end]
 }
 
 // limitedWriter wraps a bytes.Buffer and returns an error once more than limit

--- a/internal/tasks/device_render_vm_test.go
+++ b/internal/tasks/device_render_vm_test.go
@@ -478,6 +478,114 @@ func TestVmRenderOptionsFromConfig(t *testing.T) {
 	assert.False(t, defaults.vmRenderOptions.PasstWorkarounds)
 }
 
+func TestParseDistroMajor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "When VERSION is RHEL 9 pretty string it should return 9", version: "9.5 (Plow)", want: "9"},
+		{name: "When VERSION is RHEL 10 pretty string it should return 10", version: "10.0 (Coughlan)", want: "10"},
+		{name: "When VERSION is a bare major it should return it", version: "9", want: "9"},
+		{name: "When VERSION has leading space it should trim", version: " 10.1", want: "10"},
+		{name: "When VERSION is empty it should return empty", version: "", want: ""},
+		{name: "When VERSION has no leading digits it should return empty", version: "Plow", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseDistroMajor(tt.version))
+		})
+	}
+}
+
+func TestOsKeyFromDevice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When status is missing it should return empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, osKeyFromDevice(&domain.Device{}))
+	})
+
+	t.Run("When distroId and distroVersion are reported it should return id-major", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroIdKey, "rhel")
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "9.5 (Plow)")
+		assert.Equal(t, "rhel-9", osKeyFromDevice(device))
+	})
+
+	t.Run("When distroId is fedora it should not look like rhel", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroIdKey, "fedora")
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "42 (Adams)")
+		assert.Equal(t, "fedora-42", osKeyFromDevice(device))
+	})
+
+	t.Run("When distroId is missing it should return empty", func(t *testing.T) {
+		t.Parallel()
+		device := &domain.Device{Status: &domain.DeviceStatus{}}
+		device.Status.SystemInfo.Set(deviceDistroVersionKey, "9.5 (Plow)")
+		assert.Empty(t, osKeyFromDevice(device))
+	})
+}
+
+func TestBindVmLauncher_SelectsPerOSImage(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"worker": {
+			"vmRender": {
+				"launcherImages": {
+					"rhel-9": "registry.example.com/virt-launcher-rhel9:v1",
+					"rhel-10": "registry.example.com/virt-launcher-rhel10:v1"
+				}
+			}
+		}
+	}`), cfg))
+
+	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
+	device := &domain.Device{Status: &domain.DeviceStatus{}}
+	device.Status.SystemInfo.Set(deviceDistroIdKey, "rhel")
+	device.Status.SystemInfo.Set(deviceDistroVersionKey, "10.0 (Coughlan)")
+	logic.bindVmLauncher(device)
+	assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", logic.vmRenderOptions.LauncherImage)
+}
+
+func TestBindVmLauncher_UnknownOSUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"worker": {
+			"vmRender": {
+				"launcherImages": {
+					"rhel-9": "registry.example.com/virt-launcher-rhel9:v1"
+				}
+			}
+		}
+	}`), cfg))
+
+	logic := NewDeviceRenderLogic(logrus.New(), nil, nil, nil, nil, nil, cfg, [16]byte{}, domain.Event{})
+	device := &domain.Device{Status: &domain.DeviceStatus{}}
+	device.Status.SystemInfo.Set(deviceDistroIdKey, "fedora")
+	device.Status.SystemInfo.Set(deviceDistroVersionKey, "42 (Adams)")
+	logic.bindVmLauncher(device)
+	assert.Equal(t, config.DefaultVirtLauncherImage, logic.vmRenderOptions.LauncherImage)
+}
+
+func TestHashRenderedWithSpec_IncludesLauncherImage(t *testing.T) {
+	t.Parallel()
+	spec := &domain.DeviceSpec{}
+	hash9 := hashRenderedWithSpec(spec, "image-rhel9")
+	hash10 := hashRenderedWithSpec(spec, "image-rhel10")
+	assert.NotEmpty(t, hash9)
+	assert.NotEqual(t, hash9, hash10)
+}
+
 // TestRenderVmApplication_ImageProviderUnsupported verifies that a VmApplication
 // using the image: provider returns a clear error.
 func TestRenderVmApplication_ImageProviderUnsupported(t *testing.T) {

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -14,18 +14,21 @@ USER 0
 RUN dnf install -y --nobest gcc glibc-devel
 
 # Configure CentOS Stream 10 repositories for PAM packages
-# PAM from CentOS Stream 10 is required for build compatibility
-RUN echo -e '[centos-baseos]\nname=CentOS Stream 10 - BaseOS\nbaseurl=https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/centos.repo && \
-    echo -e '[centos-appstream]\nname=CentOS Stream 10 - AppStream\nbaseurl=https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0' >> /etc/yum.repos.d/centos.repo && \
-    dnf install -y pam pam-devel
+RUN ARCH=$(uname -m) && \
+    echo -e "[centos-baseos]\nname=CentOS Stream 10 - BaseOS\nbaseurl=https://mirror.stream.centos.org/10-stream/BaseOS/${ARCH}/os/\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/centos.repo && \
+    echo -e "[centos-appstream]\nname=CentOS Stream 10 - AppStream\nbaseurl=https://mirror.stream.centos.org/10-stream/AppStream/${ARCH}/os/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/centos.repo && \
+    dnf install -y pam pam-devel && \
+    dnf clean all
 
 # Install runtime PAM libraries and sssd-client into a separate root for the final image
-RUN mkdir -p /runtime-root && \
+RUN ARCH=$(uname -m) && \
     mkdir -p /runtime-root/etc/yum.repos.d && \
-    echo -e '[centos-baseos]\nname=CentOS Stream 10 - BaseOS\nbaseurl=https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0' > /runtime-root/etc/yum.repos.d/centos.repo && \
-    echo -e '[centos-appstream]\nname=CentOS Stream 10 - AppStream\nbaseurl=https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0' >> /runtime-root/etc/yum.repos.d/centos.repo && \
+    echo -e "[centos-baseos]\nname=CentOS Stream 10 - BaseOS\nbaseurl=https://mirror.stream.centos.org/10-stream/BaseOS/${ARCH}/os/\nenabled=1\ngpgcheck=0" > /runtime-root/etc/yum.repos.d/centos.repo && \
+    echo -e "[centos-appstream]\nname=CentOS Stream 10 - AppStream\nbaseurl=https://mirror.stream.centos.org/10-stream/AppStream/${ARCH}/os/\nenabled=1\ngpgcheck=0" >> /runtime-root/etc/yum.repos.d/centos.repo && \
     dnf install -y --installroot=/runtime-root --releasever=10 --setopt=install_weak_deps=False \
-        pam shadow-utils sssd-client
+        pam shadow-utils sssd-client && \
+    dnf --installroot=/runtime-root clean all && \
+    rm -rf /runtime-root/var/cache/dnf
 
 # Copy dependencies first (most stable)
 COPY go.mod go.sum ./

--- a/packaging/images/el10/images.yaml
+++ b/packaging/images/el10/images.yaml
@@ -26,11 +26,10 @@ db-setup:
   image: quay.io/flightctl/flightctl-db-setup-el10
   tag: latest
 gateway:
-  image: quay.io/sclorg/nginx-126-c10s
-  tag: "20260421"
+  image: registry.access.redhat.com/ubi10/nginx-126
+  tag: "1785834652"
 db:
-  # Using CentOS Stream 10 PostgreSQL for EL10 flavor
-  image: quay.io/sclorg/postgresql-16-c10s
+  image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
   # Using Valkey (Redis replacement) for EL10 flavor

--- a/packaging/images/el10/local-images.yaml
+++ b/packaging/images/el10/local-images.yaml
@@ -23,15 +23,14 @@ db-setup:
   image: flightctl-db-setup-el10
   tag: latest
 gateway:
-  image: quay.io/sclorg/nginx-126-c10s
-  tag: "20260421"
+  image: registry.access.redhat.com/ubi10/nginx-126
+  tag: "1785834652"
 ui:
   # UI images are built from flightctl-ui repo
   image: quay.io/flightctl/flightctl-ui-el10
   tag: latest
 db:
-  # Using CentOS Stream 10 PostgreSQL for EL10 flavor
-  image: quay.io/sclorg/postgresql-16-c10s
+  image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
   # Using Valkey (Redis replacement) for EL10 flavor

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -12,19 +12,24 @@ USER 0
 RUN dnf install -y --nobest gcc glibc-devel
 
 # Install matching PAM and pam-devel from CentOS mirror for build
-RUN dnf install -y https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/pam-1.5.1-24.el9.x86_64.rpm && \
-    dnf install -y https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/pam-devel-1.5.1-24.el9.x86_64.rpm
+RUN ARCH=$(uname -m) && \
+    dnf install -y https://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/pam-1.5.1-24.el9.${ARCH}.rpm && \
+    dnf install -y https://mirror.stream.centos.org/9-stream/AppStream/${ARCH}/os/Packages/pam-devel-1.5.1-24.el9.${ARCH}.rpm && \
+    dnf clean all
 
 # Install runtime PAM libraries and sssd-client into a separate root for the final image
-RUN mkdir -p /runtime-root && \
+RUN ARCH=$(uname -m) && \
+    mkdir -p /runtime-root && \
     dnf install -y --installroot=/runtime-root --releasever=9 --setopt=install_weak_deps=False \
-        https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/pam-1.5.1-24.el9.x86_64.rpm \
+        https://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/pam-1.5.1-24.el9.${ARCH}.rpm \
         shadow-utils && \
     mkdir -p /runtime-root/etc/yum.repos.d && \
-    echo -e '[centos-baseos]\nname=CentOS Stream 9 - BaseOS\nbaseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/\nenabled=1\ngpgcheck=0' > /runtime-root/etc/yum.repos.d/centos.repo && \
-    echo -e '[centos-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/\nenabled=1\ngpgcheck=0' >> /runtime-root/etc/yum.repos.d/centos.repo && \
+    echo -e "[centos-baseos]\nname=CentOS Stream 9 - BaseOS\nbaseurl=https://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/\nenabled=1\ngpgcheck=0" > /runtime-root/etc/yum.repos.d/centos.repo && \
+    echo -e "[centos-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/${ARCH}/os/\nenabled=1\ngpgcheck=0" >> /runtime-root/etc/yum.repos.d/centos.repo && \
     dnf install -y --installroot=/runtime-root --releasever=9 --setopt=install_weak_deps=False \
-        sssd-client
+        sssd-client && \
+    dnf --installroot=/runtime-root clean all && \
+    rm -rf /runtime-root/var/cache/dnf
 
 # Copy dependencies first (most stable)
 COPY go.mod go.sum ./

--- a/packaging/images/el9/images.yaml
+++ b/packaging/images/el9/images.yaml
@@ -26,16 +26,16 @@ db-setup:
   image: quay.io/flightctl/flightctl-db-setup-el9
   tag: latest
 gateway:
-  image: quay.io/sclorg/nginx-124-c9s
-  tag: "20260422"
+  image: registry.access.redhat.com/ubi9/nginx-124
+  tag: "9.8-1785993104"
 db:
   image: quay.io/sclorg/postgresql-16-c9s
   tag: "20250214"
 kv:
   # Must match helm-chart-opts.yaml community-el9 kv image so the bundle and
   # the rendered quadlet reference the same image and tag.
-  image: quay.io/sclorg/redis-7-c9s
-  tag: "20250108"
+  image: quay.io/sclorg/valkey-8-c10s
+  tag: "20260121"
 alertmanager:
   image: quay.io/prometheus/alertmanager
   tag: v0.28.1

--- a/packaging/images/el9/local-images.yaml
+++ b/packaging/images/el9/local-images.yaml
@@ -23,8 +23,8 @@ db-setup:
   image: flightctl-db-setup-el9
   tag: latest
 gateway:
-  image: quay.io/sclorg/nginx-124-c9s
-  tag: "20260422"
+  image: registry.access.redhat.com/ubi9/nginx-124
+  tag: "9.8-1785993104"
 ui:
   # UI images are built from flightctl-ui repo
   image: quay.io/flightctl/flightctl-ui-el9

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -637,11 +637,7 @@ fi
     %{_datadir}/flightctl/flightctl-api/config.yaml.template
     %{_datadir}/flightctl/flightctl-api/env.template
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-db/enable-superuser.sh
-    %if 0%{?rhel} == 10
     %{_datadir}/flightctl/flightctl-kv/valkey.conf
-    %else
-    %{_datadir}/flightctl/flightctl-kv/redis.conf
-    %endif
     %{_datadir}/flightctl/flightctl-ui/env.template
     %attr(0755,root,root) %{_datadir}/flightctl/flightctl-ui/init.sh
     %attr(0755,root,root) %{_datadir}/flightctl/init_utils.sh

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -730,11 +730,11 @@ if [ "$1" -eq 2 ]; then
         DB_SETUP_IMAGE="%{db_setup_image}" \
         CONFIG_PATH="%{_sysconfdir}/flightctl/flightctl-api/config.yaml" \
         bash "$SCRIPT" "$IMAGE_TAG" "%{_sysconfdir}/flightctl/flightctl-api/config.yaml" || {
-            [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
+            [ -z "${TMPSCRIPT:-}" ] || rm -f "$TMPSCRIPT"
             echo "flightctl: dry-run failed; aborting upgrade." >&2
             exit 1
         }
-        [ -n "${TMPSCRIPT:-}" ] && rm -f "$TMPSCRIPT"
+        [ -z "${TMPSCRIPT:-}" ] || rm -f "$TMPSCRIPT"
     else
         echo "flightctl: pre-upgrade-dry-run.sh not found at %{_libexecdir}/flightctl; skipping."
     fi

--- a/scripts/air-gap/mirror-images/embedded_data_generated.go
+++ b/scripts/air-gap/mirror-images/embedded_data_generated.go
@@ -90,16 +90,16 @@ var embeddedBuildManifest = []byte(`
           "tag": "v0.28.1"
         },
         {
-          "ref": "quay.io/sclorg/nginx-126-c10s",
-          "tag": "20260421"
-        },
-        {
-          "ref": "quay.io/sclorg/postgresql-16-c10s",
+          "ref": "quay.io/sclorg/postgresql-16-c9s",
           "tag": "20250214"
         },
         {
           "ref": "quay.io/sclorg/valkey-8-c10s",
           "tag": "20260121"
+        },
+        {
+          "ref": "registry.access.redhat.com/ubi10/nginx-126",
+          "tag": "1785834652"
         },
         {
           "ref": "registry.access.redhat.com/ubi10/ubi-minimal",
@@ -196,16 +196,16 @@ var embeddedBuildManifest = []byte(`
           "tag": "v0.28.1"
         },
         {
-          "ref": "quay.io/sclorg/nginx-124-c9s",
-          "tag": "20260422"
-        },
-        {
           "ref": "quay.io/sclorg/postgresql-16-c9s",
           "tag": "20250214"
         },
         {
-          "ref": "quay.io/sclorg/redis-7-c9s",
-          "tag": "20250108"
+          "ref": "quay.io/sclorg/valkey-8-c10s",
+          "tag": "20260121"
+        },
+        {
+          "ref": "registry.access.redhat.com/ubi9/nginx-124",
+          "tag": "9.8-1785993104"
         },
         {
           "ref": "registry.access.redhat.com/ubi9/ubi-minimal",

--- a/test/e2e/agent/agent_test.go
+++ b/test/e2e/agent/agent_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
-	apiclient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/test/e2e/infra"
 	"github.com/flightctl/flightctl/test/e2e/infra/setup"
@@ -57,16 +56,9 @@ var _ = Describe("VM Agent behavior", func() {
 			Expect(enrollmentRequest.Spec.DeviceStatus).ToNot(BeNil())
 			Expect(enrollmentRequest.Spec.DeviceStatus.SystemInfo.IsEmpty()).NotTo(BeTrue())
 
-			// Approve the enrollment and wait for the device details to be populated by the agent
 			harness.ApproveEnrollment(enrollmentID, harness.TestEnrollmentApproval())
-			GinkgoWriter.Printf("Waiting for device %s to report status\n", enrollmentID)
-
-			// wait for the device to pickup enrollment and report measurements on device status
-			Eventually(func() *apiclient.GetDeviceResponse {
-				resp, err := harness.GetDeviceWithStatusSystem(enrollmentID)
-				Expect(err).ToNot(HaveOccurred())
-				return resp
-			}, TIMEOUT, POLLING).ShouldNot(BeNil())
+			GinkgoWriter.Printf("Waiting for device %s to come online\n", enrollmentID)
+			harness.WaitForOnlineStatus(enrollmentID)
 		})
 		It("Should report a message when a device is assigned to multiple fleets", Label("75992", "agent"), func() {
 			// Get harness directly - no shared package-level variable

--- a/test/e2e/backup_restore/backup_restore_test.go
+++ b/test/e2e/backup_restore/backup_restore_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Service backup and restore", Label("backup-restore"), func() {
 
 			By("Approving third ER (after backup)")
 			harness3.ApproveEnrollment(er3ID, harness3.TestEnrollmentApproval())
-			Eventually(harness3.GetDeviceWithStatusSummary, testutil.TIMEOUT, testutil.POLLING).WithArguments(er3ID).ShouldNot(BeEmpty())
+			Eventually(harness3.GetDeviceWithStatusSummary, testutil.TIMEOUT, testutil.POLLING).WithArguments(er3ID).Should(Equal(v1beta1.DeviceSummaryStatusOnline))
 
 			// --- Step 4: Wait for device to apply new version; verify new RV > rvAtBackup ---
 			By("Step 4: Waiting for device 1 to apply new version (new RV > previous RV) and be UpToDate")

--- a/test/e2e/cli/cli_console_test.go
+++ b/test/e2e/cli/cli_console_test.go
@@ -284,11 +284,8 @@ var _ = Describe("CLI - device console", Label(e2e.NeedVMLabel), func() {
 
 		By("verifying that the ~. sequence exits the shell")
 		cs := harness.NewConsoleSession(deviceID)
-		cs.SkipGracefulExitOnClose()
 		DeferCleanup(cs.Close)
-
-		Expect(cs.Stdin.Write([]byte("\n~.\n"))).To(BeNumerically(">", 0))
-		Eventually(cs.Stdout.Closed).Should(BeTrue())
+		cs.Disconnect()
 
 		By("running a command without opening a shell")
 		out, err = harness.RunConsoleCommand(deviceID, nil, "flightctl-agent", "system-info")

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -356,23 +356,26 @@ var _ = Describe("cli operation", func() {
 			Expect(out).To(ContainSubstring(deviceName))
 
 			By("Comparing with-slash and no-slash forms for table and JSON output")
-			withSlash, err := harness.CLI("get", "device/"+deviceName)
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s failed", deviceName)
+			// Device status can change between the two GETs (Updated UpToDate vs OutOfDate).
+			Eventually(func(g Gomega) {
+				withSlash, err := harness.CLI("get", "device/"+deviceName)
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s failed", deviceName)
 
-			noSlash, err := harness.CLI("get", "device", deviceName)
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device %s failed", deviceName)
+				noSlash, err := harness.CLI("get", "device", deviceName)
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device %s failed", deviceName)
 
-			Expect(collapse(withSlash)).To(Equal(collapse(noSlash)),
-				"no-slash table output must equal with-slash")
+				g.Expect(collapse(withSlash)).To(Equal(collapse(noSlash)),
+					"no-slash table output must equal with-slash")
 
-			withSlashJSON, err := harness.CLI("get", "device/"+deviceName, "-o", "json")
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s -o json failed", deviceName)
+				withSlashJSON, err := harness.CLI("get", "device/"+deviceName, "-o", "json")
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device/%s -o json failed", deviceName)
 
-			noSlashJSON, err := harness.CLI("get", "device", deviceName, "-o", "json")
-			Expect(err).NotTo(HaveOccurred(), "flightctl get device %s -o json failed", deviceName)
+				noSlashJSON, err := harness.CLI("get", "device", deviceName, "-o", "json")
+				g.Expect(err).NotTo(HaveOccurred(), "flightctl get device %s -o json failed", deviceName)
 
-			Expect(noSlashJSON).To(MatchJSON(withSlashJSON),
-				"no-slash JSON must deep-equal with-slash")
+				g.Expect(noSlashJSON).To(MatchJSON(withSlashJSON),
+					"no-slash JSON must deep-equal with-slash")
+			}, "10s", "200ms").Should(Succeed())
 		})
 
 		It("Should show last-seen with proper flag", Label("85014", "sanity", "client", e2e.NeedVMLabel), func() {

--- a/test/e2e/decommission/decommission_test.go
+++ b/test/e2e/decommission/decommission_test.go
@@ -79,14 +79,7 @@ var _ = Describe("CLI decommission test", func() {
 			GinkgoWriter.Printf("Approved new enrollment request: %s\n", newEnrollmentId)
 
 			By("Verifying the re-enrolled device comes online with the new ID")
-			Eventually(harness.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-				newEnrollmentId).ShouldNot(BeNil())
-
-			newDevice, err := harness.GetDevice(newEnrollmentId)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(newDevice).NotTo(BeNil())
-			Expect(newDevice.Status.Summary.Status).To(Equal(v1beta1.DeviceSummaryStatusOnline),
-				"Expected re-enrolled device to be online")
+			harness.WaitForOnlineStatus(newEnrollmentId)
 			GinkgoWriter.Printf("Re-enrolled device %s is now online\n", newEnrollmentId)
 		})
 	})

--- a/test/e2e/fips/fips_test.go
+++ b/test/e2e/fips/fips_test.go
@@ -114,6 +114,6 @@ var _ = Describe("FIPS verification", Label("fips"), func() {
 		Expect(enrollmentID).NotTo(BeEmpty())
 		_ = harness.WaitForEnrollmentRequest(enrollmentID)
 		harness.ApproveEnrollment(enrollmentID, harness.TestEnrollmentApproval())
-		Eventually(harness.GetDeviceWithStatusSystem, fipsTestTimeout, fipsTestPolling).WithArguments(enrollmentID).ShouldNot(BeNil())
+		harness.WaitForOnlineStatus(enrollmentID)
 	})
 })

--- a/test/e2e/infra/quadlet/service_config_mapping_test.go
+++ b/test/e2e/infra/quadlet/service_config_mapping_test.go
@@ -160,6 +160,10 @@ vulnerabilityReporting:
 					require.True(t, ok)
 					assert.Equal(t, "quay.io/kubevirt/virt-launcher:v1.9.0", vmRender["launcherImage"])
 					assert.Equal(t, false, vmRender["passtWorkarounds"])
+					images, ok := vmRender["launcherImages"].(map[string]interface{})
+					require.True(t, ok)
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel9:v1", images["rhel-9"])
+					assert.Equal(t, "registry.example.com/virt-launcher-rhel10:v1", images["rhel-10"])
 				}
 			case infra.ServiceImageBuilderWorker:
 				sectionKey = "imageBuilderWorker"
@@ -223,6 +227,10 @@ vulnerabilityReporting:
 				require.True(t, ok)
 				vmRender["launcherImage"] = setValue
 				vmRender["passtWorkarounds"] = false
+				vmRender["launcherImages"] = map[string]interface{}{
+					"rhel-9":  "registry.example.com/virt-launcher-rhel9:v1",
+					"rhel-10": "registry.example.com/virt-launcher-rhel10:v1",
+				}
 			case infra.ServiceImageBuilderWorker:
 				section["maxConcurrentBuilds"] = setValue
 			case infra.ServiceTelemetryGateway:

--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -2,8 +2,12 @@ package vm_test
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -16,23 +20,33 @@ import (
 )
 
 const (
-	vmAppName                    = "test-vm"
-	vmAppAName                   = "test-vm-a"
-	vmAppBName                   = "test-vm-b"
-	defaultVMImage               = "quay.io/containerdisks/fedora:40"
-	vmGuestUser                  = "fedora"
-	vmGuestPassword              = "fedora"
-	vmCloudUser                  = "cloud-user"
-	vmCloudUserPassword          = "cloud-user-pass"
-	vmPublishedSSHPort           = 2222
-	vmBPublishedSSHPort          = 2223
-	vmBPublishedUDPPort          = 9090
-	vmGuestMemory                = "1024M"
-	configDriveIndexHTMLContent  = "Hello from ConfigDrive"
-	systemdSubStateActive        = "active"
-	systemdSubStateRunning       = "running"
-	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
-	systemdActiveStateActive     = string(v1beta1.SystemdActiveStateActive)
+	vmAppName                   = "test-vm"
+	vmAppAName                  = "test-vm-a"
+	vmAppBName                  = "test-vm-b"
+	defaultVMImage              = "quay.io/containerdisks/fedora:40"
+	defaultVMUpdatedImage       = "quay.io/containerdisks/fedora:41"
+	vmGuestUser                 = "fedora"
+	vmGuestPassword             = "fedora"
+	vmModifiedGuestPassword     = "fedora-new"
+	vmModifyBaselineGuestMemory = "1G"
+	vmModifyBaselineCPUCores    = 1
+	vmModifiedGuestMemory       = "2G"
+	vmModifiedCPUCores          = 2
+	// Guest-visible MemTotal for 2G is slightly below the requested quantity.
+	vmModifiedGuestMemoryMinKiB      = 1700000
+	vmCloudUser                      = "cloud-user"
+	vmCloudUserPassword              = "cloud-user-pass"
+	vmPublishedSSHPort               = 2222
+	vmBPublishedSSHPort              = 2223
+	vmPublishedPortUnavailableWindow = "10s"
+	vmBPublishedUDPPort              = 9090
+	vmGuestSSHPort                   = 22
+	vmGuestMemory                    = "1024M"
+	configDriveIndexHTMLContent      = "Hello from ConfigDrive"
+	systemdSubStateActive            = "active"
+	systemdSubStateRunning           = "running"
+	systemdLoadStateLoadedString     = string(v1beta1.SystemdLoadStateLoaded)
+	systemdActiveStateActive         = string(v1beta1.SystemdActiveStateActive)
 )
 
 func getVMImage() string {
@@ -40,6 +54,13 @@ func getVMImage() string {
 		return image
 	}
 	return defaultVMImage
+}
+
+func getVMUpdatedImage() string {
+	if image := os.Getenv("FLIGHTCTL_E2E_VM_UPDATED_IMAGE"); image != "" {
+		return image
+	}
+	return defaultVMUpdatedImage
 }
 
 var _ = Describe("VM Applications", Ordered, func() {
@@ -69,20 +90,7 @@ var _ = Describe("VM Applications", Ordered, func() {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppSpec}
 		})
 		Expect(err).ToNot(HaveOccurred())
-
-		By("Verifying the VM application reports Running status")
-		err = harness.WaitForApplicationStatus(deviceID, vmAppName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
-		if err != nil {
-			logVMApplicationUnitStatus(harness, vmAppName)
-		}
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Verifying the applications summary is Healthy")
-		err = harness.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
-		if err != nil {
-			logVMApplicationUnitStatus(harness, vmAppName)
-		}
-		Expect(err).ToNot(HaveOccurred())
+		waitForVMAppRunningHealthy(harness, deviceID, vmAppName)
 
 		By("Waiting for the VM serial console login prompt")
 		cs := harness.NewAppConsoleSessionWaitingForLogin(deviceID, vmAppName, testutil.LONG_TIMEOUT, testutil.POLLING)
@@ -105,6 +113,51 @@ var _ = Describe("VM Applications", Ordered, func() {
 		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 	})
 
+	// Unexpected virt-launcher compute death (not flightctl app stop) should restart via
+	// pod/systemd policy and return the app to Running/Healthy without operator start.
+	// After recovery, serial console exclusivity is checked: a second connect without
+	// --force is rejected, and --force takes over the active session.
+	It("recovers Running and Healthy after an unexpected virt-launcher compute crash", Label("vm", "90232", "90239"), func() {
+		By("Deploying the VM application")
+		err := harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+		waitForVMAppRunningHealthy(harness, deviceID, vmAppName)
+
+		By("Verifying SSH before the crash")
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		computeContainer := findRunningVMComputeContainerName(harness, vmAppName)
+		containerIDBefore := getPodmanContainerID(harness, computeContainer)
+		GinkgoWriter.Printf("Pre-crash compute container %q ID %q\n", computeContainer, containerIDBefore)
+
+		By("Force-killing the virt-launcher compute container")
+		_, err = harness.VM.RunSSH([]string{"sudo", "podman", "kill", computeContainer}, nil)
+		Expect(err).NotTo(HaveOccurred(), "killing podman container %q", computeContainer)
+
+		By("Waiting for the compute container to be recreated")
+		var computeContainerAfter, containerIDAfter string
+		Eventually(func(g Gomega) {
+			name, lookupErr := runningVMComputeContainerName(harness, vmAppName)
+			g.Expect(lookupErr).NotTo(HaveOccurred(), "finding running compute container")
+			id, idErr := podmanContainerID(harness, name)
+			g.Expect(idErr).NotTo(HaveOccurred(), "reading podman container ID for %q", name)
+			g.Expect(id).NotTo(Equal(containerIDBefore), "compute container should be recreated after crash")
+			computeContainerAfter = name
+			containerIDAfter = id
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+		GinkgoWriter.Printf("Post-recovery compute container %q ID %q\n", computeContainerAfter, containerIDAfter)
+
+		By("Waiting for the VM application to recover to Running/Healthy without operator start")
+		waitForVMAppRunningHealthy(harness, deviceID, vmAppName)
+
+		By("Verifying SSH works again after recovery")
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		expectSerialConsoleForceTakeover(harness, deviceID, vmAppName, vmGuestUser, vmGuestPassword)
+	})
+
 	// Two VM apps on one device without conflict. Both use KubeVirt ConfigDrive
 	// (userDataBase64). test-vm-a maps 2222:22; test-vm-b maps 2223:22/tcp and
 	// 9090:9090/udp. Verifies concurrent Running/Healthy state, cloud-user login
@@ -119,7 +172,7 @@ var _ = Describe("VM Applications", Ordered, func() {
 		image := getVMImage()
 		vmAppASpec, err := e2e.NewVmApplicationSpecFromYAML(
 			vmAppAName,
-			[]string{fmt.Sprintf("%d:22", vmPublishedSSHPort)},
+			[]string{fmt.Sprintf("%d:%d", vmPublishedSSHPort, vmGuestSSHPort)},
 			e2e.VMYAMLWithConfigDrive(vmAppAName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserData(sshPublicKey, vmCloudUserPassword))),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -127,7 +180,7 @@ var _ = Describe("VM Applications", Ordered, func() {
 		vmAppBSpec, err := e2e.NewVmApplicationSpecFromYAML(
 			vmAppBName,
 			[]string{
-				fmt.Sprintf("%d:22/tcp", vmBPublishedSSHPort),
+				fmt.Sprintf("%d:%d/tcp", vmBPublishedSSHPort, vmGuestSSHPort),
 				fmt.Sprintf("%d:%d/udp", vmBPublishedUDPPort, vmBPublishedUDPPort),
 			},
 			e2e.VMYAMLWithConfigDrive(vmAppBName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserDataWithServices(sshPublicKey, vmCloudUserPassword))),
@@ -141,21 +194,8 @@ var _ = Describe("VM Applications", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, appName := range []string{vmAppAName, vmAppBName} {
-			By(fmt.Sprintf("Waiting for VM application %s to reach Running", appName))
-			err = harness.WaitForApplicationStatus(deviceID, appName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
-			if err != nil {
-				logVMApplicationUnitStatus(harness, appName)
-			}
-			Expect(err).ToNot(HaveOccurred())
+			waitForVMAppRunningHealthy(harness, deviceID, appName)
 		}
-
-		By("Verifying the applications summary is Healthy")
-		err = harness.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
-		if err != nil {
-			logVMApplicationUnitStatus(harness, vmAppAName)
-			logVMApplicationUnitStatus(harness, vmAppBName)
-		}
-		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying SSH via published host ports for both VMs")
 		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppAName, vmCloudUser, vmCloudUserPassword)
@@ -248,7 +288,78 @@ var _ = Describe("VM Applications", Ordered, func() {
 
 		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppBName, vmCloudUser, vmCloudUserPassword)
 	})
+
+	// Changing VM sizing, publishPorts, containerdisk image, and cloud-init password in the
+	// device spec re-renders the app; the VM returns to Running/Healthy with observable updates.
+	It("re-renders and applies modified VM memory, cores, publishPorts, disk image, and cloud-init password", Label("vm", "90233"), func() {
+		baselineImage := getVMImage()
+		updatedImage := getVMUpdatedImage()
+
+		baselineSpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppName,
+			[]string{fmt.Sprintf("%d:%d", vmPublishedSSHPort, vmGuestSSHPort)},
+			e2e.VMYAMLWithCPU(vmAppName, vmModifyBaselineGuestMemory, baselineImage, vmModifyBaselineCPUCores, e2e.VMFedoraNoCloudUserData(vmGuestPassword)),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		modifiedSpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppName,
+			[]string{fmt.Sprintf("%d:%d", vmBPublishedSSHPort, vmGuestSSHPort)},
+			e2e.VMYAMLWithCPU(vmAppName, vmModifiedGuestMemory, updatedImage, vmModifiedCPUCores, e2e.VMFedoraNoCloudUserData(vmModifiedGuestPassword)),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Deploying the baseline VM application")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{baselineSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+		waitForVMAppRunningHealthy(harness, deviceID, vmAppName)
+
+		By("Verifying baseline SSH on the original published port")
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmGuestPassword)
+
+		By("Applying the modified VM application spec")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{modifiedSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+		waitForVMAppRunningHealthy(harness, deviceID, vmAppName)
+
+		By("Verifying SSH on the new published port with the updated password")
+		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppName, vmGuestUser, vmModifiedGuestPassword)
+
+		By("Verifying SSH on the previous published port is removed")
+		expectSSHUnavailableOnPort(harness, vmPublishedSSHPort, vmAppName, vmGuestUser, vmModifiedGuestPassword)
+
+		By("Verifying guest CPU and memory reflect the updated spec")
+		expectGuestCPUCount(harness, vmBPublishedSSHPort, vmAppName, vmGuestUser, vmModifiedGuestPassword, vmModifiedCPUCores)
+		expectGuestMemoryAtLeastKiB(harness, vmBPublishedSSHPort, vmAppName, vmGuestUser, vmModifiedGuestPassword, vmModifiedGuestMemoryMinKiB)
+
+		By("Verifying the rendered quadlet workload references the updated containerdisk image")
+		expectVMQuadletDirContainsImage(harness, vmAppName, updatedImage)
+
+		By("Verifying serial console login with the updated cloud-init password")
+		expectSerialLoginWithPassword(harness, deviceID, vmAppName, vmGuestUser, vmModifiedGuestPassword)
+	})
 })
+
+func waitForVMAppRunningHealthy(h *e2e.Harness, deviceID, appName string) {
+	GinkgoHelper()
+	By(fmt.Sprintf("Waiting for VM application %s to reach Running", appName))
+	err := h.WaitForApplicationStatus(deviceID, appName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+	if err != nil {
+		logVMApplicationUnitStatus(h, appName)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Verifying the applications summary is Healthy")
+	err = h.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+	if err != nil {
+		logVMApplicationUnitStatus(h, appName)
+	}
+	Expect(err).ToNot(HaveOccurred())
+}
 
 // expectSSHWhoamiWithPassword polls password SSH to a published host port until whoami returns the guest user.
 func expectSSHWhoamiWithPassword(h *e2e.Harness, port int, appName, user, password string) {
@@ -268,6 +379,176 @@ func expectSSHWhoamiWithPassword(h *e2e.Harness, port int, appName, user, passwo
 		g.Expect(sshErr).NotTo(HaveOccurred(), "password SSH to %s on published port %d failed", appName, port)
 		g.Expect(strings.TrimSpace(out)).To(Equal(user))
 	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+// expectSSHUnavailableOnPort polls until password SSH on port fails, then verifies it stays unavailable.
+func expectSSHUnavailableOnPort(h *e2e.Harness, port int, appName, user, password string) {
+	GinkgoHelper()
+	const remoteCmd = "/usr/bin/whoami"
+	Eventually(func(g Gomega) {
+		_, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		g.Expect(sshErr).To(HaveOccurred(), "SSH to %s on published port %d should be unavailable", appName, port)
+		g.Expect(errors.Is(sshErr, e2e.ErrSSHConnectionRefused) || errors.Is(sshErr, e2e.ErrSSHTimeout)).
+			To(BeTrue(), "SSH to %s on port %d failed with %v, want connection refused or timeout", appName, port, sshErr)
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+	Consistently(func(g Gomega) {
+		_, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		g.Expect(sshErr).To(HaveOccurred(), "SSH to %s on published port %d should remain unavailable", appName, port)
+		g.Expect(errors.Is(sshErr, e2e.ErrSSHConnectionRefused) || errors.Is(sshErr, e2e.ErrSSHTimeout)).
+			To(BeTrue(), "SSH to %s on port %d failed with %v, want connection refused or timeout", appName, port, sshErr)
+	}, vmPublishedPortUnavailableWindow, testutil.POLLING).Should(Succeed())
+}
+
+// runningVMComputeContainerName finds the running virt-launcher compute container name for appName.
+func runningVMComputeContainerName(h *e2e.Harness, appName string) (string, error) {
+	pattern := fmt.Sprintf("virt-launcher-%s-compute", appName)
+	out, err := h.VM.RunSSH([]string{"sudo", "podman", "ps", "--format", "{{.Names}}"}, nil)
+	if err != nil {
+		return "", fmt.Errorf("listing running podman containers: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && strings.Contains(line, pattern) {
+			return line, nil
+		}
+	}
+	return "", fmt.Errorf("running compute container matching %q not found", pattern)
+}
+
+// findRunningVMComputeContainerName returns the running virt-launcher compute container name for appName.
+func findRunningVMComputeContainerName(h *e2e.Harness, appName string) string {
+	GinkgoHelper()
+	var containerName string
+	Eventually(func(g Gomega) {
+		var err error
+		containerName, err = runningVMComputeContainerName(h, appName)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+	return containerName
+}
+
+// podmanContainerID returns the running podman container ID for containerName on the device.
+func podmanContainerID(h *e2e.Harness, containerName string) (string, error) {
+	out, err := h.VM.RunSSH([]string{
+		"sudo", "podman", "ps",
+		"--filter", "name=^" + regexp.QuoteMeta(containerName) + "$",
+		"--format", "{{.ID}}",
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("reading podman container ID for %q: %w", containerName, err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return "", fmt.Errorf("podman container ID for %q not found", containerName)
+	}
+	return strings.TrimSpace(lines[0]), nil
+}
+
+// getPodmanContainerID returns the running podman container ID for containerName on the device.
+func getPodmanContainerID(h *e2e.Harness, containerName string) string {
+	GinkgoHelper()
+	id, err := podmanContainerID(h, containerName)
+	Expect(err).NotTo(HaveOccurred())
+	return id
+}
+
+func expectGuestCPUCount(h *e2e.Harness, port int, appName, user, password string, wantCPUs int) {
+	GinkgoHelper()
+	want := strconv.Itoa(wantCPUs)
+	Eventually(func(g Gomega) {
+		out, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, "nproc")
+		g.Expect(sshErr).NotTo(HaveOccurred(), "reading nproc on %s failed", appName)
+		g.Expect(strings.TrimSpace(out)).To(Equal(want))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+func expectGuestMemoryAtLeastKiB(h *e2e.Harness, port int, appName, user, password string, minKiB int) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		out, sshErr := h.RunSSHOnDeviceLocalPort(
+			port,
+			user,
+			password,
+			`bash -lc 'grep MemTotal /proc/meminfo | tr -s " " | cut -d" " -f2'`,
+		)
+		g.Expect(sshErr).NotTo(HaveOccurred(), "reading MemTotal on %s failed", appName)
+		memKiB, parseErr := strconv.Atoi(strings.TrimSpace(out))
+		g.Expect(parseErr).NotTo(HaveOccurred(), "parsing MemTotal output %q", out)
+		g.Expect(memKiB).To(BeNumerically(">=", minKiB), "guest MemTotal on %s", appName)
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+func expectVMQuadletDirContainsImage(h *e2e.Harness, appName, imageRef string) {
+	GinkgoHelper()
+	computeContainerFile := vmApplicationComputeContainerFileName(appName)
+	filePath := fmt.Sprintf("%s/%s/%s", e2e.QuadletUnitPath, appName, computeContainerFile)
+	expectedSource := fmt.Sprintf("source=%s", imageRef)
+	Eventually(func(g Gomega) {
+		out, err := h.VM.RunSSH([]string{"sudo", "cat", filePath}, nil)
+		g.Expect(err).NotTo(HaveOccurred(), "reading compute quadlet workload %q", filePath)
+		g.Expect(out.String()).To(ContainSubstring(expectedSource), "containerdisk image in %q", filePath)
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+func expectSerialLoginWithPassword(h *e2e.Harness, deviceID, appName, user, password string) {
+	GinkgoHelper()
+	cs := h.NewAppConsoleSessionWaitingForLogin(deviceID, appName, testutil.LONG_TIMEOUT, testutil.POLLING)
+	DeferCleanup(cs.Close)
+	loginOnSerialConsole(cs, user, password)
+	cs.Disconnect()
+}
+
+// loginOnSerialConsole completes a password login on an already-open serial session
+// and checks whoami. The session is left connected.
+func loginOnSerialConsole(cs *e2e.ConsoleSession, user, password string) {
+	GinkgoHelper()
+	cs.MustSend(user)
+	cs.MustExpectWithin(`(?i)password:`, testutil.DURATION_TIMEOUT, testutil.POLLING)
+	cs.MustSend(password)
+	cs.MustExpectWithin(fmt.Sprintf(`.*%s@.*\$`, user), testutil.DURATION_TIMEOUT, testutil.POLLING)
+	cs.MustSend(fmt.Sprintf("printf '<<whoami>>%%s<<whoami>>\\n' \"$(whoami)\""))
+	cs.MustExpectWithin(fmt.Sprintf("<<whoami>>%s<<whoami>>", user), testutil.DURATION_TIMEOUT, testutil.POLLING)
+}
+
+// expectSerialConsoleForceTakeover verifies serial login, then that a second connect
+// without --force is rejected and --force replaces the first session.
+func expectSerialConsoleForceTakeover(h *e2e.Harness, deviceID, appName, user, password string) {
+	GinkgoHelper()
+	By("Verifying serial console login works")
+	cs1 := h.NewAppConsoleSessionWaitingForLogin(deviceID, appName, testutil.LONG_TIMEOUT, testutil.POLLING)
+	DeferCleanup(cs1.Close)
+	loginOnSerialConsole(cs1, user, password)
+
+	By("Rejecting a second serial console without --force")
+	out, err := h.CLI(
+		"app", "console",
+		fmt.Sprintf("device/%s", deviceID),
+		"--name", appName,
+		"--type", "serial",
+	)
+	Expect(err).To(HaveOccurred())
+	Expect(out).To(ContainSubstring(fmt.Sprintf("serial console session already active for application %s", appName)))
+
+	By("Logging out of the guest so the replacement session sees a login prompt")
+	cs1.MustSend("exit")
+	cs1.MustExpectWithin(`(?i)login:`, testutil.DURATION_TIMEOUT, testutil.POLLING)
+
+	By("Taking over the serial console with --force")
+	cs2 := h.NewAppConsoleSession(deviceID, appName, "serial", "--force")
+	DeferCleanup(cs2.Close)
+
+	By("Waiting for the first session to disconnect with a replacement message")
+	Eventually(func(g Gomega) {
+		g.Expect(string(cs1.Stdout.Contents())).To(ContainSubstring("console session replaced by a new connection"))
+	}, testutil.DURATION_TIMEOUT, testutil.POLLING).Should(Succeed())
+	Eventually(cs1.Stdout.Closed).WithTimeout(testutil.DURATION_TIMEOUT).WithPolling(testutil.POLLING).Should(BeTrue())
+
+	By("Verifying the replacement serial session is usable")
+	_, err = io.WriteString(cs2.Stdin, "\n")
+	Expect(err).NotTo(HaveOccurred())
+	cs2.MustExpectWithin(`(?i)login:`, testutil.DURATION_TIMEOUT, testutil.POLLING)
+	loginOnSerialConsole(cs2, user, password)
 }
 
 // expectGuestUDPHello polls a UDP probe inside the guest via SSH to a published TCP port.
@@ -404,6 +685,11 @@ func vmApplicationTargetUnitName(appName string) string {
 // vmApplicationComputeServiceName returns the generated virt-launcher compute service name for a VM app.
 func vmApplicationComputeServiceName(appName string) string {
 	return quadlet.NamespaceResource(vmApplicationID(appName), fmt.Sprintf("virt-launcher-%s-compute.service", appName))
+}
+
+// vmApplicationComputeContainerFileName returns the generated virt-launcher compute container quadlet file name.
+func vmApplicationComputeContainerFileName(appName string) string {
+	return quadlet.NamespaceResource(vmApplicationID(appName), fmt.Sprintf("virt-launcher-%s-compute.container", appName))
 }
 
 // vmApplicationID returns the production app ID used to namespace generated VM units.

--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -1,6 +1,7 @@
 package vm_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -16,10 +17,18 @@ import (
 
 const (
 	vmAppName                    = "test-vm"
+	vmAppAName                   = "test-vm-a"
+	vmAppBName                   = "test-vm-b"
 	defaultVMImage               = "quay.io/containerdisks/fedora:40"
 	vmGuestUser                  = "fedora"
 	vmGuestPassword              = "fedora"
+	vmCloudUser                  = "cloud-user"
+	vmCloudUserPassword          = "cloud-user-pass"
 	vmPublishedSSHPort           = 2222
+	vmBPublishedSSHPort          = 2223
+	vmBPublishedUDPPort          = 9090
+	vmGuestMemory                = "1024M"
+	configDriveIndexHTMLContent  = "Hello from ConfigDrive"
 	systemdSubStateActive        = "active"
 	systemdSubStateRunning       = "running"
 	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
@@ -95,7 +104,210 @@ var _ = Describe("VM Applications", Ordered, func() {
 			g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty())
 		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 	})
+
+	// Two VM apps on one device without conflict. Both use KubeVirt ConfigDrive
+	// (userDataBase64). test-vm-a maps 2222:22; test-vm-b maps 2223:22/tcp and
+	// 9090:9090/udp. Verifies concurrent Running/Healthy state, cloud-user login
+	// via password, ssh_authorized_keys in ConfigDrive userdata, write_files/runcmd
+	// on test-vm-b (python3 http.server, index.html), TCP/UDP publishPorts, and that
+	// stopping one VM leaves the other reachable.
+	It("runs two VM applications concurrently with TCP and UDP publishPorts", Label("vm", "90230", "90235"), func() {
+		sshPublicKey, _, sshKeyCleanup, err := testutil.GenerateTempSSHKeyPair()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(sshKeyCleanup)
+
+		image := getVMImage()
+		vmAppASpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppAName,
+			[]string{fmt.Sprintf("%d:22", vmPublishedSSHPort)},
+			e2e.VMYAMLWithConfigDrive(vmAppAName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserData(sshPublicKey, vmCloudUserPassword))),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		vmAppBSpec, err := e2e.NewVmApplicationSpecFromYAML(
+			vmAppBName,
+			[]string{
+				fmt.Sprintf("%d:22/tcp", vmBPublishedSSHPort),
+				fmt.Sprintf("%d:%d/udp", vmBPublishedUDPPort, vmBPublishedUDPPort),
+			},
+			e2e.VMYAMLWithConfigDrive(vmAppBName, vmGuestMemory, image, encodeConfigDriveUserData(configDriveCloudUserDataWithServices(sshPublicKey, vmCloudUserPassword))),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Adding both VM applications to the device")
+		err = harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
+			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppASpec, vmAppBSpec}
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, appName := range []string{vmAppAName, vmAppBName} {
+			By(fmt.Sprintf("Waiting for VM application %s to reach Running", appName))
+			err = harness.WaitForApplicationStatus(deviceID, appName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+			if err != nil {
+				logVMApplicationUnitStatus(harness, appName)
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Verifying the applications summary is Healthy")
+		err = harness.WaitForApplicationSummary(deviceID, testutil.LONG_TIMEOUT, testutil.POLLING, v1beta1.ApplicationsSummaryStatusHealthy)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppAName)
+			logVMApplicationUnitStatus(harness, vmAppBName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying SSH via published host ports for both VMs")
+		expectSSHWhoamiWithPassword(harness, vmPublishedSSHPort, vmAppAName, vmCloudUser, vmCloudUserPassword)
+		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppBName, vmCloudUser, vmCloudUserPassword)
+
+		expectAuthorizedKeyPresent := func(port int, appName string) {
+			Eventually(func(g Gomega) {
+				out, sshErr := harness.RunSSHOnDeviceLocalPort(
+					port,
+					vmCloudUser,
+					vmCloudUserPassword,
+					fmt.Sprintf(`bash -lc 'grep -F %q ~/.ssh/authorized_keys'`, sshPublicKey),
+				)
+				g.Expect(sshErr).NotTo(HaveOccurred(), "checking authorized_keys on %s failed", appName)
+				g.Expect(strings.TrimSpace(out)).To(Equal(sshPublicKey))
+			}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+		}
+
+		By("Verifying ssh_authorized_keys from ConfigDrive are present on both VMs")
+		expectAuthorizedKeyPresent(vmPublishedSSHPort, vmAppAName)
+		expectAuthorizedKeyPresent(vmBPublishedSSHPort, vmAppBName)
+
+		By("Verifying ConfigDrive write_files and runcmd on test-vm-b")
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmBPublishedSSHPort, vmCloudUser, vmCloudUserPassword, `bash -lc 'systemctl is-active hello-http.service'`)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("active"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'command -v python3'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(ContainSubstring("python3"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'cat /var/www/html/index.html'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal(configDriveIndexHTMLContent))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(
+				vmBPublishedSSHPort,
+				vmCloudUser,
+				vmCloudUserPassword,
+				`bash -lc 'curl -sS http://127.0.0.1/'`,
+			)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal(configDriveIndexHTMLContent))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmBPublishedSSHPort, vmCloudUser, vmCloudUserPassword, `bash -lc 'systemctl is-active hello-udp.service'`)
+			g.Expect(sshErr).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("active"))
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+
+		By("Verifying UDP hello service inside test-vm-b")
+		expectGuestUDPHello(harness, vmBPublishedSSHPort, vmBPublishedUDPPort, vmAppBName)
+
+		By("Verifying published UDP port on the device host")
+		expectPublishedUDPHello(harness, vmBPublishedUDPPort, vmAppBName, "hello")
+
+		By(fmt.Sprintf("Stopping %s and verifying %s remains reachable", vmAppAName, vmAppBName))
+		_, err = harness.CLI("app", "stop", fmt.Sprintf("device/%s", deviceID), "--name", vmAppAName, "-y")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = harness.WaitForApplicationStatus(deviceID, vmAppAName, v1beta1.ApplicationStatusStopped, testutil.LONG_TIMEOUT, testutil.POLLING)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppAName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		err = harness.WaitForApplicationStatus(deviceID, vmAppBName, v1beta1.ApplicationStatusRunning, testutil.LONG_TIMEOUT, testutil.POLLING)
+		if err != nil {
+			logVMApplicationUnitStatus(harness, vmAppBName)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		expectSSHWhoamiWithPassword(harness, vmBPublishedSSHPort, vmAppBName, vmCloudUser, vmCloudUserPassword)
+	})
 })
+
+// expectSSHWhoamiWithPassword polls password SSH to a published host port until whoami returns the guest user.
+func expectSSHWhoamiWithPassword(h *e2e.Harness, port int, appName, user, password string) {
+	GinkgoHelper()
+	const remoteCmd = "/usr/bin/whoami"
+	Eventually(func(g Gomega) {
+		GinkgoWriter.Printf(
+			"Password SSH probe on device host to %s@127.0.0.1:%d running %s (app=%s)\n",
+			user, port, remoteCmd, appName,
+		)
+		out, sshErr := h.RunSSHOnDeviceLocalPort(port, user, password, remoteCmd)
+		if sshErr != nil {
+			GinkgoWriter.Printf("SSH failed for %s on port %d: %v\n", appName, port, sshErr)
+		} else {
+			GinkgoWriter.Printf("SSH output for %s on port %d: %q\n", appName, port, strings.TrimSpace(out))
+		}
+		g.Expect(sshErr).NotTo(HaveOccurred(), "password SSH to %s on published port %d failed", appName, port)
+		g.Expect(strings.TrimSpace(out)).To(Equal(user))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+// expectGuestUDPHello polls a UDP probe inside the guest via SSH to a published TCP port.
+func expectGuestUDPHello(h *e2e.Harness, sshPort, udpPort int, appName string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		probeCmd := e2e.UDPProbePythonCommand(udpPort)
+		GinkgoWriter.Printf(
+			"Guest UDP probe via SSH on %s@127.0.0.1:%d running %q (app=%s)\n",
+			vmCloudUser, sshPort, probeCmd, appName,
+		)
+		out, sshErr := h.RunSSHOnDeviceLocalPort(sshPort, vmCloudUser, vmCloudUserPassword, probeCmd)
+		if sshErr != nil {
+			GinkgoWriter.Printf("Guest UDP probe failed for %s on guest port %d: %v\n", appName, udpPort, sshErr)
+		} else {
+			GinkgoWriter.Printf("Guest UDP probe output for %s on guest port %d: %q\n", appName, udpPort, strings.TrimSpace(out))
+		}
+		g.Expect(sshErr).NotTo(HaveOccurred(), "guest UDP probe for %s on port %d failed", appName, udpPort)
+		g.Expect(strings.TrimSpace(out)).To(Equal("hello"))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
+
+// expectPublishedUDPHello polls a UDP probe on the device host published port until the expected reply is received.
+func expectPublishedUDPHello(h *e2e.Harness, port int, appName, expectedReply string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		GinkgoWriter.Printf(
+			"UDP probe: socat/python3 send b\"ping\" recv UDP4:127.0.0.1:%d (app=%s)\n",
+			port, appName,
+		)
+		out, udpErr := h.RunUDPProbeOnDeviceLocalPort(port)
+		if udpErr != nil {
+			GinkgoWriter.Printf("UDP probe failed for %s on port %d: %v\n", appName, port, udpErr)
+		} else {
+			GinkgoWriter.Printf("UDP probe output for %s on port %d: %q\n", appName, port, out)
+		}
+		g.Expect(udpErr).NotTo(HaveOccurred(), "UDP probe to %s on published port %d failed", appName, port)
+		g.Expect(out).To(Equal(expectedReply))
+	}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
+}
 
 // logVMApplicationUnitStatus logs generated systemd unit state when product-level VM app status checks fail.
 func logVMApplicationUnitStatus(h *e2e.Harness, appName string) {
@@ -197,4 +409,92 @@ func vmApplicationComputeServiceName(appName string) string {
 // vmApplicationID returns the production app ID used to namespace generated VM units.
 func vmApplicationID(appName string) string {
 	return lifecycle.GenerateAppID(appName, v1beta1.CurrentProcessUsername)
+}
+
+func encodeConfigDriveUserData(cloudConfig string) string {
+	return base64.StdEncoding.EncodeToString([]byte(cloudConfig))
+}
+
+func configDriveCloudUserIdentityYAML(sshPublicKey, password string) string {
+	return fmt.Sprintf(`ssh_pwauth: true
+users:
+  - name: %s
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: false
+    ssh_authorized_keys:
+      - %s
+chpasswd:
+  expire: false
+  users:
+    - name: %s
+      password: %s
+      type: text`, vmCloudUser, sshPublicKey, vmCloudUser, password)
+}
+
+func configDriveCloudUserData(sshPublicKey, password string) string {
+	return "#cloud-config\n" + configDriveCloudUserIdentityYAML(sshPublicKey, password) + "\n"
+}
+
+func configDriveCloudUserDataWithServices(sshPublicKey, password string) string {
+	return fmt.Sprintf(`#cloud-config
+%s
+write_files:
+  - path: /var/www/html/index.html
+    content: %q
+    owner: root:root
+    permissions: '0644'
+  - path: /usr/local/bin/hello-udp-listener.py
+    owner: root:root
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env python3
+      import socket
+
+      PORT = %d
+
+      sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+      sock.bind(("0.0.0.0", PORT))
+      while True:
+          _data, addr = sock.recvfrom(1024)
+          sock.sendto(b"hello\n", addr)
+  - path: /etc/systemd/system/hello-http.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Hello HTTP service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      WorkingDirectory=/var/www/html
+      ExecStart=/usr/bin/python3 -m http.server 80
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/hello-udp.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Hello UDP reply service
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/python3 /usr/local/bin/hello-udp-listener.py
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable --now hello-http.service
+  - systemctl enable --now hello-udp.service
+`, configDriveCloudUserIdentityYAML(sshPublicKey, password), configDriveIndexHTMLContent, vmBPublishedUDPPort)
 }

--- a/test/e2e/vm/vm_test.go
+++ b/test/e2e/vm/vm_test.go
@@ -17,6 +17,9 @@ import (
 const (
 	vmAppName                    = "test-vm"
 	defaultVMImage               = "quay.io/containerdisks/fedora:40"
+	vmGuestUser                  = "fedora"
+	vmGuestPassword              = "fedora"
+	vmPublishedSSHPort           = 2222
 	systemdSubStateActive        = "active"
 	systemdSubStateRunning       = "running"
 	systemdLoadStateLoadedString = string(v1beta1.SystemdLoadStateLoaded)
@@ -51,7 +54,7 @@ var _ = Describe("VM Applications", Ordered, func() {
 		deviceID, _ = harness.EnrollAndWaitForOnlineStatus()
 	})
 
-	It("deploys a VM application and reports Running status", Label("vm"), func() {
+	It("deploys a VM application and reports Running status", Label("vm", "90228"), func() {
 		By("Adding the VM application to the device")
 		err := harness.UpdateDeviceAndWaitForVersion(deviceID, func(device *v1beta1.Device) {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{vmAppSpec}
@@ -71,6 +74,26 @@ var _ = Describe("VM Applications", Ordered, func() {
 			logVMApplicationUnitStatus(harness, vmAppName)
 		}
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for the VM serial console login prompt")
+		cs := harness.NewAppConsoleSessionWaitingForLogin(deviceID, vmAppName, testutil.LONG_TIMEOUT, testutil.POLLING)
+		DeferCleanup(cs.Close)
+		cs.MustSend(vmGuestUser)
+		cs.MustExpectWithin(`(?i)password:`, testutil.DURATION_TIMEOUT, testutil.POLLING)
+		cs.MustSend(vmGuestPassword)
+		cs.MustExpectWithin(fmt.Sprintf(`.*%s@.*\$`, vmGuestUser), testutil.DURATION_TIMEOUT, testutil.POLLING)
+		cs.MustSend(fmt.Sprintf("printf '<<whoami>>%%s<<whoami>>\\n' \"$(whoami)\""))
+		cs.MustExpectWithin(fmt.Sprintf("<<whoami>>%s<<whoami>>", vmGuestUser), testutil.DURATION_TIMEOUT, testutil.POLLING)
+
+		By("Disconnecting the serial console with ~.")
+		cs.Disconnect()
+
+		By("Verifying SSH via the published host port works")
+		Eventually(func(g Gomega) {
+			out, sshErr := harness.RunSSHOnDeviceLocalPort(vmPublishedSSHPort, vmGuestUser, vmGuestPassword, "hostname")
+			g.Expect(sshErr).NotTo(HaveOccurred(), "SSH to published port %d failed", vmPublishedSSHPort)
+			g.Expect(strings.TrimSpace(out)).NotTo(BeEmpty())
+		}, testutil.LONG_TIMEOUT, testutil.POLLING).Should(Succeed())
 	})
 })
 

--- a/test/harness/e2e/harness.go
+++ b/test/harness/e2e/harness.go
@@ -698,18 +698,8 @@ func (h *Harness) StartVMAndEnroll() string {
 	err := h.VM.RunAndWaitForSSH()
 	Expect(err).ToNot(HaveOccurred())
 
-	enrollmentID := h.GetEnrollmentIDFromServiceLogs("flightctl-agent")
-	logrus.Infof("Enrollment ID found in flightctl-agent service logs: %s", enrollmentID)
-
-	_ = h.WaitForEnrollmentRequest(enrollmentID)
-	h.ApproveEnrollment(enrollmentID, h.TestEnrollmentApproval())
-	logrus.Infof("Waiting for device %s to report status", enrollmentID)
-
-	// wait for the device to pickup enrollment and report measurements on device status
-	Eventually(h.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-		enrollmentID).ShouldNot(BeNil())
-
-	return enrollmentID
+	deviceId, _ := h.EnrollAndWaitForOnlineStatus()
+	return deviceId
 }
 
 func (h *Harness) ApiEndpoint() string {
@@ -991,32 +981,39 @@ func waitForResourceContents[T any](id string, description string, fetch func(st
 	}, timeout, pollingRate).Should(BeNil())
 }
 
+func (h *Harness) WaitForOnlineStatus(deviceId string) *v1beta1.Device {
+	var device *v1beta1.Device
+	Eventually(func() error {
+		response, err := h.GetDeviceWithStatusSystem(deviceId)
+		if err != nil {
+			return err
+		}
+		if response == nil || response.JSON200 == nil || response.JSON200.Status == nil {
+			return fmt.Errorf("device %s status not ready", deviceId)
+		}
+		device = response.JSON200
+		if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
+			return fmt.Errorf("device %s summary status is %s", deviceId, device.Status.Summary.Status)
+		}
+		if device.Status.Summary.Info == nil || *device.Status.Summary.Info != service.DeviceStatusInfoHealthy {
+			return fmt.Errorf("device %s is not healthy", deviceId)
+		}
+		return nil
+	}, TIMEOUT, POLLING).Should(Succeed())
+	logrus.Infof("The device %s is online", deviceId)
+	return device
+}
+
 func (h *Harness) EnrollAndWaitForOnlineStatus(labels ...map[string]string) (string, *v1beta1.Device) {
 	deviceId := h.GetEnrollmentIDFromServiceLogs("flightctl-agent")
 	logrus.Infof("Enrollment ID found in flightctl-agent service logs: %s", deviceId)
 	Expect(deviceId).NotTo(BeNil())
 
-	// Wait for the approve enrollment request response to not be nil
 	h.WaitForEnrollmentRequest(deviceId)
-
-	// Approve the enrollment and wait for the device details to be populated by the agent.
 	h.ApproveEnrollment(deviceId, h.TestEnrollmentApproval(labels...))
-
-	Eventually(h.GetDeviceWithStatusSummary, TIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeEmpty())
 	logrus.Infof("The device %s was approved", deviceId)
 
-	// Wait for the device to pickup enrollment and report measurements on device status.
-	Eventually(h.GetDeviceWithStatusSystem, TIMEOUT, POLLING).WithArguments(
-		deviceId).ShouldNot(BeNil())
-	logrus.Infof("The device %s is reporting its status", deviceId)
-
-	// Check the device status.
-	response, err := h.GetDeviceWithStatusSystem(deviceId)
-	Expect(err).NotTo(HaveOccurred())
-	device := response.JSON200
-	Expect(device.Status.Summary.Status).To(Equal(v1beta1.DeviceSummaryStatusOnline))
-	Expect(*device.Status.Summary.Info).To(Equal(service.DeviceStatusInfoHealthy))
+	device := h.WaitForOnlineStatus(deviceId)
 	return deviceId, device
 }
 

--- a/test/harness/e2e/harness_agent.go
+++ b/test/harness/e2e/harness_agent.go
@@ -231,21 +231,28 @@ func (h *Harness) ApproveEnrollmentRequestWithLabels(enrollmentID string, labels
 	return resp.StatusCode(), nil
 }
 
-// WaitForDeviceWithSystemInfo polls until the Device exists and reports populated systemInfo.
+// WaitForDeviceWithSystemInfo polls until the Device is Online with populated systemInfo.
 func (h *Harness) WaitForDeviceWithSystemInfo(deviceID, timeout, polling string) (*v1beta1.Device, error) {
 	if strings.TrimSpace(deviceID) == "" {
 		return nil, fmt.Errorf("device ID is empty")
 	}
 
-	return pollUntil(timeout, polling, fmt.Sprintf("device %s systemInfo", deviceID), func() (*v1beta1.Device, bool, error) {
+	return pollUntil(timeout, polling, fmt.Sprintf("device %s online with systemInfo", deviceID), func() (*v1beta1.Device, bool, error) {
 		resp, err := h.Client.GetDeviceWithResponse(h.Context, deviceID)
 		if err != nil {
 			return nil, false, err
 		}
-		if resp != nil && resp.JSON200 != nil && resp.JSON200.Status != nil && !resp.JSON200.Status.SystemInfo.IsEmpty() {
-			return resp.JSON200, true, nil
+		if resp == nil || resp.JSON200 == nil || resp.JSON200.Status == nil {
+			return nil, false, nil
 		}
-		return nil, false, nil
+		device := resp.JSON200
+		if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
+			return nil, false, nil
+		}
+		if device.Status.SystemInfo.IsEmpty() {
+			return nil, false, nil
+		}
+		return device, true, nil
 	})
 }
 

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -90,22 +90,6 @@ func deviceHasApplicationWithStatus(device *v1beta1.Device, appName string, stat
 	return false
 }
 
-func applicationReadyForRunning(device *v1beta1.Device, appName string) bool {
-	if device == nil || device.Status == nil {
-		return false
-	}
-	for _, app := range device.Status.Applications {
-		if app.Name == appName && app.Status == v1beta1.ApplicationStatusRunning {
-			parts := strings.Split(app.Ready, "/")
-			if len(parts) != 2 {
-				return false
-			}
-			return parts[0] == parts[1]
-		}
-	}
-	return false
-}
-
 func deviceSummaryMatchesAny(device *v1beta1.Device, statuses []v1beta1.ApplicationsSummaryStatusType) bool {
 	if device == nil || device.Status == nil {
 		return false
@@ -778,7 +762,6 @@ func (h *Harness) waitForApplicationsSummaryCondition(deviceID string, descripti
 }
 
 // WaitForApplicationStatusByName waits for an application to reach the specified status.
-// For Running status, it also verifies ready replicas match.
 func (h *Harness) WaitForApplicationStatusByName(deviceId string, applicationName string, expectedStatus v1beta1.ApplicationStatusType) {
 	GinkgoWriter.Printf("Waiting for application %s to reach %s status\n", applicationName, expectedStatus)
 	h.WaitForDeviceContents(deviceId, fmt.Sprintf("Application %s", expectedStatus),
@@ -788,13 +771,6 @@ func (h *Harness) WaitForApplicationStatusByName(deviceId string, applicationNam
 			}
 			for _, application := range device.Status.Applications {
 				if application.Name == applicationName && application.Status == expectedStatus {
-					if expectedStatus == v1beta1.ApplicationStatusRunning {
-						parts := strings.Split(application.Ready, "/")
-						if len(parts) != 2 {
-							return false
-						}
-						return parts[0] == parts[1]
-					}
 					return true
 				}
 			}
@@ -832,7 +808,29 @@ func (h *Harness) WaitForApplicationsSummaryStatus(deviceId string, expectedStat
 
 // WaitForApplicationStatus polls until the device reports the given application with the given status, or timeout.
 func (h *Harness) WaitForApplicationStatus(deviceID, appName string, status v1beta1.ApplicationStatusType, timeout, polling time.Duration) error {
+	GinkgoWriter.Printf("Waiting for application %s to reach %s on device %s (timeout=%s, polling=%s)\n",
+		appName, status, deviceID, timeout, polling)
+
+	formatStatus := func(device *v1beta1.Device) string {
+		if device == nil || device.Status == nil {
+			return "<no device status>"
+		}
+		summary := string(device.Status.ApplicationsSummary.Status)
+		if device.Status.ApplicationsSummary.Info != nil && *device.Status.ApplicationsSummary.Info != "" {
+			summary = fmt.Sprintf("%s info=%q", summary, *device.Status.ApplicationsSummary.Info)
+		}
+		for _, app := range device.Status.Applications {
+			if app.Name == appName {
+				return fmt.Sprintf("status=%s ready=%s applicationsSummary=%s", app.Status, app.Ready, summary)
+			}
+		}
+		return fmt.Sprintf("app not in status.applications (applicationsSummary=%s)", summary)
+	}
+
 	deadline := time.Now().Add(timeout)
+	var lastStatus string
+	loggedInitial := false
+
 	for time.Now().Before(deadline) {
 		resp, err := h.GetDeviceWithStatusSystem(deviceID)
 		if err != nil {
@@ -840,16 +838,27 @@ func (h *Harness) WaitForApplicationStatus(deviceID, appName string, status v1be
 			time.Sleep(polling)
 			continue
 		}
-		if resp.JSON200 != nil && deviceHasApplicationWithStatus(resp.JSON200, appName, status) {
-			if status == v1beta1.ApplicationStatusRunning {
-				if applicationReadyForRunning(resp.JSON200, appName) {
-					return nil
-				}
-			} else {
+		if resp != nil && resp.JSON200 != nil {
+			current := formatStatus(resp.JSON200)
+			switch {
+			case !loggedInitial:
+				GinkgoWriter.Printf("Application %s initial status: %s\n", appName, current)
+				lastStatus = current
+				loggedInitial = true
+			case current != lastStatus:
+				GinkgoWriter.Printf("Application %s status changed: %s\n", appName, current)
+				lastStatus = current
+			}
+			if deviceHasApplicationWithStatus(resp.JSON200, appName, status) {
+				GinkgoWriter.Printf("Application %s reached %s: %s\n", appName, status, lastStatus)
 				return nil
 			}
 		}
 		time.Sleep(polling)
+	}
+	if loggedInitial {
+		return fmt.Errorf("timed out after %s waiting for application %s to have status %s (last observed: %s)",
+			timeout, appName, status, lastStatus)
 	}
 	return fmt.Errorf("timed out after %s waiting for application %s to have status %s", timeout, appName, status)
 }
@@ -867,7 +876,7 @@ func (h *Harness) WaitForApplicationSummary(deviceID string, timeout, polling ti
 			time.Sleep(polling)
 			continue
 		}
-		if resp.JSON200 != nil && deviceSummaryMatchesAny(resp.JSON200, expectedStatuses) {
+		if resp != nil && resp.JSON200 != nil && deviceSummaryMatchesAny(resp.JSON200, expectedStatuses) {
 			return nil
 		}
 		time.Sleep(polling)

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -24,14 +25,30 @@ const (
 	VMGuestMemoryDefault = "1024M"
 )
 
-const vmFedoraNoCloudUserData = `#cloud-config
-ssh_pwauth: true
-password: fedora
-chpasswd: { expire: False }`
-
 // VMYAML builds a KubeVirt VirtualMachine manifest for e2e tests. cloudInitVolumeYAML
 // is the cloudinitdisk volume entry (including list-item indentation under volumes)
 func VMYAML(name, guestMemory, image, cloudInitVolumeYAML string) string {
+	return vmYAMLManifest(name, guestMemory, image, 0, cloudInitVolumeYAML)
+}
+
+// VMFedoraNoCloudUserData returns cloud-init userData that enables password SSH for the fedora user.
+func VMFedoraNoCloudUserData(password string) string {
+	return fmt.Sprintf(`#cloud-config
+ssh_pwauth: true
+password: %s
+chpasswd: { expire: False }`, password)
+}
+
+// VMYAMLWithCPU builds a KubeVirt VirtualMachine manifest. cpuCores <= 0 omits the cpu block.
+func VMYAMLWithCPU(name, guestMemory, image string, cpuCores int, cloudInitUserData string) string {
+	return vmYAMLManifest(name, guestMemory, image, cpuCores, VMCloudInitNoCloudVolume(cloudInitUserData))
+}
+
+func vmYAMLManifest(name, guestMemory, image string, cpuCores int, cloudInitVolumeYAML string) string {
+	cpuBlock := ""
+	if cpuCores > 0 {
+		cpuBlock = fmt.Sprintf("        cpu:\n          cores: %d\n", cpuCores)
+	}
 	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -41,7 +58,7 @@ spec:
   template:
     spec:
       domain:
-        devices:
+%s        devices:
           disks:
           - disk:
               bus: virtio
@@ -63,7 +80,7 @@ spec:
       - containerdisk:
           image: %s
         name: containerdisk
-%s`, name, guestMemory, image, cloudInitVolumeYAML)
+%s`, name, cpuBlock, guestMemory, image, cloudInitVolumeYAML)
 }
 
 // VMYAMLWithConfigDrive builds a VM manifest using cloudInitConfigDrive userDataBase64.
@@ -299,7 +316,7 @@ func NewMountVolume(name, mountPath string) (v1beta1.ApplicationVolume, error) {
 // publishPorts so that the server-side renderer can inject it into the
 // generated .pod unit.
 func NewVmApplicationSpec(name, image string) (v1beta1.ApplicationProviderSpec, error) {
-	vmYAML := VMYAML(name, VMGuestMemoryDefault, image, VMCloudInitNoCloudVolume(vmFedoraNoCloudUserData))
+	vmYAML := VMYAML(name, VMGuestMemoryDefault, image, VMCloudInitNoCloudVolume(VMFedoraNoCloudUserData("fedora")))
 	return NewVmApplicationSpecFromYAML(name, []string{"2222:22"}, vmYAML)
 }
 
@@ -1243,12 +1260,35 @@ fi`,
 	)
 	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", script}, nil)
 	if err != nil {
-		return "", fmt.Errorf(
+		return "", classifyDeviceLocalSSHError(fmt.Errorf(
 			"running /bin/sh -c ssh script on device VM (localhost:%d user=%s remote=%s): %w",
 			port, user, strings.Join(remoteArgs, " "), err,
-		)
+		))
 	}
 	return trimSSHCommandOutput(out.String()), nil
+}
+
+var (
+	ErrSSHConnectionRefused = errors.New("ssh connection refused")
+	ErrSSHAuthFailed        = errors.New("ssh authentication failed")
+	ErrSSHTimeout           = errors.New("ssh connection timed out")
+)
+
+func classifyDeviceLocalSSHError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "connection refused"):
+		return fmt.Errorf("%w: %s", ErrSSHConnectionRefused, err.Error())
+	case strings.Contains(msg, "permission denied"), strings.Contains(msg, "authentication failed"):
+		return fmt.Errorf("%w: %s", ErrSSHAuthFailed, err.Error())
+	case strings.Contains(msg, "connection timed out"), strings.Contains(msg, "operation timed out"):
+		return fmt.Errorf("%w: %s", ErrSSHTimeout, err.Error())
+	default:
+		return err
+	}
 }
 
 // trimSSHCommandOutput returns the last non-empty line from nested SSH output. Device-side

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -42,8 +42,6 @@ spec:
           interfaces:
           - masquerade: {}
             name: default
-            ports:
-            - port: 2222
           rng: {}
         memory:
           guest: 1024M
@@ -271,7 +269,7 @@ func NewMountVolume(name, mountPath string) (v1beta1.ApplicationVolume, error) {
 // generated .pod unit.
 func NewVmApplicationSpec(name, image string) (v1beta1.ApplicationProviderSpec, error) {
 	vmYAML := fmt.Sprintf(vmYAMLTemplate, name, image)
-	publishPorts := []string{"2222:2222"}
+	publishPorts := []string{"2222:22"}
 
 	vmApp := v1beta1.VmApplication{
 		AppType:      v1beta1.AppTypeVm,
@@ -1153,6 +1151,63 @@ func (h *Harness) GetContainerPorts() (string, error) {
 // =============================================================================
 // VM operations
 // =============================================================================
+
+// RunSSHOnDeviceLocalPort runs ssh on the device host to localhost:port using password auth.
+// This exercises VM publishPorts mappings (e.g. host 2222 to guest 22).
+func (h *Harness) RunSSHOnDeviceLocalPort(port int, user, password string, remoteArgs ...string) (string, error) {
+	if h.VM == nil {
+		return "", fmt.Errorf("device VM is not configured")
+	}
+	if port <= 0 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+	if user == "" {
+		return "", fmt.Errorf("ssh user is required")
+	}
+	if password == "" {
+		return "", fmt.Errorf("ssh password is required")
+	}
+	if len(remoteArgs) == 0 {
+		return "", fmt.Errorf("remote command is required")
+	}
+
+	quotedRemoteArgs := make([]string, len(remoteArgs))
+	for i, arg := range remoteArgs {
+		quotedRemoteArgs[i] = shellQuote(arg)
+	}
+	quotedPassword := shellQuote(password)
+	script := fmt.Sprintf(`set -euo pipefail
+ssh_common=(ssh -p %d \
+  -o ConnectTimeout=10 \
+  -o PubkeyAuthentication=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=no \
+  -o LogLevel=ERROR \
+  %s %s)
+if command -v sshpass >/dev/null 2>&1; then
+  sshpass -p %s "${ssh_common[@]}"
+else
+  askpass=$(mktemp)
+  trap 'rm -f "$askpass"' EXIT
+  printf '#!/bin/sh\necho %%s\n' %s >"$askpass"
+  chmod 700 "$askpass"
+  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid "${ssh_common[@]}"
+fi`,
+		port,
+		shellQuote(user+"@127.0.0.1"),
+		strings.Join(quotedRemoteArgs, " "),
+		quotedPassword,
+		quotedPassword,
+	)
+	out, err := h.VM.RunSSH([]string{"bash", "-lc", script}, nil)
+	if err != nil {
+		return "", fmt.Errorf(
+			"running bash -lc ssh script on device VM (localhost:%d user=%s remote=%s): %w",
+			port, user, strings.Join(remoteArgs, " "), err,
+		)
+	}
+	return out.String(), nil
+}
 
 // RebootVMAndWaitForSSH triggers a reboot on the VM and waits for SSH to become ready again.
 func (h *Harness) RebootVMAndWaitForSSH(waitInterval time.Duration, maxAttempts int) error {

--- a/test/harness/e2e/harness_application.go
+++ b/test/harness/e2e/harness_application.go
@@ -20,9 +20,19 @@ const (
 	// QuadletUnitPath is the quadlet unit path on device (rootful)
 	QuadletUnitPath = "/etc/containers/systemd"
 
-	// vmYAMLTemplate is a KubeVirt VirtualMachine manifest template for e2e VM tests.
-	// Placeholders: 1=name, 2=containerdisk image.
-	vmYAMLTemplate = `apiVersion: kubevirt.io/v1
+	// VMGuestMemoryDefault is the guest RAM for e2e KubeVirt VM manifests.
+	VMGuestMemoryDefault = "1024M"
+)
+
+const vmFedoraNoCloudUserData = `#cloud-config
+ssh_pwauth: true
+password: fedora
+chpasswd: { expire: False }`
+
+// VMYAML builds a KubeVirt VirtualMachine manifest for e2e tests. cloudInitVolumeYAML
+// is the cloudinitdisk volume entry (including list-item indentation under volumes)
+func VMYAML(name, guestMemory, image, cloudInitVolumeYAML string) string {
+	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: %s
@@ -44,7 +54,7 @@ spec:
             name: default
           rng: {}
         memory:
-          guest: 1024M
+          guest: %s
         resources: {}
       networks:
       - name: default
@@ -53,15 +63,36 @@ spec:
       - containerdisk:
           image: %s
         name: containerdisk
-      - cloudInitNoCloud:
+%s`, name, guestMemory, image, cloudInitVolumeYAML)
+}
+
+// VMYAMLWithConfigDrive builds a VM manifest using cloudInitConfigDrive userDataBase64.
+func VMYAMLWithConfigDrive(name, guestMemory, image, userDataBase64 string) string {
+	return VMYAML(name, guestMemory, image, vmCloudInitConfigDriveVolume(userDataBase64))
+}
+
+// VMCloudInitNoCloudVolume returns the cloudinitdisk volume using cloudInitNoCloud.
+func VMCloudInitNoCloudVolume(userData string) string {
+	return fmt.Sprintf(`      - cloudInitNoCloud:
           userData: |-
-            #cloud-config
-            ssh_pwauth: true
-            password: fedora
-            chpasswd: { expire: False }
-        name: cloudinitdisk
-`
-)
+%s
+        name: cloudinitdisk`, vmIndentCloudInitUserData(userData, 12))
+}
+
+func vmCloudInitConfigDriveVolume(userDataBase64 string) string {
+	return fmt.Sprintf(`      - cloudInitConfigDrive:
+          userDataBase64: %s
+        name: cloudinitdisk`, userDataBase64)
+}
+
+func vmIndentCloudInitUserData(userData string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimSuffix(userData, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
 
 // QuadletPathForUser returns the quadlet systemd path for the given user.
 // Empty or "root" returns the root path; any other user returns the user's config path.
@@ -268,9 +299,13 @@ func NewMountVolume(name, mountPath string) (v1beta1.ApplicationVolume, error) {
 // publishPorts so that the server-side renderer can inject it into the
 // generated .pod unit.
 func NewVmApplicationSpec(name, image string) (v1beta1.ApplicationProviderSpec, error) {
-	vmYAML := fmt.Sprintf(vmYAMLTemplate, name, image)
-	publishPorts := []string{"2222:22"}
+	vmYAML := VMYAML(name, VMGuestMemoryDefault, image, VMCloudInitNoCloudVolume(vmFedoraNoCloudUserData))
+	return NewVmApplicationSpecFromYAML(name, []string{"2222:22"}, vmYAML)
+}
 
+// NewVmApplicationSpecFromYAML creates an inline VmApplication spec from a pre-built
+// KubeVirt VirtualMachine manifest and publishPorts list.
+func NewVmApplicationSpecFromYAML(name string, publishPorts []string, vmYAML string) (v1beta1.ApplicationProviderSpec, error) {
 	vmApp := v1beta1.VmApplication{
 		AppType:      v1beta1.AppTypeVm,
 		Name:         lo.ToPtr(name),
@@ -1176,37 +1211,123 @@ func (h *Harness) RunSSHOnDeviceLocalPort(port int, user, password string, remot
 		quotedRemoteArgs[i] = shellQuote(arg)
 	}
 	quotedPassword := shellQuote(password)
-	script := fmt.Sprintf(`set -euo pipefail
-ssh_common=(ssh -p %d \
-  -o ConnectTimeout=10 \
-  -o PubkeyAuthentication=no \
-  -o UserKnownHostsFile=/dev/null \
-  -o StrictHostKeyChecking=no \
-  -o LogLevel=ERROR \
-  %s %s)
-if command -v sshpass >/dev/null 2>&1; then
-  sshpass -p %s "${ssh_common[@]}"
-else
-  askpass=$(mktemp)
-  trap 'rm -f "$askpass"' EXIT
-  printf '#!/bin/sh\necho %%s\n' %s >"$askpass"
-  chmod 700 "$askpass"
-  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid "${ssh_common[@]}"
-fi`,
+	remoteCommand := strings.Join(quotedRemoteArgs, " ")
+	sshCommand := fmt.Sprintf(
+		`ssh -T -p %d -o ConnectTimeout=10 -o RequestTTY=no -o PubkeyAuthentication=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR %s %s`,
 		port,
 		shellQuote(user+"@127.0.0.1"),
-		strings.Join(quotedRemoteArgs, " "),
-		quotedPassword,
-		quotedPassword,
+		remoteCommand,
 	)
-	out, err := h.VM.RunSSH([]string{"bash", "-lc", script}, nil)
+	// Run via /bin/sh on the device. Inline the ssh command (not a shell function) because
+	// sshpass/setsid execute a binary and cannot invoke shell functions.
+	script := fmt.Sprintf(`set -eu
+ssh_home=$(mktemp -d)
+trap 'rm -rf "$ssh_home"' EXIT
+export HOME="$ssh_home"
+export PATH=/usr/local/bin:/usr/bin:/bin
+if command -v sshpass >/dev/null 2>&1; then
+  sshpass -p %s %s
+else
+  askpass="$ssh_home/askpass"
+  {
+    printf '%%s\n' '#!/bin/sh'
+    printf '%%s\n' "printf '%%s\n' %s"
+  } >"$askpass"
+  chmod 700 "$askpass"
+  SSH_ASKPASS="$askpass" SSH_ASKPASS_REQUIRE=force DISPLAY=:0 setsid %s
+fi`,
+		quotedPassword,
+		sshCommand,
+		quotedPassword,
+		sshCommand,
+	)
+	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", script}, nil)
 	if err != nil {
 		return "", fmt.Errorf(
-			"running bash -lc ssh script on device VM (localhost:%d user=%s remote=%s): %w",
+			"running /bin/sh -c ssh script on device VM (localhost:%d user=%s remote=%s): %w",
 			port, user, strings.Join(remoteArgs, " "), err,
 		)
 	}
-	return out.String(), nil
+	return trimSSHCommandOutput(out.String()), nil
+}
+
+// trimSSHCommandOutput returns the last non-empty line from nested SSH output. Device-side
+// shell profiles can print environment noise before the guest command result on stdout.
+func trimSSHCommandOutput(stdout string) string {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// UDPProbePythonCommand returns a remote shell command that sends a UDP datagram with
+// payload "ping" to 127.0.0.1:port and prints the trimmed reply. Intended for nested
+// SSH (device host -> guest published TCP port); uses a single-quoted python -c string.
+func UDPProbePythonCommand(port int) string {
+	return fmt.Sprintf(
+		`python3 -c 'import socket; port=%d; s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM); s.settimeout(2); s.sendto(b"ping", ("127.0.0.1", port)); print(s.recv(1024).decode().strip())'`,
+		port,
+	)
+}
+
+// udpProbeDeviceHostScript returns a shell script that probes localhost:port over UDP
+// using socat when available, otherwise python3 via a heredoc (avoids fragile -c quoting).
+func udpProbeDeviceHostScript(port int) string {
+	return fmt.Sprintf(`set -eu
+export PATH=/usr/local/bin:/usr/bin:/bin
+port=%d
+if command -v socat >/dev/null 2>&1; then
+  printf 'ping\n' | socat -t2 - UDP4:127.0.0.1:${port}
+elif command -v python3 >/dev/null 2>&1; then
+  python3 - "$port" <<'PY'
+import socket
+import sys
+port = int(sys.argv[1])
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.settimeout(2)
+s.sendto(b"ping", ("127.0.0.1", port))
+print(s.recv(1024).decode().strip())
+PY
+else
+  echo "UDP probe requires socat or python3" >&2
+  exit 127
+fi`, port)
+}
+
+// lastNonEmptyLine returns the last non-empty line from command output.
+func lastNonEmptyLine(stdout string) string {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// RunUDPProbeOnDeviceLocalPort sends a UDP "ping" datagram to localhost:port on the device host
+// and returns the response. This exercises VM publishPorts UDP mappings.
+func (h *Harness) RunUDPProbeOnDeviceLocalPort(port int) (string, error) {
+	if h.VM == nil {
+		return "", fmt.Errorf("device VM is not configured")
+	}
+	if port <= 0 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+
+	out, err := h.VM.RunSSH([]string{"/bin/sh", "-c", udpProbeDeviceHostScript(port)}, nil)
+	if err != nil {
+		return "", fmt.Errorf("running UDP probe on device host localhost:%d: %w", port, err)
+	}
+	raw := out.String()
+	reply := lastNonEmptyLine(raw)
+	if reply == "" {
+		return "", fmt.Errorf("UDP probe on localhost:%d returned empty output (raw stdout=%q)", port, raw)
+	}
+	return reply, nil
 }
 
 // RebootVMAndWaitForSSH triggers a reboot on the VM and waits for SSH to become ready again.

--- a/test/harness/e2e/harness_console.go
+++ b/test/harness/e2e/harness_console.go
@@ -3,7 +3,9 @@ package e2e
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,10 +14,70 @@ import (
 
 // ConsoleSession represents a PTY console session to a device
 type ConsoleSession struct {
-	Stdin            io.WriteCloser
-	Stdout           *Buffer
-	closeOnce        sync.Once
-	skipGracefulExit bool // when true, Close only releases fds (e.g. after flightctl "~." disconnect)
+	Stdin     io.WriteCloser
+	Stdout    *Buffer
+	closeOnce sync.Once
+}
+
+// NewAppConsoleSession starts a PTY console session to a VM application's serial or VNC console.
+func (h *Harness) NewAppConsoleSession(deviceID, appName, consoleType string) *ConsoleSession {
+	in, out, err := h.RunInteractiveCLI(
+		"app", "console", fmt.Sprintf("device/%s", deviceID),
+		"--name", appName,
+		"--type", consoleType,
+		"--tty",
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &ConsoleSession{Stdin: in, Stdout: BufferReader(out)}
+}
+
+// NewAppConsoleSessionWaitingForLogin opens a serial console and retries until the guest
+// login prompt appears. The VM app may report Running before getty is ready; connecting
+// too early can drop the session before boot completes.
+func (h *Harness) NewAppConsoleSessionWaitingForLogin(deviceID, appName string, timeout, polling time.Duration) *ConsoleSession {
+	if polling <= 0 {
+		polling = time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+	loginRE := regexp.MustCompile(`(?i)login:`)
+	var cs *ConsoleSession
+
+	for time.Now().Before(deadline) {
+		if cs == nil || cs.Stdout.Closed() {
+			if cs != nil {
+				cs.Close()
+				cs = nil
+			}
+			in, out, err := h.RunInteractiveCLI(
+				"app", "console", fmt.Sprintf("device/%s", deviceID),
+				"--name", appName,
+				"--type", "serial",
+				"--tty",
+			)
+			if err != nil {
+				GinkgoWriter.Printf("app serial console start failed: %v\n", err)
+				time.Sleep(polling)
+				continue
+			}
+			cs = &ConsoleSession{Stdin: in, Stdout: BufferReader(out)}
+		}
+
+		contents := cs.Stdout.Contents()
+		if loginRE.Match(contents) {
+			Expect(cs.Stdout.Clear()).To(Succeed())
+			return cs
+		}
+
+		time.Sleep(polling)
+	}
+
+	if cs != nil {
+		cs.Close()
+	}
+	Expect(fmt.Errorf("serial console login prompt not seen within %s", timeout)).NotTo(HaveOccurred())
+	return nil
 }
 
 // NewConsoleSession starts a PTY console session to the specified device.
@@ -40,24 +102,39 @@ func (cs *ConsoleSession) MustSend(cmd string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-// MustExpect waits for a pattern to appear in the console output
+// MustExpect waits for a pattern to appear in the console output.
+// Uses the suite's default Eventually timeout (e.g. cli_suite_test sets 1m/1s).
 func (cs *ConsoleSession) MustExpect(pattern string) {
 	GinkgoWriter.Printf("console EXPECT %q\n", pattern)
 	Eventually(cs.Stdout).Should(Say(pattern))
 	Expect(cs.Stdout.Clear()).To(Succeed())
 }
 
-// When called set Close function not to send the "exit" command before disconnecting the client
-// (e.g. flightctl "~." escape) and only release local PTY fds.
-func (cs *ConsoleSession) SkipGracefulExitOnClose() {
-	cs.skipGracefulExit = true
+// MustExpectWithin waits up to timeout for a pattern to appear in the console output.
+// Use a long timeout when the remote end may still be booting (e.g. VM serial console).
+func (cs *ConsoleSession) MustExpectWithin(pattern string, timeout, polling time.Duration) {
+	GinkgoWriter.Printf("console EXPECT %q (timeout %s)\n", pattern, timeout)
+	Eventually(cs.Stdout).WithTimeout(timeout).WithPolling(polling).Should(Say(pattern))
+	Expect(cs.Stdout.Clear()).To(Succeed())
 }
 
-// Close terminates the console session. When SkipGracefulExitOnClose was set (e.g. after "~."),
-// it only closes stdin/stdout without sending "exit".
+func mustParseDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	Expect(err).NotTo(HaveOccurred(), "parsing duration %q", s)
+	return d
+}
+
+// Disconnect sends the flightctl ~. escape sequence and waits for the CLI to exit.
+func (cs *ConsoleSession) Disconnect() {
+	Expect(cs.Stdin.Write([]byte("\n~.\n"))).To(BeNumerically(">", 0))
+	Eventually(cs.Stdout.Closed).WithTimeout(mustParseDuration(TIMEOUT)).WithPolling(mustParseDuration(POLLING)).Should(BeTrue())
+}
+
+// Close releases the console session. Sends exit when the session is still open;
+// after Disconnect() the buffer is already closed so only local fds are released.
 func (cs *ConsoleSession) Close() {
 	cs.closeOnce.Do(func() {
-		if !cs.skipGracefulExit {
+		if cs.Stdout != nil && !cs.Stdout.Closed() {
 			cs.sendExit()
 		}
 
@@ -72,6 +149,24 @@ func (cs *ConsoleSession) Close() {
 			}
 		}
 	})
+}
+
+// sendExit attempts to gracefully close the remote console without failing cleanup.
+func (cs *ConsoleSession) sendExit() {
+	if cs.Stdout == nil {
+		GinkgoWriter.Printf("console stdout is nil; sending graceful exit without clearing stdout\n")
+	} else if err := cs.Stdout.Clear(); err != nil {
+		GinkgoWriter.Printf("failed to clear console stdout before graceful exit: %v\n", err)
+	}
+	if cs.Stdin == nil {
+		GinkgoWriter.Printf("console stdin is nil; skipping graceful exit\n")
+		return
+	}
+
+	GinkgoWriter.Printf("console> exit\n")
+	if _, err := io.WriteString(cs.Stdin, "exit\n"); err != nil {
+		GinkgoWriter.Printf("failed to send graceful console exit: %v\n", err)
+	}
 }
 
 // RunConsoleCommand executes the flightctl console command for the given
@@ -93,24 +188,4 @@ func (h *Harness) RunConsoleCommand(deviceID string, flags []string, cmd ...stri
 	}
 
 	return h.CLI(args...)
-}
-
-// sendExit attempts to gracefully close the remote console without failing cleanup.
-func (cs *ConsoleSession) sendExit() {
-	if cs.Stdout == nil {
-		GinkgoWriter.Printf("console stdout is nil; sending graceful exit without clearing stdout\n")
-	} else if cs.Stdout.Closed() {
-		GinkgoWriter.Printf("console stdout is already closed; sending graceful exit without clearing stdout\n")
-	} else if err := cs.Stdout.Clear(); err != nil {
-		GinkgoWriter.Printf("failed to clear console stdout before graceful exit: %v\n", err)
-	}
-	if cs.Stdin == nil {
-		GinkgoWriter.Printf("console stdin is nil; skipping graceful exit\n")
-		return
-	}
-
-	GinkgoWriter.Printf("console> exit\n")
-	if _, err := io.WriteString(cs.Stdin, "exit\n"); err != nil {
-		GinkgoWriter.Printf("failed to send graceful console exit: %v\n", err)
-	}
 }

--- a/test/harness/e2e/harness_console.go
+++ b/test/harness/e2e/harness_console.go
@@ -20,13 +20,16 @@ type ConsoleSession struct {
 }
 
 // NewAppConsoleSession starts a PTY console session to a VM application's serial or VNC console.
-func (h *Harness) NewAppConsoleSession(deviceID, appName, consoleType string) *ConsoleSession {
-	in, out, err := h.RunInteractiveCLI(
+// extraArgs are appended to the flightctl app console command (for example "--force").
+func (h *Harness) NewAppConsoleSession(deviceID, appName, consoleType string, extraArgs ...string) *ConsoleSession {
+	args := []string{
 		"app", "console", fmt.Sprintf("device/%s", deviceID),
 		"--name", appName,
 		"--type", consoleType,
 		"--tty",
-	)
+	}
+	args = append(args, extraArgs...)
+	in, out, err := h.RunInteractiveCLI(args...)
 	Expect(err).ToNot(HaveOccurred())
 
 	return &ConsoleSession{Stdin: in, Stdout: BufferReader(out)}
@@ -107,7 +110,7 @@ func (cs *ConsoleSession) MustSend(cmd string) {
 func (cs *ConsoleSession) MustExpect(pattern string) {
 	GinkgoWriter.Printf("console EXPECT %q\n", pattern)
 	Eventually(cs.Stdout).Should(Say(pattern))
-	Expect(cs.Stdout.Clear()).To(Succeed())
+	cs.clearStdoutIfOpen()
 }
 
 // MustExpectWithin waits up to timeout for a pattern to appear in the console output.
@@ -115,7 +118,19 @@ func (cs *ConsoleSession) MustExpect(pattern string) {
 func (cs *ConsoleSession) MustExpectWithin(pattern string, timeout, polling time.Duration) {
 	GinkgoWriter.Printf("console EXPECT %q (timeout %s)\n", pattern, timeout)
 	Eventually(cs.Stdout).WithTimeout(timeout).WithPolling(polling).Should(Say(pattern))
-	Expect(cs.Stdout.Clear()).To(Succeed())
+	cs.clearStdoutIfOpen()
+}
+
+// clearStdoutIfOpen drops already-matched output so the next expect starts clean.
+// A session that has already exited (for example after --force takeover) closes the
+// buffer; clearing it would fail even though the pattern was seen.
+func (cs *ConsoleSession) clearStdoutIfOpen() {
+	if cs.Stdout == nil || cs.Stdout.Closed() {
+		return
+	}
+	if err := cs.Stdout.Clear(); err != nil {
+		GinkgoWriter.Printf("skipping stdout clear: %v\n", err)
+	}
 }
 
 func mustParseDuration(s string) time.Duration {

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -386,16 +386,9 @@ func (h *Harness) EnsureDeviceContents(deviceId string, description string, cond
 
 func (h *Harness) WaitForBootstrapAndUpdateToVersion(deviceId string, version string) (*v1beta1.Device, util.ImageReference, error) {
 	var imageReference = util.ImageReference{}
-	// Check the device status right after bootstrap
-	response, err := h.GetDeviceWithStatusSystem(deviceId)
-	if err != nil {
-		return nil, imageReference, err
-	}
-	device := response.JSON200
-	if device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
-		return nil, imageReference, fmt.Errorf("device: %q is not online", deviceId)
-	}
+	device := h.WaitForOnlineStatus(deviceId)
 
+	var err error
 	err = h.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
 		currentImage := device.Status.Os.Image
 		logrus.Infof("current image for %s is %s", deviceId, currentImage)

--- a/test/harness/e2e/vm/vm.go
+++ b/test/harness/e2e/vm/vm.go
@@ -137,6 +137,10 @@ func (v *TestVM) sshCommandWithUserContext(ctx context.Context, inputArgs []stri
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "LogLevel=ERROR",
 		"-o", "SetEnv=LC_ALL="}
+	if len(inputArgs) > 0 {
+		// Non-interactive remote commands: no TTY so motd/profile noise stays off stdout.
+		sshArgs = append(sshArgs, "-T")
+	}
 
 	var cmd *exec.Cmd
 	if v.SSHPrivateKeyPath != "" {

--- a/test/integration/service/enrollmentrequest_device_creation_test.go
+++ b/test/integration/service/enrollmentrequest_device_creation_test.go
@@ -187,6 +187,88 @@ var _ = Describe("EnrollmentRequest Device Creation Unit Tests", func() {
 		})
 	})
 
+	Context("createDeviceFromEnrollmentRequest with enrollment systemInfo", func() {
+		It("When enrollment systemInfo has distroId it should copy it onto the device after approval", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.OperatingSystem = "linux"
+			enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+			enrollmentStatus.SystemInfo.Set("distroVersion", "9.5 (Plow)")
+			er.Spec.DeviceStatus = &enrollmentStatus
+
+			By("creating enrollment request with systemInfo")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(suite.Ctx, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			By("verifying device systemInfo")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status).ToNot(BeNil())
+			id, found := device.Status.SystemInfo.Get("distroId")
+			Expect(found).To(BeTrue())
+			Expect(id).To(Equal("rhel"))
+			version, found := device.Status.SystemInfo.Get("distroVersion")
+			Expect(found).To(BeTrue())
+			Expect(version).To(Equal("9.5 (Plow)"))
+			Expect(device.Status.SystemInfo.OperatingSystem).To(Equal("linux"))
+			Expect(device.Status.Lifecycle.Status).To(Equal(api.DeviceLifecycleStatusEnrolled))
+		})
+
+		It("When awaitingReconnect is set it should keep systemInfo and set awaiting reconnect summary", func() {
+			er := CreateTestER()
+			erName := lo.FromPtr(er.Metadata.Name)
+			er.Metadata.Annotations = &map[string]string{
+				api.DeviceAnnotationAwaitingReconnect: "true",
+			}
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.Set("distroId", "rhel")
+			enrollmentStatus.SystemInfo.Set("distroVersion", "10.0 (Coughlan)")
+			er.Spec.DeviceStatus = &enrollmentStatus
+
+			By("creating enrollment request")
+			created, status := suite.EnrollmentRequest.CreateEnrollmentRequest(suite.Ctx, suite.OrgID, er)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusCreated))
+			Expect(created).ToNot(BeNil())
+
+			By("approving the enrollment request")
+			defaultOrg := &model.Organization{
+				ID:          org.DefaultID,
+				ExternalID:  org.DefaultID.String(),
+				DisplayName: org.DefaultID.String(),
+			}
+			mappedIdentity := identity.NewMappedIdentity("testuser", "", []*model.Organization{defaultOrg}, map[string][]string{}, false, nil)
+			ctxApproval := context.WithValue(suite.Ctx, consts.MappedIdentityCtxKey, mappedIdentity)
+
+			approval := api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{"approved": "true"},
+			}
+			_, st := suite.EnrollmentRequest.ApproveEnrollmentRequest(ctxApproval, suite.OrgID, erName, approval)
+			Expect(st.Code).To(BeEquivalentTo(http.StatusOK))
+
+			By("verifying device systemInfo and awaiting reconnect summary")
+			device, status := suite.Device.GetDevice(suite.Ctx, suite.OrgID, erName)
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(device.Status.Summary.Status).To(Equal(api.DeviceSummaryStatusAwaitingReconnect))
+			id, found := device.Status.SystemInfo.Get("distroId")
+			Expect(found).To(BeTrue())
+			Expect(id).To(Equal("rhel"))
+			version, found := device.Status.SystemInfo.Get("distroVersion")
+			Expect(found).To(BeTrue())
+			Expect(version).To(Equal("10.0 (Coughlan)"))
+		})
+	})
+
 	Context("createDeviceFromEnrollmentRequest with osMode capabilities", func() {
 		It("When osMode is package it should set device capabilities.osMode to package", func() {
 			er := CreateTestER()

--- a/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
+++ b/test/integration/tasks/vmrender/enrollment_vm_launcher_test.go
@@ -1,0 +1,288 @@
+package vmrender_test
+
+import (
+	"context"
+	"crypto"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/config"
+	cacfg "github.com/flightctl/flightctl/internal/config/ca"
+	"github.com/flightctl/flightctl/internal/consts"
+	icrypto "github.com/flightctl/flightctl/internal/crypto"
+	"github.com/flightctl/flightctl/internal/identity"
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/rendered"
+	dependencyrefservice "github.com/flightctl/flightctl/internal/service/dependencyref"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	enrollmentrequestservice "github.com/flightctl/flightctl/internal/service/enrollmentrequest"
+	"github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
+	"github.com/flightctl/flightctl/internal/store"
+	certificatesigningrequeststore "github.com/flightctl/flightctl/internal/store/certificatesigningrequest"
+	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
+	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	enrollmentrequeststore "github.com/flightctl/flightctl/internal/store/enrollmentrequest"
+	eventstore "github.com/flightctl/flightctl/internal/store/event"
+	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
+	repositorystore "github.com/flightctl/flightctl/internal/store/repository"
+	templateversionstore "github.com/flightctl/flightctl/internal/store/templateversion"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	fcrypto "github.com/flightctl/flightctl/pkg/crypto"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+const (
+	testFleetLabelKey    = "vm-fleet"
+	testFleetLabelValue  = "true"
+	rhel9LauncherImage   = "registry.example.com/virt-launcher-rhel9:test"
+	rhel10LauncherImage  = "registry.example.com/virt-launcher-rhel10:test"
+	defaultLauncherImage = "registry.example.com/virt-launcher:default"
+)
+
+const testVmYAML = `apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 1
+        memory:
+          guest: 1Gi
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/containerdisks/fedora:40
+`
+
+var _ = Describe("Enrollment VM launcher image selection", func() {
+	var (
+		log                *logrus.Logger
+		ctx                context.Context
+		orgId              uuid.UUID
+		cfg                *config.Config
+		dbName             string
+		db                 *gorm.DB
+		ctrl               *gomock.Controller
+		kvStoreInst        kvstore.KVStore
+		deviceStore        devicestore.Store
+		fleetStore         fleetstore.Store
+		tvStore            templateversionstore.Store
+		deviceSvc          deviceservice.Service
+		fleetSvc           fleetservice.Service
+		templateVersionSvc templateversionservice.Service
+		dependencyrefSvc   dependencyrefservice.Service
+		repositorySvc      repositoryservice.Service
+		enrollmentSvc      enrollmentrequestservice.Service
+		origPath           string
+		origPathSet        bool
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		orgId = store.NullOrgId
+		log = flightlog.InitLogs()
+
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(json.Unmarshal([]byte(`{
+			"worker": {
+				"vmRender": {
+					"launcherImage": "`+defaultLauncherImage+`",
+					"launcherImages": {
+						"rhel-9": "`+rhel9LauncherImage+`",
+						"rhel-10": "`+rhel10LauncherImage+`"
+					}
+				}
+			}
+		}`), cfg)).To(Succeed())
+
+		deviceStore = devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+		fleetStore = fleetstore.NewFleetStore(db, log.WithField("pkg", "fleet-store"))
+		tvStore = templateversionstore.NewTemplateVersionStore(db, log.WithField("pkg", "templateversion-store"))
+		erStore := enrollmentrequeststore.NewEnrollmentRequestStore(db, log.WithField("pkg", "enrollmentrequest-store"))
+		csrStore := certificatesigningrequeststore.NewCertificateSigningRequestStore(db, log.WithField("pkg", "csr-store"))
+		eventStore := eventstore.NewEventStore(db, log.WithField("pkg", "event-store"))
+		repoStore := repositorystore.NewRepositoryStore(db, log.WithField("pkg", "repository-store"))
+		depStore := dependencyrefstore.NewDependencyRefStore(db, log.WithField("pkg", "dependencyref-store"))
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer := queues.NewMockQueueProducer(ctrl)
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		workerClient := worker_client.NewWorkerClient(mockQueueProducer, log)
+
+		kvStoreInst, err = kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+		Expect(err).ToNot(HaveOccurred())
+		eventsSvc := events.NewServiceHandler(eventStore, workerClient, log)
+
+		caClient, _, err := icrypto.EnsureCA(cacfg.NewDefault(GinkgoT().TempDir()))
+		Expect(err).ToNot(HaveOccurred())
+
+		deviceSvc = deviceservice.NewDeviceServiceHandler(deviceStore, nil, fleetStore, eventsSvc, kvStoreInst, "", log)
+		fleetSvc = fleetservice.NewServiceHandler(fleetStore, nil, eventsSvc, log)
+		templateVersionSvc = templateversionservice.NewServiceHandler(tvStore, kvStoreInst, eventsSvc, log)
+		dependencyrefSvc = dependencyrefservice.NewServiceHandler(depStore, log)
+		repositorySvc = repositoryservice.NewServiceHandler(repoStore, eventsSvc, log)
+		enrollmentSvc = enrollmentrequestservice.NewServiceHandler(erStore, deviceStore, csrStore, caClient, kvStoreInst, eventsSvc, log, []string{}, "", "")
+
+		ctx = context.WithValue(ctx, consts.MappedIdentityCtxKey, identity.NewMappedIdentity("admin", "uid-admin", nil, nil, true, nil))
+
+		queuesProvider, err := queues.NewRedisProvider(ctx, log, fmt.Sprintf("vm-enroll-launcher-%s", uuid.New().String()), redisHost, redisPort, redisPassword, queues.DefaultRetryConfig())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rendered.Bus.Initialize(ctx, kvStoreInst, queuesProvider, 10*time.Second, log)).To(Succeed())
+
+		origPath, origPathSet = os.LookupEnv("PATH")
+		Expect(os.Setenv("PATH", filepath.Dir(vmBinaryPath)+string(os.PathListSeparator)+origPath)).To(Succeed())
+
+		testutil.CreateTestFleet(ctx, fleetStore, orgId, "vm-launcher-fleet", &map[string]string{testFleetLabelKey: testFleetLabelValue}, nil)
+		vmApp := inlineTestVmApp()
+		appSpec := api.ApplicationProviderSpec{}
+		Expect(appSpec.FromVmApplication(vmApp)).To(Succeed())
+		tvStatus := api.TemplateVersionStatus{Applications: &[]api.ApplicationProviderSpec{appSpec}}
+		Expect(testutil.CreateTestTemplateVersion(ctx, tvStore, orgId, "vm-launcher-fleet", "1.0.0", &tvStatus)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		restoreOrigPath(origPath, origPathSet)
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+		ctrl.Finish()
+	})
+
+	DescribeTable("When a device enrolls into a VM fleet it should render the virt-launcher for its OS",
+		func(distroId, distroVersion, wantImage string) {
+			deviceName, csr := enrollmentNameAndCSR()
+			enrollmentStatus := api.NewDeviceStatus()
+			enrollmentStatus.SystemInfo.Set("distroId", distroId)
+			enrollmentStatus.SystemInfo.Set("distroVersion", distroVersion)
+
+			er := api.EnrollmentRequest{
+				ApiVersion: "v1beta1",
+				Kind:       "EnrollmentRequest",
+				Metadata:   api.ObjectMeta{Name: lo.ToPtr(deviceName)},
+				Spec: api.EnrollmentRequestSpec{
+					Csr:          csr,
+					DeviceStatus: &enrollmentStatus,
+					Labels:       &map[string]string{testFleetLabelKey: testFleetLabelValue},
+				},
+			}
+			created, status := enrollmentSvc.CreateEnrollmentRequest(ctx, orgId, er)
+			Expect(status.Code).To(BeNumerically("==", 201))
+			Expect(created).ToNot(BeNil())
+
+			_, status = enrollmentSvc.ApproveEnrollmentRequest(ctx, orgId, deviceName, api.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   &map[string]string{},
+			})
+			Expect(status.Code).To(BeNumerically("==", 200))
+
+			event := api.Event{
+				Reason:         api.EventReasonResourceCreated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: deviceName},
+			}
+			selectorLogic := tasks.NewFleetSelectorMatchingLogic(log, deviceSvc, fleetSvc, orgId, event)
+			Expect(selectorLogic.DeviceLabelsUpdated(ctx)).To(Succeed())
+
+			device, err := deviceStore.Get(ctx, orgId, deviceName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lo.FromPtr(device.Metadata.Owner)).To(Equal("Fleet/vm-launcher-fleet"))
+
+			rolloutLogic := tasks.NewFleetRolloutsLogic(log, fleetSvc, templateVersionSvc, deviceSvc, dependencyrefSvc, orgId, event)
+			Expect(rolloutLogic.RolloutDevice(ctx)).To(Succeed())
+
+			renderLogic := tasks.NewDeviceRenderLogic(log, deviceSvc, repositorySvc, nil, &mockK8sClient{}, kvStoreInst, cfg, orgId, event)
+			Expect(renderLogic.RenderDevice(ctx)).To(Succeed())
+
+			renderedDevice, getStatus := deviceSvc.GetRenderedDevice(ctx, orgId, deviceName, api.GetRenderedDeviceParams{})
+			Expect(getStatus.Code).To(BeNumerically("==", 200))
+			Expect(renderedDevice.Spec).ToNot(BeNil())
+			Expect(renderedDevice.Spec.Applications).ToNot(BeNil())
+			Expect(renderedContents(*renderedDevice.Spec.Applications)).To(ContainSubstring("Image=" + wantImage))
+		},
+		Entry("When distro is rhel 9 it should use the rhel-9 launcher", "rhel", "9.5 (Plow)", rhel9LauncherImage),
+		Entry("When distro is rhel 10 it should use the rhel-10 launcher", "rhel", "10.0 (Coughlan)", rhel10LauncherImage),
+		Entry("When distro is fedora it should use launcherImage", "fedora", "42 (Adams)", defaultLauncherImage),
+	)
+})
+
+func restoreOrigPath(origPath string, origPathSet bool) {
+	GinkgoHelper()
+	if origPathSet {
+		Expect(os.Setenv("PATH", origPath)).To(Succeed())
+		return
+	}
+	Expect(os.Unsetenv("PATH")).To(Succeed())
+}
+
+func inlineTestVmApp() api.VmApplication {
+	GinkgoHelper()
+	inlineSpec := api.InlineApplicationProviderSpec{
+		Inline: []api.ApplicationContent{
+			{Path: "vm.yaml", Content: lo.ToPtr(testVmYAML)},
+		},
+	}
+	vmApp := api.VmApplication{
+		AppType: api.AppTypeVm,
+		Name:    lo.ToPtr("test-vm"),
+	}
+	Expect(vmApp.FromInlineApplicationProviderSpec(inlineSpec)).To(Succeed())
+	return vmApp
+}
+
+func enrollmentNameAndCSR() (string, string) {
+	GinkgoHelper()
+	publicKey, privateKey, err := fcrypto.NewKeyPair()
+	Expect(err).ToNot(HaveOccurred())
+	publicKeyHash, err := fcrypto.HashPublicKey(publicKey)
+	Expect(err).ToNot(HaveOccurred())
+	deviceName := strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(publicKeyHash))
+	csrPEM, err := fcrypto.MakeCSR(privateKey.(crypto.Signer), deviceName)
+	Expect(err).ToNot(HaveOccurred())
+	return deviceName, string(csrPEM)
+}
+
+func renderedContents(apps []api.ApplicationProviderSpec) string {
+	GinkgoHelper()
+	var b strings.Builder
+	for _, app := range apps {
+		quadlet, err := app.AsQuadletApplication()
+		Expect(err).ToNot(HaveOccurred())
+		inline, err := quadlet.AsInlineApplicationProviderSpec()
+		Expect(err).ToNot(HaveOccurred())
+		for _, f := range inline.Inline {
+			if f.Content != nil {
+				b.WriteString(*f.Content)
+				b.WriteByte('\n')
+			}
+		}
+	}
+	return b.String()
+}

--- a/test/integration/tasks/vmrender/suite_test.go
+++ b/test/integration/tasks/vmrender/suite_test.go
@@ -33,6 +33,7 @@ var (
 	redisCleanup  func()
 
 	vmConverter     tasks.VmConverterFn
+	vmBinaryPath    string
 	vmBinaryCleanup func()
 )
 
@@ -63,7 +64,8 @@ var _ = SynchronizedBeforeSuite(
 			suiteCtx, flightlog.InitLogs())
 		Expect(err).NotTo(HaveOccurred())
 
-		vmConverter = tasks.NewVmConverter(string(binaryPathBytes), tasks.DefaultVmRenderOptions())
+		vmBinaryPath = string(binaryPathBytes)
+		vmConverter = tasks.NewVmConverter(vmBinaryPath, tasks.DefaultVmRenderOptions())
 	},
 )
 

--- a/test/scripts/agent-images/agent-images.mk
+++ b/test/scripts/agent-images/agent-images.mk
@@ -10,19 +10,9 @@ bin/output/qcow2/disk.qcow2: $(E2E_AGENT_IMAGES_SENTINEL)
 # Build + bundle artifacts (no push)
 $(E2E_AGENT_IMAGES_SENTINEL): | bin
 	@if [ ! -f "$(AGENT_BUNDLE)" ]; then \
-		# For EL10, use COPR packages instead of local RPMs \
-		case "$(AGENT_OS_ID)" in \
-			cs10*) \
-				echo "Using COPR packages for EL10 build"; \
-				BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
-					FLIGHTCTL_RPM=stable AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
-				;; \
-			*) \
-				$(MAKE) bin/.rpm; \
-				BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
-					AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
-				;; \
-		esac; \
+		$(MAKE) bin/.rpm; \
+		BREW_BUILD_URL=$(BREW_BUILD_URL) SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) SOURCE_GIT_TREE_STATE=$(SOURCE_GIT_TREE_STATE) SOURCE_GIT_COMMIT=$(SOURCE_GIT_COMMIT) \
+			AGENT_OS_ID=$(AGENT_OS_ID) PUSH_IMAGES=false ARTIFACTS_OUTPUT_DIR=$(AGENT_BUNDLE_DIR) $(ROOT_DIR)/test/scripts/agent-images/create_agent_images.sh; \
 	else \
 		echo "Device bundle already exists at $(AGENT_BUNDLE)"; \
 	fi

--- a/test/scripts/deploy_with_helm.sh
+++ b/test/scripts/deploy_with_helm.sh
@@ -8,8 +8,8 @@ DB_SIZE_PARAMS=
 # IMAGE_PULL_SECRET_PATH=
 SQL_IMAGE="quay.io/sclorg/postgresql-16-c9s"
 SQL_VERSION="20250214"
-KV_IMAGE="quay.io/sclorg/redis-7-c9s"
-KV_VERSION="20250108"
+KV_IMAGE="quay.io/sclorg/valkey-8-c10s"
+KV_VERSION="20260121"
 
 source "${SCRIPT_DIR}"/functions
 # Dup stderr to fd 3 for run_on_quadlet command traces (test/scripts/functions); same as e2e_startup.sh.

--- a/test/scripts/detect_container_runtime.sh
+++ b/test/scripts/detect_container_runtime.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the socket precedence here aligned with
+# test/harness/containers/docker_host.go (detectContainerSocket,
+# ConfigureDockerHost, RuntimeCLIName).
+
+detect_container_socket() {
+  local uid home_dir
+
+  uid="$(id -u)"
+  home_dir=""
+
+  if command -v getent >/dev/null 2>&1; then
+    home_dir="$(getent passwd "${uid}" | cut -d: -f6 2>/dev/null || true)"
+  fi
+  if [[ -z "${home_dir}" ]]; then
+    home_dir="${HOME:-}"
+  fi
+
+  if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    if [[ -S "${XDG_RUNTIME_DIR}/podman/podman.sock" ]]; then
+      printf '%s\n' "${XDG_RUNTIME_DIR}/podman/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ "${uid}" != "0" ]]; then
+    if [[ -S "/run/user/${uid}/podman/podman.sock" ]]; then
+      printf '%s\n' "/run/user/${uid}/podman/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ -n "${home_dir}" ]]; then
+    if [[ -S "${home_dir}/.local/share/containers/podman/machine/podman.sock" ]]; then
+      printf '%s\n' "${home_dir}/.local/share/containers/podman/machine/podman.sock"
+      return 0
+    fi
+  fi
+
+  if [[ -S /var/run/docker.sock ]]; then
+    printf '%s\n' /var/run/docker.sock
+    return 0
+  fi
+
+  if [[ -S /run/podman/podman.sock ]]; then
+    printf '%s\n' /run/podman/podman.sock
+    return 0
+  fi
+
+  return 1
+}
+
+configure_testcontainers_docker_host() {
+  local socket_path
+
+  if [[ -n "${DOCKER_HOST:-}" ]]; then
+    return 0
+  fi
+
+  if socket_path="$(detect_container_socket)"; then
+    export DOCKER_HOST="unix://${socket_path}"
+  fi
+}
+
+detect_testcontainers_runtime() {
+  if [[ "${DOCKER_HOST:-}" == *podman* ]]; then
+    printf '%s\n' podman
+    return 0
+  fi
+
+  if [[ -n "${DOCKER_HOST:-}" ]]; then
+    printf '%s\n' docker
+    return 0
+  fi
+
+  printf '%s\n' docker
+}

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -85,6 +85,7 @@ var DefaultSystemInfo = []string{
 	"kernel",
 	"distroName",
 	"distroVersion",
+	"distroId",
 	"productName",
 	"productUuid",
 	"productSerial",


### PR DESCRIPTION
*Backporting PRs for release 1.3:*

PR 3370 *[EDM-4742: Remove the ready-replica gate for Running](https://github.com/flightctl/flightctl/pull/3370)*
PR 3375 *[NO-ISSUE: align package image preload with testcontainers runtime](https://github.com/flightctl/flightctl/pull/3375)*
PR 3226 *[Fixes #3347: Add aarch64 container image builds](https://github.com/flightctl/flightctl/pull/3226)*
PR 3360 *[EDM-5037: Use host networking for ImageExport bootc-image-builder](https://github.com/flightctl/flightctl/pull/3360)*
PR 3380 *[NO-ISSUE: include remote-access in flightctl.target](https://github.com/flightctl/flightctl/pull/3380)*
PR 3379 *[EDM-4115: Extend VM e2e Basic test](https://github.com/flightctl/flightctl/pull/3379)*
PR 3413 *[EDM-5204: do not fail RPM %pre when no dry-run temp script is created](https://github.com/flightctl/flightctl/pull/3413)*
PR 3412 *[4.2 multiple vms](https://github.com/flightctl/flightctl/pull/3412)*
PR 3414 *[EDM-4115: Add VM e2e tests for spec updates and crash recovery](https://github.com/flightctl/flightctl/pull/3414)*
PR 3429 *[EDM-5266: Select virt-launcher image from device OS major](https://github.com/flightctl/flightctl/pull/3429)*
