### PR TITLE
EDM-4858: Backport version check fix to release 1.2

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -523,15 +523,14 @@ var _ = Describe("cli operation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clientVersion).ToNot(BeEmpty(), "client version should be found")
 			Expect(serverVersion).ToNot(BeEmpty(), "server version should be found")
-			Expect(agentVersion).ToNot(BeEmpty(), "agent version should be found")
+			Expect(agentVersion).To(BeEmpty(), "agent version lookup should be skipped when the VM is not initialized")
 
 			GinkgoWriter.Printf("Client version: %s\n", clientVersion)
 			GinkgoWriter.Printf("Server version: %s\n", serverVersion)
 			GinkgoWriter.Printf("Agent version: %s\n", agentVersion)
 
 			By("Comparing versions")
-			// Expect(clientVersion).To(Equal(serverVersion), "client and server versions should match")
-			Expect(agentVersion).To(Equal(serverVersion), "agent and server versions should match")
+			Expect(clientVersion).To(Equal(serverVersion), "client and server versions should match")
 		})
 
 		It("should show FIPS runtime compliance", Label("rpm-sanity", "84648", "client"), func() {


### PR DESCRIPTION
Backports the 79621 version check behavior to release-1.2.

The test title and current behavior validate that the local CLI client matches the deployed server. release-1.2 still required the agent version to match the server, which can fail in this CLI-only test path even though the client/server versions are aligned

This keeps the test focused on client/server and expects the agent lookup to be skipped when no VM is initialized.

backport of fix made here:
https://github.com/flightctl/flightctl/pull/3247/changes#diff-6d90889beb67a5e1b18c665f20add64ca4e339ab6a32611ecf48fc85b7814fe5R526