### PR TITLE
EDM-5284: Accept runAs alongside catalog item references

### DIFF
--- a/api/core/v1alpha1/validation.go
+++ b/api/core/v1alpha1/validation.go
@@ -452,9 +452,9 @@ func validateCatalogItemConfig(category CatalogItemCategory, itemType CatalogIte
 }
 
 // Known fields for each CatalogItem type
-var containerKnownFields = []string{"envVars", "ports", "resources", "volumes"}
+var containerKnownFields = []string{"envVars", "ports", "resources", "runAs", "volumes"}
 var helmKnownFields = []string{"namespace", "values", "valuesFiles"}
-var quadletKnownFields = []string{"envVars", "volumes"}
+var quadletKnownFields = []string{"envVars", "runAs", "volumes"}
 
 // validateContainerConfig validates config for container type.
 func validateContainerConfig(config map[string]interface{}, pathPrefix string) []error {
@@ -469,6 +469,9 @@ func validateContainerConfig(config map[string]interface{}, pathPrefix string) [
 	} else if envVars != nil {
 		allErrs = append(allErrs, validateEnvVars(envVars, pathPrefix)...)
 	}
+
+	// Validate runAs
+	allErrs = append(allErrs, validateRunAs(config, pathPrefix)...)
 
 	// Validate ports
 	if ports, err := extractStringSlice(config, "ports"); err != nil {
@@ -553,6 +556,9 @@ func validateQuadletConfig(config map[string]interface{}, pathPrefix string) []e
 	} else if envVars != nil {
 		allErrs = append(allErrs, validateEnvVars(envVars, pathPrefix)...)
 	}
+
+	// Validate runAs
+	allErrs = append(allErrs, validateRunAs(config, pathPrefix)...)
 
 	// Validate volumes
 	if raw, exists := config["volumes"]; exists {
@@ -675,6 +681,19 @@ func validateConfigSchema(schema *map[string]any, path string) []error {
 // validateEnvVars validates environment variable names and values.
 func validateEnvVars(envVars *map[string]string, pathPrefix string) []error {
 	return validation.ValidateStringMap(envVars, pathPrefix+".envVars", 1, validation.DNS1123MaxLength, validation.EnvVarNameRegexp, nil, "")
+}
+
+// validateRunAs validates the runAs field, which names the system user the
+// application should run under. When present it must be a string.
+func validateRunAs(config map[string]interface{}, pathPrefix string) []error {
+	raw, exists := config["runAs"]
+	if !exists {
+		return nil
+	}
+	if _, ok := raw.(string); !ok {
+		return []error{fmt.Errorf("%s.runAs: must be a string", pathPrefix)}
+	}
+	return nil
 }
 
 // Port validation constants

--- a/api/core/v1alpha1/validation_test.go
+++ b/api/core/v1alpha1/validation_test.go
@@ -578,6 +578,54 @@ func TestCatalogItemValuesValidation(t *testing.T) {
 			wantErr:     true,
 			errContains: `"ports" is not a valid key`,
 		},
+		// runAs (EDM-5284)
+		{
+			name:     "container with runAs",
+			category: CatalogItemCategoryApplication,
+			itemType: CatalogItemTypeContainer,
+			config: &map[string]interface{}{
+				"runAs": "app-user",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "quadlet with runAs",
+			category: CatalogItemCategoryApplication,
+			itemType: CatalogItemTypeQuadlet,
+			config: &map[string]interface{}{
+				"runAs": "app-user",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "compose with runAs",
+			category: CatalogItemCategoryApplication,
+			itemType: CatalogItemTypeCompose,
+			config: &map[string]interface{}{
+				"runAs": "app-user",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "container with runAs wrong type",
+			category: CatalogItemCategoryApplication,
+			itemType: CatalogItemTypeContainer,
+			config: &map[string]interface{}{
+				"runAs": 1234,
+			},
+			wantErr:     true,
+			errContains: "runAs: must be a string",
+		},
+		{
+			name:     "helm with runAs field (not allowed)",
+			category: CatalogItemCategoryApplication,
+			itemType: CatalogItemTypeHelm,
+			config: &map[string]interface{}{
+				"runAs": "app-user",
+			},
+			wantErr:     true,
+			errContains: `"runAs" is not a valid key`,
+		},
 		// complete examples for each type
 		{
 			name:     "container complete example",
@@ -590,6 +638,7 @@ func TestCatalogItemValuesValidation(t *testing.T) {
 					"ENABLE_DEBUG": "false",
 				},
 				"ports": []interface{}{"8080:80", "9090:9090", "443:443"},
+				"runAs": "app-user",
 				"resources": map[string]interface{}{
 					"limits": map[string]interface{}{
 						"cpu":    "1.5",


### PR DESCRIPTION
Previously this would fail validation at the initial API validation layer.

Assisted-by: Claude <noreply@anthropic.com>