### PR TITLE
EDM-4845: Retry transient vulnerability fleet creation

### DIFF
--- a/test/e2e/vulnerability/vulnerability_test.go
+++ b/test/e2e/vulnerability/vulnerability_test.go
@@ -46,11 +46,11 @@ var _ = Describe("Vulnerability API", Label("vulnerability"), func() {
 
 		It("should detect vulnerabilities and track CVE lifecycle through OS upgrades", Label("89034"), func() {
 			By("Creating a fleet with label selector")
-			err := harness.CreateFleetWithSelector(fleetName, map[string]string{"fleet": fleetName})
-			Expect(err).ToNot(HaveOccurred())
+			fleetSelector := map[string]string{"fleet": fleetName}
+			Eventually(harness.CreateFleetWithSelectorRetry(fleetName, fleetSelector), syncWaitTimeout, syncInterval).Should(Succeed())
 
 			By("Creating device with digest-a (5 CVEs: 1 Critical, 2 High, 1 Medium, 1 Low)")
-			err = harness.CreateDeviceWithDigest(deviceName1, fleetName, DigestA)
+			err := harness.CreateDeviceWithDigest(deviceName1, fleetName, DigestA)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for vulnerability sync to detect CVEs")

--- a/test/harness/e2e/harness_fleet.go
+++ b/test/harness/e2e/harness_fleet.go
@@ -1,8 +1,13 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -121,7 +126,7 @@ func (h *Harness) CreateOrUpdateTestFleet(testFleetName string, fleetSpecOrSelec
 
 	resp, err := h.Client.ReplaceFleetWithResponse(h.Context, testFleetName, testFleet)
 	if err != nil {
-		return fmt.Errorf("replace fleet %q: %w", testFleetName, err)
+		return apiWriteTransportError{operation: fmt.Sprintf("replace fleet %q", testFleetName), err: err}
 	}
 	// Replace creates with 201 or updates with 200; anything else is a failed apply.
 	if resp.StatusCode() != 200 && resp.StatusCode() != 201 {
@@ -155,6 +160,21 @@ func (h *Harness) CreateFleetWithSelector(fleetName string, labelSelector map[st
 	return h.CreateOrUpdateTestFleet(fleetName, selector)
 }
 
+// CreateFleetWithSelectorRetry returns an Eventually-compatible function that creates a fleet with the specified selector.
+// Transient API transport errors are retried, while non-retryable errors stop polling immediately.
+func (h *Harness) CreateFleetWithSelectorRetry(fleetName string, labelSelector map[string]string) func() error {
+	return func() error {
+		err := h.CreateFleetWithSelector(fleetName, labelSelector)
+		if err == nil {
+			return nil
+		}
+		if isRetryableAPIWriteError(err) {
+			return fmt.Errorf("create fleet %q with selector %v: %w", fleetName, labelSelector, err)
+		}
+		return StopTrying(fmt.Sprintf("non-retryable error creating fleet %q with selector %v", fleetName, labelSelector)).Wrap(err)
+	}
+}
+
 // CreateTestFleetWithConfig creates a test fleet with a configuration.
 func (h *Harness) CreateTestFleetWithConfig(testFleetName string, testFleetSelector v1beta1.LabelSelector, configProviderSpec v1beta1.ConfigProviderSpec) error {
 	var testFleetSpec = v1beta1.DeviceSpec{
@@ -164,6 +184,76 @@ func (h *Harness) CreateTestFleetWithConfig(testFleetName string, testFleetSelec
 	}
 	err := h.CreateOrUpdateTestFleet(testFleetName, testFleetSelector, testFleetSpec)
 	return err
+}
+
+type apiWriteTransportError struct {
+	operation string
+	err       error
+}
+
+func (e apiWriteTransportError) Error() string {
+	return fmt.Sprintf("%s: %v", e.operation, e.err)
+}
+
+func (e apiWriteTransportError) Unwrap() error {
+	return e.err
+}
+
+// isRetryableAPIWriteError reports whether an API write failed before the server returned
+// an HTTP response. It is intentionally limited to transport-level failures that can occur
+// while routes or pods settle, and does not classify API status responses as retryable.
+func isRetryableAPIWriteError(err error) bool {
+	transportErr, ok := apiWriteTransportCause(err)
+	if !ok {
+		return false
+	}
+
+	// Prefer sentinel checks when the transport error is preserved in the error chain.
+	if errors.Is(transportErr, io.EOF) || errors.Is(transportErr, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// Some net/http and TLS failures are wrapped as url errors with only message text
+	// available at this layer, so keep the string checks narrow and transport-specific.
+	errText := strings.ToLower(transportErr.Error())
+	return strings.Contains(errText, "eof") ||
+		strings.Contains(errText, "connection reset") ||
+		strings.Contains(errText, "connection refused") ||
+		strings.Contains(errText, "server closed idle connection") ||
+		strings.Contains(errText, "tls: bad record mac")
+}
+
+func apiWriteTransportCause(err error) (error, bool) {
+	if err == nil {
+		return nil, false
+	}
+
+	var writeErr apiWriteTransportError
+	if errors.As(err, &writeErr) {
+		if writeErr.err != nil {
+			return writeErr.err, true
+		}
+		return writeErr, true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Err != nil {
+			return urlErr.Err, true
+		}
+		return urlErr, true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr, true
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return err, true
+	}
+
+	return nil, false
 }
 
 // CreateFleetWithLabelConfig creates a fleet that selects devices by a single label key/value

--- a/test/harness/e2e/harness_test.go
+++ b/test/harness/e2e/harness_test.go
@@ -1,6 +1,9 @@
 package e2e
 
 import (
+	"errors"
+	"io"
+	"net/url"
 	"slices"
 	"strings"
 	"testing"
@@ -29,6 +32,31 @@ func TestIsCLIRateLimitOutputPreservesExisting429Checks(t *testing.T) {
 	for _, output := range cases {
 		if !isCLIRateLimitOutput(output) {
 			t.Fatalf("expected %q to be classified as rate-limited", output)
+		}
+	}
+}
+
+// TestIsRetryableAPIWriteErrorRequiresTransportError verifies API response errors are not
+// retried just because their formatted status message contains transport-looking text.
+func TestIsRetryableAPIWriteErrorRequiresTransportError(t *testing.T) {
+	apiStatusErr := errors.New("unexpected status creating/updating fleet test: 400: EOF in validation message")
+	if isRetryableAPIWriteError(apiStatusErr) {
+		t.Fatalf("expected formatted API status error not to be classified as retryable")
+	}
+}
+
+// TestIsRetryableAPIWriteErrorAllowsTransportErrors verifies marked and typed transport
+// failures are still retried.
+func TestIsRetryableAPIWriteErrorAllowsTransportErrors(t *testing.T) {
+	cases := []error{
+		apiWriteTransportError{operation: "replace fleet test", err: io.EOF},
+		&url.Error{Op: "Put", URL: "https://flightctl.example/api/v1/fleets/test", Err: io.ErrUnexpectedEOF},
+		apiWriteTransportError{operation: "replace fleet test", err: errors.New("server closed idle connection")},
+	}
+
+	for _, err := range cases {
+		if !isRetryableAPIWriteError(err) {
+			t.Fatalf("expected %q to be classified as retryable", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Retry transient API transport failures when the vulnerability lifecycle test creates its fleet after suite setup restarts services.
- Preserve fail-fast behavior for non-retryable fleet creation errors with `StopTrying`.

## Release target

- [x] release-1.3

Target release: release-1.3
