### PR TITLE
EDM-5248: Define Scanner interface and extend store query

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -433,7 +433,7 @@ For more detailed configuration options, see the [Values](#values) section below
 | upgradeHooks.scaleDown.deployments | list | `["flightctl-periodic","flightctl-worker"]` | List of Deployments to scale down in order |
 | upgradeHooks.scaleDown.timeoutSeconds | int | `120` | Timeout in seconds to wait for rollout per Deployment |
 | vulnerabilityReporting | object | `{"backend":"","enabled":false,"syncInterval":"15m","trustify":{"auth":{"mode":"none","oidcIssuerUrl":"","secretName":""},"endpoint":""}}` | Vulnerability Integration Configuration |
-| vulnerabilityReporting.backend | string | `""` | Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present. |
+| vulnerabilityReporting.backend | string | `""` | Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config with a non-empty endpoint is present. |
 | vulnerabilityReporting.enabled | bool | `false` | Enable vulnerability integration (sync task + API endpoints). |
 | vulnerabilityReporting.syncInterval | string | `"15m"` | Sync interval for periodic Trustify fetch (e.g. "15m", "1h"). |
 | vulnerabilityReporting.trustify.auth.mode | string | `"none"` | Authentication mode for Trustify. Allowed values: 'client-credentials', 'none'. |

--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -432,7 +432,8 @@ For more detailed configuration options, see the [Values](#values) section below
 | upgradeHooks.scaleDown.condition | string | `"chart"` | When to run pre-upgrade scale down job: "always", "never", or "chart" (default). "chart" runs only if helm.sh/chart changed. |
 | upgradeHooks.scaleDown.deployments | list | `["flightctl-periodic","flightctl-worker"]` | List of Deployments to scale down in order |
 | upgradeHooks.scaleDown.timeoutSeconds | int | `120` | Timeout in seconds to wait for rollout per Deployment |
-| vulnerabilityReporting | object | `{"enabled":false,"syncInterval":"15m","trustify":{"auth":{"mode":"none","oidcIssuerUrl":"","secretName":""},"endpoint":""}}` | Vulnerability Integration Configuration |
+| vulnerabilityReporting | object | `{"backend":"","enabled":false,"syncInterval":"15m","trustify":{"auth":{"mode":"none","oidcIssuerUrl":"","secretName":""},"endpoint":""}}` | Vulnerability Integration Configuration |
+| vulnerabilityReporting.backend | string | `""` | Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present. |
 | vulnerabilityReporting.enabled | bool | `false` | Enable vulnerability integration (sync task + API endpoints). |
 | vulnerabilityReporting.syncInterval | string | `"15m"` | Sync interval for periodic Trustify fetch (e.g. "15m", "1h"). |
 | vulnerabilityReporting.trustify.auth.mode | string | `"none"` | Authentication mode for Trustify. Allowed values: 'client-credentials', 'none'. |

--- a/deploy/helm/flightctl/templates/periodic/flightctl-periodic-config.yaml
+++ b/deploy/helm/flightctl/templates/periodic/flightctl-periodic-config.yaml
@@ -71,6 +71,9 @@ data:
     vulnerabilityReporting:
         enabled: true
         syncInterval: {{ $vuln.syncInterval | default "15m" | quote }}
+        {{- if $vuln.backend }}
+        backend: {{ $vuln.backend | quote }}
+        {{- end }}
         {{- if $vuln.trustify }}
         trustify:
             endpoint: {{ $trustify.endpoint | quote }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -975,7 +975,7 @@
         "syncInterval": { "type": "string", "description": "Sync interval for periodic Trustify fetch (e.g. \"15m\", \"1h\")" },
         "backend": {
           "type": "string",
-          "description": "Vulnerability scanning backend. Currently only 'trustify' is supported; leave empty to default to Trustify when a trustify config is present.",
+          "description": "Vulnerability scanning backend. Currently only 'trustify' is supported; leave empty to default to Trustify when a trustify config with a non-empty endpoint is present.",
           "enum": ["", "trustify"]
         },
         "trustify": {

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -973,6 +973,11 @@
       "properties": {
         "enabled": { "type": "boolean", "description": "Enable vulnerability integration (sync task + API endpoints)" },
         "syncInterval": { "type": "string", "description": "Sync interval for periodic Trustify fetch (e.g. \"15m\", \"1h\")" },
+        "backend": {
+          "type": "string",
+          "description": "Vulnerability scanning backend. Currently only 'trustify' is supported; leave empty to default to Trustify when a trustify config is present.",
+          "enum": ["", "trustify"]
+        },
         "trustify": {
           "type": "object",
           "description": "Trustify API connection details",

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -551,7 +551,7 @@ vulnerabilityReporting:
   enabled: false
   # -- Sync interval for periodic Trustify fetch (e.g. "15m", "1h").
   syncInterval: "15m"
-  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present.
+  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config with a non-empty endpoint is present.
   backend: ""
   trustify:
     # -- Trustify API base URL (do not include /api/v1 or /api/v2 paths).

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -551,6 +551,8 @@ vulnerabilityReporting:
   enabled: false
   # -- Sync interval for periodic Trustify fetch (e.g. "15m", "1h").
   syncInterval: "15m"
+  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present.
+  backend: ""
   trustify:
     # -- Trustify API base URL (do not include /api/v1 or /api/v2 paths).
     endpoint: ""

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -551,7 +551,7 @@ vulnerabilityReporting:
   enabled: false
   # -- Sync interval for periodic Trustify fetch (e.g. "15m", "1h").
   syncInterval: "15m"
-  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present.
+  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config with a non-empty endpoint is present.
   backend: ""
   trustify:
     # -- Trustify API base URL (do not include /api/v1 or /api/v2 paths).

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -551,6 +551,8 @@ vulnerabilityReporting:
   enabled: false
   # -- Sync interval for periodic Trustify fetch (e.g. "15m", "1h").
   syncInterval: "15m"
+  # -- Vulnerability scanning backend. Currently only "trustify" is supported; leave empty to default to Trustify when a trustify config is present.
+  backend: ""
   trustify:
     # -- Trustify API base URL (do not include /api/v1 or /api/v2 paths).
     endpoint: ""

--- a/docs/user/installing/configuring-vulnerability-integration.md
+++ b/docs/user/installing/configuring-vulnerability-integration.md
@@ -61,6 +61,7 @@ The following table describes all configuration fields under the `vulnerabilityR
 |---|---|---|---|
 | `enabled` | boolean | `false` | Enables vulnerability integration. Set to `true` to activate sync and API endpoints. |
 | `syncInterval` | duration | `15m` | Interval between Trustify sync runs. Use Go duration syntax, for example `15m`, `1h`. |
+| `backend` | string | — | Vulnerability scanning backend. Currently only `trustify` is supported. When empty, defaults to Trustify if a `trustify` config is present. |
 | `trustify.endpoint` | string | — | Trustify API base URL. Required when `enabled` is `true`. |
 | `trustify.auth.mode` | string | `none` | Authentication mode. Allowed values: `none`, `client-credentials`. |
 | `trustify.auth.oidcIssuerUrl` | string | — | OIDC issuer URL. Required when `mode` is `client-credentials`. |
@@ -152,6 +153,7 @@ credentials as environment variables.
 |---|---|
 | `FLIGHTCTL_VULNERABILITY_REPORTING_ENABLED` | Enables or disables vulnerability integration. Accepted values: `true`, `1`, `false`, `0`. |
 | `FLIGHTCTL_VULNERABILITY_REPORTING_SYNC_INTERVAL` | Sync interval. Use Go duration syntax, for example `15m`. |
+| `FLIGHTCTL_VULNERABILITY_REPORTING_BACKEND` | Vulnerability scanning backend. Currently only `trustify` is supported. |
 | `FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_ENDPOINT` | Trustify API base URL. |
 | `FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_AUTH_MODE` | Authentication mode (`none` or `client-credentials`). |
 | `FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_OIDC_ISSUER_URL` | OIDC issuer URL for client-credentials mode. |

--- a/docs/user/installing/configuring-vulnerability-integration.md
+++ b/docs/user/installing/configuring-vulnerability-integration.md
@@ -61,7 +61,7 @@ The following table describes all configuration fields under the `vulnerabilityR
 |---|---|---|---|
 | `enabled` | boolean | `false` | Enables vulnerability integration. Set to `true` to activate sync and API endpoints. |
 | `syncInterval` | duration | `15m` | Interval between Trustify sync runs. Use Go duration syntax, for example `15m`, `1h`. |
-| `backend` | string | — | Vulnerability scanning backend. Currently only `trustify` is supported. When empty, defaults to Trustify if a `trustify` config is present. |
+| `backend` | string | — | Vulnerability scanning backend. Currently only `trustify` is supported. When empty, defaults to Trustify if a `trustify` config with a non-empty `endpoint` is present. |
 | `trustify.endpoint` | string | — | Trustify API base URL. Required when `enabled` is `true`. |
 | `trustify.auth.mode` | string | `none` | Authentication mode. Allowed values: `none`, `client-credentials`. |
 | `trustify.auth.oidcIssuerUrl` | string | — | OIDC issuer URL. Required when `mode` is `client-credentials`. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -776,12 +776,23 @@ func (c *Config) GetDependenciesSyncPollInterval() time.Duration {
 	return DefaultDependenciesSyncPollInterval
 }
 
+// VulnerabilityBackend selects which vulnerability scanning backend is active.
+type VulnerabilityBackend string
+
+const (
+	// VulnerabilityBackendTrustify selects the Trustify (TPA) backend.
+	VulnerabilityBackendTrustify VulnerabilityBackend = "trustify"
+)
+
 // VulnerabilityConfig holds configuration for the vulnerability integration feature.
 type VulnerabilityConfig struct {
 	// Enabled enables vulnerability integration (sync task + API endpoints).
 	Enabled bool `json:"enabled,omitempty"`
-	// SyncInterval is the interval between Trustify sync runs (e.g. "15m", "1h").
+	// SyncInterval is the interval between backend sync runs (e.g. "15m", "1h").
 	SyncInterval util.Duration `json:"syncInterval,omitempty"`
+	// Backend selects the vulnerability scanning backend. When empty, the sync
+	// task defaults to Trustify if a Trustify config is present.
+	Backend VulnerabilityBackend `json:"backend,omitempty"`
 	// Trustify holds the Trustify connection details (periodic service only).
 	Trustify *TrustifyConfig `json:"trustify,omitempty"`
 }
@@ -1191,19 +1202,24 @@ func applyEnvVarOverrides(c *Config) {
 func applyVulnerabilityReportingEnvVarOverrides(c *Config) {
 	enabled := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_ENABLED")
 	syncInterval := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_SYNC_INTERVAL")
+	backend := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_BACKEND")
 	trustifyEndpoint := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_ENDPOINT")
 	trustifyAuthMode := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_AUTH_MODE")
 	trustifyOIDCIssuerURL := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_OIDC_ISSUER_URL")
 	trustifyClientID := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_CLIENT_ID")
 	trustifyClientSecret := os.Getenv("FLIGHTCTL_VULNERABILITY_REPORTING_TRUSTIFY_CLIENT_SECRET")
 
-	if enabled == "" && syncInterval == "" && trustifyEndpoint == "" && trustifyAuthMode == "" &&
+	if enabled == "" && syncInterval == "" && backend == "" && trustifyEndpoint == "" && trustifyAuthMode == "" &&
 		trustifyOIDCIssuerURL == "" && trustifyClientID == "" && trustifyClientSecret == "" {
 		return
 	}
 
 	if c.VulnerabilityReporting == nil {
 		c.VulnerabilityReporting = &VulnerabilityConfig{}
+	}
+
+	if backend != "" {
+		c.VulnerabilityReporting.Backend = VulnerabilityBackend(backend)
 	}
 
 	switch enabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -791,7 +791,8 @@ type VulnerabilityConfig struct {
 	// SyncInterval is the interval between backend sync runs (e.g. "15m", "1h").
 	SyncInterval util.Duration `json:"syncInterval,omitempty"`
 	// Backend selects the vulnerability scanning backend. When empty, the sync
-	// task defaults to Trustify if a Trustify config is present.
+	// task defaults to Trustify if a Trustify config with a non-empty endpoint
+	// is present.
 	Backend VulnerabilityBackend `json:"backend,omitempty"`
 	// Trustify holds the Trustify connection details (periodic service only).
 	Trustify *TrustifyConfig `json:"trustify,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -198,5 +199,37 @@ func TestConfig_String_HandlesEmptyClientSecrets(t *testing.T) {
 	// Should not panic with empty secrets
 	if !strings.Contains(result, "test-client-id") {
 		t.Error("Should handle empty client secrets gracefully")
+	}
+}
+
+func TestVulnerabilityConfig_BackendJSONRoundTrip(t *testing.T) {
+	var v VulnerabilityConfig
+	if err := json.Unmarshal([]byte(`{"backend":"trustify"}`), &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v.Backend != VulnerabilityBackendTrustify {
+		t.Errorf("When backend is set in JSON it should deserialize to the enum, got %q", v.Backend)
+	}
+
+	out, err := json.Marshal(VulnerabilityConfig{Backend: VulnerabilityBackendTrustify})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"backend":"trustify"`) {
+		t.Errorf("When backend is set it should serialize to JSON, got %s", out)
+	}
+}
+
+func TestApplyVulnerabilityReportingEnvVarOverrides_Backend(t *testing.T) {
+	t.Setenv("FLIGHTCTL_VULNERABILITY_REPORTING_BACKEND", "trustify")
+
+	c := &Config{}
+	applyVulnerabilityReportingEnvVarOverrides(c)
+
+	if c.VulnerabilityReporting == nil {
+		t.Fatal("When the backend env var is set it should initialize VulnerabilityReporting")
+	}
+	if c.VulnerabilityReporting.Backend != VulnerabilityBackendTrustify {
+		t.Errorf("When the backend env var is set it should populate Backend, got %q", c.VulnerabilityReporting.Backend)
 	}
 }

--- a/internal/store/vulnerabilityfinding/store.go
+++ b/internal/store/vulnerabilityfinding/store.go
@@ -272,7 +272,8 @@ func (s *VulnerabilityFindingStore) createDeviceOpenCveEventIndexes(db *gorm.DB)
 // deployed image reference. Digests that are NULL or empty are excluded; the
 // image reference may be empty when a device reports a digest but no image.
 // When several devices report the same digest with different references, the
-// lexicographically smallest reference is returned so the result is stable.
+// smallest non-empty reference is returned (or an empty reference when none has
+// one) so the result is stable; NULL and empty images both project to "".
 func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error) {
 	var refs []vulnerability.ImageRef
 	err := s.getDB(ctx).Model(&model.Device{}).

--- a/internal/store/vulnerabilityfinding/store.go
+++ b/internal/store/vulnerabilityfinding/store.go
@@ -284,7 +284,7 @@ func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context
 		Where("status->'os'->>'imageDigest' != ''").
 		Select("DISTINCT ON (status->'os'->>'imageDigest') " +
 			"status->'os'->>'imageDigest' AS digest, " +
-			"COALESCE(status->'os'->>'image', '') AS image_ref").
+			"COALESCE(status->'os'->>'image', '') AS image").
 		Order("status->'os'->>'imageDigest', NULLIF(status->'os'->>'image', '')").
 		Scan(&refs).Error
 	return refs, err

--- a/internal/store/vulnerabilityfinding/store.go
+++ b/internal/store/vulnerabilityfinding/store.go
@@ -273,7 +273,9 @@ func (s *VulnerabilityFindingStore) createDeviceOpenCveEventIndexes(db *gorm.DB)
 // image reference may be empty when a device reports a digest but no image.
 // When several devices report the same digest with different references, the
 // smallest non-empty reference is returned (or an empty reference when none has
-// one) so the result is stable; NULL and empty images both project to "".
+// one) so the result is stable. NULLIF collapses empty images to NULL, which
+// sorts last (ASC = NULLS LAST), so a real reference always wins over an
+// empty/NULL one; the outer COALESCE then projects any remaining NULL back to "".
 func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error) {
 	var refs []vulnerability.ImageRef
 	err := s.getDB(ctx).Model(&model.Device{}).
@@ -283,7 +285,7 @@ func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context
 		Select("DISTINCT ON (status->'os'->>'imageDigest') " +
 			"status->'os'->>'imageDigest' AS digest, " +
 			"COALESCE(status->'os'->>'image', '') AS image_ref").
-		Order("status->'os'->>'imageDigest', status->'os'->>'image'").
+		Order("status->'os'->>'imageDigest', NULLIF(status->'os'->>'image', '')").
 		Scan(&refs).Error
 	return refs, err
 }

--- a/internal/store/vulnerabilityfinding/store.go
+++ b/internal/store/vulnerabilityfinding/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/internal/vulnerability"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -115,7 +116,7 @@ type VulnerabilityGroup struct {
 
 type Store interface {
 	InitialMigration(ctx context.Context) error
-	ListDeployedImageDigests(ctx context.Context) ([]string, error)
+	ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error)
 	// UpsertFindings inserts or updates vulnerability findings and returns the findings
 	// that were actually inserted or had their severity/status changed.
 	UpsertFindings(ctx context.Context, findings []model.VulnerabilityFinding) ([]model.ChangedFinding, error)
@@ -266,17 +267,24 @@ func (s *VulnerabilityFindingStore) createDeviceOpenCveEventIndexes(db *gorm.DB)
 	return nil
 }
 
-// ListDeployedImageDigests returns the distinct set of OS image digests reported
-// across all devices (all organizations), excluding empty or NULL values.
-func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context) ([]string, error) {
-	var digests []string
+// ListDeployedImageDigests returns one entry per distinct OS image digest
+// reported across all devices (all organizations), pairing each digest with a
+// deployed image reference. Digests that are NULL or empty are excluded; the
+// image reference may be empty when a device reports a digest but no image.
+// When several devices report the same digest with different references, the
+// lexicographically smallest reference is returned so the result is stable.
+func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error) {
+	var refs []vulnerability.ImageRef
 	err := s.getDB(ctx).Model(&model.Device{}).
 		Where("deleted_at IS NULL").
 		Where("status->'os'->>'imageDigest' IS NOT NULL").
 		Where("status->'os'->>'imageDigest' != ''").
-		Select("DISTINCT status->'os'->>'imageDigest' AS image_digest").
-		Scan(&digests).Error
-	return digests, err
+		Select("DISTINCT ON (status->'os'->>'imageDigest') " +
+			"status->'os'->>'imageDigest' AS digest, " +
+			"COALESCE(status->'os'->>'image', '') AS image_ref").
+		Order("status->'os'->>'imageDigest', status->'os'->>'image'").
+		Scan(&refs).Error
+	return refs, err
 }
 
 // UpsertFindings inserts or updates vulnerability findings and returns the findings

--- a/internal/store/vulnerabilityfinding/store.go
+++ b/internal/store/vulnerabilityfinding/store.go
@@ -116,7 +116,7 @@ type VulnerabilityGroup struct {
 
 type Store interface {
 	InitialMigration(ctx context.Context) error
-	ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error)
+	ListDeployedImageRefs(ctx context.Context) ([]vulnerability.ImageRef, error)
 	// UpsertFindings inserts or updates vulnerability findings and returns the findings
 	// that were actually inserted or had their severity/status changed.
 	UpsertFindings(ctx context.Context, findings []model.VulnerabilityFinding) ([]model.ChangedFinding, error)
@@ -267,7 +267,7 @@ func (s *VulnerabilityFindingStore) createDeviceOpenCveEventIndexes(db *gorm.DB)
 	return nil
 }
 
-// ListDeployedImageDigests returns one entry per distinct OS image digest
+// ListDeployedImageRefs returns one entry per distinct OS image digest
 // reported across all devices (all organizations), pairing each digest with a
 // deployed image reference. Digests that are NULL or empty are excluded; the
 // image reference may be empty when a device reports a digest but no image.
@@ -276,7 +276,7 @@ func (s *VulnerabilityFindingStore) createDeviceOpenCveEventIndexes(db *gorm.DB)
 // one) so the result is stable. NULLIF collapses empty images to NULL, which
 // sorts last (ASC = NULLS LAST), so a real reference always wins over an
 // empty/NULL one; the outer COALESCE then projects any remaining NULL back to "".
-func (s *VulnerabilityFindingStore) ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error) {
+func (s *VulnerabilityFindingStore) ListDeployedImageRefs(ctx context.Context) ([]vulnerability.ImageRef, error) {
 	var refs []vulnerability.ImageRef
 	err := s.getDB(ctx).Model(&model.Device{}).
 		Where("deleted_at IS NULL").

--- a/internal/tasks/vulnerability_sync.go
+++ b/internal/tasks/vulnerability_sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flightctl/flightctl/internal/instrumentation/tracing"
 	"github.com/flightctl/flightctl/internal/store/model"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
+	"github.com/flightctl/flightctl/internal/vulnerability"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -51,7 +52,7 @@ type VulnerabilitySync struct {
 
 // FindingStoreUpsertLister is the subset of VulnerabilityFinding the sync task depends on for Trustify ingestion.
 type FindingStoreUpsertLister interface {
-	ListDeployedImageDigests(ctx context.Context) ([]string, error)
+	ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error)
 	// UpsertFindings inserts or updates vulnerability findings and returns the findings
 	// that were actually inserted or had their severity/status changed.
 	UpsertFindings(ctx context.Context, findings []model.VulnerabilityFinding) ([]model.ChangedFinding, error)
@@ -103,19 +104,19 @@ func (t *VulnerabilitySync) Poll(ctx context.Context) {
 // Returns the list of findings that were actually changed (inserted or updated).
 func (t *VulnerabilitySync) syncFindings(ctx context.Context) ([]model.ChangedFinding, error) {
 	t.log.Debug("Querying deployed image digests")
-	digests, err := t.findingStore.ListDeployedImageDigests(ctx)
+	imageRefs, err := t.findingStore.ListDeployedImageDigests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list deployed image digests: %w", err)
 	}
 
-	if len(digests) == 0 {
+	if len(imageRefs) == 0 {
 		t.log.Info("No deployed image digests found, nothing to sync")
 		return nil, nil
 	}
 
-	t.log.Infof("Syncing vulnerabilities for %d unique image digests", len(digests))
+	t.log.Infof("Syncing vulnerabilities for %d unique image digests", len(imageRefs))
 
-	findingsMap, err := t.vulnClient.GetVulnerabilitiesForDigests(ctx, digests)
+	findingsMap, err := t.vulnClient.GetVulnerabilitiesForDigests(ctx, digestsFromImageRefs(imageRefs))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get vulnerabilities from Trustify: %w", err)
 	}
@@ -155,6 +156,16 @@ func (t *VulnerabilitySync) syncFindings(ctx context.Context) ([]model.ChangedFi
 	t.log.Infof("Vulnerability sync: upserted %d findings, %d changed", len(allFindings), len(changed))
 
 	return changed, nil
+}
+
+// digestsFromImageRefs extracts the digest strings from image refs. The Trustify
+// client keys findings by digest and ignores the image reference.
+func digestsFromImageRefs(refs []vulnerability.ImageRef) []string {
+	digests := make([]string, 0, len(refs))
+	for _, r := range refs {
+		digests = append(digests, r.Digest)
+	}
+	return digests
 }
 
 // runCVELifecyclePhase computes and applies CVE lifecycle events using a delta-based approach.

--- a/internal/tasks/vulnerability_sync.go
+++ b/internal/tasks/vulnerability_sync.go
@@ -52,7 +52,7 @@ type VulnerabilitySync struct {
 
 // FindingStoreUpsertLister is the subset of VulnerabilityFinding the sync task depends on for Trustify ingestion.
 type FindingStoreUpsertLister interface {
-	ListDeployedImageDigests(ctx context.Context) ([]vulnerability.ImageRef, error)
+	ListDeployedImageRefs(ctx context.Context) ([]vulnerability.ImageRef, error)
 	// UpsertFindings inserts or updates vulnerability findings and returns the findings
 	// that were actually inserted or had their severity/status changed.
 	UpsertFindings(ctx context.Context, findings []model.VulnerabilityFinding) ([]model.ChangedFinding, error)
@@ -104,7 +104,7 @@ func (t *VulnerabilitySync) Poll(ctx context.Context) {
 // Returns the list of findings that were actually changed (inserted or updated).
 func (t *VulnerabilitySync) syncFindings(ctx context.Context) ([]model.ChangedFinding, error) {
 	t.log.Debug("Querying deployed image digests")
-	imageRefs, err := t.findingStore.ListDeployedImageDigests(ctx)
+	imageRefs, err := t.findingStore.ListDeployedImageRefs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list deployed image digests: %w", err)
 	}
@@ -116,6 +116,7 @@ func (t *VulnerabilitySync) syncFindings(ctx context.Context) ([]model.ChangedFi
 
 	t.log.Infof("Syncing vulnerabilities for %d unique image digests", len(imageRefs))
 
+	// TODO(EDM-5249): pass imageRefs to Scanner.ScanImages; Trustify ignores Image today.
 	findingsMap, err := t.vulnClient.GetVulnerabilitiesForDigests(ctx, digestsFromImageRefs(imageRefs))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get vulnerabilities from Trustify: %w", err)

--- a/internal/tasks/vulnerability_sync_test.go
+++ b/internal/tasks/vulnerability_sync_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/store/model"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
+	"github.com/flightctl/flightctl/internal/vulnerability"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -51,8 +52,12 @@ type fakeFindingStore struct {
 	batchErr       error
 }
 
-func (f *fakeFindingStore) ListDeployedImageDigests(_ context.Context) ([]string, error) {
-	return f.digests, f.listErr
+func (f *fakeFindingStore) ListDeployedImageDigests(_ context.Context) ([]vulnerability.ImageRef, error) {
+	refs := make([]vulnerability.ImageRef, 0, len(f.digests))
+	for _, d := range f.digests {
+		refs = append(refs, vulnerability.ImageRef{Digest: d})
+	}
+	return refs, f.listErr
 }
 
 func (f *fakeFindingStore) UpsertFindings(_ context.Context, findings []model.VulnerabilityFinding) ([]model.ChangedFinding, error) {
@@ -389,4 +394,17 @@ func TestVulnerabilitySync_Poll_UpdatesCheckpointAfterProcessing(t *testing.T) {
 	data, err := cp.Get(context.Background(), cveEventSyncConsumer, cveEventSyncKey)
 	req.NoError(err)
 	req.NotEmpty(data)
+}
+
+func TestDigestsFromImageRefs(t *testing.T) {
+	req := require.New(t)
+
+	refs := []vulnerability.ImageRef{
+		{Digest: "sha256:aaaa", ImageRef: "quay.io/org/repo:tag"},
+		{Digest: "sha256:bbbb", ImageRef: ""},
+	}
+
+	// The Trustify path keys on digest only; image references are dropped.
+	req.Equal([]string{"sha256:aaaa", "sha256:bbbb"}, digestsFromImageRefs(refs))
+	req.Empty(digestsFromImageRefs(nil))
 }

--- a/internal/tasks/vulnerability_sync_test.go
+++ b/internal/tasks/vulnerability_sync_test.go
@@ -52,7 +52,7 @@ type fakeFindingStore struct {
 	batchErr       error
 }
 
-func (f *fakeFindingStore) ListDeployedImageDigests(_ context.Context) ([]vulnerability.ImageRef, error) {
+func (f *fakeFindingStore) ListDeployedImageRefs(_ context.Context) ([]vulnerability.ImageRef, error) {
 	refs := make([]vulnerability.ImageRef, 0, len(f.digests))
 	for _, d := range f.digests {
 		refs = append(refs, vulnerability.ImageRef{Digest: d})
@@ -195,7 +195,7 @@ func TestVulnerabilitySync_Poll(t *testing.T) {
 			wantUpserted:   0,
 		},
 		{
-			name:    "When ListDeployedImageDigests fails it should return without calling Trustify",
+			name:    "When ListDeployedImageRefs fails it should return without calling Trustify",
 			listErr: errors.New("db error"),
 			digests: []string{digest1},
 			// listErr prevents return of digests, so Trustify is never called

--- a/internal/tasks/vulnerability_sync_test.go
+++ b/internal/tasks/vulnerability_sync_test.go
@@ -400,8 +400,8 @@ func TestDigestsFromImageRefs(t *testing.T) {
 	req := require.New(t)
 
 	refs := []vulnerability.ImageRef{
-		{Digest: "sha256:aaaa", ImageRef: "quay.io/org/repo:tag"},
-		{Digest: "sha256:bbbb", ImageRef: ""},
+		{Digest: "sha256:aaaa", Image: "quay.io/org/repo:tag"},
+		{Digest: "sha256:bbbb", Image: ""},
 	}
 
 	// The Trustify path keys on digest only; image references are dropped.

--- a/internal/vulnerability/registry.go
+++ b/internal/vulnerability/registry.go
@@ -34,7 +34,8 @@ func Register(name string, factory ScannerFactory) {
 
 // NewScanner resolves the backend selected by cfg.Backend and constructs its
 // Scanner. When cfg.Backend is empty it defaults to Trustify if a Trustify
-// config is present (logging a deprecation warning), otherwise it errors.
+// config with a non-empty endpoint is present (logging a deprecation warning),
+// otherwise it errors.
 func NewScanner(cfg *config.VulnerabilityConfig) (Scanner, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("vulnerability config is nil")
@@ -43,7 +44,7 @@ func NewScanner(cfg *config.VulnerabilityConfig) (Scanner, error) {
 	if backend == "" {
 		if cfg.Trustify != nil && strings.TrimSpace(cfg.Trustify.Endpoint) != "" {
 			defaultBackendWarnOnce.Do(func() {
-				logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because trustify config is present. Set backend explicitly — this fallback will be removed in a future release.`)
+				logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because a non-empty trustify endpoint is configured. Set backend explicitly — this fallback will be removed in a future release.`)
 			})
 			backend = config.VulnerabilityBackendTrustify
 		} else {

--- a/internal/vulnerability/registry.go
+++ b/internal/vulnerability/registry.go
@@ -2,6 +2,7 @@ package vulnerability
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/sirupsen/logrus"
@@ -22,21 +23,26 @@ func Register(name string, factory ScannerFactory) {
 // Scanner. When cfg.Backend is empty it defaults to Trustify if a Trustify
 // config is present (logging a deprecation warning), otherwise it errors.
 func NewScanner(cfg *config.VulnerabilityConfig) (Scanner, error) {
-	if cfg.Backend == "" {
+	if cfg == nil {
+		return nil, fmt.Errorf("vulnerability config is nil")
+	}
+	backend := cfg.Backend
+	if backend == "" {
 		if cfg.Trustify != nil {
 			logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because trustify config is present. Set backend explicitly — this fallback will be removed in a future release.`)
-			cfg.Backend = config.VulnerabilityBackendTrustify
+			backend = config.VulnerabilityBackendTrustify
 		} else {
 			return nil, fmt.Errorf("no vulnerability backend configured (set vulnerability.backend)")
 		}
 	}
-	factory, ok := registry[string(cfg.Backend)]
+	factory, ok := registry[string(backend)]
 	if !ok {
 		known := make([]string, 0, len(registry))
 		for k := range registry {
 			known = append(known, k)
 		}
-		return nil, fmt.Errorf("unknown vulnerability backend %q (known: %v)", cfg.Backend, known)
+		sort.Strings(known)
+		return nil, fmt.Errorf("unknown vulnerability backend %q (known: %v)", backend, known)
 	}
 	return factory(cfg)
 }

--- a/internal/vulnerability/registry.go
+++ b/internal/vulnerability/registry.go
@@ -3,6 +3,8 @@ package vulnerability
 import (
 	"fmt"
 	"sort"
+	"strings"
+	"sync"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/sirupsen/logrus"
@@ -13,9 +15,20 @@ type ScannerFactory func(cfg *config.VulnerabilityConfig) (Scanner, error)
 
 var registry = map[string]ScannerFactory{}
 
+// defaultBackendWarnOnce ensures the "backend not set" deprecation warning is
+// logged at most once, even when NewScanner is called repeatedly (e.g. once per
+// periodic poll).
+var defaultBackendWarnOnce sync.Once
+
 // Register associates a backend name with a factory. Backends call this from an
-// init function so they self-register when their package is imported.
+// init function so they self-register when their package is imported. It panics
+// if a name is registered twice, since that indicates a duplicate init-time
+// registration (a programming error) that would otherwise silently overwrite
+// the earlier factory.
 func Register(name string, factory ScannerFactory) {
+	if _, exists := registry[name]; exists {
+		panic(fmt.Sprintf("vulnerability: backend %q already registered", name))
+	}
 	registry[name] = factory
 }
 
@@ -28,8 +41,10 @@ func NewScanner(cfg *config.VulnerabilityConfig) (Scanner, error) {
 	}
 	backend := cfg.Backend
 	if backend == "" {
-		if cfg.Trustify != nil {
-			logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because trustify config is present. Set backend explicitly — this fallback will be removed in a future release.`)
+		if cfg.Trustify != nil && strings.TrimSpace(cfg.Trustify.Endpoint) != "" {
+			defaultBackendWarnOnce.Do(func() {
+				logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because trustify config is present. Set backend explicitly — this fallback will be removed in a future release.`)
+			})
 			backend = config.VulnerabilityBackendTrustify
 		} else {
 			return nil, fmt.Errorf("no vulnerability backend configured (set vulnerability.backend)")

--- a/internal/vulnerability/registry.go
+++ b/internal/vulnerability/registry.go
@@ -1,0 +1,42 @@
+package vulnerability
+
+import (
+	"fmt"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/sirupsen/logrus"
+)
+
+// ScannerFactory constructs a Scanner from the vulnerability configuration.
+type ScannerFactory func(cfg *config.VulnerabilityConfig) (Scanner, error)
+
+var registry = map[string]ScannerFactory{}
+
+// Register associates a backend name with a factory. Backends call this from an
+// init function so they self-register when their package is imported.
+func Register(name string, factory ScannerFactory) {
+	registry[name] = factory
+}
+
+// NewScanner resolves the backend selected by cfg.Backend and constructs its
+// Scanner. When cfg.Backend is empty it defaults to Trustify if a Trustify
+// config is present (logging a deprecation warning), otherwise it errors.
+func NewScanner(cfg *config.VulnerabilityConfig) (Scanner, error) {
+	if cfg.Backend == "" {
+		if cfg.Trustify != nil {
+			logrus.Warn(`vulnerability.backend not set; defaulting to "trustify" because trustify config is present. Set backend explicitly — this fallback will be removed in a future release.`)
+			cfg.Backend = config.VulnerabilityBackendTrustify
+		} else {
+			return nil, fmt.Errorf("no vulnerability backend configured (set vulnerability.backend)")
+		}
+	}
+	factory, ok := registry[string(cfg.Backend)]
+	if !ok {
+		known := make([]string, 0, len(registry))
+		for k := range registry {
+			known = append(known, k)
+		}
+		return nil, fmt.Errorf("unknown vulnerability backend %q (known: %v)", cfg.Backend, known)
+	}
+	return factory(cfg)
+}

--- a/internal/vulnerability/registry_test.go
+++ b/internal/vulnerability/registry_test.go
@@ -29,13 +29,11 @@ func TestNewScanner(t *testing.T) {
 		cfg         *config.VulnerabilityConfig
 		wantErr     bool
 		errContains []string
-		wantBackend config.VulnerabilityBackend
 	}{
 		{
-			name:        "When the configured backend is registered it should return its scanner",
-			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
-			cfg:         &config.VulnerabilityConfig{Backend: config.VulnerabilityBackendTrustify},
-			wantBackend: config.VulnerabilityBackendTrustify,
+			name:     "When the configured backend is registered it should return its scanner",
+			register: map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:      &config.VulnerabilityConfig{Backend: config.VulnerabilityBackendTrustify},
 		},
 		{
 			name:        "When the configured backend is unknown it should error listing known backends",
@@ -45,10 +43,9 @@ func TestNewScanner(t *testing.T) {
 			errContains: []string{"bogus", "trustify"},
 		},
 		{
-			name:        "When the backend is empty but Trustify config is present it should default to trustify",
-			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
-			cfg:         &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{}},
-			wantBackend: config.VulnerabilityBackendTrustify,
+			name:     "When the backend is empty but Trustify config is present it should default to trustify",
+			register: map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:      &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{}},
 		},
 		{
 			name:        "When the backend is empty and no config is present it should error",
@@ -56,6 +53,13 @@ func TestNewScanner(t *testing.T) {
 			cfg:         &config.VulnerabilityConfig{},
 			wantErr:     true,
 			errContains: []string{"no vulnerability backend"},
+		},
+		{
+			name:        "When the config is nil it should error rather than panic",
+			register:    map[string]ScannerFactory{},
+			cfg:         nil,
+			wantErr:     true,
+			errContains: []string{"nil"},
 		},
 	}
 
@@ -77,9 +81,11 @@ func TestNewScanner(t *testing.T) {
 				return
 			}
 
+			// The only registered backend is trustify, so a non-nil scanner
+			// confirms the backend resolved (including the empty->trustify
+			// default) without NewScanner mutating the caller's cfg.
 			req.NoError(err)
 			req.NotNil(scanner)
-			req.Equal(tt.wantBackend, tt.cfg.Backend)
 		})
 	}
 }

--- a/internal/vulnerability/registry_test.go
+++ b/internal/vulnerability/registry_test.go
@@ -1,0 +1,101 @@
+package vulnerability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeScanner struct{}
+
+func (fakeScanner) ScanImages(_ context.Context, _ []ImageRef) (map[string][]Finding, error) {
+	return nil, nil
+}
+
+// withCleanRegistry isolates each test case from the package-level registry.
+func withCleanRegistry(t *testing.T) {
+	t.Helper()
+	saved := registry
+	registry = map[string]ScannerFactory{}
+	t.Cleanup(func() { registry = saved })
+}
+
+func TestNewScanner(t *testing.T) {
+	tests := []struct {
+		name        string
+		register    map[string]ScannerFactory
+		cfg         *config.VulnerabilityConfig
+		wantErr     bool
+		errContains []string
+		wantBackend config.VulnerabilityBackend
+	}{
+		{
+			name:        "When the configured backend is registered it should return its scanner",
+			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:         &config.VulnerabilityConfig{Backend: config.VulnerabilityBackendTrustify},
+			wantBackend: config.VulnerabilityBackendTrustify,
+		},
+		{
+			name:        "When the configured backend is unknown it should error listing known backends",
+			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:         &config.VulnerabilityConfig{Backend: "bogus"},
+			wantErr:     true,
+			errContains: []string{"bogus", "trustify"},
+		},
+		{
+			name:        "When the backend is empty but Trustify config is present it should default to trustify",
+			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:         &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{}},
+			wantBackend: config.VulnerabilityBackendTrustify,
+		},
+		{
+			name:        "When the backend is empty and no config is present it should error",
+			register:    map[string]ScannerFactory{},
+			cfg:         &config.VulnerabilityConfig{},
+			wantErr:     true,
+			errContains: []string{"no vulnerability backend"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			withCleanRegistry(t)
+			for name, factory := range tt.register {
+				Register(name, factory)
+			}
+
+			scanner, err := NewScanner(tt.cfg)
+			if tt.wantErr {
+				req.Error(err)
+				for _, sub := range tt.errContains {
+					req.Contains(err.Error(), sub)
+				}
+				req.Nil(scanner)
+				return
+			}
+
+			req.NoError(err)
+			req.NotNil(scanner)
+			req.Equal(tt.wantBackend, tt.cfg.Backend)
+		})
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	req := require.New(t)
+	withCleanRegistry(t)
+
+	called := false
+	Register("trustify", func(*config.VulnerabilityConfig) (Scanner, error) {
+		called = true
+		return fakeScanner{}, nil
+	})
+
+	scanner, err := NewScanner(&config.VulnerabilityConfig{Backend: config.VulnerabilityBackendTrustify})
+	req.NoError(err)
+	req.NotNil(scanner)
+	req.True(called, "registered factory should be invoked")
+}

--- a/internal/vulnerability/registry_test.go
+++ b/internal/vulnerability/registry_test.go
@@ -43,9 +43,16 @@ func TestNewScanner(t *testing.T) {
 			errContains: []string{"bogus", "trustify"},
 		},
 		{
-			name:     "When the backend is empty but Trustify config is present it should default to trustify",
+			name:     "When the backend is empty but a Trustify endpoint is present it should default to trustify",
 			register: map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
-			cfg:      &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{}},
+			cfg:      &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{Endpoint: "https://trustify.example.com"}},
+		},
+		{
+			name:        "When the backend is empty and the Trustify config has no endpoint it should error",
+			register:    map[string]ScannerFactory{"trustify": func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }},
+			cfg:         &config.VulnerabilityConfig{Trustify: &config.TrustifyConfig{}},
+			wantErr:     true,
+			errContains: []string{"no vulnerability backend"},
 		},
 		{
 			name:        "When the backend is empty and no config is present it should error",
@@ -104,4 +111,16 @@ func TestRegisterAndLookup(t *testing.T) {
 	req.NoError(err)
 	req.NotNil(scanner)
 	req.True(called, "registered factory should be invoked")
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	req := require.New(t)
+	withCleanRegistry(t)
+
+	factory := func(*config.VulnerabilityConfig) (Scanner, error) { return fakeScanner{}, nil }
+	Register("trustify", factory)
+
+	req.PanicsWithValue(`vulnerability: backend "trustify" already registered`, func() {
+		Register("trustify", factory)
+	})
 }

--- a/internal/vulnerability/scanner.go
+++ b/internal/vulnerability/scanner.go
@@ -1,0 +1,45 @@
+// Package vulnerability defines the backend-agnostic contract for vulnerability
+// scanning. Backends (e.g. Trustify, Quay) implement Scanner and return Finding
+// DTOs owned by this package; the sync task converts them to persistence models
+// centrally, so backends never depend on the store schema.
+package vulnerability
+
+import (
+	"context"
+	"time"
+)
+
+// ImageRef pairs a deployed image's digest with its full image reference.
+// Digest is always populated; ImageRef may be empty when a device reports a
+// digest but no image reference.
+type ImageRef struct {
+	Digest   string
+	ImageRef string
+}
+
+// Issuer identifies the publisher of an advisory (e.g. "Red Hat", "NVD").
+type Issuer struct {
+	ID      string
+	Name    string
+	CpeKey  *string
+	Website *string
+}
+
+// Finding is a backend-agnostic vulnerability finding for a single image digest.
+type Finding struct {
+	CveID       string
+	ImageDigest string
+	Severity    string
+	CvssScore   *float64
+	Status      string
+	Issuer      *Issuer
+	AdvisoryID  *string
+	Description string
+	PublishedAt *time.Time
+}
+
+// Scanner retrieves vulnerability findings for a set of deployed images.
+type Scanner interface {
+	// ScanImages returns findings keyed by image digest for the given images.
+	ScanImages(ctx context.Context, images []ImageRef) (map[string][]Finding, error)
+}

--- a/internal/vulnerability/scanner.go
+++ b/internal/vulnerability/scanner.go
@@ -10,11 +10,11 @@ import (
 )
 
 // ImageRef pairs a deployed image's digest with its full image reference.
-// Digest is always populated; ImageRef may be empty when a device reports a
+// Digest is always populated; Image may be empty when a device reports a
 // digest but no image reference.
 type ImageRef struct {
-	Digest   string
-	ImageRef string
+	Digest string
+	Image  string
 }
 
 // Issuer identifies the publisher of an advisory (e.g. "Red Hat", "NVD").

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -23,6 +23,7 @@ import (
 	vulnerabilityfindingstore "github.com/flightctl/flightctl/internal/store/vulnerabilityfinding"
 	"github.com/flightctl/flightctl/internal/tasks"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
+	"github.com/flightctl/flightctl/internal/vulnerability"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
 	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/flightctl/flightctl/test/util/testdb"
@@ -70,41 +71,77 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 
 	Context("ListDeployedImageDigests", func() {
 		It("When no devices exist it should return an empty slice", func() {
-			digests, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(digests).To(BeEmpty())
+			Expect(refs).To(BeEmpty())
 		})
 
 		It("When devices exist but have no OS image digest it should return an empty slice", func() {
 			testutil.CreateTestDevices(ctx, 2, deviceStore, orgId, nil, false)
 
-			digests, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(digests).To(BeEmpty())
+			Expect(refs).To(BeEmpty())
 		})
 
-		It("When devices have OS image digests it should return distinct digests across all orgs", func() {
+		It("When devices have OS image digests it should return distinct digests with their image refs across all orgs", func() {
 			digest1 := "sha256:aaaa1111"
 			digest2 := "sha256:bbbb2222"
+			image1 := "quay.io/example/os:1.0"
+			image2 := "quay.io/example/os:2.0"
 
 			// Create a device and set its OS status to include digest1.
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-1", nil, nil, nil)
-			setDeviceOsDigest(ctx, deviceStore, orgId, "device-1", digest1)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "device-1", digest1, image1)
 
 			// Create a second device in the same org with digest2.
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "device-2", nil, nil, nil)
-			setDeviceOsDigest(ctx, deviceStore, orgId, "device-2", digest2)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "device-2", digest2, image2)
 
 			// Create a third device in a different org with digest1 (duplicate, should collapse).
 			orgId2 := uuid.New()
 			err := testutil.CreateTestOrganization(ctx, organizationStore, orgId2)
 			Expect(err).ToNot(HaveOccurred())
 			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil, nil)
-			setDeviceOsDigest(ctx, deviceStore, orgId2, "device-3", digest1)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId2, "device-3", digest1, image1)
 
-			digests, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(digests).To(ConsistOf(digest1, digest2))
+			Expect(refs).To(ConsistOf(
+				vulnerability.ImageRef{Digest: digest1, ImageRef: image1},
+				vulnerability.ImageRef{Digest: digest2, ImageRef: image2},
+			))
+		})
+
+		It("When a digest is reported with different image refs it should collapse to one row with a deterministic ref", func() {
+			digest := "sha256:cccc3333"
+
+			// Two devices report the same digest but different image refs. The
+			// query orders by digest then image, so the lexicographically
+			// smallest ref is the deterministic winner.
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "diff-ref-1", nil, nil, nil)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "diff-ref-1", digest, "quay.io/example/os:zzz")
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "diff-ref-2", nil, nil, nil)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "diff-ref-2", digest, "quay.io/example/os:aaa")
+
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(refs).To(ConsistOf(
+				vulnerability.ImageRef{Digest: digest, ImageRef: "quay.io/example/os:aaa"},
+			))
+		})
+
+		It("When a digest is reported with an empty image ref it should return a row with an empty ImageRef", func() {
+			digest := "sha256:dddd4444"
+
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "empty-ref", nil, nil, nil)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "empty-ref", digest, "")
+
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(refs).To(ConsistOf(
+				vulnerability.ImageRef{Digest: digest, ImageRef: ""},
+			))
 		})
 	})
 

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -116,9 +116,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("When a digest is reported with different image refs it should collapse to one row with a deterministic ref", func() {
 			digest := "sha256:cccc3333"
 
-			// Two devices report the same digest but different image refs. The
-			// query orders by digest then image, so the lexicographically
-			// smallest ref is the deterministic winner.
+			// Two devices report the same digest but different non-empty image
+			// refs. The query orders by digest then image (NULLS LAST), so the
+			// lexicographically smallest non-empty ref is the deterministic winner.
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "diff-ref-1", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "diff-ref-1", digest, "quay.io/example/os:zzz")
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "diff-ref-2", nil, nil, nil)
@@ -141,6 +141,24 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
 				vulnerability.ImageRef{Digest: digest, ImageRef: ""},
+			))
+		})
+
+		It("When a digest is reported with both an empty and a non-empty ref it should prefer the non-empty ref", func() {
+			digest := "sha256:eeee5555"
+			realRef := "quay.io/example/os:5.0"
+
+			// One device reports the digest with no image ref, another with a
+			// real ref. Empty refs sort last (NULLS LAST), so the real ref wins.
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mixed-empty", nil, nil, nil)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "mixed-empty", digest, "")
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mixed-real", nil, nil, nil)
+			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "mixed-real", digest, realRef)
+
+			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(refs).To(ConsistOf(
+				vulnerability.ImageRef{Digest: digest, ImageRef: realRef},
 			))
 		})
 	})

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -69,9 +69,9 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
 	})
 
-	Context("ListDeployedImageDigests", func() {
+	Context("ListDeployedImageRefs", func() {
 		It("When no devices exist it should return an empty slice", func() {
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(BeEmpty())
 		})
@@ -79,7 +79,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 		It("When devices exist but have no OS image digest it should return an empty slice", func() {
 			testutil.CreateTestDevices(ctx, 2, deviceStore, orgId, nil, false)
 
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(BeEmpty())
 		})
@@ -105,7 +105,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId2, "device-3", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId2, "device-3", digest1, image1)
 
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
 				vulnerability.ImageRef{Digest: digest1, Image: image1},
@@ -124,7 +124,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "diff-ref-2", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "diff-ref-2", digest, "quay.io/example/os:aaa")
 
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
 				vulnerability.ImageRef{Digest: digest, Image: "quay.io/example/os:aaa"},
@@ -137,7 +137,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "empty-ref", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "empty-ref", digest, "")
 
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
 				vulnerability.ImageRef{Digest: digest, Image: ""},
@@ -155,7 +155,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mixed-real", nil, nil, nil)
 			setDeviceOsDigestWithImage(ctx, deviceStore, orgId, "mixed-real", digest, realRef)
 
-			refs, err := findingStore.ListDeployedImageDigests(ctx)
+			refs, err := findingStore.ListDeployedImageRefs(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
 				vulnerability.ImageRef{Digest: digest, Image: realRef},
@@ -735,7 +735,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tasks.NewVulnerabilitySync(log, vulnClient, findingStore, nil, nil).Poll(ctx)
 
-			// ListDeployedImageDigests deduplicates, so PURL list should be called once per batch,
+			// ListDeployedImageRefs deduplicates, so PURL list should be called once per batch,
 			// and advisory should be called once per unique SBOM.
 			Expect(atomic.LoadInt32(&purlListCallCount)).To(Equal(int32(1)))
 			Expect(atomic.LoadInt32(&advisoryCallCount)).To(Equal(int32(1)))

--- a/test/integration/store/vulnerability_finding_test.go
+++ b/test/integration/store/vulnerability_finding_test.go
@@ -108,8 +108,8 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
-				vulnerability.ImageRef{Digest: digest1, ImageRef: image1},
-				vulnerability.ImageRef{Digest: digest2, ImageRef: image2},
+				vulnerability.ImageRef{Digest: digest1, Image: image1},
+				vulnerability.ImageRef{Digest: digest2, Image: image2},
 			))
 		})
 
@@ -127,7 +127,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
-				vulnerability.ImageRef{Digest: digest, ImageRef: "quay.io/example/os:aaa"},
+				vulnerability.ImageRef{Digest: digest, Image: "quay.io/example/os:aaa"},
 			))
 		})
 
@@ -140,7 +140,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
-				vulnerability.ImageRef{Digest: digest, ImageRef: ""},
+				vulnerability.ImageRef{Digest: digest, Image: ""},
 			))
 		})
 
@@ -158,7 +158,7 @@ var _ = Describe("VulnerabilityFinding Store Integration Tests", func() {
 			refs, err := findingStore.ListDeployedImageDigests(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refs).To(ConsistOf(
-				vulnerability.ImageRef{Digest: digest, ImageRef: realRef},
+				vulnerability.ImageRef{Digest: digest, Image: realRef},
 			))
 		})
 	})


### PR DESCRIPTION
## EDM-5248: Define Scanner interface and extend store query

**Jira:** https://redhat.atlassian.net/browse/EDM-5248
**Story type:** [DEV]
**Epic:** EDM-5246 — Backend Abstraction and Trustify Adapter (Feature EDM-4869)

> ⚠️ **Base of a stack.** This is the first PR in a stack. EDM-5249 (Trustify
> Scanner adapter and sync task refactor) is stacked on top and targets this
> branch. Merge this PR first, then EDM-5249 will retarget `main`.

### Summary
Introduces the backend-agnostic `vulnerability.Scanner` abstraction (interface,
DTOs, and a backend registry/factory) that lets Flight Control support multiple
vulnerability backends behind one contract, and extends the store query so the
sync pipeline can key on image references. No behavioral change to the existing
Trustify sync — this lays the groundwork for the Trustify adapter (EDM-5249) and
the Quay backend (EDM-5250).

### Changes
- **`internal/vulnerability`** — new package: `Scanner` interface,
  `Finding`/`Issuer`/`ImageRef` DTOs, and a `Register`/`NewScanner` backend
  registry + factory.
- **Config** — add vulnerability backend selection (`vulnerabilityReporting.backend`)
  with a Trustify default when a Trustify config is present.
- **Store** — `ListDeployedImageDigests` returns image references (digest + ref),
  with a stable tie-break that prefers a non-empty ref over an empty one for the
  same digest.
- **Sync task** — adapt to the `ImageRef`-based store query.

### Testing
- **Unit tests:** registry/factory resolution, config backend parsing, DTO
  handling; sync-task tests updated for the `ImageRef` return type.
- **Integration tests:** `ListDeployedImageDigests` `ImageRef` coverage,
  including the empty-vs-non-empty ref tie-break (320/320 store integration
  specs pass).
- **Coverage:** comprehensive behavioral coverage of the new public surface.

### Acceptance Criteria
- [ ] AC-1: Backend-agnostic `Scanner` interface + DTOs defined in `internal/vulnerability`.
- [ ] AC-2: Backend registry (`Register`/`NewScanner`) with factory resolution.
- [ ] AC-3: Vulnerability backend selection added to config.
- [ ] AC-4: `ListDeployedImageDigests` returns image references.
- [ ] AC-5: Non-empty image ref preferred in the tie-break for a shared digest.
- [ ] AC-6: Sync task adapted to the `ImageRef`-based query.
- [ ] AC-7: Existing tests pass; no behavioral change to Trustify sync.

---

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
