### PR TITLE
EDM-5283: Fall back to socat when virt-launcher has no nc

### DIFF
--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -32,6 +32,7 @@ type mockExecStreamer struct {
 	streamCmds [][]string
 	streamN    int
 	ncMissing  bool
+	probeErr   error
 	mu         sync.Mutex
 }
 
@@ -56,8 +57,13 @@ func (m *mockExecStreamer) Exec(_ context.Context, _ string, cmd ...string) erro
 	defer m.mu.Unlock()
 	cp := append([]string(nil), cmd...)
 	m.execCalls = append(m.execCalls, cp)
-	if m.ncMissing && strings.Contains(strings.Join(cmd, " "), "command -v nc") {
-		return fmt.Errorf("nc not found")
+	if strings.Contains(strings.Join(cmd, " "), "command -v nc") {
+		if m.probeErr != nil {
+			return m.probeErr
+		}
+		if m.ncMissing {
+			return fmt.Errorf("podman exec compute: %s ", ncAbsentExitMarker)
+		}
 	}
 	return nil
 }

--- a/internal/agent/device/applications/console/manager_test.go
+++ b/internal/agent/device/applications/console/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -28,14 +29,17 @@ type mockExecStreamer struct {
 	err        error
 	streamErrs []error // if non-empty, each ExecStream pops the next error (nil means success with conn)
 	execCalls  [][]string
+	streamCmds [][]string
 	streamN    int
+	ncMissing  bool
 	mu         sync.Mutex
 }
 
