### PR TITLE
EDM-3772: omit zero rollout minAvailable

### DIFF
--- a/test/e2e/rollout/rollout_test.go
+++ b/test/e2e/rollout/rollout_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Rollout Policies", Label("rollout"), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			fleetSpec := createFleetSpecWithoutDeviceSelection(lo.ToPtr(api.Percentage(SuccessThreshold)), deviceSpec)
-			fleetSpec.RolloutPolicy.DisruptionBudget = createDisruptionBudget(2, 2, []string{})
+			fleetSpec.RolloutPolicy.DisruptionBudget = createDisruptionBudget(2, lo.ToPtr(2), []string{})
 
 			err = tc.harness.CreateOrUpdateTestFleet(fleetName, fleetSpec)
 			Expect(err).ToNot(HaveOccurred())
@@ -172,7 +172,7 @@ var _ = Describe("Rollout Policies", Label("rollout"), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			fleetSpec = createFleetSpecWithoutDeviceSelection(lo.ToPtr(api.Percentage(SuccessThreshold)), deviceSpec)
-			fleetSpec.RolloutPolicy.DisruptionBudget = createDisruptionBudget(2, 0, []string{labelSite})
+			fleetSpec.RolloutPolicy.DisruptionBudget = createDisruptionBudget(2, nil, []string{labelSite})
 
 			err = tc.harness.CreateOrUpdateTestFleet(fleetName, fleetSpec)
 			Expect(err).ToNot(HaveOccurred())
@@ -543,11 +543,11 @@ func createFleetSpecWithoutDeviceSelection(threshold *api.Percentage, testFleetS
 	}
 }
 
-func createDisruptionBudget(maxUnavailable, minAvailable int, groupBy []string) *api.DisruptionBudget {
+func createDisruptionBudget(maxUnavailable int, minAvailable *int, groupBy []string) *api.DisruptionBudget {
 	return &api.DisruptionBudget{
 		GroupBy:        &groupBy,
 		MaxUnavailable: lo.ToPtr(maxUnavailable),
-		MinAvailable:   lo.ToPtr(minAvailable),
+		MinAvailable:   minAvailable,
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix the rollout disruption budget E2E so it no longer sends `minAvailable: 0`, which current API schema rejects because `minAvailable` must be at least 1 when present.

The grouped scenario only needs `maxUnavailable: 2`, so omitting `minAvailable` preserves the intended test coverage without creating an invalid fleet request.


## Release target
release-1.3
Target release: release-1.3