### PR TITLE
EDM-5217: Persist delta prepares and generations

### DIFF
--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -16,6 +16,7 @@ import (
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
 	certificatesigningrequeststore "github.com/flightctl/flightctl/internal/store/certificatesigningrequest"
 	checkpointstore "github.com/flightctl/flightctl/internal/store/checkpoint"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	enrollmentrequeststore "github.com/flightctl/flightctl/internal/store/enrollmentrequest"
@@ -119,6 +120,9 @@ func runMainStoreMigrations(ctx context.Context, tx *gorm.DB, log logrus.FieldLo
 		return err
 	}
 	if err := canarystore.NewCanaryStore(tx, log).InitialMigration(ctx); err != nil {
+		return err
+	}
+	if err := deltastore.NewStore(tx, log).InitialMigration(ctx); err != nil {
 		return err
 	}
 

--- a/internal/store/delta/store.go
+++ b/internal/store/delta/store.go
@@ -14,11 +14,14 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-const waitingPrepareIndex = "idx_delta_prepares_one_waiting"
-
 const (
+	waitingPrepareIndex         = "idx_delta_prepares_one_waiting"
+	waitingPrepareDeadlineIndex = "idx_delta_prepares_waiting_deadline"
+
 	fkPrepareGenerationPrepare    = "fk_delta_prepare_generations_prepare"
 	fkPrepareGenerationGeneration = "fk_delta_prepare_generations_generation"
+
+	MaxListWaitingPastDeadline = 1000
 )
 
 type Store interface {
@@ -29,7 +32,7 @@ type Store interface {
 	InsertPrepare(ctx context.Context, prep *model.DeltaPrepare) error
 	GetPrepare(ctx context.Context, id uuid.UUID) (*model.DeltaPrepare, error)
 	CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error
-	ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error)
+	ListWaitingPastDeadline(ctx context.Context, limit int) ([]model.DeltaPrepare, error)
 	InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error
 }
 
@@ -87,6 +90,9 @@ func (s *DeltaStore) InitialMigration(ctx context.Context) error {
 	if err := s.createWaitingPrepareIndex(db); err != nil {
 		return err
 	}
+	if err := s.createWaitingPrepareDeadlineIndex(db); err != nil {
+		return err
+	}
 	return s.createJoinForeignKeys(db)
 }
 
@@ -98,9 +104,23 @@ func (s *DeltaStore) createWaitingPrepareIndex(db *gorm.DB) error {
 		return nil
 	}
 	return db.Exec(`
-		CREATE UNIQUE INDEX IF NOT EXISTS ` + waitingPrepareIndex + `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_delta_prepares_one_waiting
 		ON delta_prepares (org_id, kind, name)
 		WHERE status = 'waiting'
+	`).Error
+}
+
+func (s *DeltaStore) createWaitingPrepareDeadlineIndex(db *gorm.DB) error {
+	if db.Migrator().HasIndex(&model.DeltaPrepare{}, waitingPrepareDeadlineIndex) {
+		return nil
+	}
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	return db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_delta_prepares_waiting_deadline
+		ON delta_prepares (deadline, id)
+		WHERE status = 'waiting' AND deadline IS NOT NULL
 	`).Error
 }
 
@@ -111,7 +131,7 @@ func (s *DeltaStore) createJoinForeignKeys(db *gorm.DB) error {
 	if !db.Migrator().HasConstraint(&model.DeltaPrepareGeneration{}, fkPrepareGenerationPrepare) {
 		if err := db.Exec(`
 			ALTER TABLE delta_prepare_generations
-			ADD CONSTRAINT ` + fkPrepareGenerationPrepare + `
+			ADD CONSTRAINT fk_delta_prepare_generations_prepare
 			FOREIGN KEY (prepare_id) REFERENCES delta_prepares (id)
 		`).Error; err != nil {
 			return err
@@ -120,7 +140,7 @@ func (s *DeltaStore) createJoinForeignKeys(db *gorm.DB) error {
 	if !db.Migrator().HasConstraint(&model.DeltaPrepareGeneration{}, fkPrepareGenerationGeneration) {
 		if err := db.Exec(`
 			ALTER TABLE delta_prepare_generations
-			ADD CONSTRAINT ` + fkPrepareGenerationGeneration + `
+			ADD CONSTRAINT fk_delta_prepare_generations_generation
 			FOREIGN KEY (org_id, image_repository, source_digest, target_digest)
 			REFERENCES delta_generations (org_id, image_repository, source_digest, target_digest)
 		`).Error; err != nil {
@@ -304,12 +324,15 @@ func (s *DeltaStore) InsertPrepareGenerations(ctx context.Context, prepareID uui
 	return store.ErrorFromGormError(s.getDB(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&joins).Error)
 }
 
-func (s *DeltaStore) ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error) {
+func (s *DeltaStore) ListWaitingPastDeadline(ctx context.Context, limit int) ([]model.DeltaPrepare, error) {
+	if limit < 1 || limit > MaxListWaitingPastDeadline {
+		return nil, fmt.Errorf("limit must be between 1 and %d", MaxListWaitingPastDeadline)
+	}
 	var rows []model.DeltaPrepare
 	result := s.getDB(ctx).Where(
 		"status = ? AND deadline IS NOT NULL AND deadline < NOW()",
 		model.DeltaPrepareWaiting,
-	).Find(&rows)
+	).Order("deadline ASC, id ASC").Limit(limit).Find(&rows)
 	if result.Error != nil {
 		return nil, store.ErrorFromGormError(result.Error)
 	}

--- a/internal/store/delta/store.go
+++ b/internal/store/delta/store.go
@@ -117,11 +117,14 @@ func (s *DeltaStore) createWaitingPrepareDeadlineIndex(db *gorm.DB) error {
 	if db.Dialector.Name() != "postgres" {
 		return nil
 	}
-	return db.Exec(`
+	if err := db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_delta_prepares_waiting_deadline
 		ON delta_prepares (deadline, id)
 		WHERE status = 'waiting' AND deadline IS NOT NULL
-	`).Error
+	`).Error; err != nil {
+		return fmt.Errorf("create waiting prepare deadline index: %w", err)
+	}
+	return nil
 }
 
 func (s *DeltaStore) createJoinForeignKeys(db *gorm.DB) error {

--- a/internal/store/delta/store.go
+++ b/internal/store/delta/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -32,7 +33,7 @@ type Store interface {
 	InsertPrepare(ctx context.Context, prep *model.DeltaPrepare) error
 	GetPrepare(ctx context.Context, id uuid.UUID) (*model.DeltaPrepare, error)
 	CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error
-	ListWaitingPastDeadline(ctx context.Context, limit int) ([]model.DeltaPrepare, error)
+	ListWaitingPastDeadline(ctx context.Context, limit int, asOf time.Time) ([]model.DeltaPrepare, error)
 	InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error
 }
 
@@ -182,33 +183,12 @@ func generationKeyOf(gen *model.DeltaGeneration) GenerationKey {
 }
 
 func uniqueGenerations(gens []*model.DeltaGeneration) ([]*model.DeltaGeneration, error) {
-	out := make([]*model.DeltaGeneration, 0, len(gens))
-	seen := make(map[GenerationKey]struct{}, len(gens))
 	for _, gen := range gens {
 		if gen == nil {
 			return nil, fmt.Errorf("cannot insert nil DeltaGeneration")
 		}
-		key := generationKeyOf(gen)
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, gen)
 	}
-	return out, nil
-}
-
-func uniqueGenerationKeys(keys []GenerationKey) []GenerationKey {
-	out := make([]GenerationKey, 0, len(keys))
-	seen := make(map[GenerationKey]struct{}, len(keys))
-	for _, key := range keys {
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, key)
-	}
-	return out
+	return lo.UniqBy(gens, generationKeyOf), nil
 }
 
 func (s *DeltaStore) InsertGenerations(ctx context.Context, gens []*model.DeltaGeneration) ([]GenerationKey, error) {
@@ -310,7 +290,7 @@ func (s *DeltaStore) GetPrepare(ctx context.Context, id uuid.UUID) (*model.Delta
 }
 
 func (s *DeltaStore) InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error {
-	keys = uniqueGenerationKeys(keys)
+	keys = lo.Uniq(keys)
 	if len(keys) == 0 {
 		return nil
 	}
@@ -327,14 +307,17 @@ func (s *DeltaStore) InsertPrepareGenerations(ctx context.Context, prepareID uui
 	return store.ErrorFromGormError(s.getDB(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&joins).Error)
 }
 
-func (s *DeltaStore) ListWaitingPastDeadline(ctx context.Context, limit int) ([]model.DeltaPrepare, error) {
+func (s *DeltaStore) ListWaitingPastDeadline(ctx context.Context, limit int, asOf time.Time) ([]model.DeltaPrepare, error) {
 	if limit < 1 || limit > MaxListWaitingPastDeadline {
 		return nil, fmt.Errorf("limit must be between 1 and %d", MaxListWaitingPastDeadline)
 	}
+	if asOf.IsZero() {
+		return nil, fmt.Errorf("asOf time is required")
+	}
 	var rows []model.DeltaPrepare
 	result := s.getDB(ctx).Where(
-		"status = ? AND deadline IS NOT NULL AND deadline < NOW()",
-		model.DeltaPrepareWaiting,
+		"status = ? AND deadline IS NOT NULL AND deadline < ?",
+		model.DeltaPrepareWaiting, asOf,
 	).Order("deadline ASC, id ASC").Limit(limit).Find(&rows)
 	if result.Error != nil {
 		return nil, store.ErrorFromGormError(result.Error)

--- a/internal/store/delta/store.go
+++ b/internal/store/delta/store.go
@@ -1,0 +1,353 @@
+package delta
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const waitingPrepareIndex = "idx_delta_prepares_one_waiting"
+
+const (
+	fkPrepareGenerationPrepare    = "fk_delta_prepare_generations_prepare"
+	fkPrepareGenerationGeneration = "fk_delta_prepare_generations_generation"
+)
+
+type Store interface {
+	InitialMigration(ctx context.Context) error
+	InsertGenerations(ctx context.Context, gens []*model.DeltaGeneration) (changed []GenerationKey, err error)
+	GetGeneration(ctx context.Context, key GenerationKey, opts ...GenerationGetOption) (*model.DeltaGeneration, error)
+	CASGeneration(ctx context.Context, key GenerationKey, expectedRV int64, update GenerationCAS) error
+	InsertPrepare(ctx context.Context, prep *model.DeltaPrepare) error
+	GetPrepare(ctx context.Context, id uuid.UUID) (*model.DeltaPrepare, error)
+	CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error
+	ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error)
+	InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error
+}
+
+type GenerationKey struct {
+	OrgID           uuid.UUID
+	ImageRepository string
+	SourceDigest    string
+	TargetDigest    string
+}
+
+type generationGet struct {
+	status *string
+}
+
+type GenerationGetOption func(*generationGet)
+
+func WithStatus(status string) GenerationGetOption {
+	return func(o *generationGet) {
+		o.status = &status
+	}
+}
+
+type GenerationCAS struct {
+	Status         string
+	DeltaRef       *string
+	SizeBytes      *int64
+	LastVerifiedAt *time.Time
+	GeneratedAt    *time.Time
+}
+
+type DeltaStore struct {
+	dbHandler *gorm.DB
+	log       logrus.FieldLogger
+}
+
+var _ Store = (*DeltaStore)(nil)
+
+func NewStore(db *gorm.DB, log logrus.FieldLogger) Store {
+	return &DeltaStore{dbHandler: db, log: log}
+}
+
+func (s *DeltaStore) getDB(ctx context.Context) *gorm.DB {
+	return s.dbHandler.WithContext(ctx)
+}
+
+func (s *DeltaStore) InitialMigration(ctx context.Context) error {
+	db := s.getDB(ctx)
+	if err := db.AutoMigrate(
+		&model.DeltaGeneration{},
+		&model.DeltaPrepare{},
+		&model.DeltaPrepareGeneration{},
+	); err != nil {
+		return err
+	}
+	if err := s.createWaitingPrepareIndex(db); err != nil {
+		return err
+	}
+	return s.createJoinForeignKeys(db)
+}
+
+func (s *DeltaStore) createWaitingPrepareIndex(db *gorm.DB) error {
+	if db.Migrator().HasIndex(&model.DeltaPrepare{}, waitingPrepareIndex) {
+		return nil
+	}
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	return db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS ` + waitingPrepareIndex + `
+		ON delta_prepares (org_id, kind, name)
+		WHERE status = 'waiting'
+	`).Error
+}
+
+func (s *DeltaStore) createJoinForeignKeys(db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	if !db.Migrator().HasConstraint(&model.DeltaPrepareGeneration{}, fkPrepareGenerationPrepare) {
+		if err := db.Exec(`
+			ALTER TABLE delta_prepare_generations
+			ADD CONSTRAINT ` + fkPrepareGenerationPrepare + `
+			FOREIGN KEY (prepare_id) REFERENCES delta_prepares (id)
+		`).Error; err != nil {
+			return err
+		}
+	}
+	if !db.Migrator().HasConstraint(&model.DeltaPrepareGeneration{}, fkPrepareGenerationGeneration) {
+		if err := db.Exec(`
+			ALTER TABLE delta_prepare_generations
+			ADD CONSTRAINT ` + fkPrepareGenerationGeneration + `
+			FOREIGN KEY (org_id, image_repository, source_digest, target_digest)
+			REFERENCES delta_generations (org_id, image_repository, source_digest, target_digest)
+		`).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generationConflict() clause.OnConflict {
+	return clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "org_id"},
+			{Name: "image_repository"},
+			{Name: "source_digest"},
+			{Name: "target_digest"},
+		},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"status":           model.DeltaGenerationPending,
+			"resource_version": gorm.Expr("delta_generations.resource_version + 1"),
+			"updated_at":       gorm.Expr("NOW()"),
+		}),
+		Where: clause.Where{Exprs: []clause.Expression{
+			clause.Eq{Column: clause.Column{Table: "delta_generations", Name: "status"}, Value: model.DeltaGenerationFailed},
+		}},
+	}
+}
+
+func generationKeyOf(gen *model.DeltaGeneration) GenerationKey {
+	return GenerationKey{
+		OrgID:           gen.OrgID,
+		ImageRepository: gen.ImageRepository,
+		SourceDigest:    gen.SourceDigest,
+		TargetDigest:    gen.TargetDigest,
+	}
+}
+
+func uniqueGenerations(gens []*model.DeltaGeneration) ([]*model.DeltaGeneration, error) {
+	out := make([]*model.DeltaGeneration, 0, len(gens))
+	seen := make(map[GenerationKey]struct{}, len(gens))
+	for _, gen := range gens {
+		if gen == nil {
+			return nil, fmt.Errorf("cannot insert nil DeltaGeneration")
+		}
+		key := generationKeyOf(gen)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, gen)
+	}
+	return out, nil
+}
+
+func uniqueGenerationKeys(keys []GenerationKey) []GenerationKey {
+	out := make([]GenerationKey, 0, len(keys))
+	seen := make(map[GenerationKey]struct{}, len(keys))
+	for _, key := range keys {
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+func (s *DeltaStore) InsertGenerations(ctx context.Context, gens []*model.DeltaGeneration) ([]GenerationKey, error) {
+	gens, err := uniqueGenerations(gens)
+	if err != nil {
+		return nil, err
+	}
+	if len(gens) == 0 {
+		return nil, nil
+	}
+	rows := make([]model.DeltaGeneration, len(gens))
+	for i, gen := range gens {
+		if gen.Status == "" {
+			gen.Status = model.DeltaGenerationPending
+		}
+		rows[i] = *gen
+	}
+	returning := clause.Returning{
+		Columns: []clause.Column{
+			{Name: "org_id"},
+			{Name: "image_repository"},
+			{Name: "source_digest"},
+			{Name: "target_digest"},
+		},
+	}
+	dry := s.getDB(ctx).Session(&gorm.Session{DryRun: true}).Clauses(generationConflict(), returning).Create(&rows)
+	if dry.Error != nil {
+		return nil, store.ErrorFromGormError(dry.Error)
+	}
+	var changed []GenerationKey
+	if err := s.getDB(ctx).Raw(dry.Statement.SQL.String(), dry.Statement.Vars...).Scan(&changed).Error; err != nil {
+		return nil, store.ErrorFromGormError(err)
+	}
+	return changed, nil
+}
+
+func (s *DeltaStore) GetGeneration(ctx context.Context, key GenerationKey, opts ...GenerationGetOption) (*model.DeltaGeneration, error) {
+	cfg := &generationGet{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	q := s.getDB(ctx).Where("org_id = ?", key.OrgID)
+	if key.ImageRepository != "" {
+		q = q.Where("image_repository = ?", key.ImageRepository)
+	}
+	if key.SourceDigest != "" {
+		q = q.Where("source_digest = ?", key.SourceDigest)
+	}
+	if key.TargetDigest != "" {
+		q = q.Where("target_digest = ?", key.TargetDigest)
+	}
+	if cfg.status != nil {
+		q = q.Where("status = ?", *cfg.status)
+	}
+	uniqueKey := key.ImageRepository != "" && key.SourceDigest != "" && key.TargetDigest != ""
+	if uniqueKey {
+		var gen model.DeltaGeneration
+		result := q.Take(&gen)
+		if result.Error != nil {
+			return nil, store.ErrorFromGormError(result.Error)
+		}
+		return &gen, nil
+	}
+	var gens []model.DeltaGeneration
+	result := q.Order("updated_at DESC").Limit(2).Find(&gens)
+	if result.Error != nil {
+		return nil, store.ErrorFromGormError(result.Error)
+	}
+	if len(gens) == 0 {
+		return nil, flterrors.ErrResourceNotFound
+	}
+	if len(gens) > 1 {
+		return nil, fmt.Errorf("multiple generations matched org=%s repo=%s source=%s target=%s",
+			key.OrgID, key.ImageRepository, key.SourceDigest, key.TargetDigest)
+	}
+	return &gens[0], nil
+}
+
+func (s *DeltaStore) InsertPrepare(ctx context.Context, prep *model.DeltaPrepare) error {
+	if prep == nil {
+		return fmt.Errorf("cannot insert nil DeltaPrepare")
+	}
+	if prep.ID == uuid.Nil {
+		prep.ID = uuid.New()
+	}
+	if prep.Status == "" {
+		prep.Status = model.DeltaPrepareWaiting
+	}
+	return store.ErrorFromGormError(s.getDB(ctx).Create(prep).Error)
+}
+
+func (s *DeltaStore) GetPrepare(ctx context.Context, id uuid.UUID) (*model.DeltaPrepare, error) {
+	var prep model.DeltaPrepare
+	result := s.getDB(ctx).Where("id = ?", id).Take(&prep)
+	if result.Error != nil {
+		return nil, store.ErrorFromGormError(result.Error)
+	}
+	return &prep, nil
+}
+
+func (s *DeltaStore) InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error {
+	keys = uniqueGenerationKeys(keys)
+	if len(keys) == 0 {
+		return nil
+	}
+	joins := make([]model.DeltaPrepareGeneration, len(keys))
+	for i, key := range keys {
+		joins[i] = model.DeltaPrepareGeneration{
+			PrepareID:       prepareID,
+			OrgID:           key.OrgID,
+			ImageRepository: key.ImageRepository,
+			SourceDigest:    key.SourceDigest,
+			TargetDigest:    key.TargetDigest,
+		}
+	}
+	return store.ErrorFromGormError(s.getDB(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&joins).Error)
+}
+
+func (s *DeltaStore) ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error) {
+	var rows []model.DeltaPrepare
+	result := s.getDB(ctx).Where(
+		"status = ? AND deadline IS NOT NULL AND deadline < NOW()",
+		model.DeltaPrepareWaiting,
+	).Find(&rows)
+	if result.Error != nil {
+		return nil, store.ErrorFromGormError(result.Error)
+	}
+	return rows, nil
+}
+
+func (s *DeltaStore) CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error {
+	result := s.getDB(ctx).Model(&model.DeltaPrepare{}).
+		Where("id = ? AND status = ?", id, model.DeltaPrepareWaiting).
+		Update("status", to)
+	if result.Error != nil {
+		return store.ErrorFromGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return flterrors.ErrNoRowsUpdated
+	}
+	return nil
+}
+
+func (s *DeltaStore) CASGeneration(ctx context.Context, key GenerationKey, expectedRV int64, update GenerationCAS) error {
+	updates := map[string]interface{}{
+		"status":           update.Status,
+		"delta_ref":        update.DeltaRef,
+		"size_bytes":       update.SizeBytes,
+		"last_verified_at": update.LastVerifiedAt,
+		"generated_at":     update.GeneratedAt,
+		"resource_version": gorm.Expr("resource_version + 1"),
+	}
+	result := s.getDB(ctx).Model(&model.DeltaGeneration{}).
+		Where(
+			"org_id = ? AND image_repository = ? AND source_digest = ? AND target_digest = ? AND resource_version = ?",
+			key.OrgID, key.ImageRepository, key.SourceDigest, key.TargetDigest, expectedRV,
+		).Updates(updates)
+	if result.Error != nil {
+		return store.ErrorFromGormError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return flterrors.ErrNoRowsUpdated
+	}
+	return nil
+}

--- a/internal/store/delta/store_test.go
+++ b/internal/store/delta/store_test.go
@@ -1,0 +1,16 @@
+package delta
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_ReturnsNonNilStore(t *testing.T) {
+	req := require.New(t)
+
+	s := NewStore(nil, logrus.New())
+
+	req.NotNil(s)
+}

--- a/internal/store/delta/store_test.go
+++ b/internal/store/delta/store_test.go
@@ -3,6 +3,7 @@ package delta
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -21,9 +22,10 @@ func TestListWaitingPastDeadline_WhenLimitIsOutOfRangeItShouldError(t *testing.T
 	s := NewStore(nil, logrus.New())
 	ctx := context.Background()
 
-	_, err := s.ListWaitingPastDeadline(ctx, 0)
+	now := time.Now()
+	_, err := s.ListWaitingPastDeadline(ctx, 0, now)
 	require.Error(t, err)
 
-	_, err = s.ListWaitingPastDeadline(ctx, MaxListWaitingPastDeadline+1)
+	_, err = s.ListWaitingPastDeadline(ctx, MaxListWaitingPastDeadline+1, now)
 	require.Error(t, err)
 }

--- a/internal/store/delta/store_test.go
+++ b/internal/store/delta/store_test.go
@@ -1,6 +1,7 @@
 package delta
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -13,4 +14,16 @@ func TestNewStore_ReturnsNonNilStore(t *testing.T) {
 	s := NewStore(nil, logrus.New())
 
 	req.NotNil(s)
+}
+
+func TestListWaitingPastDeadline_WhenLimitIsOutOfRangeItShouldError(t *testing.T) {
+	t.Parallel()
+	s := NewStore(nil, logrus.New())
+	ctx := context.Background()
+
+	_, err := s.ListWaitingPastDeadline(ctx, 0)
+	require.Error(t, err)
+
+	_, err = s.ListWaitingPastDeadline(ctx, MaxListWaitingPastDeadline+1)
+	require.Error(t, err)
 }

--- a/internal/store/model/delta.go
+++ b/internal/store/model/delta.go
@@ -53,6 +53,8 @@ func (DeltaPrepare) TableName() string {
 	return "delta_prepares"
 }
 
+// DeltaPrepareGeneration is the join row that attaches a DeltaPrepare to the
+// DeltaGeneration keys it is waiting on.
 type DeltaPrepareGeneration struct {
 	PrepareID       uuid.UUID `gorm:"type:uuid;primaryKey"`
 	OrgID           uuid.UUID `gorm:"type:uuid;primaryKey"`

--- a/internal/store/model/delta.go
+++ b/internal/store/model/delta.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	DeltaGenerationPending    = "pending"
+	DeltaGenerationInProgress = "in_progress"
+	DeltaGenerationSucceeded  = "succeeded"
+	DeltaGenerationFailed     = "failed"
+	DeltaGenerationRejected   = "rejected"
+
+	DeltaPrepareWaiting  = "waiting"
+	DeltaPrepareComplete = "complete"
+	DeltaPrepareFailed   = "failed"
+)
+
+type DeltaGeneration struct {
+	OrgID           uuid.UUID `gorm:"type:uuid;primaryKey"`
+	ImageRepository string    `gorm:"type:text;primaryKey"`
+	SourceDigest    string    `gorm:"type:text;primaryKey"`
+	TargetDigest    string    `gorm:"type:text;primaryKey"`
+
+	DeltaRef        *string
+	SizeBytes       *int64
+	Status          string `gorm:"type:text"`
+	LastVerifiedAt  *time.Time
+	GeneratedAt     *time.Time
+	ResourceVersion int64
+	UpdatedAt       time.Time
+}
+
+func (DeltaGeneration) TableName() string {
+	return "delta_generations"
+}
+
+type DeltaPrepare struct {
+	ID                  uuid.UUID `gorm:"type:uuid;primaryKey"`
+	OrgID               uuid.UUID `gorm:"type:uuid;index"`
+	Kind                string    `gorm:"type:text"`
+	Name                string    `gorm:"type:text"`
+	TemplateVersion     *string   `gorm:"type:text"`
+	SpecResourceVersion *int64
+	Deadline            *time.Time
+	CreatedAt           time.Time
+	Status              string `gorm:"type:text"`
+}
+
+func (DeltaPrepare) TableName() string {
+	return "delta_prepares"
+}
+
+type DeltaPrepareGeneration struct {
+	PrepareID       uuid.UUID `gorm:"type:uuid;primaryKey"`
+	OrgID           uuid.UUID `gorm:"type:uuid;primaryKey"`
+	ImageRepository string    `gorm:"type:text;primaryKey"`
+	SourceDigest    string    `gorm:"type:text;primaryKey"`
+	TargetDigest    string    `gorm:"type:text;primaryKey"`
+}
+
+func (DeltaPrepareGeneration) TableName() string {
+	return "delta_prepare_generations"
+}

--- a/test/integration/store/delta_test.go
+++ b/test/integration/store/delta_test.go
@@ -320,7 +320,7 @@ var _ = Describe("DeltaStore", func() {
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("future", &future))).To(Succeed())
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("none", nil))).To(Succeed())
 
-			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline)
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listed).To(HaveLen(1))
 			Expect(listed[0].Name).To(Equal("expired"))
@@ -340,7 +340,7 @@ var _ = Describe("DeltaStore", func() {
 			}
 			Expect(deltaStore.InsertPrepare(ctx, otherPrep)).To(Succeed())
 
-			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline)
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listed).To(HaveLen(2))
 			names := []string{listed[0].Name, listed[1].Name}
@@ -353,7 +353,7 @@ var _ = Describe("DeltaStore", func() {
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("first", &earlier))).To(Succeed())
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("second", &later))).To(Succeed())
 
-			listed, err := deltaStore.ListWaitingPastDeadline(ctx, 1)
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, 1, time.Now())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listed).To(HaveLen(1))
 			Expect(listed[0].Name).To(Equal("first"))

--- a/test/integration/store/delta_test.go
+++ b/test/integration/store/delta_test.go
@@ -320,7 +320,7 @@ var _ = Describe("DeltaStore", func() {
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("future", &future))).To(Succeed())
 			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("none", nil))).To(Succeed())
 
-			listed, err := deltaStore.ListWaitingPastDeadline(ctx)
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listed).To(HaveLen(1))
 			Expect(listed[0].Name).To(Equal("expired"))
@@ -340,11 +340,23 @@ var _ = Describe("DeltaStore", func() {
 			}
 			Expect(deltaStore.InsertPrepare(ctx, otherPrep)).To(Succeed())
 
-			listed, err := deltaStore.ListWaitingPastDeadline(ctx)
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, deltastore.MaxListWaitingPastDeadline)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listed).To(HaveLen(2))
 			names := []string{listed[0].Name, listed[1].Name}
 			Expect(names).To(ConsistOf("org-a", "org-b"))
+		})
+
+		It("should return at most limit rows ordered by deadline then id", func() {
+			earlier := time.Now().Add(-2 * time.Hour)
+			later := time.Now().Add(-time.Hour)
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("first", &earlier))).To(Succeed())
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("second", &later))).To(Succeed())
+
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listed).To(HaveLen(1))
+			Expect(listed[0].Name).To(Equal("first"))
 		})
 	})
 

--- a/test/integration/store/delta_test.go
+++ b/test/integration/store/delta_test.go
@@ -1,0 +1,484 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
+	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
+	"github.com/flightctl/flightctl/internal/store/model"
+	organizationstore "github.com/flightctl/flightctl/internal/store/organization"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("DeltaStore", func() {
+	var (
+		log               *logrus.Logger
+		ctx               context.Context
+		orgId             uuid.UUID
+		deltaStore        deltastore.Store
+		organizationStore organizationstore.Store
+		cfg               *config.Config
+		dbName            string
+		db                *gorm.DB
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		log = flightlog.InitLogs()
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		deltaStore = deltastore.NewStore(db, log.WithField("pkg", "delta-store"))
+		organizationStore = organizationstore.NewOrganizationStore(db)
+
+		orgId = uuid.New()
+		err = testutil.CreateTestOrganization(ctx, organizationStore, orgId)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+	})
+
+	generation := func(org uuid.UUID, repo string) *model.DeltaGeneration {
+		return &model.DeltaGeneration{
+			OrgID:           org,
+			ImageRepository: repo,
+			SourceDigest:    "sha256:aaa",
+			TargetDigest:    "sha256:bbb",
+		}
+	}
+
+	keyOf := func(g *model.DeltaGeneration) deltastore.GenerationKey {
+		return deltastore.GenerationKey{
+			OrgID:           g.OrgID,
+			ImageRepository: g.ImageRepository,
+			SourceDigest:    g.SourceDigest,
+			TargetDigest:    g.TargetDigest,
+		}
+	}
+
+	insertGens := func(gens ...*model.DeltaGeneration) []deltastore.GenerationKey {
+		changed, err := deltaStore.InsertGenerations(ctx, gens)
+		Expect(err).ToNot(HaveOccurred())
+		return changed
+	}
+
+	Context("When inserting generations for two image repositories with the same digests", func() {
+		It("should keep both rows", func() {
+			a := generation(orgId, "quay.io/team-a/os")
+			b := generation(orgId, "quay.io/team-b/os")
+
+			changed := insertGens(a, b)
+			Expect(changed).To(ConsistOf(keyOf(a), keyOf(b)))
+
+			gotA, err := deltaStore.GetGeneration(ctx, keyOf(a))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotA.ImageRepository).To(Equal("quay.io/team-a/os"))
+			Expect(gotA.Status).To(Equal(model.DeltaGenerationPending))
+
+			gotB, err := deltaStore.GetGeneration(ctx, keyOf(b))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotB.ImageRepository).To(Equal("quay.io/team-b/os"))
+			Expect(gotB.Status).To(Equal(model.DeltaGenerationPending))
+		})
+	})
+
+	Context("When inserting the same generation key twice", func() {
+		It("should no-op when the existing row is pending", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			insertGens(g)
+
+			changed := insertGens(generation(orgId, "quay.io/team-a/os"))
+			Expect(changed).To(BeEmpty())
+
+			got, err := deltaStore.GetGeneration(ctx, keyOf(g))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaGenerationPending))
+			Expect(got.ResourceVersion).To(Equal(int64(0)))
+		})
+	})
+
+	Context("When inserting over an existing failed row", func() {
+		It("should reset status to pending and bump resource_version", func() {
+			ref := "oci://delta"
+			size := int64(42)
+			g := generation(orgId, "quay.io/team-a/os")
+			g.Status = model.DeltaGenerationFailed
+			g.ResourceVersion = 3
+			g.DeltaRef = &ref
+			g.SizeBytes = &size
+			insertGens(g)
+
+			stale := time.Now().Add(-time.Hour).UTC().Truncate(time.Microsecond)
+			Expect(db.Model(&model.DeltaGeneration{}).Where(
+				"org_id = ? AND image_repository = ? AND source_digest = ? AND target_digest = ?",
+				g.OrgID, g.ImageRepository, g.SourceDigest, g.TargetDigest,
+			).Update("updated_at", stale).Error).ToNot(HaveOccurred())
+
+			changed := insertGens(generation(orgId, "quay.io/team-a/os"))
+			Expect(changed).To(ConsistOf(keyOf(g)))
+
+			got, err := deltaStore.GetGeneration(ctx, keyOf(g))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaGenerationPending))
+			Expect(got.ResourceVersion).To(Equal(int64(4)))
+			Expect(got.DeltaRef).ToNot(BeNil())
+			Expect(*got.DeltaRef).To(Equal(ref))
+			Expect(got.SizeBytes).ToNot(BeNil())
+			Expect(*got.SizeBytes).To(Equal(size))
+			Expect(got.UpdatedAt).To(BeTemporally(">", stale))
+		})
+	})
+
+	Context("When inserting the same generation key twice in one batch", func() {
+		It("should insert the key once", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			dup := generation(orgId, "quay.io/team-a/os")
+			changed := insertGens(g, dup)
+			Expect(changed).To(ConsistOf(keyOf(g)))
+
+			var count int64
+			Expect(db.Model(&model.DeltaGeneration{}).Count(&count).Error).ToNot(HaveOccurred())
+			Expect(count).To(Equal(int64(1)))
+		})
+	})
+
+	Context("When inserting a mixed batch of new, failed, and pending generations", func() {
+		It("should return only the new and failed keys", func() {
+			pending := generation(orgId, "quay.io/team-a/os")
+			failed := generation(orgId, "quay.io/team-b/os")
+			failed.Status = model.DeltaGenerationFailed
+			insertGens(pending, failed)
+
+			fresh := generation(orgId, "quay.io/team-c/os")
+			changed := insertGens(pending, failed, fresh)
+			Expect(changed).To(ConsistOf(keyOf(failed), keyOf(fresh)))
+		})
+	})
+
+	DescribeTable("When inserting over a terminal or in-progress generation",
+		func(status string) {
+			g := generation(orgId, "quay.io/team-a/os")
+			g.Status = status
+			g.ResourceVersion = 2
+			insertGens(g)
+
+			changed := insertGens(generation(orgId, "quay.io/team-a/os"))
+			Expect(changed).To(BeEmpty())
+
+			got, err := deltaStore.GetGeneration(ctx, keyOf(g))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(status))
+			Expect(got.ResourceVersion).To(Equal(int64(2)))
+		},
+		Entry("succeeded", model.DeltaGenerationSucceeded),
+		Entry("rejected", model.DeltaGenerationRejected),
+		Entry("in_progress", model.DeltaGenerationInProgress),
+	)
+
+	Context("When inserting the same digests in two orgs", func() {
+		It("should keep both rows", func() {
+			otherOrg := uuid.New()
+			Expect(testutil.CreateTestOrganization(ctx, organizationStore, otherOrg)).To(Succeed())
+
+			a := generation(orgId, "quay.io/team-a/os")
+			b := generation(otherOrg, "quay.io/team-a/os")
+			changed := insertGens(a, b)
+			Expect(changed).To(ConsistOf(keyOf(a), keyOf(b)))
+		})
+	})
+
+	Context("When getting a missing generation", func() {
+		It("should return ErrResourceNotFound", func() {
+			_, err := deltaStore.GetGeneration(ctx, keyOf(generation(orgId, "quay.io/missing/os")))
+			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+		})
+	})
+
+	fleetPrepare := func(name string, deadline *time.Time) *model.DeltaPrepare {
+		tv := "tv-1"
+		return &model.DeltaPrepare{
+			OrgID:           orgId,
+			Kind:            domain.FleetKind,
+			Name:            name,
+			TemplateVersion: &tv,
+			Deadline:        deadline,
+		}
+	}
+
+	Context("When inserting a waiting fleet prepare and joining generations", func() {
+		It("should persist the joins without an FK from generations to prepares", func() {
+			a := generation(orgId, "quay.io/team-a/os")
+			b := generation(orgId, "quay.io/team-b/os")
+			deadline := time.Now().Add(-time.Hour)
+			prep := fleetPrepare("myfleet", &deadline)
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+			Expect(prep.ID).ToNot(Equal(uuid.Nil))
+			Expect(prep.Status).To(Equal(model.DeltaPrepareWaiting))
+
+			insertGens(a, b)
+			keys := []deltastore.GenerationKey{keyOf(a), keyOf(b)}
+			Expect(deltaStore.InsertPrepareGenerations(ctx, prep.ID, keys)).To(Succeed())
+			Expect(deltaStore.InsertPrepareGenerations(ctx, prep.ID, keys)).To(Succeed())
+
+			got, err := deltaStore.GetPrepare(ctx, prep.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Kind).To(Equal(domain.FleetKind))
+			Expect(got.Name).To(Equal("myfleet"))
+
+			var joinCount int64
+			Expect(db.Model(&model.DeltaPrepareGeneration{}).Where("prepare_id = ?", prep.ID).Count(&joinCount).Error).ToNot(HaveOccurred())
+			Expect(joinCount).To(Equal(int64(2)))
+
+			var fkCount int64
+			Expect(db.Raw(`
+				SELECT COUNT(*)
+				FROM pg_constraint
+				WHERE conrelid = 'delta_generations'::regclass
+				  AND confrelid = 'delta_prepares'::regclass
+			`).Scan(&fkCount).Error).ToNot(HaveOccurred())
+			Expect(fkCount).To(Equal(int64(0)))
+		})
+	})
+
+	Context("When inserting the same prepare-generation key twice in one batch", func() {
+		It("should keep one join row", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			insertGens(g)
+			prep := fleetPrepare("myfleet", nil)
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+
+			key := keyOf(g)
+			Expect(deltaStore.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{key, key})).To(Succeed())
+
+			var joinCount int64
+			Expect(db.Model(&model.DeltaPrepareGeneration{}).Where("prepare_id = ?", prep.ID).Count(&joinCount).Error).ToNot(HaveOccurred())
+			Expect(joinCount).To(Equal(int64(1)))
+		})
+	})
+
+	Context("When inserting a second waiting prepare for the same fleet", func() {
+		It("should return ErrDuplicateName", func() {
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("myfleet", nil))).To(Succeed())
+			err := deltaStore.InsertPrepare(ctx, fleetPrepare("myfleet", nil))
+			Expect(err).To(MatchError(flterrors.ErrDuplicateName))
+		})
+	})
+
+	Context("When inserting waiting prepares for a fleet and a device with the same name", func() {
+		It("should keep both rows", func() {
+			fleetPrep := fleetPrepare("shared", nil)
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrep)).To(Succeed())
+			specRV := int64(7)
+			devicePrep := &model.DeltaPrepare{
+				OrgID:               orgId,
+				Kind:                domain.DeviceKind,
+				Name:                "shared",
+				SpecResourceVersion: &specRV,
+			}
+			Expect(deltaStore.InsertPrepare(ctx, devicePrep)).To(Succeed())
+
+			gotFleet, err := deltaStore.GetPrepare(ctx, fleetPrep.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotFleet.Kind).To(Equal(domain.FleetKind))
+
+			gotDevice, err := deltaStore.GetPrepare(ctx, devicePrep.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotDevice.Kind).To(Equal(domain.DeviceKind))
+		})
+	})
+
+	Context("When a waiting prepare is complete, then a new waiting prepare for that fleet", func() {
+		It("should allow the second insert", func() {
+			complete := fleetPrepare("myfleet", nil)
+			complete.Status = model.DeltaPrepareComplete
+			Expect(deltaStore.InsertPrepare(ctx, complete)).To(Succeed())
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("myfleet", nil))).To(Succeed())
+		})
+	})
+
+	Context("When listing waiting prepares past deadline", func() {
+		It("should return only expired waiting rows", func() {
+			past := time.Now().Add(-time.Hour)
+			future := time.Now().Add(time.Hour)
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("expired", &past))).To(Succeed())
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("future", &future))).To(Succeed())
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("none", nil))).To(Succeed())
+
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listed).To(HaveLen(1))
+			Expect(listed[0].Name).To(Equal("expired"))
+			Expect(listed[0].Status).To(Equal(model.DeltaPrepareWaiting))
+		})
+
+		It("should return expired waiting rows from every org", func() {
+			otherOrg := uuid.New()
+			Expect(testutil.CreateTestOrganization(ctx, organizationStore, otherOrg)).To(Succeed())
+			past := time.Now().Add(-time.Hour)
+			Expect(deltaStore.InsertPrepare(ctx, fleetPrepare("org-a", &past))).To(Succeed())
+			otherPrep := &model.DeltaPrepare{
+				OrgID:    otherOrg,
+				Kind:     domain.FleetKind,
+				Name:     "org-b",
+				Deadline: &past,
+			}
+			Expect(deltaStore.InsertPrepare(ctx, otherPrep)).To(Succeed())
+
+			listed, err := deltaStore.ListWaitingPastDeadline(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listed).To(HaveLen(2))
+			names := []string{listed[0].Name, listed[1].Name}
+			Expect(names).To(ConsistOf("org-a", "org-b"))
+		})
+	})
+
+	Context("When joining a prepare to a missing parent", func() {
+		It("should return ErrResourceNotFound if the prepare does not exist", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			insertGens(g)
+
+			err := deltaStore.InsertPrepareGenerations(ctx, uuid.New(), []deltastore.GenerationKey{keyOf(g)})
+			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+		})
+
+		It("should return ErrResourceNotFound if the generation does not exist", func() {
+			prep := fleetPrepare("myfleet", nil)
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+
+			err := deltaStore.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{keyOf(generation(orgId, "quay.io/missing/os"))})
+			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+		})
+	})
+
+	Context("When getting a missing prepare", func() {
+		It("should return ErrResourceNotFound", func() {
+			_, err := deltaStore.GetPrepare(ctx, uuid.New())
+			Expect(err).To(MatchError(flterrors.ErrResourceNotFound))
+		})
+	})
+
+	Context("When CAS-ing a waiting prepare to complete", func() {
+		It("should update once and reject a second CAS", func() {
+			prep := fleetPrepare("myfleet", nil)
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+
+			Expect(deltaStore.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareComplete)).To(Succeed())
+
+			got, err := deltaStore.GetPrepare(ctx, prep.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaPrepareComplete))
+
+			err = deltaStore.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareFailed)
+			Expect(err).To(MatchError(flterrors.ErrNoRowsUpdated))
+		})
+	})
+
+	Context("When CAS-ing a generation with a stale resource_version", func() {
+		It("should leave the row unchanged", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			g.Status = model.DeltaGenerationInProgress
+			g.ResourceVersion = 1
+			insertGens(g)
+
+			ref := "oci://delta"
+			size := int64(9)
+			err := deltaStore.CASGeneration(ctx, keyOf(g), 0, deltastore.GenerationCAS{
+				Status:    model.DeltaGenerationSucceeded,
+				DeltaRef:  &ref,
+				SizeBytes: &size,
+			})
+			Expect(err).To(MatchError(flterrors.ErrNoRowsUpdated))
+
+			got, err := deltaStore.GetGeneration(ctx, keyOf(g))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaGenerationInProgress))
+			Expect(got.ResourceVersion).To(Equal(int64(1)))
+			Expect(got.DeltaRef).To(BeNil())
+		})
+	})
+
+	Context("When CAS-ing a generation with the current resource_version", func() {
+		It("should write fields and bump resource_version", func() {
+			g := generation(orgId, "quay.io/team-a/os")
+			g.Status = model.DeltaGenerationInProgress
+			g.ResourceVersion = 1
+			insertGens(g)
+
+			ref := "oci://delta"
+			size := int64(9)
+			Expect(deltaStore.CASGeneration(ctx, keyOf(g), 1, deltastore.GenerationCAS{
+				Status:    model.DeltaGenerationSucceeded,
+				DeltaRef:  &ref,
+				SizeBytes: &size,
+			})).To(Succeed())
+
+			got, err := deltaStore.GetGeneration(ctx, keyOf(g))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaGenerationSucceeded))
+			Expect(got.ResourceVersion).To(Equal(int64(2)))
+			Expect(got.DeltaRef).ToNot(BeNil())
+			Expect(*got.DeltaRef).To(Equal(ref))
+			Expect(got.SizeBytes).ToNot(BeNil())
+			Expect(*got.SizeBytes).To(Equal(size))
+		})
+	})
+
+	Context("When Device and Fleet rows exist and delta tables are written", func() {
+		It("should leave Device and Fleet JSON unchanged", func() {
+			deviceStore := devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+			fleetStore := fleetstore.NewFleetStore(db, log.WithField("pkg", "fleet-store"))
+			testutil.CreateTestDevice(ctx, deviceStore, orgId, "mydevice", nil, nil, nil)
+			testutil.CreateTestFleet(ctx, fleetStore, orgId, "myfleet", nil, nil)
+
+			beforeDevice, err := deviceStore.Get(ctx, orgId, "mydevice")
+			Expect(err).ToNot(HaveOccurred())
+			beforeFleet, err := fleetStore.Get(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			beforeDeviceJSON, err := json.Marshal(beforeDevice)
+			Expect(err).ToNot(HaveOccurred())
+			beforeFleetJSON, err := json.Marshal(beforeFleet)
+			Expect(err).ToNot(HaveOccurred())
+
+			g := generation(orgId, "quay.io/team-a/os")
+			insertGens(g)
+			prep := fleetPrepare("myfleet", nil)
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+			Expect(deltaStore.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{keyOf(g)})).To(Succeed())
+
+			afterDevice, err := deviceStore.Get(ctx, orgId, "mydevice")
+			Expect(err).ToNot(HaveOccurred())
+			afterFleet, err := fleetStore.Get(ctx, orgId, "myfleet")
+			Expect(err).ToNot(HaveOccurred())
+			afterDeviceJSON, err := json.Marshal(afterDevice)
+			Expect(err).ToNot(HaveOccurred())
+			afterFleetJSON, err := json.Marshal(afterFleet)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(afterDeviceJSON).To(Equal(beforeDeviceJSON))
+			Expect(afterFleetJSON).To(Equal(beforeFleetJSON))
+
+			var genCount, prepCount, joinCount int64
+			Expect(db.Model(&model.DeltaGeneration{}).Count(&genCount).Error).ToNot(HaveOccurred())
+			Expect(db.Model(&model.DeltaPrepare{}).Count(&prepCount).Error).ToNot(HaveOccurred())
+			Expect(db.Model(&model.DeltaPrepareGeneration{}).Count(&joinCount).Error).ToNot(HaveOccurred())
+			Expect(genCount).To(Equal(int64(1)))
+			Expect(prepCount).To(Equal(int64(1)))
+			Expect(joinCount).To(Equal(int64(1)))
+		})
+	})
+})


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [x] **`release-1.4`**

## EDM-5217: Persist delta prepares and generations

**Jira:** https://issues.redhat.com/browse/EDM-5217
**Story type:** [DEV]
**Stack:** on [EDM-5215](https://github.com/flightctl/flightctl/pull/3427) (EDM-5213 → EDM-5214 → EDM-5215 → EDM-5217)

### Summary

Adds empty Postgres tables and a store package for in-flight OS delta prepares and per-pair generation outcomes. Generation can be shared across devices, survive Redis restarts, and resume without the original queue message. No Device/Fleet JSON backfill, no worker, and no HTTP API in this story.

### Changes

- `delta_generations` keyed by `(org_id, image_repository, source_digest, target_digest)` where `image_repository` is the full repo path
- `delta_prepares` with UUID PK and at most one `waiting` row per `(org_id, kind, name)`
- `delta_prepare_generations` join; FKs from join → prepare and join → generation only
- Store APIs: `InsertPrepare`, `InsertGenerations` (one upsert; `failed` → `pending` on conflict, `RETURNING` the enqueue keys), `InsertPrepareGenerations` (mass join), CAS on `waiting` and `resource_version`, list waiting prepares past deadline

### Testing

- **Unit tests:** constructor-only (`NewStore`), matching other internal stores
- **Integration tests:** Ginkgo specs in `test/integration/store` covering PK uniqueness, batch insert, mixed-batch RETURNING, failed→pending, at-most-one waiting, join FKs, list-by-deadline (including cross-org), CAS hit/miss, and Device/Fleet JSON unchanged

### Acceptance Criteria

- [ ] AC-1: `delta_generations` PK and columns; `image_repository` is full repo path
- [ ] AC-2: `delta_prepares` columns; at most one waiting per fleet and per device
- [ ] AC-3: Join table; no FK from generations to a prepare
- [ ] AC-4: Insert, conflict-noop (except `failed` → `pending`), CAS waiting / resource_version, list expired waiting
- [ ] AC-5: Empty tables, no Device/Fleet JSON backfill