-func (m *mockExecStreamer) ExecStream(_ context.Context, _ string, _ ...string) (io.ReadWriteCloser, error) {
+func (m *mockExecStreamer) ExecStream(_ context.Context, _ string, cmd ...string) (io.ReadWriteCloser, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.streamN++
+	m.streamCmds = append(m.streamCmds, append([]string(nil), cmd...))
 	if len(m.streamErrs) > 0 {
 		err := m.streamErrs[0]
 		m.streamErrs = m.streamErrs[1:]
@@ -52,6 +56,9 @@ func (m *mockExecStreamer) Exec(_ context.Context, _ string, cmd ...string) erro
 	defer m.mu.Unlock()
 	cp := append([]string(nil), cmd...)
 	m.execCalls = append(m.execCalls, cp)
+	if m.ncMissing && strings.Contains(strings.Join(cmd, " "), "command -v nc") {
+		return fmt.Errorf("nc not found")
+	}
 	return nil
 }
 

--- a/internal/agent/device/applications/console/unix_socket.go
+++ b/internal/agent/device/applications/console/unix_socket.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/pkg/log"
@@ -12,8 +13,14 @@ import (
 
 const (
 	killSocketHoldersTimeout = 5 * time.Second
+	ncProbeTimeout           = 5 * time.Second
 	maxDialAttempts          = 3
-	ncProbeScript            = "command -v nc >/dev/null"
+	ncAbsentExitCode         = 42
+)
+
+var (
+	ncProbeScript      = fmt.Sprintf("command -v nc >/dev/null && exit 0; exit %d", ncAbsentExitCode)
+	ncAbsentExitMarker = fmt.Sprintf("code: %d:", ncAbsentExitCode)
 )
 
 // dialRetryDelay is the pause between failed dial attempts. Mutable for tests.
@@ -27,7 +34,11 @@ func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, soc
 		return nil, fmt.Errorf("dial VM Unix socket %q: no exec streamer", socketPath)
 	}
 
-	args := unixSocketDialArgs(socketPath, containerHasNC(ctx, exec, containerName))
+	useNC, err := containerHasNC(ctx, exec, containerName)
+	if err != nil {
+		return nil, fmt.Errorf("dial VM Unix socket %q in container %q: probe nc: %w", socketPath, containerName, err)
+	}
+	args := unixSocketDialArgs(socketPath, useNC)
 
 	var lastErr error
 	for attempt := 1; attempt <= maxDialAttempts; attempt++ {
@@ -53,8 +64,21 @@ func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, soc
 	return nil, fmt.Errorf("dial VM Unix socket %q in container %q after %d attempts: %w", socketPath, containerName, maxDialAttempts, lastErr)
 }
 
-func containerHasNC(ctx context.Context, exec ExecStreamer, containerName string) bool {
-	return exec.Exec(ctx, containerName, "sh", "-c", ncProbeScript) == nil
+func containerHasNC(ctx context.Context, exec ExecStreamer, containerName string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, ncProbeTimeout)
+	defer cancel()
+	err := exec.Exec(ctx, containerName, "sh", "-c", ncProbeScript)
+	if err == nil {
+		return true, nil
+	}
+	if isNCAbsent(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func isNCAbsent(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ncAbsentExitMarker)
 }
 
 func unixSocketDialArgs(socketPath string, useNC bool) []string {

--- a/internal/agent/device/applications/console/unix_socket.go
+++ b/internal/agent/device/applications/console/unix_socket.go
@@ -11,35 +11,29 @@ import (
 )
 
 const (
-	// killNCSocketHoldersTimeout bounds best-effort cleanup of leftover `nc -U` processes
-	// left behind when the host-side `podman exec` is killed (Podman does not reliably
-	// signal the in-container process).
-	killNCSocketHoldersTimeout = 5 * time.Second
-
-	// maxDialAttempts covers the race where pkill has sent SIGTERM but the old nc has
-	// not yet released QEMU's single-client socket when the first dial runs.
-	maxDialAttempts = 3
+	killSocketHoldersTimeout = 5 * time.Second
+	maxDialAttempts          = 3
+	ncProbeScript            = "command -v nc >/dev/null"
 )
 
 // dialRetryDelay is the pause between failed dial attempts. Mutable for tests.
 var dialRetryDelay = 200 * time.Millisecond
 
-// dialVMUnixSocket connects to a Unix socket inside the container via `nc -U`.
-// It reaps any leftover `nc` clients for that socket before each dial attempt so a
-// previous crashed or cancelled session cannot permanently occupy QEMU's single-client
-// serial/VNC chardev. Cleanup runs only before dial (not on Close) so a --force
-// takeover cannot kill the successor session's newly started nc. Dial is retried a
-// limited number of times if ExecStream fails while the chardev is still freeing.
+// dialVMUnixSocket connects to a Unix socket inside the container via `nc -U`,
+// or `socat` when nc is absent. Leftover clients are reaped before each dial,
+// not on Close. Dial is retried if ExecStream fails while the chardev is freeing.
 func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) (io.ReadWriteCloser, error) {
 	if exec == nil {
 		return nil, fmt.Errorf("dial VM Unix socket %q: no exec streamer", socketPath)
 	}
 
+	args := unixSocketDialArgs(socketPath, containerHasNC(ctx, exec, containerName))
+
 	var lastErr error
 	for attempt := 1; attempt <= maxDialAttempts; attempt++ {
-		killNCSocketHolders(ctx, exec, containerName, socketPath, logger)
+		killSocketHolders(ctx, exec, containerName, socketPath, logger)
 
-		conn, err := exec.ExecStream(ctx, containerName, "nc", "-U", socketPath)
+		conn, err := exec.ExecStream(ctx, containerName, args...)
 		if err == nil {
 			if attempt > 1 {
 				logger.Debugf("dialed %s in %s on attempt %d/%d", socketPath, containerName, attempt, maxDialAttempts)
@@ -59,6 +53,17 @@ func dialVMUnixSocket(ctx context.Context, exec ExecStreamer, containerName, soc
 	return nil, fmt.Errorf("dial VM Unix socket %q in container %q after %d attempts: %w", socketPath, containerName, maxDialAttempts, lastErr)
 }
 
+func containerHasNC(ctx context.Context, exec ExecStreamer, containerName string) bool {
+	return exec.Exec(ctx, containerName, "sh", "-c", ncProbeScript) == nil
+}
+
+func unixSocketDialArgs(socketPath string, useNC bool) []string {
+	if useNC {
+		return []string{"nc", "-U", socketPath}
+	}
+	return []string{"socat", "-", "UNIX-CONNECT:" + socketPath}
+}
+
 func sleepWithContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
@@ -70,17 +75,18 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
-func killNCSocketHolders(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) {
+func killSocketHolders(ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger) {
 	if exec == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, killNCSocketHoldersTimeout)
+	ctx, cancel := context.WithTimeout(ctx, killSocketHoldersTimeout)
 	defer cancel()
 
-	// Anchor the pattern so virt-serial0 does not match virt-serial0-log.
-	pattern := "^nc -U " + regexp.QuoteMeta(socketPath) + "$"
-	script := fmt.Sprintf("pkill -f %q || true", pattern)
+	quoted := regexp.QuoteMeta(socketPath)
+	ncPat := "^nc -U " + quoted + "$"
+	socatPat := "^socat - UNIX-CONNECT:" + quoted + "$"
+	script := fmt.Sprintf("pkill -f %q || true; pkill -f %q || true", ncPat, socatPat)
 	if err := exec.Exec(ctx, containerName, "sh", "-c", script); err != nil {
-		logger.Debugf("failed to kill leftover nc for %s in %s: %v", socketPath, containerName, err)
+		logger.Debugf("failed to kill leftover socket clients for %s in %s: %v", socketPath, containerName, err)
 	}
 }

--- a/internal/agent/device/applications/console/unix_socket_test.go
+++ b/internal/agent/device/applications/console/unix_socket_test.go
@@ -68,6 +68,23 @@ func TestDialVMUnixSocket_WhenNCIsMissingItShouldDialWithSocat(t *testing.T) {
 	require.Equal([]string{"socat", "-", "UNIX-CONNECT:" + vmSerialSocketPath}, exec.streamCmds[0])
 }
 
+func TestDialVMUnixSocket_WhenNCProbeFailsItShouldNotFallBackToSocat(t *testing.T) {
+	require := require.New(t)
+	exec := &mockExecStreamer{
+		conn:     &recordingCloser{},
+		probeErr: fmt.Errorf("podman exec compute: no such container"),
+	}
+	logger := log.NewPrefixLogger("test")
+
+	conn, err := dialVMUnixSocket(context.Background(), exec, "compute", vmSerialSocketPath, logger)
+	require.Error(err)
+	require.Nil(conn)
+	require.Contains(err.Error(), "probe nc")
+	require.Contains(err.Error(), "no such container")
+	require.Equal(0, exec.streamN)
+	require.Empty(pkillScripts(exec))
+}
+
 func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverClientsBeforeDial(t *testing.T) {
 	require := require.New(t)
 	closer := &recordingCloser{}

--- a/internal/agent/device/applications/console/unix_socket_test.go
+++ b/internal/agent/device/applications/console/unix_socket_test.go
@@ -23,6 +23,17 @@ func (c *recordingCloser) Close() error {
 	return nil
 }
 
+func pkillScripts(exec *mockExecStreamer) []string {
+	var scripts []string
+	for _, call := range exec.execCalls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "pkill") {
+			scripts = append(scripts, joined)
+		}
+	}
+	return scripts
+}
+
 func TestDialVMUnixSocket_WhenExecIsNilItShouldReturnError(t *testing.T) {
 	require := require.New(t)
 	logger := log.NewPrefixLogger("test")
@@ -33,7 +44,31 @@ func TestDialVMUnixSocket_WhenExecIsNilItShouldReturnError(t *testing.T) {
 	require.Contains(err.Error(), "no exec streamer")
 }
 
-func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverNCBeforeDial(t *testing.T) {
+func TestDialVMUnixSocket_WhenNCIsPresentItShouldDialWithNC(t *testing.T) {
+	require := require.New(t)
+	closer := &recordingCloser{}
+	exec := &mockExecStreamer{conn: closer}
+	logger := log.NewPrefixLogger("test")
+
+	conn, err := dialVMUnixSocket(context.Background(), exec, "compute", vmSerialSocketPath, logger)
+	require.NoError(err)
+	require.NotNil(conn)
+	require.Equal([]string{"nc", "-U", vmSerialSocketPath}, exec.streamCmds[0])
+}
+
+func TestDialVMUnixSocket_WhenNCIsMissingItShouldDialWithSocat(t *testing.T) {
+	require := require.New(t)
+	closer := &recordingCloser{}
+	exec := &mockExecStreamer{conn: closer, ncMissing: true}
+	logger := log.NewPrefixLogger("test")
+
+	conn, err := dialVMUnixSocket(context.Background(), exec, "compute", vmSerialSocketPath, logger)
+	require.NoError(err)
+	require.NotNil(conn)
+	require.Equal([]string{"socat", "-", "UNIX-CONNECT:" + vmSerialSocketPath}, exec.streamCmds[0])
+}
+
+func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverClientsBeforeDial(t *testing.T) {
 	require := require.New(t)
 	closer := &recordingCloser{}
 	exec := &mockExecStreamer{conn: closer}
@@ -44,14 +79,15 @@ func TestDialVMUnixSocket_WhenOpeningItShouldReapLeftoverNCBeforeDial(t *testing
 	require.NoError(err)
 	require.NotNil(conn)
 
-	require.Len(exec.execCalls, 1, "expected a pre-dial cleanup Exec call")
-	require.Contains(strings.Join(exec.execCalls[0], " "), socketPath)
-	require.Contains(strings.Join(exec.execCalls[0], " "), "pkill")
+	require.Len(exec.execCalls, 2, "expected nc probe then pre-dial cleanup")
+	pkill := pkillScripts(exec)
+	require.Len(pkill, 1)
+	require.Contains(pkill[0], socketPath)
 	require.Equal(1, exec.streamN)
 
 	require.NoError(conn.Close())
 	require.True(closer.closed)
-	require.Len(exec.execCalls, 1, "Close must not pkill (avoids killing a --force successor's nc)")
+	require.Len(pkillScripts(exec), 1, "Close must not pkill (avoids killing a --force successor)")
 }
 
 func TestDialVMUnixSocket_WhenDialFailsItShouldRetryUpToThreeTimes(t *testing.T) {
@@ -72,7 +108,7 @@ func TestDialVMUnixSocket_WhenDialFailsItShouldRetryUpToThreeTimes(t *testing.T)
 	require.NoError(err)
 	require.NotNil(conn)
 	require.Equal(3, exec.streamN)
-	require.Len(exec.execCalls, 3, "each attempt reaps before dial")
+	require.Len(pkillScripts(exec), 3, "each attempt reaps before dial")
 	require.Less(time.Since(start), time.Second)
 	require.NoError(conn.Close())
 }
@@ -93,7 +129,7 @@ func TestDialVMUnixSocket_WhenAllDialAttemptsFailItShouldReturnError(t *testing.
 	require.Nil(conn)
 	require.Contains(err.Error(), "after 3 attempts")
 	require.Equal(3, exec.streamN)
-	require.Len(exec.execCalls, 3)
+	require.Len(pkillScripts(exec), 3)
 }
 
 func TestDialVMUnixSocket_WhenOldSessionClosesAfterNewDialItShouldNotReap(t *testing.T) {
@@ -104,33 +140,32 @@ func TestDialVMUnixSocket_WhenOldSessionClosesAfterNewDialItShouldNotReap(t *tes
 
 	oldConn, err := dialVMUnixSocket(context.Background(), shared, "compute", socketPath, logger)
 	require.NoError(err)
-	require.Len(shared.execCalls, 1)
+	require.Len(pkillScripts(shared), 1)
 
-	// Simulate --force: new dial starts while old session still open.
 	shared.conn = &recordingCloser{}
 	newConn, err := dialVMUnixSocket(context.Background(), shared, "compute", socketPath, logger)
 	require.NoError(err)
-	require.Len(shared.execCalls, 2, "new dial issues its own pre-dial pkill")
+	require.Len(pkillScripts(shared), 2, "new dial issues its own pre-dial pkill")
 
 	require.NoError(oldConn.Close())
-	require.Len(shared.execCalls, 2, "old Close must not issue another pkill")
+	require.Len(pkillScripts(shared), 2, "old Close must not issue another pkill")
 	require.NoError(newConn.Close())
-	require.Len(shared.execCalls, 2)
+	require.Len(pkillScripts(shared), 2)
 }
 
-func TestKillNCSocketHolders_WhenPatternBuiltItShouldNotMatchLogSuffix(t *testing.T) {
+func TestKillSocketHolders_WhenPatternBuiltItShouldCoverNCAndSocatWithoutLogSuffix(t *testing.T) {
 	require := require.New(t)
 	exec := &mockExecStreamer{}
 	logger := log.NewPrefixLogger("test")
 
-	killNCSocketHolders(context.Background(), exec, "compute", vmSerialSocketPath, logger)
+	killSocketHolders(context.Background(), exec, "compute", vmSerialSocketPath, logger)
 	require.Len(exec.execCalls, 1)
 	script := strings.Join(exec.execCalls[0], " ")
 	require.Contains(script, "^nc -U "+vmSerialSocketPath+"$")
+	require.Contains(script, "^socat - UNIX-CONNECT:"+vmSerialSocketPath+"$")
 	require.NotContains(script, "virt-serial0-log")
 }
 
-// dialWithRetryDelay runs dialVMUnixSocket with a shortened retry delay for tests.
 func dialWithRetryDelay(t *testing.T, ctx context.Context, exec ExecStreamer, containerName, socketPath string, logger *log.PrefixLogger, delay time.Duration) (io.ReadWriteCloser, error) {
 	t.Helper()
 	prev := dialRetryDelay

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -1657,7 +1657,7 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		// always return the same session type. Assert the VNC-specific observable
 		// behavior instead: the underlying exec targets the serial socket, not the VNC one.
 		execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "exec", "systemd-my-vm-compute", "sh", "-c", gomock.Any()).
-			Return("", "", 0).Times(1)
+			Return("", "", 0).Times(2)
 		execMock.EXPECT().CommandContext(gomock.Any(), "podman", "exec", "-i", "systemd-my-vm-compute", "nc", "-U", "/var/run/kubevirt-private/default/virt-serial0").
 			DoAndReturn(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 				return exec.CommandContext(ctx, "cat")
@@ -1716,7 +1716,7 @@ func TestPodmanMonitorResolveConsole(t *testing.T) {
 		// always return the serial session. Assert the VNC-specific observable behavior
 		// instead: the underlying exec targets the VNC socket, not the serial one.
 		execMock.EXPECT().ExecuteWithContext(gomock.Any(), "podman", "exec", "systemd-my-vm-compute", "sh", "-c", gomock.Any()).
-			Return("", "", 0).Times(1)
+			Return("", "", 0).Times(2)
 		execMock.EXPECT().CommandContext(gomock.Any(), "podman", "exec", "-i", "systemd-my-vm-compute", "nc", "-U", "/var/run/kubevirt-private/default/virt-vnc").
 			DoAndReturn(func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 				return exec.CommandContext(ctx, "cat")


### PR DESCRIPTION
Fixes [EDM-5283](https://issues.redhat.com/browse/EDM-5283).

## Summary
- Downstream CNV `virt-launcher-rhel9` does not ship `nc`/`ncat`, so VM serial and VNC consoles fail (`podman exec … nc -U …`).
- Community `virt-launcher` ships `nc` and does not ship `socat`, so the agent cannot switch to socat only.
- Probe for `nc` in the compute container and use `socat - UNIX-CONNECT:` when it is absent. Reap leftover clients for both command lines.

## Test plan
- [x] `go test ./internal/agent/device/applications/console/ ./internal/agent/device/applications/`
- [ ] On a device using community virt-launcher, open serial and VNC (still uses `nc`)
- [ ] On a device using CNV virt-launcher-rhel9, open serial and VNC (uses `socat`)


Made with [Cursor](https://cursor.com)